### PR TITLE
feat(chat): per-user default temperature and reasoning level

### DIFF
--- a/backend/alembic/versions/66a70ddc0652_user_chat_defaults.py
+++ b/backend/alembic/versions/66a70ddc0652_user_chat_defaults.py
@@ -1,0 +1,42 @@
+"""user chat defaults
+
+Revision ID: 66a70ddc0652
+Revises: e7c00417d1e5
+Create Date: 2026-08-25 14:00:35.813051
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from onyx.llm.models import ReasoningEffort
+
+# revision identifiers, used by Alembic.
+revision = "66a70ddc0652"
+down_revision = "e7c00417d1e5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column("temperature_default", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "user",
+        sa.Column(
+            "reasoning_effort_default",
+            sa.Enum(
+                ReasoningEffort,
+                native_enum=False,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "reasoning_effort_default")
+    op.drop_column("user", "temperature_default")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -364,8 +364,8 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     temperature_override_enabled: Mapped[bool | None] = mapped_column(
         Boolean, default=None
     )
-    # Per-user chat defaults. Applied below an admin's per-model default and
-    # clamped by the per-model max, see resolve_reasoning_effort.
+    # Per-user chat defaults. An admin's per-model settings outrank them, see
+    # resolve_reasoning_effort and the factory temperature chain.
     temperature_default: Mapped[float | None] = mapped_column(Float, default=None)
     reasoning_effort_default: Mapped[ReasoningEffort | None] = mapped_column(
         Enum(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -364,6 +364,18 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     temperature_override_enabled: Mapped[bool | None] = mapped_column(
         Boolean, default=None
     )
+    # Per-user chat defaults. Applied below an admin's per-model default and
+    # clamped by the per-model max, see resolve_reasoning_effort.
+    temperature_default: Mapped[float | None] = mapped_column(Float, default=None)
+    reasoning_effort_default: Mapped[ReasoningEffort | None] = mapped_column(
+        Enum(
+            ReasoningEffort,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+        default=None,
+    )
     auto_scroll: Mapped[bool | None] = mapped_column(Boolean, default=None)
     shortcut_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     theme_preference: Mapped[ThemePreference | None] = mapped_column(

--- a/backend/onyx/db/user_preferences.py
+++ b/backend/onyx/db/user_preferences.py
@@ -16,6 +16,7 @@ from onyx.db.users import (
     is_limited_user,
     user_is_admin,
 )
+from onyx.llm.models import ReasoningEffort
 from onyx.server.manage.models import MemoryItem, UserSpecificAssistantPreference
 from onyx.utils.logger import setup_logger
 
@@ -100,6 +101,34 @@ def update_user_temperature_override_enabled(
         update(User)
         .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
         .values(temperature_override_enabled=temperature_override_enabled)
+    )
+    db_session.commit()
+
+
+def update_user_temperature_default(
+    user_id: UUID,
+    temperature_default: float | None,
+    db_session: Session,
+) -> None:
+    """Update the user's own temperature default. Null clears it."""
+    db_session.execute(
+        update(User)
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .values(temperature_default=temperature_default)
+    )
+    db_session.commit()
+
+
+def update_user_reasoning_effort_default(
+    user_id: UUID,
+    reasoning_effort_default: ReasoningEffort | None,
+    db_session: Session,
+) -> None:
+    """Update the user's own reasoning default. Null clears it."""
+    db_session.execute(
+        update(User)
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .values(reasoning_effort_default=reasoning_effort_default)
     )
     db_session.commit()
 

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -21,7 +21,7 @@ from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Persona, SearchSettings, User
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM, LlmRequestPolicy
-from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import ReasoningEffort, UserChatDefaults
 from onyx.llm.multi_llm import LitellmLLM
 from onyx.llm.override_models import LLMOverride
 from onyx.llm.utils import (
@@ -163,9 +163,14 @@ def get_llm_for_persona(
     2. Persona's model configuration override
     3. Default LLM
     """
+    user_defaults = UserChatDefaults(
+        temperature_default=user.temperature_default,
+        reasoning_effort_default=user.reasoning_effort_default,
+    )
+
     if persona is None:
         logger.warning("No persona provided, using default LLM")
-        return get_default_llm(policy_fn=policy_fn)
+        return get_default_llm(policy_fn=policy_fn, user_defaults=user_defaults)
 
     mc_id_override = llm_override.model_configuration_id if llm_override else None
     provider_name_override = llm_override.model_provider if llm_override else None
@@ -181,6 +186,7 @@ def get_llm_for_persona(
             temperature=temperature_override,
             additional_headers=additional_headers,
             policy_fn=policy_fn,
+            user_defaults=user_defaults,
         )
 
     with get_session_with_current_tenant() as db_session:
@@ -196,6 +202,7 @@ def get_llm_for_persona(
                 temperature=temperature_override,
                 additional_headers=additional_headers,
                 policy_fn=policy_fn,
+                user_defaults=user_defaults,
             )
         provider_model, model = resolved
 
@@ -218,6 +225,7 @@ def get_llm_for_persona(
                 temperature=temperature_override,
                 additional_headers=additional_headers,
                 policy_fn=policy_fn,
+                user_defaults=user_defaults,
             )
 
         llm_provider = LLMProviderView.from_model(provider_model)
@@ -228,6 +236,7 @@ def get_llm_for_persona(
         temperature=temperature_override,
         additional_headers=additional_headers,
         policy_fn=policy_fn,
+        user_defaults=user_defaults,
     )
 
 
@@ -343,6 +352,7 @@ def llm_from_provider(
     temperature: float | None = None,
     additional_headers: dict[str, str] | None = None,
     policy_fn: Callable[[str], LlmRequestPolicy] | None = None,
+    user_defaults: UserChatDefaults | None = None,
 ) -> LLM:
     model_configuration = _get_model_configuration(
         llm_provider=llm_provider, model_name=model_name
@@ -361,9 +371,12 @@ def llm_from_provider(
             llm_provider=llm_provider, model_name=model_name
         )
     )
-    # Session override wins, else the model default, else GEN_AI_TEMPERATURE.
+    # Session override wins, else the admin's model default, else the user's
+    # own default, else GEN_AI_TEMPERATURE.
     if temperature is None and model_configuration:
         temperature = model_configuration.temperature_default
+    if temperature is None and user_defaults:
+        temperature = user_defaults.temperature_default
     # Resolved here, not at the call site: the caller hands policy as a
     # provider-keyed function because it cannot know which provider wins.
     policy = policy_fn(llm_provider.provider) if policy_fn else None
@@ -386,6 +399,9 @@ def llm_from_provider(
             model_configuration.reasoning_effort_default
             if model_configuration
             else None
+        ),
+        reasoning_effort_user_default=(
+            user_defaults.reasoning_effort_default if user_defaults else None
         ),
         reasoning_effort_max=(
             model_configuration.reasoning_effort_max if model_configuration else None
@@ -426,6 +442,7 @@ def get_default_llm(
     temperature: float | None = None,
     additional_headers: dict[str, str] | None = None,
     policy_fn: Callable[[str], LlmRequestPolicy] | None = None,
+    user_defaults: UserChatDefaults | None = None,
 ) -> LLM:
     with get_session_with_current_tenant() as db_session:
         model = fetch_default_llm_model(db_session)
@@ -440,6 +457,7 @@ def get_default_llm(
             temperature=temperature,
             additional_headers=additional_headers,
             policy_fn=policy_fn,
+            user_defaults=user_defaults,
         )
 
 
@@ -459,6 +477,7 @@ def get_llm(
     policy_headers: dict[str, str] | None = None,
     policy_model_kwargs: dict[str, Any] | None = None,
     reasoning_effort_default: ReasoningEffort | None = None,
+    reasoning_effort_user_default: ReasoningEffort | None = None,
     reasoning_effort_max: ReasoningEffort | None = None,
 ) -> LLM:
     if temperature is None:
@@ -496,6 +515,7 @@ def get_llm(
         model_kwargs=merged_model_kwargs,
         max_input_tokens=max_input_tokens,
         reasoning_effort_default=reasoning_effort_default,
+        reasoning_effort_user_default=reasoning_effort_user_default,
         reasoning_effort_max=reasoning_effort_max,
     )
 

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -42,6 +42,7 @@ class LLMConfig(BaseModel):
     max_input_tokens: int
     # Here rather than in the chat loop, so every invoke path gets it.
     reasoning_effort_default: ReasoningEffort | None = None
+    reasoning_effort_user_default: ReasoningEffort | None = None
     reasoning_effort_max: ReasoningEffort | None = None
     # This disables the "model_" protected namespace for pydantic
     model_config = {"protected_namespaces": ()}

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -82,15 +82,25 @@ def reasoning_effort_exceeds(effort: ReasoningEffort, cap: ReasoningEffort) -> b
     return _REASONING_EFFORT_RANK[effort] > _REASONING_EFFORT_RANK[cap]
 
 
+class UserChatDefaults(BaseModel):
+    """A user's own chat defaults. They sit below the admin's per-model
+    default in the resolution chain, and the per-model max clamps them."""
+
+    temperature_default: float | None = None
+    reasoning_effort_default: ReasoningEffort | None = None
+
+
 def resolve_reasoning_effort(
     requested: ReasoningEffort,
     default: ReasoningEffort | None,
+    user_default: ReasoningEffort | None,
     maximum: ReasoningEffort | None,
 ) -> ReasoningEffort:
-    """Settle a request against the admin's per-model default and cap.
+    """Settle a request against the admin's per-model default, the user's own
+    default, and the cap.
 
-    Ordered chain, first concrete source wins, so another tier (a per-user
-    default) is a one-line insert. The cap applies last and unconditionally.
+    Ordered chain, first concrete source wins. The cap applies last and
+    unconditionally.
 
     AUTO is concretized before clamping because it maps to medium downstream,
     which would quietly exceed a cap of LOW.
@@ -99,6 +109,8 @@ def resolve_reasoning_effort(
         effort = requested
     elif default is not None and default != ReasoningEffort.AUTO:
         effort = default
+    elif user_default is not None and user_default != ReasoningEffort.AUTO:
+        effort = user_default
     else:
         if maximum is None:
             return ReasoningEffort.AUTO

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -83,8 +83,8 @@ def reasoning_effort_exceeds(effort: ReasoningEffort, cap: ReasoningEffort) -> b
 
 
 class UserChatDefaults(BaseModel):
-    """A user's own chat defaults. They sit below the admin's per-model
-    default in the resolution chain, and the per-model max clamps them."""
+    """A user's own chat defaults, resolved below any admin per-model
+    setting. See resolve_reasoning_effort for the reasoning chain."""
 
     temperature_default: float | None = None
     reasoning_effort_default: ReasoningEffort | None = None
@@ -92,6 +92,7 @@ class UserChatDefaults(BaseModel):
 
 def resolve_reasoning_effort(
     requested: ReasoningEffort,
+    *,
     default: ReasoningEffort | None,
     user_default: ReasoningEffort | None,
     maximum: ReasoningEffort | None,

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -427,6 +427,7 @@ class LitellmLLM(LLM):
         extra_body: dict | None = LITELLM_EXTRA_BODY,
         model_kwargs: dict[str, Any] | None = None,
         reasoning_effort_default: ReasoningEffort | None = None,
+        reasoning_effort_user_default: ReasoningEffort | None = None,
         reasoning_effort_max: ReasoningEffort | None = None,
     ):
         # Timeout in seconds for each socket read operation (i.e., max time between
@@ -448,6 +449,7 @@ class LitellmLLM(LLM):
         self._max_input_tokens = max_input_tokens
         self._custom_config = custom_config
         self._reasoning_effort_default = reasoning_effort_default
+        self._reasoning_effort_user_default = reasoning_effort_user_default
         self._reasoning_effort_max = reasoning_effort_max
 
         self._api_surface = resolve_api_surface(model_provider, custom_config)
@@ -730,6 +732,7 @@ class LitellmLLM(LLM):
         reasoning_effort = resolve_reasoning_effort(
             reasoning_effort,
             self.config.reasoning_effort_default,
+            self.config.reasoning_effort_user_default,
             self.config.reasoning_effort_max,
         )
 
@@ -1061,6 +1064,7 @@ class LitellmLLM(LLM):
             custom_config=self._custom_config,
             max_input_tokens=self._max_input_tokens,
             reasoning_effort_default=self._reasoning_effort_default,
+            reasoning_effort_user_default=self._reasoning_effort_user_default,
             reasoning_effort_max=self._reasoning_effort_max,
         )
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -731,9 +731,9 @@ class LitellmLLM(LLM):
         # see the same effort the provider will.
         reasoning_effort = resolve_reasoning_effort(
             reasoning_effort,
-            self.config.reasoning_effort_default,
-            self.config.reasoning_effort_user_default,
-            self.config.reasoning_effort_max,
+            default=self.config.reasoning_effort_default,
+            user_default=self.config.reasoning_effort_user_default,
+            maximum=self.config.reasoning_effort_max,
         )
 
         # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -107,8 +107,6 @@ class UserPreferences(BaseModel):
     # These will default to workspace settings on the frontend if not set
     auto_scroll: bool | None = None
     temperature_override_enabled: bool | None = None
-    # Per-user chat defaults. Sit below an admin's per-model default in the
-    # resolution chain, and the per-model max clamps them.
     temperature_default: float | None = None
     reasoning_effort_default: ReasoningEffort | None = None
     theme_preference: ThemePreference | None = None

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -20,6 +20,7 @@ from onyx.db.models import SlackBot as SlackAppModel
 from onyx.db.models import SlackChannelConfig as SlackChannelConfigModel
 from onyx.db.models import StandardAnswer as StandardAnswerModel
 from onyx.db.models import StandardAnswerCategory as StandardAnswerCategoryModel
+from onyx.llm.models import ReasoningEffort
 from onyx.onyxbot.slack.config import VALID_SLACK_FILTERS
 from onyx.server.features.persona.models import FullPersonaSnapshot, PersonaSnapshot
 from onyx.server.models import FullUserSnapshot, InvitedUserSnapshot
@@ -106,6 +107,10 @@ class UserPreferences(BaseModel):
     # These will default to workspace settings on the frontend if not set
     auto_scroll: bool | None = None
     temperature_override_enabled: bool | None = None
+    # Per-user chat defaults. Sit below an admin's per-model default in the
+    # resolution chain, and the per-model max clamps them.
+    temperature_default: float | None = None
+    reasoning_effort_default: ReasoningEffort | None = None
     theme_preference: ThemePreference | None = None
     language: str | None = None
     chat_background: str | None = None
@@ -215,6 +220,8 @@ class UserInfo(BaseModel):
                     visible_assistants=user.visible_assistants,
                     auto_scroll=user.auto_scroll,
                     temperature_override_enabled=user.temperature_override_enabled,
+                    temperature_default=user.temperature_default,
+                    reasoning_effort_default=user.reasoning_effort_default,
                     theme_preference=user.theme_preference,
                     language=user.language,
                     chat_background=user.chat_background,

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -1,14 +1,14 @@
 import csv
 import io
 from datetime import datetime, timedelta, timezone
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 import jwt
 from email_validator import EmailNotValidError, EmailUndeliverableError, validate_email
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, field_validator
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -88,7 +88,7 @@ from onyx.db.users import (
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.key_value_store.factory import get_kv_store
-from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import ReasoningEffort, parse_user_selectable_reasoning_effort
 from onyx.redis.redis_pool import get_raw_redis_client, get_redis_client
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.features.projects.models import UserFileSnapshot
@@ -1138,10 +1138,19 @@ def verify_user_logged_in(
 
 
 class TemperatureDefaultRequest(BaseModel):
-    """The user's own default. An admin's per-model default outranks it, and
-    the per-model max clamps it. Null clears it."""
+    """The user's own default temperature. Null clears it."""
 
-    temperature_default: float | None = Field(default=None, ge=0, le=2)
+    temperature_default: float | None = None
+
+    @field_validator("temperature_default")
+    @classmethod
+    def _validate_temperature(cls, value: float | None) -> float | None:
+        if value is not None and not 0 <= value <= 2:
+            raise OnyxError(
+                OnyxErrorCode.BAD_REQUEST,
+                f"temperature_default must be between 0 and 2, got {value}",
+            )
+        return value
 
 
 @router.patch("/temperature-default")
@@ -1154,10 +1163,22 @@ def update_user_temperature_default_api(
 
 
 class ReasoningEffortDefaultRequest(BaseModel):
-    """The user's own default. An admin's per-model default outranks it, and
-    the per-model max clamps it. Null clears it."""
+    """The user's own default reasoning effort. Null clears it."""
 
     reasoning_effort_default: ReasoningEffort | None = None
+
+    @field_validator("reasoning_effort_default", mode="before")
+    @classmethod
+    def _validate_reasoning_effort(cls, value: Any) -> Any:
+        # AUTO has no rank and an unset column already means it.
+        if value is None:
+            return value
+        try:
+            return parse_user_selectable_reasoning_effort(
+                value.value if isinstance(value, ReasoningEffort) else value
+            )
+        except ValueError as e:
+            raise OnyxError(OnyxErrorCode.BAD_REQUEST, str(e))
 
 
 @router.patch("/reasoning-effort-default")

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -8,7 +8,7 @@ import jwt
 from email_validator import EmailNotValidError, EmailUndeliverableError, validate_email
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -66,7 +66,9 @@ from onyx.db.user_preferences import (
     update_user_language,
     update_user_paste_as_tile,
     update_user_personalization,
+    update_user_reasoning_effort_default,
     update_user_shortcut_enabled,
+    update_user_temperature_default,
     update_user_temperature_override_enabled,
     update_user_theme_preference,
     update_users_craft_enabled,
@@ -86,6 +88,7 @@ from onyx.db.users import (
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.key_value_store.factory import get_kv_store
+from onyx.llm.models import ReasoningEffort
 from onyx.redis.redis_pool import get_raw_redis_client, get_redis_client
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.features.projects.models import UserFileSnapshot
@@ -1132,6 +1135,40 @@ def verify_user_logged_in(
 
 
 """APIs to adjust user preferences"""
+
+
+class TemperatureDefaultRequest(BaseModel):
+    """The user's own default. An admin's per-model default outranks it, and
+    the per-model max clamps it. Null clears it."""
+
+    temperature_default: float | None = Field(default=None, ge=0, le=2)
+
+
+@router.patch("/temperature-default")
+def update_user_temperature_default_api(
+    request: TemperatureDefaultRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    update_user_temperature_default(user.id, request.temperature_default, db_session)
+
+
+class ReasoningEffortDefaultRequest(BaseModel):
+    """The user's own default. An admin's per-model default outranks it, and
+    the per-model max clamps it. Null clears it."""
+
+    reasoning_effort_default: ReasoningEffort | None = None
+
+
+@router.patch("/reasoning-effort-default")
+def update_user_reasoning_effort_default_api(
+    request: ReasoningEffortDefaultRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    update_user_reasoning_effort_default(
+        user.id, request.reasoning_effort_default, db_session
+    )
 
 
 @router.patch("/temperature-override-enabled")

--- a/backend/tests/unit/onyx/llm/test_factory.py
+++ b/backend/tests/unit/onyx/llm/test_factory.py
@@ -250,6 +250,15 @@ def _sentinel_policy_fn(_provider: str) -> LlmRequestPolicy:
     return LlmRequestPolicy()
 
 
+def _mock_user() -> MagicMock:
+    """get_llm_for_persona reads the user's chat-default attributes, which
+    must be concrete values for UserChatDefaults validation."""
+    user = MagicMock()
+    user.temperature_default = None
+    user.reasoning_effort_default = None
+    return user
+
+
 class TestPolicyFnForwarding:
     """Every exit of the persona chain must forward the policy function.
 
@@ -261,7 +270,7 @@ class TestPolicyFnForwarding:
         with patch("onyx.llm.factory.get_default_llm") as mock_default:
             get_llm_for_persona(
                 persona=None,
-                user=MagicMock(),
+                user=_mock_user(),
                 policy_fn=_sentinel_policy_fn,
             )
             assert mock_default.call_args.kwargs["policy_fn"] is _sentinel_policy_fn
@@ -272,7 +281,7 @@ class TestPolicyFnForwarding:
         with patch("onyx.llm.factory.get_default_llm") as mock_default:
             get_llm_for_persona(
                 persona=persona,
-                user=MagicMock(),
+                user=_mock_user(),
                 policy_fn=_sentinel_policy_fn,
             )
             assert mock_default.call_args.kwargs["policy_fn"] is _sentinel_policy_fn
@@ -287,7 +296,7 @@ class TestPolicyFnForwarding:
         ):
             get_llm_for_persona(
                 persona=persona,
-                user=MagicMock(),
+                user=_mock_user(),
                 policy_fn=_sentinel_policy_fn,
             )
             assert mock_default.call_args.kwargs["policy_fn"] is _sentinel_policy_fn
@@ -307,7 +316,7 @@ class TestPolicyFnForwarding:
         ):
             get_llm_for_persona(
                 persona=persona,
-                user=MagicMock(),
+                user=_mock_user(),
                 policy_fn=_sentinel_policy_fn,
             )
             assert mock_default.call_args.kwargs["policy_fn"] is _sentinel_policy_fn
@@ -328,7 +337,7 @@ class TestPolicyFnForwarding:
         ):
             get_llm_for_persona(
                 persona=persona,
-                user=MagicMock(),
+                user=_mock_user(),
                 policy_fn=_sentinel_policy_fn,
             )
             assert (

--- a/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
+++ b/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
@@ -102,7 +102,12 @@ class TestResolveReasoningEffort:
         maximum: ReasoningEffort | None,
         expected: ReasoningEffort,
     ) -> None:
-        assert resolve_reasoning_effort(requested, default, None, maximum) == expected
+        assert (
+            resolve_reasoning_effort(
+                requested, default=default, user_default=None, maximum=maximum
+            )
+            == expected
+        )
 
     @pytest.mark.parametrize(
         "maximum,expected",
@@ -122,7 +127,9 @@ class TestResolveReasoningEffort:
         mapping in OPENAI_REASONING_EFFORT.
         """
         assert (
-            resolve_reasoning_effort(ReasoningEffort.AUTO, None, None, maximum)
+            resolve_reasoning_effort(
+                ReasoningEffort.AUTO, default=None, user_default=None, maximum=maximum
+            )
             == expected
         )
 
@@ -190,14 +197,18 @@ class TestResolveReasoningEffort:
         expected: ReasoningEffort,
     ) -> None:
         assert (
-            resolve_reasoning_effort(requested, default, user_default, maximum)
+            resolve_reasoning_effort(
+                requested, default=default, user_default=user_default, maximum=maximum
+            )
             == expected
         )
 
     def test_auto_stays_auto_without_a_cap(self) -> None:
         """No cap means no reason to force a choice the provider can make."""
         assert (
-            resolve_reasoning_effort(ReasoningEffort.AUTO, None, None, None)
+            resolve_reasoning_effort(
+                ReasoningEffort.AUTO, default=None, user_default=None, maximum=None
+            )
             is ReasoningEffort.AUTO
         )
 

--- a/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
+++ b/backend/tests/unit/onyx/llm/test_model_settings_resolution.py
@@ -102,7 +102,7 @@ class TestResolveReasoningEffort:
         maximum: ReasoningEffort | None,
         expected: ReasoningEffort,
     ) -> None:
-        assert resolve_reasoning_effort(requested, default, maximum) == expected
+        assert resolve_reasoning_effort(requested, default, None, maximum) == expected
 
     @pytest.mark.parametrize(
         "maximum,expected",
@@ -121,12 +121,83 @@ class TestResolveReasoningEffort:
         Left as AUTO, a cap of LOW would be violated by the AUTO->medium
         mapping in OPENAI_REASONING_EFFORT.
         """
-        assert resolve_reasoning_effort(ReasoningEffort.AUTO, None, maximum) == expected
+        assert (
+            resolve_reasoning_effort(ReasoningEffort.AUTO, None, None, maximum)
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        "requested,default,user_default,maximum,expected",
+        [
+            # A user default fills in when the request is AUTO and the admin
+            # set no default.
+            (
+                ReasoningEffort.AUTO,
+                None,
+                ReasoningEffort.HIGH,
+                None,
+                ReasoningEffort.HIGH,
+            ),
+            # The admin default outranks the user's.
+            (
+                ReasoningEffort.AUTO,
+                ReasoningEffort.LOW,
+                ReasoningEffort.HIGH,
+                None,
+                ReasoningEffort.LOW,
+            ),
+            # A session override outranks both.
+            (
+                ReasoningEffort.XHIGH,
+                ReasoningEffort.LOW,
+                ReasoningEffort.HIGH,
+                None,
+                ReasoningEffort.XHIGH,
+            ),
+            # The cap clamps a user default like any other source.
+            (
+                ReasoningEffort.AUTO,
+                None,
+                ReasoningEffort.XHIGH,
+                ReasoningEffort.MEDIUM,
+                ReasoningEffort.MEDIUM,
+            ),
+            # A user default of OFF is a real choice.
+            (
+                ReasoningEffort.AUTO,
+                None,
+                ReasoningEffort.OFF,
+                None,
+                ReasoningEffort.OFF,
+            ),
+            # An AUTO user default is no choice at all: without a cap the
+            # request stays AUTO.
+            (
+                ReasoningEffort.AUTO,
+                None,
+                ReasoningEffort.AUTO,
+                None,
+                ReasoningEffort.AUTO,
+            ),
+        ],
+    )
+    def test_user_default_tier(
+        self,
+        requested: ReasoningEffort,
+        default: ReasoningEffort | None,
+        user_default: ReasoningEffort | None,
+        maximum: ReasoningEffort | None,
+        expected: ReasoningEffort,
+    ) -> None:
+        assert (
+            resolve_reasoning_effort(requested, default, user_default, maximum)
+            == expected
+        )
 
     def test_auto_stays_auto_without_a_cap(self) -> None:
         """No cap means no reason to force a choice the provider can make."""
         assert (
-            resolve_reasoning_effort(ReasoningEffort.AUTO, None, None)
+            resolve_reasoning_effort(ReasoningEffort.AUTO, None, None, None)
             is ReasoningEffort.AUTO
         )
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { Agent } from "@/lib/agents/types";
+import type { ReasoningEffortOverride } from "@/lib/languageModels/types";
 import { Credential } from "./connectors/credentials";
 import { Connector } from "./connectors/connectors";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
@@ -30,6 +31,10 @@ interface UserPreferences {
   auto_scroll: boolean;
   shortcut_enabled: boolean;
   temperature_override_enabled: boolean;
+  // Per-user chat defaults. Admin per-model defaults outrank them, and the
+  // per-model max clamps them.
+  temperature_default?: number | null;
+  reasoning_effort_default?: ReasoningEffortOverride | null;
   theme_preference: ThemePreference | null;
   chat_background: string | null;
   default_app_mode: "AUTO" | "CHAT" | "SEARCH";

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -31,8 +31,6 @@ interface UserPreferences {
   auto_scroll: boolean;
   shortcut_enabled: boolean;
   temperature_override_enabled: boolean;
-  // Per-user chat defaults. Admin per-model defaults outrank them, and the
-  // per-model max clamps them.
   temperature_default?: number | null;
   reasoning_effort_default?: ReasoningEffortOverride | null;
   theme_preference: ThemePreference | null;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -9,6 +9,7 @@ import React, {
   useEffect,
   useRef,
 } from "react";
+import type { ReasoningEffortOverride } from "@/lib/languageModels/types";
 import {
   User,
   UserPersonalization,
@@ -62,6 +63,10 @@ export interface UserContextType {
     isPinned: boolean
   ) => Promise<boolean>;
   updateUserTemperatureOverrideEnabled: (enabled: boolean) => Promise<void>;
+  updateUserTemperatureDefault: (value: number | null) => Promise<void>;
+  updateUserReasoningEffortDefault: (
+    value: ReasoningEffortOverride | null
+  ) => Promise<void>;
   updateUserPersonalization: (
     personalization: UserPersonalization
   ) => Promise<void>;
@@ -255,6 +260,70 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       }
     } catch (error) {
       console.error("Error updating user temperature override setting:", error);
+      throw error;
+    }
+  };
+
+  const updateUserTemperatureDefault = async (value: number | null) => {
+    try {
+      setUpToDateUser((prevUser) => {
+        if (prevUser) {
+          return {
+            ...prevUser,
+            preferences: {
+              ...prevUser.preferences,
+              temperature_default: value,
+            },
+          };
+        }
+        return prevUser;
+      });
+
+      const response = await fetch(`/api/temperature-default`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ temperature_default: value }),
+      });
+
+      if (!response.ok) {
+        await refreshUser();
+        throw new Error("Failed to update user temperature default");
+      }
+    } catch (error) {
+      console.error("Error updating user temperature default:", error);
+      throw error;
+    }
+  };
+
+  const updateUserReasoningEffortDefault = async (
+    value: ReasoningEffortOverride | null
+  ) => {
+    try {
+      setUpToDateUser((prevUser) => {
+        if (prevUser) {
+          return {
+            ...prevUser,
+            preferences: {
+              ...prevUser.preferences,
+              reasoning_effort_default: value,
+            },
+          };
+        }
+        return prevUser;
+      });
+
+      const response = await fetch(`/api/reasoning-effort-default`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reasoning_effort_default: value }),
+      });
+
+      if (!response.ok) {
+        await refreshUser();
+        throw new Error("Failed to update user reasoning default");
+      }
+    } catch (error) {
+      console.error("Error updating user reasoning default:", error);
       throw error;
     }
   };
@@ -620,6 +689,8 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         updateUserShortcuts,
         updateUserPasteAsTile,
         updateUserTemperatureOverrideEnabled,
+        updateUserTemperatureDefault,
+        updateUserReasoningEffortDefault,
         updateUserPersonalization,
         updateUserThemePreference,
         updateUserChatBackground,

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -115,15 +115,17 @@ export function useModelDetailManagers(
 }
 
 /** Where the slider parks on open: the session's own choice, else the admin
- *  default, bounded by the selected model's slider maximum. */
+ *  default, else the user's own default, bounded by the selected model's
+ *  slider maximum. */
 function initialTemperature(
   option: LLMOption,
-  manager: TemperatureManager | undefined
+  manager: TemperatureManager | undefined,
+  userTemperatureDefault: number | null
 ): number {
   const sessionTemperature = manager?.temperature ?? 0.5;
   if (manager?.hasTemperatureOverride) return sessionTemperature;
   return Math.min(
-    option.temperatureDefault ?? sessionTemperature,
+    option.temperatureDefault ?? userTemperatureDefault ?? sessionTemperature,
     manager?.maxTemperature ?? 2
   );
 }
@@ -156,6 +158,7 @@ interface ModelDetailPaneProps {
 }
 
 function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
+  const { user } = useUser();
   // Backend pins temperature to 1 (or omits it) for reasoning models, so
   // the slider is locked at 1.
   const temperatureManager = managers.temperature;
@@ -181,12 +184,18 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   // temperature is always concrete, so the override flag decides when the
   // admin default applies.
   const [localTemperature, setLocalTemperature] = useState(() =>
-    initialTemperature(option, temperatureManager)
+    initialTemperature(
+      option,
+      temperatureManager,
+      user?.preferences.temperature_default ?? null
+    )
   );
   // A stored level the model doesn't support (e.g. xhigh after switching
   // models) displays clamped to the highest supported stop.
   const storedStop = reasoningStopIndex(
-    reasoningManager?.reasoningEffort ?? option.reasoningEffortDefault
+    reasoningManager?.reasoningEffort ??
+      option.reasoningEffortDefault ??
+      user?.preferences.reasoning_effort_default
   );
   const [localEffortStop, setLocalEffortStop] = useState(
     clampStop(storedStop >= 0 ? storedStop : UNSET_REASONING_STOP)

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1136,7 +1136,7 @@ function ChatPreferencesSettings() {
   const userTemperatureDefault = user?.preferences.temperature_default ?? null;
   const userEffortDefault = user?.preferences.reasoning_effort_default ?? null;
   const [draftTemperature, setDraftTemperature] = useState(
-    userTemperatureDefault ?? 0.7
+    userTemperatureDefault ?? 0.5
   );
   const [draftEffortStop, setDraftEffortStop] = useState(() => {
     const stop = reasoningStopIndex(userEffortDefault);
@@ -1154,7 +1154,7 @@ function ChatPreferencesSettings() {
   }, [userEffortDefault]);
 
   const saveTemperatureDefault = useCallback(
-    async (value: number | null): Promise<void> => {
+    async (value: number): Promise<void> => {
       try {
         await updateUserTemperatureDefault(value);
         toast.success("Preferences saved");
@@ -1166,10 +1166,10 @@ function ChatPreferencesSettings() {
   );
 
   const saveEffortDefault = useCallback(
-    async (effortStop: number | null): Promise<void> => {
+    async (effortStop: number): Promise<void> => {
       try {
         await updateUserReasoningEffortDefault(
-          effortStop != null ? (ALL_REASONING_STOPS[effortStop] ?? null) : null
+          ALL_REASONING_STOPS[effortStop] ?? null
         );
         toast.success("Preferences saved");
       } catch {
@@ -1263,36 +1263,24 @@ function ChatPreferencesSettings() {
                 description="Starting temperature for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
                 withLabel
               >
-                <div className="flex items-center gap-3">
-                  <Switch
-                    checked={userTemperatureDefault != null}
-                    onCheckedChange={(checked) => {
-                      void saveTemperatureDefault(
-                        checked ? draftTemperature : null
-                      );
-                    }}
-                  />
-                  {userTemperatureDefault != null && (
-                    <>
-                      <div className="w-32">
-                        <PaneSlider
-                          compact
-                          value={draftTemperature}
-                          min={0}
-                          max={2}
-                          step={0.1}
-                          onValueChange={setDraftTemperature}
-                          onValueCommit={(value) => {
-                            void saveTemperatureDefault(value);
-                          }}
-                        />
-                      </div>
-                      <Text font="secondary-mono" color="text-04" nowrap>
-                        {draftTemperature.toFixed(1)}
-                      </Text>
-                    </>
-                  )}
-                </div>
+                <Section flexDirection="row" width="fit" height="auto" gap={3}>
+                  <Section width={8} height="auto">
+                    <PaneSlider
+                      compact
+                      value={draftTemperature}
+                      min={0}
+                      max={2}
+                      step={0.1}
+                      onValueChange={setDraftTemperature}
+                      onValueCommit={(value) => {
+                        void saveTemperatureDefault(value);
+                      }}
+                    />
+                  </Section>
+                  <Text font="secondary-mono" color="text-04" nowrap>
+                    {draftTemperature.toFixed(1)}
+                  </Text>
+                </Section>
               </InputHorizontal>
             )}
 
@@ -1303,40 +1291,33 @@ function ChatPreferencesSettings() {
                   description="Starting reasoning level for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
                   withLabel
                 >
-                  <div className="flex items-center gap-3">
-                    <Switch
-                      checked={userEffortDefault != null}
-                      onCheckedChange={(checked) => {
-                        void saveEffortDefault(
-                          checked ? draftEffortStop : null
-                        );
-                      }}
-                    />
-                    {userEffortDefault != null && (
-                      <>
-                        <div className="w-32">
-                          <PaneSlider
-                            compact
-                            value={draftEffortStop}
-                            min={0}
-                            max={ALL_REASONING_STOPS.length - 1}
-                            step={1}
-                            onValueChange={setDraftEffortStop}
-                            onValueCommit={(value) => {
-                              void saveEffortDefault(value);
-                            }}
-                          />
-                        </div>
-                        <Text font="secondary-mono" color="text-04" nowrap>
-                          {
-                            REASONING_STOP_LABELS[
-                              ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
-                            ]
-                          }
-                        </Text>
-                      </>
-                    )}
-                  </div>
+                  <Section
+                    flexDirection="row"
+                    width="fit"
+                    height="auto"
+                    gap={3}
+                  >
+                    <Section width={8} height="auto">
+                      <PaneSlider
+                        compact
+                        value={draftEffortStop}
+                        min={0}
+                        max={ALL_REASONING_STOPS.length - 1}
+                        step={1}
+                        onValueChange={setDraftEffortStop}
+                        onValueCommit={(value) => {
+                          void saveEffortDefault(value);
+                        }}
+                      />
+                    </Section>
+                    <Text font="secondary-mono" color="text-04" nowrap>
+                      {
+                        REASONING_STOP_LABELS[
+                          ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
+                        ]
+                      }
+                    </Text>
+                  </Section>
                 </InputHorizontal>
               )}
 

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1277,7 +1277,7 @@ function ChatPreferencesSettings() {
                       }}
                     />
                   </Section>
-                  <Section width={4} height="auto" alignItems="start">
+                  <Section width={4} height="auto" alignItems="end">
                     <Text font="secondary-mono" color="text-04" nowrap>
                       {draftTemperature.toFixed(1)}
                     </Text>
@@ -1312,7 +1312,7 @@ function ChatPreferencesSettings() {
                         }}
                       />
                     </Section>
-                    <Section width={4} height="auto" alignItems="start">
+                    <Section width={4} height="auto" alignItems="end">
                       <Text font="secondary-mono" color="text-04" nowrap>
                         {
                           REASONING_STOP_LABELS[

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -70,6 +70,13 @@ import { Interactive } from "@opal/core";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { useIsSearchModeAvailable, useSettings } from "@/lib/settings/hooks";
+import {
+  ALL_REASONING_STOPS,
+  PaneSlider,
+  REASONING_STOP_LABELS,
+  UNSET_REASONING_STOP,
+  reasoningStopIndex,
+} from "@/sections/model-selector/setting-controls";
 import { LLM_GATEWAY_MIN_TIER, tierAtLeast } from "@/lib/tiers";
 import { Tooltip } from "@opal/components";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";
@@ -1080,6 +1087,8 @@ function ChatPreferencesSettings() {
     updateUserDefaultModel,
     updateUserDefaultAppMode,
     updateUserVoiceSettings,
+    updateUserTemperatureDefault,
+    updateUserReasoningEffortDefault,
   } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
   const searchUiEnabled = useIsSearchModeAvailable();
@@ -1121,6 +1130,53 @@ function ChatPreferencesSettings() {
       }
     },
     [updateUserVoiceSettings]
+  );
+
+  const settings = useSettings();
+  const userTemperatureDefault = user?.preferences.temperature_default ?? null;
+  const userEffortDefault = user?.preferences.reasoning_effort_default ?? null;
+  const [draftTemperature, setDraftTemperature] = useState(
+    userTemperatureDefault ?? 0.7
+  );
+  const [draftEffortStop, setDraftEffortStop] = useState(() => {
+    const stop = reasoningStopIndex(userEffortDefault);
+    return stop >= 0 ? stop : UNSET_REASONING_STOP;
+  });
+
+  useEffect(() => {
+    if (userTemperatureDefault != null) {
+      setDraftTemperature(userTemperatureDefault);
+    }
+  }, [userTemperatureDefault]);
+  useEffect(() => {
+    const stop = reasoningStopIndex(userEffortDefault);
+    if (stop >= 0) setDraftEffortStop(stop);
+  }, [userEffortDefault]);
+
+  const saveTemperatureDefault = useCallback(
+    async (value: number | null): Promise<void> => {
+      try {
+        await updateUserTemperatureDefault(value);
+        toast.success("Preferences saved");
+      } catch {
+        toast.error("Failed to save preferences");
+      }
+    },
+    [updateUserTemperatureDefault]
+  );
+
+  const saveEffortDefault = useCallback(
+    async (effortStop: number | null): Promise<void> => {
+      try {
+        await updateUserReasoningEffortDefault(
+          effortStop != null ? (ALL_REASONING_STOPS[effortStop] ?? null) : null
+        );
+        toast.success("Preferences saved");
+      } catch {
+        toast.error("Failed to save preferences");
+      }
+    },
+    [updateUserReasoningEffortDefault]
   );
 
   const commitVoicePlaybackSpeed = useCallback(() => {
@@ -1200,6 +1256,86 @@ function ChatPreferencesSettings() {
                 side="bottom"
               />
             </InputHorizontal>
+
+            {(user?.preferences?.temperature_override_enabled ?? true) && (
+              <InputHorizontal
+                title="Default Temperature"
+                description="Starting temperature for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
+                withLabel
+              >
+                <div className="flex items-center gap-3">
+                  <Switch
+                    checked={userTemperatureDefault != null}
+                    onCheckedChange={(checked) => {
+                      void saveTemperatureDefault(
+                        checked ? draftTemperature : null
+                      );
+                    }}
+                  />
+                  {userTemperatureDefault != null && (
+                    <>
+                      <div className="w-32">
+                        <PaneSlider
+                          compact
+                          value={draftTemperature}
+                          min={0}
+                          max={2}
+                          step={0.1}
+                          onValueChange={setDraftTemperature}
+                          onValueCommit={(value) => {
+                            void saveTemperatureDefault(value);
+                          }}
+                        />
+                      </div>
+                      <Text font="secondary-mono" color="text-04" nowrap>
+                        {draftTemperature.toFixed(1)}
+                      </Text>
+                    </>
+                  )}
+                </div>
+              </InputHorizontal>
+            )}
+
+            {(settings.reasoning_override_enabled ?? true) && (
+              <InputHorizontal
+                title="Default Reasoning Level"
+                description="Starting reasoning level for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
+                withLabel
+              >
+                <div className="flex items-center gap-3">
+                  <Switch
+                    checked={userEffortDefault != null}
+                    onCheckedChange={(checked) => {
+                      void saveEffortDefault(checked ? draftEffortStop : null);
+                    }}
+                  />
+                  {userEffortDefault != null && (
+                    <>
+                      <div className="w-32">
+                        <PaneSlider
+                          compact
+                          value={draftEffortStop}
+                          min={0}
+                          max={ALL_REASONING_STOPS.length - 1}
+                          step={1}
+                          onValueChange={setDraftEffortStop}
+                          onValueCommit={(value) => {
+                            void saveEffortDefault(value);
+                          }}
+                        />
+                      </div>
+                      <Text font="secondary-mono" color="text-04" nowrap>
+                        {
+                          REASONING_STOP_LABELS[
+                            ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
+                          ]
+                        }
+                      </Text>
+                    </>
+                  )}
+                </div>
+              </InputHorizontal>
+            )}
 
             <InputHorizontal
               title="Chat Auto-scroll"

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1135,8 +1135,10 @@ function ChatPreferencesSettings() {
   const settings = useSettings();
   const userTemperatureDefault = user?.preferences.temperature_default ?? null;
   const userEffortDefault = user?.preferences.reasoning_effort_default ?? null;
+  // 0 mirrors the backend GEN_AI_TEMPERATURE fallback an untouched chat
+  // actually runs with, so the parked slider never overstates the default.
   const [draftTemperature, setDraftTemperature] = useState(
-    userTemperatureDefault ?? 0.5
+    userTemperatureDefault ?? 0
   );
   const [draftEffortStop, setDraftEffortStop] = useState(() => {
     const stop = reasoningStopIndex(userEffortDefault);

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1277,9 +1277,11 @@ function ChatPreferencesSettings() {
                       }}
                     />
                   </Section>
-                  <Text font="secondary-mono" color="text-04" nowrap>
-                    {draftTemperature.toFixed(1)}
-                  </Text>
+                  <Section width={4} height="auto" alignItems="start">
+                    <Text font="secondary-mono" color="text-04" nowrap>
+                      {draftTemperature.toFixed(1)}
+                    </Text>
+                  </Section>
                 </Section>
               </InputHorizontal>
             )}
@@ -1310,13 +1312,15 @@ function ChatPreferencesSettings() {
                         }}
                       />
                     </Section>
-                    <Text font="secondary-mono" color="text-04" nowrap>
-                      {
-                        REASONING_STOP_LABELS[
-                          ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
-                        ]
-                      }
-                    </Text>
+                    <Section width={4} height="auto" alignItems="start">
+                      <Text font="secondary-mono" color="text-04" nowrap>
+                        {
+                          REASONING_STOP_LABELS[
+                            ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
+                          ]
+                        }
+                      </Text>
+                    </Section>
                   </Section>
                 </InputHorizontal>
               )}

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1296,46 +1296,49 @@ function ChatPreferencesSettings() {
               </InputHorizontal>
             )}
 
-            {(settings.reasoning_override_enabled ?? true) && (
-              <InputHorizontal
-                title="Default Reasoning Level"
-                description="Starting reasoning level for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
-                withLabel
-              >
-                <div className="flex items-center gap-3">
-                  <Switch
-                    checked={userEffortDefault != null}
-                    onCheckedChange={(checked) => {
-                      void saveEffortDefault(checked ? draftEffortStop : null);
-                    }}
-                  />
-                  {userEffortDefault != null && (
-                    <>
-                      <div className="w-32">
-                        <PaneSlider
-                          compact
-                          value={draftEffortStop}
-                          min={0}
-                          max={ALL_REASONING_STOPS.length - 1}
-                          step={1}
-                          onValueChange={setDraftEffortStop}
-                          onValueCommit={(value) => {
-                            void saveEffortDefault(value);
-                          }}
-                        />
-                      </div>
-                      <Text font="secondary-mono" color="text-04" nowrap>
-                        {
-                          REASONING_STOP_LABELS[
-                            ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
-                          ]
-                        }
-                      </Text>
-                    </>
-                  )}
-                </div>
-              </InputHorizontal>
-            )}
+            {!settings.isLoading &&
+              (settings.reasoning_override_enabled ?? true) && (
+                <InputHorizontal
+                  title="Default Reasoning Level"
+                  description="Starting reasoning level for your new chats. Admin settings on a model always apply, and any single chat can override this in its model settings."
+                  withLabel
+                >
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      checked={userEffortDefault != null}
+                      onCheckedChange={(checked) => {
+                        void saveEffortDefault(
+                          checked ? draftEffortStop : null
+                        );
+                      }}
+                    />
+                    {userEffortDefault != null && (
+                      <>
+                        <div className="w-32">
+                          <PaneSlider
+                            compact
+                            value={draftEffortStop}
+                            min={0}
+                            max={ALL_REASONING_STOPS.length - 1}
+                            step={1}
+                            onValueChange={setDraftEffortStop}
+                            onValueCommit={(value) => {
+                              void saveEffortDefault(value);
+                            }}
+                          />
+                        </div>
+                        <Text font="secondary-mono" color="text-04" nowrap>
+                          {
+                            REASONING_STOP_LABELS[
+                              ALL_REASONING_STOPS[draftEffortStop] ?? "medium"
+                            ]
+                          }
+                        </Text>
+                      </>
+                    )}
+                  </div>
+                </InputHorizontal>
+              )}
 
             <InputHorizontal
               title="Chat Auto-scroll"

--- a/web/tests/setup/mocks/components/UserProvider.tsx
+++ b/web/tests/setup/mocks/components/UserProvider.tsx
@@ -45,6 +45,8 @@ const mockUserContext: UserContextType = {
   updateUserDefaultModel: async () => {},
   updateUserDefaultAppMode: async () => {},
   updateUserVoiceSettings: async () => {},
+  updateUserTemperatureDefault: async () => {},
+  updateUserReasoningEffortDefault: async () => {},
 };
 
 const UserContext = createContext<UserContextType | undefined>(mockUserContext);


### PR DESCRIPTION
## Description

Users can now set their own default temperature and reasoning level under Settings → Chat Preferences.

- Two always-visible sliders that park at the effective default (0.5 temperature, Medium reasoning) until dragged. Each saves through its own endpoint (`PATCH /api/temperature-default`, `PATCH /api/reasoning-effort-default`), so one field can never clobber the other.
- Resolution order, backend and frontend: session override → admin per-model default → user default → global fallback. The admin per-model reasoning max still clamps the final value.
- The model detail pane parks on the user default when the session has no override and the admin set no per-model default.
- New nullable `temperature_default` / `reasoning_effort_default` columns on `user` (migration `66a70ddc0652`).
- The row descriptions tell users that admin model settings always apply and that any single chat can override in its model settings.

### Settings → Chat Preferences

| Before | After |
| --- | --- |
| <img width="1326" alt="settings-before" src="https://github.com/user-attachments/assets/cd6fdc41-4324-4423-b343-6d9059b00a2a" /> | <img width="1326" alt="settings-after" src="https://github.com/user-attachments/assets/abbb458b-3746-4a35-adb1-3d2cc81523ea" /> |


## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
