### PR TITLE
feat(cli): run user skills as slash commands in the chat TUI

### DIFF
--- a/cli/internal/skills/fifo_unix_test.go
+++ b/cli/internal/skills/fifo_unix_test.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package skills
+
+import "syscall"
+
+// makeFIFO creates a named pipe, used to check that Load never reads one.
+func makeFIFO(path string) error {
+	return syscall.Mkfifo(path, 0o600)
+}

--- a/cli/internal/skills/fifo_windows_test.go
+++ b/cli/internal/skills/fifo_windows_test.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package skills
+
+import "errors"
+
+// makeFIFO reports that named pipes are unavailable, so the caller skips.
+func makeFIFO(string) error {
+	return errors.New("named pipes are not supported on windows")
+}

--- a/cli/internal/skills/skills.go
+++ b/cli/internal/skills/skills.go
@@ -125,6 +125,11 @@ func Load(path string) (Skill, error) {
 	if err != nil {
 		return Skill{}, err
 	}
+	// Reading a FIFO or device file can block forever, and Size() is
+	// meaningless for them.
+	if !info.Mode().IsRegular() {
+		return Skill{}, fmt.Errorf("%s is not a regular file", path)
+	}
 	if info.Size() > maxBodyBytes {
 		return Skill{}, fmt.Errorf("%s is larger than %d bytes", path, maxBodyBytes)
 	}
@@ -134,7 +139,10 @@ func Load(path string) (Skill, error) {
 		return Skill{}, err
 	}
 
-	meta, body := splitFrontmatter(string(data))
+	meta, body, err := splitFrontmatter(string(data))
+	if err != nil {
+		return Skill{}, fmt.Errorf("%s: %w", path, err)
+	}
 	body = strings.TrimSpace(body)
 	if body == "" {
 		return Skill{}, errors.New("skill body is empty")
@@ -157,21 +165,23 @@ func Load(path string) (Skill, error) {
 }
 
 // splitFrontmatter separates a leading YAML frontmatter block from the body.
-// Only flat `key: value` pairs are read; anything else is ignored.
-func splitFrontmatter(content string) (map[string]string, string) {
+// Only flat `key: value` pairs are read; anything else is ignored. A file that
+// opens a frontmatter block but never closes it is an error, because returning
+// it whole would send the YAML metadata as prompt content.
+func splitFrontmatter(content string) (map[string]string, string, error) {
 	meta := make(map[string]string)
 
 	rest, ok := strings.CutPrefix(content, "---\n")
 	if !ok {
 		rest, ok = strings.CutPrefix(content, "---\r\n")
 		if !ok {
-			return meta, content
+			return meta, content, nil
 		}
 	}
 
 	end := strings.Index(rest, "\n---")
 	if end < 0 {
-		return meta, content
+		return nil, "", errors.New("frontmatter block is not closed")
 	}
 	block := rest[:end]
 	body := rest[end+len("\n---"):]
@@ -194,7 +204,7 @@ func splitFrontmatter(content string) (map[string]string, string) {
 		}
 	}
 
-	return meta, body
+	return meta, body, nil
 }
 
 // normalizeName lowercases a name and keeps only characters that are safe in a

--- a/cli/internal/skills/skills.go
+++ b/cli/internal/skills/skills.go
@@ -1,0 +1,219 @@
+// Package skills discovers user-authored SKILL.md files and turns them into
+// reusable chat prompts.
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ArgsPlaceholder is replaced with the text the user typed after the command.
+// A skill without the placeholder gets the text appended instead.
+const ArgsPlaceholder = "$ARGUMENTS"
+
+// maxBodyBytes caps how much of a SKILL.md file is sent as a prompt. Files
+// above this size are skipped rather than silently truncated.
+const maxBodyBytes = 128 * 1024
+
+// skillDirs are the skill directory layouts searched under each root, in
+// precedence order. The canonical .agents directory wins over agent-specific
+// directories, which are usually symlinks back to it.
+var skillDirs = []string{
+	filepath.Join(".agents", "skills"),
+	filepath.Join(".claude", "skills"),
+}
+
+// Skill is a user-authored prompt loaded from a SKILL.md file.
+type Skill struct {
+	// Name is the slash command name, without the leading slash.
+	Name string
+	// Description is a one-line summary shown in the command menu.
+	Description string
+	// Body is the file content with any YAML frontmatter removed.
+	Body string
+	// Path is the SKILL.md file the skill was loaded from.
+	Path string
+}
+
+// Prompt builds the message to send for this skill. args is the text the user
+// typed after the command name.
+func (s Skill) Prompt(args string) string {
+	args = strings.TrimSpace(args)
+	if strings.Contains(s.Body, ArgsPlaceholder) {
+		return strings.ReplaceAll(s.Body, ArgsPlaceholder, args)
+	}
+	if args == "" {
+		return s.Body
+	}
+	return s.Body + "\n\n" + args
+}
+
+// Roots returns the base directories searched for skills, project first.
+func Roots() []string {
+	var roots []string
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, cwd)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		roots = append(roots, home)
+	}
+	return roots
+}
+
+// Discover loads skills from the project directory and the home directory.
+func Discover() []Skill {
+	return DiscoverIn(Roots())
+}
+
+// DiscoverIn loads skills from the given roots. Earlier roots win when two
+// skills share a name, as does .agents/skills over an agent-specific directory
+// within the same root. Unreadable or malformed skills are skipped.
+func DiscoverIn(roots []string) []Skill {
+	seen := make(map[string]bool)
+	var found []Skill
+
+	for _, root := range roots {
+		for _, dir := range skillDirs {
+			for _, skill := range scanDir(filepath.Join(root, dir)) {
+				if seen[skill.Name] {
+					continue
+				}
+				seen[skill.Name] = true
+				found = append(found, skill)
+			}
+		}
+	}
+
+	sort.Slice(found, func(i, j int) bool { return found[i].Name < found[j].Name })
+	return found
+}
+
+// scanDir loads every <dir>/<name>/SKILL.md, sorted by directory name.
+func scanDir(dir string) []Skill {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var found []Skill
+	for _, entry := range entries {
+		// A skill directory is often a symlink to the canonical copy, and
+		// ReadDir reports symlinks as non-directories.
+		info, err := os.Stat(filepath.Join(dir, entry.Name()))
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		skill, err := Load(filepath.Join(dir, entry.Name(), "SKILL.md"))
+		if err != nil {
+			continue
+		}
+		found = append(found, skill)
+	}
+
+	sort.Slice(found, func(i, j int) bool { return found[i].Name < found[j].Name })
+	return found
+}
+
+// Load reads a single SKILL.md file. The command name comes from the
+// frontmatter `name` field, falling back to the parent directory name.
+func Load(path string) (Skill, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Skill{}, err
+	}
+	if info.Size() > maxBodyBytes {
+		return Skill{}, fmt.Errorf("%s is larger than %d bytes", path, maxBodyBytes)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	meta, body := splitFrontmatter(string(data))
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return Skill{}, errors.New("skill body is empty")
+	}
+
+	name := normalizeName(meta["name"])
+	if name == "" {
+		name = normalizeName(filepath.Base(filepath.Dir(path)))
+	}
+	if name == "" {
+		return Skill{}, fmt.Errorf("%s has no usable skill name", path)
+	}
+
+	return Skill{
+		Name:        name,
+		Description: firstLine(meta["description"]),
+		Body:        body,
+		Path:        path,
+	}, nil
+}
+
+// splitFrontmatter separates a leading YAML frontmatter block from the body.
+// Only flat `key: value` pairs are read; anything else is ignored.
+func splitFrontmatter(content string) (map[string]string, string) {
+	meta := make(map[string]string)
+
+	rest, ok := strings.CutPrefix(content, "---\n")
+	if !ok {
+		rest, ok = strings.CutPrefix(content, "---\r\n")
+		if !ok {
+			return meta, content
+		}
+	}
+
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return meta, content
+	}
+	block := rest[:end]
+	body := rest[end+len("\n---"):]
+	if idx := strings.Index(body, "\n"); idx >= 0 {
+		body = body[idx+1:]
+	} else {
+		body = ""
+	}
+
+	for _, line := range strings.Split(block, "\n") {
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		if key != "" && value != "" {
+			meta[key] = value
+		}
+	}
+
+	return meta, body
+}
+
+// normalizeName lowercases a name and keeps only characters that are safe in a
+// slash command. It returns "" when nothing usable remains.
+func normalizeName(raw string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(raw)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-_")
+}
+
+// firstLine collapses a value to its first line for menu display.
+func firstLine(value string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(value), "\n")
+	return strings.TrimSpace(line)
+}

--- a/cli/internal/skills/skills_test.go
+++ b/cli/internal/skills/skills_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // writeSkill creates <root>/<dir>/<name>/SKILL.md with the given content.
@@ -220,7 +221,10 @@ func TestNormalizeName(t *testing.T) {
 
 func TestSplitFrontmatterWithoutBlock(t *testing.T) {
 	content := "# Just markdown\n\nNo frontmatter here.\n"
-	meta, body := splitFrontmatter(content)
+	meta, body, err := splitFrontmatter(content)
+	if err != nil {
+		t.Fatalf("splitFrontmatter: %v", err)
+	}
 	if len(meta) != 0 {
 		t.Errorf("meta = %+v, want empty", meta)
 	}
@@ -230,12 +234,46 @@ func TestSplitFrontmatterWithoutBlock(t *testing.T) {
 }
 
 func TestSplitFrontmatterUnterminatedBlock(t *testing.T) {
-	content := "---\nname: broken\n"
-	meta, body := splitFrontmatter(content)
-	if len(meta) != 0 {
-		t.Errorf("meta = %+v, want empty", meta)
+	if _, _, err := splitFrontmatter("---\nname: broken\n"); err == nil {
+		t.Fatal("splitFrontmatter accepted an unclosed block, want an error")
 	}
-	if body != content {
-		t.Errorf("body = %q, want the whole content", body)
+}
+
+// An unclosed frontmatter block must be skipped, never sent as prompt content.
+func TestLoadRejectsUnterminatedFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	path := writeSkill(t, root, ".agents/skills", "broken", "---\nname: broken\ndescription: Oops.\n")
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load accepted an unclosed frontmatter block, want an error")
+	}
+}
+
+func TestLoadRejectsNonRegularFile(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".agents", "skills", "fifo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(dir, "SKILL.md")
+	if err := makeFIFO(path); err != nil {
+		t.Skipf("cannot create a FIFO: %v", err)
+	}
+
+	// A blocking read here would hang the test rather than fail it, so the
+	// mode check has to happen before os.ReadFile.
+	done := make(chan error, 1)
+	go func() {
+		_, err := Load(path)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Load accepted a FIFO, want an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load blocked on a FIFO")
 	}
 }

--- a/cli/internal/skills/skills_test.go
+++ b/cli/internal/skills/skills_test.go
@@ -1,0 +1,241 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkill creates <root>/<dir>/<name>/SKILL.md with the given content.
+func writeSkill(t *testing.T, root, dir, name, content string) string {
+	t.Helper()
+	skillDir := filepath.Join(root, dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestLoadUsesFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	path := writeSkill(t, root, ".agents/skills", "dirname", `---
+name: Release Notes
+description: Draft release notes.
+---
+
+# Body
+
+Do the thing.
+`)
+
+	skill, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if skill.Name != "release-notes" {
+		t.Errorf("Name = %q, want %q", skill.Name, "release-notes")
+	}
+	if skill.Description != "Draft release notes." {
+		t.Errorf("Description = %q", skill.Description)
+	}
+	if strings.Contains(skill.Body, "description:") {
+		t.Errorf("body still contains frontmatter: %q", skill.Body)
+	}
+	if !strings.HasPrefix(skill.Body, "# Body") {
+		t.Errorf("Body = %q, want it to start with the heading", skill.Body)
+	}
+}
+
+func TestLoadFallsBackToDirectoryName(t *testing.T) {
+	root := t.TempDir()
+	path := writeSkill(t, root, ".agents/skills", "Stand Up", "Summarize standup notes.\n")
+
+	skill, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if skill.Name != "stand-up" {
+		t.Errorf("Name = %q, want %q", skill.Name, "stand-up")
+	}
+	if skill.Description != "" {
+		t.Errorf("Description = %q, want empty", skill.Description)
+	}
+}
+
+func TestLoadRejectsEmptyBody(t *testing.T) {
+	root := t.TempDir()
+	path := writeSkill(t, root, ".agents/skills", "empty", "---\nname: empty\n---\n")
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load succeeded on an empty body, want an error")
+	}
+}
+
+func TestLoadRejectsOversizedFile(t *testing.T) {
+	root := t.TempDir()
+	path := writeSkill(t, root, ".agents/skills", "big", strings.Repeat("x", maxBodyBytes+1))
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load succeeded on an oversized file, want an error")
+	}
+}
+
+func TestDiscoverInPrefersProjectOverHome(t *testing.T) {
+	project := t.TempDir()
+	home := t.TempDir()
+	writeSkill(t, project, ".agents/skills", "triage", "project version")
+	writeSkill(t, home, ".agents/skills", "triage", "home version")
+	writeSkill(t, home, ".agents/skills", "standup", "home standup")
+
+	found := DiscoverIn([]string{project, home})
+	if len(found) != 2 {
+		t.Fatalf("got %d skills, want 2: %+v", len(found), found)
+	}
+	if found[0].Name != "standup" || found[1].Name != "triage" {
+		t.Errorf("skills are not sorted by name: %q, %q", found[0].Name, found[1].Name)
+	}
+	if found[1].Body != "project version" {
+		t.Errorf("triage body = %q, want the project version", found[1].Body)
+	}
+}
+
+func TestDiscoverInPrefersAgentsOverClaudeDir(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, ".agents/skills", "triage", "canonical")
+	writeSkill(t, root, ".claude/skills", "triage", "claude copy")
+
+	found := DiscoverIn([]string{root})
+	if len(found) != 1 {
+		t.Fatalf("got %d skills, want 1: %+v", len(found), found)
+	}
+	if found[0].Body != "canonical" {
+		t.Errorf("body = %q, want %q", found[0].Body, "canonical")
+	}
+}
+
+func TestDiscoverInFollowsSymlinkedSkillDirs(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, ".agents/skills", "triage", "canonical")
+
+	claudeSkills := filepath.Join(root, ".claude", "skills")
+	if err := os.MkdirAll(claudeSkills, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	target := filepath.Join(root, ".agents", "skills", "triage")
+	if err := os.Symlink(target, filepath.Join(claudeSkills, "linked")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	found := DiscoverIn([]string{root})
+	if len(found) != 2 {
+		t.Fatalf("got %d skills, want 2: %+v", len(found), found)
+	}
+	if found[0].Name != "linked" || found[1].Name != "triage" {
+		t.Errorf("names = %q, %q", found[0].Name, found[1].Name)
+	}
+}
+
+func TestDiscoverInSkipsBrokenSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, ".agents/skills", "good", "usable body")
+	writeSkill(t, root, ".agents/skills", "empty", "")
+	// A directory with no SKILL.md at all.
+	if err := os.MkdirAll(filepath.Join(root, ".agents", "skills", "bare"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	found := DiscoverIn([]string{root})
+	if len(found) != 1 || found[0].Name != "good" {
+		t.Fatalf("got %+v, want only the good skill", found)
+	}
+}
+
+func TestPrompt(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		args string
+		want string
+	}{
+		{
+			name: "placeholder is substituted",
+			body: "Triage this incident: $ARGUMENTS\nBe brief.",
+			args: "payments 500s",
+			want: "Triage this incident: payments 500s\nBe brief.",
+		},
+		{
+			name: "empty args clear the placeholder",
+			body: "Triage: $ARGUMENTS",
+			args: "  ",
+			want: "Triage: ",
+		},
+		{
+			name: "args are appended without a placeholder",
+			body: "Draft release notes.",
+			args: "v1.2.0",
+			want: "Draft release notes.\n\nv1.2.0",
+		},
+		{
+			name: "body is unchanged without args",
+			body: "Draft release notes.",
+			args: "",
+			want: "Draft release notes.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Skill{Body: tt.body}.Prompt(tt.args)
+			if got != tt.want {
+				t.Errorf("Prompt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Release Notes", "release-notes"},
+		{"  Triage  ", "triage"},
+		{"my_skill", "my_skill"},
+		{"weird!!name", "weirdname"},
+		{"--dashes--", "dashes"},
+		{"!!!", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := normalizeName(tt.in); got != tt.want {
+			t.Errorf("normalizeName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSplitFrontmatterWithoutBlock(t *testing.T) {
+	content := "# Just markdown\n\nNo frontmatter here.\n"
+	meta, body := splitFrontmatter(content)
+	if len(meta) != 0 {
+		t.Errorf("meta = %+v, want empty", meta)
+	}
+	if body != content {
+		t.Errorf("body = %q, want the whole content", body)
+	}
+}
+
+func TestSplitFrontmatterUnterminatedBlock(t *testing.T) {
+	content := "---\nname: broken\n"
+	meta, body := splitFrontmatter(content)
+	if len(meta) != 0 {
+		t.Errorf("meta = %+v, want empty", meta)
+	}
+	if body != content {
+		t.Errorf("body = %q, want the whole content", body)
+	}
+}

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/api"
 	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/onyx-dot-app/onyx/cli/internal/skills"
 )
 
 // Model is the root Bubble Tea model.
@@ -45,6 +46,9 @@ type Model struct {
 	needsRename     bool
 	agentStarted    bool
 
+	// Skills discovered on disk, keyed by command name (no leading slash).
+	skills map[string]skills.Skill
+
 	// Configure state
 	configState *configState
 
@@ -58,7 +62,7 @@ type Model struct {
 func NewModel(cfg config.OnyxCliConfig, client api.ClientAPI) Model {
 	parentID := -1
 
-	return Model{
+	m := Model{
 		config:          cfg,
 		client:          client,
 		viewport:        newViewport(80, cfg.Features.StreamMarkdownEnabled()),
@@ -69,6 +73,44 @@ func NewModel(cfg config.OnyxCliConfig, client api.ClientAPI) Model {
 		parentMessageID: &parentID,
 		citations:       make(map[int]string),
 	}
+	return m.loadSkills()
+}
+
+// loadSkills rescans the skill directories and refreshes the command menu.
+// Skills that collide with a built-in command name are dropped, because the
+// built-in always wins in handleSlashCommand.
+func (m Model) loadSkills() Model {
+	m.skills = make(map[string]skills.Skill)
+	reserved := builtinNames()
+
+	var entries []slashCommand
+	for _, skill := range skills.Discover() {
+		if reserved["/"+skill.Name] {
+			continue
+		}
+		m.skills[skill.Name] = skill
+		entries = append(entries, slashCommand{
+			command:     "/" + skill.Name,
+			description: skillMenuDescription(skill),
+			optionalArg: true,
+		})
+	}
+
+	m.input.setSkillCommands(entries)
+	return m
+}
+
+// skillMenuDescription keeps menu rows to a single readable line.
+func skillMenuDescription(skill skills.Skill) string {
+	const maxLen = 60
+	desc := skill.Description
+	if desc == "" {
+		desc = "Skill"
+	}
+	if len(desc) > maxLen {
+		desc = desc[:maxLen-1] + "…"
+	}
+	return desc
 }
 
 // NewFirstRunModel creates a TUI model that auto-enters configure mode on startup.

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -107,8 +107,9 @@ func skillMenuDescription(skill skills.Skill) string {
 	if desc == "" {
 		desc = "Skill"
 	}
-	if len(desc) > maxLen {
-		desc = desc[:maxLen-1] + "…"
+	// Truncate by rune, so a multibyte character is never cut in half.
+	if runes := []rune(desc); len(runes) > maxLen {
+		desc = string(runes[:maxLen-1]) + "…"
 	}
 	return desc
 }

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -94,8 +94,13 @@ func cmdRunSkill(m Model, skill skills.Skill, arg string) (Model, tea.Cmd) {
 		m.viewport.addWarning("Wait for the current response to finish.")
 		return m, nil
 	}
+	prompt := skill.Prompt(arg)
+	if strings.TrimSpace(prompt) == "" {
+		m.viewport.addWarning(fmt.Sprintf("Skill %s needs arguments.", skill.Name))
+		return m, nil
+	}
 	m.viewport.addInfo("Running skill: " + skill.Name)
-	return m.sendMessage(skill.Prompt(arg))
+	return m.sendMessage(prompt)
 }
 
 // cmdSkills rescans the skill directories and lists what is available.

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/browser"
 	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/onyx-dot-app/onyx/cli/internal/skills"
 )
 
 // handleSlashCommand dispatches slash commands and returns updated model + cmd.
@@ -70,13 +73,64 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 		m.viewport.addInfo(config.ExperimentsText(m.config.Features))
 		return m, nil
 
+	case "/skills":
+		return cmdSkills(m)
+
 	case "/quit":
 		return m, tea.Quit
 
 	default:
+		if skill, ok := m.skills[strings.TrimPrefix(command, "/")]; ok {
+			return cmdRunSkill(m, skill, arg)
+		}
 		m.viewport.addWarning(fmt.Sprintf("Unknown command: %s. Type /help for available commands.", command))
 		return m, nil
 	}
+}
+
+// cmdRunSkill expands a skill into a prompt and sends it as the next message.
+func cmdRunSkill(m Model, skill skills.Skill, arg string) (Model, tea.Cmd) {
+	if m.isStreaming {
+		m.viewport.addWarning("Wait for the current response to finish.")
+		return m, nil
+	}
+	m.viewport.addInfo("Running skill: " + skill.Name)
+	return m.sendMessage(skill.Prompt(arg))
+}
+
+// cmdSkills rescans the skill directories and lists what is available.
+func cmdSkills(m Model) (Model, tea.Cmd) {
+	m = m.loadSkills()
+
+	if len(m.skills) == 0 {
+		var b strings.Builder
+		b.WriteString("No skills found. Add a SKILL.md file in one of:\n")
+		for _, root := range skills.Roots() {
+			b.WriteString("  " + filepath.Join(root, ".agents", "skills", "<name>", "SKILL.md") + "\n")
+		}
+		m.viewport.addInfo(strings.TrimRight(b.String(), "\n"))
+		return m, nil
+	}
+
+	names := make([]string, 0, len(m.skills))
+	for name := range m.skills {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Skills (%d)\n\n", len(names))
+	for _, name := range names {
+		skill := m.skills[name]
+		fmt.Fprintf(&b, "  /%s", name)
+		if skill.Description != "" {
+			b.WriteString("  " + skill.Description)
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\nRun one with /<name> [arguments].")
+	m.viewport.addInfo(b.String())
+	return m, nil
 }
 
 func cmdNew(m Model) (Model, tea.Cmd) {

--- a/cli/internal/tui/help.go
+++ b/cli/internal/tui/help.go
@@ -10,8 +10,16 @@ const helpText = `Onyx CLI Commands
   /configure         Re-run connection setup
   /connectors        Open connectors page in browser
   /settings          Open Onyx settings in browser
+  /skills            List local skills and reload them from disk
   /experiments       List experimental features and their status
   /quit              Exit Onyx CLI
+
+Skills
+
+  Put a SKILL.md file in .agents/skills/<name>/ (project) or
+  ~/.agents/skills/<name>/ (global) to get a /<name> command. Running it
+  sends the file content as your next message. Text after the command name
+  replaces $ARGUMENTS, or is appended when the skill has no placeholder.
 
 Keyboard Shortcuts
 

--- a/cli/internal/tui/input.go
+++ b/cli/internal/tui/input.go
@@ -13,29 +13,44 @@ import (
 type slashCommand struct {
 	command     string
 	description string
+	// requiresArg commands are prefilled with a trailing space instead of
+	// running when picked from the menu.
+	requiresArg bool
+	// optionalArg commands run on Enter but prefill with a trailing space on
+	// Tab, so the user can add arguments.
+	optionalArg bool
 }
 
-var slashCommands = []slashCommand{
-	{"/help", "Show help message"},
-	{"/clear", "Clear chat and start a new session"},
-	{"/agent", "List and switch agents"},
-	{"/attach", "Attach a file to next message"},
-	{"/sessions", "Browse and resume previous sessions"},
-	{"/configure", "Re-run connection setup"},
-	{"/connectors", "Open connectors in browser"},
-	{"/settings", "Open settings in browser"},
-	{"/experiments", "List experimental features"},
-	{"/quit", "Exit Onyx CLI"},
+var builtinCommands = []slashCommand{
+	{command: "/help", description: "Show help message"},
+	{command: "/clear", description: "Clear chat and start a new session"},
+	{command: "/agent", description: "List and switch agents"},
+	{command: "/attach", description: "Attach a file to next message", requiresArg: true},
+	{command: "/sessions", description: "Browse and resume previous sessions"},
+	{command: "/configure", description: "Re-run connection setup"},
+	{command: "/connectors", description: "Open connectors in browser"},
+	{command: "/settings", description: "Open settings in browser"},
+	{command: "/skills", description: "List and reload local skills"},
+	{command: "/experiments", description: "List experimental features"},
+	{command: "/quit", description: "Exit Onyx CLI"},
 }
 
-// Commands that take arguments (filled in with trailing space on Tab/Enter).
-var argCommands = map[string]bool{
-	"/attach": true,
+// builtinNames reports the command names that skills cannot override.
+func builtinNames() map[string]bool {
+	names := make(map[string]bool, len(builtinCommands)+2)
+	for _, sc := range builtinCommands {
+		names[sc.command] = true
+	}
+	// Aliases handled by handleSlashCommand but absent from the menu.
+	names["/new"] = true
+	names["/resume"] = true
+	return names
 }
 
 // inputModel manages the text input and slash command menu.
 type inputModel struct {
 	textInput     textinput.Model
+	commands      []slashCommand
 	menuVisible   bool
 	menuItems     []slashCommand
 	menuIndex     int
@@ -54,7 +69,16 @@ func newInputModel() inputModel {
 
 	return inputModel{
 		textInput: ti,
+		commands:  builtinCommands,
 	}
+}
+
+// setSkillCommands appends skill commands to the menu, after the built-ins.
+func (m *inputModel) setSkillCommands(entries []slashCommand) {
+	commands := make([]slashCommand, 0, len(builtinCommands)+len(entries))
+	commands = append(commands, builtinCommands...)
+	commands = append(commands, entries...)
+	m.commands = commands
 }
 
 func (m inputModel) update(msg tea.Msg) (inputModel, tea.Cmd) {
@@ -82,21 +106,21 @@ func (m inputModel) handleKey(msg tea.KeyPressMsg) (inputModel, tea.Cmd) {
 		}
 	case "tab":
 		if m.menuVisible && len(m.menuItems) > 0 {
-			cmd := m.menuItems[m.menuIndex].command
-			if argCommands[cmd] {
-				m.textInput.SetValue(cmd + " ")
-				m.textInput.SetCursor(len(cmd) + 1)
-			} else {
-				m.textInput.SetValue(cmd)
-				m.textInput.SetCursor(len(cmd))
+			item := m.menuItems[m.menuIndex]
+			value := item.command
+			if item.requiresArg || item.optionalArg {
+				value += " "
 			}
+			m.textInput.SetValue(value)
+			m.textInput.SetCursor(len(value))
 			m.menuVisible = false
 			return m, nil
 		}
 	case "enter":
 		if m.menuVisible && len(m.menuItems) > 0 {
-			cmd := m.menuItems[m.menuIndex].command
-			if argCommands[cmd] {
+			item := m.menuItems[m.menuIndex]
+			cmd := item.command
+			if item.requiresArg {
 				m.textInput.SetValue(cmd + " ")
 				m.textInput.SetCursor(len(cmd) + 1)
 				m.menuVisible = false
@@ -145,7 +169,7 @@ func (m inputModel) updateMenu() inputModel {
 	if strings.HasPrefix(val, "/") && !strings.Contains(val, " ") {
 		needle := strings.ToLower(val)
 		var filtered []slashCommand
-		for _, sc := range slashCommands {
+		for _, sc := range m.commands {
 			if strings.HasPrefix(sc.command, needle) {
 				filtered = append(filtered, sc)
 			}

--- a/cli/internal/tui/skills_test.go
+++ b/cli/internal/tui/skills_test.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/onyx-dot-app/onyx/cli/internal/api"
+	"github.com/onyx-dot-app/onyx/cli/internal/config"
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+)
+
+// stubClient records the message passed to SendMessageStream.
+type stubClient struct {
+	api.ClientAPI
+	sent []string
+}
+
+func (c *stubClient) SendMessageStream(
+	ctx context.Context,
+	message string,
+	chatSessionID *string,
+	agentID int,
+	parentMessageID *int,
+	fileDescriptors []models.FileDescriptorPayload,
+) <-chan models.StreamEvent {
+	c.sent = append(c.sent, message)
+	ch := make(chan models.StreamEvent)
+	close(ch)
+	return ch
+}
+
+// newSkillsModel builds a Model whose skills come from a temporary project
+// directory, with an empty home directory so real skills cannot leak in.
+func newSkillsModel(t *testing.T, files map[string]string) (Model, *stubClient) {
+	t.Helper()
+
+	project := t.TempDir()
+	for name, content := range files {
+		dir := filepath.Join(project, ".agents", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	t.Chdir(project)
+	t.Setenv("HOME", t.TempDir())
+
+	client := &stubClient{}
+	return NewModel(config.OnyxCliConfig{ServerURL: "http://localhost"}, client), client
+}
+
+func TestSkillCommandSendsExpandedPrompt(t *testing.T) {
+	m, client := newSkillsModel(t, map[string]string{
+		"triage": "---\nname: triage\ndescription: Triage an incident.\n---\n\nTriage: $ARGUMENTS\n",
+	})
+
+	if _, ok := m.skills["triage"]; !ok {
+		t.Fatalf("triage skill not discovered, got %v", m.skills)
+	}
+
+	m, _ = handleSlashCommand(m, "/triage payments API 500s")
+
+	if len(client.sent) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(client.sent))
+	}
+	if client.sent[0] != "Triage: payments API 500s" {
+		t.Errorf("sent %q, want the expanded prompt", client.sent[0])
+	}
+	if !m.isStreaming {
+		t.Error("expected the model to be streaming after running a skill")
+	}
+}
+
+func TestSkillCommandWithoutArguments(t *testing.T) {
+	m, client := newSkillsModel(t, map[string]string{
+		"standup": "Summarize yesterday's standup.\n",
+	})
+
+	m, _ = handleSlashCommand(m, "/standup")
+
+	if len(client.sent) != 1 || client.sent[0] != "Summarize yesterday's standup." {
+		t.Fatalf("sent %v, want the skill body", client.sent)
+	}
+}
+
+func TestSkillCommandIsCaseInsensitive(t *testing.T) {
+	m, client := newSkillsModel(t, map[string]string{
+		"standup": "Summarize yesterday's standup.\n",
+	})
+
+	m, _ = handleSlashCommand(m, "/StandUp")
+
+	if len(client.sent) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(client.sent))
+	}
+}
+
+func TestSkillCannotOverrideBuiltinCommand(t *testing.T) {
+	m, client := newSkillsModel(t, map[string]string{
+		"help": "This skill must never run.\n",
+	})
+
+	if _, ok := m.skills["help"]; ok {
+		t.Error("a skill named help should be dropped, not registered")
+	}
+
+	m, _ = handleSlashCommand(m, "/help")
+
+	if len(client.sent) != 0 {
+		t.Fatalf("sent %v, want the built-in /help to win", client.sent)
+	}
+	last := m.viewport.entries[len(m.viewport.entries)-1]
+	if !strings.Contains(stripANSI(last.rendered), "Onyx CLI Commands") {
+		t.Errorf("expected built-in help output, got %q", stripANSI(last.rendered))
+	}
+}
+
+func TestUnknownCommandStillWarns(t *testing.T) {
+	m, client := newSkillsModel(t, nil)
+
+	m, _ = handleSlashCommand(m, "/nope")
+
+	if len(client.sent) != 0 {
+		t.Fatalf("sent %v, want nothing", client.sent)
+	}
+	last := m.viewport.entries[len(m.viewport.entries)-1]
+	if !strings.Contains(stripANSI(last.rendered), "Unknown command") {
+		t.Errorf("expected an unknown command warning, got %q", stripANSI(last.rendered))
+	}
+}
+
+func TestSkillIsRefusedWhileStreaming(t *testing.T) {
+	m, client := newSkillsModel(t, map[string]string{
+		"standup": "Summarize yesterday's standup.\n",
+	})
+	m.isStreaming = true
+
+	m, _ = handleSlashCommand(m, "/standup")
+
+	if len(client.sent) != 0 {
+		t.Fatalf("sent %v while streaming, want nothing", client.sent)
+	}
+	last := m.viewport.entries[len(m.viewport.entries)-1]
+	if !strings.Contains(stripANSI(last.rendered), "Wait for the current response") {
+		t.Errorf("expected a wait warning, got %q", stripANSI(last.rendered))
+	}
+}
+
+func TestSkillsAppearInCommandMenu(t *testing.T) {
+	m, _ := newSkillsModel(t, map[string]string{
+		"triage": "---\nname: triage\ndescription: Triage an incident.\n---\n\nTriage it.\n",
+	})
+
+	m.input.textInput.SetValue("/tri")
+	m.input = m.input.updateMenu()
+
+	if !m.input.menuVisible || len(m.input.menuItems) != 1 {
+		t.Fatalf("menu items = %+v, want the triage skill", m.input.menuItems)
+	}
+	item := m.input.menuItems[0]
+	if item.command != "/triage" {
+		t.Errorf("command = %q, want /triage", item.command)
+	}
+	if item.description != "Triage an incident." {
+		t.Errorf("description = %q", item.description)
+	}
+	if !item.optionalArg {
+		t.Error("skill commands should prefill with a trailing space on Tab")
+	}
+}
+
+func TestSkillMenuEnterRunsTheSkill(t *testing.T) {
+	m, _ := newSkillsModel(t, map[string]string{
+		"triage": "Triage it.\n",
+	})
+
+	m.input.textInput.SetValue("/tri")
+	m.input = m.input.updateMenu()
+
+	in, cmd := m.input.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a command from Enter on a skill menu item")
+	}
+	if in.menuVisible {
+		t.Error("menu should close after Enter")
+	}
+	msg, ok := cmd().(submitMsg)
+	if !ok {
+		t.Fatalf("got %T, want submitMsg", cmd())
+	}
+	if msg.text != "/triage" {
+		t.Errorf("submitted %q, want /triage", msg.text)
+	}
+}
+
+func TestSkillsCommandListsSkills(t *testing.T) {
+	m, _ := newSkillsModel(t, map[string]string{
+		"triage": "---\nname: triage\ndescription: Triage an incident.\n---\n\nTriage it.\n",
+	})
+
+	m, _ = cmdSkills(m)
+
+	last := stripANSI(m.viewport.entries[len(m.viewport.entries)-1].rendered)
+	if !strings.Contains(last, "/triage") || !strings.Contains(last, "Triage an incident.") {
+		t.Errorf("listing = %q, want the triage skill", last)
+	}
+}
+
+func TestSkillsCommandReloadsFromDisk(t *testing.T) {
+	m, _ := newSkillsModel(t, nil)
+
+	if len(m.skills) != 0 {
+		t.Fatalf("skills = %v, want none", m.skills)
+	}
+
+	dir := filepath.Join(".agents", "skills", "late")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("Added later.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m, _ = cmdSkills(m)
+
+	if _, ok := m.skills["late"]; !ok {
+		t.Errorf("skills = %v, want the newly added skill", m.skills)
+	}
+}

--- a/cli/internal/tui/skills_test.go
+++ b/cli/internal/tui/skills_test.go
@@ -83,7 +83,7 @@ func TestSkillCommandWithoutArguments(t *testing.T) {
 		"standup": "Summarize yesterday's standup.\n",
 	})
 
-	m, _ = handleSlashCommand(m, "/standup")
+	_, _ = handleSlashCommand(m, "/standup")
 
 	if len(client.sent) != 1 || client.sent[0] != "Summarize yesterday's standup." {
 		t.Fatalf("sent %v, want the skill body", client.sent)
@@ -95,10 +95,30 @@ func TestSkillCommandIsCaseInsensitive(t *testing.T) {
 		"standup": "Summarize yesterday's standup.\n",
 	})
 
-	m, _ = handleSlashCommand(m, "/StandUp")
+	_, _ = handleSlashCommand(m, "/StandUp")
 
 	if len(client.sent) != 1 {
 		t.Fatalf("sent %d messages, want 1", len(client.sent))
+	}
+}
+
+// A body of only $ARGUMENTS expands to nothing, which must not be sent.
+func TestSkillWithEmptyExpansionIsNotSent(t *testing.T) {
+	m, client := newSkillsModel(t, map[string]string{
+		"echo": "$ARGUMENTS\n",
+	})
+
+	m, _ = handleSlashCommand(m, "/echo")
+
+	if len(client.sent) != 0 {
+		t.Fatalf("sent %v, want nothing", client.sent)
+	}
+	if m.isStreaming {
+		t.Error("expected no stream for an empty expansion")
+	}
+	last := m.viewport.entries[len(m.viewport.entries)-1]
+	if !strings.Contains(stripANSI(last.rendered), "needs arguments") {
+		t.Errorf("expected an arguments warning, got %q", stripANSI(last.rendered))
 	}
 }
 


### PR DESCRIPTION
## Summary

The chat TUI now discovers user-authored `SKILL.md` files and exposes each one as a slash command.

- Scans `.agents/skills/<name>/SKILL.md` and `.claude/skills/<name>/SKILL.md`, in the current directory first, then the home directory. This is the layout `onyx-cli install-skill` already writes.
- Each skill becomes a `/<name>` command. The command name comes from the frontmatter `name` field, or the directory name.
- Running a skill sends its body as the next message. Text after the command name replaces `$ARGUMENTS`, or is appended when the skill has no placeholder.
- Skills appear in the slash command menu with their frontmatter `description`. Tab prefills with a trailing space for arguments; Enter runs the skill.
- `/skills` lists the discovered skills and reloads them from disk.

Built-in commands always win. A skill named `help` is dropped, so it cannot shadow `/help`.

Example:

```
.agents/skills/triage/SKILL.md   ->  /triage payments API 500s
```

## Notes

- Discovery is best-effort. Unreadable, empty, or oversized (>128 KB) skill files are skipped rather than reported as errors.
- `.agents/skills` wins over `.claude/skills` within the same root, which dedupes the symlink `install-skill` creates.
- Running a skill is refused while a response is streaming.

## Testing

- `internal/skills` unit tests cover frontmatter parsing, name normalization, precedence between roots and directories, symlinked skill directories, and argument expansion.
- `internal/tui` tests cover command dispatch, the built-in override rule, the command menu, and `/skills` listing and reload.
- `go build ./...`, `go vet ./...`, and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run user-authored SKILL.md skills as slash commands in the chat TUI. Previously skills were not runnable; now the TUI discovers them, exposes /<name>, adds /skills to list/reload, and hardens loading to reject unsafe files and empty expansions.

- Discovery and precedence: scan .agents/skills/<name>/SKILL.md then .claude/skills/<name>/SKILL.md in the project, then home; project wins over home, and .agents wins over .claude. Symlinked skill dirs work. Skip unreadable, empty, >128 KB, non-regular (e.g., FIFOs) files, and SKILL.md with unterminated frontmatter.
- Command behavior: each SKILL.md becomes /<name> (from frontmatter name or dir). Text after the command replaces $ARGUMENTS, or appends when absent; refuse to send when expansion is empty. A skill cannot override a built-in (e.g., /help), and running a skill is refused while a response is streaming.
- UI: skills appear in the slash menu with their description (truncated by rune to 60 chars); Tab adds a trailing space for arguments; Enter runs. /skills lists discovered skills and reloads them from disk. Unknown commands try skills before warning. New `cli/internal/skills` handles discovery and parsing; tests cover parsing, precedence, menu integration, execution, and safety checks.

<sup>Written for commit cb9c1797747351d0fcde6a054040f0aab238528b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

