### PR TITLE
fix(indexing): mark all-skipped batches complete so attempts don't stall

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -1734,6 +1734,17 @@ def _docprocessing_task(
         )
         if not documents:
             task_logger.error(f"No documents found for batch {batch_num}")
+            # Every doc was dropped at deserialization (legacy or unknown
+            # section types). Mark the batch complete with zero counts so
+            # the attempt's completion check does not wait on it forever.
+            with get_session_with_current_tenant() as db_session:
+                IndexingCoordination.update_batch_completion_and_docs(
+                    db_session=db_session,
+                    index_attempt_id=index_attempt_id,
+                    total_docs_indexed=0,
+                    new_docs_indexed=0,
+                    total_chunks=0,
+                )
             return
 
         # FIX: Monitor memory after loading documents

--- a/backend/tests/unit/onyx/background/celery/test_docprocessing_empty_batch.py
+++ b/backend/tests/unit/onyx/background/celery/test_docprocessing_empty_batch.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+from onyx.background.celery.tasks.docprocessing.tasks import _docprocessing_task
+
+MODULE = "onyx.background.celery.tasks.docprocessing.tasks"
+
+
+def test_empty_batch_records_completion() -> None:
+    """A batch whose documents were all dropped at deserialization must still
+    count toward completed_batches — a bare return would stall the attempt."""
+    storage = MagicMock()
+    storage.get_batch.return_value = []
+
+    with (
+        patch(f"{MODULE}.USAGE_LIMITS_ENABLED", False),
+        patch(f"{MODULE}.MANAGED_VESPA", False),
+        patch(f"{MODULE}.httpx_init_vespa_pool"),
+        patch(f"{MODULE}.get_document_batch_storage", return_value=storage),
+        patch(f"{MODULE}.RedisConnector"),
+        patch(f"{MODULE}.get_redis_client"),
+        patch(f"{MODULE}.emit_process_memory"),
+        patch(f"{MODULE}.safe_record_single_event"),
+        patch(f"{MODULE}.get_session_with_current_tenant"),
+        patch(f"{MODULE}.IndexingCoordination") as coordination,
+    ):
+        _docprocessing_task(
+            index_attempt_id=7,
+            cc_pair_id=3,
+            tenant_id="public",
+            batch_num=2,
+        )
+
+    storage.get_batch.assert_called_once_with(2)
+    coordination.update_batch_completion_and_docs.assert_called_once()
+    kwargs = coordination.update_batch_completion_and_docs.call_args.kwargs
+    assert kwargs["index_attempt_id"] == 7
+    assert kwargs["total_docs_indexed"] == 0
+    assert kwargs["new_docs_indexed"] == 0
+    assert kwargs["total_chunks"] == 0


### PR DESCRIPTION
## Description

`_deserialize_documents` skips documents it cannot safely parse: legacy inline tabular sections, or a section type staged by a newer docfetching worker during a rolling deploy. When every document in a batch is skipped, `_docprocessing_task` returned without recording the batch. `completed_batches` then never reached `total_batches`, and the index attempt hung until the stuck-attempt watchdog failed it — taking the successfully indexed batches down with it.

This records a zero-count batch completion (`IndexingCoordination.update_batch_completion_and_docs`) before returning, mirroring the existing recovery-path pattern in the same file. The skipped documents re-stage on the next scheduled indexing run.

Extracted from #14225 (review finding there): the bug is reachable on `main` today via the legacy-tabular skip and should ship independently of that stack.

## How Has This Been Tested?

Unit test drives `_docprocessing_task` with an empty batch and asserts the zero-count completion write. Verified the test fails against the pre-fix code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)