### PR TITLE
feat(github): snapshot-backed FILES stage via archive provider

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -80,6 +80,7 @@ from onyx.file_processing.extract_file_text import (
     is_text_file,
 )
 from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.repo_archives.models import RepoRef
 from onyx.repo_archives.snapshot import RepoSnapshot, snapshot_or_none
 from onyx.utils.logger import setup_logger
 
@@ -782,11 +783,11 @@ class GithubConnector(
         if cache_key in self._snapshot_cache:
             return self._snapshot_cache[cache_key]
 
-        provider = GitHubArchiveProvider.from_token(self._github_token)
         owner, _, name = repo.full_name.partition("/")
+        repo_ref = RepoRef(provider="github", host="github.com", owner=owner, name=name)
         snapshot = snapshot_or_none(
-            provider,
-            provider.repo_ref(owner, name),
+            GitHubArchiveProvider.from_token(self._github_token),
+            repo_ref,
             branch,
             max_size_bytes=REPO_ARCHIVE_MAX_BYTES,
             timeout=REPO_ARCHIVE_FETCH_TIMEOUT,
@@ -913,17 +914,27 @@ class GithubConnector(
         # the file stage. Also immune to GitHub's tree truncation.
         snapshot = self._ensure_snapshot(repo)
         if snapshot is not None:
-            paths = sorted(
-                path
-                for path, size in snapshot.walk_files()
-                if _is_indexable_path(
-                    path,
-                    size,
-                    include_docs=self.include_files,
-                    include_code_files=self.include_code_files,
+            try:
+                paths = sorted(
+                    path
+                    for path, size in snapshot.walk_files()
+                    if _is_indexable_path(
+                        path,
+                        size,
+                        include_docs=self.include_files,
+                        include_code_files=self.include_code_files,
+                    )
                 )
-            )
-            return paths, False
+                return paths, False
+            except Exception:
+                # A concurrent prune can remove the snapshot mid-walk. The
+                # tree API listing below substitutes, so fall through.
+                logger.warning(
+                    "Listing files from the snapshot of %s failed; "
+                    "falling back to the git tree API",
+                    repo.full_name,
+                    exc_info=True,
+                )
 
         assert self.github_client is not None  # for type-checking
         try:
@@ -1075,7 +1086,9 @@ class GithubConnector(
         # A resumed checkpoint on a different worker re-downloads the tarball
         # once; if that fails, each file falls back to the content API.
         snapshot = self._ensure_snapshot(repo) if batch and not is_slim else None
-        commit_sha = snapshot.revision.commit_sha if snapshot is not None else None
+        snapshot_commit_sha = (
+            snapshot.revision.commit_sha if snapshot is not None else None
+        )
 
         for path in batch:
             html_url = f"{repo.html_url}/blob/{branch}/{path}"
@@ -1091,9 +1104,13 @@ class GithubConnector(
                 continue
             try:
                 raw: bytes | None = None
+                # Only snapshot-sourced content may claim the snapshot's
+                # revision; the content API serves the branch head.
+                commit_sha: str | None = None
                 if snapshot is not None:
                     try:
                         raw = snapshot.read_file(path, GITHUB_MAX_FILE_SIZE_BYTES)
+                        commit_sha = snapshot_commit_sha
                     except Exception as e:
                         logger.warning(
                             "Reading %s from snapshot failed (%s); "
@@ -1103,6 +1120,7 @@ class GithubConnector(
                         )
                 if raw is None:
                     raw = self._fetch_file_content(repo, path)
+                    commit_sha = None
                 content_text = _decode_file_content(raw)
                 if content_text is None:
                     yield ConnectorFailure(

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -1122,12 +1122,24 @@ class GithubConnector(
                         raw = snapshot.read_file(path, GITHUB_MAX_FILE_SIZE_BYTES)
                         commit_sha = snapshot_commit_sha
                     except (RepoSnapshotError, OSError) as e:
-                        logger.warning(
-                            "Reading %s from snapshot failed (%s); "
-                            "falling back to the content API",
-                            path,
-                            e,
-                        )
+                        if snapshot.is_available:
+                            logger.warning(
+                                "Reading %s from snapshot failed (%s); "
+                                "falling back to the content API",
+                                path,
+                                e,
+                            )
+                        else:
+                            # The snapshot went away mid-batch, so every later
+                            # read fails the same way. Decide once and say so:
+                            # the rest of this batch costs an API call a file.
+                            logger.warning(
+                                "Snapshot of %s is gone (%s); the rest of this "
+                                "batch falls back to the content API",
+                                repo.full_name,
+                                e,
+                            )
+                            snapshot = None
                 if raw is None:
                     raw = self._fetch_file_content(repo, path)
                     commit_sha = None

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -1,6 +1,7 @@
 import copy
 import os
 from collections.abc import Callable, Generator
+from contextlib import AbstractContextManager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from io import BytesIO
@@ -74,6 +75,10 @@ from onyx.file_processing.extract_file_text import (
     get_file_ext,
     is_text_file,
 )
+from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.repo_archives.models import RepoArchive, RepoRevision
+from onyx.repo_archives.snapshot import RepoSnapshot, get_or_create_snapshot
+from onyx.repo_archives.tarball_cache import open_revision_archive, resolve_revision
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -141,6 +146,9 @@ GITHUB_PATH_DENYLIST = {
 }
 # Skip files larger than this (checked against the git tree size before fetching).
 GITHUB_MAX_FILE_SIZE_BYTES = 1_000_000
+# Cap on the one-request tarball download that serves the FILES stage.
+GITHUB_REPO_ARCHIVE_MAX_BYTES = 500 * 1024 * 1024
+GITHUB_REPO_ARCHIVE_TIMEOUT = (30, 300)
 # Number of files emitted per checkpoint batch in the FILES stage.
 FILE_BATCH_SIZE = 100
 
@@ -576,6 +584,7 @@ def _convert_file_to_document(
     content_text: str,
     repo_external_access: ExternalAccess | None,
     branch: str,
+    commit_sha: str | None = None,
 ) -> Document:
     repo_full_name = repo.full_name
     parts = repo_full_name.split("/", 1)
@@ -607,6 +616,11 @@ def _convert_file_to_document(
         "file_extension": get_file_ext(path),
         CODE_FILE_BRANCH_KEY: branch,
     }
+    if commit_sha:
+        # The exact revision indexed; lets downstream consumers (e.g. the
+        # coding agent) pin their analysis to it.
+        metadata["commit_sha"] = commit_sha
+
     # Source-code files become CodeSections so they chunk at syntactic
     # boundaries; everything else stays prose.
     language = _code_language(path)
@@ -714,6 +728,15 @@ class GithubConnector(
         # Branch to index files from; None means each repo's default branch.
         self.branch = (branch or "").strip() or None
         self.github_client: Github | None = None
+        self._github_token: str | None = None
+        # Resolved API base URL: the credential's, else the env var. Set in
+        # load_credentials; None means github.com.
+        self._base_url: str | None = None
+        # Per-invocation snapshot cache: (repo, branch) -> snapshot, or None
+        # when it is unavailable so a batch doesn't retry per file. The
+        # snapshot itself is keyed by the resolved head SHA, so a branch that
+        # advances never serves stale content under the new revision.
+        self._snapshot_cache: dict[tuple[str, str], RepoSnapshot | None] = {}
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         # Prefer the per-credential URL so one deployment can index github.com
@@ -729,7 +752,10 @@ class GithubConnector(
         base_url: str | None = credential_base_url or normalize_github_base_url(
             GITHUB_CONNECTOR_BASE_URL
         )
+        self._base_url = base_url
 
+        # Kept for the one-request tarball download that serves the FILES stage.
+        self._github_token = credentials["github_access_token"]
         # defaults to 30 items per page, can be set to as high as 100
         self.github_client = (
             Github(
@@ -741,6 +767,58 @@ class GithubConnector(
             else Github(credentials["github_access_token"], per_page=ITEMS_PER_PAGE)
         )
         return None
+
+    def _ensure_snapshot(self, repo: Repository.Repository) -> RepoSnapshot | None:
+        """Local snapshot of the repo's files at the branch head, served by
+        ONE archive fetch, or None when unavailable (callers fall back to the
+        per-file content API). GitHub Enterprise deployments use the API path
+        — the archive provider only speaks to github.com."""
+        # The base URL can come from the credential as well as the env var, so
+        # check the resolved one: fetching a github.com archive for a repo on
+        # an enterprise host would send that host's PAT to github.com.
+        if self._base_url:
+            return None
+        branch = self._resolve_branch(repo)
+        cache_key = (repo.full_name, branch)
+        if cache_key in self._snapshot_cache:
+            return self._snapshot_cache[cache_key]
+
+        provider = GitHubArchiveProvider(
+            f"Bearer {self._github_token}" if self._github_token else None
+        )
+        owner, _, name = repo.full_name.partition("/")
+        snapshot: RepoSnapshot | None = None
+        try:
+            # No resolved SHA, no snapshot: a branch-keyed cache could serve
+            # a stale tree after the branch moves.
+            revision = resolve_revision(
+                provider, provider.repo_ref(owner, name), branch
+            )
+            if revision is not None:
+                snapshot = get_or_create_snapshot(
+                    revision, lambda: self._open_archive(provider, revision)
+                )
+        except Exception:
+            logger.warning(
+                "Snapshot of %s@%s failed; falling back to the GitHub content "
+                "API for file fetching",
+                repo.full_name,
+                branch,
+                exc_info=True,
+            )
+        self._snapshot_cache[cache_key] = snapshot
+        return snapshot
+
+    @staticmethod
+    def _open_archive(
+        provider: GitHubArchiveProvider, revision: RepoRevision
+    ) -> AbstractContextManager[RepoArchive]:
+        return open_revision_archive(
+            provider,
+            revision,
+            max_size_bytes=GITHUB_REPO_ARCHIVE_MAX_BYTES,
+            timeout=GITHUB_REPO_ARCHIVE_TIMEOUT,
+        )
 
     def get_github_repo(
         self, github_client: Github, attempt_num: int = 0
@@ -855,6 +933,23 @@ class GithubConnector(
                 "Re-tried listing repo files too many times. "
                 "Something is going wrong with fetching objects from Github"
             )
+
+        # Snapshot-first: one tarball request lists (and later serves) every
+        # file with zero per-file API calls, so large repos cannot rate-limit
+        # the file stage. Also immune to GitHub's tree truncation.
+        snapshot = self._ensure_snapshot(repo)
+        if snapshot is not None:
+            paths = sorted(
+                path
+                for path, size in snapshot.walk_files()
+                if _is_indexable_path(
+                    path,
+                    size,
+                    include_docs=self.include_files,
+                    include_code_files=self.include_code_files,
+                )
+            )
+            return paths, False
 
         assert self.github_client is not None  # for type-checking
         try:
@@ -1002,6 +1097,12 @@ class GithubConnector(
         batch = file_paths[page * FILE_BATCH_SIZE : (page + 1) * FILE_BATCH_SIZE]
         checkpoint.curr_page += 1
 
+        # The local snapshot serves file contents without per-file API calls.
+        # A resumed checkpoint on a different worker re-downloads the tarball
+        # once; if that fails, each file falls back to the content API.
+        snapshot = self._ensure_snapshot(repo) if batch and not is_slim else None
+        commit_sha = snapshot.revision.commit_sha if snapshot is not None else None
+
         for path in batch:
             html_url = f"{repo.html_url}/blob/{branch}/{path}"
             if is_slim:
@@ -1015,7 +1116,19 @@ class GithubConnector(
                 )
                 continue
             try:
-                raw = self._fetch_file_content(repo, path)
+                raw: bytes | None = None
+                if snapshot is not None:
+                    try:
+                        raw = snapshot.read_file(path, GITHUB_MAX_FILE_SIZE_BYTES)
+                    except Exception as e:
+                        logger.warning(
+                            "Reading %s from snapshot failed (%s); "
+                            "falling back to the content API",
+                            path,
+                            e,
+                        )
+                if raw is None:
+                    raw = self._fetch_file_content(repo, path)
                 content_text = _decode_file_content(raw)
                 if content_text is None:
                     yield ConnectorFailure(
@@ -1027,7 +1140,12 @@ class GithubConnector(
                     )
                     continue
                 yield _convert_file_to_document(
-                    repo, path, content_text, repo_external_access, branch
+                    repo,
+                    path,
+                    content_text,
+                    repo_external_access,
+                    branch,
+                    commit_sha=commit_sha,
                 )
             except Exception as e:
                 error_msg = f"Error converting file {path} to document: {e}"

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -81,7 +81,11 @@ from onyx.file_processing.extract_file_text import (
 )
 from onyx.repo_archives.github import GitHubArchiveProvider
 from onyx.repo_archives.models import RepoRef
-from onyx.repo_archives.snapshot import RepoSnapshot, snapshot_or_none
+from onyx.repo_archives.snapshot import (
+    RepoSnapshot,
+    RepoSnapshotError,
+    snapshot_or_none,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -773,10 +777,12 @@ class GithubConnector(
         ONE archive fetch, or None when unavailable (callers fall back to the
         per-file content API). GitHub Enterprise deployments use the API path
         — the archive provider only speaks to github.com."""
+        # A doc-only connector fetches a handful of markdown files. Trading
+        # those for a whole-repo download would be a straight regression.
         # The base URL can come from the credential as well as the env var, so
         # check the resolved one: fetching a github.com archive for a repo on
         # an enterprise host would send that host's PAT to github.com.
-        if self._base_url:
+        if not self.include_code_files or self._base_url:
             return None
         branch = self._resolve_branch(repo)
         cache_key = (repo.full_name, branch)
@@ -895,7 +901,7 @@ class GithubConnector(
         return self.branch or repo.default_branch
 
     def _list_indexable_files(
-        self, repo: Repository.Repository, attempt_num: int = 0
+        self, repo: Repository.Repository, is_slim: bool, attempt_num: int = 0
     ) -> tuple[list[str], bool]:
         """Resolve the configured (or default) branch tree and return indexable file paths.
 
@@ -911,8 +917,10 @@ class GithubConnector(
 
         # Snapshot-first: one tarball request lists (and later serves) every
         # file with zero per-file API calls, so large repos cannot rate-limit
-        # the file stage. Also immune to GitHub's tree truncation.
-        snapshot = self._ensure_snapshot(repo)
+        # the file stage. Also immune to GitHub's tree truncation. Slim runs
+        # want paths and nothing else, which one tree call already gives, and
+        # they run far more often than indexing.
+        snapshot = None if is_slim else self._ensure_snapshot(repo)
         if snapshot is not None:
             try:
                 paths = sorted(
@@ -926,9 +934,11 @@ class GithubConnector(
                     )
                 )
                 return paths, False
-            except Exception:
+            except (RepoSnapshotError, OSError):
                 # A concurrent prune can remove the snapshot mid-walk. The
-                # tree API listing below substitutes, so fall through.
+                # tree API listing below substitutes, so fall through. Narrow
+                # on purpose: a bug in the filter must surface instead of
+                # silently reverting to the rate-limiting path.
                 logger.warning(
                     "Listing files from the snapshot of %s failed; "
                     "falling back to the git tree API",
@@ -961,7 +971,7 @@ class GithubConnector(
             return paths, truncated
         except RateLimitExceededException:
             sleep_after_rate_limit_exception(self.github_client)
-            return self._list_indexable_files(repo, attempt_num + 1)
+            return self._list_indexable_files(repo, is_slim, attempt_num + 1)
         except GithubException as e:
             if e.status == 404 and self.branch:
                 raise ConnectorValidationError(
@@ -1056,7 +1066,7 @@ class GithubConnector(
                 checkpoint.file_paths_include_code = self.include_code_files
             else:
                 logger.info("Listing files for repo: %s", repo.name)
-                paths, truncated = self._list_indexable_files(repo)
+                paths, truncated = self._list_indexable_files(repo, is_slim)
                 checkpoint.file_paths = paths
                 checkpoint.file_paths_branch = branch
                 checkpoint.file_paths_include_code = self.include_code_files
@@ -1111,7 +1121,7 @@ class GithubConnector(
                     try:
                         raw = snapshot.read_file(path, GITHUB_MAX_FILE_SIZE_BYTES)
                         commit_sha = snapshot_commit_sha
-                    except Exception as e:
+                    except (RepoSnapshotError, OSError) as e:
                         logger.warning(
                             "Reading %s from snapshot failed (%s); "
                             "falling back to the content API",

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -1,7 +1,6 @@
 import copy
 import os
 from collections.abc import Callable, Generator
-from contextlib import AbstractContextManager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from io import BytesIO
@@ -17,9 +16,14 @@ from pydantic import BaseModel
 from typing_extensions import override
 
 from onyx.access.models import ExternalAccess
-from onyx.configs.app_configs import GITHUB_CONNECTOR_BASE_URL
+from onyx.configs.app_configs import (
+    GITHUB_CONNECTOR_BASE_URL,
+    REPO_ARCHIVE_FETCH_TIMEOUT,
+    REPO_ARCHIVE_MAX_BYTES,
+)
 from onyx.configs.constants import (
     CODE_FILE_BRANCH_KEY,
+    CODE_FILE_COMMIT_SHA_KEY,
     CODE_FILE_LANGUAGE_KEY,
     CODE_FILE_METADATA_TYPE,
     CODE_FILE_PATH_KEY,
@@ -76,9 +80,7 @@ from onyx.file_processing.extract_file_text import (
     is_text_file,
 )
 from onyx.repo_archives.github import GitHubArchiveProvider
-from onyx.repo_archives.models import RepoArchive, RepoRevision
-from onyx.repo_archives.snapshot import RepoSnapshot, get_or_create_snapshot
-from onyx.repo_archives.tarball_cache import open_revision_archive, resolve_revision
+from onyx.repo_archives.snapshot import RepoSnapshot, snapshot_or_none
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -146,9 +148,6 @@ GITHUB_PATH_DENYLIST = {
 }
 # Skip files larger than this (checked against the git tree size before fetching).
 GITHUB_MAX_FILE_SIZE_BYTES = 1_000_000
-# Cap on the one-request tarball download that serves the FILES stage.
-GITHUB_REPO_ARCHIVE_MAX_BYTES = 500 * 1024 * 1024
-GITHUB_REPO_ARCHIVE_TIMEOUT = (30, 300)
 # Number of files emitted per checkpoint batch in the FILES stage.
 FILE_BATCH_SIZE = 100
 
@@ -619,7 +618,7 @@ def _convert_file_to_document(
     if commit_sha:
         # The exact revision indexed; lets downstream consumers (e.g. the
         # coding agent) pin their analysis to it.
-        metadata["commit_sha"] = commit_sha
+        metadata[CODE_FILE_COMMIT_SHA_KEY] = commit_sha
 
     # Source-code files become CodeSections so they chunk at syntactic
     # boundaries; everything else stays prose.
@@ -783,42 +782,17 @@ class GithubConnector(
         if cache_key in self._snapshot_cache:
             return self._snapshot_cache[cache_key]
 
-        provider = GitHubArchiveProvider(
-            f"Bearer {self._github_token}" if self._github_token else None
-        )
+        provider = GitHubArchiveProvider.from_token(self._github_token)
         owner, _, name = repo.full_name.partition("/")
-        snapshot: RepoSnapshot | None = None
-        try:
-            # No resolved SHA, no snapshot: a branch-keyed cache could serve
-            # a stale tree after the branch moves.
-            revision = resolve_revision(
-                provider, provider.repo_ref(owner, name), branch
-            )
-            if revision is not None:
-                snapshot = get_or_create_snapshot(
-                    revision, lambda: self._open_archive(provider, revision)
-                )
-        except Exception:
-            logger.warning(
-                "Snapshot of %s@%s failed; falling back to the GitHub content "
-                "API for file fetching",
-                repo.full_name,
-                branch,
-                exc_info=True,
-            )
+        snapshot = snapshot_or_none(
+            provider,
+            provider.repo_ref(owner, name),
+            branch,
+            max_size_bytes=REPO_ARCHIVE_MAX_BYTES,
+            timeout=REPO_ARCHIVE_FETCH_TIMEOUT,
+        )
         self._snapshot_cache[cache_key] = snapshot
         return snapshot
-
-    @staticmethod
-    def _open_archive(
-        provider: GitHubArchiveProvider, revision: RepoRevision
-    ) -> AbstractContextManager[RepoArchive]:
-        return open_revision_archive(
-            provider,
-            revision,
-            max_size_bytes=GITHUB_REPO_ARCHIVE_MAX_BYTES,
-            timeout=GITHUB_REPO_ARCHIVE_TIMEOUT,
-        )
 
     def get_github_repo(
         self, github_client: Github, attempt_num: int = 0
@@ -1560,9 +1534,6 @@ class GithubConnector(
                     validation_errors = []
 
                     for repo_name in repo_names:
-                        if not repo_name:
-                            continue
-
                         try:
                             test_repo = self.github_client.get_repo(
                                 f"{self.repo_owner}/{repo_name}"

--- a/backend/onyx/repo_archives/github.py
+++ b/backend/onyx/repo_archives/github.py
@@ -1,13 +1,16 @@
-from dataclasses import replace
 from typing import BinaryIO
 
 from onyx.repo_archives.models import RepoRef
 from onyx.utils.github import (
-    GITHUB_COMMIT_SHA_PATTERN,
     GitHubSource,
+    parse_github_source,
     resolve_github_revision,
     stream_github_archive,
 )
+
+
+def _source(repo: RepoRef, tree_tail: tuple[str, ...] = ()) -> GitHubSource:
+    return GitHubSource(owner=repo.owner, repo=repo.name, tree_tail=tree_tail)
 
 
 class GitHubArchiveProvider:
@@ -20,23 +23,29 @@ class GitHubArchiveProvider:
         self._authorization_header = authorization_header
 
     @classmethod
+    def from_token(cls, token: str | None) -> "GitHubArchiveProvider":
+        """Provider for a GitHub access token; anonymous when None."""
+        return cls(f"Bearer {token}" if token else None)
+
+    @classmethod
     def repo_ref(cls, owner: str, name: str) -> RepoRef:
         return RepoRef(provider=cls.PROVIDER, host=cls.HOST, owner=owner, name=name)
+
+    @classmethod
+    def repo_ref_from_url(cls, repo_url: str) -> RepoRef:
+        """Identity of the repo named by a URL, `owner/repo`, or SSH remote.
+        Raises OnyxError when the source cannot be parsed."""
+        source = parse_github_source(repo_url, allow_ssh=True)
+        return cls.repo_ref(source.owner, source.repo)
 
     @property
     def authenticated(self) -> bool:
         return self._authorization_header is not None
 
     def resolve_commit(self, repo: RepoRef, ref: str | None) -> str:
-        source = GitHubSource(owner=repo.owner, repo=repo.name)
-        if ref and GITHUB_COMMIT_SHA_PATTERN.fullmatch(ref):
-            # A pinned SHA needs no resolution, but one authenticated repo
-            # call still runs so a caller without access cannot read cached
-            # source. On failure the download path enforces access itself.
-            resolve_github_revision(source, self._authorization_header)
-            return ref.lower()
-        if ref:
-            source = replace(source, tree_tail=(ref,))
+        # GitHub's commits endpoint accepts a branch, tag, or SHA, so one call
+        # both resolves `ref` and proves the caller can access the repo.
+        source = _source(repo, tree_tail=(ref,) if ref else ())
         return resolve_github_revision(source, self._authorization_header).revision
 
     def stream_archive(
@@ -49,7 +58,7 @@ class GitHubArchiveProvider:
         timeout: float | tuple[float, float],
     ) -> int:
         return stream_github_archive(
-            GitHubSource(owner=repo.owner, repo=repo.name),
+            _source(repo),
             revision,
             self._authorization_header,
             max_size_bytes=max_size_bytes,

--- a/backend/onyx/repo_archives/github.py
+++ b/backend/onyx/repo_archives/github.py
@@ -1,0 +1,58 @@
+from dataclasses import replace
+from typing import BinaryIO
+
+from onyx.repo_archives.models import RepoRef
+from onyx.utils.github import (
+    GITHUB_COMMIT_SHA_PATTERN,
+    GitHubSource,
+    resolve_github_revision,
+    stream_github_archive,
+)
+
+
+class GitHubArchiveProvider:
+    """RepoArchiveProvider for github.com."""
+
+    PROVIDER = "github"
+    HOST = "github.com"
+
+    def __init__(self, authorization_header: str | None = None) -> None:
+        self._authorization_header = authorization_header
+
+    @classmethod
+    def repo_ref(cls, owner: str, name: str) -> RepoRef:
+        return RepoRef(provider=cls.PROVIDER, host=cls.HOST, owner=owner, name=name)
+
+    @property
+    def authenticated(self) -> bool:
+        return self._authorization_header is not None
+
+    def resolve_commit(self, repo: RepoRef, ref: str | None) -> str:
+        source = GitHubSource(owner=repo.owner, repo=repo.name)
+        if ref and GITHUB_COMMIT_SHA_PATTERN.fullmatch(ref):
+            # A pinned SHA needs no resolution, but one authenticated repo
+            # call still runs so a caller without access cannot read cached
+            # source. On failure the download path enforces access itself.
+            resolve_github_revision(source, self._authorization_header)
+            return ref.lower()
+        if ref:
+            source = replace(source, tree_tail=(ref,))
+        return resolve_github_revision(source, self._authorization_header).revision
+
+    def stream_archive(
+        self,
+        repo: RepoRef,
+        revision: str,
+        sink: BinaryIO,
+        *,
+        max_size_bytes: int,
+        timeout: float | tuple[float, float],
+    ) -> int:
+        return stream_github_archive(
+            GitHubSource(owner=repo.owner, repo=repo.name),
+            revision,
+            self._authorization_header,
+            max_size_bytes=max_size_bytes,
+            timeout=timeout,
+            sink=sink,
+        )

--- a/backend/onyx/repo_archives/snapshot.py
+++ b/backend/onyx/repo_archives/snapshot.py
@@ -30,8 +30,10 @@ from onyx.configs.app_configs import (
     REPO_SNAPSHOT_MAX_TOTAL_BYTES,
     REPO_SNAPSHOT_TTL_SECONDS,
 )
+from onyx.error_handling.exceptions import OnyxError
 from onyx.repo_archives.models import RepoArchive, RepoRef, RepoRevision
 from onyx.repo_archives.provider import RepoArchiveProvider
+from onyx.repo_archives.tarball_cache import open_revision_archive, resolve_revision
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -291,12 +293,6 @@ def snapshot_or_none(
     No resolved SHA, no snapshot: a ref-keyed cache could serve a stale tree
     after the ref moves.
     """
-    # Imported here so the tarball cache can depend on this module later.
-    from onyx.repo_archives.tarball_cache import (
-        open_revision_archive,
-        resolve_revision,
-    )
-
     try:
         pinned = resolve_revision(provider, repo, ref)
         if pinned is None:
@@ -307,7 +303,9 @@ def snapshot_or_none(
                 provider, pinned, max_size_bytes=max_size_bytes, timeout=timeout
             ),
         )
-    except Exception:
+    # Deliberately narrow: a bug in extraction must surface, not turn into a
+    # silent fallback to the much slower per-file path.
+    except (RepoSnapshotError, OnyxError, OSError):
         logger.warning(
             "Snapshot of %s@%s failed; falling back to per-file fetching",
             repo.display,

--- a/backend/onyx/repo_archives/snapshot.py
+++ b/backend/onyx/repo_archives/snapshot.py
@@ -80,6 +80,13 @@ class RepoSnapshot:
                 rel_path = os.path.relpath(full_path, root).replace(os.sep, "/")
                 yield rel_path, st.st_size
 
+    @property
+    def is_available(self) -> bool:
+        """False once the snapshot directory is gone — pruned by another
+        worker, or its disk lost. Tells a per-file read failure apart from
+        one that means every later read fails too."""
+        return self.root.is_dir()
+
     def read_file(self, rel_path: str, max_size_bytes: int) -> bytes:
         """Read a repo-relative file.
 

--- a/backend/onyx/repo_archives/snapshot.py
+++ b/backend/onyx/repo_archives/snapshot.py
@@ -30,7 +30,8 @@ from onyx.configs.app_configs import (
     REPO_SNAPSHOT_MAX_TOTAL_BYTES,
     REPO_SNAPSHOT_TTL_SECONDS,
 )
-from onyx.repo_archives.models import RepoArchive, RepoRevision
+from onyx.repo_archives.models import RepoArchive, RepoRef, RepoRevision
+from onyx.repo_archives.provider import RepoArchiveProvider
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -274,3 +275,43 @@ def get_or_create_snapshot(
         archive_size,
     )
     return RepoSnapshot(dest, revision)
+
+
+def snapshot_or_none(
+    provider: RepoArchiveProvider,
+    repo: RepoRef,
+    ref: str | None,
+    *,
+    max_size_bytes: int,
+    timeout: float | tuple[float, float],
+) -> RepoSnapshot | None:
+    """Snapshot of `repo` at `ref`, or None when one cannot be produced;
+    callers then fall back to their per-file path.
+
+    No resolved SHA, no snapshot: a ref-keyed cache could serve a stale tree
+    after the ref moves.
+    """
+    # Imported here so the tarball cache can depend on this module later.
+    from onyx.repo_archives.tarball_cache import (
+        open_revision_archive,
+        resolve_revision,
+    )
+
+    try:
+        pinned = resolve_revision(provider, repo, ref)
+        if pinned is None:
+            return None
+        return get_or_create_snapshot(
+            pinned,
+            lambda: open_revision_archive(
+                provider, pinned, max_size_bytes=max_size_bytes, timeout=timeout
+            ),
+        )
+    except Exception:
+        logger.warning(
+            "Snapshot of %s@%s failed; falling back to per-file fetching",
+            repo.display,
+            ref or "HEAD",
+            exc_info=True,
+        )
+        return None

--- a/backend/onyx/utils/github.py
+++ b/backend/onyx/utils/github.py
@@ -1,6 +1,7 @@
+import io
 import re
 from dataclasses import dataclass
-from typing import Final
+from typing import BinaryIO, Final
 from urllib.parse import quote, unquote, urlparse
 
 import requests
@@ -255,7 +256,30 @@ def download_github_archive(
     max_size_bytes: int,
     timeout: float | tuple[float, float] = _GITHUB_FETCH_TIMEOUT_SECONDS,
 ) -> bytes:
-    """Download a bounded tarball without forwarding credentials to archive hosts."""
+    """Download a bounded tarball into memory. See `stream_github_archive`."""
+    buf = io.BytesIO()
+    stream_github_archive(
+        source,
+        revision,
+        authorization_header,
+        max_size_bytes=max_size_bytes,
+        timeout=timeout,
+        sink=buf,
+    )
+    return buf.getvalue()
+
+
+def stream_github_archive(
+    source: GitHubSource,
+    revision: str,
+    authorization_header: str | None = None,
+    *,
+    max_size_bytes: int,
+    timeout: float | tuple[float, float] = _GITHUB_FETCH_TIMEOUT_SECONDS,
+    sink: BinaryIO,
+) -> int:
+    """Stream a bounded tarball into `sink` without forwarding credentials to
+    archive hosts. Returns the number of bytes written."""
     encoded_owner = quote(source.owner, safe="")
     encoded_repo = quote(source.repo, safe="")
     encoded_revision = quote(revision, safe="")
@@ -331,7 +355,6 @@ def download_github_archive(
                 OnyxErrorCode.BAD_GATEWAY,
                 "Couldn't download the repository from GitHub. Try again in a few minutes.",
             )
-        archive_chunks: list[bytes] = []
         archive_size = 0
         try:
             for chunk in response.iter_content(chunk_size=64 * 1024):
@@ -343,11 +366,11 @@ def download_github_archive(
                         OnyxErrorCode.PAYLOAD_TOO_LARGE,
                         f"Repository download exceeds the {max_size_bytes // (1024 * 1024)} MiB limit. Remove large files or use a smaller repository.",
                     )
-                archive_chunks.append(chunk)
+                sink.write(chunk)
         except requests.RequestException as exc:
             raise OnyxError(
                 OnyxErrorCode.BAD_GATEWAY,
                 "The GitHub repository download was interrupted. Try again.",
             ) from exc
 
-    return b"".join(archive_chunks)
+    return archive_size

--- a/backend/tests/unit/onyx/connectors/github/test_github_base_url.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_base_url.py
@@ -1,8 +1,10 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
-from unittest.mock import patch
+from typing import cast
+from unittest.mock import MagicMock, patch
 
 import pytest
+from github import Repository
 
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.github.connector import GithubConnector
@@ -189,3 +191,30 @@ class TestCredentialBaseUrlSSRF:
         with _ssrf_env():
             connector.load_credentials({"github_access_token": "token"})
         assert _base_url_of(connector) == "https://10.0.0.1/api/v3"
+
+
+def test_enterprise_credential_disables_repo_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The archive provider only speaks to github.com. A GitHub Enterprise host
+    supplied by the credential — with the env var unset — must still take the
+    API path, or that host's PAT would be sent to github.com."""
+    monkeypatch.setattr(
+        "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL", None
+    )
+    connector = GithubConnector(
+        repo_owner="onyx-dot-app", repositories="onyx", include_code_files=True
+    )
+    with _ssrf_env():
+        connector.load_credentials(
+            {
+                "github_access_token": "token",
+                "github_base_url": "https://github.example.com",
+            }
+        )
+    repo = cast(Repository.Repository, MagicMock())
+    with patch(
+        "onyx.connectors.github.connector.GitHubArchiveProvider"
+    ) as archive_provider:
+        assert connector._ensure_snapshot(repo) is None
+    archive_provider.assert_not_called()

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -592,7 +592,7 @@ def test_nonexistent_branch_raises_clear_error(
     )
 
     with pytest.raises(ConnectorValidationError, match="no-such-branch"):
-        connector._list_indexable_files(mock_repo)
+        connector._list_indexable_files(mock_repo, is_slim=False)
 
 
 def test_prs_disabled_404_does_not_crash_files(

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -113,6 +113,18 @@ def test_is_indexable_path_code_only_excludes_docs() -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def no_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tests exercise the API fetching path; snapshot-based fetching is
+    covered in test_github_snapshot_stage.py."""
+
+    def _no_snapshot(self: GithubConnector, repo: object) -> None:
+        del self, repo
+        return None
+
+    monkeypatch.setattr(GithubConnector, "_ensure_snapshot", _no_snapshot)
+
+
 @pytest.fixture
 def create_mock_repo() -> Callable[..., MagicMock]:
     def _create(

--- a/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
@@ -88,7 +88,9 @@ def test_connector_files_stage_uses_snapshot_not_api(
 def test_connector_falls_back_to_api_when_resolution_fails() -> None:
     """No resolved SHA, no snapshot: the branch could move under a
     branch-keyed cache."""
-    connector = GithubConnector(repo_owner="o", repositories="r")
+    connector = GithubConnector(
+        repo_owner="o", repositories="r", include_code_files=True
+    )
     provider = FakeArchiveProvider(
         archives={}, resolve_error=OnyxError(OnyxErrorCode.RATE_LIMITED)
     )
@@ -98,13 +100,57 @@ def test_connector_falls_back_to_api_when_resolution_fails() -> None:
 
 
 def test_connector_falls_back_to_api_when_download_fails() -> None:
-    connector = GithubConnector(repo_owner="o", repositories="r")
+    connector = GithubConnector(
+        repo_owner="o", repositories="r", include_code_files=True
+    )
     provider = FakeArchiveProvider(archives={SHA: b"x" * 100}, refs={"main": SHA})
     with (
         _patch_provider(provider),
         patch("onyx.connectors.github.connector.REPO_ARCHIVE_MAX_BYTES", 10),
     ):
         assert connector._ensure_snapshot(make_mock_repo()) is None
+
+
+def test_document_only_connector_never_downloads_an_archive() -> None:
+    """Existing doc connectors fetch a few markdown files. A whole-repo
+    tarball would cost far more than the API calls it replaces."""
+    connector = GithubConnector(
+        repo_owner="o", repositories="r", include_files=True, include_code_files=False
+    )
+    provider = FakeArchiveProvider(
+        archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
+    )
+
+    with _patch_provider(provider):
+        assert connector._ensure_snapshot(make_mock_repo()) is None
+
+    assert provider.resolve_calls == 0
+    assert provider.downloads == []
+
+
+def test_slim_listing_never_downloads_an_archive(
+    mock_github_client: MagicMock,
+) -> None:
+    """Permission sync only needs paths, which one tree call gives, and it
+    runs far more often than indexing does."""
+    mock_repo = make_mock_repo(files=FILES)
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_files=True,
+        include_code_files=True,
+    )
+    connector.github_client = mock_github_client
+    provider = FakeArchiveProvider(
+        archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
+    )
+
+    with _patch_provider(provider):
+        paths, _ = connector._list_indexable_files(mock_repo, is_slim=True)
+
+    assert paths == ["README.md", "src/main.py"]
+    assert provider.downloads == []
+    mock_repo.get_git_tree.assert_called_once()
 
 
 def test_snapshot_walk_failure_falls_back_to_tree_listing(
@@ -130,7 +176,7 @@ def test_snapshot_walk_failure_falls_back_to_tree_listing(
             RepoSnapshot, "walk_files", side_effect=RepoSnapshotError("pruned")
         ),
     ):
-        paths, truncated = connector._list_indexable_files(mock_repo)
+        paths, truncated = connector._list_indexable_files(mock_repo, is_slim=False)
 
     assert paths == ["README.md", "src/main.py"]
     assert truncated is False

--- a/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
@@ -1,7 +1,6 @@
 import time
-from collections.abc import Iterator
-from datetime import datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,9 +9,13 @@ from onyx.connectors.github.connector import GithubConnector
 from onyx.connectors.models import CodeSection, Document
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.repo_archives import snapshot
+from tests.unit.onyx.connectors.github.conftest import make_mock_repo
 from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
-from tests.utils.repo_archives import FakeArchiveProvider, make_repo_tarball
+from tests.utils.repo_archives import (
+    FakeArchiveProvider,
+    isolate_repo_archive_caches,
+    make_repo_tarball,
+)
 
 SHA = "a" * 40
 FILES = {
@@ -22,51 +25,26 @@ FILES = {
 
 
 @pytest.fixture(autouse=True)
-def isolated_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    monkeypatch.setattr(snapshot, "_CACHE_ROOT", tmp_path / "snapshot_cache")
-    store = MagicMock()
-    store.has_file.return_value = False
-    store.list_files_by_prefix.return_value = []
-    with patch(
-        "onyx.repo_archives.tarball_cache.get_default_file_store", return_value=store
-    ):
-        yield
+def isolated_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    return isolate_repo_archive_caches(monkeypatch, tmp_path)
 
 
-def _patch_provider(provider: FakeArchiveProvider):
+def _patch_provider(provider: FakeArchiveProvider) -> Any:
+    provider_cls = MagicMock()
+    provider_cls.from_token.return_value = provider
     return patch(
         "onyx.connectors.github.connector.GitHubArchiveProvider",
-        return_value=provider,
+        provider_cls,
     )
 
 
-def _mock_github_repo() -> MagicMock:
-    repo = MagicMock()
-    repo.name = "test-repo"
-    repo.id = 1
-    repo.full_name = "test-org/test-repo"
-    repo.html_url = "https://github.com/test-org/test-repo"
-    repo.default_branch = "main"
-    repo.pushed_at = datetime(2023, 1, 1)
-    repo.configure_mock(
-        raw_headers={"status": "200 OK"},
-        raw_data={"id": 1, "full_name": "test-org/test-repo"},
-    )
-    return repo
-
-
-def test_connector_files_stage_uses_snapshot_not_api() -> None:
-    from github import Github
-    from github.RateLimit import RateLimit
-    from github.Requester import Requester
-
+def test_connector_files_stage_uses_snapshot_not_api(
+    mock_github_client: MagicMock,
+) -> None:
     from onyx.connectors.github.models import SerializedRepository
 
-    mock_repo = _mock_github_repo()
-    mock_client = MagicMock(spec=Github)
-    mock_client.get_repo = MagicMock(return_value=mock_repo)
-    mock_client.get_rate_limit = MagicMock(return_value=MagicMock(spec=RateLimit))
-    mock_client._requester = MagicMock(spec=Requester)
+    mock_repo = make_mock_repo()
+    mock_github_client.get_repo.return_value = mock_repo
 
     connector = GithubConnector(
         repo_owner="test-org",
@@ -76,7 +54,7 @@ def test_connector_files_stage_uses_snapshot_not_api() -> None:
         include_files=True,
         include_code_files=True,
     )
-    connector.github_client = mock_client
+    connector.github_client = mock_github_client
     provider = FakeArchiveProvider(
         archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
     )
@@ -114,7 +92,7 @@ def test_connector_falls_back_to_api_when_resolution_fails() -> None:
         archives={}, resolve_error=OnyxError(OnyxErrorCode.RATE_LIMITED)
     )
     with _patch_provider(provider):
-        assert connector._ensure_snapshot(_mock_github_repo()) is None
+        assert connector._ensure_snapshot(make_mock_repo()) is None
     assert provider.downloads == []
 
 
@@ -123,6 +101,6 @@ def test_connector_falls_back_to_api_when_download_fails() -> None:
     provider = FakeArchiveProvider(archives={SHA: b"x" * 100}, refs={"main": SHA})
     with (
         _patch_provider(provider),
-        patch("onyx.connectors.github.connector.GITHUB_REPO_ARCHIVE_MAX_BYTES", 10),
+        patch("onyx.connectors.github.connector.REPO_ARCHIVE_MAX_BYTES", 10),
     ):
-        assert connector._ensure_snapshot(_mock_github_repo()) is None
+        assert connector._ensure_snapshot(make_mock_repo()) is None

--- a/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
@@ -1,0 +1,128 @@
+import time
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.connectors.github.connector import GithubConnector
+from onyx.connectors.models import CodeSection, Document
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.repo_archives import snapshot
+from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
+from tests.utils.repo_archives import FakeArchiveProvider, make_repo_tarball
+
+SHA = "a" * 40
+FILES = {
+    "src/main.py": b"def main():\n    return 1\n",
+    "README.md": b"# Hello\n",
+}
+
+
+@pytest.fixture(autouse=True)
+def isolated_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(snapshot, "_CACHE_ROOT", tmp_path / "snapshot_cache")
+    store = MagicMock()
+    store.has_file.return_value = False
+    store.list_files_by_prefix.return_value = []
+    with patch(
+        "onyx.repo_archives.tarball_cache.get_default_file_store", return_value=store
+    ):
+        yield
+
+
+def _patch_provider(provider: FakeArchiveProvider):
+    return patch(
+        "onyx.connectors.github.connector.GitHubArchiveProvider",
+        return_value=provider,
+    )
+
+
+def _mock_github_repo() -> MagicMock:
+    repo = MagicMock()
+    repo.name = "test-repo"
+    repo.id = 1
+    repo.full_name = "test-org/test-repo"
+    repo.html_url = "https://github.com/test-org/test-repo"
+    repo.default_branch = "main"
+    repo.pushed_at = datetime(2023, 1, 1)
+    repo.configure_mock(
+        raw_headers={"status": "200 OK"},
+        raw_data={"id": 1, "full_name": "test-org/test-repo"},
+    )
+    return repo
+
+
+def test_connector_files_stage_uses_snapshot_not_api() -> None:
+    from github import Github
+    from github.RateLimit import RateLimit
+    from github.Requester import Requester
+
+    from onyx.connectors.github.models import SerializedRepository
+
+    mock_repo = _mock_github_repo()
+    mock_client = MagicMock(spec=Github)
+    mock_client.get_repo = MagicMock(return_value=mock_repo)
+    mock_client.get_rate_limit = MagicMock(return_value=MagicMock(spec=RateLimit))
+    mock_client._requester = MagicMock(spec=Requester)
+
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=False,
+        include_issues=False,
+        include_files=True,
+        include_code_files=True,
+    )
+    connector.github_client = mock_client
+    provider = FakeArchiveProvider(
+        archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
+    )
+
+    with (
+        patch.object(SerializedRepository, "to_Repository", return_value=mock_repo),
+        _patch_provider(provider),
+    ):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [
+        item
+        for output in outputs
+        for item in output.items
+        if isinstance(item, Document)
+    ]
+    assert sorted(d.semantic_identifier for d in docs) == ["README.md", "src/main.py"]
+
+    # The whole file stage ran on ONE archive fetch — zero per-file calls.
+    assert provider.downloads == [SHA]
+    mock_repo.get_git_tree.assert_not_called()
+    mock_repo.get_contents.assert_not_called()
+    mock_repo.get_branch.assert_not_called()
+
+    code_doc = next(d for d in docs if d.semantic_identifier == "src/main.py")
+    assert isinstance(code_doc.sections[0], CodeSection)
+    assert code_doc.metadata["commit_sha"] == SHA
+
+
+def test_connector_falls_back_to_api_when_resolution_fails() -> None:
+    """No resolved SHA, no snapshot: the branch could move under a
+    branch-keyed cache."""
+    connector = GithubConnector(repo_owner="o", repositories="r")
+    provider = FakeArchiveProvider(
+        archives={}, resolve_error=OnyxError(OnyxErrorCode.RATE_LIMITED)
+    )
+    with _patch_provider(provider):
+        assert connector._ensure_snapshot(_mock_github_repo()) is None
+    assert provider.downloads == []
+
+
+def test_connector_falls_back_to_api_when_download_fails() -> None:
+    connector = GithubConnector(repo_owner="o", repositories="r")
+    provider = FakeArchiveProvider(archives={SHA: b"x" * 100}, refs={"main": SHA})
+    with (
+        _patch_provider(provider),
+        patch("onyx.connectors.github.connector.GITHUB_REPO_ARCHIVE_MAX_BYTES", 10),
+    ):
+        assert connector._ensure_snapshot(_mock_github_repo()) is None

--- a/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
@@ -9,6 +9,7 @@ from onyx.connectors.github.connector import GithubConnector
 from onyx.connectors.models import CodeSection, Document
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.repo_archives.snapshot import RepoSnapshot, RepoSnapshotError
 from tests.unit.onyx.connectors.github.conftest import make_mock_repo
 from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
 from tests.utils.repo_archives import (
@@ -104,3 +105,84 @@ def test_connector_falls_back_to_api_when_download_fails() -> None:
         patch("onyx.connectors.github.connector.REPO_ARCHIVE_MAX_BYTES", 10),
     ):
         assert connector._ensure_snapshot(make_mock_repo()) is None
+
+
+def test_snapshot_walk_failure_falls_back_to_tree_listing(
+    mock_github_client: MagicMock,
+) -> None:
+    """A concurrent prune can break the walk mid-flight. The tree API listing
+    is a complete substitute, so the attempt must not fail."""
+    mock_repo = make_mock_repo(files=FILES)
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_files=True,
+        include_code_files=True,
+    )
+    connector.github_client = mock_github_client
+    provider = FakeArchiveProvider(
+        archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
+    )
+
+    with (
+        _patch_provider(provider),
+        patch.object(
+            RepoSnapshot, "walk_files", side_effect=RepoSnapshotError("pruned")
+        ),
+    ):
+        paths, truncated = connector._list_indexable_files(mock_repo)
+
+    assert paths == ["README.md", "src/main.py"]
+    assert truncated is False
+    mock_repo.get_git_tree.assert_called_once()
+
+
+def test_commit_sha_only_stamped_on_snapshot_sourced_documents(
+    mock_github_client: MagicMock,
+) -> None:
+    """Files served by the content API come from the branch head, which can be
+    a different commit than the snapshot — they must claim no revision."""
+    from onyx.connectors.github.models import SerializedRepository
+
+    mock_repo = make_mock_repo(files=FILES)
+    mock_github_client.get_repo.return_value = mock_repo
+
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=False,
+        include_issues=False,
+        include_files=True,
+        include_code_files=True,
+    )
+    connector.github_client = mock_github_client
+    provider = FakeArchiveProvider(
+        archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
+    )
+
+    real_read_file = RepoSnapshot.read_file
+
+    def _read_file(self: RepoSnapshot, rel_path: str, max_size_bytes: int) -> bytes:
+        if rel_path == "README.md":
+            raise RepoSnapshotError("pruned mid-batch")
+        return real_read_file(self, rel_path, max_size_bytes)
+
+    with (
+        patch.object(SerializedRepository, "to_Repository", return_value=mock_repo),
+        _patch_provider(provider),
+        patch.object(RepoSnapshot, "read_file", _read_file),
+    ):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = {
+        item.semantic_identifier: item
+        for output in outputs
+        for item in output.items
+        if isinstance(item, Document)
+    }
+    assert set(docs) == {"README.md", "src/main.py"}
+    # Read from the snapshot, so the snapshot's revision produced these bytes.
+    assert docs["src/main.py"].metadata["commit_sha"] == SHA
+    # Fell back to the content API, so no revision may be claimed.
+    assert "commit_sha" not in docs["README.md"].metadata
+    mock_repo.get_contents.assert_called_once()

--- a/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_snapshot_stage.py
@@ -232,3 +232,54 @@ def test_commit_sha_only_stamped_on_snapshot_sourced_documents(
     # Fell back to the content API, so no revision may be claimed.
     assert "commit_sha" not in docs["README.md"].metadata
     mock_repo.get_contents.assert_called_once()
+
+
+def test_vanished_snapshot_is_dropped_rather_than_retried_per_file(
+    mock_github_client: MagicMock,
+) -> None:
+    """A pruned snapshot fails every later read the same way. The connector
+    decides once and serves the rest of the batch from the content API,
+    instead of trying the snapshot again for each file."""
+    from onyx.connectors.github.models import SerializedRepository
+
+    mock_repo = make_mock_repo(files=FILES)
+    mock_github_client.get_repo.return_value = mock_repo
+
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=False,
+        include_issues=False,
+        include_files=True,
+        include_code_files=True,
+    )
+    connector.github_client = mock_github_client
+    provider = FakeArchiveProvider(
+        archives={SHA: make_repo_tarball(FILES)}, refs={"main": SHA}
+    )
+
+    reads: list[str] = []
+
+    def _read_file(_self: RepoSnapshot, rel_path: str, _max_size: int) -> bytes:
+        reads.append(rel_path)
+        raise RepoSnapshotError("pruned mid-batch")
+
+    with (
+        patch.object(SerializedRepository, "to_Repository", return_value=mock_repo),
+        _patch_provider(provider),
+        patch.object(RepoSnapshot, "read_file", _read_file),
+        patch.object(RepoSnapshot, "is_available", False),
+    ):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [
+        item
+        for output in outputs
+        for item in output.items
+        if isinstance(item, Document)
+    ]
+    # Both files are still indexed, via the content API...
+    assert len(docs) == len(FILES)
+    assert mock_repo.get_contents.call_count == len(FILES)
+    # ...but the snapshot was only consulted for the first of them.
+    assert len(reads) == 1

--- a/backend/tests/unit/onyx/repo_archives/test_github_provider.py
+++ b/backend/tests/unit/onyx/repo_archives/test_github_provider.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 from unittest.mock import patch
 
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
 from onyx.repo_archives.github import GitHubArchiveProvider
 from onyx.utils.github import GitHubRevision, GitHubSource
 
@@ -35,11 +38,34 @@ def test_resolve_branch_and_default_branch() -> None:
         assert resolve.call_args.args[0] == GitHubSource(owner="org", repo="repo")
 
 
-def test_pinned_sha_is_kept_but_access_is_checked() -> None:
+def test_pinned_sha_is_resolved_and_access_is_checked() -> None:
+    """A SHA goes through the same commits call as a branch: it both confirms
+    the commit exists and proves the caller can read the repo."""
     provider = GitHubArchiveProvider()
-    with patch(f"{MODULE}.resolve_github_revision") as resolve:
+    with patch(
+        f"{MODULE}.resolve_github_revision",
+        return_value=GitHubRevision(revision=SHA, subpath=None),
+    ) as resolve:
         assert provider.resolve_commit(REPO, SHA.upper()) == SHA
-    resolve.assert_called_once_with(GitHubSource(owner="org", repo="repo"), None)
+    resolve.assert_called_once_with(
+        GitHubSource(owner="org", repo="repo", tree_tail=(SHA.upper(),)), None
+    )
+
+
+def test_from_token_and_repo_ref_from_url() -> None:
+    assert GitHubArchiveProvider.from_token("t")._authorization_header == "Bearer t"
+    assert GitHubArchiveProvider.from_token(None)._authorization_header is None
+
+    for source in (
+        "https://github.com/org/repo",
+        "https://github.com/org/repo.git",
+        "org/repo",
+        "git@github.com:org/repo.git",
+    ):
+        assert GitHubArchiveProvider.repo_ref_from_url(source) == REPO
+
+    with pytest.raises(OnyxError):
+        GitHubArchiveProvider.repo_ref_from_url("https://example.com/org/repo")
 
 
 def test_stream_archive_delegates() -> None:

--- a/backend/tests/unit/onyx/repo_archives/test_github_provider.py
+++ b/backend/tests/unit/onyx/repo_archives/test_github_provider.py
@@ -1,0 +1,59 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from onyx.repo_archives.github import GitHubArchiveProvider
+from onyx.utils.github import GitHubRevision, GitHubSource
+
+MODULE = "onyx.repo_archives.github"
+REPO = GitHubArchiveProvider.repo_ref("org", "repo")
+SHA = "a" * 40
+
+
+def test_repo_ref_identity() -> None:
+    assert (REPO.provider, REPO.host, REPO.owner, REPO.name) == (
+        "github",
+        "github.com",
+        "org",
+        "repo",
+    )
+    assert GitHubArchiveProvider("Bearer t").authenticated
+    assert not GitHubArchiveProvider().authenticated
+
+
+def test_resolve_branch_and_default_branch() -> None:
+    provider = GitHubArchiveProvider("Bearer t")
+    with patch(
+        f"{MODULE}.resolve_github_revision",
+        return_value=GitHubRevision(revision=SHA, subpath=None),
+    ) as resolve:
+        assert provider.resolve_commit(REPO, "main") == SHA
+        assert resolve.call_args.args == (
+            GitHubSource(owner="org", repo="repo", tree_tail=("main",)),
+            "Bearer t",
+        )
+        assert provider.resolve_commit(REPO, None) == SHA
+        assert resolve.call_args.args[0] == GitHubSource(owner="org", repo="repo")
+
+
+def test_pinned_sha_is_kept_but_access_is_checked() -> None:
+    provider = GitHubArchiveProvider()
+    with patch(f"{MODULE}.resolve_github_revision") as resolve:
+        assert provider.resolve_commit(REPO, SHA.upper()) == SHA
+    resolve.assert_called_once_with(GitHubSource(owner="org", repo="repo"), None)
+
+
+def test_stream_archive_delegates() -> None:
+    provider = GitHubArchiveProvider("Bearer t")
+    sink = BytesIO()
+    with patch(f"{MODULE}.stream_github_archive", return_value=3) as stream:
+        assert (
+            provider.stream_archive(REPO, SHA, sink, max_size_bytes=10, timeout=5) == 3
+        )
+    stream.assert_called_once_with(
+        GitHubSource(owner="org", repo="repo"),
+        SHA,
+        "Bearer t",
+        max_size_bytes=10,
+        timeout=5,
+        sink=sink,
+    )

--- a/backend/tests/unit/onyx/repo_archives/test_snapshot.py
+++ b/backend/tests/unit/onyx/repo_archives/test_snapshot.py
@@ -9,13 +9,19 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.repo_archives import snapshot
 from onyx.repo_archives.models import RepoArchive, RepoRevision
 from onyx.repo_archives.snapshot import (
     RepoSnapshotError,
     get_or_create_snapshot,
+    snapshot_or_none,
 )
 from tests.utils.repo_archives import (
+    TEST_REPO,
+    FakeArchiveProvider,
+    isolate_repo_archive_caches,
     make_repo_tarball,
     revision,
 )
@@ -299,3 +305,60 @@ def test_read_refuses_symlink_escaping_root_but_allows_internal(
     assert snap.read_file("alias.md", max_size_bytes=1_000_000) == FILES["README.md"]
     # Walks report only regular files; symlinks are never yielded.
     assert "alias.md" not in dict(snap.walk_files())
+
+
+# --- snapshot_or_none ----------------------------------------------------------------
+
+
+def _fake_provider(sha: str, archive: bytes) -> FakeArchiveProvider:
+    return FakeArchiveProvider(archives={sha: archive}, refs={"main": sha})
+
+
+def test_snapshot_or_none_fetches_once_and_serves_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolate_repo_archive_caches(monkeypatch, tmp_path)
+    sha = _rev("or-none-ok").commit_sha
+    provider = _fake_provider(sha, make_repo_tarball(FILES))
+
+    snap = snapshot_or_none(
+        provider, TEST_REPO, "main", max_size_bytes=1_000_000, timeout=30
+    )
+
+    assert snap is not None
+    assert dict(snap.walk_files()) == {path: len(c) for path, c in FILES.items()}
+    assert provider.downloads == [sha]
+
+
+def test_snapshot_or_none_returns_none_without_a_resolved_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolate_repo_archive_caches(monkeypatch, tmp_path)
+    provider = FakeArchiveProvider(
+        archives={}, resolve_error=OnyxError(OnyxErrorCode.RATE_LIMITED)
+    )
+
+    assert (
+        snapshot_or_none(
+            provider, TEST_REPO, "main", max_size_bytes=1_000_000, timeout=30
+        )
+        is None
+    )
+    assert provider.downloads == []
+
+
+def test_snapshot_or_none_swallows_extraction_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolate_repo_archive_caches(monkeypatch, tmp_path)
+    wrapper = tarfile.TarInfo(name="org-repo-abc1234")
+    wrapper.type = tarfile.DIRTYPE
+    sha = _rev("or-none-bad").commit_sha
+    provider = _fake_provider(sha, make_repo_tarball({}, extra_members=[wrapper]))
+
+    assert (
+        snapshot_or_none(
+            provider, TEST_REPO, "main", max_size_bytes=1_000_000, timeout=30
+        )
+        is None
+    )

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -355,7 +355,9 @@ export const connectorConfigs: Record<
         label: "Include Code Files?",
         name: "include_code_files",
         description:
-          "Index source code files from repositories so they can be searched",
+          "Index source code files from repositories so they can be searched. " +
+          "On GitHub Enterprise each file is fetched individually, which can " +
+          "exhaust the API rate limit on large repositories.",
         optional: true,
       },
     ],


### PR DESCRIPTION
## Description

Part 7/10 of the code-indexing stack. Stacked on #14221 (code-file indexing) and #14288 (tarball cache).

Adds `GitHubArchiveProvider`, the GitHub implementation of `RepoArchiveProvider`, plus a streaming `stream_github_archive` helper (`download_github_archive` becomes a thin in-memory wrapper). The connector's FILES stage now resolves the branch head once, opens the tarball through the file-store cache, extracts it into the local snapshot, and serves both the file listing and file reads from it — zero per-file API calls, immune to GitHub's tree truncation. Documents carry the indexed `commit_sha`.

No resolved SHA means no snapshot, so a moved branch is never served stale. Any snapshot failure falls back to the content API path that #14221 ships. GitHub Enterprise deployments always use the API path.

## How Has This Been Tested?

Unit tests: the provider (pinned-SHA access check, branch/default resolution, stream delegation) and the connector FILES stage over an in-memory provider (one archive fetch, no tree/content API calls, `commit_sha` metadata, fallback on resolution failure and on download failure). Live: indexed onyx (~6.8k files) and onyx-control-plane on a local k8s deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the GitHub connector's FILES stage through snapshot-backed archives so large repos stop hitting rate limits and truncated git trees from per-file content API calls. The branch head is resolved once, the tarball comes through the file-store cache, and listings and reads are served from the local snapshot, with documents stamped with the indexed `commit_sha` only when the bytes came from the snapshot.

- Snapshot fetching only runs when code files are indexed on github.com; document-only connectors, slim permission-sync runs, and GitHub Enterprise use the per-file API path.
- No resolved SHA means no snapshot, so a moved branch is never served stale; resolution, listing, and read failures fall back to the content API/tree path, a vanished snapshot is dropped once rather than retried per file, and only "no snapshot" failures are caught so extraction bugs surface.
- Adds `GitHubArchiveProvider` (via `from_token`) and `snapshot_or_none`, composing revision resolution, cached-archive open, and extraction in `repo_archives`; `download_github_archive` becomes a wrapper over the streaming `stream_github_archive` sink helper.

<sup>Written for commit a54f19aa9df5e87d4d8d0e210c36277828cafd1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
