### PR TITLE
fix(web): send chat navigation to /app instead of /chat

### DIFF
--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -566,10 +566,10 @@ export function buildChatUrl(
   const finalSearchParamsString = finalSearchParams.join("&");
 
   if (finalSearchParamsString) {
-    return `/${search ? "search" : "chat"}?${finalSearchParamsString}`;
+    return `/${search ? "search" : "app"}?${finalSearchParamsString}`;
   }
 
-  return `/${search ? "search" : "chat"}`;
+  return `/${search ? "search" : "app"}`;
 }
 
 export async function uploadFilesForChat(

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
+import { useAppRouter } from "@/hooks/appNavigation";
 import CommandMenu, {
   useCommandMenuContext,
 } from "@/refresh-components/commandmenu/CommandMenu";
@@ -68,6 +69,7 @@ export default function ChatSearchCommandMenu({
     string | undefined
   >();
   const router = useRouter();
+  const route = useAppRouter();
 
   // Data hooks
   const { projects } = useProjects();
@@ -152,18 +154,18 @@ export default function ChatSearchCommandMenu({
 
   const handleChatSelect = useCallback(
     (chatId: string) => {
-      router.push(`/chat?chatId=${chatId}` as Route);
+      route({ chatSessionId: chatId });
       setOpen(false);
     },
-    [router]
+    [route]
   );
 
   const handleProjectSelect = useCallback(
     (projectId: number) => {
-      router.push(`/chat?projectId=${projectId}` as Route);
+      route({ projectId });
       setOpen(false);
     },
-    [router]
+    [route]
   );
 
   const handleNewProject = useCallback(


### PR DESCRIPTION
## Description

There is no `/chat` route — `web/src/app/` has `app/`, not `chat/`. `next.config.js` carries a permanent (308) redirect from `/chat` to `/app`, left over from the rename.

So today every chat-search selection and every URL `buildChatUrl` produces takes a redirect hop. And `useChatController.ts:274` asserts `pathname === "/app"` while `buildChatUrl` pushes `/chat` into that same page's history.

- `buildChatUrl` returns `/app`.
- `ChatSearchCommandMenu` uses `useAppRouter` instead of hand-built `/chat?...` pushes, which is what everything else that navigates already does.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send chat navigation to /app instead of /chat to remove the 308 redirect and align with controller expectations. Previously, chat-search and buildChatUrl pushed /chat, which redirected to /app and conflicted with useChatController’s pathname === "/app" assertion; now buildChatUrl and the command menu target /app directly.

**Notes**
- buildChatUrl returns `/app` (or `/search`) and no longer writes `/chat` into history.
- ChatSearchCommandMenu uses `useAppRouter` to route by chatSessionId or projectId, matching other navigators.

<sup>Written for commit 4834b5663e0c7016f21cf5fe553f51c440e72732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->