### PR TITLE
test(usage): make budget reset date assertion locale-independent

### DIFF
--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UsageSettings from "@/app/app/settings/usage/UsageSettings";
 import { useUserUsage } from "@/app/app/settings/usage/lib";
+import { formatCalendarDay } from "@/lib/dateUtils";
 
 jest.mock("@/app/app/settings/usage/lib", () => ({
   useUserUsage: jest.fn(),
@@ -71,7 +72,9 @@ describe("UsageSettings", () => {
 
     render(<UsageSettings />);
 
-    expect(screen.getByText("Resets on Sep 1")).toBeInTheDocument();
+    expect(
+      screen.getByText(`Resets on ${formatCalendarDay("2026-09-01")}`)
+    ).toBeInTheDocument();
   });
 
   it("shows the top three models before expanding the breakdown", async () => {


### PR DESCRIPTION
## Problem

`UsageSettings.test.tsx › shows the fixed budget reset date` hardcodes the string `"Resets on Sep 1"` — the en-US rendering of `toLocaleDateString(undefined, { month: "short", day: "numeric" })`.

On any machine whose default locale is not English (e.g. ru-RU renders `1 сент.`), the test fails even though the component is correct:

```
TestingLibraryElementError: Unable to find an element with the text: Resets on Sep 1
```

## Fix

Derive the expected string through the same `formatCalendarDay` helper the component uses, so the assertion matches whatever the runtime locale produces.

## Verification

- `bunx jest src/app/app/settings/usage/UsageSettings.test.tsx` — 3/3 passed under a ru-RU environment (previously 1 failed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the budget reset date assertion in `UsageSettings.test.tsx` locale-independent to avoid failures on non-English locales. Previously the test looked for "Resets on Sep 1"; it now expects the string from `formatCalendarDay("2026-09-01")` in `@/lib/dateUtils`, matching the component’s formatter. Test-only change.

<sup>Written for commit c470bde41f840563a4cb27e5259ba48130ecd3f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

