### PR TITLE
fix(web): resolve the open chat when it belongs to a project

### DIFF
--- a/web/src/hooks/useChatSessions.ts
+++ b/web/src/hooks/useChatSessions.ts
@@ -14,6 +14,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { MinimalAgent } from "@/lib/agents/types";
 import useAppFocus from "./useAppFocus";
 import { useAgents } from "@/lib/agents/hooks";
+import { useActiveProject } from "@/lib/projects/hooks";
 import { DEFAULT_AGENT_ID } from "@/lib/constants";
 
 const PAGE_SIZE = 50;
@@ -175,6 +176,7 @@ export default function useChatSessions(): UseChatSessionsOutput {
   );
 
   const appFocus = useAppFocus();
+  const activeProject = useActiveProject();
   const pendingSessions = usePendingSessions();
 
   // Flatten all pages into a single session list
@@ -241,10 +243,23 @@ export default function useChatSessions(): UseChatSessionsOutput {
   }, [allFetchedSessions, pendingSessions]);
 
   const currentChatSessionId = appFocus.isChat() ? appFocus.getId() : null;
-  const currentChatSession =
-    chatSessions.find(
-      (chatSession) => chatSession.id === currentChatSessionId
-    ) ?? null;
+
+  // `chatSessions` is the Recents feed, which excludes project chats on purpose
+  // (`only_non_project_chats` defaults to true on the server). Fall back to the
+  // owning project's session list so a project chat still resolves — otherwise
+  // the header actions, document title, and agent lookup all see `null`.
+  const currentChatSession = useMemo(() => {
+    if (!currentChatSessionId) return null;
+    return (
+      chatSessions.find(
+        (chatSession) => chatSession.id === currentChatSessionId
+      ) ??
+      activeProject?.chat_sessions.find(
+        (chatSession) => chatSession.id === currentChatSessionId
+      ) ??
+      null
+    );
+  }, [chatSessions, activeProject, currentChatSessionId]);
 
   const agentForCurrentChatSession =
     useFindAgentForCurrentChatSession(currentChatSession);


### PR DESCRIPTION
## Description

Opening a chat that belongs to a project left `currentChatSession` as `null`, so the header actions, document title, and agent lookup all saw nothing.

`chatSessions` is the Recents feed, and Recents excludes project chats on purpose — `only_non_project_chats` defaults to true on the server. The lookup now falls back to the owning project's session list.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve currentChatSession for project chats by falling back from the Recents feed to the active project's session list. Previously Recents excluded project chats, leaving currentChatSession null and breaking header actions, document title, and agent lookup.

- Update useChatSessions: useMemo searches chatSessions, then activeProject.chat_sessions; import useActiveProject.
- No server changes; Recents still excludes project chats (`only_non_project_chats` default).
- Verify by opening a project chat from the sidebar and confirming header actions, document title, and agent selection render correctly.

<sup>Written for commit 0eef57b76c534cc68cdaa16f42ab1e83f2a73224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->