### PR TITLE
fix(mcp): emit search results once instead of content + structuredContent

### DIFF
--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -5,7 +5,9 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+import pydantic_core
 from fastmcp.server.auth.auth import AccessToken
+from fastmcp.tools.tool import ToolResult
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from onyx.configs.constants import DocumentSource
@@ -92,6 +94,19 @@ def _error_payload(error: str) -> dict[str, Any]:
     return {"error": error, "results": []}
 
 
+def _as_tool_result(payload: dict[str, Any]) -> ToolResult:
+    """Emit the payload once, as content text only.
+
+    Returning a bare dict lets FastMCP derive an output schema from the
+    annotation and send the payload twice - once as ``structuredContent`` and
+    again as serialised JSON in a text block. For search the payload is the
+    retrieved document content, so that duplicate is expensive. The schema is
+    derived from ``dict[str, Any]`` and conveys no structure, so clients gain
+    nothing from the structured copy. The text is byte-identical either way.
+    """
+    return ToolResult(content=pydantic_core.to_json(payload, fallback=str).decode())
+
+
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
 
@@ -113,7 +128,7 @@ async def search_indexed_documents(
     document_set_names: list[str] | None = None,
     time_cutoff: str | None = None,
     skip_query_expansion: bool = False,
-) -> dict[str, Any]:
+) -> ToolResult:
     """
     Search the user's knowledge base indexed in Onyx.
     Use this tool for information that is not public knowledge and specific to the user,
@@ -182,15 +197,19 @@ async def search_indexed_documents(
                 err,
                 exc_info=True,
             )
-            return _error_payload(f"Failed to check indexed sources: {str(err)}")
+            return _as_tool_result(
+                _error_payload(f"Failed to check indexed sources: {str(err)}")
+            )
 
         if not sources:
             logger.info("Onyx MCP Server: No indexed sources available for tenant")
             outcome = MCPToolCallStatus.SUCCESS
             result_count = 0
-            return _error_payload(
-                "No document sources are indexed yet. Add connectors or upload data "
-                "through Onyx before calling search_indexed_documents."
+            return _as_tool_result(
+                _error_payload(
+                    "No document sources are indexed yet. Add connectors or upload "
+                    "data through Onyx before calling search_indexed_documents."
+                )
             )
 
         source_type_enums: list[DocumentSource] | None = None
@@ -225,7 +244,7 @@ async def search_indexed_documents(
         endpoint = f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/search"
         response = await _post_model(endpoint, request, access_token)
         if not response.is_success:
-            return _error_payload(_extract_error_detail(response))
+            return _as_tool_result(_error_payload(_extract_error_detail(response)))
 
         payload = SearchResponse.model_validate_json(response.content)
         results = [_to_mcp_dict(result) for result in payload.results]
@@ -234,10 +253,10 @@ async def search_indexed_documents(
         logger.info(
             "Onyx MCP Server: Internal search returned %s results", len(results)
         )
-        return {"results": results}
+        return _as_tool_result({"results": results})
     except Exception as err:
         logger.error("Onyx MCP Server: Document search error: %s", err, exc_info=True)
-        return _error_payload(f"Document search failed: {str(err)}")
+        return _as_tool_result(_error_payload(f"Document search failed: {str(err)}"))
     finally:
         record_mcp_server_tool_outcome(tool, _start, outcome)
         if result_count is not None:


### PR DESCRIPTION
Fixes #14171

### Problem

`search_indexed_documents` is annotated `-> dict[str, Any]`, so FastMCP derives an output schema from the annotation and sends the payload **twice** — once as `structuredContent`, and again as serialised JSON in a text content block. Every search result crosses the wire in duplicate.

For most tools that is cheap. For a *search* tool the payload **is** the retrieved document content, so the duplicate scales with everything retrieved.

### Measurement

On `fastmcp==3.2.0` (the pinned version), with a single-document payload:

| | content | structuredContent | total |
|---|---|---|---|
| current (`-> dict[str, Any]`) | 2531 | 2541 | **5072 chars** |
| this PR (`-> ToolResult`) | 2531 | 0 | **2531 chars** (−50.1%) |

In a self-hosted deployment with an agent client that forwards tool results to the model without capping, this was worth roughly **2.4k input tokens per search** — about half the tool-result injection. Full standalone reproduction in #14171.

### Why this is safe

- The **content text is byte-identical** — same `pydantic_core.to_json` of the same dict — so anything parsing the text path sees no change.
- The derived schema comes from `dict[str, Any]`, which describes no structure, so clients gain nothing from the structured copy for this tool.
- `search_web` and `open_urls` are deliberately **left as-is**. They dual-emit too, but their payloads are small enough not to matter, and `_error_payload` stays a plain dict since `open_urls` shares it.

### Note

`output_schema=None` on the decorator does **not** fix this — it drops the declared `outputSchema` from `tools/list` but the result still carries both representations. Verified on 3.2.0. An explicit `ToolResult` is what suppresses the duplicate.

### Caveat

Dual emission is the spec-compliant default when a tool declares an output schema, so a client genuinely consuming the structured path for this tool would be affected. If you would rather have this behind a flag than as a change of default, I am happy to rework it — or to close this in favour of an approach you prefer.

### Checks

- `ruff format` clean (0.16.0, per `.pre-commit-config.yaml`)
- `ruff check` reports **no new findings** — identical counts before and after
- Variant has been running in production for about a month


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `search_indexed_documents` results once by returning a `ToolResult` instead of a bare dict, removing the duplicate `structuredContent`. This halves the wire size on typical payloads and reduces token usage without changing the content text.

- Old vs new: previously `fastmcp` derived a schema from `dict[str, Any]` and sent both `structuredContent` and text; now only text content is sent.
- The text payload is byte-identical to before; parsers of the text path see no change.
- `search_web` and `open_urls` are unchanged.
- Migration: if any client consumes `structuredContent` for `search_indexed_documents`, switch to parsing the `content` text.

<sup>Written for commit 2ae57d2088a13079f19f74c59606d029eeaf1bf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

