### PR TITLE
fix(web): stop the usage settings screenshot from flaking

### DIFF
--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -144,6 +144,10 @@ describe("UsageSettings", () => {
       "true"
     );
     expect(screen.getByText("Show 1 more")).toBeInTheDocument();
+    // The settings screenshot spec hides these counts, so keep the hook stable.
+    expect(screen.getAllByTestId("usage-model-tokens")[0]).toHaveTextContent(
+      "100 in · 10 out"
+    );
     expect(screen.getByTestId("usage-model-preview")).toHaveClass(
       "[mask-image:linear-gradient(to_bottom,black_5%,transparent_75%)]"
     );

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -140,7 +140,11 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
                     />
                   </div>
 
-                  <Text font="secondary-body" color="text-03">
+                  <Text
+                    font="secondary-body"
+                    color="text-03"
+                    data-testid="usage-model-tokens"
+                  >
                     {`${formatTokens(row.input_tokens)} in · ${formatTokens(
                       row.output_tokens
                     )} out${

--- a/web/tests/e2e/settings/settings_pages.spec.ts
+++ b/web/tests/e2e/settings/settings_pages.spec.ts
@@ -12,6 +12,23 @@ const SLUG_TO_HEADER: Record<string, string> = {
   connectors: "Connectors",
 };
 
+/**
+ * Per-page selectors to hide before the screenshot, keyed by settings slug.
+ *
+ * These elements render values that change between CI runs, so leaving them
+ * visible makes the visual diff fail for reasons unrelated to the change under
+ * review.
+ */
+const SLUG_TO_HIDE_SELECTORS: Record<string, string[]> = {
+  // The access-tokens list loads via SWR, so it flakily flips between
+  // "Loading tokens..." and "No access tokens created." depending on whether
+  // the fetch has settled.
+  "accounts-access": ['[data-testid="access-token-list-status"]'],
+  // Token counts come from the chats that earlier specs ran against a live
+  // model, so the exact numbers differ on every run.
+  usage: ['[data-testid="usage-model-tokens"]'],
+};
+
 for (const theme of THEMES) {
   test.describe(`Settings pages (${theme} mode)`, () => {
     test.beforeEach(async ({ page }) => {
@@ -51,18 +68,11 @@ for (const theme of THEMES) {
         // Scope the screenshot to the settings container (rendered by
         // `SettingsLayouts.Root`) so dynamic app chrome (sidebar, greeting
         // text, etc.) doesn't cause spurious diffs.
-        //
-        // The access-tokens list loads via SWR, so it flakily flips between
-        // "Loading tokens..." and "No access tokens created." depending on
-        // whether the fetch has settled — hide it to keep the diff stable.
         await expectElementScreenshot(
           page.locator("#page-wrapper-scroll-container"),
           {
             name: `settings-${theme}-${slug}`,
-            hide:
-              slug === "accounts-access"
-                ? ['[data-testid="access-token-list-status"]']
-                : [],
+            hide: SLUG_TO_HIDE_SELECTORS[slug] ?? [],
           }
         );
       }

--- a/web/tests/e2e/utils/visualRegression.ts
+++ b/web/tests/e2e/utils/visualRegression.ts
@@ -283,6 +283,10 @@ export async function expectScreenshot(
         path: screenshotPath,
         fullPage,
         mask: maskLocators.length > 0 ? maskLocators : undefined,
+        // `toHaveScreenshot()` disables animations by default; `screenshot()`
+        // does not. Match the assert path so a transition that starts after
+        // `waitForAnimations()` can't be captured mid-flight.
+        animations: "disabled",
         ...options.screenshotOptions,
       });
     }
@@ -373,6 +377,9 @@ export async function expectElementScreenshot(
       await locator.screenshot({
         path: screenshotPath,
         mask: maskLocators.length > 0 ? maskLocators : undefined,
+        // Same reasoning as `expectScreenshot()`: keep the capture-only path in
+        // step with `toHaveScreenshot()`, which disables animations by default.
+        animations: "disabled",
       });
     }
   } finally {


### PR DESCRIPTION
## Problem

The visual regression report for #14190 flagged two screenshots as changed:

- `settings-light-usage.png` — 0.06% changed
- `settings-dark-usage.png` — 0.06% changed

That PR only refreshes the recommended model catalog, so it cannot touch the usage settings page. Both diffs are flake. Pixel comparison of the baseline and current captures shows exactly two changed regions.

**1. The per-model token counts.**

| Baseline | Current |
| --- | --- |
| `398 in · 40 out` | `1,294 in · 84 out` |

These counts come from the chats that earlier specs run against a live model, so the numbers change on every CI run.

**2. The provider chevron on the Model prices card.**

The baseline caught the chevron at roughly 45°, mid-rotation. `ModelPriceSection` expands the default provider from a `useEffect` after the usage fetch resolves, and the chevron animates via `transition-transform` + `rotate-90`.

`expectElementScreenshot()` already calls `waitForAnimations()`, but the capture-only branch then calls `locator.screenshot()`, which defaults to `animations: "allow"`. A transition that starts after `waitForAnimations()` returns can still be captured in flight. This matters for every screenshot: CI never sets `VISUAL_REGRESSION=true`, so the capture-only path is the one that produces all 187 images the diff report compares.

## Changes

- Tag the token line with `data-testid="usage-model-tokens"` and hide it for the `usage` slug in `settings_pages.spec.ts`. Hiding keeps the layout box, so the card does not resize. Masking would not work here — the mask box is sized to the element, and the text width changes with the numbers.
- Move the per-page hide selectors into a `SLUG_TO_HIDE_SELECTORS` map next to the existing `SLUG_TO_HEADER`, so the `accounts-access` entry and the new `usage` entry sit together instead of growing a ternary.
- Pass `animations: "disabled"` to the capture-only `page.screenshot()` and `locator.screenshot()` calls, matching what `toHaveScreenshot()` does by default. Playwright fast-forwards finite animations to completion and freezes infinite ones.

## Tests

Extended the existing `UsageSettings.test.tsx` case to assert the token line carries the test id, which pins the selector the e2e spec depends on. `bun run jest src/app/app/settings/usage` passes (5 tests).

The screenshot itself is verified by the next visual regression run on this PR: the two usage screenshots should come back unchanged.

Note: `bun run types:check` fails on this branch, but it fails identically on a clean checkout of `main` (544 errors, all `prominence`/`variant` on `ButtonProps`). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the usage settings visual snapshot by hiding variable token counts and disabling animations during screenshot capture. Previously, counts changed per run and the provider chevron could be captured mid-rotation; now both are stable.

- Add `data-testid="usage-model-tokens"` to the token line and hide it for the `usage` slug in the settings screenshot spec (keeps layout size unchanged).
- Introduce `SLUG_TO_HIDE_SELECTORS` and use it for per-page hides (includes `accounts-access` and new `usage` entries).
- Disable animations in capture-only `page.screenshot()` and `locator.screenshot()` to match `toHaveScreenshot()` defaults.
- Extend `UsageSettings.test.tsx` to assert the token line test id, pinning the selector the e2e spec depends on.

<sup>Written for commit 22ad031295225561cf926d9fcfa58b4c73b9d61a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

