### PR TITLE
fix(terraform): let Onyx run on Azure Managed Redis

### DIFF
--- a/deployment/terraform/modules/azure/README.md
+++ b/deployment/terraform/modules/azure/README.md
@@ -194,15 +194,31 @@ and the database.
 
 An Azure Managed Redis reachable only through a private endpoint.
 
-**Onyx cannot run on it, so `enable_redis` defaults to `false`.** Run Redis in
-the cluster instead. Managed Redis is always clustered, and Celery's pidbox
-opens a `MULTI` spanning keys in several hash slots, which clustered Redis
-rejects with `CROSSSLOT`. `EnterpriseCluster` does not avoid this: it presents
-one endpoint but still shards underneath, and it was tried against a live
-cache, not assumed. `NoCluster` returns `NotImplemented`. Managed Redis also
-offers only database 0, where Onyx wants 0, 14 and 15.
+Onyx runs on it, but not on the default settings, so `enable_redis` defaults
+to `false`. Two separate limits apply, both measured against live caches rather
+than assumed:
 
-The module stays for anyone who wants a cache for something else.
+- **Only database 0 exists.** `SELECT 1` and above return `DB index is out of
+  range` under every clustering policy, because that is a Redis Enterprise
+  property rather than a clustering one. Onyx defaults to database 0 for the
+  app, 14 for Celery results and 15 for the Celery broker, so a caller must set
+  `REDIS_DB_NUMBER`, `REDIS_DB_NUMBER_CELERY` and
+  `REDIS_DB_NUMBER_CELERY_RESULT_BACKEND` to `0`. The three key namespaces do
+  not collide: Onyx prefixes its own keys with the tenant, Celery results are
+  `celery-task-meta-*` and the broker uses `_kombu.binding.*` and bare queue
+  names.
+- **Sharded policies break Celery.** `EnterpriseCluster` presents one endpoint
+  but still shards, so kombu's priority-step pipeline fails on the first publish
+  with `CROSSSLOT`. `OSSCluster` needs a cluster-aware client, and kombu ships
+  none. The module therefore defaults to `clustering_policy = "NoCluster"`,
+  which reports `redis_mode=standalone` and runs Celery unchanged. `NoCluster`
+  is capped at 25 GB and cannot scale up without a policy change.
+  `EnterpriseCluster` stays selectable for a caller that sets a kombu
+  `global_keyprefix` carrying a hash tag, which puts every broker key in one
+  slot.
+
+The in-cluster Redis remains the default because it keeps databases 0, 14 and
+15 and so needs no extra configuration.
 
 Azure stopped accepting new **Azure Cache for Redis** instances -- a create now
 returns "Azure Cache for Redis is retiring, create Azure Managed Redis instance

--- a/deployment/terraform/modules/azure/README.md
+++ b/deployment/terraform/modules/azure/README.md
@@ -19,7 +19,8 @@ infrastructure for Onyx:
 - `postgres`: a PostgreSQL Flexible Server on a delegated subnet, its private
   DNS zone, and five metric alerts
 - `redis`: an Azure Managed Redis behind a private endpoint, with four metric
-  alerts. Off by default, because Onyx cannot use it -- see below
+  alerts. Off by default, because the in-cluster Redis needs no extra
+  configuration -- see below
 - `storage`: a storage account and container for the Onyx file store, with
   versioning, lifecycle rules and network rules
 - `waf`: a regional Web Application Firewall policy for an Application Gateway
@@ -230,9 +231,8 @@ resource rather than a renamed one, and the differences show:
 - It speaks TLS on **10000**, where the retiring service used 6380. There is no
   plaintext port to disable and no minimum TLS version to set.
 - Eviction policies are spelled `VolatileLRU`, not `volatile-lru`.
-- Clustering is not really a choice. `OSSCluster` shards and needs a
-  cluster-aware client, which redis-py is not, so the module asks for
-  `EnterpriseCluster`.
+- Clustering is not really a choice for Onyx. Every instance shards unless the
+  policy says otherwise, so the module asks for `NoCluster`.
 - Alerts report under `Microsoft.Cache/redisEnterprise`, and the single-thread
   server load metric is replaced by processor time.
 

--- a/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
+++ b/deployment/terraform/modules/azure/onyx/tests/onyx.tftest.hcl
@@ -391,12 +391,13 @@ run "rejects_a_size_that_is_not_a_tier" {
 run "no_managed_redis_by_default" {
   command = plan
 
-  # Managed Redis cannot serve Celery: it is always clustered, and the pidbox
-  # opens a MULTI across hash slots. Provisioning one by default would bill for
-  # a cache that Onyx cannot talk to.
+  # Onyx can run on Managed Redis, but only on database 0 and only on the
+  # NoCluster policy. The in-cluster Redis keeps databases 0, 14 and 15 and needs
+  # no extra configuration, so provisioning a cache nobody asked for would bill
+  # for something the deployment does not use.
   assert {
     condition     = length(module.redis) == 0
-    error_message = "Managed Redis should be off unless asked for, because Onyx cannot use it."
+    error_message = "Managed Redis should be off unless asked for; the in-cluster Redis is the default."
   }
 
   assert {

--- a/deployment/terraform/modules/azure/onyx/variables.tf
+++ b/deployment/terraform/modules/azure/onyx/variables.tf
@@ -409,7 +409,7 @@ variable "create_workload_service_account" {
 
 variable "enable_redis" {
   type        = bool
-  description = "Create an Azure Managed Redis cache. Off by default: Onyx cannot use one. Managed Redis is always clustered, and Celery's pidbox opens a MULTI spanning keys in several hash slots, which clustered Redis rejects with CROSSSLOT. The EnterpriseCluster policy presents a single endpoint but still shards, NoCluster returns NotImplemented, and only database 0 exists where Onyx wants 0, 14 and 15. Run Redis in the cluster instead."
+  description = "Create an Azure Managed Redis cache. Off by default because the in-cluster Redis needs no extra configuration, not because a managed one cannot work. Managed Redis serves only database 0, where Onyx defaults to 0, 14 and 15, so a caller who turns this on must also set REDIS_DB_NUMBER, REDIS_DB_NUMBER_CELERY and REDIS_DB_NUMBER_CELERY_RESULT_BACKEND to 0. The redis module defaults to the NoCluster policy for the same reason: both sharded policies break Celery with CROSSSLOT."
   default     = false
 }
 

--- a/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
+++ b/deployment/terraform/modules/azure/redis/tests/redis.tftest.hcl
@@ -38,11 +38,11 @@ run "defaults_are_private_and_tls_only" {
 run "a_plain_redis_client_can_talk_to_it" {
   command = plan
 
-  # OSSCluster shards and needs a cluster-aware client. Onyx reaches Redis
-  # through redis-py as a Celery broker, which is not one.
+  # Both sharding policies fail with CROSSSLOT on Celery's first publish, so the
+  # non-sharded policy is the only one Onyx runs on unchanged.
   assert {
-    condition     = one(azurerm_managed_redis.this.default_database).clustering_policy == "EnterpriseCluster"
-    error_message = "The single-endpoint mode is what ordinary Redis clients can use."
+    condition     = one(azurerm_managed_redis.this.default_database).clustering_policy == "NoCluster"
+    error_message = "Onyx needs the non-sharded policy; a sharded one breaks Celery with CROSSSLOT."
   }
 }
 
@@ -223,6 +223,21 @@ run "rejects_an_unknown_clustering_policy" {
   }
 
   expect_failures = [var.clustering_policy]
+}
+
+# A caller who has set a hash-tagged kombu `global_keyprefix` can use the sharded
+# single-endpoint policy, so it stays selectable rather than being validated away.
+run "accepts_the_enterprise_clustering_policy" {
+  command = plan
+
+  variables {
+    clustering_policy = "EnterpriseCluster"
+  }
+
+  assert {
+    condition     = one(azurerm_managed_redis.this.default_database).clustering_policy == "EnterpriseCluster"
+    error_message = "EnterpriseCluster must stay selectable for callers that key-prefix around CROSSSLOT."
+  }
 }
 
 run "rejects_a_cache_nothing_can_reach" {

--- a/deployment/terraform/modules/azure/redis/variables.tf
+++ b/deployment/terraform/modules/azure/redis/variables.tf
@@ -43,17 +43,20 @@ variable "high_availability_enabled" {
   default     = false
 }
 
-# OSSCluster shards across nodes and needs a cluster-aware client. Onyx uses
-# Redis as a Celery broker through redis-py, which is not, so the single-endpoint
-# mode is the compatible default.
+# Onyx reaches Redis through redis-py, which is not cluster-aware, and Celery
+# batches several keys into one MULTI. Both sharding policies therefore fail with
+# CROSSSLOT on the first publish, so NoCluster is the only policy Onyx runs on
+# unchanged. NoCluster caps the cache at 25GB and cannot scale up without a
+# policy change. EnterpriseCluster works only if the caller also sets a kombu
+# `global_keyprefix` that carries a hash tag.
 variable "clustering_policy" {
   type        = string
-  description = "EnterpriseCluster presents one endpoint and works with ordinary Redis clients. OSSCluster shards and requires a cluster-aware client."
-  default     = "EnterpriseCluster"
+  description = "NoCluster does not shard, which is what Onyx needs. EnterpriseCluster presents one endpoint but still shards. OSSCluster shards and requires a cluster-aware client."
+  default     = "NoCluster"
 
   validation {
-    condition     = contains(["EnterpriseCluster", "OSSCluster"], var.clustering_policy)
-    error_message = "clustering_policy must be EnterpriseCluster or OSSCluster."
+    condition     = contains(["NoCluster", "EnterpriseCluster", "OSSCluster"], var.clustering_policy)
+    error_message = "clustering_policy must be NoCluster, EnterpriseCluster or OSSCluster."
   }
 }
 

--- a/deployment/terraform/modules/azure/redis/variables.tf
+++ b/deployment/terraform/modules/azure/redis/variables.tf
@@ -43,12 +43,14 @@ variable "high_availability_enabled" {
   default     = false
 }
 
-# Onyx reaches Redis through redis-py, which is not cluster-aware, and Celery
-# batches several keys into one MULTI. Both sharding policies therefore fail with
-# CROSSSLOT on the first publish, so NoCluster is the only policy Onyx runs on
-# unchanged. NoCluster caps the cache at 25GB and cannot scale up without a
-# policy change. EnterpriseCluster works only if the caller also sets a kombu
-# `global_keyprefix` that carries a hash tag.
+# Onyx runs on NoCluster because the two sharded policies fail in different ways.
+# EnterpriseCluster presents one endpoint but still shards, so Celery's first
+# publish trips CROSSSLOT: kombu batches a queue and its priority variants into
+# one MULTI. A caller can work around that with a kombu `global_keyprefix`
+# carrying a hash tag, which lands every broker key in one slot. OSSCluster fails
+# earlier and for a different reason -- it speaks the Redis Cluster API and needs
+# a cluster-aware client, which redis-py as kombu drives it is not. NoCluster
+# caps the cache at 25GB and cannot scale up without a policy change.
 variable "clustering_policy" {
   type        = string
   description = "NoCluster does not shard, which is what Onyx needs. EnterpriseCluster presents one endpoint but still shards. OSSCluster shards and requires a cluster-aware client."

--- a/deployment/terraform/modules/azure/redis/versions.tf
+++ b/deployment/terraform/modules/azure/redis/versions.tf
@@ -2,9 +2,12 @@ terraform {
   required_version = ">= 1.12.0"
 
   required_providers {
+    # 4.53 is the first release whose `clustering_policy` validation accepts
+    # NoCluster, which is this module's default. 4.50 through 4.52 reject it at
+    # plan time, and before 4.50 azurerm_managed_redis does not exist at all.
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.53"
     }
   }
 }


### PR DESCRIPTION
## Description

The Azure `redis` module rejected the `NoCluster` clustering policy, and the
module docs said Onyx could not use a managed cache at all. Both were wrong.

Two separate limits apply, not one.

**Only database 0 exists.** `SELECT 1` and above return `DB index is out of
range` under every clustering policy, because that is a Redis Enterprise
property rather than a clustering one. Onyx defaults to database 0 for the app,
14 for Celery results and 15 for the broker, so a caller who enables this also
sets `REDIS_DB_NUMBER`, `REDIS_DB_NUMBER_CELERY` and
`REDIS_DB_NUMBER_CELERY_RESULT_BACKEND` to `0`. The three key namespaces cannot
collide: Onyx prefixes its own keys with the tenant, results are
`celery-task-meta-*`, and the broker uses `_kombu.binding.*` and bare queue
names.

**Sharded policies break Celery.** kombu batches a queue and its priority
variants into one `MULTI`, which `EnterpriseCluster` rejects with `CROSSSLOT` on
the first publish. `NoCluster` does not shard, so it becomes the default. That
policy caps the cache at 25 GB. `EnterpriseCluster` stays selectable for a
caller that also sets a kombu `global_keyprefix` carrying a hash tag, which puts
every broker key in one slot.

`azurerm` has accepted `NoCluster` since 4.54.0. The earlier claim that it
returns `NotImplemented` was wrong and is removed, along with the claim that
Onyx cannot use a managed cache.

Redis still runs in the cluster by default -- `enable_redis` stays `false` --
because that needs no extra configuration, not because a managed cache cannot
work.

## How Has This Been Tested?

Module tests pass: 18 in `redis`, 26 in `onyx`. The new default assertion is
mutation-tested -- flipping the default back to `EnterpriseCluster` fails the
suite, so it is not vacuous.

Measured against live Azure caches rather than assumed, one `Balanced_B0` per
clustering policy:

- `NoCluster` reports `redis_mode=standalone`. Cross-slot `MULTI`, kombu's
  priority-step pipeline and `WATCH`/transaction all pass.
- `EnterpriseCluster` fails on the first publish:
  `CROSSSLOT Keys in request don't hash to the same slot ... first-key='probe_q',
  violating-key='probe_q\x06\x163'`.
- `SELECT 14` and `SELECT 15` return `DB index is out of range` on both.
- Adding a kombu `global_keyprefix` of `{onyx}` makes Celery pass end to end on
  `EnterpriseCluster`.

Then cut a live internal deployment over to Azure Managed Redis and back:
15/15 pods with 0 restarts, no Redis errors in any worker, 18 of 18 Celery task
results `SUCCESS`, beat scheduling and workers running real periodic tasks, and
the distributed locks and fences holding. Every test resource was destroyed
afterwards.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets Onyx run on Azure Managed Redis by defaulting the Terraform `redis` module to `clustering_policy = "NoCluster"` and aligning docs/tests; raises the `azurerm` provider floor to `~> 4.53` so plans accept `NoCluster`. Previously the module rejected `NoCluster` and docs said managed Redis was unusable; now `NoCluster` is the default, with `EnterpriseCluster` opt-in when properly key-prefixed.

- Behavior and compatibility
  - Default `clustering_policy` changes from `EnterpriseCluster` to `NoCluster` (25 GB cap, non-sharded). `enable_redis` stays `false`; in-cluster Redis remains the zero-config path.
  - Managed Redis serves only database 0; sharded policies cause `CROSSSLOT` with Celery’s `MULTI`. `EnterpriseCluster` remains selectable for callers using a `kombu` `global_keyprefix` with a hash tag; `OSSCluster` requires a cluster-aware client.
  - Validation now allows `NoCluster`, `EnterpriseCluster`, and `OSSCluster`; `azurerm` is pinned to `~> 4.53` (4.50–4.52 reject `NoCluster` at plan time).

- Migration
  - If enabling Managed Redis, set `REDIS_DB_NUMBER`, `REDIS_DB_NUMBER_CELERY`, and `REDIS_DB_NUMBER_CELERY_RESULT_BACKEND` to `0`.
  - If you rely on sharding, set `clustering_policy = "EnterpriseCluster"` and configure a `kombu` `global_keyprefix` with a hash tag so all broker keys hash to one slot. No action if you keep in-cluster Redis.

<sup>Written for commit 76c441efa1bfeb753f69ab4e63fd4af302dcc7ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

