### PR TITLE
feat(indexing): CodeSection model and tree-sitter code chunking

### DIFF
--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -47,7 +47,7 @@ from onyx.connectors.models import (
     ConnectorStopSignal,
     Document,
     HierarchyNode,
-    TextSection,
+    is_text_bearing,
 )
 from onyx.db.connector import mark_ccpair_with_indexing_trigger
 from onyx.db.connector_alerts import notify_admins_of_connector_alert
@@ -796,10 +796,7 @@ def connector_document_extraction(
 
                     doc_size = 0
                     for section in doc.sections:
-                        if (
-                            isinstance(section, TextSection)
-                            and section.text is not None
-                        ):
+                        if is_text_bearing(section) and section.text is not None:
                             doc_size += len(section.text)
 
                     if doc_size > INDEXING_SIZE_WARNING_THRESHOLD:

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -18,9 +18,8 @@ MASK_CREDENTIAL_LONG_RE = re.compile(r"^.{4}\.{3}.{4}$")
 
 SOURCE_TYPE = "source_type"
 
-# Document-metadata contract for source-code files. Connectors set these;
-# retrieval and the coding agent read them, so the keys live here rather than
-# under `connectors/` where retrieval would have to import across layers.
+# Document-metadata contract for source-code files. Here rather than under
+# `connectors/` so retrieval can read it without importing across layers.
 CODE_FILE_METADATA_TYPE = "CodeFile"
 CODE_FILE_TYPE_KEY = "type"
 CODE_FILE_LANGUAGE_KEY = "language"

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -17,6 +17,17 @@ MASK_CREDENTIAL_CHAR = "\u2022"
 MASK_CREDENTIAL_LONG_RE = re.compile(r"^.{4}\.{3}.{4}$")
 
 SOURCE_TYPE = "source_type"
+
+# Document-metadata contract for source-code files. Connectors set these;
+# retrieval and the coding agent read them, so the keys live here rather than
+# under `connectors/` where retrieval would have to import across layers.
+CODE_FILE_METADATA_TYPE = "CodeFile"
+CODE_FILE_TYPE_KEY = "type"
+CODE_FILE_LANGUAGE_KEY = "language"
+CODE_FILE_REPO_KEY = "repo"
+CODE_FILE_PATH_KEY = "path"
+CODE_FILE_BRANCH_KEY = "branch"
+CODE_FILE_COMMIT_SHA_KEY = "commit_sha"
 # stored in the `metadata` of a chunk. Used to signify that this chunk should
 # not be used for QA. For example, Google Drive file types which can't be parsed
 # are still useful as a search result but not for QA.
@@ -420,6 +431,7 @@ class FileOrigin(str, Enum):
     PLAINTEXT_CACHE = "plaintext_cache"
     OTHER = "other"
     QUERY_HISTORY_CSV = "query_history_csv"
+    REPO_ARCHIVE_CACHE = "repo_archive_cache"
     SANDBOX_SNAPSHOT = "sandbox_snapshot"
     SKILL_BUNDLE = "skill_bundle"
     USER_FILE = "user_file"

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -13,9 +13,8 @@ from pathlib import PurePosixPath
 SENSITIVE_FILE_LANGUAGES = frozenset({"dotenv", "pem"})
 
 # The grammar detector keys off the final extension, so it misses the names
-# secrets are usually stored under: `.env.local` and `.env.production` resolve
-# to no grammar at all, as do key files with no extension. Match the basename
-# instead, since that is what the convention is about.
+# secrets are stored under: `.env.local` and key files resolve to no grammar
+# at all. Match the basename, which is what the convention is about.
 SENSITIVE_FILE_PATTERNS = (
     ".env*",
     "*.env",

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -5,9 +5,40 @@ lives in `onyx.configs.constants`, so retrieval can read it without importing
 from `connectors`.
 """
 
+from fnmatch import fnmatch
+from pathlib import PurePosixPath
+
 # Grammars for text formats that commonly hold credentials (.env, .pem).
 # Never indexed, regardless of connector settings.
 SENSITIVE_FILE_LANGUAGES = frozenset({"dotenv", "pem"})
+
+# The grammar detector keys off the final extension, so it misses the names
+# secrets are usually stored under: `.env.local` and `.env.production` resolve
+# to no grammar at all, as do key files with no extension. Match the basename
+# instead, since that is what the convention is about.
+SENSITIVE_FILE_PATTERNS = (
+    ".env*",
+    "*.env",
+    "id_rsa*",
+    "id_dsa*",
+    "id_ecdsa*",
+    "id_ed25519*",
+    "*.key",
+    "*.pem",
+    "*.p12",
+    "*.pfx",
+    "*.jks",
+    "*.keystore",
+    "*.ppk",
+    "*_rsa",
+    "*_ed25519",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    ".pgpass",
+    "credentials",
+    "*.kdbx",
+)
 
 
 def _detect_language(file_path: str | None) -> str | None:
@@ -22,11 +53,18 @@ def _detect_language(file_path: str | None) -> str | None:
 
 
 def is_sensitive_code_file(file_path: str | None) -> bool:
-    """True when the path maps to a credential-holding format (.env, .pem).
+    """True when the path names a file that conventionally holds credentials.
 
     Checked at the chunker as well as in connectors, so directly-ingested
     CodeSections cannot bypass the exclusion via a supplied ``language``.
+    Matches the basename against SENSITIVE_FILE_PATTERNS, then falls back to
+    the grammar detector for formats it recognises by extension.
     """
+    if not file_path:
+        return False
+    basename = PurePosixPath(file_path.replace("\\", "/")).name.lower()
+    if any(fnmatch(basename, pattern) for pattern in SENSITIVE_FILE_PATTERNS):
+        return True
     return _detect_language(file_path) in SENSITIVE_FILE_LANGUAGES
 
 
@@ -40,7 +78,6 @@ def infer_code_language(file_path: str | None) -> str | None:
     must keep prose out of code indexing subtract their own document
     extensions (e.g. the GitHub connector's docs set) before calling this.
     """
-    language = _detect_language(file_path)
-    if language in SENSITIVE_FILE_LANGUAGES:
+    if is_sensitive_code_file(file_path):
         return None
-    return language
+    return _detect_language(file_path)

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -1,12 +1,24 @@
-"""Shared helpers for connectors that index source-code files."""
+"""Shared helpers for connectors that index source-code files.
 
-# Document-metadata `type` value connectors set on source-code file docs.
-# Retrieval recognizes code chunks by this alone.
-CODE_FILE_METADATA_TYPE = "CodeFile"
+The document-metadata contract these connectors write (`CODE_FILE_*` keys)
+lives in `onyx.configs.constants`, so retrieval can read it without importing
+from `connectors`.
+"""
 
 # Grammars for text formats that commonly hold credentials (.env, .pem).
 # Never indexed, regardless of connector settings.
 SENSITIVE_FILE_LANGUAGES = frozenset({"dotenv", "pem"})
+
+
+def _detect_language(file_path: str | None) -> str | None:
+    """Grammar name for a path, from tree-sitter-language-pack's extension
+    registry. None when the path is empty or the extension is unknown."""
+    if not file_path:
+        return None
+    # Local import: keeps the language pack off the connector import path.
+    from tree_sitter_language_pack import detect_language_from_path
+
+    return detect_language_from_path(file_path)
 
 
 def is_sensitive_code_file(file_path: str | None) -> bool:
@@ -15,18 +27,12 @@ def is_sensitive_code_file(file_path: str | None) -> bool:
     Checked at the chunker as well as in connectors, so directly-ingested
     CodeSections cannot bypass the exclusion via a supplied ``language``.
     """
-    if not file_path:
-        return False
-    # Local import: keeps the language pack off the connector import path.
-    from tree_sitter_language_pack import detect_language_from_path
-
-    return detect_language_from_path(file_path) in SENSITIVE_FILE_LANGUAGES
+    return _detect_language(file_path) in SENSITIVE_FILE_LANGUAGES
 
 
 def infer_code_language(file_path: str | None) -> str | None:
-    """Grammar name for a file path, from tree-sitter-language-pack's public
-    extension registry — so the name always matches a grammar the code
-    chunker can load. Returns None for unknown extensions and credential
+    """Grammar name for a file path — so the name always matches a grammar the
+    code chunker can load. Returns None for unknown extensions and credential
     formats.
 
     This is a grammar lookup, not a code-vs-prose judgment: prose formats
@@ -34,12 +40,7 @@ def infer_code_language(file_path: str | None) -> str | None:
     must keep prose out of code indexing subtract their own document
     extensions (e.g. the GitHub connector's docs set) before calling this.
     """
-    if not file_path:
-        return None
-    # Local import: keeps the language pack off the connector import path.
-    from tree_sitter_language_pack import detect_language_from_path
-
-    language = detect_language_from_path(file_path)
-    if language is None or language in SENSITIVE_FILE_LANGUAGES:
+    language = _detect_language(file_path)
+    if language in SENSITIVE_FILE_LANGUAGES:
         return None
     return language

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -1,0 +1,45 @@
+"""Shared helpers for connectors that index source-code files."""
+
+# Document-metadata `type` value connectors set on source-code file docs.
+# Retrieval recognizes code chunks by this alone.
+CODE_FILE_METADATA_TYPE = "CodeFile"
+
+# Grammars for text formats that commonly hold credentials (.env, .pem).
+# Never indexed, regardless of connector settings.
+SENSITIVE_FILE_LANGUAGES = frozenset({"dotenv", "pem"})
+
+
+def is_sensitive_code_file(file_path: str | None) -> bool:
+    """True when the path maps to a credential-holding format (.env, .pem).
+
+    Checked at the chunker as well as in connectors, so directly-ingested
+    CodeSections cannot bypass the exclusion via a supplied ``language``.
+    """
+    if not file_path:
+        return False
+    # Local import: keeps the language pack off the connector import path.
+    from tree_sitter_language_pack import detect_language_from_path
+
+    return detect_language_from_path(file_path) in SENSITIVE_FILE_LANGUAGES
+
+
+def infer_code_language(file_path: str | None) -> str | None:
+    """Grammar name for a file path, from tree-sitter-language-pack's public
+    extension registry — so the name always matches a grammar the code
+    chunker can load. Returns None for unknown extensions and credential
+    formats.
+
+    This is a grammar lookup, not a code-vs-prose judgment: prose formats
+    with grammars (e.g. .md -> markdown) return that grammar. Connectors that
+    must keep prose out of code indexing subtract their own document
+    extensions (e.g. the GitHub connector's docs set) before calling this.
+    """
+    if not file_path:
+        return None
+    # Local import: keeps the language pack off the connector import path.
+    from tree_sitter_language_pack import detect_language_from_path
+
+    language = detect_language_from_path(file_path)
+    if language is None or language in SENSITIVE_FILE_LANGUAGES:
+        return None
+    return language

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -40,9 +40,15 @@ SENSITIVE_FILE_PATTERNS = (
 )
 
 
-def _detect_language(file_path: str | None) -> str | None:
+def infer_code_language(file_path: str | None) -> str | None:
     """Grammar name for a path, from tree-sitter-language-pack's extension
-    registry. None when the path is empty or the extension is unknown."""
+    registry. None when the path is empty or the extension is unknown.
+
+    A grammar lookup, not a code-vs-prose judgment: prose formats with
+    grammars (e.g. .md -> markdown) return that grammar. Callers decide what
+    to exclude — connectors subtract their own document extensions, and both
+    connectors and the chunker call `is_sensitive_code_file` themselves.
+    """
     if not file_path:
         return None
     # Local import: keeps the language pack off the connector import path.
@@ -64,19 +70,4 @@ def is_sensitive_code_file(file_path: str | None) -> bool:
     basename = PurePosixPath(file_path.replace("\\", "/")).name.lower()
     if any(fnmatch(basename, pattern) for pattern in SENSITIVE_FILE_PATTERNS):
         return True
-    return _detect_language(file_path) in SENSITIVE_FILE_LANGUAGES
-
-
-def infer_code_language(file_path: str | None) -> str | None:
-    """Grammar name for a file path — so the name always matches a grammar the
-    code chunker can load. Returns None for unknown extensions and credential
-    formats.
-
-    This is a grammar lookup, not a code-vs-prose judgment: prose formats
-    with grammars (e.g. .md -> markdown) return that grammar. Connectors that
-    must keep prose out of code indexing subtract their own document
-    extensions (e.g. the GitHub connector's docs set) before calling this.
-    """
-    if is_sensitive_code_file(file_path):
-        return None
-    return _detect_language(file_path)
+    return infer_code_language(file_path) in SENSITIVE_FILE_LANGUAGES

--- a/backend/onyx/connectors/cross_connector_utils/section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/section_utils.py
@@ -1,14 +1,19 @@
 from onyx.configs.app_configs import CONNECTOR_MAX_EXTRACTED_TEXT_CHARS
-from onyx.connectors.models import ImageSection, TabularSection, TextSection
+from onyx.connectors.models import (
+    CodeSection,
+    ImageSection,
+    TabularSection,
+    TextSection,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
 def cap_sections_text(
-    sections: list[TextSection | ImageSection | TabularSection],
+    sections: list[TextSection | ImageSection | TabularSection | CodeSection],
     file_name: str | None,
-) -> list[TextSection | ImageSection | TabularSection]:
+) -> list[TextSection | ImageSection | TabularSection | CodeSection]:
     """Bound the total text retained per file to bound connector worker memory.
     Needed when a source can't be size-checked before fetch (e.g. Google-native
     files report no `size` metadata). A non-positive cap disables."""

--- a/backend/onyx/connectors/cross_connector_utils/section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/section_utils.py
@@ -1,19 +1,21 @@
+from typing import TypeVar
+
 from onyx.configs.app_configs import CONNECTOR_MAX_EXTRACTED_TEXT_CHARS
-from onyx.connectors.models import (
-    CodeSection,
-    ImageSection,
-    TabularSection,
-    TextSection,
-)
+from onyx.connectors.models import ImageSection, Section
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# Preserves the caller's section union: `list` is invariant, so a connector
+# that only builds text/image sections cannot pass a list typed for the full
+# document union.
+SectionT = TypeVar("SectionT", bound=Section)
+
 
 def cap_sections_text(
-    sections: list[TextSection | ImageSection | TabularSection | CodeSection],
+    sections: list[SectionT],
     file_name: str | None,
-) -> list[TextSection | ImageSection | TabularSection | CodeSection]:
+) -> list[SectionT]:
     """Bound the total text retained per file to bound connector worker memory.
     Needed when a source can't be size-checked before fetch (e.g. Google-native
     files report no `size` metadata). A non-positive cap disables."""

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -13,7 +13,11 @@ from onyx.configs.app_configs import (
     GITLAB_CONNECTOR_INCLUDE_CODE_FILES,
     INDEX_BATCH_SIZE,
 )
-from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import (
+    CODE_FILE_METADATA_TYPE,
+    CODE_FILE_TYPE_KEY,
+    DocumentSource,
+)
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.interfaces import (
     GenerateDocumentsOutput,
@@ -140,7 +144,7 @@ def _convert_code_to_document(
         semantic_identifier=file["name"],
         doc_updated_at=datetime.now().replace(tzinfo=timezone.utc),
         primary_owners=[],  # Add owners if needed
-        metadata={"type": "CodeFile"},
+        metadata={CODE_FILE_TYPE_KEY: CODE_FILE_METADATA_TYPE},
     )
     return doc
 

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -476,7 +476,7 @@ class IndexingDocument(Document):
             section_len = sum(
                 len(section.text) if section.text is not None else 0
                 for section in self.sections
-                if isinstance(section, (TextSection, TabularSection, CodeSection))
+                if is_text_bearing(section)
             )
 
         return title_len + section_len

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -120,7 +120,11 @@ TextBearingSection = TextSection | CodeSection
 
 
 def is_text_bearing(section: "Section") -> TypeGuard[TextBearingSection]:
-    """Sections whose content is a text string (extend when adding one)."""
+    """Sections whose content is a text string (extend when adding one).
+
+    TabularSection is deliberately excluded: its content is file-backed via
+    csv_file_id, so it carries no inline text to read.
+    """
     return isinstance(section, (TextSection, CodeSection))
 
 

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
-from typing import Any, Literal, cast
+from typing import Any, Literal, TypeGuard, cast
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -35,6 +35,7 @@ class SectionType(str, Enum):
     TEXT = "text"
     IMAGE = "image"
     TABULAR = "tabular"
+    CODE = "code"
 
 
 class Section(BaseModel):
@@ -94,6 +95,33 @@ class TabularSection(Section):
             self.csv_file_id, use_tempfile=True
         ) as raw:
             return raw.read().decode("utf-8", errors="replace")
+
+
+class CodeSection(Section):
+    """Source code from a repository file. Carries the language and the
+    repo-relative path so chunking can split at syntactic boundaries and
+    cite line ranges."""
+
+    type: Literal[SectionType.CODE] = SectionType.CODE
+    text: str
+    language: str | None = None
+    file_path: str | None = None
+
+    def __sizeof__(self) -> int:
+        return (
+            sys.getsizeof(self.text)
+            + sys.getsizeof(self.link)
+            + sys.getsizeof(self.language)
+            + sys.getsizeof(self.file_path)
+        )
+
+
+TextBearingSection = TextSection | CodeSection
+
+
+def is_text_bearing(section: "Section") -> TypeGuard[TextBearingSection]:
+    """Sections whose content is a text string (extend when adding one)."""
+    return isinstance(section, (TextSection, CodeSection))
 
 
 class BasicExpertInfo(BaseModel):
@@ -197,7 +225,7 @@ class DocumentBase(BaseModel):
     """Used for Onyx ingestion api, the ID is inferred before use if not provided"""
 
     id: str | None = None
-    sections: Sequence[TextSection | ImageSection | TabularSection]
+    sections: Sequence[TextSection | ImageSection | TabularSection | CodeSection]
     source: DocumentSource | None = None
     semantic_identifier: str  # displayed in the UI as the main identifier for the doc
     # TODO(andrei): Ideally we could improve this to where each value is just a
@@ -308,7 +336,7 @@ class DocumentBase(BaseModel):
         """
         parts = []
         for s in self.sections:
-            if isinstance(s, TextSection) and s.text:
+            if is_text_bearing(s) and s.text:
                 parts.append(s.text)
             elif isinstance(s, ImageSection) and s.image_file_id:
                 parts.append(f"[img:{s.image_file_id}]")
@@ -448,7 +476,7 @@ class IndexingDocument(Document):
             section_len = sum(
                 len(section.text) if section.text is not None else 0
                 for section in self.sections
-                if isinstance(section, (TextSection, TabularSection))
+                if isinstance(section, (TextSection, TabularSection, CodeSection))
             )
 
         return title_len + section_len

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
-from typing import Any, Literal, TypeGuard, cast
+from typing import Any, Literal, TypeAlias, TypeGuard, cast
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -115,6 +115,10 @@ class CodeSection(Section):
             + sys.getsizeof(self.file_path)
         )
 
+
+# Every section type a Document can carry. Named so the union has one
+# definition to extend when a new section type lands.
+DocumentSection: TypeAlias = TextSection | ImageSection | TabularSection | CodeSection
 
 TextBearingSection = TextSection | CodeSection
 
@@ -229,7 +233,7 @@ class DocumentBase(BaseModel):
     """Used for Onyx ingestion api, the ID is inferred before use if not provided"""
 
     id: str | None = None
-    sections: Sequence[TextSection | ImageSection | TabularSection | CodeSection]
+    sections: Sequence[DocumentSection]
     source: DocumentSource | None = None
     semantic_identifier: str  # displayed in the UI as the main identifier for the doc
     # TODO(andrei): Ideally we could improve this to where each value is just a

--- a/backend/onyx/file_store/document_batch_storage.py
+++ b/backend/onyx/file_store/document_batch_storage.py
@@ -121,9 +121,8 @@ class DocumentBatchStorage(ABC):
                     Document.model_validate(self._normalize_doc_dict(doc_dict))
                 )
             except ValidationError:
-                # Tolerate only the shapes a differently-versioned worker
-                # stages. Anything else is a real model error: raising keeps a
-                # bug from quietly indexing a short batch as a clean attempt.
+                # Anything but version skew is a real model error: raising
+                # keeps a bug from indexing a short batch as a clean attempt.
                 skip_reason = _skew_skip_reason(doc_dict)
                 if skip_reason is None:
                     raise

--- a/backend/onyx/file_store/document_batch_storage.py
+++ b/backend/onyx/file_store/document_batch_storage.py
@@ -4,7 +4,7 @@ from enum import Enum
 from io import StringIO
 from typing import List, Optional, TypeAlias
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from onyx.configs.constants import FileOrigin
 from onyx.connectors.models import (
@@ -18,32 +18,29 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+_KNOWN_SECTION_TYPES = frozenset(t.value for t in SectionType)
 
-def _has_legacy_tabular_section(doc_dict: dict) -> bool:
-    """True if a section is a pre-`csv_file_id` tabular section (inline text only).
-    Such a section was staged by an older docfetcher and the current file-backed-only
-    `TabularSection` can't validate it; during rolling-deploy skew we skip the doc
-    rather than fail the whole batch on `model_validate`."""
+
+def _skew_skip_reason(doc_dict: dict) -> str | None:
+    """Why a doc that failed validation looks like version skew, or None.
+
+    Rolling deploys mix worker versions in both directions: an older docfetcher
+    stages a pre-`csv_file_id` tabular section, a newer one stages a section
+    type this worker has no model for. Only consulted once validation has
+    already failed, so it decides how to react rather than what is valid.
+    """
     sections = doc_dict.get("sections")
     if not isinstance(sections, list):
-        return False
-    return any(
-        isinstance(s, dict) and s.get("type") == "tabular" and not s.get("csv_file_id")
-        for s in sections
-    )
-
-
-def _has_unknown_section_type(doc_dict: dict) -> bool:
-    """True if a section carries a `type` this worker's models don't know.
-    Such a doc was staged by a newer docfetcher during rolling-deploy skew;
-    we skip it rather than fail the whole batch on `model_validate`."""
-    known_types = {t.value for t in SectionType}
-    sections = doc_dict.get("sections")
-    if not isinstance(sections, list):
-        return False
-    return any(
-        isinstance(s, dict) and s.get("type") not in known_types for s in sections
-    )
+        return None
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        section_type = section.get("type")
+        if section_type == SectionType.TABULAR.value and not section.get("csv_file_id"):
+            return "a legacy inline tabular section (no csv_file_id)"
+        if section_type not in _KNOWN_SECTION_TYPES:
+            return f"an unknown section type ({section_type!r})"
+    return None
 
 
 class DocumentBatchStorageStateType(str, Enum):
@@ -119,23 +116,22 @@ class DocumentBatchStorage(ABC):
         doc_dicts = json.loads(data)
         documents: list[Document] = []
         for doc_dict in doc_dicts:
-            if _has_legacy_tabular_section(doc_dict):
-                logger.warning(
-                    "Skipping doc %s with a legacy inline tabular section "
-                    "(no csv_file_id); it re-indexes on the next attempt",
-                    doc_dict.get("id", "unknown"),
+            try:
+                documents.append(
+                    Document.model_validate(self._normalize_doc_dict(doc_dict))
                 )
-                continue
-            if _has_unknown_section_type(doc_dict):
+            except ValidationError:
+                # Tolerate only the shapes a differently-versioned worker
+                # stages. Anything else is a real model error: raising keeps a
+                # bug from quietly indexing a short batch as a clean attempt.
+                skip_reason = _skew_skip_reason(doc_dict)
+                if skip_reason is None:
+                    raise
                 logger.warning(
-                    "Skipping doc %s with an unknown section type (staged by a "
-                    "newer worker); it re-indexes on the next attempt",
+                    "Skipping doc %s with %s; it re-indexes on the next attempt",
                     doc_dict.get("id", "unknown"),
+                    skip_reason,
                 )
-                continue
-            documents.append(
-                Document.model_validate(self._normalize_doc_dict(doc_dict))
-            )
         return documents
 
     def _normalize_doc_dict(self, doc_dict: dict) -> dict:

--- a/backend/onyx/file_store/document_batch_storage.py
+++ b/backend/onyx/file_store/document_batch_storage.py
@@ -7,7 +7,12 @@ from typing import List, Optional, TypeAlias
 from pydantic import BaseModel
 
 from onyx.configs.constants import FileOrigin
-from onyx.connectors.models import DocExtractionContext, DocIndexingContext, Document
+from onyx.connectors.models import (
+    DocExtractionContext,
+    DocIndexingContext,
+    Document,
+    SectionType,
+)
 from onyx.file_store.file_store import FileStore, get_default_file_store
 from onyx.utils.logger import setup_logger
 
@@ -25,6 +30,19 @@ def _has_legacy_tabular_section(doc_dict: dict) -> bool:
     return any(
         isinstance(s, dict) and s.get("type") == "tabular" and not s.get("csv_file_id")
         for s in sections
+    )
+
+
+def _has_unknown_section_type(doc_dict: dict) -> bool:
+    """True if a section carries a `type` this worker's models don't know.
+    Such a doc was staged by a newer docfetcher during rolling-deploy skew;
+    we skip it rather than fail the whole batch on `model_validate`."""
+    known_types = {t.value for t in SectionType}
+    sections = doc_dict.get("sections")
+    if not isinstance(sections, list):
+        return False
+    return any(
+        isinstance(s, dict) and s.get("type") not in known_types for s in sections
     )
 
 
@@ -105,6 +123,13 @@ class DocumentBatchStorage(ABC):
                 logger.warning(
                     "Skipping doc %s with a legacy inline tabular section "
                     "(no csv_file_id); it re-indexes on the next attempt",
+                    doc_dict.get("id", "unknown"),
+                )
+                continue
+            if _has_unknown_section_type(doc_dict):
+                logger.warning(
+                    "Skipping doc %s with an unknown section type (staged by a "
+                    "newer worker); it re-indexes on the next attempt",
                     doc_dict.get("id", "unknown"),
                 )
                 continue

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -17,7 +17,7 @@ from onyx.indexing.chunking.section_chunker import (
 )
 from onyx.natural_language_processing.utils import BaseTokenizer, count_tokens
 from onyx.utils.logger import setup_logger
-from onyx.utils.text_processing import clean_text
+from onyx.utils.text_processing import clean_code_text
 
 logger = setup_logger()
 
@@ -68,7 +68,7 @@ class CodeChunker(SectionChunker):
                 accumulator=AccumulatorState(),
             )
 
-        section_text = clean_text(section.text)
+        section_text = clean_code_text(section.text)
         section_link = section.link or ""
         language = section.language or infer_code_language(section.file_path)
 

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -1,0 +1,196 @@
+from typing import Any, cast
+
+from onyx.connectors.cross_connector_utils.code_file_utils import (
+    infer_code_language,
+    is_sensitive_code_file,
+)
+from onyx.connectors.models import CodeSection, Section
+from onyx.indexing.chunking.section_chunker import (
+    AccumulatorState,
+    ChunkPayload,
+    SectionChunker,
+    SectionChunkerOutput,
+)
+from onyx.natural_language_processing.utils import (
+    BaseTokenizer,
+    count_tokens,
+    split_text_by_tokens,
+)
+from onyx.utils.logger import setup_logger
+from onyx.utils.text_processing import clean_text
+
+logger = setup_logger()
+
+# Language passed to chonkie's CodeChunker when we cannot name one; magika
+# then detects the language from the content itself.
+_AUTO_LANGUAGE = "auto"
+
+
+def _line_anchored_link(link: str, start_line: int, end_line: int) -> str:
+    """Append a line-range fragment to a code file link (GitHub-style anchors)."""
+    if not link or "#" in link:
+        return link
+    if start_line == end_line:
+        return f"{link}#L{start_line}"
+    return f"{link}#L{start_line}-L{end_line}"
+
+
+class CodeChunker(SectionChunker):
+    """Chunks CodeSections at syntactic boundaries via chonkie's tree-sitter
+    CodeChunker. Falls back to token-based splitting when the language cannot
+    be parsed. Code never merges with buffered prose from other sections."""
+
+    def __init__(self, tokenizer: BaseTokenizer) -> None:
+        self.tokenizer = tokenizer
+        # One chonkie splitter per language, stored with the token budget it
+        # was built for. The budget varies per document (title/metadata
+        # deductions), so a mismatched entry is rebuilt; keying by language
+        # alone keeps the cache bounded.
+        self._splitters: dict[str, tuple[int, Any]] = {}
+
+    def chunk_section(
+        self,
+        section: Section,
+        accumulator: AccumulatorState,
+        content_token_limit: int,
+    ) -> SectionChunkerOutput:
+        assert isinstance(section, CodeSection)
+
+        # Enforced here, not only in connectors: sections can arrive from the
+        # ingestion API with any path/language, and a supplied language must
+        # not bypass the credential-format exclusion.
+        if is_sensitive_code_file(section.file_path):
+            logger.warning(
+                "Refusing to chunk sensitive code file %s; section dropped",
+                section.file_path,
+            )
+            return SectionChunkerOutput(
+                payloads=accumulator.flush_to_list(),
+                accumulator=AccumulatorState(),
+            )
+
+        section_text = clean_text(section.text)
+        section_link = section.link or ""
+        language = section.language or infer_code_language(section.file_path)
+
+        # Flush any buffered prose — code chunks stay pure code.
+        payloads = accumulator.flush_to_list()
+        payloads.extend(
+            self._chunk_code(
+                section_text=section_text,
+                section_link=section_link,
+                language=language,
+                content_token_limit=content_token_limit,
+            )
+        )
+
+        return SectionChunkerOutput(
+            payloads=payloads,
+            accumulator=AccumulatorState(),
+        )
+
+    def _chunk_code(
+        self,
+        section_text: str,
+        section_link: str,
+        language: str | None,
+        content_token_limit: int,
+    ) -> list[ChunkPayload]:
+        def make_payload(text: str, link: str, is_continuation: bool) -> ChunkPayload:
+            return ChunkPayload(
+                text=text,
+                links={0: link},
+                is_continuation=is_continuation,
+                # Sentence-based mini-chunks cut code mid-statement.
+                skip_mini_chunks=True,
+            )
+
+        if count_tokens(section_text, self.tokenizer) <= content_token_limit:
+            return [make_payload(section_text, section_link, is_continuation=False)]
+
+        try:
+            spans = self._split_at_syntax_boundaries(
+                section_text, language, content_token_limit
+            )
+        except Exception:
+            logger.warning(
+                "Syntax-aware code chunking failed for language=%s; "
+                "falling back to token splitting",
+                language,
+                exc_info=True,
+            )
+            spans = None
+
+        if spans is None:
+            texts = split_text_by_tokens(
+                section_text, self.tokenizer, content_token_limit
+            )
+            return [
+                make_payload(text, section_link, is_continuation=(i != 0))
+                for i, text in enumerate(texts)
+            ]
+
+        payloads: list[ChunkPayload] = []
+        for i, (text, start_line, end_line) in enumerate(spans):
+            link = _line_anchored_link(section_link, start_line, end_line)
+            # A single syntax node can exceed the budget (e.g. a giant
+            # literal); hard-split it so the embedder never truncates.
+            if count_tokens(text, self.tokenizer) > content_token_limit:
+                payloads.extend(
+                    make_payload(small_text, link, is_continuation=(i != 0 or j != 0))
+                    for j, small_text in enumerate(
+                        split_text_by_tokens(text, self.tokenizer, content_token_limit)
+                    )
+                )
+            else:
+                payloads.append(make_payload(text, link, is_continuation=(i != 0)))
+        return payloads
+
+    def _split_at_syntax_boundaries(
+        self,
+        section_text: str,
+        language: str | None,
+        content_token_limit: int,
+    ) -> list[tuple[str, int, int]] | None:
+        """Split at tree-sitter node boundaries. Returns (text, start_line,
+        end_line) per chunk, or None if the language is unsupported."""
+        # Local import: pulls in tree-sitter language packs.
+        from chonkie import CodeChunker as ChonkieCodeChunker
+
+        language_key = language or _AUTO_LANGUAGE
+        cached = self._splitters.get(language_key)
+        splitter = (
+            cached[1]
+            if cached is not None and cached[0] == content_token_limit
+            else None
+        )
+        if splitter is None:
+            try:
+                splitter = ChonkieCodeChunker(
+                    tokenizer_or_token_counter=(
+                        lambda text: len(self.tokenizer.encode(text))
+                    ),
+                    chunk_size=content_token_limit,
+                    language=language_key,
+                    return_type="chunks",
+                )
+            except Exception:
+                logger.warning(
+                    "No tree-sitter grammar for language=%s; "
+                    "falling back to token splitting",
+                    language,
+                )
+                return None
+            self._splitters[language_key] = (content_token_limit, splitter)
+
+        chunks = cast(list[Any], splitter.chunk(section_text))
+        spans: list[tuple[str, int, int]] = []
+        for chunk in chunks:
+            if not chunk.text.strip():
+                continue
+            # Anchor to the first real code line, past any leading newlines.
+            leading = len(chunk.text) - len(chunk.text.lstrip("\n"))
+            start_line = section_text.count("\n", 0, chunk.start_index + leading) + 1
+            end_line = start_line + chunk.text.strip("\n").count("\n")
+            spans.append((chunk.text, start_line, end_line))
+        return spans

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -1,4 +1,7 @@
-from typing import Any, cast
+from typing import cast
+
+from chonkie import CodeChunker as ChonkieCodeChunker
+from tree_sitter_language_pack import has_language
 
 from onyx.connectors.cross_connector_utils.code_file_utils import (
     infer_code_language,
@@ -10,20 +13,13 @@ from onyx.indexing.chunking.section_chunker import (
     ChunkPayload,
     SectionChunker,
     SectionChunkerOutput,
+    build_payloads,
 )
-from onyx.natural_language_processing.utils import (
-    BaseTokenizer,
-    count_tokens,
-    split_text_by_tokens,
-)
+from onyx.natural_language_processing.utils import BaseTokenizer, count_tokens
 from onyx.utils.logger import setup_logger
 from onyx.utils.text_processing import clean_text
 
 logger = setup_logger()
-
-# Language passed to chonkie's CodeChunker when we cannot name one; magika
-# then detects the language from the content itself.
-_AUTO_LANGUAGE = "auto"
 
 
 def _line_anchored_link(link: str, start_line: int, end_line: int) -> str:
@@ -46,7 +42,7 @@ class CodeChunker(SectionChunker):
         # was built for. The budget varies per document (title/metadata
         # deductions), so a mismatched entry is rebuilt; keying by language
         # alone keeps the cache bounded.
-        self._splitters: dict[str, tuple[int, Any]] = {}
+        self._splitters: dict[str, tuple[int, ChonkieCodeChunker]] = {}
 
     def chunk_section(
         self,
@@ -54,7 +50,10 @@ class CodeChunker(SectionChunker):
         accumulator: AccumulatorState,
         content_token_limit: int,
     ) -> SectionChunkerOutput:
-        assert isinstance(section, CodeSection)
+        if not isinstance(section, CodeSection):
+            raise ValueError(
+                f"CodeChunker received a non-code section: {type(section).__name__}"
+            )
 
         # Enforced here, not only in connectors: sections can arrive from the
         # ingestion API with any path/language, and a supplied language must
@@ -96,17 +95,21 @@ class CodeChunker(SectionChunker):
         language: str | None,
         content_token_limit: int,
     ) -> list[ChunkPayload]:
-        def make_payload(text: str, link: str, is_continuation: bool) -> ChunkPayload:
-            return ChunkPayload(
+        def code_payloads(
+            text: str, link: str, is_continuation: bool
+        ) -> list[ChunkPayload]:
+            return build_payloads(
                 text=text,
-                links={0: link},
+                link=link,
+                tokenizer=self.tokenizer,
+                content_token_limit=content_token_limit,
                 is_continuation=is_continuation,
                 # Sentence-based mini-chunks cut code mid-statement.
                 skip_mini_chunks=True,
             )
 
         if count_tokens(section_text, self.tokenizer) <= content_token_limit:
-            return [make_payload(section_text, section_link, is_continuation=False)]
+            return code_payloads(section_text, section_link, is_continuation=False)
 
         try:
             spans = self._split_at_syntax_boundaries(
@@ -122,28 +125,19 @@ class CodeChunker(SectionChunker):
             spans = None
 
         if spans is None:
-            texts = split_text_by_tokens(
-                section_text, self.tokenizer, content_token_limit
-            )
-            return [
-                make_payload(text, section_link, is_continuation=(i != 0))
-                for i, text in enumerate(texts)
-            ]
+            return code_payloads(section_text, section_link, is_continuation=False)
 
         payloads: list[ChunkPayload] = []
         for i, (text, start_line, end_line) in enumerate(spans):
-            link = _line_anchored_link(section_link, start_line, end_line)
             # A single syntax node can exceed the budget (e.g. a giant
-            # literal); hard-split it so the embedder never truncates.
-            if count_tokens(text, self.tokenizer) > content_token_limit:
-                payloads.extend(
-                    make_payload(small_text, link, is_continuation=(i != 0 or j != 0))
-                    for j, small_text in enumerate(
-                        split_text_by_tokens(text, self.tokenizer, content_token_limit)
-                    )
+            # literal); build_payloads hard-splits it.
+            payloads.extend(
+                code_payloads(
+                    text,
+                    _line_anchored_link(section_link, start_line, end_line),
+                    is_continuation=(i != 0),
                 )
-            else:
-                payloads.append(make_payload(text, link, is_continuation=(i != 0)))
+            )
         return payloads
 
     def _split_at_syntax_boundaries(
@@ -153,44 +147,63 @@ class CodeChunker(SectionChunker):
         content_token_limit: int,
     ) -> list[tuple[str, int, int]] | None:
         """Split at tree-sitter node boundaries. Returns (text, start_line,
-        end_line) per chunk, or None if the language is unsupported."""
-        # Local import: pulls in tree-sitter language packs.
-        from chonkie import CodeChunker as ChonkieCodeChunker
+        end_line) per chunk, or None when no grammar is available."""
+        if language is None:
+            return None
 
-        language_key = language or _AUTO_LANGUAGE
-        cached = self._splitters.get(language_key)
-        splitter = (
-            cached[1]
-            if cached is not None and cached[0] == content_token_limit
-            else None
-        )
+        splitter = self._get_splitter(language, content_token_limit)
         if splitter is None:
-            try:
-                splitter = ChonkieCodeChunker(
-                    tokenizer_or_token_counter=(
-                        lambda text: len(self.tokenizer.encode(text))
-                    ),
-                    chunk_size=content_token_limit,
-                    language=language_key,
-                    return_type="chunks",
-                )
-            except Exception:
-                logger.warning(
-                    "No tree-sitter grammar for language=%s; "
-                    "falling back to token splitting",
-                    language,
-                )
-                return None
-            self._splitters[language_key] = (content_token_limit, splitter)
+            return None
 
-        chunks = cast(list[Any], splitter.chunk(section_text))
+        # chonkie's chunk texts are contiguous and reconstruct the input
+        # exactly, so one running line counter covers the whole file.
+        # (CodeChunk carries start_line/end_line fields, but chonkie never
+        # populates them.)
+        texts = cast(list[str], splitter.chunk(section_text))
         spans: list[tuple[str, int, int]] = []
-        for chunk in chunks:
-            if not chunk.text.strip():
-                continue
-            # Anchor to the first real code line, past any leading newlines.
-            leading = len(chunk.text) - len(chunk.text.lstrip("\n"))
-            start_line = section_text.count("\n", 0, chunk.start_index + leading) + 1
-            end_line = start_line + chunk.text.strip("\n").count("\n")
-            spans.append((chunk.text, start_line, end_line))
+        line = 1
+        for text in texts:
+            if text.strip():
+                # Anchor to the first real code line, past any leading newlines.
+                start_line = line + len(text) - len(text.lstrip("\n"))
+                end_line = start_line + text.strip("\n").count("\n")
+                spans.append((text, start_line, end_line))
+            line += text.count("\n")
         return spans
+
+    def _get_splitter(
+        self, language: str, content_token_limit: int
+    ) -> ChonkieCodeChunker | None:
+        """Cached chonkie splitter for a language, or None when its grammar is
+        unavailable."""
+        cached = self._splitters.get(language)
+        if cached is not None and cached[0] == content_token_limit:
+            return cached[1]
+
+        if not has_language(language):
+            logger.info(
+                "No tree-sitter grammar named %s; falling back to token splitting",
+                language,
+            )
+            return None
+
+        try:
+            splitter = ChonkieCodeChunker(
+                tokenizer_or_token_counter=(
+                    lambda text: len(self.tokenizer.encode(text))
+                ),
+                chunk_size=content_token_limit,
+                language=language,
+                return_type="texts",
+            )
+        except Exception:
+            logger.warning(
+                "Could not load the tree-sitter grammar for language=%s; "
+                "falling back to token splitting.",
+                language,
+                exc_info=True,
+            )
+            return None
+
+        self._splitters[language] = (content_token_limit, splitter)
+        return splitter

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import NamedTuple, cast
 
 from chonkie import CodeChunker as ChonkieCodeChunker
 from tree_sitter_language_pack import has_language
@@ -22,6 +22,20 @@ from onyx.utils.text_processing import clean_code_text
 logger = setup_logger()
 
 
+class _CachedSplitter(NamedTuple):
+    """A splitter and the token budget it was built for. The budget varies per
+    document, so an entry built for a different one is rebuilt."""
+
+    token_limit: int
+    splitter: ChonkieCodeChunker
+
+
+def _line_range(text: str, first_line: int) -> tuple[int, int]:
+    """Lines `text` spans, starting from its first non-blank line."""
+    start = first_line + len(text) - len(text.lstrip("\n"))
+    return start, start + text.strip("\n").count("\n")
+
+
 def _line_anchored_link(link: str, start_line: int, end_line: int) -> str:
     """Append a line-range fragment to a code file link (GitHub-style anchors)."""
     if not link or "#" in link:
@@ -38,11 +52,7 @@ class CodeChunker(SectionChunker):
 
     def __init__(self, tokenizer: BaseTokenizer) -> None:
         self.tokenizer = tokenizer
-        # One chonkie splitter per language, stored with the token budget it
-        # was built for. The budget varies per document (title/metadata
-        # deductions), so a mismatched entry is rebuilt; keying by language
-        # alone keeps the cache bounded.
-        self._splitters: dict[str, tuple[int, ChonkieCodeChunker]] = {}
+        self._splitters: dict[str, _CachedSplitter] = {}
 
     def chunk_section(
         self,
@@ -55,9 +65,8 @@ class CodeChunker(SectionChunker):
                 f"CodeChunker received a non-code section: {type(section).__name__}"
             )
 
-        # Enforced here, not only in connectors: sections can arrive from the
-        # ingestion API with any path/language, and a supplied language must
-        # not bypass the credential-format exclusion.
+        # Also enforced in connectors, but sections can arrive from the
+        # ingestion API with any path or language.
         if is_sensitive_code_file(section.file_path):
             logger.warning(
                 "Refusing to chunk sensitive code file %s; section dropped",
@@ -72,7 +81,6 @@ class CodeChunker(SectionChunker):
         section_link = section.link or ""
         language = section.language or infer_code_language(section.file_path)
 
-        # Flush any buffered prose — code chunks stay pure code.
         payloads = accumulator.flush_to_list()
         payloads.extend(
             self._chunk_code(
@@ -129,8 +137,8 @@ class CodeChunker(SectionChunker):
 
         payloads: list[ChunkPayload] = []
         for i, (text, start_line, end_line) in enumerate(spans):
-            # A single syntax node can exceed the budget (e.g. a giant
-            # literal); build_payloads hard-splits it.
+            # A single syntax node can exceed the budget; build_payloads
+            # hard-splits it.
             payloads.extend(
                 code_payloads(
                     text,
@@ -155,19 +163,14 @@ class CodeChunker(SectionChunker):
         if splitter is None:
             return None
 
-        # chonkie's chunk texts are contiguous and reconstruct the input
-        # exactly, so one running line counter covers the whole file.
-        # (CodeChunk carries start_line/end_line fields, but chonkie never
-        # populates them.)
+        # chonkie's chunks reconstruct the input exactly, so a running counter
+        # tracks lines. Its CodeChunk.start_line is never populated.
         texts = cast(list[str], splitter.chunk(section_text))
         spans: list[tuple[str, int, int]] = []
         line = 1
         for text in texts:
             if text.strip():
-                # Anchor to the first real code line, past any leading newlines.
-                start_line = line + len(text) - len(text.lstrip("\n"))
-                end_line = start_line + text.strip("\n").count("\n")
-                spans.append((text, start_line, end_line))
+                spans.append((text, *_line_range(text, line)))
             line += text.count("\n")
         return spans
 
@@ -177,8 +180,8 @@ class CodeChunker(SectionChunker):
         """Cached chonkie splitter for a language, or None when its grammar is
         unavailable."""
         cached = self._splitters.get(language)
-        if cached is not None and cached[0] == content_token_limit:
-            return cached[1]
+        if cached is not None and cached.token_limit == content_token_limit:
+            return cached.splitter
 
         if not has_language(language):
             logger.info(
@@ -205,5 +208,5 @@ class CodeChunker(SectionChunker):
             )
             return None
 
-        self._splitters[language] = (content_token_limit, splitter)
+        self._splitters[language] = _CachedSplitter(content_token_limit, splitter)
         return splitter

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -22,6 +22,15 @@ from onyx.utils.text_processing import clean_code_text
 logger = setup_logger()
 
 
+class _CodeSpan(NamedTuple):
+    """One syntax-bounded slice of a code section, and the 1-based line range
+    it occupies in that section."""
+
+    text: str
+    start_line: int
+    end_line: int
+
+
 class _CachedSplitter(NamedTuple):
     """A splitter and the token budget it was built for. The budget varies per
     document, so an entry built for a different one is rebuilt."""
@@ -136,13 +145,13 @@ class CodeChunker(SectionChunker):
             return code_payloads(section_text, section_link, is_continuation=False)
 
         payloads: list[ChunkPayload] = []
-        for i, (text, start_line, end_line) in enumerate(spans):
+        for i, span in enumerate(spans):
             # A single syntax node can exceed the budget; build_payloads
             # hard-splits it.
             payloads.extend(
                 code_payloads(
-                    text,
-                    _line_anchored_link(section_link, start_line, end_line),
+                    span.text,
+                    _line_anchored_link(section_link, span.start_line, span.end_line),
                     is_continuation=(i != 0),
                 )
             )
@@ -153,9 +162,9 @@ class CodeChunker(SectionChunker):
         section_text: str,
         language: str | None,
         content_token_limit: int,
-    ) -> list[tuple[str, int, int]] | None:
-        """Split at tree-sitter node boundaries. Returns (text, start_line,
-        end_line) per chunk, or None when no grammar is available."""
+    ) -> list[_CodeSpan] | None:
+        """Split at tree-sitter node boundaries, or None when no grammar is
+        available."""
         if language is None:
             return None
 
@@ -163,14 +172,18 @@ class CodeChunker(SectionChunker):
         if splitter is None:
             return None
 
+        # chunk() returns list[CodeChunk] | list[str] depending on the
+        # return_type passed to the constructor, which the signature cannot
+        # express. _get_splitter always builds with return_type="texts".
+        texts = cast(list[str], splitter.chunk(section_text))
+
         # chonkie's chunks reconstruct the input exactly, so a running counter
         # tracks lines. Its CodeChunk.start_line is never populated.
-        texts = cast(list[str], splitter.chunk(section_text))
-        spans: list[tuple[str, int, int]] = []
+        spans: list[_CodeSpan] = []
         line = 1
         for text in texts:
             if text.strip():
-                spans.append((text, *_line_range(text, line)))
+                spans.append(_CodeSpan(text, *_line_range(text, line)))
             line += text.count("\n")
         return spans
 

--- a/backend/onyx/indexing/chunking/document_chunker.py
+++ b/backend/onyx/indexing/chunking/document_chunker.py
@@ -91,8 +91,6 @@ class DocumentChunker:
         payloads: list[ChunkPayload] = []
 
         for section_idx, section in enumerate(sections):
-            # Code keeps its punctuation and emoji: they are meaningful in
-            # literals, and the indexed text should match the linked file.
             cleaner = (
                 clean_code_text if isinstance(section, CodeSection) else clean_text
             )

--- a/backend/onyx/indexing/chunking/document_chunker.py
+++ b/backend/onyx/indexing/chunking/document_chunker.py
@@ -1,6 +1,7 @@
 from chonkie import SentenceChunker
 
 from onyx.connectors.models import (
+    CodeSection,
     IndexingDocument,
     Section,
     SectionType,
@@ -18,7 +19,7 @@ from onyx.indexing.chunking.text_section_chunker import TextChunker
 from onyx.indexing.models import DocAwareChunk
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.utils.logger import setup_logger
-from onyx.utils.text_processing import clean_text
+from onyx.utils.text_processing import clean_code_text, clean_text
 
 logger = setup_logger()
 
@@ -90,7 +91,12 @@ class DocumentChunker:
         payloads: list[ChunkPayload] = []
 
         for section_idx, section in enumerate(sections):
-            section_text = clean_text(str(section.text or ""))
+            # Code keeps its punctuation and emoji: they are meaningful in
+            # literals, and the indexed text should match the linked file.
+            cleaner = (
+                clean_code_text if isinstance(section, CodeSection) else clean_text
+            )
+            section_text = cleaner(str(section.text or ""))
             # File-backed tabular sections hold their content in csv_file_id, not
             # text, so they look empty here — keep them for the tabular chunker.
             is_file_backed = (

--- a/backend/onyx/indexing/chunking/document_chunker.py
+++ b/backend/onyx/indexing/chunking/document_chunker.py
@@ -6,6 +6,7 @@ from onyx.connectors.models import (
     SectionType,
     TabularSection,
 )
+from onyx.indexing.chunking.code_section_chunker import CodeChunker
 from onyx.indexing.chunking.image_section_chunker import ImageChunker
 from onyx.indexing.chunking.section_chunker import (
     AccumulatorState,
@@ -45,6 +46,7 @@ class DocumentChunker:
             ),
             SectionType.IMAGE: ImageChunker(),
             SectionType.TABULAR: TabularChunker(tokenizer=tokenizer),
+            SectionType.CODE: CodeChunker(tokenizer=tokenizer),
         }
 
     def chunk(

--- a/backend/onyx/indexing/chunking/section_chunker.py
+++ b/backend/onyx/indexing/chunking/section_chunker.py
@@ -7,6 +7,11 @@ from pydantic import BaseModel, Field
 
 from onyx.connectors.models import IndexingDocument, Section
 from onyx.indexing.models import DocAwareChunk
+from onyx.natural_language_processing.utils import (
+    BaseTokenizer,
+    count_tokens,
+    split_text_by_tokens,
+)
 
 
 def extract_blurb(text: str, blurb_splitter: SentenceChunker) -> str:
@@ -71,6 +76,41 @@ class ChunkPayload(BaseModel):
             chunk_context="",
             contextual_rag_reserved_tokens=0,
         )
+
+
+def build_payloads(
+    text: str,
+    link: str,
+    tokenizer: BaseTokenizer,
+    content_token_limit: int,
+    *,
+    is_continuation: bool = False,
+    enforce_token_limit: bool = True,
+    reset_continuation_on_split: bool = False,
+    skip_mini_chunks: bool = False,
+) -> list[ChunkPayload]:
+    """Payloads for one piece of section text, hard-split by tokens when it
+    exceeds the budget so the embedder never truncates.
+
+    `is_continuation` marks the first payload; the rest always continue.
+    `reset_continuation_on_split` instead marks the first hard-split piece as a
+    fresh chunk, which is what the text chunker has always done.
+    """
+    texts = [text]
+    if enforce_token_limit and count_tokens(text, tokenizer) > content_token_limit:
+        texts = split_text_by_tokens(text, tokenizer, content_token_limit)
+        if reset_continuation_on_split:
+            is_continuation = False
+
+    return [
+        ChunkPayload(
+            text=piece,
+            links={0: link},
+            is_continuation=is_continuation or i != 0,
+            skip_mini_chunks=skip_mini_chunks,
+        )
+        for i, piece in enumerate(texts)
+    ]
 
 
 class AccumulatorState(BaseModel):

--- a/backend/onyx/indexing/chunking/section_chunker.py
+++ b/backend/onyx/indexing/chunking/section_chunker.py
@@ -37,6 +37,8 @@ class ChunkPayload(BaseModel):
     links: dict[int, str]
     is_continuation: bool = False
     image_file_id: str | None = None
+    # Set by chunkers whose content doesn't split on sentence boundaries.
+    skip_mini_chunks: bool = False
 
     def to_doc_aware_chunk(
         self,
@@ -59,7 +61,11 @@ class ChunkPayload(BaseModel):
             title_prefix=title_prefix,
             metadata_suffix_semantic=metadata_suffix_semantic,
             metadata_suffix_keyword=metadata_suffix_keyword,
-            mini_chunk_texts=get_mini_chunk_texts(self.text, mini_chunk_splitter),
+            mini_chunk_texts=(
+                None
+                if self.skip_mini_chunks
+                else get_mini_chunk_texts(self.text, mini_chunk_splitter)
+            ),
             large_chunk_id=None,
             doc_summary="",
             chunk_context="",

--- a/backend/onyx/indexing/chunking/text_section_chunker.py
+++ b/backend/onyx/indexing/chunking/text_section_chunker.py
@@ -6,15 +6,11 @@ from onyx.configs.constants import SECTION_SEPARATOR
 from onyx.connectors.models import Section
 from onyx.indexing.chunking.section_chunker import (
     AccumulatorState,
-    ChunkPayload,
     SectionChunker,
     SectionChunkerOutput,
+    build_payloads,
 )
-from onyx.natural_language_processing.utils import (
-    BaseTokenizer,
-    count_tokens,
-    split_text_by_tokens,
-)
+from onyx.natural_language_processing.utils import BaseTokenizer, count_tokens
 from onyx.utils.text_processing import clean_text, shared_precompare_cleanup
 from shared_configs.configs import STRICT_CHUNK_TOKEN_LIMIT
 
@@ -90,29 +86,17 @@ class TextChunker(SectionChunker):
 
         split_texts = cast(list[str], self.chunk_splitter.chunk(section_text))
         for i, split_text in enumerate(split_texts):
-            if (
-                STRICT_CHUNK_TOKEN_LIMIT
-                and count_tokens(split_text, self.tokenizer) > content_token_limit
-            ):
-                smaller_chunks = split_text_by_tokens(
-                    split_text, self.tokenizer, content_token_limit
+            payloads.extend(
+                build_payloads(
+                    text=split_text,
+                    link=section_link,
+                    tokenizer=self.tokenizer,
+                    content_token_limit=content_token_limit,
+                    is_continuation=(i != 0),
+                    enforce_token_limit=STRICT_CHUNK_TOKEN_LIMIT,
+                    reset_continuation_on_split=True,
                 )
-                for j, small_chunk in enumerate(smaller_chunks):
-                    payloads.append(
-                        ChunkPayload(
-                            text=small_chunk,
-                            links={0: section_link},
-                            is_continuation=(j != 0),
-                        )
-                    )
-            else:
-                payloads.append(
-                    ChunkPayload(
-                        text=split_text,
-                        links={0: section_link},
-                        is_continuation=(i != 0),
-                    )
-                )
+            )
 
         return SectionChunkerOutput(
             payloads=payloads,

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1132,12 +1132,12 @@ def _apply_document_ingestion_hook(
                 "Document ingestion hook dropped document doc_id=%r: %s", doc.id, reason
             )
             return None
-        # The hook's sections carry no type. A rewritten code section must
-        # come back as code: as prose it loses syntax chunking and file_path,
-        # which is what the chunker uses to refuse a credential file. Match on
-        # the link the hook kept, else by position when it returned the same
-        # number of sections. TabularSection cannot be recovered either way —
-        # its content lives in csv_file_id, which the hook never sees.
+        # The hook's sections carry no type. Returned as prose, a code
+        # section loses syntax chunking and file_path — the signal the chunker
+        # uses to refuse a credential file. Recover it by the link the hook
+        # kept, else by position when the section count is unchanged.
+        # TabularSection cannot be: its content lives in csv_file_id, which
+        # the hook never sees.
         originals = list(doc.sections)
         aligned = len(hook_result.sections) == len(originals)
         code_by_link = {
@@ -1262,22 +1262,20 @@ def _maybe_push_documents(
             doc = doc_map.get(doc_id)
             if doc is None:
                 continue
-            # Prose only. is_text_bearing now covers CodeSection, but a
-            # deployment that enabled this sink for documents did not agree to
-            # ship repository source off-box, and turning code indexing on
-            # must not change what leaves the deployment.
-            pushable = [
+            # A deployment that enabled this sink for documents did not agree
+            # to ship repository source off-box.
+            prose_sections = [
                 s
                 for s in doc.sections
                 if is_text_bearing(s) and not isinstance(s, CodeSection)
             ]
-            content = " ".join(s.text for s in pushable if s.text)
+            content = " ".join(s.text for s in prose_sections if s.text)
             payload = DocumentPushPayload(
                 document_id=doc_id,
                 title=doc.title or doc.semantic_identifier,
                 content=content,
                 source=str(doc.source.value) if doc.source else "unknown",
-                url=next((s.link for s in pushable if s.link), None),
+                url=next((s.link for s in prose_sections if s.link), None),
                 doc_updated_at=(
                     doc.doc_updated_at.isoformat() if doc.doc_updated_at else None
                 ),

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -32,6 +32,7 @@ from onyx.connectors.models import (
     Section,
     SectionType,
     TextSection,
+    is_text_bearing,
 )
 from onyx.db.connector_credential_pair import get_connector_credential_pair
 from onyx.db.document import (
@@ -625,7 +626,7 @@ def filter_documents(
 
     for document in document_batch:
         empty_contents = not any(
-            isinstance(section, TextSection)
+            is_text_bearing(section)
             and section.text is not None
             and section.text.strip()
             for section in document.sections
@@ -656,7 +657,7 @@ def filter_documents(
         section_chars = sum(
             (
                 len(section.text)
-                if isinstance(section, TextSection) and section.text is not None
+                if is_text_bearing(section) and section.text is not None
                 else 0
             )
             for section in document.sections
@@ -1079,7 +1080,7 @@ def _apply_document_ingestion_hook(
             source=doc.source.value if doc.source is not None else "",
             sections=[
                 DocumentIngestionSection(
-                    text=s.text if isinstance(s, TextSection) else None,
+                    text=s.text if is_text_bearing(s) else None,
                     link=s.link,
                     image_file_id=(
                         s.image_file_id if isinstance(s, ImageSection) else None
@@ -1233,7 +1234,7 @@ def _maybe_push_documents(
             if doc is None:
                 continue
             content = " ".join(
-                s.text for s in doc.sections if isinstance(s, TextSection) and s.text
+                s.text for s in doc.sections if is_text_bearing(s) and s.text
             )
             payload = DocumentPushPayload(
                 document_id=doc_id,
@@ -1241,11 +1242,7 @@ def _maybe_push_documents(
                 content=content,
                 source=str(doc.source.value) if doc.source else "unknown",
                 url=next(
-                    (
-                        s.link
-                        for s in doc.sections
-                        if isinstance(s, TextSection) and s.link
-                    ),
+                    (s.link for s in doc.sections if is_text_bearing(s) and s.link),
                     None,
                 ),
                 doc_updated_at=(

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1132,30 +1132,37 @@ def _apply_document_ingestion_hook(
                 "Document ingestion hook dropped document doc_id=%r: %s", doc.id, reason
             )
             return None
-        # Hook sections carry no type, so a returned code section would come
-        # back as prose and lose syntax chunking; match on link to restore it.
-        # TabularSection cannot be recovered this way — its content lives in
-        # csv_file_id, which the hook never sees.
+        # The hook's sections carry no type. A rewritten code section must
+        # come back as code: as prose it loses syntax chunking and file_path,
+        # which is what the chunker uses to refuse a credential file. Match on
+        # the link the hook kept, else by position when it returned the same
+        # number of sections. TabularSection cannot be recovered either way —
+        # its content lives in csv_file_id, which the hook never sees.
+        originals = list(doc.sections)
+        aligned = len(hook_result.sections) == len(originals)
         code_by_link = {
-            section.link: section
-            for section in doc.sections
-            if isinstance(section, CodeSection) and section.link
+            s.link: s for s in originals if isinstance(s, CodeSection) and s.link
         }
+
         new_sections: list[TextSection | ImageSection | CodeSection] = []
-        for s in hook_result.sections:
+        for index, s in enumerate(hook_result.sections):
             if s.image_file_id is not None:
                 new_sections.append(
                     ImageSection(image_file_id=s.image_file_id, link=s.link)
                 )
             elif s.text is not None:
-                original_code = code_by_link.get(s.link) if s.link else None
-                if original_code is not None:
+                origin = (
+                    code_by_link.get(s.link)
+                    if s.link
+                    else (originals[index] if aligned else None)
+                )
+                if isinstance(origin, CodeSection):
                     new_sections.append(
                         CodeSection(
                             text=s.text,
                             link=s.link,
-                            language=original_code.language,
-                            file_path=original_code.file_path,
+                            language=origin.language,
+                            file_path=origin.file_path,
                         )
                     )
                 else:
@@ -1165,6 +1172,7 @@ def _apply_document_ingestion_hook(
                     "Document ingestion hook returned a section with neither text nor image_file_id for doc_id=%r — skipping section.",
                     doc.id,
                 )
+
         if not new_sections:
             logger.info(
                 "Document ingestion hook produced no valid sections for doc_id=%r — dropping document.",
@@ -1254,18 +1262,22 @@ def _maybe_push_documents(
             doc = doc_map.get(doc_id)
             if doc is None:
                 continue
-            content = " ".join(
-                s.text for s in doc.sections if is_text_bearing(s) and s.text
-            )
+            # Prose only. is_text_bearing now covers CodeSection, but a
+            # deployment that enabled this sink for documents did not agree to
+            # ship repository source off-box, and turning code indexing on
+            # must not change what leaves the deployment.
+            pushable = [
+                s
+                for s in doc.sections
+                if is_text_bearing(s) and not isinstance(s, CodeSection)
+            ]
+            content = " ".join(s.text for s in pushable if s.text)
             payload = DocumentPushPayload(
                 document_id=doc_id,
                 title=doc.title or doc.semantic_identifier,
                 content=content,
                 source=str(doc.source.value) if doc.source else "unknown",
-                url=next(
-                    (s.link for s in doc.sections if is_text_bearing(s) and s.link),
-                    None,
-                ),
+                url=next((s.link for s in pushable if s.link), None),
                 doc_updated_at=(
                     doc.doc_updated_at.isoformat() if doc.doc_updated_at else None
                 ),

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -22,6 +22,7 @@ from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     get_experts_stores_representations,
 )
 from onyx.connectors.models import (
+    CodeSection,
     ConnectorFailure,
     ConnectorStopSignal,
     Document,
@@ -1131,14 +1132,34 @@ def _apply_document_ingestion_hook(
                 "Document ingestion hook dropped document doc_id=%r: %s", doc.id, reason
             )
             return None
-        new_sections: list[TextSection | ImageSection] = []
+        # Hook sections carry no type, so a returned code section would come
+        # back as prose and lose syntax chunking; match on link to restore it.
+        # TabularSection cannot be recovered this way — its content lives in
+        # csv_file_id, which the hook never sees.
+        code_by_link = {
+            section.link: section
+            for section in doc.sections
+            if isinstance(section, CodeSection) and section.link
+        }
+        new_sections: list[TextSection | ImageSection | CodeSection] = []
         for s in hook_result.sections:
             if s.image_file_id is not None:
                 new_sections.append(
                     ImageSection(image_file_id=s.image_file_id, link=s.link)
                 )
             elif s.text is not None:
-                new_sections.append(TextSection(text=s.text, link=s.link))
+                original_code = code_by_link.get(s.link) if s.link else None
+                if original_code is not None:
+                    new_sections.append(
+                        CodeSection(
+                            text=s.text,
+                            link=s.link,
+                            language=original_code.language,
+                            file_path=original_code.file_path,
+                        )
+                    )
+                else:
+                    new_sections.append(TextSection(text=s.text, link=s.link))
             else:
                 logger.warning(
                     "Document ingestion hook returned a section with neither text nor image_file_id for doc_id=%r — skipping section.",

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1262,20 +1262,14 @@ def _maybe_push_documents(
             doc = doc_map.get(doc_id)
             if doc is None:
                 continue
-            # A deployment that enabled this sink for documents did not agree
-            # to ship repository source off-box.
-            prose_sections = [
-                s
-                for s in doc.sections
-                if is_text_bearing(s) and not isinstance(s, CodeSection)
-            ]
-            content = " ".join(s.text for s in prose_sections if s.text)
+            text_sections = [s for s in doc.sections if is_text_bearing(s)]
+            content = " ".join(s.text for s in text_sections if s.text)
             payload = DocumentPushPayload(
                 document_id=doc_id,
                 title=doc.title or doc.semantic_identifier,
                 content=content,
                 source=str(doc.source.value) if doc.source else "unknown",
-                url=next((s.link for s in prose_sections if s.link), None),
+                url=next((s.link for s in text_sections if s.link), None),
                 doc_updated_at=(
                     doc.doc_updated_at.isoformat() if doc.doc_updated_at else None
                 ),

--- a/backend/onyx/utils/text_processing.py
+++ b/backend/onyx/utils/text_processing.py
@@ -275,6 +275,16 @@ def clean_text(text: str) -> str:
     return cleaned
 
 
+def clean_code_text(text: str) -> str:
+    """Strip control characters only, keeping every printable character.
+
+    clean_text also removes the General Punctuation and Emoticons blocks,
+    which are meaningful inside string literals and comments. Code is indexed
+    to be matched against the file it links to, so it keeps them.
+    """
+    return "".join(ch for ch in text if ch >= " " or ch in "\n\t")
+
+
 def is_valid_email(text: str) -> bool:
     """Can use a library instead if more detailed checks are needed"""
     regex = r"^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"

--- a/backend/tests/daily/connectors/utils.py
+++ b/backend/tests/daily/connectors/utils.py
@@ -14,9 +14,8 @@ from onyx.connectors.models import (
     ConnectorCheckpoint,
     ConnectorFailure,
     Document,
+    DocumentSection,
     HierarchyNode,
-    ImageSection,
-    TabularSection,
     TextSection,
 )
 
@@ -170,14 +169,14 @@ def load_all_from_connector(
 
 def to_sections(
     documents: list[Document],
-) -> Iterator[TextSection | ImageSection | TabularSection]:
+) -> Iterator[DocumentSection]:
     for doc in documents:
         for section in doc.sections:
             yield section
 
 
 def to_text_sections(
-    sections: Iterator[TextSection | ImageSection | TabularSection],
+    sections: Iterator[DocumentSection],
 ) -> Iterator[str]:
     for section in sections:
         if isinstance(section, TextSection):

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
@@ -4,6 +4,7 @@ from tree_sitter_language_pack import manifest_languages
 from onyx.connectors.cross_connector_utils.code_file_utils import (
     SENSITIVE_FILE_LANGUAGES,
     infer_code_language,
+    is_sensitive_code_file,
 )
 
 
@@ -42,3 +43,50 @@ def test_sensitive_languages_are_real_grammars() -> None:
 )
 def test_infer_code_language(path: str | None, expected: str | None) -> None:
     assert infer_code_language(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # the grammar detector catches only these two
+        ".env",
+        "key.pem",
+        # ...and misses the names secrets are actually stored under
+        ".env.local",
+        ".env.production",
+        "config/.env.staging",
+        "backend/.env.docker",
+        "id_rsa",
+        "id_ed25519",
+        "deploy_rsa",
+        "server.key",
+        "creds.p12",
+        "cert.pfx",
+        "store.jks",
+        "app.keystore",
+        "putty.ppk",
+        ".npmrc",
+        ".pypirc",
+        ".netrc",
+        ".pgpass",
+        "credentials",
+        "vault.kdbx",
+        # case and separators must not defeat it
+        ".ENV.Local",
+        "windows\\path\\.env.local",
+    ],
+)
+def test_credential_files_are_refused(path: str) -> None:
+    """These hold secrets and must never be chunked, whatever the caller
+    supplies as `language`."""
+    assert is_sensitive_code_file(path) is True
+    assert infer_code_language(path) is None
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["main.py", "README.md", "data.json", "src/keyboard.py", "envelope.py", ""],
+)
+def test_ordinary_files_are_not_refused(path: str) -> None:
+    """The patterns must not swallow normal source files."""
+    assert is_sensitive_code_file(path) is False

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
@@ -1,0 +1,44 @@
+import pytest
+from tree_sitter_language_pack import manifest_languages
+
+from onyx.connectors.cross_connector_utils.code_file_utils import (
+    SENSITIVE_FILE_LANGUAGES,
+    infer_code_language,
+)
+
+
+def test_sensitive_languages_are_real_grammars() -> None:
+    """A pack upgrade that renames a guarded grammar would make its entry
+    dead — and credential files would silently start indexing. Fail here."""
+    manifest = set(manifest_languages())
+    unknown = SENSITIVE_FILE_LANGUAGES - manifest
+    assert not unknown, f"Not grammars in tree-sitter-language-pack: {unknown}"
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # source code, named per tree-sitter-language-pack
+        ("main.py", "python"),
+        ("src/app.tsx", "tsx"),
+        ("native/lib.cpp", "cpp"),
+        ("Service.cs", "csharp"),
+        ("query.sql", "sql"),
+        ("deep/nested/mod.rs", "rust"),
+        # config / data formats have grammars too
+        ("data.json", "json"),
+        ("config.yaml", "yaml"),
+        # grammar lookup, not a prose judgment — callers subtract doc formats
+        ("README.md", "markdown"),
+        # credential formats are refused
+        ("key.pem", None),
+        ("secrets.env", None),
+        # unknown / not files
+        ("image.png", None),
+        ("no_extension", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_infer_code_language(path: str | None, expected: str | None) -> None:
+    assert infer_code_language(path) == expected

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
@@ -31,9 +31,10 @@ def test_sensitive_languages_are_real_grammars() -> None:
         ("config.yaml", "yaml"),
         # grammar lookup, not a prose judgment — callers subtract doc formats
         ("README.md", "markdown"),
-        # credential formats are refused
-        ("key.pem", None),
-        ("secrets.env", None),
+        # a grammar lookup only — refusing credential formats is
+        # is_sensitive_code_file's job, and callers ask it separately
+        ("key.pem", "pem"),
+        ("secrets.env", "dotenv"),
         # unknown / not files
         ("image.png", None),
         ("no_extension", None),
@@ -80,7 +81,6 @@ def test_credential_files_are_refused(path: str) -> None:
     """These hold secrets and must never be chunked, whatever the caller
     supplies as `language`."""
     assert is_sensitive_code_file(path) is True
-    assert infer_code_language(path) is None
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
+++ b/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
@@ -1,6 +1,10 @@
 """Tests for FileStoreDocumentBatchStorage."""
 
+import json
 from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
 
 from onyx.file_store.document_batch_storage import FileStoreDocumentBatchStorage
 from onyx.file_store.file_store import S3BackedFileStore
@@ -41,3 +45,44 @@ def test_cleanup_all_batches_completes_when_files_already_deleted(
         cc_pair_id=1, index_attempt_id=42, file_store=file_store
     )
     storage.cleanup_all_batches()  # must not raise
+
+
+def _storage() -> FileStoreDocumentBatchStorage:
+    return FileStoreDocumentBatchStorage(
+        cc_pair_id=1, index_attempt_id=1, file_store=MagicMock()
+    )
+
+
+def _doc(**overrides: object) -> dict:
+    doc: dict = {
+        "id": "doc-1",
+        "source": "github",
+        "semantic_identifier": "a.py",
+        "sections": [{"type": "text", "text": "hi", "link": "http://x"}],
+        "metadata": {},
+    }
+    doc.update(overrides)
+    return doc
+
+
+def test_skips_only_the_known_rolling_deploy_shapes() -> None:
+    """Both directions of version skew are skipped, and a doc this worker can
+    validate still comes through."""
+    legacy_tabular = _doc(id="legacy", sections=[{"type": "tabular", "text": "a,b"}])
+    newer_type = _doc(id="newer", sections=[{"type": "quantum", "text": "?"}])
+
+    documents = _storage()._deserialize_documents(
+        json.dumps([legacy_tabular, newer_type, _doc()])
+    )
+
+    assert [d.id for d in documents] == ["doc-1"]
+
+
+def test_a_real_validation_error_still_raises() -> None:
+    """A model bug must not be swallowed as skew: dropping documents silently
+    would leave a POLL connector permanently short with the attempt reported
+    clean."""
+    broken = _doc(sections=[{"type": "text", "link": "http://x"}])  # no text
+
+    with pytest.raises(ValidationError):
+        _storage()._deserialize_documents(json.dumps([broken]))

--- a/backend/tests/unit/onyx/indexing/conftest.py
+++ b/backend/tests/unit/onyx/indexing/conftest.py
@@ -1,7 +1,72 @@
 import pytest
+from chonkie import SentenceChunker
 
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import IndexingDocument, Section
+from onyx.indexing.chunking import DocumentChunker
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.natural_language_processing.utils import BaseTokenizer
+
+
+class CharTokenizer(BaseTokenizer):
+    """1 character == 1 token. Deterministic & trivial to reason about."""
+
+    def encode(self, string: str) -> list[int]:
+        return [ord(c) for c in string]
+
+    def tokenize(self, string: str) -> list[str]:
+        return list(string)
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+# With a char-level tokenizer, each char is a token. 200 is comfortably
+# above BLURB_SIZE (128) so the blurb splitter won't get weird on small text.
+CHUNK_LIMIT = 200
+
+
+def make_document_chunker(
+    chunk_token_limit: int = CHUNK_LIMIT,
+    with_mini_chunks: bool = False,
+) -> DocumentChunker:
+    """DocumentChunker over CharTokenizer, with mini-chunking optional."""
+
+    def token_counter(text: str) -> int:
+        return len(text)
+
+    def sentence_chunker(chunk_size: int) -> SentenceChunker:
+        return SentenceChunker(
+            tokenizer_or_token_counter=token_counter,
+            chunk_size=chunk_size,
+            chunk_overlap=0,
+            return_type="texts",
+        )
+
+    return DocumentChunker(
+        tokenizer=CharTokenizer(),
+        blurb_splitter=sentence_chunker(128),
+        chunk_splitter=sentence_chunker(chunk_token_limit),
+        mini_chunk_splitter=sentence_chunker(150) if with_mini_chunks else None,
+    )
+
+
+def make_doc(
+    sections: list[Section],
+    title: str | None = "Test Doc",
+    doc_id: str = "doc1",
+    source: DocumentSource = DocumentSource.WEB,
+) -> IndexingDocument:
+    return IndexingDocument(
+        id=doc_id,
+        source=source,
+        semantic_identifier=doc_id,
+        title=title,
+        metadata={},
+        sections=[],  # real sections unused — method reads processed_sections
+        processed_sections=sections,
+    )
 
 
 class MockHeartbeat(IndexingHeartbeatInterface):

--- a/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
@@ -1,0 +1,256 @@
+import pytest
+from chonkie import SentenceChunker
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import (
+    CodeSection,
+    IndexingDocument,
+    Section,
+    TextSection,
+)
+from onyx.indexing.chunking import DocumentChunker
+from onyx.indexing.chunking.code_section_chunker import _line_anchored_link
+from onyx.natural_language_processing.utils import BaseTokenizer
+
+
+class CharTokenizer(BaseTokenizer):
+    """1 character == 1 token. Deterministic & trivial to reason about."""
+
+    def encode(self, string: str) -> list[int]:
+        return [ord(c) for c in string]
+
+    def tokenize(self, string: str) -> list[str]:
+        return list(string)
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+CHUNK_LIMIT = 200
+
+
+def _make_document_chunker(
+    chunk_token_limit: int = CHUNK_LIMIT,
+    with_mini_chunks: bool = False,
+) -> DocumentChunker:
+    def token_counter(text: str) -> int:
+        return len(text)
+
+    return DocumentChunker(
+        tokenizer=CharTokenizer(),
+        blurb_splitter=SentenceChunker(
+            tokenizer_or_token_counter=token_counter,
+            chunk_size=128,
+            chunk_overlap=0,
+            return_type="texts",
+        ),
+        chunk_splitter=SentenceChunker(
+            tokenizer_or_token_counter=token_counter,
+            chunk_size=chunk_token_limit,
+            chunk_overlap=0,
+            return_type="texts",
+        ),
+        mini_chunk_splitter=(
+            SentenceChunker(
+                tokenizer_or_token_counter=token_counter,
+                chunk_size=150,
+                chunk_overlap=0,
+                return_type="texts",
+            )
+            if with_mini_chunks
+            else None
+        ),
+    )
+
+
+def _make_doc(sections: list[Section], doc_id: str = "doc1") -> IndexingDocument:
+    return IndexingDocument(
+        id=doc_id,
+        source=DocumentSource.GITLAB,
+        semantic_identifier=doc_id,
+        title="pkg/mod.py",
+        metadata={},
+        sections=[],  # real sections unused — method reads processed_sections
+        processed_sections=sections,
+    )
+
+
+def _make_python_code(num_functions: int, body_width: int = 30) -> str:
+    lines: list[str] = []
+    for i in range(num_functions):
+        lines.append(f"def func_{i}(x):")
+        lines.append(f"    y = x * {i}")
+        lines.append("    return y + " + " + ".join(str(j) for j in range(body_width)))
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _chunk(dc: DocumentChunker, sections: list[Section]) -> list:
+    doc = _make_doc(sections)
+    return dc.chunk(
+        document=doc,
+        sections=sections,
+        title_prefix="",
+        metadata_suffix_semantic="",
+        metadata_suffix_keyword="",
+        content_token_limit=CHUNK_LIMIT,
+    )
+
+
+# --- Whole-file fits ------------------------------------------------------------
+
+
+def test_small_code_section_is_one_chunk_with_fields() -> None:
+    dc = _make_document_chunker()
+    code = "def f(x):\n    return x + 1\n"
+    section = CodeSection(
+        text=code,
+        language="python",
+        file_path="pkg/mod.py",
+        link="https://git.example.com/repo/-/blob/main/pkg/mod.py",
+    )
+
+    chunks = _chunk(dc, [section])
+
+    assert len(chunks) == 1
+    assert chunks[0].content == code
+    assert chunks[0].source_links == {
+        0: "https://git.example.com/repo/-/blob/main/pkg/mod.py"
+    }
+
+
+# --- Syntax-boundary splitting ---------------------------------------------------
+
+
+def test_oversized_code_splits_at_function_boundaries() -> None:
+    dc = _make_document_chunker()
+    code = _make_python_code(num_functions=12)
+    section = CodeSection(
+        text=code,
+        language="python",
+        file_path="pkg/mod.py",
+        link="https://git.example.com/blob/main/pkg/mod.py",
+    )
+
+    chunks = _chunk(dc, [section])
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        # Every chunk starts at a function boundary, not mid-function.
+        assert chunk.content.strip("\n").startswith("def func_")
+        assert len(chunk.content) <= CHUNK_LIMIT
+
+
+def test_line_anchors_point_at_chunk_start_lines() -> None:
+    dc = _make_document_chunker()
+    code = _make_python_code(num_functions=12)
+    lines = code.split("\n")
+    section = CodeSection(
+        text=code,
+        language="python",
+        file_path="pkg/mod.py",
+        link="https://git.example.com/blob/main/pkg/mod.py",
+    )
+
+    chunks = _chunk(dc, [section])
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        link = chunk.source_links[0]
+        assert "#L" in link
+        start_line = int(link.split("#L")[1].split("-")[0])
+        # 1-based line number must point at the chunk's first code line.
+        assert lines[start_line - 1] == chunk.content.strip("\n").split("\n")[0]
+
+
+def test_unknown_language_falls_back_to_token_splitting() -> None:
+    dc = _make_document_chunker()
+    # A made-up language forces the tree-sitter lookup to fail.
+    code = "x " * 300
+    section = CodeSection(
+        text=code,
+        language="not_a_language",
+        file_path="weird.xyz",
+        link="https://git.example.com/blob/main/weird.xyz",
+    )
+
+    chunks = _chunk(dc, [section])
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk.content) <= CHUNK_LIMIT
+
+
+# --- Interaction with other sections ----------------------------------------------
+
+
+def test_prose_buffer_flushes_before_code() -> None:
+    """Prose accumulated before a code section becomes its own chunk — code
+    never merges with buffered text."""
+    dc = _make_document_chunker()
+    prose = TextSection(text="Some short prose.", link="prose-link")
+    code = CodeSection(
+        text="def f():\n    return 1\n",
+        language="python",
+        file_path="a.py",
+        link="code-link",
+    )
+
+    chunks = _chunk(dc, [prose, code])
+
+    assert len(chunks) == 2
+    assert chunks[0].content == "Some short prose."
+    assert chunks[1].content == "def f():\n    return 1\n"
+
+
+def test_code_chunks_have_no_mini_chunks() -> None:
+    dc = _make_document_chunker(with_mini_chunks=True)
+    prose = TextSection(text="Some short prose.", link="prose-link")
+    code = CodeSection(
+        text="def f():\n    return 1\n",
+        language="python",
+        file_path="a.py",
+        link="code-link",
+    )
+
+    chunks = _chunk(dc, [prose, code])
+
+    assert chunks[0].mini_chunk_texts is not None
+    assert chunks[1].mini_chunk_texts is None
+
+
+# --- Link anchoring helper ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "link,start,end,expected",
+    [
+        ("https://x/blob/main/a.py", 5, 9, "https://x/blob/main/a.py#L5-L9"),
+        ("https://x/blob/main/a.py", 5, 5, "https://x/blob/main/a.py#L5"),
+        ("https://x/a.py#L1", 5, 9, "https://x/a.py#L1"),  # existing fragment kept
+        ("", 5, 9, ""),
+    ],
+)
+def test_line_anchored_link(link: str, start: int, end: int, expected: str) -> None:
+    assert _line_anchored_link(link, start, end) == expected
+
+
+# --- Sensitive-format exclusion ---------------------------------------------------
+
+
+def test_sensitive_file_is_dropped_even_with_explicit_language() -> None:
+    dc = _make_document_chunker()
+    section = CodeSection(
+        text="AWS_SECRET_ACCESS_KEY=abc123\n",
+        # A supplied language must not bypass the path-based exclusion.
+        language="python",
+        file_path="deploy/.env",
+        link="https://git.example.com/repo/-/blob/main/deploy/.env",
+    )
+
+    chunks = _chunk(dc, [section])
+
+    # The document chunker may emit a contentless fallback chunk, but the
+    # credential text itself must never reach the index.
+    assert all("AWS_SECRET_ACCESS_KEY" not in chunk.content for chunk in chunks)
+    assert all(not chunk.content.strip() for chunk in chunks)

--- a/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
@@ -1,78 +1,17 @@
 import pytest
-from chonkie import SentenceChunker
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import (
     CodeSection,
-    IndexingDocument,
     Section,
     TextSection,
 )
 from onyx.indexing.chunking import DocumentChunker
 from onyx.indexing.chunking.code_section_chunker import _line_anchored_link
-from onyx.natural_language_processing.utils import BaseTokenizer
-
-
-class CharTokenizer(BaseTokenizer):
-    """1 character == 1 token. Deterministic & trivial to reason about."""
-
-    def encode(self, string: str) -> list[int]:
-        return [ord(c) for c in string]
-
-    def tokenize(self, string: str) -> list[str]:
-        return list(string)
-
-    def decode(self, tokens: list[int]) -> str:
-        return "".join(chr(t) for t in tokens)
-
-
-CHUNK_LIMIT = 200
-
-
-def _make_document_chunker(
-    chunk_token_limit: int = CHUNK_LIMIT,
-    with_mini_chunks: bool = False,
-) -> DocumentChunker:
-    def token_counter(text: str) -> int:
-        return len(text)
-
-    return DocumentChunker(
-        tokenizer=CharTokenizer(),
-        blurb_splitter=SentenceChunker(
-            tokenizer_or_token_counter=token_counter,
-            chunk_size=128,
-            chunk_overlap=0,
-            return_type="texts",
-        ),
-        chunk_splitter=SentenceChunker(
-            tokenizer_or_token_counter=token_counter,
-            chunk_size=chunk_token_limit,
-            chunk_overlap=0,
-            return_type="texts",
-        ),
-        mini_chunk_splitter=(
-            SentenceChunker(
-                tokenizer_or_token_counter=token_counter,
-                chunk_size=150,
-                chunk_overlap=0,
-                return_type="texts",
-            )
-            if with_mini_chunks
-            else None
-        ),
-    )
-
-
-def _make_doc(sections: list[Section], doc_id: str = "doc1") -> IndexingDocument:
-    return IndexingDocument(
-        id=doc_id,
-        source=DocumentSource.GITLAB,
-        semantic_identifier=doc_id,
-        title="pkg/mod.py",
-        metadata={},
-        sections=[],  # real sections unused — method reads processed_sections
-        processed_sections=sections,
-    )
+from tests.unit.onyx.indexing.conftest import CHUNK_LIMIT, make_doc
+from tests.unit.onyx.indexing.conftest import (
+    make_document_chunker as _make_document_chunker,
+)
 
 
 def _make_python_code(num_functions: int, body_width: int = 30) -> str:
@@ -86,7 +25,7 @@ def _make_python_code(num_functions: int, body_width: int = 30) -> str:
 
 
 def _chunk(dc: DocumentChunker, sections: list[Section]) -> list:
-    doc = _make_doc(sections)
+    doc = make_doc(sections, title="pkg/mod.py", source=DocumentSource.GITLAB)
     return dc.chunk(
         document=doc,
         sections=sections,

--- a/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
@@ -120,6 +120,29 @@ def test_unknown_language_falls_back_to_token_splitting() -> None:
         assert len(chunk.content) <= CHUNK_LIMIT
 
 
+def test_code_text_keeps_punctuation_and_emoji() -> None:
+    """The prose cleaner strips the General Punctuation and Emoticons blocks,
+    which are meaningful inside literals. Indexed code must match the file it
+    links to."""
+    code = 'MSG = "an — em dash"  # ✅ ok\n'
+    dc = _make_document_chunker()
+
+    chunks = _chunk(
+        dc,
+        [
+            CodeSection(
+                text=code,
+                language="python",
+                file_path="a.py",
+                link="https://git.example.com/blob/main/a.py",
+            )
+        ],
+    )
+
+    assert "—" in chunks[0].content
+    assert "✅" in chunks[0].content
+
+
 # --- Interaction with other sections ----------------------------------------------
 
 

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -1,76 +1,19 @@
 import io
 
 import pytest
-from chonkie import SentenceChunker
 
-from onyx.configs.constants import SECTION_SEPARATOR, DocumentSource
+from onyx.configs.constants import SECTION_SEPARATOR
 from onyx.connectors.models import (
-    IndexingDocument,
     Section,
     SectionType,
     TabularSection,
 )
-from onyx.indexing.chunking import DocumentChunker
 from onyx.indexing.chunking import text_section_chunker as text_chunker_module
-from onyx.natural_language_processing.utils import BaseTokenizer
-
-
-class CharTokenizer(BaseTokenizer):
-    """1 character == 1 token. Deterministic & trivial to reason about."""
-
-    def encode(self, string: str) -> list[int]:
-        return [ord(c) for c in string]
-
-    def tokenize(self, string: str) -> list[str]:
-        return list(string)
-
-    def decode(self, tokens: list[int]) -> str:
-        return "".join(chr(t) for t in tokens)
-
-
-# With a char-level tokenizer, each char is a token. 200 is comfortably
-# above BLURB_SIZE (128) so the blurb splitter won't get weird on small text.
-CHUNK_LIMIT = 200
-
-
-def _make_document_chunker(
-    chunk_token_limit: int = CHUNK_LIMIT,
-) -> DocumentChunker:
-    def token_counter(text: str) -> int:
-        return len(text)
-
-    return DocumentChunker(
-        tokenizer=CharTokenizer(),
-        blurb_splitter=SentenceChunker(
-            tokenizer_or_token_counter=token_counter,
-            chunk_size=128,
-            chunk_overlap=0,
-            return_type="texts",
-        ),
-        chunk_splitter=SentenceChunker(
-            tokenizer_or_token_counter=token_counter,
-            chunk_size=chunk_token_limit,
-            chunk_overlap=0,
-            return_type="texts",
-        ),
-    )
-
-
-def _make_doc(
-    sections: list[Section],
-    title: str | None = "Test Doc",
-    doc_id: str = "doc1",
-) -> IndexingDocument:
-    return IndexingDocument(
-        id=doc_id,
-        source=DocumentSource.WEB,
-        semantic_identifier=doc_id,
-        title=title,
-        metadata={},
-        sections=[],  # real sections unused — method reads processed_sections
-        processed_sections=sections,
-    )
-
+from tests.unit.onyx.indexing.conftest import CHUNK_LIMIT
+from tests.unit.onyx.indexing.conftest import make_doc as _make_doc
+from tests.unit.onyx.indexing.conftest import (
+    make_document_chunker as _make_document_chunker,
+)
 
 # --- Empty / degenerate input -------------------------------------------------
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -645,6 +645,33 @@ def test_document_ingestion_hook_new_section_stays_text() -> None:
     assert isinstance(result[0].sections[0], TextSection)
 
 
+def test_document_ingestion_hook_keeps_linkless_code_sections_as_code() -> None:
+    """A code section with no link cannot be matched by link. Losing its type
+    also loses file_path, which is the only signal the chunker uses to refuse
+    a credential file — so recover it by position instead."""
+    doc = _make_doc(
+        sections=[
+            CodeSection(
+                text="TOKEN=abc\n", link=None, language="dotenv", file_path=".env.local"
+            )
+        ]
+    )
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=[DocumentIngestionSection(text="TOKEN=redacted\n", link=None)]
+            ),
+        ),
+        patch(_PATCH_GET_SESSION),
+    ):
+        result = _apply_document_ingestion_hook([doc])
+
+    section = result[0].sections[0]
+    assert isinstance(section, CodeSection)
+    assert section.file_path == ".env.local"
+
+
 def test_document_ingestion_hook_preserves_image_section_order() -> None:
     """Hook receives all sections including images and controls final ordering."""
     image = ImageSection(image_file_id="img-1", link=None)

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -2,12 +2,13 @@ import random
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, List, cast
+from typing import Any, List
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from onyx.connectors.models import (
+    CodeSection,
     Document,
     DocumentSource,
     ImageSection,
@@ -45,7 +46,7 @@ def create_test_document(
         id=doc_id,
         title=title,
         semantic_identifier=semantic_id,
-        sections=cast(list[TextSection | ImageSection], sections),
+        sections=sections,
         source=DocumentSource.FILE,
         metadata={},
     )
@@ -263,7 +264,7 @@ _PATCH_GET_SESSION = "onyx.indexing.indexing_pipeline.get_session_with_current_t
 
 def _make_doc(
     doc_id: str = "doc1",
-    sections: list[TextSection | ImageSection] | None = None,
+    sections: list[TextSection | ImageSection | CodeSection] | None = None,
 ) -> Document:
     if sections is None:
         sections = [TextSection(text="Hello", link="http://example.com")]
@@ -588,6 +589,60 @@ def test_document_ingestion_hook_rewrites_text_sections() -> None:
     assert isinstance(section, TextSection)
     assert section.text == "rewritten"
     assert section.link == "http://b.com"
+
+
+def test_document_ingestion_hook_keeps_code_sections_as_code() -> None:
+    """A hook section carries no type, so a rewritten code section would come
+    back as prose and lose syntax chunking. The link identifies it."""
+    doc = _make_doc(
+        sections=[
+            CodeSection(
+                text="def f():\n    pass\n",
+                link="http://a.com/mod.py",
+                language="python",
+                file_path="pkg/mod.py",
+            )
+        ]
+    )
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=[
+                    DocumentIngestionSection(
+                        text="def f():\n    return 1\n", link="http://a.com/mod.py"
+                    )
+                ]
+            ),
+        ),
+        patch(_PATCH_GET_SESSION),
+    ):
+        result = _apply_document_ingestion_hook([doc])
+    section = result[0].sections[0]
+    assert isinstance(section, CodeSection)
+    assert section.text == "def f():\n    return 1\n"
+    assert section.language == "python"
+    assert section.file_path == "pkg/mod.py"
+
+
+def test_document_ingestion_hook_new_section_stays_text() -> None:
+    """A section the hook invents (no matching original link) is prose."""
+    doc = _make_doc(
+        sections=[
+            CodeSection(text="x = 1\n", link="http://a.com/mod.py", language="python")
+        ]
+    )
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=[DocumentIngestionSection(text="a note", link="http://z.com")]
+            ),
+        ),
+        patch(_PATCH_GET_SESSION),
+    ):
+        result = _apply_document_ingestion_hook([doc])
+    assert isinstance(result[0].sections[0], TextSection)
 
 
 def test_document_ingestion_hook_preserves_image_section_order() -> None:

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -27,19 +27,8 @@ from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
     TOTALS_HEADER,
     build_total_descriptor_chunks,
 )
-from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.utils.csv_utils import parse_csv_string, read_csv_header
-
-
-class CharTokenizer(BaseTokenizer):
-    def encode(self, string: str) -> list[int]:
-        return [ord(c) for c in string]
-
-    def tokenize(self, string: str) -> list[str]:
-        return list(string)
-
-    def decode(self, tokens: list[int]) -> str:
-        return "".join(chr(t) for t in tokens)
+from tests.unit.onyx.indexing.conftest import CharTokenizer
 
 
 def _make_chunker_no_metadata() -> TabularChunker:


### PR DESCRIPTION
## Description

Part 2/10 of the code-indexing stack. Stacked on #14246.

A source file chunked like prose splits mid-function and cites the whole file. This PR gives code its own section type and chunker, so a chunk is a syntactic unit and its link points at the lines it came from.

- `SectionType.CODE` and a `CodeSection` model (`language`, `file_path`), threaded through chunking dispatch, content hashing, length checks and ingestion payloads. The document push sink still ships prose only.
- `CodeChunker` splits at tree-sitter node boundaries through `chonkie[code]`, anchors each chunk's link as `#Lstart[-Lend]`, and disables mini-chunks. It flushes buffered prose first, so code never merges into a prose chunk. A language with no grammar falls back to token splitting and logs why — an unknown language and a grammar that fails to load are different problems.
- Code text is indexed verbatim. The prose cleaner removes punctuation and emoji, which made the indexed copy differ from the file its link points at.
- `infer_code_language` maps a path to a grammar name, and the docs/tabular grammars are subtracted so prose formats keep their existing path.
- Credential files are refused by basename (`.env*`, `id_rsa*`, `*.key`, `*.pem`, ...) in both the connectors and the chunker. The extension test they replace missed the names secrets actually use: `.env.local` and `.env.production` resolve to no grammar at all.
- Moves the code-file metadata contract to `configs.constants` (`CODE_FILE_METADATA_TYPE`), so retrieval can read it without importing from `connectors`.
- `DocumentBatchStorage` skips a document whose validation failure looks like version skew — a legacy inline tabular section, or a section type a newer docfetching worker staged during a rolling deploy — instead of failing the whole batch. Real model errors still raise, and the skipped document re-indexes on the next run.
- The document ingestion hook rebuilds sections, which downgraded code back to text. Code sections are now matched back by link, or by position when the section count is unchanged, so they keep their language, file path and line anchors.

No connector emits `CodeSection` yet; #14221 is the first. Workers that chunk code need the new deps from #14246.

## How Has This Been Tested?

Unit tests cover language inference and the credential-file refusal, splitting at syntax boundaries, link anchoring, the token-split fallback, code and prose in the same document, the batch-storage skip, and code sections surviving the ingestion hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds syntax-aware code chunking via a new `CodeSection` type, so source files split at tree-sitter boundaries with stable line-anchored links instead of being chunked like prose. Code chunks stay pure code, never merge with buffered prose, and fall back to token splitting when a grammar is unavailable.

- Introduces `SectionType.CODE` and `CodeSection` (with `language` and `file_path`) and threads them through chunking dispatch, content hashing, length checks, and ingestion payloads; `is_text_bearing` now covers code, so code sections also flow through the document push sink.
- Adds a `CodeChunker` (`chonkie[code]` + `tree-sitter-language-pack`) that splits at syntax nodes, anchors links as `#Lstart[-Lend]`, disables mini-chunks, flushes buffered prose first, and logs distinctly for unknown languages vs grammar load failures.
- Indexes code text verbatim, keeping punctuation and emoji so the indexed copy matches the linked file.
- Refuses credential files by basename pattern (`.env*`, `id_rsa*`, `*.key`, `*.pem`, …) via `is_sensitive_code_file`, enforced in both connectors and the chunker.
- Moves the code-file metadata contract to `configs.constants` (`CODE_FILE_METADATA_TYPE`).
- Makes `DocumentBatchStorage` skip docs whose validation failure looks like version skew (legacy inline tabular or unknown section type) instead of failing the whole batch; real model errors still raise, and the skipped doc re-indexes on retry.
- Preserves code sections that pass through the document ingestion hook by matching on link — or by position when the section count is unchanged — so they keep their language, file path, and line anchors.
- Updates deps (`chonkie[code]`, `tree-sitter`, `tree-sitter-language-pack`) and shares `build_payloads` between the code and text chunkers; adds unit tests for language inference, syntax-boundary splitting, link anchoring, and prose/code interaction.

**Rollout and migration**
- Ensure environments pick up the new deps, especially workers that chunk code.
- Connectors emitting code should produce `CodeSection` and set `link`; `language` and `file_path` are optional but improve accuracy.
- `infer_code_language` keys off the final extension, so connectors should subtract their own document extensions — prose formats like `.md` return a grammar.

<sup>Written for commit 146d71836cebd3e5a6b73c98862730bbc1bcc0de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
