### PR TITLE
fix(llm): add admin vision override and fix provider resolution for custom models

### DIFF
--- a/web/src/lib/languageModels/hooks.ts
+++ b/web/src/lib/languageModels/hooks.ts
@@ -357,8 +357,10 @@ export function useLlmDefaults(): LlmDefaults {
       if (!llmProviders || !raw) return null;
       const provider = llmProviders.find((p) => p.id === raw.provider_id);
       if (!provider) return null;
-      if (!provider.name) return null;
-      return { providerName: provider.name, modelName: raw.model_name };
+      return {
+        providerName: provider.name || provider.provider,
+        modelName: raw.model_name,
+      };
     },
     [llmProviders]
   );

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -517,9 +517,37 @@ function buildModelDescription(model: ModelConfiguration): string | undefined {
   return parts.length > 0 ? parts.join("  ·  ") : undefined;
 }
 
-/** Eye marker for vision models, shown on the right of the picker row. */
-function modelRightChildren(model: ModelConfiguration): React.ReactNode {
-  if (!hasModelMetadata(model) || !model.supports_image_input) return undefined;
+/** Eye marker for vision models, shown on the right of the picker row.
+ *  When onToggleVision is provided, the eye is clickable to toggle
+ *  supports_image_input (admin override for models not recognized by
+ *  LiteLLM cost map). */
+function modelRightChildren(
+  model: ModelConfiguration,
+  onToggleVision?: () => void
+): React.ReactNode {
+  if (!onToggleVision && !model.supports_image_input) return undefined;
+  if (onToggleVision) {
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleVision();
+        }}
+        title={
+          model.supports_image_input
+            ? "Vision enabled — click to disable"
+            : "Click to enable vision (overrides LiteLLM auto-detection)"
+        }
+        className="cursor-pointer hover:opacity-80 transition-opacity"
+        style={{ opacity: model.supports_image_input ? 1 : 0.3 }}
+      >
+        <Text secondaryBody text03>
+          👁
+        </Text>
+      </button>
+    );
+  }
   return (
     <Text secondaryBody text03 title="Vision">
       👁
@@ -535,6 +563,7 @@ interface ModelRowProps {
   onRename: (value: string | undefined) => void;
   onSettingsChange: (patch: ModelSettingsPatch) => void;
   onSetDefaultModel?: () => void;
+  onToggleVision?: () => void;
 }
 
 /**
@@ -557,6 +586,7 @@ function ModelRow({
   onRename,
   onSettingsChange,
   onSetDefaultModel,
+  onToggleVision,
 }: ModelRowProps) {
   const editHandle = useRef<ContentMdEditHandle>(null);
   // Keeps the hover-revealed actions visible while the settings popover,
@@ -636,7 +666,7 @@ function ModelRow({
                   height="auto"
                   gap={1}
                 >
-                  {modelRightChildren(model)}
+                  {modelRightChildren(model, onToggleVision)}
                   <Hoverable.Item group="model-row" variant="appear-on-hover">
                     <OpalSection
                       flexDirection="row"
@@ -759,6 +789,13 @@ export function ModelSelectionField({
     await setDefaultLlmModelAndRefresh(providerId, modelName, mutate);
   }
 
+  function setVisionSupport(modelName: string, supports: boolean) {
+    const updated = models.map((m) =>
+      m.name === modelName ? { ...m, supports_image_input: supports } : m
+    );
+    formikProps.setFieldValue("model_configurations", updated);
+  }
+
   function setCustomDisplayName(modelName: string, value: string | undefined) {
     const updated = models.map((m) =>
       m.name === modelName
@@ -868,6 +905,12 @@ export function ModelSelectionField({
                         providerId != null && model.is_visible
                           ? () => void setDefaultModel(model.name)
                           : undefined
+                      }
+                      onToggleVision={() =>
+                        setVisionSupport(
+                          model.name,
+                          !model.supports_image_input
+                        )
                       }
                     />
                   ))}

--- a/web/src/sections/modals/languageModels/utils.test.tsx
+++ b/web/src/sections/modals/languageModels/utils.test.tsx
@@ -1,0 +1,62 @@
+import { mergeFetchedModelConfigurations } from "@/sections/modals/languageModels/utils";
+import type { ModelConfiguration } from "@/lib/languageModels/types";
+
+function makeModel(overrides: Partial<ModelConfiguration>): ModelConfiguration {
+  return {
+    id: undefined,
+    name: "test-model",
+    is_visible: true,
+    max_input_tokens: null,
+    supports_image_input: false,
+    supports_reasoning: false,
+    effectiveDisplayName: "test-model",
+    ...overrides,
+  };
+}
+
+describe("mergeFetchedModelConfigurations", () => {
+  test("returns fetched list as-is when existing is empty", () => {
+    const fetched = [makeModel({ name: "a", supports_image_input: true })];
+    const result = mergeFetchedModelConfigurations(fetched, []);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe("a");
+  });
+
+  test("preserves is_visible from existing models", () => {
+    const existing = [
+      makeModel({ name: "a", is_visible: false }),
+      makeModel({ name: "b", is_visible: true }),
+    ];
+    const fetched = [
+      makeModel({ name: "a", is_visible: true }),
+      makeModel({ name: "b", is_visible: false }),
+    ];
+    const result = mergeFetchedModelConfigurations(fetched, existing);
+    expect(result[0]!.is_visible).toBe(false);
+    expect(result[1]!.is_visible).toBe(true);
+  });
+
+  test("preserves supports_image_input override from existing models", () => {
+    const existing = [
+      makeModel({ name: "qwen-vl", supports_image_input: true }),
+      makeModel({ name: "qwen-instruct", supports_image_input: false }),
+    ];
+    const fetched = [
+      makeModel({ name: "qwen-vl", supports_image_input: false }),
+      makeModel({ name: "qwen-instruct", supports_image_input: false }),
+    ];
+    const result = mergeFetchedModelConfigurations(fetched, existing);
+    expect(result[0]!.supports_image_input).toBe(true);
+    expect(result[1]!.supports_image_input).toBe(false);
+  });
+
+  test("new models from fetch are added with is_visible=false", () => {
+    const existing = [makeModel({ name: "a", is_visible: true })];
+    const fetched = [
+      makeModel({ name: "a", is_visible: true }),
+      makeModel({ name: "b", is_visible: true }),
+    ];
+    const result = mergeFetchedModelConfigurations(fetched, existing);
+    expect(result[1]!.is_visible).toBe(false);
+  });
+});

--- a/web/src/sections/modals/languageModels/utils.ts
+++ b/web/src/sections/modals/languageModels/utils.ts
@@ -182,6 +182,7 @@ export function mergeFetchedModelConfigurations(
     return clampModelSettings({
       ...model,
       is_visible: prior.is_visible,
+      supports_image_input: prior.supports_image_input,
       custom_display_name: prior.custom_display_name,
       reasoning_effort_max: prior.reasoning_effort_max,
       reasoning_effort_default: prior.reasoning_effort_default,


### PR DESCRIPTION
## Problem

OpenAI-compatible providers with models unknown to LiteLLM cost map (e.g. `qwen-vl`, custom vLLM endpoints) have three issues:

1. **Unnamed providers discarded**: `resolveDefault` in `hooks.ts` returns `null` when `provider.name` is falsy, even though the provider is valid and has a slug (`provider.provider`).

2. **No admin vision override**: The vision eye indicator (`modelRightChildren`) only renders for providers with rich metadata (`hasModelMetadata`). Providers like OpenAI-compatible don't ship metadata, so admins can't toggle `supports_image_input` for models that LiteLLM doesn't recognize as vision-capable.

3. **Vision override lost on refetch**: `mergeFetchedModelConfigurations` preserves `is_visible` and `custom_display_name` from prior form state, but not `supports_image_input` — so an admin override gets clobbered when models are refetched.

## Fix

1. `hooks.ts`: `resolveDefault` falls back to `provider.provider` (slug) when `provider.name` is null.

2. `shared.tsx`: Vision eye indicator is now a clickable toggle on all model rows. Admins can click to override `supports_image_input` for any model. The eye shows at full opacity when enabled, dimmed (30%) when disabled.

3. `utils.ts`: `mergeFetchedModelConfigurations` preserves `supports_image_input` from prior form state alongside the existing preserved fields.

## Tests

4 unit tests for `mergeFetchedModelConfigurations` covering: empty existing, is_visible preservation, supports_image_input override preservation, new model default visibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three issues with custom models on OpenAI-compatible providers: unnamed providers no longer break default resolution, admins can now override vision support for any model, and vision overrides persist across refetches.

**Bug Fixes**
- Provider resolution now falls back to the provider slug when the display name is missing.
- The vision eye indicator is now a clickable toggle on all rows, not just those with rich metadata.
- `mergeFetchedModelConfigurations` preserves `supports_image_input` along with existing preserved fields.
- Adds 4 unit tests covering the merge behavior.

<sup>Written for commit 6739372856cfadacd78dd3c004b53de6c0fbd4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

