### PR TITLE
fix(llms): downgrade required tool_choice to auto for GLM models

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -612,6 +612,7 @@ class LitellmLLM(LLM):
         )
         is_claude_model = any("claude" in name.lower() for name in model_identity_names)
         is_qwen_model = any("qwen" in name.lower() for name in model_identity_names)
+        is_glm_model = any("glm" in name.lower() for name in model_identity_names)
         uses_adaptive_thinking = any(
             anthropic_uses_adaptive_thinking(name) for name in model_identity_names
         )
@@ -687,16 +688,17 @@ class LitellmLLM(LLM):
 
         # Tool choice
         # Downgrade tool_choice=required to AUTO for models that mishandle it:
-        # Claude skips reasoning when it's set, and Qwen thinking models reject
-        # it with a 400. The chat loop's fallback tool-call extraction still
-        # enforces the forced tool. Matched by model name rather than
-        # `is_reasoning` because the litellm/local registry lags behind new
-        # Qwen releases (e.g. qwen3.7-plus).
+        # Claude skips reasoning when it's set, Qwen thinking models reject it
+        # with a 400, and Z.AI rejects any GLM tool_choice other than auto
+        # ("Tool choice must be auto"). The chat loop's fallback tool-call
+        # extraction still enforces the forced tool. Matched by model name
+        # rather than `is_reasoning` because the litellm/local registry lags
+        # behind new Qwen/GLM releases (e.g. qwen3.7-plus, glm-5.3).
         # A NamedToolChoice is deliberately NOT downgraded: legacy Claude
-        # thinking is skipped below instead, and Qwen thinking models may still
+        # thinking is skipped below instead, and the other models may still
         # reject the forced tool upstream (a loud 400 beats silently ignoring
         # the caller's forced tool).
-        if (is_claude_model or is_qwen_model) and (
+        if (is_claude_model or is_qwen_model or is_glm_model) and (
             tool_choice == ToolChoiceOptions.REQUIRED
         ):
             tool_choice = ToolChoiceOptions.AUTO

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -2527,13 +2527,14 @@ _TOOL_CHOICE_DOWNGRADE_TOOLS = [
     [
         (LlmProviderNames.OPENROUTER, "qwen/qwen3.7-plus"),
         (LlmProviderNames.ANTHROPIC, "claude-sonnet-5"),
+        (LlmProviderNames.OPENROUTER, "z-ai/glm-5.3"),
     ],
 )
 def test_required_tool_choice_downgraded_to_auto(
     model_provider: str, model_name: str
 ) -> None:
-    """Claude and Qwen thinking models reject/degrade required tool_choice, so
-    it must be sent to the provider as AUTO instead."""
+    """Claude, Qwen thinking, and GLM models reject/degrade required
+    tool_choice, so it must be sent to the provider as AUTO instead."""
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,


### PR DESCRIPTION
## Description

The nightly provider chat test fails for `z-ai/glm-5.3` via OpenRouter ([failing run](https://github.com/onyx-dot-app/onyx/actions/runs/32732087813/job/97446893160?pr=14190) on #14190, which promotes it as the OpenRouter default):

```
OpenrouterException - {"error":{"message":"Tool choice must be auto","code":400,
"metadata":{"provider_name":"Z.AI"}}}
```

The test forces the `internal_search` tool. The chat loop turns a forced tool into `tool_choice=required`, and Z.AI rejects any GLM `tool_choice` other than `auto`.

Fix: extend the existing Claude/Qwen `required` -> `auto` downgrade in `multi_llm.py` to GLM models. The chat loop's fallback tool-call extraction still enforces the forced tool, so behavior is preserved. Matched by model name, same as Qwen, because the litellm registry lags new releases.

## How Has This Been Tested?

- Added `(OPENROUTER, "z-ai/glm-5.3")` to the parametrized downgrade unit test in `test_multi_llm.py`; all `tool_choice` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrades `tool_choice=required` to `auto` for GLM models like `z-ai/glm-5.3` to avoid OpenRouter 400s. Previously we sent `required` and Z.AI rejected any GLM tool choice other than `auto`; now GLM uses `auto`, and the chat loop’s fallback still enforces the forced tool.

**Review notes**
- Extends the existing Claude/Qwen downgrade to GLM, matched by model name due to registry lag.
- Only downgrades when `tool_choice` is `required`; `NamedToolChoice` is not downgraded.
- Adds `(OPENROUTER, "z-ai/glm-5.3")` to the `tool_choice` downgrade unit test to cover GLM.

<sup>Written for commit 59c1202d72081511724e5cf964fdaebd3646fbc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

