### PR TITLE
fix(chat): sample the incognito sweep from a subquery so DISTINCT stays valid Postgres

### DIFF
--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -258,5 +258,7 @@ def get_session_ids_with_incognito_files(
         .where(FileRecord.file_metadata.has_key(INCOGNITO_SESSION_METADATA_KEY))
     )
     if limit is not None:
-        stmt = stmt.order_by(func.random()).limit(limit)
+        # Postgres rejects ORDER BY random() on a DISTINCT select, so the
+        # sample draws from a subquery.
+        stmt = select(stmt.subquery()).order_by(func.random()).limit(limit)
     return list(db_session.scalars(stmt))

--- a/backend/tests/external_dependency_unit/chat/test_incognito_persistence.py
+++ b/backend/tests/external_dependency_unit/chat/test_incognito_persistence.py
@@ -265,3 +265,14 @@ def test_a_refused_deletion_keeps_the_stamp(db_session: Session) -> None:
     assert delete_incognito_generated_files(session_id, db_session)
     with pytest.raises(FileRecordNotFoundError):
         file_store.read_file(file_id)
+
+
+def test_the_sweep_lookup_samples_under_a_limit(db_session: Session) -> None:
+    """The sweep always passes a limit, which turns on random sampling, so the
+    DISTINCT lookup must stay valid Postgres with ORDER BY random() applied."""
+    session_id = uuid4()
+    _content_free_blob(session_id)
+
+    assert len(get_session_ids_with_incognito_files(db_session, limit=1)) == 1
+
+    assert delete_incognito_generated_files(session_id, db_session)


### PR DESCRIPTION
## Description

Since v4.6.0 the stale incognito sweep fails on every run and spams the api server log with:

`psycopg2.errors.InvalidColumnReference: for SELECT DISTINCT, ORDER BY expressions must appear in select list`

#13933 added random sampling to `get_session_ids_with_incognito_files` by putting `ORDER BY random()` on the `SELECT DISTINCT` lookup. Postgres rejects that combination, and the sweep always passes a limit, so the incognito file cleanup has been dead since release. Leaked incognito blobs were never cleaned up.

The sample now draws from a subquery over the distinct session ids, which Postgres accepts.

## How Has This Been Tested?

New external-dependency-unit test `test_the_sweep_lookup_samples_under_a_limit` exercises the limited lookup against real Postgres. It reproduces the reported `InvalidColumnReference` on the old code and passes with the fix. Full `test_incognito_persistence.py` passes (9/9).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check