### PR TITLE
feat(web): options button selects the model it configures

### DIFF
--- a/web/src/sections/model-selector/ModelSelector.tsx
+++ b/web/src/sections/model-selector/ModelSelector.tsx
@@ -169,6 +169,7 @@ export default function ModelSelector({
           includeGlobalDefault={includeGlobalDefault}
           scrollContainerRef={scrollContainerRef}
           modelDetail={modelDetail}
+          onDetailSelect={onChange}
         />
       </Popover.Content>
     </Popover>

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -367,6 +367,9 @@ export interface ModelSelectorContentProps {
   includeGlobalDefault?: boolean;
   /** When provided, model rows gain a drill-in settings pane. */
   modelDetail?: ModelDetailManagers;
+  /** Opening a model's settings also selects it. Hosts pass their select
+   *  action WITHOUT closing the popover, so the pane stays visible. */
+  onDetailSelect?: (option: LLMOption) => void;
 }
 
 export default function ModelSelectorContent({
@@ -381,6 +384,7 @@ export default function ModelSelectorContent({
   scrollContainerRef: externalScrollRef,
   includeGlobalDefault = false,
   modelDetail,
+  onDetailSelect,
 }: ModelSelectorContentProps) {
   const [detailOption, setDetailOption] = useState<LLMOption | null>(null);
   const {
@@ -489,8 +493,10 @@ export default function ModelSelectorContent({
                     prominence="tertiary"
                     size="sm"
                     aria-label={`${option.displayName} settings`}
+                    tooltip="Model settings"
                     onClick={(e) => {
                       e.stopPropagation();
+                      onDetailSelect?.(option);
                       setDetailOption(option);
                     }}
                   />

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -114,14 +114,16 @@ export default function MultiModelSelector({
     return !selectedKeys.has(key) && atMax;
   };
 
+  const toSelectedModel = (option: LLMOption): SelectedModel => ({
+    name: option.name,
+    provider: option.provider,
+    modelName: option.modelName,
+    modelConfigurationId: option.modelConfigurationId ?? null,
+    displayName: option.displayName,
+  });
+
   const handleSelect = (option: LLMOption) => {
-    const model: SelectedModel = {
-      name: option.name,
-      provider: option.provider,
-      modelName: option.modelName,
-      modelConfigurationId: option.modelConfigurationId ?? null,
-      displayName: option.displayName,
-    };
+    const model = toSelectedModel(option);
 
     if (replacingIndex !== null) {
       onReplace(replacingIndex, model);
@@ -141,6 +143,20 @@ export default function MultiModelSelector({
       if (selectedModels.length + 1 >= MAX_MODELS) {
         setOpen(false);
       }
+    }
+  };
+
+  // The settings button selects its model but keeps the popover open for the
+  // pane, and it never deselects: opening settings must not remove a model.
+  const handleDetailSelect = (option: LLMOption) => {
+    if (replacingIndex !== null) {
+      onReplace(replacingIndex, toSelectedModel(option));
+      setReplacingIndex(null);
+      return;
+    }
+    const key = llmOptionKey(option);
+    if (!selectedModels.some((m) => llmOptionKey(m) === key) && !atMax) {
+      onAdd(toSelectedModel(option));
     }
   };
 
@@ -264,6 +280,7 @@ export default function MultiModelSelector({
             isSelected={isSelected}
             isDisabled={isDisabled}
             modelDetail={modelDetail}
+            onDetailSelect={handleDetailSelect}
           />
         </Popover.Content>
       )}

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -273,17 +273,19 @@ export default function MultiModelSelector({
         </div>
       </Tooltip>
 
-      {!(atMax && replacingIndex === null) && (
-        <Popover.Content side="top" align="end" width="xl">
-          <ModelSelectorContent
-            onSelect={handleSelect}
-            isSelected={isSelected}
-            isDisabled={isDisabled}
-            modelDetail={modelDetail}
-            onDetailSelect={handleDetailSelect}
-          />
-        </Popover.Content>
-      )}
+      {/* Always mounted while open: a settings click that adds the third
+          model (or completes a replacement at max) must not unmount the pane
+          it just opened. Opening at max is still blocked at the entry points:
+          the add button hides and pill clicks set replacingIndex. */}
+      <Popover.Content side="top" align="end" width="xl">
+        <ModelSelectorContent
+          onSelect={handleSelect}
+          isSelected={isSelected}
+          isDisabled={isDisabled}
+          modelDetail={modelDetail}
+          onDetailSelect={handleDetailSelect}
+        />
+      </Popover.Content>
     </Popover>
   );
 }


### PR DESCRIPTION
## Description

Clicking the settings (sliders) button on a model row now also selects that model, so the pane you adjust always belongs to the active model. The popover stays open showing the pane.

- Single selector: the model becomes the session model.
- Multi-model selector: the model is added (or replaces the pill being edited), never removed.
- The settings button gains a "Model settings" tooltip.

### Options click on a non-selected model

| Before (chip keeps the old model) | After (chip switches to the model being adjusted) |
| --- | --- |
| <img width="1326" alt="options-before" src="https://github.com/user-attachments/assets/0ec8c072-3188-453c-ac88-47ef59c3a5a5" /> | <img width="1326" alt="options-after" src="https://github.com/user-attachments/assets/4883b835-913d-4dc7-af32-76fa79e8e6b5" /> |

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
