### PR TITLE
feat(audit): emit audit events for group permission and membership changes

### DIFF
--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from collections.abc import Sequence
 from operator import and_
+from typing import NamedTuple
 from uuid import UUID
 
 from sqlalchemy import Select, delete, func, select
@@ -880,6 +881,9 @@ def update_user_group(
 
     db_session.commit()
 
+    group_name = db_user_group.name
+    group_is_default = db_user_group.is_default
+
     # Core writes above leave the loaded ORM collections stale, and sessions run
     # expire_on_commit=False — without this the caller serializes pre-update membership.
     db_session.expire(db_user_group)
@@ -892,6 +896,8 @@ def update_user_group(
             resource_type="user_group",
             resource_id=user_group_id,
             extra={
+                "group_name": group_name,
+                "is_default": group_is_default,
                 "added_user_ids": [str(uid) for uid in added_user_ids],
                 "removed_user_ids": [str(uid) for uid in removed_user_ids],
             },
@@ -1087,12 +1093,23 @@ def delete_user_group_cc_pair_relationship__no_commit(
     db_session.execute(delete_stmt)
 
 
+class PermissionChange(NamedTuple):
+    """The diff is computed here, not by the caller, because this is the only place
+    holding the row lock. A caller diffing before and after would race a concurrent
+    save and would read whatever the ORM had already cached.
+    """
+
+    enabled: list[Permission]
+    added: list[Permission]
+    removed: list[Permission]
+
+
 def set_group_permissions_bulk__no_commit(
     group_id: int,
     desired_permissions: set[Permission],
     granted_by: UUID,
     db_session: Session,
-) -> list[Permission]:
+) -> PermissionChange:
     """Set the full desired permission state for a group in one pass.
 
     Enables permissions in `desired_permissions`, disables any toggleable
@@ -1102,8 +1119,6 @@ def set_group_permissions_bulk__no_commit(
     Grants are soft-deleted: revoking flips `is_deleted`, re-granting flips it back and
     re-stamps `granted_by`/`granted_at`, so a row is INSERTed only once per group and the
     grant history survives. Readers must filter `is_deleted.is_(False)`.
-
-    Returns the resulting list of enabled permissions.
     """
 
     existing_grants = (
@@ -1124,6 +1139,9 @@ def set_group_permissions_bulk__no_commit(
     # not managed here — never enabled, never disabled.
     desired_permissions = desired_permissions - NON_TOGGLEABLE_PERMISSIONS
 
+    added: list[Permission] = []
+    removed: list[Permission] = []
+
     # Enable desired permissions
     for perm in desired_permissions:
         existing = grant_map.get(perm)
@@ -1132,6 +1150,7 @@ def set_group_permissions_bulk__no_commit(
                 existing.is_deleted = False
                 existing.granted_by = granted_by
                 existing.granted_at = func.now()
+                added.append(perm)
         else:
             db_session.add(
                 PermissionGrant(
@@ -1141,6 +1160,7 @@ def set_group_permissions_bulk__no_commit(
                     granted_by=granted_by,
                 )
             )
+            added.append(perm)
 
     # Disable toggleable permissions not in the desired set
     for perm, grant in grant_map.items():
@@ -1150,12 +1170,12 @@ def set_group_permissions_bulk__no_commit(
             and not grant.is_deleted
         ):
             grant.is_deleted = True
+            removed.append(perm)
 
     db_session.flush()
     recompute_permissions_for_group__no_commit(group_id, db_session)
 
-    # Return the resulting enabled set
-    return [
+    enabled = [
         g.permission
         for g in db_session.execute(
             select(PermissionGrant).where(
@@ -1166,3 +1186,8 @@ def set_group_permissions_bulk__no_commit(
         .scalars()
         .all()
     ]
+    return PermissionChange(
+        enabled=enabled,
+        added=sorted(added, key=lambda p: p.value),
+        removed=sorted(removed, key=lambda p: p.value),
+    )

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -12,7 +12,7 @@ require a valid SCIM bearer token.
 from __future__ import annotations
 
 import re
-from typing import NamedTuple
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, FastAPI, Query, Request, Response
@@ -72,10 +72,67 @@ from onyx.db.permissions import (
 )
 from onyx.db.users import assign_user_to_default_groups__no_commit, user_is_admin
 from onyx.db.utils import is_unique_violation
+from onyx.utils.audit import (
+    AuditAction,
+    AuditActor,
+    AuditOutcome,
+    emit_audit_event,
+)
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
+
+
+def _scim_actor(token: ScimToken) -> AuditActor:
+    """The ``scim_token:`` prefix keeps this id from colliding with the numeric
+    api-key ids that share the same field."""
+    return AuditActor(api_key_id=f"scim_token:{token.id}", auth_type="scim")
+
+
+def _scim_extra(token: ScimToken, **fields: Any) -> dict[str, Any]:
+    return {"source": "scim", "scim_token_name": token.name, **fields}
+
+
+def _emit_scim_group_update(
+    token: ScimToken,
+    *,
+    group_id: int,
+    group_name: str,
+    previous_name: str,
+    added_user_ids: list[UUID],
+    removed_user_ids: list[UUID],
+) -> None:
+    """Both emits are gated on a real change. IdPs re-PUT a group's full state on
+    routine reconciliation, so an ungated emit would fire on every no-op sync.
+    """
+    if group_name != previous_name:
+        emit_audit_event(
+            AuditAction.USER_GROUP_RENAME,
+            AuditOutcome.SUCCESS,
+            actor=_scim_actor(token),
+            resource_type="user_group",
+            resource_id=group_id,
+            extra=_scim_extra(token, previous_name=previous_name, new_name=group_name),
+        )
+
+    if added_user_ids or removed_user_ids:
+        emit_audit_event(
+            AuditAction.USER_GROUP_CHANGE,
+            AuditOutcome.SUCCESS,
+            actor=_scim_actor(token),
+            resource_type="user_group",
+            resource_id=group_id,
+            extra=_scim_extra(
+                token,
+                group_name=group_name,
+                # SCIM refuses reserved names, so it can never reach a default group.
+                is_default=False,
+                added_user_ids=[str(uid) for uid in added_user_ids],
+                removed_user_ids=[str(uid) for uid in removed_user_ids],
+            ),
+        )
+
 
 # Group names reserved for system default groups (seeded by migration).
 _RESERVED_GROUP_NAMES = frozenset({"Admin", "Basic"})
@@ -1314,6 +1371,20 @@ def create_group(
 
     dal.commit()
 
+    emit_audit_event(
+        AuditAction.USER_GROUP_CREATE,
+        AuditOutcome.SUCCESS,
+        actor=_scim_actor(_token),
+        resource_type="user_group",
+        resource_id=db_group.id,
+        extra=_scim_extra(
+            _token,
+            name=group_resource.displayName,
+            user_ids=[str(uid) for uid in member_uuids],
+            cc_pair_ids=[],
+        ),
+    )
+
     members = dal.get_group_members(db_group.id)
     return _scim_resource_response(
         provider.build_group_resource(db_group, members, external_id),
@@ -1359,6 +1430,8 @@ def replace_group(
     # permissions after they are removed from the group.
     old_member_ids = {uid for uid, _ in dal.get_group_members(group.id)}
 
+    previous_name = group.name
+
     dal.update_group(group, name=group_resource.displayName)
     dal.replace_group_members(group.id, member_uuids)
     dal.sync_group_external_id(group.id, group_resource.externalId)
@@ -1369,6 +1442,16 @@ def replace_group(
     recompute_user_permissions__no_commit(removed_ids, db_session)
 
     dal.commit()
+
+    added_ids = sorted(set(member_uuids) - old_member_ids)
+    _emit_scim_group_update(
+        _token,
+        group_id=group.id,
+        group_name=group_resource.displayName,
+        previous_name=previous_name,
+        added_user_ids=added_ids,
+        removed_user_ids=sorted(removed_ids),
+    )
 
     members = dal.get_group_members(group.id)
     return _scim_resource_response(
@@ -1419,9 +1502,13 @@ def patch_group(
     if new_name and new_name in _RESERVED_GROUP_NAMES:
         return _scim_error_response(409, f"'{new_name}' is a reserved group name.")
 
+    previous_name = group.name
+
     dal.update_group(group, name=new_name)
 
     affected_uuids: list[UUID] = []
+    applied_added: list[UUID] = []
+    applied_removed: list[UUID] = []
 
     if added_ids:
         add_uuids = [UUID(mid) for mid in added_ids if _is_valid_uuid(mid)]
@@ -1434,17 +1521,30 @@ def patch_group(
                 )
             dal.upsert_group_members(group.id, add_uuids)
             affected_uuids.extend(add_uuids)
+            applied_added = add_uuids
 
     if removed_ids:
         remove_uuids = [UUID(mid) for mid in removed_ids if _is_valid_uuid(mid)]
         dal.remove_group_members(group.id, remove_uuids)
         affected_uuids.extend(remove_uuids)
+        applied_removed = remove_uuids
 
     # Recompute permissions for all users whose group membership changed.
     recompute_user_permissions__no_commit(affected_uuids, db_session)
 
     dal.sync_group_external_id(group.id, patched.externalId)
     dal.commit()
+
+    # Report the validated sets that were applied, not the raw added_ids /
+    # removed_ids from the request, which can contain entries that were rejected.
+    _emit_scim_group_update(
+        _token,
+        group_id=group.id,
+        group_name=patched.displayName,
+        previous_name=previous_name,
+        added_user_ids=applied_added,
+        removed_user_ids=applied_removed,
+    )
 
     members = dal.get_group_members(group.id)
     return _scim_resource_response(
@@ -1477,12 +1577,28 @@ def delete_group(
     if mapping:
         dal.delete_group_mapping(mapping.id)
 
+    deleted_group_id = group.id
+    group_name = group.name
     dal.delete_group_with_members(group)
 
     # Recompute permissions for users who lost this group membership.
     recompute_user_permissions__no_commit(affected_user_ids, db_session)
 
     dal.commit()
+
+    emit_audit_event(
+        AuditAction.USER_GROUP_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=_scim_actor(_token),
+        resource_type="user_group",
+        resource_id=deleted_group_id,
+        extra=_scim_extra(
+            _token,
+            name=group_name,
+            member_ids=[str(uid) for uid in affected_user_ids],
+            member_count=len(affected_user_ids),
+        ),
+    )
 
     return Response(status_code=204)
 

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -65,6 +65,12 @@ from onyx.db.user_group import assert_group_config_is_editable
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.security.store import get_security_settings
+from onyx.utils.audit import (
+    AuditAction,
+    AuditOutcome,
+    actor_from_user,
+    emit_audit_event,
+)
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -197,7 +203,9 @@ def set_user_group_permissions(
             f"Permissions {non_toggleable} cannot be toggled via this endpoint",
         )
 
-    result = set_group_permissions_bulk__no_commit(
+    group_name = group.name
+
+    change = set_group_permissions_bulk__no_commit(
         group_id=user_group_id,
         desired_permissions=set(request.permissions),
         granted_by=user.id,
@@ -205,13 +213,26 @@ def set_user_group_permissions(
     )
     db_session.commit()
 
-    return result
+    emit_audit_event(
+        AuditAction.USER_GROUP_PERMISSION_CHANGE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="user_group",
+        resource_id=user_group_id,
+        extra={
+            "group_name": group_name,
+            "added": [permission.value for permission in change.added],
+            "removed": [permission.value for permission in change.removed],
+        },
+    )
+
+    return change.enabled
 
 
 @router.post("/admin/user-group")
 def create_user_group(
     user_group: UserGroupCreate,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
     try:
@@ -222,6 +243,20 @@ def create_user_group(
             f"User group with name '{user_group.name}' already exists. Please "
             "choose a different name.",
         )
+
+    emit_audit_event(
+        AuditAction.USER_GROUP_CREATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="user_group",
+        resource_id=db_user_group.id,
+        extra={
+            "name": user_group.name,
+            "user_ids": [str(uid) for uid in user_group.user_ids],
+            "cc_pair_ids": list(user_group.cc_pair_ids),
+        },
+    )
+
     return UserGroup.from_model(
         db_user_group,
         mask_credential_prefix=get_security_settings().mask_credential_prefix,
@@ -239,13 +274,26 @@ def rename_user_group_endpoint(
     # GATE 2: rename's DB fn takes no user and re-reads nothing, so gate here.
     assert_manages_group(user, db_session, group_id=rename_request.id)
     assert_group_config_is_editable(db_session, rename_request.id, "rename")
+
+    existing = fetch_user_group(db_session, rename_request.id)
+    previous_name = existing.name if existing else None
+
     try:
+        renamed = rename_user_group(
+            db_session=db_session,
+            user_group_id=rename_request.id,
+            new_name=rename_request.name,
+        )
+        emit_audit_event(
+            AuditAction.USER_GROUP_RENAME,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="user_group",
+            resource_id=rename_request.id,
+            extra={"previous_name": previous_name, "new_name": rename_request.name},
+        )
         return UserGroup.from_model(
-            rename_user_group(
-                db_session=db_session,
-                user_group_id=rename_request.id,
-                new_name=rename_request.name,
-            ),
+            renamed,
             mask_credential_prefix=get_security_settings().mask_credential_prefix,
         )
     except IntegrityError:
@@ -334,15 +382,34 @@ def add_users(
 @router.delete("/admin/user-group/{user_group_id}")
 def delete_user_group(
     user_group_id: int,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     assert_group_config_is_editable(db_session, user_group_id, "delete")
     assert_group_membership_survives_deletion(db_session, user_group_id)
+
+    # Deletion drops every membership, so capture the roster before it runs.
+    existing = fetch_user_group(db_session, user_group_id)
+    group_name = existing.name if existing else None
+    member_ids = [str(member.id) for member in existing.users] if existing else []
+
     try:
         prepare_user_group_for_deletion(db_session, user_group_id)
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, str(e))
+
+    emit_audit_event(
+        AuditAction.USER_GROUP_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="user_group",
+        resource_id=user_group_id,
+        extra={
+            "name": group_name,
+            "member_ids": member_ids,
+            "member_count": len(member_ids),
+        },
+    )
 
     if DISABLE_VECTOR_DB:
         user_group = fetch_user_group(db_session, user_group_id)
@@ -521,6 +588,14 @@ def set_group_manager(
     # a manager can delegate within their own group but not beyond it.
     assert_manages_group(user, db_session, group_id=user_group_id)
     assert_group_config_is_editable(db_session, user_group_id, "assign a manager on")
+
+    group = fetch_user_group(db_session, user_group_id)
+    target = (
+        next((member for member in group.users if member.id == request.user_id), None)
+        if group
+        else None
+    )
+
     try:
         if request.is_manager:
             make_group_manager(db_session, request.user_id, user_group_id)
@@ -530,3 +605,17 @@ def set_group_manager(
         # Target isn't a member of the group (a manager is always a member).
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
     db_session.commit()
+
+    emit_audit_event(
+        AuditAction.USER_GROUP_MANAGER_CHANGE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="user_group",
+        resource_id=user_group_id,
+        extra={
+            "group_name": group.name if group else None,
+            "target_user_id": str(request.user_id),
+            "target_email": target.email if target else None,
+            "is_manager": request.is_manager,
+        },
+    )

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -6,8 +6,6 @@ scope — the bundle guard and the write-side gate. DB access itself lives in
 ``onyx/db/scoped_permissions.py``; this layer only consumes that interface.
 """
 
-import hashlib
-import json
 from collections.abc import Collection
 from typing import Any
 
@@ -30,10 +28,6 @@ from onyx.utils.audit import (
     emit_audit_event,
 )
 
-# Deliberately shorter than the 600s default: a burst of attempts should stay
-# visible rather than collapse into one line.
-_DENIAL_DEDUP_TTL_SECONDS = 60
-
 
 def _emit_denial(
     user: User,
@@ -42,21 +36,12 @@ def _emit_denial(
     group_id: int | None = None,
     extra: dict[str, Any],
 ) -> None:
-    # Dedup on the whole attempt. Keying on the gate alone would collapse every
-    # refusal a user hits in the window into one line, hiding a walk across
-    # resources — which is the pattern this event exists to surface. Hashing keeps
-    # the key bounded and stays complete if a caller adds a field.
-    fingerprint = hashlib.sha256(
-        json.dumps([group_id, extra], sort_keys=True, default=str).encode()
-    ).hexdigest()[:16]
     emit_audit_event(
         AuditAction.PERMISSION_DENIED,
         AuditOutcome.DENIED,
         actor=actor_from_user(user),
         resource_type="user_group" if group_id is not None else None,
         resource_id=group_id,
-        dedup_key=f"permission_denied:{user.id}:{gate}:{fingerprint}",
-        dedup_ttl_seconds=_DENIAL_DEDUP_TTL_SECONDS,
         extra={"gate": gate, **extra},
     )
 

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -6,6 +6,8 @@ scope — the bundle guard and the write-side gate. DB access itself lives in
 ``onyx/db/scoped_permissions.py``; this layer only consumes that interface.
 """
 
+import hashlib
+import json
 from collections.abc import Collection
 from typing import Any
 
@@ -40,13 +42,20 @@ def _emit_denial(
     group_id: int | None = None,
     extra: dict[str, Any],
 ) -> None:
+    # Dedup on the whole attempt. Keying on the gate alone would collapse every
+    # refusal a user hits in the window into one line, hiding a walk across
+    # resources — which is the pattern this event exists to surface. Hashing keeps
+    # the key bounded and stays complete if a caller adds a field.
+    fingerprint = hashlib.sha256(
+        json.dumps([group_id, extra], sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
     emit_audit_event(
         AuditAction.PERMISSION_DENIED,
         AuditOutcome.DENIED,
         actor=actor_from_user(user),
         resource_type="user_group" if group_id is not None else None,
         resource_id=group_id,
-        dedup_key=f"permission_denied:{user.id}:{gate}:{group_id}",
+        dedup_key=f"permission_denied:{user.id}:{gate}:{fingerprint}",
         dedup_ttl_seconds=_DENIAL_DEDUP_TTL_SECONDS,
         extra={"gate": gate, **extra},
     )

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -7,6 +7,7 @@ scope — the bundle guard and the write-side gate. DB access itself lives in
 """
 
 from collections.abc import Collection
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -20,6 +21,35 @@ from onyx.db.models import User
 from onyx.db.scoped_permissions import fetch_managed_group_ids
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.audit import (
+    AuditAction,
+    AuditOutcome,
+    actor_from_user,
+    emit_audit_event,
+)
+
+# Deliberately shorter than the 600s default: a burst of attempts should stay
+# visible rather than collapse into one line.
+_DENIAL_DEDUP_TTL_SECONDS = 60
+
+
+def _emit_denial(
+    user: User,
+    gate: str,
+    *,
+    group_id: int | None = None,
+    extra: dict[str, Any],
+) -> None:
+    emit_audit_event(
+        AuditAction.PERMISSION_DENIED,
+        AuditOutcome.DENIED,
+        actor=actor_from_user(user),
+        resource_type="user_group" if group_id is not None else None,
+        resource_id=group_id,
+        dedup_key=f"permission_denied:{user.id}:{gate}:{group_id}",
+        dedup_ttl_seconds=_DENIAL_DEDUP_TTL_SECONDS,
+        extra={"gate": gate, **extra},
+    )
 
 
 def get_scoped_groups(
@@ -98,6 +128,16 @@ def assert_within_scope(
         requested_group_ids=requested_group_ids,
         is_non_public=is_non_public,
     ):
+        _emit_denial(
+            user,
+            "within_scope",
+            extra={
+                "permission": permission.value,
+                "current_group_ids": sorted(current_group_ids),
+                "requested_group_ids": sorted(requested_group_ids),
+                "is_non_public": is_non_public,
+            },
+        )
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "Group managers can only act on private resources "
@@ -132,6 +172,12 @@ def assert_manages_group(user: User, db_session: Session, *, group_id: int) -> N
     assignment): a GLOBAL ``MANAGE_USER_GROUPS`` holder bypasses; a scoped manager
     passes only for a group they manage. NONE, or out-of-scope, rejects."""
     if not manages_group(user, db_session, group_id=group_id):
+        _emit_denial(
+            user,
+            "manages_group",
+            group_id=group_id,
+            extra={"permission": Permission.MANAGE_USER_GROUPS.value},
+        )
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "Group managers can only act within the groups they manage.",
@@ -143,6 +189,7 @@ def assert_global(user: User, *, permission: Permission) -> None:
     scoped create/update: the route admits a SCOPED manager, this rejects them —
     only GLOBAL authority passes."""
     if has_permission(user, permission) is not PermissionAuthority.GLOBAL:
+        _emit_denial(user, "global_only", extra={"permission": permission.value})
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "This action is restricted to administrators.",

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1225,6 +1225,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         tenant_id = await resolve_tenant_for_user(user.email, request)
 
         user_count = None
+        is_admin = False
         token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
         try:
             user_count = await get_user_count()
@@ -1328,6 +1329,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             AuditAction.REGISTER,
             AuditOutcome.SUCCESS,
             actor=AuditActor(user_id=str(user.id), email=user.email),
+            # This is the only record of the first-user and
+            # DEFAULT_ADMIN_USER_EMAILS admin grants; neither one goes through
+            # the admin-access route.
+            extra={"is_admin": is_admin},
         )
 
     async def on_after_forgot_password(

--- a/backend/onyx/server/api_key/api.py
+++ b/backend/onyx/server/api_key/api.py
@@ -49,6 +49,7 @@ def create_api_key(
         actor=actor_from_user(user),
         resource_type="api_key",
         resource_id=api_key.api_key_id,
+        extra={"name": api_key_args.name, "group_ids": list(api_key_args.group_ids)},
     )
     return api_key
 
@@ -76,10 +77,23 @@ def regenerate_existing_api_key(
 def update_existing_api_key(
     api_key_id: int,
     api_key_args: APIKeyArgs,
-    _: User = Depends(require_permission(Permission.MANAGE_SERVICE_ACCOUNT_API_KEYS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_SERVICE_ACCOUNT_API_KEYS)
+    ),
     db_session: Session = Depends(get_session),
 ) -> ApiKeyDescriptor:
-    return update_api_key(db_session, api_key_id, api_key_args)
+    # update_api_key replaces every group the service account belongs to, and
+    # those groups are what grant the key its permissions.
+    api_key = update_api_key(db_session, api_key_id, api_key_args)
+    emit_audit_event(
+        AuditAction.API_KEY_UPDATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="api_key",
+        resource_id=api_key_id,
+        extra={"name": api_key_args.name, "group_ids": list(api_key_args.group_ids)},
+    )
+    return api_key
 
 
 @router.delete("/{api_key_id}")

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -178,6 +178,7 @@ def set_user_admin_access_endpoint(
         resource_id=str(target.id),
         extra={
             "target_email": target.email,
+            "previous_is_admin": was_admin,
             "is_admin": admin_access_update_request.is_admin,
         },
     )

--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -3,8 +3,9 @@
 Emits one JSON line per security-relevant action (auth, admin-config /
 access-control change, credential access) on the ``onyx.audit`` logger tree.
 Field names and the action taxonomy are shaped toward OCSF so the stream maps
-onto OCSF event classes (Authentication / Account Change / API Activity) and
-drops into any SIEM. See ``docs/AUDIT_LOGGING.md`` for the schema + export path.
+onto OCSF event classes (Authentication / Account Change / User Access
+Management / Group Management / API Activity) and drops into any SIEM. See
+``docs/AUDIT_LOGGING.md`` for the schema + export path.
 
 Invariants (from the ``credential_audit`` seed): never raise into the caller
 (emission sits on hot paths), never log a secret, always tenant-tag, and dedup
@@ -38,6 +39,8 @@ class OCSFEventClass(str, Enum):
 
     AUTHENTICATION = "authentication"  # OCSF class_uid 3002
     ACCOUNT_CHANGE = "account_change"  # OCSF class_uid 3001
+    USER_ACCESS_MANAGEMENT = "user_access_management"  # OCSF class_uid 3005
+    GROUP_MANAGEMENT = "group_management"  # OCSF class_uid 3006
     API_ACTIVITY = "api_activity"  # OCSF class_uid 6003
 
 
@@ -66,9 +69,18 @@ class AuditAction(str, Enum):
     USER_DELETE = "user.delete"
     USER_DEACTIVATE = "user.deactivate"
     USER_REACTIVATE = "user.reactivate"
+
+    # User access management
     USER_ROLE_CHANGE = "user.role_change"
-    USER_GROUP_CHANGE = "user.group_change"
     USER_CRAFT_ACCESS_CHANGE = "user.craft_access_change"
+
+    # Group management
+    USER_GROUP_CHANGE = "user.group_change"
+    USER_GROUP_CREATE = "user_group.create"
+    USER_GROUP_RENAME = "user_group.rename"
+    USER_GROUP_DELETE = "user_group.delete"
+    USER_GROUP_PERMISSION_CHANGE = "user_group.permission_change"
+    USER_GROUP_MANAGER_CHANGE = "user_group.manager_change"
 
     # API activity (admin config + resource CRUD)
     CRAFT_DEFAULT_CHANGE = "settings.craft_default_change"
@@ -84,11 +96,15 @@ class AuditAction(str, Enum):
     CC_PAIR_DELETE = "cc_pair.delete"
     API_KEY_CREATE = "api_key.create"
     API_KEY_REGENERATE = "api_key.regenerate"
+    API_KEY_UPDATE = "api_key.update"
     API_KEY_DELETE = "api_key.delete"
     CREDENTIAL_CREATE = "credential.create"
     CREDENTIAL_UPDATE = "credential.update"
     CREDENTIAL_DELETE = "credential.delete"
     CREDENTIAL_ACCESS = "credential.access"
+    # Fires only when a scoped write gate refuses an actor who already holds
+    # partial authority, not on every 403.
+    PERMISSION_DENIED = "permission.denied"
 
 
 _OCSF_CLASS_BY_ACTION: dict[AuditAction, OCSFEventClass] = {
@@ -104,9 +120,14 @@ _OCSF_CLASS_BY_ACTION: dict[AuditAction, OCSFEventClass] = {
     AuditAction.USER_DELETE: OCSFEventClass.ACCOUNT_CHANGE,
     AuditAction.USER_DEACTIVATE: OCSFEventClass.ACCOUNT_CHANGE,
     AuditAction.USER_REACTIVATE: OCSFEventClass.ACCOUNT_CHANGE,
-    AuditAction.USER_ROLE_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
-    AuditAction.USER_GROUP_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
-    AuditAction.USER_CRAFT_ACCESS_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.USER_ROLE_CHANGE: OCSFEventClass.USER_ACCESS_MANAGEMENT,
+    AuditAction.USER_CRAFT_ACCESS_CHANGE: OCSFEventClass.USER_ACCESS_MANAGEMENT,
+    AuditAction.USER_GROUP_CHANGE: OCSFEventClass.GROUP_MANAGEMENT,
+    AuditAction.USER_GROUP_CREATE: OCSFEventClass.GROUP_MANAGEMENT,
+    AuditAction.USER_GROUP_RENAME: OCSFEventClass.GROUP_MANAGEMENT,
+    AuditAction.USER_GROUP_DELETE: OCSFEventClass.GROUP_MANAGEMENT,
+    AuditAction.USER_GROUP_PERMISSION_CHANGE: OCSFEventClass.GROUP_MANAGEMENT,
+    AuditAction.USER_GROUP_MANAGER_CHANGE: OCSFEventClass.GROUP_MANAGEMENT,
     AuditAction.CRAFT_DEFAULT_CHANGE: OCSFEventClass.API_ACTIVITY,
     AuditAction.CONTEXTUAL_RAG_MODEL_UPDATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.LLM_PROVIDER_CREATE: OCSFEventClass.API_ACTIVITY,
@@ -120,11 +141,15 @@ _OCSF_CLASS_BY_ACTION: dict[AuditAction, OCSFEventClass] = {
     AuditAction.CC_PAIR_DELETE: OCSFEventClass.API_ACTIVITY,
     AuditAction.API_KEY_CREATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.API_KEY_REGENERATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.API_KEY_UPDATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.API_KEY_DELETE: OCSFEventClass.API_ACTIVITY,
     AuditAction.CREDENTIAL_CREATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.CREDENTIAL_UPDATE: OCSFEventClass.API_ACTIVITY,
     AuditAction.CREDENTIAL_DELETE: OCSFEventClass.API_ACTIVITY,
     AuditAction.CREDENTIAL_ACCESS: OCSFEventClass.API_ACTIVITY,
+    # OCSF has no authorization-denial class, so a refused request maps onto the
+    # request surface instead.
+    AuditAction.PERMISSION_DENIED: OCSFEventClass.API_ACTIVITY,
 }
 
 # Guard: every action must map to a class, so a new action can't ship untagged.

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -1258,7 +1258,7 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
         )
         assert tags["manage"] == manage_enforced, actor.email
         assert tags["manage_members"] == manage_enforced, actor.email
-        assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
+        assert tags["delete"] == _route_admits(delete_user_group, "user", actor), (
             actor.email
         )
         assert tags["edit_permissions"] == _route_admits(

--- a/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
+++ b/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
@@ -605,3 +605,51 @@ def test_each_gate_records_its_refusal(
     assert_manages_group(admin, db_session, group_id=unmanaged.id)
     assert_global(admin, permission=Permission.MANAGE_DOCUMENT_SETS)
     assert events_for(caplog, "permission.denied") == []
+
+
+@pytest.mark.usefixtures("audit_stream")
+def test_denials_are_deduped_per_attempt_not_per_gate(
+    db_session: Session, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A manager walking several resources must produce one event each. Keying the
+    dedup window on the gate alone would record only the first and hide the walk."""
+    manager = create_test_user(db_session, "denial-walk")
+    manager.effective_permissions = []
+    managed = _make_group(db_session)
+    first = _make_group(db_session)
+    second = _make_group(db_session)
+    third = _make_group(db_session)
+    _manage(db_session, manager, managed)
+
+    for target in (first, second):
+        with pytest.raises(OnyxError):
+            assert_within_scope(
+                manager,
+                db_session,
+                permission=Permission.MANAGE_DOCUMENT_SETS,
+                current_group_ids=[managed.id],
+                requested_group_ids=[target.id],
+                is_non_public=True,
+            )
+
+    events = events_for(caplog, "permission.denied")
+    assert [e["extra"]["requested_group_ids"] for e in events] == [
+        [first.id],
+        [second.id],
+    ]
+
+    # A genuine retry — same permission, same groups — still collapses. Uses an
+    # untouched group, since the attempts above already claimed their windows.
+    caplog.clear()
+    for _ in range(2):
+        with pytest.raises(OnyxError):
+            assert_within_scope(
+                manager,
+                db_session,
+                permission=Permission.MANAGE_DOCUMENT_SETS,
+                current_group_ids=[managed.id],
+                requested_group_ids=[third.id],
+                is_non_public=True,
+            )
+
+    assert len(events_for(caplog, "permission.denied")) == 1

--- a/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
+++ b/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
@@ -608,48 +608,38 @@ def test_each_gate_records_its_refusal(
 
 
 @pytest.mark.usefixtures("audit_stream")
-def test_denials_are_deduped_per_attempt_not_per_gate(
+def test_every_refusal_is_recorded(
     db_session: Session, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A manager walking several resources must produce one event each. Keying the
-    dedup window on the gate alone would record only the first and hide the walk."""
+    """A manager walking several resources produces one event each. These gates see
+    no resource identity, so nothing here may be suppressed as a duplicate — a bulk
+    update refusing two look-alike document sets is two separate attempts."""
     manager = create_test_user(db_session, "denial-walk")
     manager.effective_permissions = []
     managed = _make_group(db_session)
     first = _make_group(db_session)
     second = _make_group(db_session)
-    third = _make_group(db_session)
     _manage(db_session, manager, managed)
 
-    for target in (first, second):
+    def refuse(target_group_id: int) -> None:
         with pytest.raises(OnyxError):
             assert_within_scope(
                 manager,
                 db_session,
                 permission=Permission.MANAGE_DOCUMENT_SETS,
                 current_group_ids=[managed.id],
-                requested_group_ids=[target.id],
+                requested_group_ids=[target_group_id],
                 is_non_public=True,
             )
+
+    refuse(first.id)
+    refuse(second.id)
+    # Indistinguishable from the first at this gate, but a distinct attempt.
+    refuse(first.id)
 
     events = events_for(caplog, "permission.denied")
     assert [e["extra"]["requested_group_ids"] for e in events] == [
         [first.id],
         [second.id],
+        [first.id],
     ]
-
-    # A genuine retry — same permission, same groups — still collapses. Uses an
-    # untouched group, since the attempts above already claimed their windows.
-    caplog.clear()
-    for _ in range(2):
-        with pytest.raises(OnyxError):
-            assert_within_scope(
-                manager,
-                db_session,
-                permission=Permission.MANAGE_DOCUMENT_SETS,
-                current_group_ids=[managed.id],
-                requested_group_ids=[third.id],
-                is_non_public=True,
-            )
-
-    assert len(events_for(caplog, "permission.denied")) == 1

--- a/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
+++ b/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
@@ -39,6 +39,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.models import UserInfo
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.utils.audit import events_for
 
 
 def _make_group(db_session: Session) -> UserGroup:
@@ -558,3 +559,49 @@ def test_admin_capabilities_stay_global_only_without_a_manager_edge(
 
     assert not info.is_group_manager
     assert info.admin_capabilities == granted
+
+
+@pytest.mark.usefixtures("audit_stream")
+def test_each_gate_records_its_refusal(
+    db_session: Session, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A refused write is the escalation signal — the actor holds some authority
+    and reached the handler. ``extra.gate`` says which gate refused, so an alert
+    can tell an out-of-scope write from an admin-only one."""
+    manager = create_test_user(db_session, "denial-mgr")
+    manager.effective_permissions = []
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+    _manage(db_session, manager, managed)
+
+    with pytest.raises(OnyxError):
+        assert_manages_group(manager, db_session, group_id=unmanaged.id)
+    with pytest.raises(OnyxError):
+        assert_global(manager, permission=Permission.MANAGE_DOCUMENT_SETS)
+    with pytest.raises(OnyxError):
+        assert_within_scope(
+            manager,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[unmanaged.id],
+            is_non_public=True,
+        )
+
+    events = events_for(caplog, "permission.denied")
+    assert [e["extra"]["gate"] for e in events] == [
+        "manages_group",
+        "global_only",
+        "within_scope",
+    ]
+    assert all(e["outcome"] == "denied" for e in events)
+    assert all(e["actor"]["email"] == manager.email for e in events)
+    # Only the per-group gate has a single resource to name.
+    assert events[0]["resource_id"] == str(unmanaged.id)
+    assert events[1]["resource_id"] is None
+
+    caplog.clear()
+    admin = create_test_user(db_session, "denial-admin", is_admin=True)
+    assert_manages_group(admin, db_session, group_id=unmanaged.id)
+    assert_global(admin, permission=Permission.MANAGE_DOCUMENT_SETS)
+    assert events_for(caplog, "permission.denied") == []

--- a/backend/tests/external_dependency_unit/conftest.py
+++ b/backend/tests/external_dependency_unit/conftest.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator
 from uuid import uuid4
 
@@ -21,6 +22,20 @@ from tests.utils.pytest_secrets import (
 )
 from tests.utils.pytest_secrets import pytest_configure as pytest_configure
 from tests.utils.pytest_secrets import test_secrets as test_secrets
+
+
+@pytest.fixture
+def audit_stream(caplog: pytest.LogCaptureFixture) -> Generator[None, None, None]:
+    """``onyx.audit`` sets ``propagate=False``, so caplog's root handler never sees
+    its records; hang caplog's handler below that barrier instead. Not autouse — it
+    would feed audit records to tests that capture logs for other reasons.
+    """
+    audit_logger = logging.getLogger("onyx.audit")
+    audit_logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        audit_logger.removeHandler(caplog.handler)
 
 
 @pytest.fixture(scope="function")

--- a/backend/tests/external_dependency_unit/ee/onyx/server/scim/test_scim_group_audit_events.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/scim/test_scim_group_audit_events.py
@@ -1,0 +1,179 @@
+"""Audit coverage for the SCIM group write surface.
+
+The delta guard is the whole risk. IdPs re-``PUT`` a group's full state on routine
+reconciliation, so an ungated emit would fire on every no-op sync and drown the
+real changes. A dedup window would be worse than a guard, because it would also
+hide a real change that landed inside the window.
+"""
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ee.onyx.server.scim.api import create_group, delete_group, replace_group
+from ee.onyx.server.scim.models import (
+    ScimGroupMember,
+    ScimGroupResource,
+)
+from ee.onyx.server.scim.providers.base import get_default_provider
+from onyx.db.models import ScimToken, User, UserGroup
+from onyx.utils.audit import AuditAction
+from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
+
+_EMIT = "ee.onyx.server.scim.api.emit_audit_event"
+
+
+def _resource(name: str, *members: User) -> ScimGroupResource:
+    return ScimGroupResource(
+        displayName=name,
+        members=[ScimGroupMember(value=str(m.id)) for m in members],
+    )
+
+
+def _create(db_session: Session, token: ScimToken, resource: ScimGroupResource) -> int:
+    """The route returns a serialized JSON response, so read the row back by name."""
+    create_group(resource, token, get_default_provider(), db_session)
+    group = db_session.scalar(
+        select(UserGroup).where(UserGroup.name == resource.displayName)
+    )
+    assert group is not None
+    return group.id
+
+
+def _calls(emit: MagicMock, action: AuditAction) -> list[dict[str, Any]]:
+    return [
+        call.kwargs["extra"] for call in emit.call_args_list if call.args[0] is action
+    ]
+
+
+@pytest.fixture
+def token(db_session: Session) -> ScimToken:
+    scim_token = ScimToken(
+        name="okta-prod",
+        hashed_token=uuid4().hex,
+        token_display="onyx_scim_****abcd",
+        created_by_id=create_test_user(db_session, "scim_audit_owner").id,
+    )
+    db_session.add(scim_token)
+    db_session.commit()
+    return scim_token
+
+
+@pytest.fixture
+def member_factory(
+    db_session: Session,
+) -> Callable[[], User]:
+    def _create() -> User:
+        return create_test_user(
+            db_session, "scim_audit_member", assign_default_group=False
+        )
+
+    return _create
+
+
+def test_create_group_records_the_name_and_actor(
+    db_session: Session, token: ScimToken, member_factory: Callable[[], User]
+) -> None:
+    member = member_factory()
+    name = f"scim-audit-{uuid4().hex[:12]}"
+
+    with patch(_EMIT) as emit:
+        create_group(_resource(name, member), token, get_default_provider(), db_session)
+
+    calls = [
+        c for c in emit.call_args_list if c.args[0] is AuditAction.USER_GROUP_CREATE
+    ]
+    assert len(calls) == 1
+    extra = calls[0].kwargs["extra"]
+    assert extra["name"] == name
+    assert extra["user_ids"] == [str(member.id)]
+    assert extra["source"] == "scim"
+    assert extra["scim_token_name"] == "okta-prod"
+    actor = calls[0].kwargs["actor"]
+    assert actor.api_key_id == f"scim_token:{token.id}"
+    assert actor.auth_type == "scim"
+
+    delete_test_user(db_session, member)
+
+
+def test_replace_group_with_no_changes_emits_nothing(
+    db_session: Session, token: ScimToken, member_factory: Callable[[], User]
+) -> None:
+    """The reconciliation case: an IdP re-PUTs the same state on a schedule."""
+    member = member_factory()
+    name = f"scim-audit-{uuid4().hex[:12]}"
+    group_id = _create(db_session, token, _resource(name, member))
+
+    with patch(_EMIT) as emit:
+        replace_group(
+            str(group_id),
+            _resource(name, member),
+            token,
+            get_default_provider(),
+            db_session,
+        )
+
+    assert emit.call_args_list == []
+    delete_test_user(db_session, member)
+
+
+def test_replace_group_reports_the_rename_and_the_membership_delta(
+    db_session: Session, token: ScimToken, member_factory: Callable[[], User]
+) -> None:
+    """One PUT can do both, which is what an IdP actually sends. The rename must
+    report the pre-rename name — update_group renames in place, so a naive read
+    would report the new name twice."""
+    kept, dropped, joined = member_factory(), member_factory(), member_factory()
+    original = f"scim-audit-{uuid4().hex[:12]}"
+    renamed = f"scim-audit-{uuid4().hex[:12]}"
+    group_id = _create(db_session, token, _resource(original, kept, dropped))
+
+    with patch(_EMIT) as emit:
+        replace_group(
+            str(group_id),
+            _resource(renamed, kept, joined),
+            token,
+            get_default_provider(),
+            db_session,
+        )
+
+    renames = _calls(emit, AuditAction.USER_GROUP_RENAME)
+    assert len(renames) == 1
+    assert renames[0]["previous_name"] == original
+    assert renames[0]["new_name"] == renamed
+
+    changes = _calls(emit, AuditAction.USER_GROUP_CHANGE)
+    assert len(changes) == 1
+    assert changes[0]["added_user_ids"] == [str(joined.id)]
+    assert changes[0]["removed_user_ids"] == [str(dropped.id)]
+    assert changes[0]["source"] == "scim"
+
+    delete_test_user(db_session, kept, dropped, joined)
+
+
+def test_delete_group_records_who_lost_access(
+    db_session: Session, token: ScimToken, member_factory: Callable[[], User]
+) -> None:
+    member = member_factory()
+    name = f"scim-audit-{uuid4().hex[:12]}"
+    group_id = _create(db_session, token, _resource(name, member))
+
+    with patch(_EMIT) as emit:
+        delete_group(str(group_id), token, db_session)
+
+    calls = [
+        c for c in emit.call_args_list if c.args[0] is AuditAction.USER_GROUP_DELETE
+    ]
+    assert len(calls) == 1
+    # The row is gone by the time the emit runs, so the id must be captured first.
+    assert calls[0].kwargs["resource_id"] == group_id
+    extra = calls[0].kwargs["extra"]
+    assert extra["name"] == name
+    assert extra["member_ids"] == [str(member.id)]
+
+    delete_test_user(db_session, member)

--- a/backend/tests/external_dependency_unit/ee/onyx/server/user_group/test_user_group_audit_events.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/user_group/test_user_group_audit_events.py
@@ -1,0 +1,175 @@
+"""Audit coverage for the group write paths that are more than call-a-function-
+then-emit.
+
+Plain emit-on-success wiring is covered once by the API-key representatives in
+tests/unit/onyx/server/test_admin_audit_events.py, so only the paths with real
+logic live here: the permission diff, the two reads that must happen before the
+value they capture is destroyed, and the two places a second event could sneak in.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.user_group import prepare_user_group_for_deletion
+from ee.onyx.server.user_group.api import (
+    add_users,
+    delete_user_group,
+    rename_user_group_endpoint,
+    set_user_group_permissions,
+)
+from ee.onyx.server.user_group.models import (
+    AddUsersToUserGroupRequest,
+    BulkSetPermissionsRequest,
+    UserGroupRename,
+)
+from onyx.db.enums import Permission
+from onyx.db.models import User, User__UserGroup, UserGroup
+from onyx.utils.audit import AuditAction, AuditOutcome
+from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
+from tests.utils.audit import audit_actions, events_for
+
+_EMIT = "ee.onyx.server.user_group.api.emit_audit_event"
+
+pytestmark = pytest.mark.usefixtures("tenant_context")
+
+
+@pytest.fixture
+def admin(db_session: Session) -> User:
+    return create_test_user(db_session, "group_audit_admin", is_admin=True)
+
+
+def _make_group(db_session: Session, *members: User) -> UserGroup:
+    # is_up_to_date=True: the rename/delete guards refuse a group mid-sync.
+    group = UserGroup(name=f"audit-test-{uuid4().hex[:12]}", is_up_to_date=True)
+    db_session.add(group)
+    db_session.flush()
+    for member in members:
+        db_session.add(User__UserGroup(user_id=member.id, user_group_id=group.id))
+    db_session.commit()
+    return group
+
+
+def _one_call(emit: MagicMock, action: AuditAction) -> dict:
+    calls = [call for call in emit.call_args_list if call.args[0] is action]
+    assert len(calls) == 1, f"expected one {action.value}, got {len(calls)}"
+    assert calls[0].args[1] is AuditOutcome.SUCCESS
+    return {
+        "resource_id": calls[0].kwargs["resource_id"],
+        "resource_type": calls[0].kwargs["resource_type"],
+        "extra": calls[0].kwargs["extra"],
+    }
+
+
+def test_permission_change_reports_the_diff(db_session: Session, admin: User) -> None:
+    group = _make_group(db_session)
+
+    # Start from a known state so the second save is a genuine add-and-remove.
+    set_user_group_permissions(
+        group.id,
+        BulkSetPermissionsRequest(
+            permissions=[Permission.MANAGE_CONNECTORS, Permission.READ_QUERY_HISTORY]
+        ),
+        admin,
+        db_session,
+    )
+
+    with patch(_EMIT) as emit:
+        set_user_group_permissions(
+            group.id,
+            BulkSetPermissionsRequest(
+                permissions=[Permission.MANAGE_CONNECTORS, Permission.MANAGE_LLMS]
+            ),
+            admin,
+            db_session,
+        )
+
+    event = _one_call(emit, AuditAction.USER_GROUP_PERMISSION_CHANGE)
+    assert event["resource_id"] == group.id
+    assert event["resource_type"] == "user_group"
+    assert event["extra"]["group_name"] == group.name
+    assert event["extra"]["added"] == ["manage:llms"]
+    assert event["extra"]["removed"] == ["read:query_history"]
+    # Unchanged and non-toggleable grants sit on both sides and cancel.
+    assert "manage:connectors" not in event["extra"]["added"]
+    assert "basic" not in event["extra"]["added"] + event["extra"]["removed"]
+
+    # Re-saving the same state still emits (it is a deliberate admin action) but
+    # reports no delta, so an alert keyed on `added` stays quiet.
+    with patch(_EMIT) as emit:
+        set_user_group_permissions(
+            group.id,
+            BulkSetPermissionsRequest(
+                permissions=[Permission.MANAGE_CONNECTORS, Permission.MANAGE_LLMS]
+            ),
+            admin,
+            db_session,
+        )
+    resave = _one_call(emit, AuditAction.USER_GROUP_PERMISSION_CHANGE)
+    assert resave["extra"]["added"] == []
+    assert resave["extra"]["removed"] == []
+
+
+def test_rename_records_the_previous_name(db_session: Session, admin: User) -> None:
+    """The DB fn renames in place, so a naive read would report the new name twice."""
+    group = _make_group(db_session)
+    original = group.name
+    new_name = f"audit-renamed-{uuid4().hex[:12]}"
+
+    with patch(_EMIT) as emit:
+        rename_user_group_endpoint(
+            UserGroupRename(id=group.id, name=new_name), admin, db_session
+        )
+
+    event = _one_call(emit, AuditAction.USER_GROUP_RENAME)
+    assert event["extra"]["previous_name"] == original
+    assert event["extra"]["new_name"] == new_name
+
+
+@pytest.mark.usefixtures("audit_stream")
+def test_delete_records_who_lost_access_exactly_once(
+    db_session: Session, admin: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """monitor_usergroup_taskset deliberately re-runs prepare_user_group_for_deletion
+    after marking the group synced. The emit lives on the route so that second pass
+    stays silent — inside the DB function it would fire again with no actor.
+    """
+    member = create_test_user(db_session, "group_audit_deleted")
+    group = _make_group(db_session, member)
+    name = group.name
+
+    delete_user_group(group.id, admin, db_session)
+
+    assert audit_actions(caplog) == ["user_group.delete"]
+    event = events_for(caplog, "user_group.delete")[0]
+    assert event["extra"]["name"] == name
+    assert event["extra"]["member_ids"] == [str(member.id)]
+
+    group.is_up_to_date = True
+    db_session.commit()
+    prepare_user_group_for_deletion(db_session, group.id)
+
+    assert audit_actions(caplog) == ["user_group.delete"]
+    delete_test_user(db_session, member)
+
+
+@pytest.mark.usefixtures("audit_stream")
+def test_add_users_emits_exactly_one_membership_event(
+    db_session: Session, admin: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """add-users delegates to update_user_group, which already emits. A second
+    emit on the route would double-count one membership change."""
+    member = create_test_user(db_session, "group_audit_added")
+    group = _make_group(db_session)
+
+    add_users(
+        group.id,
+        AddUsersToUserGroupRequest(user_ids=[member.id]),
+        admin,
+        db_session,
+    )
+
+    assert audit_actions(caplog) == ["user.group_change"]
+    delete_test_user(db_session, member)

--- a/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
+++ b/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
@@ -4,7 +4,6 @@ The emit is guarded on an actual membership delta, so a pure cc_pair update
 must emit nothing while an add/remove of users must emit exactly one event.
 """
 
-import json
 import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -15,20 +14,14 @@ import pytest
 from ee.onyx.db.user_group import update_user_group
 from ee.onyx.server.user_group.models import UserGroupUpdate
 from onyx.db.enums import AccountType, Permission
-
-
-def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
-    return [
-        json.loads(r.getMessage())
-        for r in caplog.records
-        if r.name.startswith("onyx.audit")
-    ]
+from tests.utils.audit import audit_events
 
 
 def _make_db_session(
     existing_user_ids: list[Any], existing_cc_pair_ids: list[int]
 ) -> MagicMock:
     group = MagicMock()
+    group.name = "Engineering"
     group.is_default = False
     group.users = [MagicMock(id=uid) for uid in existing_user_ids]
     group.cc_pairs = [MagicMock(id=cid) for cid in existing_cc_pair_ids]
@@ -82,7 +75,7 @@ def test_update_user_group_emits_on_membership_change(
             ),
         )
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "user.group_change"
     assert events[0]["outcome"] == "success"
@@ -90,6 +83,8 @@ def test_update_user_group_emits_on_membership_change(
     assert events[0]["actor"]["email"] == "admin@example.com"
     assert events[0]["extra"]["added_user_ids"] == [str(added)]
     assert events[0]["extra"]["removed_user_ids"] == []
+    assert events[0]["extra"]["group_name"] == "Engineering"
+    assert events[0]["extra"]["is_default"] is False
 
 
 @patch("ee.onyx.db.user_group.recompute_user_permissions__no_commit")
@@ -127,4 +122,4 @@ def test_update_user_group_cc_pair_only_emits_nothing(
             ),
         )
 
-    assert _audit_events(caplog) == []
+    assert audit_events(caplog) == []

--- a/backend/tests/unit/onyx/auth/test_auth_audit_events.py
+++ b/backend/tests/unit/onyx/auth/test_auth_audit_events.py
@@ -6,23 +6,14 @@ heavier register/logout flows (their emit calls follow the same one-line
 pattern). Emission itself is covered in tests/unit/onyx/utils/test_audit.py.
 """
 
-import json
 import logging
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.security import OAuth2PasswordRequestForm
 
 from onyx.auth.users import UserManager
-
-
-def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
-    return [
-        json.loads(r.getMessage())
-        for r in caplog.records
-        if r.name.startswith("onyx.audit")
-    ]
+from tests.utils.audit import audit_events
 
 
 @pytest.mark.asyncio
@@ -37,7 +28,7 @@ async def test_on_after_login_emits_login_success(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         await manager.on_after_login(user, request=None, response=None)
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "auth.login"
     assert events[0]["outcome"] == "success"
@@ -59,7 +50,7 @@ async def test_authenticate_unknown_user_emits_login_failure(
         result = await manager.authenticate(creds)
 
     assert result is None
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "auth.login_failure"
     assert events[0]["outcome"] == "failure"
@@ -82,7 +73,7 @@ async def test_on_after_forgot_password_emits_event(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         await manager.on_after_forgot_password(user, token="tok", request=None)
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "auth.password_forgot"
     assert events[0]["outcome"] == "success"
@@ -109,7 +100,7 @@ async def test_on_after_request_verify_emits_event(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         await manager.on_after_request_verify(user, token="tok", request=None)
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "auth.email_verify"
     assert events[0]["outcome"] == "success"
@@ -125,7 +116,7 @@ async def test_on_after_reset_password_emits_event(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         await manager.on_after_reset_password(user, request=None)
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "auth.password_reset"
     assert events[0]["outcome"] == "success"

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -1,10 +1,8 @@
 """Test bulk invite limit for free trial tenants."""
 
-import json
 import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +11,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.models import EmailInviteStatus, UserByEmail
 from onyx.server.manage.users import bulk_invite_users, remove_invited_user
+from tests.utils.audit import audit_events
 
 
 def _make_shared_session_mock(next_total: int) -> MagicMock:
@@ -159,11 +158,7 @@ def test_bulk_invite_emits_user_create(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         bulk_invite_users(emails=["new@example.com"], current_user=admin)
 
-    events: list[dict[str, Any]] = [
-        json.loads(r.getMessage())
-        for r in caplog.records
-        if r.name.startswith("onyx.audit")
-    ]
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "user.create"
     assert events[0]["outcome"] == "success"
@@ -195,8 +190,7 @@ def test_bulk_invite_reinvite_emits_nothing(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         bulk_invite_users(emails=["known@example.com"], current_user=MagicMock())
 
-    events = [r for r in caplog.records if r.name.startswith("onyx.audit")]
-    assert events == []
+    assert audit_events(caplog) == []
 
 
 @_with_common_patches

--- a/backend/tests/unit/onyx/server/test_admin_audit_events.py
+++ b/backend/tests/unit/onyx/server/test_admin_audit_events.py
@@ -7,9 +7,7 @@ credential, and user endpoints. Emission itself is covered in
 tests/unit/onyx/utils/test_audit.py.
 """
 
-import json
 import logging
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,16 +16,10 @@ from onyx.server.api_key.api import (
     create_api_key,
     delete_api_key,
     regenerate_existing_api_key,
+    update_existing_api_key,
 )
 from onyx.server.manage.llm.api import delete_llm_provider
-
-
-def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
-    return [
-        json.loads(r.getMessage())
-        for r in caplog.records
-        if r.name.startswith("onyx.audit")
-    ]
+from tests.utils.audit import audit_events
 
 
 @patch("onyx.server.api_key.api.insert_api_key")
@@ -41,7 +33,7 @@ def test_create_api_key_emits_event(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         create_api_key(MagicMock(), user=user, db_session=MagicMock())
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "api_key.create"
     assert events[0]["outcome"] == "success"
@@ -60,10 +52,32 @@ def test_regenerate_api_key_emits_event(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         regenerate_existing_api_key(api_key_id=42, user=user, db_session=MagicMock())
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "api_key.regenerate"
     assert events[0]["resource_id"] == "42"
+
+
+@patch("onyx.server.api_key.api.update_api_key")
+def test_update_api_key_emits_event(
+    _mock_update: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Updating a key replaces every group the service account belongs to, and
+    those groups are what grant it permissions — so the groups are in the payload."""
+    user = MagicMock(id="admin-1", email="admin@example.com")
+    args = MagicMock(name="ci-key", group_ids=[3, 9])
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        update_existing_api_key(
+            api_key_id=42, api_key_args=args, user=user, db_session=MagicMock()
+        )
+
+    events = audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "api_key.update"
+    assert events[0]["resource_id"] == "42"
+    assert events[0]["extra"]["group_ids"] == [3, 9]
 
 
 @patch("onyx.server.api_key.api.remove_api_key")
@@ -76,7 +90,7 @@ def test_delete_api_key_emits_event(
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         delete_api_key(api_key_id=99, user=user, db_session=MagicMock())
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "api_key.delete"
     assert events[0]["outcome"] == "success"
@@ -98,7 +112,7 @@ def test_delete_llm_provider_emits_event(
             provider_id=5, force=True, user=user, db_session=MagicMock()
         )
 
-    events = _audit_events(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     assert events[0]["action"] == "llm_provider.delete"
     assert events[0]["ocsf_class"] == "api_activity"

--- a/backend/tests/unit/onyx/utils/test_audit.py
+++ b/backend/tests/unit/onyx/utils/test_audit.py
@@ -25,16 +25,7 @@ from onyx.utils.audit import (
     actor_from_user,
     emit_audit_event,
 )
-
-
-def _capture(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
-    """Parse every captured ``onyx.audit`` JSON message into a dict."""
-    events: list[dict[str, Any]] = [
-        json.loads(record.getMessage())
-        for record in caplog.records
-        if record.name.startswith("onyx.audit")
-    ]
-    return events
+from tests.utils.audit import audit_events
 
 
 def test_every_action_has_an_ocsf_class() -> None:
@@ -43,6 +34,39 @@ def test_every_action_has_an_ocsf_class() -> None:
     for action in AuditAction:
         assert action in _OCSF_CLASS_BY_ACTION
         assert isinstance(_OCSF_CLASS_BY_ACTION[action], OCSFEventClass)
+
+
+def test_reclassified_actions_keep_their_new_class() -> None:
+    """These three moved off ``account_change``, which changed the child logger
+    they land on. Moving them back would silently break a consumer's routing."""
+    assert (
+        _OCSF_CLASS_BY_ACTION[AuditAction.USER_GROUP_CHANGE]
+        is OCSFEventClass.GROUP_MANAGEMENT
+    )
+    assert (
+        _OCSF_CLASS_BY_ACTION[AuditAction.USER_ROLE_CHANGE]
+        is OCSFEventClass.USER_ACCESS_MANAGEMENT
+    )
+    assert (
+        _OCSF_CLASS_BY_ACTION[AuditAction.USER_CRAFT_ACCESS_CHANGE]
+        is OCSFEventClass.USER_ACCESS_MANAGEMENT
+    )
+
+
+def test_class_selects_the_child_logger(caplog: pytest.LogCaptureFixture) -> None:
+    """``ocsf_class`` drives the logger name, which is what makes a class routable
+    without parsing the JSON body."""
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(
+            AuditAction.USER_GROUP_PERMISSION_CHANGE,
+            AuditOutcome.SUCCESS,
+            resource_type="user_group",
+            resource_id=7,
+        )
+
+    records = [r for r in caplog.records if r.name.startswith("onyx.audit")]
+    assert len(records) == 1
+    assert records[0].name == "onyx.audit.group_management"
 
 
 def test_emits_stable_ocsf_shaped_schema(caplog: pytest.LogCaptureFixture) -> None:
@@ -55,7 +79,7 @@ def test_emits_stable_ocsf_shaped_schema(caplog: pytest.LogCaptureFixture) -> No
             resource_id=42,
         )
 
-    events = _capture(caplog)
+    events = audit_events(caplog)
     assert len(events) == 1
     event = events[0]
 
@@ -155,7 +179,7 @@ def test_dedup_suppresses_within_window(
             AuditAction.CREDENTIAL_ACCESS, AuditOutcome.SUCCESS, dedup_key="k1"
         )
 
-    assert len(_capture(caplog)) == 1
+    assert len(audit_events(caplog)) == 1
 
 
 def test_dedup_degrades_to_emit_when_redis_down(
@@ -177,7 +201,7 @@ def test_no_dedup_key_always_emits(caplog: pytest.LogCaptureFixture) -> None:
         emit_audit_event(AuditAction.USER_ROLE_CHANGE, AuditOutcome.SUCCESS)
         emit_audit_event(AuditAction.USER_ROLE_CHANGE, AuditOutcome.SUCCESS)
 
-    assert len(_capture(caplog)) == 2
+    assert len(audit_events(caplog)) == 2
 
 
 def test_audit_logger_self_contained_without_root_handler() -> None:

--- a/backend/tests/utils/audit.py
+++ b/backend/tests/utils/audit.py
@@ -1,0 +1,26 @@
+"""Parse audit events out of caplog.
+
+These return nothing unless a handler is attached to ``onyx.audit``. The unit
+conftests do that automatically; external-dependency tests use ``audit_stream``.
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+
+def audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
+    return [
+        json.loads(record.getMessage())
+        for record in caplog.records
+        if record.name.startswith("onyx.audit")
+    ]
+
+
+def audit_actions(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [event["action"] for event in audit_events(caplog)]
+
+
+def events_for(caplog: pytest.LogCaptureFixture, action: str) -> list[dict[str, Any]]:
+    return [event for event in audit_events(caplog) if event["action"] == action]

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -98,9 +98,9 @@ gate refused: `within_scope`, `manages_group`, or `global_only`. Plain 403s from
 route-level permission check are not audited; they are ordinary access control, not
 an escalation signal.
 
-Denials are deduped per (user, gate, resource) on a 60-second window, so a retrying
-client collapses to one line while a scan across many resources still records each
-one.
+Every refusal is recorded. These gates see no resource identity, so suppressing
+repeats would also drop distinct attempts — a bulk update refusing two look-alike
+document sets is two separate events.
 
 ### SCIM-sourced events
 

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -35,6 +35,8 @@ always-emit (an audit event is never silently dropped because of infra trouble).
 | `onyx.audit` | Root of the audit tree (filter on this prefix to capture everything). |
 | `onyx.audit.authentication` | OCSF Authentication class events. |
 | `onyx.audit.account_change` | OCSF Account Change class events. |
+| `onyx.audit.user_access_management` | OCSF User Access Management class events. |
+| `onyx.audit.group_management` | OCSF Group Management class events (group membership, permissions, lifecycle). |
 | `onyx.audit.api_activity` | OCSF API Activity class events. |
 | `onyx.audit.credential_access` | Credential-decrypt events (predates the generalized schema; see note below). |
 
@@ -52,7 +54,7 @@ Generalized events (`emit_audit_event`, `backend/onyx/utils/audit.py`):
 | `audit_schema_version` | string | Schema version (currently `"1.0"`). |
 | `ts` | float | Event time, epoch seconds. |
 | `action` | string | Action taxonomy value, `<domain>.<verb>` (e.g. `llm_provider.update`). Append-only contract. |
-| `ocsf_class` | string | `authentication` \| `account_change` \| `api_activity`. |
+| `ocsf_class` | string | `authentication` \| `account_change` \| `user_access_management` \| `group_management` \| `api_activity`. |
 | `outcome` | string | `success` \| `failure` \| `denied`. |
 | `tenant_id` | string \| null | Tenant the action occurred in (best-effort). |
 | `actor` | object \| null | `{ user_id, email, api_key_id, auth_type }`. Never contains a secret. |
@@ -72,13 +74,44 @@ them). Current taxonomy (`AuditAction` in `backend/onyx/utils/audit.py`):
   `auth.register`, `auth.password_forgot`, `auth.password_reset`,
   `auth.email_verify`, `auth.impersonate`
 - **Account change:** `user.create`, `user.delete`, `user.deactivate`,
-  `user.reactivate`, `user.role_change`, `user.group_change`
-- **API activity (admin config / resource CRUD):** `llm_provider.{create,update,delete}`,
+  `user.reactivate`
+- **User access management:** `user.role_change`, `user.craft_access_change`
+- **Group management:** `user.group_change`, `user_group.create`,
+  `user_group.rename`, `user_group.delete`, `user_group.permission_change`,
+  `user_group.manager_change`
+- **API activity (admin config / resource CRUD):** `settings.craft_default_change`,
+  `search_settings.contextual_rag_model_update`, `llm_provider.{create,update,delete}`,
   `connector.{create,update,delete}`, `cc_pair.{create,update,delete}`,
-  `api_key.{create,regenerate,delete}`, `credential.{create,update,delete}`,
-  `credential.access`
+  `api_key.{create,regenerate,update,delete}`, `credential.{create,update,delete}`,
+  `credential.access`, `permission.denied`
 
-> All actions in the taxonomy are wired to call sites.
+> Two actions are defined without a call site: `auth.logout`, and
+> `credential.access` (the live credential path still uses the older
+> `emit_credential_access`, described below).
+
+### Authorization refusals
+
+`permission.denied` carries `outcome: "denied"` and fires when a scoped write gate
+refuses an actor who holds *partial* authority — a group manager acting outside the
+groups they manage, or one hitting an admin-only operation. `extra.gate` says which
+gate refused: `within_scope`, `manages_group`, or `global_only`. Plain 403s from the
+route-level permission check are not audited; they are ordinary access control, not
+an escalation signal.
+
+Denials are deduped per (user, gate, resource) on a 60-second window, so a retrying
+client collapses to one line while a scan across many resources still records each
+one.
+
+### SCIM-sourced events
+
+Group writes arriving over SCIM reuse the same actions as the admin UI, so
+"every membership change" stays a single filter. They are distinguished by
+`extra.source == "scim"`, carry `extra.scim_token_name`, and their actor is the
+provisioning token rather than a user:
+`{"api_key_id": "scim_token:<id>", "auth_type": "scim", "user_id": null}`.
+
+SCIM emits only on a real change. IdPs re-`PUT` a group's full state on routine
+reconciliation, and a sync that changes nothing produces no event.
 
 ### Example event
 
@@ -142,6 +175,23 @@ Example **Fluent Bit** grep filter:
     Match   onyx.*
     Regex   logger ^onyx\.audit
 ```
+
+## Schema changes
+
+`audit_schema_version` is still `1.0` — no field has been added, removed or
+retyped. Three actions did move to a more accurate OCSF class, which changes their
+`ocsf_class` value and therefore the child logger they land on:
+
+| Action | Was | Now |
+|---|---|---|
+| `user.group_change` | `account_change` | `group_management` |
+| `user.role_change` | `account_change` | `user_access_management` |
+| `user.craft_access_change` | `account_change` | `user_access_management` |
+
+The `action` values are unchanged, so a consumer that filters on the `onyx.audit`
+prefix and parses the JSON (the pattern documented above, and what the example
+shipper configs do) needs no update. Update any rule that routes on a specific
+child logger name or matches `ocsf_class` directly.
 
 > Roadmap: a syslog/CEF formatter, an OCSF-native emitter mode, and an in-product
 > `audit_event` table + read API are planned follow-ups. The JSON export path


### PR DESCRIPTION
## Description

- Emit audit events for the group-based permission system, which was previously silent: group create / rename / delete, permission grants and revokes, and group-manager assignment.
- Audit `PATCH /admin/api-key/{id}`, which replaces a service account's entire group list — and therefore its permissions — with no record today.
- Record authorization refusals from the scoped write gates as `permission.denied`, so an actor acting outside their granted scope is visible.
- Cover the SCIM group surface, which writes the same memberships as the admin UI but was entirely unaudited; SCIM events are tagged `extra.source = "scim"` and emit only on a real change, so routine IdP reconciliation stays quiet.
- Add `user_access_management` and `group_management` OCSF classes, and move `user.role_change`, `user.craft_access_change` and `user.group_change` onto them. Action values are unchanged, but these three now land on a different child logger — see the "Schema changes" section of `docs/AUDIT_LOGGING.md`.
- Enrich existing events so a grant is traceable: `previous_is_admin` on `user.role_change`, `group_name` + `is_default` on `user.group_change`, `is_admin` on `auth.register` (the only record of a first-user or SAML admin), and `group_ids` on `api_key.create`.

## How Has This Been Tested?

Unit and external-dependency-unit tests added, covering the permission diff against real `permission_grant` rows, the SCIM no-op reconciliation guard, and that group deletion emits exactly once despite the sync task re-running the deletion prep.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits audit events for group permission and membership changes from the admin UI and SCIM, and records every scoped write denial. Previously denials were deduped and could hide bulk walks; now each refusal is logged so out‑of‑scope access is visible.

- New Features - New features added
  - Emit user_group.create, user_group.rename, user_group.delete, user_group.permission_change (adds/removed diff), user_group.manager_change, and user.group_change.
  - Emit api_key.update for PATCH /admin/api-key/{id} with name and group_ids; api_key.create now includes group_ids.
  - Emit permission.denied when scoped gates refuse writes (within_scope, manages_group, global_only); events include gate and context and are no longer deduped.
  - SCIM group writes reuse the same actions, tag extra.source="scim" and scim_token_name, act as api_key_id "scim_token:<id>", and only emit on real changes.
  - Enrich events: user.role_change adds previous_is_admin; user.group_change adds group_name and is_default; auth.register adds is_admin.

- Migration
  - user.group_change now lands under the group_management logger; user.role_change and user.craft_access_change now land under user_access_management.
  - Update SIEM routing only if you filter by child logger or ocsf_class; JSON consumers filtering on onyx.audit need no change.

<sup>Written for commit 9bb2264bb7f18360cfa381d28e70d87bdd59877f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



