### PR TITLE
feat(cli): expose local skills as slash commands in the chat TUI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -183,10 +183,34 @@ onyx-cli install-skill --agent claude-code
 | `/agent` | List and switch agents |
 | `/attach <path>` | Attach a file to next message |
 | `/sessions` | List recent chat sessions |
+| `/skills` | List available skills |
 | `/configure` | Re-run connection setup |
 | `/connectors` | Open connectors in browser |
 | `/settings` | Open settings in browser |
 | `/quit` | Exit Onyx CLI |
+| `/<skill> [request]` | Run a local skill (see below) |
+
+### Skills as slash commands
+
+The TUI discovers local agent skills and exposes each one as a slash command.
+A skill is a `SKILL.md` file at `.agents/skills/<name>/SKILL.md`, in the
+current directory or in your home directory. Skills in the current directory
+win on name collisions; built-in commands always win over skills.
+
+`SKILL.md` starts with optional YAML frontmatter:
+
+```markdown
+---
+name: release-notes
+description: Draft release notes from recent changes.
+---
+
+Instructions for the agent...
+```
+
+Type `/release-notes summarize this week` to run it. The CLI sends the skill
+instructions and your request to the agent as one message. Use `/skills` to
+list discovered skills.
 
 ## Keyboard Shortcuts
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -209,8 +209,9 @@ Instructions for the agent...
 ```
 
 Type `/release-notes summarize this week` to run it. The CLI sends the skill
-instructions and your request to the agent as one message. Use `/skills` to
-list discovered skills.
+instructions and your request to the agent as one message. If the skill body
+contains `$ARGUMENTS`, your request is substituted there instead of being
+appended. Use `/skills` to list discovered skills.
 
 ## Keyboard Shortcuts
 

--- a/cli/internal/skills/skills.go
+++ b/cli/internal/skills/skills.go
@@ -1,0 +1,128 @@
+// Package skills discovers local agent skills (SKILL.md files) so the chat
+// TUI can expose them as slash commands.
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Skill is a parsed SKILL.md file.
+type Skill struct {
+	// Name is the skill's frontmatter name (falls back to the directory name).
+	Name string
+	// Description is the frontmatter description (may be empty).
+	Description string
+	// Body is the markdown content after the frontmatter.
+	Body string
+	// Path is the absolute path of the SKILL.md file.
+	Path string
+}
+
+// Command returns the slash command that invokes the skill.
+func (s Skill) Command() string {
+	return "/" + s.Name
+}
+
+// skillsSubdir is the canonical skills directory relative to a base directory.
+var skillsSubdir = filepath.Join(".agents", "skills")
+
+// validName matches skill names that are safe to use as slash commands.
+var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+// Discover loads skills from the project (working directory) and the user's
+// home directory. Project skills shadow home skills with the same name.
+// Results are sorted by name. Discovery errors are silently skipped — a
+// malformed skill must not break the chat TUI.
+func Discover() []Skill {
+	var bases []string
+	if cwd, err := os.Getwd(); err == nil {
+		bases = append(bases, cwd)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		bases = append(bases, home)
+	}
+	return discoverFrom(bases)
+}
+
+// discoverFrom loads skills from each base directory in order. Earlier bases
+// shadow later ones on name collisions.
+func discoverFrom(bases []string) []Skill {
+	seen := make(map[string]bool)
+	var result []Skill
+
+	for _, base := range bases {
+		dir := filepath.Join(base, skillsSubdir)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			// Allow symlinked skill directories (install-skill creates them).
+			info, err := os.Stat(filepath.Join(dir, entry.Name()))
+			if err != nil || !info.IsDir() {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name(), "SKILL.md")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			skill := Parse(string(raw), entry.Name())
+			skill.Path = path
+			if !validName.MatchString(skill.Name) || seen[skill.Name] {
+				continue
+			}
+			seen[skill.Name] = true
+			result = append(result, skill)
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+// Parse extracts the frontmatter name/description and the body from SKILL.md
+// content. fallbackName is used when the frontmatter has no name.
+func Parse(content string, fallbackName string) Skill {
+	skill := Skill{Name: fallbackName, Body: strings.TrimSpace(content)}
+
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	if !strings.HasPrefix(normalized, "---\n") {
+		return skill
+	}
+	rest := normalized[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return skill
+	}
+	frontmatter := rest[:end]
+	body := rest[end+len("\n---"):]
+	if i := strings.Index(body, "\n"); i >= 0 {
+		body = body[i+1:]
+	} else {
+		body = ""
+	}
+	skill.Body = strings.TrimSpace(body)
+
+	for _, line := range strings.Split(frontmatter, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		switch strings.TrimSpace(key) {
+		case "name":
+			if value != "" {
+				skill.Name = value
+			}
+		case "description":
+			skill.Description = value
+		}
+	}
+	return skill
+}

--- a/cli/internal/skills/skills_test.go
+++ b/cli/internal/skills/skills_test.go
@@ -1,0 +1,92 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSkill(t *testing.T, base, name, content string) {
+	t.Helper()
+	dir := filepath.Join(base, ".agents", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	content := "---\nname: my-skill\ndescription: Does a thing.\n---\n\n# Heading\n\nBody text.\n"
+	skill := Parse(content, "dir-name")
+
+	if skill.Name != "my-skill" {
+		t.Errorf("Name = %q, want %q", skill.Name, "my-skill")
+	}
+	if skill.Description != "Does a thing." {
+		t.Errorf("Description = %q, want %q", skill.Description, "Does a thing.")
+	}
+	if skill.Body != "# Heading\n\nBody text." {
+		t.Errorf("Body = %q", skill.Body)
+	}
+	if skill.Command() != "/my-skill" {
+		t.Errorf("Command() = %q", skill.Command())
+	}
+}
+
+func TestParseNoFrontmatter(t *testing.T) {
+	skill := Parse("# Just markdown\n", "fallback")
+	if skill.Name != "fallback" {
+		t.Errorf("Name = %q, want %q", skill.Name, "fallback")
+	}
+	if skill.Body != "# Just markdown" {
+		t.Errorf("Body = %q", skill.Body)
+	}
+}
+
+func TestParseQuotedValues(t *testing.T) {
+	content := "---\nname: \"quoted\"\ndescription: 'single'\n---\nbody\n"
+	skill := Parse(content, "x")
+	if skill.Name != "quoted" || skill.Description != "single" {
+		t.Errorf("got name=%q description=%q", skill.Name, skill.Description)
+	}
+}
+
+func TestParseUnterminatedFrontmatter(t *testing.T) {
+	content := "---\nname: broken\nno end marker\n"
+	skill := Parse(content, "fallback")
+	if skill.Name != "fallback" {
+		t.Errorf("Name = %q, want fallback", skill.Name)
+	}
+}
+
+func TestDiscoverFrom(t *testing.T) {
+	project := t.TempDir()
+	home := t.TempDir()
+
+	writeSkill(t, project, "alpha", "---\nname: alpha\ndescription: Project alpha.\n---\nA\n")
+	writeSkill(t, project, "shared", "---\nname: shared\ndescription: Project copy.\n---\nP\n")
+	writeSkill(t, home, "shared", "---\nname: shared\ndescription: Home copy.\n---\nH\n")
+	writeSkill(t, home, "beta", "---\nname: beta\n---\nB\n")
+	// Invalid name — must be skipped.
+	writeSkill(t, home, "bad", "---\nname: Bad Name!\n---\nX\n")
+
+	found := discoverFrom([]string{project, home})
+
+	if len(found) != 3 {
+		t.Fatalf("got %d skills, want 3: %+v", len(found), found)
+	}
+	if found[0].Name != "alpha" || found[1].Name != "beta" || found[2].Name != "shared" {
+		t.Errorf("unexpected order: %+v", found)
+	}
+	if found[2].Description != "Project copy." {
+		t.Errorf("project skill should shadow home skill, got %q", found[2].Description)
+	}
+}
+
+func TestDiscoverFromMissingDir(t *testing.T) {
+	if found := discoverFrom([]string{t.TempDir()}); len(found) != 0 {
+		t.Errorf("expected no skills, got %+v", found)
+	}
+}

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/api"
 	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/onyx-dot-app/onyx/cli/internal/skills"
 )
 
 // Model is the root Bubble Tea model.
@@ -44,6 +45,7 @@ type Model struct {
 	attachedFiles   []models.FileDescriptorPayload
 	needsRename     bool
 	agentStarted    bool
+	skills          []skills.Skill
 
 	// Configure state
 	configState *configState
@@ -58,16 +60,37 @@ type Model struct {
 func NewModel(cfg config.OnyxCliConfig, client api.ClientAPI) Model {
 	parentID := -1
 
+	localSkills := skills.Discover()
+	filtered := localSkills[:0]
+	for _, s := range localSkills {
+		if !isBuiltinCommand(s.Command()) {
+			filtered = append(filtered, s)
+		}
+	}
+	localSkills = filtered
+
+	input := newInputModel()
+	skillCmds := make([]slashCommand, len(localSkills))
+	for i, s := range localSkills {
+		desc := s.Description
+		if desc == "" {
+			desc = "Run the " + s.Name + " skill"
+		}
+		skillCmds[i] = slashCommand{command: s.Command(), description: desc}
+	}
+	input.setSkillCommands(skillCmds)
+
 	return Model{
 		config:          cfg,
 		client:          client,
 		viewport:        newViewport(80, cfg.Features.StreamMarkdownEnabled()),
-		input:           newInputModel(),
+		input:           input,
 		status:          newStatusBar(),
 		agentID:         cfg.DefaultAgentID,
 		agentName:       "Default",
 		parentMessageID: &parentID,
 		citations:       make(map[int]string),
+		skills:          localSkills,
 	}
 }
 
@@ -366,11 +389,17 @@ func (m Model) cancelStream() (Model, tea.Cmd) {
 }
 
 func (m Model) sendMessage(message string) (Model, tea.Cmd) {
+	return m.sendMessageWithDisplay(message, message)
+}
+
+// sendMessageWithDisplay sends message to the agent but shows display in the
+// chat view. Used by skill commands, whose full prompt is too long to show.
+func (m Model) sendMessageWithDisplay(message string, display string) (Model, tea.Cmd) {
 	if m.isStreaming {
 		return m, nil
 	}
 
-	m.viewport.addUserMessage(message)
+	m.viewport.addUserMessage(display)
 	m.viewport.startAgent()
 
 	// Prepare file descriptors

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -105,17 +105,28 @@ func cmdRunSkill(m Model, s skills.Skill, arg string) (Model, tea.Cmd) {
 	return m.sendMessageWithDisplay(skillPrompt(s, arg), display)
 }
 
-// skillPrompt builds the chat message for a skill invocation.
+// skillPrompt builds the chat message for a skill invocation. If the skill
+// body references $ARGUMENTS, the user's request is substituted there;
+// otherwise it is appended after the skill instructions.
 func skillPrompt(s skills.Skill, arg string) string {
+	body := s.Body
+	inlineArgs := strings.Contains(body, "$ARGUMENTS")
+	if inlineArgs {
+		body = strings.ReplaceAll(body, "$ARGUMENTS", arg)
+	}
+
 	var b strings.Builder
 	b.WriteString("Follow the instructions in this skill to complete my request.\n\n")
 	b.WriteString("<skill name=\"" + s.Name + "\">\n")
-	b.WriteString(s.Body)
-	b.WriteString("\n</skill>\n\n")
+	b.WriteString(body)
+	b.WriteString("\n</skill>")
+	if inlineArgs {
+		return b.String()
+	}
 	if arg != "" {
-		b.WriteString("My request: " + arg)
+		b.WriteString("\n\nMy request: " + arg)
 	} else {
-		b.WriteString("My request: run this skill.")
+		b.WriteString("\n\nMy request: run this skill.")
 	}
 	return b.String()
 }

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/browser"
 	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/onyx-dot-app/onyx/cli/internal/skills"
 )
 
 // handleSlashCommand dispatches slash commands and returns updated model + cmd.
@@ -24,7 +25,11 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 
 	switch command {
 	case "/help":
-		m.viewport.addInfo(helpText)
+		m.viewport.addInfo(renderHelp(m.skills))
+		return m, nil
+
+	case "/skills":
+		m.viewport.addInfo(renderSkillList(m.skills))
 		return m, nil
 
 	case "/agent":
@@ -74,9 +79,45 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 		return m, tea.Quit
 
 	default:
+		for _, s := range m.skills {
+			if s.Command() == command {
+				return cmdRunSkill(m, s, arg)
+			}
+		}
 		m.viewport.addWarning(fmt.Sprintf("Unknown command: %s. Type /help for available commands.", command))
 		return m, nil
 	}
+}
+
+// cmdRunSkill sends the skill's instructions (plus the user's request, if
+// any) to the agent as a chat message.
+func cmdRunSkill(m Model, s skills.Skill, arg string) (Model, tea.Cmd) {
+	if m.isStreaming {
+		m.viewport.addWarning("Wait for the current response to finish before running a skill.")
+		return m, nil
+	}
+
+	arg = strings.TrimSpace(arg)
+	display := s.Command()
+	if arg != "" {
+		display += " " + arg
+	}
+	return m.sendMessageWithDisplay(skillPrompt(s, arg), display)
+}
+
+// skillPrompt builds the chat message for a skill invocation.
+func skillPrompt(s skills.Skill, arg string) string {
+	var b strings.Builder
+	b.WriteString("Follow the instructions in this skill to complete my request.\n\n")
+	b.WriteString("<skill name=\"" + s.Name + "\">\n")
+	b.WriteString(s.Body)
+	b.WriteString("\n</skill>\n\n")
+	if arg != "" {
+		b.WriteString("My request: " + arg)
+	} else {
+		b.WriteString("My request: run this skill.")
+	}
+	return b.String()
 }
 
 func cmdNew(m Model) (Model, tea.Cmd) {

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/skills"
+)
+
+func TestSkillPrompt(t *testing.T) {
+	s := skills.Skill{Name: "release-notes", Body: "Do the thing."}
+
+	withArg := skillPrompt(s, "for v2")
+	if !strings.Contains(withArg, `<skill name="release-notes">`) {
+		t.Errorf("missing skill tag: %q", withArg)
+	}
+	if !strings.Contains(withArg, "Do the thing.") {
+		t.Errorf("missing skill body: %q", withArg)
+	}
+	if !strings.Contains(withArg, "My request: for v2") {
+		t.Errorf("missing user request: %q", withArg)
+	}
+
+	noArg := skillPrompt(s, "")
+	if !strings.Contains(noArg, "My request: run this skill.") {
+		t.Errorf("missing default request: %q", noArg)
+	}
+}
+
+func TestIsBuiltinCommand(t *testing.T) {
+	for _, cmd := range []string{"/help", "/skills", "/new", "/resume", "/quit"} {
+		if !isBuiltinCommand(cmd) {
+			t.Errorf("isBuiltinCommand(%q) = false, want true", cmd)
+		}
+	}
+	if isBuiltinCommand("/release-notes") {
+		t.Error("isBuiltinCommand(/release-notes) = true, want false")
+	}
+}
+
+func TestRenderHelpIncludesSkills(t *testing.T) {
+	help := renderHelp([]skills.Skill{{Name: "foo", Description: "Foo skill."}})
+	if !strings.Contains(help, "/foo") || !strings.Contains(help, "Foo skill.") {
+		t.Errorf("help missing skill entry: %q", help)
+	}
+
+	bare := renderHelp(nil)
+	if strings.Contains(bare, "Skills\n") {
+		t.Errorf("help without skills should omit the Skills section: %q", bare)
+	}
+}
+
+func TestSkillMenuCompletion(t *testing.T) {
+	m := newInputModel()
+	m.setSkillCommands([]slashCommand{{command: "/release-notes", description: "Draft notes"}})
+	m.textInput.SetValue("/rel")
+	m = m.updateMenu()
+
+	if !m.menuVisible || len(m.menuItems) != 1 || m.menuItems[0].command != "/release-notes" {
+		t.Errorf("menu = visible:%v items:%+v", m.menuVisible, m.menuItems)
+	}
+}

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -1,10 +1,17 @@
 package tui
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/onyx-dot-app/onyx/cli/internal/config"
 	"github.com/onyx-dot-app/onyx/cli/internal/skills"
+	"github.com/onyx-dot-app/onyx/cli/internal/testutil"
 )
 
 func TestSkillPrompt(t *testing.T) {
@@ -47,6 +54,76 @@ func TestRenderHelpIncludesSkills(t *testing.T) {
 	bare := renderHelp(nil)
 	if strings.Contains(bare, "Skills\n") {
 		t.Errorf("help without skills should omit the Skills section: %q", bare)
+	}
+}
+
+// TestSkillInvocationSendsPrompt verifies the full invocation path: the
+// agent receives the skill body plus the user's request, while the chat
+// view shows only the compact command line.
+func TestSkillInvocationSendsPrompt(t *testing.T) {
+	bodyCh := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat/send-chat-message" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		raw, _ := io.ReadAll(r.Body)
+		bodyCh <- string(raw)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := NewModel(config.OnyxCliConfig{ServerURL: srv.URL}, testutil.NewClient(srv.URL))
+	m.skills = []skills.Skill{{
+		Name:        "release-notes",
+		Description: "Draft release notes.",
+		Body:        "Collect changes and draft release notes.",
+	}}
+
+	updated, cmd := handleSlashCommand(m, "/release-notes for v2.1")
+	if cmd == nil {
+		t.Fatal("expected a stream command, got nil")
+	}
+
+	var sent string
+	select {
+	case sent = <-bodyCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent never received the chat message")
+	}
+
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(sent), &payload); err != nil {
+		t.Fatalf("bad payload: %v", err)
+	}
+	if !strings.Contains(payload.Message, `<skill name="release-notes">`) ||
+		!strings.Contains(payload.Message, "Collect changes and draft release notes.") ||
+		!strings.Contains(payload.Message, "My request: for v2.1") {
+		t.Errorf("sent message missing skill content: %q", payload.Message)
+	}
+
+	var userEntry string
+	for _, e := range updated.viewport.entries {
+		if e.kind == entryUser {
+			userEntry = e.content
+		}
+	}
+	if userEntry != "/release-notes for v2.1" {
+		t.Errorf("chat view shows %q, want compact command line", userEntry)
+	}
+}
+
+func TestSkillPromptArgumentsPlaceholder(t *testing.T) {
+	s := skills.Skill{Name: "greet", Body: "Say hello to $ARGUMENTS politely."}
+
+	got := skillPrompt(s, "Alice")
+	if !strings.Contains(got, "Say hello to Alice politely.") {
+		t.Errorf("$ARGUMENTS not substituted: %q", got)
+	}
+	if strings.Contains(got, "My request:") {
+		t.Errorf("request line should be omitted when $ARGUMENTS is used: %q", got)
 	}
 }
 

--- a/cli/internal/tui/help.go
+++ b/cli/internal/tui/help.go
@@ -1,18 +1,28 @@
 package tui
 
-const helpText = `Onyx CLI Commands
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/skills"
+)
+
+const baseHelpText = `Onyx CLI Commands
 
   /help              Show this help message
   /clear             Clear chat and start a new session
   /agent             List and switch agents
   /attach <path>     Attach a file to next message
   /sessions          Browse and resume previous sessions
+  /skills            List available skills
   /configure         Re-run connection setup
   /connectors        Open connectors page in browser
   /settings          Open Onyx settings in browser
   /experiments       List experimental features and their status
   /quit              Exit Onyx CLI
+`
 
+const keyboardHelpText = `
 Keyboard Shortcuts
 
   Enter              Send message
@@ -22,3 +32,36 @@ Keyboard Shortcuts
   Scroll Up/Down     Mouse wheel or Shift+Up/Down
   Page Up/Down       Scroll half page
 `
+
+// renderHelp builds the /help text, including discovered skills.
+func renderHelp(localSkills []skills.Skill) string {
+	var b strings.Builder
+	b.WriteString(baseHelpText)
+	if len(localSkills) > 0 {
+		b.WriteString("\nSkills\n\n")
+		b.WriteString(skillLines(localSkills))
+	}
+	b.WriteString(keyboardHelpText)
+	return b.String()
+}
+
+// renderSkillList builds the /skills output.
+func renderSkillList(localSkills []skills.Skill) string {
+	if len(localSkills) == 0 {
+		return "No skills found. Add SKILL.md files under .agents/skills/<name>/ " +
+			"in this directory or your home directory."
+	}
+	return "Available skills\n\n" + skillLines(localSkills)
+}
+
+func skillLines(localSkills []skills.Skill) string {
+	var b strings.Builder
+	for _, s := range localSkills {
+		desc := s.Description
+		if desc == "" {
+			desc = "(no description)"
+		}
+		fmt.Fprintf(&b, "  %-18s %s\n", s.Command(), desc)
+	}
+	return b.String()
+}

--- a/cli/internal/tui/input.go
+++ b/cli/internal/tui/input.go
@@ -21,6 +21,7 @@ var slashCommands = []slashCommand{
 	{"/agent", "List and switch agents"},
 	{"/attach", "Attach a file to next message"},
 	{"/sessions", "Browse and resume previous sessions"},
+	{"/skills", "List available skills"},
 	{"/configure", "Re-run connection setup"},
 	{"/connectors", "Open connectors in browser"},
 	{"/settings", "Open settings in browser"},
@@ -33,6 +34,18 @@ var argCommands = map[string]bool{
 	"/attach": true,
 }
 
+// isBuiltinCommand reports whether cmd is a built-in slash command or alias.
+// Skills with these names are ignored — built-ins always win.
+func isBuiltinCommand(cmd string) bool {
+	for _, sc := range slashCommands {
+		if sc.command == cmd {
+			return true
+		}
+	}
+	// Aliases handled in handleSlashCommand but not listed in the menu.
+	return cmd == "/new" || cmd == "/resume"
+}
+
 // inputModel manages the text input and slash command menu.
 type inputModel struct {
 	textInput     textinput.Model
@@ -42,6 +55,12 @@ type inputModel struct {
 	attachedFiles []string
 	customPrompt  string
 	suppressMenu  bool
+	skillCommands []slashCommand
+}
+
+// setSkillCommands registers skill slash commands for the completion menu.
+func (m *inputModel) setSkillCommands(cmds []slashCommand) {
+	m.skillCommands = cmds
 }
 
 func newInputModel() inputModel {
@@ -145,7 +164,7 @@ func (m inputModel) updateMenu() inputModel {
 	if strings.HasPrefix(val, "/") && !strings.Contains(val, " ") {
 		needle := strings.ToLower(val)
 		var filtered []slashCommand
-		for _, sc := range slashCommands {
+		for _, sc := range append(append([]slashCommand{}, slashCommands...), m.skillCommands...) {
 			if strings.HasPrefix(sc.command, needle) {
 				filtered = append(filtered, sc)
 			}


### PR DESCRIPTION
## Description

Add skills as slash commands to the Onyx CLI chat TUI.

On startup, `onyx-cli chat` discovers local agent skills — `SKILL.md` files at `.agents/skills/<name>/SKILL.md` in the working directory and in the home directory (the same canonical layout `onyx-cli install-skill` writes). Each skill becomes a `/<name>` slash command.

- `/<skill> [request]` sends one chat message to the agent: the skill body wrapped in a `<skill name="...">` tag plus the user's request. The chat view shows only the compact `/<skill> request` line.
- Skills appear in the Tab-completion menu (with their frontmatter `description`) and in `/help`. A new `/skills` command lists discovered skills.
- Project skills shadow home skills on name collision; built-in commands (including the `/new` and `/resume` aliases) always win over skills.
- Frontmatter parsing is a minimal hand-rolled `name`/`description` parser — no new YAML dependency. Malformed or invalid-named skills are skipped so they cannot break the TUI.

New package `cli/internal/skills` holds discovery and parsing. The TUI gets `sendMessageWithDisplay` so the sent prompt and displayed text can differ, and `helpText` became `renderHelp`/`renderSkillList`.

## How Has This Been Tested?

- `go test ./...` in `cli/` — all packages pass.
- New unit tests: frontmatter parsing (quoted values, unterminated frontmatter, no frontmatter), discovery (shadowing, invalid names, missing dirs), skill prompt composition, builtin-collision guard, help rendering, and completion-menu filtering.
- `go vet` clean; touched files pass `gofmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose local agent skills as slash commands in the chat TUI so users can run them without copy-paste. Previously skills were not discoverable; now `SKILL.md` files under `.agents/skills/<name>/` become `/<name>` commands with tab-completion, `/help`, and a new `/skills` list.

- Discovery and precedence: load from project and home `.agents/skills`, sort by name, project wins on collisions; built-ins always win; invalid names are filtered by `^[a-z0-9][a-z0-9._-]*$`.
- Parsing: minimal frontmatter parser for `name` and `description` (no YAML dependency), falling back to the directory name.
- Command behavior: `/<skill> [request]` sends one message composed as a `<skill name="...">` block; if the body contains `$ARGUMENTS`, substitute the request there, otherwise append it. The chat shows a compact `/<skill> [request]` line while sending the full prompt.
- TUI integration: new `cli/internal/skills` package; `sendMessageWithDisplay` decouples sent prompt from displayed text; `renderHelp` and `renderSkillList` include skills; `/skills` command; completion menu merges skill commands; `isBuiltinCommand` ensures built-ins win.
- Tests and docs: unit tests cover parsing, discovery, collisions, help rendering, completion, and `$ARGUMENTS`; an end-to-end test verifies the agent receives the full prompt while the chat shows the compact command; `cli/README.md` documents skills, `$ARGUMENTS`, and `/skills`.

<sup>Written for commit 2c273f40269f480db517efa0a6be26f54dec8fbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

