### PR TITLE
feat(cli): show the current model and add a /model command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,7 @@ Environment variables override config file values:
 | `ONYX_API_PREFIX` | No | API path prefix (default: `/api`); set to empty for direct backend access |
 | `ONYX_PAT` | No | Personal access token for authentication (required if no config file) |
 | `ONYX_PERSONA_ID` | No | Default agent/persona ID |
+| `ONYX_MODEL` | No | Model to answer with (e.g. `gpt-4o`); overrides the model saved by `/model` |
 | `ONYX_STREAM_MARKDOWN` | No | Enable/disable progressive markdown rendering (true/false) |
 | `ONYX_SSH_HOST_KEY` | No | Path to SSH host key for `serve` command |
 
@@ -181,6 +182,7 @@ onyx-cli install-skill --agent claude-code
 | `/help` | Show help message |
 | `/clear` | Clear chat and start a new session |
 | `/agent` | List and switch agents |
+| `/model [name]` | List and switch models; `/model default` returns to the agent's model |
 | `/attach <path>` | Attach a file to next message |
 | `/sessions` | List recent chat sessions |
 | `/configure` | Re-run connection setup |

--- a/cli/cmd/ask.go
+++ b/cli/cmd/ask.go
@@ -77,6 +77,7 @@ to a temp file. Set --max-output 0 to disable truncation.`,
 				agentID,
 				&parentID,
 				nil,
+				cfg.DefaultModel.Override(),
 			)
 
 			// Determine truncation threshold.

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -271,6 +271,54 @@ func (c *Client) ListAgents(ctx context.Context) ([]models.AgentSummary, error) 
 	return result, nil
 }
 
+// ListModels returns the models the given agent can answer with, flattened
+// across the LLM providers the user can access.
+//
+// The returned options are ordered provider by provider, and the agent's
+// default model is flagged with IsAgentDefault.
+func (c *Client) ListModels(ctx context.Context, agentID int) ([]models.ModelOption, error) {
+	// The per-persona endpoint applies the agent's provider restrictions and
+	// reports the agent's own default model, which /llm/provider does not.
+	path := fmt.Sprintf("/llm/persona/%d/providers", agentID)
+	var resp models.LLMProviderResponse
+	if err := c.doJSON(ctx, "GET", path, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	var options []models.ModelOption
+	for _, provider := range resp.Providers {
+		providerName := ""
+		if provider.Name != nil {
+			providerName = *provider.Name
+		}
+		for _, mc := range provider.ModelConfigurations {
+			if !mc.IsVisible {
+				continue
+			}
+			displayName := ""
+			if mc.DisplayName != nil {
+				displayName = *mc.DisplayName
+			}
+			option := models.ModelOption{
+				SelectedModel: models.SelectedModel{
+					Provider:    providerName,
+					ModelName:   mc.Name,
+					DisplayName: displayName,
+				},
+				ProviderLabel: provider.ProviderDisplayName,
+				IsAgentDefault: resp.DefaultText != nil &&
+					resp.DefaultText.ProviderID == provider.ID &&
+					resp.DefaultText.ModelName == mc.Name,
+			}
+			if mc.ID != nil {
+				option.ConfigurationID = *mc.ID
+			}
+			options = append(options, option)
+		}
+	}
+	return options, nil
+}
+
 // ListChatSessions returns recent chat sessions.
 func (c *Client) ListChatSessions(ctx context.Context) ([]models.ChatSessionDetails, error) {
 	var resp struct {
@@ -389,13 +437,14 @@ func (c *Client) StopChatSession(ctx context.Context, sessionID string) {
 type ClientAPI interface {
 	TestConnection(ctx context.Context) error
 	ListAgents(ctx context.Context) ([]models.AgentSummary, error)
+	ListModels(ctx context.Context, agentID int) ([]models.ModelOption, error)
 	ListChatSessions(ctx context.Context) ([]models.ChatSessionDetails, error)
 	GetChatSession(ctx context.Context, sessionID string) (*models.ChatSessionDetailResponse, error)
 	RenameChatSession(ctx context.Context, sessionID string, name *string) (string, error)
 	UploadFile(ctx context.Context, filePath string) (*models.FileDescriptorPayload, error)
 	GetBackendVersion(ctx context.Context) (string, error)
 	StopChatSession(ctx context.Context, sessionID string)
-	SendMessageStream(ctx context.Context, message string, chatSessionID *string, agentID int, parentMessageID *int, fileDescriptors []models.FileDescriptorPayload) <-chan models.StreamEvent
+	SendMessageStream(ctx context.Context, message string, chatSessionID *string, agentID int, parentMessageID *int, fileDescriptors []models.FileDescriptorPayload, llmOverride *models.LLMOverride) <-chan models.StreamEvent
 	Search(ctx context.Context, req models.SearchRequest) (*models.SearchResponse, error)
 	GenerateImage(ctx context.Context, req models.ImageGenerationRequest) (*models.ImageGenerationResponse, error)
 }

--- a/cli/internal/api/models_test.go
+++ b/cli/internal/api/models_test.go
@@ -1,0 +1,134 @@
+package api_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/onyx-dot-app/onyx/cli/internal/testutil"
+)
+
+const providersJSON = `{
+	"providers": [
+		{
+			"id": 1,
+			"name": "OpenAI",
+			"provider": "openai",
+			"provider_display_name": "OpenAI",
+			"model_configurations": [
+				{"id": 10, "name": "gpt-4o", "is_visible": true, "display_name": "GPT-4o"},
+				{"id": 11, "name": "gpt-hidden", "is_visible": false, "display_name": null}
+			]
+		},
+		{
+			"id": 2,
+			"name": "Anthropic",
+			"provider": "anthropic",
+			"provider_display_name": "Claude (Anthropic)",
+			"model_configurations": [
+				{"id": 20, "name": "claude-opus-5", "is_visible": true, "display_name": null}
+			]
+		}
+	],
+	"default_text": {"provider_id": 2, "model_name": "claude-opus-5"}
+}`
+
+func TestListModels_FlattensVisibleModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/llm/persona/3/providers" {
+			t.Errorf("path = %s, want /api/llm/persona/3/providers", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(providersJSON))
+	}))
+	defer srv.Close()
+
+	options, err := testutil.NewClient(srv.URL).ListModels(t.Context(), 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("got %d models, want 2 (the hidden one must be dropped)", len(options))
+	}
+
+	first := options[0]
+	if first.ConfigurationID != 10 || first.ModelName != "gpt-4o" || first.Label() != "GPT-4o" {
+		t.Errorf("first = %+v, want the visible OpenAI model", first)
+	}
+	if first.Provider != "OpenAI" || first.ProviderLabel != "OpenAI" {
+		t.Errorf("first provider = %q/%q", first.Provider, first.ProviderLabel)
+	}
+	if first.IsAgentDefault {
+		t.Error("gpt-4o must not be marked the agent default")
+	}
+
+	second := options[1]
+	if !second.IsAgentDefault {
+		t.Error("claude-opus-5 must be marked the agent default")
+	}
+	// No display_name, so the label falls back to the model name.
+	if second.Label() != "claude-opus-5" {
+		t.Errorf("second label = %q, want claude-opus-5", second.Label())
+	}
+}
+
+func TestSendMessageStream_SendsLLMOverride(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies <- body
+		w.Header().Set("Content-Type", "application/x-ndjson")
+	}))
+	defer srv.Close()
+
+	selected := &models.SelectedModel{ConfigurationID: 10, Provider: "OpenAI", ModelName: "gpt-4o"}
+	parentID := -1
+	ch := testutil.NewClient(srv.URL).SendMessageStream(
+		t.Context(), "hi", nil, 3, &parentID, nil, selected.Override(),
+	)
+	for range ch { //nolint:revive // drain the stream so the request completes
+	}
+
+	var payload models.SendMessagePayload
+	if err := json.Unmarshal(<-bodies, &payload); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if payload.LLMOverride == nil {
+		t.Fatal("llm_override missing from the request")
+	}
+	if payload.LLMOverride.ModelConfigurationID == nil || *payload.LLMOverride.ModelConfigurationID != 10 {
+		t.Errorf("model_configuration_id = %v, want 10", payload.LLMOverride.ModelConfigurationID)
+	}
+	if payload.LLMOverride.ModelVersion != "gpt-4o" {
+		t.Errorf("model_version = %q, want gpt-4o", payload.LLMOverride.ModelVersion)
+	}
+}
+
+func TestSendMessageStream_OmitsOverrideWithoutSelection(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies <- body
+		w.Header().Set("Content-Type", "application/x-ndjson")
+	}))
+	defer srv.Close()
+
+	var selected *models.SelectedModel
+	parentID := -1
+	ch := testutil.NewClient(srv.URL).SendMessageStream(
+		t.Context(), "hi", nil, 3, &parentID, nil, selected.Override(),
+	)
+	for range ch { //nolint:revive // drain the stream so the request completes
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(<-bodies, &raw); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if _, present := raw["llm_override"]; present {
+		t.Error("llm_override must be absent when no model is selected")
+	}
+}

--- a/cli/internal/api/stream.go
+++ b/cli/internal/api/stream.go
@@ -21,6 +21,7 @@ func (c *Client) SendMessageStream(
 	agentID int,
 	parentMessageID *int,
 	fileDescriptors []models.FileDescriptorPayload,
+	llmOverride *models.LLMOverride,
 ) <-chan models.StreamEvent {
 	ch := make(chan models.StreamEvent, 64)
 
@@ -34,6 +35,7 @@ func (c *Client) SendMessageStream(
 			Origin:           "api",
 			IncludeCitations: true,
 			Stream:           true,
+			LLMOverride:      llmOverride,
 		}
 		if payload.FileDescriptors == nil {
 			payload.FileDescriptors = []models.FileDescriptorPayload{}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
 )
 
 const (
@@ -14,6 +16,7 @@ const (
 	EnvAPIPrefix      = "ONYX_API_PREFIX"
 	EnvAPIKey         = "ONYX_PAT"
 	EnvAgentID        = "ONYX_PERSONA_ID"
+	EnvModel          = "ONYX_MODEL"
 	EnvSSHHostKey     = "ONYX_SSH_HOST_KEY"
 	EnvStreamMarkdown = "ONYX_STREAM_MARKDOWN"
 )
@@ -32,6 +35,8 @@ type OnyxCliConfig struct {
 	APIKey         string   `json:"api_key"`
 	DefaultAgentID int      `json:"default_persona_id"`
 	Features       Features `json:"features,omitempty"`
+	// DefaultModel overrides the agent's model. nil means use the agent default.
+	DefaultModel *models.SelectedModel `json:"default_model,omitempty"`
 }
 
 // DefaultConfig returns a config with default values.
@@ -145,6 +150,12 @@ func Load() OnyxCliConfig {
 		if id, err := strconv.Atoi(v); err == nil {
 			cfg.DefaultAgentID = id
 		}
+	}
+	// The env var names a model version (e.g. "gpt-4o"). It carries no
+	// configuration id, so the server resolves it by name against the agent's
+	// provider. Use /model in the TUI for an unambiguous selection.
+	if v := os.Getenv(EnvModel); v != "" {
+		cfg.DefaultModel = &models.SelectedModel{ModelName: v}
 	}
 	if v := os.Getenv(EnvStreamMarkdown); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {

--- a/cli/internal/models/models.go
+++ b/cli/internal/models/models.go
@@ -84,6 +84,92 @@ type SendMessagePayload struct {
 	Origin           string                   `json:"origin"`
 	IncludeCitations bool                     `json:"include_citations"`
 	Stream           bool                     `json:"stream"`
+	LLMOverride      *LLMOverride             `json:"llm_override,omitempty"`
+}
+
+// LLMOverride tells the server which model to answer with, instead of the
+// agent's configured default.
+type LLMOverride struct {
+	// ModelConfigurationID routes unambiguously; provider display names are
+	// not unique. The name fields are sent alongside it as a fallback.
+	ModelConfigurationID *int   `json:"model_configuration_id,omitempty"`
+	ModelProvider        string `json:"model_provider,omitempty"`
+	ModelVersion         string `json:"model_version,omitempty"`
+}
+
+// SelectedModel is a model the user picked with /model. It is persisted in the
+// CLI config, so it keeps the fields needed to rebuild an LLMOverride and to
+// label the model in the UI without a server round-trip.
+type SelectedModel struct {
+	ConfigurationID int    `json:"model_configuration_id,omitempty"`
+	Provider        string `json:"model_provider,omitempty"`
+	ModelName       string `json:"model_version"`
+	DisplayName     string `json:"display_name,omitempty"`
+}
+
+// Label returns the human-readable name for the model.
+func (s SelectedModel) Label() string {
+	if s.DisplayName != "" {
+		return s.DisplayName
+	}
+	return s.ModelName
+}
+
+// Override converts the selection to a wire-format LLM override.
+// A nil selection means "use the agent's default model".
+func (s *SelectedModel) Override() *LLMOverride {
+	if s == nil || (s.ConfigurationID == 0 && s.ModelName == "") {
+		return nil
+	}
+	override := &LLMOverride{
+		ModelProvider: s.Provider,
+		ModelVersion:  s.ModelName,
+	}
+	if s.ConfigurationID != 0 {
+		id := s.ConfigurationID
+		override.ModelConfigurationID = &id
+	}
+	return override
+}
+
+// ModelConfiguration is one model exposed by an LLM provider.
+type ModelConfiguration struct {
+	ID          *int    `json:"id"`
+	Name        string  `json:"name"`
+	IsVisible   bool    `json:"is_visible"`
+	DisplayName *string `json:"display_name"`
+}
+
+// LLMProviderDescriptor is a provider and its models, as visible to a
+// non-admin user.
+type LLMProviderDescriptor struct {
+	ID                  int                  `json:"id"`
+	Name                *string              `json:"name"`
+	Provider            string               `json:"provider"`
+	ProviderDisplayName string               `json:"provider_display_name"`
+	ModelConfigurations []ModelConfiguration `json:"model_configurations"`
+}
+
+// DefaultModel identifies the workspace default model.
+type DefaultModel struct {
+	ProviderID int    `json:"provider_id"`
+	ModelName  string `json:"model_name"`
+}
+
+// LLMProviderResponse is the response from GET /api/llm/provider.
+type LLMProviderResponse struct {
+	Providers   []LLMProviderDescriptor `json:"providers"`
+	DefaultText *DefaultModel           `json:"default_text"`
+}
+
+// ModelOption is a selectable model, flattened across providers.
+type ModelOption struct {
+	SelectedModel
+	// ProviderLabel is the provider's human-friendly name, for display only.
+	ProviderLabel string
+	// IsAgentDefault marks the model the agent answers with when no override
+	// is set.
+	IsAgentDefault bool
 }
 
 // SearchDoc represents a document found during search.

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -36,6 +36,9 @@ type Model struct {
 	agentID         int
 	agentName       string
 	agents          []models.AgentSummary
+	// selectedModel is nil while the agent's default model is in use.
+	selectedModel   *models.SelectedModel
+	modelOptions    []models.ModelOption
 	parentMessageID *int
 	isStreaming     bool
 	streamCancel    context.CancelFunc
@@ -66,6 +69,7 @@ func NewModel(cfg config.OnyxCliConfig, client api.ClientAPI) Model {
 		status:          newStatusBar(),
 		agentID:         cfg.DefaultAgentID,
 		agentName:       "Default",
+		selectedModel:   cfg.DefaultModel,
 		parentMessageID: &parentID,
 		citations:       make(map[int]string),
 	}
@@ -83,7 +87,7 @@ func (m Model) Init() tea.Cmd {
 	if m.client == nil {
 		return nil
 	}
-	return loadAgentsCmd(m.client)
+	return tea.Batch(loadAgentsCmd(m.client), loadModelsCmd(m.client, m.agentID, false))
 }
 
 // Update handles messages.
@@ -148,6 +152,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case AgentsLoadedMsg:
 		return m.handleAgentsLoaded(msg)
+
+	case ModelsLoadedMsg:
+		return m.handleModelsLoaded(msg)
 
 	case SessionsLoadedMsg:
 		return m.handleSessionsLoaded(msg)
@@ -297,6 +304,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					return cmdResume(m, item.id)
 				case pickerAgent:
 					return cmdSelectAgent(m, item.id)
+				case pickerModel:
+					return cmdSelectModel(m, item.id)
 				}
 			}
 			return m, nil
@@ -394,6 +403,7 @@ func (m Model) sendMessage(message string) (Model, tea.Cmd) {
 		m.agentID,
 		m.parentMessageID,
 		fileDescs,
+		m.selectedModel.Override(),
 	)
 	m.streamCh = ch
 
@@ -533,6 +543,7 @@ func (m Model) handleInitDone(msg InitDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	m.status.setServer(m.config.ServerURL)
 	m.status.setAgent(m.agentName)
+	m.refreshModelStatus()
 	return m, nil
 }
 
@@ -568,6 +579,69 @@ func (m Model) handleAgentsLoaded(msg AgentsLoadedMsg) (tea.Model, tea.Cmd) {
 		})
 	}
 	m.viewport.showPicker(pickerAgent, items)
+	return m, nil
+}
+
+// refreshModelStatus updates the status bar with the model in use: the
+// explicit selection when there is one, otherwise the agent's default.
+func (m *Model) refreshModelStatus() {
+	if m.selectedModel != nil {
+		m.status.setModel(m.selectedModel.Label())
+		return
+	}
+	for _, option := range m.modelOptions {
+		if option.IsAgentDefault {
+			m.status.setModel(option.Label())
+			return
+		}
+	}
+	m.status.setModel("")
+}
+
+func (m Model) handleModelsLoaded(msg ModelsLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		if msg.ShowPicker {
+			m.viewport.addError("Could not load models: " + msg.Err.Error())
+		}
+		return m, nil
+	}
+	m.modelOptions = msg.Options
+
+	// Drop a selection the current agent cannot use, so the status bar never
+	// claims a model the server would ignore. The saved preference is left on
+	// disk — it applies again if the user switches back to an agent that
+	// allows it. Use "/model default" to forget it.
+	if m.selectedModel != nil && !hasModel(m.modelOptions, m.selectedModel.ModelName) {
+		m.viewport.addWarning(fmt.Sprintf(
+			"Model %q is not available for this agent. Using the agent default.",
+			m.selectedModel.Label(),
+		))
+		m.selectedModel = nil
+	}
+	m.refreshModelStatus()
+
+	if !msg.ShowPicker {
+		return m, nil
+	}
+	if len(m.modelOptions) == 0 {
+		m.viewport.addInfo("No models available.")
+		return m, nil
+	}
+
+	m.viewport.addInfo("Select a model (Enter to select, Esc to cancel):")
+
+	items := []pickerItem{{id: "default", label: "Agent default"}}
+	for i, option := range m.modelOptions {
+		label := fmt.Sprintf("%d: %s", i+1, option.Label())
+		if option.ProviderLabel != "" {
+			label += " (" + option.ProviderLabel + ")"
+		}
+		if m.selectedModel != nil && m.selectedModel.ModelName == option.ModelName {
+			label += " *"
+		}
+		items = append(items, pickerItem{id: strconv.Itoa(i + 1), label: label})
+	}
+	m.viewport.showPicker(pickerModel, items)
 	return m, nil
 }
 
@@ -632,8 +706,10 @@ func (m Model) handleSessionResumed(msg SessionResumedMsg) (tea.Model, tea.Cmd) 
 		m.agentName = *detail.AgentName
 		m.status.setAgent(*detail.AgentName)
 	}
-	if detail.AgentID != nil {
+	reloadModels := false
+	if detail.AgentID != nil && *detail.AgentID != m.agentID {
 		m.agentID = *detail.AgentID
+		reloadModels = true
 	}
 
 	// Replay messages
@@ -659,6 +735,9 @@ func (m Model) handleSessionResumed(msg SessionResumedMsg) (tea.Model, tea.Cmd) 
 		desc = *detail.Description
 	}
 	m.viewport.addInfo("Resumed session: " + desc)
+	if reloadModels {
+		return m, loadModelsCmd(m.client, m.agentID, false)
+	}
 	return m, nil
 }
 

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -33,6 +33,12 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 		}
 		return cmdShowAgents(m)
 
+	case "/model":
+		if strings.TrimSpace(arg) != "" {
+			return cmdSelectModel(m, arg)
+		}
+		return cmdShowModels(m)
+
 	case "/attach":
 		return cmdAttach(m, arg)
 
@@ -137,7 +143,97 @@ func cmdSelectAgent(m Model, idStr string) (Model, tea.Cmd) {
 	m.config.DefaultAgentID = target.ID
 	_ = config.Save(m.config)
 
-	return m, nil
+	// The new agent may allow a different model set and have its own default.
+	return m, loadModelsCmd(m.client, m.agentID, false)
+}
+
+func cmdShowModels(m Model) (Model, tea.Cmd) {
+	m.viewport.addInfo("Loading models...")
+	return m, loadModelsCmd(m.client, m.agentID, true)
+}
+
+// cmdSelectModel picks a model by its list number, or by model name / display
+// name (case-insensitive, exact match first, then unique prefix). The literal
+// "default" clears the override and returns to the agent's own model.
+func cmdSelectModel(m Model, arg string) (Model, tea.Cmd) {
+	needle := strings.TrimSpace(arg)
+
+	if strings.EqualFold(needle, "default") {
+		m.selectedModel = nil
+		m.config.DefaultModel = nil
+		_ = config.Save(m.config)
+		m.refreshModelStatus()
+		m.viewport.addInfo("Using the agent's default model: " + m.status.modelName)
+		return m, nil
+	}
+
+	if len(m.modelOptions) == 0 {
+		m.viewport.addWarning("No models loaded yet. Use /model to list them.")
+		return m, nil
+	}
+
+	if n, err := strconv.Atoi(needle); err == nil {
+		if n < 1 || n > len(m.modelOptions) {
+			m.viewport.addWarning(fmt.Sprintf("No model %d. Use /model to see the list.", n))
+			return m, nil
+		}
+		return applyModel(m, m.modelOptions[n-1]), nil
+	}
+
+	match := findModel(m.modelOptions, needle)
+	if match == nil {
+		m.viewport.addWarning(fmt.Sprintf("Model %q not found. Use /model to see available models.", needle))
+		return m, nil
+	}
+	return applyModel(m, *match), nil
+}
+
+// findModel resolves a name to one model: an exact name or display-name match
+// wins, otherwise a prefix match, but only when it is unique.
+func findModel(options []models.ModelOption, needle string) *models.ModelOption {
+	var prefixMatches []models.ModelOption
+	for _, option := range options {
+		if strings.EqualFold(option.ModelName, needle) || strings.EqualFold(option.DisplayName, needle) {
+			return &option
+		}
+		if strings.HasPrefix(strings.ToLower(option.ModelName), strings.ToLower(needle)) ||
+			strings.HasPrefix(strings.ToLower(option.DisplayName), strings.ToLower(needle)) {
+			prefixMatches = append(prefixMatches, option)
+		}
+	}
+	if len(prefixMatches) == 1 {
+		return &prefixMatches[0]
+	}
+	return nil
+}
+
+// hasModel reports whether the exact model name is in the list.
+func hasModel(options []models.ModelOption, name string) bool {
+	for _, option := range options {
+		if option.ModelName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func applyModel(m Model, option models.ModelOption) Model {
+	selected := option.SelectedModel
+	m.selectedModel = &selected
+	m.config.DefaultModel = &selected
+	_ = config.Save(m.config)
+	m.refreshModelStatus()
+	m.viewport.addInfo("Switched to model: " + selected.Label())
+	return m
+}
+
+// loadModelsCmd fetches the models available to an agent. showPicker asks the
+// handler to display the selection list rather than only refresh the status bar.
+func loadModelsCmd(client api.ClientAPI, agentID int, showPicker bool) tea.Cmd {
+	return func() tea.Msg {
+		options, err := client.ListModels(context.Background(), agentID)
+		return ModelsLoadedMsg{Options: options, ShowPicker: showPicker, Err: err}
+	}
 }
 
 func cmdAttach(m Model, pathStr string) (Model, tea.Cmd) {

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -1,0 +1,90 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+)
+
+func testModelOptions() []models.ModelOption {
+	return []models.ModelOption{
+		{
+			SelectedModel: models.SelectedModel{ConfigurationID: 10, ModelName: "gpt-4o", DisplayName: "GPT-4o"},
+			ProviderLabel: "OpenAI",
+		},
+		{
+			SelectedModel:  models.SelectedModel{ConfigurationID: 20, ModelName: "claude-opus-5"},
+			ProviderLabel:  "Claude (Anthropic)",
+			IsAgentDefault: true,
+		},
+		{
+			SelectedModel: models.SelectedModel{ConfigurationID: 21, ModelName: "claude-sonnet-5"},
+			ProviderLabel: "Claude (Anthropic)",
+		},
+	}
+}
+
+func TestFindModel(t *testing.T) {
+	options := testModelOptions()
+
+	tests := []struct {
+		name string
+		arg  string
+		want string // model name, or "" when no match is expected
+	}{
+		{"exact model name", "gpt-4o", "gpt-4o"},
+		{"case insensitive", "GPT-4O", "gpt-4o"},
+		{"display name", "GPT-4o", "gpt-4o"},
+		{"unique prefix", "claude-opus", "claude-opus-5"},
+		{"ambiguous prefix", "claude", ""},
+		{"no match", "gemini", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findModel(options, tt.arg)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("findModel(%q) = %q, want no match", tt.arg, got.ModelName)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("findModel(%q) = no match, want %q", tt.arg, tt.want)
+			}
+			if got.ModelName != tt.want {
+				t.Errorf("findModel(%q) = %q, want %q", tt.arg, got.ModelName, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshModelStatus(t *testing.T) {
+	m := Model{modelOptions: testModelOptions(), status: newStatusBar()}
+
+	// With no selection the status bar shows the agent's own default.
+	m.refreshModelStatus()
+	if m.status.modelName != "claude-opus-5" {
+		t.Errorf("model status = %q, want the agent default claude-opus-5", m.status.modelName)
+	}
+
+	// An explicit selection wins, and prefers the display name.
+	m.selectedModel = &models.SelectedModel{ModelName: "gpt-4o", DisplayName: "GPT-4o"}
+	m.refreshModelStatus()
+	if m.status.modelName != "GPT-4o" {
+		t.Errorf("model status = %q, want GPT-4o", m.status.modelName)
+	}
+}
+
+func TestStatusBarShowsModel(t *testing.T) {
+	s := newStatusBar()
+	s.setWidth(120)
+	s.setAgent("Research")
+	s.setModel("GPT-4o")
+
+	view := stripANSI(s.view())
+	if !strings.Contains(view, "Research · GPT-4o") {
+		t.Errorf("status bar = %q, want it to show the agent and model", view)
+	}
+}

--- a/cli/internal/tui/help.go
+++ b/cli/internal/tui/help.go
@@ -5,6 +5,7 @@ const helpText = `Onyx CLI Commands
   /help              Show this help message
   /clear             Clear chat and start a new session
   /agent             List and switch agents
+  /model [name]      List and switch models ("/model default" to reset)
   /attach <path>     Attach a file to next message
   /sessions          Browse and resume previous sessions
   /configure         Re-run connection setup

--- a/cli/internal/tui/input.go
+++ b/cli/internal/tui/input.go
@@ -19,6 +19,7 @@ var slashCommands = []slashCommand{
 	{"/help", "Show help message"},
 	{"/clear", "Clear chat and start a new session"},
 	{"/agent", "List and switch agents"},
+	{"/model", "List and switch models"},
 	{"/attach", "Attach a file to next message"},
 	{"/sessions", "Browse and resume previous sessions"},
 	{"/configure", "Re-run connection setup"},

--- a/cli/internal/tui/messages.go
+++ b/cli/internal/tui/messages.go
@@ -35,6 +35,14 @@ type AgentsLoadedMsg struct {
 	Err    error
 }
 
+// ModelsLoadedMsg carries the models available for the current agent.
+// ShowPicker is set when the user asked for the list with /model.
+type ModelsLoadedMsg struct {
+	Options    []models.ModelOption
+	ShowPicker bool
+	Err        error
+}
+
 // ConfigTestResultMsg carries the result of an async connection test during /configure.
 type ConfigTestResultMsg struct {
 	Err error

--- a/cli/internal/tui/statusbar.go
+++ b/cli/internal/tui/statusbar.go
@@ -9,6 +9,7 @@ import (
 // statusBar manages the footer status display.
 type statusBar struct {
 	agentName string
+	modelName string
 	serverURL string
 	sessionID string
 	streaming bool
@@ -22,6 +23,7 @@ func newStatusBar() statusBar {
 }
 
 func (s *statusBar) setAgent(name string) { s.agentName = name }
+func (s *statusBar) setModel(name string) { s.modelName = name }
 func (s *statusBar) setServer(url string) { s.serverURL = url }
 func (s *statusBar) setSession(id string) {
 	if len(id) > 8 {
@@ -42,6 +44,9 @@ func (s statusBar) view() string {
 		name = "Default"
 	}
 	leftParts = append(leftParts, name)
+	if s.modelName != "" {
+		leftParts = append(leftParts, s.modelName)
+	}
 	left := statusBarStyle.Render(strings.Join(leftParts, " · "))
 
 	right := "Ctrl+D to quit"

--- a/cli/internal/tui/viewport.go
+++ b/cli/internal/tui/viewport.go
@@ -35,6 +35,7 @@ type pickerKind int
 const (
 	pickerSession pickerKind = iota
 	pickerAgent
+	pickerModel
 )
 
 // pickerItem is a selectable item in the picker.


### PR DESCRIPTION
## What

The CLI never showed which LLM answers, and gave no way to change it. This adds both.

**Status bar** now reads `server · agent · model`. With no override it shows the agent's own default model, read from `GET /llm/persona/{id}/providers` (that endpoint applies the agent's provider restrictions and reports its default, which `/llm/provider` does not).

**`/model`** lists the models the agent can use and switches between them:

- `/model` — open a picker (Enter to select, Esc to cancel)
- `/model <n>` — pick by list number
- `/model <name>` — pick by model name or display name (case-insensitive; exact match wins, then a unique prefix)
- `/model default` — clear the override and go back to the agent's model

The choice is saved to `default_model` in the CLI config, and sent as `llm_override` on every message, so `onyx-cli ask` uses it too. `model_configuration_id` is the routing key because provider display names are not unique; provider/version go along as a fallback. `ONYX_MODEL` overrides the saved choice.

Switching agents reloads the model list. If the saved model is not available for the new agent, the CLI warns and falls back to the agent default without erasing the saved preference from disk.

## Tests

- `cli/internal/api/models_test.go` — `ListModels` flattens providers, drops `is_visible: false` models, flags the agent default, falls back to the model name when there is no display name; `SendMessageStream` sends `llm_override` and omits it when nothing is selected.
- `cli/internal/tui/commands_test.go` — name resolution (exact, case-insensitive, display name, unique prefix, ambiguous prefix, no match), status-bar refresh, and status-bar rendering.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Manual verification

Against a local dev stack: the picker listed 65 models, `/model o3` produced `Initialized TiktokenTokenizer for: o3` in the API log (workspace default was `gpt-4o`), the selection survived a restart, and `/model default` restored the agent default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the answering model in the TUI and add a `/model` command to list and switch models. Previously the CLI hid the model and could not change it; now users can set a persisted override that applies to chat and `onyx-cli ask`.

- Status bar shows server · agent · model. Without an override it shows the agent’s default.
- `/model` opens a picker or accepts a number/name. `/model default` clears the override. Name resolution prefers exact (case-insensitive) match, then a unique prefix.
- The choice persists as `default_model` in the CLI config; `ONYX_MODEL` can temporarily override it.
- The override is sent as `llm_override` with `model_configuration_id` (plus provider/version fallback) on every message; it is omitted when no selection is set. `ask` forwards the override.
- Models load from `GET /llm/persona/{id}/providers`, honoring agent restrictions, marking the agent’s default, and dropping non-visible models.
- Switching agents reloads models. If the saved model is unavailable, the CLI warns and falls back to the agent default without deleting the saved preference.

<sup>Written for commit 9f0d7a32d626b2daa74acab2cf9462e30623b1f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

