### PR TITLE
chore(lint): lower ruff C901 max-complexity to 20

### DIFF
--- a/backend/ee/onyx/server/gateway/openai_passthrough.py
+++ b/backend/ee/onyx/server/gateway/openai_passthrough.py
@@ -9,6 +9,7 @@ import queue
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from contextlib import ExitStack
 from typing import Any
 
@@ -44,6 +45,8 @@ from onyx.server.gateway.models import (
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import trace
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import Span
 from onyx.tracing.framework.traces import Trace
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_span_output
 from onyx.utils.headers import build_llm_extra_headers
@@ -386,6 +389,198 @@ def handle_openai_responses_passthrough(
     return JSONResponse(content=response_body)
 
 
+_TEXT_DELTA_EVENT = "response.output_text.delta"
+_TERMINAL_EVENTS = ("response.completed", "response.failed", "response.incomplete")
+_ERRORED_EVENTS = ("response.failed", "response.incomplete")
+_RATE_LIMIT_ERROR_TYPES = ("rate_limit_error", "rate_limit_exceeded")
+
+
+class _ResponseFrameState:
+    """Response identity an out-of-band error frame must mirror.
+
+    The upstream values are read per SSE frame into the ``pending_*`` slots and
+    adopted only once that frame has been forwarded, so an error frame never
+    claims an identity the client has not seen.
+    """
+
+    def __init__(self, response_id: str, created_at: int) -> None:
+        self.response_id = response_id
+        self.created_at = created_at
+        self.next_sequence_number = 0
+        self.pending_response_id: str | None = None
+        self.pending_created_at: int | None = None
+        self.pending_next_sequence: int | None = None
+
+    def observe(self, event: Any) -> None:
+        event_response = event.get("response")
+        if isinstance(event_response, dict):
+            upstream_response_id = event_response.get("id")
+            if isinstance(upstream_response_id, str):
+                self.pending_response_id = upstream_response_id
+            upstream_created_at = event_response.get("created_at")
+            if isinstance(upstream_created_at, int):
+                self.pending_created_at = upstream_created_at
+        upstream_sequence = event.get("sequence_number")
+        if isinstance(upstream_sequence, int):
+            self.pending_next_sequence = upstream_sequence + 1
+
+    def adopt_pending(self) -> None:
+        if self.pending_response_id is not None:
+            self.response_id = self.pending_response_id
+        if self.pending_created_at is not None:
+            self.created_at = self.pending_created_at
+        if self.pending_next_sequence is not None:
+            self.next_sequence_number = self.pending_next_sequence
+
+    def clear_pending(self) -> None:
+        self.pending_response_id = None
+        self.pending_created_at = None
+        self.pending_next_sequence = None
+
+
+def _emit_failed_frame(
+    *,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+    frame: _ResponseFrameState,
+    model: str,
+    message: str,
+    error_type: str,
+) -> None:
+    code: ResponsesErrorCode = (
+        "rate_limit_exceeded"
+        if error_type in _RATE_LIMIT_ERROR_TYPES
+        else "server_error"
+    )
+    payload = {
+        **ResponsesFailedEvent.create(
+            ResponsesObjectPayload.failed(
+                response_id=frame.response_id,
+                created_at=frame.created_at,
+                model=model,
+                message=message,
+                code=code,
+            )
+        ).to_wire(),
+        "sequence_number": frame.next_sequence_number,
+    }
+    _put_stream_item(out, f"data: {json.dumps(payload)}\n\n", cancelled)
+
+
+def _emit_upstream_status_error(
+    response: httpx.Response,
+    span: Span[GenerationSpanData] | None,
+    emit_error: Callable[..., None],
+) -> None:
+    response.read()
+    if response.status_code in _FORWARDABLE_STATUSES:
+        error_type, message = _error_type_and_message(response.content)
+    else:
+        logger.warning(
+            "OpenAI passthrough upstream stream error (sanitized): status=%s",
+            response.status_code,
+        )
+        error_type, message = "api_error", _SANITIZED_ERROR
+    if span is not None:
+        span.set_error(
+            {"message": f"upstream status {response.status_code}", "data": None}
+        )
+    emit_error(message=message, error_type=error_type)
+
+
+def _record_stream_usage(
+    response_obj: Any,
+    state: _StreamAccumulator,
+    span: Span[GenerationSpanData] | None,
+) -> None:
+    usage = response_obj.get("usage")
+    if not isinstance(usage, dict):
+        return
+    state.usage = _usage_from_openai_wire(usage)
+    reasoning_tokens = _reasoning_tokens(usage)
+    if reasoning_tokens and span is not None:
+        # No Usage slot for reasoning-token pricing yet; surface it in traces.
+        span.span_data.model_config = {
+            **(span.span_data.model_config or {}),
+            "reasoning_tokens": reasoning_tokens,
+        }
+
+
+def _observe_stream_event(
+    event: Any,
+    state: _StreamAccumulator,
+    span: Span[GenerationSpanData] | None,
+) -> None:
+    """Accumulate text, usage and errors for the trace span."""
+    event_type = event.get("type")
+    if event_type == _TEXT_DELTA_EVENT:
+        delta_text = event.get("delta")
+        if isinstance(delta_text, str):
+            state.content.append(delta_text)
+        return
+    if event_type not in _TERMINAL_EVENTS:
+        return
+    # incomplete/failed also bill real tokens, so usage cannot be read from
+    # completed alone.
+    response_obj = event.get("response") or {}
+    _record_stream_usage(response_obj, state, span)
+    if event_type in _ERRORED_EVENTS:
+        error = response_obj.get("error")
+        if error and span is not None:
+            span.set_error({"message": str(error), "data": None})
+
+
+def _flush_frame(
+    frame_lines: list[str],
+    frame: _ResponseFrameState,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> bool:
+    """Forward one buffered SSE frame verbatim, then adopt its identity."""
+    if not _put_stream_item(out, "\n".join(frame_lines) + "\n\n", cancelled):
+        return False
+    frame.adopt_pending()
+    return True
+
+
+def _forward_stream_frames(
+    response: httpx.Response,
+    frame: _ResponseFrameState,
+    state: _StreamAccumulator,
+    span: Span[GenerationSpanData] | None,
+    out: "queue.Queue[Any]",
+    cancelled: threading.Event,
+) -> None:
+    """Relay upstream SSE frames unchanged while accumulating trace state."""
+    frame_lines: list[str] = []
+    for line in response.iter_lines():
+        if cancelled.is_set():
+            break
+        if line == "":
+            if not frame_lines:
+                continue
+            buffered, frame_lines = frame_lines, []
+            if not _flush_frame(buffered, frame, out, cancelled):
+                break
+            frame.clear_pending()
+            continue
+        frame_lines.append(line)
+        if not line.startswith("data: "):
+            continue
+        raw_data = line[len("data: ") :]
+        try:
+            event = json.loads(raw_data)
+        except json.JSONDecodeError:
+            logger.warning(
+                "OpenAI passthrough: unparsable SSE data line, forwarding verbatim"
+            )
+            continue
+        frame.observe(event)
+        _observe_stream_event(event, state, span)
+    if frame_lines and not cancelled.is_set():
+        _flush_frame(frame_lines, frame, out, cancelled)
+
+
 def _openai_passthrough_stream_worker(
     url: str,
     headers: dict[str, str],
@@ -398,29 +593,19 @@ def _openai_passthrough_stream_worker(
     out: "queue.Queue[Any]",
     cancelled: threading.Event,
 ) -> None:
-    response_id = f"resp_{uuid.uuid4().hex}"
-    response_created_at = int(time.time())
-    next_sequence_number = 0
+    frame = _ResponseFrameState(
+        response_id=f"resp_{uuid.uuid4().hex}", created_at=int(time.time())
+    )
 
     def emit_error(*, message: str, error_type: str) -> None:
-        code: ResponsesErrorCode = (
-            "rate_limit_exceeded"
-            if error_type in ("rate_limit_error", "rate_limit_exceeded")
-            else "server_error"
+        _emit_failed_frame(
+            out=out,
+            cancelled=cancelled,
+            frame=frame,
+            model=model,
+            message=message,
+            error_type=error_type,
         )
-        payload = {
-            **ResponsesFailedEvent.create(
-                ResponsesObjectPayload.failed(
-                    response_id=response_id,
-                    created_at=response_created_at,
-                    model=model,
-                    message=message,
-                    code=code,
-                )
-            ).to_wire(),
-            "sequence_number": next_sequence_number,
-        }
-        _put_stream_item(out, f"data: {json.dumps(payload)}\n\n", cancelled)
 
     # Runs on its own thread after the endpoint returned, so the trace must be
     # opened here or the generation span sees no active trace.
@@ -458,106 +643,10 @@ def _openai_passthrough_stream_worker(
             ).start()
 
             if response.status_code != 200:
-                response.read()
-                if response.status_code in _FORWARDABLE_STATUSES:
-                    error_type, message = _error_type_and_message(response.content)
-                else:
-                    logger.warning(
-                        "OpenAI passthrough upstream stream error (sanitized): "
-                        "status=%s",
-                        response.status_code,
-                    )
-                    error_type, message = "api_error", _SANITIZED_ERROR
-                if span is not None:
-                    span.set_error(
-                        {
-                            "message": f"upstream status {response.status_code}",
-                            "data": None,
-                        }
-                    )
-                emit_error(message=message, error_type=error_type)
+                _emit_upstream_status_error(response, span, emit_error)
                 return
 
-            frame_lines: list[str] = []
-            frame_response_id: str | None = None
-            frame_created_at: int | None = None
-            frame_next_sequence: int | None = None
-            for line in response.iter_lines():
-                if cancelled.is_set():
-                    break
-                if line == "":
-                    if frame_lines:
-                        frame_text = "\n".join(frame_lines)
-                        frame_lines = []
-                        if not _put_stream_item(out, frame_text + "\n\n", cancelled):
-                            break
-                        if frame_response_id is not None:
-                            response_id = frame_response_id
-                        if frame_created_at is not None:
-                            response_created_at = frame_created_at
-                        if frame_next_sequence is not None:
-                            next_sequence_number = frame_next_sequence
-                        frame_response_id = None
-                        frame_created_at = None
-                        frame_next_sequence = None
-                    continue
-                frame_lines.append(line)
-                if not line.startswith("data: "):
-                    continue
-                raw_data = line[len("data: ") :]
-                try:
-                    event = json.loads(raw_data)
-                except json.JSONDecodeError:
-                    logger.warning(
-                        "OpenAI passthrough: unparsable SSE data line, "
-                        "forwarding verbatim"
-                    )
-                    continue
-                event_type = event.get("type")
-                event_response = event.get("response")
-                if isinstance(event_response, dict):
-                    upstream_response_id = event_response.get("id")
-                    if isinstance(upstream_response_id, str):
-                        frame_response_id = upstream_response_id
-                    upstream_created_at = event_response.get("created_at")
-                    if isinstance(upstream_created_at, int):
-                        frame_created_at = upstream_created_at
-                upstream_sequence = event.get("sequence_number")
-                if isinstance(upstream_sequence, int):
-                    frame_next_sequence = upstream_sequence + 1
-                if event_type == "response.output_text.delta":
-                    delta_text = event.get("delta")
-                    if isinstance(delta_text, str):
-                        state.content.append(delta_text)
-                elif event_type in (
-                    "response.completed",
-                    "response.failed",
-                    "response.incomplete",
-                ):
-                    # incomplete/failed also bill real tokens, so usage
-                    # cannot be read from completed alone.
-                    response_obj = event.get("response") or {}
-                    usage = response_obj.get("usage")
-                    if isinstance(usage, dict):
-                        state.usage = _usage_from_openai_wire(usage)
-                        reasoning_tokens = _reasoning_tokens(usage)
-                        if reasoning_tokens and span is not None:
-                            span.span_data.model_config = {
-                                **(span.span_data.model_config or {}),
-                                "reasoning_tokens": reasoning_tokens,
-                            }
-                    if event_type in ("response.failed", "response.incomplete"):
-                        error = response_obj.get("error")
-                        if error and span is not None:
-                            span.set_error({"message": str(error), "data": None})
-            if frame_lines and not cancelled.is_set():
-                if _put_stream_item(out, "\n".join(frame_lines) + "\n\n", cancelled):
-                    if frame_response_id is not None:
-                        response_id = frame_response_id
-                    if frame_created_at is not None:
-                        response_created_at = frame_created_at
-                    if frame_next_sequence is not None:
-                        next_sequence_number = frame_next_sequence
+            _forward_stream_frames(response, frame, state, span, out, cancelled)
             # Managed-key cost accounting normally happens inside
             # LLM.invoke/stream, which this path bypasses.
             if state.usage is not None and isinstance(llm, LitellmLLM):

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -2,6 +2,7 @@ import multiprocessing
 import os
 import time
 import traceback
+from multiprocessing.context import SpawnProcess
 from time import sleep
 
 import psutil
@@ -323,6 +324,367 @@ def process_job_result(
     return result
 
 
+def _wait_for_spawn(
+    job: SimpleJob,
+    process: SpawnProcess,
+    result: SimpleJobResult,
+    log_builder: ConnectorIndexingLogBuilder,
+) -> bool:
+    """Wait for the spawned process to move out of the starting state.
+
+    Returns False if the process never came alive; the caller must then stop.
+    """
+    num_waits = 0
+    while True:
+        if num_waits > 15:
+            result.status = IndexingWatchdogTerminalStatus.SPAWN_NOT_ALIVE
+            task_logger.info(
+                log_builder.build(
+                    "Indexing watchdog - finished",
+                    status=str(result.status.value),
+                    exit_code=str(result.exit_code),
+                )
+            )
+            job.release()
+            return False
+
+        if process.is_alive() or process.exitcode is not None:
+            break
+
+        sleep(1)
+        num_waits += 1
+
+    return True
+
+
+def _handle_worker_shutdown(
+    job: SimpleJob,
+    result: SimpleJobResult,
+    index_attempt_id: int,
+    log_builder: ConnectorIndexingLogBuilder,
+) -> None:
+    """Mark the attempt INTERRUPTED, then stop the subprocess."""
+    result.status = IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN
+    try:
+        with get_session_with_current_tenant() as db_session:
+            attempt = get_index_attempt(db_session, index_attempt_id)
+            if attempt and not attempt.status.is_terminal():
+                mark_attempt_interrupted(
+                    index_attempt_id,
+                    db_session,
+                    "Indexing worker shutting down (deploy or "
+                    "autoscaling). The attempt resumes automatically "
+                    "from the last checkpoint.",
+                )
+    except Exception:
+        task_logger.exception(
+            log_builder.build(
+                "Indexing watchdog - transient exception marking index "
+                "attempt as interrupted on worker shutdown"
+            )
+        )
+    try:
+        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+    except Exception:
+        task_logger.exception(
+            log_builder.build(
+                "Indexing watchdog - exception while terminating "
+                "subprocess on worker shutdown"
+            )
+        )
+    if job.process is not None:
+        result.exit_code = job.process.exitcode
+
+
+def _maybe_emit_process_memory(
+    pid: int,
+    last_memory_emit_time: float,
+    cc_pair_id: int,
+    search_settings_id: int,
+    index_attempt_id: int,
+) -> float:
+    """Emit memory info at most once per minute. Returns the last emit time."""
+    current_time = time.monotonic()
+    if current_time - last_memory_emit_time >= 60.0:
+        emit_process_memory(
+            pid,
+            "indexing_worker",
+            {
+                "cc_pair_id": cc_pair_id,
+                "search_settings_id": search_settings_id,
+                "index_attempt_id": index_attempt_id,
+            },
+        )
+        return current_time
+
+    return last_memory_emit_time
+
+
+def _enforce_memory_limit(
+    job: SimpleJob,
+    result: SimpleJobResult,
+    pid: int,
+    index_attempt_id: int,
+    log_builder: ConnectorIndexingLogBuilder,
+) -> str | None:
+    """Terminate the subprocess if its RSS exceeds the configured limit.
+
+    Returns the failure reason when the limit tripped, otherwise None.
+    """
+    if INDEXING_WORKER_MEMORY_LIMIT_MB > 0:
+        rss_mb: int | None = None
+        try:
+            rss_mb = psutil.Process(pid).memory_info().rss // (1024 * 1024)
+        except psutil.Error:
+            # process likely exited; job.done() handles it next loop
+            pass
+
+        if rss_mb is not None and rss_mb > INDEXING_WORKER_MEMORY_LIMIT_MB:
+            task_logger.warning(
+                log_builder.build(
+                    "Indexing watchdog - memory limit exceeded; terminating subprocess",
+                    rss_mb=str(rss_mb),
+                    limit_mb=str(INDEXING_WORKER_MEMORY_LIMIT_MB),
+                    pid=str(pid),
+                )
+            )
+            result.status = IndexingWatchdogTerminalStatus.TERMINATED_BY_MEMORY_LIMIT
+            memory_limit_failure_reason = (
+                "Indexing worker exceeded the memory limit while "
+                f"fetching documents: rss_mb={rss_mb} "
+                f"limit_mb={INDEXING_WORKER_MEMORY_LIMIT_MB}. "
+                "This usually means the connector encountered "
+                "very large documents."
+            )
+
+            # mark failed before terminating so the subprocess's own
+            # termination handling can't write a competing status
+            try:
+                with get_session_with_current_tenant() as db_session:
+                    mark_attempt_failed(
+                        index_attempt_id,
+                        db_session,
+                        memory_limit_failure_reason,
+                    )
+            except Exception:
+                task_logger.exception(
+                    log_builder.build(
+                        "Indexing watchdog - transient exception marking "
+                        "index attempt as failed after memory limit"
+                    )
+                )
+
+            try:
+                job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+            except Exception:
+                task_logger.exception(
+                    log_builder.build(
+                        "Indexing watchdog - exception while terminating "
+                        "subprocess after memory limit exceeded"
+                    )
+                )
+            if job.process is not None:
+                result.exit_code = job.process.exitcode
+            return memory_limit_failure_reason
+
+    return None
+
+
+def _terminate_after_attempt_finalized(
+    job: SimpleJob,
+    result: SimpleJobResult,
+    log_builder: ConnectorIndexingLogBuilder,
+) -> None:
+    """Stop the subprocess after the IndexAttempt row reached a terminal status."""
+    result.status = IndexingWatchdogTerminalStatus.TERMINATED_BY_ATTEMPT_FINALIZED
+    try:
+        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+    except Exception:
+        task_logger.exception(
+            log_builder.build(
+                "Indexing watchdog - exception while terminating subprocess "
+                "after attempt finalization"
+            )
+        )
+    if job.process is not None:
+        result.exit_code = job.process.exitcode
+
+
+def _mark_attempt_in_progress(
+    index_attempt_id: int,
+    cc_pair_id: int,
+    tenant_id: str,
+    result: SimpleJobResult,
+) -> None:
+    """Record the connector source on the result and report the in-progress status."""
+    with get_session_with_current_tenant() as db_session:
+        index_attempt = get_index_attempt(
+            db_session=db_session,
+            index_attempt_id=index_attempt_id,
+            eager_load_cc_pair=True,
+        )
+        if not index_attempt:
+            raise RuntimeError("Index attempt not found")
+
+        result.connector_source = (
+            index_attempt.connector_credential_pair.connector.source.value
+        )
+
+        cc_pair = index_attempt.connector_credential_pair
+        on_index_attempt_status_change(
+            tenant_id=tenant_id,
+            source=result.connector_source,
+            cc_pair_id=cc_pair_id,
+            connector_name=cc_pair.connector.name or f"cc_pair_{cc_pair_id}",
+            status="in_progress",
+        )
+
+
+def _get_finalized_attempt_status(
+    index_attempt_id: int,
+    log_builder: ConnectorIndexingLogBuilder,
+) -> IndexingStatus | None:
+    """Return the attempt status if the row is already terminal, else None.
+
+    None also covers a missing row and a transient db error; the watchdog keeps
+    waiting in both cases.
+    """
+    try:
+        with get_session_with_current_tenant() as db_session:
+            index_attempt = get_index_attempt(
+                db_session=db_session, index_attempt_id=index_attempt_id
+            )
+
+            if not index_attempt:
+                return None
+
+            if not index_attempt.is_finished():
+                return None
+
+            return index_attempt.status
+    except Exception:
+        task_logger.exception(
+            log_builder.build(
+                "Indexing watchdog - transient exception looking up index attempt"
+            )
+        )
+        return None
+
+
+def _mark_attempt_failed_after_exception(
+    ctx: DocProcessingContext,
+    result: SimpleJobResult,
+    log_builder: ConnectorIndexingLogBuilder,
+) -> None:
+    """Record the watchdog exception on the attempt row, best effort."""
+    try:
+        with get_session_with_current_tenant() as db_session:
+            attempt = get_index_attempt(db_session, ctx.index_attempt_id)
+
+            # only mark failures if not already terminal,
+            # otherwise we're overwriting potential real stack traces
+            if attempt and not attempt.status.is_terminal():
+                failure_reason = (
+                    f"Spawned task exceptioned: exit_code={result.exit_code}"
+                )
+                mark_attempt_failed(
+                    ctx.index_attempt_id,
+                    db_session,
+                    failure_reason=failure_reason,
+                    full_exception_trace=result.exception_str,
+                )
+    except Exception:
+        task_logger.exception(
+            log_builder.build(
+                "Indexing watchdog - transient exception marking index attempt as failed"
+            )
+        )
+
+
+def _finalize_terminal_status(
+    job: SimpleJob,
+    result: SimpleJobResult,
+    index_attempt_id: int,
+    log_builder: ConnectorIndexingLogBuilder,
+    memory_limit_failure_reason: str | None,
+) -> None:
+    """Apply the db writes and subprocess cleanup for the terminal status."""
+    if result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_SIGNAL:
+        try:
+            with get_session_with_current_tenant() as db_session:
+                logger.exception(
+                    "Marking attempt %s as canceled due to termination signal",
+                    index_attempt_id,
+                )
+                mark_attempt_canceled(
+                    index_attempt_id,
+                    db_session,
+                    "Connector termination signal detected",
+                )
+        except Exception:
+            task_logger.exception(
+                log_builder.build(
+                    "Indexing watchdog - transient exception marking index attempt as canceled"
+                )
+            )
+
+        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_ACTIVITY_TIMEOUT:
+        try:
+            with get_session_with_current_tenant() as db_session:
+                mark_attempt_failed(
+                    index_attempt_id,
+                    db_session,
+                    "Indexing watchdog - activity timeout exceeded: "
+                    f"attempt={index_attempt_id} "
+                    f"timeout={CELERY_INDEXING_WATCHDOG_CONNECTOR_TIMEOUT}s",
+                )
+        except Exception:
+            logger.exception(
+                log_builder.build(
+                    "Indexing watchdog - transient exception marking index attempt as failed"
+                )
+            )
+        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+    elif (
+        result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_ATTEMPT_FINALIZED
+    ):
+        # the IndexAttempt row was already marked terminal by whoever finalized it
+        # (e.g. heartbeat watchdog marking it FAILED, user requesting cancellation,
+        # successful completion in the spawned process before we noticed). The
+        # subprocess has been killed in the watchdog loop above; no further DB
+        # writes are needed here.
+        pass
+    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN:
+        # already marked INTERRUPTED in the loop (best-effort). The heartbeat
+        # watchdog is the fallback if that write failed, so nothing to do here.
+        pass
+    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_MEMORY_LIMIT:
+        # subprocess already terminated in the watchdog loop. Re-mark in case the
+        # in-loop mark_attempt_failed hit a transient DB error — otherwise the
+        # attempt lingers in_progress until the heartbeat watchdog fails it with
+        # the opaque "No heartbeat received" message this status exists to replace.
+        try:
+            with get_session_with_current_tenant() as db_session:
+                attempt = get_index_attempt(db_session, index_attempt_id)
+                if attempt and not attempt.status.is_terminal():
+                    mark_attempt_failed(
+                        index_attempt_id,
+                        db_session,
+                        memory_limit_failure_reason
+                        or "Indexing worker exceeded the memory limit",
+                    )
+        except Exception:
+            task_logger.exception(
+                log_builder.build(
+                    "Indexing watchdog - transient exception marking index attempt "
+                    "as failed after memory limit"
+                )
+            )
+    else:
+        pass
+
+
 @shared_task(  # ty: ignore[invalid-argument-type]
     name=OnyxCeleryTask.CONNECTOR_DOC_FETCHING_TASK,
     bind=True,
@@ -449,25 +811,8 @@ def docfetching_proxy_task(
         return
 
     # Ensure the process has moved out of the starting state
-    num_waits = 0
-    while True:
-        if num_waits > 15:
-            result.status = IndexingWatchdogTerminalStatus.SPAWN_NOT_ALIVE
-            task_logger.info(
-                log_builder.build(
-                    "Indexing watchdog - finished",
-                    status=str(result.status.value),
-                    exit_code=str(result.exit_code),
-                )
-            )
-            job.release()
-            return
-
-        if job.process.is_alive() or job.process.exitcode is not None:
-            break
-
-        sleep(1)
-        num_waits += 1
+    if not _wait_for_spawn(job, job.process, result, log_builder):
+        return
 
     task_logger.info(
         log_builder.build(
@@ -483,27 +828,7 @@ def docfetching_proxy_task(
     memory_limit_failure_reason: str | None = None
 
     try:
-        with get_session_with_current_tenant() as db_session:
-            index_attempt = get_index_attempt(
-                db_session=db_session,
-                index_attempt_id=index_attempt_id,
-                eager_load_cc_pair=True,
-            )
-            if not index_attempt:
-                raise RuntimeError("Index attempt not found")
-
-            result.connector_source = (
-                index_attempt.connector_credential_pair.connector.source.value
-            )
-
-            cc_pair = index_attempt.connector_credential_pair
-            on_index_attempt_status_change(
-                tenant_id=tenant_id,
-                source=result.connector_source,
-                cc_pair_id=cc_pair_id,
-                connector_name=cc_pair.connector.name or f"cc_pair_{cc_pair_id}",
-                status="in_progress",
-            )
+        _mark_attempt_in_progress(index_attempt_id, cc_pair_id, tenant_id, result)
 
         while True:
             sleep(5)
@@ -514,40 +839,7 @@ def docfetching_proxy_task(
             # terminating so the subprocess can't write a competing status, then
             # stop it. A fresh attempt resumes from checkpoint on the next beat.
             if is_worker_shutting_down():
-                result.status = (
-                    IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN
-                )
-                try:
-                    with get_session_with_current_tenant() as db_session:
-                        attempt = get_index_attempt(db_session, index_attempt_id)
-                        if attempt and not attempt.status.is_terminal():
-                            mark_attempt_interrupted(
-                                index_attempt_id,
-                                db_session,
-                                "Indexing worker shutting down (deploy or "
-                                "autoscaling). The attempt resumes automatically "
-                                "from the last checkpoint.",
-                            )
-                except Exception:
-                    task_logger.exception(
-                        log_builder.build(
-                            "Indexing watchdog - transient exception marking index "
-                            "attempt as interrupted on worker shutdown"
-                        )
-                    )
-                try:
-                    job.terminate_and_wait(
-                        CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS
-                    )
-                except Exception:
-                    task_logger.exception(
-                        log_builder.build(
-                            "Indexing watchdog - exception while terminating "
-                            "subprocess on worker shutdown"
-                        )
-                    )
-                if job.process is not None:
-                    result.exit_code = job.process.exitcode
+                _handle_worker_shutdown(job, result, index_attempt_id, log_builder)
                 break
 
             # if the job is done, clean up and break
@@ -570,108 +862,33 @@ def docfetching_proxy_task(
             pid = job.process.pid
             if pid is not None:
                 # Only emit memory info once per minute (60 seconds)
-                current_time = time.monotonic()
-                if current_time - last_memory_emit_time >= 60.0:
-                    emit_process_memory(
-                        pid,
-                        "indexing_worker",
-                        {
-                            "cc_pair_id": cc_pair_id,
-                            "search_settings_id": search_settings_id,
-                            "index_attempt_id": index_attempt_id,
-                        },
-                    )
-                    last_memory_emit_time = current_time
+                last_memory_emit_time = _maybe_emit_process_memory(
+                    pid,
+                    last_memory_emit_time,
+                    cc_pair_id,
+                    search_settings_id,
+                    index_attempt_id,
+                )
 
                 # Terminate the worker before it can trip the kernel OOM killer —
                 # a kernel kill takes down the whole pod (the attempt heartbeat and
                 # other tenants' tasks included) and surfaces as an opaque
                 # "No heartbeat received" failure. Checked every loop iteration
                 # since RSS can grow by GBs within the 60s emit cadence.
-                if INDEXING_WORKER_MEMORY_LIMIT_MB > 0:
-                    rss_mb: int | None = None
-                    try:
-                        rss_mb = psutil.Process(pid).memory_info().rss // (1024 * 1024)
-                    except psutil.Error:
-                        # process likely exited; job.done() handles it next loop
-                        pass
-
-                    if rss_mb is not None and rss_mb > INDEXING_WORKER_MEMORY_LIMIT_MB:
-                        task_logger.warning(
-                            log_builder.build(
-                                "Indexing watchdog - memory limit exceeded; "
-                                "terminating subprocess",
-                                rss_mb=str(rss_mb),
-                                limit_mb=str(INDEXING_WORKER_MEMORY_LIMIT_MB),
-                                pid=str(pid),
-                            )
-                        )
-                        result.status = (
-                            IndexingWatchdogTerminalStatus.TERMINATED_BY_MEMORY_LIMIT
-                        )
-                        memory_limit_failure_reason = (
-                            "Indexing worker exceeded the memory limit while "
-                            f"fetching documents: rss_mb={rss_mb} "
-                            f"limit_mb={INDEXING_WORKER_MEMORY_LIMIT_MB}. "
-                            "This usually means the connector encountered "
-                            "very large documents."
-                        )
-
-                        # mark failed before terminating so the subprocess's own
-                        # termination handling can't write a competing status
-                        try:
-                            with get_session_with_current_tenant() as db_session:
-                                mark_attempt_failed(
-                                    index_attempt_id,
-                                    db_session,
-                                    memory_limit_failure_reason,
-                                )
-                        except Exception:
-                            task_logger.exception(
-                                log_builder.build(
-                                    "Indexing watchdog - transient exception marking "
-                                    "index attempt as failed after memory limit"
-                                )
-                            )
-
-                        try:
-                            job.terminate_and_wait(
-                                CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS
-                            )
-                        except Exception:
-                            task_logger.exception(
-                                log_builder.build(
-                                    "Indexing watchdog - exception while terminating "
-                                    "subprocess after memory limit exceeded"
-                                )
-                            )
-                        if job.process is not None:
-                            result.exit_code = job.process.exitcode
-                        break
+                memory_limit_failure_reason = _enforce_memory_limit(
+                    job, result, pid, index_attempt_id, log_builder
+                )
+                if memory_limit_failure_reason is not None:
+                    break
 
             # if the IndexAttempt row has been marked terminal (failed/canceled/
             # succeeded) by anyone else, the spawned subprocess is no longer doing
             # work that anyone cares about. Kill it so the worker thread is freed
             # up and a fresh attempt can be scheduled with a clean slate.
-            try:
-                with get_session_with_current_tenant() as db_session:
-                    index_attempt = get_index_attempt(
-                        db_session=db_session, index_attempt_id=index_attempt_id
-                    )
-
-                    if not index_attempt:
-                        continue
-
-                    if not index_attempt.is_finished():
-                        continue
-
-                    attempt_status = index_attempt.status
-            except Exception:
-                task_logger.exception(
-                    log_builder.build(
-                        "Indexing watchdog - transient exception looking up index attempt"
-                    )
-                )
+            attempt_status = _get_finalized_attempt_status(
+                index_attempt_id, log_builder
+            )
+            if attempt_status is None:
                 continue
 
             task_logger.warning(
@@ -682,20 +899,7 @@ def docfetching_proxy_task(
                     pid=str(job.process.pid),
                 )
             )
-            result.status = (
-                IndexingWatchdogTerminalStatus.TERMINATED_BY_ATTEMPT_FINALIZED
-            )
-            try:
-                job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
-            except Exception:
-                task_logger.exception(
-                    log_builder.build(
-                        "Indexing watchdog - exception while terminating subprocess "
-                        "after attempt finalization"
-                    )
-                )
-            if job.process is not None:
-                result.exit_code = job.process.exitcode
+            _terminate_after_attempt_finalized(job, result, log_builder)
             break
 
     except Exception as e:
@@ -710,28 +914,7 @@ def docfetching_proxy_task(
     elapsed = time.monotonic() - start
     if result.exception_str is not None:
         # print with exception
-        try:
-            with get_session_with_current_tenant() as db_session:
-                attempt = get_index_attempt(db_session, ctx.index_attempt_id)
-
-                # only mark failures if not already terminal,
-                # otherwise we're overwriting potential real stack traces
-                if attempt and not attempt.status.is_terminal():
-                    failure_reason = (
-                        f"Spawned task exceptioned: exit_code={result.exit_code}"
-                    )
-                    mark_attempt_failed(
-                        ctx.index_attempt_id,
-                        db_session,
-                        failure_reason=failure_reason,
-                        full_exception_trace=result.exception_str,
-                    )
-        except Exception:
-            task_logger.exception(
-                log_builder.build(
-                    "Indexing watchdog - transient exception marking index attempt as failed"
-                )
-            )
+        _mark_attempt_failed_after_exception(ctx, result, log_builder)
 
         normalized_exception_str = "None"
         if result.exception_str:
@@ -752,80 +935,9 @@ def docfetching_proxy_task(
         raise RuntimeError(f"Exception encountered: traceback={result.exception_str}")
 
     # print without exception
-    if result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_SIGNAL:
-        try:
-            with get_session_with_current_tenant() as db_session:
-                logger.exception(
-                    "Marking attempt %s as canceled due to termination signal",
-                    index_attempt_id,
-                )
-                mark_attempt_canceled(
-                    index_attempt_id,
-                    db_session,
-                    "Connector termination signal detected",
-                )
-        except Exception:
-            task_logger.exception(
-                log_builder.build(
-                    "Indexing watchdog - transient exception marking index attempt as canceled"
-                )
-            )
-
-        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
-    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_ACTIVITY_TIMEOUT:
-        try:
-            with get_session_with_current_tenant() as db_session:
-                mark_attempt_failed(
-                    index_attempt_id,
-                    db_session,
-                    "Indexing watchdog - activity timeout exceeded: "
-                    f"attempt={index_attempt_id} "
-                    f"timeout={CELERY_INDEXING_WATCHDOG_CONNECTOR_TIMEOUT}s",
-                )
-        except Exception:
-            logger.exception(
-                log_builder.build(
-                    "Indexing watchdog - transient exception marking index attempt as failed"
-                )
-            )
-        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
-    elif (
-        result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_ATTEMPT_FINALIZED
-    ):
-        # the IndexAttempt row was already marked terminal by whoever finalized it
-        # (e.g. heartbeat watchdog marking it FAILED, user requesting cancellation,
-        # successful completion in the spawned process before we noticed). The
-        # subprocess has been killed in the watchdog loop above; no further DB
-        # writes are needed here.
-        pass
-    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN:
-        # already marked INTERRUPTED in the loop (best-effort). The heartbeat
-        # watchdog is the fallback if that write failed, so nothing to do here.
-        pass
-    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_MEMORY_LIMIT:
-        # subprocess already terminated in the watchdog loop. Re-mark in case the
-        # in-loop mark_attempt_failed hit a transient DB error — otherwise the
-        # attempt lingers in_progress until the heartbeat watchdog fails it with
-        # the opaque "No heartbeat received" message this status exists to replace.
-        try:
-            with get_session_with_current_tenant() as db_session:
-                attempt = get_index_attempt(db_session, index_attempt_id)
-                if attempt and not attempt.status.is_terminal():
-                    mark_attempt_failed(
-                        index_attempt_id,
-                        db_session,
-                        memory_limit_failure_reason
-                        or "Indexing worker exceeded the memory limit",
-                    )
-        except Exception:
-            task_logger.exception(
-                log_builder.build(
-                    "Indexing watchdog - transient exception marking index attempt "
-                    "as failed after memory limit"
-                )
-            )
-    else:
-        pass
+    _finalize_terminal_status(
+        job, result, index_attempt_id, log_builder, memory_limit_failure_reason
+    )
 
     task_logger.info(
         log_builder.build(

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -27,6 +27,7 @@ from onyx.configs.app_configs import (
     POLL_CONNECTOR_OFFSET,
 )
 from onyx.configs.constants import (
+    DocumentSource,
     NotificationType,
     OnyxCeleryPriority,
     OnyxCeleryQueues,
@@ -43,6 +44,7 @@ from onyx.connectors.exceptions import (
 from onyx.connectors.factory import instantiate_connector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.models import (
+    ConnectorCheckpoint,
     ConnectorFailure,
     ConnectorStopSignal,
     Document,
@@ -80,7 +82,7 @@ from onyx.db.index_attempt_metrics import (
     time_stage,
 )
 from onyx.db.indexing_coordination import IndexingCoordination
-from onyx.db.models import Connector, Credential, IndexAttempt
+from onyx.db.models import Connector, Credential, IndexAttempt, SearchSettings
 from onyx.file_store.document_batch_storage import (
     DocumentBatchStorage,
     get_document_batch_storage,
@@ -100,6 +102,7 @@ from onyx.redis.redis_hierarchy import (
     get_source_node_id_from_cache,
 )
 from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.logger import setup_logger
 from onyx.utils.postgres_sanitization import (
     sanitize_document_for_postgres,
@@ -438,6 +441,476 @@ def run_docfetching_entrypoint(
     INDEX_ATTEMPT_INFO_CONTEXTVAR.reset(token)
 
 
+def _compute_poll_window(
+    db_session: Session,
+    index_attempt: IndexAttempt,
+    search_settings: SearchSettings,
+    cc_pair_id: int,
+    earliest_index_time: float,
+) -> tuple[datetime, datetime, IndexAttempt | None]:
+    """Build the poll window for this attempt.
+
+    Returns `(window_start, window_end, most_recent_attempt)`. The most recent
+    completed attempt is also used by the caller for checkpoint decisions.
+    """
+    # Set up time windows for polling. A port-flow FUTURE's resume cursor comes from its
+    # synthetic seed (get_last_successful_... keeps ignore_synthetic_seed=False by default).
+    last_successful_index_poll_range_end = (
+        earliest_index_time
+        if index_attempt.from_beginning
+        else get_last_successful_attempt_poll_range_end(
+            cc_pair_id=cc_pair_id,
+            earliest_index=earliest_index_time,
+            search_settings=search_settings,
+            db_session=db_session,
+        )
+    )
+
+    if last_successful_index_poll_range_end > POLL_CONNECTOR_OFFSET:
+        window_start = datetime.fromtimestamp(
+            last_successful_index_poll_range_end, tz=timezone.utc
+        ) - timedelta(minutes=POLL_CONNECTOR_OFFSET)
+    else:
+        # don't go into "negative" time if we've never indexed before
+        window_start = datetime.fromtimestamp(0, tz=timezone.utc)
+
+    most_recent_attempt = next(
+        iter(
+            get_recent_completed_attempts_for_cc_pair(
+                cc_pair_id=cc_pair_id,
+                search_settings_id=index_attempt.search_settings_id,
+                db_session=db_session,
+                limit=1,
+            )
+        ),
+        None,
+    )
+
+    # if the last attempt didn't complete cleanly, reuse the same window. This
+    # is necessary to ensure correctness with checkpointing. If we don't do this,
+    # things like new slack channels could be missed (since existing slack
+    # channels are cached as part of the checkpoint).
+    if (
+        most_recent_attempt
+        and most_recent_attempt.poll_range_end
+        and most_recent_attempt.status.should_reuse_checkpoint()
+    ):
+        window_end = most_recent_attempt.poll_range_end
+    else:
+        window_end = datetime.now(tz=timezone.utc)
+
+    return window_start, window_end, most_recent_attempt
+
+
+def _load_checkpoint(
+    db_session: Session,
+    app: Celery,
+    index_attempt: IndexAttempt,
+    connector_runner: ConnectorRunner,
+    batch_storage: DocumentBatchStorage,
+    most_recent_attempt: IndexAttempt | None,
+    index_attempt_id: int,
+    cc_pair_id: int,
+    tenant_id: str,
+    window_start: datetime,
+    window_end: datetime,
+    docprocessing_priority: OnyxCeleryPriority,
+) -> tuple[ConnectorCheckpoint, int]:
+    """Get the checkpoint to start from and the batch number to continue at.
+
+    Batches left in the file store are re-issued when we resume from a
+    checkpoint, and dropped otherwise.
+    """
+    last_batch_num = 0
+
+    # don't use a checkpoint if we're explicitly indexing from
+    # the beginning in order to avoid weird interactions between
+    # checkpointing / failure handling
+    # OR
+    # if the last attempt was successful
+    with time_stage(IndexAttemptStage.CHECKPOINT_LOAD, index_attempt_id):
+        if index_attempt.from_beginning or (
+            most_recent_attempt and most_recent_attempt.status.is_successful()
+        ):
+            logger.info(
+                "Cleaning up all old batches for index attempt %s before starting new run",
+                index_attempt_id,
+            )
+            batch_storage.cleanup_all_batches()
+            checkpoint = connector_runner.connector.build_dummy_checkpoint()
+        else:
+            logger.info(
+                "Getting latest valid checkpoint for index attempt %s",
+                index_attempt_id,
+            )
+            checkpoint, resuming_from_checkpoint = get_latest_valid_checkpoint(
+                db_session=db_session,
+                cc_pair_id=cc_pair_id,
+                search_settings_id=index_attempt.search_settings_id,
+                window_start=window_start,
+                window_end=window_end,
+                connector=connector_runner.connector,
+            )
+
+            # checkpoint resumption OR the connector already finished.
+            if (
+                isinstance(connector_runner.connector, CheckpointedConnector)
+                and resuming_from_checkpoint
+            ) or (
+                most_recent_attempt
+                and most_recent_attempt.total_batches is not None
+                and not checkpoint.has_more
+            ):
+                reissued_batch_count, completed_batches = reissue_old_batches(
+                    batch_storage,
+                    index_attempt_id,
+                    cc_pair_id,
+                    tenant_id,
+                    app,
+                    most_recent_attempt,
+                    docprocessing_priority,
+                )
+                last_batch_num = reissued_batch_count + completed_batches
+                index_attempt.completed_batches = completed_batches
+                db_session.commit()
+            else:
+                logger.info(
+                    "Cleaning up all batches for index attempt %s before starting new run",
+                    index_attempt_id,
+                )
+                # for non-checkpointed connectors, throw out batches from previous unsuccessful attempts
+                # because we'll be getting those documents again anyways.
+                batch_storage.cleanup_all_batches()
+
+    return checkpoint, last_batch_num
+
+
+def _check_stop_signals(
+    callback: IndexingHeartbeatInterface | None,
+    search_settings_status: IndexModelStatus,
+    cc_pair_id: int,
+    index_attempt_id: int,
+) -> None:
+    """Raise if the run must stop: heartbeat signal, paused connector, or a
+    canceled/failed index attempt."""
+    # Check if connector is disabled mid run and stop if so unless it's the secondary
+    # index being built. We want to populate it even for paused connectors
+    # Often paused connectors are sources that aren't updated frequently but the
+    # contents still need to be initially pulled.
+    if callback and callback.should_stop():
+        raise ConnectorStopSignal("Connector stop signal detected")
+
+    # will exception if the connector/index attempt is marked as paused/failed
+    with get_session_with_current_tenant() as db_session_tmp:
+        _check_connector_and_attempt_status(
+            db_session_tmp,
+            cc_pair_id,
+            search_settings_status,
+            index_attempt_id,
+        )
+
+
+def _record_connector_failure(
+    failure: ConnectorFailure,
+    db_connector: Connector,
+    cc_pair_id: int,
+    index_attempt_id: int,
+    tenant_id: str,
+) -> None:
+    """Report a connector-level failure to Sentry and save it to the DB."""
+    if failure.exception is not None:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("stage", "connector_fetch")
+            scope.set_tag("connector_source", db_connector.source.value)
+            scope.set_tag("cc_pair_id", str(cc_pair_id))
+            scope.set_tag("index_attempt_id", str(index_attempt_id))
+            scope.set_tag("tenant_id", tenant_id)
+            if failure.failed_document:
+                scope.set_tag("doc_id", failure.failed_document.document_id)
+            if failure.failed_entity:
+                scope.set_tag("entity_id", failure.failed_entity.entity_id)
+            scope.fingerprint = [
+                "connector-fetch-failure",
+                db_connector.source.value,
+                type(failure.exception).__name__,
+            ]
+            sentry_sdk.capture_exception(failure.exception)
+
+    with get_session_with_current_tenant() as db_session:
+        create_index_attempt_error(
+            index_attempt_id,
+            cc_pair_id,
+            failure,
+            db_session,
+        )
+
+
+def _resolve_parent_hierarchy_node_ids(
+    redis_client: TenantRedisClient,
+    source: DocumentSource,
+    doc_batch: list[Document],
+) -> None:
+    """Resolve parent_hierarchy_raw_node_id to parent_hierarchy_node_id using the
+    Redis cache (just populated from the hierarchy nodes batch)."""
+    with get_session_with_current_tenant() as db_session_tmp:
+        source_node_id = get_source_node_id_from_cache(
+            redis_client, db_session_tmp, source
+        )
+    for doc in doc_batch:
+        if doc.parent_hierarchy_raw_node_id is not None:
+            node_id, found = get_node_id_from_raw_id(
+                redis_client,
+                source,
+                doc.parent_hierarchy_raw_node_id,
+            )
+            doc.parent_hierarchy_node_id = node_id if found else source_node_id
+        else:
+            doc.parent_hierarchy_node_id = source_node_id
+
+
+def _log_document_batch(doc_batch: list[Document]) -> None:
+    """Log the batch contents and warn about oversized documents."""
+    batch_description = []
+
+    for doc in doc_batch:
+        batch_description.append(doc.to_short_descriptor())
+
+        doc_size = 0
+        for section in doc.sections:
+            if isinstance(section, TextSection) and section.text is not None:
+                doc_size += len(section.text)
+
+        if doc_size > INDEXING_SIZE_WARNING_THRESHOLD:
+            logger.warning(
+                "Document size: doc='%s' size=%s threshold=%s",
+                doc.to_short_descriptor(),
+                doc_size,
+                INDEXING_SIZE_WARNING_THRESHOLD,
+            )
+
+    logger.debug("Indexing batch of documents: %s", batch_description)
+
+
+def _queue_document_batch(
+    app: Celery,
+    batch_storage: DocumentBatchStorage,
+    doc_batch: list[Document],
+    batch_num: int,
+    index_attempt_id: int,
+    cc_pair_id: int,
+    tenant_id: str,
+    docprocessing_priority: OnyxCeleryPriority,
+) -> None:
+    """Store the batch in the file store and queue its docprocessing task."""
+    # Store and queue docprocessing
+    with time_stage(IndexAttemptStage.DOC_BATCH_STORE, index_attempt_id):
+        batch_storage.store_batch(batch_num, doc_batch)
+
+    # Create processing task data. ``enqueue_time_ms`` is captured
+    # right before send so QUEUE_WAIT measures the broker latency
+    # and any docprocessing scheduling delay (not our own bookkeeping).
+    processing_batch_data = {
+        "index_attempt_id": index_attempt_id,
+        "cc_pair_id": cc_pair_id,
+        "tenant_id": tenant_id,
+        "batch_num": batch_num,  # 0-indexed
+        "enqueue_time_ms": int(time.time() * 1000),
+    }
+
+    # Queue document processing task
+    with time_stage(IndexAttemptStage.DOC_BATCH_ENQUEUE, index_attempt_id):
+        try:
+            RedisDocprocessing(
+                index_attempt_id,
+                get_redis_client(tenant_id=tenant_id),
+            ).incr_pending()
+        except Exception:
+            logger.debug(
+                "Failed to increment pending counter for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
+        app.send_task(
+            OnyxCeleryTask.DOCPROCESSING_TASK,
+            kwargs=processing_batch_data,
+            queue=OnyxCeleryQueues.DOCPROCESSING,
+            priority=docprocessing_priority,
+        )
+
+
+def _prepare_and_queue_document_batch(
+    app: Celery,
+    document_batch: list[Document],
+    db_connector: Connector,
+    redis_client: TenantRedisClient,
+    batch_storage: DocumentBatchStorage,
+    memory_tracer: MemoryTracer,
+    batch_num: int,
+    index_attempt_id: int,
+    cc_pair_id: int,
+    tenant_id: str,
+    docprocessing_priority: OnyxCeleryPriority,
+) -> list[Document]:
+    """Clean one document batch, store it, and queue it for docprocessing.
+
+    Returns the cleaned batch.
+    """
+    # Clean documents and create batch
+    doc_batch_cleaned = strip_null_characters(document_batch)
+
+    _resolve_parent_hierarchy_node_ids(
+        redis_client, db_connector.source, doc_batch_cleaned
+    )
+    _log_document_batch(doc_batch_cleaned)
+    memory_tracer.increment_and_maybe_trace()
+    _queue_document_batch(
+        app,
+        batch_storage,
+        doc_batch_cleaned,
+        batch_num,
+        index_attempt_id,
+        cc_pair_id,
+        tenant_id,
+        docprocessing_priority,
+    )
+    return doc_batch_cleaned
+
+
+def _check_and_save_checkpoint(
+    checkpoint: ConnectorCheckpoint,
+    batch_num: int,
+    index_attempt_id: int,
+) -> None:
+    """Save the checkpoint, checking its size every so often.
+
+    NOTE: checkpointing is used to track which batches have been sent to the
+    filestore, NOT which batches have been fully indexed as it used to be.
+    """
+    # Check checkpoint size periodically
+    CHECKPOINT_SIZE_CHECK_INTERVAL = 100
+    if batch_num % CHECKPOINT_SIZE_CHECK_INTERVAL == 0:
+        check_checkpoint_size(checkpoint)
+
+    # Save latest checkpoint
+    with get_session_with_current_tenant() as db_session:
+        save_checkpoint(
+            db_session=db_session,
+            index_attempt_id=index_attempt_id,
+            checkpoint=checkpoint,
+        )
+
+
+def _handle_validation_error(
+    error: ConnectorValidationError,
+    index_attempt: IndexAttempt | None,
+    db_connector: Connector,
+    db_credential: Credential,
+    is_primary: bool,
+    cc_pair_id: int,
+    index_attempt_id: int,
+) -> None:
+    """Cancel the attempt, and mark the CC Pair invalid after repeated failures.
+
+    On validation errors during indexing, we want to cancel the indexing attempt
+    and mark the CCPair as invalid. This prevents the connector from being
+    used in the future until the credentials are updated.
+    """
+    with get_session_with_current_tenant() as db_session_temp:
+        logger.exception(
+            "Marking attempt %s as canceled due to validation error.",
+            index_attempt_id,
+        )
+        mark_attempt_canceled(
+            index_attempt_id,
+            db_session_temp,
+            reason=f"{CONNECTOR_VALIDATION_ERROR_MESSAGE_PREFIX}{str(error)}",
+        )
+
+        if is_primary:
+            if not index_attempt:
+                # should always be set by now
+                raise RuntimeError("Should never happen.")
+
+            VALIDATION_ERROR_THRESHOLD = 5
+
+            recent_index_attempts = get_recent_completed_attempts_for_cc_pair(
+                cc_pair_id=cc_pair_id,
+                search_settings_id=index_attempt.search_settings_id,
+                limit=VALIDATION_ERROR_THRESHOLD,
+                db_session=db_session_temp,
+            )
+            num_validation_errors = len(
+                [
+                    attempt
+                    for attempt in recent_index_attempts
+                    if attempt.error_msg
+                    and attempt.error_msg.startswith(
+                        CONNECTOR_VALIDATION_ERROR_MESSAGE_PREFIX
+                    )
+                ]
+            )
+
+            if num_validation_errors >= VALIDATION_ERROR_THRESHOLD:
+                logger.warning(
+                    "Connector %s has %s consecutive validation errors. Marking the CC Pair as invalid.",
+                    db_connector.id,
+                    num_validation_errors,
+                )
+                update_connector_credential_pair(
+                    db_session=db_session_temp,
+                    connector_id=db_connector.id,
+                    credential_id=db_credential.id,
+                    status=ConnectorCredentialPairStatus.INVALID,
+                )
+                invalid_name = db_connector.name or f"cc_pair_{cc_pair_id}"
+                notify_admins_of_connector_alert(
+                    db_session=db_session_temp,
+                    cc_pair_id=cc_pair_id,
+                    notif_type=NotificationType.CONNECTOR_INVALID,
+                    title=f"Connector '{invalid_name}' has been marked invalid",
+                    description=(
+                        f"The {db_connector.source.value} connector failed "
+                        "validation repeatedly, usually due to expired "
+                        "credentials or revoked access. Update its "
+                        "credentials to resume indexing."
+                    ),
+                )
+
+
+def _mark_attempt_failed_if_not_terminal(
+    index_attempt_id: int,
+    error: Exception,
+) -> None:
+    """Mark the attempt as failed, unless it is already in a terminal state.
+
+    Re-raises `error` without touching the attempt if it is already terminal.
+    """
+    with get_session_with_current_tenant() as db_session_temp:
+        # don't overwrite an attempt already in a terminal state for
+        # another reason (e.g. INTERRUPTED by a worker shutdown)
+        index_attempt = get_index_attempt(db_session_temp, index_attempt_id)
+        if index_attempt and index_attempt.status.is_terminal():
+            logger.info(
+                "Attempt %s is already terminal, skipping marking as failed.",
+                index_attempt_id,
+            )
+            raise error
+
+        # PERSISTENT_INDEXING deliberately does NOT catch unhandled
+        # connector-generator exceptions: we can't isolate the failing
+        # entity from a black-box raise, and silently landing the
+        # attempt as COMPLETED_WITH_ERRORS would let the system advance
+        # past potentially-missed source data. Operators need a FAILED
+        # signal here to triage. Threshold disable + docprocessing
+        # per-batch recovery still apply.
+        mark_attempt_failed(
+            index_attempt_id,
+            db_session_temp,
+            failure_reason=str(error),
+            full_exception_trace=traceback.format_exc(),
+        )
+
+
 def connector_document_extraction(
     app: Celery,
     index_attempt_id: int,
@@ -472,7 +945,6 @@ def connector_document_extraction(
     memory_tracer.start()
 
     index_attempt = None
-    last_batch_num = 0  # used to continue from checkpointing
     # comes from _run_indexing
     with get_session_with_current_tenant() as db_session:
         index_attempt = get_index_attempt(
@@ -532,51 +1004,13 @@ def connector_document_extraction(
             and (from_beginning or not has_successful_attempt)
         )
 
-        # Set up time windows for polling. A port-flow FUTURE's resume cursor comes from its
-        # synthetic seed (get_last_successful_... keeps ignore_synthetic_seed=False by default).
-        last_successful_index_poll_range_end = (
-            earliest_index_time
-            if from_beginning
-            else get_last_successful_attempt_poll_range_end(
-                cc_pair_id=cc_pair_id,
-                earliest_index=earliest_index_time,
-                search_settings=index_attempt.search_settings,
-                db_session=db_session,
-            )
+        window_start, window_end, most_recent_attempt = _compute_poll_window(
+            db_session=db_session,
+            index_attempt=index_attempt,
+            search_settings=index_attempt.search_settings,
+            cc_pair_id=cc_pair_id,
+            earliest_index_time=earliest_index_time,
         )
-
-        if last_successful_index_poll_range_end > POLL_CONNECTOR_OFFSET:
-            window_start = datetime.fromtimestamp(
-                last_successful_index_poll_range_end, tz=timezone.utc
-            ) - timedelta(minutes=POLL_CONNECTOR_OFFSET)
-        else:
-            # don't go into "negative" time if we've never indexed before
-            window_start = datetime.fromtimestamp(0, tz=timezone.utc)
-
-        most_recent_attempt = next(
-            iter(
-                get_recent_completed_attempts_for_cc_pair(
-                    cc_pair_id=cc_pair_id,
-                    search_settings_id=index_attempt.search_settings_id,
-                    db_session=db_session,
-                    limit=1,
-                )
-            ),
-            None,
-        )
-
-        # if the last attempt didn't complete cleanly, reuse the same window. This
-        # is necessary to ensure correctness with checkpointing. If we don't do this,
-        # things like new slack channels could be missed (since existing slack
-        # channels are cached as part of the checkpoint).
-        if (
-            most_recent_attempt
-            and most_recent_attempt.poll_range_end
-            and most_recent_attempt.status.should_reuse_checkpoint()
-        ):
-            window_end = most_recent_attempt.poll_range_end
-        else:
-            window_end = datetime.now(tz=timezone.utc)
 
         # set time range in db
         index_attempt.poll_range_start = window_start
@@ -596,64 +1030,20 @@ def connector_document_extraction(
             raw_file_callback=raw_file_callback,
         )
 
-        # don't use a checkpoint if we're explicitly indexing from
-        # the beginning in order to avoid weird interactions between
-        # checkpointing / failure handling
-        # OR
-        # if the last attempt was successful
-        with time_stage(IndexAttemptStage.CHECKPOINT_LOAD, index_attempt_id):
-            if index_attempt.from_beginning or (
-                most_recent_attempt and most_recent_attempt.status.is_successful()
-            ):
-                logger.info(
-                    "Cleaning up all old batches for index attempt %s before starting new run",
-                    index_attempt_id,
-                )
-                batch_storage.cleanup_all_batches()
-                checkpoint = connector_runner.connector.build_dummy_checkpoint()
-            else:
-                logger.info(
-                    "Getting latest valid checkpoint for index attempt %s",
-                    index_attempt_id,
-                )
-                checkpoint, resuming_from_checkpoint = get_latest_valid_checkpoint(
-                    db_session=db_session,
-                    cc_pair_id=cc_pair_id,
-                    search_settings_id=index_attempt.search_settings_id,
-                    window_start=window_start,
-                    window_end=window_end,
-                    connector=connector_runner.connector,
-                )
-
-                # checkpoint resumption OR the connector already finished.
-                if (
-                    isinstance(connector_runner.connector, CheckpointedConnector)
-                    and resuming_from_checkpoint
-                ) or (
-                    most_recent_attempt
-                    and most_recent_attempt.total_batches is not None
-                    and not checkpoint.has_more
-                ):
-                    reissued_batch_count, completed_batches = reissue_old_batches(
-                        batch_storage,
-                        index_attempt_id,
-                        cc_pair_id,
-                        tenant_id,
-                        app,
-                        most_recent_attempt,
-                        docprocessing_priority,
-                    )
-                    last_batch_num = reissued_batch_count + completed_batches
-                    index_attempt.completed_batches = completed_batches
-                    db_session.commit()
-                else:
-                    logger.info(
-                        "Cleaning up all batches for index attempt %s before starting new run",
-                        index_attempt_id,
-                    )
-                    # for non-checkpointed connectors, throw out batches from previous unsuccessful attempts
-                    # because we'll be getting those documents again anyways.
-                    batch_storage.cleanup_all_batches()
+        checkpoint, last_batch_num = _load_checkpoint(
+            db_session=db_session,
+            app=app,
+            index_attempt=index_attempt,
+            connector_runner=connector_runner,
+            batch_storage=batch_storage,
+            most_recent_attempt=most_recent_attempt,
+            index_attempt_id=index_attempt_id,
+            cc_pair_id=cc_pair_id,
+            tenant_id=tenant_id,
+            window_start=window_start,
+            window_end=window_end,
+            docprocessing_priority=docprocessing_priority,
+        )
 
         # Save initial checkpoint
         save_checkpoint(
@@ -690,53 +1080,23 @@ def connector_document_extraction(
             ) in _timed_connector_runs(
                 connector_runner.run(checkpoint), index_attempt_id
             ):
-                # Check if connector is disabled mid run and stop if so unless it's the secondary
-                # index being built. We want to populate it even for paused connectors
-                # Often paused connectors are sources that aren't updated frequently but the
-                # contents still need to be initially pulled.
-                if callback and callback.should_stop():
-                    raise ConnectorStopSignal("Connector stop signal detected")
-
-                # will exception if the connector/index attempt is marked as paused/failed
-                with get_session_with_current_tenant() as db_session_tmp:
-                    _check_connector_and_attempt_status(
-                        db_session_tmp,
-                        cc_pair_id,
-                        index_attempt.search_settings.status,
-                        index_attempt_id,
-                    )
+                _check_stop_signals(
+                    callback,
+                    index_attempt.search_settings.status,
+                    cc_pair_id,
+                    index_attempt_id,
+                )
 
                 # save record of any failures at the connector level
                 if failure is not None:
-                    if failure.exception is not None:
-                        with sentry_sdk.new_scope() as scope:
-                            scope.set_tag("stage", "connector_fetch")
-                            scope.set_tag("connector_source", db_connector.source.value)
-                            scope.set_tag("cc_pair_id", str(cc_pair_id))
-                            scope.set_tag("index_attempt_id", str(index_attempt_id))
-                            scope.set_tag("tenant_id", tenant_id)
-                            if failure.failed_document:
-                                scope.set_tag(
-                                    "doc_id", failure.failed_document.document_id
-                                )
-                            if failure.failed_entity:
-                                scope.set_tag(
-                                    "entity_id", failure.failed_entity.entity_id
-                                )
-                            scope.fingerprint = [
-                                "connector-fetch-failure",
-                                db_connector.source.value,
-                                type(failure.exception).__name__,
-                            ]
-                            sentry_sdk.capture_exception(failure.exception)
                     total_failures += 1
-                    with get_session_with_current_tenant() as db_session:
-                        create_index_attempt_error(
-                            index_attempt_id,
-                            cc_pair_id,
-                            failure,
-                            db_session,
-                        )
+                    _record_connector_failure(
+                        failure,
+                        db_connector,
+                        cc_pair_id,
+                        index_attempt_id,
+                        tenant_id,
+                    )
                     _check_failure_threshold(
                         total_failures, document_count, batch_num, failure
                     )
@@ -767,86 +1127,19 @@ def connector_document_extraction(
                 if not document_batch:
                     continue
 
-                # Clean documents and create batch
-                doc_batch_cleaned = strip_null_characters(document_batch)
-
-                # Resolve parent_hierarchy_raw_node_id to parent_hierarchy_node_id
-                # using the Redis cache (just populated from hierarchy nodes batch)
-                with get_session_with_current_tenant() as db_session_tmp:
-                    source_node_id = get_source_node_id_from_cache(
-                        redis_client, db_session_tmp, db_connector.source
-                    )
-                for doc in doc_batch_cleaned:
-                    if doc.parent_hierarchy_raw_node_id is not None:
-                        node_id, found = get_node_id_from_raw_id(
-                            redis_client,
-                            db_connector.source,
-                            doc.parent_hierarchy_raw_node_id,
-                        )
-                        doc.parent_hierarchy_node_id = (
-                            node_id if found else source_node_id
-                        )
-                    else:
-                        doc.parent_hierarchy_node_id = source_node_id
-
-                batch_description = []
-
-                for doc in doc_batch_cleaned:
-                    batch_description.append(doc.to_short_descriptor())
-
-                    doc_size = 0
-                    for section in doc.sections:
-                        if (
-                            isinstance(section, TextSection)
-                            and section.text is not None
-                        ):
-                            doc_size += len(section.text)
-
-                    if doc_size > INDEXING_SIZE_WARNING_THRESHOLD:
-                        logger.warning(
-                            "Document size: doc='%s' size=%s threshold=%s",
-                            doc.to_short_descriptor(),
-                            doc_size,
-                            INDEXING_SIZE_WARNING_THRESHOLD,
-                        )
-
-                logger.debug("Indexing batch of documents: %s", batch_description)
-                memory_tracer.increment_and_maybe_trace()
-
-                # Store and queue docprocessing
-                with time_stage(IndexAttemptStage.DOC_BATCH_STORE, index_attempt_id):
-                    batch_storage.store_batch(batch_num, doc_batch_cleaned)
-
-                # Create processing task data. ``enqueue_time_ms`` is captured
-                # right before send so QUEUE_WAIT measures the broker latency
-                # and any docprocessing scheduling delay (not our own bookkeeping).
-                processing_batch_data = {
-                    "index_attempt_id": index_attempt_id,
-                    "cc_pair_id": cc_pair_id,
-                    "tenant_id": tenant_id,
-                    "batch_num": batch_num,  # 0-indexed
-                    "enqueue_time_ms": int(time.time() * 1000),
-                }
-
-                # Queue document processing task
-                with time_stage(IndexAttemptStage.DOC_BATCH_ENQUEUE, index_attempt_id):
-                    try:
-                        RedisDocprocessing(
-                            index_attempt_id,
-                            get_redis_client(tenant_id=tenant_id),
-                        ).incr_pending()
-                    except Exception:
-                        logger.debug(
-                            "Failed to increment pending counter for attempt %s",
-                            index_attempt_id,
-                            exc_info=True,
-                        )
-                    app.send_task(
-                        OnyxCeleryTask.DOCPROCESSING_TASK,
-                        kwargs=processing_batch_data,
-                        queue=OnyxCeleryQueues.DOCPROCESSING,
-                        priority=docprocessing_priority,
-                    )
+                doc_batch_cleaned = _prepare_and_queue_document_batch(
+                    app,
+                    document_batch,
+                    db_connector,
+                    redis_client,
+                    batch_storage,
+                    memory_tracer,
+                    batch_num,
+                    index_attempt_id,
+                    cc_pair_id,
+                    tenant_id,
+                    docprocessing_priority,
+                )
 
                 batch_num += 1
                 total_doc_batches_queued += 1
@@ -859,21 +1152,7 @@ def connector_document_extraction(
                     index_attempt_id,
                 )
 
-            # Check checkpoint size periodically
-            CHECKPOINT_SIZE_CHECK_INTERVAL = 100
-            if batch_num % CHECKPOINT_SIZE_CHECK_INTERVAL == 0:
-                check_checkpoint_size(checkpoint)
-
-            # Save latest checkpoint
-            # NOTE: checkpointing is used to track which batches have
-            # been sent to the filestore, NOT which batches have been fully indexed
-            # as it used to be.
-            with get_session_with_current_tenant() as db_session:
-                save_checkpoint(
-                    db_session=db_session,
-                    index_attempt_id=index_attempt_id,
-                    checkpoint=checkpoint,
-                )
+            _check_and_save_checkpoint(checkpoint, batch_num, index_attempt_id)
 
         elapsed_time = time.monotonic() - start_time
 
@@ -902,69 +1181,15 @@ def connector_document_extraction(
         # while docfetching will continue from the saved checkpoint if one exists
 
         if isinstance(e, ConnectorValidationError):
-            # On validation errors during indexing, we want to cancel the indexing attempt
-            # and mark the CCPair as invalid. This prevents the connector from being
-            # used in the future until the credentials are updated.
-            with get_session_with_current_tenant() as db_session_temp:
-                logger.exception(
-                    "Marking attempt %s as canceled due to validation error.",
-                    index_attempt_id,
-                )
-                mark_attempt_canceled(
-                    index_attempt_id,
-                    db_session_temp,
-                    reason=f"{CONNECTOR_VALIDATION_ERROR_MESSAGE_PREFIX}{str(e)}",
-                )
-
-                if is_primary:
-                    if not index_attempt:
-                        # should always be set by now
-                        raise RuntimeError("Should never happen.")
-
-                    VALIDATION_ERROR_THRESHOLD = 5
-
-                    recent_index_attempts = get_recent_completed_attempts_for_cc_pair(
-                        cc_pair_id=cc_pair_id,
-                        search_settings_id=index_attempt.search_settings_id,
-                        limit=VALIDATION_ERROR_THRESHOLD,
-                        db_session=db_session_temp,
-                    )
-                    num_validation_errors = len(
-                        [
-                            index_attempt
-                            for index_attempt in recent_index_attempts
-                            if index_attempt.error_msg
-                            and index_attempt.error_msg.startswith(
-                                CONNECTOR_VALIDATION_ERROR_MESSAGE_PREFIX
-                            )
-                        ]
-                    )
-
-                    if num_validation_errors >= VALIDATION_ERROR_THRESHOLD:
-                        logger.warning(
-                            "Connector %s has %s consecutive validation errors. Marking the CC Pair as invalid.",
-                            db_connector.id,
-                            num_validation_errors,
-                        )
-                        update_connector_credential_pair(
-                            db_session=db_session_temp,
-                            connector_id=db_connector.id,
-                            credential_id=db_credential.id,
-                            status=ConnectorCredentialPairStatus.INVALID,
-                        )
-                        invalid_name = db_connector.name or f"cc_pair_{cc_pair_id}"
-                        notify_admins_of_connector_alert(
-                            db_session=db_session_temp,
-                            cc_pair_id=cc_pair_id,
-                            notif_type=NotificationType.CONNECTOR_INVALID,
-                            title=f"Connector '{invalid_name}' has been marked invalid",
-                            description=(
-                                f"The {db_connector.source.value} connector failed "
-                                "validation repeatedly, usually due to expired "
-                                "credentials or revoked access. Update its "
-                                "credentials to resume indexing."
-                            ),
-                        )
+            _handle_validation_error(
+                e,
+                index_attempt,
+                db_connector,
+                db_credential,
+                is_primary,
+                cc_pair_id,
+                index_attempt_id,
+            )
             raise e
         elif isinstance(e, ConnectorStopSignal):
             with get_session_with_current_tenant() as db_session_temp:
@@ -979,30 +1204,7 @@ def connector_document_extraction(
                 )
 
         else:
-            with get_session_with_current_tenant() as db_session_temp:
-                # don't overwrite an attempt already in a terminal state for
-                # another reason (e.g. INTERRUPTED by a worker shutdown)
-                index_attempt = get_index_attempt(db_session_temp, index_attempt_id)
-                if index_attempt and index_attempt.status.is_terminal():
-                    logger.info(
-                        "Attempt %s is already terminal, skipping marking as failed.",
-                        index_attempt_id,
-                    )
-                    raise e
-
-                # PERSISTENT_INDEXING deliberately does NOT catch unhandled
-                # connector-generator exceptions: we can't isolate the failing
-                # entity from a black-box raise, and silently landing the
-                # attempt as COMPLETED_WITH_ERRORS would let the system advance
-                # past potentially-missed source data. Operators need a FAILED
-                # signal here to triage. Threshold disable + docprocessing
-                # per-batch recovery still apply.
-                mark_attempt_failed(
-                    index_attempt_id,
-                    db_session_temp,
-                    failure_reason=str(e),
-                    full_exception_trace=traceback.format_exc(),
-                )
+            _mark_attempt_failed_if_not_terminal(index_attempt_id, e)
 
             raise e
 

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -1,7 +1,8 @@
 import json
 import time
 from collections.abc import Callable
-from typing import Any, Literal
+from functools import partial
+from typing import Any, Literal, NamedTuple
 
 from onyx.chat.chat_state import ChatStateContainer
 from onyx.chat.chat_utils import (
@@ -377,6 +378,197 @@ def _build_project_message(
     return messages
 
 
+def _marker_replay_tokens(token_counter: Callable[[str], int] | None) -> int:
+    """Token cost of the text marker that replaces a single replayed image."""
+    sample_marker = NON_VISION_IMAGE_MARKER.format(file_id="0" * 36)
+    return (
+        token_counter(sample_marker)
+        if token_counter
+        else _NON_VISION_MARKER_TOKEN_FALLBACK
+    )
+
+
+def _replay_token_count(
+    msg: ChatMessageSimple,
+    *,
+    image_files_replayed_as_markers: bool,
+    marker_tokens: int,
+) -> int:
+    """Token cost of a message as it is actually replayed to the model."""
+    if not image_files_replayed_as_markers:
+        return msg.token_count
+    # Charge markers for every IMAGE entry, including ones whose stored
+    # token contribution is zero (project/context images are never
+    # counted) — the marker text is still sent for them.
+    num_images = sum(
+        1 for f in msg.image_files or [] if f.file_type == ChatFileType.IMAGE
+    )
+    if not num_images:
+        return msg.token_count
+    return max(0, msg.token_count - msg.image_token_count) + num_images * marker_tokens
+
+
+def _filter_to_last_n_user_messages(
+    simple_chat_history: list[ChatMessageSimple],
+    last_n_user_messages: int | None,
+) -> list[ChatMessageSimple]:
+    """Keep only the messages from the last N user messages onwards."""
+    if last_n_user_messages is None:
+        return simple_chat_history
+
+    user_msg_indices = [
+        i
+        for i, msg in enumerate(simple_chat_history)
+        if msg.message_type == MessageType.USER
+    ]
+    if not user_msg_indices:
+        raise ValueError("No user message found in simple_chat_history")
+
+    # If we have more than n user messages, keep only the last n. For example,
+    # if last_n_user_messages=2, we start at the 2nd-to-last user message.
+    if len(user_msg_indices) <= last_n_user_messages:
+        return simple_chat_history
+    return simple_chat_history[user_msg_indices[-last_n_user_messages] :]
+
+
+def _split_at_last_user_message(
+    simple_chat_history: list[ChatMessageSimple],
+) -> tuple[list[ChatMessageSimple], ChatMessageSimple, list[ChatMessageSimple]]:
+    """Split the history around the last USER message.
+
+    The history may contain tool calls and responses after the last user
+    message. Returns the messages before it, the message itself, and the
+    messages after it.
+    """
+    last_user_msg_index = None
+    for i in range(len(simple_chat_history) - 1, -1, -1):
+        if simple_chat_history[i].message_type == MessageType.USER:
+            last_user_msg_index = i
+            break
+
+    if last_user_msg_index is None:
+        raise ValueError("No user message found in simple_chat_history")
+
+    return (
+        simple_chat_history[:last_user_msg_index],
+        simple_chat_history[last_user_msg_index],
+        simple_chat_history[last_user_msg_index + 1 :],
+    )
+
+
+def _truncate_history_to_budget(
+    history_before_last_user: list[ChatMessageSimple],
+    remaining_budget: int,
+    replay_token_count: Callable[[ChatMessageSimple], int],
+) -> tuple[list[ChatMessageSimple], int]:
+    """Keep the newest messages that fit the budget and drop the older ones.
+
+    Returns the kept messages and their total replay token count.
+    """
+    kept: list[ChatMessageSimple] = []
+    current_token_count = 0
+
+    for msg in reversed(history_before_last_user):
+        msg_tokens = replay_token_count(msg)
+        if current_token_count + msg_tokens <= remaining_budget:
+            msg.should_cache = True
+            kept.insert(0, msg)
+            current_token_count += msg_tokens
+        else:
+            # Can't fit this message, stop truncating.
+            # This message and everything older is dropped.
+            break
+
+    return kept, current_token_count
+
+
+def _collect_dropped_file_ids(
+    history_before_last_user: list[ChatMessageSimple],
+    kept_history: list[ChatMessageSimple],
+    simple_chat_history: list[ChatMessageSimple],
+    all_injected_file_metadata: dict[str, FileToolMetadata] | None,
+) -> list[str]:
+    """Collect file_ids of files the truncated history no longer contains.
+
+    The truncation keeps the most recent messages, so the dropped ones are at
+    the start of the original list up to (len(history) - len(kept)).
+    """
+    num_dropped = len(history_before_last_user) - len(kept_history)
+    dropped_file_ids: list[str] = [
+        msg.file_id
+        for msg in history_before_last_user[:num_dropped]
+        if msg.file_id is not None
+    ]
+
+    # Also treat "orphaned" metadata entries as dropped -- these are files
+    # from messages removed by summary truncation (before convert_chat_history
+    # ran), so no ChatMessageSimple was ever tagged with their file_id.
+    if all_injected_file_metadata:
+        surviving_file_ids = {
+            msg.file_id for msg in simple_chat_history if msg.file_id is not None
+        }
+        for fid in all_injected_file_metadata:
+            if fid not in surviving_file_ids and fid not in dropped_file_ids:
+                dropped_file_ids.append(fid)
+
+    return dropped_file_ids
+
+
+def _build_forgotten_files_message(
+    dropped_file_ids: list[str],
+    all_injected_file_metadata: dict[str, FileToolMetadata] | None,
+    token_counter: Callable[[str], int] | None,
+    kept_history: list[ChatMessageSimple],
+    kept_token_count: int,
+    remaining_budget: int,
+    replay_token_count: Callable[[ChatMessageSimple], int],
+) -> ChatMessageSimple | None:
+    """Build the metadata message for file messages dropped from the history.
+
+    Only built when we have metadata for the dropped files, which means the
+    FileReaderTool is available. Evicts further messages from ``kept_history``
+    in place when the metadata message does not fit the budget.
+    """
+    if not (dropped_file_ids and all_injected_file_metadata and token_counter):
+        return None
+
+    forgotten_meta = [
+        all_injected_file_metadata[fid]
+        for fid in dropped_file_ids
+        if fid in all_injected_file_metadata
+    ]
+    if not forgotten_meta:
+        return None
+
+    logger.debug(
+        "FileReader: building forgotten-files message for %s",
+        [(m.file_id, m.filename) for m in forgotten_meta],
+    )
+    forgotten_files_message = _create_file_tool_metadata_message(
+        forgotten_meta, token_counter
+    )
+    # Shrink the remaining budget. If the metadata message doesn't
+    # fit we may need to drop more history messages.
+    remaining_budget -= forgotten_files_message.token_count
+    while kept_history and kept_token_count > remaining_budget:
+        evicted = kept_history.pop(0)
+        kept_token_count -= replay_token_count(evicted)
+        # If the evicted message is itself a file, add it to the
+        # forgotten metadata (it's now dropped too).
+        if (
+            evicted.file_id is not None
+            and evicted.file_id in all_injected_file_metadata
+            and evicted.file_id not in {m.file_id for m in forgotten_meta}
+        ):
+            forgotten_meta.append(all_injected_file_metadata[evicted.file_id])
+            # Rebuild the message with the new entry
+            forgotten_files_message = _create_file_tool_metadata_message(
+                forgotten_meta, token_counter
+            )
+
+    return forgotten_files_message
+
+
 def construct_message_history(
     system_prompt: ChatMessageSimple | None,
     custom_agent_prompt: ChatMessageSimple | None,
@@ -399,29 +591,14 @@ def construct_message_history(
     # input, translate_history_to_llm_format sends short text markers instead
     # of the images, so charging the stored image token cost would evict
     # history that actually fits.
-    marker_tokens = 0
-    if image_files_replayed_as_markers:
-        sample_marker = NON_VISION_IMAGE_MARKER.format(file_id="0" * 36)
-        marker_tokens = (
-            token_counter(sample_marker)
-            if token_counter
-            else _NON_VISION_MARKER_TOKEN_FALLBACK
-        )
-
-    def _replay_token_count(msg: ChatMessageSimple) -> int:
-        if not image_files_replayed_as_markers:
-            return msg.token_count
-        # Charge markers for every IMAGE entry, including ones whose stored
-        # token contribution is zero (project/context images are never
-        # counted) — the marker text is still sent for them.
-        num_images = sum(
-            1 for f in msg.image_files or [] if f.file_type == ChatFileType.IMAGE
-        )
-        if not num_images:
-            return msg.token_count
-        return (
-            max(0, msg.token_count - msg.image_token_count) + num_images * marker_tokens
-        )
+    marker_tokens = (
+        _marker_replay_tokens(token_counter) if image_files_replayed_as_markers else 0
+    )
+    replay_token_count = partial(
+        _replay_token_count,
+        image_files_replayed_as_markers=image_files_replayed_as_markers,
+        marker_tokens=marker_tokens,
+    )
 
     # Build the project / file-metadata messages up front so we can use their
     # actual token counts for the budget.
@@ -453,49 +630,23 @@ def construct_message_history(
         return result
 
     # If last_n_user_messages is set, filter history to only include the last n user messages
-    if last_n_user_messages is not None:
-        # Find all user message indices
-        user_msg_indices = [
-            i
-            for i, msg in enumerate(simple_chat_history)
-            if msg.message_type == MessageType.USER
-        ]
-
-        if not user_msg_indices:
-            raise ValueError("No user message found in simple_chat_history")
-
-        # If we have more than n user messages, keep only the last n
-        if len(user_msg_indices) > last_n_user_messages:
-            # Find the index of the n-th user message from the end
-            # For example, if last_n_user_messages=2, we want the 2nd-to-last user message
-            nth_user_msg_index = user_msg_indices[-(last_n_user_messages)]
-            # Keep everything from that user message onwards
-            simple_chat_history = simple_chat_history[nth_user_msg_index:]
-
-    # Find the last USER message in the history
-    # The history may contain tool calls and responses after the last user message
-    last_user_msg_index = None
-    for i in range(len(simple_chat_history) - 1, -1, -1):
-        if simple_chat_history[i].message_type == MessageType.USER:
-            last_user_msg_index = i
-            break
-
-    if last_user_msg_index is None:
-        raise ValueError("No user message found in simple_chat_history")
+    simple_chat_history = _filter_to_last_n_user_messages(
+        simple_chat_history, last_n_user_messages
+    )
 
     # Split history into three parts:
     # 1. History before the last user message
     # 2. The last user message
     # 3. Messages after the last user message (tool calls, responses, etc.)
-    history_before_last_user = simple_chat_history[:last_user_msg_index]
-    last_user_message = simple_chat_history[last_user_msg_index]
-    messages_after_last_user = simple_chat_history[last_user_msg_index + 1 :]
+    (
+        history_before_last_user,
+        last_user_message,
+        messages_after_last_user,
+    ) = _split_at_last_user_message(simple_chat_history)
 
     # Calculate tokens needed for the last user message and everything after it
-    last_user_tokens = _replay_token_count(last_user_message)
-    after_user_tokens = sum(
-        _replay_token_count(msg) for msg in messages_after_last_user
-    )
+    last_user_tokens = replay_token_count(last_user_message)
+    after_user_tokens = sum(replay_token_count(msg) for msg in messages_after_last_user)
 
     # Check if we can fit at least the last user message and messages after it
     required_tokens = last_user_tokens + after_user_tokens
@@ -511,78 +662,29 @@ def construct_message_history(
     # Truncate history_before_last_user from the top to fit in remaining budget.
     # Track dropped file messages so we can provide their metadata to the
     # FileReaderTool instead.
-    truncated_history_before: list[ChatMessageSimple] = []
-    current_token_count = 0
+    truncated_history_before, current_token_count = _truncate_history_to_budget(
+        history_before_last_user, remaining_budget, replay_token_count
+    )
 
-    for msg in reversed(history_before_last_user):
-        msg_tokens = _replay_token_count(msg)
-        if current_token_count + msg_tokens <= remaining_budget:
-            msg.should_cache = True
-            truncated_history_before.insert(0, msg)
-            current_token_count += msg_tokens
-        else:
-            # Can't fit this message, stop truncating.
-            # This message and everything older is dropped.
-            break
-
-    # Collect file_ids from ALL dropped messages (those not in
-    # truncated_history_before). The truncation loop above keeps the most
-    # recent messages, so the dropped ones are at the start of the original
-    # list up to (len(history) - len(kept)).
-    num_kept = len(truncated_history_before)
-    dropped_file_ids: list[str] = [
-        msg.file_id
-        for msg in history_before_last_user[: len(history_before_last_user) - num_kept]
-        if msg.file_id is not None
-    ]
-
-    # Also treat "orphaned" metadata entries as dropped -- these are files
-    # from messages removed by summary truncation (before convert_chat_history
-    # ran), so no ChatMessageSimple was ever tagged with their file_id.
-    if all_injected_file_metadata:
-        surviving_file_ids = {
-            msg.file_id for msg in simple_chat_history if msg.file_id is not None
-        }
-        for fid in all_injected_file_metadata:
-            if fid not in surviving_file_ids and fid not in dropped_file_ids:
-                dropped_file_ids.append(fid)
+    dropped_file_ids = _collect_dropped_file_ids(
+        history_before_last_user=history_before_last_user,
+        kept_history=truncated_history_before,
+        simple_chat_history=simple_chat_history,
+        all_injected_file_metadata=all_injected_file_metadata,
+    )
 
     # Build a forgotten-files metadata message if any file messages were
     # dropped AND we have metadata for them (meaning the FileReaderTool is
     # available). Reserve tokens for this message in the budget.
-    forgotten_files_message: ChatMessageSimple | None = None
-    if dropped_file_ids and all_injected_file_metadata and token_counter:
-        forgotten_meta = [
-            all_injected_file_metadata[fid]
-            for fid in dropped_file_ids
-            if fid in all_injected_file_metadata
-        ]
-        if forgotten_meta:
-            logger.debug(
-                "FileReader: building forgotten-files message for %s",
-                [(m.file_id, m.filename) for m in forgotten_meta],
-            )
-            forgotten_files_message = _create_file_tool_metadata_message(
-                forgotten_meta, token_counter
-            )
-            # Shrink the remaining budget. If the metadata message doesn't
-            # fit we may need to drop more history messages.
-            remaining_budget -= forgotten_files_message.token_count
-            while truncated_history_before and current_token_count > remaining_budget:
-                evicted = truncated_history_before.pop(0)
-                current_token_count -= _replay_token_count(evicted)
-                # If the evicted message is itself a file, add it to the
-                # forgotten metadata (it's now dropped too).
-                if (
-                    evicted.file_id is not None
-                    and evicted.file_id in all_injected_file_metadata
-                    and evicted.file_id not in {m.file_id for m in forgotten_meta}
-                ):
-                    forgotten_meta.append(all_injected_file_metadata[evicted.file_id])
-                    # Rebuild the message with the new entry
-                    forgotten_files_message = _create_file_tool_metadata_message(
-                        forgotten_meta, token_counter
-                    )
+    forgotten_files_message = _build_forgotten_files_message(
+        dropped_file_ids=dropped_file_ids,
+        all_injected_file_metadata=all_injected_file_metadata,
+        token_counter=token_counter,
+        kept_history=truncated_history_before,
+        kept_token_count=current_token_count,
+        remaining_budget=remaining_budget,
+        replay_token_count=replay_token_count,
+    )
 
     # Build the final message list according to README ordering:
     # [system], [history_before_last_user], [custom_agent], [context_files],
@@ -740,6 +842,464 @@ def select_reminder_text(
     )
 
 
+def _select_tools_for_cycle(
+    tools: list[Tool],
+    forced_tool_id: int | None,
+    out_of_cycles: bool,
+    ran_image_gen: bool,
+) -> tuple[list[Tool], ToolChoiceOptions, int | None]:
+    """Pick the tools and tool choice for one cycle.
+
+    Returns the tools, the tool choice, and the forced tool id to carry into
+    the next cycle (cleared once the forced tool has been requested).
+    """
+    if forced_tool_id:
+        # Needs to be just the single one because the "required" currently doesn't have a specified tool, just a binary
+        final_tools = [tool for tool in tools if tool.id == forced_tool_id]
+        if not final_tools:
+            raise ValueError(f"Tool {forced_tool_id} not found in tools")
+        return final_tools, ToolChoiceOptions.REQUIRED, None
+
+    if out_of_cycles or ran_image_gen:
+        # Last cycle, no tools allowed, just answer!
+        return [], ToolChoiceOptions.NONE, forced_tool_id
+
+    return tools, ToolChoiceOptions.AUTO, forced_tool_id
+
+
+def _build_cycle_prompts(
+    persona: Persona | None,
+    persona_system_prompt: str | None,
+    custom_agent_prompt: str | None,
+    default_base_system_prompt: str,
+    user_memory_context: UserMemoryContext | None,
+    inject_memories_in_prompt: bool,
+    tools: list[Tool],
+    datetime_aware: bool,
+    cite_documents: bool,
+    token_counter: Callable[[str], int],
+) -> tuple[ChatMessageSimple | None, ChatMessageSimple | None]:
+    """Build the system prompt and custom agent prompt messages for one cycle."""
+    if persona and persona.replace_base_system_prompt:
+        # Handles the case where user has checked off the "Replace base system prompt" checkbox
+        processed_system_prompt = (
+            process_prompt_template(
+                persona_system_prompt,
+                datetime_aware=datetime_aware,
+                append_datetime_if_aware=True,
+                should_cite_documents=cite_documents,
+            )
+            if persona_system_prompt
+            else None
+        )
+        system_prompt = (
+            ChatMessageSimple(
+                message=processed_system_prompt,
+                token_count=token_counter(processed_system_prompt),
+                message_type=MessageType.SYSTEM,
+            )
+            if processed_system_prompt
+            else None
+        )
+        return system_prompt, None
+
+    # If it's an empty string, we assume the user does not want to include it as an empty System message
+    if default_base_system_prompt:
+        prompt_memory_context = (
+            user_memory_context
+            if inject_memories_in_prompt
+            else (
+                user_memory_context.without_memories() if user_memory_context else None
+            )
+        )
+        system_prompt_str = build_system_prompt(
+            base_system_prompt=default_base_system_prompt,
+            datetime_aware=datetime_aware,
+            user_memory_context=prompt_memory_context,
+            tools=tools,
+            should_cite_documents=cite_documents,
+        )
+        system_prompt = ChatMessageSimple(
+            message=system_prompt_str,
+            token_count=token_counter(system_prompt_str),
+            message_type=MessageType.SYSTEM,
+        )
+        processed_custom_agent_prompt = (
+            process_prompt_template(
+                custom_agent_prompt,
+                datetime_aware=datetime_aware,
+                append_datetime_if_aware=False,
+                should_cite_documents=cite_documents,
+            )
+            if custom_agent_prompt
+            else None
+        )
+        custom_agent_prompt_msg = (
+            ChatMessageSimple(
+                message=processed_custom_agent_prompt,
+                token_count=token_counter(processed_custom_agent_prompt),
+                message_type=MessageType.USER,
+            )
+            if processed_custom_agent_prompt
+            else None
+        )
+        return system_prompt, custom_agent_prompt_msg
+
+    # If there is a custom agent prompt, it replaces the system prompt when the default system prompt is empty
+    processed_custom_agent_prompt = (
+        process_prompt_template(
+            custom_agent_prompt,
+            datetime_aware=datetime_aware,
+            append_datetime_if_aware=True,
+            should_cite_documents=cite_documents,
+        )
+        if custom_agent_prompt
+        else None
+    )
+    system_prompt = (
+        ChatMessageSimple(
+            message=processed_custom_agent_prompt,
+            token_count=token_counter(processed_custom_agent_prompt),
+            message_type=MessageType.SYSTEM,
+        )
+        if processed_custom_agent_prompt
+        else None
+    )
+    return system_prompt, None
+
+
+def _emit_tool_call_packets(
+    emitter: Emitter,
+    tool_calls: list[ToolCallKickoff],
+) -> None:
+    """Emit the per-tool-call debug packets and the parallel branching marker."""
+    if INTEGRATION_TESTS_MODE and tool_calls:
+        for tool_call in tool_calls:
+            emitter.emit(
+                Packet(
+                    placement=tool_call.placement,
+                    obj=ToolCallDebug(
+                        tool_call_id=tool_call.tool_call_id,
+                        tool_name=tool_call.tool_name,
+                        tool_args=tool_call.tool_args,
+                    ),
+                )
+            )
+
+    if len(tool_calls) > 1:
+        emitter.emit(
+            Packet(
+                placement=Placement(turn_index=tool_calls[0].placement.turn_index),
+                obj=TopLevelBranching(num_parallel_branches=len(tool_calls)),
+            )
+        )
+
+
+def _python_tool_generated_files(tool_response: ToolResponse) -> bool:
+    """Whether a Python tool response reports generated files with download links."""
+    try:
+        parsed = json.loads(tool_response.llm_facing_response)
+        return bool(parsed.get("generated_files"))
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
+def _record_search_docs(
+    search_docs: list[SearchDoc],
+    tool_name: str,
+    state_container: ChatStateContainer,
+    gathered_documents: list[SearchDoc] | None,
+    chat_files: list[ChatFile],
+) -> tuple[list[SearchDoc] | None, bool]:
+    """Persist and accumulate search hits, staging any files attached to them.
+
+    Extends ``chat_files`` in place. Returns the updated gathered documents and
+    whether a web search returned results (drives the open_url reminder).
+    """
+    # Add ALL search docs to state container for DB persistence
+    if search_docs:
+        state_container.add_search_docs(search_docs)
+
+    if gathered_documents:
+        gathered_documents.extend(search_docs)
+    else:
+        gathered_documents = search_docs
+
+    # This is used for the Open URL reminder in the next cycle
+    # only do this if the web search tool yielded results
+    ran_web_search = bool(search_docs) and tool_name == WebSearchTool.NAME
+
+    # Stage any raw source files attached to these hits into
+    # the session's chat_files so the next Python tool call
+    # sees them already uploaded under their display names.
+    if search_docs:
+        staged = build_python_chat_files_from_search_docs(
+            search_docs=search_docs,
+        )
+        if staged:
+            existing_filenames = {cf.filename for cf in chat_files}
+            chat_files.extend(
+                cf for cf in staged if cf.filename not in existing_filenames
+            )
+
+    return gathered_documents, ran_web_search
+
+
+def _persist_memory_tool_response(
+    tool_response: ToolResponse,
+    user_memory_context: UserMemoryContext | None,
+) -> tuple[MemoryToolResponseSnapshot | None, str | None]:
+    """Persist a memory tool write.
+
+    Returns the saved snapshot, or a refusal message when the chat is incognito.
+    """
+    memory_response = tool_response.rich_response
+    if not isinstance(memory_response, MemoryToolResponse):
+        return None, None
+
+    # Any incognito mode refuses memory writes with an explicit
+    # error, so neither the model nor the user sees a saved
+    # memory that does not exist.
+    if get_current_incognito_record_mode() is not None:
+        return None, (
+            "Error: memories cannot be saved from an incognito "
+            "chat. Tell the user their request was not saved."
+        )
+
+    persisted_memory_id: int | None = None
+    if user_memory_context and user_memory_context.user_id:
+        if memory_response.index_to_replace is not None:
+            persisted_memory_id = update_memory_at_index(
+                user_id=user_memory_context.user_id,
+                index=memory_response.index_to_replace,
+                new_text=memory_response.memory_text,
+            )
+        else:
+            persisted_memory_id = add_memory(
+                user_id=user_memory_context.user_id,
+                memory_text=memory_response.memory_text,
+            )
+
+    operation: Literal["add", "update"] = (
+        "update" if memory_response.index_to_replace is not None else "add"
+    )
+    return (
+        MemoryToolResponseSnapshot(
+            memory_text=memory_response.memory_text,
+            operation=operation,
+            memory_id=persisted_memory_id,
+            index=memory_response.index_to_replace,
+        ),
+        None,
+    )
+
+
+def _resolve_saved_tool_response(
+    tool_response: ToolResponse,
+    memory_snapshot: MemoryToolResponseSnapshot | None,
+    incognito_memory_refusal: str | None,
+) -> str:
+    """Pick the tool response text to persist on the tool call.
+
+    Overwrites ``llm_facing_response`` on an incognito memory refusal so the
+    next LLM cycle sees the refusal too.
+    """
+    if incognito_memory_refusal:
+        # The next LLM cycle must see the refusal too.
+        tool_response.llm_facing_response = incognito_memory_refusal
+        return incognito_memory_refusal
+    if memory_snapshot:
+        return json.dumps(memory_snapshot.model_dump())
+    if isinstance(tool_response.rich_response, CustomToolCallSummary):
+        return json.dumps(tool_response.rich_response.model_dump())
+    if isinstance(tool_response.rich_response, str):
+        return tool_response.rich_response
+    return tool_response.llm_facing_response
+
+
+class _ToolResponseOutcome(NamedTuple):
+    """Loop-carried state produced by processing a single tool response."""
+
+    gathered_documents: list[SearchDoc] | None
+    ran_search_tool: bool
+    generated_python_files: bool
+    ran_web_search: bool
+
+
+def _process_tool_response(
+    tool_response: ToolResponse,
+    final_tools: list[Tool],
+    state_container: ChatStateContainer,
+    citation_processor: DynamicCitationProcessor,
+    user_memory_context: UserMemoryContext | None,
+    reasoning: str | None,
+    turn_index: int,
+    chat_files: list[ChatFile],
+    gathered_documents: list[SearchDoc] | None,
+    code_interpreter_file_generated: bool,
+) -> _ToolResponseOutcome:
+    """Persist one tool response and fold its results into the loop state."""
+    # Extract tool_call from the response (set by run_tool_calls)
+    if tool_response.tool_call is None:
+        raise ValueError("Tool response missing tool_call reference")
+
+    tool_call = tool_response.tool_call
+    tab_index = tool_call.placement.tab_index
+
+    # Track if search tool was called (for skipping query expansion on subsequent calls)
+    ran_search_tool = tool_call.tool_name == SearchTool.NAME
+
+    # Track if code interpreter generated files with download links
+    generated_python_files = (
+        tool_call.tool_name == PythonTool.NAME
+        and not code_interpreter_file_generated
+        and _python_tool_generated_files(tool_response)
+    )
+
+    tools_by_name = {tool.name: tool for tool in final_tools}
+
+    # Add the results to the chat history. Even though tools may run in parallel,
+    # LLM APIs require linear history, so results are added sequentially.
+    # Get the tool object to retrieve tool_id
+    tool = tools_by_name.get(tool_call.tool_name)
+    if not tool:
+        raise ValueError(f"Tool '{tool_call.tool_name}' not found in tools list")
+
+    # Extract search_docs if this is a search tool response
+    search_docs = None
+    displayed_docs = None
+    ran_web_search = False
+    if isinstance(tool_response.rich_response, SearchDocsResponse):
+        search_docs = tool_response.rich_response.search_docs
+        displayed_docs = tool_response.rich_response.displayed_docs
+        gathered_documents, ran_web_search = _record_search_docs(
+            search_docs=search_docs,
+            tool_name=tool_call.tool_name,
+            state_container=state_container,
+            gathered_documents=gathered_documents,
+            chat_files=chat_files,
+        )
+
+    # Extract generated_images if this is an image generation tool response
+    generated_images = None
+    if isinstance(tool_response.rich_response, FinalImageGenerationResponse):
+        generated_images = tool_response.rich_response.generated_images
+
+    # Extract generated_files if this is a code interpreter response
+    generated_files = None
+    if isinstance(tool_response.rich_response, PythonToolRichResponse):
+        generated_files = tool_response.rich_response.generated_files or None
+
+    # Custom tools save image/CSV blobs and return their ids.
+    generated_file_ids = None
+    if isinstance(tool_response.rich_response, CustomToolCallSummary) and isinstance(
+        tool_response.rich_response.tool_result, CustomToolUserFileSnapshot
+    ):
+        generated_file_ids = tool_response.rich_response.tool_result.file_ids or None
+
+    # Persist memory if this is a memory tool response
+    memory_snapshot, incognito_memory_refusal = _persist_memory_tool_response(
+        tool_response, user_memory_context
+    )
+    saved_response = _resolve_saved_tool_response(
+        tool_response, memory_snapshot, incognito_memory_refusal
+    )
+
+    tool_call_info = ToolCallInfo(
+        parent_tool_call_id=None,  # Top-level tool calls are attached to the chat message
+        turn_index=turn_index,
+        tab_index=tab_index,
+        tool_name=tool_call.tool_name,
+        tool_call_id=tool_call.tool_call_id,
+        tool_id=tool.id,
+        reasoning_tokens=reasoning,  # All tool calls from this loop share the same reasoning
+        tool_call_arguments=tool_call.tool_args,
+        tool_call_response=saved_response,
+        search_docs=displayed_docs or search_docs,
+        generated_images=generated_images,
+        generated_files=generated_files,
+        generated_file_ids=generated_file_ids,
+    )
+    # Add to state container for partial save support
+    state_container.add_tool_call(tool_call_info)
+
+    # Update citation processor if this was a search tool
+    update_citation_processor_from_tool_response(tool_response, citation_processor)
+
+    return _ToolResponseOutcome(
+        gathered_documents=gathered_documents,
+        ran_search_tool=ran_search_tool,
+        generated_python_files=generated_python_files,
+        ran_web_search=ran_web_search,
+    )
+
+
+def _append_tool_call_history(
+    simple_chat_history: list[ChatMessageSimple],
+    tool_responses: list[ToolResponse],
+    token_counter: Callable[[str], int],
+) -> None:
+    """Append this turn's tool calls and responses to the history.
+
+    Uses the OpenAI parallel tool calling format:
+    1. ONE ASSISTANT message with tool_calls array
+    2. N TOOL_CALL_RESPONSE messages (one per tool call)
+    """
+    if not tool_responses:
+        return
+
+    # Filter to only responses with valid tool_call references
+    valid_tool_responses = [tr for tr in tool_responses if tr.tool_call is not None]
+
+    # Build ToolCallSimple list for all tool calls in this turn
+    tool_calls_simple: list[ToolCallSimple] = []
+    for tool_response in valid_tool_responses:
+        tc = tool_response.tool_call
+        assert (
+            tc is not None
+        )  # Already filtered above, this is just for typing purposes
+
+        tool_call_message = tc.to_msg_str()
+        tool_call_token_count = token_counter(tool_call_message)
+
+        tool_calls_simple.append(
+            ToolCallSimple(
+                tool_call_id=tc.tool_call_id,
+                tool_name=tc.tool_name,
+                tool_arguments=tc.tool_args,
+                token_count=tool_call_token_count,
+            )
+        )
+
+    # Create ONE ASSISTANT message with all tool calls for this turn
+    total_tool_call_tokens = sum(tc.token_count for tc in tool_calls_simple)
+    assistant_with_tools = ChatMessageSimple(
+        message="",  # No text content when making tool calls
+        token_count=total_tool_call_tokens,
+        message_type=MessageType.ASSISTANT,
+        tool_calls=tool_calls_simple,
+        image_files=None,
+    )
+    simple_chat_history.append(assistant_with_tools)
+
+    # Add TOOL_CALL_RESPONSE messages for each tool call
+    for tool_response in valid_tool_responses:
+        tc = tool_response.tool_call
+        assert tc is not None  # Already filtered above
+
+        tool_response_message = tool_response.llm_facing_response
+        tool_response_token_count = token_counter(tool_response_message)
+
+        tool_response_msg = ChatMessageSimple(
+            message=tool_response_message,
+            token_count=tool_response_token_count,
+            message_type=MessageType.TOOL_CALL_RESPONSE,
+            tool_call_id=tc.tool_call_id,
+            image_files=None,
+        )
+        simple_chat_history.append(tool_response_msg)
+
+
 def run_llm_loop(
     emitter: Emitter,
     state_container: ChatStateContainer,
@@ -882,113 +1442,30 @@ def run_llm_loop(
         for llm_cycle_count in range(MAX_LLM_CYCLES):
             # Handling tool calls based on cycle count and past cycle conditions
             out_of_cycles = llm_cycle_count == MAX_LLM_CYCLES - 1
-            if forced_tool_id:
-                # Needs to be just the single one because the "required" currently doesn't have a specified tool, just a binary
-                final_tools = [tool for tool in tools if tool.id == forced_tool_id]
-                if not final_tools:
-                    raise ValueError(f"Tool {forced_tool_id} not found in tools")
-                tool_choice = ToolChoiceOptions.REQUIRED
-                forced_tool_id = None
-            elif out_of_cycles or ran_image_gen:
-                # Last cycle, no tools allowed, just answer!
-                tool_choice = ToolChoiceOptions.NONE
-                final_tools = []
-            else:
-                tool_choice = ToolChoiceOptions.AUTO
-                final_tools = tools
+            final_tools, tool_choice, forced_tool_id = _select_tools_for_cycle(
+                tools=tools,
+                forced_tool_id=forced_tool_id,
+                out_of_cycles=out_of_cycles,
+                ran_image_gen=ran_image_gen,
+            )
 
             # Handling the system prompt and custom agent prompt
             # The section below calculates the available tokens for history a bit more accurately
             # now that project files are loaded in.
             persona_datetime_aware = persona.datetime_aware if persona else True
             cite_documents = should_cite_documents or always_cite_documents
-            if persona and persona.replace_base_system_prompt:
-                # Handles the case where user has checked off the "Replace base system prompt" checkbox
-                processed_system_prompt = (
-                    process_prompt_template(
-                        persona_system_prompt,
-                        datetime_aware=persona_datetime_aware,
-                        append_datetime_if_aware=True,
-                        should_cite_documents=cite_documents,
-                    )
-                    if persona_system_prompt
-                    else None
-                )
-                system_prompt = (
-                    ChatMessageSimple(
-                        message=processed_system_prompt,
-                        token_count=token_counter(processed_system_prompt),
-                        message_type=MessageType.SYSTEM,
-                    )
-                    if processed_system_prompt
-                    else None
-                )
-                custom_agent_prompt_msg = None
-            else:
-                # If it's an empty string, we assume the user does not want to include it as an empty System message
-                if default_base_system_prompt:
-                    prompt_memory_context = (
-                        user_memory_context
-                        if inject_memories_in_prompt
-                        else (
-                            user_memory_context.without_memories()
-                            if user_memory_context
-                            else None
-                        )
-                    )
-                    system_prompt_str = build_system_prompt(
-                        base_system_prompt=default_base_system_prompt,
-                        datetime_aware=persona_datetime_aware,
-                        user_memory_context=prompt_memory_context,
-                        tools=tools,
-                        should_cite_documents=cite_documents,
-                    )
-                    system_prompt = ChatMessageSimple(
-                        message=system_prompt_str,
-                        token_count=token_counter(system_prompt_str),
-                        message_type=MessageType.SYSTEM,
-                    )
-                    processed_custom_agent_prompt = (
-                        process_prompt_template(
-                            custom_agent_prompt,
-                            datetime_aware=persona_datetime_aware,
-                            append_datetime_if_aware=False,
-                            should_cite_documents=cite_documents,
-                        )
-                        if custom_agent_prompt
-                        else None
-                    )
-                    custom_agent_prompt_msg = (
-                        ChatMessageSimple(
-                            message=processed_custom_agent_prompt,
-                            token_count=token_counter(processed_custom_agent_prompt),
-                            message_type=MessageType.USER,
-                        )
-                        if processed_custom_agent_prompt
-                        else None
-                    )
-                else:
-                    # If there is a custom agent prompt, it replaces the system prompt when the default system prompt is empty
-                    processed_custom_agent_prompt = (
-                        process_prompt_template(
-                            custom_agent_prompt,
-                            datetime_aware=persona_datetime_aware,
-                            append_datetime_if_aware=True,
-                            should_cite_documents=cite_documents,
-                        )
-                        if custom_agent_prompt
-                        else None
-                    )
-                    system_prompt = (
-                        ChatMessageSimple(
-                            message=processed_custom_agent_prompt,
-                            token_count=token_counter(processed_custom_agent_prompt),
-                            message_type=MessageType.SYSTEM,
-                        )
-                        if processed_custom_agent_prompt
-                        else None
-                    )
-                    custom_agent_prompt_msg = None
+            system_prompt, custom_agent_prompt_msg = _build_cycle_prompts(
+                persona=persona,
+                persona_system_prompt=persona_system_prompt,
+                custom_agent_prompt=custom_agent_prompt,
+                default_base_system_prompt=default_base_system_prompt,
+                user_memory_context=user_memory_context,
+                inject_memories_in_prompt=inject_memories_in_prompt,
+                tools=tools,
+                datetime_aware=persona_datetime_aware,
+                cite_documents=cite_documents,
+                token_counter=token_counter,
+            )
 
             processed_task_prompt = (
                 process_prompt_template(
@@ -1083,28 +1560,7 @@ def run_llm_loop(
             tool_responses: list[ToolResponse] = []
             tool_calls = llm_step_result.tool_calls or []
 
-            if INTEGRATION_TESTS_MODE and tool_calls:
-                for tool_call in tool_calls:
-                    emitter.emit(
-                        Packet(
-                            placement=tool_call.placement,
-                            obj=ToolCallDebug(
-                                tool_call_id=tool_call.tool_call_id,
-                                tool_name=tool_call.tool_name,
-                                tool_args=tool_call.tool_args,
-                            ),
-                        )
-                    )
-
-            if len(tool_calls) > 1:
-                emitter.emit(
-                    Packet(
-                        placement=Placement(
-                            turn_index=tool_calls[0].placement.turn_index
-                        ),
-                        obj=TopLevelBranching(num_parallel_branches=len(tool_calls)),
-                    )
-                )
+            _emit_tool_call_packets(emitter, tool_calls)
 
             # Quick note for why citation_mapping and citation_processors are both needed:
             # 1. Tools return lightweight string mappings, not SearchDoc objects
@@ -1139,234 +1595,32 @@ def run_llm_loop(
                 continue
 
             for tool_response in tool_responses:
-                # Extract tool_call from the response (set by run_tool_calls)
-                if tool_response.tool_call is None:
-                    raise ValueError("Tool response missing tool_call reference")
-
-                tool_call = tool_response.tool_call
-                tab_index = tool_call.placement.tab_index
-
-                # Track if search tool was called (for skipping query expansion on subsequent calls)
-                if tool_call.tool_name == SearchTool.NAME:
-                    has_called_search_tool = True
-
-                # Track if code interpreter generated files with download links
-                if (
-                    tool_call.tool_name == PythonTool.NAME
-                    and not code_interpreter_file_generated
-                ):
-                    try:
-                        parsed = json.loads(tool_response.llm_facing_response)
-                        if parsed.get("generated_files"):
-                            code_interpreter_file_generated = True
-                    except (json.JSONDecodeError, AttributeError):
-                        pass
-
-                tools_by_name = {tool.name: tool for tool in final_tools}
-
-                # Add the results to the chat history. Even though tools may run in parallel,
-                # LLM APIs require linear history, so results are added sequentially.
-                # Get the tool object to retrieve tool_id
-                tool = tools_by_name.get(tool_call.tool_name)
-                if not tool:
-                    raise ValueError(
-                        f"Tool '{tool_call.tool_name}' not found in tools list"
-                    )
-
-                # Extract search_docs if this is a search tool response
-                search_docs = None
-                displayed_docs = None
-                if isinstance(tool_response.rich_response, SearchDocsResponse):
-                    search_docs = tool_response.rich_response.search_docs
-                    displayed_docs = tool_response.rich_response.displayed_docs
-
-                    # Add ALL search docs to state container for DB persistence
-                    if search_docs:
-                        state_container.add_search_docs(search_docs)
-
-                    if gathered_documents:
-                        gathered_documents.extend(search_docs)
-                    else:
-                        gathered_documents = search_docs
-
-                    # This is used for the Open URL reminder in the next cycle
-                    # only do this if the web search tool yielded results
-                    if search_docs and tool_call.tool_name == WebSearchTool.NAME:
-                        just_ran_web_search = True
-
-                    # Stage any raw source files attached to these hits into
-                    # the session's chat_files so the next Python tool call
-                    # sees them already uploaded under their display names.
-                    if search_docs:
-                        staged = build_python_chat_files_from_search_docs(
-                            search_docs=search_docs,
-                        )
-                        if staged:
-                            existing_filenames = {cf.filename for cf in chat_files}
-                            chat_files.extend(
-                                cf
-                                for cf in staged
-                                if cf.filename not in existing_filenames
-                            )
-
-                # Extract generated_images if this is an image generation tool response
-                generated_images = None
-                if isinstance(
-                    tool_response.rich_response, FinalImageGenerationResponse
-                ):
-                    generated_images = tool_response.rich_response.generated_images
-
-                # Extract generated_files if this is a code interpreter response
-                generated_files = None
-                if isinstance(tool_response.rich_response, PythonToolRichResponse):
-                    generated_files = (
-                        tool_response.rich_response.generated_files or None
-                    )
-
-                # Custom tools save image/CSV blobs and return their ids.
-                generated_file_ids = None
-                if isinstance(
-                    tool_response.rich_response, CustomToolCallSummary
-                ) and isinstance(
-                    tool_response.rich_response.tool_result, CustomToolUserFileSnapshot
-                ):
-                    generated_file_ids = (
-                        tool_response.rich_response.tool_result.file_ids or None
-                    )
-
-                # Persist memory if this is a memory tool response
-                memory_snapshot: MemoryToolResponseSnapshot | None = None
-                incognito_memory_refusal: str | None = None
-                if isinstance(tool_response.rich_response, MemoryToolResponse):
-                    # Any incognito mode refuses memory writes with an explicit
-                    # error, so neither the model nor the user sees a saved
-                    # memory that does not exist.
-                    if get_current_incognito_record_mode() is not None:
-                        incognito_memory_refusal = (
-                            "Error: memories cannot be saved from an incognito "
-                            "chat. Tell the user their request was not saved."
-                        )
-                    else:
-                        persisted_memory_id: int | None = None
-                        if user_memory_context and user_memory_context.user_id:
-                            if tool_response.rich_response.index_to_replace is not None:
-                                persisted_memory_id = update_memory_at_index(
-                                    user_id=user_memory_context.user_id,
-                                    index=tool_response.rich_response.index_to_replace,
-                                    new_text=tool_response.rich_response.memory_text,
-                                )
-                            else:
-                                persisted_memory_id = add_memory(
-                                    user_id=user_memory_context.user_id,
-                                    memory_text=tool_response.rich_response.memory_text,
-                                )
-                        operation: Literal["add", "update"] = (
-                            "update"
-                            if tool_response.rich_response.index_to_replace is not None
-                            else "add"
-                        )
-                        memory_snapshot = MemoryToolResponseSnapshot(
-                            memory_text=tool_response.rich_response.memory_text,
-                            operation=operation,
-                            memory_id=persisted_memory_id,
-                            index=tool_response.rich_response.index_to_replace,
-                        )
-
-                if incognito_memory_refusal:
-                    saved_response = incognito_memory_refusal
-                    # The next LLM cycle must see the refusal too.
-                    tool_response.llm_facing_response = incognito_memory_refusal
-                elif memory_snapshot:
-                    saved_response = json.dumps(memory_snapshot.model_dump())
-                elif isinstance(tool_response.rich_response, CustomToolCallSummary):
-                    saved_response = json.dumps(
-                        tool_response.rich_response.model_dump()
-                    )
-                elif isinstance(tool_response.rich_response, str):
-                    saved_response = tool_response.rich_response
-                else:
-                    saved_response = tool_response.llm_facing_response
-
-                tool_call_info = ToolCallInfo(
-                    parent_tool_call_id=None,  # Top-level tool calls are attached to the chat message
+                outcome = _process_tool_response(
+                    tool_response=tool_response,
+                    final_tools=final_tools,
+                    state_container=state_container,
+                    citation_processor=citation_processor,
+                    user_memory_context=user_memory_context,
+                    # All tool calls from this loop share the same reasoning
+                    reasoning=llm_step_result.reasoning,
                     turn_index=llm_cycle_count + reasoning_cycles,
-                    tab_index=tab_index,
-                    tool_name=tool_call.tool_name,
-                    tool_call_id=tool_call.tool_call_id,
-                    tool_id=tool.id,
-                    reasoning_tokens=llm_step_result.reasoning,  # All tool calls from this loop share the same reasoning
-                    tool_call_arguments=tool_call.tool_args,
-                    tool_call_response=saved_response,
-                    search_docs=displayed_docs or search_docs,
-                    generated_images=generated_images,
-                    generated_files=generated_files,
-                    generated_file_ids=generated_file_ids,
+                    chat_files=chat_files,
+                    gathered_documents=gathered_documents,
+                    code_interpreter_file_generated=code_interpreter_file_generated,
                 )
-                # Add to state container for partial save support
-                state_container.add_tool_call(tool_call_info)
-
-                # Update citation processor if this was a search tool
-                update_citation_processor_from_tool_response(
-                    tool_response, citation_processor
+                gathered_documents = outcome.gathered_documents
+                has_called_search_tool = (
+                    has_called_search_tool or outcome.ran_search_tool
                 )
+                code_interpreter_file_generated = (
+                    code_interpreter_file_generated or outcome.generated_python_files
+                )
+                just_ran_web_search = just_ran_web_search or outcome.ran_web_search
 
             # After processing all tool responses for this turn, add messages to history
-            # using OpenAI parallel tool calling format:
-            # 1. ONE ASSISTANT message with tool_calls array
-            # 2. N TOOL_CALL_RESPONSE messages (one per tool call)
-            if tool_responses:
-                # Filter to only responses with valid tool_call references
-                valid_tool_responses = [
-                    tr for tr in tool_responses if tr.tool_call is not None
-                ]
-
-                # Build ToolCallSimple list for all tool calls in this turn
-                tool_calls_simple: list[ToolCallSimple] = []
-                for tool_response in valid_tool_responses:
-                    tc = tool_response.tool_call
-                    assert (
-                        tc is not None
-                    )  # Already filtered above, this is just for typing purposes
-
-                    tool_call_message = tc.to_msg_str()
-                    tool_call_token_count = token_counter(tool_call_message)
-
-                    tool_calls_simple.append(
-                        ToolCallSimple(
-                            tool_call_id=tc.tool_call_id,
-                            tool_name=tc.tool_name,
-                            tool_arguments=tc.tool_args,
-                            token_count=tool_call_token_count,
-                        )
-                    )
-
-                # Create ONE ASSISTANT message with all tool calls for this turn
-                total_tool_call_tokens = sum(tc.token_count for tc in tool_calls_simple)
-                assistant_with_tools = ChatMessageSimple(
-                    message="",  # No text content when making tool calls
-                    token_count=total_tool_call_tokens,
-                    message_type=MessageType.ASSISTANT,
-                    tool_calls=tool_calls_simple,
-                    image_files=None,
-                )
-                simple_chat_history.append(assistant_with_tools)
-
-                # Add TOOL_CALL_RESPONSE messages for each tool call
-                for tool_response in valid_tool_responses:
-                    tc = tool_response.tool_call
-                    assert tc is not None  # Already filtered above
-
-                    tool_response_message = tool_response.llm_facing_response
-                    tool_response_token_count = token_counter(tool_response_message)
-
-                    tool_response_msg = ChatMessageSimple(
-                        message=tool_response_message,
-                        token_count=tool_response_token_count,
-                        message_type=MessageType.TOOL_CALL_RESPONSE,
-                        tool_call_id=tc.tool_call_id,
-                        image_files=None,
-                    )
-                    simple_chat_history.append(tool_response_msg)
+            _append_tool_call_history(
+                simple_chat_history, tool_responses, token_counter
+            )
 
             # If no tool calls, then it must have answered, wrap up
             if not llm_step_result.tool_calls or len(llm_step_result.tool_calls) == 0:

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -3,6 +3,7 @@ import re
 import time
 import uuid
 from collections.abc import Callable, Generator, Mapping, Sequence
+from dataclasses import dataclass, field
 from html import unescape
 from typing import Any, cast
 
@@ -28,7 +29,7 @@ from onyx.llm.interfaces import (
     LLMUserIdentity,
     ToolChoiceOptions,
 )
-from onyx.llm.model_response import Delta
+from onyx.llm.model_response import Delta, ModelResponseStream
 from onyx.llm.models import (
     AssistantMessage,
     ChatCompletionMessage,
@@ -65,6 +66,8 @@ from onyx.tools.models import ToolCallKickoff
 from onyx.tools.tool_name import sanitize_tool_name
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import Span
 from onyx.tracing.llm_utils import build_llm_model_config
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.jsonriver import Parser
@@ -1071,6 +1074,371 @@ def _delta_has_action(delta: Delta) -> bool:
     return bool(delta.content or delta.reasoning_content or delta.tool_calls)
 
 
+@dataclass
+class _StepEmitState:
+    """Mutable emit state shared by the packet-emitting helpers of an LLM step."""
+
+    tool_choice: ToolChoiceOptions
+    state_container: ChatStateContainer | None
+    citation_processor: DynamicCitationProcessor | None
+    final_documents: list[SearchDoc] | None
+    pre_answer_processing_time: float | None
+    is_deep_research: bool
+    turn_index: int
+    tab_index: int
+    sub_turn_index: int | None
+    has_reasoned: bool = False
+    reasoning_start: bool = False
+    answer_start: bool = False
+    accumulated_reasoning: str = ""
+    accumulated_answer: str = ""
+    accumulated_raw_answer: str = ""
+
+    def current_placement(self) -> Placement:
+        return Placement(
+            turn_index=self.turn_index,
+            tab_index=self.tab_index,
+            sub_turn_index=self.sub_turn_index,
+        )
+
+
+@dataclass
+class _StreamStats:
+    """Counters and tracing bookkeeping accumulated over one LLM stream."""
+
+    stream_start_time: float
+    stream_chunk_count: int = 0
+    actionable_chunk_count: int = 0
+    empty_chunk_count: int = 0
+    finish_reasons: set[str] = field(default_factory=set)
+    terminal_finish_reason: str | None = None
+    first_action_recorded: bool = False
+    processor_state: Any = None
+
+
+def _emit_citation_results(
+    state: _StepEmitState,
+    results: Generator[str | CitationInfo, None, None],
+) -> Generator[Packet, None, None]:
+    """Yield packets for citation processor results (str or CitationInfo)."""
+    for result in results:
+        if isinstance(result, str):
+            state.accumulated_answer += result
+            if state.state_container:
+                state.state_container.set_answer_tokens(state.accumulated_answer)
+            yield Packet(
+                placement=state.current_placement(),
+                obj=AgentResponseDelta(content=result),
+            )
+        elif isinstance(result, CitationInfo):
+            yield Packet(
+                placement=state.current_placement(),
+                obj=result,
+            )
+            if state.state_container:
+                state.state_container.add_emitted_citation(result.citation_number)
+
+
+def _close_reasoning_if_active(state: _StepEmitState) -> Generator[Packet, None, None]:
+    """Emit ReasoningDone and increment turns if reasoning is in progress."""
+    if state.reasoning_start:
+        yield Packet(
+            placement=state.current_placement(),
+            obj=ReasoningDone(),
+        )
+        state.has_reasoned = True
+        state.turn_index, state.sub_turn_index = _increment_turns(
+            state.turn_index, state.sub_turn_index
+        )
+        state.reasoning_start = False
+
+
+def _emit_reasoning_chunk(
+    state: _StepEmitState, reasoning_chunk: str
+) -> Generator[Packet, None, None]:
+    """Accumulate a reasoning chunk and emit its start/delta packets.
+
+    Should only start once, the frontend does not expect multiple
+    ReasoningStart or ReasoningDone packets.
+    """
+    state.accumulated_reasoning += reasoning_chunk
+    # Save reasoning incrementally to state container
+    if state.state_container:
+        state.state_container.set_reasoning_tokens(state.accumulated_reasoning)
+    if not state.reasoning_start:
+        yield Packet(
+            placement=state.current_placement(),
+            obj=ReasoningStart(),
+        )
+    yield Packet(
+        placement=state.current_placement(),
+        obj=ReasoningDelta(reasoning=reasoning_chunk),
+    )
+    state.reasoning_start = True
+
+
+def _emit_answer_start_if_needed(
+    state: _StepEmitState,
+) -> Generator[Packet, None, None]:
+    """Emit AgentResponseStart once, persisting pre-answer timing first."""
+    if state.answer_start:
+        return
+
+    # Store pre-answer processing time in state container for save_chat
+    if state.state_container and state.pre_answer_processing_time is not None:
+        state.state_container.set_pre_answer_processing_time(
+            state.pre_answer_processing_time
+        )
+
+    yield Packet(
+        placement=state.current_placement(),
+        obj=AgentResponseStart(
+            final_documents=state.final_documents,
+            pre_answer_processing_seconds=state.pre_answer_processing_time,
+        ),
+    )
+    state.answer_start = True
+
+
+def _emit_content_chunk(
+    state: _StepEmitState, content_chunk: str
+) -> Generator[Packet, None, None]:
+    # When tool_choice is REQUIRED, content before tool calls is reasoning/thinking
+    # about which tool to call, not an actual answer to the user.
+    # Treat this content as reasoning instead of answer.
+    if state.is_deep_research and state.tool_choice == ToolChoiceOptions.REQUIRED:
+        yield from _emit_reasoning_chunk(state, content_chunk)
+        return
+
+    # Normal flow for AUTO or NONE tool choice
+    yield from _close_reasoning_if_active(state)
+    yield from _emit_answer_start_if_needed(state)
+
+    if state.citation_processor:
+        yield from _emit_citation_results(
+            state, state.citation_processor.process_token(content_chunk)
+        )
+    else:
+        state.accumulated_answer += content_chunk
+        # Save answer incrementally to state container
+        if state.state_container:
+            state.state_container.set_answer_tokens(state.accumulated_answer)
+        yield Packet(
+            placement=state.current_placement(),
+            obj=AgentResponseDelta(content=content_chunk),
+        )
+
+
+def _record_first_action(
+    stats: _StreamStats,
+    delta: Delta,
+    span_generation: Span[GenerationSpanData],
+) -> None:
+    """Record time-to-first-action the first time a delta carries real output."""
+    if not stats.first_action_recorded and _delta_has_action(delta):
+        span_generation.span_data.time_to_first_action_seconds = (
+            time.monotonic() - stats.stream_start_time
+        )
+        stats.first_action_recorded = True
+
+
+def _record_chunk_stats(
+    packet: ModelResponseStream,
+    stats: _StreamStats,
+    state_container: ChatStateContainer | None,
+    span_generation: Span[GenerationSpanData],
+) -> Delta | None:
+    """Update per-chunk counters and span data.
+
+    Returns the delta to emit, or None when the chunk carries nothing usable.
+    """
+    # On the first chunk, not at stream end: a mid-step stop persists
+    # from another thread and needs this step's params already there.
+    if stats.stream_chunk_count == 0 and state_container:
+        state_container.set_request_params(get_llm_request_params())
+    stats.stream_chunk_count += 1
+    if packet.usage:
+        usage = packet.usage
+        span_generation.span_data.usage = {
+            "input_tokens": usage.prompt_tokens,
+            "output_tokens": usage.completion_tokens,
+            "cache_read_input_tokens": usage.cache_read_input_tokens,
+            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+        }
+        # Note: LLM cost tracking is now handled in multi_llm.py
+    finish_reason = packet.choice.finish_reason
+    if finish_reason:
+        stats.finish_reasons.add(str(finish_reason))
+        stats.terminal_finish_reason = str(finish_reason)
+    delta = packet.choice.delta
+
+    # Weird behavior from some model providers, just log and ignore for now
+    if not delta.content and delta.reasoning_content is None and not delta.tool_calls:
+        stats.empty_chunk_count += 1
+        logger.warning(
+            "LLM packet is empty (no content, reasoning, or tool calls). "
+            "finish_reason=%s. Skipping: %s",
+            finish_reason,
+            packet,
+        )
+        return None
+
+    _record_first_action(stats, delta, span_generation)
+    if _delta_has_action(delta):
+        stats.actionable_chunk_count += 1
+    return delta
+
+
+def _emit_delta_packets(
+    state: _StepEmitState,
+    delta: Delta,
+    id_to_tool_call_map: dict[int, dict[str, Any]],
+    arg_parsers: dict[int, Parser],
+    xml_tool_call_content_filter: _XmlToolCallContentFilter,
+) -> Generator[Packet, None, None]:
+    """Emit the reasoning, answer, and tool-call packets for one delta."""
+    if delta.reasoning_content:
+        yield from _emit_reasoning_chunk(state, delta.reasoning_content)
+
+    if delta.content:
+        # Keep raw content for fallback extraction. Display content can be
+        # filtered and, in deep-research REQUIRED mode, routed as reasoning.
+        state.accumulated_raw_answer += delta.content
+        filtered_content = xml_tool_call_content_filter.process(delta.content)
+        if filtered_content:
+            yield from _emit_content_chunk(state, filtered_content)
+
+    if delta.tool_calls:
+        yield from _close_reasoning_if_active(state)
+
+        for tool_call_delta in delta.tool_calls:
+            # maybe_emit depends and update being called first and attaching the delta
+            _update_tool_call_with_delta(id_to_tool_call_map, tool_call_delta)
+            yield from maybe_emit_argument_delta(
+                tool_calls_in_progress=id_to_tool_call_map,
+                tool_call_delta=tool_call_delta,
+                placement=state.current_placement(),
+                parsers=arg_parsers,
+            )
+
+
+def _flush_custom_token_processor(
+    custom_token_processor: Callable[[Delta | None, Any], tuple[Delta | None, Any]],
+    stats: _StreamStats,
+    span_generation: Span[GenerationSpanData],
+    id_to_tool_call_map: dict[int, dict[str, Any]],
+) -> None:
+    """Flush custom token processor to get any final tool calls."""
+    flush_delta, stats.processor_state = custom_token_processor(
+        None, stats.processor_state
+    )
+    if flush_delta is not None:
+        _record_first_action(stats, flush_delta, span_generation)
+    if flush_delta and flush_delta.tool_calls:
+        for tool_call_delta in flush_delta.tool_calls:
+            _update_tool_call_with_delta(id_to_tool_call_map, tool_call_delta)
+
+
+def _emit_empty_answer_recovery(
+    state: _StepEmitState,
+    llm_config: LLMConfig,
+    stats: _StreamStats,
+    tool_calls: list[ToolCallKickoff],
+) -> Generator[Packet, None, None]:
+    """Empty-answer recovery.
+
+    The model emitted text but content/citation processing consumed all of it
+    (e.g. an unmapped bracketed-numeric answer like "[123456789012345]" that the
+    citation processor strips). Surface the raw output instead of returning an
+    empty answer, which would raise a misleading EmptyLLMResponseError
+    downstream. Skipped for REQUIRED tool choice, where empty pre-tool content is
+    expected (fallback extraction). Also skipped when the raw output is XML
+    tool-call markup: run_llm_loop's fallback extraction will parse it into a
+    real tool call, so surfacing it as an answer would leak raw markup to the
+    client and pollute context.
+    """
+    if not (
+        state.tool_choice != ToolChoiceOptions.REQUIRED
+        and not tool_calls
+        and not state.accumulated_answer.strip()
+        and state.accumulated_raw_answer.strip()
+        and not _looks_like_xml_tool_call_payload(state.accumulated_raw_answer)
+    ):
+        return
+
+    logger.warning(
+        "Answer empty after content/citation processing; recovering raw "
+        "model output (%d chars). provider=%s, model=%s, finish_reasons=%s",
+        len(state.accumulated_raw_answer),
+        llm_config.model_provider,
+        llm_config.model_name,
+        sorted(stats.finish_reasons),
+    )
+    yield from _emit_answer_start_if_needed(state)
+    yield Packet(
+        placement=state.current_placement(),
+        obj=AgentResponseDelta(content=state.accumulated_raw_answer),
+    )
+    state.accumulated_answer = state.accumulated_raw_answer
+    if state.state_container:
+        state.state_container.set_answer_tokens(state.accumulated_answer)
+
+
+def _record_span_output(
+    span_generation: Span[GenerationSpanData],
+    state: _StepEmitState,
+    tool_calls: list[ToolCallKickoff],
+) -> None:
+    """Record assistant output and reasoning for tracing (after flush + recovery)."""
+    if tool_calls:
+        tool_calls_list: list[ToolCall] = [
+            ToolCall(
+                id=kickoff.tool_call_id,
+                type="function",
+                function=FunctionCall(
+                    name=kickoff.tool_name,
+                    arguments=json.dumps(kickoff.tool_args),
+                ),
+            )
+            for kickoff in tool_calls
+        ]
+
+        assistant_msg: AssistantMessage = AssistantMessage(
+            role="assistant",
+            content=state.accumulated_answer if state.accumulated_answer else None,
+            tool_calls=tool_calls_list,
+        )
+        span_generation.span_data.output = [assistant_msg.model_dump()]
+    elif state.accumulated_answer:
+        assistant_msg_no_tools = AssistantMessage(
+            role="assistant",
+            content=state.accumulated_answer,
+            tool_calls=None,
+        )
+        span_generation.span_data.output = [assistant_msg_no_tools.model_dump()]
+
+    # Record reasoning content for tracing (extended thinking from reasoning models)
+    if state.accumulated_reasoning:
+        span_generation.span_data.reasoning = state.accumulated_reasoning
+
+
+def _log_step_output(state: _StepEmitState, tool_calls: list[ToolCallKickoff]) -> None:
+    if not (LOG_ONYX_MODEL_INTERACTIONS and current_turn_persists_content()):
+        return
+
+    logger.debug("Accumulated reasoning: %s", state.accumulated_reasoning)
+    logger.debug("Accumulated answer: %s", state.accumulated_answer)
+
+    if tool_calls:
+        tool_calls_str = "\n".join(
+            f"  - {tc.tool_name}: {json.dumps(tc.tool_args, indent=4)}"
+            for tc in tool_calls
+        )
+        logger.debug("Tool calls:\n%s", tool_calls_str)
+    else:
+        logger.debug("Tool calls: []")
+
+
 def run_llm_step_pkt_generator(
     history: list[ChatMessageSimple],
     tool_definitions: list[dict],
@@ -1147,19 +1515,19 @@ def run_llm_step_pkt_generator(
         and yielded only after the stream completes.
     """
 
-    turn_index = placement.turn_index
-    tab_index = placement.tab_index
-    sub_turn_index = placement.sub_turn_index
-
-    def _current_placement() -> Placement:
-        return Placement(
-            turn_index=turn_index,
-            tab_index=tab_index,
-            sub_turn_index=sub_turn_index,
-        )
+    state = _StepEmitState(
+        tool_choice=tool_choice,
+        state_container=state_container,
+        citation_processor=citation_processor,
+        final_documents=final_documents,
+        pre_answer_processing_time=pre_answer_processing_time,
+        is_deep_research=is_deep_research,
+        turn_index=placement.turn_index,
+        tab_index=placement.tab_index,
+        sub_turn_index=placement.sub_turn_index,
+    )
 
     llm_msg_history = translate_history_to_llm_format(history, llm.config)
-    has_reasoned = False
 
     if LOG_ONYX_MODEL_INTERACTIONS and current_turn_persists_content():
         logger.debug(
@@ -1169,19 +1537,7 @@ def run_llm_step_pkt_generator(
 
     id_to_tool_call_map: dict[int, dict[str, Any]] = {}
     arg_parsers: dict[int, Parser] = {}
-    reasoning_start = False
-    answer_start = False
-    accumulated_reasoning = ""
-    accumulated_answer = ""
-    accumulated_raw_answer = ""
-    stream_chunk_count = 0
-    actionable_chunk_count = 0
-    empty_chunk_count = 0
-    finish_reasons: set[str] = set()
-    terminal_finish_reason: str | None = None
     xml_tool_call_content_filter = _XmlToolCallContentFilter()
-
-    processor_state: Any = None
 
     with generation_span(
         model=llm.config.model_name,
@@ -1196,113 +1552,7 @@ def run_llm_step_pkt_generator(
         span_generation.span_data.tools = cast(
             Sequence[Mapping[str, Any]], tool_definitions
         )
-        stream_start_time = time.monotonic()
-        first_action_recorded = False
-
-        def _emit_citation_results(
-            results: Generator[str | CitationInfo, None, None],
-        ) -> Generator[Packet, None, None]:
-            """Yield packets for citation processor results (str or CitationInfo)."""
-            nonlocal accumulated_answer
-
-            for result in results:
-                if isinstance(result, str):
-                    accumulated_answer += result
-                    if state_container:
-                        state_container.set_answer_tokens(accumulated_answer)
-                    yield Packet(
-                        placement=_current_placement(),
-                        obj=AgentResponseDelta(content=result),
-                    )
-                elif isinstance(result, CitationInfo):
-                    yield Packet(
-                        placement=_current_placement(),
-                        obj=result,
-                    )
-                    if state_container:
-                        state_container.add_emitted_citation(result.citation_number)
-
-        def _close_reasoning_if_active() -> Generator[Packet, None, None]:
-            """Emit ReasoningDone and increment turns if reasoning is in progress."""
-            nonlocal reasoning_start
-            nonlocal has_reasoned
-            nonlocal turn_index
-            nonlocal sub_turn_index
-
-            if reasoning_start:
-                yield Packet(
-                    placement=Placement(
-                        turn_index=turn_index,
-                        tab_index=tab_index,
-                        sub_turn_index=sub_turn_index,
-                    ),
-                    obj=ReasoningDone(),
-                )
-                has_reasoned = True
-                turn_index, sub_turn_index = _increment_turns(
-                    turn_index, sub_turn_index
-                )
-                reasoning_start = False
-
-        def _emit_content_chunk(content_chunk: str) -> Generator[Packet, None, None]:
-            nonlocal accumulated_answer
-            nonlocal accumulated_reasoning
-            nonlocal answer_start
-            nonlocal reasoning_start
-            nonlocal turn_index
-            nonlocal sub_turn_index
-
-            # When tool_choice is REQUIRED, content before tool calls is reasoning/thinking
-            # about which tool to call, not an actual answer to the user.
-            # Treat this content as reasoning instead of answer.
-            if is_deep_research and tool_choice == ToolChoiceOptions.REQUIRED:
-                accumulated_reasoning += content_chunk
-                if state_container:
-                    state_container.set_reasoning_tokens(accumulated_reasoning)
-                if not reasoning_start:
-                    yield Packet(
-                        placement=_current_placement(),
-                        obj=ReasoningStart(),
-                    )
-                yield Packet(
-                    placement=_current_placement(),
-                    obj=ReasoningDelta(reasoning=content_chunk),
-                )
-                reasoning_start = True
-                return
-
-            # Normal flow for AUTO or NONE tool choice
-            yield from _close_reasoning_if_active()
-
-            if not answer_start:
-                # Store pre-answer processing time in state container for save_chat
-                if state_container and pre_answer_processing_time is not None:
-                    state_container.set_pre_answer_processing_time(
-                        pre_answer_processing_time
-                    )
-
-                yield Packet(
-                    placement=_current_placement(),
-                    obj=AgentResponseStart(
-                        final_documents=final_documents,
-                        pre_answer_processing_seconds=pre_answer_processing_time,
-                    ),
-                )
-                answer_start = True
-
-            if citation_processor:
-                yield from _emit_citation_results(
-                    citation_processor.process_token(content_chunk)
-                )
-            else:
-                accumulated_answer += content_chunk
-                # Save answer incrementally to state container
-                if state_container:
-                    state_container.set_answer_tokens(accumulated_answer)
-                yield Packet(
-                    placement=_current_placement(),
-                    obj=AgentResponseDelta(content=content_chunk),
-                )
+        stats = _StreamStats(stream_start_time=time.monotonic())
 
         for packet in llm.stream(
             prompt=llm_msg_history,
@@ -1314,246 +1564,83 @@ def run_llm_step_pkt_generator(
             user_identity=user_identity,
             timeout_override=timeout_override,
         ):
-            # On the first chunk, not at stream end: a mid-step stop persists
-            # from another thread and needs this step's params already there.
-            if stream_chunk_count == 0 and state_container:
-                state_container.set_request_params(get_llm_request_params())
-            stream_chunk_count += 1
-            if packet.usage:
-                usage = packet.usage
-                span_generation.span_data.usage = {
-                    "input_tokens": usage.prompt_tokens,
-                    "output_tokens": usage.completion_tokens,
-                    "cache_read_input_tokens": usage.cache_read_input_tokens,
-                    "cache_creation_input_tokens": usage.cache_creation_input_tokens,
-                }
-                # Note: LLM cost tracking is now handled in multi_llm.py
-            finish_reason = packet.choice.finish_reason
-            if finish_reason:
-                finish_reasons.add(str(finish_reason))
-                terminal_finish_reason = str(finish_reason)
-            delta = packet.choice.delta
-
-            # Weird behavior from some model providers, just log and ignore for now
-            if (
-                not delta.content
-                and delta.reasoning_content is None
-                and not delta.tool_calls
-            ):
-                empty_chunk_count += 1
-                logger.warning(
-                    "LLM packet is empty (no content, reasoning, or tool calls). "
-                    "finish_reason=%s. Skipping: %s",
-                    finish_reason,
-                    packet,
-                )
+            delta = _record_chunk_stats(packet, stats, state_container, span_generation)
+            if delta is None:
                 continue
-
-            if not first_action_recorded and _delta_has_action(delta):
-                span_generation.span_data.time_to_first_action_seconds = (
-                    time.monotonic() - stream_start_time
-                )
-                first_action_recorded = True
-            if _delta_has_action(delta):
-                actionable_chunk_count += 1
 
             if custom_token_processor:
                 # The custom token processor can modify the deltas for specific custom logic
                 # It can also return a state so that it can handle aggregated delta logic etc.
                 # Loosely typed so the function can be flexible
-                modified_delta, processor_state = custom_token_processor(
-                    delta, processor_state
+                modified_delta, stats.processor_state = custom_token_processor(
+                    delta, stats.processor_state
                 )
                 if modified_delta is None:
                     continue
                 delta = modified_delta
 
-            # Should only happen once, frontend does not expect multiple
-            # ReasoningStart or ReasoningDone packets.
-            if delta.reasoning_content:
-                accumulated_reasoning += delta.reasoning_content
-                # Save reasoning incrementally to state container
-                if state_container:
-                    state_container.set_reasoning_tokens(accumulated_reasoning)
-                if not reasoning_start:
-                    yield Packet(
-                        placement=_current_placement(),
-                        obj=ReasoningStart(),
-                    )
-                yield Packet(
-                    placement=_current_placement(),
-                    obj=ReasoningDelta(reasoning=delta.reasoning_content),
-                )
-                reasoning_start = True
-
-            if delta.content:
-                # Keep raw content for fallback extraction. Display content can be
-                # filtered and, in deep-research REQUIRED mode, routed as reasoning.
-                accumulated_raw_answer += delta.content
-                filtered_content = xml_tool_call_content_filter.process(delta.content)
-                if filtered_content:
-                    yield from _emit_content_chunk(filtered_content)
-
-            if delta.tool_calls:
-                yield from _close_reasoning_if_active()
-
-                for tool_call_delta in delta.tool_calls:
-                    # maybe_emit depends and update being called first and attaching the delta
-                    _update_tool_call_with_delta(id_to_tool_call_map, tool_call_delta)
-                    yield from maybe_emit_argument_delta(
-                        tool_calls_in_progress=id_to_tool_call_map,
-                        tool_call_delta=tool_call_delta,
-                        placement=_current_placement(),
-                        parsers=arg_parsers,
-                    )
+            yield from _emit_delta_packets(
+                state,
+                delta,
+                id_to_tool_call_map,
+                arg_parsers,
+                xml_tool_call_content_filter,
+            )
 
         # Flush any tail text buffered while checking for split "<function_calls" markers.
         filtered_content_tail = xml_tool_call_content_filter.flush()
         if filtered_content_tail:
-            yield from _emit_content_chunk(filtered_content_tail)
+            yield from _emit_content_chunk(state, filtered_content_tail)
 
-        # Flush custom token processor to get any final tool calls
         if custom_token_processor:
-            flush_delta, processor_state = custom_token_processor(None, processor_state)
-            if (
-                not first_action_recorded
-                and flush_delta is not None
-                and _delta_has_action(flush_delta)
-            ):
-                span_generation.span_data.time_to_first_action_seconds = (
-                    time.monotonic() - stream_start_time
-                )
-                first_action_recorded = True
-            if flush_delta and flush_delta.tool_calls:
-                for tool_call_delta in flush_delta.tool_calls:
-                    _update_tool_call_with_delta(id_to_tool_call_map, tool_call_delta)
+            _flush_custom_token_processor(
+                custom_token_processor, stats, span_generation, id_to_tool_call_map
+            )
 
         # Narration emitted before these tool calls occupies the base tab; start
         # tool calls at the next tab so they render as their own group instead of
         # merging with the narration (which would hide them in the chat area).
-        tab_index_start = 1 if (answer_start and not use_existing_tab_index) else 0
+        tab_index_start = (
+            1 if (state.answer_start and not use_existing_tab_index) else 0
+        )
         tool_calls = _extract_tool_call_kickoffs(
             id_to_tool_call_map=id_to_tool_call_map,
-            turn_index=turn_index,
-            tab_index=tab_index if use_existing_tab_index else None,
-            sub_turn_index=sub_turn_index,
+            turn_index=state.turn_index,
+            tab_index=state.tab_index if use_existing_tab_index else None,
+            sub_turn_index=state.sub_turn_index,
             tab_index_start=tab_index_start,
         )
         # Run the flush + recovery below while the span is still open, so the
         # span output recorded afterward reflects the answer the user received.
-        yield from _close_reasoning_if_active()
+        yield from _close_reasoning_if_active(state)
 
         # Flush any remaining content from citation processor
         # Reasoning is always first so this should use the post-incremented value of turn_index
         # Note that this doesn't need to handle any sub-turns as those docs will not have citations
         # as clickable items and will be stripped out instead.
         if citation_processor:
-            yield from _emit_citation_results(citation_processor.process_token(None))
-
-        # Empty-answer recovery: the model emitted text but content/citation
-        # processing consumed all of it (e.g. an unmapped bracketed-numeric answer
-        # like "[123456789012345]" that the citation processor strips). Surface the
-        # raw output instead of returning an empty answer, which would raise a
-        # misleading EmptyLLMResponseError downstream. Skipped for REQUIRED tool
-        # choice, where empty pre-tool content is expected (fallback extraction).
-        # Also skipped when the raw output is XML tool-call markup: run_llm_loop's
-        # fallback extraction will parse it into a real tool call, so surfacing it
-        # as an answer would leak raw markup to the client and pollute context.
-        if (
-            tool_choice != ToolChoiceOptions.REQUIRED
-            and not tool_calls
-            and not accumulated_answer.strip()
-            and accumulated_raw_answer.strip()
-            and not _looks_like_xml_tool_call_payload(accumulated_raw_answer)
-        ):
-            logger.warning(
-                "Answer empty after content/citation processing; recovering raw "
-                "model output (%d chars). provider=%s, model=%s, finish_reasons=%s",
-                len(accumulated_raw_answer),
-                llm.config.model_provider,
-                llm.config.model_name,
-                sorted(finish_reasons),
+            yield from _emit_citation_results(
+                state, citation_processor.process_token(None)
             )
-            if not answer_start:
-                # Mirror _emit_content_chunk: persist pre-answer timing before the
-                # first AgentResponseStart.
-                if state_container and pre_answer_processing_time is not None:
-                    state_container.set_pre_answer_processing_time(
-                        pre_answer_processing_time
-                    )
-                yield Packet(
-                    placement=_current_placement(),
-                    obj=AgentResponseStart(
-                        final_documents=final_documents,
-                        pre_answer_processing_seconds=pre_answer_processing_time,
-                    ),
-                )
-                answer_start = True
-            yield Packet(
-                placement=_current_placement(),
-                obj=AgentResponseDelta(content=accumulated_raw_answer),
-            )
-            accumulated_answer = accumulated_raw_answer
-            if state_container:
-                state_container.set_answer_tokens(accumulated_answer)
 
-        # Record assistant output for tracing (after flush + recovery).
-        if tool_calls:
-            tool_calls_list: list[ToolCall] = [
-                ToolCall(
-                    id=kickoff.tool_call_id,
-                    type="function",
-                    function=FunctionCall(
-                        name=kickoff.tool_name,
-                        arguments=json.dumps(kickoff.tool_args),
-                    ),
-                )
-                for kickoff in tool_calls
-            ]
+        yield from _emit_empty_answer_recovery(state, llm.config, stats, tool_calls)
 
-            assistant_msg: AssistantMessage = AssistantMessage(
-                role="assistant",
-                content=accumulated_answer if accumulated_answer else None,
-                tool_calls=tool_calls_list,
-            )
-            span_generation.span_data.output = [assistant_msg.model_dump()]
-        elif accumulated_answer:
-            assistant_msg_no_tools = AssistantMessage(
-                role="assistant",
-                content=accumulated_answer,
-                tool_calls=None,
-            )
-            span_generation.span_data.output = [assistant_msg_no_tools.model_dump()]
-
-        # Record reasoning content for tracing (extended thinking from reasoning models)
-        if accumulated_reasoning:
-            span_generation.span_data.reasoning = accumulated_reasoning
+        _record_span_output(span_generation, state, tool_calls)
 
     # Note: Content (AgentResponseDelta) doesn't need an explicit end packet - OverallStop handles it
     # Tool calls are handled by tool execution code and emit their own packets (e.g., SectionEnd)
-    if LOG_ONYX_MODEL_INTERACTIONS and current_turn_persists_content():
-        logger.debug("Accumulated reasoning: %s", accumulated_reasoning)
-        logger.debug("Accumulated answer: %s", accumulated_answer)
+    _log_step_output(state, tool_calls)
 
-        if tool_calls:
-            tool_calls_str = "\n".join(
-                f"  - {tc.tool_name}: {json.dumps(tc.tool_args, indent=4)}"
-                for tc in tool_calls
-            )
-            logger.debug("Tool calls:\n%s", tool_calls_str)
-        else:
-            logger.debug("Tool calls: []")
-
-    if actionable_chunk_count == 0:
+    if stats.actionable_chunk_count == 0:
         logger.warning(
             "LLM stream completed with no actionable deltas. "
             "chunks=%s, empty_chunks=%s, "
             "finish_reasons=%s, "
             "provider=%s, model=%s, "
             "tool_choice=%s, tools_sent=%s",
-            stream_chunk_count,
-            empty_chunk_count,
-            sorted(finish_reasons),
+            stats.stream_chunk_count,
+            stats.empty_chunk_count,
+            sorted(stats.finish_reasons),
             llm.config.model_provider,
             llm.config.model_name,
             tool_choice,
@@ -1562,13 +1649,17 @@ def run_llm_step_pkt_generator(
 
     return (
         LlmStepResult(
-            reasoning=accumulated_reasoning if accumulated_reasoning else None,
-            answer=accumulated_answer if accumulated_answer else None,
+            reasoning=(
+                state.accumulated_reasoning if state.accumulated_reasoning else None
+            ),
+            answer=state.accumulated_answer if state.accumulated_answer else None,
             tool_calls=tool_calls if tool_calls else None,
-            raw_answer=accumulated_raw_answer if accumulated_raw_answer else None,
-            finish_reason=terminal_finish_reason,
+            raw_answer=(
+                state.accumulated_raw_answer if state.accumulated_raw_answer else None
+            ),
+            finish_reason=stats.terminal_finish_reason,
         ),
-        has_reasoned,
+        state.has_reasoned,
     )
 
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -142,6 +142,7 @@ from onyx.server.settings.store import load_settings
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.server.utils import get_json_line
 from onyx.tools.constants import FILE_READER_TOOL_ID, SEARCH_TOOL_ID
+from onyx.tools.interface import Tool
 from onyx.tools.models import ChatFile, SearchToolUsage
 from onyx.tools.tool_constructor import (
     CustomToolConfig,
@@ -1140,6 +1141,520 @@ def _model_error_details(
     return details
 
 
+class _MultiModelRun:
+    """Shared state for a single ``_run_models`` invocation.
+
+    One instance owns the worker threads, the writer thread, and the queues that
+    connect them. Methods run on different threads: ``_run_model`` on the pool
+    workers, ``_drain_to_completion`` on the writer, ``read_stream`` on the
+    caller's thread.
+    """
+
+    def __init__(
+        self,
+        setup: ChatTurnSetup,
+        user: User,
+        external_state_container: ChatStateContainer | None,
+        stream_buffer: StreamBufferWriter | None,
+    ) -> None:
+        self.setup = setup
+        self.user = user
+        self.stream_buffer = stream_buffer
+        self.n_models = len(setup.llms)
+
+        # Workspace toggle: infer source/time filters from the query (default on).
+        self.auto_detect_search_filters = (
+            load_settings().auto_detect_search_filters is not False
+        )
+
+        self.merged_queue: queue.Queue[tuple[int, Packet | Exception | object]] = (
+            queue.Queue()
+        )
+
+        self.state_containers: list[ChatStateContainer] = [
+            (
+                external_state_container
+                if (external_state_container is not None and i == 0)
+                else ChatStateContainer()
+            )
+            for i in range(self.n_models)
+        ]
+        self.model_succeeded: list[bool] = [False] * self.n_models
+        # Set to True when a model raises an exception (distinct from "still running").
+        # Used in the stop-button path to avoid calling completion for errored models.
+        self.model_errored: list[bool] = [False] * self.n_models
+        # Per-model classification set in _run_model and reused by the streamed
+        # packet and the persisted message.
+        self.model_error_info: list[LLMErrorInfo | None] = [None] * self.n_models
+        self.persist_lock = threading.Lock()
+        self.persisted: list[bool] = [False] * self.n_models
+        # All models share one mainline chain, so exactly one completion should
+        # run history compression — the first non-errored one to persist, not a
+        # fixed index (model 0 may have errored). Guarded by persist_lock.
+        self.compression_claimed = False
+        self.post_steps_done = threading.Event()
+
+        # Set only on stop-button: workers can't be interrupted, so their remaining
+        # emits are discarded. Client disconnects do NOT set this — the writer keeps
+        # consuming and buffering to the very end.
+        self.drain_done = threading.Event()
+
+        # Writer-thread → reader-generator hand-off. The writer is the run's
+        # lifeline and always runs to completion; the reader can die freely.
+        self.tee: queue.Queue[Packet | StreamingError | object] = queue.Queue()
+        # Set when the reader detaches; stops the tee from accumulating items
+        # nobody will consume.
+        self.reader_gone = threading.Event()
+
+        # Each worker thread needs its own Context copy — a single Context object
+        # cannot be entered concurrently by multiple threads (RuntimeError).
+        self.executor = ThreadPoolExecutor(
+            max_workers=self.n_models, thread_name_prefix="multi-model"
+        )
+
+    def start(self) -> None:
+        """Start one worker thread per model plus the writer thread."""
+        for i in range(self.n_models):
+            ctx = contextvars.copy_context()
+            self.executor.submit(ctx.run, self._run_model, i)
+
+        writer_thread = threading.Thread(
+            target=contextvars.copy_context().run,
+            args=(self._drain_to_completion,),
+            name="chat-stream-writer",
+        )
+        writer_thread.start()
+
+    def _persist_model_outcome(
+        self,
+        model_idx: int,
+        context: _PersistContext,
+        *,
+        stop_button: bool = False,
+    ) -> None:
+        """Persist one model's outcome exactly once, from any thread.
+
+        The LLM loops never observe the stop signal, so a worker that returns
+        non-errored always holds a complete answer. Partial content exists only
+        when the stop-button path snapshots a still-running model mid-loop —
+        that call forces a claim (``stop_button=True``) so the in-flight state
+        is saved with the stopped-by-user annotation and the worker's later
+        call becomes a no-op."""
+        setup = self.setup
+        with self.persist_lock:
+            if self.persisted[model_idx]:
+                return
+            succeeded = self.model_succeeded[model_idx]
+            errored = self.model_errored[model_idx]
+            if not succeeded and not errored and not stop_button:
+                return
+            self.persisted[model_idx] = True
+
+        if errored:
+            self._save_errored_message(model_idx, context)
+            return
+
+        completed_normally = succeeded if stop_button else True
+
+        def _is_connected(value: bool = completed_normally) -> bool:
+            return value
+
+        with self.persist_lock:
+            run_compression = not self.compression_claimed
+            self.compression_claimed = True
+
+        try:
+            llm_loop_completion_handle(
+                state_container=self.state_containers[model_idx],
+                is_connected=_is_connected,
+                assistant_message=setup.reserved_messages[model_idx],
+                llm=setup.llms[model_idx],
+                reserved_tokens=setup.reserved_token_count,
+                run_compression=run_compression,
+                # The single compression check must still protect the
+                # smallest-window model, so it measures against the min
+                # window across the turn's models.
+                compression_max_input_tokens=min(
+                    model_llm.config.max_input_tokens for model_llm in setup.llms
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "%s completion failed for model %d (%s)",
+                context.value,
+                model_idx,
+                setup.model_display_names[model_idx],
+            )
+            if run_compression:
+                # The handle failed before compression could have run
+                # (compress_chat_history swallows its own errors), so let a
+                # later model's completion pick it up. If every other model
+                # already persisted while the claim was held, this turn ends
+                # uncompressed — acceptable, since the next turn's completion
+                # re-evaluates the trigger and compresses then.
+                with self.persist_lock:
+                    self.compression_claimed = False
+
+    def _run_post_steps(self) -> None:
+        with self.persist_lock:
+            if self.post_steps_done.is_set():
+                return
+            self.post_steps_done.set()
+
+        for i in range(self.n_models):
+            self._persist_model_outcome(i, _PersistContext.POST_STEPS)
+
+        # The writer thread is the run's authoritative end — it owns the fence
+        # reset so the session never sticks at (or prematurely leaves)
+        # "processing", whatever happened to the request generator.
+        try:
+            set_processing_status(
+                chat_session_id=self.setup.chat_session_id,
+                cache=self.setup.cache,
+                value=False,
+            )
+        except Exception:
+            logger.exception("post-steps processing status reset failed")
+
+    def _build_model_tools(self, model_idx: int, emitter: Emitter) -> list[Tool]:
+        """Build one model's tool list and reject a missing forced tool."""
+        setup = self.setup
+        # Each function opens short-lived DB sessions on demand.
+        # Do NOT pass a long-lived session here — it would hold a
+        # connection for the entire LLM loop (minutes), and cloud
+        # infrastructure may drop idle connections.
+        thread_tool_dict = construct_tools(
+            persona=setup.persona,
+            emitter=emitter,
+            user=self.user,
+            llm=setup.llms[model_idx],
+            search_tool_config=SearchToolConfig(
+                user_selected_filters=setup.new_msg_req.internal_search_filters,
+                project_id_filter=setup.search_params.project_id_filter,
+                persona_id_filter=setup.search_params.persona_id_filter,
+                bypass_acl=setup.bypass_acl,
+                slack_context=setup.slack_context,
+                enable_slack_search=_should_enable_slack_search(
+                    setup.persona, setup.new_msg_req.internal_search_filters
+                ),
+                auto_detect_filters=self.auto_detect_search_filters,
+            ),
+            custom_tool_config=CustomToolConfig(
+                chat_session_id=setup.chat_session_id,
+                message_id=setup.user_message_id,
+                additional_headers=setup.custom_tool_additional_headers,
+                mcp_headers=setup.mcp_headers,
+            ),
+            file_reader_tool_config=FileReaderToolConfig(
+                user_file_ids=setup.available_files.user_file_ids,
+                chat_file_ids=setup.available_files.chat_file_ids,
+            ),
+            allowed_tool_ids=setup.new_msg_req.allowed_tool_ids,
+            search_usage_forcing_setting=setup.search_params.search_usage,
+        )
+        model_tools = [
+            tool for tool_list in thread_tool_dict.values() for tool in tool_list
+        ]
+
+        if setup.forced_tool_id and setup.forced_tool_id not in {
+            tool.id for tool in model_tools
+        }:
+            raise ValueError(f"Forced tool {setup.forced_tool_id} not found in tools")
+
+        return model_tools
+
+    def _run_llm_loop(
+        self,
+        model_idx: int,
+        emitter: Emitter,
+        model_tools: list[Tool],
+    ) -> None:
+        """Dispatch one model to the deep-research or the standard LLM loop."""
+        setup = self.setup
+        sc = self.state_containers[model_idx]
+        model_llm = setup.llms[model_idx]
+
+        # Per-thread copy: run_llm_loop mutates simple_chat_history in-place.
+        if self.n_models == 1 and setup.new_msg_req.deep_research:
+            if setup.chat_session_project_id:
+                raise RuntimeError("Deep research is not supported for projects")
+            run_deep_research_llm_loop(
+                emitter=emitter,
+                state_container=sc,
+                simple_chat_history=list(setup.simple_chat_history),
+                tools=model_tools,
+                custom_agent_prompt=setup.custom_agent_prompt,
+                llm=model_llm,
+                token_counter=get_llm_token_counter(model_llm),
+                reasoning_effort=setup.reasoning_effort,
+                skip_clarification=setup.skip_clarification,
+                user_identity=setup.user_identity,
+                chat_session_id=str(setup.chat_session_id),
+                all_injected_file_metadata=setup.all_injected_file_metadata,
+            )
+        else:
+            run_llm_loop(
+                emitter=emitter,
+                state_container=sc,
+                simple_chat_history=list(setup.simple_chat_history),
+                tools=model_tools,
+                custom_agent_prompt=setup.custom_agent_prompt,
+                context_files=setup.extracted_context_files,
+                persona=setup.persona,
+                user_memory_context=setup.user_memory_context,
+                llm=model_llm,
+                token_counter=get_llm_token_counter(model_llm),
+                forced_tool_id=setup.forced_tool_id,
+                user_identity=setup.user_identity,
+                chat_session_id=str(setup.chat_session_id),
+                chat_files=setup.chat_files_for_tools,
+                reasoning_effort=setup.reasoning_effort,
+                include_citations=setup.new_msg_req.include_citations,
+                all_injected_file_metadata=setup.all_injected_file_metadata,
+                inject_memories_in_prompt=self.user.use_memories,
+            )
+
+    def _run_model(self, model_idx: int) -> None:
+        """Run one LLM loop inside a worker thread, writing packets to ``merged_queue``."""
+
+        model_emitter = Emitter(
+            model_idx=model_idx,
+            merged_queue=self.merged_queue,
+            drain_done=self.drain_done,
+        )
+        model_llm = self.setup.llms[model_idx]
+
+        try:
+            model_tools = self._build_model_tools(model_idx, model_emitter)
+            self._run_llm_loop(model_idx, model_emitter, model_tools)
+
+            self.model_succeeded[model_idx] = True
+
+        except Exception as e:
+            self.model_errored[model_idx] = True
+            self.model_error_info[model_idx] = litellm_exception_to_safe_error(
+                e, model_llm, fallback_to_error_msg=True
+            )
+            self.merged_queue.put((model_idx, e))
+
+        finally:
+            self._persist_model_outcome(model_idx, _PersistContext.WORKER)
+            self.merged_queue.put((model_idx, _MODEL_DONE))
+
+    def _errored_message_text(self, model_idx: int) -> str:
+        """Build the durable error text for a model that failed mid-run."""
+        if not record_mode_persists_content(self.setup.incognito_record_mode):
+            # Provider errors can echo prompt fragments, so the
+            # durable row gets a generic marker. The live stream
+            # still carries the real error to the user.
+            return "The model encountered an error."
+
+        info = self.model_error_info[model_idx]
+        detail = (
+            info.message
+            if info is not None
+            else "model encountered an error during generation."
+        )
+        return "Error from %s: %s" % (
+            self.setup.model_display_names[model_idx],
+            detail,
+        )
+
+    def _save_errored_message(self, model_idx: int, context: _PersistContext) -> None:
+        """Save an error message to a reserved ChatMessage that failed during execution."""
+        try:
+            with get_session_with_current_tenant() as save_db_session:
+                msg = save_db_session.get(
+                    ChatMessage, self.setup.reserved_messages[model_idx].id
+                )
+                if msg is not None:
+                    error_text = self._errored_message_text(model_idx)
+                    msg.message = error_text
+                    msg.error = error_text
+                    # The reservation's placeholder count must not survive:
+                    # rows carry the real output count, zero when none emitted.
+                    sc = self.state_containers[model_idx]
+                    partial_answer = sc.get_answer_tokens()
+                    msg.token_count = (
+                        len(get_tokenizer(None, None).encode(partial_answer))
+                        if partial_answer
+                        else 0
+                    )
+                    save_db_session.commit()
+        except Exception:
+            logger.exception(
+                "%s error save failed for model %d (%s)",
+                context.value,
+                model_idx,
+                self.setup.model_display_names[model_idx],
+            )
+
+    def _publish(self, item: Packet | StreamingError) -> None:
+        """Fan one outbound item to the stream buffer and, while attached, the reader."""
+        if self.stream_buffer is not None:
+            try:
+                self.stream_buffer.append_line(get_json_line(item.model_dump()))
+            except Exception:
+                logger.exception("stream buffer append failed")
+        # Non-blocking put: a slow reader can't stall the writer.
+        if not self.reader_gone.is_set():
+            self.tee.put(item)
+
+    def _refresh_fence(self, last_fence_refresh: float) -> float:
+        """Re-arm the processing fence on schedule; returns the last refresh time."""
+        # Runs can outlive FENCE_TTL; a lapsed fence reads as a dead
+        # writer to resume readers and unblocks concurrent sends.
+        now = time.monotonic()
+        if now - last_fence_refresh < _FENCE_REFRESH_INTERVAL_S:
+            return last_fence_refresh
+        try:
+            set_processing_status(
+                chat_session_id=self.setup.chat_session_id,
+                cache=self.setup.cache,
+                value=True,
+                run_id=self.setup.processing_run_id,
+            )
+        except Exception:
+            # Worst case the fence lapses early; never kill the
+            # run over a refresh.
+            logger.exception("processing fence refresh failed")
+        return now
+
+    def _handle_idle_poll(self) -> bool:
+        """Handle an empty-queue tick; returns True when the user cancelled."""
+        if self.stream_buffer is not None:
+            self.stream_buffer.flush()
+        # Check for user-initiated cancellation every 50 ms.
+        if self.setup.check_is_connected():
+            return False
+
+        for i in range(self.n_models):
+            # Snapshot every model now: finished loops save
+            # complete, in-flight ones save partial + stopped.
+            self._persist_model_outcome(
+                i, _PersistContext.STOP_BUTTON, stop_button=True
+            )
+        self._publish(
+            Packet(
+                placement=Placement(turn_index=0),
+                obj=OverallStop(type="stop", stop_reason="user_cancelled"),
+            )
+        )
+        # Workers can't be interrupted; discard their remaining
+        # output via the Emitter no-op.
+        self.drain_done.set()
+        return True
+
+    def _publish_model_error(self, model_idx: int, error: Exception) -> None:
+        """Publish one model's failure as a secret-scrubbed ``StreamingError``."""
+        model_llm = self.setup.llms[model_idx]
+        # Classified in _run_model; fall back to a generic error.
+        info = self.model_error_info[model_idx]
+        if info is None:
+            info = LLMErrorInfo(
+                message=str(error),
+                error_code="MODEL_ERROR",
+                is_retryable=True,
+            )
+        stack_trace = "".join(
+            traceback.format_exception(type(error), error, error.__traceback__)
+        )
+        secrets = collect_credential_values(
+            model_llm.config.api_key, model_llm.config.custom_config
+        )
+        error_msg = scrub_sensitive_values(info.message, secrets)
+        stack_trace = scrub_sensitive_values(stack_trace, secrets)
+        self._publish(
+            StreamingError(
+                error=error_msg,
+                stack_trace=stack_trace,
+                error_code=info.error_code,
+                is_retryable=info.is_retryable,
+                details=_model_error_details(error, model_llm, model_idx),
+            )
+        )
+
+    def _drain_to_completion(self) -> None:
+        """Writer: consume worker output to the very end regardless of client state."""
+        models_remaining = self.n_models
+        last_fence_refresh = time.monotonic()
+        try:
+            while models_remaining > 0:
+                last_fence_refresh = self._refresh_fence(last_fence_refresh)
+                try:
+                    model_idx, item = self.merged_queue.get(
+                        timeout=_CANCEL_POLL_INTERVAL_S
+                    )
+                except queue.Empty:
+                    if self._handle_idle_poll():
+                        return
+                    continue
+                if item is _MODEL_DONE:
+                    models_remaining -= 1
+                elif isinstance(item, Exception):
+                    # Publish a tagged error for this model but keep the other
+                    # models running. Do NOT decrement models_remaining —
+                    # _run_model's finally always posts _MODEL_DONE, which is
+                    # the sole completion signal.
+                    self._publish_model_error(model_idx, item)
+                elif isinstance(item, Packet):
+                    # model_index already embedded by the model's Emitter
+                    self._publish(item)
+
+            for i in range(self.n_models):
+                self._persist_model_outcome(i, _PersistContext.NORMAL)
+        except Exception:
+            logger.exception("chat stream writer crashed")
+            # With the writer dead, merged_queue has no consumer — flip the
+            # emitters to discard so workers can't grow it unbounded.
+            self.drain_done.set()
+            # Generic message: the raw exception may embed provider API keys.
+            self._publish(
+                StreamingError(
+                    error="The response stream ended unexpectedly. Please try again.",
+                    error_code="STREAM_WRITER_ERROR",
+                    is_retryable=True,
+                )
+            )
+        finally:
+            # Mark done before _run_post_steps clears the fence so resume
+            # readers never see a fence-less, not-done buffer and drop the tail.
+            if self.stream_buffer is not None:
+                self.stream_buffer.mark_done()
+            self._run_post_steps()
+            self.tee.put(_STREAM_DONE)
+            self.executor.shutdown(wait=False)
+
+    def read_stream(self) -> AnswerStream:
+        # ── Reader: tail the tee while the client is attached ────────────────
+        stream_done = False
+        try:
+            last_packet_yield: float = time.monotonic()
+            while True:
+                try:
+                    item = self.tee.get(timeout=_CANCEL_POLL_INTERVAL_S)
+                except queue.Empty:
+                    now = time.monotonic()
+                    if now - last_packet_yield >= CHAT_HEARTBEAT_INTERVAL_S:
+                        yield heartbeat_packet()
+                        last_packet_yield = now
+                    continue
+                if item is _STREAM_DONE:
+                    stream_done = True
+                    return
+                yield cast(Packet | StreamingError, item)
+                last_packet_yield = time.monotonic()
+        finally:
+            self.reader_gone.set()
+            if not stream_done:
+                # GeneratorExit (client disconnect): the reader stops here while
+                # the writer thread keeps draining to completion in the background.
+                logger.info(
+                    "chat stream reader detached; writer continues for session %s",
+                    self.setup.chat_session_id,
+                )
+
+
 def _run_models(
     setup: ChatTurnSetup,
     user: User,
@@ -1180,457 +1695,9 @@ def _run_models(
         containing ``OverallStop`` once all models complete (or one containing
         ``OverallStop(stop_reason="user_cancelled")`` if the connection drops).
     """
-    n_models = len(setup.llms)
-
-    # Workspace toggle: infer source/time filters from the query (default on).
-    auto_detect_search_filters = load_settings().auto_detect_search_filters is not False
-
-    merged_queue: queue.Queue[tuple[int, Packet | Exception | object]] = queue.Queue()
-
-    state_containers: list[ChatStateContainer] = [
-        (
-            external_state_container
-            if (external_state_container is not None and i == 0)
-            else ChatStateContainer()
-        )
-        for i in range(n_models)
-    ]
-    model_succeeded: list[bool] = [False] * n_models
-    # Set to True when a model raises an exception (distinct from "still running").
-    # Used in the stop-button path to avoid calling completion for errored models.
-    model_errored: list[bool] = [False] * n_models
-    # Per-model classification set in _run_model and reused by the streamed
-    # packet and the persisted message.
-    model_error_info: list[LLMErrorInfo | None] = [None] * n_models
-    persist_lock = threading.Lock()
-    persisted: list[bool] = [False] * n_models
-    # All models share one mainline chain, so exactly one completion should
-    # run history compression — the first non-errored one to persist, not a
-    # fixed index (model 0 may have errored). Guarded by persist_lock.
-    compression_claimed = False
-    post_steps_done = threading.Event()
-
-    # Set only on stop-button: workers can't be interrupted, so their remaining
-    # emits are discarded. Client disconnects do NOT set this — the writer keeps
-    # consuming and buffering to the very end.
-    drain_done = threading.Event()
-
-    # Writer-thread → reader-generator hand-off. The writer is the run's
-    # lifeline and always runs to completion; the reader can die freely.
-    tee: queue.Queue[Packet | StreamingError | object] = queue.Queue()
-    # Set when the reader detaches; stops the tee from accumulating items
-    # nobody will consume.
-    reader_gone = threading.Event()
-
-    def _persist_model_outcome(
-        model_idx: int,
-        context: _PersistContext,
-        *,
-        stop_button: bool = False,
-    ) -> None:
-        """Persist one model's outcome exactly once, from any thread.
-
-        The LLM loops never observe the stop signal, so a worker that returns
-        non-errored always holds a complete answer. Partial content exists only
-        when the stop-button path snapshots a still-running model mid-loop —
-        that call forces a claim (``stop_button=True``) so the in-flight state
-        is saved with the stopped-by-user annotation and the worker's later
-        call becomes a no-op."""
-        with persist_lock:
-            if persisted[model_idx]:
-                return
-            succeeded = model_succeeded[model_idx]
-            errored = model_errored[model_idx]
-            if not succeeded and not errored and not stop_button:
-                return
-            persisted[model_idx] = True
-
-        if errored:
-            _save_errored_message(model_idx, context)
-            return
-
-        completed_normally = succeeded if stop_button else True
-
-        def _is_connected(value: bool = completed_normally) -> bool:
-            return value
-
-        nonlocal compression_claimed
-        with persist_lock:
-            run_compression = not compression_claimed
-            compression_claimed = True
-
-        try:
-            llm_loop_completion_handle(
-                state_container=state_containers[model_idx],
-                is_connected=_is_connected,
-                assistant_message=setup.reserved_messages[model_idx],
-                llm=setup.llms[model_idx],
-                reserved_tokens=setup.reserved_token_count,
-                run_compression=run_compression,
-                # The single compression check must still protect the
-                # smallest-window model, so it measures against the min
-                # window across the turn's models.
-                compression_max_input_tokens=min(
-                    model_llm.config.max_input_tokens for model_llm in setup.llms
-                ),
-            )
-        except Exception:
-            logger.exception(
-                "%s completion failed for model %d (%s)",
-                context.value,
-                model_idx,
-                setup.model_display_names[model_idx],
-            )
-            if run_compression:
-                # The handle failed before compression could have run
-                # (compress_chat_history swallows its own errors), so let a
-                # later model's completion pick it up. If every other model
-                # already persisted while the claim was held, this turn ends
-                # uncompressed — acceptable, since the next turn's completion
-                # re-evaluates the trigger and compresses then.
-                with persist_lock:
-                    compression_claimed = False
-
-    def _run_post_steps() -> None:
-        with persist_lock:
-            if post_steps_done.is_set():
-                return
-            post_steps_done.set()
-
-        for i in range(n_models):
-            _persist_model_outcome(i, _PersistContext.POST_STEPS)
-
-        # The writer thread is the run's authoritative end — it owns the fence
-        # reset so the session never sticks at (or prematurely leaves)
-        # "processing", whatever happened to the request generator.
-        try:
-            set_processing_status(
-                chat_session_id=setup.chat_session_id,
-                cache=setup.cache,
-                value=False,
-            )
-        except Exception:
-            logger.exception("post-steps processing status reset failed")
-
-    def _run_model(model_idx: int) -> None:
-        """Run one LLM loop inside a worker thread, writing packets to ``merged_queue``."""
-
-        model_emitter = Emitter(
-            model_idx=model_idx,
-            merged_queue=merged_queue,
-            drain_done=drain_done,
-        )
-        sc = state_containers[model_idx]
-        model_llm = setup.llms[model_idx]
-
-        try:
-            # Each function opens short-lived DB sessions on demand.
-            # Do NOT pass a long-lived session here — it would hold a
-            # connection for the entire LLM loop (minutes), and cloud
-            # infrastructure may drop idle connections.
-            thread_tool_dict = construct_tools(
-                persona=setup.persona,
-                emitter=model_emitter,
-                user=user,
-                llm=model_llm,
-                search_tool_config=SearchToolConfig(
-                    user_selected_filters=setup.new_msg_req.internal_search_filters,
-                    project_id_filter=setup.search_params.project_id_filter,
-                    persona_id_filter=setup.search_params.persona_id_filter,
-                    bypass_acl=setup.bypass_acl,
-                    slack_context=setup.slack_context,
-                    enable_slack_search=_should_enable_slack_search(
-                        setup.persona, setup.new_msg_req.internal_search_filters
-                    ),
-                    auto_detect_filters=auto_detect_search_filters,
-                ),
-                custom_tool_config=CustomToolConfig(
-                    chat_session_id=setup.chat_session_id,
-                    message_id=setup.user_message_id,
-                    additional_headers=setup.custom_tool_additional_headers,
-                    mcp_headers=setup.mcp_headers,
-                ),
-                file_reader_tool_config=FileReaderToolConfig(
-                    user_file_ids=setup.available_files.user_file_ids,
-                    chat_file_ids=setup.available_files.chat_file_ids,
-                ),
-                allowed_tool_ids=setup.new_msg_req.allowed_tool_ids,
-                search_usage_forcing_setting=setup.search_params.search_usage,
-            )
-            model_tools = [
-                tool for tool_list in thread_tool_dict.values() for tool in tool_list
-            ]
-
-            if setup.forced_tool_id and setup.forced_tool_id not in {
-                tool.id for tool in model_tools
-            }:
-                raise ValueError(
-                    f"Forced tool {setup.forced_tool_id} not found in tools"
-                )
-
-            # Per-thread copy: run_llm_loop mutates simple_chat_history in-place.
-            if n_models == 1 and setup.new_msg_req.deep_research:
-                if setup.chat_session_project_id:
-                    raise RuntimeError("Deep research is not supported for projects")
-                run_deep_research_llm_loop(
-                    emitter=model_emitter,
-                    state_container=sc,
-                    simple_chat_history=list(setup.simple_chat_history),
-                    tools=model_tools,
-                    custom_agent_prompt=setup.custom_agent_prompt,
-                    llm=model_llm,
-                    token_counter=get_llm_token_counter(model_llm),
-                    reasoning_effort=setup.reasoning_effort,
-                    skip_clarification=setup.skip_clarification,
-                    user_identity=setup.user_identity,
-                    chat_session_id=str(setup.chat_session_id),
-                    all_injected_file_metadata=setup.all_injected_file_metadata,
-                )
-            else:
-                run_llm_loop(
-                    emitter=model_emitter,
-                    state_container=sc,
-                    simple_chat_history=list(setup.simple_chat_history),
-                    tools=model_tools,
-                    custom_agent_prompt=setup.custom_agent_prompt,
-                    context_files=setup.extracted_context_files,
-                    persona=setup.persona,
-                    user_memory_context=setup.user_memory_context,
-                    llm=model_llm,
-                    token_counter=get_llm_token_counter(model_llm),
-                    forced_tool_id=setup.forced_tool_id,
-                    user_identity=setup.user_identity,
-                    chat_session_id=str(setup.chat_session_id),
-                    chat_files=setup.chat_files_for_tools,
-                    reasoning_effort=setup.reasoning_effort,
-                    include_citations=setup.new_msg_req.include_citations,
-                    all_injected_file_metadata=setup.all_injected_file_metadata,
-                    inject_memories_in_prompt=user.use_memories,
-                )
-
-            model_succeeded[model_idx] = True
-
-        except Exception as e:
-            model_errored[model_idx] = True
-            model_error_info[model_idx] = litellm_exception_to_safe_error(
-                e, model_llm, fallback_to_error_msg=True
-            )
-            merged_queue.put((model_idx, e))
-
-        finally:
-            _persist_model_outcome(model_idx, _PersistContext.WORKER)
-            merged_queue.put((model_idx, _MODEL_DONE))
-
-    def _save_errored_message(model_idx: int, context: _PersistContext) -> None:
-        """Save an error message to a reserved ChatMessage that failed during execution."""
-        try:
-            with get_session_with_current_tenant() as save_db_session:
-                msg = save_db_session.get(
-                    ChatMessage, setup.reserved_messages[model_idx].id
-                )
-                if msg is not None:
-                    mode = setup.incognito_record_mode
-                    if not record_mode_persists_content(mode):
-                        # Provider errors can echo prompt fragments, so the
-                        # durable row gets a generic marker. The live stream
-                        # still carries the real error to the user.
-                        error_text = "The model encountered an error."
-                    else:
-                        info = model_error_info[model_idx]
-                        detail = (
-                            info.message
-                            if info is not None
-                            else "model encountered an error during generation."
-                        )
-                        error_text = "Error from %s: %s" % (
-                            setup.model_display_names[model_idx],
-                            detail,
-                        )
-                    msg.message = error_text
-                    msg.error = error_text
-                    # The reservation's placeholder count must not survive:
-                    # rows carry the real output count, zero when none emitted.
-                    partial_answer = state_containers[model_idx].get_answer_tokens()
-                    msg.token_count = (
-                        len(get_tokenizer(None, None).encode(partial_answer))
-                        if partial_answer
-                        else 0
-                    )
-                    save_db_session.commit()
-        except Exception:
-            logger.exception(
-                "%s error save failed for model %d (%s)",
-                context.value,
-                model_idx,
-                setup.model_display_names[model_idx],
-            )
-
-    def _publish(item: Packet | StreamingError) -> None:
-        """Fan one outbound item to the stream buffer and, while attached, the reader."""
-        if stream_buffer is not None:
-            try:
-                stream_buffer.append_line(get_json_line(item.model_dump()))
-            except Exception:
-                logger.exception("stream buffer append failed")
-        # Non-blocking put: a slow reader can't stall the writer.
-        if not reader_gone.is_set():
-            tee.put(item)
-
-    def _drain_to_completion() -> None:
-        """Writer: consume worker output to the very end regardless of client state."""
-        models_remaining = n_models
-        last_fence_refresh = time.monotonic()
-        try:
-            while models_remaining > 0:
-                # Runs can outlive FENCE_TTL; a lapsed fence reads as a dead
-                # writer to resume readers and unblocks concurrent sends.
-                now = time.monotonic()
-                if now - last_fence_refresh >= _FENCE_REFRESH_INTERVAL_S:
-                    last_fence_refresh = now
-                    try:
-                        set_processing_status(
-                            chat_session_id=setup.chat_session_id,
-                            cache=setup.cache,
-                            value=True,
-                            run_id=setup.processing_run_id,
-                        )
-                    except Exception:
-                        # Worst case the fence lapses early; never kill the
-                        # run over a refresh.
-                        logger.exception("processing fence refresh failed")
-                try:
-                    model_idx, item = merged_queue.get(timeout=_CANCEL_POLL_INTERVAL_S)
-                except queue.Empty:
-                    if stream_buffer is not None:
-                        stream_buffer.flush()
-                    # Check for user-initiated cancellation every 50 ms.
-                    if not setup.check_is_connected():
-                        for i in range(n_models):
-                            # Snapshot every model now: finished loops save
-                            # complete, in-flight ones save partial + stopped.
-                            _persist_model_outcome(
-                                i, _PersistContext.STOP_BUTTON, stop_button=True
-                            )
-                        _publish(
-                            Packet(
-                                placement=Placement(turn_index=0),
-                                obj=OverallStop(
-                                    type="stop", stop_reason="user_cancelled"
-                                ),
-                            )
-                        )
-                        # Workers can't be interrupted; discard their remaining
-                        # output via the Emitter no-op.
-                        drain_done.set()
-                        return
-                    continue
-                if item is _MODEL_DONE:
-                    models_remaining -= 1
-                elif isinstance(item, Exception):
-                    # Publish a tagged error for this model but keep the other
-                    # models running. Do NOT decrement models_remaining —
-                    # _run_model's finally always posts _MODEL_DONE, which is
-                    # the sole completion signal.
-                    model_llm = setup.llms[model_idx]
-                    # Classified in _run_model; fall back to a generic error.
-                    info = model_error_info[model_idx]
-                    if info is None:
-                        info = LLMErrorInfo(
-                            message=str(item),
-                            error_code="MODEL_ERROR",
-                            is_retryable=True,
-                        )
-                    stack_trace = "".join(
-                        traceback.format_exception(type(item), item, item.__traceback__)
-                    )
-                    secrets = collect_credential_values(
-                        model_llm.config.api_key, model_llm.config.custom_config
-                    )
-                    error_msg = scrub_sensitive_values(info.message, secrets)
-                    stack_trace = scrub_sensitive_values(stack_trace, secrets)
-                    _publish(
-                        StreamingError(
-                            error=error_msg,
-                            stack_trace=stack_trace,
-                            error_code=info.error_code,
-                            is_retryable=info.is_retryable,
-                            details=_model_error_details(item, model_llm, model_idx),
-                        )
-                    )
-                elif isinstance(item, Packet):
-                    # model_index already embedded by the model's Emitter
-                    _publish(item)
-
-            for i in range(n_models):
-                _persist_model_outcome(i, _PersistContext.NORMAL)
-        except Exception:
-            logger.exception("chat stream writer crashed")
-            # With the writer dead, merged_queue has no consumer — flip the
-            # emitters to discard so workers can't grow it unbounded.
-            drain_done.set()
-            # Generic message: the raw exception may embed provider API keys.
-            _publish(
-                StreamingError(
-                    error="The response stream ended unexpectedly. Please try again.",
-                    error_code="STREAM_WRITER_ERROR",
-                    is_retryable=True,
-                )
-            )
-        finally:
-            # Mark done before _run_post_steps clears the fence so resume
-            # readers never see a fence-less, not-done buffer and drop the tail.
-            if stream_buffer is not None:
-                stream_buffer.mark_done()
-            _run_post_steps()
-            tee.put(_STREAM_DONE)
-            executor.shutdown(wait=False)
-
-    # Each worker thread needs its own Context copy — a single Context object
-    # cannot be entered concurrently by multiple threads (RuntimeError).
-    executor = ThreadPoolExecutor(
-        max_workers=n_models, thread_name_prefix="multi-model"
-    )
-    for i in range(n_models):
-        ctx = contextvars.copy_context()
-        executor.submit(ctx.run, _run_model, i)
-
-    writer_thread = threading.Thread(
-        target=contextvars.copy_context().run,
-        args=(_drain_to_completion,),
-        name="chat-stream-writer",
-    )
-    writer_thread.start()
-
-    def _read_stream() -> AnswerStream:
-        # ── Reader: tail the tee while the client is attached ────────────────
-        stream_done = False
-        try:
-            last_packet_yield: float = time.monotonic()
-            while True:
-                try:
-                    item = tee.get(timeout=_CANCEL_POLL_INTERVAL_S)
-                except queue.Empty:
-                    now = time.monotonic()
-                    if now - last_packet_yield >= CHAT_HEARTBEAT_INTERVAL_S:
-                        yield heartbeat_packet()
-                        last_packet_yield = now
-                    continue
-                if item is _STREAM_DONE:
-                    stream_done = True
-                    return
-                yield cast(Packet | StreamingError, item)
-                last_packet_yield = time.monotonic()
-        finally:
-            reader_gone.set()
-            if not stream_done:
-                # GeneratorExit (client disconnect): the reader stops here while
-                # the writer thread keeps draining to completion in the background.
-                logger.info(
-                    "chat stream reader detached; writer continues for session %s",
-                    setup.chat_session_id,
-                )
-
-    return _read_stream()
+    run = _MultiModelRun(setup, user, external_state_container, stream_buffer)
+    run.start()
+    return run.read_stream()
 
 
 def _stream_chat_turn(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -11,7 +11,7 @@ from collections import deque
 from collections.abc import Callable, Generator, Iterable
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 from urllib.parse import quote, unquote, urlsplit
 
 import msal
@@ -1262,6 +1262,13 @@ def _convert_sitepage_to_slim_document(
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
         doc_created_at=_parse_sharepoint_datetime(site_page.get("createdDateTime")),
     )
+
+
+# One phase of `_load_from_checkpoint`. It yields connector output and returns
+# True when the caller must stop and persist the checkpoint.
+_PhaseOutput: TypeAlias = Generator[
+    Document | HierarchyNode | ConnectorFailure, None, bool
+]
 
 
 class SharepointConnector(
@@ -2924,19 +2931,12 @@ class SharepointConnector(
             )
             yield _create_document_failure(driveitem, f"Failed to process: {str(e)}", e)
 
-    def _load_from_checkpoint(
+    def _phase_init_sites(
         self,
-        start: SecondsSinceUnixEpoch,
-        end: SecondsSinceUnixEpoch,
         checkpoint: SharepointConnectorCheckpoint,
-        include_permissions: bool = False,
-    ) -> CheckpointOutput[SharepointConnectorCheckpoint]:
-        if self._graph_client is None:
-            raise ConnectorMissingCredentialError("Sharepoint")
-
-        checkpoint = copy.deepcopy(checkpoint)
-
-        # Phase 1: Initialize cached_site_descriptors if needed
+        include_permissions: bool,
+    ) -> _PhaseOutput:
+        """Phase 1: cache the sites to process and select the first one."""
         if (
             checkpoint.has_more
             and checkpoint.cached_site_descriptors is None
@@ -2953,7 +2953,7 @@ class SharepointConnector(
                     "No SharePoint sites found or accessible - nothing to process"
                 )
                 checkpoint.has_more = False
-                return checkpoint
+                return True
 
             logger.info(
                 "Found %s sites to process", len(checkpoint.cached_site_descriptors)
@@ -2972,15 +2972,23 @@ class SharepointConnector(
                     checkpoint,
                     include_permissions=include_permissions,
                 )
-                return checkpoint
+                return True
 
-        # Phase 2: Initialize cached_drive_names for current site if needed
+        return False
+
+    def _phase_init_drive_names(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: SharepointConnectorCheckpoint,
+    ) -> _PhaseOutput:
+        """Phase 2: cache the drive names of the current site."""
         if checkpoint.current_site_descriptor and checkpoint.cached_drive_names is None:
             # If site documents flag is False, set empty drive list to skip document processing
             if not self.include_site_documents:
                 logger.debug("Documents disabled, skipping drive initialization")
                 checkpoint.cached_drive_names = deque()
-                return checkpoint
+                return True
 
             logger.info(
                 "Initializing drives for site: %s",
@@ -3039,193 +3047,232 @@ class SharepointConnector(
                         checkpoint.cached_site_descriptors.popleft()
                     )
                     checkpoint.cached_drive_names = None  # Reset for new site
-                    return checkpoint
                 else:
                     # No more sites - we're done
                     checkpoint.has_more = False
-                    return checkpoint
+                return True
 
             # Return checkpoint to allow persistence after drive initialization
-            return checkpoint
+            return True
 
-        # Phase 3a: Initialize the next drive for processing
+        return False
+
+    def _phase_start_next_drive(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+    ) -> _PhaseOutput:
+        """Phase 3a: resolve the next drive of the current site."""
+        site_descriptor = checkpoint.current_site_descriptor
+        drive_names = checkpoint.cached_drive_names
         if (
-            checkpoint.current_site_descriptor
-            and checkpoint.cached_drive_names
-            and len(checkpoint.cached_drive_names) > 0
-            and checkpoint.current_drive_name is None
+            site_descriptor is None
+            or not drive_names
+            or checkpoint.current_drive_name is not None
         ):
-            checkpoint.current_drive_name = checkpoint.cached_drive_names.popleft()
+            return False
 
-            start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
-            end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
-            site_descriptor = checkpoint.current_site_descriptor
+        checkpoint.current_drive_name = drive_names.popleft()
 
-            logger.info(
-                "Processing drive '%s' in site: %s",
-                checkpoint.current_drive_name,
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+
+        logger.info(
+            "Processing drive '%s' in site: %s",
+            checkpoint.current_drive_name,
+            site_descriptor.url,
+        )
+        logger.debug("Time range: %s to %s", start_dt, end_dt)
+
+        current_drive_name = checkpoint.current_drive_name
+        if current_drive_name is None:
+            logger.warning("Current drive name is None, skipping")
+            return True
+
+        try:
+            logger.info("Fetching drive items for drive name: %s", current_drive_name)
+            result = self._resolve_drive(site_descriptor, current_drive_name)
+            if result is None:
+                logger.warning("Drive '%s' not found, skipping", current_drive_name)
+                self._clear_drive_checkpoint_state(checkpoint)
+                return True
+
+            drive_id, drive_web_url = result
+            checkpoint.current_drive_id = drive_id
+            checkpoint.current_drive_web_url = drive_web_url
+        except Exception as e:
+            logger.error(
+                "Failed to retrieve items from drive '%s' in site: %s: %s",
+                current_drive_name,
+                site_descriptor.url,
+                e,
+            )
+            yield _create_entity_failure(
+                f"{site_descriptor.url}|{current_drive_name}",
+                f"Failed to access drive '{current_drive_name}' in site '{site_descriptor.url}': {str(e)}",
+                (start_dt, end_dt),
+                e,
+            )
+            self._clear_drive_checkpoint_state(checkpoint)
+            return True
+
+        display_drive_name = SHARED_DOCUMENTS_MAP.get(
+            current_drive_name, current_drive_name
+        )
+
+        if drive_web_url:
+            yield from self._yield_drive_hierarchy_node(
+                site_descriptor.url,
+                drive_web_url,
+                display_drive_name,
+                checkpoint,
+                include_permissions=include_permissions,
+            )
+
+        # For non-folder-scoped drives, use delta API with per-page
+        # checkpointing.  Build the initial URL and fall through to 3b.
+        if not site_descriptor.folder_path:
+            checkpoint.current_drive_delta_next_link = self._build_delta_start_url(
+                drive_id, start_dt
+            )
+        # else: BFS path — delta_next_link stays None;
+        # Phase 3b will use _iter_drive_items_paged.
+
+        return False
+
+    def _fetch_current_drive_items(
+        self,
+        checkpoint: SharepointConnectorCheckpoint,
+        drive_id: str,
+        site_descriptor: SiteDescriptor,
+        drive_name: str,
+        time_range: tuple[datetime, datetime],
+    ) -> Generator[ConnectorFailure, None, tuple[Iterable[DriveItemData], bool] | None]:
+        """Resolve the items of the current drive.
+
+        Returns the items plus whether more delta pages remain, or None when the
+        drive must be abandoned.
+        """
+        start_dt, end_dt = time_range
+        if not checkpoint.current_drive_delta_next_link:
+            # BFS path (folder-scoped): process all items at once
+            driveitems = self._iter_drive_items_paged(
+                drive_id=drive_id,
+                folder_path=site_descriptor.folder_path,
+                start=start_dt,
+                end=end_dt,
+            )
+            return driveitems, False
+
+        # Delta path: fetch one page at a time for checkpointing
+        try:
+            page_items, next_url = self._fetch_one_delta_page(
+                page_url=checkpoint.current_drive_delta_next_link,
+                drive_id=drive_id,
+                start=start_dt,
+                end=end_dt,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to fetch delta page for drive '%s': %s",
+                drive_name,
+                e,
+            )
+            yield _create_entity_failure(
+                f"{site_descriptor.url}|{drive_name}",
+                f"Failed to fetch delta page for drive '{drive_name}': {str(e)}",
+                (start_dt, end_dt),
+                e,
+            )
+            self._clear_drive_checkpoint_state(checkpoint)
+            return None
+
+        if next_url:
+            checkpoint.current_drive_delta_next_link = next_url
+        return page_items, next_url is not None
+
+    def _phase_process_current_drive(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+    ) -> _PhaseOutput:
+        """Phase 3b: process the items of the current drive."""
+        site_descriptor = checkpoint.current_site_descriptor
+        drive_name = checkpoint.current_drive_name
+        drive_id = checkpoint.current_drive_id
+        if site_descriptor is None or drive_name is None or drive_id is None:
+            return False
+
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        current_drive_name = SHARED_DOCUMENTS_MAP.get(drive_name, drive_name)
+        drive_web_url = checkpoint.current_drive_web_url
+
+        # --- determine item source ---
+        fetched = yield from self._fetch_current_drive_items(
+            checkpoint,
+            drive_id,
+            site_descriptor,
+            current_drive_name,
+            (start_dt, end_dt),
+        )
+        if fetched is None:
+            return True
+        driveitems, has_more_delta_pages = fetched
+
+        item_count = 0
+        # Outer try catches BFS-generator failures mid-iteration;
+        # per-item errors are still caught by the inner try below.
+        try:
+            for driveitem in driveitems:
+                item_count += 1
+                yield from self._process_drive_item(
+                    driveitem,
+                    current_drive_name,
+                    drive_web_url,
+                    site_descriptor.url,
+                    checkpoint,
+                    include_permissions,
+                )
+        except Exception as e:
+            logger.exception(
+                "Failed mid-iteration for drive '%s' in site '%s'",
+                current_drive_name,
                 site_descriptor.url,
             )
-            logger.debug("Time range: %s to %s", start_dt, end_dt)
-
-            current_drive_name = checkpoint.current_drive_name
-            if current_drive_name is None:
-                logger.warning("Current drive name is None, skipping")
-                return checkpoint
-
-            try:
-                logger.info(
-                    "Fetching drive items for drive name: %s", current_drive_name
-                )
-                result = self._resolve_drive(site_descriptor, current_drive_name)
-                if result is None:
-                    logger.warning("Drive '%s' not found, skipping", current_drive_name)
-                    self._clear_drive_checkpoint_state(checkpoint)
-                    return checkpoint
-
-                drive_id, drive_web_url = result
-                checkpoint.current_drive_id = drive_id
-                checkpoint.current_drive_web_url = drive_web_url
-            except Exception as e:
-                logger.error(
-                    "Failed to retrieve items from drive '%s' in site: %s: %s",
-                    current_drive_name,
-                    site_descriptor.url,
-                    e,
-                )
-                yield _create_entity_failure(
-                    f"{site_descriptor.url}|{current_drive_name}",
-                    f"Failed to access drive '{current_drive_name}' in site '{site_descriptor.url}': {str(e)}",
-                    (start_dt, end_dt),
-                    e,
-                )
-                self._clear_drive_checkpoint_state(checkpoint)
-                return checkpoint
-
-            display_drive_name = SHARED_DOCUMENTS_MAP.get(
-                current_drive_name, current_drive_name
+            yield _create_entity_failure(
+                f"{site_descriptor.url}|{current_drive_name}|bfs_iter",
+                f"Failed to iterate drive items after {item_count}: {e}",
+                (start_dt, end_dt),
+                e,
             )
-
-            if drive_web_url:
-                yield from self._yield_drive_hierarchy_node(
-                    site_descriptor.url,
-                    drive_web_url,
-                    display_drive_name,
-                    checkpoint,
-                    include_permissions=include_permissions,
-                )
-
-            # For non-folder-scoped drives, use delta API with per-page
-            # checkpointing.  Build the initial URL and fall through to 3b.
-            if not site_descriptor.folder_path:
-                checkpoint.current_drive_delta_next_link = self._build_delta_start_url(
-                    drive_id, start_dt
-                )
-            # else: BFS path — delta_next_link stays None;
-            # Phase 3b will use _iter_drive_items_paged.
-
-        # Phase 3b: Process items from the current drive
-        if (
-            checkpoint.current_site_descriptor
-            and checkpoint.current_drive_name is not None
-            and checkpoint.current_drive_id is not None
-        ):
-            site_descriptor = checkpoint.current_site_descriptor
-            start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
-            end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
-            current_drive_name = SHARED_DOCUMENTS_MAP.get(
-                checkpoint.current_drive_name, checkpoint.current_drive_name
-            )
-            drive_web_url = checkpoint.current_drive_web_url
-
-            # --- determine item source ---
-            driveitems: Iterable[DriveItemData]
-            has_more_delta_pages = False
-
-            if checkpoint.current_drive_delta_next_link:
-                # Delta path: fetch one page at a time for checkpointing
-                try:
-                    page_items, next_url = self._fetch_one_delta_page(
-                        page_url=checkpoint.current_drive_delta_next_link,
-                        drive_id=checkpoint.current_drive_id,
-                        start=start_dt,
-                        end=end_dt,
-                    )
-                except Exception as e:
-                    logger.error(
-                        "Failed to fetch delta page for drive '%s': %s",
-                        current_drive_name,
-                        e,
-                    )
-                    yield _create_entity_failure(
-                        f"{site_descriptor.url}|{current_drive_name}",
-                        f"Failed to fetch delta page for drive '{current_drive_name}': {str(e)}",
-                        (start_dt, end_dt),
-                        e,
-                    )
-                    self._clear_drive_checkpoint_state(checkpoint)
-                    return checkpoint
-
-                driveitems = page_items
-                has_more_delta_pages = next_url is not None
-                if next_url:
-                    checkpoint.current_drive_delta_next_link = next_url
-            else:
-                # BFS path (folder-scoped): process all items at once
-                driveitems = self._iter_drive_items_paged(
-                    drive_id=checkpoint.current_drive_id,
-                    folder_path=site_descriptor.folder_path,
-                    start=start_dt,
-                    end=end_dt,
-                )
-
-            item_count = 0
-            # Outer try catches BFS-generator failures mid-iteration;
-            # per-item errors are still caught by the inner try below.
-            try:
-                for driveitem in driveitems:
-                    item_count += 1
-                    yield from self._process_drive_item(
-                        driveitem,
-                        current_drive_name,
-                        drive_web_url,
-                        site_descriptor.url,
-                        checkpoint,
-                        include_permissions,
-                    )
-            except Exception as e:
-                logger.exception(
-                    "Failed mid-iteration for drive '%s' in site '%s'",
-                    current_drive_name,
-                    site_descriptor.url,
-                )
-                yield _create_entity_failure(
-                    f"{site_descriptor.url}|{current_drive_name}|bfs_iter",
-                    f"Failed to iterate drive items after {item_count}: {e}",
-                    (start_dt, end_dt),
-                    e,
-                )
-                # Clear drive state to avoid resuming on the same broken drive.
-                self._clear_drive_checkpoint_state(checkpoint)
-                return checkpoint
-
-            logger.info(
-                "Processed %s items in drive '%s'", item_count, current_drive_name
-            )
-
-            if has_more_delta_pages:
-                return checkpoint
-
+            # Clear drive state to avoid resuming on the same broken drive.
             self._clear_drive_checkpoint_state(checkpoint)
+            return True
 
-        # Phase 4: Progression logic - determine next step
+        logger.info("Processed %s items in drive '%s'", item_count, current_drive_name)
+
+        if has_more_delta_pages:
+            return True
+
+        self._clear_drive_checkpoint_state(checkpoint)
+        return False
+
+    def _phase_advance_within_site(
+        self, checkpoint: SharepointConnectorCheckpoint
+    ) -> bool:
+        """Phase 4: persist the checkpoint before the next drive or site pages."""
         # If we have more drives in current site, continue with current site
         if checkpoint.cached_drive_names and len(checkpoint.cached_drive_names) > 0:
             logger.debug(
                 "Continuing with %s remaining drives in current site",
                 len(checkpoint.cached_drive_names),
             )
-            return checkpoint
+            return True
 
         if (
             self.include_site_pages
@@ -3237,122 +3284,145 @@ class SharepointConnector(
                 checkpoint.current_site_descriptor.url,
             )
             checkpoint.process_site_pages = True
-            return checkpoint
+            return True
 
-        # Phase 5: Process site pages
-        if (
-            checkpoint.process_site_pages
-            and checkpoint.current_site_descriptor is not None
-        ):
-            # Fetch SharePoint site pages (.aspx files)
-            site_descriptor = checkpoint.current_site_descriptor
-            start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
-            end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
-            try:
-                site_pages = self._fetch_site_pages(
-                    site_descriptor, start=start_dt, end=end_dt
+        return False
+
+    def _yield_site_page(
+        self,
+        site_page: dict[str, Any],
+        site_descriptor: SiteDescriptor,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+        time_range: tuple[datetime, datetime],
+    ) -> Generator[Document | ConnectorFailure, None, None]:
+        """Convert one site page into a Document, or a ConnectorFailure on error."""
+        page_id = site_page.get("id")
+        page_label = site_page.get("webUrl", site_page.get("name", "Unknown"))
+        # Skip a single broken page instead of aborting the
+        # rest of the site (perm-sync error, malformed field,
+        # token refresh blip, etc.).
+        try:
+            logger.debug("Processing site page: %s", page_label)
+            client_ctx: ClientContext | None = None
+            if include_permissions:
+                client_ctx = self._create_rest_client_context(site_descriptor.url)
+            yield (
+                _convert_sitepage_to_document(
+                    site_page,
+                    site_descriptor.drive_name,
+                    client_ctx,
+                    self.graph_client,
+                    permission_cache=checkpoint.permission_cache,
+                    include_permissions=include_permissions,
+                    # Site pages have the site as their parent
+                    parent_hierarchy_raw_node_id=site_descriptor.url,
+                    treat_sharing_link_as_public=self.treat_sharing_link_as_public,
                 )
-                for site_page in site_pages:
-                    page_id = site_page.get("id")
-                    page_label = site_page.get(
-                        "webUrl", site_page.get("name", "Unknown")
-                    )
-                    # Skip a single broken page instead of aborting the
-                    # rest of the site (perm-sync error, malformed field,
-                    # token refresh blip, etc.).
-                    try:
-                        logger.debug("Processing site page: %s", page_label)
-                        client_ctx: ClientContext | None = None
-                        if include_permissions:
-                            client_ctx = self._create_rest_client_context(
-                                site_descriptor.url
-                            )
-                        yield (
-                            _convert_sitepage_to_document(
-                                site_page,
-                                site_descriptor.drive_name,
-                                client_ctx,
-                                self.graph_client,
-                                permission_cache=checkpoint.permission_cache,
-                                include_permissions=include_permissions,
-                                # Site pages have the site as their parent
-                                parent_hierarchy_raw_node_id=site_descriptor.url,
-                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
-                            )
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to process site page '%s' in site %s: %s",
-                            page_label,
-                            site_descriptor.url,
-                            e,
-                            exc_info=True,
-                        )
-                        if page_id:
-                            page_link = (
-                                page_label if isinstance(page_label, str) else None
-                            )
-                            yield ConnectorFailure(
-                                failed_document=DocumentFailure(
-                                    document_id=page_id,
-                                    document_link=page_link,
-                                ),
-                                failure_message=(
-                                    f"SharePoint site page '{page_label}': {e}"
-                                ),
-                                exception=e,
-                            )
-                        else:
-                            yield _create_entity_failure(
-                                f"{site_descriptor.url}|site_page|{page_label}",
-                                f"Failed to process site page '{page_label}': {e}",
-                                (start_dt, end_dt),
-                                e,
-                            )
-                logger.info(
-                    "Finished processing site pages for site: %s",
-                    site_descriptor.url,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to process site page '%s' in site %s: %s",
+                page_label,
+                site_descriptor.url,
+                e,
+                exc_info=True,
+            )
+            if page_id:
+                page_link = page_label if isinstance(page_label, str) else None
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=page_id,
+                        document_link=page_link,
+                    ),
+                    failure_message=(f"SharePoint site page '{page_label}': {e}"),
+                    exception=e,
                 )
-            except Exception as e:
-                # Broadened from per-site Graph 4xx to any Exception:
-                # _fetch_site_pages failures skip the site-pages stage
-                # instead of failing the attempt. Per-page errors are
-                # caught above.
-                if (
-                    isinstance(e, (ClientRequestException, HTTPError))
-                    and e.response is not None
-                ):
-                    logger.warning(
-                        "Skipping site pages for %s: Graph returned %s (%s)",
-                        site_descriptor.url,
-                        e.response.status_code,
-                        _graph_error_code(e.response),
-                        exc_info=True,
-                    )
-                else:
-                    logger.warning(
-                        "Skipping site pages for %s: %s",
-                        site_descriptor.url,
-                        e,
-                        exc_info=True,
-                    )
+            else:
                 yield _create_entity_failure(
-                    site_descriptor.url,
-                    f"Failed to fetch site pages: {e}",
-                    (start_dt, end_dt),
+                    f"{site_descriptor.url}|site_page|{page_label}",
+                    f"Failed to process site page '{page_label}': {e}",
+                    time_range,
                     e,
                 )
+
+    def _phase_process_site_pages(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+    ) -> Generator[Document | ConnectorFailure, None, None]:
+        """Phase 5: fetch and yield the SharePoint site pages (.aspx files)."""
+        site_descriptor = checkpoint.current_site_descriptor
+        if not checkpoint.process_site_pages or site_descriptor is None:
+            return
+
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        try:
+            site_pages = self._fetch_site_pages(
+                site_descriptor, start=start_dt, end=end_dt
+            )
+            for site_page in site_pages:
+                yield from self._yield_site_page(
+                    site_page,
+                    site_descriptor,
+                    checkpoint,
+                    include_permissions,
+                    (start_dt, end_dt),
+                )
+            logger.info(
+                "Finished processing site pages for site: %s",
+                site_descriptor.url,
+            )
+        except Exception as e:
+            # Broadened from per-site Graph 4xx to any Exception:
+            # _fetch_site_pages failures skip the site-pages stage
+            # instead of failing the attempt. Per-page errors are
+            # caught above.
+            if (
+                isinstance(e, (ClientRequestException, HTTPError))
+                and e.response is not None
+            ):
+                logger.warning(
+                    "Skipping site pages for %s: Graph returned %s (%s)",
+                    site_descriptor.url,
+                    e.response.status_code,
+                    _graph_error_code(e.response),
+                    exc_info=True,
+                )
+            else:
+                logger.warning(
+                    "Skipping site pages for %s: %s",
+                    site_descriptor.url,
+                    e,
+                    exc_info=True,
+                )
+            yield _create_entity_failure(
+                site_descriptor.url,
+                f"Failed to fetch site pages: {e}",
+                (start_dt, end_dt),
+                e,
+            )
+
+    def _phase_advance_to_next_site(
+        self,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+    ) -> Generator[HierarchyNode, None, None]:
+        """Phase 6: move to the next site, or mark the run complete."""
+        current_site = (
+            checkpoint.current_site_descriptor.url
+            if checkpoint.current_site_descriptor
+            else "unknown"
+        )
 
         # If no more drives, move to next site if available
         if (
             checkpoint.cached_site_descriptors
             and len(checkpoint.cached_site_descriptors) > 0
         ):
-            current_site = (
-                checkpoint.current_site_descriptor.url
-                if checkpoint.current_site_descriptor
-                else "unknown"
-            )
             checkpoint.current_site_descriptor = (
                 checkpoint.cached_site_descriptors.popleft()
             )
@@ -3373,18 +3443,56 @@ class SharepointConnector(
                 checkpoint,
                 include_permissions=include_permissions,
             )
-            return checkpoint
+            return
 
         # No more sites or drives - we're done
-        current_site = (
-            checkpoint.current_site_descriptor.url
-            if checkpoint.current_site_descriptor
-            else "unknown"
-        )
         logger.info(
             "SharePoint processing complete. Finished last site: %s", current_site
         )
         checkpoint.has_more = False
+
+    def _load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool = False,
+    ) -> CheckpointOutput[SharepointConnectorCheckpoint]:
+        if self._graph_client is None:
+            raise ConnectorMissingCredentialError("Sharepoint")
+
+        checkpoint = copy.deepcopy(checkpoint)
+
+        # Every phase updates `checkpoint` in place. A phase returns True when the
+        # run must stop here so the checkpoint gets persisted.
+        if (yield from self._phase_init_sites(checkpoint, include_permissions)):
+            return checkpoint
+
+        if (yield from self._phase_init_drive_names(start, end, checkpoint)):
+            return checkpoint
+
+        if (
+            yield from self._phase_start_next_drive(
+                start, end, checkpoint, include_permissions
+            )
+        ):
+            return checkpoint
+
+        if (
+            yield from self._phase_process_current_drive(
+                start, end, checkpoint, include_permissions
+            )
+        ):
+            return checkpoint
+
+        if self._phase_advance_within_site(checkpoint):
+            return checkpoint
+
+        yield from self._phase_process_site_pages(
+            start, end, checkpoint, include_permissions
+        )
+
+        yield from self._phase_advance_to_next_site(checkpoint, include_permissions)
         return checkpoint
 
     def load_from_checkpoint(

--- a/backend/onyx/context/search/federated/slack_search.py
+++ b/backend/onyx/context/search/federated/slack_search.py
@@ -993,6 +993,134 @@ def convert_slack_score(slack_score: float) -> float:
     return max(0.0, min(1.0, slack_score / 90_000))
 
 
+def _resolve_query_limit(entities: dict[str, Any], limit: int | None) -> int | None:
+    """Resolve the per-query message limit from the explicit limit or entity config."""
+    query_limit = limit
+    if entities:
+        try:
+            parsed_entities = SlackEntities(**entities)
+            if limit is None:
+                query_limit = parsed_entities.max_messages_per_query
+                logger.debug(
+                    "Using max_messages_per_query from config: %s", query_limit
+                )
+        except Exception as e:
+            logger.warning("Error parsing entities for limit: %s", e)
+            if limit is None:
+                query_limit = 100  # Fallback default
+    elif limit is None:
+        query_limit = 100  # Default when no entities and no limit provided
+
+    return query_limit
+
+
+def _partition_query_items(
+    query_items: list[str | DirectThreadFetch],
+) -> tuple[list[DirectThreadFetch], list[str]]:
+    """Partition into direct thread fetches and search query strings."""
+    direct_fetches: list[DirectThreadFetch] = []
+    query_strings: list[str] = []
+    for item in query_items:
+        if isinstance(item, DirectThreadFetch):
+            direct_fetches.append(item)
+        else:
+            query_strings.append(item)
+
+    return direct_fetches, query_strings
+
+
+def _resolve_bot_context_filters(
+    slack_event_context: SlackContext | None, entities: dict[str, Any]
+) -> tuple[bool, str | None]:
+    """Determine DM / private channel filtering from the bot context.
+
+    Returns (include_dm, allowed_private_channel).
+    """
+    include_dm = False
+    allowed_private_channel: str | None = None
+
+    # Bot context overrides (if entities not specified)
+    if slack_event_context and not entities:
+        channel_type = slack_event_context.channel_type
+        if channel_type == ChannelType.IM:  # DM with user
+            include_dm = True
+        if channel_type == ChannelType.PRIVATE_CHANNEL:
+            allowed_private_channel = slack_event_context.channel_id
+            logger.debug(
+                "Private channel context: will only allow messages from %s + public channels",
+                allowed_private_channel,
+            )
+
+    return include_dm, allowed_private_channel
+
+
+def _filter_messages_by_channel_type(
+    slack_messages: list[SlackMessage],
+    entities: dict[str, Any],
+    channel_metadata_dict: dict[str, ChannelMetadata] | None,
+    filtered_out_channels: set[str],
+) -> list[SlackMessage]:
+    """Drop messages whose channel type is excluded. Updates filtered_out_channels."""
+    filtered_messages = []
+    for msg in slack_messages:
+        # Pass pre-fetched metadata to avoid cache lookups
+        channel_type = get_channel_type(
+            channel_id=msg.channel_id,
+            channel_metadata=channel_metadata_dict,
+        )
+        if should_include_message(channel_type, entities):
+            filtered_messages.append(msg)
+        else:
+            # Track unique channel name for summary
+            channel_name = msg.metadata.get("channel", msg.channel_id)
+            filtered_out_channels.add(f"{channel_name}({msg.channel_id})")
+
+    return filtered_messages
+
+
+def _select_relevant_chunks(
+    chunks: list[DocAwareChunk],
+    sorted_highlighted_texts: list[str],
+    has_highlights: bool,
+    limit: int | None,
+) -> tuple[list[DocAwareChunk], dict[str, str]]:
+    """Prune chunks without highlighted texts and build their match highlights.
+
+    For recency queries without keywords, all chunks are kept.
+    """
+    relevant_chunks: list[DocAwareChunk] = []
+    chunkid_to_match_highlight: dict[str, str] = {}
+
+    if not has_highlights:
+        # No highlighted terms - keep all chunks (recency query)
+        for chunk in chunks:
+            chunk_id = f"{chunk.source_document.id}__{chunk.chunk_id}"
+            relevant_chunks.append(chunk)
+            chunkid_to_match_highlight[chunk_id] = chunk.content  # No highlighting
+            if limit and len(relevant_chunks) >= limit:
+                break
+    else:
+        # Prune chunks that don't contain highlighted terms
+        for chunk in chunks:
+            match_highlight = chunk.content
+            for highlight in sorted_highlighted_texts:  # faster than re sub
+                match_highlight = match_highlight.replace(
+                    highlight, f"<hi>{highlight}</hi>"
+                )
+
+            # if nothing got replaced, the chunk is irrelevant
+            if len(match_highlight) == len(chunk.content):
+                continue
+
+            chunk_id = f"{chunk.source_document.id}__{chunk.chunk_id}"
+            relevant_chunks.append(chunk)
+            chunkid_to_match_highlight[chunk_id] = match_highlight
+            if limit and len(relevant_chunks) >= limit:
+                break
+
+    return relevant_chunks, chunkid_to_match_highlight
+
+
 @log_function_time(print_only=True)
 def slack_retrieval(
     query: ChunkIndexRequest,
@@ -1040,21 +1168,7 @@ def slack_retrieval(
         logger.debug("Using entity configuration: %s", entities)
 
     # Extract limit from entity config if not explicitly provided
-    query_limit = limit
-    if entities:
-        try:
-            parsed_entities = SlackEntities(**entities)
-            if limit is None:
-                query_limit = parsed_entities.max_messages_per_query
-                logger.debug(
-                    "Using max_messages_per_query from config: %s", query_limit
-                )
-        except Exception as e:
-            logger.warning("Error parsing entities for limit: %s", e)
-            if limit is None:
-                query_limit = 100  # Fallback default
-    elif limit is None:
-        query_limit = 100  # Default when no entities and no limit provided
+    query_limit = _resolve_query_limit(entities, limit)
 
     # Pre-fetch channel metadata from Redis cache and extract available channels
     # This avoids repeated Redis lookups during parallel search execution
@@ -1078,29 +1192,12 @@ def slack_retrieval(
     query_items = build_slack_queries(query, llm, entities, available_channels)
 
     # Partition into direct thread fetches and search query strings
-    direct_fetches: list[DirectThreadFetch] = []
-    query_strings: list[str] = []
-    for item in query_items:
-        if isinstance(item, DirectThreadFetch):
-            direct_fetches.append(item)
-        else:
-            query_strings.append(item)
+    direct_fetches, query_strings = _partition_query_items(query_items)
 
     # Determine filtering based on entities OR context (bot)
-    include_dm = False
-    allowed_private_channel = None
-
-    # Bot context overrides (if entities not specified)
-    if slack_event_context and not entities:
-        channel_type = slack_event_context.channel_type
-        if channel_type == ChannelType.IM:  # DM with user
-            include_dm = True
-        if channel_type == ChannelType.PRIVATE_CHANNEL:
-            allowed_private_channel = slack_event_context.channel_id
-            logger.debug(
-                "Private channel context: will only allow messages from %s + public channels",
-                allowed_private_channel,
-            )
+    include_dm, allowed_private_channel = _resolve_bot_context_filters(
+        slack_event_context, entities
+    )
 
     # Build search tasks — direct thread fetches + keyword searches
     search_tasks: list[tuple] = [
@@ -1191,22 +1288,9 @@ def slack_retrieval(
     if entities and team_id:
         # Use pre-fetched channel metadata to avoid cache misses
         # Pass it directly instead of relying on Redis cache
-
-        filtered_messages = []
-        for msg in slack_messages:
-            # Pass pre-fetched metadata to avoid cache lookups
-            channel_type = get_channel_type(
-                channel_id=msg.channel_id,
-                channel_metadata=channel_metadata_dict,
-            )
-            if should_include_message(channel_type, entities):
-                filtered_messages.append(msg)
-            else:
-                # Track unique channel name for summary
-                channel_name = msg.metadata.get("channel", msg.channel_id)
-                filtered_out_channels.add(f"{channel_name}({msg.channel_id})")
-
-        slack_messages = filtered_messages
+        slack_messages = _filter_messages_by_channel_type(
+            slack_messages, entities, channel_metadata_dict, filtered_out_channels
+        )
 
     slack_messages = slack_messages[: limit or len(slack_messages)]
 
@@ -1291,35 +1375,9 @@ def slack_retrieval(
 
     # prune chunks without any highlighted texts
     # BUT: for recency queries without keywords, keep all chunks
-    relevant_chunks: list[DocAwareChunk] = []
-    chunkid_to_match_highlight: dict[str, str] = {}
-
-    if not has_highlights:
-        # No highlighted terms - keep all chunks (recency query)
-        for chunk in chunks:
-            chunk_id = f"{chunk.source_document.id}__{chunk.chunk_id}"
-            relevant_chunks.append(chunk)
-            chunkid_to_match_highlight[chunk_id] = chunk.content  # No highlighting
-            if limit and len(relevant_chunks) >= limit:
-                break
-    else:
-        # Prune chunks that don't contain highlighted terms
-        for chunk in chunks:
-            match_highlight = chunk.content
-            for highlight in sorted_highlighted_texts:  # faster than re sub
-                match_highlight = match_highlight.replace(
-                    highlight, f"<hi>{highlight}</hi>"
-                )
-
-            # if nothing got replaced, the chunk is irrelevant
-            if len(match_highlight) == len(chunk.content):
-                continue
-
-            chunk_id = f"{chunk.source_document.id}__{chunk.chunk_id}"
-            relevant_chunks.append(chunk)
-            chunkid_to_match_highlight[chunk_id] = match_highlight
-            if limit and len(relevant_chunks) >= limit:
-                break
+    relevant_chunks, chunkid_to_match_highlight = _select_relevant_chunks(
+        chunks, sorted_highlighted_texts, has_highlights, limit
+    )
 
     # convert to inference chunks
     top_chunks: list[InferenceChunk] = []

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
+from typing import NamedTuple
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -1551,6 +1552,472 @@ def _mark_files_need_persona_sync(
     )
 
 
+class _PersonaRelations(NamedTuple):
+    """Rows resolved from the ID lists passed to ``upsert_persona``. ``None`` means the
+    caller did not pass that list, so the existing associations stay untouched."""
+
+    tools: list[Tool] | None
+    document_sets: list[DocumentSet] | None
+    user_files: list[UserFile] | None
+    labels: list[PersonaLabel] | None
+    hierarchy_nodes: list[HierarchyNode] | None
+    attached_documents: list[Document] | None
+
+
+def _resolve_existing_persona_for_upsert(
+    db_session: Session,
+    user: User | None,
+    name: str,
+    persona_id: int | None,
+) -> Persona | None:
+    """Return the row ``upsert_persona`` updates, or ``None`` when it must insert."""
+    # Only a create that lands on a deleted same-name row recycles it; editing by id must
+    # not reach a deleted agent.
+    recycling_deleted = False
+
+    if persona_id is not None:
+        existing_persona = db_session.query(Persona).filter_by(id=persona_id).first()
+    else:
+        existing_persona = _get_persona_by_name(
+            persona_name=name, user=user, db_session=db_session
+        )
+
+        # Check for duplicate names when creating new personas
+        # Deleted personas are allowed to be overwritten
+        if existing_persona and not existing_persona.deleted:
+            raise ValueError(
+                f"Assistant with name '{name}' already exists. Please rename your assistant."
+            )
+        recycling_deleted = existing_persona is not None
+
+    if existing_persona and user:
+        # this checks if the user has permission to edit the persona
+        # will raise an Exception if the user does not have permission
+        # Skip check if user is None (system/admin operation)
+        existing_persona = fetch_persona_by_id_for_user(
+            db_session=db_session,
+            persona_id=existing_persona.id,
+            user=user,
+            get_editable=True,
+            include_deleted=recycling_deleted,
+        )
+
+    return existing_persona
+
+
+def _assert_mcp_tools_accessible(
+    db_session: Session,
+    user: User,
+    tools: list[Tool],
+    existing_persona: Persona | None,
+) -> None:
+    """Existing tools survive access revocation; newly attached tools require access."""
+    # local import to avoid circular import (mirrors built_in_tools below)
+    from onyx.db.mcp import user_can_access_mcp_server
+
+    existing_tool_ids: set[int] = (
+        {tool.id for tool in existing_persona.tools} if existing_persona else set()
+    )
+    checked_servers: set[int] = set()
+    for tool in tools:
+        server_id = tool.mcp_server_id
+        if (
+            tool.id in existing_tool_ids
+            or server_id is None
+            or server_id in checked_servers
+        ):
+            continue
+        checked_servers.add(server_id)
+        if not user_can_access_mcp_server(user, server_id, db_session):
+            raise ValueError(
+                "You do not have access to one or more of the selected MCP servers."
+            )
+
+
+def _fetch_tools_for_upsert(
+    db_session: Session,
+    user: User | None,
+    tool_ids: list[int] | None,
+    existing_persona: Persona | None,
+) -> list[Tool] | None:
+    """Fetch and attach tools by IDs."""
+    if tool_ids is None:
+        return None
+
+    tools = db_session.query(Tool).filter(Tool.id.in_(tool_ids)).all()
+    if not tools and tool_ids:
+        raise ValueError("Tools not found")
+
+    if user is not None:
+        _assert_mcp_tools_accessible(db_session, user, tools, existing_persona)
+
+    return tools
+
+
+def _fetch_document_sets_for_upsert(
+    db_session: Session,
+    document_set_ids: list[int] | None,
+) -> list[DocumentSet] | None:
+    """Fetch and attach document_sets by IDs."""
+    if document_set_ids is None:
+        return None
+
+    document_sets = (
+        db_session.query(DocumentSet).filter(DocumentSet.id.in_(document_set_ids)).all()
+    )
+    if len(document_sets) != len(set(document_set_ids)):
+        raise ValueError("document_sets not found")
+    return document_sets
+
+
+def _assert_document_sets_attachable(
+    db_session: Session,
+    user: User | None,
+    document_set_ids: list[int] | None,
+    existing_persona: Persona | None,
+    knowledge_guard_applies: bool,
+) -> None:
+    """Editors may only ATTACH knowledge they can access themselves; anything
+    already attached survives an update, but once removed it can't be
+    re-added by someone without access (ENG-4180)."""
+    if document_set_ids is None or not knowledge_guard_applies or user is None:
+        return
+
+    existing_set_ids: set[int] = (
+        {ds.id for ds in existing_persona.document_sets} if existing_persona else set()
+    )
+    added_set_ids = set(document_set_ids) - existing_set_ids
+    if added_set_ids:
+        accessible_set_ids = filter_document_set_ids_by_user_access(
+            db_session, list(added_set_ids), user
+        )
+        if added_set_ids - accessible_set_ids:
+            raise ValueError("Cannot attach document sets you don't have access to")
+
+
+def _fetch_user_files_for_upsert(
+    db_session: Session,
+    user: User | None,
+    user_file_ids: list[UUID] | None,
+    existing_persona: Persona | None,
+    knowledge_guard_applies: bool,
+) -> list[UserFile] | None:
+    """Fetch and attach user_files by IDs."""
+    if user_file_ids is None:
+        return None
+
+    user_files = db_session.query(UserFile).filter(UserFile.id.in_(user_file_ids)).all()
+    if len(user_files) != len(set(user_file_ids)):
+        raise ValueError("user_files not found")
+
+    # Editors may only attach files they own (admins bypass)
+    if knowledge_guard_applies and user is not None:
+        existing_file_ids: set[UUID] = (
+            {uf.id for uf in existing_persona.user_files} if existing_persona else set()
+        )
+        for user_file in user_files:
+            if user_file.id not in existing_file_ids and user_file.user_id != user.id:
+                raise ValueError("Cannot attach files you don't own")
+
+    return user_files
+
+
+def _fetch_labels_for_upsert(
+    db_session: Session,
+    label_ids: list[int] | None,
+) -> list[PersonaLabel] | None:
+    if label_ids is None:
+        return None
+
+    labels = db_session.query(PersonaLabel).filter(PersonaLabel.id.in_(label_ids)).all()
+    if len(labels) != len(label_ids):
+        raise ValueError("Some label IDs were not found in the database")
+    return labels
+
+
+def _fetch_hierarchy_nodes_for_upsert(
+    db_session: Session,
+    hierarchy_node_ids: list[int] | None,
+) -> list[HierarchyNode] | None:
+    """Fetch and attach hierarchy_nodes by IDs."""
+    if hierarchy_node_ids is None:
+        return None
+
+    hierarchy_nodes = (
+        db_session.query(HierarchyNode)
+        .filter(HierarchyNode.id.in_(hierarchy_node_ids))
+        .all()
+    )
+    if len(hierarchy_nodes) != len(set(hierarchy_node_ids)):
+        raise ValueError("hierarchy_nodes not found")
+    return hierarchy_nodes
+
+
+def _assert_hierarchy_nodes_attachable(
+    db_session: Session,
+    user: User | None,
+    hierarchy_node_ids: list[int] | None,
+    existing_persona: Persona | None,
+    knowledge_guard_applies: bool,
+) -> None:
+    """Same attach-only guard as document sets, for hierarchy nodes."""
+    if hierarchy_node_ids is None or not knowledge_guard_applies or user is None:
+        return
+
+    existing_node_ids: set[int] = (
+        {node.id for node in existing_persona.hierarchy_nodes}
+        if existing_persona
+        else set()
+    )
+    added_node_ids = set(hierarchy_node_ids) - existing_node_ids
+    if added_node_ids:
+        accessible_node_ids = filter_accessible_hierarchy_node_ids(
+            db_session,
+            list(added_node_ids),
+            user.email,
+            get_user_external_group_ids(db_session, user),
+            user_id=user.id,
+        )
+        if added_node_ids - accessible_node_ids:
+            raise ValueError("Cannot attach hierarchy nodes you don't have access to")
+
+
+def _fetch_attached_documents_for_upsert(
+    db_session: Session,
+    user: User | None,
+    document_ids: list[str] | None,
+) -> list[Document] | None:
+    """Fetch and attach documents by IDs, filtering for access permissions."""
+    if document_ids is None:
+        return None
+
+    user_email = user.email if user else None
+    external_group_ids = get_user_external_group_ids(db_session, user) if user else []
+    attached_documents = get_accessible_documents_by_ids(
+        db_session=db_session,
+        document_ids=document_ids,
+        user_email=user_email,
+        external_group_ids=external_group_ids,
+        user_id=user.id if user else None,
+    )
+    if not attached_documents and document_ids:
+        raise ValueError("documents not found or not accessible")
+    return attached_documents
+
+
+def _resolve_persona_relations(
+    db_session: Session,
+    user: User | None,
+    existing_persona: Persona | None,
+    tool_ids: list[int] | None,
+    document_set_ids: list[int] | None,
+    user_file_ids: list[UUID] | None,
+    label_ids: list[int] | None,
+    hierarchy_node_ids: list[int] | None,
+    document_ids: list[str] | None,
+) -> _PersonaRelations:
+    """Load the rows named by the ID lists and enforce the attach-time guards. The call
+    order fixes which error a bad request reports first."""
+    tools = _fetch_tools_for_upsert(db_session, user, tool_ids, existing_persona)
+    document_sets = _fetch_document_sets_for_upsert(db_session, document_set_ids)
+
+    # Admins bypass the attach-time knowledge guards below.
+    knowledge_guard_applies: bool = user is not None and not has_global_permission(
+        user, Permission.MANAGE_AGENTS
+    )
+    _assert_document_sets_attachable(
+        db_session, user, document_set_ids, existing_persona, knowledge_guard_applies
+    )
+
+    user_files = _fetch_user_files_for_upsert(
+        db_session, user, user_file_ids, existing_persona, knowledge_guard_applies
+    )
+    labels = _fetch_labels_for_upsert(db_session, label_ids)
+    hierarchy_nodes = _fetch_hierarchy_nodes_for_upsert(db_session, hierarchy_node_ids)
+    _assert_hierarchy_nodes_attachable(
+        db_session, user, hierarchy_node_ids, existing_persona, knowledge_guard_applies
+    )
+    attached_documents = _fetch_attached_documents_for_upsert(
+        db_session, user, document_ids
+    )
+
+    return _PersonaRelations(
+        tools=tools,
+        document_sets=document_sets,
+        user_files=user_files,
+        labels=labels,
+        hierarchy_nodes=hierarchy_nodes,
+        attached_documents=attached_documents,
+    )
+
+
+def _update_persona_fields(
+    existing_persona: Persona,
+    db_session: Session,
+    user: User | None,
+    *,
+    name: str,
+    description: str,
+    default_model_configuration_id: int | None,
+    starter_messages: list[StarterMessage] | None,
+    is_public: bool | None,
+    uploaded_image_id: str | None,
+    remove_image: bool | None,
+    icon_name: str | None,
+    search_start_date: datetime | None,
+    labels: list[PersonaLabel] | None,
+    is_listed: bool | None,
+    is_featured: bool | None,
+    system_prompt: str | None,
+    task_prompt: str | None,
+    datetime_aware: bool | None,
+    replace_base_system_prompt: bool,
+    builtin_persona: bool,
+) -> None:
+    # Built-in personas can only be updated through YAML configuration.
+    # This ensures that core system personas are not modified unintentionally.
+    if existing_persona.builtin_persona and not builtin_persona:
+        raise ValueError("Cannot update builtin persona with non-builtin.")
+
+    # The following update excludes `default`, `built-in`, and display priority.
+    # Display priority is handled separately in the `display-priority` endpoint.
+    # `default` and `built-in` properties can only be set when creating a persona.
+    existing_persona.name = name
+    existing_persona.description = description
+    existing_persona.default_model_configuration_id = default_model_configuration_id
+    existing_persona.starter_messages = starter_messages
+    existing_persona.deleted = False  # Un-delete if previously deleted
+    # Publishing (org-wide public) is owner-or-admin — matches the share route and the
+    # publish projection. An editor-shared user may edit content but not flip an agent
+    # they don't own to public; the change is silently dropped, like is_listed/is_featured.
+    if is_public is not None and (
+        user is None or can_delete_persona(user, existing_persona, db_session)
+    ):
+        existing_persona.is_public = is_public
+    if remove_image or uploaded_image_id:
+        existing_persona.uploaded_image_id = uploaded_image_id
+    existing_persona.icon_name = icon_name
+    existing_persona.search_start_date = search_start_date
+    if labels is not None:
+        existing_persona.labels.clear()
+        existing_persona.labels = labels or []
+    # Featured/listed changes are curator/admin-only (ENG-4179): shared
+    # editors saving the form must never flip them, so non-privileged
+    # updates silently preserve the stored values.
+    user_can_set_admin_flags = user is None or has_global_permission(
+        user, Permission.MANAGE_AGENTS
+    )
+    if is_listed is not None and user_can_set_admin_flags:
+        existing_persona.is_listed = is_listed
+    if is_featured is not None and user_can_set_admin_flags:
+        existing_persona.is_featured = is_featured
+    # Update embedded prompt fields if provided
+    if system_prompt is not None:
+        existing_persona.system_prompt = system_prompt
+    if task_prompt is not None:
+        existing_persona.task_prompt = task_prompt
+    if datetime_aware is not None:
+        existing_persona.datetime_aware = datetime_aware
+    existing_persona.replace_base_system_prompt = replace_base_system_prompt
+
+
+def _replace_persona_associations(
+    existing_persona: Persona,
+    db_session: Session,
+    relations: _PersonaRelations,
+    display_priority: int | None,
+) -> None:
+    # Do not delete any associations manually added unless
+    # a new updated list is provided
+    if relations.document_sets is not None:
+        existing_persona.document_sets.clear()
+        existing_persona.document_sets = relations.document_sets or []
+
+    # Note: prompts are now embedded in personas - no separate prompts relationship
+
+    if relations.tools is not None:
+        existing_persona.tools = relations.tools or []
+
+    if relations.user_files is not None:
+        old_file_ids = {uf.id for uf in existing_persona.user_files}
+        new_file_ids = {uf.id for uf in (relations.user_files or [])}
+        affected_file_ids = old_file_ids | new_file_ids
+        existing_persona.user_files.clear()
+        existing_persona.user_files = relations.user_files or []
+        if affected_file_ids:
+            _mark_files_need_persona_sync(db_session, list(affected_file_ids))
+
+    if relations.hierarchy_nodes is not None:
+        existing_persona.hierarchy_nodes.clear()
+        existing_persona.hierarchy_nodes = relations.hierarchy_nodes or []
+
+    if relations.attached_documents is not None:
+        existing_persona.attached_documents.clear()
+        existing_persona.attached_documents = relations.attached_documents or []
+
+    # We should only update display priority if it is not already set
+    if existing_persona.display_priority is None:
+        existing_persona.display_priority = display_priority
+
+
+def _insert_new_persona(
+    db_session: Session,
+    user: User | None,
+    relations: _PersonaRelations,
+    *,
+    persona_id: int | None,
+    name: str,
+    description: str,
+    default_model_configuration_id: int | None,
+    starter_messages: list[StarterMessage] | None,
+    is_public: bool | None,
+    uploaded_image_id: str | None,
+    icon_name: str | None,
+    display_priority: int | None,
+    search_start_date: datetime | None,
+    is_listed: bool | None,
+    is_featured: bool | None,
+    system_prompt: str | None,
+    task_prompt: str | None,
+    datetime_aware: bool | None,
+    replace_base_system_prompt: bool,
+    builtin_persona: bool,
+) -> Persona:
+    # Create new persona - prompt configuration will be set separately if needed
+    new_persona = Persona(
+        id=persona_id,
+        user_id=user.id if user else None,
+        is_public=(is_public if is_public is not None else True),
+        name=name,
+        description=description,
+        builtin_persona=builtin_persona,
+        system_prompt=system_prompt or "",
+        task_prompt=task_prompt or "",
+        datetime_aware=(datetime_aware if datetime_aware is not None else True),
+        replace_base_system_prompt=replace_base_system_prompt,
+        document_sets=relations.document_sets or [],
+        default_model_configuration_id=default_model_configuration_id,
+        starter_messages=starter_messages,
+        tools=relations.tools or [],
+        uploaded_image_id=uploaded_image_id,
+        icon_name=icon_name,
+        display_priority=display_priority,
+        is_listed=(is_listed if is_listed is not None else True),
+        search_start_date=search_start_date,
+        is_featured=(is_featured if is_featured is not None else False),
+        user_files=relations.user_files or [],
+        labels=relations.labels or [],
+        hierarchy_nodes=relations.hierarchy_nodes or [],
+        attached_documents=relations.attached_documents or [],
+    )
+    db_session.add(new_persona)
+    if relations.user_files:
+        _mark_files_need_persona_sync(
+            db_session, [uf.id for uf in relations.user_files]
+        )
+    return new_persona
+
+
 def upsert_persona(
     user: User | None,
     name: str,
@@ -1587,297 +2054,79 @@ def upsert_persona(
     whether or not the assistant is a built-in / default assistant
     """
 
-    # Only a create that lands on a deleted same-name row recycles it; editing by id must
-    # not reach a deleted agent.
-    recycling_deleted = False
-
-    if persona_id is not None:
-        existing_persona = db_session.query(Persona).filter_by(id=persona_id).first()
-    else:
-        existing_persona = _get_persona_by_name(
-            persona_name=name, user=user, db_session=db_session
-        )
-
-        # Check for duplicate names when creating new personas
-        # Deleted personas are allowed to be overwritten
-        if existing_persona and not existing_persona.deleted:
-            raise ValueError(
-                f"Assistant with name '{name}' already exists. Please rename your assistant."
-            )
-        recycling_deleted = existing_persona is not None
-
-    if existing_persona and user:
-        # this checks if the user has permission to edit the persona
-        # will raise an Exception if the user does not have permission
-        # Skip check if user is None (system/admin operation)
-        existing_persona = fetch_persona_by_id_for_user(
-            db_session=db_session,
-            persona_id=existing_persona.id,
-            user=user,
-            get_editable=True,
-            include_deleted=recycling_deleted,
-        )
-
-    # Fetch and attach tools by IDs
-    tools = None
-    if tool_ids is not None:
-        tools = db_session.query(Tool).filter(Tool.id.in_(tool_ids)).all()
-        if not tools and tool_ids:
-            raise ValueError("Tools not found")
-
-        # Existing tools survive access revocation; newly attached tools require access.
-        if user is not None:
-            # local import to avoid circular import (mirrors built_in_tools below)
-            from onyx.db.mcp import user_can_access_mcp_server
-
-            existing_tool_ids = (
-                {tool.id for tool in existing_persona.tools}
-                if existing_persona
-                else set()
-            )
-            checked_servers: set[int] = set()
-            for tool in tools:
-                server_id = tool.mcp_server_id
-                if (
-                    tool.id in existing_tool_ids
-                    or server_id is None
-                    or server_id in checked_servers
-                ):
-                    continue
-                checked_servers.add(server_id)
-                if not user_can_access_mcp_server(user, server_id, db_session):
-                    raise ValueError(
-                        "You do not have access to one or more of the "
-                        "selected MCP servers."
-                    )
-
-    # Fetch and attach document_sets by IDs
-    document_sets = None
-    if document_set_ids is not None:
-        document_sets = (
-            db_session.query(DocumentSet)
-            .filter(DocumentSet.id.in_(document_set_ids))
-            .all()
-        )
-        if len(document_sets) != len(set(document_set_ids)):
-            raise ValueError("document_sets not found")
-
-    # Editors may only ATTACH knowledge they can access themselves; anything
-    # already attached survives an update, but once removed it can't be
-    # re-added by someone without access (ENG-4180).
-    knowledge_guard_applies: bool = user is not None and not has_global_permission(
-        user, Permission.MANAGE_AGENTS
+    existing_persona = _resolve_existing_persona_for_upsert(
+        db_session=db_session,
+        user=user,
+        name=name,
+        persona_id=persona_id,
     )
-    if document_set_ids is not None and knowledge_guard_applies and user is not None:
-        existing_set_ids = (
-            {ds.id for ds in existing_persona.document_sets}
-            if existing_persona
-            else set()
-        )
-        added_set_ids = set(document_set_ids) - existing_set_ids
-        if added_set_ids:
-            accessible_set_ids = filter_document_set_ids_by_user_access(
-                db_session, list(added_set_ids), user
-            )
-            if added_set_ids - accessible_set_ids:
-                raise ValueError("Cannot attach document sets you don't have access to")
 
-    # Fetch and attach user_files by IDs
-    user_files = None
-    if user_file_ids is not None:
-        user_files = (
-            db_session.query(UserFile).filter(UserFile.id.in_(user_file_ids)).all()
-        )
-        if len(user_files) != len(set(user_file_ids)):
-            raise ValueError("user_files not found")
-
-        # Editors may only attach files they own (admins bypass)
-        if knowledge_guard_applies and user is not None:
-            existing_file_ids = (
-                {uf.id for uf in existing_persona.user_files}
-                if existing_persona
-                else set()
-            )
-            for user_file in user_files:
-                if (
-                    user_file.id not in existing_file_ids
-                    and user_file.user_id != user.id
-                ):
-                    raise ValueError("Cannot attach files you don't own")
-
-    labels = None
-    if label_ids is not None:
-        labels = (
-            db_session.query(PersonaLabel).filter(PersonaLabel.id.in_(label_ids)).all()
-        )
-        if len(labels) != len(label_ids):
-            raise ValueError("Some label IDs were not found in the database")
-
-    # Fetch and attach hierarchy_nodes by IDs
-    hierarchy_nodes = None
-    if hierarchy_node_ids is not None:
-        hierarchy_nodes = (
-            db_session.query(HierarchyNode)
-            .filter(HierarchyNode.id.in_(hierarchy_node_ids))
-            .all()
-        )
-        if len(hierarchy_nodes) != len(set(hierarchy_node_ids)):
-            raise ValueError("hierarchy_nodes not found")
-
-    if hierarchy_node_ids is not None and knowledge_guard_applies and user is not None:
-        existing_node_ids = (
-            {node.id for node in existing_persona.hierarchy_nodes}
-            if existing_persona
-            else set()
-        )
-        added_node_ids = set(hierarchy_node_ids) - existing_node_ids
-        if added_node_ids:
-            accessible_node_ids = filter_accessible_hierarchy_node_ids(
-                db_session,
-                list(added_node_ids),
-                user.email,
-                get_user_external_group_ids(db_session, user),
-                user_id=user.id,
-            )
-            if added_node_ids - accessible_node_ids:
-                raise ValueError(
-                    "Cannot attach hierarchy nodes you don't have access to"
-                )
-
-    # Fetch and attach documents by IDs, filtering for access permissions
-    attached_documents = None
-    if document_ids is not None:
-        user_email = user.email if user else None
-        external_group_ids = (
-            get_user_external_group_ids(db_session, user) if user else []
-        )
-        attached_documents = get_accessible_documents_by_ids(
-            db_session=db_session,
-            document_ids=document_ids,
-            user_email=user_email,
-            external_group_ids=external_group_ids,
-            user_id=user.id if user else None,
-        )
-        if not attached_documents and document_ids:
-            raise ValueError("documents not found or not accessible")
+    relations = _resolve_persona_relations(
+        db_session=db_session,
+        user=user,
+        existing_persona=existing_persona,
+        tool_ids=tool_ids,
+        document_set_ids=document_set_ids,
+        user_file_ids=user_file_ids,
+        label_ids=label_ids,
+        hierarchy_node_ids=hierarchy_node_ids,
+        document_ids=document_ids,
+    )
 
     # ensure all specified tools are valid
-    if tools:
-        validate_persona_tools(tools, db_session)
+    if relations.tools:
+        validate_persona_tools(relations.tools, db_session)
 
     if existing_persona:
-        # Built-in personas can only be updated through YAML configuration.
-        # This ensures that core system personas are not modified unintentionally.
-        if existing_persona.builtin_persona and not builtin_persona:
-            raise ValueError("Cannot update builtin persona with non-builtin.")
-
-        # The following update excludes `default`, `built-in`, and display priority.
-        # Display priority is handled separately in the `display-priority` endpoint.
-        # `default` and `built-in` properties can only be set when creating a persona.
-        existing_persona.name = name
-        existing_persona.description = description
-        existing_persona.default_model_configuration_id = default_model_configuration_id
-        existing_persona.starter_messages = starter_messages
-        existing_persona.deleted = False  # Un-delete if previously deleted
-        # Publishing (org-wide public) is owner-or-admin — matches the share route and the
-        # publish projection. An editor-shared user may edit content but not flip an agent
-        # they don't own to public; the change is silently dropped, like is_listed/is_featured.
-        if is_public is not None and (
-            user is None or can_delete_persona(user, existing_persona, db_session)
-        ):
-            existing_persona.is_public = is_public
-        if remove_image or uploaded_image_id:
-            existing_persona.uploaded_image_id = uploaded_image_id
-        existing_persona.icon_name = icon_name
-        existing_persona.search_start_date = search_start_date
-        if label_ids is not None:
-            existing_persona.labels.clear()
-            existing_persona.labels = labels or []
-        # Featured/listed changes are curator/admin-only (ENG-4179): shared
-        # editors saving the form must never flip them, so non-privileged
-        # updates silently preserve the stored values.
-        user_can_set_admin_flags = user is None or has_global_permission(
-            user, Permission.MANAGE_AGENTS
-        )
-        if is_listed is not None and user_can_set_admin_flags:
-            existing_persona.is_listed = is_listed
-        if is_featured is not None and user_can_set_admin_flags:
-            existing_persona.is_featured = is_featured
-        # Update embedded prompt fields if provided
-        if system_prompt is not None:
-            existing_persona.system_prompt = system_prompt
-        if task_prompt is not None:
-            existing_persona.task_prompt = task_prompt
-        if datetime_aware is not None:
-            existing_persona.datetime_aware = datetime_aware
-        existing_persona.replace_base_system_prompt = replace_base_system_prompt
-
-        # Do not delete any associations manually added unless
-        # a new updated list is provided
-        if document_sets is not None:
-            existing_persona.document_sets.clear()
-            existing_persona.document_sets = document_sets or []
-
-        # Note: prompts are now embedded in personas - no separate prompts relationship
-
-        if tools is not None:
-            existing_persona.tools = tools or []
-
-        if user_file_ids is not None:
-            old_file_ids = {uf.id for uf in existing_persona.user_files}
-            new_file_ids = {uf.id for uf in (user_files or [])}
-            affected_file_ids = old_file_ids | new_file_ids
-            existing_persona.user_files.clear()
-            existing_persona.user_files = user_files or []
-            if affected_file_ids:
-                _mark_files_need_persona_sync(db_session, list(affected_file_ids))
-
-        if hierarchy_node_ids is not None:
-            existing_persona.hierarchy_nodes.clear()
-            existing_persona.hierarchy_nodes = hierarchy_nodes or []
-
-        if document_ids is not None:
-            existing_persona.attached_documents.clear()
-            existing_persona.attached_documents = attached_documents or []
-
-        # We should only update display priority if it is not already set
-        if existing_persona.display_priority is None:
-            existing_persona.display_priority = display_priority
-
-        persona = existing_persona
-
-    else:
-        # Create new persona - prompt configuration will be set separately if needed
-        new_persona = Persona(
-            id=persona_id,
-            user_id=user.id if user else None,
-            is_public=(is_public if is_public is not None else True),
+        _update_persona_fields(
+            existing_persona,
+            db_session,
+            user,
             name=name,
             description=description,
-            builtin_persona=builtin_persona,
-            system_prompt=system_prompt or "",
-            task_prompt=task_prompt or "",
-            datetime_aware=(datetime_aware if datetime_aware is not None else True),
-            replace_base_system_prompt=replace_base_system_prompt,
-            document_sets=document_sets or [],
             default_model_configuration_id=default_model_configuration_id,
             starter_messages=starter_messages,
-            tools=tools or [],
+            is_public=is_public,
+            uploaded_image_id=uploaded_image_id,
+            remove_image=remove_image,
+            icon_name=icon_name,
+            search_start_date=search_start_date,
+            labels=relations.labels,
+            is_listed=is_listed,
+            is_featured=is_featured,
+            system_prompt=system_prompt,
+            task_prompt=task_prompt,
+            datetime_aware=datetime_aware,
+            replace_base_system_prompt=replace_base_system_prompt,
+            builtin_persona=builtin_persona,
+        )
+        _replace_persona_associations(
+            existing_persona, db_session, relations, display_priority
+        )
+        persona = existing_persona
+    else:
+        persona = _insert_new_persona(
+            db_session,
+            user,
+            relations,
+            persona_id=persona_id,
+            name=name,
+            description=description,
+            default_model_configuration_id=default_model_configuration_id,
+            starter_messages=starter_messages,
+            is_public=is_public,
             uploaded_image_id=uploaded_image_id,
             icon_name=icon_name,
             display_priority=display_priority,
-            is_listed=(is_listed if is_listed is not None else True),
             search_start_date=search_start_date,
-            is_featured=(is_featured if is_featured is not None else False),
-            user_files=user_files or [],
-            labels=labels or [],
-            hierarchy_nodes=hierarchy_nodes or [],
-            attached_documents=attached_documents or [],
+            is_listed=is_listed,
+            is_featured=is_featured,
+            system_prompt=system_prompt,
+            task_prompt=task_prompt,
+            datetime_aware=datetime_aware,
+            replace_base_system_prompt=replace_base_system_prompt,
+            builtin_persona=builtin_persona,
         )
-        db_session.add(new_persona)
-        if user_files:
-            _mark_files_need_persona_sync(db_session, [uf.id for uf in user_files])
-        persona = new_persona
     if commit:
         db_session.commit()
     else:

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -167,6 +167,360 @@ def get_normalization_pipeline_name_and_config() -> tuple[str, dict[str, Any]]:
         )
 
 
+def _get_acl_visibility_filter(
+    access_control_list: list[str],
+) -> dict[str, dict[str, list[TermQuery[bool] | TermsQuery[str]] | int]]:
+    """Returns a filter for the access control list.
+
+    Since this returns an isolated bool should clause, it can be cached in
+    OpenSearch independently of other clauses in _get_search_filters.
+
+    Args:
+        access_control_list: The access control list to restrict documents to.
+
+    Raises:
+        ValueError: The number of access control list entries is greater than
+            MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
+
+    Returns:
+        A filter for the access control list.
+    """
+    # Logical OR operator on its elements.
+    acl_visibility_filter: dict[str, dict[str, Any]] = {
+        "bool": {
+            "should": [{"term": {PUBLIC_FIELD_NAME: {"value": True}}}],
+            "minimum_should_match": 1,
+        }
+    }
+    if access_control_list:
+        if len(access_control_list) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
+            raise ValueError(
+                f"Too many access control list entries: {len(access_control_list)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
+            )
+        # Use terms instead of a list of term within a should clause because
+        # Lucene will optimize the filtering for large sets of terms. Small sets
+        # of terms are not expected to perform any differently than individual
+        # term clauses.
+        acl_subclause: TermsQuery[str] = {
+            "terms": {ACCESS_CONTROL_LIST_FIELD_NAME: list(access_control_list)}
+        }
+        acl_visibility_filter["bool"]["should"].append(
+            acl_subclause  # ty: ignore[invalid-argument-type]
+        )
+    return acl_visibility_filter
+
+
+def _get_source_type_filter(
+    source_types: list[DocumentSource],
+) -> TermsQuery[str]:
+    """Returns a filter for the source types.
+
+    Since this returns an isolated terms clause, it can be cached in OpenSearch
+    independently of other clauses in _get_search_filters.
+
+    Args:
+        source_types: The source types to restrict documents to.
+
+    Raises:
+        ValueError: The number of source types is greater than
+            MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
+        ValueError: An empty list was supplied.
+
+    Returns:
+        A filter for the source types.
+    """
+    if not source_types:
+        raise ValueError(
+            "source_types cannot be empty if trying to create a source type filter."
+        )
+    if len(source_types) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
+        raise ValueError(
+            f"Too many source types: {len(source_types)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
+        )
+    # Use terms instead of a list of term within a should clause because Lucene
+    # will optimize the filtering for large sets of terms. Small sets of terms
+    # are not expected to perform any differently than individual term clauses.
+    return {
+        "terms": {
+            SOURCE_TYPE_FIELD_NAME: [source_type.value for source_type in source_types]
+        }
+    }
+
+
+def _get_tag_filter(tags: list[Tag]) -> TermsQuery[str]:
+    """Returns a filter for the tags.
+
+    Since this returns an isolated terms clause, it can be cached in OpenSearch
+    independently of other clauses in _get_search_filters.
+
+    Args:
+        tags: The tags to restrict documents to.
+
+    Raises:
+        ValueError: The number of tags is greater than
+            MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
+        ValueError: An empty list was supplied.
+
+    Returns:
+        A filter for the tags.
+    """
+    if not tags:
+        raise ValueError("tags cannot be empty if trying to create a tag filter.")
+    if len(tags) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
+        raise ValueError(
+            f"Too many tags: {len(tags)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
+        )
+    # Kind of an abstraction leak, see convert_metadata_dict_to_list_of_strings
+    # for why metadata list entries are expected to look this way.
+    tag_str_list = [f"{tag.tag_key}{INDEX_SEPARATOR}{tag.tag_value}" for tag in tags]
+    # Use terms instead of a list of term within a should clause because Lucene
+    # will optimize the filtering for large sets of terms. Small sets of terms
+    # are not expected to perform any differently than individual term clauses.
+    return {"terms": {METADATA_LIST_FIELD_NAME: tag_str_list}}
+
+
+def _get_document_set_filter(document_sets: list[str]) -> TermsQuery[str]:
+    """Returns a filter for the document sets.
+
+    Since this returns an isolated terms clause, it can be cached in OpenSearch
+    independently of other clauses in _get_search_filters.
+
+    Args:
+        document_sets: The document sets to restrict documents to.
+
+    Raises:
+        ValueError: The number of document sets is greater than
+            MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
+        ValueError: An empty list was supplied.
+
+    Returns:
+        A filter for the document sets.
+    """
+    if not document_sets:
+        raise ValueError(
+            "document_sets cannot be empty if trying to create a document set filter."
+        )
+    if len(document_sets) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
+        raise ValueError(
+            f"Too many document sets: {len(document_sets)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
+        )
+    # Use terms instead of a list of term within a should clause because Lucene
+    # will optimize the filtering for large sets of terms. Small sets of terms
+    # are not expected to perform any differently than individual term clauses.
+    return {"terms": {DOCUMENT_SETS_FIELD_NAME: list(document_sets)}}
+
+
+def _get_user_project_filter(project_id: int) -> TermQuery[int]:
+    return {"term": {USER_PROJECTS_FIELD_NAME: {"value": project_id}}}
+
+
+def _get_persona_filter(persona_id: int) -> TermQuery[int]:
+    return {"term": {PERSONAS_FIELD_NAME: {"value": persona_id}}}
+
+
+def _get_date_range_clause(
+    field_name: str,
+    gte: datetime | None,
+    lte: datetime | None,
+    include_undated: bool,
+) -> dict[str, Any]:
+    """Inclusive [gte, lte] range clause on a date field; when include_undated
+    is True, documents missing the field also match. Isolated bool clause, so
+    OpenSearch can cache it independently."""
+    # Convert to UTC if not already so the bounds are comparable to the document
+    # data.
+    range_bounds: dict[str, int] = {}
+    if gte is not None:
+        range_bounds["gte"] = int(datetime_to_utc(gte).timestamp())
+    if lte is not None:
+        range_bounds["lte"] = int(datetime_to_utc(lte).timestamp())
+
+    # Logical OR operator on its elements.
+    date_range_clause: dict[str, Any] = {
+        "bool": {"should": [], "minimum_should_match": 1}
+    }
+    date_range_clause["bool"]["should"].append({"range": {field_name: range_bounds}})
+    if include_undated:
+        date_range_clause["bool"]["should"].append(
+            {"bool": {"must_not": {"exists": {"field": field_name}}}}
+        )
+    return date_range_clause
+
+
+def _get_document_time_filter(
+    created_at_range: TimeRange | None,
+    updated_at_range: TimeRange | None,
+) -> list[dict[str, Any]]:
+    """One null-tolerant clause per set range, to be AND-ed into the filter.
+    created_at always keeps undated documents (over-extend); last_updated keeps
+    them only for an old, open-ended lower bound, so recent-window queries
+    aren't flooded by undated docs."""
+    clauses: list[dict[str, Any]] = []
+    if created_at_range is not None and created_at_range.has_bounds():
+        clauses.append(
+            _get_date_range_clause(
+                CREATED_AT_FIELD_NAME,
+                gte=created_at_range.start,
+                lte=created_at_range.end,
+                include_undated=True,
+            )
+        )
+    if updated_at_range is not None and updated_at_range.has_bounds():
+        include_undated = (
+            updated_at_range.start is not None
+            and updated_at_range.end is None
+            and updated_at_range.start
+            < datetime.now(timezone.utc) - timedelta(days=ASSUMED_DOCUMENT_AGE_DAYS)
+        )
+        clauses.append(
+            _get_date_range_clause(
+                LAST_UPDATED_FIELD_NAME,
+                gte=updated_at_range.start,
+                lte=updated_at_range.end,
+                include_undated=include_undated,
+            )
+        )
+    return clauses
+
+
+def _get_chunk_index_filter(
+    min_chunk_index: int | None, max_chunk_index: int | None
+) -> dict[str, Any]:
+    range_clause: dict[str, Any] = {"range": {CHUNK_INDEX_FIELD_NAME: {}}}
+    if min_chunk_index is not None:
+        range_clause["range"][CHUNK_INDEX_FIELD_NAME]["gte"] = min_chunk_index
+    if max_chunk_index is not None:
+        range_clause["range"][CHUNK_INDEX_FIELD_NAME]["lte"] = max_chunk_index
+    return range_clause
+
+
+def _get_attached_document_id_filter(
+    doc_ids: list[str],
+) -> TermsQuery[str]:
+    """
+    Returns a filter for documents explicitly attached to an assistant.
+
+    Since this returns an isolated terms clause, it can be cached in OpenSearch
+    independently of other clauses in _get_search_filters.
+
+    Args:
+        doc_ids: The document IDs to restrict documents to.
+
+    Raises:
+        ValueError: The number of document IDs is greater than
+            MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
+        ValueError: An empty list was supplied.
+
+    Returns:
+        A filter for the document IDs.
+    """
+    if not doc_ids:
+        raise ValueError(
+            "doc_ids cannot be empty if trying to create a document ID filter."
+        )
+    if len(doc_ids) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
+        raise ValueError(
+            f"Too many document IDs: {len(doc_ids)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
+        )
+    # Use terms instead of a list of term within a should clause because Lucene
+    # will optimize the filtering for large sets of terms. Small sets of terms
+    # are not expected to perform any differently than individual term clauses.
+    return {"terms": {DOCUMENT_ID_FIELD_NAME: list(doc_ids)}}
+
+
+def _get_hierarchy_node_filter(
+    node_ids: list[int],
+) -> TermsQuery[int]:
+    """
+    Returns a filter for chunks whose ancestors include any of the given
+    hierarchy nodes.
+
+    Since this returns an isolated terms clause, it can be cached in OpenSearch
+    independently of other clauses in _get_search_filters.
+
+    Args:
+        node_ids: The hierarchy node IDs to restrict documents to.
+
+    Raises:
+        ValueError: The number of hierarchy node IDs is greater than
+            MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
+        ValueError: An empty list was supplied.
+
+    Returns:
+        A filter for the hierarchy node IDs.
+    """
+    if not node_ids:
+        raise ValueError(
+            "node_ids cannot be empty if trying to create a hierarchy node ID filter."
+        )
+    if len(node_ids) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
+        raise ValueError(
+            f"Too many hierarchy node IDs: {len(node_ids)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
+        )
+    # Use terms instead of a list of term within a should clause because Lucene
+    # will optimize the filtering for large sets of terms. Small sets of terms
+    # are not expected to perform any differently than individual term clauses.
+    return {"terms": {ANCESTOR_HIERARCHY_NODE_IDS_FIELD_NAME: list(node_ids)}}
+
+
+def _get_knowledge_scope_filter(
+    document_sets: list[str],
+    project_id_filter: int | None,
+    persona_id_filter: int | None,
+    attached_document_ids: list[str] | None,
+    hierarchy_node_ids: list[int] | None,
+) -> dict[str, Any] | None:
+    """Returns the knowledge scope filter, or None when there is no scope.
+
+    Explicit knowledge attachments restrict what an assistant can see. When none
+    are set the assistant searches everything.
+
+    persona_id_filter is a primary trigger — a persona with user files IS
+    explicit knowledge, so it can start a knowledge scope on its own.
+
+    project_id_filter is a primary trigger — a chat inside a project is scoped
+    to that project, so project_id_filter restricts the search to the project's
+    files on its own (project chats do not search team knowledge).
+
+    Since this returns an isolated bool should clause, it can be cached in
+    OpenSearch independently of other clauses in _get_search_filters.
+    """
+    has_knowledge_scope = (
+        attached_document_ids
+        or hierarchy_node_ids
+        or document_sets
+        or persona_id_filter is not None
+        or project_id_filter is not None
+    )
+    if not has_knowledge_scope:
+        return None
+
+    knowledge_filter: dict[str, Any] = {
+        "bool": {"should": [], "minimum_should_match": 1}
+    }
+    if attached_document_ids:
+        knowledge_filter["bool"]["should"].append(
+            _get_attached_document_id_filter(attached_document_ids)
+        )
+    if hierarchy_node_ids:
+        knowledge_filter["bool"]["should"].append(
+            _get_hierarchy_node_filter(hierarchy_node_ids)
+        )
+    if document_sets:
+        knowledge_filter["bool"]["should"].append(
+            _get_document_set_filter(document_sets)
+        )
+    if persona_id_filter is not None:
+        knowledge_filter["bool"]["should"].append(
+            _get_persona_filter(persona_id_filter)
+        )
+    if project_id_filter is not None:
+        knowledge_filter["bool"]["should"].append(
+            _get_user_project_filter(project_id_filter)
+        )
+    return knowledge_filter
+
+
 class DocumentQuery:
     """
     TODO(andrei): Implement multi-phase search strategies.
@@ -956,307 +1310,6 @@ class DocumentQuery:
                 query.
         """
 
-        def _get_acl_visibility_filter(
-            access_control_list: list[str],
-        ) -> dict[str, dict[str, list[TermQuery[bool] | TermsQuery[str]] | int]]:
-            """Returns a filter for the access control list.
-
-            Since this returns an isolated bool should clause, it can be cached
-            in OpenSearch independently of other clauses in _get_search_filters.
-
-            Args:
-                access_control_list: The access control list to restrict
-                    documents to.
-
-            Raises:
-                ValueError: The number of access control list entries is greater
-                    than MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
-
-            Returns:
-                A filter for the access control list.
-            """
-            # Logical OR operator on its elements.
-            acl_visibility_filter: dict[str, dict[str, Any]] = {
-                "bool": {
-                    "should": [{"term": {PUBLIC_FIELD_NAME: {"value": True}}}],
-                    "minimum_should_match": 1,
-                }
-            }
-            if access_control_list:
-                if len(access_control_list) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
-                    raise ValueError(
-                        f"Too many access control list entries: {len(access_control_list)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
-                    )
-                # Use terms instead of a list of term within a should clause
-                # because Lucene will optimize the filtering for large sets of
-                # terms. Small sets of terms are not expected to perform any
-                # differently than individual term clauses.
-                acl_subclause: TermsQuery[str] = {
-                    "terms": {ACCESS_CONTROL_LIST_FIELD_NAME: list(access_control_list)}
-                }
-                acl_visibility_filter["bool"]["should"].append(
-                    acl_subclause  # ty: ignore[invalid-argument-type]
-                )
-            return acl_visibility_filter
-
-        def _get_source_type_filter(
-            source_types: list[DocumentSource],
-        ) -> TermsQuery[str]:
-            """Returns a filter for the source types.
-
-            Since this returns an isolated terms clause, it can be cached in
-            OpenSearch independently of other clauses in _get_search_filters.
-
-            Args:
-                source_types: The source types to restrict documents to.
-
-            Raises:
-                ValueError: The number of source types is greater than
-                    MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
-                ValueError: An empty list was supplied.
-
-            Returns:
-                A filter for the source types.
-            """
-            if not source_types:
-                raise ValueError(
-                    "source_types cannot be empty if trying to create a source type filter."
-                )
-            if len(source_types) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
-                raise ValueError(
-                    f"Too many source types: {len(source_types)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
-                )
-            # Use terms instead of a list of term within a should clause because
-            # Lucene will optimize the filtering for large sets of terms. Small
-            # sets of terms are not expected to perform any differently than
-            # individual term clauses.
-            return {
-                "terms": {
-                    SOURCE_TYPE_FIELD_NAME: [
-                        source_type.value for source_type in source_types
-                    ]
-                }
-            }
-
-        def _get_tag_filter(tags: list[Tag]) -> TermsQuery[str]:
-            """Returns a filter for the tags.
-
-            Since this returns an isolated terms clause, it can be cached in
-            OpenSearch independently of other clauses in _get_search_filters.
-
-            Args:
-                tags: The tags to restrict documents to.
-
-            Raises:
-                ValueError: The number of tags is greater than
-                    MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
-                ValueError: An empty list was supplied.
-
-            Returns:
-                A filter for the tags.
-            """
-            if not tags:
-                raise ValueError(
-                    "tags cannot be empty if trying to create a tag filter."
-                )
-            if len(tags) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
-                raise ValueError(
-                    f"Too many tags: {len(tags)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
-                )
-            # Kind of an abstraction leak, see
-            # convert_metadata_dict_to_list_of_strings for why metadata list
-            # entries are expected to look this way.
-            tag_str_list = [
-                f"{tag.tag_key}{INDEX_SEPARATOR}{tag.tag_value}" for tag in tags
-            ]
-            # Use terms instead of a list of term within a should clause because
-            # Lucene will optimize the filtering for large sets of terms. Small
-            # sets of terms are not expected to perform any differently than
-            # individual term clauses.
-            return {"terms": {METADATA_LIST_FIELD_NAME: tag_str_list}}
-
-        def _get_document_set_filter(document_sets: list[str]) -> TermsQuery[str]:
-            """Returns a filter for the document sets.
-
-            Since this returns an isolated terms clause, it can be cached in
-            OpenSearch independently of other clauses in _get_search_filters.
-
-            Args:
-                document_sets: The document sets to restrict documents to.
-
-            Raises:
-                ValueError: The number of document sets is greater than
-                    MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
-                ValueError: An empty list was supplied.
-
-            Returns:
-                A filter for the document sets.
-            """
-            if not document_sets:
-                raise ValueError(
-                    "document_sets cannot be empty if trying to create a document set filter."
-                )
-            if len(document_sets) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
-                raise ValueError(
-                    f"Too many document sets: {len(document_sets)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
-                )
-            # Use terms instead of a list of term within a should clause because
-            # Lucene will optimize the filtering for large sets of terms. Small
-            # sets of terms are not expected to perform any differently than
-            # individual term clauses.
-            return {"terms": {DOCUMENT_SETS_FIELD_NAME: list(document_sets)}}
-
-        def _get_user_project_filter(project_id: int) -> TermQuery[int]:
-            return {"term": {USER_PROJECTS_FIELD_NAME: {"value": project_id}}}
-
-        def _get_persona_filter(persona_id: int) -> TermQuery[int]:
-            return {"term": {PERSONAS_FIELD_NAME: {"value": persona_id}}}
-
-        def _get_date_range_clause(
-            field_name: str,
-            gte: datetime | None,
-            lte: datetime | None,
-            include_undated: bool,
-        ) -> dict[str, Any]:
-            """Inclusive [gte, lte] range clause on a date field; when
-            include_undated is True, documents missing the field also match.
-            Isolated bool clause, so OpenSearch can cache it independently."""
-            # Convert to UTC if not already so the bounds are comparable to the
-            # document data.
-            range_bounds: dict[str, int] = {}
-            if gte is not None:
-                range_bounds["gte"] = int(datetime_to_utc(gte).timestamp())
-            if lte is not None:
-                range_bounds["lte"] = int(datetime_to_utc(lte).timestamp())
-
-            # Logical OR operator on its elements.
-            date_range_clause: dict[str, Any] = {
-                "bool": {"should": [], "minimum_should_match": 1}
-            }
-            date_range_clause["bool"]["should"].append(
-                {"range": {field_name: range_bounds}}
-            )
-            if include_undated:
-                date_range_clause["bool"]["should"].append(
-                    {"bool": {"must_not": {"exists": {"field": field_name}}}}
-                )
-            return date_range_clause
-
-        def _get_document_time_filter(
-            created_at_range: TimeRange | None,
-            updated_at_range: TimeRange | None,
-        ) -> list[dict[str, Any]]:
-            """One null-tolerant clause per set range, to be AND-ed into the
-            filter. created_at always keeps undated documents (over-extend);
-            last_updated keeps them only for an old, open-ended lower bound, so
-            recent-window queries aren't flooded by undated docs."""
-            clauses: list[dict[str, Any]] = []
-            if created_at_range is not None and created_at_range.has_bounds():
-                clauses.append(
-                    _get_date_range_clause(
-                        CREATED_AT_FIELD_NAME,
-                        gte=created_at_range.start,
-                        lte=created_at_range.end,
-                        include_undated=True,
-                    )
-                )
-            if updated_at_range is not None and updated_at_range.has_bounds():
-                include_undated = (
-                    updated_at_range.start is not None
-                    and updated_at_range.end is None
-                    and updated_at_range.start
-                    < datetime.now(timezone.utc)
-                    - timedelta(days=ASSUMED_DOCUMENT_AGE_DAYS)
-                )
-                clauses.append(
-                    _get_date_range_clause(
-                        LAST_UPDATED_FIELD_NAME,
-                        gte=updated_at_range.start,
-                        lte=updated_at_range.end,
-                        include_undated=include_undated,
-                    )
-                )
-            return clauses
-
-        def _get_chunk_index_filter(
-            min_chunk_index: int | None, max_chunk_index: int | None
-        ) -> dict[str, Any]:
-            range_clause: dict[str, Any] = {"range": {CHUNK_INDEX_FIELD_NAME: {}}}
-            if min_chunk_index is not None:
-                range_clause["range"][CHUNK_INDEX_FIELD_NAME]["gte"] = min_chunk_index
-            if max_chunk_index is not None:
-                range_clause["range"][CHUNK_INDEX_FIELD_NAME]["lte"] = max_chunk_index
-            return range_clause
-
-        def _get_attached_document_id_filter(
-            doc_ids: list[str],
-        ) -> TermsQuery[str]:
-            """
-            Returns a filter for documents explicitly attached to an assistant.
-
-            Since this returns an isolated terms clause, it can be cached in
-            OpenSearch independently of other clauses in _get_search_filters.
-
-            Args:
-                doc_ids: The document IDs to restrict documents to.
-
-            Raises:
-                ValueError: The number of document IDs is greater than
-                    MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
-                ValueError: An empty list was supplied.
-
-            Returns:
-                A filter for the document IDs.
-            """
-            if not doc_ids:
-                raise ValueError(
-                    "doc_ids cannot be empty if trying to create a document ID filter."
-                )
-            if len(doc_ids) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
-                raise ValueError(
-                    f"Too many document IDs: {len(doc_ids)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
-                )
-            # Use terms instead of a list of term within a should clause because
-            # Lucene will optimize the filtering for large sets of terms. Small
-            # sets of terms are not expected to perform any differently than
-            # individual term clauses.
-            return {"terms": {DOCUMENT_ID_FIELD_NAME: list(doc_ids)}}
-
-        def _get_hierarchy_node_filter(
-            node_ids: list[int],
-        ) -> TermsQuery[int]:
-            """
-            Returns a filter for chunks whose ancestors include any of the given
-            hierarchy nodes.
-
-            Since this returns an isolated terms clause, it can be cached in
-            OpenSearch independently of other clauses in _get_search_filters.
-
-            Args:
-                node_ids: The hierarchy node IDs to restrict documents to.
-
-            Raises:
-                ValueError: The number of hierarchy node IDs is greater than
-                    MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY.
-                ValueError: An empty list was supplied.
-
-            Returns:
-                A filter for the hierarchy node IDs.
-            """
-            if not node_ids:
-                raise ValueError(
-                    "node_ids cannot be empty if trying to create a hierarchy node ID filter."
-                )
-            if len(node_ids) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY:
-                raise ValueError(
-                    f"Too many hierarchy node IDs: {len(node_ids)}. Max allowed: {MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY}."
-                )
-            # Use terms instead of a list of term within a should clause because
-            # Lucene will optimize the filtering for large sets of terms. Small
-            # sets of terms are not expected to perform any differently than
-            # individual term clauses.
-            return {"terms": {ANCESTOR_HIERARCHY_NODE_IDS_FIELD_NAME: list(node_ids)}}
-
         if document_id is not None and attached_document_ids is not None:
             raise ValueError(
                 "document_id and attached_document_ids cannot be used together."
@@ -1293,52 +1346,14 @@ class DocumentQuery:
             # document's metadata list.
             filter_clauses.append(_get_tag_filter(tags))
 
-        # Knowledge scope: explicit knowledge attachments restrict what an
-        # assistant can see. When none are set the assistant searches
-        # everything.
-        #
-        # persona_id_filter is a primary trigger — a persona with user files IS
-        # explicit knowledge, so it can start a knowledge scope on its own.
-        #
-        # project_id_filter is a primary trigger — a chat inside a project is
-        # scoped to that project, so project_id_filter restricts the search to
-        # the project's files on its own (project chats do not search team
-        # knowledge).
-        has_knowledge_scope = (
-            attached_document_ids
-            or hierarchy_node_ids
-            or document_sets
-            or persona_id_filter is not None
-            or project_id_filter is not None
+        knowledge_filter = _get_knowledge_scope_filter(
+            document_sets=document_sets,
+            project_id_filter=project_id_filter,
+            persona_id_filter=persona_id_filter,
+            attached_document_ids=attached_document_ids,
+            hierarchy_node_ids=hierarchy_node_ids,
         )
-
-        if has_knowledge_scope:
-            # Since this returns an isolated bool should clause, it can be
-            # cached in OpenSearch independently of other clauses in
-            # _get_search_filters.
-            knowledge_filter: dict[str, Any] = {
-                "bool": {"should": [], "minimum_should_match": 1}
-            }
-            if attached_document_ids:
-                knowledge_filter["bool"]["should"].append(
-                    _get_attached_document_id_filter(attached_document_ids)
-                )
-            if hierarchy_node_ids:
-                knowledge_filter["bool"]["should"].append(
-                    _get_hierarchy_node_filter(hierarchy_node_ids)
-                )
-            if document_sets:
-                knowledge_filter["bool"]["should"].append(
-                    _get_document_set_filter(document_sets)
-                )
-            if persona_id_filter is not None:
-                knowledge_filter["bool"]["should"].append(
-                    _get_persona_filter(persona_id_filter)
-                )
-            if project_id_filter is not None:
-                knowledge_filter["bool"]["should"].append(
-                    _get_user_project_filter(project_id_filter)
-                )
+        if knowledge_filter is not None:
             filter_clauses.append(knowledge_filter)
 
         if created_at_range is not None or updated_at_range is not None:

--- a/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
+++ b/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
-from onyx.configs.constants import INDEX_SEPARATOR
-from onyx.context.search.models import IndexFilters
+from onyx.configs.constants import INDEX_SEPARATOR, DocumentSource
+from onyx.context.search.models import IndexFilters, Tag, TimeRange
 from onyx.document_index.vespa.internal_types import VespaChunkRequest
 from onyx.document_index.vespa_constants import (
     ACCESS_CONTROL_LIST,
@@ -27,157 +27,222 @@ def build_tenant_id_filter(tenant_id: str) -> str:
     return f'({TENANT_ID} contains "{tenant_id}")'
 
 
+def _append(parts: list[str], clause: str) -> None:
+    if clause:
+        parts.append(clause)
+
+
+def _build_or_filters(key: str, vals: list[str] | None) -> str:
+    """For string-based 'contains' filters, e.g. WSET fields or array<string> fields.
+    Returns a bare clause like '(key contains "v1" or key contains "v2")' or ""."""
+    if not key or not vals:
+        return ""
+    eq_elems = [f'{key} contains "{val}"' for val in vals if val]
+    if not eq_elems:
+        return ""
+    return f"({' or '.join(eq_elems)})"
+
+
+def _build_weighted_set_filter(key: str, vals: list[str] | None) -> str:
+    """Build a Vespa weightedSet filter for large value lists.
+
+    Uses Vespa's native weightedSet() operator instead of OR-chained
+    'contains' clauses.  This is critical for fields like
+    access_control_list where a single user may have tens of thousands
+    of ACL entries — OR clauses at that scale cause Vespa to reject
+    the query with HTTP 400."""
+    if not key or not vals:
+        return ""
+    filtered = [val for val in vals if val]
+    if not filtered:
+        return ""
+    items = ", ".join(f'"{val}":1' for val in filtered)
+    return f"weightedSet({key}, {{{items}}})"
+
+
+def _build_int_or_filters(key: str, vals: list[int] | None) -> str:
+    """For an integer field filter.
+    Returns a bare clause or ""."""
+    if vals is None or not vals:
+        return ""
+    eq_elems = [f"{key} = {val}" for val in vals]
+    return f"({' or '.join(eq_elems)})"
+
+
+def _build_kge(entity: str) -> str:
+    GENERAL = "::*"
+    if entity.endswith(GENERAL):
+        return f'({{prefix: true}}"{entity.split(GENERAL, 1)[0]}")'
+    else:
+        return f'"{entity}"'
+
+
+def _build_kg_filter(
+    kg_entities: list[str] | None,
+    kg_relationships: list[str] | None,
+    kg_terms: list[str] | None,
+) -> str:
+    if not kg_entities and not kg_relationships and not kg_terms:
+        return ""
+
+    combined_filter_parts: list[str] = []
+
+    if kg_entities:
+        filter_parts = [
+            f"(kg_entities contains {_build_kge(kg_entity)})"
+            for kg_entity in kg_entities
+        ]
+        combined_filter_parts.append(f"({' or '.join(filter_parts)})")
+
+    # TODO: handle complex nested relationship logic (e.g., A participated, and B or C participated)
+    if kg_relationships:
+        filter_parts = []
+        for kg_relationship in kg_relationships:
+            source, rel_type, target = split_relationship_id(kg_relationship)
+            filter_parts.append(
+                "(kg_relationships contains sameElement("
+                f"source contains {_build_kge(source)},"
+                f'rel_type contains "{rel_type}",'
+                f"target contains {_build_kge(target)}))"
+            )
+        combined_filter_parts.append(f"{' and '.join(filter_parts)}")
+
+    # TODO: remove kg terms entirely from prompts and codebase
+
+    return f"({' and '.join(combined_filter_parts)})"
+
+
+def _build_kg_source_filters(
+    kg_sources: list[str] | None,
+) -> str:
+    if not kg_sources:
+        return ""
+
+    source_phrases = [f'{DOCUMENT_ID} contains "{source}"' for source in kg_sources]
+    return f"({' or '.join(source_phrases)})"
+
+
+def _build_kg_chunk_id_zero_only_filter(
+    kg_chunk_id_zero_only: bool,
+) -> str:
+    if not kg_chunk_id_zero_only:
+        return ""
+    return "(chunk_id = 0)"
+
+
+def _build_time_filter(
+    cutoff: datetime | None,
+    cutoff_upper: datetime | None = None,
+    untimed_doc_cutoff: timedelta = timedelta(days=92),
+) -> str:
+    if not cutoff and not cutoff_upper:
+        return ""
+
+    clauses: list[str] = []
+    if cutoff:
+        # Untimed docs (no doc_updated_at) are only included for an old, open-
+        # ended lower bound. A bounded range excludes them — an undated doc
+        # cannot be shown to fall within [cutoff, cutoff_upper].
+        include_untimed = (
+            cutoff_upper is None
+            and datetime.now(timezone.utc) - untimed_doc_cutoff > cutoff
+        )
+        cutoff_secs = int(cutoff.timestamp())
+        if include_untimed:
+            clauses.append(f"!({DOC_UPDATED_AT} < {cutoff_secs})")
+        else:
+            clauses.append(f"({DOC_UPDATED_AT} >= {cutoff_secs})")
+    if cutoff_upper:
+        clauses.append(f"({DOC_UPDATED_AT} <= {int(cutoff_upper.timestamp())})")
+
+    return " and ".join(clauses)
+
+
+def _build_updated_at_filter(updated_at_range: TimeRange | None) -> str:
+    """Vespa only indexes doc_updated_at: created_at_range is dropped (widens
+    rather than narrows)."""
+    return _build_time_filter(
+        updated_at_range.start if updated_at_range else None,
+        updated_at_range.end if updated_at_range else None,
+    )
+
+
+def _build_user_project_filter(
+    project_id: int | None,
+) -> str:
+    if project_id is None:
+        return ""
+    try:
+        pid = int(project_id)
+    except Exception:
+        return ""
+    return f'({USER_PROJECT} contains "{pid}")'
+
+
+def _build_persona_filter(
+    persona_id: int | None,
+) -> str:
+    if persona_id is None:
+        return ""
+    try:
+        pid = int(persona_id)
+    except Exception:
+        logger.warning("Invalid persona ID: %s", persona_id)
+        return ""
+    return f'({PERSONAS} contains "{pid}")'
+
+
+def _build_source_type_filter(source_type: list[DocumentSource] | None) -> str:
+    source_strs = [s.value for s in source_type] if source_type else None
+    return _build_or_filters(SOURCE_TYPE, source_strs)
+
+
+def _build_tag_filter(tags: list[Tag] | None) -> str:
+    tag_attributes = None
+    if tags:
+        tag_attributes = [
+            f"{tag.tag_key}{INDEX_SEPARATOR}{tag.tag_value}" for tag in tags
+        ]
+    return _build_or_filters(METADATA_LIST, tag_attributes)
+
+
+def _build_knowledge_scope_filter(filters: IndexFilters) -> str:
+    """Explicit knowledge attachments restrict what an assistant can see.
+    When none are set, the assistant can see everything.
+
+    persona_id_filter is a primary trigger — a persona with user files IS
+    explicit knowledge, so it can start a knowledge scope on its own.
+
+    project_id_filter is additive — it widens the scope to also cover
+    overflowing project files but never restricts on its own (a chat
+    inside a project should still search team knowledge)."""
+    knowledge_scope_parts: list[str] = []
+
+    _append(
+        knowledge_scope_parts, _build_or_filters(DOCUMENT_SETS, filters.document_set)
+    )
+    _append(knowledge_scope_parts, _build_persona_filter(filters.persona_id_filter))
+
+    # project_id_filter only widens an existing scope.
+    if knowledge_scope_parts:
+        _append(
+            knowledge_scope_parts,
+            _build_user_project_filter(filters.project_id_filter),
+        )
+
+    if len(knowledge_scope_parts) > 1:
+        return "(" + " or ".join(knowledge_scope_parts) + ")"
+    if len(knowledge_scope_parts) == 1:
+        return knowledge_scope_parts[0]
+    return ""
+
+
 def build_vespa_filters(
     filters: IndexFilters,
     *,
     include_hidden: bool = False,
     remove_trailing_and: bool = False,  # Set to True when using as a complete Vespa query
 ) -> str:
-    def _build_or_filters(key: str, vals: list[str] | None) -> str:
-        """For string-based 'contains' filters, e.g. WSET fields or array<string> fields.
-        Returns a bare clause like '(key contains "v1" or key contains "v2")' or ""."""
-        if not key or not vals:
-            return ""
-        eq_elems = [f'{key} contains "{val}"' for val in vals if val]
-        if not eq_elems:
-            return ""
-        return f"({' or '.join(eq_elems)})"
-
-    def _build_weighted_set_filter(key: str, vals: list[str] | None) -> str:
-        """Build a Vespa weightedSet filter for large value lists.
-
-        Uses Vespa's native weightedSet() operator instead of OR-chained
-        'contains' clauses.  This is critical for fields like
-        access_control_list where a single user may have tens of thousands
-        of ACL entries — OR clauses at that scale cause Vespa to reject
-        the query with HTTP 400."""
-        if not key or not vals:
-            return ""
-        filtered = [val for val in vals if val]
-        if not filtered:
-            return ""
-        items = ", ".join(f'"{val}":1' for val in filtered)
-        return f"weightedSet({key}, {{{items}}})"
-
-    def _build_int_or_filters(key: str, vals: list[int] | None) -> str:
-        """For an integer field filter.
-        Returns a bare clause or ""."""
-        if vals is None or not vals:
-            return ""
-        eq_elems = [f"{key} = {val}" for val in vals]
-        return f"({' or '.join(eq_elems)})"
-
-    def _build_kg_filter(
-        kg_entities: list[str] | None,
-        kg_relationships: list[str] | None,
-        kg_terms: list[str] | None,
-    ) -> str:
-        if not kg_entities and not kg_relationships and not kg_terms:
-            return ""
-
-        combined_filter_parts = []
-
-        def _build_kge(entity: str) -> str:
-            GENERAL = "::*"
-            if entity.endswith(GENERAL):
-                return f'({{prefix: true}}"{entity.split(GENERAL, 1)[0]}")'
-            else:
-                return f'"{entity}"'
-
-        if kg_entities:
-            filter_parts = [
-                f"(kg_entities contains {_build_kge(kg_entity)})"
-                for kg_entity in kg_entities
-            ]
-            combined_filter_parts.append(f"({' or '.join(filter_parts)})")
-
-        # TODO: handle complex nested relationship logic (e.g., A participated, and B or C participated)
-        if kg_relationships:
-            filter_parts = []
-            for kg_relationship in kg_relationships:
-                source, rel_type, target = split_relationship_id(kg_relationship)
-                filter_parts.append(
-                    "(kg_relationships contains sameElement("
-                    f"source contains {_build_kge(source)},"
-                    f'rel_type contains "{rel_type}",'
-                    f"target contains {_build_kge(target)}))"
-                )
-            combined_filter_parts.append(f"{' and '.join(filter_parts)}")
-
-        # TODO: remove kg terms entirely from prompts and codebase
-
-        return f"({' and '.join(combined_filter_parts)})"
-
-    def _build_kg_source_filters(
-        kg_sources: list[str] | None,
-    ) -> str:
-        if not kg_sources:
-            return ""
-
-        source_phrases = [f'{DOCUMENT_ID} contains "{source}"' for source in kg_sources]
-        return f"({' or '.join(source_phrases)})"
-
-    def _build_kg_chunk_id_zero_only_filter(
-        kg_chunk_id_zero_only: bool,
-    ) -> str:
-        if not kg_chunk_id_zero_only:
-            return ""
-        return "(chunk_id = 0)"
-
-    def _build_time_filter(
-        cutoff: datetime | None,
-        cutoff_upper: datetime | None = None,
-        untimed_doc_cutoff: timedelta = timedelta(days=92),
-    ) -> str:
-        if not cutoff and not cutoff_upper:
-            return ""
-
-        clauses: list[str] = []
-        if cutoff:
-            # Untimed docs (no doc_updated_at) are only included for an old, open-
-            # ended lower bound. A bounded range excludes them — an undated doc
-            # cannot be shown to fall within [cutoff, cutoff_upper].
-            include_untimed = (
-                cutoff_upper is None
-                and datetime.now(timezone.utc) - untimed_doc_cutoff > cutoff
-            )
-            cutoff_secs = int(cutoff.timestamp())
-            if include_untimed:
-                clauses.append(f"!({DOC_UPDATED_AT} < {cutoff_secs})")
-            else:
-                clauses.append(f"({DOC_UPDATED_AT} >= {cutoff_secs})")
-        if cutoff_upper:
-            clauses.append(f"({DOC_UPDATED_AT} <= {int(cutoff_upper.timestamp())})")
-
-        return " and ".join(clauses)
-
-    def _build_user_project_filter(
-        project_id: int | None,
-    ) -> str:
-        if project_id is None:
-            return ""
-        try:
-            pid = int(project_id)
-        except Exception:
-            return ""
-        return f'({USER_PROJECT} contains "{pid}")'
-
-    def _build_persona_filter(
-        persona_id: int | None,
-    ) -> str:
-        if persona_id is None:
-            return ""
-        try:
-            pid = int(persona_id)
-        except Exception:
-            logger.warning("Invalid persona ID: %s", persona_id)
-            return ""
-        return f'({PERSONAS} contains "{pid}")'
-
-    def _append(parts: list[str], clause: str) -> None:
-        if clause:
-            parts.append(clause)
-
     # Collect all top-level filter clauses, then join with " and " at the end.
     filter_parts: list[str] = []
 
@@ -200,59 +265,10 @@ def build_vespa_filters(
             ),
         )
 
-    # Source type filters
-    source_strs = (
-        [s.value for s in filters.source_type] if filters.source_type else None
-    )
-    _append(filter_parts, _build_or_filters(SOURCE_TYPE, source_strs))
-
-    # Tag filters
-    tag_attributes = None
-    if filters.tags:
-        tag_attributes = [
-            f"{tag.tag_key}{INDEX_SEPARATOR}{tag.tag_value}" for tag in filters.tags
-        ]
-    _append(filter_parts, _build_or_filters(METADATA_LIST, tag_attributes))
-
-    # Knowledge scope: explicit knowledge attachments restrict what an
-    # assistant can see.  When none are set, the assistant can see
-    # everything.
-    #
-    # persona_id_filter is a primary trigger — a persona with user files IS
-    # explicit knowledge, so it can start a knowledge scope on its own.
-    #
-    # project_id_filter is additive — it widens the scope to also cover
-    # overflowing project files but never restricts on its own (a chat
-    # inside a project should still search team knowledge).
-    knowledge_scope_parts: list[str] = []
-
-    _append(
-        knowledge_scope_parts, _build_or_filters(DOCUMENT_SETS, filters.document_set)
-    )
-    _append(knowledge_scope_parts, _build_persona_filter(filters.persona_id_filter))
-
-    # project_id_filter only widens an existing scope.
-    if knowledge_scope_parts:
-        _append(
-            knowledge_scope_parts,
-            _build_user_project_filter(filters.project_id_filter),
-        )
-
-    if len(knowledge_scope_parts) > 1:
-        filter_parts.append("(" + " or ".join(knowledge_scope_parts) + ")")
-    elif len(knowledge_scope_parts) == 1:
-        filter_parts.append(knowledge_scope_parts[0])
-
-    # Vespa only indexes doc_updated_at: created_at_range is dropped (widens
-    # rather than narrows).
-    updated_at_range = filters.updated_at_range
-    _append(
-        filter_parts,
-        _build_time_filter(
-            updated_at_range.start if updated_at_range else None,
-            updated_at_range.end if updated_at_range else None,
-        ),
-    )
+    _append(filter_parts, _build_source_type_filter(filters.source_type))
+    _append(filter_parts, _build_tag_filter(filters.tags))
+    _append(filter_parts, _build_knowledge_scope_filter(filters))
+    _append(filter_parts, _build_updated_at_filter(filters.updated_at_range))
 
     # # Knowledge Graph Filters
     # _append(filter_parts, _build_kg_filter(

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -406,6 +406,337 @@ def _warn_dropped_env_only_keys(
     )
 
 
+def _resolve_tool_choice(
+    tool_choice: ToolChoice | None,
+    tools: list[dict] | None,
+    mishandles_required: bool,
+) -> ToolChoice | None:
+    """Downgrade tool_choice=required to AUTO for models that mishandle it:
+    Claude skips reasoning when it's set, Qwen thinking models reject it
+    with a 400, and Z.AI rejects any GLM tool_choice other than auto
+    ("Tool choice must be auto"). The chat loop's fallback tool-call
+    extraction still enforces the forced tool. Matched by model name
+    rather than `is_reasoning` because the litellm/local registry lags
+    behind new Qwen/GLM releases (e.g. qwen3.7-plus, glm-5.3).
+    A NamedToolChoice is deliberately NOT downgraded: legacy Claude
+    thinking is skipped separately instead, and the other models may still
+    reject the forced tool upstream (a loud 400 beats silently ignoring
+    the caller's forced tool)."""
+    if mishandles_required and tool_choice == ToolChoiceOptions.REQUIRED:
+        tool_choice = ToolChoiceOptions.AUTO
+
+    # If no tools are provided, tool_choice should be None
+    return tool_choice if tools else None
+
+
+def _sampling_kwargs(
+    model_identity_names: list[str],
+    is_reasoning: bool,
+    temperature: float,
+    stream: bool,
+    send_stream_options: bool,
+) -> dict[str, Any]:
+    """Temperature plus stream usage reporting."""
+    kwargs: dict[str, Any] = {}
+
+    # Some models (e.g. Claude Opus 4.7/4.8) reject a non-default
+    # temperature with a 400 invalid_request_error. For those models we
+    # must omit the param entirely.
+    # LiteLLM's drop_params is not reliable here because the upstream
+    # provider config can still claim the param is supported.
+    # https://github.com/BerriAI/litellm/issues/26444
+    # TODO(acaprau): Consider removing this once the above is resolved,
+    # although this assumes users have upgraded their litellm if relevant.
+    omits_sampling_params = any(
+        anthropic_omits_sampling_params(name) for name in model_identity_names
+    )
+    if not omits_sampling_params:
+        kwargs["temperature"] = 1 if is_reasoning else temperature
+
+    if stream and send_stream_options:
+        kwargs["stream_options"] = {"include_usage": True}
+    return kwargs
+
+
+def _openai_style_reasoning_kwargs(
+    prompt: LanguageModelInput,
+    model_identity_names: list[str],
+    is_claude_model: bool,
+    openai_style_reasoning: dict[str, Any],
+) -> dict[str, Any]:
+    if is_claude_model:
+        # Only a gateway routes Claude here, and it still translates
+        # to Anthropic, so the signed-thinking-block constraint
+        # described below applies to these requests too.
+        send_reasoning = not _prompt_contains_tool_call_history(prompt)
+    else:
+        # OpenAI API does not accept reasoning params for GPT 5 chat
+        # models (neither reasoning nor reasoning_effort are accepted)
+        # even though they are reasoning models (bug in OpenAI)
+        send_reasoning = not any(
+            openai_chat_variant_rejects_reasoning(name) for name in model_identity_names
+        )
+    return {"reasoning": openai_style_reasoning} if send_reasoning else {}
+
+
+def _anthropic_reasoning_kwargs(
+    prompt: LanguageModelInput,
+    reasoning_style: ReasoningParamStyle,
+    reasoning_effort: ReasoningEffort,
+    tool_choice: ToolChoice | None,
+    max_tokens: int | None,
+) -> tuple[dict[str, Any], int | None]:
+    """Returns the thinking kwargs plus the max_tokens to send, which an
+    Anthropic thinking budget can raise."""
+    # Anthropic requires every assistant message with tool_use
+    # blocks to start with a thinking block that carries a
+    # cryptographic signature.  We don't preserve those blocks
+    # across turns, so skip thinking when the history already
+    # contains tool-calling assistant messages.  LiteLLM's
+    # modify_params workaround doesn't cover all providers
+    # (notably Bedrock).
+    has_tool_call_history = _prompt_contains_tool_call_history(prompt)
+
+    if reasoning_style is ReasoningParamStyle.ANTHROPIC_ADAPTIVE:
+        # Newer Anthropic models (Claude Opus 4.7+) reject
+        # thinking.type.enabled — they require the adaptive
+        # thinking config with output_config.effort.
+        if has_tool_call_history:
+            return {}, max_tokens
+        return {
+            "thinking": {"type": "adaptive"},
+            "output_config": {
+                "effort": ANTHROPIC_ADAPTIVE_REASONING_EFFORT[reasoning_effort],
+            },
+        }, max_tokens
+
+    budget_tokens: int | None = ANTHROPIC_REASONING_EFFORT_BUDGET.get(reasoning_effort)
+    # thinking.type=enabled is rejected alongside a forced
+    # tool_choice (only adaptive thinking supports forced tool
+    # use), so skip thinking for a NamedToolChoice.
+    if (
+        budget_tokens is None
+        or has_tool_call_history
+        or isinstance(tool_choice, NamedToolChoice)
+    ):
+        return {}, max_tokens
+
+    if max_tokens is not None:
+        # Anthropic has a weird rule where max token has to be at least as much as budget tokens if set
+        # and the minimum budget tokens is 1024
+        # Will note that overwriting a developer set max tokens is not ideal but is the best we can do for now
+        # It is better to allow the LLM to output more reasoning tokens even if it results in a fairly small tool
+        # call as compared to reducing the budget for reasoning.
+        max_tokens = max(budget_tokens + 1, max_tokens)
+    return {"thinking": {"type": "enabled", "budget_tokens": budget_tokens}}, max_tokens
+
+
+def _litellm_reasoning_effort_kwargs(
+    reasoning_effort: ReasoningEffort,
+) -> dict[str, Any]:
+    """Hope for the best from LiteLLM."""
+    if reasoning_effort in [
+        ReasoningEffort.LOW,
+        ReasoningEffort.MEDIUM,
+        ReasoningEffort.HIGH,
+    ]:
+        return {"reasoning_effort": reasoning_effort.value}
+    if reasoning_effort is ReasoningEffort.XHIGH:
+        # Provider mappings behind litellm's reasoning_effort are
+        # uneven (Gemini raises on xhigh), clamp to high. The model
+        # picker greys the level out for these models, so reaching
+        # here means a stored override outliving a model switch.
+        return {"reasoning_effort": ReasoningEffort.HIGH.value}
+    return {"reasoning_effort": ReasoningEffort.MEDIUM.value}
+
+
+def _reasoning_kwargs(
+    prompt: LanguageModelInput,
+    model_provider: str,
+    model_identity_names: list[str],
+    api_surface: LlmApiSurface | None,
+    reasoning_effort: ReasoningEffort,
+    is_reasoning: bool,
+    is_claude_model: bool,
+    tool_choice: ToolChoice | None,
+    max_tokens: int | None,
+) -> tuple[dict[str, Any], int | None]:
+    """Returns the reasoning kwargs plus the max_tokens to send, which an
+    Anthropic thinking budget can raise."""
+    # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
+    # of the major providers. Not setting it sets it to OFF.
+    if not (
+        is_reasoning
+        # The default of this parameter not set is surprisingly not the equivalent of an Auto but is actually Off
+        and reasoning_effort != ReasoningEffort.OFF
+        and not any(
+            openai_model_rejects_reasoning_effort(name) for name in model_identity_names
+        )
+    ):
+        return {}, max_tokens
+
+    openai_style_reasoning = {
+        "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
+        "summary": "auto",
+    }
+    reasoning_style = resolve_reasoning_param_style(
+        model_provider,
+        model_identity_names,
+        api_surface,
+    )
+
+    if reasoning_style is ReasoningParamStyle.OPENAI:
+        kwargs = _openai_style_reasoning_kwargs(
+            prompt, model_identity_names, is_claude_model, openai_style_reasoning
+        )
+        return kwargs, max_tokens
+
+    if reasoning_style in (
+        ReasoningParamStyle.ANTHROPIC_ADAPTIVE,
+        ReasoningParamStyle.ANTHROPIC_BUDGET,
+    ):
+        return _anthropic_reasoning_kwargs(
+            prompt, reasoning_style, reasoning_effort, tool_choice, max_tokens
+        )
+
+    return _litellm_reasoning_effort_kwargs(reasoning_effort), max_tokens
+
+
+def _tool_and_format_kwargs(
+    tools: list[dict] | None,
+    parallel_tool_calls: bool,
+    structured_response_format: dict | None,
+    tool_choice_param_breaks_model: bool,
+    is_openai_compatible_proxy: bool,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if tools:
+        # OpenAI will error if parallel_tool_calls is True and tools are not specified
+        kwargs["parallel_tool_calls"] = parallel_tool_calls
+
+    if structured_response_format:
+        kwargs["response_format"] = structured_response_format
+
+    if not tool_choice_param_breaks_model or is_openai_compatible_proxy:
+        # Litellm bug: tool_choice is dropped silently if not specified here for OpenAI
+        # However, this param breaks Anthropic and Mistral models,
+        # so it must be conditionally included unless the request is
+        # routed through Bifrost's OpenAI-compatible endpoint.
+        # Additionally, tool_choice is not supported by Ollama and causes warnings if included.
+        # See also, https://github.com/ollama/ollama/issues/11171
+        kwargs["allowed_openai_params"] = ["tool_choice"]
+    return kwargs
+
+
+def _tool_choice_kwargs(
+    tools: list[dict] | None, tool_choice: ToolChoice | None
+) -> dict[str, Any]:
+    """Only pass tool_choice when tools are present — some providers (e.g. Fireworks)
+    reject requests where tool_choice is explicitly null."""
+    if not tools or tool_choice is None:
+        return {}
+    if isinstance(tool_choice, NamedToolChoice):
+        return {
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": tool_choice.name},
+            }
+        }
+    return {"tool_choice": tool_choice}
+
+
+def _with_openrouter_extra_body(
+    passthrough_kwargs: dict[str, Any],
+    model_kwargs: dict[str, Any],
+    model_provider: str,
+    user_identity: LLMUserIdentity | None,
+) -> dict[str, Any]:
+    """OpenRouter: inject session_id and user into extra_body.
+
+    session_id — sticky routing: pins all turns of a conversation to the
+    same upstream provider, enabling prompt cache hits across turns.
+    Without this, OpenRouter may alternate between e.g. Anthropic and Google
+    for the same model, causing cache misses on every other turn.
+    See: https://openrouter.ai/docs/features/provider-routing#session-id
+
+    user — activity tracking: OpenRouter reads the user identifier from
+    extra_body for its per-user activity logs; the top-level LiteLLM
+    `user` parameter is forwarded to the upstream model but is not picked
+    up by OpenRouter's own tracking dashboard.
+
+    Both are gated on SEND_USER_METADATA_TO_LLM_PROVIDER: an operator who
+    opted out of sending session/user identifiers to providers should not
+    have them forwarded to OpenRouter either."""
+    if not (
+        SEND_USER_METADATA_TO_LLM_PROVIDER
+        and model_provider == LlmProviderNames.OPENROUTER
+        and user_identity is not None
+    ):
+        return passthrough_kwargs
+
+    extra_body_updates: dict[str, str] = {}
+    if user_identity.session_id:
+        extra_body_updates["session_id"] = user_identity.session_id
+    if user_identity.user_id:
+        extra_body_updates["user"] = user_identity.user_id
+    if not extra_body_updates:
+        return passthrough_kwargs
+
+    if passthrough_kwargs is model_kwargs:
+        passthrough_kwargs = copy.deepcopy(model_kwargs)
+    existing_extra_body = passthrough_kwargs.get("extra_body") or {}
+    if not isinstance(existing_extra_body, dict):
+        logger.warning(
+            "OpenRouter extra_body injection: extra_body is not a dict (%s), "
+            "skipping session_id/user injection",
+            type(existing_extra_body).__name__,
+        )
+        return passthrough_kwargs
+
+    passthrough_kwargs["extra_body"] = {
+        **existing_extra_body,
+        **extra_body_updates,
+    }
+    return passthrough_kwargs
+
+
+def _completion_attempts(optional_kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+    """Retry ladder for provider 400s: drop reasoning kwargs, then every
+    best-effort kwarg. Unknown models or capability drift degrade to
+    provider defaults with a warning instead of failing the message."""
+    attempts = [optional_kwargs]
+    for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
+        stripped = {k: v for k, v in optional_kwargs.items() if k not in strip_keys}
+        if len(stripped) < len(attempts[-1]):
+            attempts.append(stripped)
+    return attempts
+
+
+def _should_retry_without_kwargs(
+    error: Exception,
+    model: str,
+    attempt_index: int,
+    attempts: list[dict[str, Any]],
+) -> bool:
+    """True when a later attempt strips a kwarg the provider's 400 named."""
+    if attempt_index == len(attempts) - 1:
+        return False
+
+    opts = attempts[attempt_index]
+    # Only retry rejections a later attempt can strip away.
+    remaining_strippable = set(opts) - set(attempts[-1])
+    if not _rejection_names_strippable_kwargs(error, remaining_strippable):
+        return False
+
+    logger.warning(
+        "Provider rejected request for model %s. Retrying without %s: %s",
+        model,
+        sorted(set(opts) - set(attempts[attempt_index + 1])),
+        error,
+    )
+    return True
+
+
 class LitellmLLM(LLM):
     """Uses Litellm library to allow easy configuration to use a multitude of LLMs
     See https://python.langchain.com/docs/integrations/chat/litellm"""
@@ -587,6 +918,90 @@ class LitellmLLM(LLM):
             # Log but don't fail the LLM call if tracking fails
             logger.warning("Failed to track LLM cost: %s", e)
 
+    def _resolve_model_target(self, is_openai_model: bool) -> tuple[str, str | None]:
+        """Resolve the LiteLLM `model` string and the api_version to send."""
+        model_provider = (
+            f"{self.config.model_provider}/responses"
+            if is_openai_model  # Uses litellm's completions -> responses bridge
+            else self.config.model_provider
+        )
+
+        # Azure responses-bridge calls must target the v1 responses surface:
+        # with a dated api-version, LiteLLM builds the legacy /openai/responses
+        # URL, which sovereign clouds (e.g. Azure Government) do not serve
+        # (#11420). Dropping the dated version lets LiteLLM apply its responses
+        # default (AZURE_DEFAULT_RESPONSES_API_VERSION env var, default
+        # "preview"), which routes to /openai/v1/responses — working on all
+        # clouds with reasoning summaries intact. Admin-configured v1 versions
+        # ("preview"/"latest"/"v1") pass through, and the dated version still
+        # applies to every non-bridge call (e.g. Azure chat completions).
+        api_version = self._api_version or None
+        if (
+            is_openai_model
+            and self._model_provider == LlmProviderNames.AZURE
+            and api_version is not None
+            and api_version not in _AZURE_V1_API_VERSIONS
+        ):
+            _log_azure_responses_api_version_override(self._api_base, api_version)
+            api_version = None
+
+        model_bare = self.config.deployment_name or self.config.model_name
+        if self._api_surface is LlmApiSurface.OPENAI_RESPONSES:
+            # Drives LiteLLM's completions -> responses bridge.
+            model = f"responses/{model_bare}"
+        elif self._api_surface is not None:
+            model = model_bare
+        else:
+            model = f"{model_provider}/{model_bare}"
+        return model, api_version
+
+    def _prepare_messages(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None,
+        is_claude_model: bool,
+        is_mistral: bool,
+        model_identity_names: list[str],
+    ) -> list[dict[str, Any]]:
+        """Convert the prompt to LiteLLM messages, then apply provider fixups."""
+        messages = _prompt_to_dicts(prompt)
+
+        if not (
+            is_claude_model
+            and (
+                self._model_provider in _THINKING_BLOCK_PROVIDERS
+                or self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES
+            )
+        ):
+            messages = _strip_thinking_blocks_from_messages(messages)
+
+        # Bedrock's Converse API requires toolConfig when messages
+        # contain toolUse/toolResult content blocks. When no tools are
+        # provided for this request but the history contains tool
+        # content from previous turns, strip it to plain text.
+        is_bedrock = self._model_provider in {
+            LlmProviderNames.BEDROCK,
+            LlmProviderNames.BEDROCK_CONVERSE,
+        }
+        if is_bedrock and not tools and _messages_contain_tool_content(messages):
+            messages = _strip_tool_content_from_messages(messages)
+
+        # Some models (e.g. Mistral) reject a user message
+        # immediately after a tool message. Insert a synthetic
+        # assistant bridge message to satisfy the ordering
+        # constraint. Check the provider, the LiteLLM routing
+        # override, and every identity name (deployment alias and
+        # model name) to catch Mistral served behind Azure or
+        # OpenAI-compatible endpoints (e.g. vLLM).
+        is_mistral_model = (
+            is_mistral
+            or self._custom_llm_provider == LlmProviderNames.MISTRAL
+            or _is_mistral_family_name(model_identity_names)
+        )
+        if is_mistral_model:
+            messages = _fix_tool_user_message_ordering(messages)
+        return messages
+
     def _completion(
         self,
         prompt: LanguageModelInput,
@@ -653,79 +1068,24 @@ class LitellmLLM(LLM):
         optional_kwargs: dict[str, Any] = {}
 
         # Model name
-        is_openai_compatible_proxy = self._api_surface in OPENAI_COMPATIBLE_SURFACES
-        model_provider = (
-            f"{self.config.model_provider}/responses"
-            if is_openai_model  # Uses litellm's completions -> responses bridge
-            else self.config.model_provider
-        )
-
-        # Azure responses-bridge calls must target the v1 responses surface:
-        # with a dated api-version, LiteLLM builds the legacy /openai/responses
-        # URL, which sovereign clouds (e.g. Azure Government) do not serve
-        # (#11420). Dropping the dated version lets LiteLLM apply its responses
-        # default (AZURE_DEFAULT_RESPONSES_API_VERSION env var, default
-        # "preview"), which routes to /openai/v1/responses — working on all
-        # clouds with reasoning summaries intact. Admin-configured v1 versions
-        # ("preview"/"latest"/"v1") pass through, and the dated version still
-        # applies to every non-bridge call (e.g. Azure chat completions).
-        api_version = self._api_version or None
-        if (
-            is_openai_model
-            and self._model_provider == LlmProviderNames.AZURE
-            and api_version is not None
-            and api_version not in _AZURE_V1_API_VERSIONS
-        ):
-            _log_azure_responses_api_version_override(self._api_base, api_version)
-            api_version = None
-
-        model_bare = self.config.deployment_name or self.config.model_name
-        if self._api_surface is LlmApiSurface.OPENAI_RESPONSES:
-            # Drives LiteLLM's completions -> responses bridge.
-            model = f"responses/{model_bare}"
-        elif self._api_surface is not None:
-            model = model_bare
-        else:
-            model = f"{model_provider}/{model_bare}"
+        model, api_version = self._resolve_model_target(is_openai_model)
 
         # Tool choice
-        # Downgrade tool_choice=required to AUTO for models that mishandle it:
-        # Claude skips reasoning when it's set, Qwen thinking models reject it
-        # with a 400, and Z.AI rejects any GLM tool_choice other than auto
-        # ("Tool choice must be auto"). The chat loop's fallback tool-call
-        # extraction still enforces the forced tool. Matched by model name
-        # rather than `is_reasoning` because the litellm/local registry lags
-        # behind new Qwen/GLM releases (e.g. qwen3.7-plus, glm-5.3).
-        # A NamedToolChoice is deliberately NOT downgraded: legacy Claude
-        # thinking is skipped below instead, and the other models may still
-        # reject the forced tool upstream (a loud 400 beats silently ignoring
-        # the caller's forced tool).
-        if (is_claude_model or is_qwen_model or is_glm_model) and (
-            tool_choice == ToolChoiceOptions.REQUIRED
-        ):
-            tool_choice = ToolChoiceOptions.AUTO
-
-        # If no tools are provided, tool_choice should be None
-        if not tools:
-            tool_choice = None
-
-        # Temperature
-        # Some models (e.g. Claude Opus 4.7/4.8) reject a non-default
-        # temperature with a 400 invalid_request_error. For those models we
-        # must omit the param entirely.
-        # LiteLLM's drop_params is not reliable here because the upstream
-        # provider config can still claim the param is supported.
-        # https://github.com/BerriAI/litellm/issues/26444
-        # TODO(acaprau): Consider removing this once the above is resolved,
-        # although this assumes users have upgraded their litellm if relevant.
-        omits_sampling_params = any(
-            anthropic_omits_sampling_params(name) for name in model_identity_names
+        tool_choice = _resolve_tool_choice(
+            tool_choice,
+            tools,
+            mishandles_required=is_claude_model or is_qwen_model or is_glm_model,
         )
-        if not omits_sampling_params:
-            optional_kwargs["temperature"] = 1 if is_reasoning else self._temperature
 
-        if stream and not is_vertex_model_rejecting_stream_options:
-            optional_kwargs["stream_options"] = {"include_usage": True}
+        optional_kwargs.update(
+            _sampling_kwargs(
+                model_identity_names,
+                is_reasoning,
+                self._temperature,
+                stream,
+                send_stream_options=not is_vertex_model_rejecting_stream_options,
+            )
+        )
 
         # Settle before anything reads it, so every branch below and tracing
         # see the same effort the provider will.
@@ -736,175 +1096,44 @@ class LitellmLLM(LLM):
             maximum=self.config.reasoning_effort_max,
         )
 
-        # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
-        # of the major providers. Not setting it sets it to OFF.
-        if (
-            is_reasoning
-            # The default of this parameter not set is surprisingly not the equivalent of an Auto but is actually Off
-            and reasoning_effort != ReasoningEffort.OFF
-            and not any(
-                openai_model_rejects_reasoning_effort(name)
-                for name in model_identity_names
+        reasoning_kwargs, max_tokens = _reasoning_kwargs(
+            prompt,
+            self.config.model_provider,
+            model_identity_names,
+            self._api_surface,
+            reasoning_effort,
+            is_reasoning,
+            is_claude_model,
+            tool_choice,
+            max_tokens,
+        )
+        optional_kwargs.update(reasoning_kwargs)
+
+        optional_kwargs.update(
+            _tool_and_format_kwargs(
+                tools,
+                parallel_tool_calls,
+                structured_response_format,
+                tool_choice_param_breaks_model=(
+                    is_claude_model or is_ollama or is_mistral
+                ),
+                is_openai_compatible_proxy=(
+                    self._api_surface in OPENAI_COMPATIBLE_SURFACES
+                ),
             )
-        ):
-            openai_style_reasoning = {
-                "effort": OPENAI_REASONING_EFFORT[reasoning_effort],
-                "summary": "auto",
-            }
-            reasoning_style = resolve_reasoning_param_style(
-                self.config.model_provider,
-                model_identity_names,
-                self._api_surface,
-            )
-
-            if reasoning_style is ReasoningParamStyle.OPENAI:
-                if is_claude_model:
-                    # Only a gateway routes Claude here, and it still translates
-                    # to Anthropic, so the signed-thinking-block constraint
-                    # described below applies to these requests too.
-                    send_reasoning = not _prompt_contains_tool_call_history(prompt)
-                else:
-                    # OpenAI API does not accept reasoning params for GPT 5 chat
-                    # models (neither reasoning nor reasoning_effort are accepted)
-                    # even though they are reasoning models (bug in OpenAI)
-                    send_reasoning = not any(
-                        openai_chat_variant_rejects_reasoning(name)
-                        for name in model_identity_names
-                    )
-                if send_reasoning:
-                    optional_kwargs["reasoning"] = openai_style_reasoning
-
-            elif reasoning_style in (
-                ReasoningParamStyle.ANTHROPIC_ADAPTIVE,
-                ReasoningParamStyle.ANTHROPIC_BUDGET,
-            ):
-                # Anthropic requires every assistant message with tool_use
-                # blocks to start with a thinking block that carries a
-                # cryptographic signature.  We don't preserve those blocks
-                # across turns, so skip thinking when the history already
-                # contains tool-calling assistant messages.  LiteLLM's
-                # modify_params workaround doesn't cover all providers
-                # (notably Bedrock).
-                has_tool_call_history = _prompt_contains_tool_call_history(prompt)
-
-                if reasoning_style is ReasoningParamStyle.ANTHROPIC_ADAPTIVE:
-                    # Newer Anthropic models (Claude Opus 4.7+) reject
-                    # thinking.type.enabled — they require the adaptive
-                    # thinking config with output_config.effort.
-                    if not has_tool_call_history:
-                        optional_kwargs["thinking"] = {"type": "adaptive"}
-                        optional_kwargs["output_config"] = {
-                            "effort": ANTHROPIC_ADAPTIVE_REASONING_EFFORT[
-                                reasoning_effort
-                            ],
-                        }
-                else:
-                    budget_tokens: int | None = ANTHROPIC_REASONING_EFFORT_BUDGET.get(
-                        reasoning_effort
-                    )
-                    # thinking.type=enabled is rejected alongside a forced
-                    # tool_choice (only adaptive thinking supports forced tool
-                    # use), so skip thinking for a NamedToolChoice.
-                    if (
-                        budget_tokens is not None
-                        and not has_tool_call_history
-                        and not isinstance(tool_choice, NamedToolChoice)
-                    ):
-                        if max_tokens is not None:
-                            # Anthropic has a weird rule where max token has to be at least as much as budget tokens if set
-                            # and the minimum budget tokens is 1024
-                            # Will note that overwriting a developer set max tokens is not ideal but is the best we can do for now
-                            # It is better to allow the LLM to output more reasoning tokens even if it results in a fairly small tool
-                            # call as compared to reducing the budget for reasoning.
-                            max_tokens = max(budget_tokens + 1, max_tokens)
-                        optional_kwargs["thinking"] = {
-                            "type": "enabled",
-                            "budget_tokens": budget_tokens,
-                        }
-
-            else:
-                # Hope for the best from LiteLLM
-                if reasoning_effort in [
-                    ReasoningEffort.LOW,
-                    ReasoningEffort.MEDIUM,
-                    ReasoningEffort.HIGH,
-                ]:
-                    optional_kwargs["reasoning_effort"] = reasoning_effort.value
-                elif reasoning_effort is ReasoningEffort.XHIGH:
-                    # Provider mappings behind litellm's reasoning_effort are
-                    # uneven (Gemini raises on xhigh), clamp to high. The model
-                    # picker greys the level out for these models, so reaching
-                    # here means a stored override outliving a model switch.
-                    optional_kwargs["reasoning_effort"] = ReasoningEffort.HIGH.value
-                else:
-                    optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value
-
-        if tools:
-            # OpenAI will error if parallel_tool_calls is True and tools are not specified
-            optional_kwargs["parallel_tool_calls"] = parallel_tool_calls
-
-        if structured_response_format:
-            optional_kwargs["response_format"] = structured_response_format
-
-        if (
-            not (is_claude_model or is_ollama or is_mistral)
-            or is_openai_compatible_proxy
-        ):
-            # Litellm bug: tool_choice is dropped silently if not specified here for OpenAI
-            # However, this param breaks Anthropic and Mistral models,
-            # so it must be conditionally included unless the request is
-            # routed through Bifrost's OpenAI-compatible endpoint.
-            # Additionally, tool_choice is not supported by Ollama and causes warnings if included.
-            # See also, https://github.com/ollama/ollama/issues/11171
-            optional_kwargs["allowed_openai_params"] = ["tool_choice"]
+        )
 
         # Passthrough kwargs
         passthrough_kwargs = build_litellm_passthrough_kwargs(
             model_kwargs=self._model_kwargs,
             user_identity=user_identity,
         )
-
-        # OpenRouter: inject session_id and user into extra_body.
-        #
-        # session_id — sticky routing: pins all turns of a conversation to the
-        # same upstream provider, enabling prompt cache hits across turns.
-        # Without this, OpenRouter may alternate between e.g. Anthropic and Google
-        # for the same model, causing cache misses on every other turn.
-        # See: https://openrouter.ai/docs/features/provider-routing#session-id
-        #
-        # user — activity tracking: OpenRouter reads the user identifier from
-        # extra_body for its per-user activity logs; the top-level LiteLLM
-        # `user` parameter is forwarded to the upstream model but is not picked
-        # up by OpenRouter's own tracking dashboard.
-        #
-        # Both are gated on SEND_USER_METADATA_TO_LLM_PROVIDER: an operator who
-        # opted out of sending session/user identifiers to providers should not
-        # have them forwarded to OpenRouter either.
-        if (
-            SEND_USER_METADATA_TO_LLM_PROVIDER
-            and self._model_provider == LlmProviderNames.OPENROUTER
-            and user_identity is not None
-        ):
-            extra_body_updates: dict[str, str] = {}
-            if user_identity.session_id:
-                extra_body_updates["session_id"] = user_identity.session_id
-            if user_identity.user_id:
-                extra_body_updates["user"] = user_identity.user_id
-            if extra_body_updates:
-                if passthrough_kwargs is self._model_kwargs:
-                    passthrough_kwargs = copy.deepcopy(self._model_kwargs)
-                existing_extra_body = passthrough_kwargs.get("extra_body") or {}
-                if isinstance(existing_extra_body, dict):
-                    passthrough_kwargs["extra_body"] = {
-                        **existing_extra_body,
-                        **extra_body_updates,
-                    }
-                else:
-                    logger.warning(
-                        "OpenRouter extra_body injection: extra_body is not a dict (%s), "
-                        "skipping session_id/user injection",
-                        type(existing_extra_body).__name__,
-                    )
+        passthrough_kwargs = _with_openrouter_extra_body(
+            passthrough_kwargs,
+            self._model_kwargs,
+            self._model_provider,
+            user_identity,
+        )
 
         try:
             # NOTE: must pass in None instead of empty strings otherwise litellm
@@ -915,53 +1144,11 @@ class LitellmLLM(LLM):
             if "api_key" not in passthrough_kwargs:
                 passthrough_kwargs["api_key"] = self._api_key or None
 
-            messages = _prompt_to_dicts(prompt)
-
-            if not (
-                is_claude_model
-                and (
-                    self._model_provider in _THINKING_BLOCK_PROVIDERS
-                    or self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES
-                )
-            ):
-                messages = _strip_thinking_blocks_from_messages(messages)
-
-            # Bedrock's Converse API requires toolConfig when messages
-            # contain toolUse/toolResult content blocks. When no tools are
-            # provided for this request but the history contains tool
-            # content from previous turns, strip it to plain text.
-            is_bedrock = self._model_provider in {
-                LlmProviderNames.BEDROCK,
-                LlmProviderNames.BEDROCK_CONVERSE,
-            }
-            if is_bedrock and not tools and _messages_contain_tool_content(messages):
-                messages = _strip_tool_content_from_messages(messages)
-
-            # Some models (e.g. Mistral) reject a user message
-            # immediately after a tool message. Insert a synthetic
-            # assistant bridge message to satisfy the ordering
-            # constraint. Check the provider, the LiteLLM routing
-            # override, and every identity name (deployment alias and
-            # model name) to catch Mistral served behind Azure or
-            # OpenAI-compatible endpoints (e.g. vLLM).
-            is_mistral_model = (
-                is_mistral
-                or self._custom_llm_provider == LlmProviderNames.MISTRAL
-                or _is_mistral_family_name(model_identity_names)
+            messages = self._prepare_messages(
+                prompt, tools, is_claude_model, is_mistral, model_identity_names
             )
-            if is_mistral_model:
-                messages = _fix_tool_user_message_ordering(messages)
 
-            # Only pass tool_choice when tools are present — some providers (e.g. Fireworks)
-            # reject requests where tool_choice is explicitly null.
-            if tools and tool_choice is not None:
-                if isinstance(tool_choice, NamedToolChoice):
-                    optional_kwargs["tool_choice"] = {
-                        "type": "function",
-                        "function": {"name": tool_choice.name},
-                    }
-                else:
-                    optional_kwargs["tool_choice"] = tool_choice
+            optional_kwargs.update(_tool_choice_kwargs(tools, tool_choice))
 
             if not _env_injection_enabled() and self._env_only_custom_config:
                 _warn_dropped_env_only_keys(
@@ -997,16 +1184,7 @@ class LitellmLLM(LLM):
                         **passthrough_kwargs,
                     )
 
-            # Retry ladder for provider 400s: drop reasoning kwargs, then every
-            # best-effort kwarg. Unknown models or capability drift degrade to
-            # provider defaults with a warning instead of failing the message.
-            attempts = [optional_kwargs]
-            for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
-                stripped = {
-                    k: v for k, v in optional_kwargs.items() if k not in strip_keys
-                }
-                if len(stripped) < len(attempts[-1]):
-                    attempts.append(stripped)
+            attempts = _completion_attempts(optional_kwargs)
 
             for i, opts in enumerate(attempts):
                 # Last write wins: sent_kwargs holds what the returning (or
@@ -1027,19 +1205,8 @@ class LitellmLLM(LLM):
                 try:
                     return _call_litellm(opts)
                 except BadRequestError as e:
-                    if i == len(attempts) - 1:
+                    if not _should_retry_without_kwargs(e, model, i, attempts):
                         raise
-                    # Only retry rejections a later attempt can strip away.
-                    remaining_strippable = set(opts) - set(attempts[-1])
-                    if not _rejection_names_strippable_kwargs(e, remaining_strippable):
-                        raise
-                    logger.warning(
-                        "Provider rejected request for model %s. Retrying "
-                        "without %s: %s",
-                        model,
-                        sorted(set(opts) - set(attempts[i + 1])),
-                        e,
-                    )
             raise RuntimeError("unreachable: retry ladder always returns or raises")
         except Exception as e:
             # for break pointing

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any, NamedTuple
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -11,7 +12,7 @@ from onyx.configs.onyxbot_configs import (
 )
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccountType
-from onyx.db.models import ChannelConfig, SlackChannelConfig
+from onyx.db.models import ChannelConfig, SlackChannelConfig, User
 from onyx.db.user_preferences import activate_user
 from onyx.db.users import add_slack_user_if_not_exists, get_user_by_email
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -28,7 +29,7 @@ from onyx.onyxbot.slack.utils import (
     update_emote_react,
 )
 from onyx.server.security.store import get_security_settings
-from onyx.utils.logger import setup_logger
+from onyx.utils.logger import OnyxLoggingAdapter, setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import SLACK_CHANNEL_ID
 from shared_configs.contextvars import get_current_tenant_id
@@ -144,6 +145,252 @@ def _resolve_allowlist_user_ids(
     return resolved, missing
 
 
+class _Denial(NamedTuple):
+    """A reason to not answer, plus the message sent back to the sender."""
+
+    log_msg: str
+    text: str
+    # Ephemeral for denials about the sender, so they never post publicly in
+    # the channel.
+    ephemeral: bool = False
+
+
+def _usage_report_action(message_info: SlackMessageInfo) -> str:
+    if message_info.is_slash_command:
+        return "slack_slash_message"
+    if message_info.bypass_filters:
+        return "slack_tag_message"
+    if message_info.is_bot_dm:
+        return "slack_dm_message"
+    return "slack_message"
+
+
+def _skip_reason(
+    message_info: SlackMessageInfo,
+    slack_channel_config: SlackChannelConfig,
+    channel_conf: ChannelConfig | None,
+    document_set_names: list[str] | None,
+    logger: OnyxLoggingAdapter,
+) -> str | None:
+    """Return why the bot must stay silent, or None to keep going."""
+    respond_tag_only = False
+
+    if channel_conf:
+        if (
+            not message_info.bypass_filters
+            and "answer_filters" in channel_conf
+            and "questionmark_prefilter" in channel_conf["answer_filters"]
+            and "?" not in message_info.thread_messages[-1].message
+        ):
+            return "Skipping message since it does not contain a question mark"
+
+        logger.info(
+            "Found slack bot config for channel. Restricting bot to use document sets: %s, validity checks enabled: %s",
+            document_set_names,
+            channel_conf.get("answer_filters", "NA"),
+        )
+
+        respond_tag_only = channel_conf.get("respond_tag_only") or False
+
+    # Only default config can be disabled.
+    # If channel config is disabled, bot should not respond to this message (including DMs)
+    if slack_channel_config.channel_config.get("disabled"):
+        return "Skipping message: OnyxBot is disabled for this channel"
+
+    # If bot should only respond to tags and is not tagged nor in a DM, skip message
+    if (
+        respond_tag_only
+        and not message_info.bypass_filters
+        and not message_info.is_bot_dm
+    ):
+        return "Skipping message: OnyxBot only responds to tags in this channel"
+
+    return None
+
+
+def _check_seat_availability(db_session: Session) -> Any:
+    """Run the EE seat check. Returns None in CE, where the noop applies."""
+    check_seat_fn = fetch_ee_implementation_or_noop(
+        "onyx.db.license",
+        "check_seat_availability",
+        None,
+    )
+    return check_seat_fn(db_session=db_session)
+
+
+def _invalidate_license_cache() -> None:
+    invalidate_fn = fetch_ee_implementation_or_noop(
+        "onyx.db.license",
+        "invalidate_license_cache",
+        None,
+    )
+    invalidate_fn()
+
+
+def _email_policy_denial(email: str) -> _Denial | None:
+    """Invite-only and email-domain policies gate provisioning like any
+    self-serve signup (JWT and OAuth pair the same checks). BOT accounts were
+    provisioned by the bot itself, never re-checked."""
+    try:
+        verify_email_is_invited(email)
+        verify_email_domain(
+            email,
+            valid_email_domains=get_security_settings().valid_email_domains,
+        )
+    except OnyxError as e:
+        if e.error_code not in (
+            OnyxErrorCode.UNAUTHORIZED,
+            OnyxErrorCode.INVALID_INPUT,
+        ):
+            raise
+        return _Denial(
+            f"Blocked Slack-bot provisioning of {email}: {e.detail}",
+            (
+                "We weren't able to respond because this workspace "
+                "is invite-only and your email has not been "
+                "invited. Please ask your Onyx administrator for "
+                "an invite."
+                if e.error_code == OnyxErrorCode.UNAUTHORIZED
+                else "We weren't able to respond because your email "
+                "address is not allowed in this workspace. Please "
+                "contact your Onyx administrator."
+            ),
+            ephemeral=True,
+        )
+
+    return None
+
+
+def _seat_denial(
+    db_session: Session,
+    existing_user: User | None,
+    email: str,
+    logger: OnyxLoggingAdapter,
+) -> _Denial | None:
+    """Check seats for the sender and reactivate a deactivated bot user."""
+    if existing_user is None:
+        # New user — check seat availability before creating
+        seat_result = _check_seat_availability(db_session)
+        if seat_result is not None and not seat_result.available:
+            return _Denial(
+                f"Blocked new Slack user {email}: {seat_result.error_message}",
+                (
+                    "We weren't able to respond because your organization "
+                    "has reached its user seat limit. Since this is your "
+                    "first time interacting with the bot, a new account "
+                    "could not be created for you. Please contact your "
+                    "Onyx administrator to add more seats."
+                ),
+            )
+
+    elif not existing_user.is_active and existing_user.account_type == AccountType.BOT:
+        # Lock + check on the same session that commits activate_user.
+        acquire_lock_fn = fetch_ee_implementation_or_noop(
+            "onyx.db.license",
+            "acquire_seat_lock",
+            None,
+        )
+        acquire_lock_fn(db_session, get_current_tenant_id())
+        seat_result = _check_seat_availability(db_session)
+        if seat_result is not None and not seat_result.available:
+            return _Denial(
+                f"Blocked inactive Slack user {email}: {seat_result.error_message}",
+                (
+                    "We weren't able to respond because your organization "
+                    "has reached its user seat limit. Your account is "
+                    "currently deactivated and cannot be reactivated "
+                    "until more seats are available. Please contact "
+                    "your Onyx administrator."
+                ),
+            )
+
+        activate_user(existing_user, db_session)
+        _invalidate_license_cache()
+        logger.info("Reactivated inactive Slack user %s", email)
+
+    elif existing_user.account_type == AccountType.EXT_PERM_USER:
+        # Pre-check so the user gets a Slack-side message; the
+        # locked enforcer below is defense-in-depth.
+        seat_result = _check_seat_availability(db_session)
+        if seat_result is not None and not seat_result.available:
+            return _Denial(
+                f"Blocked Slack-bot promotion of {email}: {seat_result.error_message}",
+                _SEAT_LIMIT_TEXT,
+            )
+
+    return None
+
+
+def _slack_seat_enforcer(session: Session, seats_needed: int) -> None:
+    """Defense-in-depth: locks + checks on the same session that commits the
+    EXT_PERM_USER -> BOT promotion."""
+    acquire_lock_fn = fetch_ee_implementation_or_noop(
+        "onyx.db.license",
+        "acquire_seat_lock",
+        None,
+    )
+    check_fn = fetch_ee_implementation_or_noop(
+        "onyx.db.license",
+        "check_seat_availability",
+        None,
+    )
+    acquire_lock_fn(session, get_current_tenant_id())
+    result = check_fn(session, seats_needed=seats_needed)
+    if result is not None and not result.available:
+        raise OnyxError(OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message)
+
+
+def _provision_slack_user(
+    db_session: Session,
+    message_info: SlackMessageInfo,
+    logger: OnyxLoggingAdapter,
+) -> _Denial | None:
+    """Create, promote, or reactivate the Onyx user for the Slack sender.
+
+    Returns a `_Denial` when a policy or the seat limit blocks the message.
+    """
+    email = message_info.email
+    if not email:
+        return None
+
+    existing_user = get_user_by_email(email, db_session)
+
+    # True when this message provisions an account (new user or
+    # EXT_PERM_USER promotion). Read before add_slack_user_if_not_exists
+    # promotes in place, else the cache invalidation below is skipped.
+    provisions_account: bool = existing_user is None or (
+        existing_user.account_type == AccountType.EXT_PERM_USER
+    )
+
+    if provisions_account:
+        policy_denial = _email_policy_denial(email)
+        if policy_denial is not None:
+            return policy_denial
+
+    seat_denial = _seat_denial(db_session, existing_user, email, logger)
+    if seat_denial is not None:
+        return seat_denial
+
+    try:
+        add_slack_user_if_not_exists(
+            db_session,
+            email,
+            enforce_seat_check=_slack_seat_enforcer,
+        )
+    except OnyxError as e:
+        if e.error_code != OnyxErrorCode.SEAT_LIMIT_EXCEEDED:
+            raise
+        return _Denial(
+            f"Blocked Slack-bot user creation/promotion for {email}: {e.detail}",
+            _SEAT_LIMIT_TEXT,
+        )
+    else:
+        if provisions_account:
+            _invalidate_license_cache()
+
+    return None
+
+
 def handle_message(
     message_info: SlackMessageInfo,
     slack_channel_config: SlackChannelConfig,
@@ -161,11 +408,8 @@ def handle_message(
 
     logger = setup_logger(extra={SLACK_CHANNEL_ID: channel})
 
-    messages = message_info.thread_messages
     sender_id = message_info.sender_id
-    bypass_filters = message_info.bypass_filters
     is_slash_command = message_info.is_slash_command
-    is_bot_dm = message_info.is_bot_dm
 
     channel_conf: ChannelConfig | None = (
         slack_channel_config.channel_config
@@ -206,52 +450,22 @@ def handle_message(
         )
         return False
 
-    action = "slack_message"
-    if is_slash_command:
-        action = "slack_slash_message"
-    elif bypass_filters:
-        action = "slack_tag_message"
-    elif is_bot_dm:
-        action = "slack_dm_message"
-    slack_usage_report(action=action, sender_id=sender_id, client=client)
+    slack_usage_report(
+        action=_usage_report_action(message_info), sender_id=sender_id, client=client
+    )
 
-    document_set_names: list[str] | None = None
     persona = slack_channel_config.persona if slack_channel_config else None
-    if persona:
-        document_set_names = [
-            document_set.name for document_set in persona.document_sets
-        ]
+    document_set_names: list[str] | None = (
+        [document_set.name for document_set in persona.document_sets]
+        if persona
+        else None
+    )
 
-    respond_tag_only = False
-
-    if channel_conf:
-        if not bypass_filters and "answer_filters" in channel_conf:
-            if (
-                "questionmark_prefilter" in channel_conf["answer_filters"]
-                and "?" not in messages[-1].message
-            ):
-                logger.info(
-                    "Skipping message since it does not contain a question mark"
-                )
-                return False
-
-        logger.info(
-            "Found slack bot config for channel. Restricting bot to use document sets: %s, validity checks enabled: %s",
-            document_set_names,
-            channel_conf.get("answer_filters", "NA"),
-        )
-
-        respond_tag_only = channel_conf.get("respond_tag_only") or False
-
-    # Only default config can be disabled.
-    # If channel config is disabled, bot should not respond to this message (including DMs)
-    if slack_channel_config.channel_config.get("disabled"):
-        logger.info("Skipping message: OnyxBot is disabled for this channel")
-        return False
-
-    # If bot should only respond to tags and is not tagged nor in a DM, skip message
-    if respond_tag_only and not bypass_filters and not is_bot_dm:
-        logger.info("Skipping message: OnyxBot only responds to tags in this channel")
+    skip_reason = _skip_reason(
+        message_info, slack_channel_config, channel_conf, document_set_names, logger
+    )
+    if skip_reason is not None:
+        logger.info(skip_reason)
         return False
 
     # Reuses the resolved allowlist as the ephemeral response-visibility scope.
@@ -259,201 +473,40 @@ def handle_message(
 
     # If configured to respond to team members only, then cannot be used with a /OnyxBot command
     # which would just respond to the sender
-    if send_to and is_slash_command:
-        if sender_id:
-            respond_in_thread_or_channel(
-                client=client,
-                channel=channel,
-                receiver_ids=[sender_id],
-                text="The OnyxBot slash command is not enabled for this channel",
-                thread_ts=None,
-            )
+    if send_to and is_slash_command and sender_id:
+        respond_in_thread_or_channel(
+            client=client,
+            channel=channel,
+            receiver_ids=[sender_id],
+            text="The OnyxBot slash command is not enabled for this channel",
+            thread_ts=None,
+        )
 
     try:
         send_msg_ack_to_user(message_info, client)
     except SlackApiError as e:
         logger.error("Was not able to react to user message due to: %s", e)
 
-    def _deny(log_msg: str, text: str, ephemeral: bool = False) -> bool:
+    def _deny(denial: _Denial) -> bool:
         """Tell the sender the bot will not respond. Always returns False."""
-        logger.info(log_msg)
+        logger.info(denial.log_msg)
         respond_in_thread_or_channel(
             client=client,
             channel=channel,
             thread_ts=message_info.msg_to_respond,
-            # Ephemeral for denials about the sender, so they never post
-            # publicly in the channel.
             receiver_ids=(
                 [message_info.sender_id]
-                if ephemeral and message_info.sender_id
+                if denial.ephemeral and message_info.sender_id
                 else None
             ),
-            text=text,
+            text=denial.text,
         )
         return False
 
     with get_session_with_current_tenant() as db_session:
-        if message_info.email:
-            existing_user = get_user_by_email(message_info.email, db_session)
-
-            # True when this message provisions an account (new user or
-            # EXT_PERM_USER promotion). Read before add_slack_user_if_not_exists
-            # promotes in place, else the cache invalidation below is skipped.
-            provisions_account: bool = existing_user is None or (
-                existing_user.account_type == AccountType.EXT_PERM_USER
-            )
-
-            # Invite-only and email-domain policies gate provisioning like any
-            # self-serve signup (JWT and OAuth pair the same checks). BOT
-            # accounts were provisioned by the bot itself, never re-checked.
-            if provisions_account:
-                try:
-                    verify_email_is_invited(message_info.email)
-                    verify_email_domain(
-                        message_info.email,
-                        valid_email_domains=get_security_settings().valid_email_domains,
-                    )
-                except OnyxError as e:
-                    if e.error_code not in (
-                        OnyxErrorCode.UNAUTHORIZED,
-                        OnyxErrorCode.INVALID_INPUT,
-                    ):
-                        raise
-                    return _deny(
-                        "Blocked Slack-bot provisioning of "
-                        f"{message_info.email}: {e.detail}",
-                        (
-                            "We weren't able to respond because this workspace "
-                            "is invite-only and your email has not been "
-                            "invited. Please ask your Onyx administrator for "
-                            "an invite."
-                            if e.error_code == OnyxErrorCode.UNAUTHORIZED
-                            else "We weren't able to respond because your email "
-                            "address is not allowed in this workspace. Please "
-                            "contact your Onyx administrator."
-                        ),
-                        ephemeral=True,
-                    )
-
-            if existing_user is None:
-                # New user — check seat availability before creating
-                check_seat_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "check_seat_availability",
-                    None,
-                )
-                # noop returns None when called; real function returns SeatAvailabilityResult
-                seat_result = check_seat_fn(db_session=db_session)
-                if seat_result is not None and not seat_result.available:
-                    return _deny(
-                        "Blocked new Slack user "
-                        f"{message_info.email}: {seat_result.error_message}",
-                        (
-                            "We weren't able to respond because your organization "
-                            "has reached its user seat limit. Since this is your "
-                            "first time interacting with the bot, a new account "
-                            "could not be created for you. Please contact your "
-                            "Onyx administrator to add more seats."
-                        ),
-                    )
-
-            elif (
-                not existing_user.is_active
-                and existing_user.account_type == AccountType.BOT
-            ):
-                # Lock + check on the same session that commits activate_user.
-                acquire_lock_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "acquire_seat_lock",
-                    None,
-                )
-                check_seat_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "check_seat_availability",
-                    None,
-                )
-                acquire_lock_fn(db_session, get_current_tenant_id())
-                seat_result = check_seat_fn(db_session=db_session)
-                if seat_result is not None and not seat_result.available:
-                    return _deny(
-                        "Blocked inactive Slack user "
-                        f"{message_info.email}: {seat_result.error_message}",
-                        (
-                            "We weren't able to respond because your organization "
-                            "has reached its user seat limit. Your account is "
-                            "currently deactivated and cannot be reactivated "
-                            "until more seats are available. Please contact "
-                            "your Onyx administrator."
-                        ),
-                    )
-
-                activate_user(existing_user, db_session)
-                invalidate_license_cache_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "invalidate_license_cache",
-                    None,
-                )
-                invalidate_license_cache_fn()
-                logger.info("Reactivated inactive Slack user %s", message_info.email)
-
-            elif existing_user.account_type == AccountType.EXT_PERM_USER:
-                # Pre-check so the user gets a Slack-side message; the
-                # locked enforcer below is defense-in-depth.
-                check_seat_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "check_seat_availability",
-                    None,
-                )
-                seat_result = check_seat_fn(db_session=db_session)
-                if seat_result is not None and not seat_result.available:
-                    return _deny(
-                        "Blocked Slack-bot promotion of "
-                        f"{message_info.email}: {seat_result.error_message}",
-                        _SEAT_LIMIT_TEXT,
-                    )
-
-            # Defense-in-depth: locks + checks on the same session that
-            # commits the EXT_PERM_USER -> BOT promotion.
-            def _slack_seat_enforcer(session: Session, seats_needed: int) -> None:
-                acquire_lock_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "acquire_seat_lock",
-                    None,
-                )
-                check_fn = fetch_ee_implementation_or_noop(
-                    "onyx.db.license",
-                    "check_seat_availability",
-                    None,
-                )
-                acquire_lock_fn(session, get_current_tenant_id())
-                result = check_fn(session, seats_needed=seats_needed)
-                if result is not None and not result.available:
-                    raise OnyxError(
-                        OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message
-                    )
-
-            try:
-                add_slack_user_if_not_exists(
-                    db_session,
-                    message_info.email,
-                    enforce_seat_check=_slack_seat_enforcer,
-                )
-            except OnyxError as e:
-                if e.error_code != OnyxErrorCode.SEAT_LIMIT_EXCEEDED:
-                    raise
-                return _deny(
-                    "Blocked Slack-bot user creation/promotion for "
-                    f"{message_info.email}: {e.detail}",
-                    _SEAT_LIMIT_TEXT,
-                )
-            else:
-                if provisions_account:
-                    invalidate_fn = fetch_ee_implementation_or_noop(
-                        "onyx.db.license",
-                        "invalidate_license_cache",
-                        None,
-                    )
-                    invalidate_fn()
+        denial = _provision_slack_user(db_session, message_info, logger)
+        if denial is not None:
+            return _deny(denial)
 
         # first check if we need to respond with a standard answer
         # standard answers should be published in a thread

--- a/backend/onyx/secondary_llm_flows/document_filter.py
+++ b/backend/onyx/secondary_llm_flows/document_filter.py
@@ -185,6 +185,156 @@ def classify_section_relevance(
     return classification
 
 
+def _format_section_for_llm(
+    idx: int,
+    section: InferenceSection,
+    max_chunks_per_section: int | None,
+) -> dict[str, str | int | list[str]]:
+    """Build the JSON-serializable description of one section for the LLM prompt.
+
+    Key insertion order defines the order of the keys in the prompt.
+    """
+    chunk = section.center_chunk
+
+    # Combine primary and secondary owners for authors
+    authors: list[str] | None = None
+    if chunk.primary_owners or chunk.secondary_owners:
+        authors = []
+        if chunk.primary_owners:
+            authors.extend(chunk.primary_owners)
+        if chunk.secondary_owners:
+            authors.extend(chunk.secondary_owners)
+
+    # Select only the most relevant chunks from the section to avoid flooding
+    # the LLM with too much content from documents with many matching sections
+    if max_chunks_per_section is not None:
+        selected_chunks = select_chunks_for_relevance(section, max_chunks_per_section)
+        selected_content = " ".join(
+            selected_chunk.content for selected_chunk in selected_chunks
+        )
+    else:
+        selected_content = section.combined_content
+
+    section_dict: dict[str, str | int | list[str]] = {
+        "section_id": idx,
+        "title": chunk.semantic_identifier,
+    }
+
+    # Only include updated_at if available
+    if chunk.updated_at:
+        section_dict["updated_at"] = chunk.updated_at.isoformat()
+
+    # Only include authors if not None
+    if authors is not None:
+        section_dict["authors"] = authors
+
+    section_dict["source_type"] = str(chunk.source_type)
+    section_dict["metadata"] = json.dumps(chunk.metadata)
+    section_dict["content"] = selected_content
+
+    return section_dict
+
+
+def _parse_id_list(list_content: str) -> tuple[list[str], set[str]]:
+    """Parse a comma-separated list of section IDs, each optionally marked by "!"."""
+    section_ids: list[str] = []
+    sections_with_exclamation: set[str] = set()
+
+    for part in [part.strip() for part in list_content.split(",")]:
+        # Check if this part has an exclamation mark
+        has_exclamation = "!" in part
+        # Extract the number (digits only)
+        numbers = re.findall(r"\d+", part)
+        if numbers:
+            section_id = numbers[0]
+            section_ids.append(section_id)
+            if has_exclamation:
+                sections_with_exclamation.add(section_id)
+
+    return section_ids, sections_with_exclamation
+
+
+def _parse_section_ids(llm_response: str) -> tuple[list[str], set[str]]:
+    """Extract the selected section IDs and the ones marked with "!" from a response.
+
+    Handles bracketed lists like "[1, 2, 3]", unbracketed lists like "1, 2, 3" and,
+    as a last resort, every number in the response.
+    """
+    # First try to find a bracketed list
+    bracket_match = re.search(r"\[([^\]]+)\]", llm_response)
+    if bracket_match:
+        return _parse_id_list(bracket_match.group(1))
+
+    # Try to find an unbracketed comma-separated list
+    # Look for patterns like "1, 2, 3" or "1, 2!, 3"
+    comma_match = re.search(r"\b\d+!?\b(?:\s*,\s*\b\d+!?\b)*", llm_response)
+    if comma_match:
+        return _parse_id_list(comma_match.group(0))
+
+    # Fallback: try to extract all numbers from the response
+    # Also check for "!" after numbers
+    section_ids: list[str] = []
+    sections_with_exclamation: set[str] = set()
+    for match in re.finditer(r"\b(\d+)(!)?\b", llm_response):
+        section_id = match.group(1)
+        section_ids.append(section_id)
+        if match.group(2) == "!":
+            sections_with_exclamation.add(section_id)
+
+    return section_ids, sections_with_exclamation
+
+
+def _collect_selected_sections(
+    section_ids: list[str],
+    sections_with_exclamation: set[str],
+    section_map: dict[str, InferenceSection],
+    num_sections: int,
+    max_sections: int,
+) -> tuple[list[InferenceSection], list[str]]:
+    """Resolve parsed section IDs to sections, up to max_sections.
+
+    Out-of-range and unparsable IDs are skipped and don't count toward max_sections.
+    Also returns the document IDs of the sections marked with "!".
+    """
+    selected_sections: list[InferenceSection] = []
+    document_ids_with_exclamation: list[str] = []
+
+    for section_id_str in section_ids:
+        # Convert to int
+        try:
+            section_id_int = int(section_id_str)
+        except ValueError:
+            logger.warning("Could not convert section ID to int: %s", section_id_str)
+            continue
+
+        # Check if in valid range
+        if section_id_int < 0 or section_id_int >= num_sections:
+            logger.warning(
+                "Section ID %s is out of range [0, %s], skipping",
+                section_id_int,
+                num_sections - 1,
+            )
+            continue
+
+        # Convert back to string for section_map lookup
+        section_id = str(section_id_int)
+        if section_id in section_map:
+            section = section_map[section_id]
+            selected_sections.append(section)
+
+            # If this section has an exclamation mark, collect its document_id
+            if section_id_str in sections_with_exclamation:
+                document_id = section.center_chunk.document_id
+                if document_id not in document_ids_with_exclamation:
+                    document_ids_with_exclamation.append(document_id)
+
+        # Stop if we've reached max_sections valid selections
+        if len(selected_sections) >= max_sections:
+            break
+
+    return selected_sections, document_ids_with_exclamation
+
+
 @log_function_time(print_only=True)
 def select_sections_for_expansion(
     sections: list[InferenceSection],
@@ -219,57 +369,10 @@ def select_sections_for_expansion(
 
     for idx, section in enumerate(sections):
         # Create a unique ID for each section
-        section_id = f"{idx}"
-        section_map[section_id] = section
-
-        # Format the section for the LLM
-        chunk = section.center_chunk
-
-        # Combine primary and secondary owners for authors
-        authors = None
-        if chunk.primary_owners or chunk.secondary_owners:
-            authors = []
-            if chunk.primary_owners:
-                authors.extend(chunk.primary_owners)
-            if chunk.secondary_owners:
-                authors.extend(chunk.secondary_owners)
-
-        # Format updated_at as ISO string if available
-        updated_at_str = None
-        if chunk.updated_at:
-            updated_at_str = chunk.updated_at.isoformat()
-
-        # Convert metadata to JSON string
-        metadata_str = json.dumps(chunk.metadata)
-
-        # Select only the most relevant chunks from the section to avoid flooding
-        # the LLM with too much content from documents with many matching sections
-        if max_chunks_per_section is not None:
-            selected_chunks = select_chunks_for_relevance(
-                section, max_chunks_per_section
-            )
-            selected_content = " ".join(chunk.content for chunk in selected_chunks)
-        else:
-            selected_content = section.combined_content
-
-        section_dict: dict[str, str | int | list[str]] = {
-            "section_id": idx,
-            "title": chunk.semantic_identifier,
-        }
-
-        # Only include updated_at if not None
-        if updated_at_str is not None:
-            section_dict["updated_at"] = updated_at_str
-
-        # Only include authors if not None
-        if authors is not None:
-            section_dict["authors"] = authors
-
-        section_dict["source_type"] = str(chunk.source_type)
-        section_dict["metadata"] = metadata_str
-        section_dict["content"] = selected_content
-
-        sections_dict.append(section_dict)
+        section_map[f"{idx}"] = section
+        sections_dict.append(
+            _format_section_for_llm(idx, section, max_chunks_per_section)
+        )
 
     # Build the prompt
     extra_instructions = TRY_TO_FILL_TO_MAX_INSTRUCTIONS if try_to_fill_to_max else ""
@@ -303,64 +406,8 @@ def select_sections_for_expansion(
             )
             return sections[:max_sections], None
 
-        # Parse the response to extract section IDs
-        # Look for patterns like [1, 2, 3] or [1,2,3] with flexible whitespace/newlines
-        # Also handle unbracketed comma-separated lists like "1, 2, 3"
-        # Track which sections have "!" marker (e.g., "1, 2!, 3" or "[1, 2!, 3]")
-        section_ids = []
-        sections_with_exclamation = set()  # Track section IDs that have "!" marker
-
-        # First try to find a bracketed list
-        bracket_pattern = r"\[([^\]]+)\]"
-        bracket_match = re.search(bracket_pattern, llm_response)
-
-        if bracket_match:
-            # Extract the content between brackets
-            list_content = bracket_match.group(1)
-            # Split by comma, preserving the parts
-            parts = [part.strip() for part in list_content.split(",")]
-            for part in parts:
-                # Check if this part has an exclamation mark
-                has_exclamation = "!" in part
-                # Extract the number (digits only)
-                numbers = re.findall(r"\d+", part)
-                if numbers:
-                    section_id = numbers[0]
-                    section_ids.append(section_id)
-                    if has_exclamation:
-                        sections_with_exclamation.add(section_id)
-        else:
-            # Try to find an unbracketed comma-separated list
-            # Look for patterns like "1, 2, 3" or "1, 2!, 3"
-            # This regex finds sequences of digits optionally followed by "!" and separated by commas
-            comma_list_pattern = r"\b\d+!?\b(?:\s*,\s*\b\d+!?\b)*"
-            comma_match = re.search(comma_list_pattern, llm_response)
-
-            if comma_match:
-                # Extract the matched comma-separated list
-                list_content = comma_match.group(0)
-                parts = [part.strip() for part in list_content.split(",")]
-                for part in parts:
-                    # Check if this part has an exclamation mark
-                    has_exclamation = "!" in part
-                    # Extract the number (digits only)
-                    numbers = re.findall(r"\d+", part)
-                    if numbers:
-                        section_id = numbers[0]
-                        section_ids.append(section_id)
-                        if has_exclamation:
-                            sections_with_exclamation.add(section_id)
-            else:
-                # Fallback: try to extract all numbers from the response
-                # Also check for "!" after numbers
-                number_pattern = r"\b(\d+)(!)?\b"
-                matches = re.finditer(number_pattern, llm_response)
-                for match in matches:
-                    section_id = match.group(1)
-                    has_exclamation = match.group(2) == "!"
-                    section_ids.append(section_id)
-                    if has_exclamation:
-                        sections_with_exclamation.add(section_id)
+        # Parse the response to extract section IDs and the "!" markers
+        section_ids, sections_with_exclamation = _parse_section_ids(llm_response)
 
         if not section_ids:
             logger.warning(
@@ -369,45 +416,13 @@ def select_sections_for_expansion(
             return sections[:max_sections], None
 
         # Filter sections based on LLM selection
-        # Skip out-of-range IDs and don't count them toward max_sections
-        selected_sections = []
-        document_ids_with_exclamation = []  # Collect document_ids for sections with "!"
-        num_sections = len(sections)
-
-        for section_id_str in section_ids:
-            # Convert to int
-            try:
-                section_id_int = int(section_id_str)
-            except ValueError:
-                logger.warning(
-                    "Could not convert section ID to int: %s", section_id_str
-                )
-                continue
-
-            # Check if in valid range
-            if section_id_int < 0 or section_id_int >= num_sections:
-                logger.warning(
-                    "Section ID %s is out of range [0, %s], skipping",
-                    section_id_int,
-                    num_sections - 1,
-                )
-                continue
-
-            # Convert back to string for section_map lookup
-            section_id = str(section_id_int)
-            if section_id in section_map:
-                section = section_map[section_id]
-                selected_sections.append(section)
-
-                # If this section has an exclamation mark, collect its document_id
-                if section_id_str in sections_with_exclamation:
-                    document_id = section.center_chunk.document_id
-                    if document_id not in document_ids_with_exclamation:
-                        document_ids_with_exclamation.append(document_id)
-
-            # Stop if we've reached max_sections valid selections
-            if len(selected_sections) >= max_sections:
-                break
+        selected_sections, document_ids_with_exclamation = _collect_selected_sections(
+            section_ids=section_ids,
+            sections_with_exclamation=sections_with_exclamation,
+            section_map=section_map,
+            num_sections=len(sections),
+            max_sections=max_sections,
+        )
 
         if not selected_sections:
             logger.warning(

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -40,6 +40,7 @@ from onyx.server.features.build.sandbox.event_schema import (
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import PromptAttachment
+from onyx.server.features.build.sandbox.serve_transport import PromptSlot
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.session.interrupt_signal import (
     clear_interrupt,
@@ -238,6 +239,263 @@ def _ready_session_runtime(
         return ensure_session_ready(db_session, get_sandbox_manager(), session, user)
 
 
+@dataclass
+class _TurnRun:
+    """Handles and shared state for one interactive turn.
+
+    Holds what the turn's steps all need (cache, db session, sandbox, ids) plus
+    the deadline flag they share, so each step stays a plain method.
+    """
+
+    cache: CacheBackend
+    db_session: Session
+    session_manager: SessionManager
+    sandbox: Sandbox
+    state: BuildStreamingState
+    turn_id: UUID
+    session_id: UUID
+    user_id: UUID
+    turn_index: int
+    runner_id: str | None
+    budget_seconds: int
+    deadline: float
+    deadline_exceeded: bool = False
+
+    def interrupt_requested(self) -> bool:
+        if time.monotonic() > self.deadline:
+            self.deadline_exceeded = True
+            return True
+        try:
+            return is_interrupt_requested(self.session_id, self.cache)
+        except CACHE_TRANSIENT_ERRORS:
+            logger.warning(
+                "[SANDBOX-SERVE] interrupt fence check failed for session %s",
+                self.session_id,
+                exc_info=True,
+            )
+            return False
+
+    def persist_turn_error(self, message: str) -> None:
+        """Best-effort user-visible failure row; never blocks finish_turn."""
+        try:
+            self.db_session.rollback()
+            self.session_manager.persist_turn_error(
+                self.session_id, self.turn_index, f"{message} {_TURN_ERROR_SUFFIX}"
+            )
+            self.db_session.commit()
+        except Exception:
+            logger.exception(
+                "Failed to persist turn error message for turn %s", self.turn_id
+            )
+
+    def reject_concurrent_turn(self) -> None:
+        """Fail this turn because another one holds the session's prompt slot."""
+        # Ownership check first: a stalled runner whose turn was reclaimed
+        # also lands here, and the successor IS processing the message —
+        # it must not leave a false "wasn't processed" row.
+        if touch_turn(cache=self.cache, turn_id=self.turn_id, runner_id=self.runner_id):
+            try:
+                self.session_manager.persist_turn_error(
+                    self.session_id,
+                    self.turn_index,
+                    "Another turn was still running for this session, so "
+                    "this message wasn't processed. Wait for it to finish, "
+                    "then send your message again.",
+                )
+                self.db_session.commit()
+            except Exception:
+                logger.exception(
+                    "Failed to persist turn error message for turn %s", self.turn_id
+                )
+        finish_turn(
+            cache=self.cache,
+            turn_id=self.turn_id,
+            status=TURN_STATUS_FAILED,
+            error_detail="Concurrent turn in flight for build session.",
+            runner_id=self.runner_id,
+        )
+
+    def drive_one_prompt(
+        self,
+        slot: PromptSlot,
+        current_prompt: str,
+        prompt_attachments: list[PromptAttachment],
+        *,
+        can_continue: bool,
+    ) -> _PromptResult:
+        """Stream one opencode prompt to completion, timeout, or a
+        turn-ending failure. On the recoverable inactivity timeout it
+        returns TIMED_OUT (only while ``can_continue``); failures finish
+        the turn here and return TERMINATED so the caller just returns."""
+        ownership_lost = False
+        final_event_seen = False
+        cancelled_event_seen = False
+        timed_out = False
+
+        event_stream = self.session_manager.yield_sandbox_events(
+            self.sandbox.id,
+            self.session_id,
+            current_prompt,
+            attachments=prompt_attachments,
+            should_interrupt=self.interrupt_requested,
+            should_abort_on_teardown=lambda: not ownership_lost,
+        )
+
+        for sandbox_event in event_stream:
+            if time.monotonic() > self.deadline:
+                self.deadline_exceeded = True
+            if self.deadline_exceeded:
+                continue
+
+            if not touch_turn(
+                cache=self.cache, turn_id=self.turn_id, runner_id=self.runner_id
+            ):
+                logger.info("Interactive turn %s runner ownership lost", self.turn_id)
+                ownership_lost = True
+                return _PromptResult(_PromptOutcome.TERMINATED)
+            slot.extend()
+            if slot.lost:
+                ownership_lost = True
+                self.session_manager.finalize_persist(self.session_id, self.state)
+                self.db_session.commit()
+                self.persist_turn_error(
+                    "This turn was interrupted and could not finish."
+                )
+                finish_turn(
+                    cache=self.cache,
+                    turn_id=self.turn_id,
+                    status=TURN_STATUS_FAILED,
+                    error_detail="Prompt slot lease lost mid-turn.",
+                    runner_id=self.runner_id,
+                )
+                return _PromptResult(_PromptOutcome.TERMINATED)
+            if isinstance(sandbox_event, SSEKeepalive):
+                continue
+
+            # The transport already aborted the timed-out step and ends the
+            # stream after this event; drain it (don't return early, which
+            # would GeneratorExit and re-abort) and let the caller re-prompt.
+            if isinstance(sandbox_event, ActivityTimeoutError) and can_continue:
+                timed_out = True
+                continue
+
+            self.session_manager.persist_sandbox_event(
+                self.session_id, self.state, sandbox_event
+            )
+            self.db_session.commit()
+
+            if isinstance(sandbox_event, SandboxError):
+                self.session_manager.finalize_persist(self.session_id, self.state)
+                self.db_session.commit()
+                self.persist_turn_error(sandbox_event.message)
+                finish_turn(
+                    cache=self.cache,
+                    turn_id=self.turn_id,
+                    status=TURN_STATUS_FAILED,
+                    error_detail=sandbox_event.message,
+                    runner_id=self.runner_id,
+                )
+                return _PromptResult(_PromptOutcome.TERMINATED)
+
+            if isinstance(sandbox_event, PromptResponse):
+                final_event_seen = True
+                cancelled_event_seen = (
+                    getattr(sandbox_event, "stop_reason", None) == "cancelled"
+                )
+
+        if timed_out:
+            return _PromptResult(_PromptOutcome.TIMED_OUT)
+        return _PromptResult(
+            _PromptOutcome.COMPLETED,
+            final_event_seen=final_event_seen,
+            cancelled=cancelled_event_seen,
+        )
+
+    def finish_completed_turn(self, result: _PromptResult) -> None:
+        """Persist the transcript and close out a turn the prompt loop ran to
+        the end of."""
+        self.session_manager.finalize_persist(self.session_id, self.state)
+        self.db_session.commit()
+
+        if self.deadline_exceeded:
+            self.persist_turn_error(
+                "This turn was stopped after reaching its "
+                f"{max(1, round(self.budget_seconds / 60))}-minute time limit."
+            )
+            finish_turn(
+                cache=self.cache,
+                turn_id=self.turn_id,
+                status=TURN_STATUS_FAILED,
+                error_detail=f"hard time cap exceeded ({self.budget_seconds}s)",
+                runner_id=self.runner_id,
+            )
+            return
+
+        if not result.final_event_seen:
+            self.persist_turn_error(
+                "This turn ended before the agent returned a final response."
+            )
+            finish_turn(
+                cache=self.cache,
+                turn_id=self.turn_id,
+                status=TURN_STATUS_FAILED,
+                error_detail="Turn ended before opencode returned a final response.",
+                runner_id=self.runner_id,
+            )
+            return
+
+        if result.cancelled:
+            finish_turn(
+                cache=self.cache,
+                turn_id=self.turn_id,
+                status=TURN_STATUS_CANCELLED,
+                runner_id=self.runner_id,
+            )
+            return
+
+        finish_turn(
+            cache=self.cache,
+            turn_id=self.turn_id,
+            status=TURN_STATUS_SUCCEEDED,
+            runner_id=self.runner_id,
+        )
+
+    def clear_fence_if_still_owned(self) -> None:
+        """Drop this turn's interrupt fence and deadline stamp, if it still
+        owns them."""
+        # True on every exit where this runner still owns the turn (normal
+        # end, owned failure, cancel, exception); False once a successor
+        # owns it (reclaim / slot-lost with a new turn). A successor sets
+        # the active-turn pointer at creation, before it ever stamps, so
+        # this guard clears our deadline exactly when no other turn's stamp
+        # can be clobbered.
+        try:
+            still_owns_turn = _can_clear_interrupt_fence(
+                cache=self.cache,
+                turn_id=self.turn_id,
+                session_id=self.session_id,
+                user_id=self.user_id,
+                runner_id=self.runner_id,
+            )
+        except CACHE_TRANSIENT_ERRORS:
+            logger.warning(
+                "[SANDBOX-SERVE] interrupt-fence ownership check failed for session %s",
+                self.session_id,
+                exc_info=True,
+            )
+            still_owns_turn = False
+        if still_owns_turn:
+            try:
+                clear_interrupt(self.session_id, self.cache)
+            except CACHE_TRANSIENT_ERRORS:
+                logger.warning(
+                    "[SANDBOX-SERVE] failed to clear interrupt fence for session %s",
+                    self.session_id,
+                    exc_info=True,
+                )
+            self.session_manager.clear_turn_deadline(self.sandbox.id, self.session_id)
+
+
 def _drive_interactive_turn(
     *,
     turn_id: UUID,
@@ -260,37 +518,20 @@ def _drive_interactive_turn(
             logger.info("Interactive turn %s runner ownership lost", turn_id)
             return
 
-        state = BuildStreamingState(turn_index=turn_index)
-        deadline = time.monotonic() + budget_seconds
-        deadline_exceeded = False
-
-        def interrupt_requested() -> bool:
-            nonlocal deadline_exceeded
-            if time.monotonic() > deadline:
-                deadline_exceeded = True
-                return True
-            try:
-                return is_interrupt_requested(session_id, cache)
-            except CACHE_TRANSIENT_ERRORS:
-                logger.warning(
-                    "[SANDBOX-SERVE] interrupt fence check failed for session %s",
-                    session_id,
-                    exc_info=True,
-                )
-                return False
-
-        def persist_turn_error(message: str) -> None:
-            """Best-effort user-visible failure row; never blocks finish_turn."""
-            try:
-                db_session.rollback()
-                session_manager.persist_turn_error(
-                    session_id, turn_index, f"{message} {_TURN_ERROR_SUFFIX}"
-                )
-                db_session.commit()
-            except Exception:
-                logger.exception(
-                    "Failed to persist turn error message for turn %s", turn_id
-                )
+        run = _TurnRun(
+            cache=cache,
+            db_session=db_session,
+            session_manager=session_manager,
+            sandbox=sandbox,
+            state=BuildStreamingState(turn_index=turn_index),
+            turn_id=turn_id,
+            session_id=session_id,
+            user_id=user_id,
+            turn_index=turn_index,
+            runner_id=runner_id,
+            budget_seconds=budget_seconds,
+            deadline=time.monotonic() + budget_seconds,
+        )
 
         prompt_slot_cm = session_manager.prompt_slot(
             sandbox.id,
@@ -303,30 +544,7 @@ def _drive_interactive_turn(
         )
         slot = prompt_slot_cm.__enter__()
         if not slot.acquired:
-            # Ownership check first: a stalled runner whose turn was reclaimed
-            # also lands here, and the successor IS processing the message —
-            # it must not leave a false "wasn't processed" row.
-            if touch_turn(cache=cache, turn_id=turn_id, runner_id=runner_id):
-                try:
-                    session_manager.persist_turn_error(
-                        session_id,
-                        turn_index,
-                        "Another turn was still running for this session, so "
-                        "this message wasn't processed. Wait for it to finish, "
-                        "then send your message again.",
-                    )
-                    db_session.commit()
-                except Exception:
-                    logger.exception(
-                        "Failed to persist turn error message for turn %s", turn_id
-                    )
-            finish_turn(
-                cache=cache,
-                turn_id=turn_id,
-                status=TURN_STATUS_FAILED,
-                error_detail="Concurrent turn in flight for build session.",
-                runner_id=runner_id,
-            )
+            run.reject_concurrent_turn()
             prompt_slot_cm.__exit__(None, None, None)
             return
 
@@ -356,8 +574,8 @@ def _drive_interactive_turn(
                 hard_cap_seconds=budget_seconds,
             )
 
-            if interrupt_requested():
-                session_manager.finalize_persist(session_id, state)
+            if run.interrupt_requested():
+                session_manager.finalize_persist(session_id, run.state)
                 db_session.commit()
                 finish_turn(
                     cache=cache,
@@ -367,107 +585,11 @@ def _drive_interactive_turn(
                 )
                 return
 
-            def drive_one_prompt(
-                current_prompt: str,
-                prompt_attachments: list[PromptAttachment],
-                *,
-                can_continue: bool,
-            ) -> _PromptResult:
-                """Stream one opencode prompt to completion, timeout, or a
-                turn-ending failure. On the recoverable inactivity timeout it
-                returns TIMED_OUT (only while ``can_continue``); failures finish
-                the turn here and return TERMINATED so the caller just returns."""
-                nonlocal deadline_exceeded
-                ownership_lost = False
-                final_event_seen = False
-                cancelled_event_seen = False
-                timed_out = False
-
-                event_stream = session_manager.yield_sandbox_events(
-                    sandbox.id,
-                    session_id,
-                    current_prompt,
-                    attachments=prompt_attachments,
-                    should_interrupt=interrupt_requested,
-                    should_abort_on_teardown=lambda: not ownership_lost,
-                )
-
-                for sandbox_event in event_stream:
-                    if time.monotonic() > deadline:
-                        deadline_exceeded = True
-                    if deadline_exceeded:
-                        continue
-
-                    if not touch_turn(
-                        cache=cache, turn_id=turn_id, runner_id=runner_id
-                    ):
-                        logger.info(
-                            "Interactive turn %s runner ownership lost", turn_id
-                        )
-                        ownership_lost = True
-                        return _PromptResult(_PromptOutcome.TERMINATED)
-                    slot.extend()
-                    if slot.lost:
-                        ownership_lost = True
-                        session_manager.finalize_persist(session_id, state)
-                        db_session.commit()
-                        persist_turn_error(
-                            "This turn was interrupted and could not finish."
-                        )
-                        finish_turn(
-                            cache=cache,
-                            turn_id=turn_id,
-                            status=TURN_STATUS_FAILED,
-                            error_detail="Prompt slot lease lost mid-turn.",
-                            runner_id=runner_id,
-                        )
-                        return _PromptResult(_PromptOutcome.TERMINATED)
-                    if isinstance(sandbox_event, SSEKeepalive):
-                        continue
-
-                    # The transport already aborted the timed-out step and ends the
-                    # stream after this event; drain it (don't return early, which
-                    # would GeneratorExit and re-abort) and let the caller re-prompt.
-                    if isinstance(sandbox_event, ActivityTimeoutError) and can_continue:
-                        timed_out = True
-                        continue
-
-                    session_manager.persist_sandbox_event(
-                        session_id, state, sandbox_event
-                    )
-                    db_session.commit()
-
-                    if isinstance(sandbox_event, SandboxError):
-                        session_manager.finalize_persist(session_id, state)
-                        db_session.commit()
-                        persist_turn_error(sandbox_event.message)
-                        finish_turn(
-                            cache=cache,
-                            turn_id=turn_id,
-                            status=TURN_STATUS_FAILED,
-                            error_detail=sandbox_event.message,
-                            runner_id=runner_id,
-                        )
-                        return _PromptResult(_PromptOutcome.TERMINATED)
-
-                    if isinstance(sandbox_event, PromptResponse):
-                        final_event_seen = True
-                        cancelled_event_seen = (
-                            getattr(sandbox_event, "stop_reason", None) == "cancelled"
-                        )
-
-                if timed_out:
-                    return _PromptResult(_PromptOutcome.TIMED_OUT)
-                return _PromptResult(
-                    _PromptOutcome.COMPLETED,
-                    final_event_seen=final_event_seen,
-                    cancelled=cancelled_event_seen,
-                )
-
             result = _PromptResult(_PromptOutcome.COMPLETED)
             current_prompt = prompt
             for attempt in range(MAX_TIMEOUT_CONTINUATIONS + 1):
-                result = drive_one_prompt(
+                result = run.drive_one_prompt(
+                    slot,
                     current_prompt,
                     attachments if attempt == 0 else [],
                     can_continue=attempt < MAX_TIMEOUT_CONTINUATIONS,
@@ -476,7 +598,7 @@ def _drive_interactive_turn(
                     break
                 # Flush the aborted step's partial output as its own message so it
                 # can't merge with the continuation, then steer the agent.
-                session_manager.finalize_persist(session_id, state)
+                session_manager.finalize_persist(session_id, run.state)
                 db_session.commit()
                 logger.info(
                     "Interactive turn %s step timed out; re-prompting (%s/%s)",
@@ -489,60 +611,16 @@ def _drive_interactive_turn(
             if result.outcome is _PromptOutcome.TERMINATED:
                 return
 
-            session_manager.finalize_persist(session_id, state)
-            db_session.commit()
-
-            if deadline_exceeded:
-                persist_turn_error(
-                    "This turn was stopped after reaching its "
-                    f"{max(1, round(budget_seconds / 60))}-minute time limit."
-                )
-                finish_turn(
-                    cache=cache,
-                    turn_id=turn_id,
-                    status=TURN_STATUS_FAILED,
-                    error_detail=f"hard time cap exceeded ({budget_seconds}s)",
-                    runner_id=runner_id,
-                )
-                return
-
-            if not result.final_event_seen:
-                persist_turn_error(
-                    "This turn ended before the agent returned a final response."
-                )
-                finish_turn(
-                    cache=cache,
-                    turn_id=turn_id,
-                    status=TURN_STATUS_FAILED,
-                    error_detail="Turn ended before opencode returned a final response.",
-                    runner_id=runner_id,
-                )
-                return
-
-            if result.cancelled:
-                finish_turn(
-                    cache=cache,
-                    turn_id=turn_id,
-                    status=TURN_STATUS_CANCELLED,
-                    runner_id=runner_id,
-                )
-                return
-
-            finish_turn(
-                cache=cache,
-                turn_id=turn_id,
-                status=TURN_STATUS_SUCCEEDED,
-                runner_id=runner_id,
-            )
+            run.finish_completed_turn(result)
         except Exception as exc:
             db_session.rollback()
             logger.exception("Interactive turn %s failed", turn_id)
             try:
-                session_manager.finalize_persist(session_id, state)
+                session_manager.finalize_persist(session_id, run.state)
                 db_session.commit()
             except Exception:
                 logger.exception("Failed to finalize persistence for turn %s", turn_id)
-            persist_turn_error("This turn failed unexpectedly.")
+            run.persist_turn_error("This turn failed unexpectedly.")
             finish_turn(
                 cache=cache,
                 turn_id=turn_id,
@@ -551,35 +629,5 @@ def _drive_interactive_turn(
                 runner_id=runner_id,
             )
         finally:
-            # True on every exit where this runner still owns the turn (normal
-            # end, owned failure, cancel, exception); False once a successor
-            # owns it (reclaim / slot-lost with a new turn). A successor sets
-            # the active-turn pointer at creation, before it ever stamps, so
-            # this guard clears our deadline exactly when no other turn's stamp
-            # can be clobbered.
-            try:
-                still_owns_turn = _can_clear_interrupt_fence(
-                    cache=cache,
-                    turn_id=turn_id,
-                    session_id=session_id,
-                    user_id=user_id,
-                    runner_id=runner_id,
-                )
-            except CACHE_TRANSIENT_ERRORS:
-                logger.warning(
-                    "[SANDBOX-SERVE] interrupt-fence ownership check failed for session %s",
-                    session_id,
-                    exc_info=True,
-                )
-                still_owns_turn = False
-            if still_owns_turn:
-                try:
-                    clear_interrupt(session_id, cache)
-                except CACHE_TRANSIENT_ERRORS:
-                    logger.warning(
-                        "[SANDBOX-SERVE] failed to clear interrupt fence for session %s",
-                        session_id,
-                        exc_info=True,
-                    )
-                session_manager.clear_turn_deadline(sandbox.id, session_id)
+            run.clear_fence_if_still_owned()
             prompt_slot_cm.__exit__(None, None, None)

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -548,96 +548,21 @@ def translate_opencode_event(
     if not isinstance(props, dict):
         return
 
-    # All events for our session must match by sessionID. Some events nest the
-    # session id under properties.info.sessionID, others under
-    # properties.sessionID; check both.
-    sess_id = props.get("sessionID")
-    if sess_id is None:
-        info = props.get("info") or {}
-        if isinstance(info, dict):
-            sess_id = info.get("sessionID")
+    sess_id = _resolve_session_id(props)
 
     if etype == "session.created":
-        info = props.get("info") or {}
-        if not isinstance(info, dict):
-            return
-        child_id = info.get("id")
-        parent_id = info.get("parentID")
-        if (
-            isinstance(child_id, str)
-            and isinstance(parent_id, str)
-            and parent_id == state.session_id
-        ):
-            yield SubagentStartedPacket(
-                subagent_session_id=child_id,
-                parent_session_id=parent_id,
-            )
+        yield from _translate_session_created(props, state)
         return
 
     if isinstance(sess_id, str) and sess_id != state.session_id:
-        # Event from another session. Forward descendant text/thought/tool
-        # events tagged so the frontend can route them to the live subagent.
-        if not _is_descendant_of(sess_id, state.session_id, parent_resolver):
-            return  # unrelated session — drop as before
-
-        child_meta = {"sessionId": sess_id, "parentSessionId": state.session_id}
-        child_state = _state_for_session(state, sess_id)
-
-        if etype == "message.updated":
-            info = props.get("info") or {}
-            if not isinstance(info, dict):
-                return
-            if info.get("role") != "assistant":
-                return
-            msg_id = info.get("id")
-            if isinstance(msg_id, str):
-                child_state.assistant_message_ids.add(msg_id)
-            return
-
-        child_fetch_message = (
-            (lambda mid: fetch_message_by_session(sess_id, mid))
-            if fetch_message_by_session is not None
-            else None
+        yield from _translate_descendant_event(
+            etype,
+            props,
+            state,
+            sess_id,
+            parent_resolver,
+            fetch_message_by_session,
         )
-
-        if etype == "message.part.delta":
-            for event in _emit_text_delta(props, child_state, child_fetch_message):
-                _merge_field_meta(event, child_meta)
-                yield event
-            return
-
-        if etype != "message.part.updated":
-            return
-
-        part = props.get("part") or {}
-        if not isinstance(part, dict):
-            return
-
-        part_type = part.get("type")
-        part_id_for_state = part.get("id")
-        if isinstance(part_id_for_state, str) and isinstance(part_type, str):
-            child_state.part_types[part_id_for_state] = part_type
-
-        if part_type == "reasoning":
-            if not _is_assistant_message(
-                child_state, part.get("messageID"), child_fetch_message
-            ):
-                return
-            events = _reconcile_reasoning_part(part, child_state)
-        elif part_type == "text":
-            if not _is_assistant_message(
-                child_state, part.get("messageID"), child_fetch_message
-            ):
-                return
-            events = _reconcile_text_part(part, child_state)
-        elif part_type == "tool":
-            events = _emit_tool_events(part, child_state)
-        else:
-            return
-
-        for event in events:
-            _merge_field_meta(event, child_meta)
-            yield event
         return
 
     # ── streaming text deltas ────────────────────────────────────────
@@ -647,90 +572,14 @@ def translate_opencode_event(
 
     # ── part lifecycle (tool calls + gap-fill anchors for text parts) ──
     if etype == "message.part.updated":
-        part = props.get("part") or {}
-        if not isinstance(part, dict):
-            return
-        part_type = part.get("type")
-
-        # Record the part's type so later ``message.part.delta`` events
-        # can route to the right sandbox event class (text → message chunk,
-        # reasoning → thought chunk). Deltas alone don't carry the part
-        # type, only the part id.
-        part_id_for_state = part.get("id")
-        if isinstance(part_id_for_state, str) and isinstance(part_type, str):
-            state.part_types[part_id_for_state] = part_type
-
-        if part_type == "reasoning":
-            if not _is_assistant_message(state, part.get("messageID"), fetch_message):
-                return
-            if _is_summary_message(state, part.get("messageID")):
-                return
-            yield from _reconcile_reasoning_part(part, state)
-            return
-
-        if part_type == "text":
-            if not _is_assistant_message(state, part.get("messageID"), fetch_message):
-                return
-            if _is_summary_message(state, part.get("messageID")):
-                return
-            yield from _reconcile_text_part(part, state)
-            return
-
-        if part_type == "tool":
-            # Tag the parent's ``task`` tool event with the subagent session it
-            # spawned so the frontend can link the call to its child stream.
-            subagent_sid: str | None = None
-            if part.get("tool") == "task" and children_resolver is not None:
-                # Each task callID claims the most-recent not-yet-claimed child.
-                call_id = part.get("callID")
-                if call_id is not None and call_id in state.task_child_by_call:
-                    subagent_sid = state.task_child_by_call[call_id]
-                else:
-                    claimed = set(state.task_child_by_call.values())
-                    unclaimed = [
-                        c
-                        for c in children_resolver(state.session_id)
-                        if c not in claimed
-                    ]
-                    if unclaimed:
-                        subagent_sid = unclaimed[-1]
-                        if call_id is not None:
-                            state.task_child_by_call[call_id] = subagent_sid
-            for event in _emit_tool_events(part, state):
-                if subagent_sid is not None:
-                    _merge_field_meta(event, {"subagentSessionId": subagent_sid})
-                yield event
-            return
-
-        # Reasoning parts: streams come via message.part.delta with
-        # field=reasoning; ignore the updated lifecycle for them.
+        yield from _translate_part_updated(
+            props, state, fetch_message, children_resolver
+        )
         return
 
     # ── role caching + error termination ─────────────────────────────
-    # NOT a turn terminator: opencode emits time.completed on EVERY step's
-    # assistant message (tool-call step, text step, etc.). The real
-    # end-of-turn signal is session.status:idle / session.idle below.
     if etype == "message.updated":
-        info = props.get("info") or {}
-        if not isinstance(info, dict):
-            return
-        if info.get("role") != "assistant":
-            return
-        msg_id = info.get("id")
-        if isinstance(msg_id, str):
-            state.assistant_message_ids.add(msg_id)
-            if info.get("summary") is True:
-                state.summary_message_ids.add(msg_id)
-        finish = info.get("finish")
-        if isinstance(finish, str):
-            state.last_finish = finish
-        usage = _context_usage_from_info(info)
-        if usage is not None:
-            yield usage
-        # A message error DOES kill the turn — surface it.
-        err = info.get("error")
-        if err and isinstance(err, dict):
-            yield from _emit_terminator(state, error=err, finish=finish)
+        yield from _translate_message_updated(props, state)
         return
 
     # ── turn terminators ─────────────────────────────────────────────
@@ -761,6 +610,230 @@ def translate_opencode_event(
     # session.next.{agent,model}.switched, session.updated, etc.) is
     # informational — ignored.
     return
+
+
+def _resolve_session_id(props: dict[str, Any]) -> Any:
+    """Session id of an event. Some events nest it under
+    ``properties.info.sessionID``, others under ``properties.sessionID``;
+    check both."""
+    sess_id = props.get("sessionID")
+    if sess_id is None:
+        info = props.get("info") or {}
+        if isinstance(info, dict):
+            sess_id = info.get("sessionID")
+    return sess_id
+
+
+def _record_part_type(part: dict[str, Any], state: _TurnState) -> Any:
+    """Record the part's type so later ``message.part.delta`` events can route
+    to the right sandbox event class (text → message chunk, reasoning →
+    thought chunk). Deltas alone don't carry the part type, only the part id.
+    Returns the part type."""
+    part_type = part.get("type")
+    part_id_for_state = part.get("id")
+    if isinstance(part_id_for_state, str) and isinstance(part_type, str):
+        state.part_types[part_id_for_state] = part_type
+    return part_type
+
+
+def _translate_session_created(
+    props: dict[str, Any], state: _TurnState
+) -> Iterable[SandboxEvent]:
+    info = props.get("info") or {}
+    if not isinstance(info, dict):
+        return
+    child_id = info.get("id")
+    parent_id = info.get("parentID")
+    if (
+        isinstance(child_id, str)
+        and isinstance(parent_id, str)
+        and parent_id == state.session_id
+    ):
+        yield SubagentStartedPacket(
+            subagent_session_id=child_id,
+            parent_session_id=parent_id,
+        )
+
+
+def _translate_descendant_event(
+    etype: str,
+    props: dict[str, Any],
+    state: _TurnState,
+    sess_id: str,
+    parent_resolver: Callable[[str], str | None] | None,
+    fetch_message_by_session: Callable[[str, str], dict[str, Any] | None] | None,
+) -> Iterable[SandboxEvent]:
+    """Event from another session. Forward descendant text/thought/tool
+    events tagged so the frontend can route them to the live subagent."""
+    if not _is_descendant_of(sess_id, state.session_id, parent_resolver):
+        return  # unrelated session — drop as before
+
+    child_meta = {"sessionId": sess_id, "parentSessionId": state.session_id}
+    child_state = _state_for_session(state, sess_id)
+
+    if etype == "message.updated":
+        _record_descendant_assistant_message(props, child_state)
+        return
+
+    child_fetch_message = (
+        (lambda mid: fetch_message_by_session(sess_id, mid))
+        if fetch_message_by_session is not None
+        else None
+    )
+
+    events: Iterable[SandboxEvent]
+    if etype == "message.part.delta":
+        events = _emit_text_delta(props, child_state, child_fetch_message)
+    elif etype == "message.part.updated":
+        events = _translate_descendant_part_updated(
+            props, child_state, child_fetch_message
+        )
+    else:
+        return
+
+    for event in events:
+        _merge_field_meta(event, child_meta)
+        yield event
+
+
+def _record_descendant_assistant_message(
+    props: dict[str, Any], child_state: _TurnState
+) -> None:
+    info = props.get("info") or {}
+    if not isinstance(info, dict):
+        return
+    if info.get("role") != "assistant":
+        return
+    msg_id = info.get("id")
+    if isinstance(msg_id, str):
+        child_state.assistant_message_ids.add(msg_id)
+
+
+def _translate_descendant_part_updated(
+    props: dict[str, Any],
+    child_state: _TurnState,
+    child_fetch_message: Callable[[str], dict[str, Any] | None] | None,
+) -> Iterable[SandboxEvent]:
+    part = props.get("part") or {}
+    if not isinstance(part, dict):
+        return
+
+    part_type = _record_part_type(part, child_state)
+
+    if part_type == "reasoning":
+        if not _is_assistant_message(
+            child_state, part.get("messageID"), child_fetch_message
+        ):
+            return
+        yield from _reconcile_reasoning_part(part, child_state)
+    elif part_type == "text":
+        if not _is_assistant_message(
+            child_state, part.get("messageID"), child_fetch_message
+        ):
+            return
+        yield from _reconcile_text_part(part, child_state)
+    elif part_type == "tool":
+        yield from _emit_tool_events(part, child_state)
+
+
+def _translate_part_updated(
+    props: dict[str, Any],
+    state: _TurnState,
+    fetch_message: Callable[[str], dict[str, Any] | None] | None,
+    children_resolver: Callable[[str], list[str]] | None,
+) -> Iterable[SandboxEvent]:
+    part = props.get("part") or {}
+    if not isinstance(part, dict):
+        return
+
+    part_type = _record_part_type(part, state)
+
+    if part_type == "reasoning":
+        if not _is_assistant_message(state, part.get("messageID"), fetch_message):
+            return
+        if _is_summary_message(state, part.get("messageID")):
+            return
+        yield from _reconcile_reasoning_part(part, state)
+        return
+
+    if part_type == "text":
+        if not _is_assistant_message(state, part.get("messageID"), fetch_message):
+            return
+        if _is_summary_message(state, part.get("messageID")):
+            return
+        yield from _reconcile_text_part(part, state)
+        return
+
+    if part_type == "tool":
+        yield from _translate_tool_part(part, state, children_resolver)
+        return
+
+    # Reasoning parts: streams come via message.part.delta with
+    # field=reasoning; ignore the updated lifecycle for them.
+    return
+
+
+def _translate_tool_part(
+    part: dict[str, Any],
+    state: _TurnState,
+    children_resolver: Callable[[str], list[str]] | None,
+) -> Iterable[SandboxEvent]:
+    subagent_sid = _claim_subagent_session(part, state, children_resolver)
+    for event in _emit_tool_events(part, state):
+        if subagent_sid is not None:
+            _merge_field_meta(event, {"subagentSessionId": subagent_sid})
+        yield event
+
+
+def _claim_subagent_session(
+    part: dict[str, Any],
+    state: _TurnState,
+    children_resolver: Callable[[str], list[str]] | None,
+) -> str | None:
+    """Subagent session spawned by a parent ``task`` tool part, so the frontend
+    can link the call to its child stream. Each task callID claims the
+    most-recent not-yet-claimed child."""
+    if part.get("tool") != "task" or children_resolver is None:
+        return None
+    call_id = part.get("callID")
+    if call_id is not None and call_id in state.task_child_by_call:
+        return state.task_child_by_call[call_id]
+    claimed = set(state.task_child_by_call.values())
+    unclaimed = [c for c in children_resolver(state.session_id) if c not in claimed]
+    if not unclaimed:
+        return None
+    subagent_sid = unclaimed[-1]
+    if call_id is not None:
+        state.task_child_by_call[call_id] = subagent_sid
+    return subagent_sid
+
+
+def _translate_message_updated(
+    props: dict[str, Any], state: _TurnState
+) -> Iterable[SandboxEvent]:
+    """NOT a turn terminator: opencode emits time.completed on EVERY step's
+    assistant message (tool-call step, text step, etc.). The real end-of-turn
+    signal is session.status:idle / session.idle."""
+    info = props.get("info") or {}
+    if not isinstance(info, dict):
+        return
+    if info.get("role") != "assistant":
+        return
+    msg_id = info.get("id")
+    if isinstance(msg_id, str):
+        state.assistant_message_ids.add(msg_id)
+        if info.get("summary") is True:
+            state.summary_message_ids.add(msg_id)
+    finish = info.get("finish")
+    if isinstance(finish, str):
+        state.last_finish = finish
+    usage = _context_usage_from_info(info)
+    if usage is not None:
+        yield usage
+    # A message error DOES kill the turn — surface it.
+    err = info.get("error")
+    if err and isinstance(err, dict):
+        yield from _emit_terminator(state, error=err, finish=finish)
 
 
 def _reconcile_text_part(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -4,7 +4,7 @@ import secrets
 import time
 from collections.abc import Mapping
 from enum import Enum
-from typing import Literal
+from typing import Literal, NamedTuple
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -1693,385 +1693,502 @@ def _invalidate_mcp_user_credentials(
     return affected_users
 
 
-def _upsert_mcp_server(
-    request: MCPToolCreateRequest,
-    db_session: Session,
+class _UpdateChangeFlags(NamedTuple):
+    """Which parts of a stored server the edit changes."""
+
+    changing_connection_config: bool
+    header_template_changed: bool
+    auth_scheme_changed: bool
+    server_url_changed: bool
+
+
+class _ResolvedUpsertInputs(NamedTuple):
+    """Effective auth inputs for an upsert after masked placeholders are
+    replaced by the values already stored on the server."""
+
+    oauth_client_id: str | None
+    oauth_client_secret: str | None
+    auth_template: MCPAuthTemplate | None
+    admin_credentials: dict[str, str] | None
+    api_token: str | None
+    client_info: OAuthClientInformationFull | None
+    changing_connection_config: bool
+    users_to_reload: set[UUID]
+
+
+def _is_admin_api_token(request: MCPToolCreateRequest) -> bool:
+    """True when one shared API token, owned by the admin, authenticates everyone."""
+    return (
+        request.auth_type == MCPAuthenticationType.API_TOKEN
+        and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+    )
+
+
+def _load_mcp_server_for_update(
+    existing_server_id: int,
     user: User,
-) -> DbMCPServer:
-    """
-    Creates a new or edits an existing MCP server. Returns the DB model
-    """
-    _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
-    _validate_mcp_server_url(
-        request.oauth_authorization_endpoint,
-        "oauth_authorization_endpoint",
-        require_https=True,
-    )
-    _validate_mcp_server_url(
-        request.oauth_token_endpoint, "oauth_token_endpoint", require_https=True
-    )
+    db_session: Session,
+) -> tuple[DbMCPServer, MCPConnectionData, OAuthClientInformationFull | None]:
+    """Load the server being edited with its stored admin config and OAuth client."""
+    try:
+        mcp_server = get_mcp_server_by_id(existing_server_id, db_session)
+    except ValueError:
+        raise HTTPException(
+            status_code=404,
+            detail=f"MCP server with ID {existing_server_id} not found",
+        )
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
-    mcp_server = None
-    admin_config = None
+    existing_admin_config: MCPConnectionData = MCPConnectionData(headers={})
     client_info: OAuthClientInformationFull | None = None
-    oauth_client_id = request.oauth_client_id
-    oauth_client_secret = request.oauth_client_secret
+    if mcp_server.admin_connection_config:
+        existing_admin_config = extract_connection_data(
+            mcp_server.admin_connection_config, apply_mask=False
+        )
+        client_info_raw = existing_admin_config.get(MCPOAuthKeys.CLIENT_INFO.value)
+        if client_info_raw:
+            client_info = OAuthClientInformationFull.model_validate(client_info_raw)
+    return mcp_server, existing_admin_config, client_info
+
+
+def _resolve_update_auth_template(
+    request: MCPToolCreateRequest,
+    mcp_server: DbMCPServer,
+    existing_admin_config: MCPConnectionData,
+) -> tuple[MCPAuthTemplate | None, dict[str, str], dict[str, str]]:
+    """Resolve the editing admin's own template values per field, plus the stored
+    headers the change detection compares against."""
     auth_template = request.auth_template
-    admin_credentials = request.admin_credentials
-    api_token = request.api_token
+    if not mcp_server.admin_connection_config:
+        return auth_template, {}, {}
 
-    changing_connection_config = True
-    users_to_reload: set[UUID] = set()
-
-    # Handle existing server update
-    if request.existing_server_id:
-        try:
-            mcp_server = get_mcp_server_by_id(request.existing_server_id, db_session)
-        except ValueError:
-            raise HTTPException(
-                status_code=404,
-                detail=f"MCP server with ID {request.existing_server_id} not found",
-            )
-        _ensure_mcp_server_owner_or_admin(mcp_server, user)
-        existing_admin_config_dict: MCPConnectionData = MCPConnectionData(headers={})
-        if mcp_server.admin_connection_config:
-            existing_admin_config_dict = extract_connection_data(
-                mcp_server.admin_connection_config, apply_mask=False
-            )
-            client_info_raw = existing_admin_config_dict.get(
-                MCPOAuthKeys.CLIENT_INFO.value
-            )
-            if client_info_raw:
-                client_info = OAuthClientInformationFull.model_validate(client_info_raw)
-
-        # Resolve the effective OAuth credentials, falling back to the stored
-        # values for any field the frontend marked as unchanged. This protects
-        # the change-detection comparison below from spurious diffs caused by
-        # masked placeholders being replayed.
-        if client_info and request.auth_type == MCPAuthenticationType.OAUTH:
-            oauth_client_id, oauth_client_secret = _resolve_oauth_credentials(
-                request_client_id=request.oauth_client_id,
-                request_client_id_changed=request.oauth_client_id_changed,
-                request_client_secret=request.oauth_client_secret,
-                request_client_secret_changed=request.oauth_client_secret_changed,
-                existing_client=client_info,
-            )
-
-        # Resolve the editing admin's own template values per field.
-        existing_admin_per_user_creds: dict[str, str] = {}
-        existing_template_headers: dict[str, str] = {}
-        existing_shared_template_headers: dict[str, str] = {}
-        existing_template: MCPAuthTemplate | None = None
-        if mcp_server.admin_connection_config:
-            existing_template = get_mcp_auth_template(mcp_server)
-            existing_template_headers = (
-                existing_template.headers if existing_template else {}
-            )
-            existing_shared_template_headers = (
-                existing_admin_config_dict.get("header_template")
-                or _default_shared_api_token_template().headers
-            )
-            if auth_template is not None:
-                auth_template = _resolve_auth_template(
-                    auth_template,
-                    request.auth_template_headers_changed,
-                    existing_template,
-                )
-            elif existing_template is not None:
-                auth_template = existing_template
-
-        if (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
-        ):
-            if admin_credentials is not None:
-                admin_credentials = _resolve_admin_credentials(
-                    request_credentials=admin_credentials,
-                    request_credentials_changed=request.admin_credentials_changed,
-                    existing_user_credentials=existing_admin_config_dict.get(
-                        HEADER_SUBSTITUTIONS, {}
-                    ),
-                )
-            auth_template = _resolve_shared_api_token_template(
-                request_template=auth_template,
-                existing_config=(
-                    existing_admin_config_dict
-                    if mcp_server.admin_connection_config
-                    else None
-                ),
-            )
-            api_token = _resolve_shared_api_token(
-                request_api_token=api_token,
-                request_api_token_changed=request.api_token_changed,
-                existing_config=(
-                    existing_admin_config_dict
-                    if mcp_server.admin_connection_config
-                    else None
-                ),
-            )
-            # The validator allows an omitted token on update so the stored
-            # one can be reused; enforce that a token actually resolved.
-            if not api_token:
-                raise OnyxError(
-                    OnyxErrorCode.INVALID_INPUT,
-                    "A shared API token is required for admin-managed API-token servers.",
-                )
-        if (
-            not (
-                request.auth_type == MCPAuthenticationType.API_TOKEN
-                and request.auth_performer == MCPAuthenticationPerformer.ADMIN
-            )
-            and user.email
-        ):
-            existing_admin_per_user_config = get_user_connection_config(
-                mcp_server.id, user.email, db_session
-            )
-            if existing_admin_per_user_config:
-                existing_admin_per_user_dict = extract_connection_data(
-                    existing_admin_per_user_config, apply_mask=False
-                )
-                existing_admin_per_user_creds = (
-                    existing_admin_per_user_dict.get(HEADER_SUBSTITUTIONS) or {}
-                )
-            if admin_credentials is not None:
-                admin_credentials = _resolve_admin_credentials(
-                    request_credentials=admin_credentials,
-                    request_credentials_changed=request.admin_credentials_changed,
-                    existing_user_credentials=existing_admin_per_user_creds,
-                )
-
-        api_token_creds_changed = (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.PER_USER
-            and existing_admin_per_user_creds != (admin_credentials or {})
+    existing_template = get_mcp_auth_template(mcp_server)
+    existing_template_headers = existing_template.headers if existing_template else {}
+    existing_shared_template_headers = (
+        existing_admin_config.get("header_template")
+        or _default_shared_api_token_template().headers
+    )
+    if auth_template is not None:
+        auth_template = _resolve_auth_template(
+            auth_template,
+            request.auth_template_headers_changed,
+            existing_template,
         )
-        header_template_changed = (
-            not (
-                request.auth_type == MCPAuthenticationType.API_TOKEN
-                and request.auth_performer == MCPAuthenticationPerformer.ADMIN
-            )
-            and auth_template is not None
-            and auth_template.headers != existing_template_headers
+    elif existing_template is not None:
+        auth_template = existing_template
+    return auth_template, existing_template_headers, existing_shared_template_headers
+
+
+def _resolve_shared_api_token_inputs(
+    *,
+    request: MCPToolCreateRequest,
+    mcp_server: DbMCPServer,
+    existing_admin_config: MCPConnectionData,
+    auth_template: MCPAuthTemplate | None,
+    admin_credentials: dict[str, str] | None,
+) -> tuple[MCPAuthTemplate | None, dict[str, str] | None, str | None]:
+    """Resolve template, credentials, and token for an admin-managed API-token
+    server, reusing stored values for fields the frontend marked unchanged."""
+    if admin_credentials is not None:
+        admin_credentials = _resolve_admin_credentials(
+            request_credentials=admin_credentials,
+            request_credentials_changed=request.admin_credentials_changed,
+            existing_user_credentials=existing_admin_config.get(
+                HEADER_SUBSTITUTIONS, {}
+            ),
         )
-        shared_api_token_template_changed = (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
-            and auth_template is not None
-            and auth_template.headers != existing_shared_template_headers
+    stored_config = (
+        existing_admin_config if mcp_server.admin_connection_config else None
+    )
+    auth_template = _resolve_shared_api_token_template(
+        request_template=auth_template,
+        existing_config=stored_config,
+    )
+    api_token = _resolve_shared_api_token(
+        request_api_token=request.api_token,
+        request_api_token_changed=request.api_token_changed,
+        existing_config=stored_config,
+    )
+    # The validator allows an omitted token on update so the stored
+    # one can be reused; enforce that a token actually resolved.
+    if not api_token:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "A shared API token is required for admin-managed API-token servers.",
         )
-        shared_api_token_credentials_changed = (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
-            and admin_credentials is not None
-            and admin_credentials
-            != existing_admin_config_dict.get(HEADER_SUBSTITUTIONS, {})
+    return auth_template, admin_credentials, api_token
+
+
+def _resolve_per_user_admin_credentials(
+    *,
+    request: MCPToolCreateRequest,
+    mcp_server: DbMCPServer,
+    user_email: str,
+    admin_credentials: dict[str, str] | None,
+    db_session: Session,
+) -> tuple[dict[str, str], dict[str, str] | None]:
+    """Resolve the editing admin's per-user credentials against their stored ones.
+    Returns the stored credentials and the resolved request credentials."""
+    existing_creds: dict[str, str] = {}
+    existing_config = get_user_connection_config(mcp_server.id, user_email, db_session)
+    if existing_config:
+        existing_data = extract_connection_data(existing_config, apply_mask=False)
+        existing_creds = existing_data.get(HEADER_SUBSTITUTIONS) or {}
+    if admin_credentials is not None:
+        admin_credentials = _resolve_admin_credentials(
+            request_credentials=admin_credentials,
+            request_credentials_changed=request.admin_credentials_changed,
+            existing_user_credentials=existing_creds,
         )
-        api_token_scheme_changed = (
-            request.auth_type == MCPAuthenticationType.API_TOKEN
-            and (
-                request.auth_type != mcp_server.auth_type
-                or request.auth_performer != mcp_server.auth_performer
-            )
-        )
-        auth_scheme_changed = (
+    return existing_creds, admin_credentials
+
+
+def _compute_update_change_flags(
+    *,
+    request: MCPToolCreateRequest,
+    mcp_server: DbMCPServer,
+    client_info: OAuthClientInformationFull | None,
+    oauth_client_id: str | None,
+    oauth_client_secret: str | None,
+    auth_template: MCPAuthTemplate | None,
+    admin_credentials: dict[str, str] | None,
+    existing_admin_config: MCPConnectionData,
+    existing_admin_per_user_creds: dict[str, str],
+    existing_template_headers: dict[str, str],
+    existing_shared_template_headers: dict[str, str],
+) -> _UpdateChangeFlags:
+    """Compare the request against the stored server to decide whether the admin
+    connection config must be rebuilt and which stored credentials it invalidates."""
+    is_admin_api_token = _is_admin_api_token(request)
+    api_token_creds_changed = (
+        request.auth_type == MCPAuthenticationType.API_TOKEN
+        and request.auth_performer == MCPAuthenticationPerformer.PER_USER
+        and existing_admin_per_user_creds != (admin_credentials or {})
+    )
+    header_template_changed = (
+        not is_admin_api_token
+        and auth_template is not None
+        and auth_template.headers != existing_template_headers
+    )
+    shared_api_token_template_changed = (
+        is_admin_api_token
+        and auth_template is not None
+        and auth_template.headers != existing_shared_template_headers
+    )
+    shared_api_token_credentials_changed = (
+        is_admin_api_token
+        and admin_credentials is not None
+        and admin_credentials != existing_admin_config.get(HEADER_SUBSTITUTIONS, {})
+    )
+    api_token_scheme_changed = (
+        request.auth_type == MCPAuthenticationType.API_TOKEN
+        and (
             request.auth_type != mcp_server.auth_type
             or request.auth_performer != mcp_server.auth_performer
         )
-        server_url_changed = request.server_url != mcp_server.server_url
-        # Known-provider OAuth settings (endpoints/mode/scopes/extra params)
-        # determine where and with what scope user tokens are minted. A change
-        # to any of them invalidates existing user tokens, so it must trigger
-        # the same re-handshake wipe as a client_id/secret change.
-        oauth_provider_config_changed = (
+    )
+    auth_scheme_changed = (
+        request.auth_type != mcp_server.auth_type
+        or request.auth_performer != mcp_server.auth_performer
+    )
+    server_url_changed = request.server_url != mcp_server.server_url
+    # Known-provider OAuth settings (endpoints/mode/scopes/extra params)
+    # determine where and with what scope user tokens are minted. A change
+    # to any of them invalidates existing user tokens, so it must trigger
+    # the same re-handshake wipe as a client_id/secret change.
+    oauth_provider_config_changed = (
+        request.auth_type == MCPAuthenticationType.OAUTH
+        and (
+            request.oauth_provider_mode != mcp_server.oauth_provider_mode
+            or request.oauth_authorization_endpoint
+            != mcp_server.oauth_authorization_endpoint
+            or request.oauth_token_endpoint != mcp_server.oauth_token_endpoint
+            or request.oauth_scopes_override != mcp_server.oauth_scopes_override
+            or request.oauth_additional_auth_params
+            != mcp_server.oauth_additional_auth_params
+        )
+    )
+
+    changing_connection_config = (
+        not mcp_server.admin_connection_config
+        or (
             request.auth_type == MCPAuthenticationType.OAUTH
             and (
-                request.oauth_provider_mode != mcp_server.oauth_provider_mode
-                or request.oauth_authorization_endpoint
-                != mcp_server.oauth_authorization_endpoint
-                or request.oauth_token_endpoint != mcp_server.oauth_token_endpoint
-                or request.oauth_scopes_override != mcp_server.oauth_scopes_override
-                or request.oauth_additional_auth_params
-                != mcp_server.oauth_additional_auth_params
+                client_info is None
+                or oauth_client_id != client_info.client_id
+                or oauth_client_secret != (client_info.client_secret or "")
+                or oauth_provider_config_changed
             )
         )
-
-        changing_connection_config = (
-            not mcp_server.admin_connection_config
-            or (
-                request.auth_type == MCPAuthenticationType.OAUTH
-                and (
-                    client_info is None
-                    or oauth_client_id != client_info.client_id
-                    or oauth_client_secret != (client_info.client_secret or "")
-                    or oauth_provider_config_changed
-                )
-            )
-            or (
-                request.auth_type == MCPAuthenticationType.API_TOKEN
-                and (
-                    api_token_creds_changed
-                    or header_template_changed
-                    or shared_api_token_template_changed
-                    or shared_api_token_credentials_changed
-                    or (
-                        request.auth_performer == MCPAuthenticationPerformer.ADMIN
-                        and request.api_token_changed
-                    )
-                    or api_token_scheme_changed
-                )
-            )
-            or header_template_changed
-            or auth_scheme_changed
-            or server_url_changed
-            or (request.transport != mcp_server.transport)
-        )
-
-        if header_template_changed or auth_scheme_changed or server_url_changed:
-            users_to_reload.update(
-                _invalidate_mcp_user_credentials(mcp_server, db_session)
-            )
-
-        if server_url_changed and mcp_server.admin_connection_config_id:
-            previous_admin_config_id = mcp_server.admin_connection_config_id
-            mcp_server.admin_connection_config_id = None
-            delete_connection_config(previous_admin_config_id, db_session)
-            if (
-                request.auth_type == MCPAuthenticationType.OAUTH
-                and request.oauth_provider_mode is MCPOAuthProviderMode.AUTO_DISCOVERY
-            ):
-                client_info = None
-                if not request.oauth_client_id_changed:
-                    oauth_client_id = None
-                if not request.oauth_client_secret_changed:
-                    oauth_client_secret = None
-        elif (
-            changing_connection_config
-            and mcp_server.admin_connection_config_id
-            and request.auth_type == MCPAuthenticationType.OAUTH
-            and not header_template_changed
-            and not auth_scheme_changed
-        ):
-            users_to_reload.update(
-                _invalidate_mcp_user_credentials(mcp_server, db_session)
-            )
-        elif (
-            changing_connection_config
-            and mcp_server.admin_connection_config_id
-            and request.auth_type == MCPAuthenticationType.API_TOKEN
-        ):
-            delete_connection_config(mcp_server.admin_connection_config_id, db_session)
-
-        # Update the server with new values
-        mcp_server = update_mcp_server__no_commit(
-            server_id=request.existing_server_id,
-            db_session=db_session,
-            name=request.name,
-            description=request.description,
-            server_url=request.server_url,
-            auth_type=request.auth_type,
-            auth_performer=request.auth_performer,
-            oauth_provider_mode=request.oauth_provider_mode,
-            oauth_authorization_endpoint=request.oauth_authorization_endpoint,
-            oauth_token_endpoint=request.oauth_token_endpoint,
-            oauth_scopes_override=request.oauth_scopes_override,
-            oauth_additional_auth_params=request.oauth_additional_auth_params,
-            transport=request.transport,
-        )
-
-        logger.info(
-            "Updated existing MCP server '%s' with ID %s", request.name, mcp_server.id
-        )
-
-    else:
-        # Handle new server creation
-        if auth_template is not None:
-            auth_template = _resolve_auth_template(
-                auth_template,
-                request.auth_template_headers_changed,
-                None,
-            )
-        # Prevent duplicate server creation with same URL
-        normalized_url = (request.server_url or "").strip()
-        if not normalized_url:
-            raise HTTPException(status_code=400, detail="server_url is required")
-
-        if not user.email:
-            raise HTTPException(
-                status_code=400,
-                detail="Authenticated user email required to create MCP servers",
-            )
-
-        mcp_server = create_mcp_server__no_commit(
-            owner_email=user.email,
-            name=request.name,
-            description=request.description,
-            server_url=request.server_url,
-            auth_type=request.auth_type,
-            auth_performer=request.auth_performer,
-            oauth_provider_mode=request.oauth_provider_mode,
-            oauth_authorization_endpoint=request.oauth_authorization_endpoint,
-            oauth_token_endpoint=request.oauth_token_endpoint,
-            oauth_scopes_override=request.oauth_scopes_override,
-            oauth_additional_auth_params=request.oauth_additional_auth_params,
-            transport=request.transport or MCPTransport.STREAMABLE_HTTP,
-            db_session=db_session,
-        )
-
-        logger.info(
-            "Created new MCP server '%s' with ID %s", request.name, mcp_server.id
-        )
-
-    # A new server defaults to public (create_mcp_server__no_commit), so always run the
-    # access gate on create — otherwise a scoped manager could publish one org-wide by
-    # omitting is_public/users/groups. On update, only touch access when the caller sent it.
-    is_new_server = request.existing_server_id is None
-    if is_new_server or any(
-        value is not None
-        for value in (request.is_public, request.users, request.groups)
-    ):
-        _apply_mcp_server_access(
-            mcp_server=mcp_server,
-            acting_user=user,
-            is_public=request.is_public,
-            user_ids=request.users,
-            group_ids=request.groups,
-            is_new=is_new_server,
-            db_session=db_session,
-        )
-
-    if (
-        auth_template is not None
-        and admin_credentials is not None
-        and not (
+        or (
             request.auth_type == MCPAuthenticationType.API_TOKEN
-            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            and (
+                api_token_creds_changed
+                or header_template_changed
+                or shared_api_token_template_changed
+                or shared_api_token_credentials_changed
+                or (
+                    request.auth_performer == MCPAuthenticationPerformer.ADMIN
+                    and request.api_token_changed
+                )
+                or api_token_scheme_changed
+            )
         )
+        or header_template_changed
+        or auth_scheme_changed
+        or server_url_changed
+        or (request.transport != mcp_server.transport)
+    )
+    return _UpdateChangeFlags(
+        changing_connection_config=changing_connection_config,
+        header_template_changed=header_template_changed,
+        auth_scheme_changed=auth_scheme_changed,
+        server_url_changed=server_url_changed,
+    )
+
+
+def _reconcile_existing_connection_config(
+    *,
+    request: MCPToolCreateRequest,
+    mcp_server: DbMCPServer,
+    flags: _UpdateChangeFlags,
+    client_info: OAuthClientInformationFull | None,
+    oauth_client_id: str | None,
+    oauth_client_secret: str | None,
+    users_to_reload: set[UUID],
+    db_session: Session,
+) -> tuple[OAuthClientInformationFull | None, str | None, str | None]:
+    """Drop the stored credentials the edit invalidates and add the affected users
+    to ``users_to_reload``. Returns the OAuth client state that survives the edit."""
+    if (
+        flags.header_template_changed
+        or flags.auth_scheme_changed
+        or flags.server_url_changed
     ):
-        _upsert_user_template_config(
+        users_to_reload.update(_invalidate_mcp_user_credentials(mcp_server, db_session))
+
+    if flags.server_url_changed and mcp_server.admin_connection_config_id:
+        previous_admin_config_id = mcp_server.admin_connection_config_id
+        mcp_server.admin_connection_config_id = None
+        delete_connection_config(previous_admin_config_id, db_session)
+        if (
+            request.auth_type == MCPAuthenticationType.OAUTH
+            and request.oauth_provider_mode is MCPOAuthProviderMode.AUTO_DISCOVERY
+        ):
+            client_info = None
+            if not request.oauth_client_id_changed:
+                oauth_client_id = None
+            if not request.oauth_client_secret_changed:
+                oauth_client_secret = None
+    elif (
+        flags.changing_connection_config
+        and mcp_server.admin_connection_config_id
+        and request.auth_type == MCPAuthenticationType.OAUTH
+        and not flags.header_template_changed
+        and not flags.auth_scheme_changed
+    ):
+        users_to_reload.update(_invalidate_mcp_user_credentials(mcp_server, db_session))
+    elif (
+        flags.changing_connection_config
+        and mcp_server.admin_connection_config_id
+        and request.auth_type == MCPAuthenticationType.API_TOKEN
+    ):
+        delete_connection_config(mcp_server.admin_connection_config_id, db_session)
+
+    return client_info, oauth_client_id, oauth_client_secret
+
+
+def _update_existing_mcp_server(
+    request: MCPToolCreateRequest,
+    existing_server_id: int,
+    db_session: Session,
+    user: User,
+) -> tuple[DbMCPServer, _ResolvedUpsertInputs]:
+    """Apply an edit to a stored MCP server and report the auth inputs it resolved."""
+    mcp_server, existing_admin_config, client_info = _load_mcp_server_for_update(
+        existing_server_id, user, db_session
+    )
+
+    # Resolve the effective OAuth credentials, falling back to the stored
+    # values for any field the frontend marked as unchanged. This protects
+    # the change-detection comparison below from spurious diffs caused by
+    # masked placeholders being replayed.
+    oauth_client_id = request.oauth_client_id
+    oauth_client_secret = request.oauth_client_secret
+    if client_info and request.auth_type == MCPAuthenticationType.OAUTH:
+        oauth_client_id, oauth_client_secret = _resolve_oauth_credentials(
+            request_client_id=request.oauth_client_id,
+            request_client_id_changed=request.oauth_client_id_changed,
+            request_client_secret=request.oauth_client_secret,
+            request_client_secret_changed=request.oauth_client_secret_changed,
+            existing_client=client_info,
+        )
+
+    (
+        auth_template,
+        existing_template_headers,
+        existing_shared_template_headers,
+    ) = _resolve_update_auth_template(request, mcp_server, existing_admin_config)
+
+    admin_credentials = request.admin_credentials
+    api_token = request.api_token
+    existing_admin_per_user_creds: dict[str, str] = {}
+    if _is_admin_api_token(request):
+        auth_template, admin_credentials, api_token = _resolve_shared_api_token_inputs(
+            request=request,
             mcp_server=mcp_server,
-            template=auth_template,
-            substitutions=admin_credentials,
+            existing_admin_config=existing_admin_config,
+            auth_template=auth_template,
+            admin_credentials=admin_credentials,
+        )
+    elif user.email:
+        (
+            existing_admin_per_user_creds,
+            admin_credentials,
+        ) = _resolve_per_user_admin_credentials(
+            request=request,
+            mcp_server=mcp_server,
             user_email=user.email,
+            admin_credentials=admin_credentials,
             db_session=db_session,
         )
-        users_to_reload.add(user.id)
 
-    if not changing_connection_config:
-        db_session.commit()
-        _hot_reload_craft_sessions(users_to_reload, db_session)
-        return mcp_server
+    flags = _compute_update_change_flags(
+        request=request,
+        mcp_server=mcp_server,
+        client_info=client_info,
+        oauth_client_id=oauth_client_id,
+        oauth_client_secret=oauth_client_secret,
+        auth_template=auth_template,
+        admin_credentials=admin_credentials,
+        existing_admin_config=existing_admin_config,
+        existing_admin_per_user_creds=existing_admin_per_user_creds,
+        existing_template_headers=existing_template_headers,
+        existing_shared_template_headers=existing_shared_template_headers,
+    )
 
+    users_to_reload: set[UUID] = set()
+    (
+        client_info,
+        oauth_client_id,
+        oauth_client_secret,
+    ) = _reconcile_existing_connection_config(
+        request=request,
+        mcp_server=mcp_server,
+        flags=flags,
+        client_info=client_info,
+        oauth_client_id=oauth_client_id,
+        oauth_client_secret=oauth_client_secret,
+        users_to_reload=users_to_reload,
+        db_session=db_session,
+    )
+
+    # Update the server with new values
+    mcp_server = update_mcp_server__no_commit(
+        server_id=existing_server_id,
+        db_session=db_session,
+        name=request.name,
+        description=request.description,
+        server_url=request.server_url,
+        auth_type=request.auth_type,
+        auth_performer=request.auth_performer,
+        oauth_provider_mode=request.oauth_provider_mode,
+        oauth_authorization_endpoint=request.oauth_authorization_endpoint,
+        oauth_token_endpoint=request.oauth_token_endpoint,
+        oauth_scopes_override=request.oauth_scopes_override,
+        oauth_additional_auth_params=request.oauth_additional_auth_params,
+        transport=request.transport,
+    )
+
+    logger.info(
+        "Updated existing MCP server '%s' with ID %s", request.name, mcp_server.id
+    )
+
+    return mcp_server, _ResolvedUpsertInputs(
+        oauth_client_id=oauth_client_id,
+        oauth_client_secret=oauth_client_secret,
+        auth_template=auth_template,
+        admin_credentials=admin_credentials,
+        api_token=api_token,
+        client_info=client_info,
+        changing_connection_config=flags.changing_connection_config,
+        users_to_reload=users_to_reload,
+    )
+
+
+def _create_new_mcp_server(
+    request: MCPToolCreateRequest,
+    db_session: Session,
+    user: User,
+) -> tuple[DbMCPServer, _ResolvedUpsertInputs]:
+    """Create a new MCP server row. Nothing is stored yet, so the request's auth
+    inputs need no fallback to stored values."""
+    auth_template = request.auth_template
+    if auth_template is not None:
+        auth_template = _resolve_auth_template(
+            auth_template,
+            request.auth_template_headers_changed,
+            None,
+        )
+    # Prevent duplicate server creation with same URL
+    normalized_url = (request.server_url or "").strip()
+    if not normalized_url:
+        raise HTTPException(status_code=400, detail="server_url is required")
+
+    if not user.email:
+        raise HTTPException(
+            status_code=400,
+            detail="Authenticated user email required to create MCP servers",
+        )
+
+    mcp_server = create_mcp_server__no_commit(
+        owner_email=user.email,
+        name=request.name,
+        description=request.description,
+        server_url=request.server_url,
+        auth_type=request.auth_type,
+        auth_performer=request.auth_performer,
+        oauth_provider_mode=request.oauth_provider_mode,
+        oauth_authorization_endpoint=request.oauth_authorization_endpoint,
+        oauth_token_endpoint=request.oauth_token_endpoint,
+        oauth_scopes_override=request.oauth_scopes_override,
+        oauth_additional_auth_params=request.oauth_additional_auth_params,
+        transport=request.transport or MCPTransport.STREAMABLE_HTTP,
+        db_session=db_session,
+    )
+
+    logger.info("Created new MCP server '%s' with ID %s", request.name, mcp_server.id)
+
+    return mcp_server, _ResolvedUpsertInputs(
+        oauth_client_id=request.oauth_client_id,
+        oauth_client_secret=request.oauth_client_secret,
+        auth_template=auth_template,
+        admin_credentials=request.admin_credentials,
+        api_token=request.api_token,
+        client_info=None,
+        changing_connection_config=True,
+        users_to_reload=set(),
+    )
+
+
+def _create_admin_connection_config(
+    *,
+    request: MCPToolCreateRequest,
+    mcp_server: DbMCPServer,
+    resolved: _ResolvedUpsertInputs,
+    user: User,
+    db_session: Session,
+) -> int | None:
+    """Write the admin connection config for the server's auth type."""
+    api_token = resolved.api_token
+    auth_template = resolved.auth_template
     admin_connection_config_id: int | None = None
-    if (
-        request.auth_type == MCPAuthenticationType.API_TOKEN
-        and request.auth_performer == MCPAuthenticationPerformer.ADMIN
-        and api_token
-    ):
+    if _is_admin_api_token(request) and api_token:
         admin_config = create_connection_config(
             config_data=_build_shared_api_token_config_data(
                 api_token=api_token,
                 auth_template=auth_template,
-                header_substitutions=admin_credentials,
+                header_substitutions=resolved.admin_credentials,
                 user_email=user.email,
             ),
             mcp_server_id=mcp_server.id,
@@ -2092,17 +2209,18 @@ def _upsert_mcp_server(
         ).id
 
     elif request.auth_type == MCPAuthenticationType.OAUTH:
+        client_info = resolved.client_info
         config_data = (
             _build_oauth_admin_config_data_for_update(
-                client_id=oauth_client_id,
-                client_secret=oauth_client_secret,
+                client_id=resolved.oauth_client_id,
+                client_secret=resolved.oauth_client_secret,
                 existing_client=client_info,
                 auth_template=auth_template,
             )
             if client_info is not None
             else _build_oauth_admin_config_data(
-                client_id=oauth_client_id,
-                client_secret=oauth_client_secret,
+                client_id=resolved.oauth_client_id,
+                client_secret=resolved.oauth_client_secret,
                 auth_template=auth_template,
             )
         )
@@ -2115,6 +2233,81 @@ def _upsert_mcp_server(
         admin_connection_config_id = _persist_admin_connection_config(
             mcp_server, config_data, db_session
         )
+    return admin_connection_config_id
+
+
+def _upsert_mcp_server(
+    request: MCPToolCreateRequest,
+    db_session: Session,
+    user: User,
+) -> DbMCPServer:
+    """
+    Creates a new or edits an existing MCP server. Returns the DB model
+    """
+    _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
+    _validate_mcp_server_url(
+        request.oauth_authorization_endpoint,
+        "oauth_authorization_endpoint",
+        require_https=True,
+    )
+    _validate_mcp_server_url(
+        request.oauth_token_endpoint, "oauth_token_endpoint", require_https=True
+    )
+
+    existing_server_id = request.existing_server_id
+    if existing_server_id:
+        mcp_server, resolved = _update_existing_mcp_server(
+            request, existing_server_id, db_session, user
+        )
+    else:
+        mcp_server, resolved = _create_new_mcp_server(request, db_session, user)
+
+    # A new server defaults to public (create_mcp_server__no_commit), so always run the
+    # access gate on create — otherwise a scoped manager could publish one org-wide by
+    # omitting is_public/users/groups. On update, only touch access when the caller sent it.
+    is_new_server = request.existing_server_id is None
+    if is_new_server or any(
+        value is not None
+        for value in (request.is_public, request.users, request.groups)
+    ):
+        _apply_mcp_server_access(
+            mcp_server=mcp_server,
+            acting_user=user,
+            is_public=request.is_public,
+            user_ids=request.users,
+            group_ids=request.groups,
+            is_new=is_new_server,
+            db_session=db_session,
+        )
+
+    auth_template = resolved.auth_template
+    admin_credentials = resolved.admin_credentials
+    if (
+        auth_template is not None
+        and admin_credentials is not None
+        and not _is_admin_api_token(request)
+    ):
+        _upsert_user_template_config(
+            mcp_server=mcp_server,
+            template=auth_template,
+            substitutions=admin_credentials,
+            user_email=user.email,
+            db_session=db_session,
+        )
+        resolved.users_to_reload.add(user.id)
+
+    if not resolved.changing_connection_config:
+        db_session.commit()
+        _hot_reload_craft_sessions(resolved.users_to_reload, db_session)
+        return mcp_server
+
+    admin_connection_config_id = _create_admin_connection_config(
+        request=request,
+        mcp_server=mcp_server,
+        resolved=resolved,
+        user=user,
+        db_session=db_session,
+    )
     if admin_connection_config_id is not None:
         mcp_server = update_mcp_server__no_commit(
             server_id=mcp_server.id,
@@ -2123,7 +2316,7 @@ def _upsert_mcp_server(
         )
 
     db_session.commit()
-    _hot_reload_craft_sessions(users_to_reload, db_session)
+    _hot_reload_craft_sessions(resolved.users_to_reload, db_session)
     return mcp_server
 
 

--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -14,7 +14,7 @@ from onyx.db.chat import (
     get_db_search_doc_by_id,
     translate_db_search_doc_to_saved_search_doc,
 )
-from onyx.db.models import ChatMessage
+from onyx.db.models import ChatMessage, Tool, ToolCall
 from onyx.db.tools import get_tool_by_id
 from onyx.deep_research.dr_mock_tools import (
     RESEARCH_AGENT_IN_CODE_ID,
@@ -526,6 +526,306 @@ def create_search_packets(
     return packets
 
 
+def _group_tool_calls_by_turn(tool_calls: list[ToolCall]) -> dict[int, list[ToolCall]]:
+    """Group tool calls by turn number, keeping their order within each turn."""
+    tool_calls_by_turn: dict[int, list[ToolCall]] = {}
+    for tool_call in tool_calls:
+        tool_calls_by_turn.setdefault(tool_call.turn_number, []).append(tool_call)
+    return tool_calls_by_turn
+
+
+def _create_python_tool_call_packets(
+    tool_call: ToolCall, turn_index: int
+) -> list[Packet]:
+    """Rebuild python tool packets from the saved code and JSON response."""
+    code = cast(str, tool_call.tool_call_arguments.get("code", ""))
+    stdout = ""
+    stderr = ""
+    file_ids: list[str] = []
+    if tool_call.tool_call_response:
+        try:
+            response_data = json.loads(tool_call.tool_call_response)
+            stdout = response_data.get("stdout", "")
+            stderr = response_data.get("stderr", "")
+            generated_files = response_data.get("generated_files", [])
+            file_ids = [
+                f.get("file_link", "").split("/")[-1]
+                for f in generated_files
+                if f.get("file_link")
+            ]
+        except (json.JSONDecodeError, KeyError):
+            # Fall back to raw response as stdout
+            stdout = tool_call.tool_call_response
+
+    return create_python_tool_packets(
+        code=code,
+        stdout=stdout,
+        stderr=stderr,
+        file_ids=file_ids,
+        turn_index=turn_index,
+        tab_index=tool_call.tab_index,
+    )
+
+
+def _create_custom_tool_call_packets(
+    tool: Tool, tool_call: ToolCall, turn_index: int
+) -> list[Packet]:
+    """Rebuild packets for a custom or unrecognized tool call."""
+    # Try to parse as structured CustomToolCallSummary JSON
+    custom_data: dict | list | str | int | float | bool | None = (
+        tool_call.tool_call_response
+    )
+    custom_error: CustomToolErrorInfo | None = None
+    custom_response_type = "text"
+
+    try:
+        parsed = json.loads(tool_call.tool_call_response)
+        if isinstance(parsed, dict) and "tool_name" in parsed:
+            custom_data = parsed.get("tool_result")
+            custom_response_type = parsed.get("response_type", "text")
+            if parsed.get("error"):
+                custom_error = CustomToolErrorInfo(**parsed["error"])
+    except (json.JSONDecodeError, KeyError, TypeError, ValidationError):
+        pass
+
+    custom_file_ids: list[str] | None = None
+    if custom_response_type in ("image", "csv") and isinstance(custom_data, dict):
+        custom_file_ids = custom_data.get("file_ids")
+        custom_data = None
+
+    custom_args = {
+        k: v
+        for k, v in (tool_call.tool_call_arguments or {}).items()
+        if k != "requestBody"
+    }
+    return create_custom_tool_packets(
+        tool_name=tool.display_name or tool.name,
+        response_type=custom_response_type,
+        turn_index=turn_index,
+        tab_index=tool_call.tab_index,
+        data=custom_data,
+        file_ids=custom_file_ids,
+        error=custom_error,
+        tool_args=custom_args if custom_args else None,
+        tool_id=tool_call.tool_id,
+    )
+
+
+def _create_tool_call_packets(
+    tool: Tool, tool_call: ToolCall, turn_index: int
+) -> list[Packet]:
+    """Rebuild the replay packets for a single saved tool call."""
+    tab_index = tool_call.tab_index
+
+    if tool.in_code_tool_id in [SearchTool.__name__, WebSearchTool.__name__]:
+        queries = cast(list[str], tool_call.tool_call_arguments.get("queries", []))
+        search_docs: list[SavedSearchDoc] = [
+            translate_db_search_doc_to_saved_search_doc(doc)
+            for doc in tool_call.search_docs
+        ]
+        return create_search_packets(
+            search_queries=queries,
+            search_docs=search_docs,
+            is_internet_search=tool.in_code_tool_id == WebSearchTool.__name__,
+            turn_index=turn_index,
+            tab_index=tab_index,
+        )
+
+    if tool.in_code_tool_id == OpenURLTool.__name__:
+        fetch_docs: list[SavedSearchDoc] = [
+            translate_db_search_doc_to_saved_search_doc(doc)
+            for doc in tool_call.search_docs
+        ]
+        # Get URLs from tool_call_arguments
+        urls = cast(list[str], tool_call.tool_call_arguments.get("urls", []))
+        return create_fetch_packets(fetch_docs, urls, turn_index, tab_index=tab_index)
+
+    if tool.in_code_tool_id == ImageGenerationTool.__name__:
+        if not tool_call.generated_images:
+            return []
+        images = [GeneratedImage(**img) for img in tool_call.generated_images]
+        return create_image_generation_packets(images, turn_index, tab_index=tab_index)
+
+    if tool.in_code_tool_id == FileReaderTool.__name__:
+        return create_file_reader_packets(
+            summary_json=tool_call.tool_call_response or "",
+            turn_index=turn_index,
+            tab_index=tab_index,
+        )
+
+    if tool.in_code_tool_id == RESEARCH_AGENT_IN_CODE_ID:
+        # Not ideal but not a huge issue if the research task is lost.
+        research_task = cast(
+            str,
+            tool_call.tool_call_arguments.get(RESEARCH_AGENT_TASK_KEY)
+            or "Could not fetch saved research task.",
+        )
+        return create_research_agent_packets(
+            research_task=research_task,
+            report_content=tool_call.tool_call_response,
+            turn_index=turn_index,
+            tab_index=tab_index,
+        )
+
+    if tool.in_code_tool_id == CodingAgentTool.__name__:
+        coding_query = cast(
+            str, tool_call.tool_call_arguments.get(CODING_AGENT_QUERY_KEY) or ""
+        )
+        coding_repo = cast(
+            str, tool_call.tool_call_arguments.get(CODING_AGENT_REPO_KEY) or ""
+        )
+        return create_coding_agent_packets(
+            query=coding_query,
+            repo=coding_repo,
+            answer=tool_call.tool_call_response,
+            turn_index=turn_index,
+            tab_index=tab_index,
+        )
+
+    if tool.in_code_tool_id == MemoryTool.__name__:
+        if not tool_call.tool_call_response:
+            return []
+        memory_data = json.loads(tool_call.tool_call_response)
+        return create_memory_packets(
+            memory_text=memory_data["memory_text"],
+            operation=cast(Literal["add", "update"], memory_data["operation"]),
+            memory_id=memory_data.get("memory_id"),
+            turn_index=turn_index,
+            tab_index=tab_index,
+            index=memory_data.get("index"),
+        )
+
+    if tool.in_code_tool_id == PythonTool.__name__:
+        return _create_python_tool_call_packets(tool_call, turn_index)
+
+    return _create_custom_tool_call_packets(tool, tool_call, turn_index)
+
+
+def _create_all_tool_call_packets(
+    tool_calls: list[ToolCall],
+    db_session: Session,
+) -> list[Packet]:
+    """Replay every tool call turn in order, with the pre-tool reasoning."""
+    packet_list: list[Packet] = []
+    tool_calls_by_turn = _group_tool_calls_by_turn(tool_calls)
+    tool_call_turns = set(tool_calls_by_turn.keys())
+
+    # Process each turn in order
+    for turn_num in sorted(tool_calls_by_turn.keys()):
+        tool_calls_in_turn = tool_calls_by_turn[turn_num]
+
+        # Insert pre-tool reasoning once per turn (if available)
+        turn_reasoning = next(
+            (
+                tool_call.reasoning_tokens
+                for tool_call in tool_calls_in_turn
+                if tool_call.reasoning_tokens
+            ),
+            None,
+        )
+        if turn_reasoning:
+            # Use the previous turn slot when free to preserve reasoning-before-tool ordering.
+            reasoning_turn_index = turn_num
+            if turn_num > 0 and (turn_num - 1) not in tool_call_turns:
+                reasoning_turn_index = turn_num - 1
+            packet_list.extend(
+                create_reasoning_packets(
+                    reasoning_text=turn_reasoning,
+                    turn_index=reasoning_turn_index,
+                )
+            )
+
+        # Process each tool call in this turn (single pass).
+        # We buffer packets for the turn so we can conditionally prepend a TopLevelBranching
+        # packet (which must appear before any tool output in the turn).
+        research_agent_count = 0
+        turn_tool_packets: list[Packet] = []
+        for tool_call in tool_calls_in_turn:
+            # Here we do a try because some tools may get deleted before the session is reloaded.
+            try:
+                tool = get_tool_by_id(tool_call.tool_id, db_session)
+                if tool.in_code_tool_id == RESEARCH_AGENT_IN_CODE_ID:
+                    research_agent_count += 1
+
+                turn_tool_packets.extend(
+                    _create_tool_call_packets(tool, tool_call, turn_num)
+                )
+            except Exception as e:
+                logger.warning("Error processing tool call %s: %s", tool_call.id, e)
+                continue
+
+        if research_agent_count > 1:
+            # Emit TopLevelBranching before processing any tool output in the turn.
+            packet_list.append(
+                Packet(
+                    placement=Placement(turn_index=turn_num),
+                    obj=TopLevelBranching(num_parallel_branches=research_agent_count),
+                )
+            )
+        packet_list.extend(turn_tool_packets)
+
+    return packet_list
+
+
+def _create_citation_info_list(
+    chat_message: ChatMessage,
+    db_session: Session,
+) -> list[CitationInfo]:
+    """Build the message citations, ordered by first appearance in the text."""
+    citations = chat_message.citations
+    if not citations:
+        return []
+
+    citation_info_list: list[CitationInfo] = []
+    for citation_num, search_doc_id in citations.items():
+        search_doc = get_db_search_doc_by_id(search_doc_id, db_session)
+        if search_doc:
+            citation_info_list.append(
+                CitationInfo(
+                    citation_number=citation_num,
+                    document_id=search_doc.document_id,
+                )
+            )
+
+    # Sort citations by order of appearance in message text
+    citation_order = extract_citation_order_from_text(chat_message.message or "")
+    order_map = {num: idx for idx, num in enumerate(citation_order)}
+    citation_info_list.sort(
+        key=lambda c: order_map.get(c.citation_number, float("inf"))
+    )
+
+    return citation_info_list
+
+
+def _compute_final_turn_index(
+    chat_message: ChatMessage,
+    message_turn_index: int,
+    citation_turn_index: int,
+    has_citations: bool,
+) -> int:
+    """Return the highest turn_index used by the message's packets."""
+    max_tool_turn = 0
+    if chat_message.tool_calls:
+        max_tool_turn = max(tc.turn_number for tc in chat_message.tool_calls)
+
+    final_turn_index = max_tool_turn
+    if chat_message.reasoning_tokens:
+        final_turn_index = max(final_turn_index, max_tool_turn + 1)
+    if chat_message.message:
+        final_turn_index = max(final_turn_index, message_turn_index)
+    if has_citations:
+        final_turn_index = max(final_turn_index, citation_turn_index)
+
+    return final_turn_index
+
+
+def _determine_stop_reason(message: str | None) -> str | None:
+    """Report a user cancellation when the saved message says so."""
+    if message and "generation was stopped" in message.lower():
+        return "user_cancelled"
+    return None
+
+
 def translate_assistant_message_to_packets(
     chat_message: ChatMessage,
     db_session: Session,
@@ -535,305 +835,20 @@ def translate_assistant_message_to_packets(
     It needs to be a list of list of packets combined into indices for "steps".
     The final answer and citations are also a "step".
     """
-    packet_list: list[Packet] = []
-
     if chat_message.message_type != MessageType.ASSISTANT:
         raise ValueError(f"Chat message {chat_message.id} is not an assistant message")
 
-    if chat_message.tool_calls:
-        # Group tool calls by turn_number
-        tool_calls_by_turn: dict[int, list] = {}
-        for tool_call in chat_message.tool_calls:
-            turn_num = tool_call.turn_number
-            if turn_num not in tool_calls_by_turn:
-                tool_calls_by_turn[turn_num] = []
-            tool_calls_by_turn[turn_num].append(tool_call)
+    packet_list: list[Packet] = []
 
-        tool_call_turns = set(tool_calls_by_turn.keys())
-        # Process each turn in order
-        for turn_num in sorted(tool_calls_by_turn.keys()):
-            tool_calls_in_turn = tool_calls_by_turn[turn_num]
-
-            # Insert pre-tool reasoning once per turn (if available)
-            turn_reasoning = next(
-                (
-                    tool_call.reasoning_tokens
-                    for tool_call in tool_calls_in_turn
-                    if tool_call.reasoning_tokens
-                ),
-                None,
-            )
-            if turn_reasoning:
-                # Use the previous turn slot when free to preserve reasoning-before-tool ordering.
-                reasoning_turn_index = turn_num
-                if turn_num > 0 and (turn_num - 1) not in tool_call_turns:
-                    reasoning_turn_index = turn_num - 1
-                packet_list.extend(
-                    create_reasoning_packets(
-                        reasoning_text=turn_reasoning,
-                        turn_index=reasoning_turn_index,
-                    )
-                )
-
-            # Process each tool call in this turn (single pass).
-            # We buffer packets for the turn so we can conditionally prepend a TopLevelBranching
-            # packet (which must appear before any tool output in the turn).
-            research_agent_count = 0
-            turn_tool_packets: list[Packet] = []
-            for tool_call in tool_calls_in_turn:
-                # Here we do a try because some tools may get deleted before the session is reloaded.
-                try:
-                    tool = get_tool_by_id(tool_call.tool_id, db_session)
-                    if tool.in_code_tool_id == RESEARCH_AGENT_IN_CODE_ID:
-                        research_agent_count += 1
-
-                    # Handle different tool types
-                    if tool.in_code_tool_id in [
-                        SearchTool.__name__,
-                        WebSearchTool.__name__,
-                    ]:
-                        queries = cast(
-                            list[str], tool_call.tool_call_arguments.get("queries", [])
-                        )
-                        search_docs: list[SavedSearchDoc] = [
-                            translate_db_search_doc_to_saved_search_doc(doc)
-                            for doc in tool_call.search_docs
-                        ]
-                        turn_tool_packets.extend(
-                            create_search_packets(
-                                search_queries=queries,
-                                search_docs=search_docs,
-                                is_internet_search=tool.in_code_tool_id
-                                == WebSearchTool.__name__,
-                                turn_index=turn_num,
-                                tab_index=tool_call.tab_index,
-                            )
-                        )
-
-                    elif tool.in_code_tool_id == OpenURLTool.__name__:
-                        fetch_docs: list[SavedSearchDoc] = [
-                            translate_db_search_doc_to_saved_search_doc(doc)
-                            for doc in tool_call.search_docs
-                        ]
-                        # Get URLs from tool_call_arguments
-                        urls = cast(
-                            list[str], tool_call.tool_call_arguments.get("urls", [])
-                        )
-                        turn_tool_packets.extend(
-                            create_fetch_packets(
-                                fetch_docs,
-                                urls,
-                                turn_num,
-                                tab_index=tool_call.tab_index,
-                            )
-                        )
-
-                    elif tool.in_code_tool_id == ImageGenerationTool.__name__:
-                        if tool_call.generated_images:
-                            images = [
-                                GeneratedImage(**img)
-                                for img in tool_call.generated_images
-                            ]
-                            turn_tool_packets.extend(
-                                create_image_generation_packets(
-                                    images, turn_num, tab_index=tool_call.tab_index
-                                )
-                            )
-
-                    elif tool.in_code_tool_id == FileReaderTool.__name__:
-                        turn_tool_packets.extend(
-                            create_file_reader_packets(
-                                summary_json=tool_call.tool_call_response or "",
-                                turn_index=turn_num,
-                                tab_index=tool_call.tab_index,
-                            )
-                        )
-
-                    elif tool.in_code_tool_id == RESEARCH_AGENT_IN_CODE_ID:
-                        # Not ideal but not a huge issue if the research task is lost.
-                        research_task = cast(
-                            str,
-                            tool_call.tool_call_arguments.get(RESEARCH_AGENT_TASK_KEY)
-                            or "Could not fetch saved research task.",
-                        )
-                        turn_tool_packets.extend(
-                            create_research_agent_packets(
-                                research_task=research_task,
-                                report_content=tool_call.tool_call_response,
-                                turn_index=turn_num,
-                                tab_index=tool_call.tab_index,
-                            )
-                        )
-
-                    elif tool.in_code_tool_id == CodingAgentTool.__name__:
-                        coding_query = cast(
-                            str,
-                            tool_call.tool_call_arguments.get(CODING_AGENT_QUERY_KEY)
-                            or "",
-                        )
-                        coding_repo = cast(
-                            str,
-                            tool_call.tool_call_arguments.get(CODING_AGENT_REPO_KEY)
-                            or "",
-                        )
-                        turn_tool_packets.extend(
-                            create_coding_agent_packets(
-                                query=coding_query,
-                                repo=coding_repo,
-                                answer=tool_call.tool_call_response,
-                                turn_index=turn_num,
-                                tab_index=tool_call.tab_index,
-                            )
-                        )
-
-                    elif tool.in_code_tool_id == MemoryTool.__name__:
-                        if tool_call.tool_call_response:
-                            memory_data = json.loads(tool_call.tool_call_response)
-                            turn_tool_packets.extend(
-                                create_memory_packets(
-                                    memory_text=memory_data["memory_text"],
-                                    operation=cast(
-                                        Literal["add", "update"],
-                                        memory_data["operation"],
-                                    ),
-                                    memory_id=memory_data.get("memory_id"),
-                                    turn_index=turn_num,
-                                    tab_index=tool_call.tab_index,
-                                    index=memory_data.get("index"),
-                                )
-                            )
-
-                    elif tool.in_code_tool_id == PythonTool.__name__:
-                        code = cast(
-                            str,
-                            tool_call.tool_call_arguments.get("code", ""),
-                        )
-                        stdout = ""
-                        stderr = ""
-                        file_ids: list[str] = []
-                        if tool_call.tool_call_response:
-                            try:
-                                response_data = json.loads(tool_call.tool_call_response)
-                                stdout = response_data.get("stdout", "")
-                                stderr = response_data.get("stderr", "")
-                                generated_files = response_data.get(
-                                    "generated_files", []
-                                )
-                                file_ids = [
-                                    f.get("file_link", "").split("/")[-1]
-                                    for f in generated_files
-                                    if f.get("file_link")
-                                ]
-                            except (json.JSONDecodeError, KeyError):
-                                # Fall back to raw response as stdout
-                                stdout = tool_call.tool_call_response
-                        turn_tool_packets.extend(
-                            create_python_tool_packets(
-                                code=code,
-                                stdout=stdout,
-                                stderr=stderr,
-                                file_ids=file_ids,
-                                turn_index=turn_num,
-                                tab_index=tool_call.tab_index,
-                            )
-                        )
-
-                    else:
-                        # Custom tool or unknown tool
-                        # Try to parse as structured CustomToolCallSummary JSON
-                        custom_data: dict | list | str | int | float | bool | None = (
-                            tool_call.tool_call_response
-                        )
-                        custom_error: CustomToolErrorInfo | None = None
-                        custom_response_type = "text"
-
-                        try:
-                            parsed = json.loads(tool_call.tool_call_response)
-                            if isinstance(parsed, dict) and "tool_name" in parsed:
-                                custom_data = parsed.get("tool_result")
-                                custom_response_type = parsed.get(
-                                    "response_type", "text"
-                                )
-                                if parsed.get("error"):
-                                    custom_error = CustomToolErrorInfo(
-                                        **parsed["error"]
-                                    )
-                        except (
-                            json.JSONDecodeError,
-                            KeyError,
-                            TypeError,
-                            ValidationError,
-                        ):
-                            pass
-
-                        custom_file_ids: list[str] | None = None
-                        if custom_response_type in ("image", "csv") and isinstance(
-                            custom_data, dict
-                        ):
-                            custom_file_ids = custom_data.get("file_ids")
-                            custom_data = None
-
-                        custom_args = {
-                            k: v
-                            for k, v in (tool_call.tool_call_arguments or {}).items()
-                            if k != "requestBody"
-                        }
-                        turn_tool_packets.extend(
-                            create_custom_tool_packets(
-                                tool_name=tool.display_name or tool.name,
-                                response_type=custom_response_type,
-                                turn_index=turn_num,
-                                tab_index=tool_call.tab_index,
-                                data=custom_data,
-                                file_ids=custom_file_ids,
-                                error=custom_error,
-                                tool_args=custom_args if custom_args else None,
-                                tool_id=tool_call.tool_id,
-                            )
-                        )
-
-                except Exception as e:
-                    logger.warning("Error processing tool call %s: %s", tool_call.id, e)
-                    continue
-
-            if research_agent_count > 1:
-                # Emit TopLevelBranching before processing any tool output in the turn.
-                packet_list.append(
-                    Packet(
-                        placement=Placement(turn_index=turn_num),
-                        obj=TopLevelBranching(
-                            num_parallel_branches=research_agent_count
-                        ),
-                    )
-                )
-            packet_list.extend(turn_tool_packets)
-
-    # Determine the next turn_index for the final message
-    # It should come after all tool calls
+    # The final message comes after all tool calls, so track the last tool turn.
     max_tool_turn = 0
     if chat_message.tool_calls:
+        packet_list.extend(
+            _create_all_tool_call_packets(chat_message.tool_calls, db_session)
+        )
         max_tool_turn = max(tc.turn_number for tc in chat_message.tool_calls)
 
-    citations = chat_message.citations
-    citation_info_list: list[CitationInfo] = []
-
-    if citations:
-        for citation_num, search_doc_id in citations.items():
-            search_doc = get_db_search_doc_by_id(search_doc_id, db_session)
-            if search_doc:
-                citation_info_list.append(
-                    CitationInfo(
-                        citation_number=citation_num,
-                        document_id=search_doc.document_id,
-                    )
-                )
-
-        # Sort citations by order of appearance in message text
-        citation_order = extract_citation_order_from_text(chat_message.message or "")
-        order_map = {num: idx for idx, num in enumerate(citation_order)}
-        citation_info_list.sort(
-            key=lambda c: order_map.get(c.citation_number, float("inf"))
-        )
+    citation_info_list = _create_citation_info_list(chat_message, db_session)
 
     # Message comes after tool calls, with optional reasoning step beforehand
     message_turn_index = max_tool_turn + 1
@@ -863,37 +878,23 @@ def translate_assistant_message_to_packets(
         message_turn_index + 1 if citation_info_list else message_turn_index
     )
 
-    if len(citation_info_list) > 0:
+    if citation_info_list:
         packet_list.extend(
             create_citation_packets(citation_info_list, citation_turn_index)
         )
 
-    # Return the highest turn_index used
-    final_turn_index = 0
-    if chat_message.message_type == MessageType.ASSISTANT:
-        max_tool_turn = 0
-        if chat_message.tool_calls:
-            max_tool_turn = max(tc.turn_number for tc in chat_message.tool_calls)
-
-        final_turn_index = max_tool_turn
-        if chat_message.reasoning_tokens:
-            final_turn_index = max(final_turn_index, max_tool_turn + 1)
-        if chat_message.message:
-            final_turn_index = max(final_turn_index, message_turn_index)
-        if citation_info_list:
-            final_turn_index = max(final_turn_index, citation_turn_index)
-
-    # Determine stop reason - check if message indicates user cancelled
-    stop_reason: str | None = None
-    if chat_message.message:
-        if "generation was stopped" in chat_message.message.lower():
-            stop_reason = "user_cancelled"
-
     # Add overall stop packet at the end
     packet_list.append(
         Packet(
-            placement=Placement(turn_index=final_turn_index),
-            obj=OverallStop(stop_reason=stop_reason),
+            placement=Placement(
+                turn_index=_compute_final_turn_index(
+                    chat_message=chat_message,
+                    message_turn_index=message_turn_index,
+                    citation_turn_index=citation_turn_index,
+                    has_citations=bool(citation_info_list),
+                )
+            ),
+            obj=OverallStop(stop_reason=_determine_stop_reason(chat_message.message)),
         )
     )
 

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from collections.abc import Sequence
-from typing import cast
+from dataclasses import dataclass
+from typing import Any, cast
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -22,6 +23,7 @@ from onyx.db.oauth_config import get_oauth_config
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.tools import get_builtin_tool
 from onyx.document_index.factory import get_default_document_index
+from onyx.document_index.interfaces_new import DocumentIndex
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.llm.interfaces import LLM, LLMConfig
 from onyx.onyxbot.slack.models import SlackContext
@@ -29,7 +31,7 @@ from onyx.server.features.mcp.credentials import (
     MCPCredentialsError,
     resolve_mcp_credentials,
 )
-from onyx.tools.built_in_tools import get_built_in_tool_by_id
+from onyx.tools.built_in_tools import BUILT_IN_TOOL_TYPES, get_built_in_tool_by_id
 from onyx.tools.interface import Tool
 from onyx.tools.models import DynamicSchemaInfo, SearchToolUsage
 from onyx.tools.tool_implementations.coding_agent.coding_agent_tool import (
@@ -140,6 +142,295 @@ def should_disable_open_url_web_fetch(
     )
 
 
+@dataclass(frozen=True)
+class _ToolBuildContext:
+    """Inputs shared by every per-tool builder below."""
+
+    persona: Persona
+    db_session: Session
+    emitter: Emitter
+    user: User
+    llm: LLM
+    document_index: DocumentIndex
+    search_tool_config: SearchToolConfig
+    custom_tool_config: CustomToolConfig
+    file_reader_tool_config: FileReaderToolConfig
+    open_url_web_fetch_disabled: bool
+    search_usage_forcing_setting: SearchToolUsage
+    user_oauth_token: str | None
+
+
+def _is_tool_available(
+    tool_cls: type[BUILT_IN_TOOL_TYPES], db_session: Session
+) -> bool:
+    try:
+        return tool_cls.is_available(db_session)
+    except Exception:
+        logger.exception("Failed checking availability for tool %s", tool_cls.__name__)
+        return False
+
+
+def _build_search_tool(tool_id: int, ctx: _ToolBuildContext) -> SearchTool:
+    persona = ctx.persona
+    persona_search_info = PersonaSearchInfo(
+        document_set_names=[ds.name for ds in persona.document_sets],
+        search_start_date=persona.search_start_date,
+        attached_document_ids=[doc.id for doc in persona.attached_documents],
+        hierarchy_node_ids=[node.id for node in persona.hierarchy_nodes],
+    )
+    config = ctx.search_tool_config
+    return SearchTool(
+        tool_id=tool_id,
+        emitter=ctx.emitter,
+        user=ctx.user,
+        persona_search_info=persona_search_info,
+        llm=ctx.llm,
+        document_index=ctx.document_index,
+        user_selected_filters=config.user_selected_filters,
+        project_id_filter=config.project_id_filter,
+        persona_id_filter=config.persona_id_filter,
+        bypass_acl=config.bypass_acl,
+        slack_context=config.slack_context,
+        enable_slack_search=config.enable_slack_search,
+        auto_detect_filters=config.auto_detect_filters,
+    )
+
+
+def _build_image_generation_tool(
+    tool_id: int, ctx: _ToolBuildContext
+) -> ImageGenerationTool:
+    img_generation_llm_config = _get_image_generation_config(ctx.llm, ctx.db_session)
+    return ImageGenerationTool(
+        image_generation_credentials=ImageGenerationProviderCredentials(
+            api_key=cast(str, img_generation_llm_config.api_key),
+            api_base=img_generation_llm_config.api_base,
+            api_version=img_generation_llm_config.api_version,
+            deployment_name=(
+                img_generation_llm_config.deployment_name
+                or img_generation_llm_config.model_name
+            ),
+            custom_config=img_generation_llm_config.custom_config,
+        ),
+        provider=img_generation_llm_config.model_provider,
+        model=img_generation_llm_config.model_name,
+        tool_id=tool_id,
+        emitter=ctx.emitter,
+    )
+
+
+def _build_web_search_tool(tool_id: int, ctx: _ToolBuildContext) -> WebSearchTool:
+    try:
+        return WebSearchTool(tool_id=tool_id, emitter=ctx.emitter)
+    except ValueError as e:
+        logger.error("Failed to initialize Internet Search Tool: %s", e)
+        raise ValueError(
+            "Internet search tool requires a search provider API key, please contact your Onyx admin to get it added!"
+        )
+
+
+def _build_open_url_tool(tool_id: int, ctx: _ToolBuildContext) -> OpenURLTool | None:
+    if ctx.open_url_web_fetch_disabled and DISABLE_VECTOR_DB:
+        # Without an index, open_url can serve nothing once web
+        # fetching is off (crawl-only deployments).
+        logger.debug(
+            "Skipping OpenURLTool: WebSearchTool is excluded for "
+            "this message and no document index is available"
+        )
+        return None
+    try:
+        return OpenURLTool(
+            tool_id=tool_id,
+            emitter=ctx.emitter,
+            document_index=ctx.document_index,
+            user=ctx.user,
+            web_fetch_disabled=ctx.open_url_web_fetch_disabled,
+        )
+    except RuntimeError as e:
+        logger.error("Failed to initialize Open URL Tool: %s", e)
+        raise ValueError(
+            "Open URL tool requires a web content provider, please contact your Onyx admin to get it configured!"
+        )
+
+
+def _build_in_code_tools(
+    tool_cls: type[BUILT_IN_TOOL_TYPES], tool_id: int, ctx: _ToolBuildContext
+) -> list[Tool] | None:
+    """Build the instances for one built-in tool. None means skip the tool."""
+    tool_name = tool_cls.__name__
+
+    if tool_name == SearchTool.__name__:
+        if ctx.search_usage_forcing_setting == SearchToolUsage.DISABLED:
+            return None
+        return [_build_search_tool(tool_id, ctx)]
+
+    if tool_name == ImageGenerationTool.__name__:
+        return [_build_image_generation_tool(tool_id, ctx)]
+
+    if tool_name == WebSearchTool.__name__:
+        return [_build_web_search_tool(tool_id, ctx)]
+
+    if tool_name == OpenURLTool.__name__:
+        open_url_tool = _build_open_url_tool(tool_id, ctx)
+        return None if open_url_tool is None else [open_url_tool]
+
+    if tool_name == PythonTool.__name__:
+        return [PythonTool(tool_id=tool_id, emitter=ctx.emitter)]
+
+    if tool_name == CodingAgentTool.__name__:
+        return [CodingAgentTool(tool_id=tool_id, emitter=ctx.emitter, llm=ctx.llm)]
+
+    if tool_name == FileReaderTool.__name__:
+        cfg = ctx.file_reader_tool_config
+        return [
+            FileReaderTool(
+                tool_id=tool_id,
+                emitter=ctx.emitter,
+                user_file_ids=cfg.user_file_ids,
+                chat_file_ids=cfg.chat_file_ids,
+            )
+        ]
+
+    # Handle KG Tool
+    # TODO: disabling for now because it's broken in the refactor
+    # if tool_name == KnowledgeGraphTool.__name__:
+
+    #     # skip the knowledge graph tool if KG is not enabled/exposed
+    #     kg_config = get_kg_config_settings()
+    #     if not kg_config.KG_ENABLED or not kg_config.KG_EXPOSED:
+    #         logger.debug("Knowledge Graph Tool is not enabled/exposed")
+    #         return None
+
+    #     if ctx.persona.name != TMP_DRALPHA_PERSONA_NAME:
+    #         # TODO: remove this after the beta period
+    #         raise ValueError(
+    #             f"The Knowledge Graph Tool should only be used by the '{TMP_DRALPHA_PERSONA_NAME}' Agent."
+    #         )
+    #     return [KnowledgeGraphTool(tool_id=tool_id)]
+
+    return None
+
+
+def _build_custom_tools(
+    db_tool_model: ToolDBModel,
+    openapi_schema: dict[str, Any],
+    ctx: _ToolBuildContext,
+) -> list[Tool] | None:
+    """Build the tools of one OpenAPI-schema tool. None means skip the tool."""
+    user = ctx.user
+    custom_tool_config = ctx.custom_tool_config
+
+    # Determine which OAuth token to use
+    oauth_token_for_tool = None
+
+    # Priority 1: OAuth config (per-tool OAuth)
+    if db_tool_model.oauth_config_id:
+        if user.is_anonymous:
+            logger.warning("Anonymous user cannot use OAuth tool %s", db_tool_model.id)
+            return None
+        oauth_config = get_oauth_config(db_tool_model.oauth_config_id, ctx.db_session)
+        if oauth_config:
+            token_manager = OAuthTokenManager(oauth_config, user.id, ctx.db_session)
+            oauth_token_for_tool = token_manager.get_valid_access_token()
+            if not oauth_token_for_tool:
+                logger.warning(
+                    "No valid OAuth token found for tool %s with OAuth config %s",
+                    db_tool_model.id,
+                    db_tool_model.oauth_config_id,
+                )
+
+    # Priority 2: Passthrough auth (user's login OAuth token)
+    elif db_tool_model.passthrough_auth:
+        if user.is_anonymous:
+            logger.warning(
+                "Anonymous user cannot use passthrough auth tool %s",
+                db_tool_model.id,
+            )
+            return None
+        oauth_token_for_tool = ctx.user_oauth_token
+
+    return cast(
+        list[Tool],
+        build_custom_tools_from_openapi_schema_and_headers(
+            tool_id=db_tool_model.id,
+            openapi_schema=openapi_schema,
+            emitter=ctx.emitter,
+            dynamic_schema_info=DynamicSchemaInfo(
+                chat_session_id=custom_tool_config.chat_session_id,
+                message_id=custom_tool_config.message_id,
+                user_id=user.id,
+                user_email="anonymous" if user.is_anonymous else user.email,
+            ),
+            custom_headers=(db_tool_model.custom_headers or [])
+            + (header_dict_to_header_list(custom_tool_config.additional_headers or {})),
+            user_oauth_token=oauth_token_for_tool,
+        ),
+    )
+
+
+def _add_mcp_tools(
+    db_tool_model: ToolDBModel,
+    mcp_server_id: int,
+    tool_dict: dict[int, list[Tool]],
+    mcp_tool_cache: dict[int, dict[int, MCPTool]],
+    ctx: _ToolBuildContext,
+) -> None:
+    """Add the MCP tool for ``db_tool_model`` to ``tool_dict``.
+
+    Every tool of the same MCP server is built once and kept in
+    ``mcp_tool_cache`` for the later tools of that server.
+    """
+    if mcp_server_id in mcp_tool_cache:
+        tool_dict[db_tool_model.id] = [mcp_tool_cache[mcp_server_id][db_tool_model.id]]
+        return
+
+    mcp_server = get_mcp_server_by_id(mcp_server_id, ctx.db_session)
+
+    try:
+        mcp_credentials = resolve_mcp_credentials(mcp_server, ctx.user, ctx.db_session)
+    except MCPCredentialsError as e:
+        logger.warning(str(e))
+        return
+
+    # Get all saved tools for this MCP server
+    saved_tools = get_all_mcp_tools_for_server(mcp_server.id, ctx.db_session)
+
+    # Find the specific tool that this database entry represents
+    expected_tool_name = db_tool_model.display_name
+
+    # Extract additional MCP headers from config
+    additional_mcp_headers = ctx.custom_tool_config.mcp_headers or None
+
+    mcp_tool_cache[mcp_server_id] = {}
+    # Find the matching tool definition
+    for saved_tool in saved_tools:
+        # Create MCPTool instance for this specific tool
+        mcp_tool = MCPTool(
+            tool_id=saved_tool.id,
+            emitter=ctx.emitter,
+            mcp_server=mcp_server,
+            tool_name=saved_tool.name,
+            tool_description=saved_tool.description,
+            tool_definition=saved_tool.mcp_input_schema or {},
+            connection_config=mcp_credentials.connection_config,
+            user_email=ctx.user.email,
+            user_id=str(ctx.user.id),
+            user_oauth_token=mcp_credentials.user_oauth_token,
+            additional_headers=additional_mcp_headers,
+            resolved_credentials=mcp_credentials,
+        )
+        mcp_tool_cache[mcp_server_id][saved_tool.id] = mcp_tool
+
+        if saved_tool.id == db_tool_model.id:
+            tool_dict[saved_tool.id] = [cast(Tool, mcp_tool)]
+
+    if db_tool_model.id not in tool_dict:
+        logger.warning(
+            "Tool '%s' not found in MCP server '%s'",
+            expected_tool_name,
+            mcp_server.name,
+        )
+
+
 def construct_tools(
     persona: Persona,
     emitter: Emitter,
@@ -200,39 +491,29 @@ def _construct_tools_impl(
 
     mcp_tool_cache: dict[int, dict[int, MCPTool]] = {}
     # Get user's OAuth token if available
-    user_oauth_token = None
-    if user.oauth_accounts:
-        user_oauth_token = user.oauth_accounts[0].access_token
+    user_oauth_token = (
+        user.oauth_accounts[0].access_token if user.oauth_accounts else None
+    )
 
     search_settings = get_current_search_settings(db_session)
     # This flow is for search so we do not get all indices.
     document_index = get_default_document_index(search_settings, None, db_session)
 
-    def _build_search_tool(tool_id: int, config: SearchToolConfig) -> SearchTool:
-        persona_search_info = PersonaSearchInfo(
-            document_set_names=[ds.name for ds in persona.document_sets],
-            search_start_date=persona.search_start_date,
-            attached_document_ids=[doc.id for doc in persona.attached_documents],
-            hierarchy_node_ids=[node.id for node in persona.hierarchy_nodes],
-        )
-        return SearchTool(
-            tool_id=tool_id,
-            emitter=emitter,
-            user=user,
-            persona_search_info=persona_search_info,
-            llm=llm,
-            document_index=document_index,
-            user_selected_filters=config.user_selected_filters,
-            project_id_filter=config.project_id_filter,
-            persona_id_filter=config.persona_id_filter,
-            bypass_acl=config.bypass_acl,
-            slack_context=config.slack_context,
-            enable_slack_search=config.enable_slack_search,
-            auto_detect_filters=config.auto_detect_filters,
-        )
-
-    open_url_web_fetch_disabled = should_disable_open_url_web_fetch(
-        persona.tools, allowed_tool_ids
+    ctx = _ToolBuildContext(
+        persona=persona,
+        db_session=db_session,
+        emitter=emitter,
+        user=user,
+        llm=llm,
+        document_index=document_index,
+        search_tool_config=search_tool_config or SearchToolConfig(),
+        custom_tool_config=custom_tool_config or CustomToolConfig(),
+        file_reader_tool_config=file_reader_tool_config or FileReaderToolConfig(),
+        open_url_web_fetch_disabled=should_disable_open_url_web_fetch(
+            persona.tools, allowed_tool_ids
+        ),
+        search_usage_forcing_setting=search_usage_forcing_setting,
+        user_oauth_token=user_oauth_token,
     )
 
     added_search_tool = False
@@ -241,262 +522,41 @@ def _construct_tools_impl(
         if allowed_tool_ids is not None and db_tool_model.id not in allowed_tool_ids:
             continue
 
+        built_tools: list[Tool] | None = None
+
+        # Handle built-in tools
         if db_tool_model.in_code_tool_id:
             tool_cls = get_built_in_tool_by_id(db_tool_model.in_code_tool_id)
-
-            try:
-                tool_is_available = tool_cls.is_available(db_session)
-            except Exception:
-                logger.exception(
-                    "Failed checking availability for tool %s", tool_cls.__name__
-                )
-                tool_is_available = False
-
-            if not tool_is_available:
+            if not _is_tool_available(tool_cls, db_session):
                 logger.debug(
                     "Skipping tool %s because it is not available",
                     tool_cls.__name__,
                 )
                 continue
 
-            # Handle Internal Search Tool
-            if tool_cls.__name__ == SearchTool.__name__:
-                added_search_tool = True
-                if search_usage_forcing_setting == SearchToolUsage.DISABLED:
-                    continue
-
-                if not search_tool_config:
-                    search_tool_config = SearchToolConfig()
-
-                tool_dict[db_tool_model.id] = [
-                    _build_search_tool(db_tool_model.id, search_tool_config)
-                ]
-
-            # Handle Image Generation Tool
-            elif tool_cls.__name__ == ImageGenerationTool.__name__:
-                img_generation_llm_config = _get_image_generation_config(
-                    llm, db_session
-                )
-
-                tool_dict[db_tool_model.id] = [
-                    ImageGenerationTool(
-                        image_generation_credentials=ImageGenerationProviderCredentials(
-                            api_key=cast(str, img_generation_llm_config.api_key),
-                            api_base=img_generation_llm_config.api_base,
-                            api_version=img_generation_llm_config.api_version,
-                            deployment_name=(
-                                img_generation_llm_config.deployment_name
-                                or img_generation_llm_config.model_name
-                            ),
-                            custom_config=img_generation_llm_config.custom_config,
-                        ),
-                        provider=img_generation_llm_config.model_provider,
-                        model=img_generation_llm_config.model_name,
-                        tool_id=db_tool_model.id,
-                        emitter=emitter,
-                    )
-                ]
-
-            # Handle Web Search Tool
-            elif tool_cls.__name__ == WebSearchTool.__name__:
-                try:
-                    tool_dict[db_tool_model.id] = [
-                        WebSearchTool(tool_id=db_tool_model.id, emitter=emitter)
-                    ]
-                except ValueError as e:
-                    logger.error("Failed to initialize Internet Search Tool: %s", e)
-                    raise ValueError(
-                        "Internet search tool requires a search provider API key, please contact your Onyx admin to get it added!"
-                    )
-
-            # Handle Open URL Tool
-            elif tool_cls.__name__ == OpenURLTool.__name__:
-                if open_url_web_fetch_disabled and DISABLE_VECTOR_DB:
-                    # Without an index, open_url can serve nothing once web
-                    # fetching is off (crawl-only deployments).
-                    logger.debug(
-                        "Skipping OpenURLTool: WebSearchTool is excluded for "
-                        "this message and no document index is available"
-                    )
-                    continue
-                try:
-                    tool_dict[db_tool_model.id] = [
-                        OpenURLTool(
-                            tool_id=db_tool_model.id,
-                            emitter=emitter,
-                            document_index=document_index,
-                            user=user,
-                            web_fetch_disabled=open_url_web_fetch_disabled,
-                        )
-                    ]
-                except RuntimeError as e:
-                    logger.error("Failed to initialize Open URL Tool: %s", e)
-                    raise ValueError(
-                        "Open URL tool requires a web content provider, please contact your Onyx admin to get it configured!"
-                    )
-
-            # Handle Python/Code Interpreter Tool
-            elif tool_cls.__name__ == PythonTool.__name__:
-                tool_dict[db_tool_model.id] = [
-                    PythonTool(tool_id=db_tool_model.id, emitter=emitter)
-                ]
-
-            # Handle Coding Agent Tool
-            elif tool_cls.__name__ == CodingAgentTool.__name__:
-                tool_dict[db_tool_model.id] = [
-                    CodingAgentTool(
-                        tool_id=db_tool_model.id,
-                        emitter=emitter,
-                        llm=llm,
-                    )
-                ]
-
-            # Handle File Reader Tool
-            elif tool_cls.__name__ == FileReaderTool.__name__:
-                cfg = file_reader_tool_config or FileReaderToolConfig()
-                tool_dict[db_tool_model.id] = [
-                    FileReaderTool(
-                        tool_id=db_tool_model.id,
-                        emitter=emitter,
-                        user_file_ids=cfg.user_file_ids,
-                        chat_file_ids=cfg.chat_file_ids,
-                    )
-                ]
-
-            # Handle KG Tool
-            # TODO: disabling for now because it's broken in the refactor
-            # elif tool_cls.__name__ == KnowledgeGraphTool.__name__:
-
-            #     # skip the knowledge graph tool if KG is not enabled/exposed
-            #     kg_config = get_kg_config_settings()
-            #     if not kg_config.KG_ENABLED or not kg_config.KG_EXPOSED:
-            #         logger.debug("Knowledge Graph Tool is not enabled/exposed")
-            #         continue
-
-            #     if persona.name != TMP_DRALPHA_PERSONA_NAME:
-            #         # TODO: remove this after the beta period
-            #         raise ValueError(
-            #             f"The Knowledge Graph Tool should only be used by the '{TMP_DRALPHA_PERSONA_NAME}' Agent."
-            #         )
-            #     tool_dict[db_tool_model.id] = [
-            #         KnowledgeGraphTool(tool_id=db_tool_model.id)
-            #     ]
+            added_search_tool = (
+                added_search_tool or tool_cls.__name__ == SearchTool.__name__
+            )
+            built_tools = _build_in_code_tools(tool_cls, db_tool_model.id, ctx)
 
         # Handle custom tools
         elif db_tool_model.openapi_schema:
-            if not custom_tool_config:
-                custom_tool_config = CustomToolConfig()
-
-            # Determine which OAuth token to use
-            oauth_token_for_tool = None
-
-            # Priority 1: OAuth config (per-tool OAuth)
-            if db_tool_model.oauth_config_id:
-                if user.is_anonymous:
-                    logger.warning(
-                        "Anonymous user cannot use OAuth tool %s", db_tool_model.id
-                    )
-                    continue
-                oauth_config = get_oauth_config(
-                    db_tool_model.oauth_config_id, db_session
-                )
-                if oauth_config:
-                    token_manager = OAuthTokenManager(oauth_config, user.id, db_session)
-                    oauth_token_for_tool = token_manager.get_valid_access_token()
-                    if not oauth_token_for_tool:
-                        logger.warning(
-                            "No valid OAuth token found for tool %s with OAuth config %s",
-                            db_tool_model.id,
-                            db_tool_model.oauth_config_id,
-                        )
-
-            # Priority 2: Passthrough auth (user's login OAuth token)
-            elif db_tool_model.passthrough_auth:
-                if user.is_anonymous:
-                    logger.warning(
-                        "Anonymous user cannot use passthrough auth tool %s",
-                        db_tool_model.id,
-                    )
-                    continue
-                oauth_token_for_tool = user_oauth_token
-
-            tool_dict[db_tool_model.id] = cast(
-                list[Tool],
-                build_custom_tools_from_openapi_schema_and_headers(
-                    tool_id=db_tool_model.id,
-                    openapi_schema=db_tool_model.openapi_schema,
-                    emitter=emitter,
-                    dynamic_schema_info=DynamicSchemaInfo(
-                        chat_session_id=custom_tool_config.chat_session_id,
-                        message_id=custom_tool_config.message_id,
-                        user_id=user.id,
-                        user_email="anonymous" if user.is_anonymous else user.email,
-                    ),
-                    custom_headers=(db_tool_model.custom_headers or [])
-                    + (
-                        header_dict_to_header_list(
-                            custom_tool_config.additional_headers or {}
-                        )
-                    ),
-                    user_oauth_token=oauth_token_for_tool,
-                ),
+            built_tools = _build_custom_tools(
+                db_tool_model, db_tool_model.openapi_schema, ctx
             )
 
         # Handle MCP tools
         elif db_tool_model.mcp_server_id:
-            if db_tool_model.mcp_server_id in mcp_tool_cache:
-                tool_dict[db_tool_model.id] = [
-                    mcp_tool_cache[db_tool_model.mcp_server_id][db_tool_model.id]
-                ]
-                continue
+            _add_mcp_tools(
+                db_tool_model,
+                db_tool_model.mcp_server_id,
+                tool_dict,
+                mcp_tool_cache,
+                ctx,
+            )
 
-            mcp_server = get_mcp_server_by_id(db_tool_model.mcp_server_id, db_session)
-
-            try:
-                mcp_credentials = resolve_mcp_credentials(mcp_server, user, db_session)
-            except MCPCredentialsError as e:
-                logger.warning(str(e))
-                continue
-
-            # Get all saved tools for this MCP server
-            saved_tools = get_all_mcp_tools_for_server(mcp_server.id, db_session)
-
-            # Find the specific tool that this database entry represents
-            expected_tool_name = db_tool_model.display_name
-
-            # Extract additional MCP headers from config
-            additional_mcp_headers = None
-            if custom_tool_config and custom_tool_config.mcp_headers:
-                additional_mcp_headers = custom_tool_config.mcp_headers
-
-            mcp_tool_cache[db_tool_model.mcp_server_id] = {}
-            # Find the matching tool definition
-            for saved_tool in saved_tools:
-                # Create MCPTool instance for this specific tool
-                mcp_tool = MCPTool(
-                    tool_id=saved_tool.id,
-                    emitter=emitter,
-                    mcp_server=mcp_server,
-                    tool_name=saved_tool.name,
-                    tool_description=saved_tool.description,
-                    tool_definition=saved_tool.mcp_input_schema or {},
-                    connection_config=mcp_credentials.connection_config,
-                    user_email=user.email,
-                    user_id=str(user.id),
-                    user_oauth_token=mcp_credentials.user_oauth_token,
-                    additional_headers=additional_mcp_headers,
-                    resolved_credentials=mcp_credentials,
-                )
-                mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool
-
-                if saved_tool.id == db_tool_model.id:
-                    tool_dict[saved_tool.id] = [cast(Tool, mcp_tool)]
-            if db_tool_model.id not in tool_dict:
-                logger.warning(
-                    "Tool '%s' not found in MCP server '%s'",
-                    expected_tool_name,
-                    mcp_server.name,
-                )
+        if built_tools is not None:
+            tool_dict[db_tool_model.id] = built_tools
 
     if (
         not added_search_tool
@@ -506,11 +566,8 @@ def _construct_tools_impl(
         # Get the database tool model for SearchTool
         search_tool_db_model = get_builtin_tool(db_session, SearchTool)
 
-        if not search_tool_config:
-            search_tool_config = SearchToolConfig()
-
         tool_dict[search_tool_db_model.id] = [
-            _build_search_tool(search_tool_db_model.id, search_tool_config)
+            _build_search_tool(search_tool_db_model.id, ctx)
         ]
 
     # Always inject MemoryTool when the user has the memory tool enabled,

--- a/backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py
+++ b/backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py
@@ -194,101 +194,87 @@ def mark_tenant_connectors_for_deletion(
     )
 
 
-def main() -> None:
-    if len(sys.argv) < 2:
-        print(
-            "Usage: python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py <tenant_id> [--force] [--concurrency N]"
-        )
-        print(
-            "       python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py --csv <csv_file_path> [--force]"
-            " [--concurrency N]"
-        )
-        print("\nArguments:")
-        print(
-            "  tenant_id        The tenant ID to process (required if not using --csv)"
-        )
-        print("  --csv PATH       Path to CSV file containing tenant IDs to process")
-        print("  --force          Skip all confirmation prompts (optional)")
-        print("  --concurrency N  Process N tenants concurrently (default: 1)")
-        print("\nExamples:")
-        print(
-            "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py tenant_abc123-def456-789"
-        )
-        print(
-            "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py tenant_abc123-def456-789 --force"
-        )
-        print(
-            "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py --csv gated_tenants_no_query_3mo.csv"
-        )
-        print(
-            "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py --csv gated_tenants_no_query_3mo.csv "
-            "--force --concurrency 16"
-        )
-        sys.exit(1)
+def _print_usage() -> None:
+    """Print usage information for the script."""
+    print(
+        "Usage: python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py <tenant_id> [--force] [--concurrency N]"
+    )
+    print(
+        "       python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py --csv <csv_file_path> [--force]"
+        " [--concurrency N]"
+    )
+    print("\nArguments:")
+    print("  tenant_id        The tenant ID to process (required if not using --csv)")
+    print("  --csv PATH       Path to CSV file containing tenant IDs to process")
+    print("  --force          Skip all confirmation prompts (optional)")
+    print("  --concurrency N  Process N tenants concurrently (default: 1)")
+    print("\nExamples:")
+    print(
+        "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py tenant_abc123-def456-789"
+    )
+    print(
+        "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py tenant_abc123-def456-789 --force"
+    )
+    print(
+        "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py --csv gated_tenants_no_query_3mo.csv"
+    )
+    print(
+        "  python backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py --csv gated_tenants_no_query_3mo.csv "
+        "--force --concurrency 16"
+    )
 
-    # Parse arguments
-    force = "--force" in sys.argv
-    tenant_ids: list[str] = []
 
-    # Parse concurrency
-    concurrency: int = 1
-    if "--concurrency" in sys.argv:
-        try:
-            concurrency_index = sys.argv.index("--concurrency")
-            if concurrency_index + 1 >= len(sys.argv):
-                print("Error: --concurrency flag requires a number", file=sys.stderr)
-                sys.exit(1)
-            concurrency = int(sys.argv[concurrency_index + 1])
-            if concurrency < 1:
-                print("Error: concurrency must be at least 1", file=sys.stderr)
-                sys.exit(1)
-        except ValueError:
-            print("Error: --concurrency value must be an integer", file=sys.stderr)
-            sys.exit(1)
+def _parse_concurrency() -> int:
+    """Return the --concurrency value, exiting on an invalid one."""
+    if "--concurrency" not in sys.argv:
+        return 1
 
-    # Validate: concurrency > 1 requires --force
-    if concurrency > 1 and not force:
-        print(
-            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    # Check for CSV mode
-    if "--csv" in sys.argv:
-        try:
-            csv_index: int = sys.argv.index("--csv")
-            if csv_index + 1 >= len(sys.argv):
-                print("Error: --csv flag requires a file path", file=sys.stderr)
-                sys.exit(1)
-
-            csv_path: str = sys.argv[csv_index + 1]
-            tenant_ids = read_tenant_ids_from_csv(csv_path)
-
-            if not tenant_ids:
-                print("Error: No tenant IDs found in CSV file", file=sys.stderr)
-                sys.exit(1)
-
-            print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
-
-        except Exception as e:
-            print(f"Error reading CSV file: {e}", file=sys.stderr)
-            sys.exit(1)
-    else:
-        # Single tenant mode
-        tenant_ids = [sys.argv[1]]
-
-    # Find heavy worker pod once before processing
     try:
-        print("Finding worker pod...")
-        pod_name: str = find_worker_pod()
-        print(f"✓ Using worker pod: {pod_name}")
-    except Exception as e:
-        print(f"✗ Failed to find heavy worker pod: {e}", file=sys.stderr)
-        print("Cannot proceed with marking connectors for deletion")
+        concurrency_index = sys.argv.index("--concurrency")
+        if concurrency_index + 1 >= len(sys.argv):
+            print("Error: --concurrency flag requires a number", file=sys.stderr)
+            sys.exit(1)
+        concurrency = int(sys.argv[concurrency_index + 1])
+        if concurrency < 1:
+            print("Error: concurrency must be at least 1", file=sys.stderr)
+            sys.exit(1)
+    except ValueError:
+        print("Error: --concurrency value must be an integer", file=sys.stderr)
         sys.exit(1)
 
-    # Initial confirmation (unless --force is used)
+    return concurrency
+
+
+def _parse_tenant_ids() -> list[str]:
+    """Return the tenant IDs from --csv, or the single positional tenant ID."""
+    if "--csv" not in sys.argv:
+        # Single tenant mode
+        return [sys.argv[1]]
+
+    try:
+        csv_index: int = sys.argv.index("--csv")
+        if csv_index + 1 >= len(sys.argv):
+            print("Error: --csv flag requires a file path", file=sys.stderr)
+            sys.exit(1)
+
+        csv_path: str = sys.argv[csv_index + 1]
+        tenant_ids = read_tenant_ids_from_csv(csv_path)
+
+        if not tenant_ids:
+            print("Error: No tenant IDs found in CSV file", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
+
+    except Exception as e:
+        print(f"Error reading CSV file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return tenant_ids
+
+
+def _confirm_start(tenant_ids: list[str], force: bool, concurrency: int) -> None:
+    """Describe the run and require confirmation unless --force is used."""
     if not force:
         print(f"\n{'=' * 80}")
         print("MARK CONNECTORS FOR DELETION - CONFIRMATION REQUIRED")
@@ -331,76 +317,92 @@ def main() -> None:
                 f"(concurrency: {concurrency}) without confirmations"
             )
 
-    # Process tenants (in parallel if concurrency > 1)
-    failed_tenants: list[tuple[str, str]] = []
-    successful_tenants: list[str] = []
 
-    if concurrency == 1:
-        # Sequential processing
-        for idx, tenant_id in enumerate(tenant_ids, 1):
-            if len(tenant_ids) > 1:
-                print(f"\n{'=' * 80}")
-                print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
-                print(f"{'=' * 80}")
+def _process_sequentially(
+    tenant_ids: list[str],
+    pod_name: str,
+    force: bool,
+    successful_tenants: list[str],
+    failed_tenants: list[tuple[str, str]],
+) -> None:
+    """Process tenants one at a time, recording the outcome of each."""
+    for idx, tenant_id in enumerate(tenant_ids, 1):
+        if len(tenant_ids) > 1:
+            print(f"\n{'=' * 80}")
+            print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
+            print(f"{'=' * 80}")
 
-            try:
-                mark_tenant_connectors_for_deletion(tenant_id, pod_name, force)
+        try:
+            mark_tenant_connectors_for_deletion(tenant_id, pod_name, force)
+            successful_tenants.append(tenant_id)
+        except Exception as e:
+            print(
+                f"✗ Failed to process tenant {tenant_id}: {e}",
+                file=sys.stderr,
+            )
+            failed_tenants.append((tenant_id, str(e)))
+
+            # If not in force mode and there are more tenants, ask if we should continue
+            if not force and idx < len(tenant_ids):
+                response = input(
+                    f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
+                )
+                if response.lower() != "y":
+                    print("Operation aborted by user")
+                    break
+
+
+def _process_in_parallel(
+    tenant_ids: list[str],
+    pod_name: str,
+    force: bool,
+    concurrency: int,
+    successful_tenants: list[str],
+    failed_tenants: list[tuple[str, str]],
+) -> None:
+    """Process tenants concurrently, recording the outcome of each."""
+    print(f"\nProcessing {len(tenant_ids)} tenant(s) with concurrency={concurrency}")
+
+    def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
+        """Process a single tenant. Returns (tenant_id, success, error_message)."""
+        try:
+            mark_tenant_connectors_for_deletion(tenant_id, pod_name, force)
+            return (tenant_id, True, None)
+        except Exception as e:
+            return (tenant_id, False, str(e))
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        # Submit all tasks
+        future_to_tenant = {
+            executor.submit(process_tenant, tenant_id): tenant_id
+            for tenant_id in tenant_ids
+        }
+
+        # Process results as they complete
+        completed: int = 0
+        for future in as_completed(future_to_tenant):
+            completed += 1
+            tenant_id, success, error = future.result()
+
+            if success:
                 successful_tenants.append(tenant_id)
-            except Exception as e:
-                print(
-                    f"✗ Failed to process tenant {tenant_id}: {e}",
+                safe_print(
+                    f"[{completed}/{len(tenant_ids)}] ✓ Successfully processed {tenant_id}"
+                )
+            else:
+                failed_tenants.append((tenant_id, error or "Unknown error"))
+                safe_print(
+                    f"[{completed}/{len(tenant_ids)}] ✗ Failed to process {tenant_id}: {error}",
                     file=sys.stderr,
                 )
-                failed_tenants.append((tenant_id, str(e)))
 
-                # If not in force mode and there are more tenants, ask if we should continue
-                if not force and idx < len(tenant_ids):
-                    response = input(
-                        f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
-                    )
-                    if response.lower() != "y":
-                        print("Operation aborted by user")
-                        break
-    else:
-        # Parallel processing
-        print(
-            f"\nProcessing {len(tenant_ids)} tenant(s) with concurrency={concurrency}"
-        )
 
-        def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
-            """Process a single tenant. Returns (tenant_id, success, error_message)."""
-            try:
-                mark_tenant_connectors_for_deletion(tenant_id, pod_name, force)
-                return (tenant_id, True, None)
-            except Exception as e:
-                return (tenant_id, False, str(e))
-
-        with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            # Submit all tasks
-            future_to_tenant = {
-                executor.submit(process_tenant, tenant_id): tenant_id
-                for tenant_id in tenant_ids
-            }
-
-            # Process results as they complete
-            completed: int = 0
-            for future in as_completed(future_to_tenant):
-                completed += 1
-                tenant_id, success, error = future.result()
-
-                if success:
-                    successful_tenants.append(tenant_id)
-                    safe_print(
-                        f"[{completed}/{len(tenant_ids)}] ✓ Successfully processed {tenant_id}"
-                    )
-                else:
-                    failed_tenants.append((tenant_id, error or "Unknown error"))
-                    safe_print(
-                        f"[{completed}/{len(tenant_ids)}] ✗ Failed to process {tenant_id}: {error}",
-                        file=sys.stderr,
-                    )
-
-    # Print summary if multiple tenants
+def _print_summary(
+    tenant_ids: list[str],
+    successful_tenants: list[str],
+    failed_tenants: list[tuple[str, str]],
+) -> None:
+    """Print the run summary and exit non-zero if any tenant failed."""
     if len(tenant_ids) > 1:
         print(f"\n{'=' * 80}")
         print("OPERATION SUMMARY")
@@ -418,6 +420,60 @@ def main() -> None:
 
         if failed_tenants:
             sys.exit(1)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _print_usage()
+        sys.exit(1)
+
+    # Parse arguments
+    force = "--force" in sys.argv
+    concurrency: int = _parse_concurrency()
+
+    # Validate: concurrency > 1 requires --force
+    if concurrency > 1 and not force:
+        print(
+            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    tenant_ids: list[str] = _parse_tenant_ids()
+
+    # Find heavy worker pod once before processing
+    try:
+        print("Finding worker pod...")
+        pod_name: str = find_worker_pod()
+        print(f"✓ Using worker pod: {pod_name}")
+    except Exception as e:
+        print(f"✗ Failed to find heavy worker pod: {e}", file=sys.stderr)
+        print("Cannot proceed with marking connectors for deletion")
+        sys.exit(1)
+
+    # Initial confirmation (unless --force is used)
+    _confirm_start(tenant_ids, force, concurrency)
+
+    # Process tenants (in parallel if concurrency > 1)
+    failed_tenants: list[tuple[str, str]] = []
+    successful_tenants: list[str] = []
+
+    if concurrency == 1:
+        _process_sequentially(
+            tenant_ids, pod_name, force, successful_tenants, failed_tenants
+        )
+    else:
+        _process_in_parallel(
+            tenant_ids,
+            pod_name,
+            force,
+            concurrency,
+            successful_tenants,
+            failed_tenants,
+        )
+
+    # Print summary if multiple tenants
+    _print_summary(tenant_ids, successful_tenants, failed_tenants)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -12,6 +12,7 @@ Usage:
         --data-plane-context <context> --control-plane-context <context> [--force]
 """
 
+import _csv
 import csv
 import fcntl
 import json
@@ -20,9 +21,11 @@ import signal
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
+from typing import IO, NamedTuple
 
 from scripts.tenant_cleanup.no_bastion_cleanup_utils import (
     TenantNotFoundInControlPlaneError,
@@ -404,6 +407,99 @@ def cleanup_control_plane(
         raise
 
 
+def check_tenant_status_before_cleanup(
+    tenant_id: str,
+    control_plane_pod: str,
+    control_plane_context: str,
+    force: bool,
+) -> tuple[bool, bool]:
+    """Check the control plane tenant status before any destructive step.
+
+    Args:
+        tenant_id: Tenant ID to process
+        control_plane_pod: Control plane pod for tenant record operations
+        control_plane_context: kubectl context for control plane cluster
+        force: Skip confirmations if True
+
+    Returns:
+        (proceed, tenant_not_found_in_control_plane)
+    """
+    # Track if tenant was not found in control plane (for force mode)
+    tenant_not_found_in_control_plane = False
+
+    print(f"\n{'=' * 80}")
+    try:
+        tenant_status = get_tenant_status(
+            control_plane_pod, tenant_id, control_plane_context
+        )
+
+        # If tenant is not GATED_ACCESS, require explicit confirmation even in force mode
+        if tenant_status and tenant_status != "GATED_ACCESS":
+            print(
+                f"\n⚠️  WARNING: Tenant status is '{tenant_status}', not 'GATED_ACCESS'!"
+            )
+            print(
+                "This tenant may be active and should not be deleted without careful review."
+            )
+            print(f"{'=' * 80}\n")
+
+            if force:
+                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+                return False, tenant_not_found_in_control_plane
+
+            # Always ask for confirmation if not gated
+            response = input(
+                "Are you ABSOLUTELY SURE you want to proceed? Type 'yes' to confirm: "
+            )
+            if response.lower() != "yes":
+                print("Cleanup aborted - tenant is not GATED_ACCESS")
+                return False, tenant_not_found_in_control_plane
+        elif tenant_status == "GATED_ACCESS":
+            print("✓ Tenant status is GATED_ACCESS - safe to proceed with cleanup")
+        elif tenant_status is None:
+            print("⚠️  WARNING: Could not determine tenant status!")
+
+            if force:
+                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+                return False, tenant_not_found_in_control_plane
+
+            response = input("Continue anyway? Type 'yes' to confirm: ")
+            if response.lower() != "yes":
+                print("Cleanup aborted - could not verify tenant status")
+                return False, tenant_not_found_in_control_plane
+    except TenantNotFoundInControlPlaneError as e:
+        # Tenant/table not found in control plane
+        error_str = str(e)
+        print(f"⚠️  WARNING: Tenant not found in control plane: {error_str}")
+        tenant_not_found_in_control_plane = True
+
+        if force:
+            print(
+                "[FORCE MODE] Tenant not found in control plane - continuing with dataplane cleanup only"
+            )
+        else:
+            response = input("Continue anyway? Type 'yes' to confirm: ")
+            if response.lower() != "yes":
+                print("Cleanup aborted - tenant not found in control plane")
+                return False, tenant_not_found_in_control_plane
+    except Exception as e:
+        # Other errors (not "not found")
+        error_str = str(e)
+        print(f"⚠️  WARNING: Failed to check tenant status: {error_str}")
+
+        if force:
+            print(f"Skipping cleanup for tenant {tenant_id} in force mode")
+            return False, tenant_not_found_in_control_plane
+
+        response = input("Continue anyway? Type 'yes' to confirm: ")
+        if response.lower() != "yes":
+            print("Cleanup aborted - could not verify tenant status")
+            return False, tenant_not_found_in_control_plane
+    print(f"{'=' * 80}\n")
+
+    return True, tenant_not_found_in_control_plane
+
+
 def cleanup_tenant(
     tenant_id: str,
     data_plane_pod: str,
@@ -424,79 +520,12 @@ def cleanup_tenant(
     """
     print(f"Starting cleanup for tenant: {tenant_id}")
 
-    # Track if tenant was not found in control plane (for force mode)
-    tenant_not_found_in_control_plane = False
-
     # Check tenant status first (from control plane)
-    print(f"\n{'=' * 80}")
-    try:
-        tenant_status = get_tenant_status(
-            control_plane_pod, tenant_id, control_plane_context
-        )
-
-        # If tenant is not GATED_ACCESS, require explicit confirmation even in force mode
-        if tenant_status and tenant_status != "GATED_ACCESS":
-            print(
-                f"\n⚠️  WARNING: Tenant status is '{tenant_status}', not 'GATED_ACCESS'!"
-            )
-            print(
-                "This tenant may be active and should not be deleted without careful review."
-            )
-            print(f"{'=' * 80}\n")
-
-            if force:
-                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
-                return False
-
-            # Always ask for confirmation if not gated
-            response = input(
-                "Are you ABSOLUTELY SURE you want to proceed? Type 'yes' to confirm: "
-            )
-            if response.lower() != "yes":
-                print("Cleanup aborted - tenant is not GATED_ACCESS")
-                return False
-        elif tenant_status == "GATED_ACCESS":
-            print("✓ Tenant status is GATED_ACCESS - safe to proceed with cleanup")
-        elif tenant_status is None:
-            print("⚠️  WARNING: Could not determine tenant status!")
-
-            if force:
-                print(f"Skipping cleanup for tenant {tenant_id} in force mode")
-                return False
-
-            response = input("Continue anyway? Type 'yes' to confirm: ")
-            if response.lower() != "yes":
-                print("Cleanup aborted - could not verify tenant status")
-                return False
-    except TenantNotFoundInControlPlaneError as e:
-        # Tenant/table not found in control plane
-        error_str = str(e)
-        print(f"⚠️  WARNING: Tenant not found in control plane: {error_str}")
-        tenant_not_found_in_control_plane = True
-
-        if force:
-            print(
-                "[FORCE MODE] Tenant not found in control plane - continuing with dataplane cleanup only"
-            )
-        else:
-            response = input("Continue anyway? Type 'yes' to confirm: ")
-            if response.lower() != "yes":
-                print("Cleanup aborted - tenant not found in control plane")
-                return False
-    except Exception as e:
-        # Other errors (not "not found")
-        error_str = str(e)
-        print(f"⚠️  WARNING: Failed to check tenant status: {error_str}")
-
-        if force:
-            print(f"Skipping cleanup for tenant {tenant_id} in force mode")
-            return False
-
-        response = input("Continue anyway? Type 'yes' to confirm: ")
-        if response.lower() != "yes":
-            print("Cleanup aborted - could not verify tenant status")
-            return False
-    print(f"{'=' * 80}\n")
+    proceed, tenant_not_found_in_control_plane = check_tenant_status_before_cleanup(
+        tenant_id, control_plane_pod, control_plane_context, force
+    )
+    if not proceed:
+        return False
 
     # Fetch tenant users for informational purposes (non-blocking) from data plane
     if not force:
@@ -579,112 +608,116 @@ def cleanup_tenant(
     return True
 
 
-def main() -> None:
-    # Register signal handlers for graceful shutdown
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
+class _RunConfig(NamedTuple):
+    """Pods, contexts, and mode shared by every tenant in a run."""
 
-    if len(sys.argv) < 2:
-        print(
-            "Usage: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py <tenant_id> \\"
-        )
-        print(
-            "           --data-plane-context <context> --control-plane-context <context> [--force]"
-        )
-        print(
-            "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py --csv <csv_file_path> \\"
-        )
-        print(
-            "           --data-plane-context <context> --control-plane-context <context> [--force]"
-        )
-        print("\nThis version runs ALL operations from pods (no bastion required)")
-        print("\nArguments:")
-        print(
-            "  tenant_id                   The tenant ID to clean up (required if not using --csv)"
-        )
-        print(
-            "  --csv PATH                  Path to CSV file containing tenant IDs to clean up"
-        )
-        print("  --force                     Skip all confirmation prompts (optional)")
-        print(
-            "  --concurrency N             Process N tenants concurrently (default: 1)"
-        )
-        print(
-            "  --data-plane-context CTX    Kubectl context for data plane cluster (required)"
-        )
-        print(
-            "  --control-plane-context CTX Kubectl context for control plane cluster (required)"
-        )
-        print(
-            "  --data-plane-pod POD        Pin the data plane pod instead of picking one"
-        )
-        print(
-            "  --control-plane-pod POD     Pin the control plane pod instead of picking one"
-        )
-        sys.exit(1)
+    data_plane_pod: str
+    control_plane_pod: str
+    data_plane_context: str
+    control_plane_context: str
+    force: bool
 
-    # Parse arguments
-    force = "--force" in sys.argv
-    tenant_ids = []
 
-    # Parse concurrency
-    concurrency: int = 1
-    if "--concurrency" in sys.argv:
-        try:
-            concurrency_index = sys.argv.index("--concurrency")
-            if concurrency_index + 1 >= len(sys.argv):
-                print("Error: --concurrency flag requires a number", file=sys.stderr)
-                sys.exit(1)
-            concurrency = int(sys.argv[concurrency_index + 1])
-            if concurrency < 1:
-                print("Error: concurrency must be at least 1", file=sys.stderr)
-                sys.exit(1)
-        except ValueError:
-            print("Error: --concurrency value must be an integer", file=sys.stderr)
+class _CleanupLog(NamedTuple):
+    """Open handles for the CSV record of cleaned tenants."""
+
+    path: str
+    file: IO[str]
+    writer: _csv.Writer
+
+
+@dataclass
+class _CleanupResults:
+    """Outcome of every tenant processed in a run."""
+
+    successful: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)
+
+
+def _print_usage() -> None:
+    """Print usage information for the script."""
+    print(
+        "Usage: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py <tenant_id> \\"
+    )
+    print(
+        "           --data-plane-context <context> --control-plane-context <context> [--force]"
+    )
+    print(
+        "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_cleanup_tenants.py --csv <csv_file_path> \\"
+    )
+    print(
+        "           --data-plane-context <context> --control-plane-context <context> [--force]"
+    )
+    print("\nThis version runs ALL operations from pods (no bastion required)")
+    print("\nArguments:")
+    print(
+        "  tenant_id                   The tenant ID to clean up (required if not using --csv)"
+    )
+    print(
+        "  --csv PATH                  Path to CSV file containing tenant IDs to clean up"
+    )
+    print("  --force                     Skip all confirmation prompts (optional)")
+    print("  --concurrency N             Process N tenants concurrently (default: 1)")
+    print(
+        "  --data-plane-context CTX    Kubectl context for data plane cluster (required)"
+    )
+    print(
+        "  --control-plane-context CTX Kubectl context for control plane cluster (required)"
+    )
+    print("  --data-plane-pod POD        Pin the data plane pod instead of picking one")
+    print(
+        "  --control-plane-pod POD     Pin the control plane pod instead of picking one"
+    )
+
+
+def _parse_concurrency() -> int:
+    """Return the --concurrency value, exiting on an invalid one."""
+    if "--concurrency" not in sys.argv:
+        return 1
+
+    try:
+        concurrency_index = sys.argv.index("--concurrency")
+        if concurrency_index + 1 >= len(sys.argv):
+            print("Error: --concurrency flag requires a number", file=sys.stderr)
             sys.exit(1)
-
-    # Validate: concurrency > 1 requires --force
-    if concurrency > 1 and not force:
-        print(
-            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
-            file=sys.stderr,
-        )
+        concurrency = int(sys.argv[concurrency_index + 1])
+        if concurrency < 1:
+            print("Error: concurrency must be at least 1", file=sys.stderr)
+            sys.exit(1)
+    except ValueError:
+        print("Error: --concurrency value must be an integer", file=sys.stderr)
         sys.exit(1)
 
-    # Parse contexts (required)
-    data_plane_context: str | None = None
-    control_plane_context: str | None = None
+    return concurrency
 
-    if "--data-plane-context" in sys.argv:
-        try:
-            idx = sys.argv.index("--data-plane-context")
-            if idx + 1 >= len(sys.argv):
-                print(
-                    "Error: --data-plane-context requires a context name",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            data_plane_context = sys.argv[idx + 1]
-        except ValueError:
-            pass
 
-    if "--control-plane-context" in sys.argv:
-        try:
-            idx = sys.argv.index("--control-plane-context")
-            if idx + 1 >= len(sys.argv):
-                print(
-                    "Error: --control-plane-context requires a context name",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            control_plane_context = sys.argv[idx + 1]
-        except ValueError:
-            pass
+def _parse_context(flag: str) -> str | None:
+    """Return the context name given for a flag, or None if the flag is absent."""
+    if flag not in sys.argv:
+        return None
 
-    # Pinning pods lets several batches run against different pods instead of all
-    # piling onto whichever one the random pick returns.
-    data_plane_pod_override = None
-    control_plane_pod_override = None
+    try:
+        idx = sys.argv.index(flag)
+        if idx + 1 >= len(sys.argv):
+            print(
+                f"Error: {flag} requires a context name",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return sys.argv[idx + 1]
+    except ValueError:
+        return None
+
+
+def _parse_pod_overrides() -> tuple[str | None, str | None]:
+    """Return the pinned data plane and control plane pods, if given.
+
+    Pinning pods lets several batches run against different pods instead of all
+    piling onto whichever one the random pick returns.
+    """
+    data_plane_pod_override: str | None = None
+    control_plane_pod_override: str | None = None
     for flag, target in (
         ("--data-plane-pod", "data"),
         ("--control-plane-pod", "control"),
@@ -699,7 +732,13 @@ def main() -> None:
             else:
                 control_plane_pod_override = sys.argv[idx + 1]
 
-    # Validate required contexts
+    return data_plane_pod_override, control_plane_pod_override
+
+
+def _require_contexts(
+    data_plane_context: str | None, control_plane_context: str | None
+) -> tuple[str, str]:
+    """Return both contexts, exiting if either one is missing."""
     if not data_plane_context:
         print(
             "Error: --data-plane-context is required",
@@ -714,31 +753,39 @@ def main() -> None:
         )
         sys.exit(1)
 
-    # Check for CSV mode
-    if "--csv" in sys.argv:
-        try:
-            csv_index = sys.argv.index("--csv")
-            if csv_index + 1 >= len(sys.argv):
-                print("Error: --csv flag requires a file path", file=sys.stderr)
-                sys.exit(1)
+    return data_plane_context, control_plane_context
 
-            csv_path = sys.argv[csv_index + 1]
-            tenant_ids = read_tenant_ids_from_csv(csv_path)
 
-            if not tenant_ids:
-                print("Error: No tenant IDs found in CSV file", file=sys.stderr)
-                sys.exit(1)
-
-            print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
-
-        except Exception as e:
-            print(f"Error reading CSV file: {e}", file=sys.stderr)
-            sys.exit(1)
-    else:
+def _parse_tenant_ids() -> list[str]:
+    """Return the tenant IDs from --csv, or the single positional tenant ID."""
+    if "--csv" not in sys.argv:
         # Single tenant mode
-        tenant_ids = [sys.argv[1]]
+        return [sys.argv[1]]
 
-    # Initial confirmation (unless --force is used)
+    try:
+        csv_index = sys.argv.index("--csv")
+        if csv_index + 1 >= len(sys.argv):
+            print("Error: --csv flag requires a file path", file=sys.stderr)
+            sys.exit(1)
+
+        csv_path = sys.argv[csv_index + 1]
+        tenant_ids = read_tenant_ids_from_csv(csv_path)
+
+        if not tenant_ids:
+            print("Error: No tenant IDs found in CSV file", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
+
+    except Exception as e:
+        print(f"Error reading CSV file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return tenant_ids
+
+
+def _confirm_start(tenant_ids: list[str], force: bool) -> None:
+    """Describe the run and require confirmation unless --force is used."""
     if not force:
         print(f"\n{'=' * 80}")
         print("TENANT CLEANUP - NO BASTION VERSION")
@@ -769,7 +816,14 @@ def main() -> None:
             f"⚠ FORCE MODE: Running cleanup for {len(tenant_ids)} tenant(s) without confirmations"
         )
 
-    # Find pods in both clusters before processing
+
+def _prepare_pods(
+    data_plane_context: str,
+    control_plane_context: str,
+    data_plane_pod_override: str | None,
+    control_plane_pod_override: str | None,
+) -> tuple[str, str]:
+    """Return both pods to run against, after copying the scripts to the data plane pod."""
     try:
         if data_plane_pod_override:
             data_plane_pod = data_plane_pod_override
@@ -795,157 +849,235 @@ def main() -> None:
         print("Cannot proceed with cleanup")
         sys.exit(1)
 
+    return data_plane_pod, control_plane_pod
+
+
+def _write_csv_header_if_empty(csv_file: IO[str], csv_writer: _csv.Writer) -> None:
+    """Write the CSV header when the output file is still empty.
+
+    Emit the header under an exclusive lock, and decide whether one is needed
+    while holding it. Two runs starting together would otherwise both see an
+    absent file and each write a header.
+    """
+    fcntl.flock(csv_file.fileno(), fcntl.LOCK_EX)
+    try:
+        if os.fstat(csv_file.fileno()).st_size == 0:
+            csv_writer.writerow(["tenant_id", "cleaned_at"])
+            csv_file.flush()
+    finally:
+        fcntl.flock(csv_file.fileno(), fcntl.LOCK_UN)
+
+
+def _cleanup_sequentially(
+    tenant_ids: list[str],
+    config: _RunConfig,
+    log: _CleanupLog,
+    results: _CleanupResults,
+) -> None:
+    """Clean up tenants one at a time, recording the outcome of each."""
+    for idx, tenant_id in enumerate(tenant_ids, 1):
+        if len(tenant_ids) > 1:
+            print(f"\n{'=' * 80}")
+            print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
+            print(f"{'=' * 80}")
+
+        try:
+            was_cleaned = cleanup_tenant(
+                tenant_id,
+                config.data_plane_pod,
+                config.control_plane_pod,
+                config.data_plane_context,
+                config.control_plane_context,
+                config.force,
+            )
+
+            if was_cleaned:
+                results.successful.append(tenant_id)
+
+                # Write to CSV immediately after successful cleanup
+                timestamp = datetime.now(timezone.utc).isoformat()
+                log.writer.writerow([tenant_id, timestamp])
+                log.file.flush()
+                print(f"✓ Recorded cleanup in {log.path}")
+            else:
+                results.skipped.append(tenant_id)
+                print(f"⚠ Tenant {tenant_id} was skipped (not recorded in CSV)")
+
+        except Exception as e:
+            print(f"✗ Cleanup failed for tenant {tenant_id}: {e}", file=sys.stderr)
+            results.failed.append((tenant_id, str(e)))
+
+            # If not in force mode and there are more tenants, ask if we should continue
+            if not config.force and idx < len(tenant_ids):
+                response = input(
+                    f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
+                )
+                if response.lower() != "y":
+                    print("Cleanup aborted by user")
+                    break
+
+
+def _cleanup_in_parallel(
+    tenant_ids: list[str],
+    config: _RunConfig,
+    concurrency: int,
+    log: _CleanupLog,
+    results: _CleanupResults,
+) -> None:
+    """Clean up tenants concurrently, recording the outcome of each."""
+    print(f"Processing {len(tenant_ids)} tenant(s) with concurrency={concurrency}\n")
+
+    def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
+        """Process a single tenant. Returns (tenant_id, was_cleaned, error_message)."""
+        try:
+            was_cleaned = cleanup_tenant(
+                tenant_id,
+                config.data_plane_pod,
+                config.control_plane_pod,
+                config.data_plane_context,
+                config.control_plane_context,
+                config.force,
+            )
+            return (tenant_id, was_cleaned, None)
+        except Exception as e:
+            return (tenant_id, False, str(e))
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        # Submit all tasks
+        future_to_tenant = {
+            executor.submit(process_tenant, tenant_id): tenant_id
+            for tenant_id in tenant_ids
+        }
+
+        # Process results as they complete
+        completed = 0
+        for future in as_completed(future_to_tenant):
+            completed += 1
+            tenant_id, was_cleaned, error = future.result()
+
+            if error:
+                with _print_lock:
+                    print(
+                        f"[{completed}/{len(tenant_ids)}] ✗ Failed: {tenant_id}: {error}",
+                        file=sys.stderr,
+                    )
+                results.failed.append((tenant_id, error))
+            elif was_cleaned:
+                with _csv_lock:
+                    timestamp = datetime.now(timezone.utc).isoformat()
+                    log.writer.writerow([tenant_id, timestamp])
+                    log.file.flush()
+                results.successful.append(tenant_id)
+                with _print_lock:
+                    print(f"[{completed}/{len(tenant_ids)}] ✓ Cleaned: {tenant_id}")
+            else:
+                results.skipped.append(tenant_id)
+                with _print_lock:
+                    print(f"[{completed}/{len(tenant_ids)}] ⊘ Skipped: {tenant_id}")
+
+
+def _print_summary(
+    tenant_ids: list[str], results: _CleanupResults, csv_output_path: str
+) -> None:
+    """Print the run summary and exit non-zero if any tenant failed."""
+    if len(tenant_ids) > 1:
+        print(f"\n{'=' * 80}")
+        print("CLEANUP SUMMARY")
+        print(f"{'=' * 80}")
+        print(f"Total tenants: {len(tenant_ids)}")
+        print(f"Successful: {len(results.successful)}")
+        print(f"Skipped: {len(results.skipped)}")
+        print(f"Failed: {len(results.failed)}")
+        print(f"\nSuccessfully cleaned tenants written to: {csv_output_path}")
+
+        if results.skipped:
+            print(f"\nSkipped tenants ({len(results.skipped)}):")
+            for tenant_id in results.skipped:
+                print(f"  - {tenant_id}")
+
+        if results.failed:
+            print(f"\nFailed tenants ({len(results.failed)}):")
+            for tenant_id, error in results.failed:
+                print(f"  - {tenant_id}: {error}")
+
+        print(f"{'=' * 80}")
+
+        if results.failed:
+            sys.exit(1)
+
+
+def main() -> None:
+    # Register signal handlers for graceful shutdown
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    if len(sys.argv) < 2:
+        _print_usage()
+        sys.exit(1)
+
+    # Parse arguments
+    force = "--force" in sys.argv
+    concurrency: int = _parse_concurrency()
+
+    # Validate: concurrency > 1 requires --force
+    if concurrency > 1 and not force:
+        print(
+            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Parse contexts (required)
+    data_plane_context = _parse_context("--data-plane-context")
+    control_plane_context = _parse_context("--control-plane-context")
+
+    data_plane_pod_override, control_plane_pod_override = _parse_pod_overrides()
+
+    data_plane_context, control_plane_context = _require_contexts(
+        data_plane_context, control_plane_context
+    )
+
+    tenant_ids = _parse_tenant_ids()
+
+    # Initial confirmation (unless --force is used)
+    _confirm_start(tenant_ids, force)
+
+    # Find pods in both clusters before processing
+    data_plane_pod, control_plane_pod = _prepare_pods(
+        data_plane_context,
+        control_plane_context,
+        data_plane_pod_override,
+        control_plane_pod_override,
+    )
+
+    config = _RunConfig(
+        data_plane_pod=data_plane_pod,
+        control_plane_pod=control_plane_pod,
+        data_plane_context=data_plane_context,
+        control_plane_context=control_plane_context,
+        force=force,
+    )
+
     # Run cleanup for each tenant
-    failed_tenants = []
-    successful_tenants = []
-    skipped_tenants = []
+    results = _CleanupResults()
 
     # Append rather than truncate: cleanup runs in batches, and this file is the only
     # record of what was deleted. Opening it "w" silently erased prior batches.
     csv_output_path = "cleaned_tenants.csv"
     with open(csv_output_path, "a", newline="") as csv_file:
         csv_writer = csv.writer(csv_file)
-
-        # Emit the header under an exclusive lock, and decide whether one is needed
-        # while holding it. Two runs starting together would otherwise both see an
-        # absent file and each write a header.
-        fcntl.flock(csv_file.fileno(), fcntl.LOCK_EX)
-        try:
-            if os.fstat(csv_file.fileno()).st_size == 0:
-                csv_writer.writerow(["tenant_id", "cleaned_at"])
-                csv_file.flush()
-        finally:
-            fcntl.flock(csv_file.fileno(), fcntl.LOCK_UN)
+        _write_csv_header_if_empty(csv_file, csv_writer)
 
         print(f"Writing successful cleanups to: {csv_output_path}\n")
 
+        log = _CleanupLog(path=csv_output_path, file=csv_file, writer=csv_writer)
         if concurrency == 1:
-            # Sequential processing
-            for idx, tenant_id in enumerate(tenant_ids, 1):
-                if len(tenant_ids) > 1:
-                    print(f"\n{'=' * 80}")
-                    print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
-                    print(f"{'=' * 80}")
-
-                try:
-                    was_cleaned = cleanup_tenant(
-                        tenant_id,
-                        data_plane_pod,
-                        control_plane_pod,
-                        data_plane_context,
-                        control_plane_context,
-                        force,
-                    )
-
-                    if was_cleaned:
-                        successful_tenants.append(tenant_id)
-
-                        # Write to CSV immediately after successful cleanup
-                        timestamp = datetime.now(timezone.utc).isoformat()
-                        csv_writer.writerow([tenant_id, timestamp])
-                        csv_file.flush()
-                        print(f"✓ Recorded cleanup in {csv_output_path}")
-                    else:
-                        skipped_tenants.append(tenant_id)
-                        print(f"⚠ Tenant {tenant_id} was skipped (not recorded in CSV)")
-
-                except Exception as e:
-                    print(
-                        f"✗ Cleanup failed for tenant {tenant_id}: {e}", file=sys.stderr
-                    )
-                    failed_tenants.append((tenant_id, str(e)))
-
-                    # If not in force mode and there are more tenants, ask if we should continue
-                    if not force and idx < len(tenant_ids):
-                        response = input(
-                            f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
-                        )
-                        if response.lower() != "y":
-                            print("Cleanup aborted by user")
-                            break
+            _cleanup_sequentially(tenant_ids, config, log, results)
         else:
-            # Parallel processing
-            print(
-                f"Processing {len(tenant_ids)} tenant(s) with concurrency={concurrency}\n"
-            )
-
-            def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
-                """Process a single tenant. Returns (tenant_id, was_cleaned, error_message)."""
-                try:
-                    was_cleaned = cleanup_tenant(
-                        tenant_id,
-                        data_plane_pod,
-                        control_plane_pod,
-                        data_plane_context,
-                        control_plane_context,
-                        force,
-                    )
-                    return (tenant_id, was_cleaned, None)
-                except Exception as e:
-                    return (tenant_id, False, str(e))
-
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                # Submit all tasks
-                future_to_tenant = {
-                    executor.submit(process_tenant, tenant_id): tenant_id
-                    for tenant_id in tenant_ids
-                }
-
-                # Process results as they complete
-                completed = 0
-                for future in as_completed(future_to_tenant):
-                    completed += 1
-                    tenant_id, was_cleaned, error = future.result()
-
-                    if error:
-                        with _print_lock:
-                            print(
-                                f"[{completed}/{len(tenant_ids)}] ✗ Failed: {tenant_id}: {error}",
-                                file=sys.stderr,
-                            )
-                        failed_tenants.append((tenant_id, error))
-                    elif was_cleaned:
-                        with _csv_lock:
-                            timestamp = datetime.now(timezone.utc).isoformat()
-                            csv_writer.writerow([tenant_id, timestamp])
-                            csv_file.flush()
-                        successful_tenants.append(tenant_id)
-                        with _print_lock:
-                            print(
-                                f"[{completed}/{len(tenant_ids)}] ✓ Cleaned: {tenant_id}"
-                            )
-                    else:
-                        skipped_tenants.append(tenant_id)
-                        with _print_lock:
-                            print(
-                                f"[{completed}/{len(tenant_ids)}] ⊘ Skipped: {tenant_id}"
-                            )
+            _cleanup_in_parallel(tenant_ids, config, concurrency, log, results)
 
     # Print summary
-    if len(tenant_ids) > 1:
-        print(f"\n{'=' * 80}")
-        print("CLEANUP SUMMARY")
-        print(f"{'=' * 80}")
-        print(f"Total tenants: {len(tenant_ids)}")
-        print(f"Successful: {len(successful_tenants)}")
-        print(f"Skipped: {len(skipped_tenants)}")
-        print(f"Failed: {len(failed_tenants)}")
-        print(f"\nSuccessfully cleaned tenants written to: {csv_output_path}")
-
-        if skipped_tenants:
-            print(f"\nSkipped tenants ({len(skipped_tenants)}):")
-            for tenant_id in skipped_tenants:
-                print(f"  - {tenant_id}")
-
-        if failed_tenants:
-            print(f"\nFailed tenants ({len(failed_tenants)}):")
-            for tenant_id, error in failed_tenants:
-                print(f"  - {tenant_id}: {error}")
-
-        print(f"{'=' * 80}")
-
-        if failed_tenants:
-            sys.exit(1)
+    _print_summary(tenant_ids, results, csv_output_path)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
@@ -19,7 +19,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
-from typing import Any
+from typing import Any, NamedTuple
 
 from scripts.tenant_cleanup.no_bastion_cleanup_utils import (
     TenantNotFoundInControlPlaneError,
@@ -282,73 +282,70 @@ def mark_tenant_connectors_for_deletion(
     )
 
 
-def main() -> None:
-    if len(sys.argv) < 2:
-        print(
-            "Usage: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py <tenant_id> \\"
-        )
-        print(
-            "           --data-plane-context <context> --control-plane-context <context> [--force]"
-        )
-        print(
-            "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py --csv <csv_file_path> \\"
-        )
-        print(
-            "           --data-plane-context <context> --control-plane-context <context> [--force] [--concurrency N]"
-        )
-        print("\nThis version runs ALL operations from pods (no bastion required)")
-        print("\nArguments:")
-        print(
-            "  tenant_id                   The tenant ID to process (required if not using --csv)"
-        )
-        print(
-            "  --csv PATH                  Path to CSV file containing tenant IDs to process"
-        )
-        print("  --force                     Skip all confirmation prompts (optional)")
-        print(
-            "  --concurrency N             Process N tenants concurrently (default: 1)"
-        )
-        print(
-            "  --data-plane-context CTX    Kubectl context for data plane cluster (required)"
-        )
-        print(
-            "  --control-plane-context CTX Kubectl context for control plane cluster (required)"
-        )
-        sys.exit(1)
+class _RunConfig(NamedTuple):
+    """Pods, contexts, and mode shared by every tenant in a run."""
 
-    # Parse arguments
-    force = "--force" in sys.argv
-    tenant_ids: list[str] = []
+    data_plane_pod: str
+    control_plane_pod: str
+    data_plane_context: str
+    control_plane_context: str
+    force: bool
 
-    # Parse contexts (required)
-    data_plane_context: str | None = None
-    control_plane_context: str | None = None
 
-    if "--data-plane-context" in sys.argv:
-        try:
-            idx = sys.argv.index("--data-plane-context")
-            if idx + 1 >= len(sys.argv):
-                print(
-                    "Error: --data-plane-context requires a context name",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            data_plane_context = sys.argv[idx + 1]
-        except ValueError:
-            pass
+def _print_usage() -> None:
+    """Print usage information for the script."""
+    print(
+        "Usage: PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py <tenant_id> \\"
+    )
+    print(
+        "           --data-plane-context <context> --control-plane-context <context> [--force]"
+    )
+    print(
+        "       PYTHONPATH=. python scripts/tenant_cleanup/no_bastion_mark_connectors.py --csv <csv_file_path> \\"
+    )
+    print(
+        "           --data-plane-context <context> --control-plane-context <context> [--force] [--concurrency N]"
+    )
+    print("\nThis version runs ALL operations from pods (no bastion required)")
+    print("\nArguments:")
+    print(
+        "  tenant_id                   The tenant ID to process (required if not using --csv)"
+    )
+    print(
+        "  --csv PATH                  Path to CSV file containing tenant IDs to process"
+    )
+    print("  --force                     Skip all confirmation prompts (optional)")
+    print("  --concurrency N             Process N tenants concurrently (default: 1)")
+    print(
+        "  --data-plane-context CTX    Kubectl context for data plane cluster (required)"
+    )
+    print(
+        "  --control-plane-context CTX Kubectl context for control plane cluster (required)"
+    )
 
-    if "--control-plane-context" in sys.argv:
-        try:
-            idx = sys.argv.index("--control-plane-context")
-            if idx + 1 >= len(sys.argv):
-                print(
-                    "Error: --control-plane-context requires a context name",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            control_plane_context = sys.argv[idx + 1]
-        except ValueError:
-            pass
+
+def _parse_context(flag: str) -> str | None:
+    """Return the context name given for a flag, or None if the flag is absent."""
+    if flag not in sys.argv:
+        return None
+
+    try:
+        idx = sys.argv.index(flag)
+        if idx + 1 >= len(sys.argv):
+            print(
+                f"Error: {flag} requires a context name",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return sys.argv[idx + 1]
+    except ValueError:
+        return None
+
+
+def _parse_contexts() -> tuple[str, str]:
+    """Return the data plane and control plane contexts, exiting if either is missing."""
+    data_plane_context = _parse_context("--data-plane-context")
+    control_plane_context = _parse_context("--control-plane-context")
 
     # Validate required contexts
     if not data_plane_context:
@@ -365,55 +362,60 @@ def main() -> None:
         )
         sys.exit(1)
 
-    # Parse concurrency
-    concurrency: int = 1
-    if "--concurrency" in sys.argv:
-        try:
-            concurrency_index = sys.argv.index("--concurrency")
-            if concurrency_index + 1 >= len(sys.argv):
-                print("Error: --concurrency flag requires a number", file=sys.stderr)
-                sys.exit(1)
-            concurrency = int(sys.argv[concurrency_index + 1])
-            if concurrency < 1:
-                print("Error: concurrency must be at least 1", file=sys.stderr)
-                sys.exit(1)
-        except ValueError:
-            print("Error: --concurrency value must be an integer", file=sys.stderr)
-            sys.exit(1)
+    return data_plane_context, control_plane_context
 
-    # Validate: concurrency > 1 requires --force
-    if concurrency > 1 and not force:
-        print(
-            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
-            file=sys.stderr,
-        )
+
+def _parse_concurrency() -> int:
+    """Return the --concurrency value, exiting on an invalid one."""
+    if "--concurrency" not in sys.argv:
+        return 1
+
+    try:
+        concurrency_index = sys.argv.index("--concurrency")
+        if concurrency_index + 1 >= len(sys.argv):
+            print("Error: --concurrency flag requires a number", file=sys.stderr)
+            sys.exit(1)
+        concurrency = int(sys.argv[concurrency_index + 1])
+        if concurrency < 1:
+            print("Error: concurrency must be at least 1", file=sys.stderr)
+            sys.exit(1)
+    except ValueError:
+        print("Error: --concurrency value must be an integer", file=sys.stderr)
         sys.exit(1)
 
-    # Check for CSV mode
-    if "--csv" in sys.argv:
-        try:
-            csv_index: int = sys.argv.index("--csv")
-            if csv_index + 1 >= len(sys.argv):
-                print("Error: --csv flag requires a file path", file=sys.stderr)
-                sys.exit(1)
+    return concurrency
 
-            csv_path: str = sys.argv[csv_index + 1]
-            tenant_ids = read_tenant_ids_from_csv(csv_path)
 
-            if not tenant_ids:
-                print("Error: No tenant IDs found in CSV file", file=sys.stderr)
-                sys.exit(1)
-
-            print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
-
-        except Exception as e:
-            print(f"Error reading CSV file: {e}", file=sys.stderr)
-            sys.exit(1)
-    else:
+def _parse_tenant_ids() -> list[str]:
+    """Return the tenant IDs from --csv, or the single positional tenant ID."""
+    if "--csv" not in sys.argv:
         # Single tenant mode
-        tenant_ids = [sys.argv[1]]
+        return [sys.argv[1]]
 
-    # Find pods in both clusters before processing
+    try:
+        csv_index: int = sys.argv.index("--csv")
+        if csv_index + 1 >= len(sys.argv):
+            print("Error: --csv flag requires a file path", file=sys.stderr)
+            sys.exit(1)
+
+        csv_path: str = sys.argv[csv_index + 1]
+        tenant_ids = read_tenant_ids_from_csv(csv_path)
+
+        if not tenant_ids:
+            print("Error: No tenant IDs found in CSV file", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Found {len(tenant_ids)} tenant(s) in CSV file: {csv_path}")
+
+    except Exception as e:
+        print(f"Error reading CSV file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return tenant_ids
+
+
+def _find_pods(data_plane_context: str, control_plane_context: str) -> tuple[str, str]:
+    """Return the data plane and control plane pods to run against."""
     try:
         print("Finding data plane worker pod...")
         data_plane_pod: str = find_worker_pod(data_plane_context)
@@ -427,7 +429,11 @@ def main() -> None:
         print("Cannot proceed with marking connectors for deletion")
         sys.exit(1)
 
-    # Initial confirmation (unless --force is used)
+    return data_plane_pod, control_plane_pod
+
+
+def _confirm_start(tenant_ids: list[str], force: bool, concurrency: int) -> None:
+    """Describe the run and require confirmation unless --force is used."""
     if not force:
         print(f"\n{'=' * 80}")
         print("MARK CONNECTORS FOR DELETION - NO BASTION VERSION")
@@ -470,90 +476,104 @@ def main() -> None:
                 f"(concurrency: {concurrency}) without confirmations"
             )
 
-    # Process tenants (in parallel if concurrency > 1)
-    failed_tenants: list[tuple[str, str]] = []
-    successful_tenants: list[str] = []
 
-    if concurrency == 1:
-        # Sequential processing
-        for idx, tenant_id in enumerate(tenant_ids, 1):
-            if len(tenant_ids) > 1:
-                print(f"\n{'=' * 80}")
-                print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
-                print(f"{'=' * 80}")
+def _process_sequentially(
+    tenant_ids: list[str],
+    config: _RunConfig,
+    successful_tenants: list[str],
+    failed_tenants: list[tuple[str, str]],
+) -> None:
+    """Process tenants one at a time, recording the outcome of each."""
+    for idx, tenant_id in enumerate(tenant_ids, 1):
+        if len(tenant_ids) > 1:
+            print(f"\n{'=' * 80}")
+            print(f"Processing tenant {idx}/{len(tenant_ids)}: {tenant_id}")
+            print(f"{'=' * 80}")
 
-            try:
-                mark_tenant_connectors_for_deletion(
-                    tenant_id,
-                    data_plane_pod,
-                    control_plane_pod,
-                    data_plane_context,
-                    control_plane_context,
-                    force,
+        try:
+            mark_tenant_connectors_for_deletion(
+                tenant_id,
+                config.data_plane_pod,
+                config.control_plane_pod,
+                config.data_plane_context,
+                config.control_plane_context,
+                config.force,
+            )
+            successful_tenants.append(tenant_id)
+        except Exception as e:
+            print(
+                f"✗ Failed to process tenant {tenant_id}: {e}",
+                file=sys.stderr,
+            )
+            failed_tenants.append((tenant_id, str(e)))
+
+            # If not in force mode and there are more tenants, ask if we should continue
+            if not config.force and idx < len(tenant_ids):
+                response = input(
+                    f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
                 )
+                if response.lower() != "y":
+                    print("Operation aborted by user")
+                    break
+
+
+def _process_in_parallel(
+    tenant_ids: list[str],
+    config: _RunConfig,
+    concurrency: int,
+    successful_tenants: list[str],
+    failed_tenants: list[tuple[str, str]],
+) -> None:
+    """Process tenants concurrently, recording the outcome of each."""
+    print(f"\nProcessing {len(tenant_ids)} tenant(s) with concurrency={concurrency}")
+
+    def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
+        """Process a single tenant. Returns (tenant_id, success, error_message)."""
+        try:
+            mark_tenant_connectors_for_deletion(
+                tenant_id,
+                config.data_plane_pod,
+                config.control_plane_pod,
+                config.data_plane_context,
+                config.control_plane_context,
+                config.force,
+            )
+            return (tenant_id, True, None)
+        except Exception as e:
+            return (tenant_id, False, str(e))
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        # Submit all tasks
+        future_to_tenant = {
+            executor.submit(process_tenant, tenant_id): tenant_id
+            for tenant_id in tenant_ids
+        }
+
+        # Process results as they complete
+        completed: int = 0
+        for future in as_completed(future_to_tenant):
+            completed += 1
+            tenant_id, success, error = future.result()
+
+            if success:
                 successful_tenants.append(tenant_id)
-            except Exception as e:
-                print(
-                    f"✗ Failed to process tenant {tenant_id}: {e}",
+                safe_print(
+                    f"[{completed}/{len(tenant_ids)}] ✓ Successfully processed {tenant_id}"
+                )
+            else:
+                failed_tenants.append((tenant_id, error or "Unknown error"))
+                safe_print(
+                    f"[{completed}/{len(tenant_ids)}] ✗ Failed to process {tenant_id}: {error}",
                     file=sys.stderr,
                 )
-                failed_tenants.append((tenant_id, str(e)))
 
-                # If not in force mode and there are more tenants, ask if we should continue
-                if not force and idx < len(tenant_ids):
-                    response = input(
-                        f"\nContinue with remaining {len(tenant_ids) - idx} tenant(s)? (y/n): "
-                    )
-                    if response.lower() != "y":
-                        print("Operation aborted by user")
-                        break
-    else:
-        # Parallel processing
-        print(
-            f"\nProcessing {len(tenant_ids)} tenant(s) with concurrency={concurrency}"
-        )
 
-        def process_tenant(tenant_id: str) -> tuple[str, bool, str | None]:
-            """Process a single tenant. Returns (tenant_id, success, error_message)."""
-            try:
-                mark_tenant_connectors_for_deletion(
-                    tenant_id,
-                    data_plane_pod,
-                    control_plane_pod,
-                    data_plane_context,
-                    control_plane_context,
-                    force,
-                )
-                return (tenant_id, True, None)
-            except Exception as e:
-                return (tenant_id, False, str(e))
-
-        with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            # Submit all tasks
-            future_to_tenant = {
-                executor.submit(process_tenant, tenant_id): tenant_id
-                for tenant_id in tenant_ids
-            }
-
-            # Process results as they complete
-            completed: int = 0
-            for future in as_completed(future_to_tenant):
-                completed += 1
-                tenant_id, success, error = future.result()
-
-                if success:
-                    successful_tenants.append(tenant_id)
-                    safe_print(
-                        f"[{completed}/{len(tenant_ids)}] ✓ Successfully processed {tenant_id}"
-                    )
-                else:
-                    failed_tenants.append((tenant_id, error or "Unknown error"))
-                    safe_print(
-                        f"[{completed}/{len(tenant_ids)}] ✗ Failed to process {tenant_id}: {error}",
-                        file=sys.stderr,
-                    )
-
-    # Print summary if multiple tenants
+def _print_summary(
+    tenant_ids: list[str],
+    successful_tenants: list[str],
+    failed_tenants: list[tuple[str, str]],
+) -> None:
+    """Print the run summary and exit non-zero if any tenant failed."""
     if len(tenant_ids) > 1:
         print(f"\n{'=' * 80}")
         print("OPERATION SUMMARY")
@@ -571,6 +591,60 @@ def main() -> None:
 
         if failed_tenants:
             sys.exit(1)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _print_usage()
+        sys.exit(1)
+
+    # Parse arguments
+    force = "--force" in sys.argv
+
+    # Parse contexts (required)
+    data_plane_context, control_plane_context = _parse_contexts()
+
+    concurrency: int = _parse_concurrency()
+
+    # Validate: concurrency > 1 requires --force
+    if concurrency > 1 and not force:
+        print(
+            "Error: --concurrency > 1 requires --force flag (interactive mode not supported with parallel processing)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    tenant_ids: list[str] = _parse_tenant_ids()
+
+    # Find pods in both clusters before processing
+    data_plane_pod, control_plane_pod = _find_pods(
+        data_plane_context, control_plane_context
+    )
+
+    # Initial confirmation (unless --force is used)
+    _confirm_start(tenant_ids, force, concurrency)
+
+    config = _RunConfig(
+        data_plane_pod=data_plane_pod,
+        control_plane_pod=control_plane_pod,
+        data_plane_context=data_plane_context,
+        control_plane_context=control_plane_context,
+        force=force,
+    )
+
+    # Process tenants (in parallel if concurrency > 1)
+    failed_tenants: list[tuple[str, str]] = []
+    successful_tenants: list[str] = []
+
+    if concurrency == 1:
+        _process_sequentially(tenant_ids, config, successful_tenants, failed_tenants)
+    else:
+        _process_in_parallel(
+            tenant_ids, config, concurrency, successful_tenants, failed_tenants
+        )
+
+    # Print summary if multiple tenants
+    _print_summary(tenant_ids, successful_tenants, failed_tenants)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,13 @@ ignore = [
     "B904", # raise-without-from-inside-except (~465 existing violations).
 ]
 # G004: f-strings in logging break Sentry's message-pattern grouping.
-select = ["ARG", "B", "E", "F", "G004", "I", "PERF", "S", "W"]
+select = ["ARG", "B", "C901", "E", "F", "G004", "I", "PERF", "S", "W"]
+
+[tool.ruff.lint.mccabe]
+# Ruff's default is 10, which flags 429 functions. 30 is a ratchet: it stops new
+# highly-branched functions without a repo-wide refactor. The 23 functions above
+# it are listed in per-file-ignores below. Lower this as those get simplified.
+max-complexity = 30
 
 [tool.ruff.lint.flake8-bugbear]
 # FastAPI dependency-injection markers are the intended way to write these
@@ -322,3 +328,29 @@ known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]
 # pipe shell commands, and build ad-hoc SQL against trusted internal inputs
 # (tenant IDs, schema names). Other S rules still apply.
 "backend/scripts/**" = ["S108", "S602", "S608"]
+# Functions above the max-complexity of 30 when C901 was enabled. The trailing
+# number is the complexity at that time. Remove an entry once its function is
+# simplified. NOTE: the ignore is per file, so it also hides new complex
+# functions added to these files.
+"backend/ee/onyx/server/gateway/openai_passthrough.py" = ["C901"] # 32
+"backend/onyx/background/celery/tasks/docfetching/tasks.py" = ["C901"] # 43
+"backend/onyx/background/indexing/run_docfetching.py" = ["C901"] # 33
+"backend/onyx/chat/llm_loop.py" = ["C901"] # 46
+"backend/onyx/chat/llm_step.py" = ["C901"] # 51
+"backend/onyx/chat/process_message.py" = ["C901"] # 47
+"backend/onyx/connectors/sharepoint/connector.py" = ["C901"] # 34
+"backend/onyx/context/search/federated/slack_search.py" = ["C901"] # 31
+"backend/onyx/db/persona.py" = ["C901"] # 49
+"backend/onyx/document_index/opensearch/search.py" = ["C901"] # 48
+"backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py" = ["C901"] # 41
+"backend/onyx/llm/multi_llm.py" = ["C901"] # 45
+"backend/onyx/onyxbot/slack/handlers/handle_message.py" = ["C901"] # 34
+"backend/onyx/secondary_llm_flows/document_filter.py" = ["C901"] # 31
+"backend/onyx/server/features/build/interactive_turns/executor.py" = ["C901"] # 35
+"backend/onyx/server/features/build/sandbox/opencode/serve_client.py" = ["C901"] # 56
+"backend/onyx/server/features/mcp/api.py" = ["C901"] # 33
+"backend/onyx/server/query_and_chat/session_loading.py" = ["C901"] # 42
+"backend/onyx/tools/tool_constructor.py" = ["C901"] # 40
+"backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py" = ["C901"] # 31
+"backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py" = ["C901"] # 49
+"backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py" = ["C901"] # 39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,12 +295,12 @@ ignore = [
 select = ["ARG", "B", "C901", "E", "F", "G004", "I", "PERF", "S", "W"]
 
 [tool.ruff.lint.mccabe]
-# Ruff's default is 10, which flags 429 functions. 30 is a ratchet: it stops new
+# Ruff's default is 10, which flags 429 functions. 20 is a ratchet: it stops new
 # highly-branched functions without a repo-wide refactor. Lower it as the
-# functions between 10 and 30 get simplified.
+# functions between 10 and 20 get simplified.
 # NOTE: ruff counts a nested function's branches toward the function that
 # encloses it, so lifting closures to module scope often fixes a violation.
-max-complexity = 30
+max-complexity = 20
 
 [tool.ruff.lint.flake8-bugbear]
 # FastAPI dependency-injection markers are the intended way to write these
@@ -330,3 +330,55 @@ known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]
 # pipe shell commands, and build ad-hoc SQL against trusted internal inputs
 # (tenant IDs, schema names). Other S rules still apply.
 "backend/scripts/**" = ["S108", "S602", "S608"]
+# Functions above the max-complexity of 20 when it was lowered from 30. The
+# trailing number is the highest complexity in that file at the time. Remove an
+# entry once its functions are simplified. NOTE: the ignore is per file, so it
+# also hides new complex functions added to these files. Tracked in #2403.
+"backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py" = ["C901"] # 21
+"backend/ee/onyx/external_permissions/google_drive/doc_sync.py" = ["C901"] # 21
+"backend/ee/onyx/server/gateway/anthropic_passthrough.py" = ["C901"] # 23
+"backend/ee/onyx/server/gateway/api.py" = ["C901"] # 27
+"backend/onyx/auth/users.py" = ["C901"] # 30
+"backend/onyx/background/celery/tasks/docprocessing/tasks.py" = ["C901"] # 24
+"backend/onyx/background/celery/tasks/port/tasks.py" = ["C901"] # 27
+"backend/onyx/chat/citation_processor.py" = ["C901"] # 30
+"backend/onyx/chat/llm_step.py" = ["C901"] # 23
+"backend/onyx/chat/process_message.py" = ["C901"] # 29
+"backend/onyx/connectors/blob/connector.py" = ["C901"] # 24
+"backend/onyx/connectors/confluence/connector.py" = ["C901"] # 22
+"backend/onyx/connectors/confluence/onyx_confluence.py" = ["C901"] # 22
+"backend/onyx/connectors/connector_runner.py" = ["C901"] # 26
+"backend/onyx/connectors/drupal_wiki/connector.py" = ["C901"] # 21
+"backend/onyx/connectors/github/connector.py" = ["C901"] # 28
+"backend/onyx/connectors/gitlab/connector.py" = ["C901"] # 22
+"backend/onyx/connectors/google_drive/connector.py" = ["C901"] # 22
+"backend/onyx/connectors/google_drive/doc_conversion.py" = ["C901"] # 24
+"backend/onyx/connectors/hubspot/connector.py" = ["C901"] # 23
+"backend/onyx/connectors/notion/connector.py" = ["C901"] # 22
+"backend/onyx/connectors/sharepoint/connector.py" = ["C901"] # 27
+"backend/onyx/connectors/slack/connector.py" = ["C901"] # 26
+"backend/onyx/connectors/testrail/connector.py" = ["C901"] # 21
+"backend/onyx/connectors/web/connector.py" = ["C901"] # 23
+"backend/onyx/deep_research/dr_loop.py" = ["C901"] # 26
+"backend/onyx/federated_connectors/federated_retrieval.py" = ["C901"] # 21
+"backend/onyx/kg/extractions/extraction_processing.py" = ["C901"] # 30
+"backend/onyx/llm/utils.py" = ["C901"] # 30
+"backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py" = ["C901"] # 22
+"backend/onyx/onyxbot/slack/listener.py" = ["C901"] # 28
+"backend/onyx/server/documents/connector.py" = ["C901"] # 28
+"backend/onyx/server/features/build/interactive_turns/api.py" = ["C901"] # 22
+"backend/onyx/server/features/build/session/streaming.py" = ["C901"] # 24
+"backend/onyx/server/features/mcp/api.py" = ["C901"] # 28
+"backend/onyx/server/manage/users.py" = ["C901"] # 22
+"backend/onyx/server/manage/voice/websocket_api.py" = ["C901"] # 29
+"backend/onyx/skills/builtin/gmail/gmail_api.py" = ["C901"] # 23
+"backend/onyx/skills/builtin/google-drive/gdrive_api.py" = ["C901"] # 26
+"backend/onyx/skills/builtin/notion/notion_api.py" = ["C901"] # 28
+"backend/onyx/skills/ingest_from_github.py" = ["C901"] # 27
+"backend/onyx/tools/tool_implementations/search/search_tool.py" = ["C901"] # 25
+"backend/onyx/tools/tool_runner.py" = ["C901"] # 21
+"backend/onyx/utils/jsonriver/tokenize.py" = ["C901"] # 22
+"backend/onyx/voice/providers/elevenlabs.py" = ["C901"] # 21
+"backend/scripts/rotate_llm_provider_keys.py" = ["C901"] # 25
+"backend/scripts/tenant_cleanup/cleanup_tenants.py" = ["C901"] # 27
+"backend/tests/unit/onyx/connectors/salesforce/test_salesforce_sqlite.py" = ["C901"] # 24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,8 +296,10 @@ select = ["ARG", "B", "C901", "E", "F", "G004", "I", "PERF", "S", "W"]
 
 [tool.ruff.lint.mccabe]
 # Ruff's default is 10, which flags 429 functions. 30 is a ratchet: it stops new
-# highly-branched functions without a repo-wide refactor. The 23 functions above
-# it are listed in per-file-ignores below. Lower this as those get simplified.
+# highly-branched functions without a repo-wide refactor. Lower it as the
+# functions between 10 and 30 get simplified.
+# NOTE: ruff counts a nested function's branches toward the function that
+# encloses it, so lifting closures to module scope often fixes a violation.
 max-complexity = 30
 
 [tool.ruff.lint.flake8-bugbear]
@@ -328,29 +330,3 @@ known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]
 # pipe shell commands, and build ad-hoc SQL against trusted internal inputs
 # (tenant IDs, schema names). Other S rules still apply.
 "backend/scripts/**" = ["S108", "S602", "S608"]
-# Functions above the max-complexity of 30 when C901 was enabled. The trailing
-# number is the complexity at that time. Remove an entry once its function is
-# simplified. NOTE: the ignore is per file, so it also hides new complex
-# functions added to these files.
-"backend/ee/onyx/server/gateway/openai_passthrough.py" = ["C901"] # 32
-"backend/onyx/background/celery/tasks/docfetching/tasks.py" = ["C901"] # 43
-"backend/onyx/background/indexing/run_docfetching.py" = ["C901"] # 33
-"backend/onyx/chat/llm_loop.py" = ["C901"] # 46
-"backend/onyx/chat/llm_step.py" = ["C901"] # 51
-"backend/onyx/chat/process_message.py" = ["C901"] # 47
-"backend/onyx/connectors/sharepoint/connector.py" = ["C901"] # 34
-"backend/onyx/context/search/federated/slack_search.py" = ["C901"] # 31
-"backend/onyx/db/persona.py" = ["C901"] # 49
-"backend/onyx/document_index/opensearch/search.py" = ["C901"] # 48
-"backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py" = ["C901"] # 41
-"backend/onyx/llm/multi_llm.py" = ["C901"] # 45
-"backend/onyx/onyxbot/slack/handlers/handle_message.py" = ["C901"] # 34
-"backend/onyx/secondary_llm_flows/document_filter.py" = ["C901"] # 31
-"backend/onyx/server/features/build/interactive_turns/executor.py" = ["C901"] # 35
-"backend/onyx/server/features/build/sandbox/opencode/serve_client.py" = ["C901"] # 56
-"backend/onyx/server/features/mcp/api.py" = ["C901"] # 33
-"backend/onyx/server/query_and_chat/session_loading.py" = ["C901"] # 42
-"backend/onyx/tools/tool_constructor.py" = ["C901"] # 40
-"backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py" = ["C901"] # 31
-"backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py" = ["C901"] # 49
-"backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py" = ["C901"] # 39


### PR DESCRIPTION
Stacked on #14301, which is stacked on #14298. Review those first.

## What this does

#14301 simplified the 23 functions that needed ignores at 30, so the
threshold can come down. This lowers `max-complexity` from 30 to 20.

48 files still hold at least one function in the 21-30 band. Each gets a
per-file ignore with its highest current complexity recorded in a trailing
comment, so the next person can see the size of the job before opening the
file. Tracked in #2403.

No source files change here — this is config only.

## Why 20 and not 10

Ruff's default of 10 flags 429 functions across 425 files. That is a
repo-wide refactor, not a lint change. The counts:

| max-complexity | functions flagged |
|---:|---:|
| 10 | 429 |
| 15 | 184 |
| 20 | 58 |
| 25 | 25 |
| 30 | 0 |

20 is the next useful ratchet. 15 is a reasonable follow-up once the
current band shrinks.

## Caveat worth knowing

`per-file-ignores` is file-scoped, not function-scoped. A new highly
branched function added to one of these 48 files will not be flagged.
That is the accepted tradeoff for landing the rule at all, and it shrinks
as entries get removed. Every other file in the repo is covered.

## Verification

- `ruff check` clean on both pinned versions (0.16.1 from `pyproject.toml`,
  0.16.0 from `.pre-commit-config.yaml`)
- confirmed the ratchet bites: a synthetic 24-branch function added to a
  non-ignored file is flagged, so the ignores are not masking the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowers Ruff's `C901` max-complexity from 30 to 20 now that the functions previously ignoring the rule at 30 are simplified. Adds per-file ignores for 48 files with functions in the 21-30 band, recording each file's current highest complexity. Config-only change; no source files change.

- Per-file ignores are file-scoped, not function-scoped, so new complex functions in those 48 files won't be flagged until each entry is removed.
- Ruff's default of 10 flags 429 functions; 20 is the next useful ratchet, with 15 as a follow-up once this band shrinks.
- Verified `ruff check` passes on both pinned Ruff versions and the ratchet flags a synthetic 24-branch function in a non-ignored file.

<sup>Written for commit 19fbe9d4a6588320d5d8f0b3df29a6466ec2e199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

