### PR TITLE
feat(coding-agent): tool steering, retrieval seeding, deep research

### DIFF
--- a/backend/onyx/coding_agent/mock_tools.py
+++ b/backend/onyx/coding_agent/mock_tools.py
@@ -4,6 +4,7 @@ CODING_AGENT_IN_CODE_ID = "CodingAgent"
 CODING_AGENT_TOOL_NAME = "coding_agent"
 CODING_AGENT_QUERY_KEY = "query"
 CODING_AGENT_REPO_KEY = "github_repo"
+CODING_AGENT_REF_KEY = "ref"
 
 BASH_TOOL_NAME = "bash"
 BASH_TOOL_CMD_KEY = "cmd"
@@ -17,9 +18,18 @@ CODING_AGENT_TOOL_DESCRIPTION = {
     "function": {
         "name": CODING_AGENT_TOOL_NAME,
         "description": (
-            "Investigate and answer a coding question against a specific GitHub "
-            "repository. The agent clones the repo into an isolated sandbox and "
-            "explores it via shell commands before returning a text answer."
+            "Deep investigation of a GitHub repository. The agent extracts a "
+            "tarball of the repo at one revision into an isolated sandbox "
+            "(no .git metadata — git commands are unavailable) and explores "
+            "the source tree with shell commands before returning a text "
+            "answer. This is a "
+            "slow, expensive multi-step agent run (tens of seconds to "
+            "minutes). Use it only when the question needs cross-file "
+            "tracing, verification against the exact current code, or "
+            "analysis the code search index cannot provide. Do NOT use it "
+            "for simple lookups the internal search tool already answers "
+            "(where something is defined, a config default, what one "
+            "function does)."
         ),
         "parameters": {
             "type": "object",
@@ -36,6 +46,15 @@ CODING_AGENT_TOOL_DESCRIPTION = {
                         "GitHub repository URL or 'owner/repo' identifier "
                         "(e.g. 'https://github.com/onyx-dot-app/onyx' or "
                         "'onyx-dot-app/onyx')."
+                    ),
+                },
+                CODING_AGENT_REF_KEY: {
+                    "type": "string",
+                    "description": (
+                        "Optional branch or commit SHA to analyze. Defaults "
+                        "to the latest default-branch state. Pass the commit "
+                        "SHA from retrieved code chunks when the answer must "
+                        "match the indexed revision."
                     ),
                 },
             },

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -67,6 +67,9 @@ from onyx.server.query_and_chat.streaming_models import (
 from onyx.tools.fake_tools.research_agent import run_research_agent_calls
 from onyx.tools.interface import Tool
 from onyx.tools.models import ToolCallInfo, ToolCallKickoff
+from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
+    CodingAgentTool,
+)
 from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
@@ -238,8 +241,15 @@ def run_deep_research_llm_loop(
 
         llm_step_result: LlmStepResult | None = None
 
-        # Filter tools to only allow web search, internal search, and open URL
-        allowed_tool_names = {SearchTool.NAME, WebSearchTool.NAME, OpenURLTool.NAME}
+        # Filter tools to only allow web search, internal search, open URL,
+        # and the coding agent (used when code search escalates to
+        # repository-wide analysis)
+        allowed_tool_names = {
+            SearchTool.NAME,
+            WebSearchTool.NAME,
+            OpenURLTool.NAME,
+            CodingAgentTool.NAME,
+        }
         allowed_tools = [tool for tool in tools if tool.name in allowed_tool_names]
         include_internal_search_tunings = SearchTool.NAME in allowed_tool_names
         orchestrator_start_turn_index = 1

--- a/backend/onyx/repo_archives/filtering.py
+++ b/backend/onyx/repo_archives/filtering.py
@@ -1,0 +1,38 @@
+"""Rewriting a repository archive without some of its files.
+
+Consumers that hand a whole repository to something other than the indexing
+pipeline need the same exclusions the pipeline applies. Filtering the archive
+rather than the extracted tree keeps the exclusion ahead of anything that
+reads the files.
+"""
+
+import tarfile
+from collections.abc import Callable
+from pathlib import Path
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def write_filtered_archive(
+    source: Path, dest: Path, exclude: Callable[[str], bool]
+) -> int:
+    """Copy the tar.gz at `source` to `dest`, dropping members whose path
+    `exclude` accepts. Returns the number of members dropped.
+
+    Both archives are streamed, so an archive far larger than memory costs
+    one decompress/recompress pass and nothing else.
+    """
+    dropped = 0
+    with (
+        tarfile.open(source, mode="r|gz") as archive,
+        tarfile.open(dest, mode="w|gz") as filtered,
+    ):
+        for member in archive:
+            if exclude(member.name):
+                dropped += 1
+                continue
+            content = archive.extractfile(member) if member.isreg() else None
+            filtered.addfile(member, content)
+    return dropped

--- a/backend/onyx/tools/fake_tools/coding_agent.py
+++ b/backend/onyx/tools/fake_tools/coding_agent.py
@@ -17,7 +17,6 @@ from onyx.coding_agent.mock_tools import (
     get_coding_agent_tool_definitions,
 )
 from onyx.coding_agent.models import CodingAgentCallResult, CodingAgentSpecialToolCalls
-from onyx.coding_agent.repo_cache import fetch_repo_archive
 from onyx.configs.constants import MessageType
 from onyx.deep_research.dr_mock_tools import (
     THINK_TOOL_NAME,
@@ -36,6 +35,8 @@ from onyx.prompts.coding_agent.coding_agent import (
     USER_FINAL_ANSWER_QUERY,
 )
 from onyx.prompts.prompt_utils import get_current_llm_day_time
+from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.repo_archives.tarball_cache import open_repo_archive
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import (
     AgentResponseDelta,
@@ -94,7 +95,8 @@ def _setup_session(
 
     The requested ref is resolved to its current commit SHA before every run,
     so the agent always analyzes the up-to-date state; unchanged repos come
-    from the file-store cache instead of a fresh download (see repo_cache).
+    from the file-store cache instead of a fresh download (see
+    repo_archives.tarball_cache).
 
     Creates its own :class:`CodeInterpreterClient` internally and tears it
     down on exit, so callers only deal with the ``session_id``.
@@ -103,21 +105,25 @@ def _setup_session(
         repo,
         allow_ssh=True,
     )
-    repo_archive = fetch_repo_archive(
-        github_source,
-        ref,
-        f"Bearer {github_token}" if github_token else None,
-        max_size_bytes=CODING_AGENT_GITHUB_MAX_REPO_BYTES,
-        timeout=CODING_AGENT_GITHUB_DOWNLOAD_TIMEOUT,
-    )
-    repo_bytes = repo_archive.archive
-    commit_sha = repo_archive.commit_sha
+    provider = GitHubArchiveProvider(f"Bearer {github_token}" if github_token else None)
 
     with CodeInterpreterClient() as client:
-        ci_file_id = client.upload_file(repo_bytes, REPO_TARBALL_PATH)
-        # The archive can be hundreds of MB; drop it as soon as it's uploaded
-        # so it isn't held for the agent's whole (potentially 25-minute) run.
-        del repo_bytes, repo_archive
+        # The archive can be hundreds of MB: it lives in a temp file that is
+        # removed when this block exits, right after the upload, so it isn't
+        # held for the agent's whole (potentially 25-minute) run.
+        with open_repo_archive(
+            provider,
+            provider.repo_ref(github_source.owner, github_source.repo),
+            ref,
+            max_size_bytes=CODING_AGENT_GITHUB_MAX_REPO_BYTES,
+            timeout=CODING_AGENT_GITHUB_DOWNLOAD_TIMEOUT,
+        ) as repo_archive:
+            ci_file_id = client.upload_file(
+                repo_archive.path.read_bytes(), REPO_TARBALL_PATH
+            )
+            commit_sha = (
+                repo_archive.revision.commit_sha if repo_archive.revision else None
+            )
         session_info = client.create_session(
             ttl_seconds=CODING_AGENT_SESSION_TTL_SECONDS,
             files=[{"path": REPO_TARBALL_PATH, "file_id": ci_file_id}],

--- a/backend/onyx/tools/fake_tools/coding_agent.py
+++ b/backend/onyx/tools/fake_tools/coding_agent.py
@@ -1,6 +1,8 @@
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Callable
 
 from onyx.chat.emitter import Emitter
@@ -19,6 +21,9 @@ from onyx.coding_agent.mock_tools import (
 from onyx.coding_agent.models import CodingAgentCallResult, CodingAgentSpecialToolCalls
 from onyx.configs.app_configs import REPO_ARCHIVE_FETCH_TIMEOUT, REPO_ARCHIVE_MAX_BYTES
 from onyx.configs.constants import MessageType
+from onyx.connectors.cross_connector_utils.code_file_utils import (
+    is_sensitive_code_file,
+)
 from onyx.deep_research.dr_mock_tools import (
     THINK_TOOL_NAME,
     THINK_TOOL_RESPONSE_MESSAGE,
@@ -36,6 +41,7 @@ from onyx.prompts.coding_agent.coding_agent import (
     USER_FINAL_ANSWER_QUERY,
 )
 from onyx.prompts.prompt_utils import get_current_llm_day_time
+from onyx.repo_archives.filtering import write_filtered_archive
 from onyx.repo_archives.github import GitHubArchiveProvider
 from onyx.repo_archives.models import RepoRef
 from onyx.repo_archives.tarball_cache import open_repo_archive
@@ -102,11 +108,11 @@ def _setup_session(
     """
     provider = GitHubArchiveProvider.from_token(github_token)
 
-    with CodeInterpreterClient() as client:
-        # The archive can be hundreds of MB: it stays in a temp file that is
-        # removed when this block exits, right after the upload, so it isn't
+    with CodeInterpreterClient() as client, TemporaryDirectory() as staging:
+        # The archive can be hundreds of MB: it lives in temp files that are
+        # removed when this block exits, right after the upload, so nothing is
         # held for the agent's whole (potentially 25-minute) run. The upload
-        # streams from that file so the bytes never enter this process.
+        # itself still buffers the file, so peak memory is the archive size.
         with open_repo_archive(
             provider,
             repo_ref,
@@ -114,7 +120,20 @@ def _setup_session(
             max_size_bytes=REPO_ARCHIVE_MAX_BYTES,
             timeout=REPO_ARCHIVE_FETCH_TIMEOUT,
         ) as repo_archive:
-            with repo_archive.path.open("rb") as archive_file:
+            # Indexing refuses credential files, so the agent — which runs
+            # shell commands over the tree and answers to a user — must not
+            # receive them either.
+            sanitized = Path(staging) / REPO_TARBALL_PATH
+            dropped = write_filtered_archive(
+                repo_archive.path, sanitized, is_sensitive_code_file
+            )
+            if dropped:
+                logger.info(
+                    "Excluded %s credential file(s) from the %s archive",
+                    dropped,
+                    repo_ref.display,
+                )
+            with sanitized.open("rb") as archive_file:
                 ci_file_id = client.upload_file(archive_file, REPO_TARBALL_PATH)
             commit_sha = (
                 repo_archive.revision.commit_sha if repo_archive.revision else None
@@ -162,8 +181,10 @@ def _revision_line(commit_sha: str | None, ref: str | None) -> str:
     if commit_sha:
         requested = f"requested: {ref}" if ref else "current default-branch state"
         return f"Checked-out revision: {commit_sha} ({requested})"
+    # No SHA means resolution failed and the fetch was unpinned, so the ref
+    # could have moved mid-flight. Say so rather than implying precision.
     if ref:
-        return f"Checked-out revision: {ref}"
+        return f"Checked-out revision: {ref} (not pinned to a commit)"
     return "Checked-out revision: latest default-branch state"
 
 
@@ -336,8 +357,9 @@ def run_coding_agent_call(
                     seed_lines = "\n".join(f"- {p}" for p in seed_paths)
                     initial_message_str += (
                         "\n\nFiles the code search index ranks as most "
-                        "relevant to this query (start here, but verify "
-                        "before trusting):\n" + seed_lines
+                        "relevant to this query. The index reflects whenever "
+                        "the repository was last indexed, so a path may have "
+                        "moved or gone; start here, but verify:\n" + seed_lines
                     )
                 initial_user_message = ChatMessageSimple(
                     message=initial_message_str,

--- a/backend/onyx/tools/fake_tools/coding_agent.py
+++ b/backend/onyx/tools/fake_tools/coding_agent.py
@@ -17,6 +17,7 @@ from onyx.coding_agent.mock_tools import (
     get_coding_agent_tool_definitions,
 )
 from onyx.coding_agent.models import CodingAgentCallResult, CodingAgentSpecialToolCalls
+from onyx.configs.app_configs import REPO_ARCHIVE_FETCH_TIMEOUT, REPO_ARCHIVE_MAX_BYTES
 from onyx.configs.constants import MessageType
 from onyx.deep_research.dr_mock_tools import (
     THINK_TOOL_NAME,
@@ -36,6 +37,7 @@ from onyx.prompts.coding_agent.coding_agent import (
 )
 from onyx.prompts.prompt_utils import get_current_llm_day_time
 from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.repo_archives.models import RepoRef
 from onyx.repo_archives.tarball_cache import open_repo_archive
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import (
@@ -56,7 +58,6 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
     CodeInterpreterClient,
 )
 from onyx.tracing.framework.create import function_span
-from onyx.utils.github import parse_github_source
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -79,19 +80,17 @@ REPO_TARBALL_PATH = "repo.tar.gz"
 # calls are not persisted to the DB through this loop, so the id is unused.
 BASH_TOOL_SENTINEL_ID = 0
 MAX_FINAL_ANSWER_TOKENS = 4000
-CODING_AGENT_GITHUB_MAX_REPO_BYTES = 500 * 1024 * 1024
-CODING_AGENT_GITHUB_DOWNLOAD_TIMEOUT = (30, 300)
 
 
 @contextmanager
 def _setup_session(
-    repo: str,
+    repo_ref: RepoRef,
     github_token: str | None,
     ref: str | None = None,
 ) -> Iterator[tuple[str, str | None]]:
-    """Materialize ``repo`` at ``ref`` (default-branch HEAD when None), create
-    a code-interpreter session with the tarball staged + extracted, yield
-    (session id, resolved commit SHA), and delete the session on exit.
+    """Materialize ``repo_ref`` at ``ref`` (default-branch HEAD when None),
+    create a code-interpreter session with the tarball staged + extracted,
+    yield (session id, resolved commit SHA), and delete the session on exit.
 
     The requested ref is resolved to its current commit SHA before every run,
     so the agent always analyzes the up-to-date state; unchanged repos come
@@ -101,26 +100,22 @@ def _setup_session(
     Creates its own :class:`CodeInterpreterClient` internally and tears it
     down on exit, so callers only deal with the ``session_id``.
     """
-    github_source = parse_github_source(
-        repo,
-        allow_ssh=True,
-    )
-    provider = GitHubArchiveProvider(f"Bearer {github_token}" if github_token else None)
+    provider = GitHubArchiveProvider.from_token(github_token)
 
     with CodeInterpreterClient() as client:
-        # The archive can be hundreds of MB: it lives in a temp file that is
+        # The archive can be hundreds of MB: it stays in a temp file that is
         # removed when this block exits, right after the upload, so it isn't
-        # held for the agent's whole (potentially 25-minute) run.
+        # held for the agent's whole (potentially 25-minute) run. The upload
+        # streams from that file so the bytes never enter this process.
         with open_repo_archive(
             provider,
-            provider.repo_ref(github_source.owner, github_source.repo),
+            repo_ref,
             ref,
-            max_size_bytes=CODING_AGENT_GITHUB_MAX_REPO_BYTES,
-            timeout=CODING_AGENT_GITHUB_DOWNLOAD_TIMEOUT,
+            max_size_bytes=REPO_ARCHIVE_MAX_BYTES,
+            timeout=REPO_ARCHIVE_FETCH_TIMEOUT,
         ) as repo_archive:
-            ci_file_id = client.upload_file(
-                repo_archive.path.read_bytes(), REPO_TARBALL_PATH
-            )
+            with repo_archive.path.open("rb") as archive_file:
+                ci_file_id = client.upload_file(archive_file, REPO_TARBALL_PATH)
             commit_sha = (
                 repo_archive.revision.commit_sha if repo_archive.revision else None
             )
@@ -301,6 +296,7 @@ def run_coding_agent_call(
     user_identity: LLMUserIdentity | None,
     github_token: str | None = None,
     seed_paths: list[str] | None = None,
+    repo_ref: RepoRef | None = None,
 ) -> CodingAgentCallResult | None:
     turn_index = coding_agent_call.placement.turn_index
     tab_index = coding_agent_call.placement.tab_index
@@ -314,8 +310,15 @@ def run_coding_agent_call(
             query = coding_agent_call.tool_args[CODING_AGENT_QUERY_KEY]
             repo = coding_agent_call.tool_args[CODING_AGENT_REPO_KEY]
             ref = coding_agent_call.tool_args.get(CODING_AGENT_REF_KEY)
+            # Callers that already parsed the repo (CodingAgentTool) pass the
+            # RepoRef through so the string is parsed once per run.
+            resolved_repo_ref = repo_ref or GitHubArchiveProvider.repo_ref_from_url(
+                repo
+            )
 
-            with _setup_session(repo=repo, github_token=github_token, ref=ref) as (
+            with _setup_session(
+                repo_ref=resolved_repo_ref, github_token=github_token, ref=ref
+            ) as (
                 session_id,
                 commit_sha,
             ):

--- a/backend/onyx/tools/fake_tools/coding_agent.py
+++ b/backend/onyx/tools/fake_tools/coding_agent.py
@@ -11,11 +11,13 @@ from onyx.coding_agent.mock_tools import (
     BASH_TOOL_CMD_KEY,
     BASH_TOOL_NAME,
     CODING_AGENT_QUERY_KEY,
+    CODING_AGENT_REF_KEY,
     CODING_AGENT_REPO_KEY,
     GENERATE_ANSWER_TOOL_NAME,
     get_coding_agent_tool_definitions,
 )
 from onyx.coding_agent.models import CodingAgentCallResult, CodingAgentSpecialToolCalls
+from onyx.coding_agent.repo_cache import fetch_repo_archive
 from onyx.configs.constants import MessageType
 from onyx.deep_research.dr_mock_tools import (
     THINK_TOOL_NAME,
@@ -53,7 +55,7 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
     CodeInterpreterClient,
 )
 from onyx.tracing.framework.create import function_span
-from onyx.utils.github import download_github_archive, parse_github_source
+from onyx.utils.github import parse_github_source
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -84,9 +86,15 @@ CODING_AGENT_GITHUB_DOWNLOAD_TIMEOUT = (30, 300)
 def _setup_session(
     repo: str,
     github_token: str | None,
-) -> Iterator[str]:
-    """Download ``repo``, create a code-interpreter session with the tarball
-    staged + extracted, yield the session id, and delete the session on exit.
+    ref: str | None = None,
+) -> Iterator[tuple[str, str | None]]:
+    """Materialize ``repo`` at ``ref`` (default-branch HEAD when None), create
+    a code-interpreter session with the tarball staged + extracted, yield
+    (session id, resolved commit SHA), and delete the session on exit.
+
+    The requested ref is resolved to its current commit SHA before every run,
+    so the agent always analyzes the up-to-date state; unchanged repos come
+    from the file-store cache instead of a fresh download (see repo_cache).
 
     Creates its own :class:`CodeInterpreterClient` internally and tears it
     down on exit, so callers only deal with the ``session_id``.
@@ -95,16 +103,21 @@ def _setup_session(
         repo,
         allow_ssh=True,
     )
-    repo_bytes = download_github_archive(
+    repo_archive = fetch_repo_archive(
         github_source,
-        "HEAD",
+        ref,
         f"Bearer {github_token}" if github_token else None,
         max_size_bytes=CODING_AGENT_GITHUB_MAX_REPO_BYTES,
         timeout=CODING_AGENT_GITHUB_DOWNLOAD_TIMEOUT,
     )
+    repo_bytes = repo_archive.archive
+    commit_sha = repo_archive.commit_sha
 
     with CodeInterpreterClient() as client:
         ci_file_id = client.upload_file(repo_bytes, REPO_TARBALL_PATH)
+        # The archive can be hundreds of MB; drop it as soon as it's uploaded
+        # so it isn't held for the agent's whole (potentially 25-minute) run.
+        del repo_bytes, repo_archive
         session_info = client.create_session(
             ttl_seconds=CODING_AGENT_SESSION_TTL_SECONDS,
             files=[{"path": REPO_TARBALL_PATH, "file_id": ci_file_id}],
@@ -130,7 +143,7 @@ def _setup_session(
                     f"Failed to extract repository tarball: {extract_result.stderr}"
                 )
             logger.info("Extracted repo into session %s", session_id)
-            yield session_id
+            yield session_id, commit_sha
         finally:
             try:
                 client.delete_session(session_id)
@@ -141,6 +154,16 @@ def _setup_session(
                 logger.warning(
                     "Failed to delete coding agent session %s: %s", session_id, e
                 )
+
+
+def _revision_line(commit_sha: str | None, ref: str | None) -> str:
+    """Agent-facing statement of the exact revision it is analyzing."""
+    if commit_sha:
+        requested = f"requested: {ref}" if ref else "current default-branch state"
+        return f"Checked-out revision: {commit_sha} ({requested})"
+    if ref:
+        return f"Checked-out revision: {ref}"
+    return "Checked-out revision: latest default-branch state"
 
 
 def _run_bash_call(
@@ -271,6 +294,7 @@ def run_coding_agent_call(
     token_counter: Callable[[str], int],
     user_identity: LLMUserIdentity | None,
     github_token: str | None = None,
+    seed_paths: list[str] | None = None,
 ) -> CodingAgentCallResult | None:
     turn_index = coding_agent_call.placement.turn_index
     tab_index = coding_agent_call.placement.tab_index
@@ -283,17 +307,32 @@ def run_coding_agent_call(
         try:
             query = coding_agent_call.tool_args[CODING_AGENT_QUERY_KEY]
             repo = coding_agent_call.tool_args[CODING_AGENT_REPO_KEY]
+            ref = coding_agent_call.tool_args.get(CODING_AGENT_REF_KEY)
 
-            with _setup_session(repo=repo, github_token=github_token) as session_id:
+            with _setup_session(repo=repo, github_token=github_token, ref=ref) as (
+                session_id,
+                commit_sha,
+            ):
                 bash_tool = BashTool(
                     tool_id=BASH_TOOL_SENTINEL_ID,
                     session_id=session_id,
                     emitter=emitter,
                 )
 
+                revision_line = _revision_line(commit_sha, ref)
+                initial_message_str = (
+                    f"Repository: {repo}\n{revision_line}\n\nQuery:\n{query}"
+                )
+                if seed_paths:
+                    seed_lines = "\n".join(f"- {p}" for p in seed_paths)
+                    initial_message_str += (
+                        "\n\nFiles the code search index ranks as most "
+                        "relevant to this query (start here, but verify "
+                        "before trusting):\n" + seed_lines
+                    )
                 initial_user_message = ChatMessageSimple(
-                    message=(f"Repository: {repo}\n\nQuery:\n{query}"),
-                    token_count=token_counter(f"Repository: {repo}\n\nQuery:\n{query}"),
+                    message=initial_message_str,
+                    token_count=token_counter(initial_message_str),
                     message_type=MessageType.USER,
                 )
                 msg_history: list[ChatMessageSimple] = [initial_user_message]

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -373,6 +373,7 @@ def _construct_tools_impl(
                         tool_id=db_tool_model.id,
                         emitter=emitter,
                         llm=llm,
+                        user=user,
                     )
                 ]
 

--- a/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
@@ -20,7 +20,7 @@ from onyx.configs.constants import (
     CODE_FILE_REPO_KEY,
     CODE_FILE_TYPE_KEY,
 )
-from onyx.db.credentials import fetch_github_access_token_for_repo
+from onyx.db.credentials import ConnectorRepoAccess, fetch_github_repo_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import User
 from onyx.llm.factory import get_llm_token_counter
@@ -189,27 +189,28 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
                 break
         return paths
 
-    def _fetch_connector_token(
+    def _fetch_connector_access(
         self, db_session: Session, repo_ref: RepoRef
-    ) -> str | None:
-        """Token of the GitHub connector that indexes ``repo_ref``, from the DB.
+    ) -> ConnectorRepoAccess | None:
+        """What a GitHub connector lends for ``repo_ref``: its token and the
+        branch it indexes.
 
-        The admin must have opted the connector in to coding-agent use, on top
-        of the other narrowing checks (see
-        fetch_github_access_token_for_repo). None → public-repo access only.
+        The grant follows this user's own access to the connector rather than
+        a separate admin toggle (see fetch_github_repo_access). None →
+        public-repo access only.
         """
-        token = fetch_github_access_token_for_repo(
+        access = fetch_github_repo_access(
             db_session=db_session,
             repo_owner=repo_ref.owner,
             repo_name=repo_ref.name,
             user=self._user,
         )
-        if token:
+        if access:
             logger.info(
                 "Using GitHub connector credential for coding agent repo %s",
                 repo_ref.display,
             )
-        return token
+        return access
 
     @override
     def run(
@@ -265,8 +266,21 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         with get_session_with_current_tenant() as db_session:
             # Separate gates: seeding reads the index under the user's own
             # ACL, while the token lends a credential and exposes the tree.
-            connector_token = self._fetch_connector_token(db_session, repo_ref)
+            connector_access = self._fetch_connector_access(db_session, repo_ref)
             seed_paths = self._fetch_seed_paths(db_session, query, repo_ref)
+
+        if connector_access is not None:
+            # A lent credential covers what the connector indexes and no more,
+            # so the model does not get to choose the ref: an older branch can
+            # still hold what was deliberately removed from the indexed one.
+            if ref and ref != connector_access.branch:
+                logger.info(
+                    "Ignoring requested ref %s for %s; the connector indexes %s",
+                    ref,
+                    repo_ref.display,
+                    connector_access.branch or "the default branch",
+                )
+            ref = connector_access.branch
 
         synthetic_call = ToolCallKickoff(
             tool_call_id=str(uuid4()),
@@ -287,7 +301,7 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
             llm=self._llm,
             token_counter=token_counter,
             user_identity=None,
-            github_token=connector_token,
+            github_token=connector_access.token if connector_access else None,
             seed_paths=seed_paths,
             repo_ref=repo_ref,
         )

--- a/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
@@ -14,19 +14,32 @@ from onyx.coding_agent.mock_tools import (
     CODING_AGENT_TOOL_DESCRIPTION,
     CODING_AGENT_TOOL_NAME,
 )
+from onyx.configs.constants import (
+    CODE_FILE_METADATA_TYPE,
+    CODE_FILE_PATH_KEY,
+    CODE_FILE_REPO_KEY,
+    CODE_FILE_TYPE_KEY,
+)
 from onyx.db.credentials import fetch_github_access_token_for_repo
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
+from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.repo_archives.models import RepoRef
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CodingAgentStart, Packet
 from onyx.tools.interface import Tool
 from onyx.tools.models import ToolCallException, ToolCallKickoff, ToolResponse
 from onyx.tools.tool_implementations.bash.bash_tool import BashTool
-from onyx.utils.github import parse_github_source
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Upper bound on seed file paths handed to the coding agent's opening prompt.
+MAX_SEED_PATHS = 10
+# Code chunks pulled from the index per seed-path lookup. Several chunks
+# usually map to the same file, so this sits well above MAX_SEED_PATHS.
+SEED_PATH_CHUNKS_TO_RETRIEVE = 50
 
 
 class CodingAgentToolOverrideKwargs(BaseModel):
@@ -44,6 +57,8 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
 
     NAME = CODING_AGENT_TOOL_NAME
     DISPLAY_NAME = "Coding Agent"
+    # UI/DB-facing summary only. The LLM sees
+    # CODING_AGENT_TOOL_DESCRIPTION via tool_definition().
     DESCRIPTION = (
         "Deep investigation of a GitHub repository in an isolated sandbox. "
         "Slow and expensive; for cross-file tracing and code verification, "
@@ -55,12 +70,10 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         tool_id: int,
         emitter: Emitter,
         llm: LLM,
-        github_token: str | None = None,
     ) -> None:
         super().__init__(emitter=emitter)
         self._id = tool_id
         self._llm = llm
-        self._github_token = github_token
 
     @property
     def id(self) -> int:
@@ -96,40 +109,52 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         return
 
     @staticmethod
-    def _fetch_seed_paths(query: str, repo: str, limit: int = 10) -> list[str]:
+    def _fetch_seed_paths(
+        db_session: Session,
+        query: str,
+        repo_ref: RepoRef,
+        limit: int = MAX_SEED_PATHS,
+    ) -> list[str]:
         """File paths from the code index most relevant to ``query``.
 
-        Keyword retrieval over indexed GitHub docs, restricted to ``repo``.
-        The query runs without a per-user ACL, so callers must only invoke
-        this for repos whose indexed docs are org-visible — ``run()`` gates
-        on the org-public connector-token eligibility for exactly this
-        reason. Failures degrade to an unseeded run.
+        Keyword retrieval over indexed GitHub source-code docs, restricted to
+        ``repo_ref``. The query runs without a per-user ACL, so callers must
+        only invoke this for repos whose indexed docs are org-visible —
+        ``run()`` gates on the org-public connector-token eligibility for
+        exactly this reason. Failures degrade to an unseeded run.
         """
         # Imported lazily: the document-index/search stack must stay off the
         # tool-construction import path.
         from onyx.configs.constants import DocumentSource
-        from onyx.context.search.models import IndexFilters
+        from onyx.context.search.models import IndexFilters, Tag
         from onyx.db.search_settings import get_current_search_settings
         from onyx.document_index.factory import get_default_document_index
         from shared_configs.contextvars import get_current_tenant_id
 
+        repo_full_name = repo_ref.display.lower()
         try:
-            github_source = parse_github_source(repo, allow_ssh=True)
-            repo_full_name = f"{github_source.owner}/{github_source.repo}".lower()
-            with get_session_with_current_tenant() as db_session:
-                search_settings = get_current_search_settings(db_session)
-                document_index = get_default_document_index(
-                    search_settings, None, db_session
-                )
-                chunks = document_index.keyword_retrieval(
-                    query=query,
-                    filters=IndexFilters(
-                        source_type=[DocumentSource.GITHUB],
-                        access_control_list=None,
-                        tenant_id=get_current_tenant_id(),
-                    ),
-                    num_to_retrieve=50,
-                )
+            search_settings = get_current_search_settings(db_session)
+            document_index = get_default_document_index(
+                search_settings, None, db_session
+            )
+            chunks = document_index.keyword_retrieval(
+                query=query,
+                filters=IndexFilters(
+                    source_type=[DocumentSource.GITHUB],
+                    # PRs, issues and docs from the same connector also carry
+                    # a repo tag; only source-code docs have a path, so spend
+                    # the whole budget on them.
+                    tags=[
+                        Tag(
+                            tag_key=CODE_FILE_TYPE_KEY,
+                            tag_value=CODE_FILE_METADATA_TYPE,
+                        )
+                    ],
+                    access_control_list=None,
+                    tenant_id=get_current_tenant_id(),
+                ),
+                num_to_retrieve=SEED_PATH_CHUNKS_TO_RETRIEVE,
+            )
         except Exception:
             logger.warning(
                 "Seed-path retrieval failed; running coding agent unseeded",
@@ -139,9 +164,14 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
 
         paths: list[str] = []
         for chunk in chunks:
-            if str(chunk.metadata.get("repo", "")).lower() != repo_full_name:
+            # Repo is compared in Python, not as a tag filter: the index match
+            # is case-sensitive and the repo string comes from the LLM.
+            if (
+                str(chunk.metadata.get(CODE_FILE_REPO_KEY, "")).lower()
+                != repo_full_name
+            ):
                 continue
-            path = chunk.metadata.get("path")
+            path = chunk.metadata.get(CODE_FILE_PATH_KEY)
             if isinstance(path, str) and path not in paths:
                 paths.append(path)
             if len(paths) >= limit:
@@ -149,26 +179,21 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         return paths
 
     @staticmethod
-    def _fetch_connector_token(repo: str) -> str | None:
-        """Token of the GitHub connector that indexes ``repo``, from the DB.
+    def _fetch_connector_token(db_session: Session, repo_ref: RepoRef) -> str | None:
+        """Token of the GitHub connector that indexes ``repo_ref``, from the DB.
 
         Only org-public connector pairs are eligible (see
         fetch_github_access_token_for_repo). None → public-repo access only.
         """
-        try:
-            github_source = parse_github_source(repo, allow_ssh=True)
-        except Exception:
-            # run_coding_agent_call re-parses and surfaces the real error.
-            return None
-        with get_session_with_current_tenant() as db_session:
-            token = fetch_github_access_token_for_repo(
-                db_session=db_session,
-                repo_owner=github_source.owner,
-                repo_name=github_source.repo,
-            )
+        token = fetch_github_access_token_for_repo(
+            db_session=db_session,
+            repo_owner=repo_ref.owner,
+            repo_name=repo_ref.name,
+        )
         if token:
             logger.info(
-                "Using GitHub connector credential for coding agent repo %s", repo
+                "Using GitHub connector credential for coding agent repo %s",
+                repo_ref.display,
             )
         return token
 
@@ -199,6 +224,19 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         repo = cast(str, llm_kwargs[CODING_AGENT_REPO_KEY])
         ref = cast(str | None, llm_kwargs.get(CODING_AGENT_REF_KEY))
 
+        # Parsed once here and threaded through; everything downstream takes
+        # the RepoRef rather than re-parsing the LLM-supplied string.
+        try:
+            repo_ref = GitHubArchiveProvider.repo_ref_from_url(repo)
+        except Exception as e:
+            raise ToolCallException(
+                message=f"Unparseable '{CODING_AGENT_REPO_KEY}' value {repo!r}: {e}",
+                llm_facing_message=(
+                    f"'{repo}' is not a valid GitHub repository. Pass either "
+                    "'owner/repo' or a github.com repository URL."
+                ),
+            )
+
         self.emitter.emit(
             Packet(
                 placement=placement,
@@ -210,14 +248,19 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         # the BashTool which lives in tool_implementations alongside us.
         from onyx.tools.fake_tools.coding_agent import run_coding_agent_call
 
-        connector_token = self._fetch_connector_token(repo)
-        github_token = self._github_token or connector_token
-        # Seed only when an org-public connector pair covers this repo: seed
-        # retrieval runs without a per-user ACL, so it must be limited to
-        # repos whose indexed docs every org member may see. A None token
-        # means no such pair exists (permission-synced or unindexed repo) —
-        # run unseeded rather than leak file paths through the agent prompt.
-        seed_paths = self._fetch_seed_paths(query, repo) if connector_token else []
+        with get_session_with_current_tenant() as db_session:
+            connector_token = self._fetch_connector_token(db_session, repo_ref)
+            # Seed only when an org-public connector pair covers this repo:
+            # seed retrieval runs without a per-user ACL, so it must be
+            # limited to repos whose indexed docs every org member may see. A
+            # None token means no such pair exists (permission-synced or
+            # unindexed repo) — run unseeded rather than leak file paths
+            # through the agent prompt.
+            seed_paths = (
+                self._fetch_seed_paths(db_session, query, repo_ref)
+                if connector_token
+                else []
+            )
 
         synthetic_call = ToolCallKickoff(
             tool_call_id=str(uuid4()),
@@ -238,8 +281,9 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
             llm=self._llm,
             token_counter=token_counter,
             user_identity=None,
-            github_token=github_token,
+            github_token=connector_token,
             seed_paths=seed_paths,
+            repo_ref=repo_ref,
         )
 
         if result is None:

--- a/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
@@ -22,6 +22,7 @@ from onyx.configs.constants import (
 )
 from onyx.db.credentials import fetch_github_access_token_for_repo
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import User
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
 from onyx.repo_archives.github import GitHubArchiveProvider
@@ -70,10 +71,15 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         tool_id: int,
         emitter: Emitter,
         llm: LLM,
+        user: User,
     ) -> None:
+        """``user`` is the actor for both index reads and the credential audit
+        trail. Seed retrieval runs under this user's ACL.
+        """
         super().__init__(emitter=emitter)
         self._id = tool_id
         self._llm = llm
+        self._user = user
 
     @property
     def id(self) -> int:
@@ -108,8 +114,8 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         # there, mirroring PythonTool's pattern.
         return
 
-    @staticmethod
     def _fetch_seed_paths(
+        self,
         db_session: Session,
         query: str,
         repo_ref: RepoRef,
@@ -118,15 +124,18 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         """File paths from the code index most relevant to ``query``.
 
         Keyword retrieval over indexed GitHub source-code docs, restricted to
-        ``repo_ref``. The query runs without a per-user ACL, so callers must
-        only invoke this for repos whose indexed docs are org-visible —
-        ``run()`` gates on the org-public connector-token eligibility for
-        exactly this reason. Failures degrade to an unseeded run.
+        ``repo_ref`` and to what this user may already read: the retrieval
+        carries the same per-user ACL every other tool uses, so it returns
+        only paths the user could reach through ordinary search. Failures
+        degrade to an unseeded run.
         """
         # Imported lazily: the document-index/search stack must stay off the
         # tool-construction import path.
         from onyx.configs.constants import DocumentSource
         from onyx.context.search.models import IndexFilters, Tag
+        from onyx.context.search.preprocessing.access_filters import (
+            build_access_filters_for_user,
+        )
         from onyx.db.search_settings import get_current_search_settings
         from onyx.document_index.factory import get_default_document_index
         from shared_configs.contextvars import get_current_tenant_id
@@ -150,7 +159,9 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
                             tag_value=CODE_FILE_METADATA_TYPE,
                         )
                     ],
-                    access_control_list=None,
+                    access_control_list=build_access_filters_for_user(
+                        self._user, db_session
+                    ),
                     tenant_id=get_current_tenant_id(),
                 ),
                 num_to_retrieve=SEED_PATH_CHUNKS_TO_RETRIEVE,
@@ -178,17 +189,20 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
                 break
         return paths
 
-    @staticmethod
-    def _fetch_connector_token(db_session: Session, repo_ref: RepoRef) -> str | None:
+    def _fetch_connector_token(
+        self, db_session: Session, repo_ref: RepoRef
+    ) -> str | None:
         """Token of the GitHub connector that indexes ``repo_ref``, from the DB.
 
-        Only org-public connector pairs are eligible (see
+        The admin must have opted the connector in to coding-agent use, on top
+        of the other narrowing checks (see
         fetch_github_access_token_for_repo). None → public-repo access only.
         """
         token = fetch_github_access_token_for_repo(
             db_session=db_session,
             repo_owner=repo_ref.owner,
             repo_name=repo_ref.name,
+            user=self._user,
         )
         if token:
             logger.info(
@@ -244,23 +258,15 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
             )
         )
 
-        # Imported lazily to avoid a circular import: coding_agent.py imports
-        # the BashTool which lives in tool_implementations alongside us.
+        # Imported lazily to break a circular import: fake_tools.coding_agent
+        # -> chat.llm_loop -> tools.built_in_tools -> this module.
         from onyx.tools.fake_tools.coding_agent import run_coding_agent_call
 
         with get_session_with_current_tenant() as db_session:
+            # Separate gates: seeding reads the index under the user's own
+            # ACL, while the token lends a credential and exposes the tree.
             connector_token = self._fetch_connector_token(db_session, repo_ref)
-            # Seed only when an org-public connector pair covers this repo:
-            # seed retrieval runs without a per-user ACL, so it must be
-            # limited to repos whose indexed docs every org member may see. A
-            # None token means no such pair exists (permission-synced or
-            # unindexed repo) — run unseeded rather than leak file paths
-            # through the agent prompt.
-            seed_paths = (
-                self._fetch_seed_paths(db_session, query, repo_ref)
-                if connector_token
-                else []
-            )
+            seed_paths = self._fetch_seed_paths(db_session, query, repo_ref)
 
         synthetic_call = ToolCallKickoff(
             tool_call_id=str(uuid4()),

--- a/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/coding_agent/coding_agent_tool.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, cast
 from uuid import uuid4
 
@@ -8,9 +9,13 @@ from typing_extensions import override
 from onyx.chat.emitter import Emitter
 from onyx.coding_agent.mock_tools import (
     CODING_AGENT_QUERY_KEY,
+    CODING_AGENT_REF_KEY,
     CODING_AGENT_REPO_KEY,
+    CODING_AGENT_TOOL_DESCRIPTION,
     CODING_AGENT_TOOL_NAME,
 )
+from onyx.db.credentials import fetch_github_access_token_for_repo
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
 from onyx.server.query_and_chat.placement import Placement
@@ -18,6 +23,7 @@ from onyx.server.query_and_chat.streaming_models import CodingAgentStart, Packet
 from onyx.tools.interface import Tool
 from onyx.tools.models import ToolCallException, ToolCallKickoff, ToolResponse
 from onyx.tools.tool_implementations.bash.bash_tool import BashTool
+from onyx.utils.github import parse_github_source
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -39,9 +45,9 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
     NAME = CODING_AGENT_TOOL_NAME
     DISPLAY_NAME = "Coding Agent"
     DESCRIPTION = (
-        "Investigate and answer a coding question against a specific GitHub "
-        "repository. Clones the repo into an isolated sandbox and explores "
-        "it via shell commands before returning a text answer."
+        "Deep investigation of a GitHub repository in an isolated sandbox. "
+        "Slow and expensive; for cross-file tracing and code verification, "
+        "not for simple lookups the code search index answers."
     )
 
     def __init__(
@@ -80,41 +86,91 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
 
     @override
     def tool_definition(self) -> dict:
-        return {
-            "type": "function",
-            "function": {
-                "name": self.name,
-                "description": self.description,
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        CODING_AGENT_QUERY_KEY: {
-                            "type": "string",
-                            "description": (
-                                "The user's question or task to perform "
-                                "against the repository."
-                            ),
-                        },
-                        CODING_AGENT_REPO_KEY: {
-                            "type": "string",
-                            "description": (
-                                "GitHub repository URL or 'owner/repo' "
-                                "identifier (e.g. "
-                                "'https://github.com/onyx-dot-app/onyx' "
-                                "or 'onyx-dot-app/onyx')."
-                            ),
-                        },
-                    },
-                    "required": [CODING_AGENT_QUERY_KEY, CODING_AGENT_REPO_KEY],
-                },
-            },
-        }
+        # Single source of truth shared with the deep-research mock-tool path.
+        return copy.deepcopy(CODING_AGENT_TOOL_DESCRIPTION)
 
     @override
     def emit_start(self, placement: Placement) -> None:
         # query and repo aren't bound until run(); CodingAgentStart is emitted
         # there, mirroring PythonTool's pattern.
         return
+
+    @staticmethod
+    def _fetch_seed_paths(query: str, repo: str, limit: int = 10) -> list[str]:
+        """File paths from the code index most relevant to ``query``.
+
+        Keyword retrieval over indexed GitHub docs, restricted to ``repo``.
+        The query runs without a per-user ACL, so callers must only invoke
+        this for repos whose indexed docs are org-visible — ``run()`` gates
+        on the org-public connector-token eligibility for exactly this
+        reason. Failures degrade to an unseeded run.
+        """
+        # Imported lazily: the document-index/search stack must stay off the
+        # tool-construction import path.
+        from onyx.configs.constants import DocumentSource
+        from onyx.context.search.models import IndexFilters
+        from onyx.db.search_settings import get_current_search_settings
+        from onyx.document_index.factory import get_default_document_index
+        from shared_configs.contextvars import get_current_tenant_id
+
+        try:
+            github_source = parse_github_source(repo, allow_ssh=True)
+            repo_full_name = f"{github_source.owner}/{github_source.repo}".lower()
+            with get_session_with_current_tenant() as db_session:
+                search_settings = get_current_search_settings(db_session)
+                document_index = get_default_document_index(
+                    search_settings, None, db_session
+                )
+                chunks = document_index.keyword_retrieval(
+                    query=query,
+                    filters=IndexFilters(
+                        source_type=[DocumentSource.GITHUB],
+                        access_control_list=None,
+                        tenant_id=get_current_tenant_id(),
+                    ),
+                    num_to_retrieve=50,
+                )
+        except Exception:
+            logger.warning(
+                "Seed-path retrieval failed; running coding agent unseeded",
+                exc_info=True,
+            )
+            return []
+
+        paths: list[str] = []
+        for chunk in chunks:
+            if str(chunk.metadata.get("repo", "")).lower() != repo_full_name:
+                continue
+            path = chunk.metadata.get("path")
+            if isinstance(path, str) and path not in paths:
+                paths.append(path)
+            if len(paths) >= limit:
+                break
+        return paths
+
+    @staticmethod
+    def _fetch_connector_token(repo: str) -> str | None:
+        """Token of the GitHub connector that indexes ``repo``, from the DB.
+
+        Only org-public connector pairs are eligible (see
+        fetch_github_access_token_for_repo). None → public-repo access only.
+        """
+        try:
+            github_source = parse_github_source(repo, allow_ssh=True)
+        except Exception:
+            # run_coding_agent_call re-parses and surfaces the real error.
+            return None
+        with get_session_with_current_tenant() as db_session:
+            token = fetch_github_access_token_for_repo(
+                db_session=db_session,
+                repo_owner=github_source.owner,
+                repo_name=github_source.repo,
+            )
+        if token:
+            logger.info(
+                "Using GitHub connector credential for coding agent repo %s", repo
+            )
+        return token
 
     @override
     def run(
@@ -141,6 +197,7 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
             )
         query = cast(str, llm_kwargs[CODING_AGENT_QUERY_KEY])
         repo = cast(str, llm_kwargs[CODING_AGENT_REPO_KEY])
+        ref = cast(str | None, llm_kwargs.get(CODING_AGENT_REF_KEY))
 
         self.emitter.emit(
             Packet(
@@ -153,12 +210,22 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
         # the BashTool which lives in tool_implementations alongside us.
         from onyx.tools.fake_tools.coding_agent import run_coding_agent_call
 
+        connector_token = self._fetch_connector_token(repo)
+        github_token = self._github_token or connector_token
+        # Seed only when an org-public connector pair covers this repo: seed
+        # retrieval runs without a per-user ACL, so it must be limited to
+        # repos whose indexed docs every org member may see. A None token
+        # means no such pair exists (permission-synced or unindexed repo) —
+        # run unseeded rather than leak file paths through the agent prompt.
+        seed_paths = self._fetch_seed_paths(query, repo) if connector_token else []
+
         synthetic_call = ToolCallKickoff(
             tool_call_id=str(uuid4()),
             tool_name=self.name,
             tool_args={
                 CODING_AGENT_QUERY_KEY: query,
                 CODING_AGENT_REPO_KEY: repo,
+                **({CODING_AGENT_REF_KEY: ref} if ref else {}),
             },
             placement=placement,
         )
@@ -171,7 +238,8 @@ class CodingAgentTool(Tool[CodingAgentToolOverrideKwargs]):
             llm=self._llm,
             token_counter=token_counter,
             user_identity=None,
-            github_token=self._github_token,
+            github_token=github_token,
+            seed_paths=seed_paths,
         )
 
         if result is None:

--- a/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
+++ b/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
@@ -5,7 +5,16 @@ import re
 import time
 from collections.abc import Callable, Generator
 from functools import wraps
-from typing import Any, Concatenate, Literal, ParamSpec, TypedDict, TypeVar, Union
+from typing import (
+    Any,
+    BinaryIO,
+    Concatenate,
+    Literal,
+    ParamSpec,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 import requests
 from pydantic import BaseModel
@@ -487,8 +496,12 @@ class CodeInterpreterClient:
 
         return BashExecResponse(**response.json())
 
-    def upload_file(self, file_content: bytes, filename: str) -> str:
-        """Upload file to Code Interpreter and return file_id"""
+    def upload_file(self, file_content: bytes | BinaryIO, filename: str) -> str:
+        """Upload file to Code Interpreter and return file_id.
+
+        Pass an open binary file object instead of bytes for large uploads:
+        requests streams it straight from disk, so it never sits in memory.
+        """
         url = f"{self.base_url}/v1/files"
 
         files = {"file": (filename, file_content)}

--- a/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
+++ b/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
@@ -499,8 +499,9 @@ class CodeInterpreterClient:
     def upload_file(self, file_content: bytes | BinaryIO, filename: str) -> str:
         """Upload file to Code Interpreter and return file_id.
 
-        Pass an open binary file object instead of bytes for large uploads:
-        requests streams it straight from disk, so it never sits in memory.
+        A file object spares the caller from holding the bytes for its own
+        lifetime, but requests reads it in full to build the multipart body,
+        so the peak is still the file size.
         """
         url = f"{self.base_url}/v1/files"
 

--- a/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
@@ -1,11 +1,26 @@
+from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from onyx.coding_agent.repo_cache import RepoArchive
+from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.repo_archives.models import RepoArchive, RepoRevision
 from onyx.tools.fake_tools import coding_agent
 
 
-def test_coding_agent_fetches_and_extracts_repo_with_existing_policy() -> None:
+def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "repo.tar.gz"
+    archive_path.write_bytes(b"repository archive")
+    archive = RepoArchive(
+        path=archive_path,
+        size=archive_path.stat().st_size,
+        revision=RepoRevision(
+            repo=GitHubArchiveProvider.repo_ref("onyx-dot-app", "onyx"),
+            commit_sha="a" * 40,
+        ),
+    )
     client = MagicMock()
     client.__enter__.return_value = client
     client.__exit__.return_value = False
@@ -18,13 +33,8 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy() -> None:
 
     with (
         patch.object(
-            coding_agent,
-            "fetch_repo_archive",
-            return_value=RepoArchive(
-                archive=b"repository archive",
-                commit_sha="a" * 40,
-            ),
-        ) as fetch_archive,
+            coding_agent, "open_repo_archive", return_value=nullcontext(archive)
+        ) as open_archive,
         patch.object(coding_agent, "CodeInterpreterClient", return_value=client),
         coding_agent._setup_session(
             repo="git@github.com:onyx-dot-app/onyx.git",
@@ -34,11 +44,12 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy() -> None:
         assert session_id == "session-id"
         assert commit_sha == "a" * 40
 
-    source, ref, authorization = fetch_archive.call_args.args
-    assert (source.owner, source.repo) == ("onyx-dot-app", "onyx")
+    provider, repo_ref, ref = open_archive.call_args.args
+    assert isinstance(provider, GitHubArchiveProvider)
+    assert provider._authorization_header == "Bearer secret"
+    assert (repo_ref.owner, repo_ref.name) == ("onyx-dot-app", "onyx")
     assert ref is None
-    assert authorization == "Bearer secret"
-    assert fetch_archive.call_args.kwargs == {
+    assert open_archive.call_args.kwargs == {
         "max_size_bytes": 500 * 1024 * 1024,
         "timeout": (30, 300),
     }

--- a/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
@@ -18,7 +18,7 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
         path=archive_path,
         size=archive_path.stat().st_size,
         revision=RepoRevision(
-            repo=GitHubArchiveProvider.repo_ref("onyx-dot-app", "onyx"),
+            repo=GitHubArchiveProvider.repo_ref_from_url("onyx-dot-app/onyx"),
             commit_sha="a" * 40,
         ),
     )
@@ -38,7 +38,7 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
         ) as open_archive,
         patch.object(coding_agent, "CodeInterpreterClient", return_value=client),
         coding_agent._setup_session(
-            repo_ref=GitHubArchiveProvider.repo_ref("onyx-dot-app", "onyx"),
+            repo_ref=GitHubArchiveProvider.repo_ref_from_url("onyx-dot-app/onyx"),
             github_token="secret",
         ) as (session_id, commit_sha),
     ):

--- a/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
@@ -1,20 +1,28 @@
+import tarfile
 from contextlib import nullcontext
+from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from onyx.configs.app_configs import REPO_ARCHIVE_FETCH_TIMEOUT, REPO_ARCHIVE_MAX_BYTES
 from onyx.repo_archives.github import GitHubArchiveProvider
 from onyx.repo_archives.models import RepoArchive, RepoRevision
 from onyx.tools.fake_tools import coding_agent
+from tests.utils.repo_archives import make_repo_tarball
+
+REPO_FILES = {
+    "src/main.py": b"def main():\n    return 1\n",
+    ".env.production": b"SECRET=hunter2\n",
+    "deploy/server.key": b"-----BEGIN PRIVATE KEY-----\n",
+}
 
 
-def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
-    tmp_path: Path,
-) -> None:
+def _archive(tmp_path: Path) -> RepoArchive:
     archive_path = tmp_path / "repo.tar.gz"
-    archive_path.write_bytes(b"repository archive")
-    archive = RepoArchive(
+    archive_path.write_bytes(make_repo_tarball(REPO_FILES))
+    return RepoArchive(
         path=archive_path,
         size=archive_path.stat().st_size,
         revision=RepoRevision(
@@ -22,6 +30,9 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
             commit_sha="a" * 40,
         ),
     )
+
+
+def _client() -> MagicMock:
     client = MagicMock()
     client.__enter__.return_value = client
     client.__exit__.return_value = False
@@ -31,6 +42,14 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
         exit_code=0,
         stderr="",
     )
+    return client
+
+
+def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
+    tmp_path: Path,
+) -> None:
+    archive = _archive(tmp_path)
+    client = _client()
 
     with (
         patch.object(
@@ -54,11 +73,10 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
         "max_size_bytes": REPO_ARCHIVE_MAX_BYTES,
         "timeout": REPO_ARCHIVE_FETCH_TIMEOUT,
     }
-    # The archive streams straight off disk instead of being read into memory.
+    # Uploaded from a file object, so the bytes are not held for the run.
     client.upload_file.assert_called_once()
     uploaded_file, uploaded_name = client.upload_file.call_args.args
     assert uploaded_name == coding_agent.REPO_TARBALL_PATH
-    assert Path(uploaded_file.name) == archive_path
     assert uploaded_file.closed
     client.execute_bash_in_session.assert_called_once_with(
         session_id="session-id",
@@ -66,3 +84,35 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
         timeout_ms=coding_agent.CODING_AGENT_SETUP_TIMEOUT_MS,
     )
     client.delete_session.assert_called_once_with("session-id")
+
+
+def test_credential_files_never_reach_the_sandbox(tmp_path: Path) -> None:
+    """Indexing refuses these files. The agent runs shell commands over the
+    tree and answers to a user, so it must not receive them either."""
+    archive = _archive(tmp_path)
+    client = _client()
+    uploaded: dict[str, bytes] = {}
+
+    def _capture(file_obj: Any, _name: str) -> str:
+        uploaded["bytes"] = file_obj.read()
+        return "file-id"
+
+    client.upload_file.side_effect = _capture
+
+    with (
+        patch.object(
+            coding_agent, "open_repo_archive", return_value=nullcontext(archive)
+        ),
+        patch.object(coding_agent, "CodeInterpreterClient", return_value=client),
+        coding_agent._setup_session(
+            repo_ref=GitHubArchiveProvider.repo_ref_from_url("onyx-dot-app/onyx"),
+            github_token="secret",
+        ),
+    ):
+        pass
+
+    with tarfile.open(fileobj=BytesIO(uploaded["bytes"]), mode="r:gz") as sent:
+        names = {Path(name).name for name in sent.getnames()}
+
+    assert "main.py" in names
+    assert names.isdisjoint({".env.production", "server.key"})

--- a/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
@@ -1,10 +1,11 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from onyx.coding_agent.repo_cache import RepoArchive
 from onyx.tools.fake_tools import coding_agent
 
 
-def test_coding_agent_downloads_and_extracts_repo_with_existing_policy() -> None:
+def test_coding_agent_fetches_and_extracts_repo_with_existing_policy() -> None:
     client = MagicMock()
     client.__enter__.return_value = client
     client.__exit__.return_value = False
@@ -18,22 +19,26 @@ def test_coding_agent_downloads_and_extracts_repo_with_existing_policy() -> None
     with (
         patch.object(
             coding_agent,
-            "download_github_archive",
-            return_value=b"repository archive",
-        ) as download_archive,
+            "fetch_repo_archive",
+            return_value=RepoArchive(
+                archive=b"repository archive",
+                commit_sha="a" * 40,
+            ),
+        ) as fetch_archive,
         patch.object(coding_agent, "CodeInterpreterClient", return_value=client),
         coding_agent._setup_session(
             repo="git@github.com:onyx-dot-app/onyx.git",
             github_token="secret",
-        ) as session_id,
+        ) as (session_id, commit_sha),
     ):
         assert session_id == "session-id"
+        assert commit_sha == "a" * 40
 
-    source, revision, authorization = download_archive.call_args.args
+    source, ref, authorization = fetch_archive.call_args.args
     assert (source.owner, source.repo) == ("onyx-dot-app", "onyx")
-    assert revision == "HEAD"
+    assert ref is None
     assert authorization == "Bearer secret"
-    assert download_archive.call_args.kwargs == {
+    assert fetch_archive.call_args.kwargs == {
         "max_size_bytes": 500 * 1024 * 1024,
         "timeout": (30, 300),
     }

--- a/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_repo_setup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from onyx.configs.app_configs import REPO_ARCHIVE_FETCH_TIMEOUT, REPO_ARCHIVE_MAX_BYTES
 from onyx.repo_archives.github import GitHubArchiveProvider
 from onyx.repo_archives.models import RepoArchive, RepoRevision
 from onyx.tools.fake_tools import coding_agent
@@ -37,7 +38,7 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
         ) as open_archive,
         patch.object(coding_agent, "CodeInterpreterClient", return_value=client),
         coding_agent._setup_session(
-            repo="git@github.com:onyx-dot-app/onyx.git",
+            repo_ref=GitHubArchiveProvider.repo_ref("onyx-dot-app", "onyx"),
             github_token="secret",
         ) as (session_id, commit_sha),
     ):
@@ -50,13 +51,15 @@ def test_coding_agent_fetches_and_extracts_repo_with_existing_policy(
     assert (repo_ref.owner, repo_ref.name) == ("onyx-dot-app", "onyx")
     assert ref is None
     assert open_archive.call_args.kwargs == {
-        "max_size_bytes": 500 * 1024 * 1024,
-        "timeout": (30, 300),
+        "max_size_bytes": REPO_ARCHIVE_MAX_BYTES,
+        "timeout": REPO_ARCHIVE_FETCH_TIMEOUT,
     }
-    client.upload_file.assert_called_once_with(
-        b"repository archive",
-        coding_agent.REPO_TARBALL_PATH,
-    )
+    # The archive streams straight off disk instead of being read into memory.
+    client.upload_file.assert_called_once()
+    uploaded_file, uploaded_name = client.upload_file.call_args.args
+    assert uploaded_name == coding_agent.REPO_TARBALL_PATH
+    assert Path(uploaded_file.name) == archive_path
+    assert uploaded_file.closed
     client.execute_bash_in_session.assert_called_once_with(
         session_id="session-id",
         cmd="tar -xzf repo.tar.gz --strip-components=1 && rm repo.tar.gz && ls",

--- a/backend/tests/unit/onyx/tools/test_coding_agent_run_gating.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_run_gating.py
@@ -13,8 +13,10 @@ import pytest
 
 from onyx.coding_agent.mock_tools import (
     CODING_AGENT_QUERY_KEY,
+    CODING_AGENT_REF_KEY,
     CODING_AGENT_REPO_KEY,
 )
+from onyx.db.credentials import ConnectorRepoAccess
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import ToolCallException
 from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
@@ -35,12 +37,14 @@ def _tool(user: Any = None) -> CodingAgentTool:
 
 
 @contextmanager
-def _run_mocks(token: str | None, seed_paths: list[str]) -> Iterator[MagicMock]:
+def _run_mocks(
+    access: ConnectorRepoAccess | None, seed_paths: list[str]
+) -> Iterator[MagicMock]:
     inner = MagicMock(return_value=MagicMock(answer="done"))
     with (
         patch(f"{_TOOL_MODULE}.get_session_with_current_tenant"),
         patch(f"{_TOOL_MODULE}.get_llm_token_counter", return_value=len),
-        patch.object(CodingAgentTool, "_fetch_connector_token", return_value=token),
+        patch.object(CodingAgentTool, "_fetch_connector_access", return_value=access),
         patch.object(CodingAgentTool, "_fetch_seed_paths", return_value=seed_paths),
         patch(
             "onyx.tools.fake_tools.coding_agent.run_coding_agent_call",
@@ -50,13 +54,14 @@ def _run_mocks(token: str | None, seed_paths: list[str]) -> Iterator[MagicMock]:
         yield inner
 
 
-def _run(tool: CodingAgentTool) -> None:
+def _run(tool: CodingAgentTool, ref: str | None = None) -> None:
     tool.run(
         placement=Placement(turn_index=0, tab_index=0),
         override_kwargs=CodingAgentToolOverrideKwargs(),
         **{
             CODING_AGENT_QUERY_KEY: "where is auth handled",
             CODING_AGENT_REPO_KEY: "onyx-dot-app/onyx",
+            **({CODING_AGENT_REF_KEY: ref} if ref else {}),
         },
     )
 
@@ -64,7 +69,7 @@ def _run(tool: CodingAgentTool) -> None:
 def test_seeds_even_without_a_connector_credential() -> None:
     """Seed paths come from the user's own ACL-filtered index read, so they
     do not depend on any credential being lendable."""
-    with _run_mocks(token=None, seed_paths=["a.py"]) as inner:
+    with _run_mocks(access=None, seed_paths=["a.py"]) as inner:
         _run(_tool())
 
     assert inner.call_args.kwargs["seed_paths"] == ["a.py"]
@@ -72,10 +77,30 @@ def test_seeds_even_without_a_connector_credential() -> None:
 
 
 def test_lends_the_credential_only_when_the_gate_returns_one() -> None:
-    with _run_mocks(token="tok", seed_paths=[]) as inner:
+    access = ConnectorRepoAccess(token="tok", branch=None)
+    with _run_mocks(access=access, seed_paths=[]) as inner:
         _run(_tool())
 
     assert inner.call_args.kwargs["github_token"] == "tok"
+
+
+def test_a_lent_credential_pins_the_ref_to_the_indexed_branch() -> None:
+    """The connector indexes one branch; an old branch can still hold what
+    was deliberately removed from it, so the model does not pick the ref."""
+    access = ConnectorRepoAccess(token="tok", branch="main")
+    with _run_mocks(access=access, seed_paths=[]) as inner:
+        _run(_tool(), ref="secrets-experiment")
+
+    call = inner.call_args.kwargs["coding_agent_call"]
+    assert call.tool_args[CODING_AGENT_REF_KEY] == "main"
+
+
+def test_a_public_repo_still_honours_the_requested_ref() -> None:
+    with _run_mocks(access=None, seed_paths=[]) as inner:
+        _run(_tool(), ref="v1.2.3")
+
+    call = inner.call_args.kwargs["coding_agent_call"]
+    assert call.tool_args[CODING_AGENT_REF_KEY] == "v1.2.3"
 
 
 def test_rejects_unparseable_repo() -> None:

--- a/backend/tests/unit/onyx/tools/test_coding_agent_run_gating.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_run_gating.py
@@ -1,0 +1,91 @@
+"""The coding agent gates two capabilities that used to share one predicate.
+
+Reading the index for seed paths is an ordinary, ACL-checked read. Borrowing
+the connector's GitHub credential hands the sandbox the full source tree.
+These tests pin them apart.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.coding_agent.mock_tools import (
+    CODING_AGENT_QUERY_KEY,
+    CODING_AGENT_REPO_KEY,
+)
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.models import ToolCallException
+from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
+    CodingAgentTool,
+    CodingAgentToolOverrideKwargs,
+)
+
+_TOOL_MODULE = "onyx.tools.tool_implementations.coding_agent.coding_agent_tool"
+
+
+def _tool(user: Any = None) -> CodingAgentTool:
+    return CodingAgentTool(
+        tool_id=1,
+        emitter=MagicMock(),
+        llm=MagicMock(),
+        user=user if user is not None else MagicMock(),
+    )
+
+
+@contextmanager
+def _run_mocks(token: str | None, seed_paths: list[str]) -> Iterator[MagicMock]:
+    inner = MagicMock(return_value=MagicMock(answer="done"))
+    with (
+        patch(f"{_TOOL_MODULE}.get_session_with_current_tenant"),
+        patch(f"{_TOOL_MODULE}.get_llm_token_counter", return_value=len),
+        patch.object(CodingAgentTool, "_fetch_connector_token", return_value=token),
+        patch.object(CodingAgentTool, "_fetch_seed_paths", return_value=seed_paths),
+        patch(
+            "onyx.tools.fake_tools.coding_agent.run_coding_agent_call",
+            new=inner,
+        ),
+    ):
+        yield inner
+
+
+def _run(tool: CodingAgentTool) -> None:
+    tool.run(
+        placement=Placement(turn_index=0, tab_index=0),
+        override_kwargs=CodingAgentToolOverrideKwargs(),
+        **{
+            CODING_AGENT_QUERY_KEY: "where is auth handled",
+            CODING_AGENT_REPO_KEY: "onyx-dot-app/onyx",
+        },
+    )
+
+
+def test_seeds_even_without_a_connector_credential() -> None:
+    """Seed paths come from the user's own ACL-filtered index read, so they
+    do not depend on any credential being lendable."""
+    with _run_mocks(token=None, seed_paths=["a.py"]) as inner:
+        _run(_tool())
+
+    assert inner.call_args.kwargs["seed_paths"] == ["a.py"]
+    assert inner.call_args.kwargs["github_token"] is None
+
+
+def test_lends_the_credential_only_when_the_gate_returns_one() -> None:
+    with _run_mocks(token="tok", seed_paths=[]) as inner:
+        _run(_tool())
+
+    assert inner.call_args.kwargs["github_token"] == "tok"
+
+
+def test_rejects_unparseable_repo() -> None:
+    tool = _tool()
+    with pytest.raises(ToolCallException):
+        tool.run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=CodingAgentToolOverrideKwargs(),
+            **{
+                CODING_AGENT_QUERY_KEY: "q",
+                CODING_AGENT_REPO_KEY: "not a repo at all",
+            },
+        )

--- a/backend/tests/unit/onyx/tools/test_coding_agent_seed_paths.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_seed_paths.py
@@ -1,0 +1,64 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
+
+from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
+    CodingAgentTool,
+)
+
+
+def _chunk(repo: str, path: Any) -> SimpleNamespace:
+    return SimpleNamespace(metadata={"repo": repo, "path": path})
+
+
+@contextmanager
+def _seed_path_mocks(chunks: list[SimpleNamespace]) -> Iterator[MagicMock]:
+    document_index = MagicMock()
+    document_index.keyword_retrieval.return_value = chunks
+    with (
+        patch(
+            "onyx.tools.tool_implementations.coding_agent.coding_agent_tool"
+            ".get_session_with_current_tenant"
+        ),
+        patch("onyx.db.search_settings.get_current_search_settings"),
+        patch(
+            "onyx.document_index.factory.get_default_document_index",
+            return_value=document_index,
+        ),
+    ):
+        yield document_index
+
+
+def test_seed_paths_filter_dedupe_and_cap() -> None:
+    chunks = [
+        _chunk("onyx-dot-app/onyx", "a.py"),
+        _chunk("other-org/other", "not-our-repo.py"),
+        _chunk("Onyx-Dot-App/Onyx", "b.py"),  # repo match is case-insensitive
+        _chunk("onyx-dot-app/onyx", "a.py"),  # duplicate path dropped
+        _chunk("onyx-dot-app/onyx", ["list.py"]),  # non-str path skipped
+        _chunk("onyx-dot-app/onyx", "c.py"),
+    ]
+    with _seed_path_mocks(chunks):
+        paths = CodingAgentTool._fetch_seed_paths(
+            "some query", "onyx-dot-app/onyx", limit=2
+        )
+    assert paths == ["a.py", "b.py"]
+
+
+def test_seed_paths_failure_degrades_to_empty() -> None:
+    with (
+        patch(
+            "onyx.tools.tool_implementations.coding_agent.coding_agent_tool"
+            ".get_session_with_current_tenant",
+            side_effect=RuntimeError("db down"),
+        ),
+    ):
+        paths = CodingAgentTool._fetch_seed_paths("query", "onyx-dot-app/onyx")
+    assert paths == []
+
+
+def test_seed_paths_unparseable_repo_degrades_to_empty() -> None:
+    with _seed_path_mocks([]):
+        paths = CodingAgentTool._fetch_seed_paths("query", "not a repo url %%%")
+    assert paths == []

--- a/backend/tests/unit/onyx/tools/test_coding_agent_seed_paths.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_seed_paths.py
@@ -3,13 +3,24 @@ from types import SimpleNamespace
 from typing import Any, Iterator
 from unittest.mock import MagicMock, patch
 
+from onyx.configs.constants import (
+    CODE_FILE_METADATA_TYPE,
+    CODE_FILE_PATH_KEY,
+    CODE_FILE_REPO_KEY,
+    CODE_FILE_TYPE_KEY,
+)
+from onyx.repo_archives.github import GitHubArchiveProvider
 from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
     CodingAgentTool,
 )
 
+ONYX_REPO = GitHubArchiveProvider.repo_ref("onyx-dot-app", "onyx")
+
 
 def _chunk(repo: str, path: Any) -> SimpleNamespace:
-    return SimpleNamespace(metadata={"repo": repo, "path": path})
+    return SimpleNamespace(
+        metadata={CODE_FILE_REPO_KEY: repo, CODE_FILE_PATH_KEY: path}
+    )
 
 
 @contextmanager
@@ -17,10 +28,6 @@ def _seed_path_mocks(chunks: list[SimpleNamespace]) -> Iterator[MagicMock]:
     document_index = MagicMock()
     document_index.keyword_retrieval.return_value = chunks
     with (
-        patch(
-            "onyx.tools.tool_implementations.coding_agent.coding_agent_tool"
-            ".get_session_with_current_tenant"
-        ),
         patch("onyx.db.search_settings.get_current_search_settings"),
         patch(
             "onyx.document_index.factory.get_default_document_index",
@@ -41,24 +48,28 @@ def test_seed_paths_filter_dedupe_and_cap() -> None:
     ]
     with _seed_path_mocks(chunks):
         paths = CodingAgentTool._fetch_seed_paths(
-            "some query", "onyx-dot-app/onyx", limit=2
+            MagicMock(), "some query", ONYX_REPO, limit=2
         )
     assert paths == ["a.py", "b.py"]
 
 
+def test_seed_paths_restrict_retrieval_to_code_files() -> None:
+    """PRs/issues/docs share the repo metadata key, so the index filter must
+    keep the retrieval budget on source-code chunks."""
+    with _seed_path_mocks([]) as document_index:
+        CodingAgentTool._fetch_seed_paths(MagicMock(), "query", ONYX_REPO)
+
+    filters = document_index.keyword_retrieval.call_args.kwargs["filters"]
+    assert filters.tags is not None
+    assert [(tag.tag_key, tag.tag_value) for tag in filters.tags] == [
+        (CODE_FILE_TYPE_KEY, CODE_FILE_METADATA_TYPE)
+    ]
+
+
 def test_seed_paths_failure_degrades_to_empty() -> None:
-    with (
-        patch(
-            "onyx.tools.tool_implementations.coding_agent.coding_agent_tool"
-            ".get_session_with_current_tenant",
-            side_effect=RuntimeError("db down"),
-        ),
+    with patch(
+        "onyx.db.search_settings.get_current_search_settings",
+        side_effect=RuntimeError("db down"),
     ):
-        paths = CodingAgentTool._fetch_seed_paths("query", "onyx-dot-app/onyx")
-    assert paths == []
-
-
-def test_seed_paths_unparseable_repo_degrades_to_empty() -> None:
-    with _seed_path_mocks([]):
-        paths = CodingAgentTool._fetch_seed_paths("query", "not a repo url %%%")
+        paths = CodingAgentTool._fetch_seed_paths(MagicMock(), "query", ONYX_REPO)
     assert paths == []

--- a/backend/tests/unit/onyx/tools/test_coding_agent_seed_paths.py
+++ b/backend/tests/unit/onyx/tools/test_coding_agent_seed_paths.py
@@ -14,7 +14,20 @@ from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
     CodingAgentTool,
 )
 
-ONYX_REPO = GitHubArchiveProvider.repo_ref("onyx-dot-app", "onyx")
+ONYX_REPO = GitHubArchiveProvider.repo_ref_from_url("onyx-dot-app/onyx")
+
+_ACCESS_FILTERS_FN = (
+    "onyx.context.search.preprocessing.access_filters.build_access_filters_for_user"
+)
+
+
+def _tool(user: Any = None) -> CodingAgentTool:
+    return CodingAgentTool(
+        tool_id=1,
+        emitter=MagicMock(),
+        llm=MagicMock(),
+        user=user if user is not None else MagicMock(),
+    )
 
 
 def _chunk(repo: str, path: Any) -> SimpleNamespace:
@@ -24,7 +37,9 @@ def _chunk(repo: str, path: Any) -> SimpleNamespace:
 
 
 @contextmanager
-def _seed_path_mocks(chunks: list[SimpleNamespace]) -> Iterator[MagicMock]:
+def _seed_path_mocks(
+    chunks: list[SimpleNamespace], acl: list[str] | None = None
+) -> Iterator[MagicMock]:
     document_index = MagicMock()
     document_index.keyword_retrieval.return_value = chunks
     with (
@@ -33,6 +48,7 @@ def _seed_path_mocks(chunks: list[SimpleNamespace]) -> Iterator[MagicMock]:
             "onyx.document_index.factory.get_default_document_index",
             return_value=document_index,
         ),
+        patch(_ACCESS_FILTERS_FN, return_value=acl if acl is not None else []),
     ):
         yield document_index
 
@@ -47,9 +63,7 @@ def test_seed_paths_filter_dedupe_and_cap() -> None:
         _chunk("onyx-dot-app/onyx", "c.py"),
     ]
     with _seed_path_mocks(chunks):
-        paths = CodingAgentTool._fetch_seed_paths(
-            MagicMock(), "some query", ONYX_REPO, limit=2
-        )
+        paths = _tool()._fetch_seed_paths(MagicMock(), "some query", ONYX_REPO, limit=2)
     assert paths == ["a.py", "b.py"]
 
 
@@ -57,7 +71,7 @@ def test_seed_paths_restrict_retrieval_to_code_files() -> None:
     """PRs/issues/docs share the repo metadata key, so the index filter must
     keep the retrieval budget on source-code chunks."""
     with _seed_path_mocks([]) as document_index:
-        CodingAgentTool._fetch_seed_paths(MagicMock(), "query", ONYX_REPO)
+        _tool()._fetch_seed_paths(MagicMock(), "query", ONYX_REPO)
 
     filters = document_index.keyword_retrieval.call_args.kwargs["filters"]
     assert filters.tags is not None
@@ -66,10 +80,25 @@ def test_seed_paths_restrict_retrieval_to_code_files() -> None:
     ]
 
 
+def test_seed_paths_apply_the_users_access_filters() -> None:
+    """Seeding is an ordinary index read. It must go through the same ACL as
+    every other tool, not a bypass justified by some other check."""
+    user = MagicMock()
+    db_session = MagicMock()
+
+    with _seed_path_mocks([], acl=["acl-entry"]) as document_index:
+        with patch(_ACCESS_FILTERS_FN, return_value=["acl-entry"]) as build_filters:
+            _tool(user)._fetch_seed_paths(db_session, "query", ONYX_REPO)
+
+    build_filters.assert_called_once_with(user, db_session)
+    filters = document_index.keyword_retrieval.call_args.kwargs["filters"]
+    assert filters.access_control_list == ["acl-entry"]
+
+
 def test_seed_paths_failure_degrades_to_empty() -> None:
     with patch(
         "onyx.db.search_settings.get_current_search_settings",
         side_effect=RuntimeError("db down"),
     ):
-        paths = CodingAgentTool._fetch_seed_paths(MagicMock(), "query", ONYX_REPO)
+        paths = _tool()._fetch_seed_paths(MagicMock(), "query", ONYX_REPO)
     assert paths == []


### PR DESCRIPTION
## Description

Part 10/10 of the code-indexing stack. Stacked on #14228.

- Tool-description steering: the LLM skips the coding agent for single-fact lookups the code index answers, and uses it for cross-file tracing and verification.
- Retrieval seeding: a fast keyword query over the code index injects the top file paths into the agent's first message. Seeding only runs for repos covered by an org-public connector pair — the seed query has no per-user ACL, so it is limited to org-visible docs.
- Allow the coding agent in deep research.

## How Has This Been Tested?

Unit tests for seed-path retrieval (filtering, dedup, failure degrades to unseeded). Live: 70-question eval — search runs first on all questions; the agent fires on cross-repo verification questions and skips simple lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
