### PR TITLE
docs: fix root-relative links, dead anchor, and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,7 +286,7 @@ You've successfully set up a local Onyx instance!
 
 ### Running on a Local Kubernetes Cluster
 
-For Onyx Craft (Build) development, sandboxes are real Kubernetes pods — run `make craft-up` to bring up a local kind cluster in one shot. See [Local Kubernetes Development](/docs/craft/dev/local-kubernetes.md) for the full workflow.
+For Onyx Craft (Build) development, sandboxes are real Kubernetes pods — run `make craft-up` to bring up a local kind cluster in one shot. See [Local Kubernetes Development](docs/craft/dev/local-kubernetes.md) for the full workflow.
 
 ### Running in Docker
 

--- a/backend/onyx/background/README.md
+++ b/backend/onyx/background/README.md
@@ -4,7 +4,7 @@ The background jobs take care of:
 
 1. Pulling/Indexing documents (from connectors)
 2. Updating document metadata (from connectors)
-3. Cleaning up checkpoints and logic around indexing work (indexing indexing checkpoints and index attempt metadata)
+3. Cleaning up checkpoints and logic around indexing work (indexing checkpoints and index attempt metadata)
 4. Handling user uploaded files and deletions (from the Projects feature and uploads via the Chat)
 5. Reporting metrics on things like queue length for monitoring purposes
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -178,7 +178,7 @@ SESSION_EXPIRE_TIME_SECONDS = int(
 # Default request timeout, mostly used by connectors
 REQUEST_TIMEOUT_SECONDS = int(os.environ.get("REQUEST_TIMEOUT_SECONDS") or 60)
 
-# set `VALID_EMAIL_DOMAINS` to a comma seperated list of domains in order to
+# set `VALID_EMAIL_DOMAINS` to a comma separated list of domains in order to
 # restrict access to Onyx to only users with emails from those domains.
 # E.g. `VALID_EMAIL_DOMAINS=example.com,example.org` will restrict Onyx
 # signups to users with either an @example.com or an @example.org email.

--- a/backend/onyx/db/README.md
+++ b/backend/onyx/db/README.md
@@ -1,6 +1,6 @@
 An explanation of how the history of messages, tool calls, and docs are stored in the database:
 
-Messages are grouped by a chat session, a tree structured is used to allow edits and for the
+Messages are grouped by a chat session, a tree structure is used to allow edits and for the
 user to switch between branches. Each ChatMessage is either a user message or an assistant message.
 It should always alternate between the two, System messages, custom agent prompt injections, and
 reminder messages are injected dynamically after the chat session is loaded into memory. The user
@@ -12,7 +12,7 @@ The assistant message includes the response, tool calls, feedback, citations, et
 Things provided as input are part of the user message, things that happen during the inference and
 LLM loop are part of the assistant message.
 
-Reasoning is part of the message or tool call that occured after the reasoning. Really the reasoning
+Reasoning is part of the message or tool call that occurred after the reasoning. Really the reasoning
 should be part of the previous message / tool call because if it branches afterwards as a result of
 the reasoning, this is somewhat unintuitive. But to not include reasoning as part of the user message,
 it is instead included with the following message or tool call. With parallel tool calls, the reasoning

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1054,7 +1054,7 @@ def _verify_indexing_completeness(
             f"Updatable IDs: {updatable_ids}, "
             f"Returned IDs: {all_returned_doc_ids}. "
             f"This should never happen. "
-            f"This occured for document index {document_index_name}"
+            f"This occurred for document index {document_index_name}"
         )
 
 

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -239,7 +239,7 @@ Other docker-compose-style values you should set deliberately:
 
 # Local testing
 
-> This section covers chart-maintainer testing; for the Onyx Craft local-kind developer workflow, see [docs/craft/dev/local-kubernetes.md](/docs/craft/dev/local-kubernetes.md).
+> This section covers chart-maintainer testing; for the Onyx Craft local-kind developer workflow, see [docs/craft/dev/local-kubernetes.md](../../docs/craft/dev/local-kubernetes.md).
 
 ## One time setup
 * brew install kind

--- a/docs/craft/dev/local-kubernetes.md
+++ b/docs/craft/dev/local-kubernetes.md
@@ -8,7 +8,7 @@ attached to api_server / celery / web.
 This is the canonical local setup for **Onyx Craft (build mode)** — sandboxes
 are real Kubernetes pods, so there is no longer a non-cluster shortcut.
 Non-Craft work can still use the docker-compose deps + vscode debugger path
-described in [CONTRIBUTING.md](/CONTRIBUTING.md); use that when you don't
+described in [CONTRIBUTING.md](../../../CONTRIBUTING.md); use that when you don't
 need a sandbox.
 
 For iterating on the **docker** sandbox backend specifically
@@ -113,7 +113,7 @@ For transparency / debugging, `craft-up.sh` runs these steps in order. You
 can also invoke them individually for tighter rebuild loops.
 
 **1. Bring up the cluster.** Delegates to
-[`deployment/helm/dev/k8s-up.sh`](/deployment/helm/dev/k8s-up.sh). The
+[`deployment/helm/dev/k8s-up.sh`](../../../deployment/helm/dev/k8s-up.sh). The
 script is idempotent and refuses to run unless your kubectl context is
 `kind-onyx-dev`. It also installs the telepresence traffic-manager once
 per cluster. New clusters use the `kindest/node:v1.33.1` node image so Craft's
@@ -127,7 +127,7 @@ kubectl -n onyx get pods -w
 ```
 
 The chart pins images to the `:edge` tag in
-[`values-localdev.yaml`](/deployment/helm/charts/onyx/values-localdev.yaml)
+[`values-localdev.yaml`](../../../deployment/helm/charts/onyx/values-localdev.yaml)
 with `pullPolicy: Always`, so in-cluster pods track nightly builds off `main`
 rather than the released `:latest`.
 
@@ -325,7 +325,7 @@ kubectl -n onyx rollout restart deployment/onyx-api-server
 For logic that doesn't depend on cluster-only behavior (safe-extract, push
 wire format, tarball round-trips), drive it from unit /
 external-dependency-unit tests against a temp dir. See
-[`backend/tests/README.md`](/backend/tests/README.md).
+[`backend/tests/README.md`](../../../backend/tests/README.md).
 
 ### End of day
 
@@ -376,7 +376,7 @@ ONYX_SANDBOX_PUSH_PRIVATE_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 ```
 
 The `onyxdotapp/sandbox:dev` image referenced here is **local-only**; build
-and load it per [step 3 of One-time setup](#3-build-and-load-the-sandbox-image)
+and load it per [step 3 of One-time setup](#one-time-setup)
 before launching the api_server.
 
 ## Troubleshooting
@@ -474,8 +474,8 @@ just-flipped flag).
 
 ## References
 
-- [CONTRIBUTING.md — Development Setup](/CONTRIBUTING.md#development-setup)
-- [deployment/helm/README.md](/deployment/helm/README.md)
-- [backend/onyx/server/features/build/sandbox/README.md](/backend/onyx/server/features/build/sandbox/README.md)
+- [CONTRIBUTING.md — Development Setup](../../../CONTRIBUTING.md#development-setup)
+- [deployment/helm/README.md](../../../deployment/helm/README.md)
+- [backend/onyx/server/features/build/sandbox/README.md](../../../backend/onyx/server/features/build/sandbox/README.md)
 - [Telepresence docs](https://www.telepresence.io/docs/)
 - [kind docs](https://kind.sigs.k8s.io/)

--- a/docs/craft/features/streaming/opencode-serve-client.md
+++ b/docs/craft/features/streaming/opencode-serve-client.md
@@ -481,4 +481,4 @@ This is a parallel work item: doesn't block the client library landing behind th
 
 ## Open questions remaining
 
-None for the client library itself. The remaining decisions are out of scope (e.g., when to flip the flag, when to delete the ACP code per [`drop-acp-layer.md`](../drop-acp-layer.md)).
+None for the client library itself. The remaining decisions are out of scope (e.g., when to flip the flag, when to delete the ACP code per [`drop-acp-layer.md`](./drop-acp-layer.md)).

--- a/web/src/app/craft/README.md
+++ b/web/src/app/craft/README.md
@@ -91,7 +91,7 @@ Craft supports two sandbox backends controlled by `SANDBOX_BACKEND`:
   - `sandbox` — Runs OpenCode agent and Next.js preview server
   - `file-sync` — Sidecar for S3 file synchronization
 
-For local development, see [docs/craft/dev/local-kubernetes.md](/docs/craft/dev/local-kubernetes.md) — one-shot setup via `make craft-up`.
+For local development, see [docs/craft/dev/local-kubernetes.md](../../../../docs/craft/dev/local-kubernetes.md) — one-shot setup via `make craft-up`.
 
 **Docker** (self-hosted docker-compose)
 


### PR DESCRIPTION
## Summary
- Root-relative markdown links (`/CONTRIBUTING.md`, `/docs/...`, `/deployment/...`, `/backend/...`) in `CONTRIBUTING.md`, `deployment/helm/README.md`, `web/src/app/craft/README.md` and `docs/craft/dev/local-kubernetes.md` resolve against the domain root on github.com and 404. Converted them to the correct repo-relative paths.
- `local-kubernetes.md` links to `#3-build-and-load-the-sandbox-image`, but "3. Build and load the sandbox image." is bold list text, not a heading — no such anchor exists. Pointed it at `#one-time-setup`.
- `docs/craft/features/streaming/opencode-serve-client.md`: `../drop-acp-layer.md` -> `./drop-acp-layer.md` (the file is in the same directory; sibling docs link it correctly).
- Typos: `backend/onyx/db/README.md` ("a tree structured is used" -> "a tree structure is used"; "occured" -> "occurred"), `backend/onyx/background/README.md` ("indexing indexing"), `indexing_pipeline.py` RuntimeError message ("occured"), `app_configs.py` comment ("seperated").

Left untouched on purpose: links in the streaming design docs pointing at `opencode-serve-migration.md` / `opencode-serve-test-report.md`, which were never committed — unclear whether they should be de-linked or the docs restored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes docs links that 404 on GitHub by converting root-relative URLs to repo-relative paths, and fixes typos in docs and one error message. Runtime behavior is unchanged except for that error message.

- Verify the updated links render correctly on GitHub.
- `opencode-serve-client.md` links to `./drop-acp-layer.md` instead of `../drop-acp-layer.md`.
- A `RuntimeError` message now reads `occurred` instead of `occured`; update any tests that assert the exact text.
- Links to never-committed files in streaming design docs are left as-is.

<sup>Written for commit 49af46ad333a88b2dda7dc4afdc9c9244e079d1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

