### PR TITLE
fix(whitelabeling): honor custom logo and name on auth pages, add login subtitle

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/models.py
+++ b/backend/ee/onyx/server/enterprise_settings/models.py
@@ -52,6 +52,9 @@ class EnterpriseSettings(BaseModel):
     consent_screen_prompt: str | None = None
     show_first_visit_notice: bool | None = None
     custom_greeting_message: str | None = None
+    # login page subtitle under the "Welcome to <app name>" heading. Blank
+    # falls back to the default Onyx tagline.
+    custom_login_subtitle: str | None = None
 
     # custom help link surfaced in the profile dropdown alongside the
     # built-in "Help & FAQ" item

--- a/web/src/app/auth/login/LoginText.tsx
+++ b/web/src/app/auth/login/LoginText.tsx
@@ -2,17 +2,22 @@
 
 import React from "react";
 import { useSettings } from "@/lib/settings/hooks";
+import { welcomeCardCopy } from "@/lib/auth/copies";
 import Text from "@/refresh-components/texts/Text";
 
 export default function LoginText() {
-  const { appName } = useSettings();
+  const { appName, enterprise } = useSettings();
+  const { title, description } = welcomeCardCopy(
+    appName,
+    enterprise?.custom_login_subtitle
+  );
   return (
     <div className="w-full flex flex-col ">
       <Text as="p" headingH2 text05>
-        Welcome to {appName}
+        {title}
       </Text>
       <Text as="p" text03 mainUiMuted>
-        Your open source AI platform for work
+        {description}
       </Text>
     </div>
   );

--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -25,6 +25,7 @@ import {
 } from "react";
 import type { PreviewHighlightTarget } from "./Preview";
 import { SvgEdit } from "@opal/icons";
+import { DEFAULT_LOGIN_SUBTITLE } from "@/lib/auth/copies";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { planTagProps } from "@/lib/tier-badge";
@@ -36,6 +37,7 @@ interface AppearanceThemeSettingsProps {
   charLimits: {
     application_name: number;
     custom_greeting_message: number;
+    custom_login_subtitle: number;
     custom_header_content: number;
     custom_lower_disclaimer_content: number;
     custom_popup_header: number;
@@ -62,6 +64,7 @@ export const AppearanceThemeSettings = forwardRef<
   const fileInputRef = useRef<HTMLInputElement>(null);
   const applicationNameInputRef = useRef<HTMLInputElement>(null);
   const greetingMessageInputRef = useRef<HTMLInputElement>(null);
+  const loginSubtitleInputRef = useRef<HTMLInputElement>(null);
   const headerContentInputRef = useRef<HTMLInputElement>(null);
   const lowerDisclaimerInputRef = useRef<HTMLTextAreaElement>(null);
   const noticeHeaderInputRef = useRef<HTMLInputElement>(null);
@@ -110,6 +113,7 @@ export const AppearanceThemeSettings = forwardRef<
           name: "custom_lower_disclaimer_content",
           ref: lowerDisclaimerInputRef,
         },
+        { name: "custom_login_subtitle", ref: loginSubtitleInputRef },
         { name: "custom_popup_header", ref: noticeHeaderInputRef },
         { name: "custom_popup_content", ref: noticeContentInputRef },
         { name: "consent_screen_prompt", ref: consentPromptTextAreaRef },
@@ -478,6 +482,38 @@ export const AppearanceThemeSettings = forwardRef<
         </FormField.Description>
         <FormField.Message
           messages={{ error: errors.custom_lower_disclaimer_content as string }}
+        />
+      </FormField>
+
+      <FormField state={errors.custom_login_subtitle ? "error" : "idle"}>
+        <FormField.Label
+          rightAction={
+            <CharacterCount
+              value={values.custom_login_subtitle}
+              limit={charLimits.custom_login_subtitle}
+            />
+          }
+        >
+          Login Page Subtitle
+        </FormField.Label>
+        <FormField.Control asChild>
+          <InputTypeIn
+            ref={loginSubtitleInputRef}
+            data-label="login-subtitle-input"
+            clearButton
+            placeholder={DEFAULT_LOGIN_SUBTITLE}
+            variant={errors.custom_login_subtitle ? "error" : undefined}
+            value={values.custom_login_subtitle}
+            onChange={(e) =>
+              setFieldValue("custom_login_subtitle", e.target.value)
+            }
+          />
+        </FormField.Control>
+        <FormField.Description>
+          Replace the tagline under the welcome heading on the login page.
+        </FormField.Description>
+        <FormField.Message
+          messages={{ error: errors.custom_login_subtitle as string }}
         />
       </FormField>
 

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -23,6 +23,7 @@ const route = ADMIN_ROUTES.THEME;
 const CHAR_LIMITS = {
   application_name: 50,
   custom_greeting_message: 50,
+  custom_login_subtitle: 100,
   custom_header_content: 100,
   custom_lower_disclaimer_content: 200,
   custom_popup_header: 100,
@@ -105,6 +106,12 @@ export default function ThemePage() {
       .max(
         CHAR_LIMITS.custom_greeting_message,
         `Maximum ${CHAR_LIMITS.custom_greeting_message} characters`
+      )
+      .nullable(),
+    custom_login_subtitle: Yup.string()
+      .max(
+        CHAR_LIMITS.custom_login_subtitle,
+        `Maximum ${CHAR_LIMITS.custom_login_subtitle} characters`
       )
       .nullable(),
     custom_header_content: Yup.string()
@@ -209,6 +216,7 @@ export default function ThemePage() {
         use_custom_logo: enterpriseSettings?.use_custom_logo || false,
         custom_greeting_message:
           enterpriseSettings?.custom_greeting_message || "",
+        custom_login_subtitle: enterpriseSettings?.custom_login_subtitle || "",
         custom_header_content: enterpriseSettings?.custom_header_content || "",
         custom_lower_disclaimer_content:
           enterpriseSettings?.custom_lower_disclaimer_content || "",
@@ -262,6 +270,7 @@ export default function ThemePage() {
           logo_display_style: values.logo_display_style || null,
           custom_nav_items: enterpriseSettings?.custom_nav_items || [],
           custom_greeting_message: values.custom_greeting_message || null,
+          custom_login_subtitle: values.custom_login_subtitle?.trim() || null,
           custom_header_content: values.custom_header_content || null,
           custom_lower_disclaimer_content:
             values.custom_lower_disclaimer_content || null,

--- a/web/src/components/auth/AuthFlowContainer.tsx
+++ b/web/src/components/auth/AuthFlowContainer.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { SvgOnyxLogo } from "@opal/logos";
 import { useSettings } from "@/lib/settings/hooks";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 export default function AuthFlowContainer({
   children,
@@ -41,8 +41,8 @@ export default function AuthFlowContainer({
         <div className="text-sm mt-6 text-center w-full text-text-03 mainUiBody mx-auto">
           {footerContent ?? (
             <>
-              <Text as="span" text03 mainUiBody>
-                New to {appName}?
+              <Text font="main-ui-body" color="text-03">
+                {`New to ${appName}?`}
               </Text>{" "}
               <Link
                 href="/auth/signup"

--- a/web/src/components/auth/AuthFlowContainer.tsx
+++ b/web/src/components/auth/AuthFlowContainer.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import Link from "next/link";
 import { SvgOnyxLogo } from "@opal/logos";
+import { useSettings } from "@/lib/settings/hooks";
+import Text from "@/refresh-components/texts/Text";
 
 export default function AuthFlowContainer({
   children,
@@ -10,17 +14,36 @@ export default function AuthFlowContainer({
   authState?: "signup" | "login" | "join";
   footerContent?: React.ReactNode;
 }) {
+  const { appName, logoUrl } = useSettings();
   return (
     <div className="p-4 flex flex-col items-center justify-center min-h-screen bg-background">
       <div className="w-full max-w-md flex items-start flex-col bg-background-tint-00 rounded-16 shadow-lg shadow-box-02 p-6">
-        <SvgOnyxLogo size={44} className="text-theme-primary-05" />
+        {/* logo_display_style only governs the sidebar; auth pages always show
+            the logo mark (custom when uploaded, Onyx otherwise) */}
+        {logoUrl ? (
+          <div
+            className="aspect-square rounded-full overflow-hidden relative"
+            style={{ height: 44 }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              alt="Logo"
+              src={logoUrl}
+              className="object-cover object-center w-full h-full"
+            />
+          </div>
+        ) : (
+          <SvgOnyxLogo size={44} className="text-theme-primary-05" />
+        )}
         <div className="w-full mt-3">{children}</div>
       </div>
       {authState === "login" && (
         <div className="text-sm mt-6 text-center w-full text-text-03 mainUiBody mx-auto">
           {footerContent ?? (
             <>
-              New to Onyx?{" "}
+              <Text as="span" text03 mainUiBody>
+                New to {appName}?
+              </Text>{" "}
               <Link
                 href="/auth/signup"
                 className="text-text-05 mainUiAction underline transition-colors duration-200"

--- a/web/src/lib/auth/copies.ts
+++ b/web/src/lib/auth/copies.ts
@@ -1,10 +1,12 @@
 import { RichStr } from "@opal/types";
 import { markdown } from "@opal/utils";
 
-export function welcomeCardCopy(appName: string) {
+export const DEFAULT_LOGIN_SUBTITLE = "Your open source AI platform for work";
+
+export function welcomeCardCopy(appName: string, subtitle?: string | null) {
   return {
     title: `Welcome to ${appName}`,
-    description: "Your open source AI platform for work",
+    description: subtitle?.trim() || DEFAULT_LOGIN_SUBTITLE,
   } as const;
 }
 

--- a/web/src/lib/settings/hooks.ts
+++ b/web/src/lib/settings/hooks.ts
@@ -63,15 +63,12 @@ export function useSettings(): AppSettings {
   );
 
   const core = rawSettings ?? DEFAULT_SETTINGS;
-  // On /auth/* the core fetch is skipped, so fall back to EE_ENABLED only —
-  // mirrors the pre-gating behavior where the core 403 disabled the derived
-  // check (avoids a new enterprise-settings fetch/404 on non-EE login pages).
+  // Auth pages need branding pre-sign-in but standard web images lack the EE
+  // flag, so probe the endpoint. A CE backend 404s once (no retry below).
   const shouldFetchEnterprise =
     EE_ENABLED ||
-    (!onAuthPath &&
-      !settingsLoading &&
-      !settingsError &&
-      core.ee_features_enabled !== false);
+    onAuthPath ||
+    (!settingsLoading && !settingsError && core.ee_features_enabled !== false);
 
   const {
     data: enterprise,
@@ -86,6 +83,9 @@ export function useSettings(): AppSettings {
       revalidateIfStale: false,
       dedupingInterval: 30_000,
       errorRetryInterval: SETTINGS_ERROR_RETRY_INTERVAL,
+      // No retry on auth pages: a CE backend 404s this endpoint and the login
+      // page should settle on default branding instead of re-fetching.
+      shouldRetryOnError: !onAuthPath,
       // Referential equality — logo can change without JSON changing, so
       // mutate() must propagate a new reference for cache-busters.
       compare: (a, b) => a === b,

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -143,6 +143,7 @@ export interface EnterpriseSettings {
   consent_screen_prompt: string | null;
   show_first_visit_notice: boolean | null;
   custom_greeting_message: string | null;
+  custom_login_subtitle: string | null;
 
   // Custom help link surfaced in the profile dropdown alongside "Help & FAQ".
   custom_help_link_url: string | null;


### PR DESCRIPTION
## Description

Whitelabeled deployments still get Onyx branding on the login page: `AuthFlowContainer` has hardcoded the Onyx logo since the UI refresh (#5529), and the tagline was never customizable. Multiple customers have reported this.

- Auth pages now render the custom logo when `use_custom_logo` is set, falling back to the Onyx mark, and use the application name in the "New to ...?" footer. `logo_display_style` stays a sidebar-only concern.
- New `custom_login_subtitle` enterprise setting replaces the "Your open source AI platform for work" tagline, editable in Appearance & Theming. Blank falls back to the default. KV-store backed, no migration.

`/api/enterprise-settings` and the logo endpoint are already unauthenticated for self-hosted deployments, so all of this renders before sign-in. Unbranded deployments are unchanged.

## How Has This Been Tested?

Live on a self-hosted EE dev stack: configured name, logo, and subtitle in Appearance & Theming, then verified the logged-out login page in the password and SSO-provider variants, the `name_only` display style, the blank-subtitle fallback, and the unbranded default. `ruff format`, `ty`, web type check, and the branding unit tests pass.

## Screenshots + Videos

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/whitelabel-login/before.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/whitelabel-login/after.jpg) |

With an SSO provider configured:

![sso](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/whitelabel-login/after-sso.jpg)

settings page

<img width="966" height="431" alt="Screenshot 2026-08-25 at 11 44 44 AM" src="https://github.com/user-attachments/assets/fb833914-c3f7-45d7-a50c-f27075959a2e" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
