### PR TITLE
feat(gateway): make LLM gateway available on Business

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -17,6 +17,7 @@ Multi-tenant cloud gating lives in `multi_tenant_gating_config.py` and is
 deliberately separate — cloud uses subscriptions, not licenses.
 """
 
+from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX, LLM_GATEWAY_MIN_TIER
 from onyx.server.settings.models import Tier
 
 # Paths that are ALWAYS accessible, even when license is expired/gated.
@@ -73,8 +74,8 @@ PATH_PREFIX_MIN_TIER: dict[str, Tier] = {
     "/admin/api-key": Tier.BUSINESS,  # service-account keys (no user-bound variant)
     "/admin/enterprise-settings": Tier.BUSINESS,  # admin writes; public /enterprise-settings stays open
     "/manage/admin/user-group": Tier.BUSINESS,  # groups + RBAC (Curator roles, group-scoped access)
+    GATEWAY_PATH_PREFIX: LLM_GATEWAY_MIN_TIER,  # external LLM gateway API
     # ----- ENTERPRISE -----
-    "/gateway": Tier.ENTERPRISE,  # external LLM gateway API
     "/admin/enterprise-settings/custom-analytics-script": Tier.ENTERPRISE,  # JS injection
     "/admin/enterprise-settings/scim": Tier.ENTERPRISE,  # SCIM token mgmt
     "/manage/admin/standard-answer": Tier.ENTERPRISE,

--- a/backend/onyx/server/gateway/configs.py
+++ b/backend/onyx/server/gateway/configs.py
@@ -1,6 +1,9 @@
 import os
 
+from onyx.server.settings.models import Tier
+
 GATEWAY_PATH_PREFIX = "/gateway"
+LLM_GATEWAY_MIN_TIER = Tier.BUSINESS
 
 # Kill switch, default ON: set to "false" to send Anthropic-backed providers
 # back through the translation path (losing server tools / thinking fidelity).

--- a/backend/onyx/server/pat/models.py
+++ b/backend/onyx/server/pat/models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validat
 from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission
 from onyx.db.permissions import parse_permission_values
+from onyx.server.gateway.configs import LLM_GATEWAY_MIN_TIER
 from onyx.server.settings.models import Tier
 
 # Assignable token scopes, grouped by `group_label`. `implies` is derived from the
@@ -54,7 +55,7 @@ _ASSIGNABLE_SCOPES: list[PatScopeOption] = [
         group_label="LLM Gateway",
         label="Use",
         description="Call the LLM gateway from external tools.",
-        min_tier=Tier.ENTERPRISE,
+        min_tier=LLM_GATEWAY_MIN_TIER,
     ),
 ]
 

--- a/backend/tests/external_dependency_unit/tier/test_tier_order.py
+++ b/backend/tests/external_dependency_unit/tier/test_tier_order.py
@@ -4,6 +4,7 @@ import pytest
 
 from ee.onyx.configs.license_enforcement_config import PATH_PREFIX_MIN_TIER
 from ee.onyx.server.middleware.tier_gate import _required_tier
+from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
 from onyx.server.settings.models import Tier
 from onyx.server.settings.tier_order import TIER_RANK, tier_at_least
 
@@ -50,6 +51,10 @@ class TestTierGateLongestPrefix:
 
     def test_business_path_resolves(self) -> None:
         assert _required_tier("/admin/query-history/start-export") == Tier.BUSINESS
+
+    def test_gateway_requires_business_tier(self) -> None:
+        assert PATH_PREFIX_MIN_TIER[GATEWAY_PATH_PREFIX] is Tier.BUSINESS
+        assert _required_tier("/gateway/v1/models") is Tier.BUSINESS
 
     def test_enterprise_path_resolves(self) -> None:
         assert _required_tier("/admin/hooks/123") == Tier.ENTERPRISE

--- a/backend/tests/integration/tests/permissions/test_pat_scope_assignment.py
+++ b/backend/tests/integration/tests/permissions/test_pat_scope_assignment.py
@@ -45,6 +45,7 @@ def test_scope_implications(permission_basic_user: DATestUser) -> None:
     assert by_scope[Permission.READ_CHAT.value]["implies"] == []
     assert by_scope[Permission.READ_SEARCH.value]["implies"] == []
     assert by_scope[Permission.USE_LLM_GATEWAY.value]["implies"] == []
+    assert by_scope[Permission.USE_LLM_GATEWAY.value]["min_tier"] == "business"
 
 
 def test_scopes_round_trip(pat_creator: DATestUser) -> None:

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
@@ -1,5 +1,6 @@
 """Tests for the unified tier_gate middleware."""
 
+import json
 from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -91,6 +92,34 @@ async def test_business_passes_business_path(
     mock_get_tier.return_value = Tier.BUSINESS
     middleware, call_next = middleware_harness
     response = await middleware(_make_request("/api/admin/query-history"), call_next)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_community_blocked_from_gateway(
+    mock_get_tier: MagicMock, middleware_harness: MiddlewareHarness
+) -> None:
+    mock_get_tier.return_value = Tier.COMMUNITY
+    middleware, call_next = middleware_harness
+    response = await middleware(_make_request("/api/gateway/v1/models"), call_next)
+
+    assert response.status_code == 402
+    assert json.loads(bytes(response.body))["required_tier"] == "business"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("current_tier", [Tier.BUSINESS, Tier.ENTERPRISE])
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_paid_tiers_pass_gateway(
+    mock_get_tier: MagicMock,
+    current_tier: Tier,
+    middleware_harness: MiddlewareHarness,
+) -> None:
+    mock_get_tier.return_value = current_tier
+    middleware, call_next = middleware_harness
+    response = await middleware(_make_request("/api/gateway/v1/models"), call_next)
+
     assert response.status_code == 200
 
 
@@ -194,7 +223,5 @@ async def test_402_payload_includes_required_tier(
     response = await middleware(_make_request("/api/admin/hooks"), call_next)
     assert response.status_code == 402
     # Body is set on JSONResponse via `content`, accessible as `.body`.
-    import json
-
     payload = json.loads(bytes(response.body))
     assert payload["required_tier"] == "enterprise"

--- a/backend/tests/unit/onyx/server/pat/test_models.py
+++ b/backend/tests/unit/onyx/server/pat/test_models.py
@@ -1,0 +1,12 @@
+from onyx.db.enums import Permission
+from onyx.server.gateway.configs import LLM_GATEWAY_MIN_TIER
+from onyx.server.pat.models import SELECTABLE_PAT_SCOPES
+from onyx.server.settings.models import Tier
+
+
+def test_llm_gateway_scope_is_available_on_business_tier() -> None:
+    assert LLM_GATEWAY_MIN_TIER is Tier.BUSINESS
+    assert (
+        SELECTABLE_PAT_SCOPES[Permission.USE_LLM_GATEWAY].min_tier
+        is LLM_GATEWAY_MIN_TIER
+    )

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -10,7 +10,7 @@ import { useUser } from "@/providers/UserProvider";
 import { useIsMultiTenant } from "@/lib/auth/hooks";
 import { Section } from "@/layouts/general-layouts";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
-import { Tier } from "@/lib/settings/types";
+import { LLM_GATEWAY_MIN_TIER } from "@/lib/tiers";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { hasVisibleLLMModel } from "@/lib/languageModels/utils";
 
@@ -28,13 +28,13 @@ export default function Layout({ children }: LayoutProps) {
   const router = useRouter();
   const { user } = useUser();
   const isMultiTenant = useIsMultiTenant();
-  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
+  const gatewayTier = useTierAtLeast(LLM_GATEWAY_MIN_TIER);
   const { llmProviders } = useLLMProviders();
 
   const showPasswordSection = Boolean(user?.password_configured);
   const showTokensSection = isMultiTenant !== null;
   const showAccountsAccessTab = showPasswordSection || showTokensSection;
-  const showGatewayTab = enterpriseTier && hasVisibleLLMModel(llmProviders);
+  const showGatewayTab = gatewayTier && hasVisibleLLMModel(llmProviders);
 
   const tabs: SettingsTab[] = [
     { href: "/app/settings/general", label: "General" },

--- a/web/src/app/app/settings/llm-gateway/page.test.tsx
+++ b/web/src/app/app/settings/llm-gateway/page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { useLLMProviders } from "@/lib/languageModels/hooks";
+import { useSettings } from "@/lib/settings/hooks";
+import { Tier } from "@/lib/settings/types";
+import LLMGatewayPage from "@/app/app/settings/llm-gateway/page";
+
+const mockReplace = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+jest.mock("@/hooks/useTierAtLeast", () => ({
+  useTierAtLeast: jest.fn(),
+}));
+jest.mock("@/lib/languageModels/hooks", () => ({
+  useLLMProviders: jest.fn(),
+}));
+jest.mock("@/lib/settings/hooks", () => ({
+  useSettings: jest.fn(),
+}));
+jest.mock("@/views/SettingsPage", () => ({
+  LLMGatewaySettings: () => <div>Gateway settings</div>,
+}));
+
+const mockUseTierAtLeast = useTierAtLeast as jest.MockedFunction<
+  typeof useTierAtLeast
+>;
+const mockUseLLMProviders = useLLMProviders as jest.MockedFunction<
+  typeof useLLMProviders
+>;
+const mockUseSettings = useSettings as jest.MockedFunction<typeof useSettings>;
+
+describe("LLMGatewayPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTierAtLeast.mockReturnValue(true);
+    mockUseSettings.mockReturnValue({ isLoading: false } as ReturnType<
+      typeof useSettings
+    >);
+    mockUseLLMProviders.mockReturnValue({
+      llmProviders: [{ model_configurations: [{ is_visible: true }] }],
+      isLoading: false,
+      error: undefined,
+    } as unknown as ReturnType<typeof useLLMProviders>);
+  });
+
+  it("renders the Gateway for the Business minimum tier", () => {
+    render(<LLMGatewayPage />);
+
+    expect(mockUseTierAtLeast).toHaveBeenCalledWith(Tier.BUSINESS);
+    expect(screen.getByText("Gateway settings")).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("redirects users below Business", async () => {
+    mockUseTierAtLeast.mockReturnValue(false);
+
+    render(<LLMGatewayPage />);
+
+    expect(screen.queryByText("Gateway settings")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith("/app/settings/general")
+    );
+  });
+});

--- a/web/src/app/app/settings/llm-gateway/page.tsx
+++ b/web/src/app/app/settings/llm-gateway/page.tsx
@@ -7,16 +7,16 @@ import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { hasVisibleLLMModel } from "@/lib/languageModels/utils";
 import { useSettings } from "@/lib/settings/hooks";
-import { Tier } from "@/lib/settings/types";
+import { LLM_GATEWAY_MIN_TIER } from "@/lib/tiers";
 import { LLMGatewaySettings } from "@/views/SettingsPage";
 
 export default function LLMGatewayPage() {
   const router = useRouter();
-  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
+  const gatewayTier = useTierAtLeast(LLM_GATEWAY_MIN_TIER);
   const settings = useSettings();
   const { llmProviders, isLoading, error } = useLLMProviders();
   const hasAccessibleGatewayModel = hasVisibleLLMModel(llmProviders);
-  const hasAccess = enterpriseTier && hasAccessibleGatewayModel;
+  const hasAccess = gatewayTier && hasAccessibleGatewayModel;
   const isLoadingAccess = settings.isLoading || isLoading;
 
   useEffect(() => {

--- a/web/src/lib/tiers.test.ts
+++ b/web/src/lib/tiers.test.ts
@@ -1,0 +1,11 @@
+import { Tier } from "@/lib/settings/types";
+import { LLM_GATEWAY_MIN_TIER, tierAtLeast } from "@/lib/tiers";
+
+describe("LLM Gateway tier", () => {
+  it("allows Business and Enterprise, but not Community", () => {
+    expect(LLM_GATEWAY_MIN_TIER).toBe(Tier.BUSINESS);
+    expect(tierAtLeast(Tier.COMMUNITY, LLM_GATEWAY_MIN_TIER)).toBe(false);
+    expect(tierAtLeast(Tier.BUSINESS, LLM_GATEWAY_MIN_TIER)).toBe(true);
+    expect(tierAtLeast(Tier.ENTERPRISE, LLM_GATEWAY_MIN_TIER)).toBe(true);
+  });
+});

--- a/web/src/lib/tiers.ts
+++ b/web/src/lib/tiers.ts
@@ -6,6 +6,8 @@ export const TIER_RANK: Record<Tier, number> = {
   [Tier.ENTERPRISE]: 2,
 };
 
+export const LLM_GATEWAY_MIN_TIER = Tier.BUSINESS;
+
 export function tierAtLeast(
   current: Tier | undefined,
   required: Tier

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -70,7 +70,7 @@ import { Interactive } from "@opal/core";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { useIsSearchModeAvailable, useSettings } from "@/lib/settings/hooks";
-import { tierAtLeast } from "@/lib/tiers";
+import { LLM_GATEWAY_MIN_TIER, tierAtLeast } from "@/lib/tiers";
 import { Tooltip } from "@opal/components";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";
 import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
@@ -1481,7 +1481,7 @@ function GatewayAccessSection({
   canCreateToken,
   onCreateToken,
 }: GatewayAccessSectionProps) {
-  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
+  const gatewayTier = useTierAtLeast(LLM_GATEWAY_MIN_TIER);
   const { llmProviders } = useLLMProviders();
   const [gatewayUrl, setGatewayUrl] = useState("");
 
@@ -1523,7 +1523,7 @@ function GatewayAccessSection({
     0
   );
 
-  if (!enterpriseTier || availableModelCount === 0) {
+  if (!gatewayTier || availableModelCount === 0) {
     return null;
   }
 


### PR DESCRIPTION
## Description

Move the Onyx LLM Gateway entitlement from Enterprise to Business. The backend route gate, PAT scope metadata, settings navigation, direct page access, and Gateway card now use the Business minimum tier. Community remains blocked, and scoped PAT authorization is unchanged.

This PR adds backend and frontend regression tests for Community denial, Business and Enterprise access, PAT metadata, and page redirects.

Known minor test gaps:

- Settings tab and inner Gateway card visibility are not independently component-tested. Page-level Business access and Community redirect are covered.
- Frontend PAT scope filtering is protected by the serialized backend minimum-tier contract but is not independently rendered for all three tiers.

## How Has This Been Tested?

- 8,780 backend unit tests passed, with 33 skipped.
- 1,174 frontend tests passed across 130 suites.
- 52 targeted Gateway and tier tests passed.
- Pre-commit, Python typing, TypeScript checks, formatting, and lint passed.

The PAT integration reset requires an explicit POSTGRES_DB target. Its safety guard refused to guess a database. Equivalent model and serialization contracts are covered by unit tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check