### PR TITLE
feat(terraform): deny non-TLS access on every S3 module bucket

### DIFF
--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -275,8 +275,11 @@ Key inputs include:
 - Always attaches a module-owned bucket policy with a `DenyInsecureTransport`
   statement, so the bucket rejects requests that do not use TLS. The module owns
   the whole policy: do not edit it outside Terraform, or the next apply replaces
-  your changes. Do not serve a module bucket through an S3 static website
-  endpoint; those endpoints are HTTP-only, so the deny blocks them
+  your changes. To keep custom statements, pass them as JSON documents via
+  `additional_policy_documents`; the module merges them into its policy. Custom
+  statements cannot replace the module's own statements — on a SID collision the
+  module statement wins. Do not serve a module bucket through an S3 static
+  website endpoint; those endpoints are HTTP-only, so the deny blocks them
 - Access can be scoped to an S3 gateway VPC endpoint (`s3_vpc_endpoint_id`), and
   optionally to source IPs or VPCs (`allow_anonymous_read` with
   `allowed_source_ips` / `allowed_vpc_ids`)
@@ -311,7 +314,9 @@ modules add settings the old ones did not manage:
 - `s3` now attaches a bucket policy to every bucket, not only when anonymous
   read or a VPC endpoint grant is configured. The policy denies non-TLS
   requests. If you attached your own policy to a module bucket outside
-  Terraform, the apply replaces it — merge those statements first
+  Terraform, the apply replaces it. Before you apply, move those statements
+  into `additional_policy_documents` on the `s3` module (on the `onyx` module:
+  `s3_additional_policy_documents` / `s3_upload_additional_policy_documents`)
 - `vpc` now creates flow logs and their IAM role
 - `postgres`, `redis`, and `opensearch` now create CloudWatch alarms
 - `postgres` now manages Multi-AZ (default false). If you enabled a standby

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -272,9 +272,14 @@ Key inputs include:
 - Creates an S3 bucket for file storage with versioning, server-side encryption
   (`aws:kms`, or `AES256` when anonymous read is enabled), a public access block,
   and lifecycle rules for noncurrent versions, expiration, and IA transition
-- Attaches a bucket policy only when one is needed. Access can be scoped to an S3
-  gateway VPC endpoint (`s3_vpc_endpoint_id`), and optionally to source IPs or VPCs
-  (`allow_anonymous_read` with `allowed_source_ips` / `allowed_vpc_ids`)
+- Always attaches a module-owned bucket policy with a `DenyInsecureTransport`
+  statement, so the bucket rejects requests that do not use TLS. The module owns
+  the whole policy: do not edit it outside Terraform, or the next apply replaces
+  your changes. Do not serve a module bucket through an S3 static website
+  endpoint; those endpoints are HTTP-only, so the deny blocks them
+- Access can be scoped to an S3 gateway VPC endpoint (`s3_vpc_endpoint_id`), and
+  optionally to source IPs or VPCs (`allow_anonymous_read` with
+  `allowed_source_ips` / `allowed_vpc_ids`)
 
 ### `opensearch`
 - Creates an Amazon OpenSearch domain inside the VPC
@@ -303,6 +308,10 @@ relabel state in place, so the plan shows moves rather than destroy/create:
 **Review the plan before applying.** Expect in-place updates where the new
 modules add settings the old ones did not manage:
 - `s3` now manages versioning, encryption, a public access block, and lifecycle rules
+- `s3` now attaches a bucket policy to every bucket, not only when anonymous
+  read or a VPC endpoint grant is configured. The policy denies non-TLS
+  requests. If you attached your own policy to a module bucket outside
+  Terraform, the apply replaces it — merge those statements first
 - `vpc` now creates flow logs and their IAM role
 - `postgres`, `redis`, and `opensearch` now create CloudWatch alarms
 - `postgres` now manages Multi-AZ (default false). If you enabled a standby

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -197,18 +197,20 @@ module "postgres" {
 }
 
 module "s3" {
-  source             = "../s3"
-  bucket_name        = local.bucket_name
-  tags               = local.merged_tags
-  s3_vpc_endpoint_id = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
+  source                      = "../s3"
+  bucket_name                 = local.bucket_name
+  tags                        = local.merged_tags
+  s3_vpc_endpoint_id          = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
+  additional_policy_documents = var.s3_additional_policy_documents
 }
 
 module "s3_upload" {
-  count              = var.enable_upload_bucket ? 1 : 0
-  source             = "../s3"
-  bucket_name        = local.upload_bucket_name
-  tags               = local.merged_tags
-  s3_vpc_endpoint_id = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
+  count                       = var.enable_upload_bucket ? 1 : 0
+  source                      = "../s3"
+  bucket_name                 = local.upload_bucket_name
+  tags                        = local.merged_tags
+  s3_vpc_endpoint_id          = var.create_vpc ? module.vpc[0].s3_vpc_endpoint_id : var.s3_vpc_endpoint_id
+  additional_policy_documents = var.s3_upload_additional_policy_documents
 }
 
 module "eks" {

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -186,6 +186,18 @@ variable "s3_vpc_endpoint_id" {
   }
 }
 
+variable "s3_additional_policy_documents" {
+  type        = list(string)
+  description = "IAM policy documents (JSON strings) merged into the main bucket's policy. See additional_policy_documents on the s3 module."
+  default     = []
+}
+
+variable "s3_upload_additional_policy_documents" {
+  type        = list(string)
+  description = "IAM policy documents (JSON strings) merged into the upload bucket's policy. Only used when enable_upload_bucket is true."
+  default     = []
+}
+
 variable "rds_db_connect_arn" {
   type        = string
   description = "Full rds-db:connect ARN to pass to the EKS module. Required when enable_rds_iam_auth is true."

--- a/deployment/terraform/modules/aws/s3/main.tf
+++ b/deployment/terraform/modules/aws/s3/main.tf
@@ -91,12 +91,38 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   }
 }
 
-locals {
-  needs_bucket_policy = (var.allow_anonymous_read && (length(var.allowed_vpc_ids) > 0 || length(var.allowed_source_ips) > 0)) || length(var.s3_vpc_endpoint_id) > 0
-}
-
 data "aws_iam_policy_document" "anonymous_read" {
-  count = local.needs_bucket_policy ? 1 : 0
+  # Always rendered. Every bucket now carries the DenyInsecureTransport
+  # statement below, so the policy is never absent. The `anonymous_read` name
+  # is historical — this address has already been renamed once (see the moved
+  # blocks at the top of this file), so it is left alone.
+
+  # Reject any request that did not arrive over TLS. Additive and safe: it
+  # denies only traffic that is already plaintext. Required by SOC 2 (Vanta
+  # test `aws-storage-buckets-enforce-https`).
+  #
+  # Never apply this to a bucket served through an S3 *static website*
+  # endpoint. Those endpoints are HTTP-only, so the deny takes the site
+  # offline. This module never configures website hosting, so the case cannot
+  # arise here.
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*"
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 
   # Allow anonymous GetObject from allowed IPs
   dynamic "statement" {
@@ -167,7 +193,10 @@ data "aws_iam_policy_document" "anonymous_read" {
 }
 
 resource "aws_s3_bucket_policy" "anonymous_read" {
-  count  = local.needs_bucket_policy ? 1 : 0
+  # count is pinned to 1 rather than removed: the index keeps the resource
+  # address at `anonymous_read[0]`, which the moved block at the top of this
+  # file targets. Dropping count would break that upgrade path.
+  count  = 1
   bucket = aws_s3_bucket.this.id
-  policy = data.aws_iam_policy_document.anonymous_read[0].json
+  policy = data.aws_iam_policy_document.anonymous_read.json
 }

--- a/deployment/terraform/modules/aws/s3/main.tf
+++ b/deployment/terraform/modules/aws/s3/main.tf
@@ -97,6 +97,10 @@ data "aws_iam_policy_document" "anonymous_read" {
   # is historical — this address has already been renamed once (see the moved
   # blocks at the top of this file), so it is left alone.
 
+  # Caller-supplied statements. On a SID collision the inline statements below
+  # win, so these cannot weaken DenyInsecureTransport.
+  source_policy_documents = var.additional_policy_documents
+
   # Reject any request that did not arrive over TLS. Additive and safe: it
   # denies only traffic that is already plaintext. Required by SOC 2 (Vanta
   # test `aws-storage-buckets-enforce-https`).

--- a/deployment/terraform/modules/aws/s3/variables.tf
+++ b/deployment/terraform/modules/aws/s3/variables.tf
@@ -81,6 +81,20 @@ variable "allow_anonymous_read" {
   default     = false
 }
 
+variable "additional_policy_documents" {
+  # Merged via source_policy_documents, so the module's own statements win on a
+  # SID collision. Callers can add statements but cannot replace
+  # DenyInsecureTransport.
+  description = "IAM policy documents (JSON strings) merged into the bucket policy. Use this to keep custom statements that the module does not generate. Give each statement a SID that no other statement uses."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for doc in var.additional_policy_documents : can(jsondecode(doc))])
+    error_message = "Each entry in additional_policy_documents must be a valid JSON policy document."
+  }
+}
+
 variable "s3_vpc_endpoint_id" {
   description = "ID of an S3 gateway VPC endpoint allowed to access this bucket. Leave empty to skip the VPCE policy statement."
   type        = string


### PR DESCRIPTION
## What

The shared S3 module (`deployment/terraform/modules/aws/s3`) emitted a bucket policy only when a caller asked for anonymous read or a VPC-endpoint grant. Buckets without one had no policy at all, so nothing rejected plaintext HTTP.

This renders the policy document unconditionally and always includes a `DenyInsecureTransport` statement. The allow statements stay conditional.

## Why

Vanta SOC 2 test `aws-storage-buckets-enforce-https` (high severity) flagged 53 buckets in the account. The live buckets have been remediated directly; this makes HTTPS-only the default so new module-created buckets pass on day one instead of drifting back.

## Safety

This changes nothing about *who* can read a bucket. It only rejects requests that did not arrive over TLS.

The one configuration a `SecureTransport` deny breaks is an S3 **static website** endpoint, which is HTTP-only. This module never configures website hosting, so the case cannot arise. A comment in the code records that constraint.

All 53 flagged buckets were checked before the live change:
- 0 of 53 use a static website endpoint.
- Both CloudFront origins among them use the S3 REST endpoint with OAI/OAC, which is always HTTPS. Verified by fetching real objects through both distributions after the change (HTTP 200).
- The account's three `http-only` CloudFront origins point at website-endpoint buckets that are **not** in scope.

## Note for reviewers

`count` on `aws_s3_bucket_policy.anonymous_read` is pinned to `1` rather than removed. The index keeps the address at `anonymous_read[0]`, which the `moved` block at the top of the file targets. Dropping `count` would break that upgrade path.

`terraform validate` passes and `terraform fmt` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces HTTPS-only access on all buckets created by the shared Terraform S3 module by always attaching a bucket policy with a DenyInsecureTransport statement. Previously, buckets only had a policy when anonymous read or a VPC endpoint grant was requested; this closes that gap without changing who can read or write.

**Migration**
- Plan/apply will add a new `aws_s3_bucket_policy` to existing module-managed buckets.
- Buckets served via the S3 static website endpoint would break because it is HTTP-only; this module does not enable website hosting, but verify no external website hosting is configured.
- CloudFront distributions using the S3 REST endpoint (with OAI/OAC) continue to work as-is.

<sup>Written for commit 61e83eb4320e5da725b32b65f036cb09f90b9294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

