### PR TITLE
feat(ods): add update-base-digests to replace Dependabot's dead Docker coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,11 @@
 version: 2
+
+# Base image digests are NOT managed here. Dependabot's Docker parser rejects any
+# `FROM` line that interpolates a variable, and every Dockerfile in this repo
+# prefixes its base with the `${BASE_IMAGE_REGISTRY}` build arg, so a `docker`
+# entry finds no dependencies and opens no pull requests. The
+# .github/workflows/update-base-image-digests.yml job covers them instead, by
+# running `ods update-base-digests`.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -58,37 +65,3 @@ updates:
     labels:
       - "dependabot:javascript"
       - "dependabot:sandbox"
-  - package-ecosystem: "docker"
-    directory: "/backend/onyx/server/features/build/sandbox/image"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 3
-    assignees:
-      - "wenxi-onyx"
-    labels:
-      - "dependabot:docker"
-      - "dependabot:sandbox"
-  - package-ecosystem: "docker"
-    directory: "/web"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 1
-    assignees:
-      - "jmelahman"
-    labels:
-      - "dependabot:docker"
-  - package-ecosystem: "docker"
-    directory: "/backend"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 1
-    assignees:
-      - "jmelahman"
-    labels:
-      - "dependabot:docker"

--- a/.github/workflows/update-base-image-digests.yml
+++ b/.github/workflows/update-base-image-digests.yml
@@ -41,6 +41,10 @@ jobs:
           private-key: ${{ secrets.CHERRY_PICK_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          # release-opal.yml pins its own `node:24` container image, so the node
+          # family touches a workflow file. GitHub rejects a push from an App that
+          # changes .github/workflows/** without this.
+          permission-workflows: write
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6

--- a/.github/workflows/update-base-image-digests.yml
+++ b/.github/workflows/update-base-image-digests.yml
@@ -1,0 +1,181 @@
+### Refreshes the pinned base image digests across the repository and opens one
+### reviewed PR per base family when any of them moved.
+###
+### This replaces Dependabot's `docker` ecosystem, which cannot cover this repo:
+### its Dockerfile parser rejects any `FROM` line that interpolates a variable,
+### and every base image here is prefixed with `${BASE_IMAGE_REGISTRY}` so CI can
+### route through the ECR pull-through cache. The Docker Hardened Image digests
+### are not in a Dockerfile at all -- they live in a shell heredoc in
+### .github/actions/dhi-base-images/action.yml, which no Dependabot ecosystem
+### reads.
+###
+### A family is the last segment of an image name, so a public base and its DHI
+### counterpart land in the same PR. That keeps the default base and the hardened
+### image CI substitutes for it from drifting apart, while still letting a node
+### bump merge without waiting on a python bump.
+
+name: Update Base Image Digests
+
+on:
+  schedule:
+    - cron: "0 15 * * 1" # weekly, Monday 15:00 UTC (off the 13:00 recommended-models slot)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-base-image-digests
+  cancel-in-progress: false
+
+jobs:
+  update-base-image-digests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.CHERRY_PICK_APP_ID }}
+          private-key: ${{ secrets.CHERRY_PICK_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: true
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity as App
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          bot_user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${bot_user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+      # Built from source rather than the published `onyx-devtools` wheel, so a fix
+      # to the refresher ships without waiting on an `ods/v*` release.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # zizmor: ignore[cache-poisoning]
+        with:
+          go-version-file: tools/ods/go.mod
+          cache-dependency-path: tools/ods/go.sum
+
+      # Authenticated Docker Hub pulls dodge the anonymous rate limit, which a run
+      # resolving this many tags would otherwise hit. `ods` reads the credentials
+      # these steps write to the Docker config.
+      - name: Login to Docker Hub
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # The DHI catalog is private. Without this the refresh fails on the dhi.io
+      # references rather than leaving them silently stale.
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # Every family resolves against this one snapshot, so a tag that moves while
+      # the run is in flight cannot leave two PRs pinning different digests.
+      - name: Resolve current digests
+        working-directory: tools/ods
+        env:
+          CACHE_FILE: ${{ runner.temp }}/digests.json
+        run: |
+          go run . update-base-digests --cache-file "${CACHE_FILE}"
+          go run . update-base-digests --cache-file "${CACHE_FILE}" \
+            --list-stale-families > "${RUNNER_TEMP}/stale-families.txt"
+          {
+            echo "## Stale base families"
+            echo
+            sed 's/^/- /' "${RUNNER_TEMP}/stale-families.txt"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      # A fixed branch per family, force-pushed, matching update-recommended-models:
+      # the digests move week over week, so an already-open PR should carry the
+      # latest resolution rather than go stale behind a second one.
+      - name: Open or update a PR per family
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CACHE_FILE: ${{ runner.temp }}/digests.json
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ ! -s "${RUNNER_TEMP}/stale-families.txt" ]; then
+            echo "All pinned digests are current. Nothing to do."
+            exit 0
+          fi
+
+          # Read the list up front. `gh` and `git` in the body would otherwise
+          # compete with the loop for stdin.
+          mapfile -t families < "${RUNNER_TEMP}/stale-families.txt"
+
+          for family in "${families[@]}"; do
+            [ -n "${family}" ] || continue
+            branch="auto/base-image-digests/${family}"
+            git switch -C "${branch}" main
+
+            (cd tools/ods && go run . update-base-digests \
+              --write --family "${family}" --cache-file "${CACHE_FILE}" \
+              --summary-file "${RUNNER_TEMP}/summary-${family}.md")
+
+            if git diff --quiet; then
+              echo "No change for ${family}, skipping."
+              continue
+            fi
+
+            git commit --all -m "chore(deps): update ${family} base image digests"
+            git push --force origin "${branch}"
+
+            {
+              echo "Generated by the [Update Base Image Digests workflow run](${RUN_URL})."
+              echo
+              cat "${RUNNER_TEMP}/summary-${family}.md"
+              echo
+              echo "Refreshes digests only. A base pinned to an immutable patch tag"
+              echo "(for example \`golang:1.26.5-alpine\`) needs a manual tag bump."
+            } > "${RUNNER_TEMP}/pr-body-${family}.md"
+
+            title="chore(deps): update ${family} base image digests"
+            existing_pr="$(gh pr list --state open --head "${branch}" --json number --jq '.[0].number')"
+            if [ -n "${existing_pr}" ]; then
+              gh pr edit "${existing_pr}" --body-file "${RUNNER_TEMP}/pr-body-${family}.md"
+              echo "Refreshed existing PR #${existing_pr} via force-push."
+            else
+              gh pr create \
+                --base main \
+                --head "${branch}" \
+                --title "${title}" \
+                --body-file "${RUNNER_TEMP}/pr-body-${family}.md"
+            fi
+          done
+
+          git switch --force main
+
+  notify-slack-on-failure:
+    needs:
+      - update-base-image-digests
+    if: always() && needs.update-base-image-digests.result == 'failure'
+    runs-on: ubuntu-latest
+    environment: ci-protected
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/slack-notify
+
+      - name: Notify Slack about update failure
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          title: "🚨 Update Base Image Digests workflow failed"
+          details: "*The weekly base image digest refresh failed.* Check the run logs."

--- a/.github/workflows/update-base-image-digests.yml
+++ b/.github/workflows/update-base-image-digests.yml
@@ -145,6 +145,10 @@ jobs:
               echo
               echo "Refreshes digests only. A base pinned to an immutable patch tag"
               echo "(for example \`golang:1.26.5-alpine\`) needs a manual tag bump."
+              echo
+              echo "Some families touch adjacent lines of the same file, so this PR"
+              echo "can conflict after another family PR merges. Re-run the workflow"
+              echo "to regenerate it instead of resolving by hand."
             } > "${RUNNER_TEMP}/pr-body-${family}.md"
 
             title="chore(deps): update ${family} base image digests"

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -69,6 +69,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewLatestStableTagCommand())
 	cmd.AddCommand(NewWhoisCommand())
 	cmd.AddCommand(NewTraceCommand())
+	cmd.AddCommand(NewUpdateBaseDigestsCommand())
 	cmd.AddCommand(NewInstallSkillCommand())
 	cmd.AddCommand(NewReleaseCommand())
 

--- a/tools/ods/cmd/update_base_digests.go
+++ b/tools/ods/cmd/update_base_digests.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/basedigest"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+)
+
+// NewUpdateBaseDigestsCommand creates the update-base-digests command.
+func NewUpdateBaseDigestsCommand() *cobra.Command {
+	var (
+		write             bool
+		summaryFile       string
+		family            string
+		listStaleFamilies bool
+		cacheFile         string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update-base-digests",
+		Short: "Refresh the pinned base image digests across the repository",
+		Long: `Refresh the pinned base image digests across the repository.
+
+Every base image here is pinned as <name>:<tag>@sha256:<digest>, and most FROM
+lines prefix the name with the ${BASE_IMAGE_REGISTRY} build arg. Dependabot's
+Docker parser rejects any FROM line that interpolates a variable, so it opens no
+pull requests for this repo. This command covers those references instead: it
+asks each registry what the tag points at now and rewrites the digest in place.
+
+Credentials come from the ambient Docker keychain, so dhi.io references need a
+` + "`docker login dhi.io`" + ` with an account that has DHI catalog access.
+
+References group into families by the last segment of the image name, so a public
+base and its DHI counterpart move together in one pull request.
+
+Only digests are refreshed. A reference pinned to an immutable patch tag (for
+example golang:1.26.5-alpine) never moves, so bumping it is still a manual edit.
+
+Examples:
+  ods update-base-digests                                  # report every reference
+  ods update-base-digests --list-stale-families            # families needing a bump
+  ods update-base-digests --write --family python \
+      --cache-file digests.json                            # rewrite one family`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runUpdateBaseDigests(write, summaryFile, family, listStaleFamilies, cacheFile)
+		},
+	}
+
+	cmd.Flags().BoolVar(&write, "write", false, "rewrite the files; without it the command only reports")
+	cmd.Flags().StringVar(&summaryFile, "summary-file", "", "write a markdown summary of the changes to this path")
+	cmd.Flags().StringVar(&family, "family", "", "only act on one base family, for example `python` or `node`")
+	cmd.Flags().BoolVar(&listStaleFamilies, "list-stale-families", false, "print the families that have a stale digest, one per line, and exit")
+	cmd.Flags().StringVar(&cacheFile, "cache-file", "", "read resolved digests from this path, or write them there if absent")
+
+	return cmd
+}
+
+func runUpdateBaseDigests(write bool, summaryFile, family string, listStaleFamilies bool, cacheFile string) {
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Could not find the repository root: %v", err)
+	}
+
+	files, err := basedigest.TrackedFiles(root)
+	if err != nil {
+		log.Fatalf("Could not list the tracked files: %v", err)
+	}
+
+	refs, err := basedigest.FindRefs(root, files)
+	if err != nil {
+		log.Fatalf("Could not read the tracked files: %v", err)
+	}
+	if len(refs) == 0 {
+		log.Fatal("No pinned image references found.")
+	}
+
+	resolved, err := resolveWithCache(refs, cacheFile)
+	if err != nil {
+		log.Fatalf("Could not resolve every tag:\n%v", err)
+	}
+
+	stale := basedigest.Stale(refs, resolved)
+
+	if listStaleFamilies {
+		for _, name := range basedigest.Families(stale) {
+			fmt.Println(name)
+		}
+		return
+	}
+
+	if family != "" {
+		refs = basedigest.FilterFamily(refs, family)
+		stale = basedigest.FilterFamily(stale, family)
+		if len(refs) == 0 {
+			log.Fatalf("No references in family %q.", family)
+		}
+	}
+
+	for _, ref := range refs {
+		state := "current"
+		if ref.Digest != resolved[ref.Query()] {
+			state = "update"
+		}
+		fmt.Printf("%7s  %-45s %s:%d\n", state, ref.Display(), ref.Path, ref.Line)
+	}
+
+	summary := basedigest.SummaryTable(stale, resolved)
+
+	if len(stale) == 0 {
+		fmt.Println("\nAll pinned digests are current.")
+	} else if write {
+		if err := basedigest.Rewrite(root, stale, resolved); err != nil {
+			log.Fatalf("Could not rewrite the digests: %v", err)
+		}
+		fmt.Printf("\nUpdated %d reference(s).\n", len(stale))
+	} else {
+		fmt.Printf("\n%d reference(s) are stale. Re-run with --write to apply.\n", len(stale))
+	}
+
+	if summaryFile != "" {
+		if err := os.WriteFile(summaryFile, []byte(summary), 0o644); err != nil {
+			log.Fatalf("Could not write the summary: %v", err)
+		}
+	}
+}
+
+// resolveWithCache resolves every distinct tag, reusing cacheFile when it exists.
+//
+// The cache lets a caller resolve once and then rewrite one family at a time
+// against that single snapshot, so every branch of a run pins the same digests
+// even if a tag moves while the run is in flight.
+func resolveWithCache(refs []basedigest.Ref, cacheFile string) (map[string]string, error) {
+	if cacheFile != "" {
+		data, err := os.ReadFile(cacheFile)
+		if err == nil {
+			var cached map[string]string
+			if err := json.Unmarshal(data, &cached); err != nil {
+				return nil, fmt.Errorf("read cache %s: %w", cacheFile, err)
+			}
+			return cached, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("read cache %s: %w", cacheFile, err)
+		}
+	}
+
+	resolved, err := basedigest.ResolveAll(refs)
+	if err != nil {
+		return nil, err
+	}
+
+	if cacheFile != "" {
+		data, err := json.MarshalIndent(resolved, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encode cache: %w", err)
+		}
+		if err := os.WriteFile(cacheFile, append(data, '\n'), 0o644); err != nil {
+			return nil, fmt.Errorf("write cache %s: %w", cacheFile, err)
+		}
+	}
+	return resolved, nil
+}

--- a/tools/ods/cmd/update_base_digests.go
+++ b/tools/ods/cmd/update_base_digests.go
@@ -55,7 +55,7 @@ Examples:
 
 	cmd.Flags().BoolVar(&write, "write", false, "rewrite the files; without it the command only reports")
 	cmd.Flags().StringVar(&summaryFile, "summary-file", "", "write a markdown summary of the changes to this path")
-	cmd.Flags().StringVar(&family, "family", "", "only act on one base family, for example `python` or `node`")
+	cmd.Flags().StringVar(&family, "family", "", "only act on one base family, for example python or node")
 	cmd.Flags().BoolVar(&listStaleFamilies, "list-stale-families", false, "print the families that have a stale digest, one per line, and exit")
 	cmd.Flags().StringVar(&cacheFile, "cache-file", "", "read resolved digests from this path, or write them there if absent")
 

--- a/tools/ods/cmd/update_base_digests.go
+++ b/tools/ods/cmd/update_base_digests.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -135,25 +136,39 @@ func runUpdateBaseDigests(write bool, summaryFile, family string, listStaleFamil
 // The cache lets a caller resolve once and then rewrite one family at a time
 // against that single snapshot, so every branch of a run pins the same digests
 // even if a tag moves while the run is in flight.
+//
+// A cache written before a new base image was added covers only part of the
+// references. The entries it does have still hold the snapshot together, so the
+// missing ones are resolved and merged in rather than discarding the file.
 func resolveWithCache(refs []basedigest.Ref, cacheFile string) (map[string]string, error) {
+	cached := map[string]string{}
 	if cacheFile != "" {
 		data, err := os.ReadFile(cacheFile)
-		if err == nil {
-			var cached map[string]string
+		switch {
+		case err == nil:
 			if err := json.Unmarshal(data, &cached); err != nil {
 				return nil, fmt.Errorf("read cache %s: %w", cacheFile, err)
 			}
-			return cached, nil
-		}
-		if !os.IsNotExist(err) {
+		case !os.IsNotExist(err):
 			return nil, fmt.Errorf("read cache %s: %w", cacheFile, err)
 		}
 	}
 
-	resolved, err := basedigest.ResolveAll(refs)
+	missing := make([]basedigest.Ref, 0, len(refs))
+	for _, ref := range refs {
+		if _, ok := cached[ref.Query()]; !ok {
+			missing = append(missing, ref)
+		}
+	}
+	if len(missing) == 0 {
+		return cached, nil
+	}
+
+	resolved, err := basedigest.ResolveAll(missing)
 	if err != nil {
 		return nil, err
 	}
+	maps.Copy(resolved, cached)
 
 	if cacheFile != "" {
 		data, err := json.MarshalIndent(resolved, "", "  ")

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/charlievieth/fastwalk v1.0.14
 	github.com/gdamore/tcell/v2 v2.13.8
+	github.com/google/go-containerregistry v0.21.6
 	github.com/google/osv-scalibr v0.4.6-0.20260612031204-164402d9140e
 	github.com/google/osv-scanner/v2 v2.4.0
 	github.com/hashicorp/hcl/v2 v2.24.0
@@ -80,7 +81,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/go-containerregistry v0.21.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20260505044615-1ff4bf46051f // indirect
 	github.com/icholy/digest v1.1.0 // indirect

--- a/tools/ods/internal/basedigest/basedigest.go
+++ b/tools/ods/internal/basedigest/basedigest.go
@@ -1,0 +1,297 @@
+// Package basedigest refreshes the pinned base image digests across the Onyx
+// repository.
+//
+// Every base image in the repo is pinned as `<name>:<tag>@sha256:<digest>`, and
+// most FROM lines prefix the name with the ${BASE_IMAGE_REGISTRY} build arg so CI
+// can route through the ECR pull-through cache. Dependabot's Docker parser rejects
+// any FROM line that interpolates a variable, so it finds no dependencies in this
+// repo and opens no pull requests. The Docker Hardened Image digests are worse off
+// still: they live in a shell heredoc in .github/actions/dhi-base-images/action.yml,
+// which no Dependabot ecosystem reads at all.
+//
+// This package replaces that missing coverage. It finds every pinned reference,
+// asks the registry what the tag points at now, and rewrites the digests in place.
+package basedigest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// defaultRegistry is where a reference carrying the ${BASE_IMAGE_REGISTRY} build
+// arg resolves. The arg always stands in for a registry host, and CI only ever
+// points it at a pull-through cache of Docker Hub.
+const defaultRegistry = "docker.io"
+
+// imageRef matches a fully pinned image reference: an optional registry-arg
+// prefix, then name, tag and digest. Requiring both a tag and a 64-hex digest
+// keeps this off GitHub Actions `uses:` pins, which are 40-hex commit shas, and
+// off prose that spells out the reference format.
+var imageRef = regexp.MustCompile(
+	`(\$\{BASE_IMAGE_REGISTRY\}/)?` +
+		`([a-z0-9][a-z0-9._-]*(?:[/.][a-z0-9._-]+)*)` +
+		`:([A-Za-z0-9_][A-Za-z0-9._-]*)` +
+		`@(sha256:[0-9a-f]{64})`)
+
+// Ref is one pinned image reference found in a tracked file.
+type Ref struct {
+	Path     string // repo-relative
+	Line     int    // 1-indexed
+	Start    int    // byte offset of the digest within the line
+	End      int
+	Name     string
+	Tag      string
+	Digest   string
+	Prefixed bool // carried the ${BASE_IMAGE_REGISTRY} prefix
+}
+
+// Query is the reference to ask the registry about.
+func (r Ref) Query() string {
+	if r.Prefixed {
+		return fmt.Sprintf("%s/%s:%s", defaultRegistry, r.Name, r.Tag)
+	}
+	return fmt.Sprintf("%s:%s", r.Name, r.Tag)
+}
+
+// Display is the reference as written, without the registry arg.
+func (r Ref) Display() string {
+	return fmt.Sprintf("%s:%s", r.Name, r.Tag)
+}
+
+// Family is the base this reference belongs to, used to group it into one pull
+// request. It is the last path segment of the name, so a public base and its
+// hardened counterpart share a family: library/python, dhi.io/python and a bare
+// python all land in "python". Bumping them together keeps the default base and
+// the DHI override CI substitutes for it from drifting apart.
+func (r Ref) Family() string {
+	if i := strings.LastIndex(r.Name, "/"); i >= 0 {
+		return r.Name[i+1:]
+	}
+	return r.Name
+}
+
+// TrackedFiles returns the tracked files under root that may pin a base image
+// digest: every Dockerfile, plus the workflow and composite-action YAML that
+// carries an image reference of its own.
+func TrackedFiles(root string) ([]string, error) {
+	cmd := exec.Command("git", "ls-files", "-z")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+
+	var paths []string
+	for entry := range strings.SplitSeq(string(out), "\x00") {
+		if entry == "" {
+			continue
+		}
+		base := filepath.Base(entry)
+		ext := filepath.Ext(entry)
+		inCI := strings.HasPrefix(entry, ".github/workflows/") ||
+			strings.HasPrefix(entry, ".github/actions/")
+		if strings.HasPrefix(base, "Dockerfile") || (inCI && (ext == ".yml" || ext == ".yaml")) {
+			paths = append(paths, entry)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// FindRefs collects every pinned reference in the given repo-relative paths.
+func FindRefs(root string, paths []string) ([]Ref, error) {
+	var refs []Ref
+	for _, path := range paths {
+		data, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			for _, m := range imageRef.FindAllStringSubmatchIndex(line, -1) {
+				refs = append(refs, Ref{
+					Path:     path,
+					Line:     i + 1,
+					Start:    m[8],
+					End:      m[9],
+					Name:     line[m[4]:m[5]],
+					Tag:      line[m[6]:m[7]],
+					Digest:   line[m[8]:m[9]],
+					Prefixed: m[2] != -1,
+				})
+			}
+		}
+	}
+	return refs, nil
+}
+
+// Resolve returns the digest that query currently points at.
+//
+// For a multi-arch image this is the manifest-list digest, which is what the repo
+// pins so a single reference serves both amd64 and arm64 builds. Credentials come
+// from the ambient Docker keychain, so `docker login dhi.io` covers the private
+// DHI catalog.
+func Resolve(query string) (string, error) {
+	const attempts = 3
+	var lastErr error
+	for attempt := range attempts {
+		if attempt > 0 {
+			// A run resolves enough tags to draw a Docker Hub rate limit, so back
+			// off and retry rather than failing the whole refresh.
+			time.Sleep(time.Duration(5*attempt) * time.Second)
+		}
+		digest, err := crane.Digest(query, crane.WithAuthFromKeychain(authn.DefaultKeychain))
+		if err == nil {
+			return digest, nil
+		}
+		lastErr = err
+		if !retryable(err) {
+			break
+		}
+	}
+	return "", fmt.Errorf("could not resolve %s: %w", query, lastErr)
+}
+
+// retryable reports whether err is a transient registry failure worth another
+// attempt. A rate limit clears on its own; an unknown manifest or a rejected
+// credential never will, so those fail immediately.
+func retryable(err error) bool {
+	if terr, ok := errors.AsType[*transport.Error](err); ok {
+		return terr.StatusCode == 429 || terr.StatusCode >= 500
+	}
+	// A transport-level failure (DNS, TLS, connection reset) carries no status.
+	return true
+}
+
+// ResolveAll resolves every distinct tag in refs, reporting all failures together
+// rather than stopping at the first. A skipped registry means a base image
+// silently stays stale, which is the exact failure this package exists to prevent.
+func ResolveAll(refs []Ref) (map[string]string, error) {
+	queries := map[string]bool{}
+	for _, ref := range refs {
+		queries[ref.Query()] = true
+	}
+	ordered := make([]string, 0, len(queries))
+	for query := range queries {
+		ordered = append(ordered, query)
+	}
+	sort.Strings(ordered)
+
+	resolved := map[string]string{}
+	var failures []string
+	for _, query := range ordered {
+		digest, err := Resolve(query)
+		if err != nil {
+			failures = append(failures, err.Error())
+			continue
+		}
+		resolved[query] = digest
+	}
+	if len(failures) > 0 {
+		return nil, errors.New(strings.Join(failures, "\n"))
+	}
+	return resolved, nil
+}
+
+// Stale returns the references whose pinned digest no longer matches the registry.
+func Stale(refs []Ref, resolved map[string]string) []Ref {
+	var stale []Ref
+	for _, ref := range refs {
+		if ref.Digest != resolved[ref.Query()] {
+			stale = append(stale, ref)
+		}
+	}
+	return stale
+}
+
+// Families returns the sorted, deduplicated families covered by refs.
+func Families(refs []Ref) []string {
+	seen := map[string]bool{}
+	for _, ref := range refs {
+		seen[ref.Family()] = true
+	}
+	families := make([]string, 0, len(seen))
+	for family := range seen {
+		families = append(families, family)
+	}
+	sort.Strings(families)
+	return families
+}
+
+// FilterFamily returns only the references belonging to family.
+func FilterFamily(refs []Ref, family string) []Ref {
+	var kept []Ref
+	for _, ref := range refs {
+		if ref.Family() == family {
+			kept = append(kept, ref)
+		}
+	}
+	return kept
+}
+
+// Rewrite applies the resolved digests to the files the given references live in.
+func Rewrite(root string, refs []Ref, resolved map[string]string) error {
+	byPath := map[string][]Ref{}
+	for _, ref := range refs {
+		byPath[ref.Path] = append(byPath[ref.Path], ref)
+	}
+
+	for path, pathRefs := range byPath {
+		full := filepath.Join(root, path)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		lines := strings.Split(string(data), "\n")
+
+		// Work back to front so an earlier replacement cannot shift a later span.
+		sort.Slice(pathRefs, func(i, j int) bool {
+			if pathRefs[i].Line != pathRefs[j].Line {
+				return pathRefs[i].Line > pathRefs[j].Line
+			}
+			return pathRefs[i].Start > pathRefs[j].Start
+		})
+		for _, ref := range pathRefs {
+			line := lines[ref.Line-1]
+			lines[ref.Line-1] = line[:ref.Start] + resolved[ref.Query()] + line[ref.End:]
+		}
+
+		info, err := os.Stat(full)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		if err := os.WriteFile(full, []byte(strings.Join(lines, "\n")), info.Mode()); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// SummaryTable renders the stale references as a markdown table, for a run summary
+// or a pull request body.
+func SummaryTable(refs []Ref, resolved map[string]string) string {
+	if len(refs) == 0 {
+		return "All pinned digests are current.\n"
+	}
+	var b strings.Builder
+	b.WriteString("| Image | Tag | New digest | File |\n| --- | --- | --- | --- |\n")
+	for _, ref := range refs {
+		short := strings.TrimPrefix(resolved[ref.Query()], "sha256:")
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		fmt.Fprintf(&b, "| `%s` | `%s` | `%s` | `%s:%d` |\n",
+			ref.Name, ref.Tag, short, ref.Path, ref.Line)
+	}
+	return b.String()
+}

--- a/tools/ods/internal/basedigest/basedigest.go
+++ b/tools/ods/internal/basedigest/basedigest.go
@@ -239,8 +239,21 @@ func FilterFamily(refs []Ref, family string) []Ref {
 	return kept
 }
 
+// digestOnly matches a well-formed digest, and nothing else.
+var digestOnly = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
 // Rewrite applies the resolved digests to the files the given references live in.
 func Rewrite(root string, refs []Ref, resolved map[string]string) error {
+	// Refuse the whole write unless every replacement is a real digest. A missing
+	// entry would otherwise substitute the empty string and leave `name:tag@` in a
+	// Dockerfile, which is worse than the stale pin this package replaces.
+	for _, ref := range refs {
+		if !digestOnly.MatchString(resolved[ref.Query()]) {
+			return fmt.Errorf("refusing to write %s at %s:%d: resolved digest %q is not valid",
+				ref.Display(), ref.Path, ref.Line, resolved[ref.Query()])
+		}
+	}
+
 	byPath := map[string][]Ref{}
 	for _, ref := range refs {
 		byPath[ref.Path] = append(byPath[ref.Path], ref)

--- a/tools/ods/internal/basedigest/basedigest_test.go
+++ b/tools/ods/internal/basedigest/basedigest_test.go
@@ -1,0 +1,157 @@
+package basedigest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const digestA = "sha256:" + "aa" + "00000000000000000000000000000000000000000000000000000000000000"
+const digestB = "sha256:" + "bb" + "00000000000000000000000000000000000000000000000000000000000000"
+const digestC = "sha256:" + "cc" + "00000000000000000000000000000000000000000000000000000000000000"
+
+// writeFile creates a file under a temporary root and returns the root.
+func writeFile(t *testing.T, name, content string) string {
+	t.Helper()
+	root := t.TempDir()
+	full := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return root
+}
+
+func TestFindRefsParsesPrefixedAndBareReferences(t *testing.T) {
+	root := writeFile(t, "Dockerfile", strings.Join([]string{
+		"ARG BASE_IMAGE_REGISTRY=docker.io",
+		"FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@" + digestA + " AS base",
+		"FROM ghcr.io/astral-sh/uv:0.11.25@" + digestB,
+	}, "\n"))
+
+	refs, err := FindRefs(root, []string{"Dockerfile"})
+	if err != nil {
+		t.Fatalf("FindRefs: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2", len(refs))
+	}
+
+	if refs[0].Line != 2 || !refs[0].Prefixed {
+		t.Errorf("first ref = line %d prefixed %v, want line 2 prefixed true", refs[0].Line, refs[0].Prefixed)
+	}
+	if got, want := refs[0].Query(), "docker.io/library/python:3.13-slim"; got != want {
+		t.Errorf("Query() = %q, want %q", got, want)
+	}
+	if refs[1].Prefixed {
+		t.Error("second ref should not be marked prefixed")
+	}
+	if got, want := refs[1].Query(), "ghcr.io/astral-sh/uv:0.11.25"; got != want {
+		t.Errorf("Query() = %q, want %q", got, want)
+	}
+}
+
+// A GitHub Actions `uses:` pin is a 40-hex commit sha, not a 64-hex digest, so it
+// must not be mistaken for an image reference in the workflow files we scan.
+func TestFindRefsIgnoresActionPins(t *testing.T) {
+	root := writeFile(t, ".github/workflows/build.yml",
+		"      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n")
+
+	refs, err := FindRefs(root, []string{".github/workflows/build.yml"})
+	if err != nil {
+		t.Fatalf("FindRefs: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("got %d refs, want 0: %+v", len(refs), refs)
+	}
+}
+
+func TestFamilyGroupsPublicAndHardenedBases(t *testing.T) {
+	cases := map[string]string{
+		"library/python":       "python",
+		"dhi.io/python":        "python",
+		"python":               "python",
+		"ghcr.io/astral-sh/uv": "uv",
+		"oven/bun":             "bun",
+	}
+	for name, want := range cases {
+		if got := (Ref{Name: name}).Family(); got != want {
+			t.Errorf("Family(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// Two references on one line must both be replaced, and the rewrite must touch
+// only the digest bytes.
+func TestRewriteReplacesOnlyDigests(t *testing.T) {
+	const path = "Dockerfile"
+	original := strings.Join([]string{
+		"FROM ${BASE_IMAGE_REGISTRY}/library/node:24-trixie-slim@" + digestA + " AS builder",
+		"# see oven/bun:1@" + digestB + " and library/node:24-trixie-slim@" + digestA,
+		"",
+	}, "\n")
+	root := writeFile(t, path, original)
+
+	refs, err := FindRefs(root, []string{path})
+	if err != nil {
+		t.Fatalf("FindRefs: %v", err)
+	}
+	resolved := map[string]string{
+		"docker.io/library/node:24-trixie-slim": digestC,
+		"library/node:24-trixie-slim":           digestC,
+		"oven/bun:1":                            digestC,
+	}
+	if err := Rewrite(root, refs, resolved); err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, path))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	want := strings.NewReplacer(digestA, digestC, digestB, digestC).Replace(original)
+	if string(got) != want {
+		t.Errorf("Rewrite produced:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestStaleAndFamilyHelpers(t *testing.T) {
+	refs := []Ref{
+		{Name: "library/python", Tag: "3.13-slim", Digest: digestA},
+		{Name: "dhi.io/python", Tag: "3.13-debian13", Digest: digestB},
+		{Name: "oven/bun", Tag: "1", Digest: digestC},
+	}
+	resolved := map[string]string{
+		"library/python:3.13-slim":    digestC, // moved
+		"dhi.io/python:3.13-debian13": digestB, // current
+		"oven/bun:1":                  digestC, // current
+	}
+
+	stale := Stale(refs, resolved)
+	if len(stale) != 1 || stale[0].Name != "library/python" {
+		t.Fatalf("Stale() = %+v, want only library/python", stale)
+	}
+	if got := Families(refs); len(got) != 2 || got[0] != "bun" || got[1] != "python" {
+		t.Errorf("Families() = %v, want [bun python]", got)
+	}
+	if got := FilterFamily(refs, "python"); len(got) != 2 {
+		t.Errorf("FilterFamily(python) returned %d refs, want 2", len(got))
+	}
+}
+
+func TestSummaryTable(t *testing.T) {
+	if got := SummaryTable(nil, nil); !strings.Contains(got, "current") {
+		t.Errorf("empty SummaryTable() = %q, want a 'current' message", got)
+	}
+
+	refs := []Ref{{Path: "web/Dockerfile", Line: 7, Name: "oven/bun", Tag: "1", Digest: digestA}}
+	got := SummaryTable(refs, map[string]string{"oven/bun:1": digestC})
+	for _, want := range []string{"`oven/bun`", "`1`", "cc0000000000", "`web/Dockerfile:7`"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("SummaryTable() = %q, missing %q", got, want)
+		}
+	}
+}

--- a/tools/ods/internal/basedigest/basedigest_test.go
+++ b/tools/ods/internal/basedigest/basedigest_test.go
@@ -118,6 +118,30 @@ func TestRewriteReplacesOnlyDigests(t *testing.T) {
 	}
 }
 
+// A resolution map missing an entry must abort the write. Substituting the empty
+// string would leave `name:tag@` in a Dockerfile, which is worse than a stale pin.
+func TestRewriteRejectsMissingDigest(t *testing.T) {
+	const path = "Dockerfile"
+	original := "FROM ${BASE_IMAGE_REGISTRY}/library/ubuntu:26.04@" + digestA + "\n"
+	root := writeFile(t, path, original)
+
+	refs, err := FindRefs(root, []string{path})
+	if err != nil {
+		t.Fatalf("FindRefs: %v", err)
+	}
+	if err := Rewrite(root, refs, map[string]string{}); err == nil {
+		t.Fatal("Rewrite with an empty resolution map returned nil, want an error")
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, path))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("file was modified despite the error:\n%s", got)
+	}
+}
+
 func TestStaleAndFamilyHelpers(t *testing.T) {
 	refs := []Ref{
 		{Name: "library/python", Tag: "3.13-slim", Digest: digestA},


### PR DESCRIPTION
## Description

Dependabot's Docker parser skips any `FROM` line that interpolates a variable. Every base here is prefixed with `${BASE_IMAGE_REGISTRY}` (#11600), so the `docker` entries added in #12932 have always found zero dependencies — silently. The DHI digests were never covered at all; they live in a shell heredoc in `dhi-base-images/action.yml`.

This drops the dead entries and adds `ods update-base-digests`, plus a weekly workflow that opens one PR per base family.

- **24 references across 9 files**, vs the 4 Dockerfiles the old entries nominally covered.
- **Family = last segment of the image name**, so `library/python` and `dhi.io/python` bump in one PR and cannot drift apart, while `node` merges without waiting on `python`. All families resolve against one cached snapshot per run.
- **Built from source** (`go run .` via `go-version-file`), so a fix ships without an `ods/v*` release.
- **Digests only.** Four refs on immutable patch tags (`bun:1.3.14`, `golang:1.26.5-alpine`, `uv:0.11.25`, `node:24.16.0-trixie-slim`) still need manual bumps. Every generated PR body says so.

I did not take the alternative of dropping the ARG to make Dependabot parse it: `--build-context` matches the `FROM` ref verbatim including the digest, and a stale key is a **silent** no-op, so release builds would have quietly shipped un-hardened bases after each bump.

## How Has This Been Tested?

Against live registries: finds 24 refs / 19 stale; `--list-stale-families` → `bun node python ubuntu` (`golang`/`uv` correctly excluded). Wrote all four families, then diffed the 9 image files — **0 changed lines without a digest**. Re-run reported all current (idempotent), then reverted.

`go test ./internal/basedigest/` passes; `pre-commit` passes zizmor, actionlint, and golangci-lint.

Two notes: `TestDeployCloud_pushFailureRollsBackLocalTag` fails identically on clean `main` (pre-existing, unrelated). The workflow's PR-opening path hasn't run yet — it has `workflow_dispatch`, so worth triggering once after merge.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
