### PR TITLE
fix(web): use a pointer cursor across the whole InputSelect item

### DIFF
--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -364,7 +364,7 @@ function InputSelectItem({
     <SelectPrimitive.Item
       ref={ref}
       value={value}
-      className="outline-hidden focus:outline-hidden rounded-08 data-highlighted:bg-background-tint-02"
+      className="cursor-pointer select-none outline-hidden focus:outline-hidden rounded-08 data-highlighted:bg-background-tint-02"
       onSelect={onClick}
     >
       {/* Hidden ItemText for Radix to track selection */}


### PR DESCRIPTION
## Description

Hovering the label text of an `InputSelect` item showed an I-beam cursor, while the rest of the row showed the default arrow.

Cause: the Radix `Select.Item` in `web/src/refresh-components/inputs/InputSelect.tsx` sets no cursor, and the inner `LineItem` skips its `cursor-pointer` when `interactive={false}`. The row fell back to `cursor: auto`.

Fix: set `cursor-pointer select-none` on the item. These are the same classes the Opal `InputSelect` item uses (`.opal-input-select-item`), so the two implementations now match. The cursor is now a pointer across the whole row, including the text.

## How Has This Been Tested?

- Opened the Language picker on `/app/settings/general` and checked `getComputedStyle(...).cursor` on each option and on its inner text element: both report `pointer`, and `user-select` is `none`.
- `pre-commit run --files web/src/refresh-components/inputs/InputSelect.tsx` passes (oxfmt, oxlint, TypeScript).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)