### PR TITLE
fix(web): sit the New Project button properly beside its title

### DIFF
--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -363,7 +363,7 @@ function SidebarSection({
           </Disabled>
         </Hoverable.Root>
       ) : (
-        <Spacer rem={0.5} />
+        <Spacer rem={1} />
       )}
       {children}
     </div>

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -83,7 +83,7 @@
    --------------------------------------------------------------------------- */
 
 .opal-sidebar-header {
-  @apply flex flex-col gap-4 pb-2;
+  @apply flex flex-col gap-4;
 }
 
 .opal-sidebar-header__topbar {
@@ -152,7 +152,7 @@
 }
 
 .opal-sidebar-body__content {
-  @apply flex-1 flex flex-col px-2 gap-2;
+  @apply flex-1 flex flex-col px-2;
 }
 .opal-sidebar-root__inner[data-folded="true"] .opal-sidebar-body__content {
   @apply hidden;
@@ -167,9 +167,9 @@
    --------------------------------------------------------------------------- */
 
 .opal-sidebar-section__header {
-  @apply pl-2 pb-1 pt-2 flex flex-row justify-between items-center;
+  @apply pt-3 pl-2 pr-1 flex flex-row justify-between items-center;
 }
 
 .opal-sidebar-section__title {
-  @apply flex p-0.5;
+  @apply flex px-0.5 py-1.5;
 }

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -83,7 +83,7 @@
    --------------------------------------------------------------------------- */
 
 .opal-sidebar-header {
-  @apply flex flex-col gap-4;
+  @apply flex flex-col gap-4 pb-2;
 }
 
 .opal-sidebar-header__topbar {

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -83,7 +83,7 @@
    --------------------------------------------------------------------------- */
 
 .opal-sidebar-header {
-  @apply flex flex-col gap-4 pb-2;
+  @apply flex flex-col gap-4;
 }
 
 .opal-sidebar-header__topbar {

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -672,7 +672,7 @@ export default function AppSidebar() {
                     <OpalButton
                       icon={SvgFolderPlus}
                       prominence="tertiary"
-                      size="sm"
+                      size="md"
                       tooltip="New Project"
                       onClick={() => createProjectModal.toggle(true)}
                     />

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -94,7 +94,7 @@ export default function CreateConnectorSidebar() {
 
   return (
     <CreateConnectorSidebarShell>
-      <div className="relative mx-2 flex flex-col">
+      <div className="relative mx-2 flex flex-col pt-2">
         {settingSteps.map((step, index) => {
           // The form numbers steps absolutely (0 = Credential, 1 = Connector,
           // 2 = Advanced) and clamps `formStep` to >= 1 when there's no

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -94,7 +94,7 @@ export default function CreateConnectorSidebar() {
 
   return (
     <CreateConnectorSidebarShell>
-      <div className="relative mx-2 flex flex-col pt-2">
+      <div className="relative mx-2 flex flex-col mt-2">
         {settingSteps.map((step, index) => {
           // The form numbers steps absolutely (0 = Credential, 1 = Connector,
           // 2 = Advanced) and clamps `formStep` to >= 1 when there's no


### PR DESCRIPTION
## Description

The "New Project" button beside the sidebar's "Projects" title was a size smaller than the row it shares, so it read as an afterthought rather than that section's action. It is now `size="md"`, and the "Close Sidebar" button above it lines up with it.

The spacing around it changes to match. Three things move:

- **`.opal-sidebar-section__header`** takes its own top padding and a right inset, and **`__title`** its own vertical padding, so the header row is sized by its own contents.
- **`.opal-sidebar-header`** loses its bottom padding. It was padding its own bottom to separate itself from whatever came next, which is not something it can know about. Nothing needs it to: a titled section brings its own top padding, and an untitled one a spacer.
- **The untitled-section spacer** grows from `0.5rem` to `1rem`. With the header's padding gone, that spacer is the only leading space such a section has, and it now stands in for the whole absent header rather than just its top padding.

`.opal-sidebar-section__header`, `__title` and the spacer are shared by every `SidebarLayouts.Section`, so Recents shifts along with Projects.

## Screenshots + Videos

### Before

("Close Sidebar" button and "New Project" button are out-of-alignment.)

<img width="243" height="297" alt="image" src="https://github.com/user-attachments/assets/47c9de0b-7e9a-4c88-8b6d-a2046dd3f36b" />

### After

("Close Sidebar" button and "New Project" button are now in full alignment.)

<img width="242" height="297" alt="image" src="https://github.com/user-attachments/assets/29cdb0af-92a9-4297-80ec-700a48e271dc" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the New Project button with the Projects header row. Previously smaller and low; now `size="md"` and aligned, with spacing owned by the section header/title. Pure styling change with no logic or migrations.

- Verify the New Project button matches the Projects title height and sits on the header row.
- Section header picks up its own top padding and right inset; title gets vertical padding. Removes sidebar header bottom padding and sidebar body content gap.
- Untitled section headers render a 1rem spacer; shared styles carry to Recents.
- Create Connector sidebar uses top margin instead of padding for step spacing to avoid interfering with absolutely positioned children.

<sup>Written for commit d4119026e8c419cc431171b5f43ae2d9b7da9a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

