### PR TITLE
feat(cli): model switcher via /model with current model in the status bar

### DIFF
--- a/cli/cmd/ask.go
+++ b/cli/cmd/ask.go
@@ -77,6 +77,7 @@ to a temp file. Set --max-output 0 to disable truncation.`,
 				agentID,
 				&parentID,
 				nil,
+				nil,
 			)
 
 			// Determine truncation threshold.

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -271,6 +271,16 @@ func (c *Client) ListAgents(ctx context.Context) ([]models.AgentSummary, error) 
 	return result, nil
 }
 
+// ListLLMProviders returns LLM providers (with their models) accessible to
+// the current user, plus the workspace default model.
+func (c *Client) ListLLMProviders(ctx context.Context) (*models.LLMProviderResponse, error) {
+	var resp models.LLMProviderResponse
+	if err := c.doJSON(ctx, "GET", "/llm/provider", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ListChatSessions returns recent chat sessions.
 func (c *Client) ListChatSessions(ctx context.Context) ([]models.ChatSessionDetails, error) {
 	var resp struct {
@@ -389,13 +399,14 @@ func (c *Client) StopChatSession(ctx context.Context, sessionID string) {
 type ClientAPI interface {
 	TestConnection(ctx context.Context) error
 	ListAgents(ctx context.Context) ([]models.AgentSummary, error)
+	ListLLMProviders(ctx context.Context) (*models.LLMProviderResponse, error)
 	ListChatSessions(ctx context.Context) ([]models.ChatSessionDetails, error)
 	GetChatSession(ctx context.Context, sessionID string) (*models.ChatSessionDetailResponse, error)
 	RenameChatSession(ctx context.Context, sessionID string, name *string) (string, error)
 	UploadFile(ctx context.Context, filePath string) (*models.FileDescriptorPayload, error)
 	GetBackendVersion(ctx context.Context) (string, error)
 	StopChatSession(ctx context.Context, sessionID string)
-	SendMessageStream(ctx context.Context, message string, chatSessionID *string, agentID int, parentMessageID *int, fileDescriptors []models.FileDescriptorPayload) <-chan models.StreamEvent
+	SendMessageStream(ctx context.Context, message string, chatSessionID *string, agentID int, parentMessageID *int, fileDescriptors []models.FileDescriptorPayload, llmOverride *models.LLMOverride) <-chan models.StreamEvent
 	Search(ctx context.Context, req models.SearchRequest) (*models.SearchResponse, error)
 	GenerateImage(ctx context.Context, req models.ImageGenerationRequest) (*models.ImageGenerationResponse, error)
 }

--- a/cli/internal/api/stream.go
+++ b/cli/internal/api/stream.go
@@ -21,6 +21,7 @@ func (c *Client) SendMessageStream(
 	agentID int,
 	parentMessageID *int,
 	fileDescriptors []models.FileDescriptorPayload,
+	llmOverride *models.LLMOverride,
 ) <-chan models.StreamEvent {
 	ch := make(chan models.StreamEvent, 64)
 
@@ -29,6 +30,7 @@ func (c *Client) SendMessageStream(
 
 		payload := models.SendMessagePayload{
 			Message:          message,
+			LLMOverride:      llmOverride,
 			ParentMessageID:  parentMessageID,
 			FileDescriptors:  fileDescriptors,
 			Origin:           "api",

--- a/cli/internal/models/models.go
+++ b/cli/internal/models/models.go
@@ -74,11 +74,62 @@ type ChatSessionCreationInfo struct {
 	AgentID int `json:"persona_id"`
 }
 
+// LLMOverride selects a specific model for a chat message, overriding the
+// agent's default. ModelConfigurationID routes unambiguously; the name-based
+// fields are a fallback for older servers.
+type LLMOverride struct {
+	ModelConfigurationID *int    `json:"model_configuration_id,omitempty"`
+	ModelProvider        *string `json:"model_provider,omitempty"`
+	ModelVersion         *string `json:"model_version,omitempty"`
+}
+
+// ModelConfiguration is one model offered by an LLM provider.
+type ModelConfiguration struct {
+	ID                *int    `json:"id"`
+	Name              string  `json:"name"`
+	IsVisible         bool    `json:"is_visible"`
+	DisplayName       *string `json:"display_name"`
+	CustomDisplayName *string `json:"custom_display_name"`
+}
+
+// Label returns the human-readable name for the model.
+func (m ModelConfiguration) Label() string {
+	if m.CustomDisplayName != nil && *m.CustomDisplayName != "" {
+		return *m.CustomDisplayName
+	}
+	if m.DisplayName != nil && *m.DisplayName != "" {
+		return *m.DisplayName
+	}
+	return m.Name
+}
+
+// LLMProviderDescriptor is an LLM provider visible to the current user.
+type LLMProviderDescriptor struct {
+	ID                  int                  `json:"id"`
+	Name                *string              `json:"name"`
+	Provider            string               `json:"provider"`
+	ProviderDisplayName string               `json:"provider_display_name"`
+	ModelConfigurations []ModelConfiguration `json:"model_configurations"`
+}
+
+// DefaultModel identifies the workspace default model.
+type DefaultModel struct {
+	ProviderID int    `json:"provider_id"`
+	ModelName  string `json:"model_name"`
+}
+
+// LLMProviderResponse is the response from GET /api/llm/provider.
+type LLMProviderResponse struct {
+	Providers   []LLMProviderDescriptor `json:"providers"`
+	DefaultText *DefaultModel           `json:"default_text"`
+}
+
 // SendMessagePayload is the request body for POST /api/chat/send-chat-message.
 type SendMessagePayload struct {
 	Message          string                   `json:"message"`
 	ChatSessionID    *string                  `json:"chat_session_id,omitempty"`
 	ChatSessionInfo  *ChatSessionCreationInfo `json:"chat_session_info,omitempty"`
+	LLMOverride      *LLMOverride             `json:"llm_override,omitempty"`
 	ParentMessageID  *int                     `json:"parent_message_id"`
 	FileDescriptors  []FileDescriptorPayload `json:"file_descriptors"`
 	Origin           string                   `json:"origin"`

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -611,15 +611,13 @@ func (m Model) handleModelsLoaded(msg ModelsLoadedMsg) (tea.Model, tea.Cmd) {
 	var items []pickerItem
 	for i, opt := range m.llmModels {
 		label := opt.label
-		if opt.providerLabel != "" {
-			label += " - " + opt.providerLabel
-		}
 		if m.isCurrentModel(opt) {
 			label += " *"
 		}
 		items = append(items, pickerItem{
-			id:    strconv.Itoa(i),
-			label: label,
+			id:     strconv.Itoa(i),
+			label:  label,
+			detail: opt.providerLabel,
 		})
 	}
 	m.viewport.showPicker(pickerModel, items)

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -36,6 +36,8 @@ type Model struct {
 	agentID         int
 	agentName       string
 	agents          []models.AgentSummary
+	llmModels       []modelOption
+	modelOverride   *models.LLMOverride
 	parentMessageID *int
 	isStreaming     bool
 	streamCancel    context.CancelFunc
@@ -83,7 +85,7 @@ func (m Model) Init() tea.Cmd {
 	if m.client == nil {
 		return nil
 	}
-	return loadAgentsCmd(m.client)
+	return tea.Batch(loadAgentsCmd(m.client), loadModelsCmd(m.client))
 }
 
 // Update handles messages.
@@ -148,6 +150,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case AgentsLoadedMsg:
 		return m.handleAgentsLoaded(msg)
+
+	case ModelsLoadedMsg:
+		return m.handleModelsLoaded(msg)
 
 	case SessionsLoadedMsg:
 		return m.handleSessionsLoaded(msg)
@@ -297,6 +302,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					return cmdResume(m, item.id)
 				case pickerAgent:
 					return cmdSelectAgent(m, item.id)
+				case pickerModel:
+					return cmdSelectModel(m, item.id)
 				}
 			}
 			return m, nil
@@ -394,6 +401,7 @@ func (m Model) sendMessage(message string) (Model, tea.Cmd) {
 		m.agentID,
 		m.parentMessageID,
 		fileDescs,
+		m.modelOverride,
 	)
 	m.streamCh = ch
 
@@ -569,6 +577,69 @@ func (m Model) handleAgentsLoaded(msg AgentsLoadedMsg) (tea.Model, tea.Cmd) {
 	}
 	m.viewport.showPicker(pickerAgent, items)
 	return m, nil
+}
+
+func (m Model) handleModelsLoaded(msg ModelsLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		// Startup fetch failures are silent — the status bar just omits the
+		// model segment. Only report when the user asked for the picker.
+		if msg.ShowPicker {
+			m.viewport.addError("Could not load models: " + msg.Err.Error())
+		}
+		return m, nil
+	}
+
+	m.llmModels = flattenModelOptions(msg.Response)
+	m.status.setModel(m.currentModelLabel())
+
+	if !msg.ShowPicker {
+		return m, nil
+	}
+	if len(m.llmModels) == 0 {
+		m.viewport.addInfo("No models available.")
+		return m, nil
+	}
+
+	m.viewport.addInfo("Select a model (Enter to select, Esc to cancel):")
+
+	var items []pickerItem
+	for i, opt := range m.llmModels {
+		label := opt.label
+		if opt.providerLabel != "" {
+			label += " - " + opt.providerLabel
+		}
+		if m.isCurrentModel(opt) {
+			label += " *"
+		}
+		items = append(items, pickerItem{
+			id:    strconv.Itoa(i),
+			label: label,
+		})
+	}
+	m.viewport.showPicker(pickerModel, items)
+	return m, nil
+}
+
+// isCurrentModel reports whether opt is the model in effect: the explicit
+// override when one is set, otherwise the workspace default.
+func (m Model) isCurrentModel(opt modelOption) bool {
+	if m.modelOverride == nil {
+		return opt.isDefault
+	}
+	if m.modelOverride.ModelConfigurationID != nil && opt.configID != nil {
+		return *m.modelOverride.ModelConfigurationID == *opt.configID
+	}
+	return m.modelOverride.ModelVersion != nil && *m.modelOverride.ModelVersion == opt.name
+}
+
+// currentModelLabel returns the display label of the model in effect.
+func (m Model) currentModelLabel() string {
+	for _, opt := range m.llmModels {
+		if m.isCurrentModel(opt) {
+			return opt.label
+		}
+	}
+	return ""
 }
 
 func (m Model) handleSessionsLoaded(msg SessionsLoadedMsg) (tea.Model, tea.Cmd) {

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -589,6 +589,12 @@ func (m Model) handleModelsLoaded(msg ModelsLoadedMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// A startup response that lands while the model picker is open must not
+	// replace the list the picker's indices point into.
+	if !msg.ShowPicker && m.viewport.pickerActive && m.viewport.pickerType == pickerModel {
+		return m, nil
+	}
+
 	m.llmModels = flattenModelOptions(msg.Response)
 	m.status.setModel(m.currentModelLabel())
 

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -33,6 +33,9 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 		}
 		return cmdShowAgents(m)
 
+	case "/model":
+		return cmdShowModels(m)
+
 	case "/attach":
 		return cmdAttach(m, arg)
 
@@ -140,6 +143,80 @@ func cmdSelectAgent(m Model, idStr string) (Model, tea.Cmd) {
 	return m, nil
 }
 
+// modelOption is one selectable model, flattened across providers.
+type modelOption struct {
+	configID      *int
+	name          string // model name sent to the API
+	label         string // display name shown in the UI
+	providerName  string // provider config name, for name-based override fallback
+	providerLabel string // provider display name shown in the UI
+	isDefault     bool   // true when this is the workspace default text model
+}
+
+// flattenModelOptions turns the provider listing into a flat list of visible
+// models, marking the workspace default.
+func flattenModelOptions(resp *models.LLMProviderResponse) []modelOption {
+	if resp == nil {
+		return nil
+	}
+	var options []modelOption
+	for _, provider := range resp.Providers {
+		providerName := provider.Provider
+		if provider.Name != nil && *provider.Name != "" {
+			providerName = *provider.Name
+		}
+		for _, mc := range provider.ModelConfigurations {
+			if !mc.IsVisible {
+				continue
+			}
+			isDefault := resp.DefaultText != nil &&
+				resp.DefaultText.ProviderID == provider.ID &&
+				resp.DefaultText.ModelName == mc.Name
+			options = append(options, modelOption{
+				configID:      mc.ID,
+				name:          mc.Name,
+				label:         mc.Label(),
+				providerName:  providerName,
+				providerLabel: provider.ProviderDisplayName,
+				isDefault:     isDefault,
+			})
+		}
+	}
+	return options
+}
+
+func cmdShowModels(m Model) (Model, tea.Cmd) {
+	m.viewport.addInfo("Loading models...")
+	client := m.client
+	return m, func() tea.Msg {
+		resp, err := client.ListLLMProviders(context.Background())
+		return ModelsLoadedMsg{Response: resp, ShowPicker: true, Err: err}
+	}
+}
+
+// cmdSelectModel applies the picker selection. idxStr is an index into
+// m.llmModels (model names and config IDs are not unique across providers).
+func cmdSelectModel(m Model, idxStr string) (Model, tea.Cmd) {
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 || idx >= len(m.llmModels) {
+		m.viewport.addWarning("Invalid model selection.")
+		return m, nil
+	}
+	opt := m.llmModels[idx]
+
+	override := &models.LLMOverride{
+		ModelConfigurationID: opt.configID,
+		ModelVersion:         &opt.name,
+	}
+	if opt.providerName != "" {
+		override.ModelProvider = &opt.providerName
+	}
+	m.modelOverride = override
+	m.status.setModel(opt.label)
+	m.viewport.addInfo("Switched to model: " + opt.label)
+	return m, nil
+}
+
 func cmdAttach(m Model, pathStr string) (Model, tea.Cmd) {
 	if pathStr == "" {
 		m.viewport.addWarning("Usage: /attach <file_path>")
@@ -199,5 +276,14 @@ func loadAgentsCmd(client api.ClientAPI) tea.Cmd {
 	return func() tea.Msg {
 		agents, err := client.ListAgents(context.Background())
 		return InitDoneMsg{Agents: agents, Err: err}
+	}
+}
+
+// loadModelsCmd fetches LLM providers at startup so the status bar can show
+// the current (default) model.
+func loadModelsCmd(client api.ClientAPI) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := client.ListLLMProviders(context.Background())
+		return ModelsLoadedMsg{Response: resp, Err: err}
 	}
 }

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -161,8 +161,10 @@ func flattenModelOptions(resp *models.LLMProviderResponse) []modelOption {
 	}
 	var options []modelOption
 	for _, provider := range resp.Providers {
-		providerName := provider.Provider
-		if provider.Name != nil && *provider.Name != "" {
+		// Only the provider config name works for the name-based override
+		// fallback on older servers; the provider type key does not resolve.
+		providerName := ""
+		if provider.Name != nil {
 			providerName = *provider.Name
 		}
 		for _, mc := range provider.ModelConfigurations {

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -146,8 +146,8 @@ func TestSelectModelSetsOverrideAndStatus(t *testing.T) {
 func TestPickerBorderLinesShareOneWidth(t *testing.T) {
 	v := newViewport(120, false)
 	v.showPicker(pickerModel, []pickerItem{
-		{id: "0", label: "Gemma 4 E2B - Ollama *"},
-		{id: "1", label: "Qwen 3 8B - Ollama"},
+		{id: "0", label: "Gemma 4 E2B *", detail: "Ollama"},
+		{id: "1", label: "Qwen 3 8B", detail: "Ollama"},
 	})
 
 	var widths []int
@@ -165,6 +165,33 @@ func TestPickerBorderLinesShareOneWidth(t *testing.T) {
 		if w != widths[0] {
 			t.Errorf("panel line %d width = %d, want %d (title border must match the panel)", i, w, widths[0])
 		}
+	}
+}
+
+func TestFormatPickerLabelAlignsDetail(t *testing.T) {
+	rows := []pickerItem{
+		{label: "Gemma 4 E2B *", detail: "Ollama"},
+		{label: "Qwen 3 8B", detail: "Ollama"},
+		{label: "GPT-4o", detail: "OpenAI"},
+	}
+	const avail = 40
+	for _, row := range rows {
+		got := formatPickerLabel(row, avail)
+		if len([]rune(got)) != avail {
+			t.Errorf("%q: width = %d, want %d", got, len([]rune(got)), avail)
+		}
+		if !strings.HasSuffix(got, row.detail) {
+			t.Errorf("%q: detail %q must be flush right", got, row.detail)
+		}
+	}
+
+	long := pickerItem{label: strings.Repeat("x", 60), detail: "Ollama"}
+	got := formatPickerLabel(long, avail)
+	if len([]rune(got)) != avail {
+		t.Errorf("long label: width = %d, want %d", len([]rune(got)), avail)
+	}
+	if !strings.Contains(got, "...") || !strings.HasSuffix(got, "Ollama") {
+		t.Errorf("long label must truncate and keep detail flush right, got %q", got)
 	}
 }
 

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -95,6 +95,31 @@ func TestModelsLoadedShowsPicker(t *testing.T) {
 	}
 }
 
+func TestStartupLoadKeepsOpenPickerListStable(t *testing.T) {
+	m := NewModel(config.DefaultConfig(), nil)
+	updated, _ := m.handleModelsLoaded(ModelsLoadedMsg{Response: testProviderResponse(), ShowPicker: true})
+	m = updated.(Model)
+
+	late := &models.LLMProviderResponse{
+		Providers: []models.LLMProviderDescriptor{
+			{
+				ID:                  3,
+				Provider:            "ollama",
+				ProviderDisplayName: "Ollama",
+				ModelConfigurations: []models.ModelConfiguration{
+					{ID: intPtr(30), Name: "llama3", IsVisible: true},
+				},
+			},
+		},
+	}
+	updated, _ = m.handleModelsLoaded(ModelsLoadedMsg{Response: late})
+	m = updated.(Model)
+
+	if len(m.llmModels) != 2 {
+		t.Errorf("expected the picker's model list to stay at 2 entries, got %d", len(m.llmModels))
+	}
+}
+
 func TestSelectModelSetsOverrideAndStatus(t *testing.T) {
 	m := NewModel(config.DefaultConfig(), nil)
 	updated, _ := m.handleModelsLoaded(ModelsLoadedMsg{Response: testProviderResponse()})

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -175,23 +175,26 @@ func TestFormatPickerLabelAlignsDetail(t *testing.T) {
 		{label: "GPT-4o", detail: "OpenAI"},
 	}
 	const avail = 40
+	col := pickerDetailCol(rows, avail)
+	if want := len([]rune("Gemma 4 E2B *")) + 2; col != want {
+		t.Errorf("detailCol = %d, want %d (widest label + 2)", col, want)
+	}
 	for _, row := range rows {
-		got := formatPickerLabel(row, avail)
-		if len([]rune(got)) != avail {
-			t.Errorf("%q: width = %d, want %d", got, len([]rune(got)), avail)
-		}
-		if !strings.HasSuffix(got, row.detail) {
-			t.Errorf("%q: detail %q must be flush right", got, row.detail)
+		got := formatPickerLabel(row, avail, col)
+		if idx := strings.Index(got, row.detail); idx != col {
+			t.Errorf("%q: detail starts at %d, want column %d", got, idx, col)
 		}
 	}
 
-	long := pickerItem{label: strings.Repeat("x", 60), detail: "Ollama"}
-	got := formatPickerLabel(long, avail)
-	if len([]rune(got)) != avail {
-		t.Errorf("long label: width = %d, want %d", len([]rune(got)), avail)
+	// A long label truncates so its detail stays on the shared column.
+	long := append(rows, pickerItem{label: strings.Repeat("x", 60), detail: "Ollama"})
+	col = pickerDetailCol(long, avail)
+	got := formatPickerLabel(long[3], avail, col)
+	if len([]rune(got)) > avail {
+		t.Errorf("long label: width = %d, want <= %d", len([]rune(got)), avail)
 	}
-	if !strings.Contains(got, "...") || !strings.HasSuffix(got, "Ollama") {
-		t.Errorf("long label must truncate and keep detail flush right, got %q", got)
+	if !strings.Contains(got, "...") || strings.Index(got, "Ollama") != col {
+		t.Errorf("long label must truncate and keep detail on column %d, got %q", col, got)
 	}
 }
 

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/config"
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+)
+
+func intPtr(v int) *int { return &v }
+
+func strPtr(v string) *string { return &v }
+
+func testProviderResponse() *models.LLMProviderResponse {
+	return &models.LLMProviderResponse{
+		Providers: []models.LLMProviderDescriptor{
+			{
+				ID:                  1,
+				Name:                strPtr("OpenAI Prod"),
+				Provider:            "openai",
+				ProviderDisplayName: "OpenAI",
+				ModelConfigurations: []models.ModelConfiguration{
+					{ID: intPtr(10), Name: "gpt-4o", IsVisible: true, DisplayName: strPtr("GPT-4o")},
+					{ID: intPtr(11), Name: "gpt-4o-mini", IsVisible: false},
+				},
+			},
+			{
+				ID:                  2,
+				Provider:            "anthropic",
+				ProviderDisplayName: "Anthropic",
+				ModelConfigurations: []models.ModelConfiguration{
+					{ID: intPtr(20), Name: "claude-sonnet-5", IsVisible: true},
+				},
+			},
+		},
+		DefaultText: &models.DefaultModel{ProviderID: 2, ModelName: "claude-sonnet-5"},
+	}
+}
+
+func TestFlattenModelOptions(t *testing.T) {
+	options := flattenModelOptions(testProviderResponse())
+
+	if len(options) != 2 {
+		t.Fatalf("expected 2 visible models, got %d", len(options))
+	}
+	if options[0].label != "GPT-4o" {
+		t.Errorf("label = %q, want %q", options[0].label, "GPT-4o")
+	}
+	if options[0].providerName != "OpenAI Prod" {
+		t.Errorf("providerName = %q, want %q", options[0].providerName, "OpenAI Prod")
+	}
+	if options[0].isDefault {
+		t.Error("gpt-4o should not be the default")
+	}
+	if options[1].label != "claude-sonnet-5" {
+		t.Errorf("label = %q, want %q", options[1].label, "claude-sonnet-5")
+	}
+	if !options[1].isDefault {
+		t.Error("claude-sonnet-5 should be the default")
+	}
+}
+
+func TestFlattenModelOptionsNil(t *testing.T) {
+	if got := flattenModelOptions(nil); got != nil {
+		t.Errorf("expected nil for nil response, got %v", got)
+	}
+}
+
+func TestModelsLoadedSetsStatusToDefault(t *testing.T) {
+	m := NewModel(config.DefaultConfig(), nil)
+	updated, _ := m.handleModelsLoaded(ModelsLoadedMsg{Response: testProviderResponse()})
+	m = updated.(Model)
+
+	if m.status.modelName != "claude-sonnet-5" {
+		t.Errorf("status model = %q, want %q", m.status.modelName, "claude-sonnet-5")
+	}
+	if m.viewport.pickerActive {
+		t.Error("startup load must not open the picker")
+	}
+}
+
+func TestModelsLoadedShowsPicker(t *testing.T) {
+	m := NewModel(config.DefaultConfig(), nil)
+	updated, _ := m.handleModelsLoaded(ModelsLoadedMsg{Response: testProviderResponse(), ShowPicker: true})
+	m = updated.(Model)
+
+	if !m.viewport.pickerActive {
+		t.Fatal("expected picker to be active")
+	}
+	if m.viewport.pickerType != pickerModel {
+		t.Errorf("pickerType = %d, want pickerModel", m.viewport.pickerType)
+	}
+	if len(m.viewport.pickerItems) != 2 {
+		t.Fatalf("expected 2 picker items, got %d", len(m.viewport.pickerItems))
+	}
+}
+
+func TestSelectModelSetsOverrideAndStatus(t *testing.T) {
+	m := NewModel(config.DefaultConfig(), nil)
+	updated, _ := m.handleModelsLoaded(ModelsLoadedMsg{Response: testProviderResponse()})
+	m = updated.(Model)
+
+	m, _ = cmdSelectModel(m, "0")
+
+	if m.modelOverride == nil {
+		t.Fatal("expected an override to be set")
+	}
+	if m.modelOverride.ModelConfigurationID == nil || *m.modelOverride.ModelConfigurationID != 10 {
+		t.Errorf("ModelConfigurationID = %v, want 10", m.modelOverride.ModelConfigurationID)
+	}
+	if m.modelOverride.ModelVersion == nil || *m.modelOverride.ModelVersion != "gpt-4o" {
+		t.Errorf("ModelVersion = %v, want gpt-4o", m.modelOverride.ModelVersion)
+	}
+	if m.status.modelName != "GPT-4o" {
+		t.Errorf("status model = %q, want %q", m.status.modelName, "GPT-4o")
+	}
+}
+
+func TestSelectModelInvalidIndex(t *testing.T) {
+	m := NewModel(config.DefaultConfig(), nil)
+	m, _ = cmdSelectModel(m, "5")
+	if m.modelOverride != nil {
+		t.Error("expected no override for an out-of-range index")
+	}
+}

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -187,9 +187,9 @@ func TestFormatPickerLabelAlignsDetail(t *testing.T) {
 	}
 
 	// A long label truncates so its detail stays on the shared column.
-	long := append(rows, pickerItem{label: strings.Repeat("x", 60), detail: "Ollama"})
-	col = pickerDetailCol(long, avail)
-	got := formatPickerLabel(long[3], avail, col)
+	longRow := pickerItem{label: strings.Repeat("x", 60), detail: "Ollama"}
+	col = pickerDetailCol(append(rows[:len(rows):len(rows)], longRow), avail)
+	got := formatPickerLabel(longRow, avail, col)
 	if len([]rune(got)) > avail {
 		t.Errorf("long label: width = %d, want <= %d", len([]rune(got)), avail)
 	}

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -1,8 +1,10 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/models"
 )
@@ -138,6 +140,31 @@ func TestSelectModelSetsOverrideAndStatus(t *testing.T) {
 	}
 	if m.status.modelName != "GPT-4o" {
 		t.Errorf("status model = %q, want %q", m.status.modelName, "GPT-4o")
+	}
+}
+
+func TestPickerBorderLinesShareOneWidth(t *testing.T) {
+	v := newViewport(120, false)
+	v.showPicker(pickerModel, []pickerItem{
+		{id: "0", label: "Gemma 4 E2B - Ollama *"},
+		{id: "1", label: "Qwen 3 8B - Ollama"},
+	})
+
+	var widths []int
+	for _, line := range strings.Split(v.renderPicker(120, 30), "\n") {
+		trimmed := strings.TrimRight(line, " ")
+		if strings.TrimSpace(stripANSI(trimmed)) == "" {
+			continue
+		}
+		widths = append(widths, lipgloss.Width(trimmed))
+	}
+	if len(widths) == 0 {
+		t.Fatal("expected rendered panel lines")
+	}
+	for i, w := range widths {
+		if w != widths[0] {
+			t.Errorf("panel line %d width = %d, want %d (title border must match the panel)", i, w, widths[0])
+		}
 	}
 }
 

--- a/cli/internal/tui/help.go
+++ b/cli/internal/tui/help.go
@@ -5,6 +5,7 @@ const helpText = `Onyx CLI Commands
   /help              Show this help message
   /clear             Clear chat and start a new session
   /agent             List and switch agents
+  /model             List and switch models
   /attach <path>     Attach a file to next message
   /sessions          Browse and resume previous sessions
   /configure         Re-run connection setup

--- a/cli/internal/tui/input.go
+++ b/cli/internal/tui/input.go
@@ -19,6 +19,7 @@ var slashCommands = []slashCommand{
 	{"/help", "Show help message"},
 	{"/clear", "Clear chat and start a new session"},
 	{"/agent", "List and switch agents"},
+	{"/model", "List and switch models"},
 	{"/attach", "Attach a file to next message"},
 	{"/sessions", "Browse and resume previous sessions"},
 	{"/configure", "Re-run connection setup"},

--- a/cli/internal/tui/messages.go
+++ b/cli/internal/tui/messages.go
@@ -35,6 +35,15 @@ type AgentsLoadedMsg struct {
 	Err    error
 }
 
+// ModelsLoadedMsg carries LLM providers fetched from the API. ShowPicker is
+// true when the fetch was triggered by /model (open the modal) and false when
+// it ran during startup (only resolve the status-bar model name).
+type ModelsLoadedMsg struct {
+	Response   *models.LLMProviderResponse
+	ShowPicker bool
+	Err        error
+}
+
 // ConfigTestResultMsg carries the result of an async connection test during /configure.
 type ConfigTestResultMsg struct {
 	Err error

--- a/cli/internal/tui/statusbar.go
+++ b/cli/internal/tui/statusbar.go
@@ -9,6 +9,7 @@ import (
 // statusBar manages the footer status display.
 type statusBar struct {
 	agentName string
+	modelName string
 	serverURL string
 	sessionID string
 	streaming bool
@@ -22,6 +23,7 @@ func newStatusBar() statusBar {
 }
 
 func (s *statusBar) setAgent(name string) { s.agentName = name }
+func (s *statusBar) setModel(name string) { s.modelName = name }
 func (s *statusBar) setServer(url string) { s.serverURL = url }
 func (s *statusBar) setSession(id string) {
 	if len(id) > 8 {
@@ -42,6 +44,9 @@ func (s statusBar) view() string {
 		name = "Default"
 	}
 	leftParts = append(leftParts, name)
+	if s.modelName != "" {
+		leftParts = append(leftParts, s.modelName)
+	}
 	left := statusBarStyle.Render(strings.Join(leftParts, " · "))
 
 	right := "Ctrl+D to quit"

--- a/cli/internal/tui/viewport.go
+++ b/cli/internal/tui/viewport.go
@@ -353,18 +353,20 @@ func (v *viewport) renderPicker(width, height int) string {
 		Bold(true).
 		Render(" " + title + " ")
 
-	// Build top border manually to avoid ANSI-corrupted rune slicing.
-	// panelWidth+2 accounts for the left and right border characters.
+	// Build top border manually to avoid ANSI-corrupted rune slicing. Measure
+	// the rendered panel instead of assuming its width — lipgloss box sizing
+	// would put the replacement line off by one.
+	panelLines := strings.Split(panel, "\n")
+	panelTotalWidth := lipgloss.Width(panelLines[len(panelLines)-1])
 	borderColor := lipgloss.NewStyle().Foreground(accentColor)
 	titleWidth := lipgloss.Width(titleRendered)
-	rightDashes := panelWidth + 2 - 3 - titleWidth // total - "╭─" - "╮" - title
+	rightDashes := panelTotalWidth - 3 - titleWidth // total - "╭─" - "╮" - title
 	if rightDashes < 0 {
 		rightDashes = 0
 	}
 	topBorder := borderColor.Render("╭─") + titleRendered +
 		borderColor.Render(strings.Repeat("─", rightDashes)+"╮")
 
-	panelLines := strings.Split(panel, "\n")
 	if len(panelLines) > 0 {
 		panelLines[0] = topBorder
 	}

--- a/cli/internal/tui/viewport.go
+++ b/cli/internal/tui/viewport.go
@@ -35,6 +35,7 @@ type pickerKind int
 const (
 	pickerSession pickerKind = iota
 	pickerAgent
+	pickerModel
 )
 
 // pickerItem is a selectable item in the picker.
@@ -275,6 +276,8 @@ func (v *viewport) pickerTitle() string {
 		return "Select Agent"
 	case pickerSession:
 		return "Resume Session"
+	case pickerModel:
+		return "Select Model"
 	default:
 		return "Select"
 	}

--- a/cli/internal/tui/viewport.go
+++ b/cli/internal/tui/viewport.go
@@ -38,10 +38,12 @@ const (
 	pickerModel
 )
 
-// pickerItem is a selectable item in the picker.
+// pickerItem is a selectable item in the picker. detail, when set, is
+// right-aligned on the row (like a tabwriter column).
 type pickerItem struct {
-	id    string
-	label string
+	id     string
+	label  string
+	detail string
 }
 
 // streamRenderInterval is the minimum time between markdown re-renders during streaming.
@@ -324,11 +326,7 @@ func (v *viewport) renderPicker(width, height int) string {
 	var itemLines []string
 	for i := startIdx; i < endIdx; i++ {
 		item := v.pickerItems[i]
-		label := item.label
-		labelRunes := []rune(label)
-		if len(labelRunes) > innerWidth-4 {
-			label = string(labelRunes[:innerWidth-7]) + "..."
-		}
+		label := formatPickerLabel(item, innerWidth-4)
 		if i == v.pickerIndex {
 			line := lipgloss.NewStyle().Foreground(accentColor).Bold(true).Render("> " + label)
 			itemLines = append(itemLines, line)
@@ -374,6 +372,31 @@ func (v *viewport) renderPicker(width, height int) string {
 
 	// Center the panel in the viewport
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, panel)
+}
+
+// formatPickerLabel fits an item into avail columns. When the item has a
+// detail, the detail is right-aligned with at least a two-space gap and the
+// label is truncated to make room.
+func formatPickerLabel(item pickerItem, avail int) string {
+	label := []rune(item.label)
+	if item.detail == "" {
+		if len(label) > avail {
+			return string(label[:avail-3]) + "..."
+		}
+		return string(label)
+	}
+
+	detail := []rune(item.detail)
+	maxLabel := avail - len(detail) - 2
+	if maxLabel < 8 {
+		// Too narrow for columns — fall back to an inline suffix.
+		return formatPickerLabel(pickerItem{label: item.label + "  " + item.detail}, avail)
+	}
+	if len(label) > maxLabel {
+		label = []rune(string(label[:maxLabel-3]) + "...")
+	}
+	gap := avail - len(label) - len(detail)
+	return string(label) + strings.Repeat(" ", gap) + string(detail)
 }
 
 // streamingContent returns the display content for the in-progress stream.

--- a/cli/internal/tui/viewport.go
+++ b/cli/internal/tui/viewport.go
@@ -323,10 +323,14 @@ func (v *viewport) renderPicker(width, height int) string {
 		}
 	}
 
+	// Computed over all items (not just the visible window) so the column
+	// stays put while scrolling.
+	detailCol := pickerDetailCol(v.pickerItems, innerWidth-4)
+
 	var itemLines []string
 	for i := startIdx; i < endIdx; i++ {
 		item := v.pickerItems[i]
-		label := formatPickerLabel(item, innerWidth-4)
+		label := formatPickerLabel(item, innerWidth-4, detailCol)
 		if i == v.pickerIndex {
 			line := lipgloss.NewStyle().Foreground(accentColor).Bold(true).Render("> " + label)
 			itemLines = append(itemLines, line)
@@ -374,29 +378,55 @@ func (v *viewport) renderPicker(width, height int) string {
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, panel)
 }
 
+// pickerDetailCol returns the column where the detail column starts, so
+// details left-align across rows: two past the widest label, pulled back so
+// the widest detail still fits in avail. Zero when no item has a detail.
+func pickerDetailCol(items []pickerItem, avail int) int {
+	maxLabel, maxDetail := 0, 0
+	for _, it := range items {
+		if it.detail == "" {
+			continue
+		}
+		if w := len([]rune(it.label)); w > maxLabel {
+			maxLabel = w
+		}
+		if w := len([]rune(it.detail)); w > maxDetail {
+			maxDetail = w
+		}
+	}
+	if maxDetail == 0 {
+		return 0
+	}
+	col := maxLabel + 2
+	if col > avail-maxDetail {
+		col = avail - maxDetail
+	}
+	if col < 10 {
+		col = 10
+	}
+	return col
+}
+
 // formatPickerLabel fits an item into avail columns. When the item has a
-// detail, the detail is right-aligned with at least a two-space gap and the
-// label is truncated to make room.
-func formatPickerLabel(item pickerItem, avail int) string {
+// detail, the label is truncated to end before detailCol and the detail is
+// left-aligned at detailCol.
+func formatPickerLabel(item pickerItem, avail int, detailCol int) string {
 	label := []rune(item.label)
-	if item.detail == "" {
+	if item.detail == "" || detailCol <= 0 {
 		if len(label) > avail {
 			return string(label[:avail-3]) + "..."
 		}
 		return string(label)
 	}
 
-	detail := []rune(item.detail)
-	maxLabel := avail - len(detail) - 2
-	if maxLabel < 8 {
-		// Too narrow for columns — fall back to an inline suffix.
-		return formatPickerLabel(pickerItem{label: item.label + "  " + item.detail}, avail)
+	if len(label) > detailCol-2 {
+		label = []rune(string(label[:detailCol-5]) + "...")
 	}
-	if len(label) > maxLabel {
-		label = []rune(string(label[:maxLabel-3]) + "...")
+	out := []rune(string(label) + strings.Repeat(" ", detailCol-len(label)) + item.detail)
+	if len(out) > avail {
+		return string(out[:avail-3]) + "..."
 	}
-	gap := avail - len(label) - len(detail)
-	return string(label) + strings.Repeat(" ", gap) + string(detail)
+	return string(out)
 }
 
 // streamingContent returns the display content for the in-progress stream.


### PR DESCRIPTION
## Summary

Adds a model switcher to the Onyx CLI chat TUI.

- `/model` fetches the LLM providers the user can access (`GET /api/llm/provider`) and opens the picker modal. Each entry shows the model's display name, its provider, and a `*` marker on the model in effect.
- Selecting a model sets an `llm_override` on subsequent `send-chat-message` requests. The override carries `model_configuration_id` (unambiguous) plus name-based fields as a fallback for older servers.
- The status bar shows the current model. On startup the CLI resolves it to the workspace default text model.
- `/model` is listed in the slash-command menu and `/help`.

## Tests

Unit tests in `cli/internal/tui/commands_test.go` cover provider flattening (visibility filter, display-name fallback, default marking), the startup vs. picker load paths, and model selection (override + status bar). `go test ./...` and pre-commit (golangci-lint) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1416" height="902" alt="20260821_18h18m20s_grim" src="https://github.com/user-attachments/assets/c1dc7595-48db-484b-9f0b-fe87ffac62ee" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-session model switcher to the CLI chat. Previously messages always used the agent/workspace default; now users can choose a model via /model, and the status bar shows the model in effect.

- `/model` loads accessible providers and visible models, opens a picker with the model label and a left-aligned provider column, marks the active model, and selection sets an `llm_override` (model_configuration_id) for subsequent messages and updates the status bar. The picker list stays stable if a late startup fetch arrives.
- On startup, the CLI loads providers to resolve and display the workspace default model; if loading fails, the status bar omits the model and the app continues.
- API/client: add `ListLLMProviders`; extend `ClientAPI.SendMessageStream` to accept `llmOverride`; include `llm_override` in the send-message payload. Send the name-based provider fallback only when the provider has a config name.
- UI: align the picker title border with the panel width, compute a shared provider column two past the widest label (stable while scrolling), and truncate long labels to preserve alignment.

<sup>Written for commit effbd87833df75662b1b8376ab12d30706f858e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





