### PR TITLE
chore: finish Salesforce OAuth review follow-ups

### DIFF
--- a/backend/onyx/connectors/salesforce/models.py
+++ b/backend/onyx/connectors/salesforce/models.py
@@ -139,9 +139,7 @@ class SalesforceSessionCredentials(BaseModel):
 
 def parse_salesforce_credentials(credentials: dict[str, Any]) -> SalesforceCredentials:
     authentication_method = credentials.get(AUTHENTICATION_METHOD_FIELD)
-    if authentication_method is None:
-        return SalesforceLegacyCredentials.model_validate(credentials)
-    if authentication_method == SalesforceAuthenticationMethod.PASSWORD:
+    if authentication_method in (None, SalesforceAuthenticationMethod.PASSWORD):
         return SalesforceLegacyCredentials.model_validate(credentials)
     if authentication_method == SalesforceAuthenticationMethod.OAUTH:
         return SalesforceOAuthCredentials.model_validate(credentials)

--- a/backend/onyx/connectors/salesforce/salesforce_calls.py
+++ b/backend/onyx/connectors/salesforce/salesforce_calls.py
@@ -172,6 +172,7 @@ def _bulk_retrieve_from_salesforce(
         try:
             results = download()
         except SalesforceExpiredSession:
+            # Refresh can rotate persisted credentials; call it only after rejection.
             sf_client.refresh_session()
             results = download()
 

--- a/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_oauth_credentials.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_oauth_credentials.py
@@ -548,6 +548,30 @@ def test_onyx_salesforce_routes_malformed_unauthorized_response(
     refresh_callback.assert_not_called()
 
 
+def test_onyx_salesforce_routes_non_json_unauthorized_response() -> None:
+    unauthorized = MagicMock(
+        status_code=401,
+        url=f"{INSTANCE_URL}/services/data/v59.0/sobjects",
+        text="unauthorized",
+    )
+    unauthorized.json.side_effect = ValueError()
+    session = MagicMock()
+    session.proxies = {}
+    session.request.return_value = unauthorized
+    refresh_callback = MagicMock()
+    client = OnyxSalesforce(
+        session_id="expired-access-token",
+        instance_url=INSTANCE_URL,
+        session=session,
+        refresh_callback=refresh_callback,
+    )
+
+    with pytest.raises(SalesforceExpiredSession):
+        client._call_salesforce("GET", unauthorized.url)
+
+    refresh_callback.assert_not_called()
+
+
 def test_bulk_download_rebuilds_client_after_session_refresh(tmp_path: Path) -> None:
     original_path = tmp_path / "result.csv"
     original_path.write_text("Id\n001\n")


### PR DESCRIPTION
## Description

Follow up on unresolved review comments from #13985. Simplify legacy credential dispatch, explain refresh timing, and cover non-JSON unauthorized responses.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/connectors/salesforce/test_salesforce_oauth_credentials.py`
- `uv run pre-commit run --files backend/onyx/connectors/salesforce/models.py backend/onyx/connectors/salesforce/salesforce_calls.py backend/tests/unit/onyx/connectors/salesforce/test_salesforce_oauth_credentials.py`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Salesforce credential parsing, clarifies refresh timing, and normalizes non‑JSON 401 handling. Previously, a non‑JSON 401 could raise a parsing error; now we raise SalesforceExpiredSession and do not invoke the refresh callback.

- Credential parsing: treat missing authentication_method the same as PASSWORD; continue routing to legacy credentials with a simpler check.
- Unauthorized responses: for non‑JSON 401 bodies, raise SalesforceExpiredSession and skip the refresh callback; adds unit test coverage.
- Refresh timing: refresh only after a 401 rejection to avoid rotating persisted credentials unnecessarily (documented inline).

<sup>Written for commit 14c1b877912c65d39dbe13b9bc92d776c95bfcff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

