### PR TITLE
ci: skip local preview builds for merge-queue branches

### DIFF
--- a/.github/workflows/local-preview.yml
+++ b/.github/workflows/local-preview.yml
@@ -16,6 +16,10 @@ on:
   push:
     branches-ignore:
       - main
+      # The merge queue pushes to these short-lived branches on its way to
+      # main. Their commits are about to land there anyway, and the deploy
+      # would only hold a server slot a real branch could use.
+      - "gh-readonly-queue/**"
     paths:
       - "web/**"
       - "backend/**"


### PR DESCRIPTION
## Summary

The merge queue pushes to `gh-readonly-queue/**` branches. Each push matched the `push` trigger in `local-preview.yml` and started a preview deploy. These branches are short-lived, and their commits land on `main` right after. The deploy only held a preview-server slot that a real branch could use.

This PR adds `gh-readonly-queue/**` to the workflow's `branches-ignore` list.

## Test plan

- `pre-commit run --files .github/workflows/local-preview.yml` passes (zizmor, YAML check, actionlint).
- After merge: confirm merge-queue pushes no longer start `Local Preview Deployment` runs, and pushes to normal branches still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips Local Preview Deployment runs on merge-queue branches by adding `gh-readonly-queue/**` to `branches-ignore` in `local-preview.yml`. Previously pushes to these short-lived branches triggered preview deploys; now they are ignored to keep preview-server slots free for real branches.

- Review/rollout
  - Change is limited to the CI workflow; no application behavior change.
  - After merge, verify pushes to `gh-readonly-queue/**` do not start Local Preview Deployment, and pushes to normal branches still do.

<sup>Written for commit 2f227419454347b74a0c28bdfc68d7ab613cb4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

