### PR TITLE
fix(ods): check-lazy-imports fails loudly on bad selectors and unreadable files

### DIFF
--- a/tools/ods/internal/lazyimports/lazyimports.go
+++ b/tools/ods/internal/lazyimports/lazyimports.go
@@ -107,7 +107,7 @@ type FileViolation struct {
 }
 
 // findEagerImports finds eager imports of protected modules in a given file.
-func findEagerImports(filePath string, patterns []modulePatterns) EagerImportResult {
+func findEagerImports(filePath string, patterns []modulePatterns) (EagerImportResult, error) {
 	result := EagerImportResult{
 		ViolationLines:  []ViolationLine{},
 		ViolatedModules: make(map[string]struct{}),
@@ -115,8 +115,8 @@ func findEagerImports(filePath string, patterns []modulePatterns) EagerImportRes
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		log.Errorf("Error reading %s: %v", filePath, err)
-		return result
+		// Fail closed: an unreadable file must not pass the check.
+		return result, err
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -163,10 +163,10 @@ func findEagerImports(filePath string, patterns []modulePatterns) EagerImportRes
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Errorf("Error scanning %s: %v", filePath, err)
+		return result, err
 	}
 
-	return result
+	return result, nil
 }
 
 // isValidPythonFile applies shared filtering rules.
@@ -199,32 +199,16 @@ func isValidPythonFile(filePath string) bool {
 	return true
 }
 
-// collectPythonFiles collects Python files from a list of start points.
+// collectPythonFiles collects Python files from a list of start points. A
+// start point that resolves to nothing is an error rather than a silent
+// empty scan.
 func collectPythonFiles(startPoints []string, backendDir string) ([]string, error) {
 	var collected []string
-	backendReal, err := filepath.Abs(backendDir)
-	if err != nil {
-		return nil, err
-	}
 
 	for _, p := range startPoints {
-		absPath, err := filepath.Abs(p)
+		absPath, info, err := paths.ResolveInBackend(p, backendDir)
 		if err != nil {
-			log.Debugf("Skipping path that cannot be resolved: %s", p)
-			continue
-		}
-
-		// Check if path is within backend directory
-		relPath, err := filepath.Rel(backendReal, absPath)
-		if err != nil || strings.HasPrefix(relPath, "..") {
-			log.Debugf("Skipping path outside backend directory: %s", p)
-			continue
-		}
-
-		info, err := os.Stat(absPath)
-		if err != nil {
-			log.Debugf("Skipping non-existent path: %s", p)
-			continue
+			return nil, err
 		}
 
 		if info.IsDir() {
@@ -232,7 +216,8 @@ func collectPythonFiles(startPoints []string, backendDir string) ([]string, erro
 			var mu sync.Mutex
 			err := fastwalk.Walk(nil, absPath, func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
-					return nil // Skip files with errors
+					// Fail closed: an unreadable file must not pass the check.
+					return err
 				}
 				if d.IsDir() {
 					// isValidPythonFile rejects these anyway; pruning avoids the descent.
@@ -249,12 +234,10 @@ func collectPythonFiles(startPoints []string, backendDir string) ([]string, erro
 				return nil
 			})
 			if err != nil {
-				log.Debugf("Error walking directory %s: %v", absPath, err)
+				return nil, err
 			}
-		} else {
-			if isValidPythonFile(absPath) {
-				collected = append(collected, absPath)
-			}
+		} else if isValidPythonFile(absPath) {
+			collected = append(collected, absPath)
 		}
 	}
 
@@ -337,7 +320,10 @@ func CheckLazyImports(modulesToLazyImport map[string]LazyImportSettings, provide
 			continue
 		}
 
-		result := findEagerImports(filePath, patternsToCheck)
+		result, err := findEagerImports(filePath, patternsToCheck)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		if len(result.ViolationLines) > 0 {
 			relPath, err := filepath.Rel(backendDir, filePath)

--- a/tools/ods/internal/lazyimports/lazyimports.go
+++ b/tools/ods/internal/lazyimports/lazyimports.go
@@ -2,6 +2,7 @@ package lazyimports
 
 import (
 	"bufio"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -163,7 +164,9 @@ func findEagerImports(filePath string, patterns []modulePatterns) (EagerImportRe
 	}
 
 	if err := scanner.Err(); err != nil {
-		return result, err
+		// Scanner errors do not carry the path; add it so a multi-file run
+		// names the file that needs attention.
+		return result, fmt.Errorf("scanning %s: %w", filePath, err)
 	}
 
 	return result, nil
@@ -199,9 +202,8 @@ func isValidPythonFile(filePath string) bool {
 	return true
 }
 
-// collectPythonFiles collects Python files from a list of start points. A
-// start point that resolves to nothing is an error rather than a silent
-// empty scan.
+// collectPythonFiles collects Python files from a list of start points. A start
+// point that resolves to nothing is an error rather than a silent empty scan.
 func collectPythonFiles(startPoints []string, backendDir string) ([]string, error) {
 	var collected []string
 

--- a/tools/ods/internal/lazyimports/lazyimports_test.go
+++ b/tools/ods/internal/lazyimports/lazyimports_test.go
@@ -68,7 +68,10 @@ from typing import Dict
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai", "transformers"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find 4 violations (lines 2, 3, 4, 5)
 	if len(result.ViolationLines) != 4 {
@@ -127,7 +130,10 @@ from transformers import BertModel
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai", "transformers"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should only find violations for top-level imports (lines 14, 15)
 	if len(result.ViolationLines) != 2 {
@@ -167,7 +173,10 @@ import mygenai  # Should not be flagged
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find 2 violations (lines 2, 3)
 	if len(result.ViolationLines) != 2 {
@@ -209,7 +218,10 @@ import os
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find no violations
 	if len(result.ViolationLines) != 0 {
@@ -236,7 +248,10 @@ def some_function():
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai", "transformers"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find no violations
 	if len(result.ViolationLines) != 0 {
@@ -248,18 +263,12 @@ def some_function():
 }
 
 func TestFindEagerImportsFileReadError(t *testing.T) {
-	// Test handling of file read errors.
+	// Test that an unreadable file fails the check instead of passing it.
 	nonexistentPath := "/nonexistent/path/test.py"
 
 	patterns := createPatterns([]string{"google.genai"})
-	result := findEagerImports(nonexistentPath, patterns)
-
-	// Should return empty result on error
-	if len(result.ViolationLines) != 0 {
-		t.Errorf("Expected 0 violations for nonexistent file, got %d", len(result.ViolationLines))
-	}
-	if len(result.ViolatedModules) != 0 {
-		t.Errorf("Expected 0 violated modules for nonexistent file, got %d", len(result.ViolatedModules))
+	if _, err := findEagerImports(nonexistentPath, patterns); err == nil {
+		t.Fatalf("Expected an error for a nonexistent file")
 	}
 }
 
@@ -280,7 +289,10 @@ def some_function():
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"onyx.llm.litellm_singleton"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find one violation (line 3)
 	if len(result.ViolationLines) != 1 {
@@ -321,7 +333,10 @@ class SomeClass:
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"onyx.llm.litellm_singleton"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find no violations
 	if len(result.ViolationLines) != 0 {
@@ -506,7 +521,10 @@ def allowed_function():
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"playwright"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find 4 violations (lines 2, 3, 4, 5)
 	if len(result.ViolationLines) != 4 {
@@ -555,7 +573,10 @@ def allowed_function():
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"nltk"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find 4 violations (lines 2, 3, 4, 5)
 	if len(result.ViolationLines) != 4 {
@@ -605,7 +626,10 @@ def allowed_usage():
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai", "playwright", "nltk"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// Should find 3 violations (lines 2, 3, 4)
 	if len(result.ViolationLines) != 3 {
@@ -841,7 +865,10 @@ func TestEmptyFile(t *testing.T) {
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	if len(result.ViolationLines) != 0 {
 		t.Errorf("Expected 0 violations for empty file, got %d", len(result.ViolationLines))
@@ -859,7 +886,10 @@ func TestFileWithOnlyComments(t *testing.T) {
 	defer func() { _ = os.Remove(testPath) }()
 
 	patterns := createPatterns([]string{"google.genai"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	if len(result.ViolationLines) != 0 {
 		t.Errorf("Expected 0 violations for comment-only file, got %d", len(result.ViolationLines))
@@ -878,7 +908,10 @@ import google.genai
 
 	// Use patterns that might both match the same line
 	patterns := createPatterns([]string{"google.genai", "google"})
-	result := findEagerImports(testPath, patterns)
+	result, err := findEagerImports(testPath, patterns)
+	if err != nil {
+		t.Fatalf("findEagerImports failed: %v", err)
+	}
 
 	// The line should be flagged by google.genai pattern
 	if len(result.ViolationLines) < 1 {
@@ -923,5 +956,29 @@ func TestIgnoreEnvDirectory(t *testing.T) {
 		if base == "env_file.py" || base == "dotenv_file.py" {
 			t.Errorf("File %s should have been ignored", f)
 		}
+	}
+}
+
+func TestCollectPythonFilesResolvesSelectors(t *testing.T) {
+	// Backend-relative selectors resolve via the backend fallback, and a
+	// selector that resolves to nothing is an error.
+	backendDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(backendDir, "pkg"), 0755); err != nil {
+		t.Fatalf("Failed to create pkg dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backendDir, "pkg", "a.py"), []byte("import os"), 0644); err != nil {
+		t.Fatalf("Failed to create pkg/a.py: %v", err)
+	}
+
+	files, err := collectPythonFiles([]string{"pkg"}, backendDir)
+	if err != nil {
+		t.Fatalf("collectPythonFiles failed: %v", err)
+	}
+	if len(files) != 1 || files[0] != filepath.Join(backendDir, "pkg", "a.py") {
+		t.Fatalf("Expected only pkg/a.py, got %v", files)
+	}
+
+	if _, err := collectPythonFiles([]string{"nonexistent"}, backendDir); err == nil {
+		t.Fatalf("Expected an error for a selector that matches nothing")
 	}
 }


### PR DESCRIPTION
## Description

Ports the `check-getattr` review fixes (#13685) to `check-lazy-imports`, which has the same bugs: a selector resolving outside `backend/` was silently skipped, so `ods check-lazy-imports onyx/llm/` run from the repo root scanned nothing and reported success, and unreadable files were logged and skipped, letting them pass the check.

- Selectors resolve via paths.ResolveInBackend: backend-relative paths work from any working directory, and a selector that resolves to nothing is an error instead of a silent empty scan.
- findEagerImports and the directory walk propagate I/O errors, so the check fails closed instead of reporting clean.
- Passing only filtered-out files (e.g. tests/) still exits 0 with the "no matching files" notice, since pre-commit routinely does this.

Depends on #13685 for paths.ResolveInBackend.

## How Has This Been Tested?

- findEagerImports tests updated for the error-returning signature; the nonexistent-file test now expects an error instead of an empty result.
- New test covering backend-relative selector fallback and loud failure on an unresolvable selector.
- Manual runs: full backend passes, "check-lazy-imports onyx/llm/" from the repo root now actually scans, a bogus selector exits 1.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `ods check-lazy-imports` fail on unreadable files and bad selectors. Previously it skipped unreadable files and ignored selectors outside `backend/`; now I/O errors and selectors that resolve to nothing exit non-zero, and backend-relative selectors work from any working directory.

- `findEagerImports` returns `(EagerImportResult, error)`; `CheckLazyImports` propagates open/scan failures. Tests updated to expect errors on unreadable files.
- File collection resolves selectors via `paths.ResolveInBackend`, errors on non-existent or out-of-backend selectors, and fails directory walks on I/O. Passing only filtered-out files still exits 0 to preserve pre-commit behavior.

<sup>Written for commit 46bdcb62002ac1f064f6cdc0879297aee2483cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

