### PR TITLE
feat(web): i18n extraction wave 1 — Settings, Auth, account popover

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -340,7 +340,9 @@ repos:
 
         language: system
         pass_filenames: false
-        files: ^web/.*\.(ts|tsx)$
+        # The i18n catalogs are part of the type graph: keyParity.ts turns a
+        # missing or extra locale key into a compile error.
+        files: ^web/(.*\.(ts|tsx)|src/i18n/messages/.*\.json)$
 
       - id: widget-typescript-check
         name: widget TypeScript type check

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -1,9 +1,26 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "unicorn", "oxc", "react", "nextjs", "jsx-a11y"],
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "oxc",
+    "react",
+    "nextjs",
+    "jsx-a11y"
+  ],
   "jsPlugins": [
-    { "name": "react-doctor", "specifier": "oxlint-plugin-react-doctor" },
-    { "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }
+    {
+      "name": "react-doctor",
+      "specifier": "oxlint-plugin-react-doctor"
+    },
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
+    },
+    {
+      "name": "i18n",
+      "specifier": "./tools/oxlint/i18n/index.ts"
+    }
   ],
   "categories": {
     "correctness": "error"
@@ -37,7 +54,8 @@
     "anti-slop/no-unsafe-dictionary-type": "warn",
     "anti-slop/require-safety-comment-for-type-assertion": "warn",
     "anti-slop/no-runtime-typeof": "off",
-    "anti-slop/no-shape-in-symbol-names": "off"
+    "anti-slop/no-shape-in-symbol-names": "off",
+    "i18n/no-raw-jsx-text": "off"
   },
   "overrides": [
     {
@@ -68,6 +86,16 @@
         "anti-slop/no-widen-then-assert": "off",
         "anti-slop/require-safety-comment-for-type-assertion": "off"
       }
+    },
+    {
+      "files": [
+        "src/views/SettingsPage.tsx",
+        "src/sections/sidebar/AccountPopover.tsx",
+        "src/app/auth/**"
+      ],
+      "rules": {
+        "i18n/no-raw-jsx-text": "error"
+      }
     }
   ],
   "ignorePatterns": [
@@ -78,7 +106,8 @@
     "public",
     "storybook-static",
     "lib/opal/dist",
-    "tools/oxlint/anti-slop"
+    "tools/oxlint/anti-slop",
+    "tools/oxlint/i18n"
   ],
   "env": {
     "builtin": true

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -483,10 +483,11 @@ The UI is being migrated to next-intl. English message catalogs live in
   violations.
 - **Update every locale when you touch a key.** `en.json` is the source of
   truth. When you add or change a key, also give `es/pt/fr/de.json` your best
-  translation of the English value. Keep the ICU shape (arguments, tags,
+  translation of the English value. Key parity is a compile-time check:
+  `src/i18n/messages/keyParity.ts` makes a missing or extra locale key fail
+  `types:check` (pre-commit, CI, IDE). Keep the ICU shape (arguments, tags,
   plurals) identical across locales — `web/src/i18n/__tests__/catalog.test.ts`
-  enforces this. Keys missing from a locale fall back to English at runtime.
-  A future translation pipeline will validate these translations.
+  enforces this.
 - Keys are stable identifiers, not English sentences:
   `<namespace>.<section>.<element>.<role>` in camelCase
   (e.g. `settings.appearance.colorMode.title`). Rewording English copy must not

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -481,9 +481,12 @@ The UI is being migrated to next-intl. English message catalogs live in
   `await getTranslations("<namespace>")` (server) and add the English value to
   `en.json`. The oxlint rule and the `types:check` key augmentation both fail on
   violations.
-- **Only edit `en.json` by hand.** The other locale files (`es/pt/fr/de.json`)
-  are owned by the translation pipeline — do not hand-edit them; untranslated
-  keys fall back to English at runtime.
+- **Update every locale when you touch a key.** `en.json` is the source of
+  truth. When you add or change a key, also give `es/pt/fr/de.json` your best
+  translation of the English value. Keep the ICU shape (arguments, tags,
+  plurals) identical across locales — `web/src/i18n/__tests__/catalog.test.ts`
+  enforces this. Keys missing from a locale fall back to English at runtime.
+  A future translation pipeline will validate these translations.
 - Keys are stable identifiers, not English sentences:
   `<namespace>.<section>.<element>.<role>` in camelCase
   (e.g. `settings.appearance.colorMode.title`). Rewording English copy must not

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -470,6 +470,35 @@ function ContactForm() {
 
 **Reason:** Client side fetching allows us to load the skeleton of the page without waiting for data to load, leading to a snappier UX. Loading data where needed reduces dependencies between a component and its parent component(s).
 
+## 7. Internationalization (i18n)
+
+The UI is being migrated to next-intl. English message catalogs live in
+`web/src/i18n/messages/en.json`; the locale registry is `web/src/i18n/config.ts`.
+
+- **In migrated directories** (listed in the `i18n/no-raw-jsx-text` override in
+  `web/.oxlintrc.json`), never hardcode user-facing strings. Use
+  `const t = useTranslations("<namespace>")` (client) or
+  `await getTranslations("<namespace>")` (server) and add the English value to
+  `en.json`. The oxlint rule and the `types:check` key augmentation both fail on
+  violations.
+- **Only edit `en.json` by hand.** The other locale files (`es/pt/fr/de.json`)
+  are owned by the translation pipeline — do not hand-edit them; untranslated
+  keys fall back to English at runtime.
+- Keys are stable identifiers, not English sentences:
+  `<namespace>.<section>.<element>.<role>` in camelCase
+  (e.g. `settings.appearance.colorMode.title`). Rewording English copy must not
+  change the key.
+- Use ICU for interpolation and plurals: `"Hello {name}"`,
+  `"{count, plural, one {# item} other {# items}}"`. Never concatenate
+  translated fragments.
+- When you finish migrating a directory, add its glob to the
+  `i18n/no-raw-jsx-text` override in `.oxlintrc.json` so it cannot regress.
+- Locale-aware date/number formatting: prefer `useFormatter`/`useLocale` from
+  next-intl over hardcoded `"en-US"` `Intl` calls.
+- Prefer CSS logical properties (`ms-`/`me-`/`ps-`/`pe-`/`start-`/`end-`) over
+  physical ones (`ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`) in new styles so a
+  future RTL locale does not require re-touching them.
+
 # Stylistic Preferences
 
 ## 1. Import Standards

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -80,6 +80,7 @@
         "zustand": "^5.0.8",
       },
       "devDependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.5.17",
         "@oxlint/plugins": "^1.71.0",
         "@playwright/test": "^1.39.0",
         "@storybook/addon-docs": "10.5.0",

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -15,6 +15,12 @@
 const esmPackages = [
   // Auth & Security
   "jose",
+  // i18n
+  "next-intl",
+  "use-intl",
+  "intl-messageformat",
+  "@formatjs",
+  "tslib",
   // UI Libraries
   "@radix-ui",
   "@floating-ui",

--- a/web/lib/opal/src/components/text/README.md
+++ b/web/lib/opal/src/components/text/README.md
@@ -14,7 +14,7 @@ inline markdown rendering via `RichStr` — pass `markdown("*bold* text")` as ch
 | `as`       | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"`         | HTML tag to render                                                                             |
 | `nowrap`   | `boolean`                                       | `false`          | Prevent text wrapping                                                                          |
 | `maxLines` | `number`                                        | —                | Truncate to N lines with an ellipsis (`1` = single-line truncate; `2+` = `-webkit-line-clamp`) |
-| `children` | `string \| RichStr`                             | —                | Plain string or `markdown()` for inline markdown                                               |
+| `children` | `string \| RichStr \| RichNodes`                | —                | Plain string, `markdown()` for inline markdown, or `richNodes()` for inline React nodes        |
 
 > **No `className` or `style`.** `Text` strips both (its props extend `WithoutStyles`); every
 > aspect of its appearance is driven by `font`, `color`, `nowrap`, and `maxLines`. For layout
@@ -90,7 +90,7 @@ import { Text } from "@opal/components";
 Inline markdown is opt-in via the `markdown()` function, which returns a `RichStr`. When `Text`
 receives a `RichStr` as children, it parses the inner string as inline markdown. Plain strings
 are rendered as-is — no parsing, no surprises. `Text` does not accept arbitrary JSX as children;
-use `string | RichStr` only.
+every non-string child must be branded via `markdown()` or `richNodes()`.
 
 ```tsx
 import { Text } from "@opal/components";
@@ -133,6 +133,41 @@ interface MyComponentProps {
 
 This avoids API coloring — no `markdown` boolean needs to be threaded through intermediate
 components. The decision to use markdown lives at the call site.
+
+## Inline React nodes via `RichNodes`
+
+Some sentences must embed an inline *component* — most often i18n rich text, where a translated
+sentence wraps part of itself in a link or button (next-intl `t.rich`). Markdown cannot express
+an element with an event handler, so for this case `richNodes()` brands a `ReactNode` as
+deliberate `Text` children:
+
+```tsx
+import { Text } from "@opal/components";
+import { richNodes } from "@opal/utils";
+
+<Text font="main-ui-body" color="text-04">
+  {richNodes(
+    t.rich("waitingOnVerification.helpPrompt.text", {
+      link: (chunks) => (
+        <RequestNewVerificationEmail email={email}>{chunks}</RequestNewVerificationEmail>
+      ),
+    })
+  )}
+</Text>
+```
+
+The nodes render verbatim and inherit the `font` and `color` presets. The brand keeps the same
+discipline as `RichStr`: naked JSX children stay a type error, and the opt-in is visible and
+greppable at the call site.
+
+Rules of thumb:
+
+- Prefer a plain string; use `markdown()` when the formatting is static (bold, code, plain
+  links); use `richNodes()` only when a real component must sit mid-sentence.
+- Keep the content inline (spans, links, buttons) — never layout JSX.
+- `RichNodes` is accepted **only** by `Text` children. Props typed `string | RichStr`
+  (`title`, `description`, `tooltip`, …) must stay plain-string-derivable for truncation and
+  aria labels, so do not widen them.
 
 ## Compatibility
 

--- a/web/lib/opal/src/components/text/Text.stories.tsx
+++ b/web/lib/opal/src/components/text/Text.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Text } from "@opal/components";
 import type { TextFont, TextColor } from "@opal/components";
-import { markdown } from "@opal/utils";
+import { markdown, richNodes } from "@opal/utils";
 
 const meta: Meta<typeof Text> = {
   title: "opal/components/Text",
@@ -254,6 +254,29 @@ export const PlainStringNotParsed: Story = {
         }
       </Text>
     </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Inline React nodes via RichNodes
+// ---------------------------------------------------------------------------
+
+export const RichNodesInlineComponent: Story = {
+  render: () => (
+    <Text font="main-ui-body" color="text-04">
+      {richNodes(
+        <>
+          Click{" "}
+          <button
+            className="underline underline-offset-2"
+            onClick={() => alert("clicked")}
+          >
+            here
+          </button>{" "}
+          to request a new email.
+        </>
+      )}
+    </Text>
   ),
 };
 

--- a/web/lib/opal/src/components/text/Text.test.tsx
+++ b/web/lib/opal/src/components/text/Text.test.tsx
@@ -1,0 +1,38 @@
+// Text children are branded (`string | RichStr | RichNodes`), never raw JSX.
+// The `richNodes()` path exists for translated sentences that embed an inline
+// component (next-intl `t.rich`), so what matters is that the nodes render
+// verbatim — handlers intact — while typography still comes from `Text`.
+import { render, screen, userEvent } from "@tests/setup/test-utils";
+import { Text } from "@opal/components";
+import { richNodes } from "@opal/utils";
+
+describe("Text with RichNodes children", () => {
+  it("renders the nodes verbatim, keeping interactive elements", async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <Text font="main-ui-body" color="text-04">
+        {richNodes(
+          <>
+            Click <button onClick={onClick}>here</button> to continue.
+          </>
+        )}
+      </Text>
+    );
+
+    await user.click(screen.getByRole("button", { name: "here" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the font and color presets on the wrapping tag", () => {
+    render(
+      <Text font="main-ui-body" color="text-04" data-testid="rich-text">
+        {richNodes(<em>emphasis</em>)}
+      </Text>
+    );
+
+    const wrapper = screen.getByTestId("rich-text");
+    expect(wrapper).toHaveClass("font-main-ui-body", "text-text-04");
+    expect(wrapper.querySelector("em")).toHaveTextContent("emphasis");
+  });
+});

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -2,8 +2,8 @@ import type { HTMLAttributes } from "react";
 // Canonical TextFont/TextColor unions, shared with mobile via the neutral
 // @onyx-ai/shared/contracts (not the RN-only /native).
 import type { TextColor, TextFont } from "@onyx-ai/shared/contracts";
-import type { RichStr, WithoutStyles } from "@opal/types";
-import { cn } from "@opal/utils";
+import type { RichNodes, RichStr, WithoutStyles } from "@opal/types";
+import { cn, isRichNodes } from "@opal/utils";
 import { resolveStr } from "@opal/components/text/InlineMarkdown";
 
 // ---------------------------------------------------------------------------
@@ -28,8 +28,11 @@ interface TextProps extends WithoutStyles<
   /** Truncate text to N lines with ellipsis. `1` uses simple truncation; `2+` uses `-webkit-line-clamp`. */
   maxLines?: number;
 
-  /** Plain string or `markdown()` for inline markdown. */
-  children?: string | RichStr;
+  /**
+   * Plain string, `markdown()` for inline markdown, or `richNodes()` for
+   * sentences that embed inline components (e.g. next-intl `t.rich` output).
+   */
+  children?: string | RichStr | RichNodes;
 }
 
 // ---------------------------------------------------------------------------
@@ -115,7 +118,8 @@ function Text({
 
   return (
     <Tag {...rest} className={resolvedClassName} style={style}>
-      {children && resolveStr(children)}
+      {children &&
+        (isRichNodes(children) ? children.nodes : resolveStr(children))}
     </Tag>
   );
 }

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -1,4 +1,4 @@
-import type { SVGProps } from "react";
+import type { ReactNode, SVGProps } from "react";
 
 // ---------------------------------------------------------------------------
 // Size Variants
@@ -236,6 +236,25 @@ export type WithoutStyles<T> = Omit<T, "className" | "style">;
 export interface RichStr {
   readonly __brand: "RichStr";
   readonly raw: string;
+}
+
+/**
+ * A branded wrapper marking React nodes as deliberate `Text` children.
+ *
+ * Created via the `richNodes()` function. `Text` renders the inner nodes
+ * verbatim; the brand exists so arbitrary JSX is still rejected at the type
+ * level and the opt-in stays visible at the call site, like `markdown()`.
+ *
+ * The main producer is i18n rich-text output (next-intl `t.rich(...)`), where
+ * translated sentences embed inline components mid-sentence.
+ *
+ * Unlike `RichStr`, a `RichNodes` value cannot be reduced to a plain string,
+ * so it is only accepted by `Text` children — never by `string | RichStr`
+ * props, which must stay derivable for tooltips and aria labels.
+ */
+export interface RichNodes {
+  readonly __brand: "RichNodes";
+  readonly nodes: ReactNode;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/utils.ts
+++ b/web/lib/opal/src/utils.ts
@@ -1,8 +1,8 @@
-import type { MutableRefObject, Ref, RefCallback } from "react";
+import type { MutableRefObject, ReactNode, Ref, RefCallback } from "react";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import copy from "copy-to-clipboard";
-import type { RichStr } from "@opal/types";
+import type { RichNodes, RichStr } from "@opal/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -18,6 +18,30 @@ export function cn(...inputs: ClassValue[]) {
  */
 export function markdown(...lines: string[]): RichStr {
   return { __brand: "RichStr", raw: lines.join("\n") };
+}
+
+/**
+ * Brands React nodes as deliberate `Text` children.
+ *
+ * Use for sentences that must embed inline components — the main case is
+ * next-intl rich-text output:
+ * ```tsx
+ * <Text font="main-ui-body" color="text-04">
+ *   {richNodes(t.rich("help.text", { link: (chunks) => <a ...>{chunks}</a> }))}
+ * </Text>
+ * ```
+ * Do not use it to pass layout JSX into `Text`; the content must stay inline.
+ */
+export function richNodes(nodes: ReactNode): RichNodes {
+  return { __brand: "RichNodes", nodes };
+}
+
+export function isRichNodes(value: unknown): value is RichNodes {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as RichNodes).__brand === "RichNodes"
+  );
 }
 
 export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {

--- a/web/package.json
+++ b/web/package.json
@@ -107,6 +107,8 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@formatjs/icu-messageformat-parser": "^3.5.17",
+    "@oxlint/plugins": "^1.71.0",
     "@playwright/test": "^1.39.0",
     "@storybook/addon-docs": "10.5.0",
     "@storybook/addon-mcp": "^0.7.0",
@@ -128,7 +130,6 @@
     "@types/node": "24.12.2",
     "@types/react": "19.2.10",
     "@types/react-dom": "19.2.3",
-    "@oxlint/plugins": "^1.71.0",
     "@types/stats.js": "^0.17.4",
     "babel-plugin-react-compiler": "^1.0.0",
     "baseline-browser-mapping": "^2.9.19",

--- a/web/src/app/auth/create-account/page.tsx
+++ b/web/src/app/auth/create-account/page.tsx
@@ -5,21 +5,23 @@ import { REGISTRATION_URL } from "@/lib/constants";
 import { Button } from "@opal/components";
 import Link from "next/link";
 import { SvgImport } from "@opal/icons";
+import { useTranslations } from "next-intl";
 
 export default function Page() {
+  const t = useTranslations("auth");
+
   return (
     <AuthFlowContainer>
       <div className="flex flex-col space-y-6">
         <h2 className="text-2xl font-bold text-text-900 text-center">
-          Account Not Found
+          {t("createAccount.heading.title")}
         </h2>
         <p className="text-text-700 max-w-md text-center">
-          We couldn&apos;t find your account in our records. To access Onyx, you
-          need to either:
+          {t("createAccount.notFound.description")}
         </p>
         <ul className="list-disc text-left text-text-600 w-full pl-6 mx-auto">
-          <li>Be invited to an existing Onyx team</li>
-          <li>Create a new Onyx team</li>
+          <li>{t("createAccount.inviteOption.text")}</li>
+          <li>{t("createAccount.createTeamOption.text")}</li>
         </ul>
         <div className="flex justify-center">
           <Button
@@ -27,16 +29,16 @@ export default function Page() {
             width="full"
             icon={SvgImport}
           >
-            Create New Organization
+            {t("createAccount.createOrgButton.label")}
           </Button>
         </div>
         <p className="text-sm text-text-500 text-center">
-          Have an account with a different email?{" "}
+          {t("createAccount.differentEmailPrompt.text")}{" "}
           <Link
             href="/auth/login"
             className="text-action-selection-05 hover:underline"
           >
-            Sign in
+            {t("createAccount.signInLink.label")}
           </Link>
         </p>
       </div>

--- a/web/src/app/auth/error/AuthErrorContent.tsx
+++ b/web/src/app/auth/error/AuthErrorContent.tsx
@@ -3,32 +3,38 @@
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
+import { useTranslations } from "next-intl";
 
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 
-// Maps raw IdP/OAuth error codes to user-friendly messages.
-// If the message is a known code, we replace it; otherwise show it as-is.
-const ERROR_CODE_MESSAGES: Record<string, string> = {
-  OAUTH_USER_ALREADY_EXISTS:
-    "An account with this email already exists under a different sign-in method. Sign in the way you first did, or ask your admin to link this provider.",
-  LOGIN_BAD_CREDENTIALS:
-    "This account can't sign in. It may be deactivated. Contact your workspace admin.",
-  access_denied: "Access was denied by your identity provider.",
-  login_required: "You need to log in with your identity provider first.",
-  consent_required:
-    "Your identity provider requires consent before continuing.",
-  interaction_required:
-    "Additional interaction with your identity provider is required.",
-  invalid_scope: "The requested permissions are not available.",
-  server_error:
-    "Your identity provider encountered an error. Please try again.",
-  temporarily_unavailable:
-    "Your identity provider is temporarily unavailable. Please try again later.",
-};
+// Raw IdP/OAuth error codes that map to a friendlier translated message.
+// Any other code is shown to the user as-is.
+const KNOWN_ERROR_CODES = [
+  "OAUTH_USER_ALREADY_EXISTS",
+  "LOGIN_BAD_CREDENTIALS",
+  "access_denied",
+  "login_required",
+  "consent_required",
+  "interaction_required",
+  "invalid_scope",
+  "server_error",
+  "temporarily_unavailable",
+] as const;
 
-function resolveMessage(raw: string | null): string | null {
+type KnownErrorCode = (typeof KNOWN_ERROR_CODES)[number];
+
+function isKnownErrorCode(value: string): value is KnownErrorCode {
+  // SAFETY: the cast only widens the argument for the readonly-array
+  // `includes` signature; membership is still checked at runtime.
+  return KNOWN_ERROR_CODES.includes(value as KnownErrorCode);
+}
+
+function resolveMessage(
+  raw: string | null,
+  messages: Record<KnownErrorCode, string>
+): string | null {
   if (!raw) return null;
-  return ERROR_CODE_MESSAGES[raw] ?? raw;
+  return isKnownErrorCode(raw) ? messages[raw] : raw;
 }
 
 interface AuthErrorContentProps {
@@ -36,15 +42,27 @@ interface AuthErrorContentProps {
 }
 
 function AuthErrorContent({ message: rawMessage }: AuthErrorContentProps) {
-  const message = resolveMessage(rawMessage);
+  const t = useTranslations("auth");
+  const errorCodeMessages = {
+    OAUTH_USER_ALREADY_EXISTS: t("error.code.oauthUserAlreadyExists"),
+    LOGIN_BAD_CREDENTIALS: t("error.code.loginBadCredentials"),
+    access_denied: t("error.code.accessDenied"),
+    login_required: t("error.code.loginRequired"),
+    consent_required: t("error.code.consentRequired"),
+    interaction_required: t("error.code.interactionRequired"),
+    invalid_scope: t("error.code.invalidScope"),
+    server_error: t("error.code.serverError"),
+    temporarily_unavailable: t("error.code.temporarilyUnavailable"),
+  } satisfies Record<KnownErrorCode, string>;
+  const message = resolveMessage(rawMessage, errorCodeMessages);
   return (
     <AuthFlowContainer>
       <div className="flex flex-col items-center gap-4">
         <Text headingH2 text05>
-          Authentication Error
+          {t("error.heading.title")}
         </Text>
         <Text mainContentBody text03>
-          There was a problem with your login attempt.
+          {t("error.heading.description")}
         </Text>
         {/* TODO: Error card component */}
         <div className="w-full rounded-12 border border-status-error-05 bg-status-error-00 p-4">
@@ -55,40 +73,38 @@ function AuthErrorContent({ message: rawMessage }: AuthErrorContentProps) {
           ) : (
             <div className="flex flex-col gap-2 px-4">
               <Text mainContentEmphasis className="text-status-error-05">
-                Possible Issues:
+                {t("error.possibleIssues.title")}
               </Text>
               <Text as="li" mainContentBody className="text-status-error-05">
-                Incorrect or expired login credentials
+                {t("error.credentialsIssue.description")}
               </Text>
               <Text as="li" mainContentBody className="text-status-error-05">
-                Temporary authentication system disruption
+                {t("error.systemDisruptionIssue.description")}
               </Text>
               <Text as="li" mainContentBody className="text-status-error-05">
-                Account access restrictions or permissions
+                {t("error.accessRestrictionIssue.description")}
               </Text>
             </div>
           )}
         </div>
 
         <Button href="/auth/login" width="full">
-          Return to Login Page
+          {t("error.returnToLoginButton.label")}
         </Button>
 
         <Text mainContentBody text04>
-          {NEXT_PUBLIC_CLOUD_ENABLED ? (
-            <>
-              If you continue to experience problems, please reach out to the
-              Onyx team at{" "}
-              <a
-                href="mailto:support@onyx.app"
-                className="text-action-selection-05"
-              >
-                support@onyx.app
-              </a>
-            </>
-          ) : (
-            "If you continue to experience problems, please reach out to your system administrator for assistance."
-          )}
+          {NEXT_PUBLIC_CLOUD_ENABLED
+            ? t.rich("error.cloudSupportPrompt.text", {
+                link: (chunks) => (
+                  <a
+                    href="mailto:support@onyx.app"
+                    className="text-action-selection-05"
+                  >
+                    {chunks}
+                  </a>
+                ),
+              })
+            : t("error.selfHostedSupportPrompt.text")}
         </Text>
       </div>
     </AuthFlowContainer>

--- a/web/src/app/auth/error/AuthErrorContent.tsx
+++ b/web/src/app/auth/error/AuthErrorContent.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
+import { richNodes } from "@opal/utils";
 import { useTranslations } from "next-intl";
 
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
@@ -58,30 +58,30 @@ function AuthErrorContent({ message: rawMessage }: AuthErrorContentProps) {
   return (
     <AuthFlowContainer>
       <div className="flex flex-col items-center gap-4">
-        <Text headingH2 text05>
+        <Text font="heading-h2" color="text-05">
           {t("error.heading.title")}
         </Text>
-        <Text mainContentBody text03>
+        <Text font="main-content-body" color="text-03">
           {t("error.heading.description")}
         </Text>
         {/* TODO: Error card component */}
         <div className="w-full rounded-12 border border-status-error-05 bg-status-error-00 p-4">
           {message ? (
-            <Text mainContentBody className="text-status-error-05">
+            <Text font="main-content-body" color="status-error-05">
               {message}
             </Text>
           ) : (
             <div className="flex flex-col gap-2 px-4">
-              <Text mainContentEmphasis className="text-status-error-05">
+              <Text font="main-content-emphasis" color="status-error-05">
                 {t("error.possibleIssues.title")}
               </Text>
-              <Text as="li" mainContentBody className="text-status-error-05">
+              <Text as="li" font="main-content-body" color="status-error-05">
                 {t("error.credentialsIssue.description")}
               </Text>
-              <Text as="li" mainContentBody className="text-status-error-05">
+              <Text as="li" font="main-content-body" color="status-error-05">
                 {t("error.systemDisruptionIssue.description")}
               </Text>
-              <Text as="li" mainContentBody className="text-status-error-05">
+              <Text as="li" font="main-content-body" color="status-error-05">
                 {t("error.accessRestrictionIssue.description")}
               </Text>
             </div>
@@ -92,18 +92,20 @@ function AuthErrorContent({ message: rawMessage }: AuthErrorContentProps) {
           {t("error.returnToLoginButton.label")}
         </Button>
 
-        <Text mainContentBody text04>
+        <Text font="main-content-body" color="text-04">
           {NEXT_PUBLIC_CLOUD_ENABLED
-            ? t.rich("error.cloudSupportPrompt.text", {
-                link: (chunks) => (
-                  <a
-                    href="mailto:support@onyx.app"
-                    className="text-action-selection-05"
-                  >
-                    {chunks}
-                  </a>
-                ),
-              })
+            ? richNodes(
+                t.rich("error.cloudSupportPrompt.text", {
+                  link: (chunks) => (
+                    <a
+                      href="mailto:support@onyx.app"
+                      className="text-action-selection-05"
+                    >
+                      {chunks}
+                    </a>
+                  ),
+                })
+              )
             : t("error.selfHostedSupportPrompt.text")}
         </Text>
       </div>

--- a/web/src/app/auth/forgot-password/page.tsx
+++ b/web/src/app/auth/forgot-password/page.tsx
@@ -15,8 +15,10 @@ import { toast } from "@opal/layouts";
 import { Spinner } from "@/components/Spinner";
 import { redirect } from "next/navigation";
 import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
+import { useTranslations } from "next-intl";
 
 const ForgotPasswordPage: React.FC = () => {
+  const t = useTranslations("auth");
   const [isWorking, setIsWorking] = useState(false);
 
   if (!NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED) {
@@ -27,7 +29,9 @@ const ForgotPasswordPage: React.FC = () => {
     <AuthFlowContainer>
       <div className="flex flex-col w-full justify-center">
         <div className="flex">
-          <Title className="mb-2 mx-auto font-bold">Forgot Password</Title>
+          <Title className="mb-2 mx-auto font-bold">
+            {t("forgotPassword.heading.title")}
+          </Title>
         </div>
         {isWorking && <Spinner />}
         <Formik
@@ -40,15 +44,16 @@ const ForgotPasswordPage: React.FC = () => {
           onSubmit={async (values) => {
             setIsWorking(true);
             try {
-              await forgotPassword(values.email);
-              toast.success(
-                "Password reset email sent. Please check your inbox."
+              await forgotPassword(
+                values.email,
+                t("forgotPassword.genericError.toast")
               );
+              toast.success(t("forgotPassword.emailSent.toast"));
             } catch (error) {
               const errorMessage =
                 error instanceof Error
                   ? error.message
-                  : "An error occurred. Please try again.";
+                  : t("forgotPassword.unexpectedError.toast");
               toast.error(errorMessage);
             } finally {
               setIsWorking(false);
@@ -59,14 +64,14 @@ const ForgotPasswordPage: React.FC = () => {
             <Form className="w-full flex flex-col items-stretch mt-2">
               <TextFormField
                 name="email"
-                label="Email"
+                label={t("forgotPassword.emailField.label")}
                 type="email"
                 placeholder="email@yourcompany.com"
               />
 
               <div className="flex">
                 <Button disabled={isSubmitting} type="submit" width="full">
-                  Reset Password
+                  {t("forgotPassword.submitButton.label")}
                 </Button>
               </div>
             </Form>
@@ -75,7 +80,9 @@ const ForgotPasswordPage: React.FC = () => {
         <Spacer rem={1} />
         <div className="flex">
           <div className="mx-auto">
-            <Text as="p">{markdown("[Back to Login](/auth/login)")}</Text>
+            <Text as="p">
+              {markdown(t("forgotPassword.backToLoginLink.label"))}
+            </Text>
           </div>
         </div>
       </div>

--- a/web/src/app/auth/forgot-password/utils.ts
+++ b/web/src/app/auth/forgot-password/utils.ts
@@ -1,4 +1,7 @@
-export const forgotPassword = async (email: string): Promise<void> => {
+export const forgotPassword = async (
+  email: string,
+  fallbackErrorMessage: string
+): Promise<void> => {
   const response = await fetch(`/api/auth/forgot-password`, {
     method: "POST",
     headers: {
@@ -9,15 +12,20 @@ export const forgotPassword = async (email: string): Promise<void> => {
 
   if (!response.ok) {
     const error = await response.json();
-    const errorMessage =
-      error?.detail || "An error occurred during password reset.";
+    const errorMessage = error?.detail || fallbackErrorMessage;
     throw new Error(errorMessage);
   }
 };
 
+interface ResetPasswordMessages {
+  invalidPassword: string;
+  genericError: string;
+}
+
 export const resetPassword = async (
   token: string,
-  password: string
+  password: string,
+  messages: ResetPasswordMessages
 ): Promise<void> => {
   const response = await fetch(`/api/auth/reset-password`, {
     method: "POST",
@@ -30,10 +38,9 @@ export const resetPassword = async (
   if (!response.ok) {
     const error = await response.json();
     if (error?.detail?.code === "RESET_PASSWORD_INVALID_PASSWORD") {
-      throw new Error(error.detail.reason || "Invalid password");
+      throw new Error(error.detail.reason || messages.invalidPassword);
     }
-    const errorMessage =
-      error?.detail || "An error occurred during password reset.";
+    const errorMessage = error?.detail || messages.genericError;
     throw new Error(errorMessage);
   }
 };

--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -10,14 +10,20 @@ import { toast } from "@opal/layouts";
 import { TextFormField } from "@/components/Field";
 import { Button } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
-
-const ImpersonateSchema = Yup.object().shape({
-  email: Yup.string().email("Invalid email").required("Required"),
-  apiKey: Yup.string().required("Required"),
-});
+import { useTranslations } from "next-intl";
 
 export default function ImpersonatePage() {
+  const t = useTranslations("auth");
   const router = useRouter();
+
+  const ImpersonateSchema = Yup.object().shape({
+    email: Yup.string()
+      .email(t("impersonate.invalidEmail.error"))
+      .required(t("impersonate.requiredField.error")),
+    apiKey: Yup.string().required(t("impersonate.requiredField.error")),
+  });
+
+  const genericError = t("impersonate.genericError.toast");
 
   const handleImpersonate = async (
     values: { email: string; apiKey: string },
@@ -36,16 +42,14 @@ export default function ImpersonatePage() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        toast.error(errorData.detail || "Failed to impersonate user");
+        toast.error(errorData.detail || genericError);
         helpers.setSubmitting(false);
       } else {
         helpers.setSubmitting(false);
         router.push("/app" as Route);
       }
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to impersonate user"
-      );
+      toast.error(error instanceof Error ? error.message : genericError);
       helpers.setSubmitting(false);
     }
   };
@@ -55,7 +59,7 @@ export default function ImpersonatePage() {
       <div className="flex flex-col w-full justify-center">
         <div className="w-full flex flex-col items-center justify-center">
           <Text as="p" headingH3 className="mb-6 text-center">
-            Impersonate User
+            {t("impersonate.heading.title")}
           </Text>
         </div>
 
@@ -69,30 +73,27 @@ export default function ImpersonatePage() {
               <TextFormField
                 name="email"
                 type="email"
-                label="Email"
+                label={t("impersonate.emailField.label")}
                 placeholder="email@yourcompany.com"
               />
 
               <TextFormField
                 name="apiKey"
                 type="password"
-                label="API Key"
-                placeholder="Enter API Key"
+                label={t("impersonate.apiKeyField.label")}
+                placeholder={t("impersonate.apiKeyField.placeholder")}
               />
 
               <Button disabled={isSubmitting} type="submit" width="full">
-                Impersonate User
+                {t("impersonate.submitButton.label")}
               </Button>
             </Form>
           )}
         </Formik>
 
-        <Text
-          as="p"
-          mainUiMuted
-          text03
-          className="mt-4 text-center px-4"
-        >{`Note: This feature is only available for @onyx.app administrators`}</Text>
+        <Text as="p" mainUiMuted text03 className="mt-4 text-center px-4">
+          {t("impersonate.adminNote.text")}
+        </Text>
       </div>
     </AuthFlowContainer>
   );

--- a/web/src/app/auth/join/page.tsx
+++ b/web/src/app/auth/join/page.tsx
@@ -6,10 +6,12 @@ import { redirect } from "next/navigation";
 import { EmailPasswordForm, SignInButton } from "@/lib/auth/components";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 import AuthErrorDisplay from "@/components/auth/AuthErrorDisplay";
+import { getTranslations } from "next-intl/server";
 
 const Page = async (props: {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 }) => {
+  const t = await getTranslations("auth");
   const searchParams = await props.searchParams;
   const nextUrl = Array.isArray(searchParams?.next)
     ? searchParams?.next[0]
@@ -65,7 +67,7 @@ const Page = async (props: {
         <div className="absolute top-10x w-full"></div>
         <div className="flex w-full flex-col justify-center">
           <h2 className="text-center text-xl text-strong font-bold">
-            Re-authenticate to join team
+            {t("join.heading.title")}
           </h2>
 
           {cloud && authUrl && (
@@ -73,7 +75,9 @@ const Page = async (props: {
               <SignInButton authorizeUrl={authUrl} />
               <div className="flex items-center w-full my-4">
                 <div className="grow border-t border-background-300"></div>
-                <span className="px-4 text-text-500">or</span>
+                <span className="px-4 text-text-500">
+                  {t("join.orDivider.text")}
+                </span>
                 <div className="grow border-t border-background-300"></div>
               </div>
             </div>

--- a/web/src/app/auth/login/CloudSSOSignIn.tsx
+++ b/web/src/app/auth/login/CloudSSOSignIn.tsx
@@ -18,17 +18,7 @@ import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
 import type { SSOProviderOption } from "@/lib/auth/types";
 import { discoverSSOProviders } from "@/lib/sso/svc";
-
-// Deliberately the same copy for "no such workspace", "several workspaces" and
-// "workspace without SSO". The endpoint does not distinguish them either.
-const NO_PROVIDERS_MESSAGE =
-  "No SSO sign-in is set up for that address. Try Google or your password below.";
-
-const LOOKUP_SCHEMA = Yup.object({
-  email: Yup.string()
-    .email("Enter a valid email address")
-    .required("Email is required"),
-});
+import { useTranslations } from "next-intl";
 
 interface LookupValues {
   email: string;
@@ -39,16 +29,28 @@ interface CloudSSOSignInProps {
 }
 
 export default function CloudSSOSignIn({ nextUrl }: CloudSSOSignInProps) {
+  const t = useTranslations("auth");
   const [expanded, setExpanded] = useState(false);
   const [providers, setProviders] = useState<SSOProviderOption[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Deliberately the same copy for "no such workspace", "several
+  // workspaces" and "workspace without SSO". The endpoint does not
+  // distinguish them either.
+  const noProvidersMessage = t("login.noSsoProviders.error");
+
+  const lookupSchema = Yup.object({
+    email: Yup.string()
+      .email(t("login.ssoEmailInvalid.error"))
+      .required(t("login.ssoEmailRequired.error")),
+  });
 
   async function handleLookup(values: LookupValues) {
     setError(null);
     try {
       const found = await discoverSSOProviders(values.email.toLowerCase());
       if (found.length === 0) {
-        setError(NO_PROVIDERS_MESSAGE);
+        setError(noProvidersMessage);
         return;
       }
       setProviders(found);
@@ -65,7 +67,7 @@ export default function CloudSSOSignIn({ nextUrl }: CloudSSOSignInProps) {
         icon={SvgUserKey}
         onClick={() => setExpanded(true)}
       >
-        Sign in with SSO
+        {t("login.ssoSignInButton.label")}
       </Button>
     );
   }
@@ -75,13 +77,16 @@ export default function CloudSSOSignIn({ nextUrl }: CloudSSOSignInProps) {
       {providers === null ? (
         <Formik
           initialValues={{ email: "" }}
-          validationSchema={LOOKUP_SCHEMA}
+          validationSchema={lookupSchema}
           onSubmit={handleLookup}
         >
           {({ isSubmitting, isValid, dirty }) => (
             <AuthLayouts.FormBody>
               <AuthLayouts.Fields>
-                <InputVertical title="Work Email" withLabel="email">
+                <InputVertical
+                  title={t("login.workEmailField.label")}
+                  withLabel="email"
+                >
                   <InputTypeInField
                     name="email"
                     placeholder="email@yourcompany.com"

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -9,6 +9,7 @@ import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
 import { useSendAuthRequiredMessage } from "@/lib/extension/hooks";
 import { Button, MessageCard } from "@opal/components";
 import { AuthLayouts } from "@opal/layouts";
+import { useTranslations } from "next-intl";
 
 interface LoginPageProps {
   authUrl: string | null;
@@ -27,6 +28,7 @@ export default function LoginPage({
   verified,
   isFirstUser,
 }: LoginPageProps) {
+  const t = useTranslations("auth");
   useSendAuthRequiredMessage();
 
   // Honor any existing nextUrl; only default to new team flow for first users with no nextUrl
@@ -42,7 +44,7 @@ export default function LoginPage({
       {verified && (
         <MessageCard
           variant="success"
-          title="Your email has been verified! Please sign in to continue."
+          title={t("login.verifiedMessage.title")}
         />
       )}
       {authTypeMetadata?.multiTenant === true && (
@@ -61,7 +63,9 @@ export default function LoginPage({
             nextUrl={effectiveNextUrl}
           />
           {NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED && (
-            <Button href="/auth/forgot-password">Reset Password</Button>
+            <Button href="/auth/forgot-password">
+              {t("login.resetPasswordButton.label")}
+            </Button>
           )}
         </div>
       )}
@@ -91,7 +95,7 @@ export default function LoginPage({
 
       {!hidePageRedirect && passwordAuthEnabled && (
         <p className="text-center mt-4">
-          Don&apos;t have an account?{" "}
+          {t("login.signupPrompt.text")}{" "}
           <button
             type="button"
             onClick={() => {
@@ -103,7 +107,7 @@ export default function LoginPage({
             }}
             className="text-link font-medium cursor-pointer"
           >
-            Create an account
+            {t("login.createAccountButton.label")}
           </button>
         </p>
       )}

--- a/web/src/app/auth/login/ProviderSignInButton.tsx
+++ b/web/src/app/auth/login/ProviderSignInButton.tsx
@@ -20,6 +20,7 @@ import { Button } from "@opal/components";
 import { InputErrorText } from "@opal/layouts";
 import { SvgGoogle } from "@opal/logos";
 import { SSOProviderOption } from "@/lib/auth/types";
+import { useTranslations } from "next-intl";
 
 interface ProviderSignInButtonProps {
   provider: SSOProviderOption;
@@ -30,6 +31,7 @@ export default function ProviderSignInButton({
   provider,
   nextUrl,
 }: ProviderSignInButtonProps) {
+  const t = useTranslations("auth");
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,11 +48,13 @@ export default function ProviderSignInButton({
       if (nextUrl) url.searchParams.set("next", nextUrl);
       const res = await fetch(url.toString(), { credentials: "include" });
       if (!res.ok) {
-        throw new Error(`Could not start sign-in (status ${res.status})`);
+        throw new Error(
+          t("login.ssoStartFailed.error", { status: res.status })
+        );
       }
       const data: { authorization_url?: string } = await res.json();
       if (!data.authorization_url) {
-        throw new Error("Sign-in response was missing the authorization URL");
+        throw new Error(t("login.ssoMissingAuthUrl.error"));
       }
       window.location.href = data.authorization_url;
     } catch (exc) {

--- a/web/src/app/auth/reset-password/page.tsx
+++ b/web/src/app/auth/reset-password/page.tsx
@@ -15,8 +15,10 @@ import { toast } from "@opal/layouts";
 import { Spinner } from "@/components/Spinner";
 import { redirect, useSearchParams } from "next/navigation";
 import { NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
+import { useTranslations } from "next-intl";
 
 const ResetPasswordPage: React.FC = () => {
+  const t = useTranslations("auth");
   const [isWorking, setIsWorking] = useState(false);
   const searchParams = useSearchParams();
   const token = searchParams?.get("token");
@@ -24,11 +26,15 @@ const ResetPasswordPage: React.FC = () => {
     redirect("/auth/login");
   }
 
+  const genericError = t("resetPassword.genericError.toast");
+
   return (
     <AuthFlowContainer>
       <div className="flex flex-col w-full justify-center">
         <div className="flex">
-          <Title className="mb-2 mx-auto font-bold">Reset Password</Title>
+          <Title className="mb-2 mx-auto font-bold">
+            {t("resetPassword.heading.title")}
+          </Title>
         </div>
         {isWorking && <Spinner />}
         <Formik
@@ -37,32 +43,36 @@ const ResetPasswordPage: React.FC = () => {
             confirmPassword: "",
           }}
           validationSchema={Yup.object().shape({
-            password: Yup.string().required("Password is required"),
+            password: Yup.string().required(
+              t("resetPassword.passwordRequired.error")
+            ),
             confirmPassword: Yup.string()
-              .oneOf([Yup.ref("password"), undefined], "Passwords must match")
-              .required("Confirm Password is required"),
+              .oneOf(
+                [Yup.ref("password"), undefined],
+                t("resetPassword.passwordsMatch.error")
+              )
+              .required(t("resetPassword.confirmPasswordRequired.error")),
           })}
           onSubmit={async (values) => {
             if (!token) {
-              toast.error("Invalid or missing reset token.");
+              toast.error(t("resetPassword.missingToken.toast"));
               return;
             }
             setIsWorking(true);
             try {
-              await resetPassword(token, values.password);
-              toast.success(
-                "Password reset successfully. Redirecting to login..."
-              );
+              await resetPassword(token, values.password, {
+                invalidPassword: t("resetPassword.invalidPassword.error"),
+                genericError,
+              });
+              toast.success(t("resetPassword.successRedirect.toast"));
               setTimeout(() => {
                 redirect("/auth/login");
               }, 1000);
             } catch (error) {
               if (error instanceof Error) {
-                toast.error(
-                  error.message || "An error occurred during password reset."
-                );
+                toast.error(error.message || genericError);
               } else {
-                toast.error("An unexpected error occurred. Please try again.");
+                toast.error(t("resetPassword.unexpectedError.toast"));
               }
             } finally {
               setIsWorking(false);
@@ -73,20 +83,22 @@ const ResetPasswordPage: React.FC = () => {
             <Form className="w-full flex flex-col items-stretch mt-2">
               <TextFormField
                 name="password"
-                label="New Password"
+                label={t("resetPassword.newPasswordField.label")}
                 type="password"
-                placeholder="Enter your new password"
+                placeholder={t("resetPassword.newPasswordField.placeholder")}
               />
               <TextFormField
                 name="confirmPassword"
-                label="Confirm New Password"
+                label={t("resetPassword.confirmPasswordField.label")}
                 type="password"
-                placeholder="Confirm your new password"
+                placeholder={t(
+                  "resetPassword.confirmPasswordField.placeholder"
+                )}
               />
 
               <div className="flex">
                 <Button disabled={isSubmitting} type="submit" width="full">
-                  Reset Password
+                  {t("resetPassword.submitButton.label")}
                 </Button>
               </div>
             </Form>
@@ -95,7 +107,9 @@ const ResetPasswordPage: React.FC = () => {
         <Spacer rem={1} />
         <div className="flex">
           <div className="mx-auto">
-            <Text as="p">{markdown("[Back to Login](/auth/login)")}</Text>
+            <Text as="p">
+              {markdown(t("resetPassword.backToLoginLink.label"))}
+            </Text>
           </div>
         </div>
       </div>

--- a/web/src/app/auth/signup/ReferralSourceSelector.tsx
+++ b/web/src/app/auth/signup/ReferralSourceSelector.tsx
@@ -3,29 +3,50 @@
 import { useState } from "react";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { Label } from "@/components/Field";
+import { useTranslations } from "next-intl";
 
 interface ReferralSourceSelectorProps {
   defaultValue?: string;
 }
 
+const REFERRAL_OPTION_VALUES = [
+  "search",
+  "friend",
+  "linkedin",
+  "twitter",
+  "hackernews",
+  "reddit",
+  "youtube",
+  "podcast",
+  "blog",
+  "ads",
+  "other",
+] as const;
+
 export default function ReferralSourceSelector({
   defaultValue,
 }: ReferralSourceSelectorProps) {
+  const t = useTranslations("auth");
   const [referralSource, setReferralSource] = useState(defaultValue);
 
-  const referralOptions = [
-    { value: "search", label: "Search Engine (Google/Bing)" },
-    { value: "friend", label: "Friend/Colleague" },
-    { value: "linkedin", label: "LinkedIn" },
-    { value: "twitter", label: "Twitter" },
-    { value: "hackernews", label: "HackerNews" },
-    { value: "reddit", label: "Reddit" },
-    { value: "youtube", label: "YouTube" },
-    { value: "podcast", label: "Podcast" },
-    { value: "blog", label: "Article/Blog" },
-    { value: "ads", label: "Advertisements" },
-    { value: "other", label: "Other" },
-  ];
+  const referralOptionLabels = {
+    search: t("signup.referralOptionSearch.label"),
+    friend: t("signup.referralOptionFriend.label"),
+    linkedin: t("signup.referralOptionLinkedin.label"),
+    twitter: t("signup.referralOptionTwitter.label"),
+    hackernews: t("signup.referralOptionHackernews.label"),
+    reddit: t("signup.referralOptionReddit.label"),
+    youtube: t("signup.referralOptionYoutube.label"),
+    podcast: t("signup.referralOptionPodcast.label"),
+    blog: t("signup.referralOptionBlog.label"),
+    ads: t("signup.referralOptionAds.label"),
+    other: t("signup.referralOptionOther.label"),
+  } satisfies Record<(typeof REFERRAL_OPTION_VALUES)[number], string>;
+
+  const referralOptions = REFERRAL_OPTION_VALUES.map((value) => ({
+    value,
+    label: referralOptionLabels[value],
+  }));
 
   const handleChange = (value: string) => {
     setReferralSource(value);
@@ -40,10 +61,12 @@ export default function ReferralSourceSelector({
   return (
     <div className="w-full gap-y-2 flex flex-col">
       <Label className="text-text-950" small={false}>
-        How did you hear about us?
+        {t("signup.referralQuestion.label")}
       </Label>
       <InputSelect value={referralSource} onValueChange={handleChange}>
-        <InputSelect.Trigger placeholder="Select an option" />
+        <InputSelect.Trigger
+          placeholder={t("signup.referralPlaceholder.placeholder")}
+        />
 
         <InputSelect.Content>
           {referralOptions.map((option) => (

--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -9,10 +9,12 @@ import ReferralSourceSelector from "./ReferralSourceSelector";
 import AuthErrorDisplay from "@/components/auth/AuthErrorDisplay";
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@opal/utils";
+import { getTranslations } from "next-intl/server";
 
 const Page = async (props: {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 }) => {
+  const t = await getTranslations("auth");
   const searchParams = await props.searchParams;
   const nextUrl = Array.isArray(searchParams?.next)
     ? searchParams?.next[0]
@@ -74,10 +76,12 @@ const Page = async (props: {
         >
           <div className="w-full">
             <Text as="p" headingH2 text05>
-              {cloud ? "Complete your sign up" : "Create account"}
+              {cloud
+                ? t("signup.cloudSignupHeading.title")
+                : t("signup.createAccountHeading.title")}
             </Text>
             <Text as="p" text03>
-              Get started with Onyx
+              {t("signup.subtitle.text")}
             </Text>
           </div>
           {cloud && authUrl && (
@@ -86,7 +90,7 @@ const Page = async (props: {
               <div className="flex items-center w-full my-4">
                 <div className="grow border-t border-border-01" />
                 <Text as="p" mainUiMuted text03 className="mx-2">
-                  or
+                  {t("signup.orDivider.text")}
                 </Text>
                 <div className="grow border-t border-border-01" />
               </div>

--- a/web/src/app/auth/verify-email/Verify.tsx
+++ b/web/src/app/auth/verify-email/Verify.tsx
@@ -8,12 +8,14 @@ import { RequestNewVerificationEmail } from "../waiting-on-verification/RequestN
 import { User } from "@/lib/types";
 import { Logo } from "@/lib/app/components";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import { useTranslations } from "next-intl";
 
 export interface VerifyProps {
   user: User | null;
 }
 
 export default function Verify({ user }: VerifyProps) {
+  const t = useTranslations("auth");
   const searchParams = useSearchParams();
 
   const [error, setError] = useState("");
@@ -23,9 +25,7 @@ export default function Verify({ user }: VerifyProps) {
     const firstUser =
       searchParams?.get("first_user") === "true" && NEXT_PUBLIC_CLOUD_ENABLED;
     if (!token) {
-      setError(
-        "Missing verification token. Try requesting a new verification email."
-      );
+      setError(t("verifyEmail.missingToken.error"));
       return;
     }
 
@@ -45,17 +45,15 @@ export default function Verify({ user }: VerifyProps) {
         : "/auth/login?verified=true";
       window.location.href = loginUrl;
     } else {
-      let errorDetail = "unknown error";
+      let errorDetail = t("verifyEmail.unknownError.text");
       try {
         errorDetail = (await response.json()).detail;
       } catch (e) {
         console.error("Failed to parse verification error response:", e);
       }
-      setError(
-        `Failed to verify your email - ${errorDetail}. Please try requesting a new verification email.`
-      );
+      setError(t("verifyEmail.verificationFailed.error", { errorDetail }));
     }
-  }, [searchParams]);
+  }, [searchParams, t]);
 
   useEffect(() => {
     verify();
@@ -68,7 +66,7 @@ export default function Verify({ user }: VerifyProps) {
         {!error ? (
           <>
             <Spacer rem={0.5} />
-            <Text as="p">Verifying your email...</Text>
+            <Text as="p">{t("verifyEmail.verifying.text")}</Text>
           </>
         ) : (
           <div>
@@ -80,7 +78,7 @@ export default function Verify({ user }: VerifyProps) {
                 <RequestNewVerificationEmail email={user.email}>
                   {/* TODO(@raunakab): migrate to @opal/components Text */}
                   <p className="text-sm mt-2 text-link">
-                    Get new verification email
+                    {t("verifyEmail.getNewEmailLink.label")}
                   </p>
                 </RequestNewVerificationEmail>
               </div>

--- a/web/src/app/auth/waiting-on-verification/RequestNewVerificationEmail.tsx
+++ b/web/src/app/auth/waiting-on-verification/RequestNewVerificationEmail.tsx
@@ -3,15 +3,17 @@
 import { toast } from "@opal/layouts";
 import { requestEmailVerification } from "../lib";
 import { Spinner } from "@/components/Spinner";
-import { useState, JSX } from "react";
+import { ReactNode, useState } from "react";
+import { useTranslations } from "next-intl";
 
 export function RequestNewVerificationEmail({
   children,
   email,
 }: {
-  children: JSX.Element | string;
+  children: ReactNode;
   email: string;
 }) {
+  const t = useTranslations("auth");
   const [isRequestingVerification, setIsRequestingVerification] =
     useState(false);
 
@@ -24,11 +26,11 @@ export function RequestNewVerificationEmail({
         setIsRequestingVerification(false);
 
         if (response.ok) {
-          toast.success("A new verification email has been sent!");
+          toast.success(t("waitingOnVerification.emailSent.toast"));
         } else {
           const errorDetail = (await response.json()).detail;
           toast.error(
-            `Failed to send a new verification email - ${errorDetail}`
+            t("waitingOnVerification.sendFailed.toast", { errorDetail })
           );
         }
       }}

--- a/web/src/app/auth/waiting-on-verification/page.tsx
+++ b/web/src/app/auth/waiting-on-verification/page.tsx
@@ -6,9 +6,12 @@ import { User } from "@/lib/types";
 import { RequestNewVerificationEmail } from "./RequestNewVerificationEmail";
 import { Logo } from "@/lib/app/components";
 import { Text } from "@opal/components";
+import LegacyText from "@/refresh-components/texts/Text";
 import { markdown } from "@opal/utils";
+import { getTranslations } from "next-intl/server";
 
 export default async function Page() {
+  const t = await getTranslations("auth");
   // catch cases where the backend is completely unreachable here
   // without try / catch, will just raise an exception and the page
   // will not render
@@ -38,16 +41,22 @@ export default async function Page() {
         <div className="flex flex-col gap-2">
           <Text as="span">
             {markdown(
-              `Hey, *${currentUser.email}*, it looks like you haven't verified your email yet.\nCheck your inbox for an email from us to get started!`
+              t("waitingOnVerification.greeting.text", {
+                email: currentUser.email,
+              })
             )}
           </Text>
-          <div className="flex flex-row items-center gap-1">
-            <Text as="span">If you don't see anything, click</Text>
-            <RequestNewVerificationEmail email={currentUser.email}>
-              <Text as="span">here</Text>
-            </RequestNewVerificationEmail>
-            <Text as="span">to request a new email.</Text>
-          </div>
+          {/* Opal Text only accepts string children; t.rich output needs the
+              legacy Text, same as AuthErrorContent's support prompt. */}
+          <LegacyText mainUiBody text04 as="span">
+            {t.rich("waitingOnVerification.helpPrompt.text", {
+              link: (chunks) => (
+                <RequestNewVerificationEmail email={currentUser.email}>
+                  {chunks}
+                </RequestNewVerificationEmail>
+              ),
+            })}
+          </LegacyText>
         </div>
       </div>
     </main>

--- a/web/src/app/auth/waiting-on-verification/page.tsx
+++ b/web/src/app/auth/waiting-on-verification/page.tsx
@@ -6,8 +6,7 @@ import { User } from "@/lib/types";
 import { RequestNewVerificationEmail } from "./RequestNewVerificationEmail";
 import { Logo } from "@/lib/app/components";
 import { Text } from "@opal/components";
-import LegacyText from "@/refresh-components/texts/Text";
-import { markdown } from "@opal/utils";
+import { markdown, richNodes } from "@opal/utils";
 import { getTranslations } from "next-intl/server";
 
 export default async function Page() {
@@ -46,17 +45,17 @@ export default async function Page() {
               })
             )}
           </Text>
-          {/* Opal Text only accepts string children; t.rich output needs the
-              legacy Text, same as AuthErrorContent's support prompt. */}
-          <LegacyText mainUiBody text04 as="span">
-            {t.rich("waitingOnVerification.helpPrompt.text", {
-              link: (chunks) => (
-                <RequestNewVerificationEmail email={currentUser.email}>
-                  {chunks}
-                </RequestNewVerificationEmail>
-              ),
-            })}
-          </LegacyText>
+          <Text as="span">
+            {richNodes(
+              t.rich("waitingOnVerification.helpPrompt.text", {
+                link: (chunks) => (
+                  <RequestNewVerificationEmail email={currentUser.email}>
+                    {chunks}
+                  </RequestNewVerificationEmail>
+                ),
+              })
+            )}
+          </Text>
         </div>
       </div>
     </main>

--- a/web/src/i18n/__tests__/catalog.test.ts
+++ b/web/src/i18n/__tests__/catalog.test.ts
@@ -1,11 +1,11 @@
 /**
- * Guards the message catalogs:
+ * Guards what the type system cannot see inside the message strings:
  * - every message in every locale parses as ICU,
- * - non-English catalogs contain no keys that are missing from en.json,
- * - shared keys use exactly the same ICU placeholders as the English source.
+ * - each translation uses exactly the same ICU placeholders as its English
+ *   source.
  *
- * Keys present in en.json but not yet translated are reported, not failed —
- * that is the expected lag window before the translation pipeline runs.
+ * Key parity (no missing or extra keys per locale) is a compile-time check —
+ * see src/i18n/messages/keyParity.ts.
  */
 import {
   parse,
@@ -81,42 +81,18 @@ describe("i18n message catalogs", () => {
   });
 
   for (const [locale, catalog] of Object.entries(TARGET_LOCALES)) {
-    describe(locale, () => {
-      const flatLocale = flatten(catalog);
+    test(`${locale}: every message is valid ICU with the same placeholders as English`, () => {
+      for (const [key, message] of Object.entries(flatten(catalog))) {
+        const englishMessage = flatEnglish[key];
+        // Key parity is compile-time checked (messages/keyParity.ts).
+        if (englishMessage === undefined) continue;
 
-      test("has no keys that are missing from en.json", () => {
-        const orphans = Object.keys(flatLocale).filter(
-          (key) => !(key in flatEnglish)
-        );
-        expect(orphans).toEqual([]);
-      });
-
-      test("every message is valid ICU with the same placeholders as English", () => {
-        for (const [key, message] of Object.entries(flatLocale)) {
-          const englishMessage = flatEnglish[key];
-          if (englishMessage === undefined) continue; // covered by orphan test
-
-          expect(() => parse(message)).not.toThrow();
-          expect({ key, placeholders: sortedArguments(message) }).toEqual({
-            key,
-            placeholders: sortedArguments(englishMessage),
-          });
-        }
-      });
-
-      test("reports untranslated keys without failing", () => {
-        const untranslated = Object.keys(flatEnglish).filter(
-          (key) => !(key in flatLocale)
-        );
-        if (untranslated.length > 0) {
-          console.warn(
-            `[i18n] ${locale}: ${untranslated.length} untranslated key(s) ` +
-              `(English fallback renders until the translation pipeline runs): ` +
-              untranslated.slice(0, 20).join(", ")
-          );
-        }
-        expect(true).toBe(true);
-      });
+        expect(() => parse(message)).not.toThrow();
+        expect({ key, placeholders: sortedArguments(message) }).toEqual({
+          key,
+          placeholders: sortedArguments(englishMessage),
+        });
+      }
     });
   }
 });

--- a/web/src/i18n/__tests__/catalog.test.ts
+++ b/web/src/i18n/__tests__/catalog.test.ts
@@ -23,16 +23,14 @@ type MessageTree = { [key: string]: string | MessageTree };
 
 const TARGET_LOCALES: Record<string, MessageTree> = { de, es, fr, pt };
 
-function flatten(tree: MessageTree, prefix = ""): Map<string, string> {
-  const flat = new Map<string, string>();
+function flatten(tree: MessageTree, prefix = ""): Record<string, string> {
+  const flat: Record<string, string> = {};
   for (const [key, value] of Object.entries(tree)) {
     const path = prefix ? `${prefix}.${key}` : key;
     if (typeof value === "string") {
-      flat.set(path, value);
+      flat[path] = value;
     } else {
-      for (const [nestedPath, nestedValue] of flatten(value, path)) {
-        flat.set(nestedPath, nestedValue);
-      }
+      Object.assign(flat, flatten(value, path));
     }
   }
   return flat;
@@ -68,11 +66,15 @@ function collectArguments(
   return into;
 }
 
+function sortedArguments(message: string): string[] {
+  return Array.from(collectArguments(parse(message), new Set<string>())).sort();
+}
+
 const flatEnglish = flatten(en as MessageTree);
 
 describe("i18n message catalogs", () => {
   test("every English message is valid ICU", () => {
-    for (const [key, message] of flatEnglish) {
+    for (const [key, message] of Object.entries(flatEnglish)) {
       expect(() => parse(message)).not.toThrow();
       expect(key).not.toBe("");
     }
@@ -83,34 +85,28 @@ describe("i18n message catalogs", () => {
       const flatLocale = flatten(catalog);
 
       test("has no keys that are missing from en.json", () => {
-        const orphans = [...flatLocale.keys()].filter(
-          (key) => !flatEnglish.has(key)
+        const orphans = Object.keys(flatLocale).filter(
+          (key) => !(key in flatEnglish)
         );
         expect(orphans).toEqual([]);
       });
 
       test("every message is valid ICU with the same placeholders as English", () => {
-        for (const [key, message] of flatLocale) {
-          const englishMessage = flatEnglish.get(key);
+        for (const [key, message] of Object.entries(flatLocale)) {
+          const englishMessage = flatEnglish[key];
           if (englishMessage === undefined) continue; // covered by orphan test
 
-          let elements: MessageFormatElement[];
-          expect(() => (elements = parse(message))).not.toThrow();
-          const localeArguments = collectArguments(parse(message), new Set());
-          const englishArguments = collectArguments(
-            parse(englishMessage),
-            new Set()
-          );
-          expect({ key, placeholders: [...localeArguments].sort() }).toEqual({
+          expect(() => parse(message)).not.toThrow();
+          expect({ key, placeholders: sortedArguments(message) }).toEqual({
             key,
-            placeholders: [...englishArguments].sort(),
+            placeholders: sortedArguments(englishMessage),
           });
         }
       });
 
       test("reports untranslated keys without failing", () => {
-        const untranslated = [...flatEnglish.keys()].filter(
-          (key) => !flatLocale.has(key)
+        const untranslated = Object.keys(flatEnglish).filter(
+          (key) => !(key in flatLocale)
         );
         if (untranslated.length > 0) {
           console.warn(

--- a/web/src/i18n/__tests__/catalog.test.ts
+++ b/web/src/i18n/__tests__/catalog.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Guards the message catalogs:
+ * - every message in every locale parses as ICU,
+ * - non-English catalogs contain no keys that are missing from en.json,
+ * - shared keys use exactly the same ICU placeholders as the English source.
+ *
+ * Keys present in en.json but not yet translated are reported, not failed —
+ * that is the expected lag window before the translation pipeline runs.
+ */
+import {
+  parse,
+  TYPE,
+  type MessageFormatElement,
+} from "@formatjs/icu-messageformat-parser";
+
+import de from "@/i18n/messages/de.json";
+import en from "@/i18n/messages/en.json";
+import es from "@/i18n/messages/es.json";
+import fr from "@/i18n/messages/fr.json";
+import pt from "@/i18n/messages/pt.json";
+
+type MessageTree = { [key: string]: string | MessageTree };
+
+const TARGET_LOCALES: Record<string, MessageTree> = { de, es, fr, pt };
+
+function flatten(tree: MessageTree, prefix = ""): Map<string, string> {
+  const flat = new Map<string, string>();
+  for (const [key, value] of Object.entries(tree)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      flat.set(path, value);
+    } else {
+      for (const [nestedPath, nestedValue] of flatten(value, path)) {
+        flat.set(nestedPath, nestedValue);
+      }
+    }
+  }
+  return flat;
+}
+
+function collectArguments(
+  elements: MessageFormatElement[],
+  into: Set<string>
+): Set<string> {
+  for (const element of elements) {
+    switch (element.type) {
+      case TYPE.argument:
+      case TYPE.number:
+      case TYPE.date:
+      case TYPE.time:
+        into.add(element.value);
+        break;
+      case TYPE.plural:
+      case TYPE.select:
+        into.add(element.value);
+        for (const option of Object.values(element.options)) {
+          collectArguments(option.value, into);
+        }
+        break;
+      case TYPE.tag:
+        into.add(element.value);
+        collectArguments(element.children, into);
+        break;
+      default:
+        break;
+    }
+  }
+  return into;
+}
+
+const flatEnglish = flatten(en as MessageTree);
+
+describe("i18n message catalogs", () => {
+  test("every English message is valid ICU", () => {
+    for (const [key, message] of flatEnglish) {
+      expect(() => parse(message)).not.toThrow();
+      expect(key).not.toBe("");
+    }
+  });
+
+  for (const [locale, catalog] of Object.entries(TARGET_LOCALES)) {
+    describe(locale, () => {
+      const flatLocale = flatten(catalog);
+
+      test("has no keys that are missing from en.json", () => {
+        const orphans = [...flatLocale.keys()].filter(
+          (key) => !flatEnglish.has(key)
+        );
+        expect(orphans).toEqual([]);
+      });
+
+      test("every message is valid ICU with the same placeholders as English", () => {
+        for (const [key, message] of flatLocale) {
+          const englishMessage = flatEnglish.get(key);
+          if (englishMessage === undefined) continue; // covered by orphan test
+
+          let elements: MessageFormatElement[];
+          expect(() => (elements = parse(message))).not.toThrow();
+          const localeArguments = collectArguments(parse(message), new Set());
+          const englishArguments = collectArguments(
+            parse(englishMessage),
+            new Set()
+          );
+          expect({ key, placeholders: [...localeArguments].sort() }).toEqual({
+            key,
+            placeholders: [...englishArguments].sort(),
+          });
+        }
+      });
+
+      test("reports untranslated keys without failing", () => {
+        const untranslated = [...flatEnglish.keys()].filter(
+          (key) => !flatLocale.has(key)
+        );
+        if (untranslated.length > 0) {
+          console.warn(
+            `[i18n] ${locale}: ${untranslated.length} untranslated key(s) ` +
+              `(English fallback renders until the translation pipeline runs): ` +
+              untranslated.slice(0, 20).join(", ")
+          );
+        }
+        expect(true).toBe(true);
+      });
+    });
+  }
+});

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -1,1 +1,609 @@
-{}
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "Konto"
+    },
+    "helpFaq": {
+      "label": "Hilfe & FAQ"
+    },
+    "logIn": {
+      "label": "Anmelden"
+    },
+    "logoutFailed": {
+      "message": "Abmeldung fehlgeschlagen"
+    },
+    "notifications": {
+      "label": "Benachrichtigungen"
+    },
+    "profileUnavailable": {
+      "title": "Profil nicht verfügbar"
+    },
+    "settings": {
+      "label": "Einstellungen"
+    },
+    "signOut": {
+      "label": "Abmelden"
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "Neue Organisation erstellen"
+      },
+      "createTeamOption": {
+        "text": "Ein neues Onyx-Team erstellen"
+      },
+      "differentEmailPrompt": {
+        "text": "Haben Sie ein Konto mit einer anderen E-Mail-Adresse?"
+      },
+      "heading": {
+        "title": "Konto nicht gefunden"
+      },
+      "inviteOption": {
+        "text": "In ein bestehendes Onyx-Team eingeladen werden"
+      },
+      "notFound": {
+        "description": "Wir konnten Ihr Konto nicht finden. Um auf Onyx zuzugreifen, haben Sie folgende Möglichkeiten:"
+      },
+      "signInLink": {
+        "label": "Anmelden"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "Zugriffsbeschränkungen oder Berechtigungen des Kontos"
+      },
+      "cloudSupportPrompt": {
+        "text": "Wenn das Problem weiterhin besteht, wenden Sie sich an das Onyx-Team unter <link>support@onyx.app</link>"
+      },
+      "code": {
+        "accessDenied": "Ihr Identitätsanbieter hat den Zugriff verweigert.",
+        "consentRequired": "Ihr Identitätsanbieter erfordert eine Zustimmung, bevor Sie fortfahren können.",
+        "interactionRequired": "Eine zusätzliche Interaktion mit Ihrem Identitätsanbieter ist erforderlich.",
+        "invalidScope": "Die angeforderten Berechtigungen sind nicht verfügbar.",
+        "loginBadCredentials": "Dieses Konto kann sich nicht anmelden. Es ist möglicherweise deaktiviert. Wenden Sie sich an den Administrator Ihres Arbeitsbereichs.",
+        "loginRequired": "Sie müssen sich zuerst bei Ihrem Identitätsanbieter anmelden.",
+        "oauthUserAlreadyExists": "Ein Konto mit dieser E-Mail-Adresse existiert bereits mit einer anderen Anmeldemethode. Melden Sie sich wie beim ersten Mal an, oder bitten Sie Ihren Administrator, diesen Anbieter zu verknüpfen.",
+        "serverError": "Bei Ihrem Identitätsanbieter ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+        "temporarilyUnavailable": "Ihr Identitätsanbieter ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut."
+      },
+      "credentialsIssue": {
+        "description": "Falsche oder abgelaufene Anmeldedaten"
+      },
+      "heading": {
+        "description": "Bei Ihrem Anmeldeversuch ist ein Problem aufgetreten.",
+        "title": "Authentifizierungsfehler"
+      },
+      "possibleIssues": {
+        "title": "Mögliche Ursachen:"
+      },
+      "returnToLoginButton": {
+        "label": "Zurück zur Anmeldeseite"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "Wenn das Problem weiterhin besteht, wenden Sie sich an Ihren Systemadministrator."
+      },
+      "systemDisruptionIssue": {
+        "description": "Vorübergehende Störung des Authentifizierungssystems"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[Zurück zur Anmeldung](/auth/login)"
+      },
+      "emailField": {
+        "label": "E-Mail"
+      },
+      "emailSent": {
+        "toast": "E-Mail zum Zurücksetzen des Passworts gesendet. Bitte prüfen Sie Ihren Posteingang."
+      },
+      "genericError": {
+        "toast": "Beim Zurücksetzen des Passworts ist ein Fehler aufgetreten."
+      },
+      "heading": {
+        "title": "Passwort vergessen"
+      },
+      "submitButton": {
+        "label": "Passwort zurücksetzen"
+      },
+      "unexpectedError": {
+        "toast": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "Hinweis: Diese Funktion ist nur für @onyx.app-Administratoren verfügbar"
+      },
+      "apiKeyField": {
+        "label": "API-Schlüssel",
+        "placeholder": "API-Schlüssel eingeben"
+      },
+      "emailField": {
+        "label": "E-Mail"
+      },
+      "genericError": {
+        "toast": "Benutzer konnte nicht übernommen werden"
+      },
+      "heading": {
+        "title": "Benutzeridentität übernehmen"
+      },
+      "invalidEmail": {
+        "error": "Ungültige E-Mail-Adresse"
+      },
+      "requiredField": {
+        "error": "Erforderlich"
+      },
+      "submitButton": {
+        "label": "Benutzeridentität übernehmen"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "Erneut anmelden, um dem Team beizutreten"
+      },
+      "orDivider": {
+        "text": "oder"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "Konto erstellen"
+      },
+      "noSsoProviders": {
+        "error": "Für diese Adresse ist keine SSO-Anmeldung eingerichtet. Versuchen Sie Google oder Ihr Passwort unten."
+      },
+      "resetPasswordButton": {
+        "label": "Passwort zurücksetzen"
+      },
+      "signupPrompt": {
+        "text": "Sie haben noch kein Konto?"
+      },
+      "ssoEmailInvalid": {
+        "error": "Geben Sie eine gültige E-Mail-Adresse ein"
+      },
+      "ssoEmailRequired": {
+        "error": "E-Mail ist erforderlich"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "In der Anmeldeantwort fehlte die Autorisierungs-URL"
+      },
+      "ssoSignInButton": {
+        "label": "Mit SSO anmelden"
+      },
+      "ssoStartFailed": {
+        "error": "Anmeldung konnte nicht gestartet werden (Status {status})"
+      },
+      "verifiedMessage": {
+        "title": "Ihre E-Mail-Adresse wurde bestätigt! Bitte melden Sie sich an, um fortzufahren."
+      },
+      "workEmailField": {
+        "label": "Geschäftliche E-Mail"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[Zurück zur Anmeldung](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "Neues Passwort bestätigen",
+        "placeholder": "Bestätigen Sie Ihr neues Passwort"
+      },
+      "confirmPasswordRequired": {
+        "error": "Passwortbestätigung ist erforderlich"
+      },
+      "genericError": {
+        "toast": "Beim Zurücksetzen des Passworts ist ein Fehler aufgetreten."
+      },
+      "heading": {
+        "title": "Passwort zurücksetzen"
+      },
+      "invalidPassword": {
+        "error": "Ungültiges Passwort"
+      },
+      "missingToken": {
+        "toast": "Ungültiges oder fehlendes Zurücksetzungs-Token."
+      },
+      "newPasswordField": {
+        "label": "Neues Passwort",
+        "placeholder": "Geben Sie Ihr neues Passwort ein"
+      },
+      "passwordRequired": {
+        "error": "Passwort ist erforderlich"
+      },
+      "passwordsMatch": {
+        "error": "Die Passwörter müssen übereinstimmen"
+      },
+      "submitButton": {
+        "label": "Passwort zurücksetzen"
+      },
+      "successRedirect": {
+        "toast": "Passwort erfolgreich zurückgesetzt. Weiterleitung zur Anmeldung..."
+      },
+      "unexpectedError": {
+        "toast": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "Registrierung abschließen"
+      },
+      "createAccountHeading": {
+        "title": "Konto erstellen"
+      },
+      "orDivider": {
+        "text": "oder"
+      },
+      "referralOptionAds": {
+        "label": "Werbung"
+      },
+      "referralOptionBlog": {
+        "label": "Artikel/Blog"
+      },
+      "referralOptionFriend": {
+        "label": "Freund/Kollege"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "Sonstiges"
+      },
+      "referralOptionPodcast": {
+        "label": "Podcast"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "Suchmaschine (Google/Bing)"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "Option auswählen"
+      },
+      "referralQuestion": {
+        "label": "Wie haben Sie von uns erfahren?"
+      },
+      "subtitle": {
+        "text": "Starten Sie mit Onyx"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "Neue Bestätigungs-E-Mail anfordern"
+      },
+      "missingToken": {
+        "error": "Bestätigungs-Token fehlt. Fordern Sie eine neue Bestätigungs-E-Mail an."
+      },
+      "unknownError": {
+        "text": "unbekannter Fehler"
+      },
+      "verificationFailed": {
+        "error": "Ihre E-Mail-Adresse konnte nicht bestätigt werden: {errorDetail}. Fordern Sie eine neue Bestätigungs-E-Mail an."
+      },
+      "verifying": {
+        "text": "Ihre E-Mail-Adresse wird bestätigt..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "Eine neue Bestätigungs-E-Mail wurde gesendet!"
+      },
+      "greeting": {
+        "text": "Hallo, *{email}*, Sie haben Ihre E-Mail-Adresse anscheinend noch nicht bestätigt.\nPrüfen Sie Ihren Posteingang auf eine E-Mail von uns, um loszulegen!"
+      },
+      "helpPrompt": {
+        "text": "Wenn Sie nichts finden, klicken Sie <link>hier</link>, um eine neue E-Mail anzufordern."
+      },
+      "sendFailed": {
+        "toast": "Es konnte keine neue Bestätigungs-E-Mail gesendet werden: {errorDetail}"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "anonym",
+        "description": "Ihre Konto-E-Mail-Adresse.",
+        "title": "E-Mail"
+      },
+      "password": {
+        "changeButton": "Passwort ändern",
+        "description": "Aktualisieren Sie das Passwort Ihres Kontos.",
+        "title": "Passwort"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "Neues Passwort bestätigen"
+        },
+        "currentPassword": {
+          "title": "Aktuelles Passwort"
+        },
+        "newPassword": {
+          "title": "Neues Passwort"
+        },
+        "submit": {
+          "update": "Aktualisieren",
+          "updating": "Wird aktualisiert..."
+        },
+        "title": "Passwort ändern",
+        "toasts": {
+          "networkError": "Beim Ändern des Passworts ist ein Fehler aufgetreten",
+          "updateFailed": "Passwort konnte nicht geändert werden",
+          "updated": "Passwort erfolgreich aktualisiert"
+        }
+      },
+      "title": "Konten"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "Alle API-Anfragen, die dieses Token verwenden, übernehmen Ihre Zugriffsberechtigungen und werden Ihnen persönlich zugeordnet.",
+        "expiration": {
+          "days30": "30 Tage",
+          "days365": "365 Tage",
+          "days7": "7 Tage",
+          "expiresAtNote": "Dieses Token läuft ab am: {date}",
+          "noExpiration": "Kein Ablaufdatum",
+          "placeholder": "Ablauf auswählen",
+          "title": "Läuft ab in"
+        },
+        "name": {
+          "placeholder": "Benennen Sie Ihr Token",
+          "title": "Token-Name"
+        },
+        "permissions": {
+          "fullAccessNote": "Übernimmt alle Ihre Berechtigungen.",
+          "fullAccessOption": "Vollzugriff",
+          "limitedAccessNote": "Beschränken Sie dieses Token auf bestimmte Funktionen.",
+          "limitedAccessOption": "Eingeschränkter Zugriff",
+          "placeholder": "Berechtigungen auswählen",
+          "title": "Berechtigungen"
+        },
+        "submit": {
+          "create": "Token erstellen",
+          "creating": "Token wird erstellt..."
+        },
+        "title": "Zugriffstoken erstellen"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {Vor # Tag erstellt} other {Vor # Tagen erstellt}}",
+        "createdToday": "Heute erstellt",
+        "deleteTokenAriaLabel": "Token {name} löschen",
+        "empty": "Keine Zugriffstoken erstellt.",
+        "expiresIn": "{count, plural, one {Läuft in # Tag ab} other {Läuft in # Tagen ab}}",
+        "loading": "Token werden geladen...",
+        "neverExpires": "Läuft nie ab",
+        "newTokenButton": "Neues Zugriffstoken",
+        "noPermissionTooltip": "Sie haben keine Berechtigung, Zugriffstoken zu erstellen",
+        "searchPlaceholder": "Suchen..."
+      },
+      "revokeModal": {
+        "description": "Jede Anwendung, die das Token {name} ({tokenDisplay}) verwendet, verliert den Zugriff auf Onyx. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "question": "Möchten Sie dieses Token wirklich widerrufen?",
+        "submit": "Widerrufen",
+        "title": "Zugriffstoken widerrufen"
+      },
+      "scopeSelector": {
+        "includedWith": "{label} (enthalten in {lockReason})",
+        "loadError": "Berechtigungen konnten nicht geladen werden.",
+        "loading": "Berechtigungen werden geladen..."
+      },
+      "section": {
+        "title": "Zugriffstoken"
+      },
+      "toasts": {
+        "createFailed": "Token konnte nicht erstellt werden",
+        "createNetworkError": "Netzwerkfehler beim Erstellen des Tokens",
+        "created": "Token erfolgreich erstellt",
+        "deleteFailed": "Token konnte nicht gelöscht werden",
+        "deleteNetworkError": "Netzwerkfehler beim Löschen des Tokens",
+        "deleted": "Token erfolgreich gelöscht",
+        "loadFailed": "Token konnten nicht geladen werden",
+        "loadPermissionsFailed": "Berechtigungsoptionen konnten nicht geladen werden",
+        "nameRequired": "Token-Name ist erforderlich"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "Token kopieren",
+        "description": "Speichern Sie dieses Token, bevor Sie fortfahren. Es wird nicht erneut angezeigt.",
+        "title": "Zugriffstoken"
+      },
+      "upsell": {
+        "description": "Zugriffstoken erfordern ein aktives kostenpflichtiges Abonnement.",
+        "upgradeButton": "Tarif upgraden"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "Keiner",
+        "optionAriaLabel": "{label}-Hintergrund{selected, select, true { (ausgewählt)} other {}}",
+        "title": "Chat-Hintergrund"
+      },
+      "colorMode": {
+        "auto": "Automatisch",
+        "dark": "Dunkel",
+        "description": "Wählen Sie Ihren bevorzugten Farbmodus für die Benutzeroberfläche.",
+        "light": "Hell",
+        "title": "Farbmodus"
+      },
+      "language": {
+        "description": "Wählen Sie die Sprache für die Benutzeroberfläche.",
+        "title": "Sprache"
+      },
+      "title": "Erscheinungsbild"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "Scrollt automatisch zu neuen Inhalten, während der Chat die Antwort generiert.",
+        "title": "Automatisches Scrollen im Chat"
+      },
+      "collapseLargePastes": {
+        "description": "Wenn Sie Text einfügen, der länger als 3 Zeilen oder 200 Zeichen ist, wird er in einer kompakten Kachel zusammengefasst, anstatt ihn direkt einzufügen. Klicken Sie auf die Kachel, um den vollständigen Text anzuzeigen oder zu bearbeiten.",
+        "title": "Große eingefügte Texte einklappen"
+      },
+      "defaultAppMode": {
+        "chatOption": "Chat",
+        "description": "Wählen Sie, ob neue Sitzungen im Such- oder im Chat-Modus starten.",
+        "disabledTooltip": "Die Suchoberfläche ist deaktiviert und kann nur von einem Administrator aktiviert werden.",
+        "searchOption": "Suche",
+        "title": "Standard-App-Modus"
+      },
+      "defaultModel": {
+        "description": "Dieses Modell wird von Onyx standardmäßig in Ihren Chats verwendet.",
+        "title": "Standardmodell"
+      },
+      "smoothStreaming": {
+        "description": "Animiert gestreamte Antworten Zeichen für Zeichen. Deaktivieren Sie diese Option, um Textblöcke sofort bei Eintreffen anzuzeigen.",
+        "title": "Sanftes Streaming"
+      },
+      "title": "Chats",
+      "toasts": {
+        "saveFailed": "Einstellungen konnten nicht gespeichert werden",
+        "saved": "Einstellungen gespeichert"
+      }
+    },
+    "connectors": {
+      "connectButton": "Verbinden",
+      "disconnectModal": {
+        "continueNote": "Sie können bestehende Sitzungen, die auf Inhalte von {name} verweisen, weiterhin fortsetzen.",
+        "description": "Onyx kann nicht mehr auf Inhalte aus Ihrem {name}-Konto zugreifen oder diese durchsuchen.",
+        "disconnecting": "Wird getrennt...",
+        "submit": "Trennen",
+        "title": "*{name}* trennen"
+      },
+      "emptyMessage": "Für Ihre Organisation sind keine Konnektoren eingerichtet.",
+      "status": {
+        "connected": "Verbunden",
+        "notConnected": "Nicht verbunden",
+        "paused": "Pausiert"
+      },
+      "title": "Konnektoren",
+      "toasts": {
+        "disconnectFailed": "Trennung fehlgeschlagen",
+        "disconnected": "Erfolgreich getrennt"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "Alle Chats löschen",
+        "confirm": {
+          "deleting": "Wird gelöscht...",
+          "description": "Alle Ihre Chat-Sitzungen und Ihr Verlauf werden dauerhaft gelöscht. Das Löschen kann nicht rückgängig gemacht werden.",
+          "question": "Möchten Sie wirklich alle Chats löschen?",
+          "submit": "Löschen",
+          "title": "Alle Chats löschen"
+        },
+        "description": "Löschen Sie alle Ihre Chat-Sitzungen dauerhaft.",
+        "title": "Alle Chats löschen",
+        "toasts": {
+          "deleteFailed": "Alle Chat-Sitzungen konnten nicht gelöscht werden",
+          "deleted": "Alle Ihre Chat-Sitzungen wurden gelöscht."
+        }
+      },
+      "title": "Gefahrenzone"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "Neues Token",
+        "description": "Erstellen Sie ein eingeschränktes Token, bevor Sie eine Anwendung verbinden.",
+        "title": "Zugriffstoken"
+      },
+      "copyButton": {
+        "copied": "Kopiert",
+        "copy": "Kopieren",
+        "copyError": "Wert konnte nicht kopiert werden."
+      },
+      "description": "Verbinden Sie externe Tools mit den Modellen, die Ihnen in Onyx zur Verfügung stehen.",
+      "guideButton": "Anleitung",
+      "models": {
+        "description": "{count, plural, other {# Modelle sind für Ihr Konto verfügbar. Öffnen Sie einen Anbieter, um eine ID zu kopieren.}}",
+        "title": "Modelle"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# Modell verfügbar} other {# Modelle verfügbar}}"
+      },
+      "title": "LLM Gateway",
+      "url": {
+        "description": "Verwenden Sie diese Basis-URL mit kompatiblen OpenAI- und Anthropic-Clients.",
+        "title": "Gateway-URL"
+      }
+    },
+    "memory": {
+      "referenceStoredMemories": {
+        "description": "Lassen Sie Onyx gespeicherte Erinnerungen in Chats verwenden.",
+        "title": "Gespeicherte Erinnerungen verwenden"
+      },
+      "title": "Erinnerungen",
+      "updateMemories": {
+        "description": "Lassen Sie Onyx gespeicherte Erinnerungen erstellen und aktualisieren.",
+        "title": "Erinnerungen aktualisieren"
+      }
+    },
+    "personalPreferences": {
+      "description": "Geben Sie Ihre individuellen Präferenzen in natürlicher Sprache an.",
+      "placeholder": "Beschreiben Sie, wie sich das System verhalten soll und welchen Ton es verwenden soll.",
+      "title": "Persönliche Präferenzen"
+    },
+    "profile": {
+      "fullName": {
+        "description": "Wir zeigen diesen Namen in der App an.",
+        "placeholder": "Ihr Name",
+        "title": "Vollständiger Name"
+      },
+      "title": "Profil",
+      "toasts": {
+        "updateFailed": "Personalisierung konnte nicht aktualisiert werden",
+        "updated": "Personalisierung erfolgreich aktualisiert"
+      },
+      "workRole": {
+        "description": "Teilen Sie Ihre Rolle mit, um Antworten besser anzupassen.",
+        "placeholder": "Ihre Rolle",
+        "title": "Berufliche Rolle"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "Geben Sie eine kurze Zusammenfassung des Folgenden in 1–2 Sätzen an:",
+        "promptPlaceholder": "Zusammenfassen",
+        "publicTooltip": "Öffentliche Prompt-Shortcuts können nicht gelöscht werden.",
+        "removeAriaLabel": "Shortcut entfernen"
+      },
+      "title": "Prompt-Shortcuts",
+      "toasts": {
+        "bothRequired": "Shortcut und Erweiterung sind beide erforderlich",
+        "created": "Shortcut erstellt",
+        "deleteFailed": "Shortcut konnte nicht gelöscht werden",
+        "deleted": "Shortcut gelöscht",
+        "loadFailed": "Shortcuts konnten nicht geladen werden",
+        "saveFailed": "Shortcut konnte nicht gespeichert werden",
+        "updated": "Shortcut aktualisiert"
+      },
+      "toggle": {
+        "description": "Aktivieren Sie Shortcuts, um häufig verwendete Prompts schnell einzufügen.",
+        "title": "Prompt-Shortcuts verwenden"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "Sprachantworten automatisch abspielen.",
+        "title": "Automatische Wiedergabe"
+      },
+      "autoSend": {
+        "description": "Spracheingabe automatisch senden, wenn Sie zu sprechen aufhören.",
+        "title": "Automatisches Senden bei Pause"
+      },
+      "playbackSpeed": {
+        "description": "Passen Sie die Geschwindigkeit der Sprachwiedergabe an.",
+        "title": "Wiedergabegeschwindigkeit"
+      },
+      "title": "Sprachfunktionen"
+    }
+  }
+}

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -435,7 +435,8 @@
       },
       "language": {
         "description": "Wählen Sie die Sprache für die Benutzeroberfläche.",
-        "title": "Sprache"
+        "title": "Sprache",
+        "updateFailed": "Die Spracheinstellung konnte nicht aktualisiert werden"
       },
       "title": "Erscheinungsbild"
     },
@@ -523,7 +524,7 @@
       "description": "Verbinden Sie externe Tools mit den Modellen, die Ihnen in Onyx zur Verfügung stehen.",
       "guideButton": "Anleitung",
       "models": {
-        "description": "{count, plural, other {# Modelle sind für Ihr Konto verfügbar. Öffnen Sie einen Anbieter, um eine ID zu kopieren.}}",
+        "description": "{count, plural, one {# Modell ist für Ihr Konto verfügbar. Öffnen Sie einen Anbieter, um eine ID zu kopieren.} other {# Modelle sind für Ihr Konto verfügbar. Öffnen Sie einen Anbieter, um eine ID zu kopieren.}}",
         "title": "Modelle"
       },
       "provider": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -460,6 +460,14 @@
         "description": "Dieses Modell wird von Onyx standardmäßig in Ihren Chats verwendet.",
         "title": "Standardmodell"
       },
+      "defaultReasoningLevel": {
+        "description": "Anfängliche Reasoning-Stufe für Ihre neuen Chats. Admin-Einstellungen eines Modells gelten immer, und jeder Chat kann sie in seinen Modelleinstellungen überschreiben.",
+        "title": "Standard-Reasoning-Stufe"
+      },
+      "defaultTemperature": {
+        "description": "Anfangstemperatur für Ihre neuen Chats. Admin-Einstellungen eines Modells gelten immer, und jeder Chat kann sie in seinen Modelleinstellungen überschreiben.",
+        "title": "Standard-Temperatur"
+      },
       "smoothStreaming": {
         "description": "Animiert gestreamte Antworten Zeichen für Zeichen. Deaktivieren Sie diese Option, um Textblöcke sofort bei Eintreffen anzuzeigen.",
         "title": "Sanftes Streaming"

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -460,6 +460,14 @@
         "description": "This model will be used by Onyx by default in your chats.",
         "title": "Default Model"
       },
+      "defaultReasoningLevel": {
+        "description": "Starting reasoning level for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings.",
+        "title": "Default Reasoning Level"
+      },
+      "defaultTemperature": {
+        "description": "Starting temperature for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings.",
+        "title": "Default Temperature"
+      },
       "smoothStreaming": {
         "description": "Animate streamed responses character-by-character. Disable to render chunks as they arrive.",
         "title": "Smooth Streaming"

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -435,7 +435,8 @@
       },
       "language": {
         "description": "Select the language for the UI.",
-        "title": "Language"
+        "title": "Language",
+        "updateFailed": "Failed to update language preference"
       },
       "title": "Appearance"
     },
@@ -523,7 +524,7 @@
       "description": "Connect external tools to the models available to you in Onyx.",
       "guideButton": "Guide",
       "models": {
-        "description": "{count, plural, other {# models are available to your account. Open a provider to copy an ID.}}",
+        "description": "{count, plural, one {# model is available to your account. Open a provider to copy an ID.} other {# models are available to your account. Open a provider to copy an ID.}}",
         "title": "Models"
       },
       "provider": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -1,1 +1,609 @@
-{}
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "Account"
+    },
+    "helpFaq": {
+      "label": "Help & FAQ"
+    },
+    "logIn": {
+      "label": "Log in"
+    },
+    "logoutFailed": {
+      "message": "Failed to logout"
+    },
+    "notifications": {
+      "label": "Notifications"
+    },
+    "profileUnavailable": {
+      "title": "Profile unavailable"
+    },
+    "settings": {
+      "label": "Settings"
+    },
+    "signOut": {
+      "label": "Log Out"
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "Create New Organization"
+      },
+      "createTeamOption": {
+        "text": "Create a new Onyx team"
+      },
+      "differentEmailPrompt": {
+        "text": "Have an account with a different email?"
+      },
+      "heading": {
+        "title": "Account Not Found"
+      },
+      "inviteOption": {
+        "text": "Be invited to an existing Onyx team"
+      },
+      "notFound": {
+        "description": "We couldn't find your account in our records. To access Onyx, you need to either:"
+      },
+      "signInLink": {
+        "label": "Sign in"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "Account access restrictions or permissions"
+      },
+      "cloudSupportPrompt": {
+        "text": "If you continue to experience problems, please reach out to the Onyx team at <link>support@onyx.app</link>"
+      },
+      "code": {
+        "accessDenied": "Access was denied by your identity provider.",
+        "consentRequired": "Your identity provider requires consent before continuing.",
+        "interactionRequired": "Additional interaction with your identity provider is required.",
+        "invalidScope": "The requested permissions are not available.",
+        "loginBadCredentials": "This account can't sign in. It may be deactivated. Contact your workspace admin.",
+        "loginRequired": "You need to log in with your identity provider first.",
+        "oauthUserAlreadyExists": "An account with this email already exists under a different sign-in method. Sign in the way you first did, or ask your admin to link this provider.",
+        "serverError": "Your identity provider encountered an error. Please try again.",
+        "temporarilyUnavailable": "Your identity provider is temporarily unavailable. Please try again later."
+      },
+      "credentialsIssue": {
+        "description": "Incorrect or expired login credentials"
+      },
+      "heading": {
+        "description": "There was a problem with your login attempt.",
+        "title": "Authentication Error"
+      },
+      "possibleIssues": {
+        "title": "Possible Issues:"
+      },
+      "returnToLoginButton": {
+        "label": "Return to Login Page"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "If you continue to experience problems, please reach out to your system administrator for assistance."
+      },
+      "systemDisruptionIssue": {
+        "description": "Temporary authentication system disruption"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[Back to Login](/auth/login)"
+      },
+      "emailField": {
+        "label": "Email"
+      },
+      "emailSent": {
+        "toast": "Password reset email sent. Please check your inbox."
+      },
+      "genericError": {
+        "toast": "An error occurred during password reset."
+      },
+      "heading": {
+        "title": "Forgot Password"
+      },
+      "submitButton": {
+        "label": "Reset Password"
+      },
+      "unexpectedError": {
+        "toast": "An error occurred. Please try again."
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "Note: This feature is only available for @onyx.app administrators"
+      },
+      "apiKeyField": {
+        "label": "API Key",
+        "placeholder": "Enter API Key"
+      },
+      "emailField": {
+        "label": "Email"
+      },
+      "genericError": {
+        "toast": "Failed to impersonate user"
+      },
+      "heading": {
+        "title": "Impersonate User"
+      },
+      "invalidEmail": {
+        "error": "Invalid email"
+      },
+      "requiredField": {
+        "error": "Required"
+      },
+      "submitButton": {
+        "label": "Impersonate User"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "Re-authenticate to join team"
+      },
+      "orDivider": {
+        "text": "or"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "Create an account"
+      },
+      "noSsoProviders": {
+        "error": "No SSO sign-in is set up for that address. Try Google or your password below."
+      },
+      "resetPasswordButton": {
+        "label": "Reset Password"
+      },
+      "signupPrompt": {
+        "text": "Don't have an account?"
+      },
+      "ssoEmailInvalid": {
+        "error": "Enter a valid email address"
+      },
+      "ssoEmailRequired": {
+        "error": "Email is required"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "Sign-in response was missing the authorization URL"
+      },
+      "ssoSignInButton": {
+        "label": "Sign in with SSO"
+      },
+      "ssoStartFailed": {
+        "error": "Could not start sign-in (status {status})"
+      },
+      "verifiedMessage": {
+        "title": "Your email has been verified! Please sign in to continue."
+      },
+      "workEmailField": {
+        "label": "Work Email"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[Back to Login](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "Confirm New Password",
+        "placeholder": "Confirm your new password"
+      },
+      "confirmPasswordRequired": {
+        "error": "Confirm Password is required"
+      },
+      "genericError": {
+        "toast": "An error occurred during password reset."
+      },
+      "heading": {
+        "title": "Reset Password"
+      },
+      "invalidPassword": {
+        "error": "Invalid password"
+      },
+      "missingToken": {
+        "toast": "Invalid or missing reset token."
+      },
+      "newPasswordField": {
+        "label": "New Password",
+        "placeholder": "Enter your new password"
+      },
+      "passwordRequired": {
+        "error": "Password is required"
+      },
+      "passwordsMatch": {
+        "error": "Passwords must match"
+      },
+      "submitButton": {
+        "label": "Reset Password"
+      },
+      "successRedirect": {
+        "toast": "Password reset successfully. Redirecting to login..."
+      },
+      "unexpectedError": {
+        "toast": "An unexpected error occurred. Please try again."
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "Complete your sign up"
+      },
+      "createAccountHeading": {
+        "title": "Create account"
+      },
+      "orDivider": {
+        "text": "or"
+      },
+      "referralOptionAds": {
+        "label": "Advertisements"
+      },
+      "referralOptionBlog": {
+        "label": "Article/Blog"
+      },
+      "referralOptionFriend": {
+        "label": "Friend/Colleague"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "Other"
+      },
+      "referralOptionPodcast": {
+        "label": "Podcast"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "Search Engine (Google/Bing)"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "Select an option"
+      },
+      "referralQuestion": {
+        "label": "How did you hear about us?"
+      },
+      "subtitle": {
+        "text": "Get started with Onyx"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "Get new verification email"
+      },
+      "missingToken": {
+        "error": "Missing verification token. Try requesting a new verification email."
+      },
+      "unknownError": {
+        "text": "unknown error"
+      },
+      "verificationFailed": {
+        "error": "Failed to verify your email - {errorDetail}. Please try requesting a new verification email."
+      },
+      "verifying": {
+        "text": "Verifying your email..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "A new verification email has been sent!"
+      },
+      "greeting": {
+        "text": "Hey, *{email}*, it looks like you haven't verified your email yet.\nCheck your inbox for an email from us to get started!"
+      },
+      "helpPrompt": {
+        "text": "If you don't see anything, click <link>here</link> to request a new email."
+      },
+      "sendFailed": {
+        "toast": "Failed to send a new verification email - {errorDetail}"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "anonymous",
+        "description": "Your account email address.",
+        "title": "Email"
+      },
+      "password": {
+        "changeButton": "Change Password",
+        "description": "Update your account password.",
+        "title": "Password"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "Confirm New Password"
+        },
+        "currentPassword": {
+          "title": "Current Password"
+        },
+        "newPassword": {
+          "title": "New Password"
+        },
+        "submit": {
+          "update": "Update",
+          "updating": "Updating..."
+        },
+        "title": "Change Password",
+        "toasts": {
+          "networkError": "An error occurred while changing the password",
+          "updateFailed": "Failed to change password",
+          "updated": "Password updated successfully"
+        }
+      },
+      "title": "Accounts"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "All API requests using this token will inherit your access permissions and be attributed to you as an individual.",
+        "expiration": {
+          "days30": "30 days",
+          "days365": "365 days",
+          "days7": "7 days",
+          "expiresAtNote": "This token will expire at: {date}",
+          "noExpiration": "No expiration",
+          "placeholder": "Select expiration",
+          "title": "Expires in"
+        },
+        "name": {
+          "placeholder": "Name your token",
+          "title": "Token Name"
+        },
+        "permissions": {
+          "fullAccessNote": "Inherits all of your permissions.",
+          "fullAccessOption": "Full access",
+          "limitedAccessNote": "Limit this token to specific capabilities.",
+          "limitedAccessOption": "Limited access",
+          "placeholder": "Select permissions",
+          "title": "Permissions"
+        },
+        "submit": {
+          "create": "Create Token",
+          "creating": "Creating Token..."
+        },
+        "title": "Create Access Token"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {Created # day ago} other {Created # days ago}}",
+        "createdToday": "Created today",
+        "deleteTokenAriaLabel": "Delete token {name}",
+        "empty": "No access tokens created.",
+        "expiresIn": "{count, plural, one {Expires in # day} other {Expires in # days}}",
+        "loading": "Loading tokens...",
+        "neverExpires": "Never expires",
+        "newTokenButton": "New Access Token",
+        "noPermissionTooltip": "You don't have permission to create access tokens",
+        "searchPlaceholder": "Search..."
+      },
+      "revokeModal": {
+        "description": "Any application using the token {name} ({tokenDisplay}) will lose access to Onyx. This action cannot be undone.",
+        "question": "Are you sure you want to revoke this token?",
+        "submit": "Revoke",
+        "title": "Revoke Access Token"
+      },
+      "scopeSelector": {
+        "includedWith": "{label} (included with {lockReason})",
+        "loadError": "Couldn't load permissions.",
+        "loading": "Loading permissions..."
+      },
+      "section": {
+        "title": "Access Tokens"
+      },
+      "toasts": {
+        "createFailed": "Failed to create token",
+        "createNetworkError": "Network error creating token",
+        "created": "Token created successfully",
+        "deleteFailed": "Failed to delete token",
+        "deleteNetworkError": "Network error deleting token",
+        "deleted": "Token deleted successfully",
+        "loadFailed": "Failed to load tokens",
+        "loadPermissionsFailed": "Failed to load permission options",
+        "nameRequired": "Token name is required"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "Copy Token",
+        "description": "Save this token before continuing. It won't be shown again.",
+        "title": "Access Token"
+      },
+      "upsell": {
+        "description": "Access tokens require an active paid subscription.",
+        "upgradeButton": "Upgrade Plan"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "None",
+        "optionAriaLabel": "{label} background{selected, select, true { (selected)} other {}}",
+        "title": "Chat Background"
+      },
+      "colorMode": {
+        "auto": "Auto",
+        "dark": "Dark",
+        "description": "Select your preferred color mode for the UI.",
+        "light": "Light",
+        "title": "Color Mode"
+      },
+      "language": {
+        "description": "Select the language for the UI.",
+        "title": "Language"
+      },
+      "title": "Appearance"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "Automatically scroll to new content as chat generates response.",
+        "title": "Chat Auto-scroll"
+      },
+      "collapseLargePastes": {
+        "description": "When pasting text longer than 3 lines or 200 characters, collapse it into a compact tile instead of inserting it inline. Click the tile to view or edit the full text.",
+        "title": "Collapse Large Pastes"
+      },
+      "defaultAppMode": {
+        "chatOption": "Chat",
+        "description": "Choose whether new sessions start in Search or Chat mode.",
+        "disabledTooltip": "Search UI is disabled and can only be enabled by an admin.",
+        "searchOption": "Search",
+        "title": "Default App Mode"
+      },
+      "defaultModel": {
+        "description": "This model will be used by Onyx by default in your chats.",
+        "title": "Default Model"
+      },
+      "smoothStreaming": {
+        "description": "Animate streamed responses character-by-character. Disable to render chunks as they arrive.",
+        "title": "Smooth Streaming"
+      },
+      "title": "Chats",
+      "toasts": {
+        "saveFailed": "Failed to save preferences",
+        "saved": "Preferences saved"
+      }
+    },
+    "connectors": {
+      "connectButton": "Connect",
+      "disconnectModal": {
+        "continueNote": "You can still continue existing sessions referencing {name} content.",
+        "description": "Onyx will no longer be able to access or search content from your {name} account.",
+        "disconnecting": "Disconnecting...",
+        "submit": "Disconnect",
+        "title": "Disconnect *{name}*"
+      },
+      "emptyMessage": "No connectors set up for your organization.",
+      "status": {
+        "connected": "Connected",
+        "notConnected": "Not connected",
+        "paused": "Paused"
+      },
+      "title": "Connectors",
+      "toasts": {
+        "disconnectFailed": "Failed to disconnect",
+        "disconnected": "Disconnected successfully"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "Delete All Chats",
+        "confirm": {
+          "deleting": "Deleting...",
+          "description": "All your chat sessions and history will be permanently deleted. Deletion cannot be undone.",
+          "question": "Are you sure you want to delete all chats?",
+          "submit": "Delete",
+          "title": "Delete All Chats"
+        },
+        "description": "Permanently delete all your chat sessions.",
+        "title": "Delete All Chats",
+        "toasts": {
+          "deleteFailed": "Failed to delete all chat sessions",
+          "deleted": "All your chat sessions have been deleted."
+        }
+      },
+      "title": "Danger Zone"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "New token",
+        "description": "Create a scoped token before you connect an application.",
+        "title": "Access token"
+      },
+      "copyButton": {
+        "copied": "Copied",
+        "copy": "Copy",
+        "copyError": "Could not copy value."
+      },
+      "description": "Connect external tools to the models available to you in Onyx.",
+      "guideButton": "Guide",
+      "models": {
+        "description": "{count, plural, other {# models are available to your account. Open a provider to copy an ID.}}",
+        "title": "Models"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# model available} other {# models available}}"
+      },
+      "title": "LLM Gateway",
+      "url": {
+        "description": "Use this base URL with compatible OpenAI and Anthropic clients.",
+        "title": "Gateway URL"
+      }
+    },
+    "memory": {
+      "referenceStoredMemories": {
+        "description": "Let Onyx reference stored memories in chats.",
+        "title": "Reference Stored Memories"
+      },
+      "title": "Memory",
+      "updateMemories": {
+        "description": "Let Onyx generate and update stored memories.",
+        "title": "Update Memories"
+      }
+    },
+    "personalPreferences": {
+      "description": "Provide your custom preferences in natural language.",
+      "placeholder": "Describe how you want the system to behave and the tone it should use.",
+      "title": "Personal Preferences"
+    },
+    "profile": {
+      "fullName": {
+        "description": "We'll display this name in the app.",
+        "placeholder": "Your name",
+        "title": "Full Name"
+      },
+      "title": "Profile",
+      "toasts": {
+        "updateFailed": "Failed to update personalization",
+        "updated": "Personalization updated successfully"
+      },
+      "workRole": {
+        "description": "Share your role to better tailor responses.",
+        "placeholder": "Your role",
+        "title": "Work Role"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "Provide a concise 1–2 sentence summary of the following:",
+        "promptPlaceholder": "Summarize",
+        "publicTooltip": "Cannot delete public prompt-shortcuts.",
+        "removeAriaLabel": "Remove shortcut"
+      },
+      "title": "Prompt Shortcuts",
+      "toasts": {
+        "bothRequired": "Both shortcut and expansion are required",
+        "created": "Shortcut created",
+        "deleteFailed": "Failed to delete shortcut",
+        "deleted": "Shortcut deleted",
+        "loadFailed": "Failed to load shortcuts",
+        "saveFailed": "Failed to save shortcut",
+        "updated": "Shortcut updated"
+      },
+      "toggle": {
+        "description": "Enable shortcuts to quickly insert common prompts.",
+        "title": "Use Prompt Shortcuts"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "Automatically play voice responses.",
+        "title": "Auto-Playback"
+      },
+      "autoSend": {
+        "description": "Automatically send voice input when you stop speaking.",
+        "title": "Auto-Send on Pause"
+      },
+      "playbackSpeed": {
+        "description": "Adjust the speed of voice playback.",
+        "title": "Playback Speed"
+      },
+      "title": "Voice"
+    }
+  }
+}

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -435,7 +435,8 @@
       },
       "language": {
         "description": "Selecciona el idioma de la interfaz.",
-        "title": "Idioma"
+        "title": "Idioma",
+        "updateFailed": "No se pudo actualizar la preferencia de idioma"
       },
       "title": "Apariencia"
     },
@@ -523,7 +524,7 @@
       "description": "Conecta herramientas externas a los modelos disponibles para ti en Onyx.",
       "guideButton": "Guía",
       "models": {
-        "description": "{count, plural, other {Hay # modelos disponibles para tu cuenta. Abre un proveedor para copiar un ID.}}",
+        "description": "{count, plural, one {Hay # modelo disponible para tu cuenta. Abre un proveedor para copiar un ID.} other {Hay # modelos disponibles para tu cuenta. Abre un proveedor para copiar un ID.}}",
         "title": "Modelos"
       },
       "provider": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -460,6 +460,14 @@
         "description": "Onyx usará este modelo de forma predeterminada en tus chats.",
         "title": "Modelo predeterminado"
       },
+      "defaultReasoningLevel": {
+        "description": "Nivel de razonamiento inicial para tus nuevos chats. La configuración del administrador en un modelo siempre se aplica, y cualquier chat puede modificarla en su configuración de modelo.",
+        "title": "Nivel de razonamiento predeterminado"
+      },
+      "defaultTemperature": {
+        "description": "Temperatura inicial para tus nuevos chats. La configuración del administrador en un modelo siempre se aplica, y cualquier chat puede modificarla en su configuración de modelo.",
+        "title": "Temperatura predeterminada"
+      },
       "smoothStreaming": {
         "description": "Anima las respuestas en tiempo real carácter por carácter. Desactívalo para mostrar los fragmentos a medida que llegan.",
         "title": "Transmisión fluida"

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -1,1 +1,609 @@
-{}
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "Cuenta"
+    },
+    "helpFaq": {
+      "label": "Ayuda y preguntas frecuentes"
+    },
+    "logIn": {
+      "label": "Iniciar sesión"
+    },
+    "logoutFailed": {
+      "message": "No se pudo cerrar la sesión"
+    },
+    "notifications": {
+      "label": "Notificaciones"
+    },
+    "profileUnavailable": {
+      "title": "Perfil no disponible"
+    },
+    "settings": {
+      "label": "Configuración"
+    },
+    "signOut": {
+      "label": "Cerrar sesión"
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "Crear nueva organización"
+      },
+      "createTeamOption": {
+        "text": "Crear un nuevo equipo de Onyx"
+      },
+      "differentEmailPrompt": {
+        "text": "¿Tienes una cuenta con otro correo electrónico?"
+      },
+      "heading": {
+        "title": "Cuenta no encontrada"
+      },
+      "inviteOption": {
+        "text": "Recibir una invitación a un equipo de Onyx existente"
+      },
+      "notFound": {
+        "description": "No encontramos tu cuenta en nuestros registros. Para acceder a Onyx, necesitas una de estas opciones:"
+      },
+      "signInLink": {
+        "label": "Iniciar sesión"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "Restricciones de acceso o permisos de la cuenta"
+      },
+      "cloudSupportPrompt": {
+        "text": "Si el problema continúa, contacta al equipo de Onyx en <link>support@onyx.app</link>"
+      },
+      "code": {
+        "accessDenied": "Tu proveedor de identidad denegó el acceso.",
+        "consentRequired": "Tu proveedor de identidad requiere tu consentimiento antes de continuar.",
+        "interactionRequired": "Se requiere una interacción adicional con tu proveedor de identidad.",
+        "invalidScope": "Los permisos solicitados no están disponibles.",
+        "loginBadCredentials": "Esta cuenta no puede iniciar sesión. Puede estar desactivada. Contacta al administrador de tu espacio de trabajo.",
+        "loginRequired": "Primero debes iniciar sesión con tu proveedor de identidad.",
+        "oauthUserAlreadyExists": "Ya existe una cuenta con este correo con otro método de inicio de sesión. Inicia sesión como lo hiciste la primera vez, o pide a tu administrador que vincule este proveedor.",
+        "serverError": "Tu proveedor de identidad encontró un error. Inténtalo de nuevo.",
+        "temporarilyUnavailable": "Tu proveedor de identidad no está disponible temporalmente. Inténtalo de nuevo más tarde."
+      },
+      "credentialsIssue": {
+        "description": "Credenciales de acceso incorrectas o caducadas"
+      },
+      "heading": {
+        "description": "Hubo un problema con tu intento de inicio de sesión.",
+        "title": "Error de autenticación"
+      },
+      "possibleIssues": {
+        "title": "Posibles causas:"
+      },
+      "returnToLoginButton": {
+        "label": "Volver a la página de inicio de sesión"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "Si el problema continúa, contacta al administrador del sistema para obtener ayuda."
+      },
+      "systemDisruptionIssue": {
+        "description": "Interrupción temporal del sistema de autenticación"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[Volver al inicio de sesión](/auth/login)"
+      },
+      "emailField": {
+        "label": "Correo electrónico"
+      },
+      "emailSent": {
+        "toast": "Correo de restablecimiento de contraseña enviado. Revisa tu bandeja de entrada."
+      },
+      "genericError": {
+        "toast": "Ocurrió un error al restablecer la contraseña."
+      },
+      "heading": {
+        "title": "Contraseña olvidada"
+      },
+      "submitButton": {
+        "label": "Restablecer contraseña"
+      },
+      "unexpectedError": {
+        "toast": "Ocurrió un error. Inténtalo de nuevo."
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "Nota: esta función solo está disponible para administradores de @onyx.app"
+      },
+      "apiKeyField": {
+        "label": "Clave de API",
+        "placeholder": "Introduce la clave de API"
+      },
+      "emailField": {
+        "label": "Correo electrónico"
+      },
+      "genericError": {
+        "toast": "No se pudo suplantar al usuario"
+      },
+      "heading": {
+        "title": "Suplantar usuario"
+      },
+      "invalidEmail": {
+        "error": "Correo electrónico no válido"
+      },
+      "requiredField": {
+        "error": "Obligatorio"
+      },
+      "submitButton": {
+        "label": "Suplantar usuario"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "Vuelve a autenticarte para unirte al equipo"
+      },
+      "orDivider": {
+        "text": "o"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "Crear una cuenta"
+      },
+      "noSsoProviders": {
+        "error": "No hay inicio de sesión SSO configurado para esa dirección. Prueba con Google o tu contraseña abajo."
+      },
+      "resetPasswordButton": {
+        "label": "Restablecer contraseña"
+      },
+      "signupPrompt": {
+        "text": "¿No tienes una cuenta?"
+      },
+      "ssoEmailInvalid": {
+        "error": "Introduce un correo electrónico válido"
+      },
+      "ssoEmailRequired": {
+        "error": "El correo electrónico es obligatorio"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "La respuesta de inicio de sesión no incluía la URL de autorización"
+      },
+      "ssoSignInButton": {
+        "label": "Iniciar sesión con SSO"
+      },
+      "ssoStartFailed": {
+        "error": "No se pudo iniciar la sesión (estado {status})"
+      },
+      "verifiedMessage": {
+        "title": "¡Tu correo ha sido verificado! Inicia sesión para continuar."
+      },
+      "workEmailField": {
+        "label": "Correo de trabajo"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[Volver al inicio de sesión](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "Confirmar nueva contraseña",
+        "placeholder": "Confirma tu nueva contraseña"
+      },
+      "confirmPasswordRequired": {
+        "error": "Debes confirmar la contraseña"
+      },
+      "genericError": {
+        "toast": "Ocurrió un error al restablecer la contraseña."
+      },
+      "heading": {
+        "title": "Restablecer contraseña"
+      },
+      "invalidPassword": {
+        "error": "Contraseña no válida"
+      },
+      "missingToken": {
+        "toast": "Token de restablecimiento no válido o ausente."
+      },
+      "newPasswordField": {
+        "label": "Nueva contraseña",
+        "placeholder": "Introduce tu nueva contraseña"
+      },
+      "passwordRequired": {
+        "error": "La contraseña es obligatoria"
+      },
+      "passwordsMatch": {
+        "error": "Las contraseñas deben coincidir"
+      },
+      "submitButton": {
+        "label": "Restablecer contraseña"
+      },
+      "successRedirect": {
+        "toast": "Contraseña restablecida correctamente. Redirigiendo al inicio de sesión..."
+      },
+      "unexpectedError": {
+        "toast": "Ocurrió un error inesperado. Inténtalo de nuevo."
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "Completa tu registro"
+      },
+      "createAccountHeading": {
+        "title": "Crear cuenta"
+      },
+      "orDivider": {
+        "text": "o"
+      },
+      "referralOptionAds": {
+        "label": "Anuncios"
+      },
+      "referralOptionBlog": {
+        "label": "Artículo/Blog"
+      },
+      "referralOptionFriend": {
+        "label": "Amigo/Colega"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "Otro"
+      },
+      "referralOptionPodcast": {
+        "label": "Pódcast"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "Motor de búsqueda (Google/Bing)"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "Selecciona una opción"
+      },
+      "referralQuestion": {
+        "label": "¿Cómo nos conociste?"
+      },
+      "subtitle": {
+        "text": "Empieza a usar Onyx"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "Recibir un nuevo correo de verificación"
+      },
+      "missingToken": {
+        "error": "Falta el token de verificación. Solicita un nuevo correo de verificación."
+      },
+      "unknownError": {
+        "text": "error desconocido"
+      },
+      "verificationFailed": {
+        "error": "No se pudo verificar tu correo: {errorDetail}. Solicita un nuevo correo de verificación."
+      },
+      "verifying": {
+        "text": "Verificando tu correo..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "¡Se ha enviado un nuevo correo de verificación!"
+      },
+      "greeting": {
+        "text": "Hola, *{email}*, parece que todavía no has verificado tu correo.\n¡Revisa tu bandeja de entrada para empezar!"
+      },
+      "helpPrompt": {
+        "text": "Si no ves nada, haz clic <link>aquí</link> para solicitar un nuevo correo."
+      },
+      "sendFailed": {
+        "toast": "No se pudo enviar un nuevo correo de verificación: {errorDetail}"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "anónimo",
+        "description": "La dirección de correo electrónico de tu cuenta.",
+        "title": "Correo electrónico"
+      },
+      "password": {
+        "changeButton": "Cambiar contraseña",
+        "description": "Actualiza la contraseña de tu cuenta.",
+        "title": "Contraseña"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "Confirmar nueva contraseña"
+        },
+        "currentPassword": {
+          "title": "Contraseña actual"
+        },
+        "newPassword": {
+          "title": "Nueva contraseña"
+        },
+        "submit": {
+          "update": "Actualizar",
+          "updating": "Actualizando..."
+        },
+        "title": "Cambiar contraseña",
+        "toasts": {
+          "networkError": "Se produjo un error al cambiar la contraseña",
+          "updateFailed": "No se pudo cambiar la contraseña",
+          "updated": "Contraseña actualizada correctamente"
+        }
+      },
+      "title": "Cuentas"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "Todas las solicitudes de API que usen este token heredarán tus permisos de acceso y se atribuirán a ti como persona.",
+        "expiration": {
+          "days30": "30 días",
+          "days365": "365 días",
+          "days7": "7 días",
+          "expiresAtNote": "Este token vencerá el: {date}",
+          "noExpiration": "Sin vencimiento",
+          "placeholder": "Selecciona el vencimiento",
+          "title": "Vence en"
+        },
+        "name": {
+          "placeholder": "Ponle un nombre a tu token",
+          "title": "Nombre del token"
+        },
+        "permissions": {
+          "fullAccessNote": "Hereda todos tus permisos.",
+          "fullAccessOption": "Acceso completo",
+          "limitedAccessNote": "Limita este token a funciones específicas.",
+          "limitedAccessOption": "Acceso limitado",
+          "placeholder": "Selecciona los permisos",
+          "title": "Permisos"
+        },
+        "submit": {
+          "create": "Crear token",
+          "creating": "Creando token..."
+        },
+        "title": "Crear token de acceso"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {Creado hace # día} other {Creado hace # días}}",
+        "createdToday": "Creado hoy",
+        "deleteTokenAriaLabel": "Eliminar token {name}",
+        "empty": "No se crearon tokens de acceso.",
+        "expiresIn": "{count, plural, one {Vence en # día} other {Vence en # días}}",
+        "loading": "Cargando tokens...",
+        "neverExpires": "Nunca vence",
+        "newTokenButton": "Nuevo token de acceso",
+        "noPermissionTooltip": "No tienes permiso para crear tokens de acceso",
+        "searchPlaceholder": "Buscar..."
+      },
+      "revokeModal": {
+        "description": "Cualquier aplicación que use el token {name} ({tokenDisplay}) perderá el acceso a Onyx. Esta acción no se puede deshacer.",
+        "question": "¿Seguro que quieres revocar este token?",
+        "submit": "Revocar",
+        "title": "Revocar token de acceso"
+      },
+      "scopeSelector": {
+        "includedWith": "{label} (incluido con {lockReason})",
+        "loadError": "No se pudieron cargar los permisos.",
+        "loading": "Cargando permisos..."
+      },
+      "section": {
+        "title": "Tokens de acceso"
+      },
+      "toasts": {
+        "createFailed": "No se pudo crear el token",
+        "createNetworkError": "Error de red al crear el token",
+        "created": "Token creado correctamente",
+        "deleteFailed": "No se pudo eliminar el token",
+        "deleteNetworkError": "Error de red al eliminar el token",
+        "deleted": "Token eliminado correctamente",
+        "loadFailed": "No se pudieron cargar los tokens",
+        "loadPermissionsFailed": "No se pudieron cargar las opciones de permisos",
+        "nameRequired": "El nombre del token es obligatorio"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "Copiar token",
+        "description": "Guarda este token antes de continuar. No volverá a mostrarse.",
+        "title": "Token de acceso"
+      },
+      "upsell": {
+        "description": "Los tokens de acceso requieren una suscripción paga activa.",
+        "upgradeButton": "Mejorar plan"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "Ninguno",
+        "optionAriaLabel": "Fondo {label}{selected, select, true { (seleccionado)} other {}}",
+        "title": "Fondo del chat"
+      },
+      "colorMode": {
+        "auto": "Automático",
+        "dark": "Oscuro",
+        "description": "Selecciona el modo de color que prefieras para la interfaz.",
+        "light": "Claro",
+        "title": "Modo de color"
+      },
+      "language": {
+        "description": "Selecciona el idioma de la interfaz.",
+        "title": "Idioma"
+      },
+      "title": "Apariencia"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "Desplázate automáticamente al nuevo contenido a medida que el chat genera la respuesta.",
+        "title": "Desplazamiento automático del chat"
+      },
+      "collapseLargePastes": {
+        "description": "Cuando pegues texto de más de 3 líneas o 200 caracteres, se agrupará en una tarjeta compacta en lugar de insertarse en línea. Haz clic en la tarjeta para ver o editar el texto completo.",
+        "title": "Agrupar textos pegados largos"
+      },
+      "defaultAppMode": {
+        "chatOption": "Chat",
+        "description": "Elige si las sesiones nuevas comienzan en modo de búsqueda o de chat.",
+        "disabledTooltip": "La interfaz de búsqueda está desactivada y solo un administrador puede activarla.",
+        "searchOption": "Búsqueda",
+        "title": "Modo de la app predeterminado"
+      },
+      "defaultModel": {
+        "description": "Onyx usará este modelo de forma predeterminada en tus chats.",
+        "title": "Modelo predeterminado"
+      },
+      "smoothStreaming": {
+        "description": "Anima las respuestas en tiempo real carácter por carácter. Desactívalo para mostrar los fragmentos a medida que llegan.",
+        "title": "Transmisión fluida"
+      },
+      "title": "Chats",
+      "toasts": {
+        "saveFailed": "No se pudieron guardar las preferencias",
+        "saved": "Preferencias guardadas"
+      }
+    },
+    "connectors": {
+      "connectButton": "Conectar",
+      "disconnectModal": {
+        "continueNote": "Aún puedes continuar las sesiones existentes que hacen referencia a contenido de {name}.",
+        "description": "Onyx ya no podrá acceder ni buscar contenido de tu cuenta de {name}.",
+        "disconnecting": "Desconectando...",
+        "submit": "Desconectar",
+        "title": "Desconectar *{name}*"
+      },
+      "emptyMessage": "No hay conectores configurados para tu organización.",
+      "status": {
+        "connected": "Conectado",
+        "notConnected": "No conectado",
+        "paused": "Pausado"
+      },
+      "title": "Conectores",
+      "toasts": {
+        "disconnectFailed": "No se pudo desconectar",
+        "disconnected": "Desconectado correctamente"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "Eliminar todos los chats",
+        "confirm": {
+          "deleting": "Eliminando...",
+          "description": "Se eliminarán de forma permanente todas tus sesiones de chat y tu historial. La eliminación no se puede deshacer.",
+          "question": "¿Seguro que quieres eliminar todos los chats?",
+          "submit": "Eliminar",
+          "title": "Eliminar todos los chats"
+        },
+        "description": "Elimina de forma permanente todas tus sesiones de chat.",
+        "title": "Eliminar todos los chats",
+        "toasts": {
+          "deleteFailed": "No se pudieron eliminar todas las sesiones de chat",
+          "deleted": "Se eliminaron todas tus sesiones de chat."
+        }
+      },
+      "title": "Zona de peligro"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "Nuevo token",
+        "description": "Crea un token con permisos limitados antes de conectar una aplicación.",
+        "title": "Token de acceso"
+      },
+      "copyButton": {
+        "copied": "Copiado",
+        "copy": "Copiar",
+        "copyError": "No se pudo copiar el valor."
+      },
+      "description": "Conecta herramientas externas a los modelos disponibles para ti en Onyx.",
+      "guideButton": "Guía",
+      "models": {
+        "description": "{count, plural, other {Hay # modelos disponibles para tu cuenta. Abre un proveedor para copiar un ID.}}",
+        "title": "Modelos"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# modelo disponible} other {# modelos disponibles}}"
+      },
+      "title": "LLM Gateway",
+      "url": {
+        "description": "Usa esta URL base con clientes compatibles de OpenAI y Anthropic.",
+        "title": "URL del Gateway"
+      }
+    },
+    "memory": {
+      "referenceStoredMemories": {
+        "description": "Permite que Onyx haga referencia a las memorias guardadas en los chats.",
+        "title": "Hacer referencia a las memorias guardadas"
+      },
+      "title": "Memoria",
+      "updateMemories": {
+        "description": "Permite que Onyx genere y actualice las memorias guardadas.",
+        "title": "Actualizar memorias"
+      }
+    },
+    "personalPreferences": {
+      "description": "Indica tus preferencias personalizadas en lenguaje natural.",
+      "placeholder": "Describe cómo quieres que se comporte el sistema y qué tono debe usar.",
+      "title": "Preferencias personales"
+    },
+    "profile": {
+      "fullName": {
+        "description": "Mostraremos este nombre en la app.",
+        "placeholder": "Tu nombre",
+        "title": "Nombre completo"
+      },
+      "title": "Perfil",
+      "toasts": {
+        "updateFailed": "No se pudo actualizar la personalización",
+        "updated": "Personalización actualizada correctamente"
+      },
+      "workRole": {
+        "description": "Comparte tu puesto para personalizar mejor las respuestas.",
+        "placeholder": "Tu puesto",
+        "title": "Puesto de trabajo"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "Proporciona un resumen breve de 1 a 2 oraciones de lo siguiente:",
+        "promptPlaceholder": "Resumir",
+        "publicTooltip": "No se pueden eliminar los atajos de prompt públicos.",
+        "removeAriaLabel": "Quitar atajo"
+      },
+      "title": "Atajos de prompt",
+      "toasts": {
+        "bothRequired": "Se requieren tanto el atajo como la expansión",
+        "created": "Atajo creado",
+        "deleteFailed": "No se pudo eliminar el atajo",
+        "deleted": "Atajo eliminado",
+        "loadFailed": "No se pudieron cargar los atajos",
+        "saveFailed": "No se pudo guardar el atajo",
+        "updated": "Atajo actualizado"
+      },
+      "toggle": {
+        "description": "Activa los atajos para insertar rápidamente prompts comunes.",
+        "title": "Usar atajos de prompt"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "Reproduce automáticamente las respuestas de voz.",
+        "title": "Reproducción automática"
+      },
+      "autoSend": {
+        "description": "Envía automáticamente la entrada de voz cuando dejas de hablar.",
+        "title": "Envío automático al pausar"
+      },
+      "playbackSpeed": {
+        "description": "Ajusta la velocidad de reproducción de voz.",
+        "title": "Velocidad de reproducción"
+      },
+      "title": "Voz"
+    }
+  }
+}

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -1,1 +1,609 @@
-{}
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "Compte"
+    },
+    "helpFaq": {
+      "label": "Aide et FAQ"
+    },
+    "logIn": {
+      "label": "Se connecter"
+    },
+    "logoutFailed": {
+      "message": "Échec de la déconnexion"
+    },
+    "notifications": {
+      "label": "Notifications"
+    },
+    "profileUnavailable": {
+      "title": "Profil indisponible"
+    },
+    "settings": {
+      "label": "Paramètres"
+    },
+    "signOut": {
+      "label": "Se déconnecter"
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "Créer une nouvelle organisation"
+      },
+      "createTeamOption": {
+        "text": "Créer une nouvelle équipe Onyx"
+      },
+      "differentEmailPrompt": {
+        "text": "Vous avez un compte avec une autre adresse e-mail ?"
+      },
+      "heading": {
+        "title": "Compte introuvable"
+      },
+      "inviteOption": {
+        "text": "Être invité dans une équipe Onyx existante"
+      },
+      "notFound": {
+        "description": "Nous n'avons pas trouvé votre compte dans nos registres. Pour accéder à Onyx, vous devez :"
+      },
+      "signInLink": {
+        "label": "Se connecter"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "Restrictions d'accès ou autorisations du compte"
+      },
+      "cloudSupportPrompt": {
+        "text": "Si le problème persiste, contactez l'équipe Onyx à <link>support@onyx.app</link>"
+      },
+      "code": {
+        "accessDenied": "Votre fournisseur d'identité a refusé l'accès.",
+        "consentRequired": "Votre fournisseur d'identité exige un consentement avant de continuer.",
+        "interactionRequired": "Une interaction supplémentaire avec votre fournisseur d'identité est requise.",
+        "invalidScope": "Les autorisations demandées ne sont pas disponibles.",
+        "loginBadCredentials": "Ce compte ne peut pas se connecter. Il est peut-être désactivé. Contactez l'administrateur de votre espace de travail.",
+        "loginRequired": "Vous devez d'abord vous connecter avec votre fournisseur d'identité.",
+        "oauthUserAlreadyExists": "Un compte avec cette adresse e-mail existe déjà avec une autre méthode de connexion. Connectez-vous comme la première fois, ou demandez à votre administrateur d'associer ce fournisseur.",
+        "serverError": "Votre fournisseur d'identité a rencontré une erreur. Veuillez réessayer.",
+        "temporarilyUnavailable": "Votre fournisseur d'identité est temporairement indisponible. Veuillez réessayer plus tard."
+      },
+      "credentialsIssue": {
+        "description": "Identifiants de connexion incorrects ou expirés"
+      },
+      "heading": {
+        "description": "Un problème est survenu lors de votre tentative de connexion.",
+        "title": "Erreur d'authentification"
+      },
+      "possibleIssues": {
+        "title": "Causes possibles :"
+      },
+      "returnToLoginButton": {
+        "label": "Retour à la page de connexion"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "Si le problème persiste, contactez votre administrateur système pour obtenir de l'aide."
+      },
+      "systemDisruptionIssue": {
+        "description": "Perturbation temporaire du système d'authentification"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[Retour à la connexion](/auth/login)"
+      },
+      "emailField": {
+        "label": "E-mail"
+      },
+      "emailSent": {
+        "toast": "E-mail de réinitialisation du mot de passe envoyé. Vérifiez votre boîte de réception."
+      },
+      "genericError": {
+        "toast": "Une erreur est survenue lors de la réinitialisation du mot de passe."
+      },
+      "heading": {
+        "title": "Mot de passe oublié"
+      },
+      "submitButton": {
+        "label": "Réinitialiser le mot de passe"
+      },
+      "unexpectedError": {
+        "toast": "Une erreur est survenue. Veuillez réessayer."
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "Remarque : cette fonctionnalité est réservée aux administrateurs @onyx.app"
+      },
+      "apiKeyField": {
+        "label": "Clé d'API",
+        "placeholder": "Saisissez la clé d'API"
+      },
+      "emailField": {
+        "label": "E-mail"
+      },
+      "genericError": {
+        "toast": "Impossible d'emprunter l'identité de l'utilisateur"
+      },
+      "heading": {
+        "title": "Emprunter l'identité d'un utilisateur"
+      },
+      "invalidEmail": {
+        "error": "E-mail non valide"
+      },
+      "requiredField": {
+        "error": "Obligatoire"
+      },
+      "submitButton": {
+        "label": "Emprunter l'identité"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "Reconnectez-vous pour rejoindre l'équipe"
+      },
+      "orDivider": {
+        "text": "ou"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "Créer un compte"
+      },
+      "noSsoProviders": {
+        "error": "Aucune connexion SSO n'est configurée pour cette adresse. Essayez Google ou votre mot de passe ci-dessous."
+      },
+      "resetPasswordButton": {
+        "label": "Réinitialiser le mot de passe"
+      },
+      "signupPrompt": {
+        "text": "Vous n'avez pas de compte ?"
+      },
+      "ssoEmailInvalid": {
+        "error": "Saisissez une adresse e-mail valide"
+      },
+      "ssoEmailRequired": {
+        "error": "L'e-mail est obligatoire"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "La réponse de connexion ne contenait pas l'URL d'autorisation"
+      },
+      "ssoSignInButton": {
+        "label": "Se connecter avec SSO"
+      },
+      "ssoStartFailed": {
+        "error": "Impossible de démarrer la connexion (statut {status})"
+      },
+      "verifiedMessage": {
+        "title": "Votre e-mail a été vérifié ! Connectez-vous pour continuer."
+      },
+      "workEmailField": {
+        "label": "E-mail professionnel"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[Retour à la connexion](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "Confirmer le nouveau mot de passe",
+        "placeholder": "Confirmez votre nouveau mot de passe"
+      },
+      "confirmPasswordRequired": {
+        "error": "La confirmation du mot de passe est obligatoire"
+      },
+      "genericError": {
+        "toast": "Une erreur est survenue lors de la réinitialisation du mot de passe."
+      },
+      "heading": {
+        "title": "Réinitialiser le mot de passe"
+      },
+      "invalidPassword": {
+        "error": "Mot de passe non valide"
+      },
+      "missingToken": {
+        "toast": "Jeton de réinitialisation non valide ou manquant."
+      },
+      "newPasswordField": {
+        "label": "Nouveau mot de passe",
+        "placeholder": "Saisissez votre nouveau mot de passe"
+      },
+      "passwordRequired": {
+        "error": "Le mot de passe est obligatoire"
+      },
+      "passwordsMatch": {
+        "error": "Les mots de passe doivent correspondre"
+      },
+      "submitButton": {
+        "label": "Réinitialiser le mot de passe"
+      },
+      "successRedirect": {
+        "toast": "Mot de passe réinitialisé. Redirection vers la connexion..."
+      },
+      "unexpectedError": {
+        "toast": "Une erreur inattendue est survenue. Veuillez réessayer."
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "Terminez votre inscription"
+      },
+      "createAccountHeading": {
+        "title": "Créer un compte"
+      },
+      "orDivider": {
+        "text": "ou"
+      },
+      "referralOptionAds": {
+        "label": "Publicités"
+      },
+      "referralOptionBlog": {
+        "label": "Article/Blog"
+      },
+      "referralOptionFriend": {
+        "label": "Ami/Collègue"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "Autre"
+      },
+      "referralOptionPodcast": {
+        "label": "Podcast"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "Moteur de recherche (Google/Bing)"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "Sélectionnez une option"
+      },
+      "referralQuestion": {
+        "label": "Comment avez-vous entendu parler de nous ?"
+      },
+      "subtitle": {
+        "text": "Commencez avec Onyx"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "Recevoir un nouvel e-mail de vérification"
+      },
+      "missingToken": {
+        "error": "Jeton de vérification manquant. Demandez un nouvel e-mail de vérification."
+      },
+      "unknownError": {
+        "text": "erreur inconnue"
+      },
+      "verificationFailed": {
+        "error": "Impossible de vérifier votre e-mail : {errorDetail}. Demandez un nouvel e-mail de vérification."
+      },
+      "verifying": {
+        "text": "Vérification de votre e-mail..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "Un nouvel e-mail de vérification a été envoyé !"
+      },
+      "greeting": {
+        "text": "Bonjour, *{email}*, il semble que vous n'ayez pas encore vérifié votre e-mail.\nConsultez votre boîte de réception pour commencer !"
+      },
+      "helpPrompt": {
+        "text": "Si vous ne voyez rien, cliquez <link>ici</link> pour demander un nouvel e-mail."
+      },
+      "sendFailed": {
+        "toast": "Impossible d'envoyer un nouvel e-mail de vérification : {errorDetail}"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "anonyme",
+        "description": "Adresse e-mail de votre compte.",
+        "title": "E-mail"
+      },
+      "password": {
+        "changeButton": "Modifier le mot de passe",
+        "description": "Mettez à jour le mot de passe de votre compte.",
+        "title": "Mot de passe"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "Confirmer le nouveau mot de passe"
+        },
+        "currentPassword": {
+          "title": "Mot de passe actuel"
+        },
+        "newPassword": {
+          "title": "Nouveau mot de passe"
+        },
+        "submit": {
+          "update": "Mettre à jour",
+          "updating": "Mise à jour..."
+        },
+        "title": "Modifier le mot de passe",
+        "toasts": {
+          "networkError": "Une erreur s'est produite lors de la modification du mot de passe",
+          "updateFailed": "Échec de la modification du mot de passe",
+          "updated": "Mot de passe mis à jour avec succès"
+        }
+      },
+      "title": "Comptes"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "Toutes les requêtes API utilisant ce jeton hériteront de vos autorisations d'accès et vous seront attribuées à titre individuel.",
+        "expiration": {
+          "days30": "30 jours",
+          "days365": "365 jours",
+          "days7": "7 jours",
+          "expiresAtNote": "Ce jeton expirera le : {date}",
+          "noExpiration": "Aucune expiration",
+          "placeholder": "Sélectionner l'expiration",
+          "title": "Expire dans"
+        },
+        "name": {
+          "placeholder": "Nommez votre jeton",
+          "title": "Nom du jeton"
+        },
+        "permissions": {
+          "fullAccessNote": "Hérite de toutes vos autorisations.",
+          "fullAccessOption": "Accès complet",
+          "limitedAccessNote": "Limitez ce jeton à des fonctionnalités spécifiques.",
+          "limitedAccessOption": "Accès limité",
+          "placeholder": "Sélectionner les autorisations",
+          "title": "Autorisations"
+        },
+        "submit": {
+          "create": "Créer le jeton",
+          "creating": "Création du jeton..."
+        },
+        "title": "Créer un jeton d'accès"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {Créé il y a # jour} other {Créé il y a # jours}}",
+        "createdToday": "Créé aujourd'hui",
+        "deleteTokenAriaLabel": "Supprimer le jeton {name}",
+        "empty": "Aucun jeton d'accès créé.",
+        "expiresIn": "{count, plural, one {Expire dans # jour} other {Expire dans # jours}}",
+        "loading": "Chargement des jetons...",
+        "neverExpires": "N'expire jamais",
+        "newTokenButton": "Nouveau jeton d'accès",
+        "noPermissionTooltip": "Vous n'avez pas l'autorisation de créer des jetons d'accès",
+        "searchPlaceholder": "Rechercher..."
+      },
+      "revokeModal": {
+        "description": "Toute application utilisant le jeton {name} ({tokenDisplay}) perdra l'accès à Onyx. Cette action est irréversible.",
+        "question": "Voulez-vous vraiment révoquer ce jeton ?",
+        "submit": "Révoquer",
+        "title": "Révoquer le jeton d'accès"
+      },
+      "scopeSelector": {
+        "includedWith": "{label} (inclus avec {lockReason})",
+        "loadError": "Impossible de charger les autorisations.",
+        "loading": "Chargement des autorisations..."
+      },
+      "section": {
+        "title": "Jetons d'accès"
+      },
+      "toasts": {
+        "createFailed": "Échec de la création du jeton",
+        "createNetworkError": "Erreur réseau lors de la création du jeton",
+        "created": "Jeton créé avec succès",
+        "deleteFailed": "Échec de la suppression du jeton",
+        "deleteNetworkError": "Erreur réseau lors de la suppression du jeton",
+        "deleted": "Jeton supprimé avec succès",
+        "loadFailed": "Échec du chargement des jetons",
+        "loadPermissionsFailed": "Échec du chargement des options d'autorisation",
+        "nameRequired": "Le nom du jeton est requis"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "Copier le jeton",
+        "description": "Enregistrez ce jeton avant de continuer. Il ne sera plus affiché.",
+        "title": "Jeton d'accès"
+      },
+      "upsell": {
+        "description": "Les jetons d'accès nécessitent un abonnement payant actif.",
+        "upgradeButton": "Mettre à niveau le forfait"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "Aucun",
+        "optionAriaLabel": "Arrière-plan {label}{selected, select, true { (sélectionné)} other {}}",
+        "title": "Arrière-plan du chat"
+      },
+      "colorMode": {
+        "auto": "Auto",
+        "dark": "Sombre",
+        "description": "Sélectionnez le mode de couleur préféré pour l'interface.",
+        "light": "Clair",
+        "title": "Mode de couleur"
+      },
+      "language": {
+        "description": "Sélectionnez la langue de l'interface.",
+        "title": "Langue"
+      },
+      "title": "Apparence"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "Faites défiler automatiquement vers le nouveau contenu pendant que le chat génère une réponse.",
+        "title": "Défilement automatique du chat"
+      },
+      "collapseLargePastes": {
+        "description": "Lorsque vous collez un texte de plus de 3 lignes ou 200 caractères, il est réduit en une vignette compacte au lieu d'être inséré en ligne. Cliquez sur la vignette pour afficher ou modifier le texte complet.",
+        "title": "Réduire les collages volumineux"
+      },
+      "defaultAppMode": {
+        "chatOption": "Chat",
+        "description": "Choisissez si les nouvelles sessions démarrent en mode Recherche ou Chat.",
+        "disabledTooltip": "L'interface de recherche est désactivée et ne peut être activée que par un administrateur.",
+        "searchOption": "Recherche",
+        "title": "Mode d'application par défaut"
+      },
+      "defaultModel": {
+        "description": "Ce modèle sera utilisé par défaut par Onyx dans vos chats.",
+        "title": "Modèle par défaut"
+      },
+      "smoothStreaming": {
+        "description": "Animez les réponses diffusées caractère par caractère. Désactivez pour afficher les segments au fur et à mesure de leur arrivée.",
+        "title": "Diffusion fluide"
+      },
+      "title": "Chats",
+      "toasts": {
+        "saveFailed": "Échec de l'enregistrement des préférences",
+        "saved": "Préférences enregistrées"
+      }
+    },
+    "connectors": {
+      "connectButton": "Connecter",
+      "disconnectModal": {
+        "continueNote": "Vous pouvez toujours poursuivre les sessions existantes faisant référence au contenu {name}.",
+        "description": "Onyx ne pourra plus accéder au contenu de votre compte {name} ni le rechercher.",
+        "disconnecting": "Déconnexion...",
+        "submit": "Déconnecter",
+        "title": "Déconnecter *{name}*"
+      },
+      "emptyMessage": "Aucun connecteur configuré pour votre organisation.",
+      "status": {
+        "connected": "Connecté",
+        "notConnected": "Non connecté",
+        "paused": "En pause"
+      },
+      "title": "Connecteurs",
+      "toasts": {
+        "disconnectFailed": "Échec de la déconnexion",
+        "disconnected": "Déconnecté avec succès"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "Supprimer tous les chats",
+        "confirm": {
+          "deleting": "Suppression...",
+          "description": "Toutes vos sessions de chat et leur historique seront définitivement supprimés. Cette suppression est irréversible.",
+          "question": "Voulez-vous vraiment supprimer tous les chats ?",
+          "submit": "Supprimer",
+          "title": "Supprimer tous les chats"
+        },
+        "description": "Supprimez définitivement toutes vos sessions de chat.",
+        "title": "Supprimer tous les chats",
+        "toasts": {
+          "deleteFailed": "Échec de la suppression de toutes les sessions de chat",
+          "deleted": "Toutes vos sessions de chat ont été supprimées."
+        }
+      },
+      "title": "Zone de danger"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "Nouveau jeton",
+        "description": "Créez un jeton à portée limitée avant de connecter une application.",
+        "title": "Jeton d'accès"
+      },
+      "copyButton": {
+        "copied": "Copié",
+        "copy": "Copier",
+        "copyError": "Impossible de copier la valeur."
+      },
+      "description": "Connectez des outils externes aux modèles disponibles pour vous dans Onyx.",
+      "guideButton": "Guide",
+      "models": {
+        "description": "{count, plural, other {# modèles sont disponibles pour votre compte. Ouvrez un fournisseur pour copier un ID.}}",
+        "title": "Modèles"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# modèle disponible} other {# modèles disponibles}}"
+      },
+      "title": "LLM Gateway",
+      "url": {
+        "description": "Utilisez cette URL de base avec les clients OpenAI et Anthropic compatibles.",
+        "title": "URL du Gateway"
+      }
+    },
+    "memory": {
+      "referenceStoredMemories": {
+        "description": "Autorisez Onyx à faire référence aux souvenirs enregistrés dans les chats.",
+        "title": "Référencer les souvenirs enregistrés"
+      },
+      "title": "Mémoire",
+      "updateMemories": {
+        "description": "Autorisez Onyx à générer et mettre à jour les souvenirs enregistrés.",
+        "title": "Mettre à jour les souvenirs"
+      }
+    },
+    "personalPreferences": {
+      "description": "Indiquez vos préférences personnalisées en langage naturel.",
+      "placeholder": "Décrivez comment vous souhaitez que le système se comporte et le ton qu'il doit utiliser.",
+      "title": "Préférences personnelles"
+    },
+    "profile": {
+      "fullName": {
+        "description": "Ce nom sera affiché dans l'application.",
+        "placeholder": "Votre nom",
+        "title": "Nom complet"
+      },
+      "title": "Profil",
+      "toasts": {
+        "updateFailed": "Échec de la mise à jour de la personnalisation",
+        "updated": "Personnalisation mise à jour avec succès"
+      },
+      "workRole": {
+        "description": "Indiquez votre rôle pour mieux adapter les réponses.",
+        "placeholder": "Votre rôle",
+        "title": "Rôle professionnel"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "Fournissez un résumé concis en 1 à 2 phrases de ce qui suit :",
+        "promptPlaceholder": "Résumer",
+        "publicTooltip": "Impossible de supprimer les raccourcis d'invite publics.",
+        "removeAriaLabel": "Supprimer le raccourci"
+      },
+      "title": "Raccourcis d'invite",
+      "toasts": {
+        "bothRequired": "Le raccourci et l'expansion sont tous deux requis",
+        "created": "Raccourci créé",
+        "deleteFailed": "Échec de la suppression du raccourci",
+        "deleted": "Raccourci supprimé",
+        "loadFailed": "Échec du chargement des raccourcis",
+        "saveFailed": "Échec de l'enregistrement du raccourci",
+        "updated": "Raccourci mis à jour"
+      },
+      "toggle": {
+        "description": "Activez les raccourcis pour insérer rapidement des invites courantes.",
+        "title": "Utiliser les raccourcis d'invite"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "Lisez automatiquement les réponses vocales.",
+        "title": "Lecture automatique"
+      },
+      "autoSend": {
+        "description": "Envoyez automatiquement la saisie vocale lorsque vous arrêtez de parler.",
+        "title": "Envoi automatique à la pause"
+      },
+      "playbackSpeed": {
+        "description": "Ajustez la vitesse de lecture vocale.",
+        "title": "Vitesse de lecture"
+      },
+      "title": "Voix"
+    }
+  }
+}

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -460,6 +460,14 @@
         "description": "Ce modèle sera utilisé par défaut par Onyx dans vos chats.",
         "title": "Modèle par défaut"
       },
+      "defaultReasoningLevel": {
+        "description": "Niveau de raisonnement initial de vos nouveaux chats. Les réglages administrateur d'un modèle s'appliquent toujours, et chaque chat peut le modifier dans ses réglages de modèle.",
+        "title": "Niveau de raisonnement par défaut"
+      },
+      "defaultTemperature": {
+        "description": "Température initiale de vos nouveaux chats. Les réglages administrateur d'un modèle s'appliquent toujours, et chaque chat peut la modifier dans ses réglages de modèle.",
+        "title": "Température par défaut"
+      },
       "smoothStreaming": {
         "description": "Animez les réponses diffusées caractère par caractère. Désactivez pour afficher les segments au fur et à mesure de leur arrivée.",
         "title": "Diffusion fluide"

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -435,7 +435,8 @@
       },
       "language": {
         "description": "Sélectionnez la langue de l'interface.",
-        "title": "Langue"
+        "title": "Langue",
+        "updateFailed": "Impossible de mettre à jour la préférence de langue"
       },
       "title": "Apparence"
     },
@@ -523,7 +524,7 @@
       "description": "Connectez des outils externes aux modèles disponibles pour vous dans Onyx.",
       "guideButton": "Guide",
       "models": {
-        "description": "{count, plural, other {# modèles sont disponibles pour votre compte. Ouvrez un fournisseur pour copier un ID.}}",
+        "description": "{count, plural, one {# modèle est disponible pour votre compte. Ouvrez un fournisseur pour copier un ID.} other {# modèles sont disponibles pour votre compte. Ouvrez un fournisseur pour copier un ID.}}",
         "title": "Modèles"
       },
       "provider": {

--- a/web/src/i18n/messages/keyParity.ts
+++ b/web/src/i18n/messages/keyParity.ts
@@ -1,0 +1,36 @@
+/**
+ * Compile-time key parity for the message catalogs.
+ *
+ * Each pair below fails `types:check` (pre-commit, CI, IDE) when a locale
+ * misses a key that en.json has, or carries a key that en.json does not.
+ * JSON imports type every value as `string`, so only the key structure is
+ * compared — ICU placeholder parity is `src/i18n/__tests__/catalog.test.ts`.
+ *
+ * Type-only module: erased at build time, nothing ships to the bundle.
+ */
+import type de from "@/i18n/messages/de.json";
+import type en from "@/i18n/messages/en.json";
+import type es from "@/i18n/messages/es.json";
+import type fr from "@/i18n/messages/fr.json";
+import type pt from "@/i18n/messages/pt.json";
+
+/** Compiles only when `Catalog` has every key of `Shape`, same nesting. */
+type Covers<Catalog extends Shape, Shape> = Catalog;
+
+/** [no missing keys vs en.json, no extra keys vs en.json] */
+export type SpanishParity = [
+  Covers<typeof es, typeof en>,
+  Covers<typeof en, typeof es>,
+];
+export type PortugueseParity = [
+  Covers<typeof pt, typeof en>,
+  Covers<typeof en, typeof pt>,
+];
+export type FrenchParity = [
+  Covers<typeof fr, typeof en>,
+  Covers<typeof en, typeof fr>,
+];
+export type GermanParity = [
+  Covers<typeof de, typeof en>,
+  Covers<typeof en, typeof de>,
+];

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -460,6 +460,14 @@
         "description": "Este modelo será usado pelo Onyx por padrão nos seus chats.",
         "title": "Modelo padrão"
       },
+      "defaultReasoningLevel": {
+        "description": "Nível de raciocínio inicial para seus novos chats. As configurações do administrador em um modelo sempre se aplicam, e qualquer chat pode substituí-lo nas configurações de modelo.",
+        "title": "Nível de raciocínio padrão"
+      },
+      "defaultTemperature": {
+        "description": "Temperatura inicial para seus novos chats. As configurações do administrador em um modelo sempre se aplicam, e qualquer chat pode substituí-la nas configurações de modelo.",
+        "title": "Temperatura padrão"
+      },
       "smoothStreaming": {
         "description": "Anime as respostas transmitidas caractere por caractere. Desative para renderizar os blocos conforme chegam.",
         "title": "Transmissão suave"

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -1,1 +1,609 @@
-{}
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "Conta"
+    },
+    "helpFaq": {
+      "label": "Ajuda e perguntas frequentes"
+    },
+    "logIn": {
+      "label": "Entrar"
+    },
+    "logoutFailed": {
+      "message": "Não foi possível sair"
+    },
+    "notifications": {
+      "label": "Notificações"
+    },
+    "profileUnavailable": {
+      "title": "Perfil indisponível"
+    },
+    "settings": {
+      "label": "Configurações"
+    },
+    "signOut": {
+      "label": "Sair"
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "Criar nova organização"
+      },
+      "createTeamOption": {
+        "text": "Criar uma nova equipe do Onyx"
+      },
+      "differentEmailPrompt": {
+        "text": "Tem uma conta com outro e-mail?"
+      },
+      "heading": {
+        "title": "Conta não encontrada"
+      },
+      "inviteOption": {
+        "text": "Ser convidado para uma equipe do Onyx existente"
+      },
+      "notFound": {
+        "description": "Não encontramos sua conta em nossos registros. Para acessar o Onyx, você precisa de uma destas opções:"
+      },
+      "signInLink": {
+        "label": "Entrar"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "Restrições de acesso ou permissões da conta"
+      },
+      "cloudSupportPrompt": {
+        "text": "Se o problema continuar, entre em contato com a equipe do Onyx em <link>support@onyx.app</link>"
+      },
+      "code": {
+        "accessDenied": "Seu provedor de identidade negou o acesso.",
+        "consentRequired": "Seu provedor de identidade exige consentimento antes de continuar.",
+        "interactionRequired": "É necessária uma interação adicional com seu provedor de identidade.",
+        "invalidScope": "As permissões solicitadas não estão disponíveis.",
+        "loginBadCredentials": "Esta conta não pode entrar. Ela pode estar desativada. Contate o administrador do seu espaço de trabalho.",
+        "loginRequired": "Você precisa primeiro entrar com seu provedor de identidade.",
+        "oauthUserAlreadyExists": "Já existe uma conta com este e-mail usando outro método de login. Entre da forma que usou pela primeira vez, ou peça ao seu administrador para vincular este provedor.",
+        "serverError": "Seu provedor de identidade encontrou um erro. Tente novamente.",
+        "temporarilyUnavailable": "Seu provedor de identidade está temporariamente indisponível. Tente novamente mais tarde."
+      },
+      "credentialsIssue": {
+        "description": "Credenciais de login incorretas ou expiradas"
+      },
+      "heading": {
+        "description": "Houve um problema com sua tentativa de login.",
+        "title": "Erro de autenticação"
+      },
+      "possibleIssues": {
+        "title": "Possíveis causas:"
+      },
+      "returnToLoginButton": {
+        "label": "Voltar à página de login"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "Se o problema continuar, entre em contato com o administrador do sistema para obter ajuda."
+      },
+      "systemDisruptionIssue": {
+        "description": "Interrupção temporária do sistema de autenticação"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[Voltar ao login](/auth/login)"
+      },
+      "emailField": {
+        "label": "E-mail"
+      },
+      "emailSent": {
+        "toast": "E-mail de redefinição de senha enviado. Verifique sua caixa de entrada."
+      },
+      "genericError": {
+        "toast": "Ocorreu um erro ao redefinir a senha."
+      },
+      "heading": {
+        "title": "Esqueci a senha"
+      },
+      "submitButton": {
+        "label": "Redefinir senha"
+      },
+      "unexpectedError": {
+        "toast": "Ocorreu um erro. Tente novamente."
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "Observação: este recurso está disponível apenas para administradores @onyx.app"
+      },
+      "apiKeyField": {
+        "label": "Chave de API",
+        "placeholder": "Insira a chave de API"
+      },
+      "emailField": {
+        "label": "E-mail"
+      },
+      "genericError": {
+        "toast": "Não foi possível personificar o usuário"
+      },
+      "heading": {
+        "title": "Personificar usuário"
+      },
+      "invalidEmail": {
+        "error": "E-mail inválido"
+      },
+      "requiredField": {
+        "error": "Obrigatório"
+      },
+      "submitButton": {
+        "label": "Personificar usuário"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "Autentique-se novamente para entrar na equipe"
+      },
+      "orDivider": {
+        "text": "ou"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "Criar uma conta"
+      },
+      "noSsoProviders": {
+        "error": "Não há login SSO configurado para esse endereço. Tente o Google ou sua senha abaixo."
+      },
+      "resetPasswordButton": {
+        "label": "Redefinir senha"
+      },
+      "signupPrompt": {
+        "text": "Não tem uma conta?"
+      },
+      "ssoEmailInvalid": {
+        "error": "Insira um endereço de e-mail válido"
+      },
+      "ssoEmailRequired": {
+        "error": "O e-mail é obrigatório"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "A resposta de login não incluía a URL de autorização"
+      },
+      "ssoSignInButton": {
+        "label": "Entrar com SSO"
+      },
+      "ssoStartFailed": {
+        "error": "Não foi possível iniciar o login (status {status})"
+      },
+      "verifiedMessage": {
+        "title": "Seu e-mail foi verificado! Entre para continuar."
+      },
+      "workEmailField": {
+        "label": "E-mail de trabalho"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[Voltar ao login](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "Confirmar nova senha",
+        "placeholder": "Confirme sua nova senha"
+      },
+      "confirmPasswordRequired": {
+        "error": "A confirmação da senha é obrigatória"
+      },
+      "genericError": {
+        "toast": "Ocorreu um erro ao redefinir a senha."
+      },
+      "heading": {
+        "title": "Redefinir senha"
+      },
+      "invalidPassword": {
+        "error": "Senha inválida"
+      },
+      "missingToken": {
+        "toast": "Token de redefinição inválido ou ausente."
+      },
+      "newPasswordField": {
+        "label": "Nova senha",
+        "placeholder": "Insira sua nova senha"
+      },
+      "passwordRequired": {
+        "error": "A senha é obrigatória"
+      },
+      "passwordsMatch": {
+        "error": "As senhas devem coincidir"
+      },
+      "submitButton": {
+        "label": "Redefinir senha"
+      },
+      "successRedirect": {
+        "toast": "Senha redefinida com sucesso. Redirecionando para o login..."
+      },
+      "unexpectedError": {
+        "toast": "Ocorreu um erro inesperado. Tente novamente."
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "Conclua seu cadastro"
+      },
+      "createAccountHeading": {
+        "title": "Criar conta"
+      },
+      "orDivider": {
+        "text": "ou"
+      },
+      "referralOptionAds": {
+        "label": "Anúncios"
+      },
+      "referralOptionBlog": {
+        "label": "Artigo/Blog"
+      },
+      "referralOptionFriend": {
+        "label": "Amigo/Colega"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "Outro"
+      },
+      "referralOptionPodcast": {
+        "label": "Podcast"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "Mecanismo de busca (Google/Bing)"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "Selecione uma opção"
+      },
+      "referralQuestion": {
+        "label": "Como você ficou sabendo de nós?"
+      },
+      "subtitle": {
+        "text": "Comece a usar o Onyx"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "Receber um novo e-mail de verificação"
+      },
+      "missingToken": {
+        "error": "Token de verificação ausente. Solicite um novo e-mail de verificação."
+      },
+      "unknownError": {
+        "text": "erro desconhecido"
+      },
+      "verificationFailed": {
+        "error": "Não foi possível verificar seu e-mail: {errorDetail}. Solicite um novo e-mail de verificação."
+      },
+      "verifying": {
+        "text": "Verificando seu e-mail..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "Um novo e-mail de verificação foi enviado!"
+      },
+      "greeting": {
+        "text": "Olá, *{email}*, parece que você ainda não verificou seu e-mail.\nConfira um e-mail nosso na sua caixa de entrada para começar!"
+      },
+      "helpPrompt": {
+        "text": "Se não encontrar nada, clique <link>aqui</link> para solicitar um novo e-mail."
+      },
+      "sendFailed": {
+        "toast": "Não foi possível enviar um novo e-mail de verificação: {errorDetail}"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "anônimo",
+        "description": "O endereço de e-mail da sua conta.",
+        "title": "E-mail"
+      },
+      "password": {
+        "changeButton": "Alterar senha",
+        "description": "Atualize a senha da sua conta.",
+        "title": "Senha"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "Confirmar nova senha"
+        },
+        "currentPassword": {
+          "title": "Senha atual"
+        },
+        "newPassword": {
+          "title": "Nova senha"
+        },
+        "submit": {
+          "update": "Atualizar",
+          "updating": "Atualizando..."
+        },
+        "title": "Alterar senha",
+        "toasts": {
+          "networkError": "Ocorreu um erro ao alterar a senha",
+          "updateFailed": "Falha ao alterar a senha",
+          "updated": "Senha atualizada com sucesso"
+        }
+      },
+      "title": "Contas"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "Todas as solicitações de API que usarem este token herdarão suas permissões de acesso e serão atribuídas a você individualmente.",
+        "expiration": {
+          "days30": "30 dias",
+          "days365": "365 dias",
+          "days7": "7 dias",
+          "expiresAtNote": "Este token expirará em: {date}",
+          "noExpiration": "Sem expiração",
+          "placeholder": "Selecione a expiração",
+          "title": "Expira em"
+        },
+        "name": {
+          "placeholder": "Nomeie seu token",
+          "title": "Nome do token"
+        },
+        "permissions": {
+          "fullAccessNote": "Herda todas as suas permissões.",
+          "fullAccessOption": "Acesso completo",
+          "limitedAccessNote": "Limite este token a recursos específicos.",
+          "limitedAccessOption": "Acesso limitado",
+          "placeholder": "Selecione as permissões",
+          "title": "Permissões"
+        },
+        "submit": {
+          "create": "Criar token",
+          "creating": "Criando token..."
+        },
+        "title": "Criar token de acesso"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {Criado há # dia} other {Criado há # dias}}",
+        "createdToday": "Criado hoje",
+        "deleteTokenAriaLabel": "Excluir token {name}",
+        "empty": "Nenhum token de acesso criado.",
+        "expiresIn": "{count, plural, one {Expira em # dia} other {Expira em # dias}}",
+        "loading": "Carregando tokens...",
+        "neverExpires": "Nunca expira",
+        "newTokenButton": "Novo token de acesso",
+        "noPermissionTooltip": "Você não tem permissão para criar tokens de acesso",
+        "searchPlaceholder": "Pesquisar..."
+      },
+      "revokeModal": {
+        "description": "Qualquer aplicativo que usar o token {name} ({tokenDisplay}) perderá o acesso ao Onyx. Esta ação não pode ser desfeita.",
+        "question": "Tem certeza de que deseja revogar este token?",
+        "submit": "Revogar",
+        "title": "Revogar token de acesso"
+      },
+      "scopeSelector": {
+        "includedWith": "{label} (incluído com {lockReason})",
+        "loadError": "Não foi possível carregar as permissões.",
+        "loading": "Carregando permissões..."
+      },
+      "section": {
+        "title": "Tokens de acesso"
+      },
+      "toasts": {
+        "createFailed": "Falha ao criar token",
+        "createNetworkError": "Erro de rede ao criar token",
+        "created": "Token criado com sucesso",
+        "deleteFailed": "Falha ao excluir token",
+        "deleteNetworkError": "Erro de rede ao excluir token",
+        "deleted": "Token excluído com sucesso",
+        "loadFailed": "Falha ao carregar tokens",
+        "loadPermissionsFailed": "Falha ao carregar opções de permissão",
+        "nameRequired": "O nome do token é obrigatório"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "Copiar token",
+        "description": "Salve este token antes de continuar. Ele não será exibido novamente.",
+        "title": "Token de acesso"
+      },
+      "upsell": {
+        "description": "Tokens de acesso exigem uma assinatura paga ativa.",
+        "upgradeButton": "Fazer upgrade do plano"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "Nenhum",
+        "optionAriaLabel": "Fundo {label}{selected, select, true { (selecionado)} other {}}",
+        "title": "Fundo do chat"
+      },
+      "colorMode": {
+        "auto": "Automático",
+        "dark": "Escuro",
+        "description": "Selecione o modo de cor preferido para a interface.",
+        "light": "Claro",
+        "title": "Modo de cor"
+      },
+      "language": {
+        "description": "Selecione o idioma da interface.",
+        "title": "Idioma"
+      },
+      "title": "Aparência"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "Rola automaticamente para o novo conteúdo enquanto o chat gera a resposta.",
+        "title": "Rolagem automática do chat"
+      },
+      "collapseLargePastes": {
+        "description": "Ao colar um texto com mais de 3 linhas ou 200 caracteres, ele é recolhido em um bloco compacto em vez de ser inserido embutido. Clique no bloco para ver ou editar o texto completo.",
+        "title": "Recolher textos colados grandes"
+      },
+      "defaultAppMode": {
+        "chatOption": "Chat",
+        "description": "Escolha se as novas sessões começam no modo Pesquisa ou Chat.",
+        "disabledTooltip": "A interface de pesquisa está desativada e só pode ser ativada por um administrador.",
+        "searchOption": "Pesquisa",
+        "title": "Modo padrão do aplicativo"
+      },
+      "defaultModel": {
+        "description": "Este modelo será usado pelo Onyx por padrão nos seus chats.",
+        "title": "Modelo padrão"
+      },
+      "smoothStreaming": {
+        "description": "Anime as respostas transmitidas caractere por caractere. Desative para renderizar os blocos conforme chegam.",
+        "title": "Transmissão suave"
+      },
+      "title": "Chats",
+      "toasts": {
+        "saveFailed": "Falha ao salvar preferências",
+        "saved": "Preferências salvas"
+      }
+    },
+    "connectors": {
+      "connectButton": "Conectar",
+      "disconnectModal": {
+        "continueNote": "Você ainda pode continuar sessões existentes que referenciam conteúdo do {name}.",
+        "description": "O Onyx não poderá mais acessar ou pesquisar conteúdo da sua conta do {name}.",
+        "disconnecting": "Desconectando...",
+        "submit": "Desconectar",
+        "title": "Desconectar *{name}*"
+      },
+      "emptyMessage": "Nenhum conector configurado para sua organização.",
+      "status": {
+        "connected": "Conectado",
+        "notConnected": "Não conectado",
+        "paused": "Pausado"
+      },
+      "title": "Conectores",
+      "toasts": {
+        "disconnectFailed": "Falha ao desconectar",
+        "disconnected": "Desconectado com sucesso"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "Excluir todos os chats",
+        "confirm": {
+          "deleting": "Excluindo...",
+          "description": "Todas as suas sessões de chat e o histórico serão excluídos permanentemente. A exclusão não pode ser desfeita.",
+          "question": "Tem certeza de que deseja excluir todos os chats?",
+          "submit": "Excluir",
+          "title": "Excluir todos os chats"
+        },
+        "description": "Exclua permanentemente todas as suas sessões de chat.",
+        "title": "Excluir todos os chats",
+        "toasts": {
+          "deleteFailed": "Falha ao excluir todas as sessões de chat",
+          "deleted": "Todas as suas sessões de chat foram excluídas."
+        }
+      },
+      "title": "Zona de perigo"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "Novo token",
+        "description": "Crie um token com escopo definido antes de conectar um aplicativo.",
+        "title": "Token de acesso"
+      },
+      "copyButton": {
+        "copied": "Copiado",
+        "copy": "Copiar",
+        "copyError": "Não foi possível copiar o valor."
+      },
+      "description": "Conecte ferramentas externas aos modelos disponíveis para você no Onyx.",
+      "guideButton": "Guia",
+      "models": {
+        "description": "{count, plural, other {# modelos estão disponíveis para sua conta. Abra um provedor para copiar um ID.}}",
+        "title": "Modelos"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# modelo disponível} other {# modelos disponíveis}}"
+      },
+      "title": "LLM Gateway",
+      "url": {
+        "description": "Use esta URL base com clientes compatíveis com OpenAI e Anthropic.",
+        "title": "URL do gateway"
+      }
+    },
+    "memory": {
+      "referenceStoredMemories": {
+        "description": "Permita que o Onyx faça referência a memórias armazenadas nos chats.",
+        "title": "Referenciar memórias armazenadas"
+      },
+      "title": "Memória",
+      "updateMemories": {
+        "description": "Permita que o Onyx gere e atualize memórias armazenadas.",
+        "title": "Atualizar memórias"
+      }
+    },
+    "personalPreferences": {
+      "description": "Forneça suas preferências personalizadas em linguagem natural.",
+      "placeholder": "Descreva como você quer que o sistema se comporte e o tom que ele deve usar.",
+      "title": "Preferências pessoais"
+    },
+    "profile": {
+      "fullName": {
+        "description": "Vamos exibir este nome no aplicativo.",
+        "placeholder": "Seu nome",
+        "title": "Nome completo"
+      },
+      "title": "Perfil",
+      "toasts": {
+        "updateFailed": "Falha ao atualizar a personalização",
+        "updated": "Personalização atualizada com sucesso"
+      },
+      "workRole": {
+        "description": "Compartilhe seu cargo para personalizar melhor as respostas.",
+        "placeholder": "Seu cargo",
+        "title": "Cargo"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "Forneça um resumo conciso de 1 a 2 frases do seguinte:",
+        "promptPlaceholder": "Resumir",
+        "publicTooltip": "Não é possível excluir atalhos de prompt públicos.",
+        "removeAriaLabel": "Remover atalho"
+      },
+      "title": "Atalhos de prompt",
+      "toasts": {
+        "bothRequired": "O atalho e a expansão são obrigatórios",
+        "created": "Atalho criado",
+        "deleteFailed": "Falha ao excluir atalho",
+        "deleted": "Atalho excluído",
+        "loadFailed": "Falha ao carregar atalhos",
+        "saveFailed": "Falha ao salvar atalho",
+        "updated": "Atalho atualizado"
+      },
+      "toggle": {
+        "description": "Ative os atalhos para inserir rapidamente prompts comuns.",
+        "title": "Usar atalhos de prompt"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "Reproduz automaticamente as respostas de voz.",
+        "title": "Reprodução automática"
+      },
+      "autoSend": {
+        "description": "Envia automaticamente a entrada de voz quando você para de falar.",
+        "title": "Envio automático ao pausar"
+      },
+      "playbackSpeed": {
+        "description": "Ajuste a velocidade da reprodução de voz.",
+        "title": "Velocidade de reprodução"
+      },
+      "title": "Voz"
+    }
+  }
+}

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -435,7 +435,8 @@
       },
       "language": {
         "description": "Selecione o idioma da interface.",
-        "title": "Idioma"
+        "title": "Idioma",
+        "updateFailed": "Não foi possível atualizar a preferência de idioma"
       },
       "title": "Aparência"
     },
@@ -523,7 +524,7 @@
       "description": "Conecte ferramentas externas aos modelos disponíveis para você no Onyx.",
       "guideButton": "Guia",
       "models": {
-        "description": "{count, plural, other {# modelos estão disponíveis para sua conta. Abra um provedor para copiar um ID.}}",
+        "description": "{count, plural, one {# modelo está disponível para sua conta. Abra um provedor para copiar um ID.} other {# modelos estão disponíveis para sua conta. Abra um provedor para copiar um ID.}}",
         "title": "Modelos"
       },
       "provider": {

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -34,6 +34,7 @@ import SidebarTabSkeleton from "@/refresh-components/skeletons/SidebarTabSkeleto
 import { useNotificationSummary } from "@/hooks/useNotifications";
 import { SvgOnyxLogo } from "@opal/logos";
 import { markdown } from "@opal/utils";
+import { useTranslations } from "next-intl";
 
 interface SettingsPopoverProps {
   onUserSettingsClick: () => void;
@@ -46,6 +47,7 @@ function SettingsPopover({
   onOpenNotifications,
   undismissedCount,
 }: SettingsPopoverProps) {
+  const t = useTranslations("accountPopover");
   const { user, userResolution } = useUser();
   const settings = useSettings();
   const enterpriseSettings = settings.enterprise;
@@ -65,11 +67,13 @@ function SettingsPopover({
     router.push(`/auth/login?next=${encodedRedirect}`);
   };
 
+  const logoutFailedMessage = t("logoutFailed.message");
+
   const handleLogout = () => {
     logout()
       .then((response) => {
         if (!response?.ok) {
-          alert("Failed to logout");
+          alert(logoutFailedMessage);
           return;
         }
 
@@ -83,7 +87,7 @@ function SettingsPopover({
       })
 
       .catch(() => {
-        toast.error("Failed to logout");
+        toast.error(logoutFailedMessage);
       });
   };
 
@@ -95,7 +99,7 @@ function SettingsPopover({
             sizePreset="main-ui"
             title={
               userResolution === "unavailable"
-                ? "Profile unavailable"
+                ? t("profileUnavailable.title")
                 : getUserEmail(user)
             }
           />
@@ -107,7 +111,7 @@ function SettingsPopover({
             variant="section"
             rounding={2}
             icon={SvgSliders}
-            title="Settings"
+            title={t("settings.label")}
             href="/app/settings"
             onClick={onUserSettingsClick}
           />
@@ -118,7 +122,7 @@ function SettingsPopover({
           variant="section"
           rounding={2}
           icon={SvgBell}
-          title="Notifications"
+          title={t("notifications.label")}
           onClick={onOpenNotifications}
           rightChildren={
             undismissedCount ? (
@@ -132,7 +136,7 @@ function SettingsPopover({
           variant="section"
           rounding={2}
           icon={SvgHelpCircle}
-          title="Help & FAQ"
+          title={t("helpFaq.label")}
           href="https://docs.onyx.app"
           target="_blank"
         />,
@@ -158,7 +162,7 @@ function SettingsPopover({
             variant="section"
             rounding={2}
             icon={SvgUser}
-            title="Log in"
+            title={t("logIn.label")}
             onClick={handleLogin}
           />
         ),
@@ -170,7 +174,7 @@ function SettingsPopover({
             color="danger"
             rounding={2}
             icon={SvgLogOut}
-            title="Log Out"
+            title={t("signOut.label")}
             onClick={handleLogout}
           />
         ),
@@ -199,6 +203,7 @@ export interface SettingsProps {
 }
 
 export default function AccountPopover({ onShowBuildIntro }: SettingsProps) {
+  const t = useTranslations("accountPopover");
   const folded = useSidebarFolded();
   const [popupState, setPopupState] = useState<
     "Settings" | "Notifications" | undefined
@@ -210,7 +215,9 @@ export default function AccountPopover({ onShowBuildIntro }: SettingsProps) {
   const { undismissedCount, refresh: refreshNotificationSummary } =
     useNotificationSummary();
   const userDisplayName =
-    userResolution === "unavailable" ? "Account" : getUserDisplayName(user);
+    userResolution === "unavailable"
+      ? t("accountFallback.label")
+      : getUserDisplayName(user);
 
   const handlePopoverOpen = (state: boolean) => {
     if (state) {

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -763,7 +763,7 @@ function GeneralSettings() {
                     // SAFETY: the items below only carry SUPPORTED_LOCALES
                     // values, so the select can't emit anything else.
                     updateUserLanguage(value as Locale).catch(() => {
-                      toast.error("Failed to update language preference");
+                      toast.error(t("appearance.language.updateFailed"));
                     });
                   }}
                 >

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Section, AttachmentItemLayout } from "@/layouts/general-layouts";
 import {
   Content,
@@ -141,6 +142,7 @@ function ScopeSelector({
   scopesError,
   disabled,
 }: ScopeSelectorProps) {
+  const t = useTranslations("settings");
   const groups = useMemo(() => {
     const byLabel = new Map<string, ScopeGroup>();
     for (const option of scopeOptions) {
@@ -160,14 +162,14 @@ function ScopeSelector({
   if (scopesError) {
     return (
       <Text font="secondary-body" color="text-03">
-        Couldn&apos;t load permissions.
+        {t("apiKeys.scopeSelector.loadError")}
       </Text>
     );
   }
   if (scopeOptions.length === 0) {
     return (
       <Text font="secondary-body" color="text-03">
-        Loading permissions...
+        {t("apiKeys.scopeSelector.loading")}
       </Text>
     );
   }
@@ -199,8 +201,11 @@ function ScopeSelector({
                 />
                 <div className="flex flex-col">
                   <Text font="main-ui-body" color="text-04">
-                    {locked
-                      ? `${option.label} (included with ${lockReason})`
+                    {lockReason !== undefined
+                      ? t("apiKeys.scopeSelector.includedWith", {
+                          label: option.label,
+                          lockReason,
+                        })
                       : option.label}
                   </Text>
                   {/* Fixed 2-line slot so every row is the same height. */}
@@ -252,15 +257,17 @@ function PATModal({
   onCreate,
   createdToken,
 }: PATModalProps) {
+  const t = useTranslations("settings");
+
   if (createdToken?.token) {
     return (
       <Modal open onOpenChange={(open) => !open && onClose()}>
         <Modal.Content width="sm" height="sm">
           <Modal.Header
-            title="Access Token"
+            title={t("apiKeys.tokenCreatedModal.title")}
             icon={SvgKey}
             onClose={onClose}
-            description="Save this token before continuing. It won't be shown again."
+            description={t("apiKeys.tokenCreatedModal.description")}
           />
           <Modal.Body>
             <Code showCopyButton={false}>{createdToken.token}</Code>
@@ -272,7 +279,7 @@ function PATModal({
                   getCopyText={() => createdToken.token}
                   prominence="primary"
                 >
-                  Copy Token
+                  {t("apiKeys.tokenCreatedModal.copyButton")}
                 </CopyButton>
               }
             />
@@ -285,8 +292,8 @@ function PATModal({
   return (
     <ConfirmationModalLayout
       icon={SvgKey}
-      title="Create Access Token"
-      description="All API requests using this token will inherit your access permissions and be attributed to you as an individual."
+      title={t("apiKeys.createModal.title")}
+      description={t("apiKeys.createModal.description")}
       onClose={onClose}
       submit={
         <Button
@@ -297,14 +304,16 @@ function PATModal({
           }
           onClick={onCreate}
         >
-          {isCreating ? "Creating Token..." : "Create Token"}
+          {isCreating
+            ? t("apiKeys.createModal.submit.creating")
+            : t("apiKeys.createModal.submit.create")}
         </Button>
       }
     >
       <Section gap={4}>
-        <InputVertical title="Token Name" withLabel>
+        <InputVertical title={t("apiKeys.createModal.name.title")} withLabel>
           <InputTypeIn
-            placeholder="Name your token"
+            placeholder={t("apiKeys.createModal.name.placeholder")}
             value={newTokenName}
             onChange={(e) => setNewTokenName(e.target.value)}
             variant={isCreating ? "disabled" : undefined}
@@ -312,7 +321,7 @@ function PATModal({
           />
         </InputVertical>
         <InputVertical
-          title="Expires in"
+          title={t("apiKeys.createModal.expiration.title")}
           subDescription={
             expirationDays === "null"
               ? undefined
@@ -322,10 +331,13 @@ function PATModal({
                     expiryDate.getUTCDate() + parseInt(expirationDays)
                   );
                   expiryDate.setUTCHours(23, 59, 59, 999);
-                  return `This token will expire at: ${expiryDate
+                  const formattedDate = expiryDate
                     .toISOString()
                     .replace("T", " ")
-                    .replace(".999Z", " UTC")}`;
+                    .replace(".999Z", " UTC");
+                  return t("apiKeys.createModal.expiration.expiresAtNote", {
+                    date: formattedDate,
+                  });
                 })()
           }
           withLabel
@@ -335,21 +347,31 @@ function PATModal({
             onValueChange={setExpirationDays}
             disabled={isCreating}
           >
-            <InputSelect.Trigger placeholder="Select expiration" />
+            <InputSelect.Trigger
+              placeholder={t("apiKeys.createModal.expiration.placeholder")}
+            />
             <InputSelect.Content>
-              <InputSelect.Item value="7">7 days</InputSelect.Item>
-              <InputSelect.Item value="30">30 days</InputSelect.Item>
-              <InputSelect.Item value="365">365 days</InputSelect.Item>
-              <InputSelect.Item value="null">No expiration</InputSelect.Item>
+              <InputSelect.Item value="7">
+                {t("apiKeys.createModal.expiration.days7")}
+              </InputSelect.Item>
+              <InputSelect.Item value="30">
+                {t("apiKeys.createModal.expiration.days30")}
+              </InputSelect.Item>
+              <InputSelect.Item value="365">
+                {t("apiKeys.createModal.expiration.days365")}
+              </InputSelect.Item>
+              <InputSelect.Item value="null">
+                {t("apiKeys.createModal.expiration.noExpiration")}
+              </InputSelect.Item>
             </InputSelect.Content>
           </InputSelect>
         </InputVertical>
         <InputVertical
-          title="Permissions"
+          title={t("apiKeys.createModal.permissions.title")}
           subDescription={
             accessMode === "full"
-              ? "Inherits all of your permissions."
-              : "Limit this token to specific capabilities."
+              ? t("apiKeys.createModal.permissions.fullAccessNote")
+              : t("apiKeys.createModal.permissions.limitedAccessNote")
           }
           withLabel
         >
@@ -358,11 +380,15 @@ function PATModal({
             onValueChange={(value) => setAccessMode(value as AccessMode)}
             disabled={isCreating}
           >
-            <InputSelect.Trigger placeholder="Select permissions" />
+            <InputSelect.Trigger
+              placeholder={t("apiKeys.createModal.permissions.placeholder")}
+            />
             <InputSelect.Content>
-              <InputSelect.Item value="full">Full access</InputSelect.Item>
+              <InputSelect.Item value="full">
+                {t("apiKeys.createModal.permissions.fullAccessOption")}
+              </InputSelect.Item>
               <InputSelect.Item value="limited">
-                Limited access
+                {t("apiKeys.createModal.permissions.limitedAccessOption")}
               </InputSelect.Item>
             </InputSelect.Content>
           </InputSelect>
@@ -394,6 +420,7 @@ function usePATCreation({
   defaultScopes = [],
   onCreateSuccess,
 }: UsePATCreationOptions = {}) {
+  const t = useTranslations("settings");
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [newTokenName, setNewTokenName] = useState(defaultName);
@@ -431,7 +458,7 @@ function usePATCreation({
 
   const createPAT = useCallback(async () => {
     if (!newTokenName.trim()) {
-      toast.error("Token name is required");
+      toast.error(t("apiKeys.toasts.nameRequired"));
       return;
     }
 
@@ -455,15 +482,15 @@ function usePATCreation({
           token: data.token,
           name: newTokenName,
         });
-        toast.success("Token created successfully");
+        toast.success(t("apiKeys.toasts.created"));
         await onCreateSuccess?.();
       } else {
         const errorData = await response.json();
-        toast.error(errorData.detail || "Failed to create token");
+        toast.error(errorData.detail || t("apiKeys.toasts.createFailed"));
       }
     } catch (error) {
       console.error("Failed to create access token", error);
-      toast.error("Network error creating token");
+      toast.error(t("apiKeys.toasts.createNetworkError"));
     } finally {
       setIsCreating(false);
     }
@@ -473,6 +500,7 @@ function usePATCreation({
     newTokenName,
     onCreateSuccess,
     selectedScopes,
+    t,
   ]);
 
   return {
@@ -494,6 +522,7 @@ function usePATCreation({
 }
 
 function GeneralSettings() {
+  const t = useTranslations("settings");
   const {
     user,
     updateUserPersonalization,
@@ -532,8 +561,8 @@ function GeneralSettings() {
     updatePersonalizationField,
     handleSavePersonalization,
   } = useUserPersonalization(user, updateUserPersonalization, {
-    onSuccess: () => toast.success("Personalization updated successfully"),
-    onError: () => toast.error("Failed to update personalization"),
+    onSuccess: () => toast.success(t("profile.toasts.updated")),
+    onError: () => toast.error(t("profile.toasts.updateFailed")),
   });
 
   // Track initial values to detect changes
@@ -551,25 +580,25 @@ function GeneralSettings() {
     try {
       const response = await deleteAllChatSessions();
       if (response.ok) {
-        toast.success("All your chat sessions have been deleted.");
+        toast.success(t("dangerZone.deleteAllChats.toasts.deleted"));
         await refreshChatSessions();
         setShowDeleteConfirmation(false);
       } else {
         throw new Error("Failed to delete all chat sessions");
       }
     } catch (error) {
-      toast.error("Failed to delete all chat sessions");
+      toast.error(t("dangerZone.deleteAllChats.toasts.deleteFailed"));
     } finally {
       setIsDeleting(false);
     }
-  }, [pathname, router, refreshChatSessions]);
+  }, [pathname, router, refreshChatSessions, t]);
 
   return (
     <>
       {showDeleteConfirmation && (
         <ConfirmationModalLayout
           icon={SvgTrash}
-          title="Delete All Chats"
+          title={t("dangerZone.deleteAllChats.confirm.title")}
           onClose={() => setShowDeleteConfirmation(false)}
           submit={
             <Button
@@ -579,17 +608,18 @@ function GeneralSettings() {
                 void handleDeleteAllChats();
               }}
             >
-              {isDeleting ? "Deleting..." : "Delete"}
+              {isDeleting
+                ? t("dangerZone.deleteAllChats.confirm.deleting")
+                : t("dangerZone.deleteAllChats.confirm.submit")}
             </Button>
           }
         >
           <Section gap={2} alignItems="start">
             <Text color="text-05">
-              All your chat sessions and history will be permanently deleted.
-              Deletion cannot be undone.
+              {t("dangerZone.deleteAllChats.confirm.description")}
             </Text>
             <Text color="text-05">
-              Are you sure you want to delete all chats?
+              {t("dangerZone.deleteAllChats.confirm.question")}
             </Text>
           </Section>
         </ConfirmationModalLayout>
@@ -598,7 +628,7 @@ function GeneralSettings() {
       <Section gap={8}>
         <Section gap={3}>
           <Content
-            title="Profile"
+            title={t("profile.title")}
             sizePreset="main-content"
             variant="section"
             width="full"
@@ -606,14 +636,14 @@ function GeneralSettings() {
           <Card border="solid" rounding={4}>
             <Section alignItems="start" height="fit">
               <InputHorizontal
-                title="Full Name"
-                description="We'll display this name in the app."
+                title={t("profile.fullName.title")}
+                description={t("profile.fullName.description")}
                 center
                 withLabel
                 responsive
               >
                 <InputTypeIn
-                  placeholder="Your name"
+                  placeholder={t("profile.fullName.placeholder")}
                   value={personalizationValues.name}
                   onChange={(e) =>
                     updatePersonalizationField("name", e.target.value)
@@ -633,14 +663,14 @@ function GeneralSettings() {
                 />
               </InputHorizontal>
               <InputHorizontal
-                title="Work Role"
-                description="Share your role to better tailor responses."
+                title={t("profile.workRole.title")}
+                description={t("profile.workRole.description")}
                 center
                 withLabel
                 responsive
               >
                 <InputTypeIn
-                  placeholder="Your role"
+                  placeholder={t("profile.workRole.placeholder")}
                   value={personalizationValues.role}
                   onChange={(e) =>
                     updatePersonalizationField("role", e.target.value)
@@ -665,7 +695,7 @@ function GeneralSettings() {
 
         <Section gap={3}>
           <Content
-            title="Appearance"
+            title={t("appearance.title")}
             sizePreset="main-content"
             variant="section"
             width="full"
@@ -673,8 +703,8 @@ function GeneralSettings() {
           <Card border="solid" rounding={4}>
             <Section alignItems="start" height="fit">
               <InputHorizontal
-                title="Color Mode"
-                description="Select your preferred color mode for the UI."
+                title={t("appearance.colorMode.title")}
+                description={t("appearance.colorMode.description")}
                 center
                 withLabel
               >
@@ -696,33 +726,34 @@ function GeneralSettings() {
                         />
                       )}
                       description={
-                        systemTheme
-                          ? systemTheme.charAt(0).toUpperCase() +
-                            systemTheme.slice(1)
-                          : undefined
+                        systemTheme === "light"
+                          ? t("appearance.colorMode.light")
+                          : systemTheme === "dark"
+                            ? t("appearance.colorMode.dark")
+                            : undefined
                       }
                     >
-                      Auto
+                      {t("appearance.colorMode.auto")}
                     </InputSelect.Item>
                     <InputSelect.Separator />
                     <InputSelect.Item
                       value={ThemePreference.LIGHT}
                       icon={() => <ColorSwatch light />}
                     >
-                      Light
+                      {t("appearance.colorMode.light")}
                     </InputSelect.Item>
                     <InputSelect.Item
                       value={ThemePreference.DARK}
                       icon={() => <ColorSwatch dark />}
                     >
-                      Dark
+                      {t("appearance.colorMode.dark")}
                     </InputSelect.Item>
                   </InputSelect.Content>
                 </InputSelect>
               </InputHorizontal>
               <InputHorizontal
-                title="Language"
-                description="Select the language for the UI."
+                title={t("appearance.language.title")}
+                description={t("appearance.language.description")}
                 center
                 withLabel
               >
@@ -746,7 +777,7 @@ function GeneralSettings() {
                   </InputSelect.Content>
                 </InputSelect>
               </InputHorizontal>
-              <InputVertical title="Chat Background">
+              <InputVertical title={t("appearance.chatBackground.title")}>
                 <div className="flex flex-wrap gap-2">
                   {CHAT_BACKGROUND_OPTIONS.map((bg) => {
                     const currentBackgroundId =
@@ -760,13 +791,19 @@ function GeneralSettings() {
                         onClick={() => applyBackground(bg)}
                         className="relative overflow-hidden rounded-lg transition-all w-[90px] h-[68px] cursor-pointer border-none p-0 bg-transparent group"
                         title={bg.label}
-                        aria-label={`${bg.label} background${
-                          isSelected ? " (selected)" : ""
-                        }`}
+                        aria-label={t(
+                          "appearance.chatBackground.optionAriaLabel",
+                          {
+                            label: bg.label,
+                            selected: isSelected ? "true" : "false",
+                          }
+                        )}
                       >
                         {isNone ? (
                           <div className="absolute inset-0 bg-background flex items-center justify-center">
-                            <span className="text-xs text-text-02">None</span>
+                            <span className="text-xs text-text-02">
+                              {t("appearance.chatBackground.none")}
+                            </span>
                           </div>
                         ) : (
                           <div
@@ -800,7 +837,7 @@ function GeneralSettings() {
 
         <Section gap={3}>
           <Content
-            title="Danger Zone"
+            title={t("dangerZone.title")}
             sizePreset="main-content"
             variant="section"
             width="full"
@@ -808,8 +845,8 @@ function GeneralSettings() {
           <Card border="solid" rounding={4}>
             <Section alignItems="start" height="fit">
               <InputHorizontal
-                title="Delete All Chats"
-                description="Permanently delete all your chat sessions."
+                title={t("dangerZone.deleteAllChats.title")}
+                description={t("dangerZone.deleteAllChats.description")}
                 center
               >
                 <Button
@@ -819,7 +856,7 @@ function GeneralSettings() {
                   icon={SvgTrash}
                   interaction={showDeleteConfirmation ? "hover" : "rest"}
                 >
-                  Delete All Chats
+                  {t("dangerZone.deleteAllChats.button")}
                 </Button>
               </InputHorizontal>
             </Section>
@@ -835,6 +872,7 @@ interface LocalShortcut extends InputPrompt {
 }
 
 function PromptShortcuts() {
+  const t = useTranslations("settings");
   const { promptShortcuts, isLoading, error, refresh } = usePromptShortcuts();
   const [shortcuts, setShortcuts] = useState<LocalShortcut[]>([]);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -870,8 +908,8 @@ function PromptShortcuts() {
   // Show error popup if fetch fails
   useEffect(() => {
     if (!error) return;
-    toast.error("Failed to load shortcuts");
-  }, [error]);
+    toast.error(t("promptShortcuts.toasts.loadFailed"));
+  }, [error, t]);
 
   const handleUpdateShortcut = useCallback(
     (index: number, field: "prompt" | "content", value: string) => {
@@ -943,22 +981,22 @@ function PromptShortcuts() {
         if (response.ok) {
           setShortcuts((prev) => prev.filter((_, i) => i !== index));
           await refresh();
-          toast.success("Shortcut deleted");
+          toast.success(t("promptShortcuts.toasts.deleted"));
         } else {
           throw new Error("Failed to delete shortcut");
         }
       } catch (error) {
-        toast.error("Failed to delete shortcut");
+        toast.error(t("promptShortcuts.toasts.deleteFailed"));
       }
     },
-    [shortcuts, refresh]
+    [shortcuts, refresh, t]
   );
 
   const handleSaveShortcut = useCallback(
     async (index: number) => {
       const shortcut = shortcuts[index];
       if (!shortcut || !shortcut.prompt.trim() || !shortcut.content.trim()) {
-        toast.error("Both shortcut and expansion are required");
+        toast.error(t("promptShortcuts.toasts.bothRequired"));
         return;
       }
 
@@ -978,7 +1016,7 @@ function PromptShortcuts() {
 
           if (response.ok) {
             await refresh();
-            toast.success("Shortcut created");
+            toast.success(t("promptShortcuts.toasts.created"));
           } else {
             throw new Error("Failed to create shortcut");
           }
@@ -997,16 +1035,16 @@ function PromptShortcuts() {
 
           if (response.ok) {
             await refresh();
-            toast.success("Shortcut updated");
+            toast.success(t("promptShortcuts.toasts.updated"));
           } else {
             throw new Error("Failed to update shortcut");
           }
         }
       } catch (error) {
-        toast.error("Failed to save shortcut");
+        toast.error(t("promptShortcuts.toasts.saveFailed"));
       }
     },
-    [shortcuts, refresh]
+    [shortcuts, refresh, t]
   );
 
   const handleBlurShortcut = useCallback(
@@ -1049,7 +1087,7 @@ function PromptShortcuts() {
               >
                 <InputTypeIn
                   prefixText="/"
-                  placeholder="Summarize"
+                  placeholder={t("promptShortcuts.row.promptPlaceholder")}
                   value={shortcut.prompt}
                   onChange={(e) =>
                     handleUpdateShortcut(index, "prompt", e.target.value)
@@ -1073,16 +1111,16 @@ function PromptShortcuts() {
                     icon={SvgMinusCircle}
                     onClick={() => void handleRemoveShortcut(index)}
                     prominence="tertiary"
-                    aria-label="Remove shortcut"
+                    aria-label={t("promptShortcuts.row.removeAriaLabel")}
                     tooltip={
                       shortcut.is_public
-                        ? "Cannot delete public prompt-shortcuts."
+                        ? t("promptShortcuts.row.publicTooltip")
                         : undefined
                     }
                   />
                 </Section>
                 <InputTextArea
-                  placeholder="Provide a concise 1–2 sentence summary of the following:"
+                  placeholder={t("promptShortcuts.row.contentPlaceholder")}
                   value={shortcut.content}
                   onChange={(e) =>
                     handleUpdateShortcut(index, "content", e.target.value)
@@ -1112,6 +1150,7 @@ function PromptShortcuts() {
 }
 
 function ChatPreferencesSettings() {
+  const t = useTranslations("settings");
   const {
     user,
     updateUserPersonalization,
@@ -1139,8 +1178,8 @@ function ChatPreferencesSettings() {
     updateUserPreferences,
     handleSavePersonalization,
   } = useUserPersonalization(user, updateUserPersonalization, {
-    onSuccess: () => toast.success("Preferences saved"),
-    onError: () => toast.error("Failed to save preferences"),
+    onSuccess: () => toast.success(t("chats.toasts.saved")),
+    onError: () => toast.error(t("chats.toasts.saveFailed")),
   });
   const [draftVoicePlaybackSpeed, setDraftVoicePlaybackSpeed] = useState(
     user?.preferences.voice_playback_speed ?? 1
@@ -1158,12 +1197,12 @@ function ChatPreferencesSettings() {
     }) => {
       try {
         await updateUserVoiceSettings(settings);
-        toast.success("Preferences saved");
+        toast.success(t("chats.toasts.saved"));
       } catch {
-        toast.error("Failed to save preferences");
+        toast.error(t("chats.toasts.saveFailed"));
       }
     },
-    [updateUserVoiceSettings]
+    [updateUserVoiceSettings, t]
   );
 
   const settings = useSettings();
@@ -1245,7 +1284,7 @@ function ChatPreferencesSettings() {
     <Section gap={8}>
       <Section gap={3}>
         <Content
-          title="Chats"
+          title={t("chats.title")}
           sizePreset="main-content"
           variant="section"
           width="full"
@@ -1253,8 +1292,8 @@ function ChatPreferencesSettings() {
         <Card border="solid" rounding={4}>
           <Section alignItems="start" height="fit">
             <InputHorizontal
-              title="Default Model"
-              description="This model will be used by Onyx by default in your chats."
+              title={t("chats.defaultModel.title")}
+              description={t("chats.defaultModel.description")}
               withLabel
             >
               <ModelSelector
@@ -1362,8 +1401,8 @@ function ChatPreferencesSettings() {
               )}
 
             <InputHorizontal
-              title="Chat Auto-scroll"
-              description="Automatically scroll to new content as chat generates response."
+              title={t("chats.autoScroll.title")}
+              description={t("chats.autoScroll.description")}
               withLabel
             >
               <Switch
@@ -1375,8 +1414,8 @@ function ChatPreferencesSettings() {
             </InputHorizontal>
 
             <InputHorizontal
-              title="Smooth Streaming"
-              description="Animate streamed responses character-by-character. Disable to render chunks as they arrive."
+              title={t("chats.smoothStreaming.title")}
+              description={t("chats.smoothStreaming.description")}
               withLabel
             >
               <Switch
@@ -1386,8 +1425,8 @@ function ChatPreferencesSettings() {
             </InputHorizontal>
 
             <InputHorizontal
-              title="Collapse Large Pastes"
-              description="When pasting text longer than 3 lines or 200 characters, collapse it into a compact tile instead of inserting it inline. Click the tile to view or edit the full text."
+              title={t("chats.collapseLargePastes.title")}
+              description={t("chats.collapseLargePastes.description")}
               withLabel
             >
               <Switch
@@ -1403,13 +1442,13 @@ function ChatPreferencesSettings() {
                 tooltip={
                   searchUiEnabled
                     ? undefined
-                    : "Search UI is disabled and can only be enabled by an admin."
+                    : t("chats.defaultAppMode.disabledTooltip")
                 }
                 side="top"
               >
                 <InputHorizontal
-                  title="Default App Mode"
-                  description="Choose whether new sessions start in Search or Chat mode."
+                  title={t("chats.defaultAppMode.title")}
+                  description={t("chats.defaultAppMode.description")}
                   center
                   disabled={!searchUiEnabled}
                   withLabel
@@ -1423,8 +1462,12 @@ function ChatPreferencesSettings() {
                   >
                     <InputSelect.Trigger />
                     <InputSelect.Content>
-                      <InputSelect.Item value="CHAT">Chat</InputSelect.Item>
-                      <InputSelect.Item value="SEARCH">Search</InputSelect.Item>
+                      <InputSelect.Item value="CHAT">
+                        {t("chats.defaultAppMode.chatOption")}
+                      </InputSelect.Item>
+                      <InputSelect.Item value="SEARCH">
+                        {t("chats.defaultAppMode.searchOption")}
+                      </InputSelect.Item>
                     </InputSelect.Content>
                   </InputSelect>
                 </InputHorizontal>
@@ -1436,12 +1479,12 @@ function ChatPreferencesSettings() {
 
       <Section gap={3}>
         <InputVertical
-          title="Personal Preferences"
-          description="Provide your custom preferences in natural language."
+          title={t("personalPreferences.title")}
+          description={t("personalPreferences.description")}
           withLabel
         >
           <InputTextArea
-            placeholder="Describe how you want the system to behave and the tone it should use."
+            placeholder={t("personalPreferences.placeholder")}
             value={personalizationValues.user_preferences}
             onChange={(e) => updateUserPreferences(e.target.value)}
             onBlur={() => void handleSavePersonalization()}
@@ -1456,7 +1499,7 @@ function ChatPreferencesSettings() {
           />
         </InputVertical>
         <Content
-          title="Memory"
+          title={t("memory.title")}
           sizePreset="main-content"
           variant="section"
           width="full"
@@ -1464,8 +1507,8 @@ function ChatPreferencesSettings() {
         <Card border="solid" rounding={4}>
           <Section alignItems="start" height="fit">
             <InputHorizontal
-              title="Reference Stored Memories"
-              description="Let Onyx reference stored memories in chats."
+              title={t("memory.referenceStoredMemories.title")}
+              description={t("memory.referenceStoredMemories.description")}
               withLabel
             >
               <Switch
@@ -1477,8 +1520,8 @@ function ChatPreferencesSettings() {
               />
             </InputHorizontal>
             <InputHorizontal
-              title="Update Memories"
-              description="Let Onyx generate and update stored memories."
+              title={t("memory.updateMemories.title")}
+              description={t("memory.updateMemories.description")}
               withLabel
             >
               <Switch
@@ -1506,7 +1549,7 @@ function ChatPreferencesSettings() {
 
       <Section gap={3}>
         <Content
-          title="Prompt Shortcuts"
+          title={t("promptShortcuts.title")}
           sizePreset="main-content"
           variant="section"
           width="full"
@@ -1514,8 +1557,8 @@ function ChatPreferencesSettings() {
         <Card border="solid" rounding={4}>
           <Section alignItems="start" height="fit">
             <InputHorizontal
-              title="Use Prompt Shortcuts"
-              description="Enable shortcuts to quickly insert common prompts."
+              title={t("promptShortcuts.toggle.title")}
+              description={t("promptShortcuts.toggle.description")}
               withLabel
             >
               <Switch
@@ -1533,7 +1576,7 @@ function ChatPreferencesSettings() {
 
       <Section gap={3}>
         <Content
-          title="Voice"
+          title={t("voice.title")}
           sizePreset="main-content"
           variant="section"
           width="full"
@@ -1541,8 +1584,8 @@ function ChatPreferencesSettings() {
         <Card border="solid" rounding={4}>
           <Section alignItems="start" height="fit">
             <InputHorizontal
-              title="Auto-Send on Pause"
-              description="Automatically send voice input when you stop speaking."
+              title={t("voice.autoSend.title")}
+              description={t("voice.autoSend.description")}
               withLabel
             >
               <Switch
@@ -1554,8 +1597,8 @@ function ChatPreferencesSettings() {
             </InputHorizontal>
 
             <InputHorizontal
-              title="Auto-Playback"
-              description="Automatically play voice responses."
+              title={t("voice.autoPlayback.title")}
+              description={t("voice.autoPlayback.description")}
               withLabel
             >
               <Switch
@@ -1567,8 +1610,8 @@ function ChatPreferencesSettings() {
             </InputHorizontal>
 
             <InputHorizontal
-              title="Playback Speed"
-              description="Adjust the speed of voice playback."
+              title={t("voice.playbackSpeed.title")}
+              description={t("voice.playbackSpeed.description")}
               withLabel
             >
               <div className="flex items-center gap-3">
@@ -1612,6 +1655,7 @@ interface GatewayCopyValueButtonProps {
 }
 
 function GatewayCopyValueButton({ value }: GatewayCopyValueButtonProps) {
+  const t = useTranslations("settings");
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
@@ -1620,7 +1664,7 @@ function GatewayCopyValueButton({ value }: GatewayCopyValueButtonProps) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      toast.error("Could not copy value.");
+      toast.error(t("gateway.copyButton.copyError"));
     }
   }
 
@@ -1630,7 +1674,9 @@ function GatewayCopyValueButton({ value }: GatewayCopyValueButtonProps) {
       size="sm"
       onClick={handleCopy}
       rightIcon={copied ? SvgCheck : undefined}
-      tooltip={copied ? "Copied" : "Copy"}
+      tooltip={
+        copied ? t("gateway.copyButton.copied") : t("gateway.copyButton.copy")
+      }
     >
       {value}
     </Button>
@@ -1641,6 +1687,7 @@ function GatewayAccessSection({
   canCreateToken,
   onCreateToken,
 }: GatewayAccessSectionProps) {
+  const t = useTranslations("settings");
   const gatewayTier = useTierAtLeast(LLM_GATEWAY_MIN_TIER);
   const { llmProviders } = useLLMProviders();
   const [gatewayUrl, setGatewayUrl] = useState("");
@@ -1692,8 +1739,8 @@ function GatewayAccessSection({
   return (
     <Section gap={3}>
       <ContentAction
-        title="LLM Gateway"
-        description="Connect external tools to the models available to you in Onyx."
+        title={t("gateway.title")}
+        description={t("gateway.description")}
         sizePreset="main-content"
         variant="section"
         width="full"
@@ -1705,15 +1752,15 @@ function GatewayAccessSection({
             target="_blank"
             size="sm"
           >
-            Guide
+            {t("gateway.guideButton")}
           </Button>
         }
       />
       <Card border="solid" rounding={4} padding={3}>
         <Section alignItems="start" height="fit" gap={3}>
           <InputHorizontal
-            title="Gateway URL"
-            description="Use this base URL with compatible OpenAI and Anthropic clients."
+            title={t("gateway.url.title")}
+            description={t("gateway.url.description")}
             center
           >
             <GatewayCopyValueButton value={gatewayAddress} />
@@ -1723,8 +1770,10 @@ function GatewayAccessSection({
 
           <Section gap={2} alignItems="start">
             <Content
-              title="Models"
-              description={`${availableModelCount} models are available to your account. Open a provider to copy an ID.`}
+              title={t("gateway.models.title")}
+              description={t("gateway.models.description", {
+                count: availableModelCount,
+              })}
               sizePreset="main-ui"
               variant="section"
             />
@@ -1734,9 +1783,9 @@ function GatewayAccessSection({
                 <SimpleCollapsible key={provider.id} defaultOpen={false}>
                   <SimpleCollapsible.Header
                     title={provider.name}
-                    description={`${provider.models.length} ${
-                      provider.models.length === 1 ? "model" : "models"
-                    } available`}
+                    description={t("gateway.provider.modelsAvailable", {
+                      count: provider.models.length,
+                    })}
                     sizePreset="main-ui"
                   />
                   <SimpleCollapsible.Content>
@@ -1766,8 +1815,8 @@ function GatewayAccessSection({
           <Divider />
 
           <InputHorizontal
-            title="Access token"
-            description="Create a scoped token before you connect an application."
+            title={t("gateway.accessToken.title")}
+            description={t("gateway.accessToken.description")}
             center
           >
             <Button
@@ -1776,7 +1825,7 @@ function GatewayAccessSection({
               disabled={!canCreateToken}
               onClick={onCreateToken}
             >
-              New token
+              {t("gateway.accessToken.button")}
             </Button>
           </InputHorizontal>
         </Section>
@@ -1786,6 +1835,7 @@ function GatewayAccessSection({
 }
 
 function LLMGatewaySettings() {
+  const t = useTranslations("settings");
   const { permissions } = useUser();
   // Same gate as the Access Tokens section: this is a second PAT-minting path.
   const canCreatePAT = hasPermission(
@@ -1794,7 +1844,7 @@ function LLMGatewaySettings() {
   );
   const canCreateTokens = useCloudSubscription();
   const tokenCreation = usePATCreation({
-    defaultName: "LLM Gateway",
+    defaultName: t("gateway.title"),
     defaultAccessMode: "limited",
     defaultScopes: ["use:llm_gateway"],
   });
@@ -1846,6 +1896,7 @@ function LLMGatewaySettings() {
 }
 
 function AccountsAccessSettings() {
+  const t = useTranslations("settings");
   const { user, authTypeMetadata, permissions } = useUser();
   const isMultiTenant = useIsMultiTenant();
   const [showPasswordModal, setShowPasswordModal] = useState(false);
@@ -1939,15 +1990,15 @@ function AccountsAccessSettings() {
   // Show error popup if SWR fetch fails
   useEffect(() => {
     if (error) {
-      toast.error("Failed to load tokens");
+      toast.error(t("apiKeys.toasts.loadFailed"));
     }
-  }, [error]);
+  }, [error, t]);
 
   useEffect(() => {
     if (scopeOptionsError) {
-      toast.error("Failed to load permission options");
+      toast.error(t("apiKeys.toasts.loadPermissionsFailed"));
     }
-  }, [scopeOptionsError]);
+  }, [scopeOptionsError, t]);
 
   const deletePAT = useCallback(
     async (patId: number) => {
@@ -1962,16 +2013,16 @@ function AccountsAccessSettings() {
             tokenCreation.closeTokenModal();
           }
           await mutate();
-          toast.success("Token deleted successfully");
+          toast.success(t("apiKeys.toasts.deleted"));
           setTokenToDelete(null);
         } else {
-          toast.error("Failed to delete token");
+          toast.error(t("apiKeys.toasts.deleteFailed"));
         }
       } catch (error) {
-        toast.error("Network error deleting token");
+        toast.error(t("apiKeys.toasts.deleteNetworkError"));
       }
     },
-    [mutate, tokenCreation]
+    [mutate, tokenCreation, t]
   );
 
   const handleChangePassword = useCallback(
@@ -1993,17 +2044,19 @@ function AccountsAccessSettings() {
         });
 
         if (response.ok) {
-          toast.success("Password updated successfully");
+          toast.success(t("accounts.passwordModal.toasts.updated"));
           setShowPasswordModal(false);
         } else {
           const errorData = await response.json();
-          toast.error(errorData.detail || "Failed to change password");
+          toast.error(
+            errorData.detail || t("accounts.passwordModal.toasts.updateFailed")
+          );
         }
       } catch (error) {
-        toast.error("An error occurred while changing the password");
+        toast.error(t("accounts.passwordModal.toasts.networkError"));
       }
     },
-    []
+    [t]
   );
 
   return (
@@ -2030,24 +2083,25 @@ function AccountsAccessSettings() {
       {tokenToDelete && (
         <ConfirmationModalLayout
           icon={SvgTrash}
-          title="Revoke Access Token"
+          title={t("apiKeys.revokeModal.title")}
           onClose={() => setTokenToDelete(null)}
           submit={
             <Button
               variant="danger"
               onClick={() => deletePAT(tokenToDelete.id)}
             >
-              Revoke
+              {t("apiKeys.revokeModal.submit")}
             </Button>
           }
         >
           <Section gap={2} alignItems="start">
             <Text color="text-05">
-              {`Any application using the token ${tokenToDelete.name} (${tokenToDelete.token_display}) will lose access to Onyx. This action cannot be undone.`}
+              {t("apiKeys.revokeModal.description", {
+                name: tokenToDelete.name,
+                tokenDisplay: tokenToDelete.token_display,
+              })}
             </Text>
-            <Text color="text-05">
-              Are you sure you want to revoke this token?
-            </Text>
+            <Text color="text-05">{t("apiKeys.revokeModal.question")}</Text>
           </Section>
         </ConfirmationModalLayout>
       )}
@@ -2078,7 +2132,7 @@ function AccountsAccessSettings() {
             <Form>
               <ConfirmationModalLayout
                 icon={SvgLock}
-                title="Change Password"
+                title={t("accounts.passwordModal.title")}
                 submit={
                   <Button
                     disabled={isSubmitting || !dirty || !isValid}
@@ -2091,7 +2145,9 @@ function AccountsAccessSettings() {
                       }
                     }}
                   >
-                    {isSubmitting ? "Updating..." : "Update"}
+                    {isSubmitting
+                      ? t("accounts.passwordModal.submit.updating")
+                      : t("accounts.passwordModal.submit.update")}
                   </Button>
                 }
                 onClose={() => {
@@ -2102,7 +2158,7 @@ function AccountsAccessSettings() {
                   <Section gap={1} alignItems="start">
                     <InputVertical
                       withLabel="currentPassword"
-                      title="Current Password"
+                      title={t("accounts.passwordModal.currentPassword.title")}
                     >
                       <PasswordInputTypeIn
                         name="currentPassword"
@@ -2116,7 +2172,10 @@ function AccountsAccessSettings() {
                     </InputVertical>
                   </Section>
                   <Section gap={1} alignItems="start">
-                    <InputVertical withLabel="newPassword" title="New Password">
+                    <InputVertical
+                      withLabel="newPassword"
+                      title={t("accounts.passwordModal.newPassword.title")}
+                    >
                       <PasswordInputTypeIn
                         name="newPassword"
                         value={values.newPassword}
@@ -2129,7 +2188,7 @@ function AccountsAccessSettings() {
                   <Section gap={1} alignItems="start">
                     <InputVertical
                       withLabel="confirmPassword"
-                      title="Confirm New Password"
+                      title={t("accounts.passwordModal.confirmPassword.title")}
                     >
                       <PasswordInputTypeIn
                         name="confirmPassword"
@@ -2152,7 +2211,7 @@ function AccountsAccessSettings() {
       <Section gap={8}>
         <Section gap={3}>
           <Content
-            title="Accounts"
+            title={t("accounts.title")}
             sizePreset="main-content"
             variant="section"
             width="full"
@@ -2160,17 +2219,19 @@ function AccountsAccessSettings() {
           <Card border="solid" rounding={4}>
             <Section alignItems="start" height="fit">
               <InputHorizontal
-                title="Email"
-                description="Your account email address."
+                title={t("accounts.email.title")}
+                description={t("accounts.email.description")}
                 center
               >
-                <Text color="text-05">{user?.email ?? "anonymous"}</Text>
+                <Text color="text-05">
+                  {user?.email ?? t("accounts.email.anonymousFallback")}
+                </Text>
               </InputHorizontal>
 
               {showPasswordSection && (
                 <InputHorizontal
-                  title="Password"
-                  description="Update your account password."
+                  title={t("accounts.password.title")}
+                  description={t("accounts.password.description")}
                   center
                 >
                   <Button
@@ -2179,7 +2240,7 @@ function AccountsAccessSettings() {
                     onClick={() => setShowPasswordModal(true)}
                     interaction={showPasswordModal ? "hover" : "rest"}
                   >
-                    Change Password
+                    {t("accounts.password.changeButton")}
                   </Button>
                 </InputHorizontal>
               )}
@@ -2190,7 +2251,7 @@ function AccountsAccessSettings() {
         {showTokensSection && (
           <Section gap={3}>
             <Content
-              title="Access Tokens"
+              title={t("apiKeys.section.title")}
               sizePreset="main-content"
               variant="section"
               width="full"
@@ -2208,13 +2269,13 @@ function AccountsAccessSettings() {
                         >
                           <Text font="secondary-body" color="text-03">
                             {isLoading
-                              ? "Loading tokens..."
-                              : "No access tokens created."}
+                              ? t("apiKeys.list.loading")
+                              : t("apiKeys.list.empty")}
                           </Text>
                         </Section>
                       ) : (
                         <InputTypeIn
-                          placeholder="Search..."
+                          placeholder={t("apiKeys.list.searchPlaceholder")}
                           value={query}
                           onChange={(e) => setQuery(e.target.value)}
                           searchIcon
@@ -2232,11 +2293,11 @@ function AccountsAccessSettings() {
                           disabled={!canCreatePAT}
                           tooltip={
                             !canCreatePAT
-                              ? "You don't have permission to create access tokens"
+                              ? t("apiKeys.list.noPermissionTooltip")
                               : undefined
                           }
                         >
-                          New Access Token
+                          {t("apiKeys.list.newTokenButton")}
                         </Button>
                       </div>
                     </Section>
@@ -2250,31 +2311,33 @@ function AccountsAccessSettings() {
                             (1000 * 60 * 60 * 24)
                         );
 
-                        let expiryText = "Never expires";
+                        let expiryText = t("apiKeys.list.neverExpires");
                         if (pat.expires_at) {
                           const expiresDate = new Date(pat.expires_at);
                           const daysUntilExpiry = Math.ceil(
                             (expiresDate.getTime() - now.getTime()) /
                               (1000 * 60 * 60 * 24)
                           );
-                          expiryText = `Expires in ${daysUntilExpiry} day${
-                            daysUntilExpiry === 1 ? "" : "s"
-                          }`;
+                          expiryText = t("apiKeys.list.expiresIn", {
+                            count: daysUntilExpiry,
+                          });
                         }
 
                         const scopeText =
                           pat.scopes === null
-                            ? "Full access"
+                            ? t(
+                                "apiKeys.createModal.permissions.fullAccessOption"
+                              )
                             : pat.scopes
                                 .map((scope) => scopeLabels.get(scope) ?? scope)
                                 .join(", ");
 
                         const createdText =
                           daysSinceCreation === 0
-                            ? "Created today"
-                            : `Created ${daysSinceCreation} day${
-                                daysSinceCreation === 1 ? "" : "s"
-                              } ago`;
+                            ? t("apiKeys.list.createdToday")
+                            : t("apiKeys.list.createdDaysAgo", {
+                                count: daysSinceCreation,
+                              });
 
                         const middleText = `${createdText} - ${expiryText} - ${scopeText}`;
 
@@ -2296,7 +2359,10 @@ function AccountsAccessSettings() {
                                     onClick={() => setTokenToDelete(pat)}
                                     prominence="tertiary"
                                     size="sm"
-                                    aria-label={`Delete token ${pat.name}`}
+                                    aria-label={t(
+                                      "apiKeys.list.deleteTokenAriaLabel",
+                                      { name: pat.name }
+                                    )}
                                   />
                                 }
                               />
@@ -2313,10 +2379,10 @@ function AccountsAccessSettings() {
                 <Section alignItems="start" height="fit">
                   <Section flexDirection="row" justifyContent="between">
                     <Text font="secondary-body" color="text-03">
-                      Access tokens require an active paid subscription.
+                      {t("apiKeys.upsell.description")}
                     </Text>
                     <Button prominence="secondary" href="/admin/billing">
-                      Upgrade Plan
+                      {t("apiKeys.upsell.upgradeButton")}
                     </Button>
                   </Section>
                 </Section>
@@ -2335,6 +2401,7 @@ interface IndexedConnectorCardProps {
 }
 
 function IndexedConnectorCard({ source, isActive }: IndexedConnectorCardProps) {
+  const t = useTranslations("settings");
   const sourceMetadata = getSourceMetadata(source);
 
   return (
@@ -2343,7 +2410,11 @@ function IndexedConnectorCard({ source, isActive }: IndexedConnectorCardProps) {
         <Content
           icon={sourceMetadata.icon}
           title={sourceMetadata.displayName}
-          description={isActive ? "Connected" : "Paused"}
+          description={
+            isActive
+              ? t("connectors.status.connected")
+              : t("connectors.status.paused")
+          }
           sizePreset="main-content"
           variant="section"
         />
@@ -2361,6 +2432,7 @@ function FederatedConnectorCard({
   connector,
   onDisconnectSuccess,
 }: FederatedConnectorCardProps) {
+  const t = useTranslations("settings");
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [showDisconnectConfirmation, setShowDisconnectConfirmation] =
     useState(false);
@@ -2375,25 +2447,29 @@ function FederatedConnectorCard({
       );
 
       if (response.ok) {
-        toast.success("Disconnected successfully");
+        toast.success(t("connectors.toasts.disconnected"));
         setShowDisconnectConfirmation(false);
         onDisconnectSuccess();
       } else {
         throw new Error("Failed to disconnect");
       }
     } catch (error) {
-      toast.error("Failed to disconnect");
+      toast.error(t("connectors.toasts.disconnectFailed"));
     } finally {
       setIsDisconnecting(false);
     }
-  }, [connector.federated_connector_id, onDisconnectSuccess]);
+  }, [connector.federated_connector_id, onDisconnectSuccess, t]);
 
   return (
     <>
       {showDisconnectConfirmation && (
         <ConfirmationModalLayout
           icon={SvgUnplug}
-          title={markdown(`Disconnect *${sourceMetadata.displayName}*`)}
+          title={markdown(
+            t("connectors.disconnectModal.title", {
+              name: sourceMetadata.displayName,
+            })
+          )}
           onClose={() => setShowDisconnectConfirmation(false)}
           submit={
             <Button
@@ -2401,16 +2477,22 @@ function FederatedConnectorCard({
               variant="danger"
               onClick={() => void handleDisconnect()}
             >
-              {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+              {isDisconnecting
+                ? t("connectors.disconnectModal.disconnecting")
+                : t("connectors.disconnectModal.submit")}
             </Button>
           }
         >
           <Section gap={2} alignItems="start">
             <Text color="text-05">
-              {`Onyx will no longer be able to access or search content from your ${sourceMetadata.displayName} account.`}
+              {t("connectors.disconnectModal.description", {
+                name: sourceMetadata.displayName,
+              })}
             </Text>
             <Text color="text-05">
-              {`You can still continue existing sessions referencing ${sourceMetadata.displayName} content.`}
+              {t("connectors.disconnectModal.continueNote", {
+                name: sourceMetadata.displayName,
+              })}
             </Text>
           </Section>
         </ConfirmationModalLayout>
@@ -2422,7 +2504,9 @@ function FederatedConnectorCard({
             icon={sourceMetadata.icon}
             title={sourceMetadata.displayName}
             description={
-              connector.has_oauth_token ? "Connected" : "Not connected"
+              connector.has_oauth_token
+                ? t("connectors.status.connected")
+                : t("connectors.status.notConnected")
             }
             sizePreset="main-content"
             variant="section"
@@ -2443,7 +2527,7 @@ function FederatedConnectorCard({
                   target="_blank"
                   rightIcon={SvgArrowExchange}
                 >
-                  Connect
+                  {t("connectors.connectButton")}
                 </Button>
               ) : undefined
             }
@@ -2455,6 +2539,7 @@ function FederatedConnectorCard({
 }
 
 function ConnectorsSettings() {
+  const t = useTranslations("settings");
   const {
     connectors: federatedConnectors,
     refetch: refetchFederatedConnectors,
@@ -2497,7 +2582,7 @@ function ConnectorsSettings() {
     <Section gap={8}>
       <Section gap={3} justifyContent="start">
         <Content
-          title="Connectors"
+          title={t("connectors.title")}
           sizePreset="main-content"
           variant="section"
           width="full"
@@ -2525,7 +2610,7 @@ function ConnectorsSettings() {
         ) : (
           <EmptyMessageCard
             sizePreset="main-ui"
-            title="No connectors set up for your organization."
+            title={t("connectors.emptyMessage")}
           />
         )}
       </Section>

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1334,8 +1334,8 @@ function ChatPreferencesSettings() {
 
             {(user?.preferences?.temperature_override_enabled ?? true) && (
               <InputHorizontal
-                title="Default Temperature"
-                description="Starting temperature for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
+                title={t("chats.defaultTemperature.title")}
+                description={t("chats.defaultTemperature.description")}
                 withLabel
               >
                 <Section flexDirection="row" width="fit" height="auto" gap={3}>
@@ -1364,8 +1364,8 @@ function ChatPreferencesSettings() {
             {!settings.isLoading &&
               (settings.reasoning_override_enabled ?? true) && (
                 <InputHorizontal
-                  title="Default Reasoning Level"
-                  description="Starting reasoning level for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
+                  title={t("chats.defaultReasoningLevel.title")}
+                  description={t("chats.defaultReasoningLevel.description")}
                   withLabel
                 >
                   <Section

--- a/web/tests/e2e/pages/SettingsGeneralPage.ts
+++ b/web/tests/e2e/pages/SettingsGeneralPage.ts
@@ -1,0 +1,53 @@
+/**
+ * Page Object Model for the General settings page (/app/settings/general).
+ *
+ * Currently covers the language picker in the Appearance section. The picker
+ * lists languages by endonym (English, Español, ...), so its trigger and
+ * option locators are locale-independent and safe to use in any UI language.
+ */
+
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class SettingsGeneralPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** Navigate to the page and wait for it to finish loading. */
+  async goto(): Promise<void> {
+    await this.page.goto("/app/settings/general");
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /** Reload the page and wait for it to finish loading. */
+  async reload(): Promise<void> {
+    await this.page.reload();
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /** The language select trigger, located by the endonym it displays. */
+  languageSelect(currentEndonym: string): Locator {
+    return this.page.getByRole("combobox").filter({ hasText: currentEndonym });
+  }
+
+  /** Open the language select and choose a language by its endonym. */
+  async switchLanguage(
+    currentEndonym: string,
+    targetEndonym: string
+  ): Promise<void> {
+    const select = this.languageSelect(currentEndonym);
+    await expect(select).toBeVisible();
+    await select.click();
+    await this.page
+      .getByRole("option", { name: targetEndonym, exact: true })
+      .click();
+  }
+
+  /** Assert the document language and a marker string for the active locale. */
+  async expectLocale(lang: string, markerText: string): Promise<void> {
+    await expect(this.page.locator("html")).toHaveAttribute("lang", lang);
+    await expect(this.page.getByText(markerText).first()).toBeVisible();
+  }
+}

--- a/web/tests/e2e/settings/language_switch.spec.ts
+++ b/web/tests/e2e/settings/language_switch.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import { loginAsRandomUser } from "@tests/e2e/utils/auth";
+import { SettingsGeneralPage } from "@tests/e2e/pages/SettingsGeneralPage";
 
 // Uses a fresh random user: changing the language mutates the user row, and
 // doing that to the shared admin fixture would leak a non-English UI into
@@ -9,33 +10,17 @@ test("language picker switches the UI locale and persists", async ({
 }) => {
   await loginAsRandomUser(page);
 
-  await page.goto("/app/settings/general");
+  const settingsPage = new SettingsGeneralPage(page);
+  await settingsPage.goto();
 
-  // The picker lists languages by endonym, so its trigger text is
-  // locale-independent and safe to target in any UI language.
-  const languageSelect = page
-    .getByRole("combobox")
-    .filter({ hasText: "English" });
-  await expect(languageSelect).toBeVisible();
-  await languageSelect.click();
-  await page.getByRole("option", { name: "Español" }).click();
-
+  await settingsPage.switchLanguage("English", "Español");
   // router.refresh() re-renders the server layout with the new locale.
-  await expect(page.locator("html")).toHaveAttribute("lang", "es");
-  await expect(page.getByText("Apariencia").first()).toBeVisible();
+  await settingsPage.expectLocale("es", "Apariencia");
 
   // The cookie and DB row both carry the preference across a full reload.
-  await page.reload();
-  await expect(page.locator("html")).toHaveAttribute("lang", "es");
-  await expect(page.getByText("Apariencia").first()).toBeVisible();
+  await settingsPage.reload();
+  await settingsPage.expectLocale("es", "Apariencia");
 
-  // Switch back, again via the locale-independent endonym.
-  const languageSelectSpanish = page
-    .getByRole("combobox")
-    .filter({ hasText: "Español" });
-  await languageSelectSpanish.click();
-  await page.getByRole("option", { name: "English", exact: true }).click();
-
-  await expect(page.locator("html")).toHaveAttribute("lang", "en");
-  await expect(page.getByText("Appearance").first()).toBeVisible();
+  await settingsPage.switchLanguage("Español", "English");
+  await settingsPage.expectLocale("en", "Appearance");
 });

--- a/web/tests/e2e/settings/language_switch.spec.ts
+++ b/web/tests/e2e/settings/language_switch.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+import { loginAsRandomUser } from "@tests/e2e/utils/auth";
+
+// Uses a fresh random user: changing the language mutates the user row, and
+// doing that to the shared admin fixture would leak a non-English UI into
+// concurrently running specs.
+test("language picker switches the UI locale and persists", async ({
+  page,
+}) => {
+  await loginAsRandomUser(page);
+
+  await page.goto("/app/settings/general");
+
+  // The picker lists languages by endonym, so its trigger text is
+  // locale-independent and safe to target in any UI language.
+  const languageSelect = page
+    .getByRole("combobox")
+    .filter({ hasText: "English" });
+  await expect(languageSelect).toBeVisible();
+  await languageSelect.click();
+  await page.getByRole("option", { name: "Español" }).click();
+
+  // router.refresh() re-renders the server layout with the new locale.
+  await expect(page.locator("html")).toHaveAttribute("lang", "es");
+  await expect(page.getByText("Apariencia").first()).toBeVisible();
+
+  // The cookie and DB row both carry the preference across a full reload.
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("lang", "es");
+  await expect(page.getByText("Apariencia").first()).toBeVisible();
+
+  // Switch back, again via the locale-independent endonym.
+  const languageSelectSpanish = page
+    .getByRole("combobox")
+    .filter({ hasText: "Español" });
+  await languageSelectSpanish.click();
+  await page.getByRole("option", { name: "English", exact: true }).click();
+
+  await expect(page.locator("html")).toHaveAttribute("lang", "en");
+  await expect(page.getByText("Appearance").first()).toBeVisible();
+});

--- a/web/tests/setup/test-utils.tsx
+++ b/web/tests/setup/test-utils.tsx
@@ -3,6 +3,8 @@ import { render, RenderOptions } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SWRConfig } from "swr";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { NextIntlClientProvider } from "next-intl";
+import englishMessages from "@/i18n/messages/en.json";
 export { makeProvider } from "./llmProviderTestUtils";
 
 /**
@@ -33,7 +35,10 @@ function AllTheProviders({ children, swrConfig = {} }: AllProvidersProps) {
         ...swrConfig,
       }}
     >
-      <TooltipPrimitive.Provider>{children}</TooltipPrimitive.Provider>
+      {/* Tests always render the English catalog, matching the app default. */}
+      <NextIntlClientProvider locale="en" messages={englishMessages}>
+        <TooltipPrimitive.Provider>{children}</TooltipPrimitive.Provider>
+      </NextIntlClientProvider>
     </SWRConfig>
   );
 }

--- a/web/tools/oxlint/i18n/index.ts
+++ b/web/tools/oxlint/i18n/index.ts
@@ -1,0 +1,16 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noRawJsxTextRule } from "./rules/no-raw-jsx-text.ts";
+
+/**
+ * i18n migration ratchet. Rules are "off" by default and enabled per-path via
+ * `overrides` in .oxlintrc.json as directories finish their string extraction.
+ */
+const i18nPlugin = eslintCompatPlugin({
+  meta: { name: "i18n" },
+  rules: {
+    "no-raw-jsx-text": noRawJsxTextRule,
+  },
+});
+
+export default i18nPlugin;

--- a/web/tools/oxlint/i18n/package.json
+++ b/web/tools/oxlint/i18n/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "oxlint-plugin-i18n",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.ts"
+}

--- a/web/tools/oxlint/i18n/rules/no-raw-jsx-text.ts
+++ b/web/tools/oxlint/i18n/rules/no-raw-jsx-text.ts
@@ -58,12 +58,19 @@ export const noRawJsxTextRule = defineRule({
         const propName = node.name.name;
         if (!USER_FACING_PROPS.has(propName)) return;
 
+        // Depending on the AST compat layer, string literals surface as
+        // "Literal" or "StringLiteral" — accept both.
+        const isStringLiteralNode = (candidate: {
+          type: string;
+        }): candidate is { type: string; value: unknown } =>
+          candidate.type === "Literal" || candidate.type === "StringLiteral";
+
         const attributeValue = node.value;
         const literal =
-          attributeValue?.type === "Literal"
+          attributeValue !== null && isStringLiteralNode(attributeValue)
             ? attributeValue
             : attributeValue?.type === "JSXExpressionContainer" &&
-                attributeValue.expression.type === "Literal"
+                isStringLiteralNode(attributeValue.expression)
               ? attributeValue.expression
               : null;
 

--- a/web/tools/oxlint/i18n/rules/no-raw-jsx-text.ts
+++ b/web/tools/oxlint/i18n/rules/no-raw-jsx-text.ts
@@ -1,0 +1,84 @@
+import { defineRule } from "@oxlint/plugins";
+
+// JSX props whose string values render as user-facing copy.
+const USER_FACING_PROPS = new Set([
+  "label",
+  "placeholder",
+  "title",
+  "description",
+  "tooltip",
+  "aria-label",
+  "alt",
+  "emptyMessage",
+  "errorMessage",
+  "sublabel",
+  "subtitle",
+]);
+
+// User-facing English copy: contains a word of letters and either starts with
+// an uppercase letter or spans multiple words. Skips technical values such as
+// "7", "es", "email@yourcompany.com", and single lowercase tokens.
+function looksLikeUserFacingCopy(value: string): boolean {
+  const trimmed = value.trim();
+  if (!/[A-Za-z]{2,}/.test(trimmed)) return false;
+  return /^[A-Z]/.test(trimmed) || /\s/.test(trimmed);
+}
+
+/**
+ * Flags raw English copy in migrated directories: JSX text nodes and
+ * user-facing string props must come from the message catalog via
+ * `useTranslations`/`getTranslations` instead of string literals.
+ *
+ * Enabled per-path in .oxlintrc.json `overrides` — the ratchet grows as
+ * directories finish their i18n migration and never blocks unmigrated code.
+ */
+export const noRawJsxTextRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow hardcoded user-facing strings in JSX on i18n-migrated paths; use t() with a key in src/i18n/messages/en.json.",
+    },
+    messages: {
+      rawJsxText:
+        "Hardcoded UI text in an i18n-migrated file. Move the string to src/i18n/messages/en.json and render it with t().",
+      rawJsxProp:
+        'Hardcoded user-facing "{{prop}}" value in an i18n-migrated file. Move the string to src/i18n/messages/en.json and pass t() output.',
+    },
+  },
+  createOnce(context) {
+    return {
+      JSXText(node) {
+        if (looksLikeUserFacingCopy(node.value)) {
+          context.report({ node, messageId: "rawJsxText" });
+        }
+      },
+      JSXAttribute(node) {
+        if (node.name.type !== "JSXIdentifier") return;
+        const propName = node.name.name;
+        if (!USER_FACING_PROPS.has(propName)) return;
+
+        const attributeValue = node.value;
+        const literal =
+          attributeValue?.type === "Literal"
+            ? attributeValue
+            : attributeValue?.type === "JSXExpressionContainer" &&
+                attributeValue.expression.type === "Literal"
+              ? attributeValue.expression
+              : null;
+
+        if (
+          literal !== null &&
+          typeof literal.value === "string" &&
+          looksLikeUserFacingCopy(literal.value)
+        ) {
+          context.report({
+            node: literal,
+            messageId: "rawJsxProp",
+            data: { prop: propName },
+          });
+        }
+      },
+    };
+  },
+});

--- a/web/tsconfig.types.json
+++ b/web/tsconfig.types.json
@@ -3,6 +3,11 @@
   "compilerOptions": {
     "target": "ES2017",
     "moduleResolution": "bundler",
+    // typescript-7's incremental cache keeps reporting fixed errors in JSON
+    // modules (the i18n catalogs are type-checked via messages/keyParity.ts),
+    // so a repaired catalog can fail types:check until the cache is deleted.
+    // A cold run costs ~3s extra; always-correct beats that.
+    "incremental": false,
     "paths": {
       "@/*": ["./src/*"],
       "@tests/*": ["./tests/*"],

--- a/web/tsconfig.types.json
+++ b/web/tsconfig.types.json
@@ -6,7 +6,8 @@
     // typescript-7's incremental cache keeps reporting fixed errors in JSON
     // modules (the i18n catalogs are type-checked via messages/keyParity.ts),
     // so a repaired catalog can fail types:check until the cache is deleted.
-    // A cold run costs ~3s extra; always-correct beats that.
+    // A cold run costs ~3s extra; always-correct beats that. Remove when
+    // https://github.com/microsoft/TypeScript/issues/64025 is fixed.
     "incremental": false,
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary

PR 3 of the i18n stack (base: #14253). The first string-extraction wave, plus the guardrails that keep the migration honest:

- **Extraction**: `SettingsPage.tsx`, every page under `src/app/auth/`, and `AccountPopover.tsx` now render copy via `useTranslations`/`getTranslations`. 273 keys land in `en.json` under `settings`, `auth`, and `accountPopover`, with stable identifier keys (`settings.appearance.colorMode.title`), ICU plurals/selects, and `t.rich` for link-embedded sentences instead of concatenated fragments.
- **Translations**: `es/pt/fr/de.json` are hand-seeded for all 273 keys this once (the automated LLM pipeline is the next PR). Register conventions: es tú, pt você, fr vous, de Sie.
- **Lint ratchet**: new in-repo oxlint plugin `i18n/no-raw-jsx-text` (modeled on `anti-slop`) flags hardcoded JSX copy and user-facing string props. It is `off` globally and enabled via `.oxlintrc.json` overrides only on the migrated paths — finished directories cannot regress, unmigrated code is never blocked.
- **Catalog test**: a Jest unit test validates every locale for ICU syntax, placeholder parity with English, and orphan keys. Untranslated keys are logged, not failed, so translation lag never blocks feature PRs (they render the English fallback at runtime).
- **E2e**: one Playwright spec logs in as a random user, switches to Español, asserts `<html lang="es">` + a translated string, reloads to prove cookie/DB persistence, and switches back.
- Shared Jest render helper now provides the English catalog via `NextIntlClientProvider`; next-intl/@formatjs added to the ESM transform list. `web/AGENTS.md` documents the workflow for future contributors and agents.

## Testing

- `types:check`, `lint`, and the full Jest suite (130 suites / 1187 tests) pass.
- The new Playwright spec passes against the live dev stack.
- Manual check: Spanish and German SSR render translated login/settings copy; English default renders no raw key paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2880" height="1920" alt="20260825_19h30m06s_grim" src="https://github.com/user-attachments/assets/465c8df1-e863-4a06-a231-217f4f7e1a0e" />
