### PR TITLE
refactor(web): move the IconButton call sites to Opal Button

### DIFF
--- a/web/lib/opal/src/core/animations/styles.css
+++ b/web/lib/opal/src/core/animations/styles.css
@@ -19,6 +19,15 @@
     opacity: 0;
   }
 
+  /* An invisible item must not intercept clicks aimed at what sits under it.
+     Local mode is excluded: it reveals on its own hover, so taking its pointer
+     events away would leave it permanently hidden. */
+  .hoverable-item[data-hoverable-variant="appear-on-hover"]:not(
+    [data-hoverable-local]
+  ) {
+    pointer-events: none;
+  }
+
   /* Group mode — Root :hover controls descendant item visibility via CSS.
      Exclude local-mode items so they aren't revealed by an ancestor root. */
   [data-hover-group]:hover
@@ -26,6 +35,7 @@
       [data-hoverable-local]
     ) {
     opacity: 1;
+    pointer-events: auto;
   }
 
   /* Local mode — item handles its own :hover */
@@ -40,6 +50,7 @@
     [data-hoverable-local]
   ) {
   opacity: 1;
+  pointer-events: auto;
 }
 
 /* Group focus — any focusable descendant of the Root receives keyboard focus,
@@ -49,11 +60,13 @@
     [data-hoverable-local]
   ) {
   opacity: 1;
+  pointer-events: auto;
 }
 
 /* Local focus — item (or a focusable descendant) receives keyboard focus */
 .hoverable-item[data-hoverable-variant="appear-on-hover"]:has(:focus-visible) {
   opacity: 1;
+  pointer-events: auto;
 }
 
 /* ---------------------------------------------------------------------------
@@ -71,6 +84,7 @@
       [data-hoverable-local]
     ) {
     opacity: 0;
+    pointer-events: none;
   }
 
   /* Local mode */
@@ -85,6 +99,7 @@
     [data-hoverable-local]
   ) {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* Group focus */
@@ -93,6 +108,7 @@
     [data-hoverable-local]
   ) {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* Local focus */

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -29,11 +29,10 @@ import RefreshText from "@/refresh-components/texts/Text";
 import { renderSidebarLogo } from "@/lib/sidebar/utils";
 import { useShowLogoWhenFolded } from "@/lib/sidebar/hooks";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";
 import LineItem from "@/refresh-components/buttons/LineItem";
+import { Hoverable } from "@opal/core";
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
 import {
   SvgEditBig,
   SvgArrowLeft,
@@ -166,16 +165,18 @@ function BuildSessionButton({
     <>
       <Popover.Trigger asChild onClick={noProp()}>
         <div>
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <IconButton
-            icon={SvgMoreHorizontal}
-            className={cn(
-              !popoverOpen && "hidden",
-              !renaming && "group-hover/SidebarTab:flex"
-            )}
-            transient={popoverOpen}
-            internal
-          />
+          {/* While renaming the row is an input, so the menu stays away unless
+              its own popover is already open. */}
+          {(!renaming || popoverOpen) && (
+            <Hoverable.Item group="CraftSessionTab">
+              <Button
+                icon={SvgMoreHorizontal}
+                prominence="internal"
+                size="sm"
+                interaction={popoverOpen ? "hover" : "rest"}
+              />
+            </Hoverable.Item>
+          )}
         </div>
       </Popover.Trigger>
       <Popover.Content side="right" align="start">
@@ -211,37 +212,42 @@ function BuildSessionButton({
         }}
       >
         <Popover.Anchor>
-          <SidebarTab
-            /* While renaming, drop the click target so the input stays usable. */
-            onClick={renaming ? undefined : onLoad}
-            selected={isActive}
-            rightChildren={rightMenu}
+          <Hoverable.Root
+            group="CraftSessionTab"
+            interaction={popoverOpen ? "hover" : "rest"}
           >
-            {renaming ? (
-              <ButtonRenaming
-                initialName={historyItem.title}
-                onRename={onRename}
-                onClose={() => setRenaming(false)}
-              />
-            ) : shouldAnimate ? (
-              // Opal Text takes string children only; this wraps <TypewriterText>.
-              <RefreshText
-                as="p"
-                data-state={isActive ? "active" : "inactive"}
-                className="line-clamp-1 break-all text-left"
-                mainUiBody
-              >
-                <TypewriterText
-                  text={historyItem.title}
-                  charSpeed={25}
-                  animateOnMount={true}
-                  onAnimationComplete={() => setShouldAnimate(false)}
+            <SidebarTab
+              /* While renaming, drop the click target so the input stays usable. */
+              onClick={renaming ? undefined : onLoad}
+              selected={isActive}
+              rightChildren={rightMenu}
+            >
+              {renaming ? (
+                <ButtonRenaming
+                  initialName={historyItem.title}
+                  onRename={onRename}
+                  onClose={() => setRenaming(false)}
                 />
-              </RefreshText>
-            ) : (
-              historyItem.title
-            )}
-          </SidebarTab>
+              ) : shouldAnimate ? (
+                // Opal Text takes string children only; this wraps <TypewriterText>.
+                <RefreshText
+                  as="p"
+                  data-state={isActive ? "active" : "inactive"}
+                  className="line-clamp-1 break-all text-left"
+                  mainUiBody
+                >
+                  <TypewriterText
+                    text={historyItem.title}
+                    charSpeed={25}
+                    animateOnMount={true}
+                    onAnimationComplete={() => setShouldAnimate(false)}
+                  />
+                </RefreshText>
+              ) : (
+                historyItem.title
+              )}
+            </SidebarTab>
+          </Hoverable.Root>
         </Popover.Anchor>
       </Popover>
       {isDeleteModalOpen && (

--- a/web/src/components/EditableStringFieldDisplay.tsx
+++ b/web/src/components/EditableStringFieldDisplay.tsx
@@ -1,8 +1,8 @@
 import { SvgEdit } from "@opal/icons";
+import { Button } from "@opal/components";
 import { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@opal/utils";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgCheck, SvgX } from "@opal/icons";
 interface EditableStringFieldDisplayProps {
   value: string;
@@ -112,19 +112,17 @@ export function EditableStringFieldDisplay({
         ))}
       {isEditing && isEditable ? (
         <>
-          <div className={cn("flex", "flex-row")}>
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <IconButton
+          <div className={cn("flex", "flex-row", "gap-2", "pl-2")}>
+            <Button
               onClick={handleUpdate}
-              internal
-              className="ml-2"
+              prominence="internal"
+              size="sm"
               icon={SvgCheck}
             />
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <IconButton
+            <Button
               onClick={resetEditing}
-              internal
-              className="ml-2"
+              prominence="internal"
+              size="sm"
               icon={SvgX}
             />
           </div>

--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -7,8 +7,8 @@ import { getIconForAction } from "@/app/app/services/actionUtils";
 import { ToolAuthStatus } from "@/lib/hooks/useToolOAuthStatus";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { Tooltip } from "@opal/components";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { Button } from "@opal/components";
+import { Hoverable } from "@opal/core";
 import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import type { IconProps } from "@opal/types";
@@ -91,125 +91,138 @@ export default function ActionLineItem({
 
   const tooltipText = tooltip || tool?.description;
 
+  // Declared once because it renders both bare and hover-revealed, depending
+  // on whether the action is already disabled.
+  const toggleButton = (
+    <Button
+      icon={SvgSlash}
+      onClick={noProp(onToggle)}
+      prominence="internal"
+      size="sm"
+      aria-label={disabled ? "Enable" : "Disable"}
+      tooltip={disabled ? "Enable" : "Disable"}
+    />
+  );
+
   return (
     <Tooltip tooltip={tooltipText}>
-      <LineItem
-        data-testid={`tool-option-${toolName}`}
-        onClick={() => {
-          if (isUnavailable) {
+      <Hoverable.Root group="ActionLineItem">
+        <LineItem
+          data-testid={`tool-option-${toolName}`}
+          onClick={() => {
+            if (isUnavailable) {
+              onForceToggle();
+              return;
+            }
+            if (disabled) onToggle();
             onForceToggle();
-            return;
+            if (isSearchToolAndNotInProject && !isForced)
+              onSourceManagementOpen?.();
+            else onClose?.();
+          }}
+          selected={isForced}
+          disabled={
+            isSearchToolWithNoConnectors || (isUnavailable && !isForced)
           }
-          if (disabled) onToggle();
-          onForceToggle();
-          if (isSearchToolAndNotInProject && !isForced)
-            onSourceManagementOpen?.();
-          else onClose?.();
-        }}
-        selected={isForced}
-        disabled={isSearchToolWithNoConnectors || (isUnavailable && !isForced)}
-        muted={isUnavailable && isForced}
-        strikethrough={disabled}
-        icon={Icon}
-        rightChildren={
-          <Section gap={1} flexDirection="row">
-            {!isUnavailable && tool?.oauth_config_id && toolAuthStatus && (
-              <Button
-                icon={SvgKey}
-                prominence="secondary"
-                size="sm"
-                onClick={noProp(() => {
-                  if (
-                    !toolAuthStatus.hasToken ||
-                    toolAuthStatus.isTokenExpired
-                  ) {
-                    onOAuthAuthenticate?.();
-                  }
-                })}
-              />
-            )}
-
-            {!isSearchToolWithNoConnectors &&
-              !isUnavailable && (
-                // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-                <IconButton
-                  icon={SvgSlash}
-                  onClick={noProp(onToggle)}
-                  internal
-                  aria-label={disabled ? "Enable" : "Disable"}
-                  className={cn(
-                    !disabled && "invisible group-hover/LineItem:visible",
-                    // Hide when showing source count (it has its own hover behavior)
-                    shouldShowSourceCount && "hidden!"
-                  )}
-                  tooltip={disabled ? "Enable" : "Disable"}
+          muted={isUnavailable && isForced}
+          strikethrough={disabled}
+          icon={Icon}
+          rightChildren={
+            <Section gap={1} flexDirection="row">
+              {!isUnavailable && tool?.oauth_config_id && toolAuthStatus && (
+                <Button
+                  icon={SvgKey}
+                  prominence="secondary"
+                  size="sm"
+                  onClick={noProp(() => {
+                    if (
+                      !toolAuthStatus.hasToken ||
+                      toolAuthStatus.isTokenExpired
+                    ) {
+                      onOAuthAuthenticate?.();
+                    }
+                  })}
                 />
               )}
 
-            {isUnavailable && showAdminConfigure && adminConfigureHref && (
-              <Button
-                icon={SvgSettings}
-                onClick={noProp(() => {
-                  router.push(adminConfigureHref as Route);
-                  onClose?.();
-                })}
-                prominence="tertiary"
-                size="sm"
-                tooltip={adminConfigureTooltip}
-              />
-            )}
+              {!isSearchToolWithNoConnectors &&
+                !isUnavailable &&
+                // The source count owns this slot when shown, and brings its own
+                // hover behaviour.
+                !shouldShowSourceCount &&
+                (disabled ? (
+                  toggleButton
+                ) : (
+                  <Hoverable.Item group="ActionLineItem">
+                    {toggleButton}
+                  </Hoverable.Item>
+                ))}
 
-            {/* Source count for internal search - show when some but not all sources selected AND tool is pinned */}
-            {shouldShowSourceCount && (
-              <span className="relative flex items-center whitespace-nowrap">
-                {/* Show count normally, disable icon on hover - both in same space */}
-                <span className="group-hover/LineItem:invisible">
-                  <EnabledCount
-                    enabledCount={sourceCounts.enabled}
-                    totalCount={sourceCounts.total}
-                  />
-                </span>
-                <span className="absolute inset-0 flex items-center justify-center invisible group-hover/LineItem:visible">
-                  <Button
-                    icon={SvgSlash}
-                    onClick={noProp(onToggle)}
-                    prominence="tertiary"
-                    size="sm"
-                    tooltip={disabled ? "Enable" : "Disable"}
-                  />
-                </span>
-              </span>
-            )}
+              {isUnavailable && showAdminConfigure && adminConfigureHref && (
+                <Button
+                  icon={SvgSettings}
+                  onClick={noProp(() => {
+                    router.push(adminConfigureHref as Route);
+                    onClose?.();
+                  })}
+                  prominence="tertiary"
+                  size="sm"
+                  tooltip={adminConfigureTooltip}
+                />
+              )}
 
-            {isSearchToolAndNotInProject && (
-              <Button
-                aria-label={
-                  isSearchToolWithNoConnectors
-                    ? "Add Connectors"
-                    : "Configure Connectors"
-                }
-                icon={
-                  isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
-                }
-                onClick={noProp(() => {
-                  if (isSearchToolWithNoConnectors)
-                    router.push("/admin/add-connector");
-                  else onSourceManagementOpen?.();
-                })}
-                prominence="tertiary"
-                size="sm"
-                tooltip={
-                  isSearchToolWithNoConnectors
-                    ? "Add Connectors"
-                    : "Configure Connectors"
-                }
-              />
-            )}
-          </Section>
-        }
-      >
-        {label}
-      </LineItem>
+              {/* Source count for internal search - show when some but not all sources selected AND tool is pinned */}
+              {shouldShowSourceCount && (
+                <span className="relative flex items-center whitespace-nowrap">
+                  {/* Show count normally, disable icon on hover - both in same space */}
+                  <span className="group-hover/LineItem:invisible">
+                    <EnabledCount
+                      enabledCount={sourceCounts.enabled}
+                      totalCount={sourceCounts.total}
+                    />
+                  </span>
+                  <span className="absolute inset-0 flex items-center justify-center invisible group-hover/LineItem:visible">
+                    <Button
+                      icon={SvgSlash}
+                      onClick={noProp(onToggle)}
+                      prominence="tertiary"
+                      size="sm"
+                      tooltip={disabled ? "Enable" : "Disable"}
+                    />
+                  </span>
+                </span>
+              )}
+
+              {isSearchToolAndNotInProject && (
+                <Button
+                  aria-label={
+                    isSearchToolWithNoConnectors
+                      ? "Add Connectors"
+                      : "Configure Connectors"
+                  }
+                  icon={
+                    isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
+                  }
+                  onClick={noProp(() => {
+                    if (isSearchToolWithNoConnectors)
+                      router.push("/admin/add-connector");
+                    else onSourceManagementOpen?.();
+                  })}
+                  prominence="tertiary"
+                  size="sm"
+                  tooltip={
+                    isSearchToolWithNoConnectors
+                      ? "Add Connectors"
+                      : "Configure Connectors"
+                  }
+                />
+              )}
+            </Section>
+          }
+        >
+          {label}
+        </LineItem>
+      </Hoverable.Root>
     </Tooltip>
   );
 }

--- a/web/src/refresh-components/popovers/FilePickerPopover.tsx
+++ b/web/src/refresh-components/popovers/FilePickerPopover.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Popover, PopoverMenu } from "@opal/components";
+import { Button, Popover, PopoverMenu } from "@opal/components";
 import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import UserFilesModal from "@/sections/modals/UserFilesModal";
 import { useCreateModal } from "@opal/components";
 import { ProjectFile, UserFileStatus } from "@/lib/projects/types";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import IconButton from "@/refresh-components/buttons/IconButton";
+import { Hoverable } from "@opal/core";
 import { toast } from "@opal/layouts";
 import { useProjectsContext } from "@/providers/ProjectsContext";
 import Text from "@/refresh-components/texts/Text";
@@ -57,42 +57,45 @@ function FileLineItem({
   );
 
   return (
-    <LineItem
-      key={projectFile.id}
-      onClick={noProp(() => onPickRecent(projectFile))}
-      icon={
-        showLoader
-          ? ({ className }) => (
-              <SvgLoader className={cn(className, "animate-spin")} />
-            )
-          : isImageFile(projectFile.name)
-            ? SvgImage
-            : SvgFileText
-      }
-      rightChildren={
-        <div className="h-4 flex flex-col justify-center">
-          {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-          <IconButton
-            icon={SvgExternalLink}
-            onClick={noProp(() => onFileClick(projectFile))}
-            tooltip="View File"
-            disabled={disableActionButton}
-            internal
-            className="hidden group-hover/LineItem:flex"
-          />
-          <Text
-            as="p"
-            className="flex group-hover/LineItem:hidden"
-            secondaryBody
-            text03
-          >
-            {getFileExtension(projectFile.name)}
-          </Text>
-        </div>
-      }
-    >
-      {projectFile.name}
-    </LineItem>
+    <Hoverable.Root group="FileLineItem">
+      <LineItem
+        key={projectFile.id}
+        onClick={noProp(() => onPickRecent(projectFile))}
+        icon={
+          showLoader
+            ? ({ className }) => (
+                <SvgLoader className={cn(className, "animate-spin")} />
+              )
+            : isImageFile(projectFile.name)
+              ? SvgImage
+              : SvgFileText
+        }
+        rightChildren={
+          <div className="h-4 flex flex-col justify-center">
+            <Hoverable.Item
+              group="FileLineItem"
+              variant="replace-on-hover"
+              resting={
+                <Text as="p" secondaryBody text03>
+                  {getFileExtension(projectFile.name)}
+                </Text>
+              }
+            >
+              <Button
+                icon={SvgExternalLink}
+                onClick={noProp(() => onFileClick(projectFile))}
+                tooltip="View File"
+                disabled={disableActionButton}
+                prominence="internal"
+                size="sm"
+              />
+            </Hoverable.Item>
+          </div>
+        }
+      >
+        {projectFile.name}
+      </LineItem>
+    </Hoverable.Root>
   );
 }
 

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -6,7 +6,6 @@ import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgMaximize2, SvgTextLines, SvgX } from "@opal/icons";
 import type { IconProps } from "@opal/types";
 import { Hoverable } from "@opal/core";
-import IconButton from "../buttons/IconButton";
 import Text from "../texts/Text";
 import Truncated from "../texts/Truncated";
 

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -1,4 +1,5 @@
 import type { FunctionComponent } from "react";
+import { Button } from "@opal/components";
 
 import { noProp } from "@/lib/utils";
 import { cn, clickOnKeyDown } from "@opal/utils";
@@ -157,7 +158,12 @@ export default function FileTile({
           )}
           {onOpen && (
             <div className="h-full">
-              <IconButton small icon={SvgMaximize2} onClick={noProp(onOpen)} />
+              <Button
+                size="xs"
+                prominence="internal"
+                icon={SvgMaximize2}
+                onClick={noProp(onOpen)}
+              />
             </div>
           )}
         </div>

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -1,11 +1,10 @@
 import type { FunctionComponent } from "react";
 import { Button } from "@opal/components";
-
-import { noProp } from "@/lib/utils";
 import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgMaximize2, SvgTextLines, SvgX } from "@opal/icons";
 import type { IconProps } from "@opal/types";
 import { Hoverable } from "@opal/core";
+import { noProp } from "@/lib/utils";
 import Text from "../texts/Text";
 import Truncated from "../texts/Truncated";
 

--- a/web/src/sections/actions/ActionCardHeader.tsx
+++ b/web/src/sections/actions/ActionCardHeader.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React, { useState } from "react";
+import { Button } from "@opal/components";
 import { cn } from "@opal/utils";
 import { ActionStatus } from "@/lib/tools/types";
 import Text from "@/refresh-components/texts/Text";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";
 import type { IconProps } from "@opal/types";
 import Truncated from "@/refresh-components/texts/Truncated";
@@ -116,16 +116,16 @@ function ActionCardHeader({
           )}
           {showRenameIcon && (
             <Hoverable.Item group="action-card" variant="appear-on-hover">
-              {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-              <IconButton
-                icon={SvgEdit}
-                tooltip="Rename"
-                internal
-                tertiary
-                onClick={handleRenameClick}
-                className="h-6 w-6 opacity-70 hover:opacity-100"
-                aria-label={`Rename ${title}`}
-              />
+              <div className="opacity-70 hover:opacity-100">
+                <Button
+                  icon={SvgEdit}
+                  tooltip="Rename"
+                  prominence="tertiary"
+                  size="sm"
+                  onClick={handleRenameClick}
+                  aria-label={`Rename ${title}`}
+                />
+              </div>
             </Hoverable.Item>
           )}
         </div>

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "@opal/layouts";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ActionCard from "@/sections/actions/ActionCard";
 import Actions from "@/sections/actions/Actions";
 import ToolsList from "@/sections/actions/ToolsList";

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -5,10 +5,8 @@ import { MinimalAgent } from "@/lib/agents/types";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import { Button } from "@opal/components";
 import { useAppRouter } from "@/hooks/appNavigation";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { usePinnedAgents, useAgent } from "@/lib/agents/hooks";
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { can } from "@/lib/permissions/resource-actions";
@@ -29,7 +27,7 @@ import { ShareAgentModal } from "@/lib/agents/components";
 import { AgentViewerModal } from "@/lib/agents/components";
 import { CardItemLayout } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
-import { Interactive } from "@opal/core";
+import { Hoverable, Interactive } from "@opal/core";
 import { Card } from "@/refresh-components/cards";
 
 export interface AgentCardProps {
@@ -59,6 +57,16 @@ export default function AgentCard({ agent }: AgentCardProps) {
     route({ agentId: agent.id });
   }, [pinned, togglePinnedAgent, agent, route]);
 
+  // Declared once because it renders both bare and wrapped, depending on `pinned`.
+  const pinButton = (
+    <Button
+      icon={pinned ? SvgPinned : SvgPin}
+      prominence="tertiary"
+      onClick={noProp(() => togglePinnedAgent(agent, !pinned))}
+      tooltip={pinned ? "Unpin from Sidebar" : "Pin to Sidebar"}
+    />
+  );
+
   return (
     <>
       <shareAgentModal.Provider>
@@ -74,107 +82,107 @@ export default function AgentCard({ agent }: AgentCardProps) {
         onClick={() => agentViewerModal.toggle(true)}
         group="group/AgentCard"
       >
-        <Card
-          padding={0}
-          gap={0}
-          height="full"
-          className="radial-00 hover:shadow-box-00"
-        >
-          <div className="flex self-stretch h-24">
-            <CardItemLayout
-              icon={(props) => <AgentAvatar agent={agent} {...props} />}
-              title={agent.name}
-              description={agent.description}
-              rightChildren={
-                <>
-                  {can(agent, "view_stats") &&
-                    businessTier && (
-                      // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-                      <IconButton
-                        icon={SvgBarChart}
-                        tertiary
-                        onClick={noProp(() =>
-                          router.push(`/ee/agents/stats/${agent.id}` as Route)
-                        )}
-                        tooltip="View Agent Stats"
-                        className="hidden group-hover/AgentCard:flex"
-                      />
+        <Hoverable.Root group="AgentCard" height="full">
+          <Card
+            padding={0}
+            gap={0}
+            height="full"
+            className="radial-00 hover:shadow-box-00"
+          >
+            <div className="flex self-stretch h-24">
+              <CardItemLayout
+                icon={(props) => <AgentAvatar agent={agent} {...props} />}
+                title={agent.name}
+                description={agent.description}
+                rightChildren={
+                  <>
+                    {can(agent, "view_stats") && businessTier && (
+                      <Hoverable.Item group="AgentCard">
+                        <Button
+                          icon={SvgBarChart}
+                          prominence="tertiary"
+                          onClick={noProp(() =>
+                            router.push(`/ee/agents/stats/${agent.id}` as Route)
+                          )}
+                          tooltip="View Agent Stats"
+                        />
+                      </Hoverable.Item>
                     )}
-                  {can(agent, "edit") && (
-                    // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-                    <IconButton
-                      icon={SvgEdit}
-                      tertiary
-                      onClick={noProp(() =>
-                        router.push(`/app/agents/edit/${agent.id}` as Route)
-                      )}
-                      tooltip="Edit Agent"
-                      className="hidden group-hover/AgentCard:flex"
-                    />
-                  )}
-                  {can(agent, "share") && (
-                    // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-                    <IconButton
-                      icon={SvgShare}
-                      tertiary
-                      onClick={noProp(() => shareAgentModal.toggle(true))}
-                      tooltip="Share Agent"
-                      className="hidden group-hover/AgentCard:flex"
-                    />
-                  )}
-                  {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-                  <IconButton
-                    icon={pinned ? SvgPinned : SvgPin}
-                    tertiary
-                    onClick={noProp(() => togglePinnedAgent(agent, !pinned))}
-                    tooltip={pinned ? "Unpin from Sidebar" : "Pin to Sidebar"}
-                    className={cn(
-                      !pinned && "hidden group-hover/AgentCard:flex"
+                    {can(agent, "edit") && (
+                      <Hoverable.Item group="AgentCard">
+                        <Button
+                          icon={SvgEdit}
+                          prominence="tertiary"
+                          onClick={noProp(() =>
+                            router.push(`/app/agents/edit/${agent.id}` as Route)
+                          )}
+                          tooltip="Edit Agent"
+                        />
+                      </Hoverable.Item>
                     )}
-                  />
-                </>
-              }
-            />
-          </div>
-
-          {/* Footer section - bg-background-tint-01 */}
-          <div className="bg-background-tint-01 p-1 flex flex-row items-end justify-between w-full">
-            {/* Left side - creator and actions */}
-            <div className="flex flex-col gap-1 py-1 px-2">
-              <Content
-                icon={SvgUser}
-                title={agent.owner?.email || "Onyx"}
-                sizePreset="secondary"
-                variant="body"
-                color="muted"
-              />
-              <Content
-                icon={SvgActions}
-                title={
-                  agent.tools.length > 0
-                    ? `${agent.tools.length} Action${
-                        agent.tools.length > 1 ? "s" : ""
-                      }`
-                    : "No Actions"
+                    {can(agent, "share") && (
+                      <Hoverable.Item group="AgentCard">
+                        <Button
+                          icon={SvgShare}
+                          prominence="tertiary"
+                          onClick={noProp(() => shareAgentModal.toggle(true))}
+                          tooltip="Share Agent"
+                        />
+                      </Hoverable.Item>
+                    )}
+                    {/* A pinned agent shows its pin at rest; an unpinned one
+                      only offers the action on hover. */}
+                    {pinned ? (
+                      pinButton
+                    ) : (
+                      <Hoverable.Item group="AgentCard">
+                        {pinButton}
+                      </Hoverable.Item>
+                    )}
+                  </>
                 }
-                sizePreset="secondary"
-                variant="body"
-                color="muted"
               />
             </div>
 
-            {/* Right side - Start Chat button */}
-            <div className="p-0.5">
-              <Button
-                prominence="tertiary"
-                rightIcon={SvgBubbleText}
-                onClick={noProp(handleStartChat)}
-              >
-                Start Chat
-              </Button>
+            {/* Footer section - bg-background-tint-01 */}
+            <div className="bg-background-tint-01 p-1 flex flex-row items-end justify-between w-full">
+              {/* Left side - creator and actions */}
+              <div className="flex flex-col gap-1 py-1 px-2">
+                <Content
+                  icon={SvgUser}
+                  title={agent.owner?.email || "Onyx"}
+                  sizePreset="secondary"
+                  variant="body"
+                  color="muted"
+                />
+                <Content
+                  icon={SvgActions}
+                  title={
+                    agent.tools.length > 0
+                      ? `${agent.tools.length} Action${
+                          agent.tools.length > 1 ? "s" : ""
+                        }`
+                      : "No Actions"
+                  }
+                  sizePreset="secondary"
+                  variant="body"
+                  color="muted"
+                />
+              </div>
+
+              {/* Right side - Start Chat button */}
+              <div className="p-0.5">
+                <Button
+                  prominence="tertiary"
+                  rightIcon={SvgBubbleText}
+                  onClick={noProp(handleStartChat)}
+                >
+                  Start Chat
+                </Button>
+              </div>
             </div>
-          </div>
-        </Card>
+          </Card>
+        </Hoverable.Root>
       </Interactive.Simple>
     </>
   );

--- a/web/src/sections/agents/InsertUserVariableMenu.tsx
+++ b/web/src/sections/agents/InsertUserVariableMenu.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from "react";
 import { useFormikContext } from "formik";
-import { Popover, PopoverMenu } from "@opal/components";
+import { Button, Popover, PopoverMenu } from "@opal/components";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgBracketCurly } from "@opal/icons";
 import {
   USER_DIRECTORY_PLACEHOLDERS,
@@ -72,9 +71,9 @@ export default function InsertUserVariableMenu({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <div>
-          <IconButton
-            internal
-            small
+          <Button
+            prominence="internal"
+            size="xs"
             icon={SvgBracketCurly}
             tooltip="Insert user variable"
           />

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -371,9 +371,10 @@ const BaseInputBar = memo(
                 <Button
                   icon={
                     sandboxInitializing
-                      ? ({ className }) => (
+                      ? ({ className, style }) => (
                           <SvgLoader
                             className={cn(className, "animate-spin")}
+                            style={style}
                           />
                         )
                       : SvgArrowUp

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -17,7 +17,7 @@ import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import IconButton from "@/refresh-components/buttons/IconButton";
-import { Text } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { SvgArrowUp, SvgLoader, SvgStop } from "@opal/icons";
 import Keycap from "@/refresh-components/Keycap";
 import { useContentEditable } from "@/hooks/useContentEditable";
@@ -368,8 +368,16 @@ const BaseInputBar = memo(
                     aria-label="Stop generating"
                   />
                 </div>
-                <IconButton
-                  icon={sandboxInitializing ? SvgLoader : SvgArrowUp}
+                <Button
+                  icon={
+                    sandboxInitializing
+                      ? ({ className }) => (
+                          <SvgLoader
+                            className={cn(className, "animate-spin")}
+                          />
+                        )
+                      : SvgArrowUp
+                  }
                   onClick={handleSubmit}
                   disabled={!canSubmit}
                   tooltip={
@@ -380,9 +388,6 @@ const BaseInputBar = memo(
                         : "Send"
                   }
                   aria-label={isRunning ? "Queue message" : "Send"}
-                  iconClassName={
-                    sandboxInitializing ? "animate-spin" : undefined
-                  }
                 />
               </div>
             </div>

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -5,7 +5,6 @@ import Text from "@/refresh-components/texts/Text";
 import { InputTypeIn } from "@opal/components";
 import { updateUserPersonalization } from "@/lib/users/svc";
 import { useUser } from "@/providers/UserProvider";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { Button } from "@opal/components";
 import InputAvatar from "@/refresh-components/inputs/InputAvatar";
 import { cn, clickOnKeyDown } from "@opal/utils";
@@ -158,7 +157,12 @@ export default function NonAdminStep() {
             <div className="p-1 flex items-center gap-1">
               {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
               <Hoverable.Item group="nonAdminName" variant="appear-on-hover">
-                <IconButton internal icon={SvgEdit} tooltip="Edit" />
+                <Button
+                  prominence="internal"
+                  size="sm"
+                  icon={SvgEdit}
+                  tooltip="Edit"
+                />
               </Hoverable.Item>
               <SvgCheckCircle className="w-4 h-4 stroke-status-success-05" />
             </div>

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from "react";
 import Text from "@/refresh-components/texts/Text";
-import { InputTypeIn } from "@opal/components";
+import { Button, InputTypeIn } from "@opal/components";
 import {
   OnboardingState,
   OnboardingActions,
@@ -10,7 +10,6 @@ import {
 } from "@/interfaces/onboarding";
 import InputAvatar from "@/refresh-components/inputs/InputAvatar";
 import { cn, clickOnKeyDown } from "@opal/utils";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { SvgCheckCircle, SvgEdit, SvgUser } from "@opal/icons";
 import { InputHorizontal } from "@opal/layouts";
 import { Hoverable } from "@opal/core";
@@ -101,9 +100,13 @@ const NameStep = React.memo(
             </Text>
           </div>
           <div className="p-1 flex items-center gap-1">
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
             <Hoverable.Item group="nameStep" variant="appear-on-hover">
-              <IconButton internal icon={SvgEdit} tooltip="Edit" />
+              <Button
+                prominence="internal"
+                size="sm"
+                icon={SvgEdit}
+                tooltip="Edit"
+              />
             </Hoverable.Item>
             <SvgCheckCircle
               className={cn(

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -7,7 +7,6 @@ import { deleteChatSession, renameChatSession } from "@/app/app/services/lib";
 import { ChatSession } from "@/app/app/interfaces";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
 import { Popover, PopoverMenu } from "@opal/components";
 import { useAppRouter } from "@/hooks/appNavigation";
 import type { Project } from "@/lib/projects/types";
@@ -20,8 +19,8 @@ import { MoveCustomAgentChatModal } from "@/lib/agents/components";
 import { UNNAMED_CHAT } from "@/lib/constants";
 import ShareChatSessionModal from "@/sections/modals/ShareChatSessionModal";
 import { Button, LineItemButton, SidebarTab } from "@opal/components";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import { InputTypeIn } from "@opal/components";
+import { Hoverable } from "@opal/core";
 import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import { DRAG_TYPES, LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
 import {
@@ -407,16 +406,18 @@ const ChatButton = memo(
       <>
         <Popover.Trigger asChild onClick={noProp()}>
           <div>
-            {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <IconButton
-              icon={SvgMoreHorizontal}
-              className={cn(
-                !popoverOpen && "hidden",
-                !renaming && "group-hover/SidebarTab:flex"
-              )}
-              transient={popoverOpen}
-              internal
-            />
+            {/* While renaming the row is an input, so the menu stays away unless
+                its own popover is already open. */}
+            {(!renaming || popoverOpen) && (
+              <Hoverable.Item group="ChatButton">
+                <Button
+                  icon={SvgMoreHorizontal}
+                  prominence="internal"
+                  size="sm"
+                  interaction={popoverOpen ? "hover" : "rest"}
+                />
+              </Hoverable.Item>
+            )}
           </div>
         </Popover.Trigger>
         <Popover.Content side="right" align="start" width="md">
@@ -436,28 +437,33 @@ const ChatButton = memo(
         }}
       >
         <Popover.Anchor>
-          <SidebarTab
-            /* While renaming, drop the click target so the input stays usable. */
-            href={
-              isDragging || renaming
-                ? undefined
-                : `/app?chatId=${chatSession.id}`
-            }
-            onClick={renaming ? undefined : handleClick}
-            selected={active}
-            rightChildren={rightMenu}
-            nested={!!project}
+          <Hoverable.Root
+            group="ChatButton"
+            interaction={popoverOpen ? "hover" : "rest"}
           >
-            {renaming ? (
-              <ButtonRenaming
-                initialName={chatSession.name}
-                onRename={handleRename}
-                onClose={() => setRenaming(false)}
-              />
-            ) : (
-              displayName
-            )}
-          </SidebarTab>
+            <SidebarTab
+              /* While renaming, drop the click target so the input stays usable. */
+              href={
+                isDragging || renaming
+                  ? undefined
+                  : `/app?chatId=${chatSession.id}`
+              }
+              onClick={renaming ? undefined : handleClick}
+              selected={active}
+              rightChildren={rightMenu}
+              nested={!!project}
+            >
+              {renaming ? (
+                <ButtonRenaming
+                  initialName={chatSession.name}
+                  onRename={handleRename}
+                  onClose={() => setRenaming(false)}
+                />
+              ) : (
+                displayName
+              )}
+            </SidebarTab>
+          </Hoverable.Root>
         </Popover.Anchor>
       </Popover>
     );

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -22,7 +22,6 @@ import {
   SvgUserShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import SvgNoResult from "@opal/illustrations/no-result";
 import { SettingsLayouts } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
@@ -312,10 +311,10 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
           return (
             <div className="flex items-center gap-1">
               {canManage && (
-                <IconButton
+                <Button
                   icon={isPending ? SvgSimpleLoader : SvgUserShield}
-                  tertiary
-                  transient={isManager}
+                  prominence="tertiary"
+                  interaction={isManager ? "hover" : "rest"}
                   disabled={!isPersisted || isPending || isOwnManager}
                   aria-label={isManager ? "Revoke manager" : "Make manager"}
                   tooltip={
@@ -333,9 +332,9 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                   }}
                 />
               )}
-              <IconButton
+              <Button
                 icon={SvgMinusCircle}
-                tertiary
+                prominence="tertiary"
                 disabled={isOwnManager || isLastGroup}
                 aria-label="Remove member"
                 tooltip={

--- a/web/src/views/admin/GroupsPage/SharedGroupResources/ResourceContent.tsx
+++ b/web/src/views/admin/GroupsPage/SharedGroupResources/ResourceContent.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { Button } from "@opal/components";
 import { SvgX } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
 import { Content } from "@opal/layouts";
-import IconButton from "@/refresh-components/buttons/IconButton";
 
 interface ResourceContentProps {
   /** SVG icon for connectors/doc sets. */
@@ -54,7 +54,14 @@ function ResourceContent({
         )}
       </div>
       {infoContent}
-      <IconButton small icon={SvgX} onClick={onRemove} className="shrink-0" />
+      <div className="shrink-0">
+        <Button
+          size="xs"
+          prominence="internal"
+          icon={SvgX}
+          onClick={onRemove}
+        />
+      </div>
     </div>
   );
 }

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -9,7 +9,6 @@ import { planTagProps } from "@/lib/tier-badge";
 import { Section } from "@/layouts/general-layouts";
 import InputNumber from "@/refresh-components/inputs/InputNumber";
 import Text from "@/refresh-components/texts/Text";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 
 // ---------------------------------------------------------------------------
@@ -194,8 +193,9 @@ function TokenLimitSection({
                         placeholder="1"
                       />
                     </div>
-                    <IconButton
-                      small
+                    <Button
+                      size="xs"
+                      prominence="internal"
                       icon={SvgMinusCircle}
                       onClick={() => removeLimit(i)}
                     />

--- a/web/src/views/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/views/admin/UsersPage/UsersSummary.tsx
@@ -4,7 +4,6 @@ import { Button, Card } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { clickOnKeyDown } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
-import IconButton from "@/refresh-components/buttons/IconButton";
 import Text from "@/refresh-components/texts/Text";
 import Link from "next/link";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -39,11 +38,11 @@ function StatCell({ value, label, onFilter }: StatCellProps) {
       {onFilter && (
         <div className="absolute right-1 top-1">
           <Hoverable.Item group="stat" variant="appear-on-hover">
-            <IconButton
-              tertiary
+            <Button
+              prominence="tertiary"
               icon={SvgFilterPlus}
               tooltip="Add Filter"
-              toolTipPosition="left"
+              tooltipSide="left"
               onClick={(e) => {
                 e.stopPropagation();
                 onFilter();


### PR DESCRIPTION
## Description

Moves the `IconButton` call sites onto Opal's `Button`. 16 of 21 files are done; the last five are listed below and are deliberately left alone.

Opal `Button` refuses `className` by design (`InteractiveStatelessProps extends WithoutStyles<...>`), so each site had to say what its class was actually for:

- **Prop translation.** The boolean flags become Opal's string enums: `tertiary`/`internal` → `prominence`, `small` → `size`, `transient` → `interaction`, `toolTipPosition` → `tooltipSide`. `action`, `danger`, `onHover` and `href` turned out to be unused across all 29 call sites.
- **Hover reveal → `Hoverable`.** Nine of the classes were `hidden group-hover/X:flex` or the CSS equivalent. Those are now `Hoverable.Root` + `Hoverable.Item`, which also reveals on `focus-visible` — so these actions are keyboard-reachable for the first time.
- **Positioning classes → the parent.** `shrink-0` moved to a wrapper; `ml-2` became the row's own `gap-2 pl-2`, which also follows the padding-over-margin rule.
- **`iconClassName` → a wrapped icon component**, the idiom `FilePickerPopover` already used for its spinner.

Two behaviours are worth a look rather than a read:

1. `Hoverable`'s `appear-on-hover` is opacity-based, so a hidden item still occupies layout space. `ActionLineItem` used `invisible` and matches exactly. **`AgentCard` used `hidden`**, so its card actions now reserve their space instead of reflowing the row on hover. I think that is an improvement, but it is a visual change.
2. `ActionCardHeader`'s `h-6 w-6` maps to `size="sm"` exactly (`--height-line-label` is `1.5rem`), but Opal's internal padding for that size differs slightly from the old `p-2`.

## Not migrated

Five sites override Opal's own appearance, which it has no prop for. Each needs a design decision, so they still use `IconButton`:

| Site | Override |
|---|---|
| `LLMProviderCard` | `hover:bg-transparent` — no prominence suppresses the hover background |
| `BaseInputBar` (stop) | `border-[1.5px] border-border-02` — Opal auto-borders only `prominence="secondary"`, at its own width |
| `InputImage` | `w-5! h-5! p-0.5! rounded-04!` |
| `ChatPanel` | `rounded-full p-2.5! bg-*!` — a round custom-coloured button |
| `AttachmentButton` | nested inside `<button className="attachment-item">`; already invalid HTML, and `Button` preserves it |

`IconButton.tsx` and its stories can be deleted once those five are resolved.

## Screenshots + Videos

Button changes were all mechanical. Should be no UI/UX changes here.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces most `IconButton` usages with `@opal/components` `Button` and migrates hover-only reveals to `@opal/core` `Hoverable` for keyboard access. Old behavior used Tailwind `hidden`/`group-hover`; new behavior uses `Hoverable` on hover and focus-visible. Also fixes invisible hover items intercepting clicks by toggling pointer-events in `Hoverable` CSS.

- Prop translation: booleans → enums (`tertiary`/`internal` → `prominence`, `small` → `size`, `transient` → `interaction`, `toolTipPosition` → `tooltipSide`). Removed unused `action`, `danger`, `onHover`, `href`; wrapped icons instead of `iconClassName`; moved positioning classes to parents.
- Hover behavior: replaced `hidden`/`invisible group-hover` with `Hoverable`. File picker now uses replace-on-hover (extension label ↔ open-file button). Sidebar row menus pin open while their popover is open; they do not render while renaming. `ActionLineItem` renders the toggle inline or as a hover item; when showing source counts it omits the toggle.
- Pointer-events fix: `Hoverable` now sets pointer-events: none when items are hidden (local mode excluded) to prevent invisible triggers from catching clicks (notably in sidebar rows).
- Visual diffs: `AgentCard` actions reserve space instead of reflowing on hover; small buttons use Opal padding. `ActionCardHeader` maps `h-6 w-6` to `size="sm"`. The send button wraps its spinner icon to size and spin correctly.

**Not migrated**
- `LLMProviderCard`: suppress hover background.
- `BaseInputBar` (stop): 1.5px border not expressible in Opal.
- `InputImage`: custom size and padding.
- `ChatPanel`: round, custom-colored button.
- `AttachmentButton`: nested in another `<button>`; invalid HTML retained.

<sup>Written for commit 0cf0f1588f9772b2877d83e91e5958495d8a44cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

