### PR TITLE
fix(slackbot): honor invite-only for Slack auto-provisioning

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -295,6 +295,11 @@ def handle_message(
                         client=client,
                         channel=channel,
                         thread_ts=message_info.msg_to_respond,
+                        # Ephemeral: the denial is about the sender, not the
+                        # channel, so it must not post publicly.
+                        receiver_ids=(
+                            [message_info.sender_id] if message_info.sender_id else None
+                        ),
                         text=(
                             "We weren't able to respond because this workspace "
                             "is invite-only and your email has not been "

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -4,7 +4,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from sqlalchemy.orm import Session
 
-from onyx.auth.users import verify_email_is_invited
+from onyx.auth.users import verify_email_domain, verify_email_is_invited
 from onyx.configs.onyxbot_configs import (
     ONYX_BOT_FEEDBACK_REMINDER,
     ONYX_BOT_REACT_EMOJI,
@@ -27,12 +27,19 @@ from onyx.onyxbot.slack.utils import (
     slack_usage_report,
     update_emote_react,
 )
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import SLACK_CHANNEL_ID
 from shared_configs.contextvars import get_current_tenant_id
 
 logger_base = setup_logger()
+
+_SEAT_LIMIT_TEXT = (
+    "We weren't able to respond because your organization "
+    "has reached its user seat limit. Please contact your "
+    "Onyx administrator to add more seats."
+)
 
 
 def send_msg_ack_to_user(details: SlackMessageInfo, client: WebClient) -> None:
@@ -267,6 +274,24 @@ def handle_message(
     except SlackApiError as e:
         logger.error("Was not able to react to user message due to: %s", e)
 
+    def _deny(log_msg: str, text: str, ephemeral: bool = False) -> bool:
+        """Tell the sender the bot will not respond. Always returns False."""
+        logger.info(log_msg)
+        respond_in_thread_or_channel(
+            client=client,
+            channel=channel,
+            thread_ts=message_info.msg_to_respond,
+            # Ephemeral for denials about the sender, so they never post
+            # publicly in the channel.
+            receiver_ids=(
+                [message_info.sender_id]
+                if ephemeral and message_info.sender_id
+                else None
+            ),
+            text=text,
+        )
+        return False
+
     with get_session_with_current_tenant() as db_session:
         if message_info.email:
             existing_user = get_user_by_email(message_info.email, db_session)
@@ -278,36 +303,37 @@ def handle_message(
                 existing_user.account_type == AccountType.EXT_PERM_USER
             )
 
-            # Invite-only gates provisioning like any self-serve signup. BOT
+            # Invite-only and email-domain policies gate provisioning like any
+            # self-serve signup (JWT and OAuth pair the same checks). BOT
             # accounts were provisioned by the bot itself, never re-checked.
             if provisions_account:
                 try:
                     verify_email_is_invited(message_info.email)
-                except OnyxError as e:
-                    if e.error_code != OnyxErrorCode.UNAUTHORIZED:
-                        raise
-                    logger.info(
-                        "Blocked Slack-bot provisioning of uninvited user %s: %s",
+                    verify_email_domain(
                         message_info.email,
-                        e.detail,
+                        valid_email_domains=get_security_settings().valid_email_domains,
                     )
-                    respond_in_thread_or_channel(
-                        client=client,
-                        channel=channel,
-                        thread_ts=message_info.msg_to_respond,
-                        # Ephemeral: the denial is about the sender, not the
-                        # channel, so it must not post publicly.
-                        receiver_ids=(
-                            [message_info.sender_id] if message_info.sender_id else None
-                        ),
-                        text=(
+                except OnyxError as e:
+                    if e.error_code not in (
+                        OnyxErrorCode.UNAUTHORIZED,
+                        OnyxErrorCode.INVALID_INPUT,
+                    ):
+                        raise
+                    return _deny(
+                        "Blocked Slack-bot provisioning of "
+                        f"{message_info.email}: {e.detail}",
+                        (
                             "We weren't able to respond because this workspace "
                             "is invite-only and your email has not been "
                             "invited. Please ask your Onyx administrator for "
                             "an invite."
+                            if e.error_code == OnyxErrorCode.UNAUTHORIZED
+                            else "We weren't able to respond because your email "
+                            "address is not allowed in this workspace. Please "
+                            "contact your Onyx administrator."
                         ),
+                        ephemeral=True,
                     )
-                    return False
 
             if existing_user is None:
                 # New user — check seat availability before creating
@@ -319,16 +345,10 @@ def handle_message(
                 # noop returns None when called; real function returns SeatAvailabilityResult
                 seat_result = check_seat_fn(db_session=db_session)
                 if seat_result is not None and not seat_result.available:
-                    logger.info(
-                        "Blocked new Slack user %s: %s",
-                        message_info.email,
-                        seat_result.error_message,
-                    )
-                    respond_in_thread_or_channel(
-                        client=client,
-                        channel=channel,
-                        thread_ts=message_info.msg_to_respond,
-                        text=(
+                    return _deny(
+                        "Blocked new Slack user "
+                        f"{message_info.email}: {seat_result.error_message}",
+                        (
                             "We weren't able to respond because your organization "
                             "has reached its user seat limit. Since this is your "
                             "first time interacting with the bot, a new account "
@@ -336,7 +356,6 @@ def handle_message(
                             "Onyx administrator to add more seats."
                         ),
                     )
-                    return False
 
             elif (
                 not existing_user.is_active
@@ -356,16 +375,10 @@ def handle_message(
                 acquire_lock_fn(db_session, get_current_tenant_id())
                 seat_result = check_seat_fn(db_session=db_session)
                 if seat_result is not None and not seat_result.available:
-                    logger.info(
-                        "Blocked inactive Slack user %s: %s",
-                        message_info.email,
-                        seat_result.error_message,
-                    )
-                    respond_in_thread_or_channel(
-                        client=client,
-                        channel=channel,
-                        thread_ts=message_info.msg_to_respond,
-                        text=(
+                    return _deny(
+                        "Blocked inactive Slack user "
+                        f"{message_info.email}: {seat_result.error_message}",
+                        (
                             "We weren't able to respond because your organization "
                             "has reached its user seat limit. Your account is "
                             "currently deactivated and cannot be reactivated "
@@ -373,7 +386,6 @@ def handle_message(
                             "your Onyx administrator."
                         ),
                     )
-                    return False
 
                 activate_user(existing_user, db_session)
                 invalidate_license_cache_fn = fetch_ee_implementation_or_noop(
@@ -394,22 +406,11 @@ def handle_message(
                 )
                 seat_result = check_seat_fn(db_session=db_session)
                 if seat_result is not None and not seat_result.available:
-                    logger.info(
-                        "Blocked Slack-bot promotion of %s: %s",
-                        message_info.email,
-                        seat_result.error_message,
+                    return _deny(
+                        "Blocked Slack-bot promotion of "
+                        f"{message_info.email}: {seat_result.error_message}",
+                        _SEAT_LIMIT_TEXT,
                     )
-                    respond_in_thread_or_channel(
-                        client=client,
-                        channel=channel,
-                        thread_ts=message_info.msg_to_respond,
-                        text=(
-                            "We weren't able to respond because your organization "
-                            "has reached its user seat limit. Please contact your "
-                            "Onyx administrator to add more seats."
-                        ),
-                    )
-                    return False
 
             # Defense-in-depth: locks + checks on the same session that
             # commits the EXT_PERM_USER -> BOT promotion.
@@ -440,22 +441,11 @@ def handle_message(
             except OnyxError as e:
                 if e.error_code != OnyxErrorCode.SEAT_LIMIT_EXCEEDED:
                     raise
-                logger.info(
-                    "Blocked Slack-bot user creation/promotion for %s: %s",
-                    message_info.email,
-                    e.detail,
+                return _deny(
+                    "Blocked Slack-bot user creation/promotion for "
+                    f"{message_info.email}: {e.detail}",
+                    _SEAT_LIMIT_TEXT,
                 )
-                respond_in_thread_or_channel(
-                    client=client,
-                    channel=channel,
-                    thread_ts=message_info.msg_to_respond,
-                    text=(
-                        "We weren't able to respond because your organization "
-                        "has reached its user seat limit. Please contact your "
-                        "Onyx administrator to add more seats."
-                    ),
-                )
-                return False
             else:
                 if provisions_account:
                     invalidate_fn = fetch_ee_implementation_or_noop(

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -4,6 +4,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from sqlalchemy.orm import Session
 
+from onyx.auth.users import verify_email_is_invited
 from onyx.configs.onyxbot_configs import (
     ONYX_BOT_FEEDBACK_REMINDER,
     ONYX_BOT_REACT_EMOJI,
@@ -269,6 +270,40 @@ def handle_message(
     with get_session_with_current_tenant() as db_session:
         if message_info.email:
             existing_user = get_user_by_email(message_info.email, db_session)
+
+            # True when this message provisions an account (new user or
+            # EXT_PERM_USER promotion). Read before add_slack_user_if_not_exists
+            # promotes in place, else the cache invalidation below is skipped.
+            provisions_account: bool = existing_user is None or (
+                existing_user.account_type == AccountType.EXT_PERM_USER
+            )
+
+            # Invite-only gates provisioning like any self-serve signup. BOT
+            # accounts were provisioned by the bot itself, never re-checked.
+            if provisions_account:
+                try:
+                    verify_email_is_invited(message_info.email)
+                except OnyxError as e:
+                    if e.error_code != OnyxErrorCode.UNAUTHORIZED:
+                        raise
+                    logger.info(
+                        "Blocked Slack-bot provisioning of uninvited user %s: %s",
+                        message_info.email,
+                        e.detail,
+                    )
+                    respond_in_thread_or_channel(
+                        client=client,
+                        channel=channel,
+                        thread_ts=message_info.msg_to_respond,
+                        text=(
+                            "We weren't able to respond because this workspace "
+                            "is invite-only and your email has not been "
+                            "invited. Please ask your Onyx administrator for "
+                            "an invite."
+                        ),
+                    )
+                    return False
+
             if existing_user is None:
                 # New user — check seat availability before creating
                 check_seat_fn = fetch_ee_implementation_or_noop(
@@ -391,14 +426,6 @@ def handle_message(
                         OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message
                     )
 
-            # Snapshot pre-call seat-counted state. ``add_slack_user_if_not_exists``
-            # mutates ``existing_user`` in place on EXT_PERM_USER -> BOT, so
-            # reading ``account_type`` after the call would see the new value
-            # and skip cache invalidation.
-            consumed_seat = existing_user is None or (
-                existing_user.account_type == AccountType.EXT_PERM_USER
-            )
-
             try:
                 add_slack_user_if_not_exists(
                     db_session,
@@ -425,7 +452,7 @@ def handle_message(
                 )
                 return False
             else:
-                if consumed_seat:
+                if provisions_account:
                     invalidate_fn = fetch_ee_implementation_or_noop(
                         "onyx.db.license",
                         "invalidate_license_cache",

--- a/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from onyx.db.enums import AccountType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.settings.models import ApplicationStatus
 
 # ---------------------------------------------------------------------------
@@ -77,6 +80,30 @@ def _make_channel_config() -> MagicMock:
     config.persona = None
     config.channel_config = {}
     return config
+
+
+def _call_handle_message(
+    email: str = "user@test.com",
+    client: MagicMock | None = None,
+    slack_channel_config: MagicMock | None = None,
+) -> bool:
+    from onyx.onyxbot.slack.handlers.handle_message import handle_message
+
+    return handle_message(
+        message_info=_make_message_info(email),
+        slack_channel_config=slack_channel_config or _make_channel_config(),
+        client=client or MagicMock(),
+        feedback_reminder_id=None,
+    )
+
+
+@pytest.fixture
+def db_session() -> Generator[MagicMock, None, None]:
+    with patch(f"{_HANDLE_MSG}.get_session_with_current_tenant") as mock:
+        session = MagicMock()
+        mock.return_value.__enter__ = MagicMock(return_value=session)
+        mock.return_value.__exit__ = MagicMock(return_value=False)
+        yield session
 
 
 # ---------------------------------------------------------------------------
@@ -249,32 +276,16 @@ class TestHandleMessageSeatCheck:
 
     @pytest.fixture(autouse=True)
     def _common_patches(self) -> Any:
-        """Patch side-effect-only dependencies that every test needs."""
+        """Patch side-effect-only dependencies that every test needs.
+
+        The invite-only gate is a no-op here; it has its own test class.
+        """
         with (
             patch(f"{_HANDLE_MSG}.slack_usage_report"),
             patch(f"{_HANDLE_MSG}.send_msg_ack_to_user"),
+            patch(f"{_HANDLE_MSG}.verify_email_is_invited"),
         ):
             yield
-
-    @pytest.fixture
-    def db_session(self) -> Generator[MagicMock, None, None]:
-        with patch(f"{_HANDLE_MSG}.get_session_with_current_tenant") as mock:
-            session = MagicMock()
-            mock.return_value.__enter__ = MagicMock(return_value=session)
-            mock.return_value.__exit__ = MagicMock(return_value=False)
-            yield session
-
-    def _call_handle_message(
-        self, client: MagicMock | None = None, email: str = "user@test.com"
-    ) -> bool:
-        from onyx.onyxbot.slack.handlers.handle_message import handle_message
-
-        return handle_message(
-            message_info=_make_message_info(email),
-            slack_channel_config=_make_channel_config(),
-            client=client or MagicMock(),
-            feedback_reminder_id=None,
-        )
 
     @pytest.mark.usefixtures("db_session")
     @patch(f"{_HANDLE_MSG}.respond_in_thread_or_channel")
@@ -289,7 +300,7 @@ class TestHandleMessageSeatCheck:
         seat_result = MagicMock(available=False, error_message="Seat limit exceeded")
         mock_fetch_ee.return_value = lambda **_kw: seat_result
 
-        result = self._call_handle_message()
+        result = _call_handle_message()
 
         assert result is False
         assert "seat limit" in mock_respond.call_args[1]["text"]
@@ -311,7 +322,7 @@ class TestHandleMessageSeatCheck:
     ) -> None:
         mock_get_user.return_value = MagicMock()  # User exists
 
-        self._call_handle_message()
+        _call_handle_message()
 
         mock_fetch_ee.assert_not_called()
 
@@ -331,7 +342,7 @@ class TestHandleMessageSeatCheck:
     ) -> None:
         mock_fetch_ee.return_value = lambda **_kw: MagicMock(available=True)
 
-        self._call_handle_message(email="new@test.com")
+        _call_handle_message(email="new@test.com")
 
         mock_add_user.assert_called_once()
         args, kwargs = mock_add_user.call_args
@@ -356,13 +367,111 @@ class TestHandleMessageSeatCheck:
         """CE mode: noop returns None, user is allowed."""
         mock_fetch_ee.return_value = lambda **_kw: None
 
-        self._call_handle_message(email="new@test.com")
+        _call_handle_message(email="new@test.com")
 
         mock_add_user.assert_called_once()
         args, kwargs = mock_add_user.call_args
         assert args == (db_session, "new@test.com")
         assert "enforce_seat_check" in kwargs
         assert callable(kwargs["enforce_seat_check"])
+
+
+# ---------------------------------------------------------------------------
+# handle_message invite-only gate
+# ---------------------------------------------------------------------------
+
+
+class TestHandleMessageInviteGate:
+    """Invite-only (Restrict Open Sign-Up) gates Slack auto-provisioning."""
+
+    @pytest.fixture(autouse=True)
+    def _common_patches(self) -> Any:
+        with (
+            patch(f"{_HANDLE_MSG}.slack_usage_report"),
+            patch(f"{_HANDLE_MSG}.send_msg_ack_to_user"),
+        ):
+            yield
+
+    @pytest.mark.usefixtures("db_session")
+    @pytest.mark.parametrize(
+        "account_type",
+        [None, AccountType.EXT_PERM_USER],
+        ids=["new_user", "ext_perm_promotion"],
+    )
+    @patch(f"{_HANDLE_MSG}.respond_in_thread_or_channel")
+    @patch(f"{_HANDLE_MSG}.add_slack_user_if_not_exists")
+    @patch(
+        f"{_HANDLE_MSG}.verify_email_is_invited",
+        side_effect=OnyxError(OnyxErrorCode.UNAUTHORIZED, "invite-only"),
+    )
+    @patch(f"{_HANDLE_MSG}.get_user_by_email")
+    def test_uninvited_provisioning_blocked(
+        self,
+        mock_get_user: MagicMock,
+        _mock_verify: MagicMock,
+        mock_add_user: MagicMock,
+        mock_respond: MagicMock,
+        account_type: AccountType | None,
+    ) -> None:
+        if account_type is None:
+            mock_get_user.return_value = None
+        else:
+            user = MagicMock()
+            user.account_type = account_type
+            mock_get_user.return_value = user
+
+        result = _call_handle_message()
+
+        assert result is False
+        mock_add_user.assert_not_called()
+        mock_respond.assert_called_once()
+        assert "invite" in mock_respond.call_args[1]["text"].lower()
+
+    @pytest.mark.usefixtures("db_session")
+    @patch(f"{_HANDLE_MSG}.handle_regular_answer", return_value=False)
+    @patch(f"{_HANDLE_MSG}.handle_standard_answers", return_value=False)
+    @patch(f"{_HANDLE_MSG}.add_slack_user_if_not_exists")
+    @patch(f"{_HANDLE_MSG}.fetch_ee_implementation_or_noop")
+    @patch(f"{_HANDLE_MSG}.verify_email_is_invited")
+    @patch(f"{_HANDLE_MSG}.get_user_by_email", return_value=None)
+    def test_invited_new_user_provisioned(
+        self,
+        _mock_get_user: MagicMock,
+        mock_verify: MagicMock,
+        mock_fetch_ee: MagicMock,
+        mock_add_user: MagicMock,
+        _mock_standard: MagicMock,
+        _mock_regular: MagicMock,
+    ) -> None:
+        mock_fetch_ee.return_value = lambda **_kw: None
+
+        _call_handle_message(email="new@test.com")
+
+        mock_verify.assert_called_once_with("new@test.com")
+        mock_add_user.assert_called_once()
+
+    @pytest.mark.usefixtures("db_session")
+    @patch(f"{_HANDLE_MSG}.handle_regular_answer", return_value=False)
+    @patch(f"{_HANDLE_MSG}.handle_standard_answers", return_value=False)
+    @patch(f"{_HANDLE_MSG}.add_slack_user_if_not_exists")
+    @patch(f"{_HANDLE_MSG}.verify_email_is_invited")
+    @patch(f"{_HANDLE_MSG}.get_user_by_email")
+    def test_existing_member_skips_invite_check(
+        self,
+        mock_get_user: MagicMock,
+        mock_verify: MagicMock,
+        _mock_add_user: MagicMock,
+        _mock_standard: MagicMock,
+        _mock_regular: MagicMock,
+    ) -> None:
+        user = MagicMock()
+        user.is_active = True
+        user.account_type = AccountType.BOT
+        mock_get_user.return_value = user
+
+        _call_handle_message()
+
+        mock_verify.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -452,14 +561,6 @@ class TestHandleMessageInvocationAllowlist:
             mock_fetch_ee.return_value = lambda **_kw: MagicMock(available=True)
             yield
 
-    @pytest.fixture
-    def db_session(self) -> Generator[MagicMock, None, None]:
-        with patch(f"{_HANDLE_MSG}.get_session_with_current_tenant") as mock:
-            session = MagicMock()
-            mock.return_value.__enter__ = MagicMock(return_value=session)
-            mock.return_value.__exit__ = MagicMock(return_value=False)
-            yield session
-
     def _make_config(
         self, allowlist: list[str] | None = None, **extra: Any
     ) -> MagicMock:
@@ -471,26 +572,12 @@ class TestHandleMessageInvocationAllowlist:
         config.channel_config = channel_config
         return config
 
-    def _call(
-        self,
-        slack_channel_config: MagicMock,
-        client: MagicMock | None = None,
-    ) -> bool:
-        from onyx.onyxbot.slack.handlers.handle_message import handle_message
-
-        return handle_message(
-            message_info=_make_message_info(),
-            slack_channel_config=slack_channel_config,
-            client=client or MagicMock(),
-            feedback_reminder_id=None,
-        )
-
     @pytest.mark.usefixtures("db_session")
     @patch(f"{_HANDLE_MSG}.slack_usage_report")
     def test_empty_allowlist_processes_normally(
         self, mock_usage_report: MagicMock
     ) -> None:
-        self._call(self._make_config(allowlist=None))
+        _call_handle_message(slack_channel_config=self._make_config(allowlist=None))
         mock_usage_report.assert_called_once()
 
     @pytest.mark.usefixtures("db_session")
@@ -506,7 +593,9 @@ class TestHandleMessageInvocationAllowlist:
         # _make_message_info() returns sender_id="U123"
         mock_fetch_emails.return_value = (["U123"], [])
 
-        self._call(self._make_config(allowlist=["allowed@test.com"]))
+        _call_handle_message(
+            slack_channel_config=self._make_config(allowlist=["allowed@test.com"])
+        )
 
         mock_usage_report.assert_called_once()
 
@@ -524,7 +613,9 @@ class TestHandleMessageInvocationAllowlist:
         mock_fetch_emails.return_value = ([], ["sales-team"])
         mock_fetch_groups.return_value = (["U123"], [])
 
-        self._call(self._make_config(allowlist=["sales-team"]))
+        _call_handle_message(
+            slack_channel_config=self._make_config(allowlist=["sales-team"])
+        )
 
         mock_usage_report.assert_called_once()
 
@@ -543,7 +634,9 @@ class TestHandleMessageInvocationAllowlist:
         # Allowlist resolves to a different user ID than the sender
         mock_fetch_emails.return_value = (["U999"], [])
 
-        result = self._call(self._make_config(allowlist=["allowed@test.com"]))
+        result = _call_handle_message(
+            slack_channel_config=self._make_config(allowlist=["allowed@test.com"])
+        )
 
         assert result is False
         mock_usage_report.assert_not_called()
@@ -564,7 +657,9 @@ class TestHandleMessageInvocationAllowlist:
         # Email never resolves to any Slack user; allowlist non-empty -> deny
         mock_fetch_emails.return_value = ([], ["unknown@test.com"])
 
-        result = self._call(self._make_config(allowlist=["unknown@test.com"]))
+        result = _call_handle_message(
+            slack_channel_config=self._make_config(allowlist=["unknown@test.com"])
+        )
 
         assert result is False
         mock_usage_report.assert_not_called()

--- a/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
@@ -426,6 +426,8 @@ class TestHandleMessageInviteGate:
         mock_add_user.assert_not_called()
         mock_respond.assert_called_once()
         assert "invite" in mock_respond.call_args[1]["text"].lower()
+        # _make_message_info() returns sender_id="U123"
+        assert mock_respond.call_args[1]["receiver_ids"] == ["U123"]
 
     @pytest.mark.usefixtures("db_session")
     @patch(f"{_HANDLE_MSG}.handle_regular_answer", return_value=False)

--- a/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
@@ -278,12 +278,14 @@ class TestHandleMessageSeatCheck:
     def _common_patches(self) -> Any:
         """Patch side-effect-only dependencies that every test needs.
 
-        The invite-only gate is a no-op here; it has its own test class.
+        The invite/domain gate is a no-op here; it has its own test class.
         """
         with (
             patch(f"{_HANDLE_MSG}.slack_usage_report"),
             patch(f"{_HANDLE_MSG}.send_msg_ack_to_user"),
             patch(f"{_HANDLE_MSG}.verify_email_is_invited"),
+            patch(f"{_HANDLE_MSG}.verify_email_domain"),
+            patch(f"{_HANDLE_MSG}.get_security_settings"),
         ):
             yield
 
@@ -382,13 +384,15 @@ class TestHandleMessageSeatCheck:
 
 
 class TestHandleMessageInviteGate:
-    """Invite-only (Restrict Open Sign-Up) gates Slack auto-provisioning."""
+    """Invite-only (Restrict Open Sign-Up) and email-domain policies gate
+    Slack auto-provisioning."""
 
     @pytest.fixture(autouse=True)
     def _common_patches(self) -> Any:
         with (
             patch(f"{_HANDLE_MSG}.slack_usage_report"),
             patch(f"{_HANDLE_MSG}.send_msg_ack_to_user"),
+            patch(f"{_HANDLE_MSG}.get_security_settings"),
         ):
             yield
 
@@ -430,16 +434,43 @@ class TestHandleMessageInviteGate:
         assert mock_respond.call_args[1]["receiver_ids"] == ["U123"]
 
     @pytest.mark.usefixtures("db_session")
+    @patch(f"{_HANDLE_MSG}.respond_in_thread_or_channel")
+    @patch(f"{_HANDLE_MSG}.add_slack_user_if_not_exists")
+    @patch(
+        f"{_HANDLE_MSG}.verify_email_domain",
+        side_effect=OnyxError(OnyxErrorCode.INVALID_INPUT, "Email domain is not valid"),
+    )
+    @patch(f"{_HANDLE_MSG}.verify_email_is_invited")
+    @patch(f"{_HANDLE_MSG}.get_user_by_email", return_value=None)
+    def test_disallowed_domain_provisioning_blocked(
+        self,
+        _mock_get_user: MagicMock,
+        _mock_verify: MagicMock,
+        _mock_domain: MagicMock,
+        mock_add_user: MagicMock,
+        mock_respond: MagicMock,
+    ) -> None:
+        result = _call_handle_message()
+
+        assert result is False
+        mock_add_user.assert_not_called()
+        mock_respond.assert_called_once()
+        assert "not allowed" in mock_respond.call_args[1]["text"]
+        assert mock_respond.call_args[1]["receiver_ids"] == ["U123"]
+
+    @pytest.mark.usefixtures("db_session")
     @patch(f"{_HANDLE_MSG}.handle_regular_answer", return_value=False)
     @patch(f"{_HANDLE_MSG}.handle_standard_answers", return_value=False)
     @patch(f"{_HANDLE_MSG}.add_slack_user_if_not_exists")
     @patch(f"{_HANDLE_MSG}.fetch_ee_implementation_or_noop")
+    @patch(f"{_HANDLE_MSG}.verify_email_domain")
     @patch(f"{_HANDLE_MSG}.verify_email_is_invited")
     @patch(f"{_HANDLE_MSG}.get_user_by_email", return_value=None)
     def test_invited_new_user_provisioned(
         self,
         _mock_get_user: MagicMock,
         mock_verify: MagicMock,
+        mock_domain: MagicMock,
         mock_fetch_ee: MagicMock,
         mock_add_user: MagicMock,
         _mock_standard: MagicMock,
@@ -450,6 +481,7 @@ class TestHandleMessageInviteGate:
         _call_handle_message(email="new@test.com")
 
         mock_verify.assert_called_once_with("new@test.com")
+        mock_domain.assert_called_once()
         mock_add_user.assert_called_once()
 
     @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
## Description

**Bug**: With Restrict Open Sign-Up enabled, any Slack workspace member who messages the bot is silently provisioned as a `slack_user`, consuming a paid seat without an invite (customer report from Jure Bevc).

**Why**: `verify_email_is_invited` gates every self-serve signup path (password, OAuth, SAML, JWT) except the Slack bot.

**Fix**: `handle_message` now runs the invite and email-domain gates (the same pair the JWT and OAuth paths use) on the two seat-granting provisioning events — new-user creation and `EXT_PERM_USER` promotion. Denied senders get an ephemeral reply and no account. Existing users are never re-checked, and unexpected errors still propagate. The five deny blocks now share one `_deny` helper.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check