### PR TITLE
feat(web): i18n extraction wave 2a — chat shell and composer

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -90,11 +90,39 @@
     {
       "files": [
         "src/views/SettingsPage.tsx",
+        "src/views/AppPage.tsx",
         "src/sections/sidebar/AccountPopover.tsx",
-        "src/app/auth/**"
+        "src/sections/Suggestions.tsx",
+        "src/sections/banners/**",
+        "src/sections/chat/**",
+        "src/sections/input/**",
+        "src/sections/model-selector/**",
+        "src/components/chat/**",
+        "src/app/auth/**",
+        "src/app/app/page.tsx",
+        "src/app/app/layout.tsx",
+        "src/app/app/components/**",
+        "src/app/app/shared/**"
       ],
       "rules": {
         "i18n/no-raw-jsx-text": "error"
+      }
+    },
+    {
+      // Last override wins: keep dev-only files exempt from the i18n ratchet
+      // even when a migrated glob above matches them.
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/__tests__/**",
+        "**/__mocks__/**",
+        "tests/**",
+        "**/*.stories.tsx"
+      ],
+      "rules": {
+        "i18n/no-raw-jsx-text": "off"
       }
     }
   ],

--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -1,8 +1,11 @@
 import type { Preview } from "@storybook/react-vite";
 import { withThemeByClassName } from "@storybook/addon-themes";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { NextIntlClientProvider } from "next-intl";
 import React from "react";
 import "../src/app/globals.css";
+
+import englishMessages from "../src/i18n/messages/en.json";
 
 const preview: Preview = {
   parameters: {
@@ -27,6 +30,13 @@ const preview: Preview = {
       React.createElement(
         TooltipPrimitive.Provider,
         null,
+        React.createElement(Story)
+      ),
+    // Stories always render the English catalog, matching the app default.
+    (Story) =>
+      React.createElement(
+        NextIntlClientProvider,
+        { locale: "en", messages: englishMessages },
         React.createElement(Story)
       ),
   ],

--- a/web/src/app/app/components/AppPopup.tsx
+++ b/web/src/app/app/components/AppPopup.tsx
@@ -13,20 +13,26 @@ import { transformLinkUri } from "@/lib/utils";
 import { SvgAlertCircle } from "@opal/icons";
 import { SvgOnyxLogo } from "@opal/logos";
 import type { IconProps } from "@opal/types";
+import { useTranslations } from "next-intl";
 
 const ALL_USERS_INITIAL_POPUP_FLOW_COMPLETED =
   "allUsersInitialPopupFlowCompleted";
 
-const CustomLogoHeaderIcon = ({ className, size = 24 }: IconProps) => (
-  <img
-    src="/api/enterprise-settings/logo"
-    alt="Logo"
-    style={{ width: size, height: size, objectFit: "contain" }}
-    className={className}
-  />
-);
+const CustomLogoHeaderIcon = ({ className, size = 24 }: IconProps) => {
+  const t = useTranslations("chat.popup");
+
+  return (
+    <img
+      src="/api/enterprise-settings/logo"
+      alt={t("logoIcon.alt")}
+      style={{ width: size, height: size, objectFit: "contain" }}
+      className={className}
+    />
+  );
+};
 
 export function AppPopup() {
+  const t = useTranslations("chat.popup");
   const [completedFlow, setCompletedFlow] = useState(true);
   const [showConsentError, setShowConsentError] = useState(false);
   const [consentChecked, setConsentChecked] = useState(false);
@@ -76,7 +82,7 @@ export function AppPopup() {
       <Modal.Content width="sm" height="lg">
         <Modal.Header
           icon={headerIcon}
-          title={popupTitle || "Welcome to Onyx!"}
+          title={popupTitle || t("header.title")}
         />
         <Modal.Body>
           <div className="overflow-y-auto text-left">
@@ -125,7 +131,7 @@ export function AppPopup() {
                 <div className="flex items-center gap-1">
                   <FormField.Control>
                     <Checkbox
-                      aria-label="Consent checkbox"
+                      aria-label={t("consentCheckbox.label")}
                       checked={consentChecked}
                       onCheckedChange={(checked) => {
                         setConsentChecked(checked);
@@ -173,10 +179,7 @@ export function AppPopup() {
                   </FormField.Label>
                 </div>
                 <FormField.Message
-                  messages={{
-                    error:
-                      "You need to agree to the terms to access the application.",
-                  }}
+                  messages={{ error: t("consentRequired.error") }}
                 />
               </FormField>
             )}
@@ -196,7 +199,7 @@ export function AppPopup() {
               setCompletedFlow(true);
             }}
           >
-            Start
+            {t("startButton.label")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -1,10 +1,6 @@
 "use client";
 
 import { Logo } from "@/lib/app/components";
-import {
-  getRandomGreeting,
-  GREETING_MESSAGES,
-} from "@/lib/chat/greetingMessages";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import Text from "@/refresh-components/texts/Text";
 import { MinimalAgent } from "@/lib/agents/types";
@@ -14,6 +10,7 @@ import FrostedDiv from "@/refresh-components/FrostedDiv";
 import { Section } from "@/layouts/general-layouts";
 import { SvgEyeClosed } from "@opal/icons";
 import { useIncognito } from "@/providers/IncognitoProvider";
+import { useTranslations } from "next-intl";
 
 export interface WelcomeMessageProps {
   agent?: MinimalAgent;
@@ -24,18 +21,21 @@ export default function WelcomeMessage({
   agent,
   isDefaultAgent,
 }: WelcomeMessageProps) {
+  const t = useTranslations("chat.welcome");
   const settings = useSettings();
 
   // Use a stable default for SSR, then randomize on client after hydration
-  const [greeting, setGreeting] = useState(GREETING_MESSAGES[0]);
+  const [greeting, setGreeting] = useState(t("greeting.helpText"));
 
   useEffect(() => {
     if (settings.enterprise?.custom_greeting_message) {
       setGreeting(settings.enterprise.custom_greeting_message);
     } else {
-      setGreeting(getRandomGreeting());
+      setGreeting(
+        Math.random() < 0.5 ? t("greeting.helpText") : t("greeting.startText")
+      );
     }
-  }, [settings.enterprise?.custom_greeting_message]);
+  }, [settings.enterprise?.custom_greeting_message, t]);
 
   const { incognitoEnabled } = useIncognito();
 
@@ -52,7 +52,7 @@ export default function WelcomeMessage({
       >
         <SvgEyeClosed size={32} className="text-text-04" />
         <Text as="p" headingH2>
-          You&apos;re incognito
+          {t("incognito.title")}
         </Text>
       </Section>
     );

--- a/web/src/app/app/components/files/images/FullImageModal.tsx
+++ b/web/src/app/app/components/files/images/FullImageModal.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { cn } from "@opal/utils";
 import * as Dialog from "@radix-ui/react-dialog";
+import { useTranslations } from "next-intl";
 
 interface FullImageModalProps {
   fileId: string;
@@ -16,6 +17,8 @@ export function FullImageModal({
   open,
   onOpenChange,
 }: FullImageModalProps) {
+  const t = useTranslations("chat.files");
+
   // pre-fetch image
   useEffect(() => {
     const img = new Image();
@@ -35,7 +38,7 @@ export function FullImageModal({
         >
           <img
             src={buildImgUrl(fileId)}
-            alt="Uploaded attachment"
+            alt={t("fullImageModal.image.alt")}
             className="max-w-full max-h-full"
           />
         </Dialog.Content>

--- a/web/src/app/app/components/files/images/InMessageImage.tsx
+++ b/web/src/app/app/components/files/images/InMessageImage.tsx
@@ -6,6 +6,7 @@ import { buildImgUrl } from "@/app/app/components/files/images/utils";
 import { Button } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { cn, clickOnKeyDown } from "@opal/utils";
+import { useTranslations } from "next-intl";
 
 const DEFAULT_SHAPE: ImageShape = "square";
 
@@ -39,6 +40,7 @@ export const InMessageImage = memo(function InMessageImage({
   fileName,
   shape = DEFAULT_SHAPE,
 }: InMessageImageProps) {
+  const t = useTranslations("chat.files");
   const [fullImageShowing, setFullImageShowing] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(loadedImages.has(fileId));
 
@@ -84,7 +86,7 @@ export const InMessageImage = memo(function InMessageImage({
           className={cn("relative", shapeContainerClasses)}
           role="button"
           tabIndex={0}
-          aria-label="View the full image"
+          aria-label={t("inMessageImage.viewFullImage.label")}
           onClick={() => setFullImageShowing(true)}
           onKeyDown={clickOnKeyDown(() => setFullImageShowing(true))}
         >
@@ -95,7 +97,7 @@ export const InMessageImage = memo(function InMessageImage({
           <img
             width={1200}
             height={1200}
-            alt="Chat attachment"
+            alt={t("inMessageImage.image.alt")}
             onLoad={() => {
               loadedImages.add(fileId);
               setImageLoaded(true);
@@ -114,7 +116,7 @@ export const InMessageImage = memo(function InMessageImage({
             <Hoverable.Item group="messageImage" variant="appear-on-hover">
               <Button
                 icon={SvgDownload}
-                tooltip="Download"
+                tooltip={t("inMessageImage.downloadButton.tooltip")}
                 onClick={handleDownload}
               />
             </Hoverable.Item>

--- a/web/src/app/app/components/files/images/InputBarPreviewImage.tsx
+++ b/web/src/app/app/components/files/images/InputBarPreviewImage.tsx
@@ -3,8 +3,10 @@
 import { useState } from "react";
 import { buildImgUrl } from "./utils";
 import { FullImageModal } from "./FullImageModal";
+import { useTranslations } from "next-intl";
 
 export function InputBarPreviewImage({ fileId }: { fileId: string }) {
+  const t = useTranslations("chat.files");
   const [fullImageShowing, setFullImageShowing] = useState(false);
 
   return (
@@ -16,7 +18,7 @@ export function InputBarPreviewImage({ fileId }: { fileId: string }) {
       />
       <button
         type="button"
-        aria-label="View the full image"
+        aria-label={t("inputBarPreviewImage.viewFullImage.label")}
         onClick={() => setFullImageShowing(true)}
         className={`
           bg-transparent
@@ -32,7 +34,7 @@ export function InputBarPreviewImage({ fileId }: { fileId: string }) {
       `}
       >
         <img
-          alt="preview"
+          alt={t("inputBarPreviewImage.image.alt")}
           className="h-6 w-6 object-cover rounded-lg bg-background cursor-pointer"
           src={buildImgUrl(fileId)}
         />

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -19,10 +19,10 @@ import { Button } from "@opal/components";
 import { Agent } from "@/lib/agents/types";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import PreviewModal from "@/sections/modals/PreviewModal";
-import { UNNAMED_CHAT } from "@/lib/constants";
 import Text from "@/refresh-components/texts/Text";
 import useOnMount from "@/hooks/useOnMount";
 import SharedAppInputBar from "@/sections/input/SharedAppInputBar";
+import { useTranslations } from "next-intl";
 
 export interface SharedChatDisplayProps {
   chatSession: BackendChatSession | null;
@@ -33,6 +33,7 @@ export default function SharedChatDisplay({
   chatSession,
   persona,
 }: SharedChatDisplayProps) {
+  const t = useTranslations("chat.sharedChat");
   const [presentingDocument, setPresentingDocument] =
     useState<MinimalOnyxDocument | null>(null);
 
@@ -52,11 +53,11 @@ export default function SharedChatDisplay({
         <Section flexDirection="column" alignItems="center" gap={4}>
           <IllustrationContent
             illustration={SvgNotFound}
-            title="Shared chat not found"
-            description="Did not find a shared chat with the specified ID."
+            title={t("notFound.title")}
+            description={t("notFound.description")}
           />
           <Button href="/app" prominence="secondary">
-            Start a new chat
+            {t("newChatButton.label")}
           </Button>
         </Section>
       </div>
@@ -77,11 +78,11 @@ export default function SharedChatDisplay({
         <Section flexDirection="column" alignItems="center" gap={4}>
           <IllustrationContent
             illustration={SvgNotFound}
-            title="Shared chat not found"
-            description="No messages found in shared chat."
+            title={t("notFound.title")}
+            description={t("emptyChat.description")}
           />
           <Button href="/app" prominence="secondary">
-            Start a new chat
+            {t("newChatButton.label")}
           </Button>
         </Section>
       </div>
@@ -101,15 +102,17 @@ export default function SharedChatDisplay({
         <div className="flex-1 flex flex-col items-center overflow-y-auto">
           <div className="sticky top-0 z-10 flex items-center justify-between w-full bg-background-tint-01 px-8 py-4">
             <Text as="p" text04 headingH2>
-              {chatSession.description || UNNAMED_CHAT}
+              {chatSession.description || t("header.untitledChat.title")}
             </Text>
             <div className="flex flex-col items-end">
               <Text as="p" text03 secondaryBody>
-                Shared on {humanReadableFormat(chatSession.time_created)}
+                {t("header.sharedOn.text", {
+                  date: humanReadableFormat(chatSession.time_created),
+                })}
               </Text>
               {chatSession.owner_name && (
                 <Text as="p" text03 secondaryBody>
-                  by {chatSession.owner_name}
+                  {t("header.owner.text", { name: chatSession.owner_name })}
                 </Text>
               )}
             </div>

--- a/web/src/app/craft/components/CraftInputBar.test.tsx
+++ b/web/src/app/craft/components/CraftInputBar.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
+import { render } from "@tests/setup/test-utils";
 import CraftInputBar from "@/app/craft/components/CraftInputBar";
 import {
   UploadFileStatus,
@@ -63,6 +64,8 @@ jest.mock("next/navigation", () => ({
 jest.mock("swr", () => ({
   __esModule: true,
   default: () => ({ data: [], mutate: jest.fn() }),
+  // The test-utils render wrapper mounts the real SWRConfig provider.
+  SWRConfig: jest.requireActual("swr").SWRConfig,
 }));
 
 jest.mock("@/hooks/useUserSkills", () => ({

--- a/web/src/components/chat/FederatedOAuthModal.tsx
+++ b/web/src/components/chat/FederatedOAuthModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Card, Modal } from "@opal/components";
 import { Button } from "@opal/components";
 import { ValidSources } from "@/lib/types";
@@ -100,6 +101,7 @@ function useFederatedOauthModal() {
 }
 
 export default function FederatedOAuthModal() {
+  const t = useTranslations("chat.federatedOAuth");
   const { appName: applicationName } = useSettings();
 
   const {
@@ -121,8 +123,8 @@ export default function FederatedOAuthModal() {
       <Modal.Content width="sm" height="sm">
         <Modal.Header
           icon={SvgLink}
-          title="Connect Your Apps"
-          description={`Improve answer quality by letting ${applicationName} search all your connected data.`}
+          title={t("header.title")}
+          description={t("header.description", { appName: applicationName })}
         />
         <Modal.Body>
           {needsAuth.map((connector) => {
@@ -149,7 +151,7 @@ export default function FederatedOAuthModal() {
                         target="_blank"
                         href={connector.authorize_url}
                       >
-                        Connect
+                        {t("connectButton.label")}
                       </Button>
                     }
                   />
@@ -159,7 +161,9 @@ export default function FederatedOAuthModal() {
           })}
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={handleOAuthModalSkip}>Skip for now</Button>
+          <Button onClick={handleOAuthModalSkip}>
+            {t("skipButton.label")}
+          </Button>
         </Modal.Footer>
       </Modal.Content>
     </Modal>

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Modal } from "@opal/components";
 import { Button } from "@opal/components";
 import { Input } from "@/components/ui/input";
@@ -41,6 +42,7 @@ export default function MCPApiKeyModal({
   isAuthenticated = false,
   existingCredentials,
 }: MCPApiKeyModalProps) {
+  const t = useTranslations("chat.mcpApiKey");
   const [apiKey, setApiKey] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [credentials, setCredentials] = useState<Record<string, string>>({});
@@ -90,7 +92,7 @@ export default function MCPApiKeyModal({
         onClose();
       } catch (error) {
         console.error("Error submitting credentials:", error);
-        let errorMessage = "Failed to save credentials";
+        let errorMessage = t("saveCredentialsError.message");
         if (error instanceof Error) {
           errorMessage = error.message;
         } else if (typeof error === "string") {
@@ -114,7 +116,7 @@ export default function MCPApiKeyModal({
         onClose();
       } catch (error) {
         console.error("Error submitting API key:", error);
-        let errorMessage = "Failed to save API key";
+        let errorMessage = t("saveApiKeyError.message");
         if (error instanceof Error) {
           errorMessage = error.message;
         } else if (typeof error === "string") {
@@ -150,25 +152,45 @@ export default function MCPApiKeyModal({
     }));
   };
 
-  const credsType = isTemplateMode ? "Credentials" : "API Key";
+  // Credentials and API key wording differ per branch, so each variant is a
+  // whole message instead of a sentence built from fragments.
+  const modalTitle = isAuthenticated
+    ? isTemplateMode
+      ? t("header.manageCredentials.title")
+      : t("header.manageApiKey.title")
+    : isTemplateMode
+      ? t("header.enterCredentials.title")
+      : t("header.enterApiKey.title");
+  const introText = isAuthenticated
+    ? isTemplateMode
+      ? t("intro.updateCredentials.text", { server: serverName })
+      : t("intro.updateApiKey.text", { server: serverName })
+    : isTemplateMode
+      ? t("intro.enterCredentials.text", { server: serverName })
+      : t("intro.enterApiKey.text", { server: serverName });
+  const validationText = isAuthenticated
+    ? t("validationNote.authenticated.text")
+    : isTemplateMode
+      ? t("validationNote.credentials.text")
+      : t("validationNote.apiKey.text");
+  const submitLabel = isSubmitting
+    ? t("submitButton.saving.label")
+    : isAuthenticated
+      ? isTemplateMode
+        ? t("submitButton.updateCredentials.label")
+        : t("submitButton.updateApiKey.label")
+      : isTemplateMode
+        ? t("submitButton.saveCredentials.label")
+        : t("submitButton.saveApiKey.label");
+
   return (
     <Modal open={isOpen} onOpenChange={handleClose}>
       <Modal.Content width="sm" height="sm">
-        <Modal.Header
-          icon={SvgKey}
-          title={isAuthenticated ? `Manage ${credsType}` : `Enter ${credsType}`}
-          onClose={handleClose}
-        />
+        <Modal.Header icon={SvgKey} title={modalTitle} onClose={handleClose} />
         <Modal.Body>
-          <Text as="p">
-            {isAuthenticated
-              ? `Update your ${credsType} for ${serverName}.`
-              : `Enter your ${credsType} for ${serverName} to enable authentication.`}
-          </Text>
+          <Text as="p">{introText}</Text>
           <Text as="p" text02>
-            {isAuthenticated
-              ? "Changes will be validated against the server before being saved."
-              : `Your ${credsType} will be validated against the server and stored securely.`}
+            {validationText}
           </Text>
 
           {error && (
@@ -199,7 +221,9 @@ export default function MCPApiKeyModal({
                         onChange={(e) =>
                           updateCredential(field, e.target.value)
                         }
-                        placeholder={`Enter your ${field.replace(/_/g, " ")}`}
+                        placeholder={t("credentialField.placeholder", {
+                          field: field.replace(/_/g, " "),
+                        })}
                         className="pr-10"
                         required
                       />
@@ -209,8 +233,8 @@ export default function MCPApiKeyModal({
                         className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-emphasis"
                         aria-label={
                           showCredentials[field]
-                            ? "Hide credential"
-                            : "Show credential"
+                            ? t("credentialVisibilityButton.hideAriaLabel")
+                            : t("credentialVisibilityButton.showAriaLabel")
                         }
                       >
                         {showCredentials[field] ? (
@@ -227,7 +251,7 @@ export default function MCPApiKeyModal({
               // Legacy API key field
               <div className="space-y-2">
                 <Label label="apiKey">
-                  <Text>{credsType}</Text>
+                  <Text>{t("apiKeyField.label")}</Text>
                 </Label>
                 <div className="relative">
                   <Input
@@ -235,7 +259,7 @@ export default function MCPApiKeyModal({
                     type={showApiKey ? "text" : "password"}
                     value={apiKey}
                     onChange={(e) => setApiKey(e.target.value)}
-                    placeholder={`Enter your ${credsType}`}
+                    placeholder={t("apiKeyField.placeholder")}
                     className="pr-10"
                     required
                   />
@@ -243,7 +267,11 @@ export default function MCPApiKeyModal({
                     type="button"
                     onClick={() => setShowApiKey(!showApiKey)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-emphasis"
-                    aria-label={showApiKey ? "Hide API key" : "Show API key"}
+                    aria-label={
+                      showApiKey
+                        ? t("apiKeyVisibilityButton.hideAriaLabel")
+                        : t("apiKeyVisibilityButton.showAriaLabel")
+                    }
                   >
                     {showApiKey ? (
                       <SvgEyeClosed className="h-4 w-4" />
@@ -261,7 +289,7 @@ export default function MCPApiKeyModal({
                 prominence="secondary"
                 onClick={handleClose}
               >
-                Cancel
+                {t("cancelButton.label")}
               </Button>
               <Button
                 disabled={
@@ -274,11 +302,7 @@ export default function MCPApiKeyModal({
                 }
                 type="submit"
               >
-                {isSubmitting
-                  ? "Saving..."
-                  : isAuthenticated
-                    ? `Update ${credsType}`
-                    : `Save ${credsType}`}
+                {submitLabel}
               </Button>
             </div>
           </form>

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -308,6 +308,502 @@
       }
     }
   },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {Eine Datei ist fehlgeschlagen und wurde entfernt: {names}} other {Dateien sind fehlgeschlagen und wurden entfernt: {names}}}"
+      },
+      "newChatButton": {
+        "label": "Neuen Chat starten"
+      },
+      "noPreviousMessage": {
+        "toast": "Keine zuvor gesendete Nachricht gefunden."
+      },
+      "oauthConnected": {
+        "toast": "Authentifizierung erfolgreich"
+      },
+      "scrollToBottomButton": {
+        "label": "Nach unten scrollen"
+      },
+      "sessionAccessDenied": {
+        "description": "Sie haben keine Berechtigung, diese Chat-Sitzung zu sehen.",
+        "title": "Zugriff verweigert"
+      },
+      "sessionGenericError": {
+        "title": "Etwas ist schiefgelaufen"
+      },
+      "sessionNotFound": {
+        "description": "Diese Chat-Sitzung existiert nicht oder wurde gelöscht.",
+        "title": "Chat nicht gefunden"
+      },
+      "sourcesModal": {
+        "title": "Quellen"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count} weitere"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "Mehrere Konnektoren haben ungültige Anmeldedaten. Öffnen Sie die Konnektoren-Seite, um sie zu überprüfen.",
+          "title": "{count, plural, one {# Konnektor ist ungültig} other {# Konnektoren sind ungültig}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "Mehrere Konnektoren haben wiederholte Indexierungsfehler. Öffnen Sie die Konnektoren-Seite, um sie zu überprüfen.",
+          "title": "{count, plural, one {# Konnektor schlägt fehl} other {# Konnektoren schlagen fehl}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "Konnektor ansehen"
+        },
+        "source": {
+          "label": "Konnektoren"
+        }
+      },
+      "defaultCta": {
+        "label": "Ansehen"
+      },
+      "defaultSource": {
+        "label": "Benachrichtigung"
+      },
+      "dismissButton": {
+        "ariaLabel": "Schließen"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "Wenn dies Ihre Ersteinrichtung ist oder Sie Ihre Onyx-Bereitstellung gerade aktualisiert haben, startet das Backend wahrscheinlich noch. Warten Sie ein bis zwei Minuten und laden Sie die Seite neu. Wenn das nicht hilft, stellen Sie sicher, dass das Backend eingerichtet ist, oder wenden Sie sich an einen Administrator.",
+          "title": "Das Backend ist derzeit nicht erreichbar"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "Lizenz"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "Nächster Banner"
+      },
+      "previousButton": {
+        "ariaLabel": "Vorheriger Banner"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "Administrator-Ankündigung"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "Testphase"
+        }
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "Verbinden"
+      },
+      "header": {
+        "description": "Verbessern Sie die Antwortqualität, indem Sie {appName} alle Ihre verbundenen Daten durchsuchen lassen.",
+        "title": "Verbinden Sie Ihre Apps"
+      },
+      "skipButton": {
+        "label": "Vorerst überspringen"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "Hochgeladener Anhang"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "Herunterladen"
+        },
+        "image": {
+          "alt": "Chat-Anhang"
+        },
+        "viewFullImage": {
+          "label": "Bild in voller Größe ansehen"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "Vorschau"
+        },
+        "viewFullImage": {
+          "label": "Bild in voller Größe ansehen"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "Dateien anhängen"
+        },
+        "createPromptItem": {
+          "title": "Neuen Prompt erstellen"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "Deep Research ist im Multi-Modell-Modus deaktiviert",
+          "label": "Deep Research"
+        },
+        "incognitoNotice": {
+          "text": "Dieser Chat erscheint nicht in Ihrem Verlauf und wird nicht für die Memory-Funktion verwendet."
+        },
+        "incognitoPolicyNotice": {
+          "text": "Ihr Administrator kann diesen Chat gemäß den Richtlinien Ihrer Organisation weiterhin sehen. Drittanbieter-Tools können Ihre Aktivität weiterhin aufzeichnen."
+        },
+        "input": {
+          "ariaLabel": "Nachrichteneingabe",
+          "listeningPlaceholder": "Höre zu...",
+          "placeholder": "Wie kann ich Ihnen heute helfen?",
+          "queuedPlaceholder": "Pfeil nach oben drücken, um Nachrichten in der Warteschlange zu bearbeiten",
+          "searchPlaceholder": "Verbundene Quellen durchsuchen",
+          "speakingPlaceholder": "Onyx spricht..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "Warten, bis die angehängten Dateien verarbeitet sind"
+        },
+        "tabReadingButton": {
+          "readLabel": "Diesen Tab lesen",
+          "readingLabel": "Tab wird gelesen..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "Sprachfunktion einrichten",
+          "tooltip": "Sprachfunktion nicht konfiguriert. Richten Sie sie in den Administrator-Einstellungen ein."
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "Nachrichteneingabe",
+          "placeholder": "Beschreiben Sie Ihre Aufgabe..."
+        },
+        "pasteExpandHint": {
+          "text": "Erneut einfügen zum Erweitern"
+        },
+        "queuedMessagesHint": {
+          "text": "zum Bearbeiten der Nachrichten in der Warteschlange"
+        },
+        "sendButton": {
+          "initializingTooltip": "Sandbox wird initialisiert...",
+          "queueLabel": "Nachricht in die Warteschlange stellen",
+          "sendLabel": "Senden"
+        },
+        "stopButton": {
+          "ariaLabel": "Generierung stoppen",
+          "tooltip": "Stopp · Esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "Warten, bis die Sitzung bereit ist..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "Skill: {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "Apps"
+        },
+        "connectAction": {
+          "label": "Verbinden"
+        },
+        "connectedRow": {
+          "description": "Verbunden"
+        },
+        "connectionRequiredRow": {
+          "description": "Verbindung erforderlich"
+        },
+        "content": {
+          "ariaLabel": "Skill-Auswahl"
+        },
+        "empty": {
+          "text": "Keine passenden Skills"
+        },
+        "mcpServersGroup": {
+          "label": "MCP-Server"
+        },
+        "skillsGroup": {
+          "label": "Skills"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "{label} entfernen"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "Zugriff auf das Mikrofon nicht möglich"
+        },
+        "autoStartError": {
+          "toast": "Mikrofon konnte nicht automatisch gestartet werden"
+        },
+        "startRecording": {
+          "ariaLabel": "Aufnahme starten"
+        },
+        "stopRecording": {
+          "ariaLabel": "Aufnahme stoppen"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "Eingefügten Text bearbeiten"
+        },
+        "expandButton": {
+          "label": "In die Eingabeleiste erweitern",
+          "tooltip": "Diese Kachel durch ihren vollständigen Text ersetzen"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "Hinzufügen-Menü öffnen",
+          "tooltip": "Hinzufügen"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "Nachricht aus der Warteschlange entfernen"
+        },
+        "editHint": {
+          "label": "bearbeiten ·"
+        },
+        "item": {
+          "ariaLabel": "Nachricht in der Warteschlange umschalten"
+        },
+        "removeHint": {
+          "label": "entfernen"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "Wie kann Onyx Ihnen heute helfen?"
+        },
+        "startSessionButton": {
+          "label": "Neue Sitzung starten"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "API-Schlüssel",
+        "placeholder": "Geben Sie Ihren API-Schlüssel ein"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "API-Schlüssel verbergen",
+        "showAriaLabel": "API-Schlüssel anzeigen"
+      },
+      "cancelButton": {
+        "label": "Abbrechen"
+      },
+      "credentialField": {
+        "placeholder": "Geben Sie {field} ein"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "Anmeldedaten verbergen",
+        "showAriaLabel": "Anmeldedaten anzeigen"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "API-Schlüssel eingeben"
+        },
+        "enterCredentials": {
+          "title": "Anmeldedaten eingeben"
+        },
+        "manageApiKey": {
+          "title": "API-Schlüssel verwalten"
+        },
+        "manageCredentials": {
+          "title": "Anmeldedaten verwalten"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "Geben Sie Ihren API-Schlüssel für {server} ein, um die Authentifizierung zu aktivieren."
+        },
+        "enterCredentials": {
+          "text": "Geben Sie Ihre Anmeldedaten für {server} ein, um die Authentifizierung zu aktivieren."
+        },
+        "updateApiKey": {
+          "text": "Aktualisieren Sie Ihren API-Schlüssel für {server}."
+        },
+        "updateCredentials": {
+          "text": "Aktualisieren Sie Ihre Anmeldedaten für {server}."
+        }
+      },
+      "saveApiKeyError": {
+        "message": "API-Schlüssel konnte nicht gespeichert werden"
+      },
+      "saveCredentialsError": {
+        "message": "Anmeldedaten konnten nicht gespeichert werden"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "API-Schlüssel speichern"
+        },
+        "saveCredentials": {
+          "label": "Anmeldedaten speichern"
+        },
+        "saving": {
+          "label": "Wird gespeichert..."
+        },
+        "updateApiKey": {
+          "label": "API-Schlüssel aktualisieren"
+        },
+        "updateCredentials": {
+          "label": "Anmeldedaten aktualisieren"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "Ihr API-Schlüssel wird beim Server validiert und sicher gespeichert."
+        },
+        "authenticated": {
+          "text": "Änderungen werden vor dem Speichern beim Server validiert."
+        },
+        "credentials": {
+          "text": "Ihre Anmeldedaten werden beim Server validiert und sicher gespeichert."
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "Ihr Administrator beschränkt dieses Modell auf eine niedrigere Reasoning-Stufe."
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "Token-Limit für jede Sitzung",
+          "title": "Kontextfenster"
+        },
+        "unknown": {
+          "tooltip": "Die Kontextgröße ist für dieses Modell nicht verfügbar. Chats wenden trotzdem automatisch ein Token-Limit an."
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "Keine Modelle gefunden"
+        },
+        "loading": {
+          "text": "Modelle werden geladen..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "Einstellungen für {model}",
+        "tooltip": "Modell-Einstellungen"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "Modell hinzufügen"
+        },
+        "noModels": {
+          "tooltip": "Derzeit sind keine Modelle konfiguriert"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "Hoch"
+        },
+        "low": {
+          "label": "Niedrig"
+        },
+        "medium": {
+          "label": "Mittel"
+        },
+        "off": {
+          "label": "Aus"
+        },
+        "row": {
+          "caption": "Wie viel das Modell nachdenken soll, bevor es antwortet",
+          "title": "Reasoning-Stufe"
+        },
+        "xhigh": {
+          "label": "Sehr hoch"
+        }
+      },
+      "searchInput": {
+        "placeholder": "Modelle suchen..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "Ausgewogen"
+        },
+        "creative": {
+          "label": "Kreativ"
+        },
+        "deterministic": {
+          "label": "Deterministisch"
+        },
+        "row": {
+          "caption": "Wie vorhersehbar oder kreativ das Modell antworten soll",
+          "title": "Temperatur"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "Modell auswählen"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "Das Ändern dieser Einstellung wird für dieses Modell nicht unterstützt."
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "Einwilligungs-Kontrollkästchen"
+      },
+      "consentRequired": {
+        "error": "Sie müssen den Bedingungen zustimmen, um auf die Anwendung zuzugreifen."
+      },
+      "header": {
+        "title": "Willkommen bei Onyx!"
+      },
+      "logoIcon": {
+        "alt": "Logo"
+      },
+      "startButton": {
+        "label": "Starten"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "Keine Nachrichten im geteilten Chat gefunden."
+      },
+      "header": {
+        "owner": {
+          "text": "von {name}"
+        },
+        "sharedOn": {
+          "text": "Geteilt am {date}"
+        },
+        "untitledChat": {
+          "title": "Neuer Chat"
+        }
+      },
+      "newChatButton": {
+        "label": "Neuen Chat starten"
+      },
+      "notFound": {
+        "description": "Kein geteilter Chat mit der angegebenen ID gefunden.",
+        "title": "Geteilter Chat nicht gefunden"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "Wie kann ich helfen?",
+        "startText": "Legen wir los."
+      },
+      "incognito": {
+        "title": "Sie sind inkognito"
+      }
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -308,6 +308,502 @@
       }
     }
   },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {File failed and was removed: {names}} other {Files failed and were removed: {names}}}"
+      },
+      "newChatButton": {
+        "label": "Start a new chat"
+      },
+      "noPreviousMessage": {
+        "toast": "No previously-submitted user message found."
+      },
+      "oauthConnected": {
+        "toast": "Authentication successful"
+      },
+      "scrollToBottomButton": {
+        "label": "Scroll to bottom"
+      },
+      "sessionAccessDenied": {
+        "description": "You don't have permission to view this chat session.",
+        "title": "Access denied"
+      },
+      "sessionGenericError": {
+        "title": "Something went wrong"
+      },
+      "sessionNotFound": {
+        "description": "This chat session doesn't exist or has been deleted.",
+        "title": "Chat not found"
+      },
+      "sourcesModal": {
+        "title": "Sources"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count} more"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "Multiple connectors have invalid credentials. Open the connectors page to review them.",
+          "title": "{count, plural, one {# connector is invalid} other {# connectors are invalid}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "Multiple connectors have repeated indexing failures. Open the connectors page to review them.",
+          "title": "{count, plural, one {# connector is failing} other {# connectors are failing}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "View connector"
+        },
+        "source": {
+          "label": "Connectors"
+        }
+      },
+      "defaultCta": {
+        "label": "View"
+      },
+      "defaultSource": {
+        "label": "Notification"
+      },
+      "dismissButton": {
+        "ariaLabel": "Dismiss"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "If this is your initial setup or you just updated your Onyx deployment, this is likely because the backend is still starting up. Give it a minute or two, and then refresh the page. If that does not work, make sure the backend is setup and/or contact an administrator.",
+          "title": "The backend is currently unavailable"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "License"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "Next banner"
+      },
+      "previousButton": {
+        "ariaLabel": "Previous banner"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "Admin announcement"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "Trial"
+        }
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "Connect"
+      },
+      "header": {
+        "description": "Improve answer quality by letting {appName} search all your connected data.",
+        "title": "Connect Your Apps"
+      },
+      "skipButton": {
+        "label": "Skip for now"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "Uploaded attachment"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "Download"
+        },
+        "image": {
+          "alt": "Chat attachment"
+        },
+        "viewFullImage": {
+          "label": "View the full image"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "preview"
+        },
+        "viewFullImage": {
+          "label": "View the full image"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "Attach Files"
+        },
+        "createPromptItem": {
+          "title": "Create New Prompt"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "Deep Research is disabled in multi-model mode",
+          "label": "Deep Research"
+        },
+        "incognitoNotice": {
+          "text": "This chat won't appear in your history or be used for memory."
+        },
+        "incognitoPolicyNotice": {
+          "text": "Your admin may still see this chat based on your organization's policy. Third party tools can still record your activity."
+        },
+        "input": {
+          "ariaLabel": "Message input",
+          "listeningPlaceholder": "Listening...",
+          "placeholder": "How can I help you today?",
+          "queuedPlaceholder": "Press up to edit queued messages",
+          "searchPlaceholder": "Search connected sources",
+          "speakingPlaceholder": "Onyx is speaking..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "Waiting for attached file(s) to finish processing"
+        },
+        "tabReadingButton": {
+          "readLabel": "Read this tab",
+          "readingLabel": "Reading tab..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "Set up voice",
+          "tooltip": "Voice not configured. Set up in admin settings."
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "Message input",
+          "placeholder": "Describe your task..."
+        },
+        "pasteExpandHint": {
+          "text": "Paste again to expand"
+        },
+        "queuedMessagesHint": {
+          "text": "to edit queued messages"
+        },
+        "sendButton": {
+          "initializingTooltip": "Initializing sandbox...",
+          "queueLabel": "Queue message",
+          "sendLabel": "Send"
+        },
+        "stopButton": {
+          "ariaLabel": "Stop generating",
+          "tooltip": "Stop · esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "Waiting for session to be ready..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "Skill: {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "Apps"
+        },
+        "connectAction": {
+          "label": "Connect"
+        },
+        "connectedRow": {
+          "description": "Connected"
+        },
+        "connectionRequiredRow": {
+          "description": "Connection required"
+        },
+        "content": {
+          "ariaLabel": "Skill picker"
+        },
+        "empty": {
+          "text": "No matching skills"
+        },
+        "mcpServersGroup": {
+          "label": "MCP servers"
+        },
+        "skillsGroup": {
+          "label": "Skills"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "Remove {label}"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "Could not access microphone"
+        },
+        "autoStartError": {
+          "toast": "Could not auto-start microphone"
+        },
+        "startRecording": {
+          "ariaLabel": "Start recording"
+        },
+        "stopRecording": {
+          "ariaLabel": "Stop recording"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "Edit pasted text"
+        },
+        "expandButton": {
+          "label": "Expand into input bar",
+          "tooltip": "Replace this tile with its full text inline"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "Open add menu",
+          "tooltip": "Add"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "Remove queued message"
+        },
+        "editHint": {
+          "label": "edit ·"
+        },
+        "item": {
+          "ariaLabel": "Toggle queued message"
+        },
+        "removeHint": {
+          "label": "remove"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "How can Onyx help you today"
+        },
+        "startSessionButton": {
+          "label": "Start New Session"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "API Key",
+        "placeholder": "Enter your API Key"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "Hide API key",
+        "showAriaLabel": "Show API key"
+      },
+      "cancelButton": {
+        "label": "Cancel"
+      },
+      "credentialField": {
+        "placeholder": "Enter your {field}"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "Hide credential",
+        "showAriaLabel": "Show credential"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "Enter API Key"
+        },
+        "enterCredentials": {
+          "title": "Enter Credentials"
+        },
+        "manageApiKey": {
+          "title": "Manage API Key"
+        },
+        "manageCredentials": {
+          "title": "Manage Credentials"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "Enter your API Key for {server} to enable authentication."
+        },
+        "enterCredentials": {
+          "text": "Enter your Credentials for {server} to enable authentication."
+        },
+        "updateApiKey": {
+          "text": "Update your API Key for {server}."
+        },
+        "updateCredentials": {
+          "text": "Update your Credentials for {server}."
+        }
+      },
+      "saveApiKeyError": {
+        "message": "Failed to save API key"
+      },
+      "saveCredentialsError": {
+        "message": "Failed to save credentials"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "Save API Key"
+        },
+        "saveCredentials": {
+          "label": "Save Credentials"
+        },
+        "saving": {
+          "label": "Saving..."
+        },
+        "updateApiKey": {
+          "label": "Update API Key"
+        },
+        "updateCredentials": {
+          "label": "Update Credentials"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "Your API Key will be validated against the server and stored securely."
+        },
+        "authenticated": {
+          "text": "Changes will be validated against the server before being saved."
+        },
+        "credentials": {
+          "text": "Your Credentials will be validated against the server and stored securely."
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "Your admin limits this model to a lower reasoning level."
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "Tokens limit for each session",
+          "title": "Context Window"
+        },
+        "unknown": {
+          "tooltip": "Context size is not available for this model. Chats still apply a token limit automatically."
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "No models found"
+        },
+        "loading": {
+          "text": "Loading models..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "{model} settings",
+        "tooltip": "Model settings"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "Add Model"
+        },
+        "noModels": {
+          "tooltip": "No models currently configured"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "High"
+        },
+        "low": {
+          "label": "Low"
+        },
+        "medium": {
+          "label": "Medium"
+        },
+        "off": {
+          "label": "Off"
+        },
+        "row": {
+          "caption": "How much thinking the model should perform before answering",
+          "title": "Reasoning Level"
+        },
+        "xhigh": {
+          "label": "XHigh"
+        }
+      },
+      "searchInput": {
+        "placeholder": "Search models..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "Balanced"
+        },
+        "creative": {
+          "label": "Creative"
+        },
+        "deterministic": {
+          "label": "Deterministic"
+        },
+        "row": {
+          "caption": "How predictable or creative the model should respond",
+          "title": "Temperature"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "Select Model"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "Modifying this setting is not supported for this model."
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "Consent checkbox"
+      },
+      "consentRequired": {
+        "error": "You need to agree to the terms to access the application."
+      },
+      "header": {
+        "title": "Welcome to Onyx!"
+      },
+      "logoIcon": {
+        "alt": "Logo"
+      },
+      "startButton": {
+        "label": "Start"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "No messages found in shared chat."
+      },
+      "header": {
+        "owner": {
+          "text": "by {name}"
+        },
+        "sharedOn": {
+          "text": "Shared on {date}"
+        },
+        "untitledChat": {
+          "title": "New Chat"
+        }
+      },
+      "newChatButton": {
+        "label": "Start a new chat"
+      },
+      "notFound": {
+        "description": "Did not find a shared chat with the specified ID.",
+        "title": "Shared chat not found"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "How can I help?",
+        "startText": "Let's get started."
+      },
+      "incognito": {
+        "title": "You're incognito"
+      }
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -308,6 +308,502 @@
       }
     }
   },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {Un archivo falló y fue eliminado: {names}} other {Algunos archivos fallaron y fueron eliminados: {names}}}"
+      },
+      "newChatButton": {
+        "label": "Iniciar un chat nuevo"
+      },
+      "noPreviousMessage": {
+        "toast": "No se encontró ningún mensaje enviado previamente."
+      },
+      "oauthConnected": {
+        "toast": "Autenticación correcta"
+      },
+      "scrollToBottomButton": {
+        "label": "Ir al final"
+      },
+      "sessionAccessDenied": {
+        "description": "No tienes permiso para ver esta sesión de chat.",
+        "title": "Acceso denegado"
+      },
+      "sessionGenericError": {
+        "title": "Algo salió mal"
+      },
+      "sessionNotFound": {
+        "description": "Esta sesión de chat no existe o fue eliminada.",
+        "title": "Chat no encontrado"
+      },
+      "sourcesModal": {
+        "title": "Fuentes"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count} más"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "Varios conectores tienen credenciales no válidas. Abre la página de conectores para revisarlos.",
+          "title": "{count, plural, one {# conector no es válido} other {# conectores no son válidos}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "Varios conectores tienen fallos de indexación repetidos. Abre la página de conectores para revisarlos.",
+          "title": "{count, plural, one {# conector está fallando} other {# conectores están fallando}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "Ver conector"
+        },
+        "source": {
+          "label": "Conectores"
+        }
+      },
+      "defaultCta": {
+        "label": "Ver"
+      },
+      "defaultSource": {
+        "label": "Notificación"
+      },
+      "dismissButton": {
+        "ariaLabel": "Descartar"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "Si esta es tu configuración inicial o acabas de actualizar tu despliegue de Onyx, probablemente el backend todavía se está iniciando. Espera uno o dos minutos y recarga la página. Si eso no funciona, asegúrate de que el backend esté configurado o contacta a un administrador.",
+          "title": "El backend no está disponible en este momento"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "Licencia"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "Siguiente aviso"
+      },
+      "previousButton": {
+        "ariaLabel": "Aviso anterior"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "Anuncio del administrador"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "Prueba"
+        }
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "Conectar"
+      },
+      "header": {
+        "description": "Mejora la calidad de las respuestas permitiendo que {appName} busque en todos tus datos conectados.",
+        "title": "Conecta tus aplicaciones"
+      },
+      "skipButton": {
+        "label": "Omitir por ahora"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "Archivo adjunto subido"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "Descargar"
+        },
+        "image": {
+          "alt": "Adjunto del chat"
+        },
+        "viewFullImage": {
+          "label": "Ver la imagen completa"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "vista previa"
+        },
+        "viewFullImage": {
+          "label": "Ver la imagen completa"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "Adjuntar archivos"
+        },
+        "createPromptItem": {
+          "title": "Crear nuevo prompt"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "La investigación profunda está deshabilitada en el modo multimodelo",
+          "label": "Investigación profunda"
+        },
+        "incognitoNotice": {
+          "text": "Este chat no aparecerá en tu historial ni se usará para la memoria."
+        },
+        "incognitoPolicyNotice": {
+          "text": "Tu administrador aún puede ver este chat según la política de tu organización. Las herramientas de terceros todavía pueden registrar tu actividad."
+        },
+        "input": {
+          "ariaLabel": "Entrada de mensaje",
+          "listeningPlaceholder": "Escuchando...",
+          "placeholder": "¿En qué puedo ayudarte hoy?",
+          "queuedPlaceholder": "Pulsa la flecha arriba para editar los mensajes en cola",
+          "searchPlaceholder": "Buscar en las fuentes conectadas",
+          "speakingPlaceholder": "Onyx está hablando..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "Esperando a que terminen de procesarse los archivos adjuntos"
+        },
+        "tabReadingButton": {
+          "readLabel": "Leer esta pestaña",
+          "readingLabel": "Leyendo la pestaña..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "Configurar voz",
+          "tooltip": "La voz no está configurada. Actívala en la configuración de administración."
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "Entrada de mensaje",
+          "placeholder": "Describe tu tarea..."
+        },
+        "pasteExpandHint": {
+          "text": "Pega de nuevo para expandir"
+        },
+        "queuedMessagesHint": {
+          "text": "para editar los mensajes en cola"
+        },
+        "sendButton": {
+          "initializingTooltip": "Inicializando el sandbox...",
+          "queueLabel": "Poner mensaje en cola",
+          "sendLabel": "Enviar"
+        },
+        "stopButton": {
+          "ariaLabel": "Detener la generación",
+          "tooltip": "Detener · esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "Esperando a que la sesión esté lista..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "Habilidad: {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "Aplicaciones"
+        },
+        "connectAction": {
+          "label": "Conectar"
+        },
+        "connectedRow": {
+          "description": "Conectado"
+        },
+        "connectionRequiredRow": {
+          "description": "Requiere conexión"
+        },
+        "content": {
+          "ariaLabel": "Selector de habilidades"
+        },
+        "empty": {
+          "text": "No hay habilidades que coincidan"
+        },
+        "mcpServersGroup": {
+          "label": "Servidores MCP"
+        },
+        "skillsGroup": {
+          "label": "Habilidades"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "Quitar {label}"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "No se pudo acceder al micrófono"
+        },
+        "autoStartError": {
+          "toast": "No se pudo iniciar automáticamente el micrófono"
+        },
+        "startRecording": {
+          "ariaLabel": "Iniciar grabación"
+        },
+        "stopRecording": {
+          "ariaLabel": "Detener grabación"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "Editar texto pegado"
+        },
+        "expandButton": {
+          "label": "Expandir en la barra de entrada",
+          "tooltip": "Reemplazar esta tarjeta por su texto completo en línea"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "Abrir el menú de añadir",
+          "tooltip": "Añadir"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "Quitar mensaje en cola"
+        },
+        "editHint": {
+          "label": "editar ·"
+        },
+        "item": {
+          "ariaLabel": "Alternar mensaje en cola"
+        },
+        "removeHint": {
+          "label": "quitar"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "¿En qué puede ayudarte Onyx hoy?"
+        },
+        "startSessionButton": {
+          "label": "Iniciar nueva sesión"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "Clave de API",
+        "placeholder": "Introduce tu clave de API"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "Ocultar clave de API",
+        "showAriaLabel": "Mostrar clave de API"
+      },
+      "cancelButton": {
+        "label": "Cancelar"
+      },
+      "credentialField": {
+        "placeholder": "Introduce tu {field}"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "Ocultar credencial",
+        "showAriaLabel": "Mostrar credencial"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "Introducir clave de API"
+        },
+        "enterCredentials": {
+          "title": "Introducir credenciales"
+        },
+        "manageApiKey": {
+          "title": "Gestionar clave de API"
+        },
+        "manageCredentials": {
+          "title": "Gestionar credenciales"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "Introduce tu clave de API para {server} para habilitar la autenticación."
+        },
+        "enterCredentials": {
+          "text": "Introduce tus credenciales para {server} para habilitar la autenticación."
+        },
+        "updateApiKey": {
+          "text": "Actualiza tu clave de API para {server}."
+        },
+        "updateCredentials": {
+          "text": "Actualiza tus credenciales para {server}."
+        }
+      },
+      "saveApiKeyError": {
+        "message": "No se pudo guardar la clave de API"
+      },
+      "saveCredentialsError": {
+        "message": "No se pudieron guardar las credenciales"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "Guardar clave de API"
+        },
+        "saveCredentials": {
+          "label": "Guardar credenciales"
+        },
+        "saving": {
+          "label": "Guardando..."
+        },
+        "updateApiKey": {
+          "label": "Actualizar clave de API"
+        },
+        "updateCredentials": {
+          "label": "Actualizar credenciales"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "Tu clave de API se validará con el servidor y se almacenará de forma segura."
+        },
+        "authenticated": {
+          "text": "Los cambios se validarán con el servidor antes de guardarse."
+        },
+        "credentials": {
+          "text": "Tus credenciales se validarán con el servidor y se almacenarán de forma segura."
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "Tu administrador limita este modelo a un nivel de razonamiento más bajo."
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "Límite de tokens para cada sesión",
+          "title": "Ventana de contexto"
+        },
+        "unknown": {
+          "tooltip": "El tamaño de contexto no está disponible para este modelo. Los chats aplican un límite de tokens automáticamente."
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "No se encontraron modelos"
+        },
+        "loading": {
+          "text": "Cargando modelos..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "Configuración de {model}",
+        "tooltip": "Configuración del modelo"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "Añadir modelo"
+        },
+        "noModels": {
+          "tooltip": "No hay modelos configurados actualmente"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "Alto"
+        },
+        "low": {
+          "label": "Bajo"
+        },
+        "medium": {
+          "label": "Medio"
+        },
+        "off": {
+          "label": "Desactivado"
+        },
+        "row": {
+          "caption": "Cuánto razonamiento debe realizar el modelo antes de responder",
+          "title": "Nivel de razonamiento"
+        },
+        "xhigh": {
+          "label": "Muy alto"
+        }
+      },
+      "searchInput": {
+        "placeholder": "Buscar modelos..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "Equilibrado"
+        },
+        "creative": {
+          "label": "Creativo"
+        },
+        "deterministic": {
+          "label": "Determinista"
+        },
+        "row": {
+          "caption": "Qué tan predecible o creativo debe responder el modelo",
+          "title": "Temperatura"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "Seleccionar modelo"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "Modificar esta configuración no es compatible con este modelo."
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "Casilla de consentimiento"
+      },
+      "consentRequired": {
+        "error": "Debes aceptar los términos para acceder a la aplicación."
+      },
+      "header": {
+        "title": "¡Te damos la bienvenida a Onyx!"
+      },
+      "logoIcon": {
+        "alt": "Logotipo"
+      },
+      "startButton": {
+        "label": "Comenzar"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "No se encontraron mensajes en el chat compartido."
+      },
+      "header": {
+        "owner": {
+          "text": "por {name}"
+        },
+        "sharedOn": {
+          "text": "Compartido el {date}"
+        },
+        "untitledChat": {
+          "title": "Chat nuevo"
+        }
+      },
+      "newChatButton": {
+        "label": "Iniciar un chat nuevo"
+      },
+      "notFound": {
+        "description": "No se encontró un chat compartido con el ID especificado.",
+        "title": "Chat compartido no encontrado"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "¿En qué puedo ayudarte?",
+        "startText": "Comencemos."
+      },
+      "incognito": {
+        "title": "Estás en modo incógnito"
+      }
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -308,6 +308,502 @@
       }
     }
   },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {Un fichier a échoué et a été supprimé : {names}} other {Des fichiers ont échoué et ont été supprimés : {names}}}"
+      },
+      "newChatButton": {
+        "label": "Démarrer une nouvelle discussion"
+      },
+      "noPreviousMessage": {
+        "toast": "Aucun message envoyé précédemment n'a été trouvé."
+      },
+      "oauthConnected": {
+        "toast": "Authentification réussie"
+      },
+      "scrollToBottomButton": {
+        "label": "Aller en bas"
+      },
+      "sessionAccessDenied": {
+        "description": "Vous n'avez pas la permission de voir cette session de discussion.",
+        "title": "Accès refusé"
+      },
+      "sessionGenericError": {
+        "title": "Une erreur s'est produite"
+      },
+      "sessionNotFound": {
+        "description": "Cette session de discussion n'existe pas ou a été supprimée.",
+        "title": "Discussion introuvable"
+      },
+      "sourcesModal": {
+        "title": "Sources"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count} de plus"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "Plusieurs connecteurs ont des identifiants non valides. Ouvrez la page des connecteurs pour les vérifier.",
+          "title": "{count, plural, one {# connecteur est non valide} other {# connecteurs sont non valides}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "Plusieurs connecteurs ont des échecs d'indexation répétés. Ouvrez la page des connecteurs pour les vérifier.",
+          "title": "{count, plural, one {# connecteur est en échec} other {# connecteurs sont en échec}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "Voir le connecteur"
+        },
+        "source": {
+          "label": "Connecteurs"
+        }
+      },
+      "defaultCta": {
+        "label": "Voir"
+      },
+      "defaultSource": {
+        "label": "Notification"
+      },
+      "dismissButton": {
+        "ariaLabel": "Ignorer"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "S'il s'agit de votre configuration initiale ou si vous venez de mettre à jour votre déploiement Onyx, le backend est probablement encore en cours de démarrage. Attendez une ou deux minutes, puis actualisez la page. Si cela ne fonctionne pas, vérifiez que le backend est configuré ou contactez un administrateur.",
+          "title": "Le backend est actuellement indisponible"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "Licence"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "Bannière suivante"
+      },
+      "previousButton": {
+        "ariaLabel": "Bannière précédente"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "Annonce de l'administrateur"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "Essai"
+        }
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "Connecter"
+      },
+      "header": {
+        "description": "Améliorez la qualité des réponses en laissant {appName} rechercher dans toutes vos données connectées.",
+        "title": "Connectez vos applications"
+      },
+      "skipButton": {
+        "label": "Ignorer pour l'instant"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "Pièce jointe téléversée"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "Télécharger"
+        },
+        "image": {
+          "alt": "Pièce jointe de la discussion"
+        },
+        "viewFullImage": {
+          "label": "Voir l'image complète"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "aperçu"
+        },
+        "viewFullImage": {
+          "label": "Voir l'image complète"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "Joindre des fichiers"
+        },
+        "createPromptItem": {
+          "title": "Créer un nouveau prompt"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "La recherche approfondie est désactivée en mode multi-modèle",
+          "label": "Recherche approfondie"
+        },
+        "incognitoNotice": {
+          "text": "Cette discussion n'apparaîtra pas dans votre historique et ne sera pas utilisée pour la mémoire."
+        },
+        "incognitoPolicyNotice": {
+          "text": "Votre administrateur peut toujours voir cette discussion selon la politique de votre organisation. Les outils tiers peuvent toujours enregistrer votre activité."
+        },
+        "input": {
+          "ariaLabel": "Saisie de message",
+          "listeningPlaceholder": "Écoute en cours...",
+          "placeholder": "Comment puis-je vous aider aujourd'hui ?",
+          "queuedPlaceholder": "Appuyez sur la flèche haut pour modifier les messages en attente",
+          "searchPlaceholder": "Rechercher dans les sources connectées",
+          "speakingPlaceholder": "Onyx parle..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "En attente de la fin du traitement des fichiers joints"
+        },
+        "tabReadingButton": {
+          "readLabel": "Lire cet onglet",
+          "readingLabel": "Lecture de l'onglet..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "Configurer la voix",
+          "tooltip": "La voix n'est pas configurée. Configurez-la dans les paramètres d'administration."
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "Saisie de message",
+          "placeholder": "Décrivez votre tâche..."
+        },
+        "pasteExpandHint": {
+          "text": "Collez à nouveau pour développer"
+        },
+        "queuedMessagesHint": {
+          "text": "pour modifier les messages en attente"
+        },
+        "sendButton": {
+          "initializingTooltip": "Initialisation du bac à sable...",
+          "queueLabel": "Mettre le message en attente",
+          "sendLabel": "Envoyer"
+        },
+        "stopButton": {
+          "ariaLabel": "Arrêter la génération",
+          "tooltip": "Arrêter · échap"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "En attente que la session soit prête..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "Compétence : {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "Applications"
+        },
+        "connectAction": {
+          "label": "Connecter"
+        },
+        "connectedRow": {
+          "description": "Connecté"
+        },
+        "connectionRequiredRow": {
+          "description": "Connexion requise"
+        },
+        "content": {
+          "ariaLabel": "Sélecteur de compétences"
+        },
+        "empty": {
+          "text": "Aucune compétence correspondante"
+        },
+        "mcpServersGroup": {
+          "label": "Serveurs MCP"
+        },
+        "skillsGroup": {
+          "label": "Compétences"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "Retirer {label}"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "Impossible d'accéder au microphone"
+        },
+        "autoStartError": {
+          "toast": "Impossible de démarrer automatiquement le microphone"
+        },
+        "startRecording": {
+          "ariaLabel": "Démarrer l'enregistrement"
+        },
+        "stopRecording": {
+          "ariaLabel": "Arrêter l'enregistrement"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "Modifier le texte collé"
+        },
+        "expandButton": {
+          "label": "Développer dans la barre de saisie",
+          "tooltip": "Remplacer cette vignette par son texte complet en ligne"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "Ouvrir le menu d'ajout",
+          "tooltip": "Ajouter"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "Retirer le message en attente"
+        },
+        "editHint": {
+          "label": "modifier ·"
+        },
+        "item": {
+          "ariaLabel": "Basculer le message en attente"
+        },
+        "removeHint": {
+          "label": "retirer"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "Comment Onyx peut-il vous aider aujourd'hui ?"
+        },
+        "startSessionButton": {
+          "label": "Démarrer une nouvelle session"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "Clé d'API",
+        "placeholder": "Saisissez votre clé d'API"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "Masquer la clé d'API",
+        "showAriaLabel": "Afficher la clé d'API"
+      },
+      "cancelButton": {
+        "label": "Annuler"
+      },
+      "credentialField": {
+        "placeholder": "Saisissez votre {field}"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "Masquer l'identifiant",
+        "showAriaLabel": "Afficher l'identifiant"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "Saisir la clé d'API"
+        },
+        "enterCredentials": {
+          "title": "Saisir les identifiants"
+        },
+        "manageApiKey": {
+          "title": "Gérer la clé d'API"
+        },
+        "manageCredentials": {
+          "title": "Gérer les identifiants"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "Saisissez votre clé d'API pour {server} afin d'activer l'authentification."
+        },
+        "enterCredentials": {
+          "text": "Saisissez vos identifiants pour {server} afin d'activer l'authentification."
+        },
+        "updateApiKey": {
+          "text": "Mettez à jour votre clé d'API pour {server}."
+        },
+        "updateCredentials": {
+          "text": "Mettez à jour vos identifiants pour {server}."
+        }
+      },
+      "saveApiKeyError": {
+        "message": "Échec de l'enregistrement de la clé d'API"
+      },
+      "saveCredentialsError": {
+        "message": "Échec de l'enregistrement des identifiants"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "Enregistrer la clé d'API"
+        },
+        "saveCredentials": {
+          "label": "Enregistrer les identifiants"
+        },
+        "saving": {
+          "label": "Enregistrement..."
+        },
+        "updateApiKey": {
+          "label": "Mettre à jour la clé d'API"
+        },
+        "updateCredentials": {
+          "label": "Mettre à jour les identifiants"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "Votre clé d'API sera validée auprès du serveur et stockée de manière sécurisée."
+        },
+        "authenticated": {
+          "text": "Les modifications seront validées auprès du serveur avant d'être enregistrées."
+        },
+        "credentials": {
+          "text": "Vos identifiants seront validés auprès du serveur et stockés de manière sécurisée."
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "Votre administrateur limite ce modèle à un niveau de raisonnement plus bas."
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "Limite de jetons pour chaque session",
+          "title": "Fenêtre de contexte"
+        },
+        "unknown": {
+          "tooltip": "La taille du contexte n'est pas disponible pour ce modèle. Les discussions appliquent tout de même une limite de jetons automatiquement."
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "Aucun modèle trouvé"
+        },
+        "loading": {
+          "text": "Chargement des modèles..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "Paramètres de {model}",
+        "tooltip": "Paramètres du modèle"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "Ajouter un modèle"
+        },
+        "noModels": {
+          "tooltip": "Aucun modèle configuré actuellement"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "Élevé"
+        },
+        "low": {
+          "label": "Faible"
+        },
+        "medium": {
+          "label": "Moyen"
+        },
+        "off": {
+          "label": "Désactivé"
+        },
+        "row": {
+          "caption": "Combien de réflexion le modèle doit effectuer avant de répondre",
+          "title": "Niveau de raisonnement"
+        },
+        "xhigh": {
+          "label": "Très élevé"
+        }
+      },
+      "searchInput": {
+        "placeholder": "Rechercher des modèles..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "Équilibré"
+        },
+        "creative": {
+          "label": "Créatif"
+        },
+        "deterministic": {
+          "label": "Déterministe"
+        },
+        "row": {
+          "caption": "À quel point le modèle doit répondre de façon prévisible ou créative",
+          "title": "Température"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "Sélectionner un modèle"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "La modification de ce paramètre n'est pas prise en charge pour ce modèle."
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "Case de consentement"
+      },
+      "consentRequired": {
+        "error": "Vous devez accepter les conditions pour accéder à l'application."
+      },
+      "header": {
+        "title": "Bienvenue sur Onyx !"
+      },
+      "logoIcon": {
+        "alt": "Logo"
+      },
+      "startButton": {
+        "label": "Commencer"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "Aucun message trouvé dans la discussion partagée."
+      },
+      "header": {
+        "owner": {
+          "text": "par {name}"
+        },
+        "sharedOn": {
+          "text": "Partagée le {date}"
+        },
+        "untitledChat": {
+          "title": "Nouvelle discussion"
+        }
+      },
+      "newChatButton": {
+        "label": "Démarrer une nouvelle discussion"
+      },
+      "notFound": {
+        "description": "Aucune discussion partagée avec l'ID spécifié n'a été trouvée.",
+        "title": "Discussion partagée introuvable"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "Comment puis-je vous aider ?",
+        "startText": "Commençons."
+      },
+      "incognito": {
+        "title": "Vous êtes en navigation privée"
+      }
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -308,6 +308,502 @@
       }
     }
   },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {Um arquivo falhou e foi removido: {names}} other {Alguns arquivos falharam e foram removidos: {names}}}"
+      },
+      "newChatButton": {
+        "label": "Iniciar um novo chat"
+      },
+      "noPreviousMessage": {
+        "toast": "Nenhuma mensagem enviada anteriormente foi encontrada."
+      },
+      "oauthConnected": {
+        "toast": "Autenticação bem-sucedida"
+      },
+      "scrollToBottomButton": {
+        "label": "Ir para o final"
+      },
+      "sessionAccessDenied": {
+        "description": "Você não tem permissão para ver esta sessão de chat.",
+        "title": "Acesso negado"
+      },
+      "sessionGenericError": {
+        "title": "Algo deu errado"
+      },
+      "sessionNotFound": {
+        "description": "Esta sessão de chat não existe ou foi excluída.",
+        "title": "Chat não encontrado"
+      },
+      "sourcesModal": {
+        "title": "Fontes"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count} mais"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "Vários conectores têm credenciais inválidas. Abra a página de conectores para revisá-los.",
+          "title": "{count, plural, one {# conector é inválido} other {# conectores são inválidos}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "Vários conectores têm falhas de indexação repetidas. Abra a página de conectores para revisá-los.",
+          "title": "{count, plural, one {# conector está falhando} other {# conectores estão falhando}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "Ver conector"
+        },
+        "source": {
+          "label": "Conectores"
+        }
+      },
+      "defaultCta": {
+        "label": "Ver"
+      },
+      "defaultSource": {
+        "label": "Notificação"
+      },
+      "dismissButton": {
+        "ariaLabel": "Dispensar"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "Se esta é sua configuração inicial ou você acabou de atualizar sua implantação do Onyx, provavelmente o backend ainda está iniciando. Aguarde um ou dois minutos e recarregue a página. Se isso não funcionar, verifique se o backend está configurado ou entre em contato com um administrador.",
+          "title": "O backend está indisponível no momento"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "Licença"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "Próximo aviso"
+      },
+      "previousButton": {
+        "ariaLabel": "Aviso anterior"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "Anúncio do administrador"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "Avaliação"
+        }
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "Conectar"
+      },
+      "header": {
+        "description": "Melhore a qualidade das respostas permitindo que {appName} pesquise em todos os seus dados conectados.",
+        "title": "Conecte seus aplicativos"
+      },
+      "skipButton": {
+        "label": "Pular por enquanto"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "Anexo enviado"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "Baixar"
+        },
+        "image": {
+          "alt": "Anexo do chat"
+        },
+        "viewFullImage": {
+          "label": "Ver a imagem completa"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "pré-visualização"
+        },
+        "viewFullImage": {
+          "label": "Ver a imagem completa"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "Anexar arquivos"
+        },
+        "createPromptItem": {
+          "title": "Criar novo prompt"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "A pesquisa profunda está desativada no modo multimodelo",
+          "label": "Pesquisa profunda"
+        },
+        "incognitoNotice": {
+          "text": "Este chat não aparecerá no seu histórico nem será usado para a memória."
+        },
+        "incognitoPolicyNotice": {
+          "text": "Seu administrador ainda pode ver este chat conforme a política da sua organização. Ferramentas de terceiros ainda podem registrar sua atividade."
+        },
+        "input": {
+          "ariaLabel": "Entrada de mensagem",
+          "listeningPlaceholder": "Ouvindo...",
+          "placeholder": "Como posso ajudar você hoje?",
+          "queuedPlaceholder": "Pressione a seta para cima para editar as mensagens na fila",
+          "searchPlaceholder": "Pesquisar nas fontes conectadas",
+          "speakingPlaceholder": "Onyx está falando..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "Aguardando o processamento dos arquivos anexados"
+        },
+        "tabReadingButton": {
+          "readLabel": "Ler esta aba",
+          "readingLabel": "Lendo a aba..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "Configurar voz",
+          "tooltip": "A voz não está configurada. Configure nas configurações de administração."
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "Entrada de mensagem",
+          "placeholder": "Descreva sua tarefa..."
+        },
+        "pasteExpandHint": {
+          "text": "Cole novamente para expandir"
+        },
+        "queuedMessagesHint": {
+          "text": "para editar as mensagens na fila"
+        },
+        "sendButton": {
+          "initializingTooltip": "Inicializando o sandbox...",
+          "queueLabel": "Colocar mensagem na fila",
+          "sendLabel": "Enviar"
+        },
+        "stopButton": {
+          "ariaLabel": "Parar a geração",
+          "tooltip": "Parar · esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "Aguardando a sessão ficar pronta..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "Habilidade: {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "Aplicativos"
+        },
+        "connectAction": {
+          "label": "Conectar"
+        },
+        "connectedRow": {
+          "description": "Conectado"
+        },
+        "connectionRequiredRow": {
+          "description": "Conexão necessária"
+        },
+        "content": {
+          "ariaLabel": "Seletor de habilidades"
+        },
+        "empty": {
+          "text": "Nenhuma habilidade correspondente"
+        },
+        "mcpServersGroup": {
+          "label": "Servidores MCP"
+        },
+        "skillsGroup": {
+          "label": "Habilidades"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "Remover {label}"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "Não foi possível acessar o microfone"
+        },
+        "autoStartError": {
+          "toast": "Não foi possível iniciar o microfone automaticamente"
+        },
+        "startRecording": {
+          "ariaLabel": "Iniciar gravação"
+        },
+        "stopRecording": {
+          "ariaLabel": "Parar gravação"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "Editar texto colado"
+        },
+        "expandButton": {
+          "label": "Expandir na barra de entrada",
+          "tooltip": "Substituir este cartão pelo texto completo em linha"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "Abrir o menu de adição",
+          "tooltip": "Adicionar"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "Remover mensagem da fila"
+        },
+        "editHint": {
+          "label": "editar ·"
+        },
+        "item": {
+          "ariaLabel": "Alternar mensagem na fila"
+        },
+        "removeHint": {
+          "label": "remover"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "Como o Onyx pode ajudar você hoje?"
+        },
+        "startSessionButton": {
+          "label": "Iniciar nova sessão"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "Chave de API",
+        "placeholder": "Insira sua chave de API"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "Ocultar chave de API",
+        "showAriaLabel": "Mostrar chave de API"
+      },
+      "cancelButton": {
+        "label": "Cancelar"
+      },
+      "credentialField": {
+        "placeholder": "Insira seu {field}"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "Ocultar credencial",
+        "showAriaLabel": "Mostrar credencial"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "Inserir chave de API"
+        },
+        "enterCredentials": {
+          "title": "Inserir credenciais"
+        },
+        "manageApiKey": {
+          "title": "Gerenciar chave de API"
+        },
+        "manageCredentials": {
+          "title": "Gerenciar credenciais"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "Insira sua chave de API para {server} para habilitar a autenticação."
+        },
+        "enterCredentials": {
+          "text": "Insira suas credenciais para {server} para habilitar a autenticação."
+        },
+        "updateApiKey": {
+          "text": "Atualize sua chave de API para {server}."
+        },
+        "updateCredentials": {
+          "text": "Atualize suas credenciais para {server}."
+        }
+      },
+      "saveApiKeyError": {
+        "message": "Falha ao salvar a chave de API"
+      },
+      "saveCredentialsError": {
+        "message": "Falha ao salvar as credenciais"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "Salvar chave de API"
+        },
+        "saveCredentials": {
+          "label": "Salvar credenciais"
+        },
+        "saving": {
+          "label": "Salvando..."
+        },
+        "updateApiKey": {
+          "label": "Atualizar chave de API"
+        },
+        "updateCredentials": {
+          "label": "Atualizar credenciais"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "Sua chave de API será validada no servidor e armazenada com segurança."
+        },
+        "authenticated": {
+          "text": "As alterações serão validadas no servidor antes de serem salvas."
+        },
+        "credentials": {
+          "text": "Suas credenciais serão validadas no servidor e armazenadas com segurança."
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "Seu administrador limita este modelo a um nível de raciocínio mais baixo."
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "Limite de tokens para cada sessão",
+          "title": "Janela de contexto"
+        },
+        "unknown": {
+          "tooltip": "O tamanho do contexto não está disponível para este modelo. Os chats ainda aplicam um limite de tokens automaticamente."
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "Nenhum modelo encontrado"
+        },
+        "loading": {
+          "text": "Carregando modelos..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "Configurações de {model}",
+        "tooltip": "Configurações do modelo"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "Adicionar modelo"
+        },
+        "noModels": {
+          "tooltip": "Nenhum modelo configurado no momento"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "Alto"
+        },
+        "low": {
+          "label": "Baixo"
+        },
+        "medium": {
+          "label": "Médio"
+        },
+        "off": {
+          "label": "Desativado"
+        },
+        "row": {
+          "caption": "Quanto raciocínio o modelo deve realizar antes de responder",
+          "title": "Nível de raciocínio"
+        },
+        "xhigh": {
+          "label": "Muito alto"
+        }
+      },
+      "searchInput": {
+        "placeholder": "Pesquisar modelos..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "Equilibrado"
+        },
+        "creative": {
+          "label": "Criativo"
+        },
+        "deterministic": {
+          "label": "Determinístico"
+        },
+        "row": {
+          "caption": "Quão previsível ou criativo o modelo deve responder",
+          "title": "Temperatura"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "Selecionar modelo"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "Modificar esta configuração não é compatível com este modelo."
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "Caixa de consentimento"
+      },
+      "consentRequired": {
+        "error": "Você precisa concordar com os termos para acessar o aplicativo."
+      },
+      "header": {
+        "title": "Boas-vindas ao Onyx!"
+      },
+      "logoIcon": {
+        "alt": "Logotipo"
+      },
+      "startButton": {
+        "label": "Começar"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "Nenhuma mensagem encontrada no chat compartilhado."
+      },
+      "header": {
+        "owner": {
+          "text": "por {name}"
+        },
+        "sharedOn": {
+          "text": "Compartilhado em {date}"
+        },
+        "untitledChat": {
+          "title": "Novo chat"
+        }
+      },
+      "newChatButton": {
+        "label": "Iniciar um novo chat"
+      },
+      "notFound": {
+        "description": "Nenhum chat compartilhado com o ID especificado foi encontrado.",
+        "title": "Chat compartilhado não encontrado"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "Como posso ajudar?",
+        "startText": "Vamos começar."
+      },
+      "incognito": {
+        "title": "Você está no modo anônimo"
+      }
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -8,6 +8,7 @@
 // there is no content area.
 
 import { usePathname, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { cn, markdown } from "@opal/utils";
 import { timeAgo } from "@opal/time";
@@ -20,7 +21,7 @@ import {
   NotificationSeverity,
   NotificationType,
 } from "@/lib/notifications/interfaces";
-import { useBannerQueue, type BannerQueueItem } from "@/lib/banner/hooks";
+import { useBannerQueue } from "@/lib/banner/hooks";
 
 // Inset from the content area's left edge, matching the card's bottom inset.
 const CONTENT_INSET_PX = 8;
@@ -61,55 +62,12 @@ interface BannerContent {
   ctaLabel: string;
 }
 
-const DEFAULT_SOURCE_LABEL = "Notification";
-const DEFAULT_CTA_LABEL = "View";
+type BannerTypeConfigMap = Partial<Record<NotificationType, BannerTypeConfig>>;
 
-function connectorAggregate(noun: string, cause: string) {
-  return (count: number): BannerContent => ({
-    title: `${count} connectors are ${noun}`,
-    description: `Multiple connectors have ${cause}. Open the connectors page to review them.`,
-    link: "/admin/indexing/status",
-    ctaLabel: DEFAULT_CTA_LABEL,
-  });
-}
-
-const BANNER_TYPE_CONFIG: Partial<Record<NotificationType, BannerTypeConfig>> =
-  {
-    [NotificationType.SYSTEM_ANNOUNCEMENT]: {
-      sourceLabel: "Admin announcement",
-      variantOverride: NotificationSeverity.INFO,
-    },
-    [NotificationType.LICENSE_EXPIRY_WARNING]: { sourceLabel: "License" },
-    [NotificationType.TRIAL_ENDS_TWO_DAYS]: { sourceLabel: "Trial" },
-    [NotificationType.CONNECTOR_REPEATED_ERRORS]: {
-      sourceLabel: "Connectors",
-      ctaLabel: "View connector",
-      aggregate: connectorAggregate("failing", "repeated indexing failures"),
-    },
-    [NotificationType.CONNECTOR_INVALID]: {
-      sourceLabel: "Connectors",
-      ctaLabel: "View connector",
-      aggregate: connectorAggregate("invalid", "invalid credentials"),
-    },
-  };
-
-// The notification's own copy when it stands alone, the type's aggregate
-// copy when it represents several.
-function bannerContent(item: BannerQueueItem): BannerContent {
-  const { notification, count } = item;
-  const config = BANNER_TYPE_CONFIG[notification.notif_type];
-  if (count > 1 && config?.aggregate) {
-    return config.aggregate(count);
-  }
-  return {
-    title: notification.title,
-    description: notification.description,
-    link: notification.additional_data?.link ?? null,
-    ctaLabel: config?.ctaLabel ?? DEFAULT_CTA_LABEL,
-  };
-}
+const CONNECTORS_LINK = "/admin/indexing/status";
 
 export default function BannerQueue() {
+  const t = useTranslations("chat.banners");
   const pathname = usePathname();
   const router = useRouter();
   const { left: contentLeft } = useContainerCenter();
@@ -118,24 +76,70 @@ export default function BannerQueue() {
 
   if (isAuthPath(pathname) || !current) return null;
 
+  const defaultCtaLabel = t("defaultCta.label");
+  const bannerTypeConfig: BannerTypeConfigMap = {
+    [NotificationType.SYSTEM_ANNOUNCEMENT]: {
+      sourceLabel: t("systemAnnouncement.source.label"),
+      variantOverride: NotificationSeverity.INFO,
+    },
+    [NotificationType.LICENSE_EXPIRY_WARNING]: {
+      sourceLabel: t("licenseExpiry.source.label"),
+    },
+    [NotificationType.TRIAL_ENDS_TWO_DAYS]: {
+      sourceLabel: t("trialEnds.source.label"),
+    },
+    [NotificationType.CONNECTOR_REPEATED_ERRORS]: {
+      sourceLabel: t("connectors.source.label"),
+      ctaLabel: t("connectors.cta.label"),
+      aggregate: (count) => ({
+        title: t("connectorRepeatedErrors.aggregate.title", { count }),
+        description: t("connectorRepeatedErrors.aggregate.description"),
+        link: CONNECTORS_LINK,
+        ctaLabel: defaultCtaLabel,
+      }),
+    },
+    [NotificationType.CONNECTOR_INVALID]: {
+      sourceLabel: t("connectors.source.label"),
+      ctaLabel: t("connectors.cta.label"),
+      aggregate: (count) => ({
+        title: t("connectorInvalid.aggregate.title", { count }),
+        description: t("connectorInvalid.aggregate.description"),
+        link: CONNECTORS_LINK,
+        ctaLabel: defaultCtaLabel,
+      }),
+    },
+  };
+
   const notification = current.notification;
-  const config = BANNER_TYPE_CONFIG[notification.notif_type];
+  const config = bannerTypeConfig[notification.notif_type];
+  // The notification's own copy when it stands alone, the type's aggregate
+  // copy when it represents several.
+  const aggregateContent =
+    current.count > 1 ? config?.aggregate?.(current.count) : undefined;
   // An aggregate card represents every collapsed notification, so dismissing
   // it must dismiss them all — not surface them one at a time.
-  const showsAggregate = current.count > 1 && Boolean(config?.aggregate);
+  const showsAggregate = aggregateContent !== undefined;
   const styles =
     VARIANT_STYLES[config?.variantOverride ?? notification.severity];
   const Icon = getNotificationIcon(notification.notif_type);
-  const { title, description, link, ctaLabel } = bannerContent(current);
+  const { title, description, link, ctaLabel }: BannerContent =
+    aggregateContent ?? {
+      title: notification.title,
+      description: notification.description,
+      link: notification.additional_data?.link ?? null,
+      ctaLabel: config?.ctaLabel ?? defaultCtaLabel,
+    };
   const relativeTime = timeAgo(notification.last_shown);
-  const sourceLabel = config?.sourceLabel ?? DEFAULT_SOURCE_LABEL;
+  const sourceLabel = config?.sourceLabel ?? t("defaultSource.label");
   // Disclose collapsed same-type siblings so dismissing the visible one
   // never surfaces the rest as a surprise.
   const footer = [
     sourceLabel,
     relativeTime,
     // Aggregate copy already states the count in the title.
-    current.count > 1 && !showsAggregate ? `+${current.count - 1} more` : null,
+    current.count > 1 && !showsAggregate
+      ? t("collapsedSiblings.label", { count: current.count - 1 })
+      : null,
   ]
     .filter(Boolean)
     .join(" • ");
@@ -182,14 +186,14 @@ export default function BannerQueue() {
                 prominence="internal"
                 size="sm"
                 onClick={goToPrevious}
-                aria-label="Previous banner"
+                aria-label={t("previousButton.ariaLabel")}
               />
               <Button
                 icon={SvgChevronRight}
                 prominence="internal"
                 size="sm"
                 onClick={goToNext}
-                aria-label="Next banner"
+                aria-label={t("nextButton.ariaLabel")}
               />
             </>
           )}
@@ -200,7 +204,7 @@ export default function BannerQueue() {
             onClick={() =>
               void dismissCurrent(showsAggregate ? current.ids : undefined)
             }
-            aria-label="Dismiss"
+            aria-label={t("dismissButton.ariaLabel")}
           />
         </Section>
 

--- a/web/src/sections/banners/HealthBanner.tsx
+++ b/web/src/sections/banners/HealthBanner.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import useSWR from "swr";
+import { useTranslations } from "next-intl";
 import { errorHandlingFetcher, RedirectError } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { MessageCard, Text } from "@opal/components";
 
 export default function HealthBanner() {
+  const t = useTranslations("chat.banners");
   const { error } = useSWR(SWR_KEYS.health, errorHandlingFetcher);
 
   if (!error || error instanceof RedirectError) {
@@ -19,8 +21,8 @@ export default function HealthBanner() {
       <div className="p-2">
         <MessageCard
           variant="error"
-          title="The backend is currently unavailable"
-          description="If this is your initial setup or you just updated your Onyx deployment, this is likely because the backend is still starting up. Give it a minute or two, and then refresh the page. If that does not work, make sure the backend is setup and/or contact an administrator."
+          title={t("healthBanner.backendUnavailable.title")}
+          description={t("healthBanner.backendUnavailable.description")}
           bottomChildren={
             <div className="px-2">
               <Text>{errorMessage}</Text>

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useTranslations } from "next-intl";
 import { MinimalAgent } from "@/lib/agents/types";
 import { InputPrompt } from "@/app/app/interfaces";
 import { FilterManager, LlmManager, useFederatedConnectors } from "@/lib/hooks";
@@ -125,6 +126,7 @@ const AppInputBar = React.memo(
     currentTabUrl,
     onToggleTabReading,
   }: AppInputBarProps) => {
+    const t = useTranslations("chat.input");
     const { incognitoEnabled } = useIncognito();
     const [isRecording, setIsRecording] = useState(false);
     const [recordingCycleCount, setRecordingCycleCount] = useState(0);
@@ -644,7 +646,7 @@ const AppInputBar = React.memo(
               <Button
                 disabled={disabled}
                 icon={SvgPaperclip}
-                tooltip="Attach Files"
+                tooltip={t("appInputBar.attachFilesButton.tooltip")}
                 interaction={open ? "hover" : "rest"}
                 prominence="tertiary"
               />
@@ -684,8 +686,8 @@ const AppInputBar = React.memo(
                           return currentTabUrl;
                         }
                       })()
-                    : "Reading tab..."
-                  : "Read this tab"}
+                    : t("appInputBar.tabReadingButton.readingLabel")
+                  : t("appInputBar.tabReadingButton.readLabel")}
               </SelectButton>
             ) : (
               showDeepResearch && (
@@ -698,11 +700,11 @@ const AppInputBar = React.memo(
                   foldable={!deepResearchEnabled}
                   tooltip={
                     isMultiModelActive
-                      ? "Deep Research is disabled in multi-model mode"
+                      ? t("appInputBar.deepResearchButton.disabledTooltip")
                       : undefined
                   }
                 >
-                  Deep Research
+                  {t("appInputBar.deepResearchButton.label")}
                 </SelectButton>
               )
             )}
@@ -762,9 +764,9 @@ const AppInputBar = React.memo(
               <Button
                 disabled
                 icon={SvgMicrophone}
-                aria-label="Set up voice"
+                aria-label={t("appInputBar.voiceSetupButton.ariaLabel")}
                 prominence="tertiary"
-                tooltip="Voice not configured. Set up in admin settings."
+                tooltip={t("appInputBar.voiceSetupButton.tooltip")}
               />
             ))}
 
@@ -779,7 +781,7 @@ const AppInputBar = React.memo(
             }
             tooltip={
               hasUploadingFiles || hasIndexingFiles
-                ? "Waiting for attached file(s) to finish processing"
+                ? t("appInputBar.sendButton.processingFilesTooltip")
                 : undefined
             }
             id="onyx-chat-input-send-button"
@@ -907,7 +909,7 @@ const AppInputBar = React.memo(
                       ref={inputRef}
                       id="onyx-chat-input-textbox"
                       role="textbox"
-                      aria-label="Message input"
+                      aria-label={t("appInputBar.input.ariaLabel")}
                       contentEditable={!disabled}
                       suppressContentEditableWarning
                       onPaste={handlePaste}
@@ -928,17 +930,17 @@ const AppInputBar = React.memo(
                       }}
                       aria-multiline={true}
                       aria-disabled={disabled}
-                      aria-placeholder="How can I help you today?"
+                      aria-placeholder={t("appInputBar.input.placeholder")}
                       data-placeholder={
                         queuedMessages.length > 0 && !message
-                          ? "Press up to edit queued messages"
+                          ? t("appInputBar.input.queuedPlaceholder")
                           : isRecording
-                            ? "Listening..."
+                            ? t("appInputBar.input.listeningPlaceholder")
                             : isVoicePlaybackActive
-                              ? "Onyx is speaking..."
+                              ? t("appInputBar.input.speakingPlaceholder")
                               : isSearchMode
-                                ? "Search connected sources"
-                                : "How can I help you today?"
+                                ? t("appInputBar.input.searchPlaceholder")
+                                : t("appInputBar.input.placeholder")
                       }
                       data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
@@ -1028,7 +1030,7 @@ const AppInputBar = React.memo(
                             ? "select-heavy"
                             : "select-light"
                         }
-                        title="Create New Prompt"
+                        title={t("appInputBar.createPromptItem.title")}
                       />,
                     ]}
                   </Popover.Menu>
@@ -1099,12 +1101,10 @@ const AppInputBar = React.memo(
             className="mt-3 text-center"
           >
             <Text font="secondary-body" color="text-02">
-              This chat won&apos;t appear in your history or be used for memory.
+              {t("appInputBar.incognitoNotice.text")}
             </Text>
             <Text font="secondary-body" color="text-02">
-              Your admin may still see this chat based on your
-              organization&apos;s policy. Third party tools can still record
-              your activity.
+              {t("appInputBar.incognitoPolicyNotice.text")}
             </Text>
           </Section>
         )}

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
   type SyntheticEvent,
 } from "react";
+import { useTranslations } from "next-intl";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { deleteTokenBeforeCursor, getTextContent } from "@/lib/contentEditable";
 import PasteTilePopover from "@/sections/input/PasteTilePopover";
@@ -78,7 +79,7 @@ const BaseInputBar = memo(
         onSubmit,
         isRunning,
         disabled = false,
-        placeholder = "Describe your task...",
+        placeholder,
         noBottomRounding = false,
         pasteTilesEnabled = false,
         sandboxInitializing = false,
@@ -98,8 +99,11 @@ const BaseInputBar = memo(
       },
       ref
     ) => {
+      const t = useTranslations("chat.input");
       const queueEnabled = !!onQueueMessage;
       const queue = queuedMessages ?? EMPTY_QUEUED_MESSAGES;
+      const resolvedPlaceholder =
+        placeholder ?? t("baseInputBar.input.placeholder");
 
       const inputWrapperRef = useRef<HTMLDivElement>(null);
       const {
@@ -311,11 +315,11 @@ const BaseInputBar = memo(
                   scrollbarColor: "var(--border-02) transparent",
                 }}
                 role="textbox"
-                aria-label="Message input"
+                aria-label={t("baseInputBar.input.ariaLabel")}
                 aria-multiline={true}
                 aria-disabled={disabled}
-                aria-placeholder={placeholder}
-                data-placeholder={placeholder}
+                aria-placeholder={resolvedPlaceholder}
+                data-placeholder={resolvedPlaceholder}
                 data-empty={!message ? "" : undefined}
                 onCopy={handleCopy}
                 onCut={handleCut}
@@ -330,7 +334,7 @@ const BaseInputBar = memo(
                 {pasteExpandHintVisible ? (
                   <div className="flex items-center gap-1 select-none">
                     <Text font="secondary-body" color="text-02">
-                      Paste again to expand
+                      {t("baseInputBar.pasteExpandHint.text")}
                     </Text>
                   </div>
                 ) : (
@@ -340,7 +344,7 @@ const BaseInputBar = memo(
                     <div className="flex items-center gap-1 select-none">
                       <Keycap>↑</Keycap>
                       <Text font="secondary-body" color="text-02">
-                        to edit queued messages
+                        {t("baseInputBar.queuedMessagesHint.text")}
                       </Text>
                     </div>
                   )
@@ -364,8 +368,8 @@ const BaseInputBar = memo(
                     className="border-[1.5px] border-border-02"
                     disabled={!interruptible || isInterrupting}
                     onClick={handleInterrupt}
-                    tooltip="Stop · esc"
-                    aria-label="Stop generating"
+                    tooltip={t("baseInputBar.stopButton.tooltip")}
+                    aria-label={t("baseInputBar.stopButton.ariaLabel")}
                   />
                 </div>
                 <Button
@@ -383,12 +387,16 @@ const BaseInputBar = memo(
                   disabled={!canSubmit}
                   tooltip={
                     sandboxInitializing
-                      ? "Initializing sandbox..."
+                      ? t("baseInputBar.sendButton.initializingTooltip")
                       : isRunning
-                        ? "Queue message"
-                        : "Send"
+                        ? t("baseInputBar.sendButton.queueLabel")
+                        : t("baseInputBar.sendButton.sendLabel")
                   }
-                  aria-label={isRunning ? "Queue message" : "Send"}
+                  aria-label={
+                    isRunning
+                      ? t("baseInputBar.sendButton.queueLabel")
+                      : t("baseInputBar.sendButton.sendLabel")
+                  }
                 />
               </div>
             </div>

--- a/web/src/sections/input/EntryInfoPopover.tsx
+++ b/web/src/sections/input/EntryInfoPopover.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 
 interface EntryInfoPopoverProps {
@@ -19,6 +20,7 @@ function EntryInfoPopover({
   tileElement,
   onDismiss,
 }: EntryInfoPopoverProps) {
+  const t = useTranslations("chat.input");
   const [rect, setRect] = useState(() => tileElement.getBoundingClientRect());
   const rafId = useRef<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -111,7 +113,7 @@ function EntryInfoPopover({
       <div
         ref={containerRef}
         role="dialog"
-        aria-label={`Skill: ${name}`}
+        aria-label={t("entryInfoPopover.dialog.ariaLabel", { name })}
         tabIndex={-1}
         data-testid="skill-info-popover"
         className="fixed z-50 flex flex-col gap-1 bg-background-neutral-00 border border-border-01 rounded-08 shadow-box-02 p-3 overflow-y-auto outline-hidden"

--- a/web/src/sections/input/EntryPickerPopover.tsx
+++ b/web/src/sections/input/EntryPickerPopover.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { useTranslations } from "next-intl";
 import { Popover, Text } from "@opal/components";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import {
@@ -39,6 +40,7 @@ function EntryPickerPopover({
   onSelect,
   onClose,
 }: EntryPickerPopoverProps) {
+  const t = useTranslations("chat.input");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -139,7 +141,7 @@ function EntryPickerPopover({
         width="xl"
         onOpenAutoFocus={(e) => e.preventDefault()}
         data-testid="skill-picker-popover"
-        aria-label="Skill picker"
+        aria-label={t("entryPickerPopover.content.ariaLabel")}
       >
         <Popover.Menu scrollContainerRef={scrollContainerRef}>
           {buildMenuChildren({
@@ -148,6 +150,12 @@ function EntryPickerPopover({
             selectedIndex,
             onSelect,
             onHover: setSelectedIndex,
+            emptyMessage: t("entryPickerPopover.empty.text"),
+            groupLabels: {
+              skills: t("entryPickerPopover.skillsGroup.label"),
+              apps: t("entryPickerPopover.appsGroup.label"),
+              mcpServers: t("entryPickerPopover.mcpServersGroup.label"),
+            },
           })}
         </Popover.Menu>
       </Popover.Content>
@@ -162,6 +170,9 @@ interface BuildMenuChildrenArgs {
   selectedIndex: number;
   onSelect: (entry: PickerEntry) => void;
   onHover: (idx: number) => void;
+  /** Translated copy: this helper is not a component, so it cannot call `t`. */
+  emptyMessage: string;
+  groupLabels: { skills: string; apps: string; mcpServers: string };
 }
 
 // `Popover.Menu` renders a literal `null` between children as a divider.
@@ -171,12 +182,14 @@ function buildMenuChildren({
   selectedIndex,
   onSelect,
   onHover,
+  emptyMessage,
+  groupLabels,
 }: BuildMenuChildrenArgs): ReactNode[] {
   if (flatEntries.length === 0) {
     return [
       <div key="empty" className="p-2">
         <Text font="secondary-body" color="text-03">
-          No matching skills
+          {emptyMessage}
         </Text>
       </div>,
     ];
@@ -184,10 +197,14 @@ function buildMenuChildren({
 
   // Groups must stay in `flattenSections` order — keyboard nav indexes into that
   // flat list, so a running index is what keeps the two aligned.
-  const groups: { label: string; entries: PickerEntry[] }[] = [
-    { label: "Skills", entries: filtered.skills },
-    { label: "Apps", entries: filtered.apps },
-    { label: "MCP servers", entries: filtered.mcpServers },
+  const groups: { key: string; label: string; entries: PickerEntry[] }[] = [
+    { key: "skills", label: groupLabels.skills, entries: filtered.skills },
+    { key: "apps", label: groupLabels.apps, entries: filtered.apps },
+    {
+      key: "mcpServers",
+      label: groupLabels.mcpServers,
+      entries: filtered.mcpServers,
+    },
   ];
 
   const children: ReactNode[] = [];
@@ -197,7 +214,7 @@ function buildMenuChildren({
     if (group.entries.length === 0) continue;
     if (children.length > 0) children.push(null);
     children.push(
-      <SectionHeader key={`${group.label}-header`} label={group.label} />
+      <SectionHeader key={`${group.key}-header`} label={group.label} />
     );
     for (const entry of group.entries) {
       const rowProps = {
@@ -306,6 +323,7 @@ function ConnectableRow({
   onPick,
   rowIndex,
 }: ConnectableRowProps) {
+  const t = useTranslations("chat.input");
   const unauth = !authenticated;
   return (
     <div className="cursor-pointer">
@@ -313,7 +331,11 @@ function ConnectableRow({
         interactive={false}
         selected={selected}
         emphasized={selected}
-        description={authenticated ? "Connected" : "Connection required"}
+        description={
+          authenticated
+            ? t("entryPickerPopover.connectedRow.description")
+            : t("entryPickerPopover.connectionRequiredRow.description")
+        }
         onMouseEnter={onHover}
         onMouseDown={(e) => {
           e.preventDefault();
@@ -322,7 +344,7 @@ function ConnectableRow({
         rightChildren={
           unauth ? (
             <Text font="secondary-action" color="text-03" nowrap>
-              Connect
+              {t("entryPickerPopover.connectAction.label")}
             </Text>
           ) : undefined
         }

--- a/web/src/sections/input/InputChipStrip.tsx
+++ b/web/src/sections/input/InputChipStrip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, type ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { cn, clickOnKeyDown } from "@opal/utils";
 import { Button, Text, Tooltip } from "@opal/components";
@@ -36,6 +37,7 @@ function InputChip({
   onRemove,
   onClick,
 }: InputChipProps) {
+  const t = useTranslations("chat.input");
   const chipRef = useRef<HTMLDivElement>(null);
 
   const chipClassName = cn(
@@ -61,7 +63,7 @@ function InputChip({
           e.stopPropagation();
           onRemove();
         }}
-        aria-label={`Remove ${label}`}
+        aria-label={t("inputChip.removeButton.ariaLabel", { label })}
       />
     </>
   );
@@ -102,6 +104,7 @@ function BuildFileCard({
   file: BuildFile;
   onRemove: (id: string) => void;
 }) {
+  const t = useTranslations("chat.input");
   const isImage = isImageFile(file.name);
   const isUploading = file.status === UploadFileStatus.UPLOADING;
   const isPending = file.status === UploadFileStatus.PENDING;
@@ -140,7 +143,7 @@ function BuildFileCard({
   }
   if (isPending) {
     return (
-      <Tooltip tooltip="Waiting for session to be ready..." side="top">
+      <Tooltip tooltip={t("buildFileCard.pending.tooltip")} side="top">
         {chip}
       </Tooltip>
     );

--- a/web/src/sections/input/MicrophoneButton.tsx
+++ b/web/src/sections/input/MicrophoneButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { SvgMicrophone, SvgSimpleLoader } from "@opal/icons";
 import { useVoiceRecorder } from "@/hooks/useVoiceRecorder";
@@ -59,6 +60,7 @@ function MicrophoneButton({
   onAudioLevel,
   isNewSession = false,
 }: MicrophoneButtonProps) {
+  const t = useTranslations("chat.input");
   const {
     isTTSPlaying,
     isTTSLoading,
@@ -198,7 +200,7 @@ function MicrophoneButton({
         hasManualRecordStartRef.current = true;
       } catch (err) {
         console.error("Microphone access failed:", err);
-        toast.error("Could not access microphone");
+        toast.error(t("microphoneButton.accessError.toast"));
       }
     }
   }, [
@@ -212,6 +214,7 @@ function MicrophoneButton({
     chatState,
     currentMessage,
     withPrefix,
+    t,
   ]);
 
   // Auto-start listening shortly after TTS finishes (only if autoListen is enabled).
@@ -254,7 +257,7 @@ function MicrophoneButton({
         messagePrefixRef.current = currentMessageRef.current;
         startRecording().catch((err) => {
           console.error("Auto-start microphone failed:", err);
-          toast.error("Could not auto-start microphone");
+          toast.error(t("microphoneButton.autoStartError.toast"));
         });
       }, 400);
     }
@@ -280,6 +283,7 @@ function MicrophoneButton({
     isRecording,
     startRecording,
     manualStopCount,
+    t,
   ]);
 
   // New sessions must start with an explicit manual mic press.
@@ -331,7 +335,11 @@ function MicrophoneButton({
       disabled={isDisabled}
       icon={icon}
       onClick={handleClick}
-      aria-label={isRecording ? "Stop recording" : "Start recording"}
+      aria-label={
+        isRecording
+          ? t("microphoneButton.stopRecording.ariaLabel")
+          : t("microphoneButton.startRecording.ariaLabel")
+      }
       prominence={prominence}
     />
   );

--- a/web/src/sections/input/PasteTilePopover.tsx
+++ b/web/src/sections/input/PasteTilePopover.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { SvgArrowRight } from "@opal/icons";
 
@@ -24,6 +25,7 @@ function PasteTilePopover({
   onTextChange,
   onExpand,
 }: PasteTilePopoverProps) {
+  const t = useTranslations("chat.input");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [rect, setRect] = useState(() => tileElement.getBoundingClientRect());
   const rafId = useRef<number | null>(null);
@@ -82,7 +84,7 @@ function PasteTilePopover({
       />
       <div
         role="dialog"
-        aria-label="Edit pasted text"
+        aria-label={t("pasteTilePopover.dialog.ariaLabel")}
         className="fixed z-50 bg-background-neutral-00 border border-border-01 rounded-08 shadow-box-02 p-1 max-w-[400px]"
         style={{
           left: Math.max(GAP, left),
@@ -111,9 +113,9 @@ function PasteTilePopover({
             size="xs"
             rightIcon={SvgArrowRight}
             onClick={onExpand}
-            tooltip="Replace this tile with its full text inline"
+            tooltip={t("pasteTilePopover.expandButton.tooltip")}
           >
-            Expand into input bar
+            {t("pasteTilePopover.expandButton.label")}
           </Button>
         </div>
       </div>

--- a/web/src/sections/input/PlusMenuButton.tsx
+++ b/web/src/sections/input/PlusMenuButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, type ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { Button, Popover } from "@opal/components";
 import { SvgChevronRight, SvgPlus } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
@@ -89,9 +90,10 @@ function FlyoutRow({
 export function PlusMenuButton({
   items,
   disabled = false,
-  tooltip = "Add",
-  ariaLabel = "Open add menu",
+  tooltip,
+  ariaLabel,
 }: PlusMenuButtonProps) {
+  const t = useTranslations("chat.input");
   const [open, setOpen] = useState(false);
   const [openKey, setOpenKey] = useState<string | null>(null);
   const pendingSwapRef = useRef<number | null>(null);
@@ -194,8 +196,8 @@ export function PlusMenuButton({
           icon={SvgPlus}
           prominence="tertiary"
           disabled={disabled}
-          tooltip={tooltip}
-          aria-label={ariaLabel}
+          tooltip={tooltip ?? t("plusMenuButton.trigger.tooltip")}
+          aria-label={ariaLabel ?? t("plusMenuButton.trigger.ariaLabel")}
         />
       </Popover.Trigger>
 

--- a/web/src/sections/input/QueuedMessageBar.tsx
+++ b/web/src/sections/input/QueuedMessageBar.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Text, Button } from "@opal/components";
 import { SvgTrash } from "@opal/icons";
 import { cn, clickOnKeyDown } from "@opal/utils";
@@ -16,6 +19,7 @@ function QueuedMessageBar({
   onDiscard,
   onHighlight,
 }: QueuedMessageBarProps) {
+  const t = useTranslations("chat.input");
   const isEmpty = messages.length === 0;
 
   return (
@@ -40,7 +44,7 @@ function QueuedMessageBar({
                 )}
                 role="button"
                 tabIndex={0}
-                aria-label="Toggle queued message"
+                aria-label={t("queuedMessageBar.item.ariaLabel")}
                 onKeyDown={clickOnKeyDown(() =>
                   onHighlight(isHighlighted ? null : index)
                 )}
@@ -65,13 +69,13 @@ function QueuedMessageBar({
                       ↵
                     </span>
                     <Text font="secondary-body" color="text-02">
-                      edit ·
+                      {t("queuedMessageBar.editHint.label")}
                     </Text>
                     <span className="translate-y-[1.5px] text-text-02 text-[0.7rem]">
                       ⌫
                     </span>
                     <Text font="secondary-body" color="text-02">
-                      remove
+                      {t("queuedMessageBar.removeHint.label")}
                     </Text>
                   </div>
                 )}
@@ -79,7 +83,7 @@ function QueuedMessageBar({
                   icon={SvgTrash}
                   prominence="tertiary"
                   size="xs"
-                  tooltip="Remove queued message"
+                  tooltip={t("queuedMessageBar.discardButton.tooltip")}
                   onClick={(e) => {
                     e.stopPropagation();
                     onDiscard(index);

--- a/web/src/sections/input/SharedAppInputBar.tsx
+++ b/web/src/sections/input/SharedAppInputBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import Text from "@/refresh-components/texts/Text";
 import { Button, OpenButton, SelectButton } from "@opal/components";
 import { SvgOpenai } from "@opal/logos";
@@ -12,13 +13,15 @@ import {
 } from "@opal/icons";
 
 export default function SharedAppInputBar() {
+  const t = useTranslations("chat.input");
+
   return (
     <div className="relative w-full">
       <div className="w-full flex flex-col shadow-box-01 bg-background-neutral-00 rounded-16">
         {/* Textarea area */}
         <div className="flex flex-row items-center w-full">
           <Text text03 className="w-full px-3 pt-3 pb-2 select-none">
-            How can Onyx help you today
+            {t("sharedAppInputBar.input.placeholder")}
           </Text>
         </div>
 
@@ -34,6 +37,7 @@ export default function SharedAppInputBar() {
           {/* Right side controls */}
           <div className="flex flex-row items-center gap-1">
             <OpenButton disabled icon={SvgOpenai}>
+              {/* oxlint-disable-next-line i18n/no-raw-jsx-text -- model name, not copy */}
               GPT-4o
             </OpenButton>
             <Button disabled icon={SvgArrowUp} />
@@ -47,7 +51,7 @@ export default function SharedAppInputBar() {
       {/* CTA button */}
       <div className="absolute inset-0 flex items-center justify-center">
         <Button prominence="secondary" icon={SvgEditBig} href="/app">
-          Start New Session
+          {t("sharedAppInputBar.startSessionButton.label")}
         </Button>
       </div>
     </div>

--- a/web/src/sections/model-selector/ModelSelector.tsx
+++ b/web/src/sections/model-selector/ModelSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useCallback, useMemo, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { Popover, OpenButton } from "@opal/components";
 import { getModelIcon } from "@/lib/languageModels";
 import {
@@ -65,6 +66,7 @@ export default function ModelSelector({
   includeGlobalDefault = false,
   side = "top",
 }: ModelSelectorProps) {
+  const t = useTranslations("chat.modelSelector");
   // Unscoped by default. An agent narrows the model list, but only a chat has
   // an agent. The admin and settings pages that embed this picker have none,
   // and must not be filtered by whichever agent happens to be active. A chat
@@ -113,7 +115,8 @@ export default function ModelSelector({
   }, [defaultText, llmProviders]);
 
   const effectiveOption = currentOption ?? defaultModelOption;
-  const currentDisplayName = effectiveOption?.displayName ?? "Select Model";
+  const currentDisplayName =
+    effectiveOption?.displayName ?? t("trigger.noSelection.label");
 
   const isSelected = useCallback(
     (option: LLMOption) => {

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import {
   Button,
@@ -33,14 +34,10 @@ import {
 } from "@/lib/languageModels/options";
 import { ReasoningEffortOverride } from "@/lib/languageModels/types";
 import {
-  ADMIN_LIMITED_SETTING_TOOLTIP,
   ALL_REASONING_STOPS,
   PaneSlider,
-  REASONING_STOP_LABELS,
   SettingRow,
-  UNKNOWN_CONTEXT_TOOLTIP,
   UNSET_REASONING_STOP,
-  UNSUPPORTED_SETTING_TOOLTIP,
   cappedReasoningStop,
   formatContextWindow,
   maxReasoningStop,
@@ -158,6 +155,7 @@ interface ModelDetailPaneProps {
 }
 
 function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
+  const t = useTranslations("chat.modelSelector");
   const { user } = useUser();
   // Backend pins temperature to 1 (or omits it) for reasoning models, so
   // the slider is locked at 1.
@@ -202,8 +200,15 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   );
 
   const displayTemperature = temperatureEnabled ? localTemperature : 1;
+  const reasoningStopLabels = {
+    off: t("reasoningLevel.off.label"),
+    low: t("reasoningLevel.low.label"),
+    medium: t("reasoningLevel.medium.label"),
+    high: t("reasoningLevel.high.label"),
+    xhigh: t("reasoningLevel.xhigh.label"),
+  } satisfies Record<ReasoningEffortOverride, string>;
   const effortLabel =
-    REASONING_STOP_LABELS[ALL_REASONING_STOPS[localEffortStop] ?? "medium"];
+    reasoningStopLabels[ALL_REASONING_STOPS[localEffortStop] ?? "medium"];
 
   const maxTemperature = temperatureManager?.maxTemperature ?? 2;
   const temperatureFraction =
@@ -245,10 +250,12 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
 
       <SettingRow
         icon={SvgCode}
-        title="Context Window"
+        title={t("contextWindow.row.title")}
         value={contextLabel ?? "—"}
-        valueTooltip={contextLabel ? undefined : UNKNOWN_CONTEXT_TOOLTIP}
-        caption="Tokens limit for each session"
+        valueTooltip={
+          contextLabel ? undefined : t("contextWindow.unknown.tooltip")
+        }
+        caption={t("contextWindow.row.caption")}
       />
 
       {/* A row is absent when an admin withheld the control, and greyed
@@ -257,11 +264,11 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
       {temperatureManager && (
         <SettingRow
           icon={SvgThermometer}
-          title="Temperature"
+          title={t("temperature.row.title")}
           value={displayTemperature.toFixed(1)}
-          caption="How predictable or creative the model should respond"
+          caption={t("temperature.row.caption")}
           disabled={!temperatureEnabled}
-          disabledTooltip={UNSUPPORTED_SETTING_TOOLTIP}
+          disabledTooltip={t("unsupportedSetting.tooltip")}
         >
           <PaneSlider
             value={displayTemperature}
@@ -275,7 +282,11 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
             }
           />
           <div className="flex flex-row items-center justify-between">
-            {["Deterministic", "Balanced", "Creative"].map((label, index) => (
+            {[
+              t("temperature.deterministic.label"),
+              t("temperature.balanced.label"),
+              t("temperature.creative.label"),
+            ].map((label, index) => (
               <Text
                 key={label}
                 font="figure-small-value"
@@ -291,11 +302,11 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
       {reasoningManager && (
         <SettingRow
           icon={SvgBarChart}
-          title="Reasoning Level"
+          title={t("reasoningLevel.row.title")}
           value={effortLabel}
-          caption="How much thinking the model should perform before answering"
+          caption={t("reasoningLevel.row.caption")}
           disabled={!reasoningEnabled}
-          disabledTooltip={UNSUPPORTED_SETTING_TOOLTIP}
+          disabledTooltip={t("unsupportedSetting.tooltip")}
         >
           <PaneSlider
             value={localEffortStop}
@@ -330,8 +341,8 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
                     disabled={reasoningEnabled && index > maxSupportedStop}
                     tooltip={
                       index > capabilityStop
-                        ? UNSUPPORTED_SETTING_TOOLTIP
-                        : ADMIN_LIMITED_SETTING_TOOLTIP
+                        ? t("unsupportedSetting.tooltip")
+                        : t("adminLimitedSetting.tooltip")
                     }
                     tooltipSide="top"
                   >
@@ -344,7 +355,7 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
                       }
                       nowrap
                     >
-                      {REASONING_STOP_LABELS[stop]}
+                      {reasoningStopLabels[stop]}
                     </Text>
                   </Disabled>
                 </div>
@@ -395,6 +406,7 @@ export default function ModelSelectorContent({
   modelDetail,
   onDetailSelect,
 }: ModelSelectorContentProps) {
+  const t = useTranslations("chat.modelSelector");
   const [detailOption, setDetailOption] = useState<LLMOption | null>(null);
   const {
     llmProviders: currentAgentProviderOptions,
@@ -501,8 +513,10 @@ export default function ModelSelectorContent({
                     icon={SvgSliders}
                     prominence="tertiary"
                     size="sm"
-                    aria-label={`${option.displayName} settings`}
-                    tooltip="Model settings"
+                    aria-label={t("modelSettingsButton.ariaLabel", {
+                      model: option.displayName,
+                    })}
+                    tooltip={t("modelSettingsButton.tooltip")}
                     onClick={(e) => {
                       e.stopPropagation();
                       onDetailSelect?.(option);
@@ -537,7 +551,7 @@ export default function ModelSelectorContent({
         variant="internal"
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
-        placeholder="Search models..."
+        placeholder={t("searchInput.placeholder")}
       />
 
       <PopoverMenu scrollContainerRef={scrollContainerRef}>
@@ -563,13 +577,13 @@ export default function ModelSelectorContent({
           ...(isLoading
             ? [
                 <Text key="loading" font="secondary-body" color="text-03">
-                  Loading models...
+                  {t("list.loading.text")}
                 </Text>,
               ]
             : groupedOptions.length === 0
               ? [
                   <Text key="empty" font="secondary-body" color="text-03">
-                    No models found
+                    {t("list.empty.text")}
                   </Text>,
                 ]
               : groupedOptions.length === 1

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { getModelIcon } from "@/lib/languageModels";
 import {
   Button,
@@ -53,6 +54,7 @@ export default function MultiModelSelector({
   temperatureManager,
   reasoningManager,
 }: MultiModelSelectorProps) {
+  const t = useTranslations("chat.modelSelector");
   const [open, setOpen] = useState(false);
   const [replacingIndex, setReplacingIndex] = useState<number | null>(null);
   const anchorRef = useRef<HTMLElement | null>(null);
@@ -79,7 +81,7 @@ export default function MultiModelSelector({
   // Container-level tooltip carries only the disabled reason. The add button
   // labels itself, so an enabled row shows no tooltip outside the button.
   const selectorTooltip = noModelsToSelect
-    ? "No models currently configured"
+    ? t("multiModel.noModels.tooltip")
     : undefined;
 
   const selectedKeys = useMemo(
@@ -193,8 +195,8 @@ export default function MultiModelSelector({
               prominence="tertiary"
               icon={SvgPlusCircle}
               size="sm"
-              tooltip="Add Model"
-              aria-label="Add Model"
+              tooltip={t("multiModel.addModelButton.label")}
+              aria-label={t("multiModel.addModelButton.label")}
               onClick={(e: React.MouseEvent) => {
                 if (noModelsToSelect) return;
                 anchorRef.current = e.currentTarget as HTMLElement;

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -86,6 +86,7 @@ import EESearchUI from "@/ee/sections/SearchUI";
 const SearchUI = paidTierGated(EESearchUI);
 import { motion, AnimatePresence } from "motion/react";
 import { useChatSessionSupportsRetrieval } from "@/lib/app/hooks";
+import { useTranslations } from "next-intl";
 
 interface FadeProps {
   show: boolean;
@@ -133,13 +134,14 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   //   }
   // });
 
+  const t = useTranslations("chat.app");
   const router = useRouter();
   const appFocus = useAppFocus();
   const { isMobile } = useScreenSize();
 
   useToastFromQuery({
     oauth_connected: {
-      message: "Authentication successful",
+      message: t("oauthConnected.toast"),
       type: "success",
     },
   });
@@ -310,13 +312,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     if (lastFailedFiles && lastFailedFiles.length > 0) {
       const names = lastFailedFiles.map((f) => f.name).join(", ");
       toast.error(
-        lastFailedFiles.length === 1
-          ? `File failed and was removed: ${names}`
-          : `Files failed and were removed: ${names}`
+        t("failedFiles.toast", { count: lastFailedFiles.length, names })
       );
       clearLastFailedFiles();
     }
-  }, [lastFailedFiles, clearLastFailedFiles]);
+  }, [lastFailedFiles, clearLastFailedFiles, t]);
 
   const chatInputBarRef = useRef<AppInputBarHandle>(null);
 
@@ -583,7 +583,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
       .reverse()
       .find((m) => m.type === "user");
     if (!lastUserMsg) {
-      toast.error("No previously-submitted user message found.");
+      toast.error(t("noPreviousMessage.toast"));
       return;
     }
 
@@ -601,6 +601,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     currentMessageFiles,
     deepResearchEnabledForCurrentWorkflow,
     multiModel.isMultiModelActive,
+    t,
   ]);
 
   if (resolvedUser === null) {
@@ -821,7 +822,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
               <Modal.Content>
                 <Modal.Header
                   icon={SvgFileText}
-                  title="Sources"
+                  title={t("sourcesModal.title")}
                   onClose={() => updateCurrentDocumentSidebarVisible(false)}
                 />
                 <Modal.Body>
@@ -934,21 +935,21 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                           }
                           title={
                             sessionFetchError.type === "not_found"
-                              ? "Chat not found"
+                              ? t("sessionNotFound.title")
                               : sessionFetchError.type === "access_denied"
-                                ? "Access denied"
-                                : "Something went wrong"
+                                ? t("sessionAccessDenied.title")
+                                : t("sessionGenericError.title")
                           }
                           description={
                             sessionFetchError.type === "not_found"
-                              ? "This chat session doesn't exist or has been deleted."
+                              ? t("sessionNotFound.description")
                               : sessionFetchError.type === "access_denied"
-                                ? "You don't have permission to view this chat session."
+                                ? t("sessionAccessDenied.description")
                                 : sessionFetchError.detail
                           }
                         />
                         <Button href="/app" prominence="secondary">
-                          Start a new chat
+                          {t("newChatButton.label")}
                         </Button>
                       </Section>
                     )}
@@ -1025,7 +1026,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                         <Button
                           icon={SvgChevronDown}
                           onClick={handleScrollToBottom}
-                          aria-label="Scroll to bottom"
+                          aria-label={t("scrollToBottomButton.label")}
                           prominence="secondary"
                         />
                       </div>


### PR DESCRIPTION
## Summary

Second string-extraction wave, first chat-core slice: the chat shell around the message list.

- Migrate `sections/{chat,input,model-selector,banners}`, `components/chat`, `app/app/{components,shared}`, `Suggestions`, and `AppPage` to next-intl. This adds 156 keys under the `chat` namespace.
- Translate every new key in `es/pt/fr/de`. ICU shapes (arguments, plurals) stay identical across locales.
- Extend the `i18n/no-raw-jsx-text` ratchet to the migrated paths. A final override keeps tests and stories exempt inside migrated globs (last match wins in oxlint).
- Add a `NextIntlClientProvider` decorator to the Storybook preview so stories of migrated components render.
- `CraftInputBar.test.tsx` now renders through `@tests/setup/test-utils` (the intl provider wrapper); its `swr` mock keeps the real `SWRConfig` for that wrapper.

## Notes for review

- English render output is unchanged. The e2e-pinned strings keep their exact values ("How can I help?", "Message input", "Expand into input bar", "How can I help you today?").
- `WelcomeMessage` keeps the SSR-stable-greeting-then-randomize behavior; the greetings moved from `lib/chat/greetingMessages.ts` into the catalog with identical values.
- `BannerQueue` aggregate copy is now one ICU message per banner type instead of sentence fragments; it also gains a proper singular form.
- Left for later waves (still English): `NoAgentModal` (`lib/agents/components`), `useVoiceRecorder` error strings, craft-side `PlusMenuButton` callers, `setting-controls.tsx` constants still consumed by unmigrated admin surfaces, `SourceCategory` enum labels.

## Test plan

- `bun run types:check` — key parity across all five catalogs (compile-time), every `t()` key resolves.
- `bun run lint` — i18n ratchet green on migrated paths.
- `bun run test` — 132 suites / 1182 tests pass, including the catalog ICU/placeholder-parity test.
- `pre-commit run` on all touched files passes.

Follow-ups: wave 2b (`app/app/message`), wave 2c (sidebar + chat modals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the chat shell and composer UI to `next-intl`, adding 156 `chat`-namespace keys translated across English, Spanish, Portuguese, French, and German. English output is unchanged except `BannerQueue`, which now renders each banner type from a single ICU message with a correct singular form.

**Review notes**
- Extends the `i18n/no-raw-jsx-text` ratchet to the migrated paths; test and story files stay exempt.
- Moves welcome greetings from `lib/chat/greetingMessages.ts` into the catalog with identical values and keeps the SSR-stable greeting behavior.
- Adds a `NextIntlClientProvider` decorator to the Storybook preview and switches `CraftInputBar.test.tsx` to the intl-aware test-utils renderer.
- Remains in English for later waves: `NoAgentModal`, `useVoiceRecorder` error strings, craft-side `PlusMenuButton` callers, `setting-controls.tsx` constants used by unmigrated admin surfaces, and `SourceCategory` enum labels.

<sup>Written for commit d2707fe2f7c759d86610c693ccdbd00e20fe821d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

