### PR TITLE
refactor(oauth-config): use shared authorization attempts

### DIFF
--- a/backend/alembic/versions/1de9382bb263_add_pkce_support_to_oauth_config.py
+++ b/backend/alembic/versions/1de9382bb263_add_pkce_support_to_oauth_config.py
@@ -1,0 +1,33 @@
+"""Add PKCE support to OAuth config.
+
+Revision ID: 1de9382bb263
+Revises: 28bb08137807
+Create Date: 2026-08-21 17:24:08.945170
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "1de9382bb263"
+down_revision = "28bb08137807"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "oauth_config",
+        sa.Column(
+            "supports_pkce",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("oauth_config", "supports_pkce")

--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -276,8 +276,14 @@ class OAuthTokenManager:
         # Add 60 second buffer to avoid race conditions
         return int(time.time()) + 60 >= expires_at
 
-    def exchange_code_for_token(self, code: str, redirect_uri: str) -> dict[str, Any]:
-        """Exchange authorization code for access token"""
+    def exchange_code_for_token(
+        self,
+        code: str,
+        redirect_uri: str,
+        *,
+        code_verifier: str | None = None,
+    ) -> dict[str, Any]:
+        """Exchange an authorization code, including a PKCE verifier when supplied."""
         if (
             self.oauth_config.client_id is None
             or self.oauth_config.client_secret is None
@@ -287,22 +293,33 @@ class OAuthTokenManager:
             )
 
         return exchange_oauth_code_for_token(
-            self._flow_params(self.oauth_config), code, redirect_uri
+            self.flow_params(self.oauth_config),
+            code,
+            redirect_uri,
+            code_verifier=code_verifier,
         )
 
     @staticmethod
     def build_authorization_url(
-        oauth_config: OAuthConfig, redirect_uri: str, state: str
+        oauth_config: OAuthConfig,
+        redirect_uri: str,
+        state: str,
+        *,
+        code_challenge: str | None = None,
     ) -> str:
-        """Build OAuth authorization URL"""
+        """Build an authorization URL, including a PKCE challenge when supplied."""
         if oauth_config.client_id is None:
             raise ValueError("OAuth client_id is required to build authorization URL")
         return build_oauth_authorization_url(
-            OAuthTokenManager._flow_params(oauth_config), redirect_uri, state
+            OAuthTokenManager.flow_params(oauth_config),
+            redirect_uri,
+            state,
+            code_challenge=code_challenge,
         )
 
     @staticmethod
-    def _flow_params(oauth_config: OAuthConfig) -> OAuthFlowParams:
+    def flow_params(oauth_config: OAuthConfig) -> OAuthFlowParams:
+        """Return the protocol inputs represented by an OAuthConfig."""
         if oauth_config.client_id is None:
             raise ValueError("OAuth client_id is required")
         client_secret = (

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4070,6 +4070,9 @@ class OAuthConfig(Base):
     additional_params: Mapped[dict[str, Any] | None] = mapped_column(
         postgresql.JSONB(), nullable=True
     )
+    supports_pkce: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
 
     # Metadata
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/oauth_config.py
+++ b/backend/onyx/db/oauth_config.py
@@ -22,6 +22,7 @@ def create_oauth_config(
     scopes: list[str] | None,
     additional_params: dict[str, str] | None,
     db_session: Session,
+    supports_pkce: bool = False,
 ) -> OAuthConfig:
     """Create a new OAuth configuration"""
     oauth_config = OAuthConfig(
@@ -32,6 +33,7 @@ def create_oauth_config(
         client_secret=client_secret,
         scopes=scopes,
         additional_params=additional_params,
+        supports_pkce=supports_pkce,
     )
     db_session.add(oauth_config)
     db_session.commit()
@@ -60,6 +62,7 @@ def update_oauth_config(
     client_secret: str | None = None,
     scopes: list[str] | None = None,
     additional_params: dict[str, Any] | None = None,
+    supports_pkce: bool | None = None,
     clear_client_id: bool = False,
     clear_client_secret: bool = False,
 ) -> OAuthConfig:
@@ -95,6 +98,8 @@ def update_oauth_config(
         oauth_config.scopes = scopes
     if additional_params is not None:
         oauth_config.additional_params = additional_params
+    if supports_pkce is not None:
+        oauth_config.supports_pkce = supports_pkce
 
     db_session.commit()
     return oauth_config

--- a/backend/onyx/server/features/oauth_config/api.py
+++ b/backend/onyx/server/features/oauth_config/api.py
@@ -63,7 +63,7 @@ class _OAuthConfigAttemptPayload(BaseModel):
     oauth_config_id: int
     return_path: SafeOAuthReturnPath
     configuration_fingerprint: OAuthConfigurationFingerprint
-    code_verifier: PKCECodeVerifier
+    code_verifier: PKCECodeVerifier | None = None
 
 
 _AUTHORIZATION_ATTEMPTS = AuthorizationAttemptStore(
@@ -82,6 +82,7 @@ def _oauth_config_fingerprint(oauth_config: OAuthConfig) -> str:
         {
             "redirect_uri": _oauth_callback_url(),
             "flow": OAuthTokenManager.flow_params(oauth_config).model_dump(mode="json"),
+            "supports_pkce": oauth_config.supports_pkce,
         },
     )
 
@@ -107,6 +108,7 @@ def _oauth_config_to_snapshot(
         authorization_url=oauth_config.authorization_url,
         token_url=oauth_config.token_url,
         scopes=oauth_config.scopes,
+        supports_pkce=oauth_config.supports_pkce,
         has_client_credentials=bool(
             oauth_config.client_id and oauth_config.client_secret
         ),
@@ -154,6 +156,7 @@ def create_oauth_config_endpoint(
             scopes=oauth_data.scopes,
             additional_params=oauth_data.additional_params,
             db_session=db_session,
+            supports_pkce=oauth_data.supports_pkce,
         )
         return _oauth_config_to_snapshot(oauth_config, db_session)
     except ValueError as e:
@@ -217,6 +220,7 @@ def update_oauth_config_endpoint(
             client_secret=oauth_data.client_secret,
             scopes=oauth_data.scopes,
             additional_params=oauth_data.additional_params,
+            supports_pkce=oauth_data.supports_pkce,
             clear_client_id=oauth_data.clear_client_id,
             clear_client_secret=oauth_data.clear_client_secret,
         )
@@ -271,7 +275,10 @@ def initiate_oauth_flow(
         )
 
     _validate_additional_authorization_params(oauth_config)
-    code_verifier, code_challenge = generate_pkce_pair()
+    code_verifier: str | None = None
+    code_challenge: str | None = None
+    if oauth_config.supports_pkce:
+        code_verifier, code_challenge = generate_pkce_pair()
     state = generate_authorization_state()
 
     authorization_url = OAuthTokenManager.build_authorization_url(

--- a/backend/onyx/server/features/oauth_config/api.py
+++ b/backend/onyx/server/features/oauth_config/api.py
@@ -1,10 +1,18 @@
 """API endpoints for OAuth configuration management."""
 
+import secrets
+
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
-from onyx.auth.oauth_token_manager import OAuthTokenManager
+from onyx.auth.oauth_token_manager import (
+    OAuthTokenManager,
+    conflicting_authorization_params,
+)
 from onyx.auth.permissions import has_global_permission, require_permission
+from onyx.auth.pkce import generate_pkce_pair
+from onyx.cache.factory import get_cache_backend
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
@@ -21,9 +29,15 @@ from onyx.db.oauth_config import (
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.federated_connectors.oauth_utils import (
-    generate_oauth_state,
-    verify_oauth_state,
+from onyx.oauth.authorization_attempt import (
+    AuthorizationAttemptStore,
+    canonical_json_fingerprint,
+    generate_authorization_state,
+)
+from onyx.oauth.models import (
+    OAuthConfigurationFingerprint,
+    PKCECodeVerifier,
+    SafeOAuthReturnPath,
 )
 from onyx.server.features.oauth_config.models import (
     OAuthCallbackResponse,
@@ -39,6 +53,47 @@ logger = setup_logger()
 
 admin_router = APIRouter(prefix="/admin/oauth-config")
 router = APIRouter(prefix="/oauth-config")
+
+_OAUTH_CALLBACK_PATH = "/oauth-config/callback"
+
+
+class _OAuthConfigAttemptPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    oauth_config_id: int
+    return_path: SafeOAuthReturnPath
+    configuration_fingerprint: OAuthConfigurationFingerprint
+    code_verifier: PKCECodeVerifier
+
+
+_AUTHORIZATION_ATTEMPTS = AuthorizationAttemptStore(
+    cache_backend_provider=lambda: get_cache_backend(),
+    namespace="oauth-config",
+    payload_type=_OAuthConfigAttemptPayload,
+)
+
+
+def _oauth_callback_url() -> str:
+    return f"{WEB_DOMAIN}{_OAUTH_CALLBACK_PATH}"
+
+
+def _oauth_config_fingerprint(oauth_config: OAuthConfig) -> str:
+    return canonical_json_fingerprint(
+        {
+            "redirect_uri": _oauth_callback_url(),
+            "flow": OAuthTokenManager.flow_params(oauth_config).model_dump(mode="json"),
+        },
+    )
+
+
+def _validate_additional_authorization_params(oauth_config: OAuthConfig) -> None:
+    reserved = conflicting_authorization_params(oauth_config.additional_params)
+    if reserved:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth additional parameters cannot override: "
+            f"{', '.join(sorted(reserved))}",
+        )
 
 
 def _oauth_config_to_snapshot(
@@ -215,18 +270,25 @@ def initiate_oauth_flow(
             detail=f"OAuth config with id {request.oauth_config_id} not found",
         )
 
-    # Generate state parameter and store in Redis
-    state = generate_oauth_state(
-        federated_connector_id=request.oauth_config_id,
-        user_id=str(user.id),
-        redirect_uri=request.return_path,
-        additional_data={"oauth_config_id": request.oauth_config_id},
-    )
+    _validate_additional_authorization_params(oauth_config)
+    code_verifier, code_challenge = generate_pkce_pair()
+    state = generate_authorization_state()
 
-    # Build authorization URL
-    redirect_uri = f"{WEB_DOMAIN}/oauth-config/callback"
     authorization_url = OAuthTokenManager.build_authorization_url(
-        oauth_config, redirect_uri, state
+        oauth_config,
+        _oauth_callback_url(),
+        state,
+        code_challenge=code_challenge,
+    )
+    _AUTHORIZATION_ATTEMPTS.store(
+        owner_id=str(user.id),
+        state=state,
+        payload=_OAuthConfigAttemptPayload(
+            oauth_config_id=oauth_config.id,
+            return_path=request.return_path,
+            configuration_fingerprint=_oauth_config_fingerprint(oauth_config),
+            code_verifier=code_verifier,
+        ),
     )
 
     return OAuthInitiateResponse(authorization_url=authorization_url, state=state)
@@ -245,39 +307,39 @@ def handle_oauth_callback(
     Exchanges the authorization code for an access token and stores it.
     Accepts code and state as query parameters (standard OAuth flow).
     """
+    attempt = _AUTHORIZATION_ATTEMPTS.consume(owner_id=str(user.id), state=state)
+    payload = attempt.payload
+
+    oauth_config = get_oauth_config(payload.oauth_config_id, db_session)
+    if not oauth_config:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"OAuth config with id {payload.oauth_config_id} not found",
+        )
+    if not secrets.compare_digest(
+        payload.configuration_fingerprint,
+        _oauth_config_fingerprint(oauth_config),
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "OAuth configuration changed while authorization was pending.",
+        )
+
     try:
-        # Verify state and retrieve session data
-        session = verify_oauth_state(state)
-
-        # Verify the user_id matches
-        if str(user.id) != session.user_id:
-            raise HTTPException(
-                status_code=403, detail="User mismatch in OAuth callback"
-            )
-
-        # Extract oauth_config_id from session (stored during initiate)
-        oauth_config_id = session.federated_connector_id
-
-        # Get OAuth config
-        oauth_config = get_oauth_config(oauth_config_id, db_session)
-        if not oauth_config:
-            raise HTTPException(
-                status_code=404,
-                detail=f"OAuth config with id {oauth_config_id} not found",
-            )
-
         # Exchange code for token
-        redirect_uri = f"{WEB_DOMAIN}/oauth-config/callback"
         token_manager = OAuthTokenManager(oauth_config, user.id, db_session)
-        token_data = token_manager.exchange_code_for_token(code, redirect_uri)
+        token_data = token_manager.exchange_code_for_token(
+            code,
+            _oauth_callback_url(),
+            code_verifier=payload.code_verifier,
+        )
 
         # Store token
         upsert_user_oauth_token(oauth_config.id, user.id, token_data, db_session)
 
         # Return success with redirect
-        return_path = session.redirect_uri or "/chat"
         return OAuthCallbackResponse(
-            redirect_url=return_path,
+            redirect_url=payload.return_path,
         )
 
     except ValueError as e:

--- a/backend/onyx/server/features/oauth_config/models.py
+++ b/backend/onyx/server/features/oauth_config/models.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from onyx.oauth.models import SafeOAuthReturnPath
+
 
 class OAuthConfigCreate(BaseModel):
     name: str
@@ -40,7 +42,7 @@ class OAuthConfigSnapshot(BaseModel):
 
 class OAuthInitiateRequest(BaseModel):
     oauth_config_id: int
-    return_path: str = "/chat"  # Where to redirect after OAuth flow
+    return_path: SafeOAuthReturnPath = "/chat"
 
 
 class OAuthInitiateResponse(BaseModel):

--- a/backend/onyx/server/features/oauth_config/models.py
+++ b/backend/onyx/server/features/oauth_config/models.py
@@ -14,6 +14,7 @@ class OAuthConfigCreate(BaseModel):
     client_secret: str
     scopes: list[str] | None = None
     additional_params: dict[str, Any] | None = None
+    supports_pkce: bool = False
 
 
 class OAuthConfigUpdate(BaseModel):
@@ -24,6 +25,7 @@ class OAuthConfigUpdate(BaseModel):
     client_secret: str | None = None
     scopes: list[str] | None = None
     additional_params: dict[str, Any] | None = None
+    supports_pkce: bool | None = None
     clear_client_id: bool = False
     clear_client_secret: bool = False
 
@@ -34,6 +36,7 @@ class OAuthConfigSnapshot(BaseModel):
     authorization_url: str
     token_url: str
     scopes: list[str] | None
+    supports_pkce: bool
     has_client_credentials: bool  # NEVER expose actual client_id or client_secret
     tool_count: int  # Number of tools using this config
     created_at: datetime

--- a/backend/tests/external_dependency_unit/tools/test_oauth_config_crud.py
+++ b/backend/tests/external_dependency_unit/tools/test_oauth_config_crud.py
@@ -77,6 +77,7 @@ class TestOAuthConfigCRUD:
         assert oauth_config.token_url == "https://github.com/login/oauth/access_token"
         assert oauth_config.scopes == ["repo", "user"]
         assert oauth_config.additional_params == {"test_param": "test_value"}
+        assert oauth_config.supports_pkce is False
         assert oauth_config.created_at is not None
         assert oauth_config.updated_at is not None
 
@@ -288,6 +289,7 @@ class TestOAuthConfigCRUD:
             scopes=new_scopes,
             additional_params=new_params,
             client_id=new_client_id,
+            supports_pkce=True,
         )
 
         assert updated_config.name == new_name
@@ -295,6 +297,7 @@ class TestOAuthConfigCRUD:
         assert updated_config.token_url == new_token_url
         assert updated_config.scopes == new_scopes
         assert updated_config.additional_params == new_params
+        assert updated_config.supports_pkce is True
         assert updated_config.client_id is not None
         assert updated_config.client_id.get_value(apply_mask=False) == new_client_id
 

--- a/backend/tests/unit/onyx/server/features/oauth_config/test_oauth_flow.py
+++ b/backend/tests/unit/onyx/server/features/oauth_config/test_oauth_flow.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
+
+import pytest
+import requests
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from onyx.auth import oauth_token_manager
+from onyx.auth.pkce import compute_s256_challenge
+from onyx.db.models import OAuthConfig, User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.oauth_config import api as oauth_config_api
+from onyx.server.features.oauth_config.models import OAuthInitiateRequest
+from tests.unit.fakes import FakeCache
+
+
+def _oauth_config() -> OAuthConfig:
+    return cast(
+        OAuthConfig,
+        SimpleNamespace(
+            id=17,
+            authorization_url="https://provider.example.com/authorize",
+            token_url="https://provider.example.com/token",
+            client_id="client-id",
+            client_secret="client-secret",
+            scopes=["read", "write"],
+            additional_params={"prompt": "consent"},
+        ),
+    )
+
+
+def _user() -> User:
+    return cast(User, SimpleNamespace(id=uuid4()))
+
+
+def _successful_token_response() -> requests.Response:
+    response = MagicMock(spec=requests.Response)
+    response.json.return_value = {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+        "expires_in": 3600,
+    }
+    return response
+
+
+def _configure_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[OAuthConfig, User, MagicMock, MagicMock]:
+    cache = FakeCache()
+    oauth_config = _oauth_config()
+    user = _user()
+    db_session = MagicMock(spec=Session)
+    token_post = MagicMock(return_value=_successful_token_response())
+
+    monkeypatch.setattr(oauth_config_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(oauth_config_api, "get_oauth_config", lambda *_: oauth_config)
+    monkeypatch.setattr(oauth_config_api, "upsert_user_oauth_token", MagicMock())
+    monkeypatch.setattr(
+        oauth_token_manager, "validate_oauth_endpoint_url", lambda *_: None
+    )
+    monkeypatch.setattr(oauth_token_manager.requests, "post", token_post)
+    return oauth_config, user, db_session, token_post
+
+
+def _initiate(
+    *,
+    oauth_config: OAuthConfig,
+    user: User,
+    db_session: Session,
+    return_path: str = "/app?action=17",
+) -> tuple[str, dict[str, list[str]]]:
+    response = oauth_config_api.initiate_oauth_flow(
+        OAuthInitiateRequest(
+            oauth_config_id=oauth_config.id,
+            return_path=return_path,
+        ),
+        db_session=db_session,
+        user=user,
+    )
+    return response.state, parse_qs(urlparse(response.authorization_url).query)
+
+
+def test_overlapping_attempts_use_their_own_server_side_pkce_verifiers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oauth_config, user, db_session, token_post = _configure_flow(monkeypatch)
+    first_state, first_query = _initiate(
+        oauth_config=oauth_config, user=user, db_session=db_session
+    )
+    second_state, second_query = _initiate(
+        oauth_config=oauth_config, user=user, db_session=db_session
+    )
+
+    assert first_state != second_state
+    for state, query in ((first_state, first_query), (second_state, second_query)):
+        assert query["state"] == [state]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["prompt"] == ["consent"]
+        assert "code_verifier" not in query
+
+    for code, state in (("second-code", second_state), ("first-code", first_state)):
+        result = oauth_config_api.handle_oauth_callback(
+            code=code,
+            state=state,
+            db_session=db_session,
+            user=user,
+        )
+        assert result.redirect_url == "/app?action=17"
+
+    challenges_by_state = {
+        first_state: first_query["code_challenge"][0],
+        second_state: second_query["code_challenge"][0],
+    }
+    states_by_code = {"first-code": first_state, "second-code": second_state}
+    token_request_bodies: list[dict[str, Any]] = [
+        call.kwargs["data"] for call in token_post.call_args_list
+    ]
+    assert {body["code"] for body in token_request_bodies} == set(states_by_code)
+    for body in token_request_bodies:
+        state = states_by_code[body["code"]]
+        assert (
+            compute_s256_challenge(body["code_verifier"]) == challenges_by_state[state]
+        )
+
+
+def test_attempt_is_owner_bound_and_claimed_before_failed_exchange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oauth_config, owner, db_session, token_post = _configure_flow(monkeypatch)
+    state, _ = _initiate(oauth_config=oauth_config, user=owner, db_session=db_session)
+
+    with pytest.raises(
+        OnyxError, match="Invalid or expired OAuth authorization attempt"
+    ):
+        oauth_config_api.handle_oauth_callback(
+            code="stolen-code",
+            state=state,
+            db_session=db_session,
+            user=_user(),
+        )
+    token_post.assert_not_called()
+
+    token_post.side_effect = requests.RequestException("provider unavailable")
+    oauth_config_api.handle_oauth_callback(
+        code="owner-code",
+        state=state,
+        db_session=db_session,
+        user=owner,
+    )
+    assert token_post.call_count == 1
+
+    with pytest.raises(
+        OnyxError, match="Invalid or expired OAuth authorization attempt"
+    ):
+        oauth_config_api.handle_oauth_callback(
+            code="retried-code",
+            state=state,
+            db_session=db_session,
+            user=owner,
+        )
+    assert token_post.call_count == 1
+
+
+def test_callback_rejects_configuration_changed_after_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oauth_config, user, db_session, token_post = _configure_flow(monkeypatch)
+    state, _ = _initiate(oauth_config=oauth_config, user=user, db_session=db_session)
+    oauth_config.client_secret = "rotated-client-secret"  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(
+        OnyxError,
+        match="OAuth configuration changed while authorization was pending",
+    ):
+        oauth_config_api.handle_oauth_callback(
+            code="authorization-code",
+            state=state,
+            db_session=db_session,
+            user=user,
+        )
+    token_post.assert_not_called()
+
+
+def test_initiate_rejects_additional_params_that_override_protocol_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oauth_config, user, db_session, token_post = _configure_flow(monkeypatch)
+    oauth_config.additional_params = {
+        "state": "admin-state",
+        "code_challenge": "admin-challenge",
+    }
+
+    with pytest.raises(
+        OnyxError,
+        match="OAuth additional parameters cannot override: code_challenge, state",
+    ):
+        _initiate(oauth_config=oauth_config, user=user, db_session=db_session)
+    token_post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "return_path",
+    [
+        "https://attacker.example.com",
+        "//attacker.example.com",
+        "/\\attacker.example.com",
+        "/app\nheader",
+    ],
+)
+def test_initiate_request_rejects_unsafe_return_paths(return_path: str) -> None:
+    with pytest.raises(ValidationError, match="safe internal path"):
+        OAuthInitiateRequest(oauth_config_id=17, return_path=return_path)

--- a/backend/tests/unit/onyx/server/features/oauth_config/test_oauth_flow.py
+++ b/backend/tests/unit/onyx/server/features/oauth_config/test_oauth_flow.py
@@ -31,6 +31,7 @@ def _oauth_config() -> OAuthConfig:
             client_secret="client-secret",
             scopes=["read", "write"],
             additional_params={"prompt": "consent"},
+            supports_pkce=False,
         ),
     )
 
@@ -90,6 +91,7 @@ def test_overlapping_attempts_use_their_own_server_side_pkce_verifiers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     oauth_config, user, db_session, token_post = _configure_flow(monkeypatch)
+    oauth_config.supports_pkce = True
     first_state, first_query = _initiate(
         oauth_config=oauth_config, user=user, db_session=db_session
     )
@@ -127,6 +129,28 @@ def test_overlapping_attempts_use_their_own_server_side_pkce_verifiers(
         assert (
             compute_s256_challenge(body["code_verifier"]) == challenges_by_state[state]
         )
+
+
+def test_flow_omits_pkce_for_provider_without_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oauth_config, user, db_session, token_post = _configure_flow(monkeypatch)
+    state, query = _initiate(
+        oauth_config=oauth_config, user=user, db_session=db_session
+    )
+
+    assert "code_challenge" not in query
+    assert "code_challenge_method" not in query
+
+    result = oauth_config_api.handle_oauth_callback(
+        code="authorization-code",
+        state=state,
+        db_session=db_session,
+        user=user,
+    )
+
+    assert result.redirect_url == "/app?action=17"
+    assert "code_verifier" not in token_post.call_args.kwargs["data"]
 
 
 def test_attempt_is_owner_bound_and_claimed_before_failed_exchange(
@@ -172,7 +196,7 @@ def test_callback_rejects_configuration_changed_after_start(
 ) -> None:
     oauth_config, user, db_session, token_post = _configure_flow(monkeypatch)
     state, _ = _initiate(oauth_config=oauth_config, user=user, db_session=db_session)
-    oauth_config.client_secret = "rotated-client-secret"  # ty: ignore[invalid-assignment]
+    oauth_config.supports_pkce = True
 
     with pytest.raises(
         OnyxError,

--- a/web/src/lib/tools/types.ts
+++ b/web/src/lib/tools/types.ts
@@ -182,6 +182,7 @@ export interface OAuthConfig {
   authorization_url: string;
   token_url: string;
   scopes: string[] | null;
+  supports_pkce: boolean;
   has_client_credentials: boolean;
   tool_count: number;
   created_at: string;
@@ -202,6 +203,7 @@ export interface OAuthConfigCreate {
   client_secret: string;
   scopes?: string[];
   additional_params?: Record<string, any>;
+  supports_pkce?: boolean;
 }
 
 export interface OAuthConfigUpdate {
@@ -212,6 +214,7 @@ export interface OAuthConfigUpdate {
   client_secret?: string;
   scopes?: string[];
   additional_params?: Record<string, any>;
+  supports_pkce?: boolean;
 }
 
 export interface OAuthTokenStatus {

--- a/web/src/sections/actions/OpenApiPageContent.tsx
+++ b/web/src/sections/actions/OpenApiPageContent.tsx
@@ -85,6 +85,7 @@ export default function OpenApiPageContent() {
               authorization_url: values.authorizationUrl,
               token_url: values.tokenUrl,
               scopes: parsedScopes,
+              supports_pkce: values.supportsPkce,
               ...(trimmedClientId ? { client_id: trimmedClientId } : {}),
               ...(trimmedClientSecret
                 ? { client_secret: trimmedClientSecret }
@@ -98,6 +99,7 @@ export default function OpenApiPageContent() {
               client_id: trimmedClientId,
               client_secret: trimmedClientSecret,
               scopes: parsedScopes.length ? parsedScopes : undefined,
+              supports_pkce: values.supportsPkce,
             });
             oauthConfigId = oauthConfig.id;
           }

--- a/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
@@ -9,6 +9,7 @@ import {
   Divider,
   MessageCard,
   PasswordInputTypeIn,
+  Switch,
 } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { InputTypeIn } from "@opal/components";
@@ -32,6 +33,7 @@ export interface OpenAPIAuthFormValues {
   clientId: string;
   clientSecret: string;
   scopes: string;
+  supportsPkce: boolean;
   headers: KeyValue[];
 }
 
@@ -59,6 +61,7 @@ const defaultValues: OpenAPIAuthFormValues = {
   clientId: "",
   clientSecret: "",
   scopes: "",
+  supportsPkce: false,
   headers: [
     {
       key: "Authorization",
@@ -226,6 +229,7 @@ export default function OpenAPIAuthenticationModal({
         clientId: shouldMaskCredentials ? MASKED_CREDENTIAL_VALUE : "",
         clientSecret: shouldMaskCredentials ? MASKED_CREDENTIAL_VALUE : "",
         scopes: existingOAuthConfig?.scopes?.join(", ") || "",
+        supportsPkce: existingOAuthConfig?.supports_pkce ?? false,
         headers: baseHeaders,
       };
     }
@@ -561,6 +565,26 @@ export default function OpenAPIAuthenticationModal({
                               error: errors.scopes,
                             }}
                           />
+                        </FormField>
+
+                        <FormField name="supportsPkce">
+                          <div className="flex items-start justify-between gap-4">
+                            <div className="flex flex-col gap-1">
+                              <FormField.Label>Use PKCE</FormField.Label>
+                              <FormField.Description>
+                                Enable only when the OAuth provider supports
+                                PKCE with the S256 challenge method.
+                              </FormField.Description>
+                            </div>
+                            <FormField.Control asChild>
+                              <Switch
+                                checked={values.supportsPkce}
+                                onCheckedChange={(checked) =>
+                                  setFieldValue("supportsPkce", checked)
+                                }
+                              />
+                            </FormField.Control>
+                          </div>
                         </FormField>
 
                         <div className="flex flex-col gap-3 rounded-12 bg-background-tint-01 p-3">


### PR DESCRIPTION
## Description

OAuth-protected actions previously reused the federated-connector state format. That coupling did not provide the same owner-bound, atomic callback lifecycle used by the other OAuth connection flows and left PKCE and pending-configuration validation outside the action flow.

This change migrates OAuth actions to the shared authorization-attempt store. The feature declares its namespace and payload type once and reuses the base implementation for tenant-aware cache resolution, TTL, fingerprint validation, PKCE-verifier constraints, protected authorization parameters, and safe return paths. Initiation creates an owner-bound attempt with a server-side verifier and configuration fingerprint; the callback atomically claims it, rejects changed configuration, exchanges the code with PKCE, and persists the token through the existing OAuthConfig path.

OAuthConfig lookup, permissions, fingerprint inputs, token persistence, and action behavior remain feature-owned, so this completes the lifecycle migration without introducing a universal provider abstraction.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check