### PR TITLE
refactor(web): `refresh/LineItem` -> `opal/LineItemButton` migration (pt1)

### DIFF
--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -13,6 +13,7 @@ import {
 import { CRAFT_SEARCH_PARAM_NAMES } from "@/app/craft/services/searchParams";
 import {
   Button,
+  LineItemButton,
   Popover,
   PopoverMenu,
   SidebarTab,
@@ -30,7 +31,6 @@ import { renderSidebarLogo } from "@/lib/sidebar/utils";
 import { useShowLogoWhenFolded } from "@/lib/sidebar/hooks";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { Hoverable } from "@opal/core";
 import { noProp } from "@/lib/utils";
 import {
@@ -182,22 +182,24 @@ function BuildSessionButton({
       <Popover.Content side="right" align="start">
         <PopoverMenu>
           {[
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               key="rename"
               icon={SvgEdit}
               onClick={noProp(() => setRenaming(true))}
-            >
-              Rename
-            </LineItem>,
+              title="Rename"
+            />,
             null,
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               key="delete"
               icon={SvgTrash}
               onClick={noProp(() => setIsDeleteModalOpen(true))}
-              danger
-            >
-              Delete
-            </LineItem>,
+              color="danger"
+              title="Delete"
+            />,
           ]}
         </PopoverMenu>
       </Popover.Content>

--- a/web/src/app/nrf/NRFChrome.tsx
+++ b/web/src/app/nrf/NRFChrome.tsx
@@ -5,10 +5,7 @@ import { ensureHrefProtocol, noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import type { Components } from "react-markdown";
 import Text from "@/refresh-components/texts/Text";
-import { Popover } from "@opal/components";
-import { OpenButton } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
-import { Button } from "@opal/components";
+import { Button, LineItemButton, OpenButton, Popover } from "@opal/components";
 import { SvgBubbleText, SvgSearchMenu, SvgSidebar } from "@opal/icons";
 import MinimalMarkdown from "@/components/chat/MinimalMarkdown";
 import { useIsSearchModeAvailable } from "@/lib/settings/hooks";
@@ -107,28 +104,30 @@ export default function NRFChrome() {
               </Popover.Trigger>
               <Popover.Content align="start" width="lg">
                 <Popover.Menu>
-                  <LineItem
+                  <LineItemButton
+                    sizePreset="main-ui"
+                    rounding="sm"
                     icon={SvgSearchMenu}
-                    selected={effectiveMode === "search"}
+                    state={effectiveMode === "search" ? "selected" : "empty"}
                     description="Quick search for documents"
                     onClick={noProp(() => {
                       setAppMode("search");
                       setModePopoverOpen(false);
                     })}
-                  >
-                    Search
-                  </LineItem>
-                  <LineItem
+                    title="Search"
+                  />
+                  <LineItemButton
+                    sizePreset="main-ui"
+                    rounding="sm"
                     icon={SvgBubbleText}
-                    selected={effectiveMode === "chat"}
+                    state={effectiveMode === "chat" ? "selected" : "empty"}
                     description="Conversation and research"
                     onClick={noProp(() => {
                       setAppMode("chat");
                       setModePopoverOpen(false);
                     })}
-                  >
-                    Chat
-                  </LineItem>
+                    title="Chat"
+                  />
                 </Popover.Menu>
               </Popover.Content>
             </Popover>

--- a/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useCreateModal } from "@opal/components";
+import {
+  Button,
+  CopyButton,
+  Divider,
+  LineItemButton,
+  Popover,
+  Text,
+  useCreateModal,
+} from "@opal/components";
 import { noProp } from "@/lib/utils";
 import { formatDateTimeLog } from "@/lib/dateUtils";
-import { Button, Divider, Text } from "@opal/components";
 import { Content } from "@opal/layouts";
-import LineItem from "@/refresh-components/buttons/LineItem";
-import { Popover } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import {
   SvgAlertTriangle,
@@ -16,7 +21,6 @@ import {
   SvgXOctagon,
   SvgSimpleLoader,
 } from "@opal/icons";
-import { CopyButton } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { useHookExecutionLogs } from "@/ee/hooks/useHookExecutionLogs";
 import HookLogsModal from "@/ee/views/admin/HooksPage/HookLogsModal";
@@ -273,16 +277,17 @@ export default function HookStatusPopover({
                   <Divider paddingPerpendicular={0} />
                 )}
 
-                <LineItem
-                  muted
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  color="muted"
                   icon={SvgMaximize2}
                   onClick={noProp(() => {
                     handleOpenChange(false);
                     logsModal.toggle(true);
                   })}
-                >
-                  View More Lines
-                </LineItem>
+                  title="View More Lines"
+                />
               </>
             ) : hasRecentErrors ? (
               <>
@@ -328,16 +333,17 @@ export default function HookStatusPopover({
                 </Section>
 
                 {/* View More Lines */}
-                <LineItem
-                  muted
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  color="muted"
                   icon={SvgMaximize2}
                   onClick={noProp(() => {
                     handleOpenChange(false);
                     logsModal.toggle(true);
                   })}
-                >
-                  View More Lines
-                </LineItem>
+                  title="View More Lines"
+                />
               </>
             ) : (
               // No errors state
@@ -355,16 +361,17 @@ export default function HookStatusPopover({
                 <Divider paddingPerpendicular={0} />
 
                 {/* View Older Errors */}
-                <LineItem
-                  muted
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  color="muted"
                   icon={SvgMaximize2}
                   onClick={noProp(() => {
                     handleOpenChange(false);
                     logsModal.toggle(true);
                   })}
-                >
-                  View Older Errors
-                </LineItem>
+                  title="View Older Errors"
+                />
               </>
             )}
           </Section>

--- a/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
@@ -10,6 +10,7 @@ import {
   Switch,
   Tooltip,
 } from "@opal/components";
+import { ContentAction } from "@opal/layouts";
 import type { IconProps } from "@opal/types";
 import { SvgChevronLeft, SvgPlug, SvgUnplug } from "@opal/icons";
 
@@ -97,25 +98,30 @@ export default function SwitchList({
             : item.description;
           return (
             <Tooltip key={item.id} tooltip={tooltip}>
-              <LineItemButton
-                sizePreset="main-ui"
-                rounding="sm"
-                icon={
-                  item.leading
-                    ? ((() =>
-                        item.leading) as React.FunctionComponent<IconProps>)
-                    : undefined
-                }
-                rightChildren={
-                  <Switch
-                    checked={item.isEnabled}
-                    onCheckedChange={item.onToggle}
-                    aria-label={`Toggle ${item.label}`}
-                    disabled={item.disabled}
-                  />
-                }
-                title={item.label}
-              />
+              {/* The row does nothing when pressed — the Switch beside it is
+                  the control — so it is a label, not a button. Padding matches
+                  LineItemButton so it lines up with the rows around it. */}
+              <div className="w-full p-1.5">
+                <ContentAction
+                  sizePreset="main-ui"
+                  padding={0.5}
+                  icon={
+                    item.leading
+                      ? ((() =>
+                          item.leading) as React.FunctionComponent<IconProps>)
+                      : undefined
+                  }
+                  rightChildren={
+                    <Switch
+                      checked={item.isEnabled}
+                      onCheckedChange={item.onToggle}
+                      aria-label={`Toggle ${item.label}`}
+                      disabled={item.disabled}
+                    />
+                  }
+                  title={item.label}
+                />
+              </div>
             </Tooltip>
           );
         }),

--- a/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
@@ -100,8 +100,18 @@ export default function SwitchList({
             <Tooltip key={item.id} tooltip={tooltip}>
               {/* The row does nothing when pressed — the Switch beside it is
                   the control — so it is a label, not a button. Padding matches
-                  LineItemButton so it lines up with the rows around it. */}
-              <div className="w-full p-1.5">
+                  LineItemButton so it lines up with the rows around it.
+
+                  It takes a tab stop only while disabled. The Switch is a
+                  native disabled button then, so it cannot be focused, and the
+                  tooltip explaining why would be reachable by pointer alone.
+                  Enabled, the Switch carries the focus and the tooltip opens
+                  from it, so a stop here would only be a second one. */}
+              <div
+                className="w-full p-1.5"
+                // oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the stop exists so a keyboard can reach the tooltip that says why the row is disabled; its Switch is a disabled button and cannot hold focus
+                tabIndex={item.disabled ? 0 : undefined}
+              >
                 <ContentAction
                   sizePreset="main-ui"
                   padding={0.5}

--- a/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
@@ -5,11 +5,11 @@ import useFocusOnMount from "@opal/hooks/useFocusOnMount";
 import {
   Button,
   InputTypeIn,
+  LineItemButton,
   PopoverMenu,
   Switch,
   Tooltip,
 } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import type { IconProps } from "@opal/types";
 import { SvgChevronLeft, SvgPlug, SvgUnplug } from "@opal/icons";
 
@@ -82,13 +82,14 @@ export default function SwitchList({
           />
         </div>,
 
-        <LineItem
+        <LineItemButton
+          sizePreset="main-ui"
+          rounding="sm"
           key="enable-disable-all"
           icon={allDisabled ? SvgPlug : SvgUnplug}
           onClick={allDisabled ? onEnableAll : onDisableAll}
-        >
-          {allDisabled ? "Enable All" : "Disable All"}
-        </LineItem>,
+          title={allDisabled ? "Enable All" : "Disable All"}
+        />,
 
         ...filteredItems.map((item) => {
           const tooltip = item.disabled
@@ -96,14 +97,15 @@ export default function SwitchList({
             : item.description;
           return (
             <Tooltip key={item.id} tooltip={tooltip}>
-              <LineItem
+              <LineItemButton
+                sizePreset="main-ui"
+                rounding="sm"
                 icon={
                   item.leading
                     ? ((() =>
                         item.leading) as React.FunctionComponent<IconProps>)
                     : undefined
                 }
-                strokeIcon={false}
                 rightChildren={
                   <Switch
                     checked={item.isEnabled}
@@ -112,9 +114,8 @@ export default function SwitchList({
                     disabled={item.disabled}
                   />
                 }
-              >
-                {item.label}
-              </LineItem>
+                title={item.label}
+              />
             </Tooltip>
           );
         }),

--- a/web/src/refresh-components/popovers/FilePickerPopover.tsx
+++ b/web/src/refresh-components/popovers/FilePickerPopover.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Button, Popover, PopoverMenu } from "@opal/components";
+import {
+  Button,
+  LineItemButton,
+  Popover,
+  PopoverMenu,
+  useCreateModal,
+} from "@opal/components";
 import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import UserFilesModal from "@/sections/modals/UserFilesModal";
-import { useCreateModal } from "@opal/components";
 import { ProjectFile, UserFileStatus } from "@/lib/projects/types";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { Hoverable } from "@opal/core";
 import { toast } from "@opal/layouts";
 import { useProjectsContext } from "@/lib/projects/providers";
@@ -58,7 +62,9 @@ function FileLineItem({
 
   return (
     <Hoverable.Root group="FileLineItem">
-      <LineItem
+      <LineItemButton
+        sizePreset="main-ui"
+        rounding="sm"
         key={projectFile.id}
         onClick={noProp(() => onPickRecent(projectFile))}
         icon={
@@ -92,9 +98,8 @@ function FileLineItem({
             </Hoverable.Item>
           </div>
         }
-      >
-        {projectFile.name}
-      </LineItem>
+        title={projectFile.name}
+      />
     </Hoverable.Root>
   );
 }
@@ -124,14 +129,15 @@ function FilePickerPopoverContents({
     <PopoverMenu>
       {[
         // Action button to upload more files
-        <LineItem
+        <LineItemButton
+          sizePreset="main-ui"
+          rounding="sm"
           key="upload-files"
           icon={SvgUploadSquare}
           description="Upload a file from your device"
           onClick={triggerUploadPicker}
-        >
-          Upload Files
-        </LineItem>,
+          title="Upload Files"
+        />,
 
         // Separator
         null,
@@ -157,13 +163,14 @@ function FilePickerPopoverContents({
 
         // Rest of the files
         shouldShowMoreFilesButton && (
-          <LineItem
+          <LineItemButton
+            sizePreset="main-ui"
+            rounding="sm"
             key="more-files"
             icon={SvgMoreHorizontal}
             onClick={openRecentFilesModal}
-          >
-            All Recent Files
-          </LineItem>
+            title="All Recent Files"
+          />
         ),
       ]}
     </PopoverMenu>

--- a/web/src/sections/agents/InsertUserVariableMenu.tsx
+++ b/web/src/sections/agents/InsertUserVariableMenu.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from "react";
 import { useFormikContext } from "formik";
-import { Button, Popover, PopoverMenu } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
+import { Button, LineItemButton, Popover, PopoverMenu } from "@opal/components";
 import { SvgBracketCurly } from "@opal/icons";
 import {
   USER_DIRECTORY_PLACEHOLDERS,
@@ -56,14 +55,15 @@ export default function InsertUserVariableMenu({
 
   function renderItem(placeholder: UserPlaceholder) {
     return (
-      <LineItem
+      <LineItemButton
+        sizePreset="main-ui"
+        rounding="sm"
         key={placeholder.key}
         icon={SvgBracketCurly}
         description={userPlaceholderToken(placeholder.key)}
         onClick={() => insertToken(placeholder.key)}
-      >
-        {placeholder.label}
-      </LineItem>
+        title={placeholder.label}
+      />
     );
   }
 

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -7,7 +7,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { MinimalAgent } from "@/lib/agents/types";
 import { InputPrompt } from "@/app/app/interfaces";
 import { FilterManager, LlmManager, useFederatedConnectors } from "@/lib/hooks";
@@ -49,12 +48,17 @@ import {
   SvgX,
   SvgSimpleLoader,
 } from "@opal/icons";
-import { Button, SelectButton, Text } from "@opal/components";
-import { Popover } from "@opal/components";
+import {
+  Button,
+  LineItemButton,
+  Popover,
+  SelectButton,
+  Spacer,
+  Text,
+} from "@opal/components";
 import { useQueryController } from "@/providers/QueryControllerProvider";
 import { Section } from "@/layouts/general-layouts";
 import { useIncognito } from "@/providers/IncognitoProvider";
-import { Spacer } from "@opal/components";
 import MicrophoneButton from "@/sections/input/MicrophoneButton";
 import Waveform from "@/components/voice/Waveform";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";
@@ -990,30 +994,42 @@ const AppInputBar = React.memo(
                   <Popover.Menu>
                     {[
                       ...sortedFilteredPrompts.map((prompt, index) => (
-                        <LineItem
+                        <LineItemButton
+                          sizePreset="main-ui"
+                          rounding="sm"
                           key={prompt.id}
-                          selected={tabbingIconIndex === index}
-                          emphasized={tabbingIconIndex === index}
+                          state={
+                            tabbingIconIndex === index ? "selected" : "empty"
+                          }
+                          selectVariant={
+                            tabbingIconIndex === index
+                              ? "select-heavy"
+                              : "select-light"
+                          }
                           description={prompt.content?.trim()}
                           onClick={() => updateInputPrompt(prompt)}
-                        >
-                          {prompt.prompt}
-                        </LineItem>
+                          title={prompt.prompt}
+                        />
                       )),
                       sortedFilteredPrompts.length > 0 ? null : undefined,
-                      <LineItem
+                      <LineItemButton
+                        sizePreset="main-ui"
+                        rounding="sm"
                         key="create-new"
                         href="/app/settings/chat-preferences"
                         icon={SvgPlus}
-                        selected={
+                        state={
                           tabbingIconIndex === sortedFilteredPrompts.length
+                            ? "selected"
+                            : "empty"
                         }
-                        emphasized={
+                        selectVariant={
                           tabbingIconIndex === sortedFilteredPrompts.length
+                            ? "select-heavy"
+                            : "select-light"
                         }
-                      >
-                        Create New Prompt
-                      </LineItem>,
+                        title="Create New Prompt"
+                      />,
                     ]}
                   </Popover.Menu>
                 </Popover.Content>

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -9,14 +9,19 @@ import React, {
 } from "react";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
-import { Button, CopyButton, Divider as OpalDivider } from "@opal/components";
+import {
+  Button,
+  Checkbox,
+  CopyButton,
+  Divider as OpalDivider,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  Spacer,
+} from "@opal/components";
 import { Hoverable } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
-import { Checkbox } from "@opal/components";
-import { InputTypeIn } from "@opal/components";
-import { Popover } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import SelectButton from "@/refresh-components/buttons/SelectButton";
 import Divider from "@/refresh-components/Divider";
 import {
@@ -47,7 +52,6 @@ import {
 } from "@/lib/hierarchy/svc";
 import { AgentAttachedDocument } from "@/lib/agents/types";
 import { timeAgo } from "@opal/time";
-import { Spacer } from "@opal/components";
 
 // Compact, human-readable form of a node/document link, used as a secondary
 // label so siblings that share a display name (common for orphaned nodes that
@@ -822,72 +826,78 @@ export default function SourceHierarchyBrowser({
               <Popover.Menu>
                 {/* Sort by section */}
                 <Divider showTitle text="Sort by" dividerLine={false} />
-                <LineItem
-                  selected={sortField === "name"}
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  state={sortField === "name" ? "selected" : "empty"}
                   onClick={() => setSortField("name")}
                   rightChildren={
                     sortField === "name" ? <SvgCheck size={16} /> : undefined
                   }
-                >
-                  Name
-                </LineItem>
-                <LineItem
-                  selected={sortField === "last_updated"}
+                  title="Name"
+                />
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  state={sortField === "last_updated" ? "selected" : "empty"}
                   onClick={() => setSortField("last_updated")}
                   rightChildren={
                     sortField === "last_updated" ? (
                       <SvgCheck size={16} />
                     ) : undefined
                   }
-                >
-                  Last Updated
-                </LineItem>
+                  title="Last Updated"
+                />
                 {/* Sorting Order section */}
                 <Divider showTitle text="Sorting Order" dividerLine={false} />
-                <LineItem
-                  selected={sortDirection === "desc"}
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  state={sortDirection === "desc" ? "selected" : "empty"}
                   onClick={() => setSortDirection("desc")}
                   rightChildren={
                     sortDirection === "desc" ? (
                       <SvgCheck size={16} />
                     ) : undefined
                   }
-                >
-                  {sortField === "name" ? "Z to A" : "Recent to Old"}
-                </LineItem>
-                <LineItem
-                  selected={sortDirection === "asc"}
+                  title={sortField === "name" ? "Z to A" : "Recent to Old"}
+                />
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  state={sortDirection === "asc" ? "selected" : "empty"}
                   onClick={() => setSortDirection("asc")}
                   rightChildren={
                     sortDirection === "asc" ? <SvgCheck size={16} /> : undefined
                   }
-                >
-                  {sortField === "name" ? "A to Z" : "Old to Recent"}
-                </LineItem>
+                  title={sortField === "name" ? "A to Z" : "Old to Recent"}
+                />
                 {/* Folders section */}
                 <Divider showTitle text="Folders" dividerLine={false} />
-                <LineItem
-                  selected={folderPosition === "on_top"}
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  state={folderPosition === "on_top" ? "selected" : "empty"}
                   onClick={() => setFolderPosition("on_top")}
                   rightChildren={
                     folderPosition === "on_top" ? (
                       <SvgCheck size={16} />
                     ) : undefined
                   }
-                >
-                  On top
-                </LineItem>
-                <LineItem
-                  selected={folderPosition === "mixed"}
+                  title="On top"
+                />
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
+                  state={folderPosition === "mixed" ? "selected" : "empty"}
                   onClick={() => setFolderPosition("mixed")}
                   rightChildren={
                     folderPosition === "mixed" ? (
                       <SvgCheck size={16} />
                     ) : undefined
                   }
-                >
-                  Mixed with Files
-                </LineItem>
+                  title="Mixed with Files"
+                />
               </Popover.Menu>
             </Popover.Content>
           </Popover>

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { getSourceMetadata } from "@/lib/sources";
@@ -13,7 +12,13 @@ import type {
 } from "@/lib/hierarchy/interfaces";
 import type { SearchDocWithContent } from "@/lib/search/interfaces";
 import type { ValidSources } from "@/lib/types";
-import { Button, Checkbox, Divider, InputTypeIn } from "@opal/components";
+import {
+  Button,
+  Checkbox,
+  Divider,
+  InputTypeIn,
+  LineItemButton,
+} from "@opal/components";
 import {
   SvgArrowLeft,
   SvgChevronRight,
@@ -120,9 +125,11 @@ export function KnowledgeSearchSidebar({
 
   return (
     <TableLayouts.SidebarLayout aria-label="knowledge-search-sidebar">
-      <LineItem
+      <LineItemButton
+        sizePreset="main-ui"
+        rounding="sm"
         icon={SvgFiles}
-        selected={activeSourceFilter === null}
+        state={activeSourceFilter === null ? "selected" : "empty"}
         onClick={() => onSourceFilterClick(null)}
         rightChildren={
           totalCount > 0 ? (
@@ -131,20 +138,20 @@ export function KnowledgeSearchSidebar({
             </Text>
           ) : undefined
         }
-      >
-        All
-      </LineItem>
+        title="All"
+      />
 
       {vectorDbEnabled &&
         connectedSources.map((cs) => {
           const sourceMetadata = getSourceMetadata(cs.source);
           const count = resultCountBySource.get(cs.source) ?? 0;
           return (
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               key={cs.source}
               icon={sourceMetadata.icon}
-              strokeIcon={false}
-              selected={activeSourceFilter === cs.source}
+              state={activeSourceFilter === cs.source ? "selected" : "empty"}
               onClick={() => onSourceFilterClick(cs.source)}
               rightChildren={
                 count > 0 ? (
@@ -153,9 +160,8 @@ export function KnowledgeSearchSidebar({
                   </Text>
                 ) : undefined
               }
-            >
-              {sourceMetadata.displayName}
-            </LineItem>
+              title={sourceMetadata.displayName}
+            />
           );
         })}
     </TableLayouts.SidebarLayout>

--- a/web/src/sections/skills/SkillFileTree.tsx
+++ b/web/src/sections/skills/SkillFileTree.tsx
@@ -10,6 +10,7 @@ import {
   SvgFolderOpen,
   SvgTrash,
 } from "@opal/icons";
+import { ContentAction } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import { formatBytes } from "@/lib/utils";
 import type { SkillBundleFile } from "@/lib/skills/types";
@@ -49,45 +50,61 @@ function SkillFileTreeNodes({
         : SvgFolder
       : SvgFileText;
 
+    const rightChildren = isDirectory ? (
+      <SvgChevronRight
+        size={14}
+        className={cn(
+          "stroke-text-03 transition-transform",
+          isExpanded && "rotate-90"
+        )}
+      />
+    ) : (
+      <div className="flex items-center gap-1">
+        <Text font="secondary-body" color="text-02">
+          {formatBytes(node.size!, 1)}
+        </Text>
+        {onRemove && (
+          <Button
+            type="button"
+            icon={SvgTrash}
+            size="sm"
+            prominence="tertiary"
+            aria-label={`Remove ${node.name}`}
+            tooltip={`Remove ${node.name}`}
+            disabled={removeDisabled || removingPath !== null}
+            onClick={() => onRemove(node.path)}
+          />
+        )}
+      </div>
+    );
+
     return (
       <div key={node.path}>
         <div style={{ paddingLeft: `${depth * 20}px` }}>
-          <LineItemButton
-            sizePreset="main-ui"
-            rounding="sm"
-            icon={FileIcon}
-            onClick={isDirectory ? () => onToggle(node.path) : undefined}
-            rightChildren={
-              isDirectory ? (
-                <SvgChevronRight
-                  size={14}
-                  className={cn(
-                    "stroke-text-03 transition-transform",
-                    isExpanded && "rotate-90"
-                  )}
-                />
-              ) : (
-                <div className="flex items-center gap-1">
-                  <Text font="secondary-body" color="text-02">
-                    {formatBytes(node.size!, 1)}
-                  </Text>
-                  {onRemove && (
-                    <Button
-                      type="button"
-                      icon={SvgTrash}
-                      size="sm"
-                      prominence="tertiary"
-                      aria-label={`Remove ${node.name}`}
-                      tooltip={`Remove ${node.name}`}
-                      disabled={removeDisabled || removingPath !== null}
-                      onClick={() => onRemove(node.path)}
-                    />
-                  )}
-                </div>
-              )
-            }
-            title={node.name}
-          />
+          {isDirectory ? (
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
+              icon={FileIcon}
+              onClick={() => onToggle(node.path)}
+              rightChildren={rightChildren}
+              title={node.name}
+            />
+          ) : (
+            // A file row does nothing when pressed. Only the directory rows
+            // toggle, so only they are buttons — the file row is a label with
+            // its own controls beside it. The padding matches what
+            // LineItemButton applies, so the two line up.
+            <div className="w-full p-1.5">
+              <ContentAction
+                sizePreset="main-ui"
+                padding={0.5}
+                icon={FileIcon}
+                rightChildren={rightChildren}
+                title={node.name}
+              />
+            </div>
+          )}
         </div>
         {isDirectory && isExpanded && (
           <SkillFileTreeNodes

--- a/web/src/sections/skills/SkillFileTree.tsx
+++ b/web/src/sections/skills/SkillFileTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Button, Text } from "@opal/components";
+import { Button, LineItemButton, Text } from "@opal/components";
 import type { RichStr } from "@opal/types";
 import {
   SvgChevronRight,
@@ -13,7 +13,6 @@ import {
 import { cn } from "@opal/utils";
 import { formatBytes } from "@/lib/utils";
 import type { SkillBundleFile } from "@/lib/skills/types";
-import LineItem from "@/refresh-components/buttons/LineItem";
 
 interface SkillFileTreeNode {
   name: string;
@@ -53,8 +52,9 @@ function SkillFileTreeNodes({
     return (
       <div key={node.path}>
         <div style={{ paddingLeft: `${depth * 20}px` }}>
-          <LineItem
-            interactive={isDirectory}
+          <LineItemButton
+            sizePreset="main-ui"
+            rounding="sm"
             icon={FileIcon}
             onClick={isDirectory ? () => onToggle(node.path) : undefined}
             rightChildren={
@@ -86,9 +86,8 @@ function SkillFileTreeNodes({
                 </div>
               )
             }
-          >
-            {node.name}
-          </LineItem>
+            title={node.name}
+          />
         </div>
         {isDirectory && isExpanded && (
           <SkillFileTreeNodes

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -4,7 +4,18 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
-import { Button, Card, Divider, MessageCard } from "@opal/components";
+import {
+  Button,
+  Card,
+  Divider,
+  InputTypeIn,
+  LineItemButton,
+  MessageCard,
+  Popover,
+  PopoverMenu,
+  Tooltip,
+  useCreateModal,
+} from "@opal/components";
 import { Hoverable, Disabled } from "@opal/core";
 import { FullAgent, PersonaSharingStatus } from "@/lib/agents/types";
 import { buildAgentAvatarUrl } from "@/lib/agents/utils";
@@ -40,15 +51,11 @@ import {
 import Text from "@/refresh-components/texts/Text";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SwitchField from "@/refresh-components/form/SwitchField";
-import { Tooltip } from "@opal/components";
 import { useDocumentSets } from "@/app/admin/documents/sets/hooks";
 import { useProjectsContext } from "@/lib/projects/providers";
-import { useCreateModal } from "@opal/components";
 import UserFilesModal from "@/sections/modals/UserFilesModal";
 import { ProjectFile, UserFileStatus } from "@/lib/projects/types";
 import { ChatFileType } from "@/app/app/interfaces";
-import { Popover, PopoverMenu } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import {
   SvgActions,
   SvgExpand,
@@ -79,7 +86,6 @@ import useOpenApiTools from "@/hooks/useOpenApiTools";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 import { AgentEditorMCPServer, MCPTool, ToolSnapshot } from "@/lib/tools/types";
-import { InputTypeIn } from "@opal/components";
 import useFilter from "@/hooks/useFilter";
 import EnabledCount from "@/refresh-components/EnabledCount";
 import { useAppRouter } from "@/hooks/appNavigation";
@@ -239,14 +245,15 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
         <Popover.Content>
           <PopoverMenu>
             {[
-              <LineItem
+              <LineItemButton
+                sizePreset="main-ui"
+                rounding="sm"
                 key="upload-image"
                 icon={SvgImage}
                 onClick={() => fileInputRef.current?.click()}
-                emphasized
-              >
-                Upload Image
-              </LineItem>,
+                selectVariant="select-heavy"
+                title="Upload Image"
+              />,
               null,
               <div key="icon-grid" className="grid grid-cols-4 gap-1">
                 <SquareButton

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -6,6 +6,7 @@ import type { Route } from "next";
 import {
   Button,
   InputTypeIn,
+  LineItemButton,
   MessageCard,
   Popover,
   Text,
@@ -38,7 +39,6 @@ import ImportSkillsFromGitHubModal from "@/sections/modals/skills/ImportSkillsFr
 import SkillPreviewModal from "@/sections/modals/SkillPreviewModal";
 import type { BuiltinSkill, CustomSkill } from "@/lib/skills/types";
 import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { isSkillNameConflict, setSkillEnabled } from "@/lib/skills/api";
 
 // ---------------------------------------------------------------------------
@@ -292,39 +292,39 @@ export default function SkillsPage() {
             </Popover.Trigger>
             <Popover.Content align="end" sideOffset={4} width="xl">
               <Popover.Menu>
-                <LineItem
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
                   icon={SvgEdit}
                   description="Write the instructions and add supporting files in Onyx."
-                  wrapDescription
                   onClick={() => {
                     setCreateMenuOpen(false);
                     router.push("/craft/v1/skills/new" as Route);
                   }}
-                >
-                  Start from scratch
-                </LineItem>
-                <LineItem
+                  title="Start from scratch"
+                />
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
                   icon={SvgUploadCloud}
                   description="Import a SKILL.md file, ZIP file, or skill folder."
-                  wrapDescription
                   onClick={() => {
                     setCreateMenuOpen(false);
                     setCreateOpen(true);
                   }}
-                >
-                  Upload a skill
-                </LineItem>
-                <LineItem
+                  title="Upload a skill"
+                />
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
                   icon={SvgGithub}
                   description="Import one or more skills from a repository."
-                  wrapDescription
                   onClick={() => {
                     setCreateMenuOpen(false);
                     setGitHubImportOpen(true);
                   }}
-                >
-                  Import from GitHub
-                </LineItem>
+                  title="Import from GitHub"
+                />
               </Popover.Menu>
             </Popover.Content>
           </Popover>

--- a/web/src/views/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/views/admin/AgentsPage/AgentRowActions.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "@opal/components";
+import {
+  Button,
+  LineItemButton,
+  Popover,
+  PopoverMenu,
+  useCreateModal,
+} from "@opal/components";
 // TODO(@raunakab): migrate to Opal LineItemButton once it supports danger variant
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { cn, markdown } from "@opal/utils";
 import {
   SvgMoreHorizontal,
@@ -16,7 +21,6 @@ import {
   SvgBarChart,
   SvgTrash,
 } from "@opal/icons";
-import { Popover, PopoverMenu } from "@opal/components";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
 import { toast } from "@opal/layouts";
@@ -29,7 +33,6 @@ import {
 import type { Agent } from "@/lib/agents/types";
 import type { Route } from "next";
 import { ShareAgentModal } from "@/lib/agents/components";
-import { useCreateModal } from "@opal/components";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { can } from "@/lib/permissions/resource-actions";
@@ -180,7 +183,9 @@ export default function AgentRowActions({
               <PopoverMenu>
                 {[
                   canList ? (
-                    <LineItem
+                    <LineItemButton
+                      sizePreset="main-ui"
+                      rounding="sm"
                       key="visibility"
                       icon={agent.is_listed ? SvgEyeOff : SvgEye}
                       onClick={() => {
@@ -194,46 +199,48 @@ export default function AgentRowActions({
                           );
                         }
                       }}
-                    >
-                      {agent.is_listed ? "Unlist Agent" : "List Agent"}
-                    </LineItem>
+                      title={agent.is_listed ? "Unlist Agent" : "List Agent"}
+                    />
                   ) : undefined,
                   canShare ? (
-                    <LineItem
+                    <LineItemButton
+                      sizePreset="main-ui"
+                      rounding="sm"
                       key="share"
                       icon={SvgShare}
                       onClick={() => {
                         setPopoverOpen(false);
                         shareModal.toggle(true);
                       }}
-                    >
-                      Share
-                    </LineItem>
+                      title="Share"
+                    />
                   ) : undefined,
                   businessTier && canViewStats ? (
-                    <LineItem
+                    <LineItemButton
+                      sizePreset="main-ui"
+                      rounding="sm"
                       key="stats"
                       icon={SvgBarChart}
                       onClick={() => {
                         setPopoverOpen(false);
                         router.push(`/ee/agents/stats/${agent.id}` as Route);
                       }}
-                    >
-                      Stats
-                    </LineItem>
+                      title="Stats"
+                    />
                   ) : undefined,
                   canDeleteRow ? (
-                    <LineItem
+                    <LineItemButton
+                      sizePreset="main-ui"
+                      rounding="sm"
                       key="delete"
                       icon={SvgTrash}
-                      danger
+                      color="danger"
                       onClick={() => {
                         setPopoverOpen(false);
                         setDeleteOpen(true);
                       }}
-                    >
-                      Delete
-                    </LineItem>
+                      title="Delete"
+                    />
                   ) : undefined,
                 ]}
               </PopoverMenu>

--- a/web/src/views/admin/ExternalAppsPage/IntegrationCard.tsx
+++ b/web/src/views/admin/ExternalAppsPage/IntegrationCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   Button,
   Card,
+  LineItemButton,
   Popover,
   PopoverMenu,
   Switch,
@@ -13,7 +14,6 @@ import {
 import { Hoverable } from "@opal/core";
 import { cn } from "@opal/utils";
 // TODO(@raunakab): migrate to Opal LineItemButton once it supports danger variant
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { ConfirmationModalLayout, toast } from "@opal/layouts";
 import { SvgEdit, SvgMoreHorizontal, SvgTrash } from "@opal/icons";
 import { ConfiguredIntegration } from "@/views/admin/ExternalAppsPage/interfaces";
@@ -114,29 +114,31 @@ export default function IntegrationCard({ integration }: IntegrationCardProps) {
                 <PopoverMenu>
                   {[
                     edit ? (
-                      <LineItem
+                      <LineItemButton
+                        sizePreset="main-ui"
+                        rounding="sm"
                         key="edit"
                         icon={SvgEdit}
                         onClick={() => {
                           setMenuOpen(false);
                           edit();
                         }}
-                      >
-                        Edit
-                      </LineItem>
+                        title="Edit"
+                      />
                     ) : undefined,
                     remove ? (
-                      <LineItem
+                      <LineItemButton
+                        sizePreset="main-ui"
+                        rounding="sm"
                         key="delete"
                         icon={SvgTrash}
-                        danger
+                        color="danger"
                         onClick={() => {
                           setMenuOpen(false);
                           setConfirmingRemoval(true);
                         }}
-                      >
-                        Delete
-                      </LineItem>
+                        title="Delete"
+                      />
                     ) : undefined,
                   ]}
                 </PopoverMenu>

--- a/web/src/views/admin/ServiceAccountsPage/index.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/index.tsx
@@ -5,7 +5,19 @@ import useSWR, { mutate } from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { SettingsLayouts, toast } from "@opal/layouts";
-import { Button, Tag, Text, MessageCard } from "@opal/components";
+import {
+  BasicModalFooter,
+  Button,
+  Code,
+  LineItemButton,
+  MessageCard,
+  Modal,
+  Popover,
+  PopoverMenu,
+  Table,
+  Tag,
+  Text,
+} from "@opal/components";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import {
@@ -21,10 +33,6 @@ import {
 } from "@opal/icons";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
-import { BasicModalFooter, Modal } from "@opal/components";
-import { Code } from "@opal/components";
-import { Popover, PopoverMenu } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { markdown } from "@opal/utils";
 
@@ -39,7 +47,6 @@ import type { APIKey } from "@/views/admin/ServiceAccountsPage/interfaces";
 import { DISCORD_SERVICE_API_KEY_NAME } from "@/views/admin/ServiceAccountsPage/interfaces";
 import ApiKeyFormModal from "@/views/admin/ServiceAccountsPage/ApiKeyFormModal";
 import EditServiceAccountModal from "@/views/admin/ServiceAccountsPage/EditServiceAccountModal";
-import { Table } from "@opal/components";
 import { createTableColumns } from "@opal/components/table/columns";
 import { Section } from "@/layouts/general-layouts";
 
@@ -189,28 +196,31 @@ export default function ServiceAccountsPage() {
               </Popover.Trigger>
               <Popover.Content side="bottom" align="end" width="md">
                 <PopoverMenu>
-                  <LineItem
+                  <LineItemButton
+                    sizePreset="main-ui"
+                    rounding="sm"
                     icon={SvgUsers}
                     onClick={() => setGroupsRolesTarget(row)}
-                  >
-                    Groups
-                  </LineItem>
-                  <LineItem
+                    title="Groups"
+                  />
+                  <LineItemButton
+                    sizePreset="main-ui"
+                    rounding="sm"
                     icon={SvgUserEdit}
                     onClick={() => {
                       setSelectedApiKey(row);
                       setShowCreateUpdateForm(true);
                     }}
-                  >
-                    Edit Account
-                  </LineItem>
-                  <LineItem
+                    title="Edit Account"
+                  />
+                  <LineItemButton
+                    sizePreset="main-ui"
+                    rounding="sm"
                     icon={SvgTrash}
-                    danger
+                    color="danger"
                     onClick={() => setDeleteTarget(row)}
-                  >
-                    Delete Account
-                  </LineItem>
+                    title="Delete Account"
+                  />
                 </PopoverMenu>
               </Popover.Content>
             </Popover>

--- a/web/src/views/admin/UsersPage/UserFilters.tsx
+++ b/web/src/views/admin/UsersPage/UserFilters.tsx
@@ -10,12 +10,14 @@ import {
   SvgUsers,
 } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
-import { FilterButton } from "@opal/components";
-import { Popover } from "@opal/components";
-import { InputTypeIn } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
+import {
+  FilterButton,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  ShadowDiv,
+} from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
-import { ShadowDiv } from "@opal/components";
 import {
   AccountType,
   ACCOUNT_TYPE_LABELS,
@@ -182,28 +184,30 @@ export default function UserFilters({
         </Popover.Trigger>
         <Popover.Content align="start">
           <div className="flex flex-col gap-1 p-1 min-w-[200px]">
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={!hasTypeFilter ? SvgCheck : SvgUsers}
-              selected={!hasTypeFilter}
-              emphasized={!hasTypeFilter}
+              state={!hasTypeFilter ? "selected" : "empty"}
+              selectVariant={!hasTypeFilter ? "select-heavy" : "select-light"}
               onClick={() => onAccountTypesChange([])}
-            >
-              All Account Types
-            </LineItem>
+              title="All Account Types"
+            />
             {FILTERABLE_ACCOUNT_TYPES.map(([type, label]) => {
               const isSelected = selectedAccountTypes.includes(type);
               const typeIcon = ACCOUNT_TYPE_ICONS[type] ?? SvgUser;
               return (
-                <LineItem
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
                   key={type}
                   icon={isSelected ? SvgCheck : typeIcon}
-                  selected={isSelected}
-                  emphasized={isSelected}
+                  state={isSelected ? "selected" : "empty"}
+                  selectVariant={isSelected ? "select-heavy" : "select-light"}
                   onClick={() => toggleAccountType(type)}
                   rightChildren={<CountBadge count={accountTypeCounts[type]} />}
-                >
-                  {label}
-                </LineItem>
+                  title={label}
+                />
               );
             })}
           </div>
@@ -237,28 +241,30 @@ export default function UserFilters({
               searchIcon
               variant="internal"
             />
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={!hasGroupFilter ? SvgCheck : SvgUsers}
-              selected={!hasGroupFilter}
-              emphasized={!hasGroupFilter}
+              state={!hasGroupFilter ? "selected" : "empty"}
+              selectVariant={!hasGroupFilter ? "select-heavy" : "select-light"}
               onClick={() => onGroupsChange([])}
-            >
-              All Groups
-            </LineItem>
+              title="All Groups"
+            />
             <ShadowDiv className="flex flex-col gap-1 max-h-[240px]">
               {filteredGroups.map((group) => {
                 const isSelected = selectedGroups.includes(group.id);
                 return (
-                  <LineItem
+                  <LineItemButton
+                    sizePreset="main-ui"
+                    rounding="sm"
                     key={group.id}
                     icon={isSelected ? SvgCheck : SvgUsers}
-                    selected={isSelected}
-                    emphasized={isSelected}
+                    state={isSelected ? "selected" : "empty"}
+                    selectVariant={isSelected ? "select-heavy" : "select-light"}
                     onClick={() => toggleGroup(group.id)}
                     rightChildren={<CountBadge count={group.memberCount} />}
-                  >
-                    {group.name}
-                  </LineItem>
+                    title={group.name}
+                  />
                 );
               })}
               {filteredGroups.length === 0 && (
@@ -285,28 +291,30 @@ export default function UserFilters({
         </Popover.Trigger>
         <Popover.Content align="start">
           <div className="flex flex-col gap-1 p-1 min-w-[200px]">
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={!hasStatusFilter ? SvgCheck : SvgUser}
-              selected={!hasStatusFilter}
-              emphasized={!hasStatusFilter}
+              state={!hasStatusFilter ? "selected" : "empty"}
+              selectVariant={!hasStatusFilter ? "select-heavy" : "select-light"}
               onClick={() => onStatusesChange([])}
-            >
-              All Status
-            </LineItem>
+              title="All Status"
+            />
             {FILTERABLE_STATUSES.map(([status, label]) => {
               const isSelected = selectedStatuses.includes(status);
               const countKey = STATUS_COUNT_KEY[status];
               return (
-                <LineItem
+                <LineItemButton
+                  sizePreset="main-ui"
+                  rounding="sm"
                   key={status}
                   icon={isSelected ? SvgCheck : SvgUser}
-                  selected={isSelected}
-                  emphasized={isSelected}
+                  state={isSelected ? "selected" : "empty"}
+                  selectVariant={isSelected ? "select-heavy" : "select-light"}
                   onClick={() => toggleStatus(status)}
                   rightChildren={<CountBadge count={statusCounts[countKey]} />}
-                >
-                  {label}
-                </LineItem>
+                  title={label}
+                />
               );
             })}
           </div>

--- a/web/src/views/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/views/admin/UsersPage/UserRowActions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Divider } from "@opal/components";
+import { Button, Divider, LineItemButton, Popover } from "@opal/components";
 import {
   SvgMoreHorizontal,
   SvgUsers,
@@ -13,8 +13,6 @@ import {
   SvgUserManage,
 } from "@opal/icons";
 import { Disabled } from "@opal/core";
-import LineItem from "@/refresh-components/buttons/LineItem";
-import { Popover } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import { AccountType, UserStatus } from "@/lib/types";
@@ -91,9 +89,13 @@ export default function UserRowActions({
   };
 
   const adminAccessItem = user.account_type === AccountType.STANDARD && (
-    <LineItem icon={SvgUserManage} onClick={toggleAdminAccess}>
-      {user.is_admin ? "Remove Admin Access" : "Make Admin"}
-    </LineItem>
+    <LineItemButton
+      sizePreset="main-ui"
+      rounding="sm"
+      icon={SvgUserManage}
+      onClick={toggleAdminAccess}
+      title={user.is_admin ? "Remove Admin Access" : "Make Admin"}
+    />
   );
 
   // Status-aware action menus
@@ -104,17 +106,22 @@ export default function UserRowActions({
       return (
         <>
           {user.id && canManageGroups && (
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={SvgUsers}
               onClick={() => openModal(Modal.EDIT_GROUPS)}
-            >
-              Groups &amp; Roles
-            </LineItem>
+              title="Groups & Roles"
+            />
           )}
           <Disabled disabled>
-            <LineItem danger icon={SvgUserX}>
-              Deactivate User
-            </LineItem>
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
+              color="danger"
+              icon={SvgUserX}
+              title="Deactivate User"
+            />
           </Disabled>
           <Divider paddingPerpendicular={4} />
           <Text as="p" secondaryBody text03 className="px-3 py-1">
@@ -127,18 +134,21 @@ export default function UserRowActions({
     switch (user.status) {
       case UserStatus.INVITED:
         return (
-          <LineItem
-            danger
+          <LineItemButton
+            sizePreset="main-ui"
+            rounding="sm"
+            color="danger"
             icon={SvgXCircle}
             onClick={() => openModal(Modal.CANCEL_INVITE)}
-          >
-            Cancel Invite
-          </LineItem>
+            title="Cancel Invite"
+          />
         );
 
       case UserStatus.REQUESTED:
         return (
-          <LineItem
+          <LineItemButton
+            sizePreset="main-ui"
+            rounding="sm"
             icon={SvgUserCheck}
             onClick={() => {
               setPopoverOpen(false);
@@ -154,37 +164,39 @@ export default function UserRowActions({
                 }
               })();
             }}
-          >
-            Approve
-          </LineItem>
+            title="Approve"
+          />
         );
 
       case UserStatus.ACTIVE:
         return (
           <>
             {user.id && canManageGroups && (
-              <LineItem
+              <LineItemButton
+                sizePreset="main-ui"
+                rounding="sm"
                 icon={SvgUsers}
                 onClick={() => openModal(Modal.EDIT_GROUPS)}
-              >
-                Groups &amp; Roles
-              </LineItem>
+                title="Groups & Roles"
+              />
             )}
             {user.id && adminAccessItem}
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={SvgKey}
               onClick={() => openModal(Modal.RESET_PASSWORD)}
-            >
-              Reset Password
-            </LineItem>
+              title="Reset Password"
+            />
             <Divider paddingPerpendicular={4} />
-            <LineItem
-              danger
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
+              color="danger"
               icon={SvgUserX}
               onClick={() => openModal(Modal.DEACTIVATE)}
-            >
-              Deactivate User
-            </LineItem>
+              title="Deactivate User"
+            />
           </>
         );
 
@@ -192,35 +204,39 @@ export default function UserRowActions({
         return (
           <>
             {user.id && canManageGroups && (
-              <LineItem
+              <LineItemButton
+                sizePreset="main-ui"
+                rounding="sm"
                 icon={SvgUsers}
                 onClick={() => openModal(Modal.EDIT_GROUPS)}
-              >
-                Groups &amp; Roles
-              </LineItem>
+                title="Groups & Roles"
+              />
             )}
             {user.id && adminAccessItem}
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={SvgKey}
               onClick={() => openModal(Modal.RESET_PASSWORD)}
-            >
-              Reset Password
-            </LineItem>
+              title="Reset Password"
+            />
             <Divider paddingPerpendicular={4} />
-            <LineItem
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
               icon={SvgUserPlus}
               onClick={() => openModal(Modal.ACTIVATE)}
-            >
-              Activate User
-            </LineItem>
+              title="Activate User"
+            />
             <Divider paddingPerpendicular={4} />
-            <LineItem
-              danger
+            <LineItemButton
+              sizePreset="main-ui"
+              rounding="sm"
+              color="danger"
               icon={SvgUserX}
               onClick={() => openModal(Modal.DELETE)}
-            >
-              Delete User
-            </LineItem>
+              title="Delete User"
+            />
           </>
         );
 

--- a/web/src/views/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/views/admin/UsersPage/UserRowActions.tsx
@@ -16,7 +16,7 @@ import { Disabled } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import { AccountType, UserStatus } from "@/lib/types";
-import { toast } from "@opal/layouts";
+import { ContentAction, toast } from "@opal/layouts";
 import { approveRequest, setUserAdminAccess } from "./svc";
 import { useCanManageGroups } from "@/lib/permissions/hooks";
 import EditUserModal from "./EditUserModal";
@@ -114,14 +114,19 @@ export default function UserRowActions({
               title="Groups & Roles"
             />
           )}
+          {/* Shown so a SCIM admin can see the action exists, but it never
+              fires — so it is a label, not a button. Padding matches
+              LineItemButton so it lines up with the rows above. */}
           <Disabled disabled>
-            <LineItemButton
-              sizePreset="main-ui"
-              rounding="sm"
-              color="danger"
-              icon={SvgUserX}
-              title="Deactivate User"
-            />
+            <div className="w-full p-1.5">
+              <ContentAction
+                sizePreset="main-ui"
+                padding={0.5}
+                color="danger"
+                icon={SvgUserX}
+                title="Deactivate User"
+              />
+            </div>
           </Disabled>
           <Divider paddingPerpendicular={4} />
           <Text as="p" secondaryBody text03 className="px-3 py-1">


### PR DESCRIPTION
## Description

First batch of the `refresh/LineItem` → `opal/LineItemButton` migration. Moves
the 55 rows that needed nothing from opal — the label is already a string, and
every prop has a direct equivalent.

Mapping, matching what all 48 existing `LineItemButton` call sites already do:

| refresh | opal |
| --- | --- |
| `children` | `title` |
| `danger` / `muted` | `color` |
| `selected` | `state="selected" \| "empty"` |
| `emphasized` | `selectVariant="select-heavy" \| "select-light"` |
| — | `sizePreset="main-ui"`, `rounding="sm"` |

`rounding="sm"` is the `rounded-08` the old row had. `strokeIcon` and
`wrapDescription` are dropped rather than translated: opal colours icons from
`--interactive-foreground-icon` unconditionally, and `Content` wraps
descriptions by default, so both props were asking for what opal already does.

**Titles get heavier.** `sizePreset="main-ui"` renders at weight 600 where the
old row used `main-ui-muted` at 400. That difference already existed between the
two components, so this removes an inconsistency rather than introducing one.

95 → 40 call sites remaining, 32 → 15 files. The rest are blocked on opal:
`skeleton` (10), `interactive={false}` (8), HTML attribute pass-through (17),
`disabled` (4), plus a few call-site oddities. Those come in later PRs.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
