### PR TITLE
fix: name the prompt_cache args the docstrings describe

### DIFF
--- a/backend/onyx/llm/prompt_cache/cache_manager.py
+++ b/backend/onyx/llm/prompt_cache/cache_manager.py
@@ -61,7 +61,6 @@ class CacheManager:
 
         Args:
             metadata: Cache metadata to store
-            ttl_seconds: Optional TTL in seconds. If None, uses provider default.
         """
         try:
             cache_key = self._build_cache_key(

--- a/backend/onyx/llm/prompt_cache/processor.py
+++ b/backend/onyx/llm/prompt_cache/processor.py
@@ -29,7 +29,7 @@ def process_with_prompt_cache(
     ready for LLM API calls along with optional cache metadata.
 
     Args:
-        llm: The LLM instance (used to determine provider and model)
+        llm_config: Config of the LLM, used to determine provider and model
         cacheable_prefix: Optional cacheable prefix. If None, no caching is attempted.
         suffix: The non-cacheable suffix to append
         continuation: If True, suffix should be appended to the last message

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -25,7 +25,7 @@ def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
     """Get the appropriate prompt cache provider adapter for a given provider.
 
     Args:
-        provider: Provider name (e.g., "openai", "anthropic", "vertex_ai")
+        llm_config: Config of the LLM whose provider decides the caching strategy
 
     Returns:
         PromptCacheProvider instance for the given provider

--- a/backend/onyx/llm/prompt_cache/utils.py
+++ b/backend/onyx/llm/prompt_cache/utils.py
@@ -22,7 +22,6 @@ def combine_messages_with_continuation(
         prefix_msgs: Normalized cacheable prefix messages
         suffix_msgs: Normalized suffix messages
         continuation: If True, append suffix content to the last message of prefix
-        was_prefix_string: Deprecated, no longer used
 
     Returns:
         Combined messages


### PR DESCRIPTION
## Description

Four `Args:` entries in `llm/prompt_cache` name things the functions do not take. Two of the names never existed on those signatures: `ttl_seconds` on `store_cache_metadata`, and `was_prefix_string` on `combine_messages_with_continuation`, which the docstring itself already called deprecated. The other two are the same argument under an old name, `llm` and `provider` where the parameter is `llm_config`, so I rewrote those two lines to describe the config rather than just renaming the label.

## How Has This Been Tested?

Docstrings only, no code paths touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `prompt_cache` docstrings with current function signatures to remove stale argument names and clarify parameter intent. No runtime behavior changes.

- Remove nonexistent `ttl_seconds` (from `store_cache_metadata`) and deprecated `was_prefix_string` (from `combine_messages_with_continuation`).
- Replace stale parameter names with `llm_config` in `process_with_prompt_cache` and `get_provider_adapter`, and clarify how the config determines provider/model.
- No migrations, no tests required.

<sup>Written for commit 7f3c630473e3b31eecdb0e3e7ddc21c1b1f69c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

