### PR TITLE
feat: read a single document set by id

### DIFF
--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -19,6 +19,7 @@ from onyx.db.document_set import (
     check_document_sets_are_public,
     fetch_all_document_sets_for_user,
     get_document_set_by_id,
+    get_document_set_by_id_for_user,
     get_group_ids_for_document_set,
     insert_document_set,
     mark_document_set_as_to_be_deleted,
@@ -223,6 +224,55 @@ def delete_document_set(
             kwargs={"tenant_id": tenant_id},
             priority=OnyxCeleryPriority.HIGH,
         )
+
+
+@router.get("/admin/document-set/{document_set_id}")
+def get_document_set(
+    document_set_id: int,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_DOCUMENT_SETS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> DocumentSetSummary:
+    """Read one document set.
+
+    The listing is scoped to the caller, so a client managing a single set had
+    to fetch every set and filter. This returns the same shape as the listing.
+    """
+    document_set = get_document_set_by_id_for_user(
+        db_session=db_session,
+        document_set_id=document_set_id,
+        user=user,
+        get_editable=False,
+    )
+    if document_set is None:
+        raise OnyxError(
+            OnyxErrorCode.DOCUMENT_SET_NOT_FOUND,
+            f"Document set {document_set_id} does not exist",
+        )
+
+    is_document_sets_admin = (
+        has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
+        is PermissionAuthority.GLOBAL
+    )
+    is_editable = is_document_sets_admin or (
+        get_document_set_by_id_for_user(
+            db_session=db_session,
+            document_set_id=document_set_id,
+            user=user,
+            get_editable=True,
+        )
+        is not None
+    )
+    return DocumentSetSummary.from_model(
+        document_set,
+        permissions=document_set_permissions(
+            is_editable=is_editable,
+            is_document_sets_admin=is_document_sets_admin,
+            owns_groupless=is_editable
+            and user_owns_groupless_document_set(document_set, user),
+        ),
+    )
 
 
 """Endpoints for non-admins"""

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -239,12 +239,22 @@ def get_document_set(
     The listing is scoped to the caller, so a client managing a single set had
     to fetch every set and filter. This returns the same shape as the listing.
     """
-    document_set = get_document_set_by_id_for_user(
+    # The two scopes are not nested: the readable filter needs membership or a
+    # public set, while the editable one matches a managed scope and a creator's
+    # groupless set. The listing unions them, so this does too.
+    readable = get_document_set_by_id_for_user(
         db_session=db_session,
         document_set_id=document_set_id,
         user=user,
         get_editable=False,
     )
+    editable = get_document_set_by_id_for_user(
+        db_session=db_session,
+        document_set_id=document_set_id,
+        user=user,
+        get_editable=True,
+    )
+    document_set = readable or editable
     if document_set is None:
         raise OnyxError(
             OnyxErrorCode.DOCUMENT_SET_NOT_FOUND,
@@ -255,15 +265,7 @@ def get_document_set(
         has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
         is PermissionAuthority.GLOBAL
     )
-    is_editable = is_document_sets_admin or (
-        get_document_set_by_id_for_user(
-            db_session=db_session,
-            document_set_id=document_set_id,
-            user=user,
-            get_editable=True,
-        )
-        is not None
-    )
+    is_editable = is_document_sets_admin or editable is not None
     return DocumentSetSummary.from_model(
         document_set,
         permissions=document_set_permissions(

--- a/backend/tests/external_dependency_unit/db/test_document_set_get_by_id.py
+++ b/backend/tests/external_dependency_unit/db/test_document_set_get_by_id.py
@@ -11,14 +11,19 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.models import DocumentSet as DocumentSetDBModel
+from onyx.db.models import User
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.document_set.api import get_document_set
 from tests.external_dependency_unit.conftest import create_test_user
 
 
-def _document_set(db_session: Session, *, is_public: bool) -> int:
+def _document_set(
+    db_session: Session, *, is_public: bool, owner: User | None = None
+) -> int:
     document_set = DocumentSetDBModel(
-        name=f"ds-{uuid4().hex[:12]}", is_public=is_public
+        name=f"ds-{uuid4().hex[:12]}",
+        is_public=is_public,
+        user_id=owner.id if owner else None,
     )
     db_session.add(document_set)
     db_session.commit()
@@ -56,3 +61,17 @@ def test_a_private_set_stays_hidden_from_a_basic_user(db_session: Session) -> No
         get_document_set(
             document_set_id=document_set_id, user=basic, db_session=db_session
         )
+
+
+def test_a_creators_groupless_set_is_found(db_session: Session) -> None:
+    # The readable filter needs a public set or group membership, so this set
+    # is reachable only through the editable scope. Reading with one scope
+    # would answer not-found for a set its own creator manages.
+    creator = create_test_user(db_session, "docset-get-creator")
+    document_set_id = _document_set(db_session, is_public=False, owner=creator)
+
+    read = get_document_set(
+        document_set_id=document_set_id, user=creator, db_session=db_session
+    )
+
+    assert read.id == document_set_id

--- a/backend/tests/external_dependency_unit/db/test_document_set_get_by_id.py
+++ b/backend/tests/external_dependency_unit/db/test_document_set_get_by_id.py
@@ -1,0 +1,58 @@
+"""Covers reading a single document set.
+
+The listing is scoped to the caller, so before this endpoint a client that
+managed one set had to fetch every set and filter. The read must stay scoped:
+a caller who cannot see a set must get the not-found error, not its contents.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import DocumentSet as DocumentSetDBModel
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.document_set.api import get_document_set
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _document_set(db_session: Session, *, is_public: bool) -> int:
+    document_set = DocumentSetDBModel(
+        name=f"ds-{uuid4().hex[:12]}", is_public=is_public
+    )
+    db_session.add(document_set)
+    db_session.commit()
+    return document_set.id
+
+
+def test_an_admin_reads_one_set_by_id(db_session: Session) -> None:
+    admin = create_test_user(db_session, "docset-get-admin", is_admin=True)
+    document_set_id = _document_set(db_session, is_public=True)
+
+    read = get_document_set(
+        document_set_id=document_set_id, user=admin, db_session=db_session
+    )
+
+    assert read.id == document_set_id
+    # The shape matches the listing, so clients parse one model.
+    assert read.is_public is True
+    assert read.is_up_to_date is not None
+
+
+def test_a_missing_set_is_not_found(db_session: Session) -> None:
+    admin = create_test_user(db_session, "docset-get-missing", is_admin=True)
+
+    with pytest.raises(OnyxError):
+        get_document_set(
+            document_set_id=2_000_000_000, user=admin, db_session=db_session
+        )
+
+
+def test_a_private_set_stays_hidden_from_a_basic_user(db_session: Session) -> None:
+    basic = create_test_user(db_session, "docset-get-basic")
+    document_set_id = _document_set(db_session, is_public=False)
+
+    with pytest.raises(OnyxError):
+        get_document_set(
+            document_set_id=document_set_id, user=basic, db_session=db_session
+        )


### PR DESCRIPTION
## Description

The document set listing is scoped to the caller and there was no get-by-id, so a client that
manages one document set had to fetch every set and filter it out. Adds
`GET /manage/admin/document-set/{id}`.

It returns the same `DocumentSetSummary` the listing returns, so clients parse one model rather
than two, and it stays scoped: a caller who cannot see the set gets `DOCUMENT_SET_NOT_FOUND`
rather than its contents.

Wanted by the Terraform provider — an `onyx_document_set` resource needs a read-by-id for
refresh and import, and landing this first means it never has to carry the list-and-filter
workaround. Useful to any API client with the same shape of problem.

Part of ENG-4322.

## How Has This Been Tested?

Three external-dependency-unit tests in
`backend/tests/external_dependency_unit/db/test_document_set_get_by_id.py`:

- an admin reads one set by id, and the shape matches the listing
- a missing id raises not-found
- a private set stays hidden from a basic user, rather than leaking through the new route

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- ENG-4322 is the umbrella plan issue for this work. Linking it with a closing
keyword would close the whole plan when this merges, so it is referenced in prose. -->



## Review resolutions

**One visibility scope was not enough — now unions both.** Both reviewers flagged that reading
with `get_editable=False` alone can answer not-found for a set the listing shows. Confirmed in
`_add_user_filters`: the readable branch needs a public set or group membership, while the
editable branch matches a managed scope *and* a creator's groupless private set. Neither
contains the other, which is exactly why the listing unions them.

The read now unions both and derives `is_editable` from the same lookups rather than a third
query. Added a test for the creator's groupless private set, which is visible only through the
editable scope; against the previous code it fails with `DOCUMENT_SET_NOT_FOUND`.

Tests: 4 passing.
