### PR TITLE
fix(opal): keep SidebarTab tree shape stable across label types

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -72,6 +72,9 @@ interface FoldedTooltipProps {
   /** Explicit fold state. Falls back to the enclosing sidebar's. */
   folded?: boolean;
 
+  /** Turns the tooltip off regardless of fold state. */
+  suppressed?: boolean;
+
   children: React.ReactElement;
 }
 
@@ -87,7 +90,12 @@ interface FoldedTooltipProps {
  * added and removed. Dropping it would change the tree shape on a fold, which
  * remounts the tab and cuts the label's fade short.
  */
-function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
+function FoldedTooltip({
+  label,
+  folded,
+  suppressed,
+  children,
+}: FoldedTooltipProps) {
   const foldedFromSidebar = useSidebarFolded();
 
   const effectiveFolded = folded ?? foldedFromSidebar;
@@ -95,7 +103,11 @@ function FoldedTooltip({ label, folded, children }: FoldedTooltipProps) {
   /* `suppressed`, not a controlled `open`: hover stays Radix's to track, so an
   unfolded tab keeps no hover state of its own that a later fold could act on. */
   return (
-    <Tooltip tooltip={label} side="right" suppressed={!effectiveFolded}>
+    <Tooltip
+      tooltip={label}
+      side="right"
+      suppressed={suppressed || !effectiveFolded}
+    >
       {children}
     </Tooltip>
   );
@@ -240,11 +252,16 @@ function SidebarTab({
     );
   }
 
-  // Only a string label can stand in as its own tooltip.
-  if (label === undefined) return content;
-
+  /* Only a string label can stand in as its own tooltip, but the wrapper stays
+  either way: dropping it when `children` is an element would change the tree
+  shape, and a tab that swaps its label for an inline editor would remount —
+  taking the open actions popover (and the editor's focus) with it. */
   return (
-    <FoldedTooltip label={label} folded={folded}>
+    <FoldedTooltip
+      label={label ?? ""}
+      folded={folded}
+      suppressed={label === undefined}
+    >
       {content}
     </FoldedTooltip>
   );

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -398,7 +398,7 @@ const ChatButton = memo(
     const rightMenu = (
       <>
         <Popover.Trigger asChild onClick={noProp()}>
-          <div>
+          <div data-testid="ChatButton/options">
             {/* While renaming the row is an input, so the menu stays away unless
                 its own popover is already open. */}
             {(!renaming || popoverOpen) && (
@@ -413,7 +413,12 @@ const ChatButton = memo(
             )}
           </div>
         </Popover.Trigger>
-        <Popover.Content side="right" align="start" width="md">
+        <Popover.Content
+          data-testid="ChatButton/popover"
+          side="right"
+          align="start"
+          width="md"
+        >
           <PopoverMenu>{popoverItems}</PopoverMenu>
         </Popover.Content>
       </>
@@ -432,6 +437,7 @@ const ChatButton = memo(
         <Popover.Anchor>
           <Hoverable.Root
             group="ChatButton"
+            data-testid="ChatButton"
             interaction={popoverOpen ? "hover" : "rest"}
           >
             <SidebarTab

--- a/web/tests/e2e/chat/sidebar_chat_rename.spec.ts
+++ b/web/tests/e2e/chat/sidebar_chat_rename.spec.ts
@@ -1,0 +1,53 @@
+// Regression test for renaming a chat from the sidebar popout.
+//
+// SidebarTab must keep its tree shape stable when its label is swapped for
+// the inline rename editor. When the shape changed, React remounted the row
+// and the open popover; the remounted popover took focus back from the
+// editor, whose blur handler closed it before it could be used.
+import { test, expect } from "@playwright/test";
+import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import { AppSidebarPage } from "@tests/e2e/pages/AppSidebarPage";
+
+const CHAT_NAME = "E2E Rename Target";
+const NEW_NAME = "E2E Renamed Chat";
+
+test.describe("Sidebar chat rename", () => {
+  let sidebar: AppSidebarPage;
+  let chatId: string;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+
+    const apiClient = new OnyxApiClient(page.request);
+    chatId = await apiClient.createChatSession(CHAT_NAME);
+
+    sidebar = new AppSidebarPage(page);
+    await sidebar.goto();
+  });
+
+  test.afterEach(async ({ page }) => {
+    const apiClient = new OnyxApiClient(page.request);
+    await apiClient.deleteChatSession(chatId);
+  });
+
+  test("renames a chat session from the row's options popover", async () => {
+    const row = sidebar.chatRow(CHAT_NAME);
+    await row.startRename();
+
+    // The editor must appear, hold focus, and start from the current name.
+    await expect(row.renameInput).toBeVisible();
+    await expect(row.renameInput).toBeFocused();
+    await expect(row.renameInput).toHaveValue(CHAT_NAME);
+
+    await row.submitRename(NEW_NAME);
+
+    await expect(sidebar.chatRow(NEW_NAME).root).toBeVisible();
+    await expect(row.renameInput).toBeHidden();
+
+    // The new name survives a reload.
+    await sidebar.goto();
+    await expect(sidebar.chatRow(NEW_NAME).root).toBeVisible();
+  });
+});

--- a/web/tests/e2e/pages/AppSidebarPage.ts
+++ b/web/tests/e2e/pages/AppSidebarPage.ts
@@ -86,12 +86,70 @@ export class ProjectsPopover {
   }
 }
 
+/** A chat session row in the sidebar (Recents or an unfolded project). */
+export class SidebarChatRow {
+  constructor(
+    readonly page: Page,
+    readonly name: string
+  ) {}
+
+  /**
+   * The row container. Matched by the visible label, so it matches nothing
+   * while the row shows the inline rename editor.
+   */
+  get root(): Locator {
+    return this.page.getByTestId("ChatButton").filter({ hasText: this.name });
+  }
+
+  /** The "..." button that opens the row's options popover. */
+  get optionsButton(): Locator {
+    return this.root.getByTestId("ChatButton/options");
+  }
+
+  /** The options popover. Only one row's popover is open at a time. */
+  get optionsPopover(): Locator {
+    return this.page.getByTestId("ChatButton/popover");
+  }
+
+  /**
+   * The inline rename editor. The editor replaces the row's label, so this
+   * cannot be scoped to the row by name; only one row renames at a time.
+   */
+  get renameInput(): Locator {
+    return this.page.getByTestId("ChatButton").getByRole("textbox");
+  }
+
+  /** Reveals the row's actions and opens the options popover. */
+  async openOptions(): Promise<void> {
+    await this.root.hover();
+    await this.optionsButton.click();
+    await expect(this.optionsPopover).toBeVisible();
+  }
+
+  /** Opens the options popover and clicks "Rename". */
+  async startRename(): Promise<void> {
+    await this.openOptions();
+    await this.optionsPopover.getByRole("button", { name: "Rename" }).click();
+  }
+
+  /** Types a new name into the rename editor and submits it. */
+  async submitRename(newName: string): Promise<void> {
+    await this.renameInput.fill(newName);
+    await this.renameInput.press("Enter");
+  }
+}
+
 /** The main application sidebar. */
 export class AppSidebarPage {
   readonly projectsPopover: ProjectsPopover;
 
   constructor(private readonly page: Page) {
     this.projectsPopover = new ProjectsPopover(page);
+  }
+
+  /** A chat session row, looked up by its visible name. */
+  chatRow(name: string): SidebarChatRow {
+    return new SidebarChatRow(this.page, name);
   }
 
   async goto(): Promise<void> {


### PR DESCRIPTION
## Summary

Clicking **Rename** in a sidebar chat's popout closed the inline editor at once, so the chat could not be renamed. Bisected to 43841e8519.

Since that commit, `SidebarTab` wrapped string labels in `FoldedTooltip` but returned element children bare. `ChatButton` swaps its string label for the inline rename editor, so the swap changed the tree shape at the tab's root. React then remounted the whole row, including the open options popover. The remounted popover took focus back from the editor, and the editor's blur handler closed it.

The `Tooltip` component already documents this hazard and provides `suppressed` for it. The fix keeps the `FoldedTooltip` wrapper for element children and suppresses the tooltip instead of dropping the wrapper. The tab no longer remounts, and the editor keeps focus.

## Changes

- `web/lib/opal/.../sidebar-tab/components.tsx` — always wrap content in `FoldedTooltip`; add a `suppressed` prop for tabs without a string label.
- `web/src/sections/sidebar/ChatButton.tsx` — add `data-testid` hooks for the row, its options trigger, and its popover.
- `web/tests/e2e/pages/AppSidebarPage.ts` — add a `SidebarChatRow` page object.
- `web/tests/e2e/chat/sidebar_chat_rename.spec.ts` — regression test: rename a chat from the popout, assert the editor appears, holds focus, and the new name survives a reload.

## Testing

- Reproduced the bug in the app, then verified the fix manually (editor appears, rename persists).
- New e2e test fails on the pre-fix code and passes with the fix.
- `jest` SidebarTab suite passes; `pre-commit` (oxfmt, oxlint, tsc) passes on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [Optional] Please cherry-pick this PR to the latest release version.