### PR TITLE
refactor(i18n): backend owns the NEXT_LOCALE cookie

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -37,6 +37,10 @@ FASTAPI_USERS_AUTH_COOKIE_NAME = (
     os.environ.get("AUTH_COOKIE_NAME") or "fastapiusersauth"
 )
 ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user"
+# Locale cookie the Next.js server layout reads to render the UI language.
+# The backend owns this cookie: PATCH /user/language and GET /me set it from
+# the user's stored preference. Name must match web/src/i18n/config.ts.
+NEXT_LOCALE_COOKIE_NAME = "NEXT_LOCALE"
 
 # ID used in UserInfo API responses for anonymous users (not a UUID, just a string identifier)
 ANONYMOUS_USER_INFO_ID = "__anonymous_user__"

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import jwt
 from email_validator import EmailNotValidError, EmailUndeliverableError, validate_email
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select
@@ -41,9 +41,14 @@ from onyx.configs.app_configs import (
     REDIS_AUTH_KEY_PREFIX,
     SESSION_EXPIRE_TIME_SECONDS,
     USER_AUTH_SECRET,
+    WEB_DOMAIN,
     AuthBackend,
 )
-from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME, PUBLIC_API_TAGS
+from onyx.configs.constants import (
+    FASTAPI_USERS_AUTH_COOKIE_NAME,
+    NEXT_LOCALE_COOKIE_NAME,
+    PUBLIC_API_TAGS,
+)
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.auth import get_live_users_count
 from onyx.db.engine.sql_engine import get_session, get_session_with_shared_schema
@@ -1044,6 +1049,7 @@ def get_current_user_permissions(
 @router.get("/me", tags=PUBLIC_API_TAGS, dependencies=[Depends(scope_exempt)])
 def verify_user_logged_in(
     request: Request,
+    response: Response,
     user: User | None = Depends(optional_user),
     db_session: Session = Depends(get_session),
 ) -> UserInfo:
@@ -1130,6 +1136,11 @@ def verify_user_logged_in(
         memories=memories,
         effective_permissions=sorted(p.value for p in get_effective_permissions(user)),
     )
+
+    # Reconcile the locale cookie with the stored preference so a login on a
+    # fresh browser (or after an identity switch) renders the user's language.
+    if request.cookies.get(NEXT_LOCALE_COOKIE_NAME) != user.language:
+        set_locale_cookie(response, user.language)
 
     return user_info
 
@@ -1243,13 +1254,33 @@ def update_user_theme_preference_api(
     update_user_theme_preference(user.id, request.theme_preference, db_session)
 
 
+LOCALE_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60
+
+
+def set_locale_cookie(response: Response, language: str) -> None:
+    """The backend owns the locale cookie: it is set from the stored
+    preference on PATCH /user/language and reconciled on GET /me, so the
+    client never writes it. The Next.js server layout is the only reader."""
+    response.set_cookie(
+        key=NEXT_LOCALE_COOKIE_NAME,
+        value=language,
+        max_age=LOCALE_COOKIE_MAX_AGE_SECONDS,
+        path="/",
+        secure=WEB_DOMAIN.startswith("https"),
+        httponly=True,
+        samesite="lax",
+    )
+
+
 @router.patch("/user/language")
 def update_user_language_api(
     request: LanguageRequest,
+    response: Response,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     update_user_language(user.id, request.language.value, db_session)
+    set_locale_cookie(response, request.language.value)
 
 
 @router.patch("/user/chat-background")

--- a/backend/tests/integration/tests/users/test_language_cookie.py
+++ b/backend/tests/integration/tests/users/test_language_cookie.py
@@ -5,22 +5,23 @@ The backend owns the NEXT_LOCALE cookie the web server layout reads:
 - GET /me sets it when the request cookie disagrees with the stored preference
 """
 
-import requests
+import httpx
 
 from onyx.configs.constants import NEXT_LOCALE_COOKIE_NAME
 from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def _locale_cookie(response: requests.Response) -> str | None:
+def _locale_cookie(response: httpx.Response) -> str | None:
     return response.cookies.get(NEXT_LOCALE_COOKIE_NAME)
 
 
-def _headers_with_locale_cookie(user: DATestUser, locale: str) -> dict:
+def _headers_with_locale_cookie(user: DATestUser, locale: str) -> dict[str, str]:
     # user.headers carries the auth cookie in an explicit Cookie header, and
-    # requests silently ignores a `cookies=` jar when that header is present —
-    # the locale cookie must be appended to the header itself.
+    # the client's cookie jar is skipped when a request already has one — the
+    # locale cookie must be appended to the header itself.
     return {
         **user.headers,
         "Cookie": f"{user.headers['Cookie']}; {NEXT_LOCALE_COOKIE_NAME}={locale}",
@@ -30,46 +31,46 @@ def _headers_with_locale_cookie(user: DATestUser, locale: str) -> dict:
 def test_language_patch_sets_locale_cookie(reset: None) -> None:  # noqa: ARG001
     user: DATestUser = UserManager.create()
 
-    response = requests.patch(
-        f"{API_SERVER_URL}/user/language",
+    response = client.patch(
+        url=f"{API_SERVER_URL}/user/language",
         json={"language": "es"},
         headers=user.headers,
     )
-    assert response.ok
+    response.raise_for_status()
     assert _locale_cookie(response) == "es"
 
     # The stored preference now reads back as Spanish.
-    me = requests.get(f"{API_SERVER_URL}/me", headers=user.headers)
-    assert me.ok
+    me = client.get(url=f"{API_SERVER_URL}/me", headers=user.headers)
+    me.raise_for_status()
     assert me.json()["preferences"]["language"] == "es"
 
 
 def test_me_reconciles_stale_locale_cookie(reset: None) -> None:  # noqa: ARG001
     user: DATestUser = UserManager.create()
 
-    requests.patch(
-        f"{API_SERVER_URL}/user/language",
+    client.patch(
+        url=f"{API_SERVER_URL}/user/language",
         json={"language": "de"},
         headers=user.headers,
     ).raise_for_status()
 
     # A request without a locale cookie gets one set from the preference.
-    missing = requests.get(f"{API_SERVER_URL}/me", headers=user.headers)
-    assert missing.ok
+    missing = client.get(url=f"{API_SERVER_URL}/me", headers=user.headers)
+    missing.raise_for_status()
     assert _locale_cookie(missing) == "de"
 
     # A request carrying a stale locale cookie gets it reconciled.
-    stale = requests.get(
-        f"{API_SERVER_URL}/me",
+    stale = client.get(
+        url=f"{API_SERVER_URL}/me",
         headers=_headers_with_locale_cookie(user, "fr"),
     )
-    assert stale.ok
+    stale.raise_for_status()
     assert _locale_cookie(stale) == "de"
 
     # A request already carrying the right cookie is left alone.
-    current = requests.get(
-        f"{API_SERVER_URL}/me",
+    current = client.get(
+        url=f"{API_SERVER_URL}/me",
         headers=_headers_with_locale_cookie(user, "de"),
     )
-    assert current.ok
+    current.raise_for_status()
     assert _locale_cookie(current) is None

--- a/backend/tests/integration/tests/users/test_language_cookie.py
+++ b/backend/tests/integration/tests/users/test_language_cookie.py
@@ -1,0 +1,75 @@
+"""Integration tests for backend-owned locale cookie reconciliation.
+
+The backend owns the NEXT_LOCALE cookie the web server layout reads:
+- PATCH /user/language sets it alongside the DB update
+- GET /me sets it when the request cookie disagrees with the stored preference
+"""
+
+import requests
+
+from onyx.configs.constants import NEXT_LOCALE_COOKIE_NAME
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _locale_cookie(response: requests.Response) -> str | None:
+    return response.cookies.get(NEXT_LOCALE_COOKIE_NAME)
+
+
+def _headers_with_locale_cookie(user: DATestUser, locale: str) -> dict:
+    # user.headers carries the auth cookie in an explicit Cookie header, and
+    # requests silently ignores a `cookies=` jar when that header is present —
+    # the locale cookie must be appended to the header itself.
+    return {
+        **user.headers,
+        "Cookie": f"{user.headers['Cookie']}; {NEXT_LOCALE_COOKIE_NAME}={locale}",
+    }
+
+
+def test_language_patch_sets_locale_cookie(reset: None) -> None:  # noqa: ARG001
+    user: DATestUser = UserManager.create()
+
+    response = requests.patch(
+        f"{API_SERVER_URL}/user/language",
+        json={"language": "es"},
+        headers=user.headers,
+    )
+    assert response.ok
+    assert _locale_cookie(response) == "es"
+
+    # The stored preference now reads back as Spanish.
+    me = requests.get(f"{API_SERVER_URL}/me", headers=user.headers)
+    assert me.ok
+    assert me.json()["preferences"]["language"] == "es"
+
+
+def test_me_reconciles_stale_locale_cookie(reset: None) -> None:  # noqa: ARG001
+    user: DATestUser = UserManager.create()
+
+    requests.patch(
+        f"{API_SERVER_URL}/user/language",
+        json={"language": "de"},
+        headers=user.headers,
+    ).raise_for_status()
+
+    # A request without a locale cookie gets one set from the preference.
+    missing = requests.get(f"{API_SERVER_URL}/me", headers=user.headers)
+    assert missing.ok
+    assert _locale_cookie(missing) == "de"
+
+    # A request carrying a stale locale cookie gets it reconciled.
+    stale = requests.get(
+        f"{API_SERVER_URL}/me",
+        headers=_headers_with_locale_cookie(user, "fr"),
+    )
+    assert stale.ok
+    assert _locale_cookie(stale) == "de"
+
+    # A request already carrying the right cookie is left alone.
+    current = requests.get(
+        f"{API_SERVER_URL}/me",
+        headers=_headers_with_locale_cookie(user, "de"),
+    )
+    assert current.ok
+    assert _locale_cookie(current) is None

--- a/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
+++ b/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
@@ -132,7 +132,12 @@ def test_me_service_account_skips_tenant_mapping_lookup() -> None:
         patch("onyx.server.manage.users._get_token_expires_at", return_value=None),
         patch("onyx.server.manage.users.UserInfo") as mock_user_info,
     ):
-        verify_user_logged_in(request=MagicMock(), user=user, db_session=MagicMock())
+        verify_user_logged_in(
+            request=MagicMock(),
+            response=MagicMock(),
+            user=user,
+            db_session=MagicMock(),
+        )
 
     kwargs = mock_user_info.from_model.call_args.kwargs
     assert kwargs["team_name"] == "tenant_current"

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -10,8 +10,9 @@ export type Locale = (typeof SUPPORTED_LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = "en";
 
 // Cookie the server layout reads to resolve the locale without a DB round
-// trip. The DB preference (`user.language`) is canonical for logged-in users;
-// UserProvider keeps this cookie in sync with it.
+// trip. The backend owns it: PATCH /user/language and GET /me set it from the
+// stored preference (NEXT_LOCALE_COOKIE_NAME in backend/onyx/configs/
+// constants.py). The client never writes it.
 export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
 
 // Endonyms (each language named in itself) so users can always find their own

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -590,8 +590,12 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       // error); the stored preference is unchanged server-side.
       try {
         await refreshUser();
-      } catch {
+      } catch (refreshError) {
         // Best effort: the next successful /me resolves any drift.
+        console.error(
+          "Error restoring user state after failed language update:",
+          refreshError
+        );
       }
       console.error("Error updating language preference:", error);
       throw error;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -29,20 +29,7 @@ import {
 } from "@/lib/users/svc";
 import { useTheme } from "next-themes";
 import { useRouter } from "next/navigation";
-import Cookies from "js-cookie";
-import {
-  LOCALE_COOKIE_NAME,
-  isSupportedLocale,
-  type Locale,
-} from "@/i18n/config";
-
-// path "/" (js-cookie's default, made explicit) so every route sees the
-// locale, not just the tree the settings page lives under.
-const LOCALE_COOKIE_OPTIONS = {
-  expires: 365,
-  sameSite: "lax" as const,
-  path: "/",
-};
+import { isSupportedLocale, type Locale } from "@/i18n/config";
 
 const EMPTY_PERMISSIONS: string[] = [];
 
@@ -245,45 +232,17 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     setTheme,
   ]);
 
-  // Sync the user's language preference from DB to the NEXT_LOCALE cookie the
-  // server layout reads (src/i18n/request.ts). The DB is canonical; one
-  // refresh re-renders the tree in the right locale after login. Keyed by user
-  // id so switching identities without a remount (e.g. impersonation) re-syncs
-  // the new user's preference.
-  //
-  // TODO: move the NEXT_LOCALE write to the backend — PATCH /user/language and
-  // session establishment should Set-Cookie so the server owns reconciliation.
-  // That deletes the sequencing/identity guards below (client becomes "PATCH,
-  // then router.refresh()") and removes the first-paint language flash on new
-  // sessions. Do this before another preference copies this pattern.
+  // The backend owns the NEXT_LOCALE cookie (set on PATCH /user/language,
+  // reconciled on GET /me). This effect only closes the SSR gap: when the
+  // rendered locale lags the signed-in user's stored preference — e.g. right
+  // after login on a fresh browser, where the page was rendered before /me's
+  // Set-Cookie arrived — one refresh re-renders with the reconciled cookie.
   const router = useRouter();
-  const lastLanguageSyncUserIdRef = useRef<string | null>(null);
-  const languageRequestSeqRef = useRef(0);
-  const languagePatchChainRef = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
-    // Wait for user data to load; sync once per user identity
-    if (!upToDateUser?.id) {
-      // Signed out: drop the served identity and advance the sequence so
-      // pending language requests neither commit nor roll back — not now,
-      // and not after the same user signs back in.
-      lastLanguageSyncUserIdRef.current = null;
-      languageRequestSeqRef.current++;
-      return;
-    }
-    if (lastLanguageSyncUserIdRef.current === upToDateUser.id) return;
-    lastLanguageSyncUserIdRef.current = upToDateUser.id;
-
-    const savedLanguage = upToDateUser.preferences?.language;
-    if (isSupportedLocale(savedLanguage)) {
-      if (Cookies.get(LOCALE_COOKIE_NAME) !== savedLanguage) {
-        Cookies.set(LOCALE_COOKIE_NAME, savedLanguage, LOCALE_COOKIE_OPTIONS);
-        router.refresh();
-      }
-    } else if (Cookies.get(LOCALE_COOKIE_NAME) !== undefined) {
-      // This user has no stored preference: drop a cookie left behind by a
-      // previous identity in this tab so the default locale renders.
-      Cookies.remove(LOCALE_COOKIE_NAME, { path: "/" });
+    const language = upToDateUser?.preferences?.language;
+    if (!isSupportedLocale(language)) return;
+    if (document.documentElement.lang !== language) {
       router.refresh();
     }
   }, [upToDateUser?.id, upToDateUser?.preferences?.language, router]);
@@ -597,24 +556,6 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   };
 
   const updateUserLanguage = async (language: Locale) => {
-    const previousLanguage = upToDateUser?.preferences?.language;
-    // No signed-in identity to persist for — the picker is only rendered for
-    // signed-in users, so there is nothing to do.
-    const requestUserId = upToDateUser?.id ?? null;
-    if (requestUserId === null) {
-      return;
-    }
-    // Guards overlapping updates: only the newest request may commit, roll
-    // back, or refresh, so a slow older request can't clobber a newer choice.
-    // Also bound to the identity that issued it: after an in-place identity
-    // switch (impersonation), a queued request must neither PATCH the new
-    // identity's preference row nor roll back the new identity's cookie.
-    // lastLanguageSyncUserIdRef tracks the identity this provider currently
-    // serves (updated by the sync effect above on every id change).
-    const requestId = ++languageRequestSeqRef.current;
-    const isLatestRequest = () =>
-      requestId === languageRequestSeqRef.current &&
-      requestUserId === lastLanguageSyncUserIdRef.current;
     try {
       setUpToDateUser((prevUser) => {
         if (prevUser) {
@@ -629,78 +570,28 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         return prevUser;
       });
 
-      // Optimistically switch the locale the server layout renders with.
-      Cookies.set(LOCALE_COOKIE_NAME, language, LOCALE_COOKIE_OPTIONS);
-
-      // Strictly serialize PATCHes: wait until the in-flight request has a
-      // response (not just a client-side rejection) before sending the next
-      // one, so the backend commits updates in selection order. A selection
-      // superseded while it waits skips its send — the newest one covers it.
-      const previousSend = languagePatchChainRef.current;
-      const send = (async (): Promise<Response | null> => {
-        await previousSend;
-        if (!isLatestRequest()) {
-          return null;
-        }
-        return fetch(`/api/user/language`, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ language }),
-        });
-      })();
-      languagePatchChainRef.current = send.then(
-        () => undefined,
-        () => undefined
-      );
-
-      const response = await send;
-
-      // Superseded while queued: the newer request owns all state from here.
-      if (response === null) {
-        return;
-      }
+      const response = await fetch(`/api/user/language`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ language }),
+      });
 
       if (!response.ok) {
         throw new Error("Failed to update language preference");
       }
 
-      if (isLatestRequest()) {
-        // Re-run the server layout so getLocale()/getMessages() re-resolve.
-        router.refresh();
-      }
+      // The response's Set-Cookie carries the new locale; re-render the
+      // server layout with it.
+      router.refresh();
     } catch (error) {
-      // Roll back the optimistic cookie and in-memory preference on every
-      // failure path, including network errors where fetch itself rejects.
-      if (isLatestRequest()) {
-        setUpToDateUser((prevUser) => {
-          if (prevUser) {
-            return {
-              ...prevUser,
-              preferences: {
-                ...prevUser.preferences,
-                language: previousLanguage ?? null,
-              },
-            };
-          }
-          return prevUser;
-        });
-        if (isSupportedLocale(previousLanguage)) {
-          Cookies.set(
-            LOCALE_COOKIE_NAME,
-            previousLanguage,
-            LOCALE_COOKIE_OPTIONS
-          );
-        } else {
-          Cookies.remove(LOCALE_COOKIE_NAME, { path: "/" });
-        }
-        try {
-          await refreshUser();
-        } catch {
-          // Best effort: the direct rollback above already restored local
-          // state, so a failed refetch changes nothing user-visible.
-        }
+      // Restore server truth on any failure path (bad status or network
+      // error); the stored preference is unchanged server-side.
+      try {
+        await refreshUser();
+      } catch {
+        // Best effort: the next successful /me resolves any drift.
       }
       console.error("Error updating language preference:", error);
       throw error;


### PR DESCRIPTION
## Summary

Follow-up to #14253 that removes the client-side locale-cookie machinery before it reaches `main`. Based on the picker branch so it can merge immediately behind it.

The client previously wrote `NEXT_LOCALE` and reconciled it with the DB preference. Keeping that correct across overlapping updates, impersonation, logout, and re-login required a request sequence, an identity ref, a serialized PATCH chain, and a three-part currency predicate (see the resolved review threads on #14253) — and fresh sessions still first-painted in the wrong language until the client effect kicked in.

This PR moves cookie ownership to the backend:

- `PATCH /user/language` sets the cookie (httpOnly, `path=/`, `secure` per `WEB_DOMAIN`, same flags as neighboring auth cookies) together with the DB update.
- `GET /me` reconciles the cookie with the stored preference whenever they disagree — covering fresh browsers, identity switches, and preference changes made on another device.
- The client collapses to "PATCH, then `router.refresh()`" plus one stateless six-line effect that refreshes when the rendered `<html lang>` lags the signed-in user's preference. `js-cookie` usage and all sequencing/identity guards are deleted (~100 lines).

Semantics change: overlapping updates resolve to server truth on the next `/me` reconciliation instead of client-side sequencing — simpler and self-healing.

## Testing

- New integration tests: `PATCH` sets the cookie; `/me` sets it when missing or stale and leaves it alone when current. Pass against the live dev deployment.
- UserProvider Jest suite, `types:check`, and `lint` pass.
- Live browser check: picking Español flips `<html lang="es")` without reload, the cookie is invisible to `document.cookie` (httpOnly, server-set), Spanish persists across a full reload, and the DB row reads `es`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)