### PR TITLE
fix(file-processing): honor Extract & Caption Images setting for docx/pptx

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -896,10 +896,19 @@ def _extract_text_and_images(
     # Default processing
     try:
         extension = get_file_ext(file_name)
+
+        # The "Extract & Caption Images" workspace setting gates *all* embedded
+        # image extraction, not just PDFs. Resolved once here so every
+        # image-bearing branch below agrees and we only hit the KV store once.
+        extract_images = get_image_extraction_and_analysis_enabled()
+
         # docx example for embedded images
         if extension == ".docx":
             text_content, images = read_docx_file(
-                file, file_name, extract_images=True, image_callback=image_callback
+                file,
+                file_name,
+                extract_images=extract_images,
+                image_callback=image_callback if extract_images else None,
             )
             return ExtractionResult(
                 text_content=text_content, embedded_images=images, metadata={}
@@ -911,8 +920,8 @@ def _extract_text_and_images(
             text_content, pdf_metadata, images = read_pdf_file(
                 file,
                 pdf_pass,
-                extract_images=get_image_extraction_and_analysis_enabled(),
-                image_callback=image_callback,
+                extract_images=extract_images,
+                image_callback=image_callback if extract_images else None,
             )
             return ExtractionResult(
                 text_content=text_content, embedded_images=images, metadata=pdf_metadata
@@ -920,7 +929,10 @@ def _extract_text_and_images(
 
         if extension == ".pptx":
             text_content, images = read_pptx_file(
-                file, file_name, extract_images=True, image_callback=image_callback
+                file,
+                file_name,
+                extract_images=extract_images,
+                image_callback=image_callback if extract_images else None,
             )
             return ExtractionResult(
                 text_content=text_content, embedded_images=images, metadata={}

--- a/backend/tests/unit/onyx/file_processing/test_extract_images_setting.py
+++ b/backend/tests/unit/onyx/file_processing/test_extract_images_setting.py
@@ -1,0 +1,191 @@
+"""Regression tests for the "Extract & Caption Images" workspace setting.
+
+`extract_text_and_images` is the extractor used by the file connector, which
+backs both connector indexing *and* chat/project file uploads. Every
+image-bearing branch in it must honour the workspace setting; previously only
+the PDF branch did, so a DOCX/PPTX uploaded in chat had its embedded images
+extracted and stored (and later captioned) even with the toggle off.
+
+The docx/pptx fixtures are built in-memory so these tests need no new binary
+fixtures: the docx is written with python-docx (already a hard dependency, and
+markitdown must be able to parse it for the text branch), and the pptx is a
+minimal zip since pptx image extraction just reads `ppt/media/*` out of it.
+"""
+
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from onyx.file_processing import extract_file_text as extract_file_text_module
+from onyx.file_processing.extract_file_text import extract_text_and_images
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _png_bytes(size: int = 32) -> bytes:
+    """A small but real PNG. Generated rather than hard-coded so python-docx's
+    image header parsing gets something genuinely valid."""
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (size, size), (200, 30, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _load_pdf() -> BytesIO:
+    return BytesIO((FIXTURES / "with_image.pdf").read_bytes())
+
+
+def _make_docx_with_image() -> BytesIO:
+    """A real docx containing one embedded image, built with python-docx.
+
+    Hand-rolling the zip is not enough here: markitdown parses the document for
+    the text half of the same call, so the package has to be well-formed.
+    """
+    import docx
+    from docx.shared import Inches
+
+    document = docx.Document()
+    document.add_paragraph("Hello docx")
+    document.add_picture(BytesIO(_png_bytes()), width=Inches(1))
+
+    buf = BytesIO()
+    document.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def _make_pptx_with_image() -> BytesIO:
+    """Minimal pptx containing one embedded image under ppt/media/."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(
+            "[Content_Types].xml",
+            '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org'
+            '/package/2006/content-types"><Default Extension="xml" ContentType='
+            '"application/xml"/><Default Extension="png" ContentType="image/png"/>'
+            "</Types>",
+        )
+        z.writestr(
+            "_rels/.rels",
+            '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats'
+            '.org/package/2006/relationships"/>',
+        )
+        z.writestr("ppt/media/image1.png", _png_bytes())
+    buf.seek(0)
+    return buf
+
+
+@pytest.fixture(autouse=True)
+def _no_unstructured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the Unstructured short-circuit out of the way."""
+    monkeypatch.setattr(
+        extract_file_text_module, "get_unstructured_api_key", lambda: None
+    )
+
+
+def _set_setting(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
+    monkeypatch.setattr(
+        extract_file_text_module,
+        "get_image_extraction_and_analysis_enabled",
+        lambda: enabled,
+    )
+
+
+# ── setting disabled: no images from any format ──────────────────────────
+
+
+class TestImageExtractionDisabled:
+    """With the toggle off, nothing image-bearing may come back — this is the
+    path a chat PDF/DOCX/PPTX upload takes via LocalFileConnector."""
+
+    def test_pdf_yields_no_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_setting(monkeypatch, False)
+        result = extract_text_and_images(_load_pdf(), "with_image.pdf")
+        assert result.embedded_images == []
+
+    def test_docx_yields_no_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_setting(monkeypatch, False)
+        result = extract_text_and_images(_make_docx_with_image(), "sample.docx")
+        assert result.embedded_images == []
+
+    def test_pptx_yields_no_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_setting(monkeypatch, False)
+        result = extract_text_and_images(_make_pptx_with_image(), "sample.pptx")
+        assert result.embedded_images == []
+
+    @pytest.mark.parametrize(
+        ("file_factory", "file_name"),
+        [
+            (_load_pdf, "with_image.pdf"),
+            (_make_docx_with_image, "sample.docx"),
+            (_make_pptx_with_image, "sample.pptx"),
+        ],
+    )
+    def test_image_callback_is_never_invoked(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        file_factory: Any,
+        file_name: str,
+    ) -> None:
+        """The streaming path must be suppressed too. Connectors pass a callback
+        that writes straight to the FileStore, so an un-gated callback would
+        persist images even though `embedded_images` comes back empty."""
+        _set_setting(monkeypatch, False)
+        collected: list[tuple[bytes, str]] = []
+
+        result = extract_text_and_images(
+            file_factory(),
+            file_name,
+            image_callback=lambda data, name: collected.append((data, name)),
+        )
+
+        assert collected == []
+        assert result.embedded_images == []
+
+    def test_text_extraction_is_unaffected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Disabling image extraction must not cost us the document text."""
+        _set_setting(monkeypatch, False)
+        result = extract_text_and_images(_load_pdf(), "with_image.pdf")
+        assert isinstance(result.text_content, str)
+
+
+# ── setting enabled: images still flow ───────────────────────────────────
+
+
+class TestImageExtractionEnabled:
+    def test_pdf_yields_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_setting(monkeypatch, True)
+        result = extract_text_and_images(_load_pdf(), "with_image.pdf")
+        assert len(result.embedded_images) >= 1
+
+    def test_docx_yields_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_setting(monkeypatch, True)
+        result = extract_text_and_images(_make_docx_with_image(), "sample.docx")
+        assert len(result.embedded_images) >= 1
+
+    def test_pptx_yields_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_setting(monkeypatch, True)
+        result = extract_text_and_images(_make_pptx_with_image(), "sample.pptx")
+        assert len(result.embedded_images) >= 1
+
+    def test_image_callback_still_streams(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_setting(monkeypatch, True)
+        collected: list[tuple[bytes, str]] = []
+
+        result = extract_text_and_images(
+            _load_pdf(),
+            "with_image.pdf",
+            image_callback=lambda data, name: collected.append((data, name)),
+        )
+
+        assert len(collected) >= 1
+        # Streaming mode returns an empty list by design.
+        assert result.embedded_images == []


### PR DESCRIPTION
## Problem

With **Extract & Caption Images** turned off in Index Settings, uploading a file in chat could still have its embedded images extracted and captioned.

`_extract_text_and_images` in `backend/onyx/file_processing/extract_file_text.py` only consulted the setting on the `.pdf` branch. The `.docx` and `.pptx` branches hardcoded `extract_images=True`:

```python
if extension == ".docx":
    text_content, images = read_docx_file(
        file, file_name, extract_images=True, image_callback=image_callback
    )
...
if extension == ".pdf":
    text_content, pdf_metadata, images = read_pdf_file(
        file, pdf_pass,
        extract_images=get_image_extraction_and_analysis_enabled(),  # only here
        image_callback=image_callback,
    )
...
if extension == ".pptx":
    text_content, images = read_pptx_file(
        file, file_name, extract_images=True, image_callback=image_callback
    )
```

This is most visible on chat/project file uploads. That path is:

`POST /user/file/upload` → `upload_files_to_user_files_with_indexing` → `PROCESS_SINGLE_USER_FILE` → `_load_user_file_documents` → `LocalFileConnector` → `_process_file` → **`extract_text_and_images`**

i.e. chat uploads share the exact extractor connectors use, so a DOCX/PPTX uploaded in chat had its images pulled out and written to the FileStore as `ImageSection`s even with the toggle off. Those sections then reach `process_image_sections`, which is where captioning happens.

## Fix

Resolve the setting once per call and apply it to every image-bearing branch.

The `image_callback` is suppressed as well when the setting is off. This matters: connectors pass a callback that writes each image straight to the FileStore, so leaving it wired up would still persist images even though `embedded_images` comes back empty (`read_*_file` returns an empty list whenever a callback is supplied).

Resolving once also drops the per-call KV-store lookups to one.

Text extraction is unchanged in every case — only embedded-image extraction is gated. A scanned/image-only PDF is still admitted at upload by the existing `image_extraction_enabled` check in `projects_file_utils.py`.

## Tests

New `backend/tests/unit/onyx/file_processing/test_extract_images_setting.py` covers PDF, DOCX and PPTX in both states:

- setting off → no images returned, and the streaming `image_callback` is never invoked (parametrized across all three formats)
- setting off → text extraction still works
- setting on → images still flow, callback still streams

Fixtures are built in-memory (python-docx for the DOCX so markitdown can parse it; a minimal zip for the PPTX), so no new binary fixtures are added.

Verified the tests fail on `main` and pass with this change:

```
# with the fix reverted
4 failed, 7 passed
  TestImageExtractionDisabled::test_docx_yields_no_images
  TestImageExtractionDisabled::test_pptx_yields_no_images
  TestImageExtractionDisabled::test_image_callback_is_never_invoked[docx]
  TestImageExtractionDisabled::test_image_callback_is_never_invoked[pptx]

# with the fix
11 passed
```

Existing suites still green (`test_pdf.py`, `test_pptx_to_text.py`, `test_detect_encoding.py` + the new file: **62 passed**). `ruff check`, `ruff format --check` and `mypy` clean on both files.

## Note / possible follow-up

Two adjacent gaps I did **not** change, since they're outside this fix's scope:

1. `projects_file_utils.py` counts embedded images for `.pdf`/`.docx` (`MAX_EMBEDDED_IMAGES_PER_FILE`) before the setting is consulted, so an image-heavy DOCX can still be rejected at upload for "too many embedded images" even when image extraction is off.
2. `_load_user_file_documents` builds `LocalFileConnector` directly, bypassing `instantiate_connector` and therefore the `set_allow_images(...)` hook in `connectors/factory.py`. Harmless today because `LocalFileConnector` doesn't implement that hook, but it's a latent inconsistency.

Happy to fold either in if you'd prefer them handled here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the “Extract & Caption Images” setting for `.docx` and `.pptx` uploads. Previously these formats always extracted and stored embedded images; now they only do so when the setting is on, matching `.pdf`. When off, `image_callback` is suppressed to prevent streaming persistence.

- Resolves the setting once per call in `extract_text_and_images` and applies it to `.pdf`, `.docx`, and `.pptx`; gates `image_callback` accordingly.
- Text extraction is unchanged; image-only PDFs are still admitted by the existing `image_extraction_enabled` check.
- Adds unit tests covering enabled/disabled states for all three formats; no new binary fixtures. 

**Follow-ups (not included)**
- Upload rejection for “too many embedded images” is computed before checking the setting for `.pdf`/`.docx`.
- Chat upload path builds `LocalFileConnector` directly and bypasses the `set_allow_images(...)` hook.

<sup>Written for commit ae5baf5c3f2ee263af42b3ae85df8f6a359d2434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

