### PR TITLE
ci: replace EE CODEOWNERS entries with an org-membership check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,3 @@
 
 # Beta cherry-pick workflow owners
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman
-
-# Enterprise Edition code owners
-/backend/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
-/web/src/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
-/web/src/app/ee/ @evan-onyx @Weves @jmelahman @justin-tahara

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -33,9 +33,21 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # Automation and AI-agent logins that author commits for org developers.
+          # Note: anyone can run these agents, also on forks. A commit authored by
+          # one of these logins passes without proof of who drove the agent.
           IGNORED_AUTHORS: |
             dependabot[bot]
             onyx-cherry-pick[bot]
+            claude[bot]
+            cursoragent
+            Copilot
+            devin-ai-integration[bot]
+            greptile-apps[bot]
+            cubic-dev-ai[bot]
+          # Bot author emails that are not linked to any GitHub account.
+          IGNORED_AUTHOR_EMAILS: |
+            contact@cubic.dev
         run: |
           # The pull request commits API returns at most 250 commits.
           # Fail if the check cannot see every commit.
@@ -75,11 +87,18 @@ jobs:
           }
 
           # Commits whose author email is not linked to any GitHub account
-          # cannot be verified, so they fail the check.
-          unmapped="$(jq -r '.[] | select(.author == null) | "  commit \(.sha[0:10]) has no linked GitHub account (\(.commit.author.name) <\(.commit.author.email)>)"' <<< "${commits}")"
-          if [ -n "${unmapped}" ]; then
-            add_failure "${unmapped}"
-          fi
+          # cannot be verified, so they fail the check unless the email is
+          # on the email ignorelist.
+          normalized_ignored_emails="$(printf '%s\n' "${IGNORED_AUTHOR_EMAILS}" | tr '[:upper:]' '[:lower:]')"
+          unmapped="$(jq -r '.[] | select(.author == null) | "\(.sha[0:10])\t\(.commit.author.email)\t\(.commit.author.name)"' <<< "${commits}")"
+          while IFS=$'\t' read -r sha email name; do
+            [ -z "${sha}" ] && continue
+            normalized_email="$(printf '%s' "${email}" | tr '[:upper:]' '[:lower:]')"
+            if printf '%s\n' "${normalized_ignored_emails}" | grep -Fxq "${normalized_email}"; then
+              continue
+            fi
+            add_failure "  commit ${sha} has no linked GitHub account (${name} <${email}>)"
+          done <<< "${unmapped}"
 
           commit_logins="$(jq -r '[.[] | select(.author != null) | .author.login] | unique | .[]' <<< "${commits}")"
           all_logins="$(printf '%s\n%s\n' "${PR_AUTHOR}" "${commit_logins}" | sort -u)"

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -2,7 +2,7 @@
 # It asserts that the PR author and every commit author of changes to the ee/ directories
 # are inside the organization. "Inside the organization" is approximated as "has write
 # access to this repository", because the default GITHUB_TOKEN cannot read org membership.
-# TODO(jmelahman): Decide the long-term ownership model for the ee/ directories. A future
+# TODO: Decide the long-term ownership model for the ee/ directories. A future
 # version can check true org membership (needs an org-scoped token) and add an
 # explicit-approval path (for example, a maintainer-applied label).
 name: Ensure EE changes come from org members

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -1,6 +1,10 @@
 # Interim replacement for the Enterprise Edition entries that were in .github/CODEOWNERS.
-# It asserts that only organization members change the ee/ directories.
-# TODO: Decide the long-term ownership model for the ee/ directories.
+# It asserts that the PR author and every commit author of changes to the ee/ directories
+# are inside the organization. "Inside the organization" is approximated as "has write
+# access to this repository", because the default GITHUB_TOKEN cannot read org membership.
+# TODO: Decide the long-term ownership model for the ee/ directories. A future version can
+# check true org membership (needs an org-scoped token) and add an explicit-approval path
+# (for example, a maintainer-applied label).
 name: Ensure EE changes come from org members
 concurrency:
   group: Ensure-EE-changes-come-from-org-members-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -15,33 +19,85 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   ee-ownership-check:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Check that the PR author is an organization member
+      - name: Check that the PR author and all commit authors are org members
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           IGNORED_AUTHORS: |
             dependabot[bot]
             onyx-cherry-pick[bot]
         run: |
-          normalized_author="$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')"
-          normalized_ignored="$(printf '%s\n' "${IGNORED_AUTHORS}" | tr '[:upper:]' '[:lower:]')"
-          if printf '%s\n' "${normalized_ignored}" | grep -Fxq "${normalized_author}"; then
-            echo "PR author ${PR_AUTHOR} is on the ignorelist. Check passed."
-            exit 0
+          # The pull request commits API returns at most 250 commits.
+          # Fail if the check cannot see every commit.
+          if [ "${PR_COMMIT_COUNT}" -gt 250 ]; then
+            echo "::error::This PR has ${PR_COMMIT_COUNT} commits. The EE ownership check can only inspect 250. Split the PR."
+            exit 1
           fi
 
-          case "${AUTHOR_ASSOCIATION}" in
-            MEMBER|OWNER)
-              echo "PR author ${PR_AUTHOR} is an organization member. Check passed."
-              exit 0
-              ;;
-          esac
+          commits="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" --jq '.[]' | jq -s '.')"
 
-          echo "::error::This PR changes EE code (backend/ee/, web/src/ee/, or web/src/app/ee/), but the author ${PR_AUTHOR} (${AUTHOR_ASSOCIATION}) is not a member of the organization. Ask an organization member to make these changes."
-          exit 1
+          normalized_ignored="$(printf '%s\n' "${IGNORED_AUTHORS}" | tr '[:upper:]' '[:lower:]')"
+
+          # A login is allowed when it is on the ignorelist, is an org-member PR
+          # author, or has write access to this repository.
+          is_allowed() {
+            login="$1"
+            normalized_login="$(printf '%s' "${login}" | tr '[:upper:]' '[:lower:]')"
+            if printf '%s\n' "${normalized_ignored}" | grep -Fxq "${normalized_login}"; then
+              return 0
+            fi
+            if [ "${login}" = "${PR_AUTHOR}" ]; then
+              case "${AUTHOR_ASSOCIATION}" in
+                MEMBER|OWNER) return 0 ;;
+              esac
+            fi
+            permission="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${login}/permission" --jq '.permission' 2>/dev/null || echo "unknown")"
+            [ "${permission}" = "admin" ] || [ "${permission}" = "write" ]
+          }
+
+          failures=""
+          add_failure() {
+            if [ -n "${failures}" ]; then
+              failures="${failures}"$'\n'"$1"
+            else
+              failures="$1"
+            fi
+          }
+
+          # Commits whose author email is not linked to any GitHub account
+          # cannot be verified, so they fail the check.
+          unmapped="$(jq -r '.[] | select(.author == null) | "  commit \(.sha[0:10]) has no linked GitHub account (\(.commit.author.name) <\(.commit.author.email)>)"' <<< "${commits}")"
+          if [ -n "${unmapped}" ]; then
+            add_failure "${unmapped}"
+          fi
+
+          commit_logins="$(jq -r '[.[] | select(.author != null) | .author.login] | unique | .[]' <<< "${commits}")"
+          all_logins="$(printf '%s\n%s\n' "${PR_AUTHOR}" "${commit_logins}" | sort -u)"
+
+          while IFS= read -r login; do
+            [ -z "${login}" ] && continue
+            if ! is_allowed "${login}"; then
+              add_failure "  ${login} is not in the organization (no write access to this repository)"
+            fi
+          done <<< "${all_logins}"
+
+          if [ -n "${failures}" ]; then
+            echo "This PR changes EE code (backend/ee/, web/src/ee/, or web/src/app/ee/)."
+            echo "Only organization members can author changes to these directories."
+            echo "Problems found:"
+            echo "${failures}"
+            echo "::error::EE ownership check failed. See the job log for the list of authors."
+            exit 1
+          fi
+
+          echo "The PR author and all commit authors are allowed. Check passed."

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -1,0 +1,47 @@
+# Interim replacement for the Enterprise Edition entries that were in .github/CODEOWNERS.
+# It asserts that only organization members change the ee/ directories.
+# TODO: Decide the long-term ownership model for the ee/ directories.
+name: Ensure EE changes come from org members
+concurrency:
+  group: Ensure-EE-changes-come-from-org-members-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "backend/ee/**"
+      - "web/src/ee/**"
+      - "web/src/app/ee/**"
+
+permissions:
+  contents: read
+
+jobs:
+  ee-ownership-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check that the PR author is an organization member
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          IGNORED_AUTHORS: |
+            dependabot[bot]
+            onyx-cherry-pick[bot]
+        run: |
+          normalized_author="$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')"
+          normalized_ignored="$(printf '%s\n' "${IGNORED_AUTHORS}" | tr '[:upper:]' '[:lower:]')"
+          if printf '%s\n' "${normalized_ignored}" | grep -Fxq "${normalized_author}"; then
+            echo "PR author ${PR_AUTHOR} is on the ignorelist. Check passed."
+            exit 0
+          fi
+
+          case "${AUTHOR_ASSOCIATION}" in
+            MEMBER|OWNER)
+              echo "PR author ${PR_AUTHOR} is an organization member. Check passed."
+              exit 0
+              ;;
+          esac
+
+          echo "::error::This PR changes EE code (backend/ee/, web/src/ee/, or web/src/app/ee/), but the author ${PR_AUTHOR} (${AUTHOR_ASSOCIATION}) is not a member of the organization. Ask an organization member to make these changes."
+          exit 1

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -45,7 +45,9 @@ jobs:
             devin-ai-integration[bot]
             greptile-apps[bot]
             cubic-dev-ai[bot]
-          # Bot author emails that are not linked to any GitHub account.
+          # Bot author emails that are not linked to any GitHub account (cubic, OmX).
+          # These emails are easy to spoof, so commits with them pass only when the
+          # PR also has a commit author from the organization.
           IGNORED_AUTHOR_EMAILS: |
             contact@cubic.dev
             omx@oh-my-codex.dev
@@ -60,15 +62,17 @@ jobs:
           commits="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits?per_page=100" --jq '.[]' | jq -s '.')"
 
           normalized_ignored="$(printf '%s\n' "${IGNORED_AUTHORS}" | tr '[:upper:]' '[:lower:]')"
+          normalized_ignored_emails="$(printf '%s\n' "${IGNORED_AUTHOR_EMAILS}" | tr '[:upper:]' '[:lower:]')"
 
-          # A login is allowed when it is on the ignorelist, is an org-member PR
-          # author, or has write access to this repository.
-          is_allowed() {
+          is_ignorelisted() {
+            normalized_login="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+            printf '%s\n' "${normalized_ignored}" | grep -Fxq "${normalized_login}"
+          }
+
+          # A login is "org" when it is an org-member PR author or has write
+          # access to this repository.
+          is_org() {
             login="$1"
-            normalized_login="$(printf '%s' "${login}" | tr '[:upper:]' '[:lower:]')"
-            if printf '%s\n' "${normalized_ignored}" | grep -Fxq "${normalized_login}"; then
-              return 0
-            fi
             if [ "${login}" = "${PR_AUTHOR}" ]; then
               case "${AUTHOR_ASSOCIATION}" in
                 MEMBER|OWNER) return 0 ;;
@@ -87,29 +91,49 @@ jobs:
             fi
           }
 
-          # Commits whose author email is not linked to any GitHub account
-          # cannot be verified, so they fail the check unless the email is
-          # on the email ignorelist.
-          normalized_ignored_emails="$(printf '%s\n' "${IGNORED_AUTHOR_EMAILS}" | tr '[:upper:]' '[:lower:]')"
+          # Check every mapped commit author. Record whether the PR has at least
+          # one commit author from the organization. Ignorelisted bot logins do
+          # not count as org authors.
+          commit_logins="$(jq -r '[.[] | select(.author != null) | .author.login] | unique | .[]' <<< "${commits}")"
+          org_author_present=false
+          while IFS= read -r login; do
+            [ -z "${login}" ] && continue
+            if is_ignorelisted "${login}"; then
+              continue
+            fi
+            if is_org "${login}"; then
+              org_author_present=true
+            else
+              add_failure "  ${login} is not in the organization (no write access to this repository)"
+            fi
+          done <<< "${commit_logins}"
+
+          # Check the PR author too. The PR author can have zero commits, for
+          # example on a run-ci mirror of a fork PR.
+          if ! printf '%s\n' "${commit_logins}" | grep -Fxq "${PR_AUTHOR}"; then
+            if ! is_ignorelisted "${PR_AUTHOR}" && ! is_org "${PR_AUTHOR}"; then
+              add_failure "  ${PR_AUTHOR} is not in the organization (no write access to this repository)"
+            fi
+          fi
+
+          # Commits whose author email is not linked to any GitHub account cannot
+          # be verified. Ignorelisted agent emails pass only when an org member
+          # also authored a commit in this PR. The PR author does not count: a
+          # run-ci mirror has an org PR author, and must not excuse agent commits
+          # from a fork. All other unlinked emails fail.
           unmapped="$(jq -r '.[] | select(.author == null) | "\(.sha[0:10])\t\(.commit.author.email)\t\(.commit.author.name)"' <<< "${commits}")"
           while IFS=$'\t' read -r sha email name; do
             [ -z "${sha}" ] && continue
             normalized_email="$(printf '%s' "${email}" | tr '[:upper:]' '[:lower:]')"
             if printf '%s\n' "${normalized_ignored_emails}" | grep -Fxq "${normalized_email}"; then
-              continue
+              if [ "${org_author_present}" = "true" ]; then
+                continue
+              fi
+              add_failure "  commit ${sha} is authored by agent email ${email}, but no commit in this PR has an author from the organization"
+            else
+              add_failure "  commit ${sha} has no linked GitHub account (${name} <${email}>)"
             fi
-            add_failure "  commit ${sha} has no linked GitHub account (${name} <${email}>)"
           done <<< "${unmapped}"
-
-          commit_logins="$(jq -r '[.[] | select(.author != null) | .author.login] | unique | .[]' <<< "${commits}")"
-          all_logins="$(printf '%s\n%s\n' "${PR_AUTHOR}" "${commit_logins}" | sort -u)"
-
-          while IFS= read -r login; do
-            [ -z "${login}" ] && continue
-            if ! is_allowed "${login}"; then
-              add_failure "  ${login} is not in the organization (no write access to this repository)"
-            fi
-          done <<< "${all_logins}"
 
           if [ -n "${failures}" ]; then
             echo "This PR changes EE code (backend/ee/, web/src/ee/, or web/src/app/ee/)."

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -2,16 +2,19 @@
 # It asserts that the PR author and every commit author of changes to the ee/ directories
 # are inside the organization. "Inside the organization" is approximated as "has write
 # access to this repository", because the default GITHUB_TOKEN cannot read org membership.
-# TODO: Decide the long-term ownership model for the ee/ directories. A future version can
-# check true org membership (needs an org-scoped token) and add an explicit-approval path
-# (for example, a maintainer-applied label).
+# TODO(jmelahman): Decide the long-term ownership model for the ee/ directories. A future
+# version can check true org membership (needs an org-scoped token) and add an
+# explicit-approval path (for example, a maintainer-applied label).
 name: Ensure EE changes come from org members
 concurrency:
-  group: Ensure-EE-changes-come-from-org-members-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: Ensure-EE-changes-come-from-org-members-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:
-  pull_request:
+  # pull_request_target runs the base-branch version of this workflow, so a PR
+  # cannot edit this file to bypass the check. This is safe ONLY because the job
+  # never checks out or executes PR code. Do not add a checkout step.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     paths:
       - "backend/ee/**"
       - "web/src/ee/**"

--- a/.github/workflows/pr-ee-ownership-check.yml
+++ b/.github/workflows/pr-ee-ownership-check.yml
@@ -48,6 +48,7 @@ jobs:
           # Bot author emails that are not linked to any GitHub account.
           IGNORED_AUTHOR_EMAILS: |
             contact@cubic.dev
+            omx@oh-my-codex.dev
         run: |
           # The pull request commits API returns at most 250 commits.
           # Fail if the check cannot see every commit.


### PR DESCRIPTION
## Description

Removes the Enterprise Edition entries from `.github/CODEOWNERS`. The global `*` rule still assigns `@onyx-dot-app/onyx-core-team` to every file, so `ee/` changes keep baseline review coverage.

As an interim replacement, adds `pr-ee-ownership-check.yml`. The workflow runs only when a PR changes `backend/ee/**`, `web/src/ee/**`, or `web/src/app/ee/**`. It fails unless the PR author **and every commit author** are inside the organization or on the bot ignorelist.

Checking commit authors (not just the PR author) means `ods run-ci` mirrors of fork PRs that touch `ee/` also fail the check. A fork contributor's `ee/` changes cannot merge through a mirror or a shepherded branch.

The ignorelist covers automation and AI agents that author commits for org developers: `dependabot[bot]`, `onyx-cherry-pick[bot]`, `claude[bot]`, `cursoragent`, `Copilot`, `devin-ai-integration[bot]`, `greptile-apps[bot]`, and `cubic-dev-ai[bot]`. Cubic and OmX author commits with emails that have no linked GitHub account (`contact@cubic.dev`, `omx@oh-my-codex.dev`). Commits with these emails pass only when the PR also has a commit author from the organization. The PR author does not count, so a run-ci mirror cannot excuse agent commits from a fork, and spoofing these plain-text emails does not help. Known tradeoff: anyone can run these agents, also on forks, so a commit authored by an ignorelisted agent passes without proof of who drove it.

Implementation notes:

- Org membership is approximated as write access to this repository, via `GET /repos/{owner}/{repo}/collaborators/{username}/permission`. That endpoint only needs `Metadata: read`, which every `GITHUB_TOKEN` has — including the read-only token on fork PRs. Contributors without explicit access get `read` and fail. True org-membership lookup would need an org-scoped token; noted in the TODO.
- Commits whose author email is not linked to a GitHub account fail the check, unless the email is ignorelisted.
- PRs with more than 250 commits fail, because the commits API cannot list them all.
- The workflow runs on `pull_request_target`, so the base-branch version of the check runs and a PR cannot edit the workflow file to bypass it. The job never checks out PR code.
- A TODO in the workflow tracks the long-term ownership model, including a future explicit-approval path.

## How Has This Been Tested?

- `pre-commit run --files ...` passes (zizmor, actionlint, YAML check).
- Ran the check's script logic locally against real PRs: an outsider fork PR fails, an org member's PR passes, and a simulated run-ci mirror (member PR author, outsider commit author) fails.
- Ran the unmapped-email logic against synthetic commit data: the cubic email passes, an unknown unmapped email fails, ignorelisted bot logins pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


