### PR TITLE
feat(github): index source-code files as documents

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -39,6 +39,21 @@ SENSITIVE_FILE_PATTERNS = (
     "*.kdbx",
 )
 
+# Machine-written files: build output and dependency lock files. They are
+# large, they dominate a repo's file count, and they are noise in retrieval.
+GENERATED_FILE_PATTERNS = (
+    "*.min.*",
+    "*.lock",
+    "*-lock.json",
+    "*-lock.yaml",
+    "*.lockb",
+    "*.pb.go",
+    "*.pb.cc",
+    "*.pb.h",
+    "*_pb2.py",
+    "*_pb2_grpc.py",
+)
+
 # Formats the pack has grammars for but that are not code: .txt resolves to
 # the Vim help-file grammar, and .csv/.tsv have a TabularSection path.
 NON_CODE_LANGUAGES = frozenset({"vimdoc", "rst", "csv", "tsv"})
@@ -99,3 +114,15 @@ def is_sensitive_code_file(file_path: str | None) -> bool:
     if any(fnmatch(basename, pattern) for pattern in SENSITIVE_FILE_PATTERNS):
         return True
     return infer_code_language(file_path) in SENSITIVE_FILE_LANGUAGES
+
+
+def is_generated_code_file(file_path: str | None) -> bool:
+    """True when the path names build output or a dependency lock file.
+
+    Separate from language inference: a lock file has a perfectly good
+    grammar, it is just not worth indexing.
+    """
+    if not file_path:
+        return False
+    basename = PurePosixPath(file_path.replace("\\", "/")).name.lower()
+    return any(fnmatch(basename, pattern) for pattern in GENERATED_FILE_PATTERNS)

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -41,6 +41,12 @@ SENSITIVE_FILE_PATTERNS = (
 
 # Machine-written files: build output and dependency lock files. They are
 # large, they dominate a repo's file count, and they are noise in retrieval.
+#
+# Hand-maintained because no authoritative list ships as a Python package.
+# GitHub's own answer is linguist (`vendor.yml` plus `generated.rb`), which is
+# Ruby, has no maintained port, and would have to be vendored and translated.
+# The naming conventions below have been stable for years, so the list is
+# short and rarely moves; extend it rather than reaching for a dependency.
 GENERATED_FILE_PATTERNS = (
     "*.min.*",
     "*.lock",

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -27,7 +27,11 @@ from onyx.configs.constants import (
     DocumentSource,
 )
 from onyx.connectors.connector_runner import CheckpointOutputWrapper, ConnectorRunner
-from onyx.connectors.cross_connector_utils.code_file_utils import infer_code_language
+from onyx.connectors.cross_connector_utils.code_file_utils import (
+    infer_code_language,
+    is_generated_code_file,
+    is_sensitive_code_file,
+)
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
     CredentialExpiredError,
@@ -111,14 +115,29 @@ GITHUB_INDEXABLE_FILENAMES = {
     "support",
 }
 # Path segments whose presence anywhere in a file's path excludes it.
+# Dependency trees and build output: with code indexing on these hold most
+# of a repo's files and none of its source.
 GITHUB_PATH_DENYLIST = {
     ".git",
-    "node_modules",
-    "vendor",
-    "dist",
-    "build",
+    ".gradle",
+    ".mypy_cache",
+    ".next",
+    ".nuxt",
+    ".pytest_cache",
+    ".terraform",
+    ".tox",
     ".venv",
     "__pycache__",
+    "bower_components",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "Pods",
+    "target",
+    "third_party",
+    "vendor",
 }
 # Skip files larger than this (checked against the git tree size before fetching).
 GITHUB_MAX_FILE_SIZE_BYTES = 1_000_000
@@ -134,8 +153,13 @@ def _code_language(path: str) -> str | None:
 
     Document extensions are never code — grammars exist for prose formats
     like markdown, so the docs set must be subtracted, not just preferred.
+    Generated files are dropped for the same reason the denylist drops
+    build directories. Credential files are never indexed at all; the chunker
+    refuses them again for sections that arrive from the ingestion API.
     """
     if get_file_ext(path) in GITHUB_INDEXABLE_FILE_EXTENSIONS:
+        return None
+    if is_sensitive_code_file(path) or is_generated_code_file(path):
         return None
     return infer_code_language(path)
 
@@ -628,9 +652,11 @@ class GithubConnectorCheckpoint(ConnectorCheckpoint):
     # Resolved + filtered file paths for the current repo's FILES stage.
     # Populated once when the stage begins, then paginated via curr_page.
     file_paths: list[str] | None = None
-    # Branch file_paths was listed from; a resumed checkpoint whose branch no
-    # longer matches (connector edited, default branch changed) is re-listed.
+    # Branch and code-file setting file_paths was listed under. A resumed
+    # checkpoint that no longer matches (connector edited, default branch
+    # changed) is re-listed, since both decide what the listing contains.
     file_paths_branch: str | None = None
+    file_paths_include_code: bool | None = None
 
     # Used for the fallback cursor-based pagination strategy
     num_retrieved: int
@@ -638,14 +664,15 @@ class GithubConnectorCheckpoint(ConnectorCheckpoint):
 
     def reset(self) -> None:
         """
-        Resets curr_page, num_retrieved, cursor_url, file_paths, and
-        file_paths_branch to their initial values (0, 0, None, None, None)
+        Resets curr_page, num_retrieved, cursor_url, and the file listing
+        to their initial values (0, 0, None, None, None, None)
         """
         self.curr_page = 0
         self.num_retrieved = 0
         self.cursor_url = None
         self.file_paths = None
         self.file_paths_branch = None
+        self.file_paths_include_code = None
 
 
 def make_cursor_url_callback(
@@ -917,25 +944,27 @@ class GithubConnector(
         caller should return the checkpoint to resume), False once drained.
         """
         branch = self._resolve_branch(repo)
-        branch_changed = (
-            checkpoint.file_paths is not None and checkpoint.file_paths_branch != branch
+        listing_stale = checkpoint.file_paths is not None and (
+            checkpoint.file_paths_branch != branch
+            or checkpoint.file_paths_include_code != self.include_code_files
         )
-        if branch_changed:
-            # The cached listing came from a different branch (resumed
-            # checkpoint after a connector edit or default-branch change) —
-            # discard it so paths and content come from the same branch.
+        if listing_stale:
+            # The cached listing came from a different branch or filter (a
+            # resumed checkpoint after a connector edit or default-branch
+            # change) — discard it so paths and content agree.
             checkpoint.file_paths = None
             checkpoint.file_paths_branch = None
+            checkpoint.file_paths_include_code = None
             checkpoint.curr_page = 0
 
         if checkpoint.file_paths is None:
             pushed_at = (
                 repo.pushed_at.replace(tzinfo=timezone.utc) if repo.pushed_at else None
             )
-            # After a branch change the new branch was never indexed, so the
-            # pushed_at freshness gate must not skip the re-listing.
+            # After a branch or filter change the listing was never taken
+            # this way, so the pushed_at gate must not skip the re-listing.
             if (
-                not branch_changed
+                not listing_stale
                 and start is not None
                 and pushed_at is not None
                 and pushed_at < start
@@ -944,11 +973,13 @@ class GithubConnector(
                 logger.info("Skipping files for repo %s (pushed_at < start)", repo.name)
                 checkpoint.file_paths = []
                 checkpoint.file_paths_branch = branch
+                checkpoint.file_paths_include_code = self.include_code_files
             else:
                 logger.info("Listing files for repo: %s", repo.name)
                 paths, truncated = self._list_indexable_files(repo)
                 checkpoint.file_paths = paths
                 checkpoint.file_paths_branch = branch
+                checkpoint.file_paths_include_code = self.include_code_files
                 logger.info(
                     "Found %s indexable files for repo: %s", len(paths), repo.name
                 )

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -17,12 +17,17 @@ from typing_extensions import override
 
 from onyx.access.models import ExternalAccess
 from onyx.configs.app_configs import GITHUB_CONNECTOR_BASE_URL
-from onyx.configs.constants import DocumentSource
-from onyx.connectors.connector_runner import CheckpointOutputWrapper, ConnectorRunner
-from onyx.connectors.cross_connector_utils.code_file_utils import (
+from onyx.configs.constants import (
+    CODE_FILE_BRANCH_KEY,
+    CODE_FILE_LANGUAGE_KEY,
     CODE_FILE_METADATA_TYPE,
-    infer_code_language,
+    CODE_FILE_PATH_KEY,
+    CODE_FILE_REPO_KEY,
+    CODE_FILE_TYPE_KEY,
+    DocumentSource,
 )
+from onyx.connectors.connector_runner import CheckpointOutputWrapper, ConnectorRunner
+from onyx.connectors.cross_connector_utils.code_file_utils import infer_code_language
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
     CredentialExpiredError,
@@ -36,6 +41,7 @@ from onyx.connectors.github.utils import (
     deserialize_repository,
     get_external_access_permission,
     normalize_github_base_url,
+    parse_repositories_config,
     validate_credential_base_url,
 )
 from onyx.connectors.interfaces import (
@@ -59,7 +65,11 @@ from onyx.connectors.models import (
     SlimDocument,
     TextSection,
 )
-from onyx.file_processing.extract_file_text import file_io_to_text, is_text_file
+from onyx.file_processing.extract_file_text import (
+    file_io_to_text,
+    get_file_ext,
+    is_text_file,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -119,6 +129,17 @@ _GITHUB_EMPTY_REPOSITORY_TREE_STATUS = 409
 _GITHUB_EMPTY_REPOSITORY_TREE_MESSAGE = "Git Repository is empty."
 
 
+def _code_language(path: str) -> str | None:
+    """The source-code language of `path`, or None when it is not code.
+
+    Document extensions are never code — grammars exist for prose formats
+    like markdown, so the docs set must be subtracted, not just preferred.
+    """
+    if get_file_ext(path) in GITHUB_INDEXABLE_FILE_EXTENSIONS:
+        return None
+    return infer_code_language(path)
+
+
 def _is_indexable_path(
     path: str,
     size: int | None,
@@ -140,8 +161,8 @@ def _is_indexable_path(
         return False
 
     basename = path.rsplit("/", 1)[-1]
-    _, extension = os.path.splitext(basename)
-    if include_docs and extension.lower() in GITHUB_INDEXABLE_FILE_EXTENSIONS:
+    extension = get_file_ext(basename)
+    if include_docs and extension in GITHUB_INDEXABLE_FILE_EXTENSIONS:
         return True
 
     # Extensionless docs like README / LICENSE (basename has no extension).
@@ -152,13 +173,7 @@ def _is_indexable_path(
     ):
         return True
 
-    # Document extensions are never code — grammars exist for prose formats
-    # like markdown, so the docs set must be subtracted, not just preferred.
-    if (
-        include_code_files
-        and extension.lower() not in GITHUB_INDEXABLE_FILE_EXTENSIONS
-        and infer_code_language(path) is not None
-    ):
+    if include_code_files and _code_language(path) is not None:
         return True
 
     return False
@@ -544,7 +559,6 @@ def _convert_file_to_document(
     repo_name = parts[1] if len(parts) > 1 else repo_full_name
 
     html_url = f"{repo.html_url}/blob/{branch}/{path}"
-    _, extension = os.path.splitext(path)
 
     # NOTE: GitHub's tree API does not expose per-file modification times without
     # additional per-file commit-history calls. repo.pushed_at is the closest
@@ -564,19 +578,14 @@ def _convert_file_to_document(
 
     metadata: dict[str, str | list[str]] = {
         "object_type": "File",
-        "repo": repo_full_name,
-        "path": path,
-        "file_extension": extension.lower(),
-        "branch": branch,
+        CODE_FILE_REPO_KEY: repo_full_name,
+        CODE_FILE_PATH_KEY: path,
+        "file_extension": get_file_ext(path),
+        CODE_FILE_BRANCH_KEY: branch,
     }
-    # Source-code files (recognized by extension, excluding the docs set —
-    # prose formats like markdown also have grammars) become CodeSections so
-    # they chunk at syntactic boundaries; everything else stays prose.
-    language = (
-        infer_code_language(path)
-        if extension.lower() not in GITHUB_INDEXABLE_FILE_EXTENSIONS
-        else None
-    )
+    # Source-code files become CodeSections so they chunk at syntactic
+    # boundaries; everything else stays prose.
+    language = _code_language(path)
     section: TextSection | CodeSection
     if language is not None:
         section = CodeSection(
@@ -585,8 +594,8 @@ def _convert_file_to_document(
             language=language,
             file_path=path,
         )
-        metadata["type"] = CODE_FILE_METADATA_TYPE
-        metadata["language"] = language
+        metadata[CODE_FILE_TYPE_KEY] = CODE_FILE_METADATA_TYPE
+        metadata[CODE_FILE_LANGUAGE_KEY] = language
     else:
         section = TextSection(link=html_url, text=content_text)
 
@@ -731,23 +740,19 @@ class GithubConnector(
 
         try:
             repos = []
-            # Split repo_name by comma and strip whitespace
-            repo_names = [
-                name.strip() for name in (cast(str, self.repositories)).split(",")
-            ]
+            repo_names = parse_repositories_config(self.repositories)
 
             for repo_name in repo_names:
-                if repo_name:  # Skip empty strings
-                    try:
-                        repo = github_client.get_repo(f"{self.repo_owner}/{repo_name}")
-                        repos.append(repo)
-                    except GithubException as e:
-                        logger.warning(
-                            "Could not fetch repo %s/%s: %s",
-                            self.repo_owner,
-                            repo_name,
-                            e,
-                        )
+                try:
+                    repo = github_client.get_repo(f"{self.repo_owner}/{repo_name}")
+                    repos.append(repo)
+                except GithubException as e:
+                    logger.warning(
+                        "Could not fetch repo %s/%s: %s",
+                        self.repo_owner,
+                        repo_name,
+                        e,
+                    )
 
             return repos
         except RateLimitExceededException:
@@ -1395,7 +1400,7 @@ class GithubConnector(
             if self.repositories:
                 if "," in self.repositories:
                     # Multiple repositories specified
-                    repo_names = [name.strip() for name in self.repositories.split(",")]
+                    repo_names = parse_repositories_config(self.repositories)
                     if not repo_names:
                         raise ConnectorValidationError(
                             "Invalid connector settings: No valid repository names provided."

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -19,6 +19,10 @@ from onyx.access.models import ExternalAccess
 from onyx.configs.app_configs import GITHUB_CONNECTOR_BASE_URL
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.connector_runner import CheckpointOutputWrapper, ConnectorRunner
+from onyx.connectors.cross_connector_utils.code_file_utils import (
+    CODE_FILE_METADATA_TYPE,
+    infer_code_language,
+)
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
     CredentialExpiredError,
@@ -46,6 +50,7 @@ from onyx.connectors.interfaces import (
     SlimConnectorWithPermSync,
 )
 from onyx.connectors.models import (
+    CodeSection,
     ConnectorMissingCredentialError,
     Document,
     DocumentFailure,
@@ -114,12 +119,18 @@ _GITHUB_EMPTY_REPOSITORY_TREE_STATUS = 409
 _GITHUB_EMPTY_REPOSITORY_TREE_MESSAGE = "Git Repository is empty."
 
 
-def _is_indexable_path(path: str, size: int | None) -> bool:
+def _is_indexable_path(
+    path: str,
+    size: int | None,
+    include_docs: bool = True,
+    include_code_files: bool = False,
+) -> bool:
     """Pure predicate: should this repo file be indexed?
 
-    Filters on a max size and path-segment denylist, then matches either a
-    document extension (.md, .txt, ...) or a conventional extensionless
-    document basename (README, LICENSE, ...).
+    Filters on a max size and path-segment denylist, then matches a document
+    extension (.md, .txt, ...), a conventional extensionless document basename
+    (README, LICENSE, ...), or — when code indexing is enabled — a known
+    source-code extension.
     """
     if size is not None and size > GITHUB_MAX_FILE_SIZE_BYTES:
         return False
@@ -130,11 +141,24 @@ def _is_indexable_path(path: str, size: int | None) -> bool:
 
     basename = path.rsplit("/", 1)[-1]
     _, extension = os.path.splitext(basename)
-    if extension.lower() in GITHUB_INDEXABLE_FILE_EXTENSIONS:
+    if include_docs and extension.lower() in GITHUB_INDEXABLE_FILE_EXTENSIONS:
         return True
 
     # Extensionless docs like README / LICENSE (basename has no extension).
-    if not extension and basename.lower() in GITHUB_INDEXABLE_FILENAMES:
+    if (
+        include_docs
+        and not extension
+        and basename.lower() in GITHUB_INDEXABLE_FILENAMES
+    ):
+        return True
+
+    # Document extensions are never code — grammars exist for prose formats
+    # like markdown, so the docs set must be subtracted, not just preferred.
+    if (
+        include_code_files
+        and extension.lower() not in GITHUB_INDEXABLE_FILE_EXTENSIONS
+        and infer_code_language(path) is not None
+    ):
         return True
 
     return False
@@ -537,21 +561,44 @@ def _convert_file_to_document(
             "object_type": "file",
         },
     }
+
+    metadata: dict[str, str | list[str]] = {
+        "object_type": "File",
+        "repo": repo_full_name,
+        "path": path,
+        "file_extension": extension.lower(),
+        "branch": branch,
+    }
+    # Source-code files (recognized by extension, excluding the docs set —
+    # prose formats like markdown also have grammars) become CodeSections so
+    # they chunk at syntactic boundaries; everything else stays prose.
+    language = (
+        infer_code_language(path)
+        if extension.lower() not in GITHUB_INDEXABLE_FILE_EXTENSIONS
+        else None
+    )
+    section: TextSection | CodeSection
+    if language is not None:
+        section = CodeSection(
+            link=html_url,
+            text=content_text,
+            language=language,
+            file_path=path,
+        )
+        metadata["type"] = CODE_FILE_METADATA_TYPE
+        metadata["language"] = language
+    else:
+        section = TextSection(link=html_url, text=content_text)
+
     return Document(
         id=html_url,
-        sections=[TextSection(link=html_url, text=content_text)],
+        sections=[section],
         source=DocumentSource.GITHUB,
         external_access=repo_external_access,
         semantic_identifier=path,
         doc_updated_at=updated_at,
         doc_metadata=doc_metadata,
-        metadata={
-            "object_type": "File",
-            "repo": repo_full_name,
-            "path": path,
-            "file_extension": extension.lower(),
-            "branch": branch,
-        },
+        metadata=metadata,
     )
 
 
@@ -618,6 +665,7 @@ class GithubConnector(
         include_prs: bool = True,
         include_issues: bool = False,
         include_files: bool = False,
+        include_code_files: bool = False,
         branch: str | None = None,
     ) -> None:
         self.repo_owner = repo_owner
@@ -626,6 +674,7 @@ class GithubConnector(
         self.include_prs = include_prs
         self.include_issues = include_issues
         self.include_files = include_files
+        self.include_code_files = include_code_files
         # Branch to index files from; None means each repo's default branch.
         self.branch = (branch or "").strip() or None
         self.github_client: Github | None = None
@@ -774,6 +823,7 @@ class GithubConnector(
                 "Re-tried listing repo files too many times. "
                 "Something is going wrong with fetching objects from Github"
             )
+
         assert self.github_client is not None  # for type-checking
         try:
             git_tree = repo.get_git_tree(self._resolve_branch(repo), recursive=True)
@@ -788,7 +838,12 @@ class GithubConnector(
                 element.path
                 for element in git_tree.tree
                 if element.type == "blob"
-                and _is_indexable_path(element.path, element.size)
+                and _is_indexable_path(
+                    element.path,
+                    element.size,
+                    include_docs=self.include_files,
+                    include_code_files=self.include_code_files,
+                )
             ]
             paths.sort()
             return paths, truncated
@@ -1176,7 +1231,9 @@ class GithubConnector(
         ):
             checkpoint.stage = GithubConnectorStage.FILES
 
-        if self.include_files and checkpoint.stage == GithubConnectorStage.FILES:
+        if (
+            self.include_files or self.include_code_files
+        ) and checkpoint.stage == GithubConnectorStage.FILES:
             has_more_file_batches = yield from self._fetch_repo_files(
                 repo, checkpoint, start, is_slim, repo_external_access
             )
@@ -1323,10 +1380,15 @@ class GithubConnector(
                 "Invalid connector settings: 'repo_owner' must be provided."
             )
 
-        if not (self.include_prs or self.include_issues or self.include_files):
+        if not (
+            self.include_prs
+            or self.include_issues
+            or self.include_files
+            or self.include_code_files
+        ):
             raise ConnectorValidationError(
                 "Invalid connector settings: at least one of pull requests, "
-                "issues, or files must be selected for indexing."
+                "issues, documents, or code files must be selected for indexing."
             )
 
         try:

--- a/backend/onyx/connectors/github/utils.py
+++ b/backend/onyx/connectors/github/utils.py
@@ -131,3 +131,14 @@ def deserialize_repository(
         )
         repo_id = cached_repo.id
         return github_client.get_repo(repo_id)
+
+
+def parse_repositories_config(repositories: str | None) -> list[str]:
+    """Split the connector's comma-separated `repositories` config.
+
+    Whitespace is stripped and empty entries dropped. Case is preserved —
+    callers that compare names case-fold themselves.
+    """
+    if not repositories:
+        return []
+    return [name.strip() for name in repositories.split(",") if name.strip()]

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
@@ -4,6 +4,7 @@ from tree_sitter_language_pack import manifest_languages
 from onyx.connectors.cross_connector_utils.code_file_utils import (
     SENSITIVE_FILE_LANGUAGES,
     infer_code_language,
+    is_generated_code_file,
     is_sensitive_code_file,
 )
 
@@ -118,3 +119,30 @@ def test_prose_and_tabular_files_are_not_code(path: str) -> None:
     """.txt resolves to the Vim help-file grammar and .csv/.tsv have their own
     tabular path; chunking them as code produces meaningless boundaries."""
     assert infer_code_language(path) is None
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "package-lock.json",
+        "yarn.lock",
+        "Cargo.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "static/jquery.min.js",
+        "static/site.min.css",
+        "gen/service.pb.go",
+        "gen/service_pb2.py",
+    ],
+)
+def test_generated_files_are_refused(path: str) -> None:
+    """Machine-written files outnumber source in a repo and add nothing to
+    retrieval, so connectors must be able to drop them."""
+    assert is_generated_code_file(path) is True
+
+
+@pytest.mark.parametrize(
+    "path", ["main.py", "lockfile_utils.py", "src/minify.js", "protobuf.py", ""]
+)
+def test_handwritten_files_are_not_generated(path: str) -> None:
+    assert is_generated_code_file(path) is False

--- a/backend/tests/unit/onyx/connectors/github/conftest.py
+++ b/backend/tests/unit/onyx/connectors/github/conftest.py
@@ -1,0 +1,87 @@
+"""Shared doubles for the GitHub connector unit tests."""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from github import Github
+from github.RateLimit import RateLimit
+from github.Requester import Requester
+
+
+@pytest.fixture
+def mock_github_client() -> MagicMock:
+    """A PyGithub client mock with the accessors the connector touches."""
+    mock = MagicMock(spec=Github)
+    mock.get_repo = MagicMock()
+    mock.get_organization = MagicMock()
+    mock.get_user = MagicMock()
+    mock.get_rate_limit = MagicMock(return_value=MagicMock(spec=RateLimit))
+    mock._requester = MagicMock(spec=Requester)
+    return mock
+
+
+def _tree_element(path: str, size: int, type_: str = "blob") -> MagicMock:
+    el = MagicMock()
+    el.path = path
+    el.size = size
+    el.type = type_
+    return el
+
+
+def make_mock_repo(
+    *,
+    name: str = "test-repo",
+    id: int = 1,
+    owner: str = "test-org",
+    default_branch: str = "main",
+    pushed_at: datetime | None = None,
+    files: dict[str, bytes] | None = None,
+    truncated: bool = False,
+) -> MagicMock:
+    """A PyGithub Repository mock.
+
+    Pass `files` to also wire `get_git_tree` / `get_contents` off that
+    mapping; leave it None to keep them plain mocks.
+    """
+    full_name = f"{owner}/{name}"
+    repo = MagicMock()
+    repo.name = name
+    repo.id = id
+    repo.full_name = full_name
+    repo.html_url = f"https://github.com/{full_name}"
+    repo.default_branch = default_branch
+    repo.pushed_at = pushed_at or datetime(2023, 1, 1)
+
+    raw_data: dict[str, Any] = {
+        "id": id,
+        "name": name,
+        "full_name": full_name,
+        "private": False,
+        "description": "Test repository",
+    }
+    repo.configure_mock(
+        raw_headers={"status": "200 OK", "content-type": "application/json"},
+        raw_data=raw_data,
+    )
+
+    repo.get_pulls = MagicMock()
+    repo.get_issues = MagicMock()
+    repo.get_contents = MagicMock()
+
+    if files is not None:
+        tree = MagicMock()
+        tree.tree = [_tree_element(p, len(c)) for p, c in files.items()]
+        tree.raw_data = {"truncated": truncated}
+        repo.get_git_tree = MagicMock(return_value=tree)
+
+        def _get_contents(path: str, ref: str | None = None) -> MagicMock:
+            del ref  # accepted as a kwarg by the connector, unused in the mock
+            cf = MagicMock()
+            cf.decoded_content = files[path]
+            return cf
+
+        repo.get_contents = MagicMock(side_effect=_get_contents)
+
+    return repo

--- a/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
@@ -22,6 +22,7 @@ from onyx.connectors.exceptions import (
 from onyx.connectors.github.connector import GithubConnector, GithubConnectorStage
 from onyx.connectors.github.models import SerializedRepository
 from onyx.connectors.models import Document
+from tests.unit.onyx.connectors.github.conftest import make_mock_repo
 from tests.unit.onyx.connectors.utils import (
     load_everything_from_checkpoint_connector,
     load_everything_from_checkpoint_connector_from_checkpoint,
@@ -36,18 +37,6 @@ def repo_owner() -> str:
 @pytest.fixture
 def repositories() -> str:
     return "test-repo"
-
-
-@pytest.fixture
-def mock_github_client() -> MagicMock:
-    """Create a mock GitHub client with proper typing"""
-    mock = MagicMock(spec=Github)
-    mock.get_repo = MagicMock()
-    mock.get_organization = MagicMock()
-    mock.get_user = MagicMock()
-    mock.get_rate_limit = MagicMock(return_value=MagicMock(spec=RateLimit))
-    mock._requester = MagicMock(spec=Requester)
-    return mock
 
 
 @pytest.fixture
@@ -138,26 +127,7 @@ def create_mock_repo() -> Callable[..., MagicMock]:
         name: str = "test-repo",
         id: int = 1,
     ) -> MagicMock:
-        mock_repo = MagicMock()
-        mock_repo.name = name
-        mock_repo.id = id
-
-        headers_dict = {"status": "200 OK", "content-type": "application/json"}
-        data_dict = {
-            "id": id,
-            "name": name,
-            "full_name": f"test-org/{name}",
-            "private": False,
-            "description": "Test repository",
-        }
-
-        mock_repo.configure_mock(raw_headers=headers_dict, raw_data=data_dict)
-
-        mock_repo.get_pulls = MagicMock()
-        mock_repo.get_issues = MagicMock()
-        mock_repo.get_contents = MagicMock()
-
-        return mock_repo
+        return make_mock_repo(name=name, id=id)
 
     return _create_mock_repo
 

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -4,10 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-from github import Github
 from github.GithubException import GithubException, UnknownObjectException
-from github.RateLimit import RateLimit
-from github.Requester import Requester
 
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.github.connector import (
@@ -22,6 +19,7 @@ from onyx.connectors.models import (
     Document,
     TextSection,
 )
+from tests.unit.onyx.connectors.github.conftest import make_mock_repo
 from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
 
 
@@ -108,54 +106,13 @@ def test_is_indexable_path_code_only_excludes_docs() -> None:
 
 
 @pytest.fixture
-def mock_github_client() -> MagicMock:
-    mock = MagicMock(spec=Github)
-    mock.get_repo = MagicMock()
-    mock.get_rate_limit = MagicMock(return_value=MagicMock(spec=RateLimit))
-    mock._requester = MagicMock(spec=Requester)
-    return mock
-
-
-def _tree_element(path: str, size: int, type_: str = "blob") -> MagicMock:
-    el = MagicMock()
-    el.path = path
-    el.size = size
-    el.type = type_
-    return el
-
-
-@pytest.fixture
 def create_mock_repo() -> Callable[..., MagicMock]:
     def _create(
         files: dict[str, bytes],
         pushed_at: datetime | None = None,
         truncated: bool = False,
     ) -> MagicMock:
-        mock_repo = MagicMock()
-        mock_repo.name = "test-repo"
-        mock_repo.id = 1
-        mock_repo.full_name = "test-org/test-repo"
-        mock_repo.html_url = "https://github.com/test-org/test-repo"
-        mock_repo.default_branch = "main"
-        mock_repo.pushed_at = pushed_at or datetime(2023, 1, 1)
-        mock_repo.configure_mock(
-            raw_headers={"status": "200 OK"},
-            raw_data={"id": 1, "full_name": "test-org/test-repo"},
-        )
-
-        tree = MagicMock()
-        tree.tree = [_tree_element(p, len(c)) for p, c in files.items()]
-        tree.raw_data = {"truncated": truncated}
-        mock_repo.get_git_tree = MagicMock(return_value=tree)
-
-        def _get_contents(path: str, ref: str | None = None) -> MagicMock:
-            del ref  # accepted as a kwarg by the connector, unused in the mock
-            cf = MagicMock()
-            cf.decoded_content = files[path]
-            return cf
-
-        mock_repo.get_contents = MagicMock(side_effect=_get_contents)
-        return mock_repo
+        return make_mock_repo(files=files, pushed_at=pushed_at, truncated=truncated)
 
     return _create
 

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -16,7 +16,12 @@ from onyx.connectors.github.connector import (
     _is_indexable_path,
 )
 from onyx.connectors.github.models import SerializedRepository
-from onyx.connectors.models import ConnectorFailure, Document
+from onyx.connectors.models import (
+    CodeSection,
+    ConnectorFailure,
+    Document,
+    TextSection,
+)
 from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
 
 
@@ -59,6 +64,47 @@ from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_con
 )
 def test_is_indexable_path(path: str, size: int | None, expected: bool) -> None:
     assert _is_indexable_path(path, size) is expected
+
+
+@pytest.mark.parametrize(
+    "path,size,expected",
+    [
+        # source code is included when the flag is on
+        ("main.py", 100, True),
+        ("src/app.tsx", 100, True),
+        ("native/lib.cpp", 100, True),
+        ("schema.sql", 100, True),
+        # config formats magika classifies as code are included too
+        ("data.json", 100, True),
+        ("config.yaml", 100, True),
+        # non-code stays excluded
+        ("logo.png", 100, False),
+        ("secrets.env", 100, False),
+        ("key.pem", 100, False),
+        # size cap and denylist still apply to code
+        ("huge.py", 5_000_000, False),
+        ("node_modules/pkg/index.js", 100, False),
+        # docs still included alongside code
+        ("README.md", 100, True),
+    ],
+)
+def test_is_indexable_path_with_code_files(
+    path: str, size: int | None, expected: bool
+) -> None:
+    assert _is_indexable_path(path, size, include_code_files=True) is expected
+
+
+def test_is_indexable_path_code_only_excludes_docs() -> None:
+    assert (
+        _is_indexable_path(
+            "README.md", 100, include_docs=False, include_code_files=True
+        )
+        is False
+    )
+    assert (
+        _is_indexable_path("main.py", 100, include_docs=False, include_code_files=True)
+        is True
+    )
 
 
 @pytest.fixture
@@ -117,6 +163,7 @@ def create_mock_repo() -> Callable[..., MagicMock]:
 def _build_connector(
     mock_github_client: MagicMock,
     include_files: bool = True,
+    include_code_files: bool = False,
     branch: str | None = None,
 ) -> GithubConnector:
     connector = GithubConnector(
@@ -125,6 +172,7 @@ def _build_connector(
         include_prs=False,
         include_issues=False,
         include_files=include_files,
+        include_code_files=include_code_files,
         branch=branch,
     )
     connector.github_client = mock_github_client
@@ -189,6 +237,65 @@ def test_files_indexed_when_enabled(
         "README.md",
     ]
     assert outputs[-1].next_checkpoint.has_more is False
+
+
+def test_code_files_indexed_as_code_sections(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client, include_code_files=True)
+    mock_repo = create_mock_repo(
+        {
+            "README.md": b"# Hello world",
+            "src/main.py": b"print('hi')",
+        }
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    assert sorted(d.semantic_identifier for d in docs) == [
+        "README.md",
+        "src/main.py",
+    ]
+
+    code_doc = next(d for d in docs if d.semantic_identifier == "src/main.py")
+    code_section = code_doc.sections[0]
+    assert isinstance(code_section, CodeSection)
+    assert code_section.language == "python"
+    assert code_section.file_path == "src/main.py"
+    assert code_section.text == "print('hi')"
+    assert code_doc.metadata["type"] == "CodeFile"
+    assert code_doc.metadata["language"] == "python"
+
+    readme_doc = next(d for d in docs if d.semantic_identifier == "README.md")
+    assert isinstance(readme_doc.sections[0], TextSection)
+    assert "type" not in readme_doc.metadata
+
+
+def test_code_files_excluded_when_flag_off(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(
+        mock_github_client, include_files=False, include_code_files=True
+    )
+    mock_repo = create_mock_repo(
+        {
+            "README.md": b"# Hello world",
+            "src/main.py": b"print('hi')",
+        }
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    # Docs off + code on: only the code file is indexed.
+    assert [d.semantic_identifier for d in docs] == ["src/main.py"]
 
 
 def test_binary_file_yields_failure(

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -83,6 +83,13 @@ def test_is_indexable_path(path: str, size: int | None, expected: bool) -> None:
         # size cap and denylist still apply to code
         ("huge.py", 5_000_000, False),
         ("node_modules/pkg/index.js", 100, False),
+        ("target/debug/gen.rs", 100, False),
+        ("web/.next/static/chunk.js", 100, False),
+        ("coverage/lcov-report/index.js", 100, False),
+        # generated files are code, and are still not worth indexing
+        ("package-lock.json", 100, False),
+        ("Cargo.lock", 100, False),
+        ("static/jquery.min.js", 100, False),
         # docs still included alongside code
         ("README.md", 100, True),
     ],
@@ -491,6 +498,36 @@ def test_resumed_checkpoint_from_other_branch_relists(
     mock_repo.get_git_tree.assert_called_once_with("gh-pages", recursive=True)
     assert checkpoint.file_paths == ["new-only.md"]
     assert checkpoint.file_paths_branch == "gh-pages"
+
+
+def test_resumed_checkpoint_relists_when_code_indexing_is_toggled(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """Turning code indexing on changes what the listing contains, so a
+    checkpoint listed under the old setting has to be discarded like one
+    listed from another branch."""
+    connector = _build_connector(mock_github_client, include_code_files=True)
+    mock_repo = create_mock_repo({"README.md": b"docs", "main.py": b"code"})
+
+    checkpoint = connector.build_dummy_checkpoint()
+    checkpoint.stage = GithubConnectorStage.FILES
+    checkpoint.file_paths = ["README.md"]  # listed with code indexing off
+    checkpoint.file_paths_include_code = False
+    checkpoint.file_paths_branch = connector._resolve_branch(mock_repo)
+
+    list(
+        connector._fetch_repo_files(
+            mock_repo,
+            checkpoint,
+            start=None,
+            is_slim=False,
+            repo_external_access=None,
+        )
+    )
+
+    assert sorted(checkpoint.file_paths or []) == ["README.md", "main.py"]
+    assert checkpoint.file_paths_include_code is True
 
 
 def test_resumed_branch_change_bypasses_pushed_at_gate(

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -1,6 +1,7 @@
 import time
 from collections.abc import Callable
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -610,3 +611,21 @@ def test_files_paginated_with_issues_enabled_no_stage_regression(
     assert len(ids) == 250
     assert len(set(ids)) == 250  # no duplicates from re-indexing page 0
     assert outputs[-1].next_checkpoint.has_more is False
+
+
+def test_connector_accepts_full_connector_specific_config() -> None:
+    """`instantiate_connector` splats connector_specific_config into __init__
+    unfiltered, so every key the admin form saves must be accepted."""
+    config: dict[str, Any] = {
+        "repo_owner": "test-org",
+        "repositories": "test-repo",
+        "include_prs": True,
+        "include_issues": False,
+        "include_files": True,
+        "include_code_files": True,
+        "branch": "main",
+    }
+
+    connector = GithubConnector(**config)
+
+    assert connector.include_code_files is True

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -2152,7 +2152,8 @@ export interface GithubConfig {
   include_prs: boolean;
   include_issues: boolean;
   include_files: boolean;
-  include_code_files: boolean;
+  // Absent from every connector saved before code indexing existed.
+  include_code_files?: boolean;
   branch?: string;
 }
 

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -349,6 +349,15 @@ export const connectorConfigs: Record<
           "Index text-based documents (markdown, text, etc.) from repositories",
         optional: true,
       },
+      {
+        type: "checkbox",
+        query: "Include code files?",
+        label: "Include Code Files?",
+        name: "include_code_files",
+        description:
+          "Index source code files from repositories so they can be searched",
+        optional: true,
+      },
     ],
     advanced_values: [
       {
@@ -358,7 +367,7 @@ export const connectorConfigs: Record<
         name: "branch",
         optional: true,
         description:
-          "Branch to index documents from (e.g. gh-pages). Leave blank to use each repository's default branch. Only applies when 'Include Documents?' is enabled. After changing this on an existing connector, trigger a re-index to pick up the new branch immediately.",
+          "Branch to index documents from (e.g. gh-pages). Leave blank to use each repository's default branch. Only applies when 'Include Documents?' or 'Include Code Files?' is enabled. After changing this on an existing connector, trigger a re-index to pick up the new branch immediately.",
       },
     ],
   },
@@ -2143,6 +2152,7 @@ export interface GithubConfig {
   include_prs: boolean;
   include_issues: boolean;
   include_files: boolean;
+  include_code_files: boolean;
   branch?: string;
 }
 


### PR DESCRIPTION
## Description

Part 6/10 of the code-indexing stack. Stacked on #14288.

Add the `include_code_files` connector option (with web UI toggle). Files with a known source-code extension — excluding the docs set, since prose formats like markdown also have grammars — are indexed as `CodeSection` documents so they chunk at syntactic boundaries; documents keep their `TextSection` path. This PR uses the existing content-API fetching; the snapshot-backed FILES stage that serves large repos without per-file API calls follows in the next PR of the stack.

## How Has This Been Tested?

Unit tests for path filtering with the new flag, `CodeSection` conversion and metadata, and the docs-off/code-on combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
