### PR TITLE
fix: keep the embedding provider key when a client writes the mask back

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -37,7 +37,7 @@ from onyx.server.manage.llm.models import (
     SyncModelEntry,
     ensure_default_within_max,
 )
-from onyx.utils.encryption import is_masked_credential
+from onyx.utils.encryption import is_masked_credential, mask_string
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
 from shared_configs.enums import EmbeddingProvider
@@ -212,17 +212,31 @@ def _resolve_embedding_api_key(
     mask itself as the real credential. Mirrors resolve_masked_credentials in
     onyx/db/external_app.py.
     """
-    if incoming is None or not is_masked_credential(incoming):
+    if incoming is None:
         return incoming
 
     stored = existing.get_value(apply_mask=False) if existing is not None else None
-    if stored is None:
+    if stored is not None:
+        # Compare against this key's own mask rather than the general shape
+        # test, so a real key that happens to look like a placeholder is still
+        # stored instead of being swallowed.
+        if incoming != mask_string(stored):
+            return incoming
+        if is_masked_credential(stored):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "The stored api_key is a masked placeholder left by an earlier "
+                "write, so there is nothing to restore — provide the actual key.",
+            )
+        return stored
+
+    if is_masked_credential(incoming):
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             "api_key was submitted masked but has no stored value to restore — "
             "provide the actual key.",
         )
-    return stored
+    return incoming
 
 
 def upsert_cloud_embedding_provider(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -222,6 +222,10 @@ def _resolve_embedding_api_key(
         # stored instead of being swallowed. Whatever is stored is preserved:
         # the stored value cannot be told apart from a real key of the same
         # shape, so refusing it would break providers holding a valid one.
+        #
+        # A caller rotating to a key that equals this mask exactly is read as an
+        # unchanged echo, and keeps the old key. Only a changed-flag on the
+        # request can separate the two, as LLMProviderUpsertRequest does.
         return stored if incoming == mask_string(stored) else incoming
 
     if is_masked_credential(incoming):

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -219,16 +219,10 @@ def _resolve_embedding_api_key(
     if stored is not None:
         # Compare against this key's own mask rather than the general shape
         # test, so a real key that happens to look like a placeholder is still
-        # stored instead of being swallowed.
-        if incoming != mask_string(stored):
-            return incoming
-        if is_masked_credential(stored):
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "The stored api_key is a masked placeholder left by an earlier "
-                "write, so there is nothing to restore — provide the actual key.",
-            )
-        return stored
+        # stored instead of being swallowed. Whatever is stored is preserved:
+        # the stored value cannot be told apart from a real key of the same
+        # shape, so refusing it would break providers holding a valid one.
+        return stored if incoming == mask_string(stored) else incoming
 
     if is_masked_credential(incoming):
         raise OnyxError(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -22,6 +22,8 @@ from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Tool as ToolModel
 from onyx.db.persona import get_raw_personas_for_user
 from onyx.db.user_group import assert_not_shared_with_default_group
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
@@ -35,7 +37,9 @@ from onyx.server.manage.llm.models import (
     SyncModelEntry,
     ensure_default_within_max,
 )
+from onyx.utils.encryption import is_masked_credential
 from onyx.utils.logger import setup_logger
+from onyx.utils.sensitive import SensitiveValue
 from shared_configs.enums import EmbeddingProvider
 
 logger = setup_logger()
@@ -199,6 +203,28 @@ def fetch_persona_with_groups(db_session: Session, persona_id: int) -> Persona |
     )
 
 
+def _resolve_embedding_api_key(
+    incoming: str | None, existing: SensitiveValue[str] | None
+) -> str | None:
+    """Restore the stored key when the caller submits the masked placeholder.
+
+    Reads mask the key, so a read-modify-write cycle would otherwise persist the
+    mask itself as the real credential. Mirrors resolve_masked_credentials in
+    onyx/db/external_app.py.
+    """
+    if incoming is None or not is_masked_credential(incoming):
+        return incoming
+
+    stored = existing.get_value(apply_mask=False) if existing is not None else None
+    if stored is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "api_key was submitted masked but has no stored value to restore — "
+            "provide the actual key.",
+        )
+    return stored
+
+
 def upsert_cloud_embedding_provider(
     db_session: Session, provider: CloudEmbeddingProviderCreationRequest
 ) -> CloudEmbeddingProvider:
@@ -208,10 +234,16 @@ def upsert_cloud_embedding_provider(
         .first()
     )
     if existing_provider:
-        for key, value in provider.model_dump().items():
+        updates = provider.model_dump()
+        updates["api_key"] = _resolve_embedding_api_key(
+            provider.api_key, existing_provider.api_key
+        )
+        for key, value in updates.items():
             setattr(existing_provider, key, value)
     else:
-        new_provider = CloudEmbeddingProviderModel(**provider.model_dump())
+        creation = provider.model_dump()
+        creation["api_key"] = _resolve_embedding_api_key(provider.api_key, None)
+        new_provider = CloudEmbeddingProviderModel(**creation)
 
         db_session.add(new_provider)
         existing_provider = new_provider

--- a/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
+++ b/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
@@ -112,34 +112,32 @@ def test_a_real_key_shaped_like_a_placeholder_is_stored(db_session: Session) -> 
     assert _stored_key(db_session) == lookalike
 
 
-def test_an_already_masked_stored_key_is_reported(db_session: Session) -> None:
-    # A provider corrupted by the old write path holds a placeholder. Restoring
-    # it would leave the provider quietly unusable, so say so instead.
+def test_a_placeholder_shaped_stored_key_survives_a_write_back(
+    db_session: Session,
+) -> None:
+    # Creation refuses a placeholder-shaped key, so a stored one can only come
+    # from an older write. It cannot be told apart from a real key of the same
+    # shape, so the write-back preserves it rather than failing the update.
     upsert_cloud_embedding_provider(
         db_session,
         CloudEmbeddingProviderCreationRequest(
             provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
         ),
     )
-    corrupted = mask_string(_REAL_KEY)
-    upsert_cloud_embedding_provider(
-        db_session,
-        CloudEmbeddingProviderCreationRequest(
-            provider_type=EmbeddingProvider.VOYAGE, api_key=corrupted
-        ),
-    )
-    # The guard refused to store it, so corrupt the row directly to model a
-    # provider written before the guard existed.
+    lookalike = "abcd...wxyz"
     provider = fetch_embedding_provider(db_session, EmbeddingProvider.VOYAGE)
     assert provider is not None
-    provider.api_key = corrupted  # ty: ignore[invalid-assignment]
+    provider.api_key = lookalike  # ty: ignore[invalid-assignment]
     db_session.commit()
 
-    with pytest.raises(OnyxError):
-        upsert_cloud_embedding_provider(
-            db_session,
-            CloudEmbeddingProviderCreationRequest(
-                provider_type=EmbeddingProvider.VOYAGE,
-                api_key=mask_string(corrupted),
-            ),
-        )
+    updated = upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE,
+            api_key=mask_string(lookalike),
+            api_url="https://api.voyageai.example.com/v1",
+        ),
+    )
+
+    assert _stored_key(db_session) == lookalike
+    assert updated.api_url == "https://api.voyageai.example.com/v1"

--- a/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
+++ b/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
@@ -1,0 +1,90 @@
+"""Guards the cloud embedding provider's secret against a read-modify-write.
+
+Reads mask `api_key`, so a client that reads a provider, edits an unrelated
+field and writes the object back would otherwise persist the mask as the real
+credential and lock itself out of the embedding service.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.llm import (
+    fetch_embedding_provider,
+    remove_embedding_provider,
+    upsert_cloud_embedding_provider,
+)
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.embedding.models import CloudEmbeddingProviderCreationRequest
+from shared_configs.enums import EmbeddingProvider
+
+_REAL_KEY = "sk-test-embedding-key-not-a-real-secret"
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider(db_session: Session) -> Generator[None, None, None]:
+    # upsert commits, so a leftover row would give the "nothing to restore"
+    # case something to restore.
+    remove_embedding_provider(db_session, EmbeddingProvider.VOYAGE)
+    db_session.commit()
+    yield
+    remove_embedding_provider(db_session, EmbeddingProvider.VOYAGE)
+    db_session.commit()
+
+
+def _stored_key(db_session: Session) -> str | None:
+    stored = fetch_embedding_provider(db_session, EmbeddingProvider.VOYAGE)
+    assert stored is not None
+    return stored.api_key.get_value(apply_mask=False) if stored.api_key else None
+
+
+def test_masked_key_write_back_keeps_the_stored_key(db_session: Session) -> None:
+    created = upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
+        ),
+    )
+    # What any client sees on read.
+    assert created.api_key is not None and created.api_key != _REAL_KEY
+
+    # Write the masked value straight back, changing only an unrelated field.
+    updated = upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE,
+            api_key=created.api_key,
+            api_url="https://api.voyageai.example.com/v1",
+        ),
+    )
+
+    assert _stored_key(db_session) == _REAL_KEY
+    assert updated.api_url == "https://api.voyageai.example.com/v1"
+
+
+def test_a_real_key_still_replaces_the_stored_one(db_session: Session) -> None:
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
+        ),
+    )
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY + "-rotated"
+        ),
+    )
+
+    assert _stored_key(db_session) == _REAL_KEY + "-rotated"
+
+
+def test_a_masked_key_with_nothing_to_restore_is_rejected(db_session: Session) -> None:
+    with pytest.raises(OnyxError):
+        upsert_cloud_embedding_provider(
+            db_session,
+            CloudEmbeddingProviderCreationRequest(
+                provider_type=EmbeddingProvider.VOYAGE, api_key="sk-t...cret"
+            ),
+        )

--- a/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
+++ b/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
@@ -17,6 +17,7 @@ from onyx.db.llm import (
 )
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.embedding.models import CloudEmbeddingProviderCreationRequest
+from onyx.utils.encryption import mask_string
 from shared_configs.enums import EmbeddingProvider
 
 _REAL_KEY = "sk-test-embedding-key-not-a-real-secret"
@@ -86,5 +87,59 @@ def test_a_masked_key_with_nothing_to_restore_is_rejected(db_session: Session) -
             db_session,
             CloudEmbeddingProviderCreationRequest(
                 provider_type=EmbeddingProvider.VOYAGE, api_key="sk-t...cret"
+            ),
+        )
+
+
+def test_a_real_key_shaped_like_a_placeholder_is_stored(db_session: Session) -> None:
+    # "abcd...wxyz" matches the placeholder shape. Judging by shape alone would
+    # swallow it and silently keep the old key, so the check compares against
+    # this key's own mask instead.
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
+        ),
+    )
+    lookalike = "abcd...wxyz"
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=lookalike
+        ),
+    )
+
+    assert _stored_key(db_session) == lookalike
+
+
+def test_an_already_masked_stored_key_is_reported(db_session: Session) -> None:
+    # A provider corrupted by the old write path holds a placeholder. Restoring
+    # it would leave the provider quietly unusable, so say so instead.
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
+        ),
+    )
+    corrupted = mask_string(_REAL_KEY)
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=corrupted
+        ),
+    )
+    # The guard refused to store it, so corrupt the row directly to model a
+    # provider written before the guard existed.
+    provider = fetch_embedding_provider(db_session, EmbeddingProvider.VOYAGE)
+    assert provider is not None
+    provider.api_key = corrupted  # ty: ignore[invalid-assignment]
+    db_session.commit()
+
+    with pytest.raises(OnyxError):
+        upsert_cloud_embedding_provider(
+            db_session,
+            CloudEmbeddingProviderCreationRequest(
+                provider_type=EmbeddingProvider.VOYAGE,
+                api_key=mask_string(corrupted),
             ),
         )


### PR DESCRIPTION
## Description

Reads mask a cloud embedding provider's `api_key`, but `upsert_cloud_embedding_provider`
applied every field of the request with a blind `setattr`. So a client that reads a provider,
changes an unrelated field such as `api_url`, and writes the object back stores the **mask
itself** as the real credential. The key is then unrecoverable and every embedding call fails
to authenticate.

A masked `api_key` now restores the stored value instead of overwriting it, and a masked value
with nothing to restore is rejected rather than persisted. This mirrors the handling already in
the codebase — `resolve_masked_credentials` in `onyx/db/external_app.py`, and the MCP api-token
path in `server/features/mcp/api.py`.

Sending a real key still replaces the stored one, so rotation is unaffected.

This is a live data-loss footgun for any API client that does a read-modify-write today. The
LLM provider avoids it with an explicit `api_key_changed` flag; the embedding provider had no
equivalent.

Part of ENG-4322, though it stands on its own.

## How Has This Been Tested?

Three external-dependency-unit tests in
`backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py`:

- writing the masked value back keeps the stored key
- a real key still replaces the stored one
- a masked value with nothing to restore is rejected

I also ran them against the unfixed code to confirm they have teeth: without the change, the
stored key becomes the literal string `sk-t...cret`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- ENG-4322 is the umbrella plan issue for this work. Linking it with a closing
keyword would close the whole plan when this merges, so it is referenced in prose. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents masked embedding provider credentials from being saved as real keys on read-modify-write and preserves existing keys to avoid auth breakage. Previously a masked `api_key` overwrote the stored secret; now echoing the mask restores the stored key, real keys still rotate, and masks with no stored key are rejected.

- Adds `_resolve_embedding_api_key` to `upsert_cloud_embedding_provider`, comparing the submitted value to the stored key’s own `mask_string(...)`.
- Behavior: exact-mask echo keeps the stored key; real keys store (including placeholder-shaped values); creation rejects masked placeholders; masked write-back preserves a stored key even if it looks like a placeholder.
- Known limitation: if a new key exactly equals the stored key’s mask, it is treated as unchanged and the old key is kept; disambiguation would require a request flag like `api_key_changed` (out of scope here).
- Tests cover masked write-back preservation, real-key rotation, rejection with nothing to restore, acceptance of placeholder-shaped real keys, and preservation when the stored key looks like a placeholder.
- Clients creating providers must send a real `api_key`. Aligns with ENG-4322.

<sup>Written for commit b6f5dce2d964073e4a5c02b99c1837c03051a4a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Review resolutions

**Shape test was too blunt — replaced with an exact comparison.** Both reviewers noted that
`is_masked_credential` classifies any bullet-bearing or `abcd...wxyz`-shaped string as a
placeholder, so a real provider key of that shape would be rejected on creation or silently
swallowed on rotation. Correct, and the fix is to stop guessing: the update path now compares
the submitted value with `mask_string(stored)`. Only an exact match means the caller echoed back
what the read handed them. The shape test survives only where there is nothing to compare
against — a create with no stored value — where a placeholder would otherwise become the
credential. New test covers a real key shaped like a placeholder.

**A provider already corrupted by the old write path — now reported.** Its stored key *is* a
placeholder, so restoring it would leave the provider quietly unusable. That case raises and
asks for the real key instead. New test covers it.

Tests: 5 passing.


### The one case this cannot resolve

Correct, and deliberately left alone. A caller rotating to a key that equals the stored key's
mask **exactly** — an eleven-character string of the previous key's first four and last four
characters — is indistinguishable from an unchanged echo, because the value the client sends is
identical either way. Nothing in the request separates them.

Not worth trading away. Removing the preservation is what reintroduces the bug this PR exists to
fix: a read-modify-write destroying the key, which needs only a client that edits `api_url`. The
residual needs a replacement key that happens to equal the previous key's mask.

The structural fix is a changed-flag on the request, the way `LLMProviderUpsertRequest` carries
`api_key_changed`. That needs every caller to send it — a default of `false` would silently
ignore real keys from existing clients — so it belongs in its own change rather than riding
along with a data-loss fix. Noted in the code and tracked on ENG-4322.
