### PR TITLE
refactor(oauth): consolidate authorization flow primitives

### DIFF
--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from uuid import UUID
@@ -51,6 +52,26 @@ _OFFLINE_ACCESS_AUTH_PARAMS_BY_HOST: dict[str, dict[str, str]] = {
     # config without one. Matches Onyx's own Google login flow.
     "accounts.google.com": {"access_type": "offline", "prompt": "consent"},
 }
+
+_PROTOCOL_AUTHORIZATION_PARAMS = frozenset(
+    {
+        "client_id",
+        "code_challenge",
+        "code_challenge_method",
+        "redirect_uri",
+        "resource",
+        "response_type",
+        "scope",
+        "state",
+    }
+)
+
+
+def conflicting_authorization_params(
+    additional_params: Mapping[str, object] | None,
+) -> frozenset[str]:
+    """Return configured parameters whose values the OAuth flow must own."""
+    return _PROTOCOL_AUTHORIZATION_PARAMS.intersection(additional_params or {})
 
 
 def ensure_offline_access_auth_params(authorization_url: str) -> str:

--- a/backend/onyx/oauth/authorization_attempt.py
+++ b/backend/onyx/oauth/authorization_attempt.py
@@ -1,10 +1,12 @@
 import hashlib
+import json
 import re
 import secrets
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Generic, cast
 
-from pydantic import ValidationError
+from pydantic import JsonValue, ValidationError
 
 from onyx.cache.interface import CacheBackend
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -20,16 +22,28 @@ _INVALID_ATTEMPT_MESSAGE = "Invalid or expired OAuth authorization attempt"
 MAX_AUTHORIZATION_ATTEMPT_TTL_SECONDS = 10 * 60
 
 
+def canonical_json_fingerprint(value: JsonValue) -> str:
+    """Fingerprint configuration captured by a pending authorization attempt."""
+    serialized = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
 class AuthorizationAttemptStore(Generic[PayloadT]):
     """Stores typed OAuth attempts in a tenant-scoped cache."""
 
     def __init__(
         self,
-        cache: CacheBackend,
         *,
+        cache_backend_provider: Callable[[], CacheBackend],
         namespace: str,
         payload_type: type[PayloadT],
-        ttl_seconds: int,
+        ttl_seconds: int = MAX_AUTHORIZATION_ATTEMPT_TTL_SECONDS,
     ) -> None:
         if not _NAMESPACE_PATTERN.fullmatch(namespace) or len(namespace) > 64:
             raise ValueError("OAuth attempt namespace is invalid")
@@ -39,7 +53,7 @@ class AuthorizationAttemptStore(Generic[PayloadT]):
                 f"{MAX_AUTHORIZATION_ATTEMPT_TTL_SECONDS} seconds"
             )
 
-        self._cache = cache
+        self._cache_backend_provider = cache_backend_provider
         self._namespace = namespace
         self._attempt_type = cast(
             type[AuthorizationAttempt[PayloadT]],
@@ -67,7 +81,7 @@ class AuthorizationAttemptStore(Generic[PayloadT]):
             expires_at=expires_at,
             payload=payload,
         )
-        stored = self._cache.set_if_absent(
+        stored = self._cache_backend_provider().set_if_absent(
             self._key(attempt.owner_id, attempt.state),
             attempt.model_dump_json(),
             ex=self._ttl_seconds,
@@ -85,7 +99,7 @@ class AuthorizationAttemptStore(Generic[PayloadT]):
         owner_id: str,
         state: str,
     ) -> AuthorizationAttempt[PayloadT]:
-        stored = self._cache.getdel(self._key(owner_id, state))
+        stored = self._cache_backend_provider().getdel(self._key(owner_id, state))
         if stored is None:
             raise _invalid_attempt_error()
 

--- a/backend/onyx/oauth/models.py
+++ b/backend/onyx/oauth/models.py
@@ -1,8 +1,27 @@
-from typing import Generic, TypeVar
+from typing import Annotated, Generic, TypeVar
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+from pydantic import AfterValidator, AwareDatetime, BaseModel, ConfigDict, Field
+
+from onyx.utils.url import sanitize_next_url
 
 PayloadT = TypeVar("PayloadT", bound=BaseModel)
+
+
+def _validate_safe_oauth_return_path(value: str) -> str:
+    if sanitize_next_url(value) != value or any(
+        not character.isprintable() for character in value
+    ):
+        raise ValueError("OAuth return path must be a safe internal path")
+    return value
+
+
+SafeOAuthReturnPath = Annotated[
+    str,
+    Field(max_length=2048),
+    AfterValidator(_validate_safe_oauth_return_path),
+]
+OAuthConfigurationFingerprint = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+PKCECodeVerifier = Annotated[str, Field(min_length=43, max_length=128)]
 
 
 class AuthorizationAttempt(BaseModel, Generic[PayloadT]):

--- a/backend/onyx/server/documents/standard_oauth.py
+++ b/backend/onyx/server/documents/standard_oauth.py
@@ -2,7 +2,7 @@ from typing import Annotated, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
@@ -21,10 +21,10 @@ from onyx.oauth.authorization_attempt import (
     AuthorizationAttemptStore,
     generate_authorization_state,
 )
+from onyx.oauth.models import PKCECodeVerifier, SafeOAuthReturnPath
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
 from onyx.utils.subclasses import find_all_subclasses_in_package
-from onyx.utils.url import sanitize_next_url
 
 logger = setup_logger()
 
@@ -83,25 +83,16 @@ def _validate_additional_kwargs(
 class _ConnectorOAuthAttemptPayload(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    desired_return_path: str
+    desired_return_path: SafeOAuthReturnPath
     additional_kwargs: dict[str, str]
-    code_verifier: str | None = None
-
-    @field_validator("desired_return_path")
-    @classmethod
-    def validate_return_path(cls, value: str) -> str:
-        if sanitize_next_url(value) != value or any(
-            not character.isprintable() for character in value
-        ):
-            raise ValueError("OAuth return path must be a local application path")
-        return value
+    code_verifier: PKCECodeVerifier | None = None
 
 
 def _authorization_attempt_store(
     source: DocumentSource,
 ) -> AuthorizationAttemptStore[_ConnectorOAuthAttemptPayload]:
     return AuthorizationAttemptStore(
-        get_cache_backend(),
+        cache_backend_provider=get_cache_backend,
         namespace=f"{_OAUTH_ATTEMPT_NAMESPACE_PREFIX}-{source.value}",
         payload_type=_ConnectorOAuthAttemptPayload,
         ttl_seconds=_OAUTH_STATE_EXPIRATION_SECONDS,

--- a/backend/onyx/server/features/mcp/credentials.py
+++ b/backend/onyx/server/features/mcp/credentials.py
@@ -19,19 +19,18 @@ This module holds pure logic plus the resolve orchestration; the DB fetch lives
 in ``onyx.db.mcp``. It must not import ``onyx.server.features.mcp.oauth``.
 """
 
-import hashlib
-import json
 import time
 from collections.abc import Mapping
 from typing import cast
 
 from mcp.shared.auth import OAuthClientInformationFull
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, JsonValue
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import MCPAuthenticationPerformer, MCPAuthenticationType
 from onyx.db.mcp import get_user_connection_config
 from onyx.db.models import MCPConnectionConfig, MCPServer, User
+from onyx.oauth.authorization_attempt import canonical_json_fingerprint
 from onyx.server.features.mcp.models import (
     DENYLISTED_MCP_HEADERS,
     MCPAuthTemplate,
@@ -71,31 +70,27 @@ def mcp_token_expired(config_data: MCPConnectionData) -> bool:
 
 
 def mcp_oauth_connection_headers_fingerprint(headers: dict[str, str]) -> str:
-    routing_headers = sorted(
-        (key.lower(), value)
-        for key, value in headers.items()
-        if key.lower() != "authorization"
-    )
-    serialized_headers = json.dumps(
-        routing_headers, ensure_ascii=True, separators=(",", ":")
-    )
-    return hashlib.sha256(serialized_headers.encode()).hexdigest()
+    routing_headers: JsonValue = [
+        [key, value]
+        for key, value in sorted(
+            (key.lower(), value)
+            for key, value in headers.items()
+            if key.lower() != "authorization"
+        )
+    ]
+    return canonical_json_fingerprint(routing_headers)
 
 
 def mcp_oauth_client_information_fingerprint(
     client_information: OAuthClientInformationFull,
 ) -> str:
-    serialized_client = json.dumps(
+    return canonical_json_fingerprint(
         client_information.model_dump(
             mode="json",
             exclude_none=True,
             by_alias=True,
         ),
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
     )
-    return hashlib.sha256(serialized_client.encode()).hexdigest()
 
 
 def requires_user_authentication(

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -11,6 +11,7 @@ from mcp.shared.auth import (
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl, BaseModel, Field, model_validator
 
+from onyx.auth.oauth_token_manager import conflicting_authorization_params
 from onyx.db.enums import (
     EndpointPolicy,
     MCPAuthenticationPerformer,
@@ -19,21 +20,16 @@ from onyx.db.enums import (
     MCPServerStatus,
     MCPTransport,
 )
+from onyx.oauth.models import (
+    OAuthConfigurationFingerprint,
+    PKCECodeVerifier,
+    SafeOAuthReturnPath,
+)
 
 # Matches `{placeholder_name}` inside header value templates.
 _PLACEHOLDER_RE = re.compile(r"\{([^}]+)\}")
 # RFC 9110 field-name syntax: a non-empty sequence of HTTP token characters.
 _HTTP_FIELD_NAME_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
-RESERVED_MCP_OAUTH_AUTHORIZATION_PARAMS = {
-    "client_id",
-    "code_challenge",
-    "code_challenge_method",
-    "redirect_uri",
-    "resource",
-    "response_type",
-    "scope",
-    "state",
-}
 
 
 def _build_auto_substitution_map(*, user_email: str) -> dict[str, str]:
@@ -387,8 +383,8 @@ class MCPToolCreateRequest(BaseModel):
                 raise ValueError(
                     "oauth_token_endpoint is required for known-provider OAuth mode"
                 )
-            reserved_params = RESERVED_MCP_OAUTH_AUTHORIZATION_PARAMS.intersection(
-                self.oauth_additional_auth_params or {}
+            reserved_params = conflicting_authorization_params(
+                self.oauth_additional_auth_params
             )
             if reserved_params:
                 raise ValueError(
@@ -511,7 +507,9 @@ class MCPOAuthConnectResponse(BaseModel):
 
 class MCPUserOAuthConnectRequest(BaseModel):
     server_id: int = Field(..., description="ID of the MCP server")
-    return_path: str = Field(..., description="Path to redirect to after callback")
+    return_path: SafeOAuthReturnPath = Field(
+        ..., description="Path to redirect to after callback"
+    )
     include_resource_param: bool = Field(..., description="Include resource parameter")
     force_reauthentication: bool = Field(
         default=False,
@@ -539,17 +537,6 @@ class MCPUserOAuthConnectRequest(BaseModel):
         ),
     )
 
-    @model_validator(mode="after")
-    def validate_return_path(self) -> "MCPUserOAuthConnectRequest":
-        if (
-            not self.return_path.startswith("/")
-            or self.return_path.startswith("//")
-            or "\\" in self.return_path
-            or any(not character.isprintable() for character in self.return_path)
-        ):
-            raise ValueError("return_path must be a safe internal path")
-        return self
-
 
 class MCPUserOAuthConnectResponse(BaseModel):
     server_id: int
@@ -574,7 +561,7 @@ class MCPUserOAuthConnectResponse(BaseModel):
 class MCPPendingOAuthAuthorization(BaseModel):
     authorization_url: str
     state: str
-    code_verifier: str
+    code_verifier: PKCECodeVerifier
 
 
 class MCPOAuthServerSnapshot(BaseModel):
@@ -592,12 +579,12 @@ class MCPOAuthServerSnapshot(BaseModel):
 class MCPOAuthFlowState(BaseModel):
     server_id: int
     connection_config_id: int
-    return_path: str
-    code_verifier: str
+    return_path: SafeOAuthReturnPath
+    code_verifier: PKCECodeVerifier
     redirect_uri: AnyUrl
     server_snapshot: MCPOAuthServerSnapshot
-    connection_headers_fingerprint: str
-    client_information_fingerprint: str
+    connection_headers_fingerprint: OAuthConfigurationFingerprint
+    client_information_fingerprint: OAuthConfigurationFingerprint
     protected_resource_metadata: ProtectedResourceMetadata | None = None
     oauth_metadata: OAuthMetadata | None = None
     authorization_server_url: str | None = None

--- a/backend/onyx/server/features/mcp/oauth_flow.py
+++ b/backend/onyx/server/features/mcp/oauth_flow.py
@@ -18,6 +18,7 @@ from pydantic import AnyUrl
 from onyx.auth.oauth_token_manager import (
     OAuthFlowParams,
     build_oauth_authorization_url,
+    conflicting_authorization_params,
 )
 from onyx.cache.factory import get_cache_backend
 from onyx.db.enums import MCPTransport
@@ -36,7 +37,6 @@ from onyx.server.features.mcp.credentials import (
 )
 from onyx.server.features.mcp.models import (
     DENYLISTED_MCP_HEADERS,
-    RESERVED_MCP_OAUTH_AUTHORIZATION_PARAMS,
     MCPOAuthFlowState,
     MCPOAuthServerSnapshot,
     MCPPendingOAuthAuthorization,
@@ -85,8 +85,8 @@ def _known_provider_flow_params(
             "Known-provider OAuth requires oauth_authorization_endpoint, "
             "oauth_token_endpoint, and a non-empty client_id.",
         )
-    reserved_params = RESERVED_MCP_OAUTH_AUTHORIZATION_PARAMS.intersection(
-        mcp_server.oauth_additional_auth_params or {}
+    reserved_params = conflicting_authorization_params(
+        mcp_server.oauth_additional_auth_params
     )
     if reserved_params:
         raise OnyxError(
@@ -180,7 +180,7 @@ def validate_mcp_oauth_flow_configuration(
 
 def mcp_oauth_attempt_store() -> AuthorizationAttemptStore[MCPOAuthFlowState]:
     return AuthorizationAttemptStore(
-        get_cache_backend(),
+        cache_backend_provider=get_cache_backend,
         namespace="mcp",
         payload_type=MCPOAuthFlowState,
         ttl_seconds=MCP_OAUTH_FLOW_TTL_SECONDS,

--- a/backend/tests/unit/onyx/oauth/test_authorization_attempt.py
+++ b/backend/tests/unit/onyx/oauth/test_authorization_attempt.py
@@ -5,7 +5,10 @@ from pydantic import BaseModel, ConfigDict
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.oauth.authorization_attempt import AuthorizationAttemptStore
+from onyx.oauth.authorization_attempt import (
+    AuthorizationAttemptStore,
+    canonical_json_fingerprint,
+)
 from onyx.oauth.models import AuthorizationAttempt
 from tests.unit.fakes import FakeCache
 
@@ -27,11 +30,37 @@ def _store(
     cache: FakeCache, namespace: str = "mcp"
 ) -> AuthorizationAttemptStore[_Payload]:
     return AuthorizationAttemptStore(
-        cache,
+        cache_backend_provider=lambda: cache,
         namespace=namespace,
         payload_type=_Payload,
         ttl_seconds=300,
     )
+
+
+def test_configuration_fingerprint_is_canonical_and_value_sensitive() -> None:
+    first = {"client": {"id": "client-id", "secret": "secret"}, "scopes": ["a"]}
+    reordered = {"scopes": ["a"], "client": {"secret": "secret", "id": "client-id"}}
+    changed = {
+        "client": {"id": "client-id", "secret": "rotated"},
+        "scopes": ["a"],
+    }
+
+    assert canonical_json_fingerprint(first) == canonical_json_fingerprint(reordered)
+    assert canonical_json_fingerprint(first) != canonical_json_fingerprint(changed)
+
+
+def test_store_uses_cache_provider_and_default_ttl() -> None:
+    cache = FakeCache()
+    store = AuthorizationAttemptStore(
+        cache_backend_provider=lambda: cache,
+        namespace="mcp",
+        payload_type=_Payload,
+    )
+
+    attempt = store.store(owner_id="user-1", payload=_Payload(target_id=1))
+
+    assert set(cache.expiries.values()) == {600}
+    assert store.consume(owner_id="user-1", state=attempt.state) == attempt
 
 
 def test_store_generates_isolated_one_time_attempts() -> None:
@@ -218,7 +247,7 @@ def test_store_rejects_invalid_namespace(namespace: str) -> None:
 def test_store_rejects_out_of_range_ttl(ttl_seconds: int) -> None:
     with pytest.raises(ValueError, match="TTL"):
         AuthorizationAttemptStore(
-            FakeCache(),
+            cache_backend_provider=FakeCache,
             namespace="mcp",
             payload_type=_Payload,
             ttl_seconds=ttl_seconds,

--- a/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
+++ b/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
@@ -18,6 +18,8 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.server.documents import standard_oauth
 from tests.unit.fakes import FakeCache
 
+_CODE_VERIFIER = "v" * 43
+
 
 class DisabledOAuthConnector(OAuthConnector):
     supports_manual_credentials = True
@@ -121,7 +123,7 @@ def test_authorize_passes_pkce_challenge(
         lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
     )
     monkeypatch.setattr(
-        standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
+        standard_oauth, "generate_pkce_pair", lambda: (_CODE_VERIFIER, "challenge")
     )
     monkeypatch.setattr(standard_oauth, "WEB_DOMAIN", "https://onyx.example")
     monkeypatch.setattr(
@@ -202,7 +204,7 @@ def test_callback_consumes_owned_attempt_and_passes_stored_verifier(
         lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
     )
     monkeypatch.setattr(
-        standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
+        standard_oauth, "generate_pkce_pair", lambda: (_CODE_VERIFIER, "challenge")
     )
     monkeypatch.setattr(
         PKCEOAuthConnector, "oauth_authorization_url", authorization_url
@@ -237,7 +239,7 @@ def test_callback_consumes_owned_attempt_and_passes_stored_verifier(
         standard_oauth.WEB_DOMAIN,
         "authorization-code",
         {"instance": "example"},
-        "verifier",
+        _CODE_VERIFIER,
     )
 
 
@@ -351,7 +353,7 @@ def test_callback_revalidates_stored_connector_arguments(
         lambda: {DocumentSource.LINEAR: PKCEOAuthConnector},
     )
     monkeypatch.setattr(
-        standard_oauth, "generate_pkce_pair", lambda: ("verifier", "challenge")
+        standard_oauth, "generate_pkce_pair", lambda: (_CODE_VERIFIER, "challenge")
     )
     monkeypatch.setattr(
         PKCEOAuthConnector, "oauth_authorization_url", authorization_url

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_flow.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_flow.py
@@ -69,7 +69,7 @@ def _flow(
 ) -> MCPOAuthFlowState:
     mcp_server = cast(MCPServer, _server())
     client_information = _client_information(client_id)
-    code_verifier = f"{state}-verifier"
+    code_verifier = f"{state}-verifier".ljust(43, "v")
     return MCPOAuthFlowState(
         server_id=mcp_server.id,
         connection_config_id=101,
@@ -572,8 +572,8 @@ def test_reverse_order_completions_restore_their_own_registration(
     )
     assert providers[1].context.client_info == _client_information("first-registration")
     exchanges[0].assert_awaited_once_with(
-        "second-code", "second-state-verifier", resource=None
+        "second-code", "second-state-verifier".ljust(43, "v"), resource=None
     )
     exchanges[1].assert_awaited_once_with(
-        "first-code", "first-state-verifier", resource=None
+        "first-code", "first-state-verifier".ljust(43, "v"), resource=None
     )


### PR DESCRIPTION
## Description

OAuth connection flows now share one authorization-attempt lifecycle, but callers still repeated security-sensitive setup: tenant-aware cache lookup, the ten-minute TTL, payload field constraints, stable configuration fingerprints, protected authorization parameters, and internal return-path validation. Small differences in these rules can make callbacks accept stale configuration or allow provider options to replace fields owned by the OAuth flow.

This base change gives those rules one implementation. AuthorizationAttemptStore can now be declared once with a namespace and payload type; it resolves the current tenant cache for each operation, uses the standard TTL by default, and still accepts an injected cache for isolated tests. Canonical configuration fingerprints live with the attempt store, while shared OAuth models define fingerprint, PKCE-verifier, and safe return-path constraints. Protected authorization parameters remain beside authorization URL construction.

The scope remains intentionally narrow. Domain payload fields, configuration inputs, provider behavior, persistence, and callback side effects stay in their owning features. The next PRs can therefore declare one store and supply their own payload without rebuilding the common lifecycle or introducing a universal OAuth framework.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check