### PR TITLE
feat(cli): apply a user-supplied docker-compose.override.yml

### DIFF
--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/README.md
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/README.md
@@ -56,6 +56,37 @@ the directory with the docker-compose.yml file. First bring the containers down 
 verify the version you want in the environment file (see below), (if using `latest` tag, be sure to run
 `docker compose pull`) and run `docker compose up` to restart the services on the latest version
 
+### Customizing the compose files
+The CLI owns the compose files it writes. Each `onyx-cli deploy upgrade` refreshes them to match the
+new version. If you edit one, the CLI asks before it replaces the file, and it keeps a backup — but
+your edits are not applied again.
+
+To customize the deployment, put your changes in a file called `docker-compose.override.yml`, in the
+same directory as `docker-compose.yml`. The CLI applies that file last, after its own files, so your
+changes win. The CLI does not manage the override: it never writes, replaces, or backs it up, and an
+upgrade does not touch it. `install`, `upgrade`, `stop`, `logs`, and `uninstall` all apply it. This
+is the same file name that `docker compose` finds on its own.
+
+For example, to put Onyx behind your own reverse proxy, stop nginx from publishing a host port and
+attach it to your proxy's network:
+
+```yaml
+# deployment/docker-compose.override.yml
+services:
+  nginx:
+    # !reset replaces the list. Without it, Compose adds to the list.
+    ports: !reset []
+    networks: [default, proxy]
+
+networks:
+  proxy:
+    external: true
+```
+
+Use `docker compose -f docker-compose.yml -f docker-compose.override.yml config` in the deployment
+directory to see the merged result. Add each file the CLI applies (`docker-compose.onyx-lite.yml`,
+`docker-compose.prod.yml`, and so on) in the same order the CLI does.
+
 ### Environment variables
 The Docker Compose files try to look for a .env file in the same directory. The installer sets it up
 from a file called env.template. Feel free to edit the .env file to customize your deployment. The most

--- a/cli/internal/deploy/deployfiles/files.go
+++ b/cli/internal/deploy/deployfiles/files.go
@@ -118,6 +118,13 @@ var (
 	}
 )
 
+// OverrideName is the user-owned compose override. It is deliberately not a
+// File: the CLI never writes, fetches, checksums, or backs it up — it only
+// stacks it last on the -f list when the deployment directory has one. The
+// name is the one vanilla Compose auto-discovers, which the CLI's explicit
+// -f flags otherwise suppress.
+const OverrideName = "docker-compose.override.yml"
+
 // All lists every managed file.
 var All = []File{
 	Compose,

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -366,6 +366,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 	if in.dev {
 		in.warnf("Dev overlay: Postgres, Redis, OpenSearch, MinIO, the model server and the API are published on this host, not just nginx. Only run it on a machine you trust the network of.")
 	}
+	in.noteComposeOverride()
 
 	// Captured for rollback: a failed pull must not leave .env pointing at a
 	// version that never ran (nil means there was no .env before this run).
@@ -1516,13 +1517,41 @@ func (in *installer) starRepo(ctx context.Context) {
 	}
 }
 
-// composeFileNames returns the -f list. Prod deployments run the standalone
-// docker-compose.prod.yml on its own; every other mode stacks overlays on
-// docker-compose.yml. With autoDetect, previously downloaded files are
-// picked up from disk so users don't have to repeat
-// --lite/--prod/--include-craft/--dev for lifecycle commands (install.sh's
-// build_compose_file_args true).
+// composeFileNames returns the -f list: the managed files for the mode, then
+// the user's own docker-compose.override.yml when the deployment directory
+// has one. The override always comes last so its edits win the merge, and it
+// ignores autoDetect — no flag selects it, only its presence on disk.
 func (in *installer) composeFileNames(autoDetect bool) []string {
+	files := in.managedComposeFiles(autoDetect)
+	if in.hasComposeOverride() {
+		files = append(files, deployfiles.OverrideName)
+	}
+	return files
+}
+
+// hasComposeOverride reports whether the user dropped an override file next
+// to the managed compose files.
+func (in *installer) hasComposeOverride() bool {
+	return in.overlayOnDisk(deployfiles.OverrideName)
+}
+
+// noteComposeOverride says the override is in the -f list. Its presence on
+// disk is the only thing that selects it, so a run that stays quiet makes the
+// user's customizations look like they came from the managed files.
+func (in *installer) noteComposeOverride() {
+	if !in.hasComposeOverride() {
+		return
+	}
+	in.infof("Using your %s — it is applied last, and the CLI never overwrites it", deployfiles.OverrideName)
+}
+
+// managedComposeFiles returns the CLI-managed part of the -f list. Prod
+// deployments run the standalone docker-compose.prod.yml on its own; every
+// other mode stacks overlays on docker-compose.yml. With autoDetect,
+// previously downloaded files are picked up from disk so users don't have to
+// repeat --lite/--prod/--include-craft/--dev for lifecycle commands
+// (install.sh's build_compose_file_args true).
+func (in *installer) managedComposeFiles(autoDetect bool) []string {
 	prodName := filepath.Base(deployfiles.ProdCompose.DestRel)
 	craftName := filepath.Base(deployfiles.CraftOverlay.DestRel)
 	if in.prod || (autoDetect && in.overlayOnDisk(prodName)) {
@@ -1540,8 +1569,9 @@ func (in *installer) composeFileNames(autoDetect bool) []string {
 	if in.craft || (autoDetect && in.overlayOnDisk(craftName)) {
 		files = append(files, craftName)
 	}
-	// Last, so the ports and build targets it publishes are the ones that
-	// survive the merge — that is the whole point of the overlay.
+	// Last of the managed files, so the ports and build targets it publishes
+	// are the ones that survive the merge — that is the whole point of the
+	// overlay.
 	devName := filepath.Base(deployfiles.DevOverlay.DestRel)
 	if in.dev || (autoDetect && in.overlayOnDisk(devName)) {
 		files = append(files, devName)

--- a/cli/internal/deploy/install/override_test.go
+++ b/cli/internal/deploy/install/override_test.go
@@ -1,0 +1,206 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+)
+
+const overrideBody = "services:\n  nginx:\n    ports: !override []\n"
+
+// writeOverride drops a user-owned override into the deployment directory.
+func writeOverride(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "deployment")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "docker-compose.override.yml")
+	if err := os.WriteFile(path, []byte(overrideBody), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// composeArgv returns the argv of the last compose call ending in suffix.
+func composeArgv(t *testing.T, runner *fakeRunner, suffix string) string {
+	t.Helper()
+	var found string
+	for _, c := range runner.calls {
+		if a := argv(c); strings.Contains(a, suffix) {
+			found = a
+		}
+	}
+	if found == "" {
+		t.Fatalf("no compose call containing %q", suffix)
+	}
+	return found
+}
+
+// assertOverrideUntouched checks the CLI left the user's file exactly as it
+// found it: same bytes, no backup, and nothing recorded in the manifest.
+func assertOverrideUntouched(t *testing.T, root, path string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("override gone: %v", err)
+	}
+	if string(got) != overrideBody {
+		t.Errorf("override rewritten:\n%s", got)
+	}
+	backups, err := filepath.Glob(path + ".bak-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) > 0 {
+		t.Errorf("override backed up: %v", backups)
+	}
+	m, err := state.Load(root)
+	if err != nil || m == nil {
+		t.Fatalf("manifest: %v, %v", m, err)
+	}
+	if _, ok := m.Files["deployment/docker-compose.override.yml"]; ok {
+		t.Errorf("override recorded as managed: %v", m.Files)
+	}
+}
+
+// An override present at install time is stacked after every managed file, so
+// its edits win the merge, and the checksum/backup system never sees it.
+func TestInstallStacksComposeOverrideLast(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, runner, notFoundServer(t))
+	root := t.TempDir()
+	path := writeOverride(t, root)
+
+	err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, // non-interactive default mode is Lite
+		Dev:      true,
+		Tag:      "v4.2.0",
+		Dir:      root,
+		NoWait:   true,
+	})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	up := composeArgv(t, runner, "up -d")
+	base := strings.Index(up, "-f docker-compose.yml")
+	lite := strings.Index(up, "-f docker-compose.onyx-lite.yml")
+	dev := strings.Index(up, "-f docker-compose.dev.yml")
+	override := strings.Index(up, "-f docker-compose.override.yml")
+	if base < 0 || lite < 0 || dev < 0 || override < 0 {
+		t.Fatalf("up argv missing a compose file: %s", up)
+	}
+	if override < base || override < lite || override < dev {
+		t.Errorf("override must come last in the -f list: %s", up)
+	}
+
+	assertOverrideUntouched(t, root, path)
+	if !strings.Contains(outBuf(deps).String(), "docker-compose.override.yml") {
+		t.Errorf("override pickup not announced:\n%s", outBuf(deps).String())
+	}
+}
+
+// An override dropped in after the install is picked up by the lifecycle
+// verbs and survives an upgrade, which refreshes every managed file.
+func TestComposeOverrideAutoDetectedAndSurvivesUpgrade(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+	path := writeOverride(t, root)
+
+	upgradeRunner := &fakeRunner{handler: healthyDockerHandler}
+	upgradeDeps := testDeps(t, upgradeRunner, rawServer(t, "# compose at v4.2.0\nname: onyx\n"))
+	if err := RunUpgrade(context.Background(), upgradeDeps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("RunUpgrade: %v\noutput:\n%s", err, outBuf(upgradeDeps).String())
+	}
+	if up := composeArgv(t, upgradeRunner, "up -d"); !strings.Contains(up, "-f docker-compose.override.yml") {
+		t.Errorf("upgrade dropped the override: %s", up)
+	}
+	assertOverrideUntouched(t, root, path)
+
+	stopRunner := &fakeRunner{handler: healthyDockerHandler}
+	stopDeps := testDeps(t, stopRunner, notFoundServer(t))
+	if err := RunStop(context.Background(), stopDeps, Options{Dir: root}); err != nil {
+		t.Fatalf("RunStop: %v\noutput:\n%s", err, outBuf(stopDeps).String())
+	}
+	if stop := composeArgv(t, stopRunner, " stop"); !strings.Contains(stop, "-f docker-compose.override.yml") {
+		t.Errorf("override not auto-detected by stop: %s", stop)
+	}
+
+	logsRunner := &fakeRunner{handler: healthyDockerHandler}
+	logsDeps := testDeps(t, logsRunner, notFoundServer(t))
+	if err := RunLogs(context.Background(), logsDeps, Options{Dir: root}, LogOptions{Tail: "200"}); err != nil {
+		t.Fatalf("RunLogs: %v\noutput:\n%s", err, outBuf(logsDeps).String())
+	}
+	if logs := composeArgv(t, logsRunner, " logs"); !strings.Contains(logs, "-f docker-compose.override.yml") {
+		t.Errorf("override not auto-detected by logs: %s", logs)
+	}
+}
+
+// The override is selected by its presence on disk alone, in every mode and
+// whether or not the caller asked for overlay auto-detection.
+func TestComposeFileNamesOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode func(*installer)
+		want []string
+	}{
+		{
+			name: "standard",
+			mode: func(in *installer) {},
+			want: []string{"docker-compose.yml", "docker-compose.override.yml"},
+		},
+		{
+			name: "lite with craft",
+			mode: func(in *installer) { in.lite, in.craft = true, true },
+			want: []string{
+				"docker-compose.yml",
+				"docker-compose.onyx-lite.yml",
+				"docker-compose.craft.yml",
+				"docker-compose.override.yml",
+			},
+		},
+		{
+			name: "prod",
+			mode: func(in *installer) { in.prod = true },
+			want: []string{"docker-compose.prod.yml", "docker-compose.override.yml"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeOverride(t, root)
+			for _, autoDetect := range []bool{false, true} {
+				in := newInstaller(testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t)), Options{Dir: root})
+				in.root = paths.InstallRoot{Dir: root}
+				tc.mode(in)
+				got := in.composeFileNames(autoDetect)
+				if strings.Join(got, " ") != strings.Join(tc.want, " ") {
+					t.Errorf("composeFileNames(%t) = %v, want %v", autoDetect, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// Without an override on disk the -f list is unchanged.
+func TestComposeFileNamesWithoutOverride(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "deployment"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	in := newInstaller(testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t)), Options{Dir: root})
+	in.root = paths.InstallRoot{Dir: root}
+	got := in.composeFileNames(true)
+	if len(got) != 1 || got[0] != "docker-compose.yml" {
+		t.Errorf("composeFileNames = %v, want just the base file", got)
+	}
+}

--- a/cli/internal/deploy/install/plan.go
+++ b/cli/internal/deploy/install/plan.go
@@ -3,6 +3,7 @@ package install
 import (
 	"runtime"
 
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
 )
@@ -18,6 +19,9 @@ func (in *installer) printPlan(defaultTag string) {
 	}
 	if in.dev {
 		in.plainf("  • Dev overlay: true (service ports published on the host)")
+	}
+	if in.hasComposeOverride() {
+		in.plainf("  • Compose override: %s (yours, applied last)", deployfiles.OverrideName)
 	}
 	if in.opts.Project != "" {
 		in.plainf("  • Compose project: %s", in.opts.Project)

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -160,6 +160,9 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 			craftNote += ", Dev overlay: true"
 		}
 		in.plainf("  • Mode: %s%s", in.modeName(), craftNote)
+		if in.hasComposeOverride() {
+			in.plainf("  • Compose override: %s (yours, applied last)", deployfiles.OverrideName)
+		}
 		if in.project != dockercmd.DefaultProjectName {
 			in.plainf("  • Compose project: %s", in.project)
 		}
@@ -198,6 +201,7 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	if err := in.materializeFiles(ctx, configRef, managedFiles(in.prod, in.lite, in.craft, in.dev), manifest, fetcher); err != nil {
 		return err
 	}
+	in.noteComposeOverride()
 
 	if in.craft {
 		in.ensureCraftResources(ctx)

--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -56,6 +56,37 @@ the directory with the docker-compose.yml file. First bring the containers down 
 verify the version you want in the environment file (see below), (if using `latest` tag, be sure to run
 `docker compose pull`) and run `docker compose up` to restart the services on the latest version
 
+### Customizing the compose files
+The CLI owns the compose files it writes. Each `onyx-cli deploy upgrade` refreshes them to match the
+new version. If you edit one, the CLI asks before it replaces the file, and it keeps a backup — but
+your edits are not applied again.
+
+To customize the deployment, put your changes in a file called `docker-compose.override.yml`, in the
+same directory as `docker-compose.yml`. The CLI applies that file last, after its own files, so your
+changes win. The CLI does not manage the override: it never writes, replaces, or backs it up, and an
+upgrade does not touch it. `install`, `upgrade`, `stop`, `logs`, and `uninstall` all apply it. This
+is the same file name that `docker compose` finds on its own.
+
+For example, to put Onyx behind your own reverse proxy, stop nginx from publishing a host port and
+attach it to your proxy's network:
+
+```yaml
+# deployment/docker-compose.override.yml
+services:
+  nginx:
+    # !reset replaces the list. Without it, Compose adds to the list.
+    ports: !reset []
+    networks: [default, proxy]
+
+networks:
+  proxy:
+    external: true
+```
+
+Use `docker compose -f docker-compose.yml -f docker-compose.override.yml config` in the deployment
+directory to see the merged result. Add each file the CLI applies (`docker-compose.onyx-lite.yml`,
+`docker-compose.prod.yml`, and so on) in the same order the CLI does.
+
 ### Environment variables
 The Docker Compose files try to look for a .env file in the same directory. The installer sets it up
 from a file called env.template. Feel free to edit the .env file to customize your deployment. The most


### PR DESCRIPTION
## Problem

`onyx-cli` always invokes Compose with explicit `-f` flags. Compose only auto-discovers `docker-compose.override.yml` when **zero** `-f` flags are passed, so a same-directory override file was silently ignored.

Users who front Onyx with their own reverse proxy (Traefik, Caddy, an existing nginx) had to hand-edit the managed `docker-compose.yml`. The checksum/backup system then treated that as a hand-edit on every `deploy upgrade`: a warning and a backup each time, and their edits were not applied again.

Closes #14196.

## Change

`composeFileNames` now stacks `docker-compose.override.yml` last on the `-f` list when the deployment directory has one. Auto-detection, per the maintainer's call on the issue — it is the exact filename vanilla Compose would find on its own, and needs no new flag.

The override is user-owned, so it stays out of `managedFiles()` and the manifest. The CLI never fetches, checksums, backs up, or replaces it. It ignores `autoDetect`: no flag selects the file, only its presence on disk.

`install`, `upgrade`, `stop`, `logs`, and `uninstall` all pick it up, because they share `composeFileNames`. `status` is unchanged — it reads `docker ps` labels, not compose `-f`.

Presence on disk is the only trigger, so a silent run would make the user's customizations look like they came from the managed files. `install` and `upgrade` print a line when they use the override, and both dry runs list it.

Also documents the convention in `deployment/docker_compose/README.md`, with a reverse-proxy example. The embedded copy is synced by `ods generate-compose --write`.

## Tests

`cli/internal/deploy/install/override_test.go`:

- `TestInstallStacksComposeOverrideLast` — a fresh install with an override present puts it after the base, lite, and dev files; the file keeps its bytes, gets no `.bak-*`, is absent from the manifest, and the pickup is announced.
- `TestComposeOverrideAutoDetectedAndSurvivesUpgrade` — an override dropped in after install survives `deploy upgrade` (which refreshes every managed file) and is auto-detected by `stop` and `logs`.
- `TestComposeFileNamesOverride` / `TestComposeFileNamesWithoutOverride` — the `-f` list across standard, lite+craft, and prod, with `autoDetect` both ways.

`go test ./...` passes for the `cli` module. `pre-commit run --files ...` passes on every touched file.

## Note

The README example uses `ports: !reset []` rather than `!override []`. `!reset` matches the CLI's `minComposeVersion` floor of 2.24.0; `!override` needs 2.24.4. The syntax matches Docker's own [merge docs](https://docs.docker.com/reference/compose-file/merge/). No Docker daemon was available in this environment, so the merge example itself was not executed — the `-f` ordering is covered by the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies a user `docker-compose.override.yml` so local changes layer on top of managed compose files. Previously the CLI always passed explicit -f flags, so Compose never auto-discovered overrides; users edited managed files and hit warnings/backups on upgrade. Now the CLI appends `docker-compose.override.yml` last when present, and never manages it.

- Presence on disk selects the override; no new flags. `install`, `upgrade`, `stop`, `logs`, and `uninstall` include it; `status` is unchanged.
- Existing deployments with a `docker-compose.override.yml` will now have it applied; verify resulting ports/networking (e.g., reverse proxy setups).
- The override is excluded from the manifest and backups; checksum logic ignores it. `install`/`upgrade` print a notice when using it and list it in dry runs.
- Docs add the convention and a reverse-proxy example in `deployment/docker_compose/README.md`; tests cover -f ordering and lifecycle behavior.

<sup>Written for commit 2b2d5a540d8809ccdd836050d46797fa4770fc28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

