### PR TITLE
fix(saml): allow disabling requestedAuthnContext and redirect after callback

### DIFF
--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -72,6 +72,11 @@ class SAMLProviderConfig(_ProviderConfig):
     # IdP attribute the email is read from. None falls back to the common keys
     # (email, mail, the Entra/ADFS claim URIs) the SAML callback already tries.
     email_attribute: str | None = None
+    # Whether AuthnRequests demand an exact-match PasswordProtectedTransport
+    # context. IdPs that require MFA/FIDO2 (e.g. Microsoft Entra ID with
+    # Conditional Access) reject the exact match with AADSTS75011, since the
+    # user's actual auth context is stronger than the requested one.
+    request_authn_context: bool = True
 
 
 # provider_type selects the config shape. A new auth method adds a model here.

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -159,6 +159,12 @@ def _sanitize_relay_state(candidate: str | None) -> str | None:
     if not relay_state or not relay_state.startswith("/"):
         return None
 
+    # Reject protocol-relative ("//evil.com") and Chrome's absolute "///" form.
+    # urlparse alone misses the "///" case: it reports an empty netloc for it,
+    # even though some browsers resolve it to a scheme-relative navigation.
+    if relay_state.startswith("//"):
+        return None
+
     if "\\" in relay_state:
         return None
 

--- a/backend/onyx/server/saml_multi.py
+++ b/backend/onyx/server/saml_multi.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, NoReturn, TypedDict
 
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import RedirectResponse
 from fastapi_users.authentication import Strategy
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
@@ -72,11 +73,16 @@ class _SamlIdpSettings(TypedDict):
     x509cert: str
 
 
+class _SamlSecuritySettings(TypedDict):
+    requestedAuthnContext: bool
+
+
 class _SamlSettings(TypedDict):
     strict: bool
     debug: bool
     sp: _SamlSpSettings
     idp: _SamlIdpSettings
+    security: _SamlSecuritySettings
 
 
 def build_saml_settings(config: SAMLProviderConfig) -> _SamlSettings:
@@ -101,6 +107,9 @@ def build_saml_settings(config: SAMLProviderConfig) -> _SamlSettings:
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
             },
             "x509cert": config.idp_x509_cert,
+        },
+        "security": {
+            "requestedAuthnContext": config.request_authn_context,
         },
     }
 
@@ -356,7 +365,33 @@ async def _process_saml_callback(
     )
     response = await auth_backend.login(strategy, user)
     await user_manager.on_after_login(user, request, response)
-    return response
+
+    # The IdP posts the SAMLResponse via a genuine top-level browser navigation
+    # (its own auto-submitting form), not frontend JS. auth_backend.login()
+    # returns fastapi-users' CookieTransport default - a bare 204 with only a
+    # Set-Cookie header, meant for a JS caller that redirects itself. A 204
+    # with no Location header on a real navigation leaves the browser on the
+    # IdP's blank intermediate page even though the cookie was set. Wrap the
+    # response in a redirect to the relay-state destination, the same way
+    # onyx.auth.users.complete_login_flow (the OIDC/OAuth equivalent) wraps
+    # backend.login()'s response.
+    relay_state = req["post_data"].get("RelayState") or req["get_data"].get(
+        "RelayState"
+    )
+    next_path = (
+        _sanitize_relay_state(relay_state if isinstance(relay_state, str) else None)
+        or "/app"
+    )
+    redirect_response = RedirectResponse(next_path, status_code=302)
+    for header_name, header_value in response.headers.items():
+        header_name_lower = header_name.lower()
+        if header_name_lower == "set-cookie":
+            redirect_response.headers.append(header_name, header_value)
+            continue
+        if header_name_lower in {"location", "content-length"}:
+            continue
+        redirect_response.headers[header_name] = header_value
+    return redirect_response
 
 
 @router.post("/logout")

--- a/backend/tests/unit/onyx/server/test_saml_multi.py
+++ b/backend/tests/unit/onyx/server/test_saml_multi.py
@@ -19,6 +19,7 @@ from onyx.db.models import SSOProvider
 from onyx.db.sso_provider import SAMLProviderConfig
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server import saml_multi
+from onyx.server.saml import _sanitize_relay_state
 from onyx.utils.sensitive import make_mock_sensitive_value
 
 _IDP = {
@@ -341,3 +342,55 @@ async def test_process_saml_callback_rejects_external_relay_state(
     )
 
     assert response.headers["location"] == "/app"
+
+
+@pytest.mark.asyncio
+async def test_process_saml_callback_rejects_protocol_relative_relay_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # "///evil.example" has no netloc under urlparse, but some browsers still
+    # resolve it as scheme-relative navigation to evil.example.
+    _stub_callback_dependencies(monkeypatch, relay_state="///evil.example")
+
+    async def _fake_on_after_login(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    user_manager = cast(Any, SimpleNamespace(on_after_login=_fake_on_after_login))
+    response = await saml_multi._process_saml_callback(
+        cast(Any, SimpleNamespace()), _DB, cast(Any, None), user_manager
+    )
+
+    assert response.headers["location"] == "/app"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_relay_state: internal-path guard shared by the /authorize `next`
+# param and the callback's RelayState handling.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        None,
+        "",
+        "relative/no-leading-slash",
+        "//evil.example",
+        "///evil.example",
+        "////evil.example",
+        "/\\evil.example",
+        "/path:with-colon",
+        "https://evil.example/steal",
+        "javascript:alert(1)",
+    ],
+)
+def test_sanitize_relay_state_rejects_unsafe_values(candidate: str | None) -> None:
+    assert _sanitize_relay_state(candidate) is None
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    ["/app", "/settings?x=1", "/path#fragment"],
+)
+def test_sanitize_relay_state_accepts_internal_paths(candidate: str) -> None:
+    assert _sanitize_relay_state(candidate) == candidate

--- a/backend/tests/unit/onyx/server/test_saml_multi.py
+++ b/backend/tests/unit/onyx/server/test_saml_multi.py
@@ -1,15 +1,18 @@
 """Unit coverage for the DB-backed SAML router: the OneLogin settings built from
 a provider row (fixed ACS), fail-closed resolution by name and by issuer, the
 issuer extraction that routes the single callback, the per-provider email-domain
-gate, and email extraction from SAML attributes. No DB or live IdP."""
+gate, email extraction from SAML attributes, and the post-login redirect. No DB
+or live IdP."""
 
 import base64
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from fastapi.responses import RedirectResponse
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from sqlalchemy.orm import Session
+from starlette.responses import Response as StarletteResponse
 
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
@@ -53,6 +56,16 @@ def test_build_saml_settings_optional_sp_defaults_empty() -> None:
     settings = saml_multi.build_saml_settings(_config())
     assert settings["sp"]["x509cert"] == ""
     assert settings["sp"]["privateKey"] == ""
+
+
+def test_build_saml_settings_requested_authn_context_defaults_true() -> None:
+    settings = saml_multi.build_saml_settings(_config())
+    assert settings["security"]["requestedAuthnContext"] is True
+
+
+def test_build_saml_settings_requested_authn_context_can_be_disabled() -> None:
+    settings = saml_multi.build_saml_settings(_config(request_authn_context=False))
+    assert settings["security"]["requestedAuthnContext"] is False
 
 
 def _provider(**overrides: object) -> SSOProvider:
@@ -203,3 +216,128 @@ def test_extract_email_missing_raises() -> None:
     auth = _fake_auth({"displayName": ["Alice"]})
     with pytest.raises(OnyxError):
         saml_multi._extract_user_email(auth, _config())
+
+
+# ---------------------------------------------------------------------------
+# Post-login redirect: the IdP posts SAMLResponse via a real top-level
+# navigation, so the callback must wrap auth_backend.login()'s bare 204 in a
+# redirect the same way onyx.auth.users.complete_login_flow does for OIDC/OAuth,
+# or the browser is left stuck on the IdP's blank auto-submit page.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCallbackAuth:
+    def __init__(self, _req: dict[str, Any], old_settings: Any) -> None:
+        del old_settings
+
+    def process_response(self) -> None:
+        pass
+
+    def get_errors(self) -> list[str]:
+        return []
+
+    def get_last_error_reason(self) -> str:
+        return ""
+
+    def is_authenticated(self) -> bool:
+        return True
+
+    def get_attribute(self, key: str) -> list[str] | None:
+        return {"email": ["user@example.com"]}.get(key)
+
+    def get_attributes(self) -> dict[str, list[str]]:
+        return {"email": ["user@example.com"]}
+
+
+def _stub_callback_dependencies(
+    monkeypatch: pytest.MonkeyPatch, *, relay_state: str | None
+) -> StarletteResponse:
+    xml = _RESPONSE.format(body=f"<saml:Issuer>{_IDP['idp_entity_id']}</saml:Issuer>")
+    post_data: dict[str, Any] = {"SAMLResponse": _encode(xml)}
+    if relay_state is not None:
+        post_data["RelayState"] = relay_state
+
+    async def _fake_prepare(_request: Any) -> dict[str, Any]:
+        return {"post_data": post_data, "get_data": {}}
+
+    monkeypatch.setattr(saml_multi, "prepare_from_fastapi_request", _fake_prepare)
+    monkeypatch.setattr(
+        saml_multi, "fetch_sso_providers", lambda **_kw: [_provider(name="saml")]
+    )
+    monkeypatch.setattr(saml_multi, "OneLogin_Saml2_Auth", _FakeCallbackAuth)
+
+    async def _fake_upsert(email: str) -> Any:
+        del email
+        return SimpleNamespace(is_active=True)
+
+    monkeypatch.setattr(saml_multi, "upsert_saml_user", _fake_upsert)
+
+    async def _fake_capture(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    monkeypatch.setattr(saml_multi, "capture_saml_login_claims", _fake_capture)
+
+    login_response = StarletteResponse(status_code=204)
+    login_response.headers["set-cookie"] = "onyxauth=abc; Path=/; HttpOnly"
+
+    async def _fake_login(_strategy: Any, _user: Any) -> StarletteResponse:
+        return login_response
+
+    monkeypatch.setattr(saml_multi.auth_backend, "login", _fake_login)
+    return login_response
+
+
+@pytest.mark.asyncio
+async def test_process_saml_callback_redirects_and_carries_cookie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_callback_dependencies(monkeypatch, relay_state="/settings")
+
+    async def _fake_on_after_login(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    user_manager = cast(Any, SimpleNamespace(on_after_login=_fake_on_after_login))
+    response = await saml_multi._process_saml_callback(
+        cast(Any, SimpleNamespace()), _DB, cast(Any, None), user_manager
+    )
+
+    assert isinstance(response, RedirectResponse)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/settings"
+    assert response.headers["set-cookie"] == "onyxauth=abc; Path=/; HttpOnly"
+
+
+@pytest.mark.asyncio
+async def test_process_saml_callback_falls_back_to_app_without_relay_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_callback_dependencies(monkeypatch, relay_state=None)
+
+    async def _fake_on_after_login(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    user_manager = cast(Any, SimpleNamespace(on_after_login=_fake_on_after_login))
+    response = await saml_multi._process_saml_callback(
+        cast(Any, SimpleNamespace()), _DB, cast(Any, None), user_manager
+    )
+
+    assert response.headers["location"] == "/app"
+
+
+@pytest.mark.asyncio
+async def test_process_saml_callback_rejects_external_relay_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_callback_dependencies(
+        monkeypatch, relay_state="https://evil.example.com/steal"
+    )
+
+    async def _fake_on_after_login(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    user_manager = cast(Any, SimpleNamespace(on_after_login=_fake_on_after_login))
+    response = await saml_multi._process_saml_callback(
+        cast(Any, SimpleNamespace()), _DB, cast(Any, None), user_manager
+    )
+
+    assert response.headers["location"] == "/app"

--- a/web/src/lib/sso/utils.ts
+++ b/web/src/lib/sso/utils.ts
@@ -53,6 +53,11 @@ export interface SSOConfigField {
   description: string;
   optional?: boolean;
   placeholder?: string;
+  // Value a "switch" field starts at when the stored config has no key for
+  // it yet (a row saved before the field existed, or a brand-new provider).
+  // Must match the backend model's default so re-saving an untouched
+  // provider round-trips its value instead of silently overriding it.
+  switchDefault?: boolean;
 }
 
 const CLIENT_ID_FIELD: SSOConfigField = {
@@ -184,6 +189,10 @@ export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
           "Turn off for IdPs that enforce MFA or FIDO2 (such as Microsoft " +
           "Entra ID with Conditional Access), which reject the exact match " +
           "with AADSTS75011.",
+        // Matches SAMLProviderConfig.request_authn_context's backend default,
+        // so a provider saved before this field existed keeps behaving the
+        // same way the first time its form is opened and re-saved.
+        switchDefault: true,
       },
     ],
   };

--- a/web/src/lib/sso/utils.ts
+++ b/web/src/lib/sso/utils.ts
@@ -175,6 +175,16 @@ export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
         optional: true,
         placeholder: "email",
       },
+      {
+        name: "request_authn_context",
+        label: "Require Exact-Match Authentication Context",
+        kind: "switch",
+        description:
+          "Request PasswordProtectedTransport specifically at sign-in. " +
+          "Turn off for IdPs that enforce MFA or FIDO2 (such as Microsoft " +
+          "Entra ID with Conditional Access), which reject the exact match " +
+          "with AADSTS75011.",
+      },
     ],
   };
 

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -154,7 +154,9 @@ function initialConfig(
   const initial: Record<string, string | boolean | string[]> = {};
   for (const field of ALL_CONFIG_FIELDS) {
     if (field.kind === "switch") {
-      initial[field.name] = config[field.name] === true;
+      const stored = config[field.name];
+      initial[field.name] =
+        stored === undefined ? Boolean(field.switchDefault) : stored === true;
       continue;
     }
     if (field.kind === "chips") {


### PR DESCRIPTION
## Summary

Fixes #14187.

- `build_saml_settings()` built no `security` block, so `python3-saml` defaulted `requestedAuthnContext` to `True` and demanded an exact-match `PasswordProtectedTransport` context on every AuthnRequest. IdPs that enforce MFA/FIDO2 (e.g. Microsoft Entra ID with Conditional Access) reject that with `AADSTS75011`. Add a per-provider `request_authn_context` toggle on `SAMLProviderConfig` (default `True`, preserving current behavior for existing rows) with a matching admin-UI switch, so admins can turn exact-match off for IdPs that need it.
- `_process_saml_callback()` also returned `auth_backend.login()`'s bare 204 as-is. Entra posts the `SAMLResponse` via a genuine top-level browser navigation (its own auto-submitting form), not frontend JS, so the 204 with no `Location` header left the browser stuck on the IdP's blank intermediate page after a successful sign-in (the session cookie was set correctly; only the navigation was missing). Wrap it in a 302 redirect to the sanitized `RelayState` destination (falling back to `/app`), copying headers over the same way `onyx.auth.users.complete_login_flow` already does for the OIDC/OAuth callback.

## Test plan

- [x] `uv run pytest -xq backend/tests/unit/onyx/server/test_saml_multi.py` — new unit coverage for both the `security.requestedAuthnContext` toggle and the post-login redirect (with/without RelayState, and rejecting an external RelayState).
- [x] `uv run ty check backend/onyx/server/saml_multi.py backend/onyx/db/sso_provider.py backend/tests/unit/onyx/server/test_saml_multi.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows disabling exact-match SAML AuthnContext per provider and redirects the browser after a successful SAML login. Previously we required PasswordProtectedTransport and returned a 204 with no Location; now users land in the app, RelayState is hardened against protocol-relative paths, and the admin switch default matches the backend.

**New Features**
- Adds a `request_authn_context` toggle on SAML providers; default true for existing rows.
- Adds an admin UI switch for the toggle.

**Bug Fixes**
- Redirects to the sanitized RelayState (or `/app`) after login and preserves Set-Cookie.
- Rejects external and protocol-relative RelayState values, including triple-slash.
- Defaults the admin switch to the backend’s value when the key is missing to prevent unintended flips on re-save.

<sup>Written for commit 56cb9176389193044867d9d76e2e5e62ec06b7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

