### PR TITLE
Add regional image generation provider support

### DIFF
--- a/backend/onyx/image_gen/factory.py
+++ b/backend/onyx/image_gen/factory.py
@@ -5,6 +5,7 @@ from onyx.image_gen.interfaces import (
     ImageGenerationProviderCredentials,
 )
 from onyx.image_gen.providers.azure_img_gen import AzureImageGenerationProvider
+from onyx.image_gen.providers.minimax_img_gen import MiniMaxImageGenerationProvider
 from onyx.image_gen.providers.openai_img_gen import OpenAIImageGenerationProvider
 from onyx.image_gen.providers.vertex_img_gen import VertexImageGenerationProvider
 
@@ -13,12 +14,14 @@ class ImageGenerationProviderName(str, Enum):
     AZURE = "azure"
     OPENAI = "openai"
     VERTEX_AI = "vertex_ai"
+    MINIMAX = "minimax"
 
 
 PROVIDERS: dict[ImageGenerationProviderName, type[ImageGenerationProvider]] = {
     ImageGenerationProviderName.AZURE: AzureImageGenerationProvider,
     ImageGenerationProviderName.OPENAI: OpenAIImageGenerationProvider,
     ImageGenerationProviderName.VERTEX_AI: VertexImageGenerationProvider,
+    ImageGenerationProviderName.MINIMAX: MiniMaxImageGenerationProvider,
 }
 
 

--- a/backend/onyx/image_gen/providers/minimax_img_gen.py
+++ b/backend/onyx/image_gen/providers/minimax_img_gen.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING, Any
+
+import requests
+
+from onyx.image_gen.exceptions import ImageProviderCredentialsError
+from onyx.image_gen.interfaces import (
+    ImageGenerationProvider,
+    ImageGenerationProviderCredentials,
+    ReferenceImage,
+)
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
+
+if TYPE_CHECKING:
+    from onyx.image_gen.interfaces import ImageGenerationResponse
+
+
+class MiniMaxImageGenerationProvider(ImageGenerationProvider):
+    """MiniMax image-01 provider using the regional image-generation API."""
+
+    _DEFAULT_API_BASE = "https://api.minimax.io/v1/image_generation"
+    _MODEL_NAMES = frozenset(("image-01", "image-01-live"))
+    _ASPECT_RATIOS = {
+        "1024x1024": "1:1",
+        "1792x1024": "16:9",
+        "1024x1792": "9:16",
+        "1536x1024": "3:2",
+        "1024x1536": "2:3",
+    }
+
+    def __init__(self, api_key: str, api_base: str | None = None):
+        self._api_key = api_key
+        base = (api_base or self._DEFAULT_API_BASE).rstrip("/")
+        self._api_base = (
+            f"{base}/image_generation" if base.endswith("/v1") else base
+        )
+
+    @classmethod
+    def validate_credentials(
+        cls, credentials: ImageGenerationProviderCredentials
+    ) -> bool:
+        return bool(credentials.api_key)
+
+    @classmethod
+    def _build_from_credentials(
+        cls, credentials: ImageGenerationProviderCredentials
+    ) -> MiniMaxImageGenerationProvider:
+        if not credentials.api_key:
+            raise ImageProviderCredentialsError("MiniMax API key is required")
+        return cls(api_key=credentials.api_key, api_base=credentials.api_base)
+
+    @property
+    def supports_reference_images(self) -> bool:
+        return False
+
+    def generate_image(
+        self,
+        prompt: str,
+        model: str,
+        size: str,
+        n: int,
+        quality: str | None = None,
+        reference_images: list[ReferenceImage] | None = None,
+        **kwargs: Any,
+    ) -> ImageGenerationResponse:
+        if reference_images:
+            raise ValueError(
+                "MiniMax image generation does not support reference images."
+            )
+
+        model_name = model.rsplit("/", 1)[-1]
+        if model_name not in self._MODEL_NAMES:
+            raise ValueError(f"Unsupported MiniMax image model: {model_name}")
+
+        payload: dict[str, Any] = {
+            "model": model_name,
+            "prompt": prompt,
+            "aspect_ratio": self._ASPECT_RATIOS.get(size, "1:1"),
+            "n": n,
+            # MiniMax returns generated assets in data.image_urls. Downloading
+            # those short-lived URLs lets Onyx retain the same base64 response
+            # contract as its other image-generation providers.
+            "response_format": "url",
+        }
+        if quality:
+            payload["quality"] = quality
+        for field in (
+            "subject_reference",
+            "width",
+            "height",
+            "seed",
+            "prompt_optimizer",
+        ):
+            if field in kwargs and kwargs[field] is not None:
+                payload[field] = kwargs[field]
+
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_GENERATION,
+            model=model_name,
+            provider="minimax",
+            image_count=n,
+            input_messages=[{"role": "user", "content": prompt}],
+        ):
+            response = requests.post(
+                self._api_base,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=120,
+            )
+            response.raise_for_status()
+            response_json = response.json()
+
+        if response_json.get("base_resp", {}).get("status_code") not in (None, 0):
+            raise RuntimeError("MiniMax image generation returned an error.")
+
+        image_urls = response_json.get("data", {}).get("image_urls") or []
+        if not image_urls:
+            raise RuntimeError("MiniMax image generation returned no image URLs.")
+
+        from litellm.types.utils import ImageObject, ImageResponse
+
+        generated = []
+        for image_url in image_urls[:n]:
+            image_response = requests.get(image_url, timeout=120)
+            image_response.raise_for_status()
+            generated.append(
+                ImageObject(
+                    b64_json=base64.b64encode(image_response.content).decode("ascii"),
+                    revised_prompt=prompt,
+                )
+            )
+        if not generated:
+            raise RuntimeError(
+                "MiniMax image generation returned no downloadable images."
+            )
+        return ImageResponse(data=generated)

--- a/backend/tests/unit/onyx/image_gen/test_provider_building.py
+++ b/backend/tests/unit/onyx/image_gen/test_provider_building.py
@@ -7,12 +7,14 @@ from onyx.image_gen.exceptions import ImageProviderCredentialsError
 from onyx.image_gen.factory import get_image_generation_provider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials, ReferenceImage
 from onyx.image_gen.providers.azure_img_gen import AzureImageGenerationProvider
+from onyx.image_gen.providers.minimax_img_gen import MiniMaxImageGenerationProvider
 from onyx.image_gen.providers.openai_img_gen import OpenAIImageGenerationProvider
 from onyx.image_gen.providers.vertex_img_gen import VertexImageGenerationProvider
 
 OPENAI_PROVIDER = "openai"
 AZURE_PROVIDER = "azure"
 VERTEX_PROVIDER = "vertex_ai"
+MINIMAX_PROVIDER = "minimax"
 
 
 def _get_default_image_gen_creds() -> ImageGenerationProviderCredentials:
@@ -59,6 +61,19 @@ def test_build_openai_provider_fails_no_api_key() -> None:
 
     with pytest.raises(ImageProviderCredentialsError):
         get_image_generation_provider(provider, credentials)
+
+
+def test_build_minimax_provider_from_api_key_and_base() -> None:
+    credentials = _get_default_image_gen_creds()
+    credentials.api_key = "test"
+    credentials.api_base = "https://api.minimaxi.com/v1"
+
+    provider = get_image_generation_provider(MINIMAX_PROVIDER, credentials)
+
+    assert isinstance(provider, MiniMaxImageGenerationProvider)
+    assert provider._api_key == "test"
+    assert provider._api_base == "https://api.minimaxi.com/v1/image_generation"
+    assert provider.supports_reference_images is False
 
 
 def test_build_azure_provider_from_api_key_and_base_and_version() -> None:


### PR DESCRIPTION
Reason: Add support for the configured text-to-image API.

This change adds a regional image-generation provider with configurable model, aspect ratio, count, and request options. Generated image URLs are downloaded and converted to the existing base64 response shape. Provider construction coverage was added for regional endpoint normalization.

Checks:
- `python3 -m compileall -q backend/onyx/image_gen/providers/minimax_img_gen.py backend/onyx/image_gen/factory.py backend/tests/unit/onyx/image_gen/test_provider_building.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a MiniMax regional image-generation provider and registers it in the factory, enabling MiniMax-backed image generation while preserving the existing base64 response shape. Previously MiniMax was unsupported; now `minimax` can be selected, and passing reference images will raise an error.

- New provider key `minimax` in `ImageGenerationProviderName` and `PROVIDERS`; construction requires `api_key` and accepts `api_base` (if `api_base` ends with `/v1`, it normalizes to `/v1/image_generation`).
- Supports models `image-01` and `image-01-live`; maps sizes to aspect ratios (e.g., `1024x1024`→`1:1`, `1792x1024`→`16:9`), defaulting to `1:1` when unknown.
- Returns base64 images by downloading short-lived URLs from the provider (`response_format: "url"`); enforces `n`; raises on MiniMax errors or empty results.
- Does not support reference images; calling with `reference_images` raises `ValueError`.
- Unit tests cover provider construction and endpoint normalization.

<sup>Written for commit bc5aea78bc74c98f6d258d7561eb7d7f851ff670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

