### PR TITLE
fix(auth): bind the admin user_db adapter in the oauth tenant session

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -540,7 +540,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         previous_user_db = self.user_db
         try:
             async with get_async_session_context_manager(tenant_id) as db_session:
-                self.user_db = SQLAlchemyUserDatabase[User, uuid.UUID](
+                # Admin adapter: only its create() assigns role, which has no
+                # column default (the default= on its Enum type is dead).
+                self.user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
                     db_session, User, OAuthAccount
                 )
                 yield db_session

--- a/backend/tests/external_dependency_unit/auth/test_oauth_callback_new_user_role.py
+++ b/backend/tests/external_dependency_unit/auth/test_oauth_callback_new_user_role.py
@@ -1,0 +1,83 @@
+"""A first OIDC login for an unknown email must create the user with a role.
+
+The oauth signup path builds a user dict without `role` and relies on the
+bound user_db adapter to assign it. `user.role` is NOT NULL with no default,
+so binding the wrong adapter fails the INSERT (regression from #14193,
+shipped in v4.6.2).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+import onyx.auth.users as users_module
+from onyx.auth.schemas import UserRole
+from onyx.auth.users import UserManager
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.db.models import OAuthAccount, User, User__UserGroup
+from onyx.server.security.store import _build_env_defaults
+from tests.external_dependency_unit.conftest import create_test_user
+
+_OAUTH_NAME = "oidc"
+
+
+def _user_by_email(db_session: Session, email: str) -> User | None:
+    return (
+        db_session.query(User)
+        .filter(User.email == email)  # ty: ignore[invalid-argument-type]
+        .first()
+    )
+
+
+def _delete_user_fully(db_session: Session, email: str) -> None:
+    user = _user_by_email(db_session, email)
+    if user is None:
+        return
+    db_session.execute(
+        delete(OAuthAccount).where(OAuthAccount.__table__.c.user_id == user.id)
+    )
+    db_session.execute(
+        delete(User__UserGroup).where(User__UserGroup.user_id == user.id)
+    )
+    db_session.delete(user)
+    db_session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_new_oauth_user_is_created_with_role(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(users_module, "MULTI_TENANT", False)
+    monkeypatch.setattr(users_module, "get_security_settings", _build_env_defaults)
+
+    # An existing user keeps the first-user ADMIN promotion out of the picture.
+    seed_user = create_test_user(db_session, "oauth_role_seed")
+    new_email = f"oauth_role_new_{uuid4().hex[:8]}@example.com"
+
+    try:
+        async with get_async_session_context_manager() as injected_session:
+            manager = UserManager(
+                SQLAlchemyUserDatabase(injected_session, User, OAuthAccount)
+            )
+            created = await manager.oauth_callback(
+                oauth_name=_OAUTH_NAME,
+                access_token="test-access-token",
+                account_id=f"entra-{uuid4().hex}",
+                account_email=new_email,
+                is_verified_by_default=True,
+            )
+            assert created.role == UserRole.BASIC
+
+        db_session.expire_all()
+        persisted = _user_by_email(db_session, new_email)
+        assert persisted is not None
+        assert persisted.role == UserRole.BASIC
+    finally:
+        _delete_user_fully(db_session, new_email)
+        _delete_user_fully(db_session, seed_user.email)

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -583,7 +583,7 @@ class TestOAuthDottedGmail:
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    @patch("onyx.auth.users.SQLAlchemyUserDatabase")
+    @patch("onyx.auth.users.SQLAlchemyUserAdminDB")
     async def test_oauth_create_does_not_block_dotted_gmail(
         self,
         mock_user_db_cls: MagicMock,
@@ -700,7 +700,7 @@ class TestOAuthNoAutoLinkExemptions:
     @patch("onyx.auth.users.assign_user_to_default_groups__no_commit")
     @patch("onyx.auth.users._upgrade_will_add_seat", return_value=False)
     @patch("onyx.auth.users.get_session_with_current_tenant")
-    @patch("onyx.auth.users.SQLAlchemyUserDatabase")
+    @patch("onyx.auth.users.SQLAlchemyUserAdminDB")
     async def test_placeholder_promoted_without_auto_link(
         self,
         mock_user_db_cls: MagicMock,
@@ -771,7 +771,7 @@ class TestOAuthNoAutoLinkExemptions:
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    @patch("onyx.auth.users.SQLAlchemyUserDatabase")
+    @patch("onyx.auth.users.SQLAlchemyUserAdminDB")
     async def test_unclaimed_row_is_claimed_by_first_login(
         self,
         mock_user_db_cls: MagicMock,
@@ -820,7 +820,7 @@ class TestOAuthNoAutoLinkExemptions:
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    @patch("onyx.auth.users.SQLAlchemyUserDatabase")
+    @patch("onyx.auth.users.SQLAlchemyUserAdminDB")
     async def test_spoken_for_row_is_rejected(
         self,
         mock_user_db_cls: MagicMock,
@@ -859,7 +859,7 @@ class TestOAuthNoAutoLinkExemptions:
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    @patch("onyx.auth.users.SQLAlchemyUserDatabase")
+    @patch("onyx.auth.users.SQLAlchemyUserAdminDB")
     async def test_deactivated_row_is_not_linked(
         self,
         mock_user_db_cls: MagicMock,


### PR DESCRIPTION
## Description

On v4.6.2, every new user's first OIDC/OAuth login fails with `NotNullViolationError: null value in column "role"`. The oidc self-deadlock fix (#14193) bound the base `SQLAlchemyUserDatabase` inside `oauth_callback`'s tenant session. Only `SQLAlchemyUserAdminDB.create()` assigns `role` on the oauth signup path (`user.role` is NOT NULL, and the `default=` kwarg inside its `Enum()` type is silently ignored by SQLAlchemy, so the insert sends an explicit NULL). Password signup, SAML, and JWT provisioning set role elsewhere and are unaffected.

The fix binds `SQLAlchemyUserAdminDB` in `_tenant_session_with_bound_user_db`, restoring the pre-4.6.2 adapter for both single-tenant and multi-tenant, including the first-user ADMIN promotion. The deadlock fix is untouched: `AdminDB.create()` only adds a plain `SELECT count` on its own short-lived session, which the advisory seat lock does not block.

Main is not affected: `role` is a nullable tombstone column there.

## How Has This Been Tested?

- New regression test `test_oauth_callback_new_user_role.py` (external_dependency_unit): reproduces the exact `NotNullViolationError` on unfixed code, passes with the fix.
- Full `tests/external_dependency_unit/auth/` suite (50 passed), including the #14181 deadlock tests.
- `ruff format --check`, project-wide `ty check`, pre-commit on touched files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
