### PR TITLE
fix: resume OAuth shared drive pagination from checkpoint page token

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1438,12 +1438,13 @@ class GoogleDriveConnector(
                 start,
             )
             for file_or_token in _yield_from_drive(drive_id, resume_start):
-                if isinstance(file_or_token, str):
-                    checkpoint.completion_map[
-                        self.primary_admin_email
-                    ].next_page_token = file_or_token
-                    return  # done with the max num pages, return checkpoint
+                # Propagate page tokens so the caller records them and pauses at
+                # this stage. Consuming a token here looks like normal completion
+                # to the caller, which then advances the stage and drops the
+                # remaining pages of the drive.
                 yield file_or_token
+                if isinstance(file_or_token, str):
+                    return  # done with the max num pages, return checkpoint
             checkpoint.completion_map[self.primary_admin_email].next_page_token = None
 
         for drive_id in drive_ids_to_retrieve:
@@ -1457,13 +1458,18 @@ class GoogleDriveConnector(
                 drive_id,
                 self.primary_admin_email,
             )
+            # Record the drive being listed before any file is yielded (as the
+            # service account path does), so a page token emitted before the
+            # first yielded file resumes this drive, not the previous one.
+            checkpoint.completion_map[self.primary_admin_email].completed_until = 0
+            checkpoint.completion_map[
+                self.primary_admin_email
+            ].current_folder_or_drive_id = drive_id
             for file_or_token in _yield_from_drive(drive_id, start):
-                if isinstance(file_or_token, str):
-                    checkpoint.completion_map[
-                        self.primary_admin_email
-                    ].next_page_token = file_or_token
-                    return  # done with the max num pages, return checkpoint
+                # See the resume loop above: the caller records page tokens.
                 yield file_or_token
+                if isinstance(file_or_token, str):
+                    return  # done with the max num pages, return checkpoint
             checkpoint.completion_map[self.primary_admin_email].next_page_token = None
 
     def _oauth_retrieval_folders(

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1458,13 +1458,17 @@ class GoogleDriveConnector(
                 drive_id,
                 self.primary_admin_email,
             )
-            # Record the drive being listed before any file is yielded (as the
-            # service account path does), so a page token emitted before the
-            # first yielded file resumes this drive, not the previous one.
-            checkpoint.completion_map[self.primary_admin_email].completed_until = 0
-            checkpoint.completion_map[
-                self.primary_admin_email
-            ].current_folder_or_drive_id = drive_id
+            # Record the stage and drive being listed before any file is
+            # yielded (as the service account path does), so a page token
+            # emitted before the first yielded file resumes this drive, not the
+            # previous one. Without the stage, the resume branch above is
+            # skipped and the token leaks into the first unretrieved drive's
+            # fresh listing.
+            checkpoint.completion_map[self.primary_admin_email].update(
+                stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+                completed_until=0,
+                current_folder_or_drive_id=drive_id,
+            )
             for file_or_token in _yield_from_drive(drive_id, start):
                 # See the resume loop above: the caller records page tokens.
                 yield file_or_token

--- a/backend/tests/unit/onyx/connectors/google_drive/test_oauth_shared_drive_pagination.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_oauth_shared_drive_pagination.py
@@ -153,6 +153,33 @@ def test_oauth_shared_drive_retrieval_spans_all_pages(
     _assert_retrieved_exactly(retrieved_ids, files_by_drive)
 
 
+def test_oauth_shared_drive_token_before_any_file_resumes_same_drive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token pause before ANY file was ever yielded (empty drive first).
+
+    The per-user stage is still START when the pause happens, so without a
+    proactive stage update the resume branch is skipped, the token leaks into
+    the empty drive's fresh listing, gets cleared there, and the paused drive
+    restarts from page 1 on every span without ever completing.
+    """
+    files_by_drive: dict[str, list[dict[str, Any]]] = {
+        "drive_a": [],
+        "drive_b": [_drive_file(i) for i in range(14)],
+    }
+    connector = _build_oauth_connector(
+        monkeypatch,
+        drive_ids=["drive_a", "drive_b"],
+        fake_retrieval=_make_fake_get_files_in_shared_drive(
+            files_by_drive, filtered_first_span_drives=frozenset({"drive_b"})
+        ),
+    )
+
+    retrieved_ids = _run_all_checkpoint_spans(connector, max_spans=40)
+
+    _assert_retrieved_exactly(retrieved_ids, files_by_drive)
+
+
 def test_oauth_shared_drive_token_before_first_file_resumes_same_drive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_oauth_shared_drive_pagination.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_oauth_shared_drive_pagination.py
@@ -1,0 +1,173 @@
+"""OAuth shared-drive retrieval must resume from the saved page token.
+
+Shared-drive listing fetches SHARED_DRIVE_PAGES_PER_CHECKPOINT pages per
+checkpoint span, then emits a page token so the next span can continue.
+A regression here silently truncates large shared drives: the token is
+dropped, the stage machine advances to FOLDER_FILES, and the folder crawl
+skips everything because the drive and its folders are already marked
+traversed (https://github.com/onyx-dot-app/onyx/issues/14165).
+
+Also covers the pause-before-first-file case: a span can emit a page token
+before the current drive yields any file (empty pages, or leading files all
+dropped by shortcut resolution). The checkpoint must attribute that token to
+the drive being listed, not to the previous drive, or the resume re-lists the
+wrong drive and the paused one restarts from page 1 on every span.
+"""
+
+import copy
+from collections.abc import Callable, Iterator
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import onyx.connectors.google_drive.connector as connector_module
+from onyx.connectors.google_drive.connector import GoogleDriveConnector
+from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
+from onyx.connectors.google_drive.models import DriveRetrievalStage
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+
+_USER = "user@example.com"
+_PAGE_SIZE = 3
+
+FakeRetrieval = Callable[..., Iterator[dict[str, Any] | str]]
+
+
+def _drive_file(index: int) -> dict[str, Any]:
+    modified = datetime(2024, 1, 1, index, 0, 0, tzinfo=timezone.utc)
+    return {
+        "id": f"file_{index}",
+        "name": f"file_{index}",
+        "modifiedTime": modified.isoformat(),
+        "webViewLink": f"https://drive.google.com/file/d/file_{index}",
+    }
+
+
+def _make_fake_get_files_in_shared_drive(
+    files_by_drive: dict[str, list[dict[str, Any]]],
+    filtered_first_span_drives: frozenset[str] = frozenset(),
+) -> FakeRetrieval:
+    """Pages through a drive's files; the page token encodes the next offset.
+
+    Drives in filtered_first_span_drives yield only a page token on their
+    first span, simulating leading pages whose files were all dropped by
+    shortcut resolution.
+    """
+
+    def _fake(
+        service: Any,  # noqa: ARG001
+        drive_id: str,
+        field_type: DriveFileFieldType,  # noqa: ARG001
+        max_num_pages: int,
+        update_traversed_ids_func: Callable[[str], None] = lambda _: None,
+        cache_folders: bool = True,  # noqa: ARG001
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG001
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG001
+        page_token: str | None = None,
+    ) -> Iterator[dict[str, Any] | str]:
+        if drive_id in filtered_first_span_drives and page_token is None:
+            yield "0"
+            return
+        files = files_by_drive[drive_id]
+        offset = int(page_token) if page_token else 0
+        for _ in range(max_num_pages):
+            if offset >= len(files):
+                return
+            for file in files[offset : offset + _PAGE_SIZE]:
+                update_traversed_ids_func(drive_id)
+                yield file
+            offset += _PAGE_SIZE
+        if offset < len(files):
+            yield str(offset)
+
+    return _fake
+
+
+def _build_oauth_connector(
+    monkeypatch: pytest.MonkeyPatch,
+    drive_ids: list[str],
+    fake_retrieval: FakeRetrieval,
+) -> GoogleDriveConnector:
+    urls = ",".join(
+        f"https://drive.google.com/drive/folders/{drive_id}" for drive_id in drive_ids
+    )
+    connector = GoogleDriveConnector(shared_drive_urls=urls)
+    # Any non-service-account creds select the OAuth retrieval path.
+    connector._creds = MagicMock()
+    connector._primary_admin_email = _USER
+    monkeypatch.setattr(connector, "get_all_drive_ids", lambda: set(drive_ids))
+    monkeypatch.setattr(connector_module, "get_drive_service", MagicMock())
+    monkeypatch.setattr(connector_module, "get_files_in_shared_drive", fake_retrieval)
+    return connector
+
+
+def _run_all_checkpoint_spans(
+    connector: GoogleDriveConnector, max_spans: int
+) -> list[str]:
+    """Mimics the _load_from_checkpoint span loop, returning retrieved ids."""
+    checkpoint = connector.build_dummy_checkpoint()
+    retrieved_ids: list[str] = []
+    for _ in range(max_spans):
+        if checkpoint.completion_stage == DriveRetrievalStage.DONE:
+            return retrieved_ids
+        checkpoint = copy.deepcopy(checkpoint)
+        connector._retrieved_folder_and_drive_ids = (
+            checkpoint.retrieved_folder_and_drive_ids
+        )
+        retrieved_ids.extend(
+            file.drive_file["id"]
+            for file in connector._fetch_drive_items(
+                field_type=DriveFileFieldType.STANDARD,
+                checkpoint=checkpoint,
+                start=0,
+                end=datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+            )
+        )
+        checkpoint.retrieved_folder_and_drive_ids = (
+            connector._retrieved_folder_and_drive_ids
+        )
+    raise AssertionError("retrieval never reached the DONE stage")
+
+
+def _assert_retrieved_exactly(
+    retrieved_ids: list[str], files_by_drive: dict[str, list[dict[str, Any]]]
+) -> None:
+    assert len(retrieved_ids) == len(set(retrieved_ids))
+    expected_ids = [file["id"] for files in files_by_drive.values() for file in files]
+    assert sorted(retrieved_ids) == sorted(expected_ids)
+
+
+def test_oauth_shared_drive_retrieval_spans_all_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files_by_drive = {"drive_1": [_drive_file(i) for i in range(20)]}
+    connector = _build_oauth_connector(
+        monkeypatch,
+        drive_ids=["drive_1"],
+        fake_retrieval=_make_fake_get_files_in_shared_drive(files_by_drive),
+    )
+
+    retrieved_ids = _run_all_checkpoint_spans(connector, max_spans=40)
+
+    _assert_retrieved_exactly(retrieved_ids, files_by_drive)
+
+
+def test_oauth_shared_drive_token_before_first_file_resumes_same_drive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files_by_drive = {
+        "drive_a": [_drive_file(i) for i in range(6)],
+        "drive_b": [_drive_file(i) for i in range(6, 20)],
+    }
+    connector = _build_oauth_connector(
+        monkeypatch,
+        drive_ids=["drive_a", "drive_b"],
+        fake_retrieval=_make_fake_get_files_in_shared_drive(
+            files_by_drive, filtered_first_span_drives=frozenset({"drive_b"})
+        ),
+    )
+
+    retrieved_ids = _run_all_checkpoint_spans(connector, max_spans=40)
+
+    _assert_retrieved_exactly(retrieved_ids, files_by_drive)


### PR DESCRIPTION
## Description

Fixes #14165: a Google Drive connector using OAuth credentials with `shared_drive_urls` silently indexed only ~200 files of a 6,500+ file shared drive, while the same drive indexed fully when its subfolders were passed as `shared_folder_urls`.

Two fixes in the OAuth retrieval path, bringing it to parity with the service account path:

1. **Propagate the checkpoint page token.** Shared drive listing fetches `SHARED_DRIVE_PAGES_PER_CHECKPOINT` (2) pages (~200 files) per checkpoint span, then emits a page token so the next span resumes. `_oauth_retrieval_drives` consumed that token and returned, so `_manage_oauth_retrieval` saw normal completion, advanced the stage to `FOLDER_FILES`, and cleared the token. The remaining pages were never requested, and the fallback folder crawl skipped everything because the drive and its folders were already marked traversed. No `ConnectorFailure` was surfaced. The token is now yielded to the stage machine, which saves it and resumes the listing on the next span.

2. **Record the drive being listed before any file is yielded**, as the service account path does. Without this, a token emitted before the current drive yields its first file (empty pages, or leading files dropped by shortcut resolution) is attributed to the previous drive on resume, and the paused drive restarts from page 1 on every span without ever completing.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/connectors/google_drive/test_oauth_shared_drive_pagination.py` drive the real checkpoint span loop (`_fetch_drive_items`) against a fake paginated drive listing. Both tests fail on the pre-fix code (the first retrieves only the first checkpoint span's files; the second never reaches `DONE`) and pass with the fix.
- Verified against production logs for the reporting tenant: the failing run retrieved exactly 200 files (2 pages x 100) in one span, then loaded the next checkpoint at `FOLDER_FILES` and finished with 195 indexed (5 skipped over the size threshold).
- All 41 google_drive unit tests pass; pre-commit (`ty`, `ruff`) clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes OAuth shared-drive listing from the saved page token and the correct drive, preventing silent truncation at ~200 files and avoiding restart loops when a pause occurs before any file is yielded. Previously, the OAuth path consumed the token and advanced to FOLDER_FILES; tokens emitted before the first file could be attributed to the previous or an empty drive. Now the token is yielded to the stage machine and the target drive and stage are recorded before any files are yielded.

- Propagates page tokens to the stage machine so listing pauses at `SHARED_DRIVE_FILES` and resumes from the token across checkpoint spans, matching the service-account path.
- Records `SHARED_DRIVE_FILES` and the current drive id before yielding, ensuring a pre-first-file token is owned by the resume branch for that drive (no leaking to another or empty drive).
- Adds unit tests covering checkpoint truncation and pre-first-file pauses (including an empty-drive-first case); they fail pre-fix and pass now.
- No configuration changes or migrations.

<sup>Written for commit e56e67245db89bb5033f17d46694b7dc14f7e923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

