### PR TITLE
refactor(permissions): remove leftover UserRole references

### DIFF
--- a/backend/onyx/onyxbot/discord/DISCORD_MULTITENANT_README.md
+++ b/backend/onyx/onyxbot/discord/DISCORD_MULTITENANT_README.md
@@ -200,12 +200,11 @@ def get_or_create_discord_service_api_key(db_session: Session, tenant_id: str) -
     if existing:
         return regenerate_key(existing)
 
-    # Create LIMITED role key (chat-only permissions)
+    # Create a service key with the default service-account permissions.
     return insert_api_key(
         db_session=db_session,
         api_key_args=APIKeyArgs(
             name=DISCORD_SERVICE_API_KEY_NAME,
-            role=UserRole.LIMITED,  # Minimal permissions
         ),
         user_id=None,  # Service account (system-owned)
     ).api_key

--- a/backend/scripts/chat_feedback_dump.py
+++ b/backend/scripts/chat_feedback_dump.py
@@ -26,27 +26,9 @@ logger = getLogger(__name__)
 # from datetime import datetime
 # from enum import Enum
 
-# class UserRole(str, Enum):
-#     """
-#     User roles
-#     - Basic can't perform any admin actions
-#     - Admin can perform all admin actions
-#     - Curator can perform admin actions for
-#         groups they are curators of
-#     - Global Curator can perform admin actions
-#         for all groups they are a member of
-#     """
-
-#     BASIC = "basic"
-#     ADMIN = "admin"
-#     CURATOR = "curator"
-#     GLOBAL_CURATOR = "global_curator"
-
-
 # class FullUserSnapshot(BaseModel):
 #     id: UUID
 #     email: str
-#     role: UserRole
 #     is_active: bool
 
 

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -27,7 +27,6 @@ from fastapi_users.password import PasswordHelper
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.orm import Session
 
-from onyx.auth.schemas import UserRole
 from onyx.auth.users import cookie_transport
 from onyx.db.enums import AccountType, SSOProviderType
 from onyx.db.models import ScimUserMapping, SSOProvider, User, User__UserGroup
@@ -163,7 +162,6 @@ def _provision(
         **{
             "email": _SCIM_USER,
             "hashed_password": pw_helper.hash(pw_helper.generate()),
-            "role": UserRole.BASIC,
             "account_type": AccountType.STANDARD,
             "is_active": True,
             "is_verified": True,

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -37,7 +37,6 @@ from onyx.db.models import (
     Skill__UserGroup,
     User,
     UserGroup,
-    UserRole,
 )
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
@@ -160,6 +159,11 @@ def test_user(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> Generator[User, None, None]:
+    """A group-less, permission-less external-permission placeholder.
+
+    That is deliberate: it matches the row production's permission sync creates.
+    Use ``make_user(standard_account=True)`` when a test needs real authority.
+    """
     password_helper = PasswordHelper()
     user = User(
         id=uuid4(),
@@ -168,7 +172,6 @@ def test_user(
         is_active=True,
         is_superuser=False,
         is_verified=True,
-        role=UserRole.EXT_PERM_USER,
         account_type=AccountType.EXT_PERM_USER,
     )
     db_session.add(user)

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -32,7 +32,6 @@ from onyx.db.enums import (
     EndpointPolicy,
     ExternalAppType,
     GatedAppKind,
-    Permission,
     SandboxStatus,
     SkillSharePermission,
 )
@@ -53,8 +52,9 @@ from onyx.db.models import (
     User__UserGroup,
     UserGroup,
     UserGroup__ConnectorCredentialPair,
-    UserRole,
 )
+from onyx.db.permissions import recompute_user_permissions__no_commit
+from onyx.db.users import assign_user_to_default_groups__no_commit
 
 
 def force_approval_created_at(
@@ -74,25 +74,20 @@ def force_approval_created_at(
 def make_user(
     db_session: Session,
     *,
-    role: UserRole = UserRole.EXT_PERM_USER,
+    standard_account: bool = False,
+    is_admin: bool = False,
+    is_group_manager: bool = False,
     email_prefix: str = "craft_helper",
 ) -> User:
-    """Create a single ``User`` row with random email + UUID.
+    """Create a ``User`` row whose authority is derived the way production derives it.
 
-    ``role`` is kept as the caller-facing knob so the existing craft suite keeps
-    working, but authorization now comes from ``effective_permissions`` and
-    ``is_group_manager`` — the legacy column drives nothing. Translate here so
-    callers get a user whose authority actually matches the role they asked for.
+    Permissions come from the seeded default groups rather than a list written
+    here, because a list written here drifts the first time a group's grants
+    change. The no-flag default is a group-less placeholder, matching the users
+    that external permission sync creates.
     """
     helper = PasswordHelper()
-    account_type = (
-        AccountType.EXT_PERM_USER
-        if role == UserRole.EXT_PERM_USER
-        else AccountType.STANDARD
-    )
-    granted = [Permission.BASIC_ACCESS.value]
-    if role == UserRole.ADMIN:
-        granted.append(Permission.FULL_ADMIN_PANEL_ACCESS.value)
+    joins_a_group = standard_account or is_admin or is_group_manager
     user = User(
         id=uuid4(),
         email=f"{email_prefix}_{uuid4().hex[:8]}@example.com",
@@ -100,14 +95,37 @@ def make_user(
         is_active=True,
         is_superuser=False,
         is_verified=True,
-        account_type=account_type,
-        effective_permissions=granted,
-        # Curator == group manager; the per-group edge (is_manager) still decides scope.
-        is_group_manager=role in (UserRole.CURATOR, UserRole.GLOBAL_CURATOR),
+        account_type=(
+            AccountType.STANDARD if joins_a_group else AccountType.EXT_PERM_USER
+        ),
     )
     db_session.add(user)
     db_session.flush()
+
+    if joins_a_group:
+        assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
+    if is_group_manager:
+        _grant_manager_edge(db_session, user)
+
+    # The recompute updates the row in SQL, so re-read it or the caller gets stale permissions.
+    db_session.refresh(user)
     return user
+
+
+def _grant_manager_edge(db_session: Session, user: User) -> None:
+    """Give *user* a real manager edge so ``is_group_manager`` is derived, not asserted.
+
+    The group they manage is deliberately not the group a test shares resources
+    with. The route gate only reads the cached flag, while scope checks look for
+    a manager edge on that specific group, so tests that care about scope add
+    that edge themselves.
+    """
+    group = make_group(db_session, name=f"craft-managed-{uuid4().hex[:8]}")
+    db_session.add(
+        User__UserGroup(user_id=user.id, user_group_id=group.id, is_manager=True)
+    )
+    db_session.flush()
+    recompute_user_permissions__no_commit(user.id, db_session)
 
 
 def make_group(db_session: Session, name: str | None = None) -> UserGroup:

--- a/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
@@ -23,7 +23,6 @@ from onyx.db.models import (
     LLMProvider__Persona,
     LLMProvider__UserGroup,
     User,
-    UserRole,
 )
 from onyx.server.manage.llm.models import (
     LLMProviderUpsertRequest,
@@ -73,7 +72,7 @@ def test_group_restricted_provider_scoped_by_membership(
     member = make_user(db_session)
     add_user_to_group(db_session, member, group)
     non_member = make_user(db_session)
-    admin = make_user(db_session, role=UserRole.ADMIN)
+    admin = make_user(db_session, is_admin=True)
     db_session.commit()
 
     provider_id = _make_group_restricted_anthropic_provider(db_session, group.id)
@@ -128,7 +127,7 @@ def test_focused_provider_fetch_is_ordered_and_access_scoped(
 ) -> None:
     member = make_user(db_session)
     non_member = make_user(db_session)
-    admin = make_user(db_session, role=UserRole.ADMIN)
+    admin = make_user(db_session, is_admin=True)
     group = make_group(db_session)
     add_user_to_group(db_session, member, group)
 

--- a/backend/tests/external_dependency_unit/craft/test_craft_access_admin.py
+++ b/backend/tests/external_dependency_unit/craft/test_craft_access_admin.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.auth.schemas import UserRole
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.feature_flags.interface import NoOpFeatureFlagProvider
@@ -35,9 +34,9 @@ def test_admin_batch_disable_and_reset_to_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _enable_craft_deployment(monkeypatch)
-    admin = make_user(db_session, role=UserRole.ADMIN, email_prefix="craft_admin")
-    target_a = make_user(db_session, role=UserRole.BASIC, email_prefix="craft_a")
-    target_b = make_user(db_session, role=UserRole.BASIC, email_prefix="craft_b")
+    admin = make_user(db_session, is_admin=True, email_prefix="craft_admin")
+    target_a = make_user(db_session, standard_account=True, email_prefix="craft_a")
+    target_b = make_user(db_session, standard_account=True, email_prefix="craft_b")
 
     # No override: everyone follows the workspace default (True out of the box).
     assert target_a.craft_enabled is None
@@ -84,8 +83,8 @@ def test_unknown_user_rejects_whole_batch(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
-    admin = make_user(db_session, role=UserRole.ADMIN, email_prefix="craft_admin")
-    target = make_user(db_session, role=UserRole.BASIC, email_prefix="craft_known")
+    admin = make_user(db_session, is_admin=True, email_prefix="craft_admin")
+    target = make_user(db_session, standard_account=True, email_prefix="craft_known")
 
     with pytest.raises(OnyxError) as exc_info:
         set_user_craft_access(

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
@@ -14,7 +14,7 @@ from onyx.db.external_app import (
     get_skills_for_external_app,
     replace_custom_skill_associations__no_commit,
 )
-from onyx.db.models import Skill, User, UserRole, UserSkillPreference
+from onyx.db.models import Skill, User, UserSkillPreference
 from onyx.db.skill import set_skill_public_permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -49,7 +49,7 @@ def test_associate_promotes_visibility_and_preserves_preferences(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
     skill = make_skill(
         db_session,
         is_public=False,
@@ -222,7 +222,7 @@ def test_unlink_retains_skill_visibility_content_and_preferences(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
     skill = make_skill(db_session, is_public=True, author_user_id=owner.id)
     original_bundle_file_id = skill.bundle_file_id
     db_session.add(
@@ -298,8 +298,8 @@ def test_app_update_batches_associations_into_one_sandbox_refresh(
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    other_user = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    other_user = make_user(db_session, standard_account=True)
     make_sandbox(db_session, owner)
     make_sandbox(db_session, other_user)
     skill = make_skill(
@@ -353,7 +353,7 @@ def test_editor_creation_with_app_context_is_atomic_and_not_auto_enabled(
     test_user: User,  # noqa: ARG001
     initialize_file_store: None,  # noqa: ARG001
 ) -> None:
-    admin = make_user(db_session, role=UserRole.ADMIN)
+    admin = make_user(db_session, is_admin=True)
     app_id = _make_app(db_session)
     response = create_custom_skill_from_editor(
         name=f"associated-{uuid4().hex[:8]}",
@@ -393,7 +393,7 @@ def test_editor_app_context_requires_an_admin_before_writing_skill_content(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    user = make_user(db_session, role=UserRole.BASIC)
+    user = make_user(db_session, standard_account=True)
     app_id = _make_app(db_session)
     skill_ids_before = set(db_session.scalars(select(Skill.id)))
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
@@ -13,7 +13,7 @@ from onyx.db.external_app import (
     get_external_app_by_skill_id,
     get_skills_for_external_app,
 )
-from onyx.db.models import ExternalApp__Skill, User, UserRole, UserSkillPreference
+from onyx.db.models import ExternalApp__Skill, User, UserSkillPreference
 from onyx.db.skill import (
     SkillManagementPolicy,
     fetch_skill,
@@ -97,7 +97,7 @@ def test_admin_view_includes_associated_custom_but_hides_associated_builtin(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    admin = make_user(db_session, role=UserRole.ADMIN)
+    admin = make_user(db_session, is_admin=True)
     regular = make_skill(db_session, is_public=True, name="plain-admin-skill")
     custom = make_skill(db_session, is_public=True, name="ext-admin-custom")
     built_in = make_built_in_skill_row(

--- a/backend/tests/external_dependency_unit/craft/test_make_user_fidelity.py
+++ b/backend/tests/external_dependency_unit/craft/test_make_user_fidelity.py
@@ -1,0 +1,88 @@
+"""``make_user`` must derive authority the way production does.
+
+``effective_permissions`` is a cache column and the authorization read path
+never joins the group tables, so a fixture can hand-write any value and every
+permission check will believe it. These tests pin the helper to the real
+default-group grants, so a hard-coded permission list fails here instead of
+drifting silently.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import AccountType, Permission
+from onyx.db.models import PermissionGrant, User__UserGroup, UserGroup
+from onyx.db.users import DEFAULT_ADMIN_GROUP_NAME, DEFAULT_BASIC_GROUP_NAME
+from tests.external_dependency_unit.craft.db_helpers import make_user
+
+
+def _default_group_grants(db_session: Session, group_name: str) -> set[str]:
+    return {
+        permission.value
+        for permission in db_session.scalars(
+            select(PermissionGrant.permission)
+            .join(UserGroup, UserGroup.id == PermissionGrant.group_id)
+            .where(
+                UserGroup.name == group_name,
+                UserGroup.is_default.is_(True),
+                PermissionGrant.is_deleted.is_(False),
+            )
+        )
+    }
+
+
+def _group_names(db_session: Session, user_id: UUID) -> set[str]:
+    return set(
+        db_session.scalars(
+            select(UserGroup.name)
+            .join(User__UserGroup, User__UserGroup.user_group_id == UserGroup.id)
+            .where(User__UserGroup.user_id == user_id)
+        )
+    )
+
+
+def test_standard_user_permissions_come_from_the_basic_group(
+    db_session: Session,
+) -> None:
+    user = make_user(db_session, standard_account=True)
+
+    assert DEFAULT_BASIC_GROUP_NAME in _group_names(db_session, user.id)
+    assert set(user.effective_permissions) == _default_group_grants(
+        db_session, DEFAULT_BASIC_GROUP_NAME
+    )
+
+
+def test_admin_user_joins_the_admin_group(db_session: Session) -> None:
+    user = make_user(db_session, is_admin=True)
+
+    assert DEFAULT_ADMIN_GROUP_NAME in _group_names(db_session, user.id)
+    assert set(user.effective_permissions) == _default_group_grants(
+        db_session, DEFAULT_ADMIN_GROUP_NAME
+    )
+    assert Permission.FULL_ADMIN_PANEL_ACCESS.value in user.effective_permissions
+
+
+def test_group_manager_flag_is_backed_by_a_manager_edge(db_session: Session) -> None:
+    user = make_user(db_session, is_group_manager=True)
+
+    assert user.is_group_manager is True
+    managed = db_session.scalars(
+        select(User__UserGroup.user_group_id).where(
+            User__UserGroup.user_id == user.id,
+            User__UserGroup.is_manager.is_(True),
+        )
+    ).all()
+    assert len(managed) == 1
+
+
+def test_default_user_is_a_group_less_placeholder(db_session: Session) -> None:
+    """This is the row production's ``_generate_ext_permissioned_user`` builds."""
+    user = make_user(db_session)
+
+    assert user.account_type == AccountType.EXT_PERM_USER
+    assert _group_names(db_session, user.id) == set()
+    assert user.effective_permissions == []

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -17,7 +17,6 @@ import pytest
 from fastapi_users.password import PasswordHelper
 from sqlalchemy.orm import Query, Session
 
-from onyx.auth.schemas import UserRole
 from onyx.configs.constants import FileOrigin, MessageType
 from onyx.db.enums import (
     AccountType,
@@ -1103,7 +1102,6 @@ class TestPortAllocator:
             hashed_password=password_helper.hash(password_helper.generate()),
             is_active=True,
             is_verified=True,
-            role=UserRole.EXT_PERM_USER,
             account_type=AccountType.EXT_PERM_USER,
         )
         db_session.add(other_user)

--- a/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
@@ -12,7 +12,7 @@ from fastapi import UploadFile
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import SkillAccessLevel, SkillSharePermission
-from onyx.db.models import User, UserRole, UserSkillPreference
+from onyx.db.models import User, UserSkillPreference
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.skill.api import (
@@ -50,7 +50,7 @@ def test_curator_without_group_scope_cannot_patch_shared_skill(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    curator = make_user(db_session, role=UserRole.CURATOR)
+    curator = make_user(db_session, is_group_manager=True)
     group = make_group(db_session)
     add_user_to_group(db_session, curator, group)
     private_skill = make_skill(db_session, is_public=False)
@@ -71,7 +71,7 @@ def test_fetch_direct_shared_skill_is_not_personal(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    user = make_user(db_session, role=UserRole.BASIC)
+    user = make_user(db_session, standard_account=True)
     private_skill = make_skill(db_session, is_public=False)
     share_skill_with_user(db_session, private_skill, user)
 
@@ -90,7 +90,7 @@ def test_fetch_associated_skill_reports_current_user_dependency_readiness(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    user = make_user(db_session, role=UserRole.BASIC)
+    user = make_user(db_session, standard_account=True)
     skill = make_skill(db_session, is_public=True)
     app = make_external_app(
         db_session,
@@ -158,8 +158,8 @@ def test_viewer_share_cannot_patch_skill(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    shared_user = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    shared_user = make_user(db_session, standard_account=True)
     private_skill = make_skill(
         db_session,
         is_public=False,
@@ -188,7 +188,7 @@ def test_preference_commit_succeeds_when_sandbox_push_fails(
     test_user: User,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    user = make_user(db_session, role=UserRole.BASIC)
+    user = make_user(db_session, standard_account=True)
     skill = make_skill(db_session, is_public=True)
 
     def fail_sandbox_lookup(*_args: object, **_kwargs: object) -> None:
@@ -218,7 +218,7 @@ def test_create_reserved_name_rejects_from_bundle_metadata(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    user = make_user(db_session, role=UserRole.BASIC)
+    user = make_user(db_session, standard_account=True)
     bundle = build_single_file_bundle(
         SKILL_MD_NAME,
         build_skill_md(
@@ -243,7 +243,7 @@ def test_editor_create_rejects_whitespace_only_fields(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    user = make_user(db_session, role=UserRole.BASIC)
+    user = make_user(db_session, standard_account=True)
 
     with pytest.raises(OnyxError) as exc_info:
         create_custom_skill_from_editor(
@@ -265,8 +265,8 @@ def test_replace_bundle_authorizes_before_reading_bundle(
     test_user: User,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    shared_user = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    shared_user = make_user(db_session, standard_account=True)
     private_skill = make_skill(
         db_session,
         is_public=False,
@@ -301,8 +301,8 @@ def test_upload_files_authorizes_before_reading_upload(
     test_user: User,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    shared_user = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    shared_user = make_user(db_session, standard_account=True)
     private_skill = make_skill(
         db_session,
         is_public=False,
@@ -337,8 +337,8 @@ def test_remove_file_authorizes_before_reading_bundle(
     test_user: User,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    shared_user = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    shared_user = make_user(db_session, standard_account=True)
     private_skill = make_skill(
         db_session,
         is_public=False,
@@ -373,7 +373,7 @@ def test_remove_file_rejects_empty_path_before_reading_bundle(
     test_user: User,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
     private_skill = make_skill(
         db_session,
         is_public=False,

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -7,7 +7,6 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from onyx.auth.schemas import UserRole
 from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill, Skill__User, Skill__UserGroup, UserSkillPreference
 from onyx.db.skill import (
@@ -132,7 +131,7 @@ def test_new_skill_name_is_not_reserved_by_external_app_association(
 def test_orphaned_private_skill_has_boolean_admin_state(
     db_session: Session,
 ) -> None:
-    admin = make_user(db_session, role=UserRole.ADMIN)
+    admin = make_user(db_session, is_admin=True)
     orphaned_skill = make_skill(
         db_session,
         is_public=False,

--- a/backend/tests/external_dependency_unit/craft/test_skill_ownership_transfer.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_ownership_transfer.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import AccountType, SkillSharePermission
-from onyx.db.models import Skill, Skill__User, User, UserRole
+from onyx.db.models import Skill, Skill__User, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.skill.api import transfer_current_user_skill_ownership
@@ -52,8 +52,8 @@ def test_owner_transfers_to_active_user(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    new_owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    new_owner = make_user(db_session, standard_account=True)
     skill = _owned_skill(db_session, owner)
     share_skill_with_user(
         db_session,
@@ -83,8 +83,8 @@ def test_transfer_pushes_previous_and_new_owner_sandboxes(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    new_owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    new_owner = make_user(db_session, standard_account=True)
     make_sandbox(db_session, owner)
     make_sandbox(db_session, new_owner)
     skill = _owned_skill(db_session, owner)
@@ -108,9 +108,9 @@ def test_non_owner_sharee_cannot_transfer(
     permission: SkillSharePermission,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    sharee = make_user(db_session, role=UserRole.BASIC)
-    target = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    sharee = make_user(db_session, standard_account=True)
+    target = make_user(db_session, standard_account=True)
     skill = _owned_skill(db_session, owner)
     share_skill_with_user(db_session, skill, sharee, permission)
 
@@ -133,8 +133,8 @@ def test_transfer_rejects_inactive_target(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    target = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    target = make_user(db_session, standard_account=True)
     target.is_active = False
     skill = _owned_skill(db_session, owner)
     db_session.flush()
@@ -158,10 +158,10 @@ def test_transfer_rejects_unsupported_target_account_type(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
     target = make_user(
         db_session,
-        role=UserRole.BASIC,
+        standard_account=True,
     )
     target.account_type = AccountType.BOT
     skill = _owned_skill(db_session, owner)
@@ -186,8 +186,8 @@ def test_admin_transfers_vacant_skill(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    admin = make_user(db_session, role=UserRole.ADMIN)
-    target = make_user(db_session, role=UserRole.BASIC)
+    admin = make_user(db_session, is_admin=True)
+    target = make_user(db_session, standard_account=True)
     skill = make_skill(db_session)
 
     response = transfer_current_user_skill_ownership(
@@ -208,9 +208,9 @@ def test_admin_cannot_transfer_owned_skill(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
-    admin = make_user(db_session, role=UserRole.ADMIN)
-    target = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
+    admin = make_user(db_session, is_admin=True)
+    target = make_user(db_session, standard_account=True)
     skill = _owned_skill(db_session, owner)
 
     with pytest.raises(OnyxError) as exc_info:
@@ -232,7 +232,7 @@ def test_transfer_rejects_missing_target(
     db_session: Session,
     push_calls: list[set[object]],
 ) -> None:
-    owner = make_user(db_session, role=UserRole.BASIC)
+    owner = make_user(db_session, standard_account=True)
     skill = _owned_skill(db_session, owner)
 
     with pytest.raises(OnyxError) as exc_info:

--- a/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import SkillSharePermission
-from onyx.db.models import User, UserRole
+from onyx.db.models import User
 from onyx.db.skill import (
     SkillManagementPolicy,
     fetch_skill,
@@ -36,7 +36,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        admin = make_user(db_session, role=UserRole.ADMIN)
+        admin = make_user(db_session, is_admin=True)
         skill = make_skill(db_session, is_public=False)
 
         result = fetch_skill(
@@ -63,7 +63,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        user = make_user(db_session, role=UserRole.BASIC)
+        user = make_user(db_session, standard_account=True)
         group = make_group(db_session)
         add_user_to_group(db_session, user, group)
         skill = make_skill(db_session, is_public=False)
@@ -83,7 +83,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        user = make_user(db_session, role=UserRole.BASIC)
+        user = make_user(db_session, standard_account=True)
         skill = make_skill(db_session, is_public=False)
         assert (
             fetch_skill(
@@ -129,7 +129,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        user = make_user(db_session, role=UserRole.BASIC)
+        user = make_user(db_session, standard_account=True)
         group = make_group(db_session)
         membership = add_user_to_group(db_session, user, group)
         private_skill = make_skill(db_session, is_public=False)
@@ -153,8 +153,8 @@ class TestSkillVisibility:
         # Current behavior pinned: ONLY a global MANAGE_SKILLS holder bypasses the visibility
         # filter. Curators (and global curators) walk the same path as
         # regular users — no admin-style "see every row" override.
-        curator = make_user(db_session, role=UserRole.CURATOR)
-        basic = make_user(db_session, role=UserRole.BASIC)
+        curator = make_user(db_session, is_group_manager=True)
+        basic = make_user(db_session, standard_account=True)
 
         # A private skill shared with a group the curator is NOT in.
         other_group = make_group(db_session)
@@ -180,7 +180,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        curator = make_user(db_session, role=UserRole.CURATOR)
+        curator = make_user(db_session, is_group_manager=True)
         group = make_group(db_session)
         membership = add_user_to_group(db_session, curator, group)
         membership.is_manager = True
@@ -203,7 +203,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        curator = make_user(db_session, role=UserRole.CURATOR)
+        curator = make_user(db_session, is_group_manager=True)
         group = make_group(db_session)
         add_user_to_group(db_session, curator, group)
         private_skill = make_skill(db_session, is_public=False)
@@ -223,7 +223,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        curator = make_user(db_session, role=UserRole.CURATOR)
+        curator = make_user(db_session, is_group_manager=True)
         curated_group = make_group(db_session)
         other_group = make_group(db_session)
         membership = add_user_to_group(db_session, curator, curated_group)
@@ -247,7 +247,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        curator = make_user(db_session, role=UserRole.GLOBAL_CURATOR)
+        curator = make_user(db_session, is_group_manager=True)
         group = make_group(db_session)
         membership = add_user_to_group(db_session, curator, group)
         membership.is_manager = True
@@ -270,7 +270,7 @@ class TestSkillVisibility:
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
-        curator = make_user(db_session, role=UserRole.CURATOR)
+        curator = make_user(db_session, is_group_manager=True)
         public_skill = make_skill(db_session, is_public=True)
 
         result = fetch_skill(

--- a/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
@@ -113,10 +113,10 @@ def test_update_preserves_basic_key_permissions(db_session: Session) -> None:
     remove_api_key(db_session, descriptor.api_key_id)
 
 
-def test_update_role_change_swaps_permission_source(db_session: Session) -> None:
+def test_update_group_change_swaps_permission_source(db_session: Session) -> None:
     descriptor = insert_api_key(
         db_session,
-        APIKeyArgs(name="role-swap", group_ids=[_basic_group_id(db_session)]),
+        APIKeyArgs(name="group-swap", group_ids=[_basic_group_id(db_session)]),
         user_id=None,
     )
     user = _get_key_user(db_session, descriptor.user_id)
@@ -126,7 +126,7 @@ def test_update_role_change_swaps_permission_source(db_session: Session) -> None
     update_api_key(
         db_session,
         descriptor.api_key_id,
-        APIKeyArgs(name="role-swap"),
+        APIKeyArgs(name="group-swap"),
     )
     db_session.refresh(user)
     assert user.effective_permissions == ["write:chat"]
@@ -134,7 +134,7 @@ def test_update_role_change_swaps_permission_source(db_session: Session) -> None
     update_api_key(
         db_session,
         descriptor.api_key_id,
-        APIKeyArgs(name="role-swap", group_ids=[_basic_group_id(db_session)]),
+        APIKeyArgs(name="group-swap", group_ids=[_basic_group_id(db_session)]),
     )
     db_session.refresh(user)
     assert user.effective_permissions == basic_perms

--- a/backend/tests/external_dependency_unit/db/test_prior_email_claim_release.py
+++ b/backend/tests/external_dependency_unit/db/test_prior_email_claim_release.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.auth.schemas import UserRole
 from onyx.db.enums import AccountType
 from onyx.db.models import User
 from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
@@ -51,7 +50,6 @@ def test_inserting_a_user_strips_the_address_from_other_aliases(
         hashed_password="unused",
         is_active=True,
         is_verified=True,
-        role=UserRole.BASIC,
         account_type=AccountType.STANDARD,
     )
     db_session.add(claimant)

--- a/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
@@ -9,7 +9,6 @@ from sqlalchemy import text, update
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.hierarchy import _get_accessible_hierarchy_nodes_for_source
-from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DocumentSource
 from onyx.db.document import get_accessible_documents_for_hierarchy_node_paginated
 from onyx.db.enums import AccessType, AccountType, HierarchyNodeType
@@ -48,7 +47,6 @@ class UserSeed(BaseModel):
     is_active: bool
     is_superuser: bool
     is_verified: bool
-    role: UserRole
     account_type: AccountType
 
 
@@ -121,7 +119,6 @@ def connector_access_seed(
             is_active=True,
             is_superuser=False,
             is_verified=True,
-            role=UserRole.BASIC,
             account_type=AccountType.STANDARD,
         )
         for kind in ("owner", "member", "outsider")
@@ -130,9 +127,9 @@ def connector_access_seed(
         text(
             'INSERT INTO "user" '
             "(id, email, hashed_password, is_active, is_superuser, is_verified, "
-            "role, account_type) "
+            "account_type) "
             "VALUES (:id, :email, :hashed_password, :is_active, :is_superuser, "
-            ":is_verified, :role, :account_type)"
+            ":is_verified, :account_type)"
         ),
         [user.model_dump(mode="json") for user in user_rows],
     )

--- a/backend/tests/integration/common_utils/managers/api_key.py
+++ b/backend/tests/integration/common_utils/managers/api_key.py
@@ -16,8 +16,7 @@ class APIKeyManager:
     ) -> DATestAPIKey:
         name = f"{name}-api-key" if name else f"test-api-key-{uuid4()}"
         # Default to the Admin default group so API keys created without
-        # explicit groups inherit admin-level permissions, matching the
-        # pre-permission-migration default of UserRole.ADMIN.
+        # explicit groups inherit admin-level permissions.
         if group_ids is None:
             admin_group = UserGroupManager.get_default(
                 user_performing_action=user_performing_action,

--- a/backend/tests/integration/tests/users/test_user_pagination.py
+++ b/backend/tests/integration/tests/users/test_user_pagination.py
@@ -191,9 +191,8 @@ def test_user_pagination_account_types_filter(reset: None) -> None:  # noqa: ARG
     users whose ``account_type`` is in the supplied list, while omitting the
     filter returns the full accepted-user set.
 
-    This guards against the silent filter removal that shipped in the
-    UserRole-cleanup PR: an endpoint tagged PUBLIC_API_TAGS must not drop
-    filter params without a replacement.
+    This guards against silent filter removal: an endpoint tagged
+    PUBLIC_API_TAGS must not drop filter params without a replacement.
     """
     admin: DATestUser = UserManager.create(name="admin_account_types")
 

--- a/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
+++ b/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
@@ -49,13 +49,11 @@ def _patch_canonical_predicate() -> Iterator[None]:
 def _user(
     *,
     is_active: bool = True,
-    role: object = "BASIC",
     email: str = "u@test.com",
     account_type: object = AccountType.STANDARD,
 ) -> MagicMock:
     user = MagicMock()
     user.is_active = is_active
-    user.role = role
     user.email = email
     user.account_type = account_type
     return user
@@ -63,117 +61,80 @@ def _user(
 
 class TestUserCurrentlyCountsTowardSeats:
     def test_active_standard_user_counts(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         assert _user_currently_counts_toward_seats(
-            _user(role=UserRole.BASIC, account_type=AccountType.STANDARD)
+            _user(account_type=AccountType.STANDARD)
         )
 
     def test_active_bot_user_counts(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         # BOT account_type is included in the seat count by design.
-        assert _user_currently_counts_toward_seats(
-            _user(role=UserRole.SLACK_USER, account_type=AccountType.BOT)
-        )
+        assert _user_currently_counts_toward_seats(_user(account_type=AccountType.BOT))
 
     def test_inactive_user_does_not_count(self) -> None:
-        from onyx.auth.schemas import UserRole
-
-        assert not _user_currently_counts_toward_seats(
-            _user(is_active=False, role=UserRole.BASIC)
-        )
+        assert not _user_currently_counts_toward_seats(_user(is_active=False))
 
     def test_ext_perm_user_does_not_count(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         assert not _user_currently_counts_toward_seats(
-            _user(role=UserRole.EXT_PERM_USER, account_type=AccountType.EXT_PERM_USER)
+            _user(account_type=AccountType.EXT_PERM_USER)
         )
 
     def test_service_account_does_not_count(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         assert not _user_currently_counts_toward_seats(
-            _user(role=UserRole.BASIC, account_type=AccountType.SERVICE_ACCOUNT)
+            _user(account_type=AccountType.SERVICE_ACCOUNT)
         )
 
     def test_anonymous_user_does_not_count(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         assert not _user_currently_counts_toward_seats(
-            _user(role=UserRole.BASIC, email=ANONYMOUS_USER_EMAIL)
+            _user(email=ANONYMOUS_USER_EMAIL)
         )
 
 
 class TestUpgradeWillAddSeat:
     def test_ext_perm_to_standard_active_adds_seat(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=True,
-            role=UserRole.EXT_PERM_USER,
             account_type=AccountType.EXT_PERM_USER,
         )
         assert _upgrade_will_add_seat(before, will_become_active=True)
 
     def test_service_account_to_standard_active_adds_seat(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=True,
-            role=UserRole.BASIC,
             account_type=AccountType.SERVICE_ACCOUNT,
         )
         assert _upgrade_will_add_seat(before, will_become_active=True)
 
     def test_inactive_to_active_standard_adds_seat(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=False,
-            role=UserRole.BASIC,
             account_type=AccountType.STANDARD,
         )
         assert _upgrade_will_add_seat(before, will_become_active=True)
 
     def test_inactive_remaining_inactive_does_not_add_seat(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=False,
-            role=UserRole.EXT_PERM_USER,
             account_type=AccountType.EXT_PERM_USER,
         )
         assert not _upgrade_will_add_seat(before, will_become_active=False)
 
     def test_bot_to_standard_does_not_add_seat(self) -> None:
         # BOT counts already; upgrade keeps it counted.
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=True,
-            role=UserRole.SLACK_USER,
             account_type=AccountType.BOT,
         )
         assert not _upgrade_will_add_seat(before, will_become_active=True)
 
     def test_already_standard_active_does_not_add_seat(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=True,
-            role=UserRole.BASIC,
             account_type=AccountType.STANDARD,
         )
         assert not _upgrade_will_add_seat(before, will_become_active=True)
 
     def test_anonymous_email_never_adds_seat(self) -> None:
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=False,
-            role=UserRole.BASIC,
             email=ANONYMOUS_USER_EMAIL,
             account_type=AccountType.EXT_PERM_USER,
         )
@@ -184,11 +145,8 @@ class TestUpgradeWillAddSeat:
         an EXT_PERM_USER upgrade leaves the mapping count unchanged, so
         ``_upgrade_will_add_seat`` must return ``False`` to avoid
         over-billing the tenant on every promotion."""
-        from onyx.auth.schemas import UserRole
-
         before = _user(
             is_active=True,
-            role=UserRole.EXT_PERM_USER,
             account_type=AccountType.EXT_PERM_USER,
         )
         with patch("onyx.auth.users.MULTI_TENANT", True):

--- a/backend/tests/unit/onyx/db/test_email_reconcile.py
+++ b/backend/tests/unit/onyx/db/test_email_reconcile.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
-from onyx.auth.schemas import UserRole
 from onyx.db.enums import AccountType
 from onyx.db.models import User
 from onyx.db.users import (
@@ -31,11 +30,6 @@ def _user(
             email=email,
             prior_emails=prior_emails if prior_emails is not None else [],
             account_type=account_type,
-            role=(
-                UserRole.EXT_PERM_USER
-                if account_type == AccountType.EXT_PERM_USER
-                else UserRole.BASIC
-            ),
             oauth_accounts=[],
         ),
     )

--- a/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
@@ -12,7 +12,6 @@ admin-authored header template values.
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from onyx.auth.schemas import UserRole
 from onyx.db.enums import (
     MCPAuthenticationPerformer,
     MCPAuthenticationType,
@@ -60,10 +59,9 @@ def _make_db_server(
     return server
 
 
-def _make_user(*, email: str, role: UserRole) -> MagicMock:
+def _make_user(*, email: str) -> MagicMock:
     user = MagicMock()
     user.email = email
-    user.role = role
     return user
 
 
@@ -115,7 +113,7 @@ class TestPerUserAuthTemplateInvariants:
             auth_performer=MCPAuthenticationPerformer.PER_USER,
             admin_config=_oauth_admin_config_with_runtime_headers(),
         )
-        basic_user = _make_user(email="user@example.com", role=UserRole.BASIC)
+        basic_user = _make_user(email="user@example.com")
 
         with patch(
             "onyx.server.features.mcp.api.get_user_connection_config",
@@ -133,15 +131,13 @@ class TestPerUserAuthTemplateInvariants:
         assert api_server.user_credentials is None
 
     def test_admin_user_oauth_server_listing_returns_no_auth_template(self) -> None:
-        """Admins on the listing endpoint share the same code path as
-        basic users; the OAuth invariant must apply regardless of role.
-        """
+        """The listing endpoint must never return OAuth auth templates."""
         db_server = _make_db_server(
             auth_type=MCPAuthenticationType.OAUTH,
             auth_performer=MCPAuthenticationPerformer.PER_USER,
             admin_config=_oauth_admin_config_with_runtime_headers(),
         )
-        admin = _make_user(email="admin@example.com", role=UserRole.ADMIN)
+        admin = _make_user(email="admin@example.com")
 
         with patch(
             "onyx.server.features.mcp.api.get_user_connection_config",
@@ -169,7 +165,7 @@ class TestPerUserAuthTemplateInvariants:
             auth_performer=MCPAuthenticationPerformer.PER_USER,
             admin_config=_oauth_admin_config_with_runtime_headers(),
         )
-        owner = _make_user(email="owner@example.com", role=UserRole.ADMIN)
+        owner = _make_user(email="owner@example.com")
 
         with patch(
             "onyx.server.features.mcp.api.get_user_connection_config",
@@ -196,7 +192,7 @@ class TestPerUserAuthTemplateInvariants:
             auth_performer=MCPAuthenticationPerformer.PER_USER,
             admin_config=_api_token_template_admin_config(),
         )
-        user = _make_user(email="user@example.com", role=UserRole.BASIC)
+        user = _make_user(email="user@example.com")
 
         with patch(
             "onyx.server.features.mcp.api.get_user_connection_config",
@@ -221,7 +217,7 @@ class TestPerUserAuthTemplateInvariants:
             auth_performer=MCPAuthenticationPerformer.PER_USER,
             admin_config=_api_token_template_admin_config(),
         )
-        owner = _make_user(email="owner@example.com", role=UserRole.ADMIN)
+        owner = _make_user(email="owner@example.com")
 
         with patch(
             "onyx.server.features.mcp.api.get_user_connection_config",

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -539,10 +539,10 @@ function UserCard({ user, showActions = false, onEdit }: UserCardProps) {
 export interface User {
   id: string
   name: string
-  role: UserRole
+  accessLevel: AccessLevel
 }
 
-export type UserRole = "admin" | "member" | "viewer"
+export type AccessLevel = "admin" | "member" | "viewer"
 
 // ❌ Bad — inline prop types
 function UserCard({

--- a/web/src/views/admin/GroupsPage/useGroupMemberCandidates.ts
+++ b/web/src/views/admin/GroupsPage/useGroupMemberCandidates.ts
@@ -69,11 +69,10 @@ interface UseGroupMemberCandidatesResult {
 /**
  * Returns the candidate list for the group create/edit member pickers.
  *
- * Hits `/api/manage/users?include_api_keys=true`, which is gated by
- * `current_curator_or_admin_user` on the backend, so this works for both
- * admins and global curators (the admin-only `/accepted/all` and `/invited`
- * endpoints used to be called here, which 403'd for global curators and broke
- * the Edit Group page entirely).
+ * Hits `/api/manage/users?include_api_keys=true`, which is gated by scoped
+ * READ_USERS permission on the backend. This works for admins and group
+ * managers. The admin-only `/accepted/all` and `/invited` endpoints used to be
+ * called here, which 403'd for group managers and broke the Edit Group page.
  *
  * For admins, we additionally fetch `/admin/api-key` to enrich service-account
  * rows with the masked api-key display string. That call is admin-only and is


### PR DESCRIPTION
## Description

- Removes the last `UserRole` references from 19 test files and 3 docs; production code was already group-based apart from two deliberate tombstones (the enum and the nullable `user.role` column) that await the deferred drop migration.
- Craft's `make_user` helper now derives permissions from the seeded default groups instead of a hard-coded list, and backs `is_group_manager` with a real manager edge, so test users can no longer drift from what a real user actually holds.
- Fixes a stale Discord readme example using `role=UserRole.LIMITED` for API key creation, and renames an illustrative `UserRole` type in `web/AGENTS.md` that was never an Onyx type.

The `user.role_change` audit action is deliberately left alone — it is a wire value on an append-only SIEM contract, so it belongs with the wider audit-coverage work.

## How Has This Been Tested?
By running tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes remaining `UserRole` references and updates the `make_user` test helper to derive permissions from default groups, aligning tests and docs with the group-based permission model. Previously `make_user(role=...)` set permissions and flags directly; now `standard_account`, `is_admin`, and `is_group_manager` assign seeded default groups and back group managers with a real manager edge, then recompute user permissions. Default users are now group-less EXT_PERM placeholders.

- Production behavior is unchanged; the `user.role` column and the `UserRole` enum remain as tombstones until the deferred drop migration. The `user.role_change` audit action is unchanged.

**Review notes**
- Replaces `role=...` in tests with `standard_account`, `is_admin`, or `is_group_manager`; removes `UserRole` imports. Adds `tests/external_dependency_unit/craft/test_make_user_fidelity.py` to pin helper behavior to real default-group grants.
- Adjusts examples and comments: removes `role=UserRole.LIMITED` from Discord README; renames illustrative `UserRole` type to `AccessLevel` in `web/AGENTS.md`; clarifies `/manage/users` gating in `useGroupMemberCandidates`.
- Helper changes: `make_user` uses `assign_user_to_default_groups__no_commit` and `recompute_user_permissions__no_commit`; backs `is_group_manager` via a `User__UserGroup.is_manager` edge in a separate group.

**Migration for tests/docs**
- Replace `make_user(..., role=UserRole.ADMIN)` with `make_user(..., is_admin=True)`.
- Replace `role=UserRole.BASIC` with `standard_account=True`.
- Replace `role in {UserRole.CURATOR, UserRole.GLOBAL_CURATOR}` with `is_group_manager=True` and add explicit manager edges where scope matters.
- Remove `UserRole` imports and any `user.role` writes in tests; use group membership and permissions instead.

<sup>Written for commit dada80d872b7a8beabf2f7cf928829601106d0f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

