### PR TITLE
refactor(web): move the language setting into its own card

### DIFF
--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -1629,11 +1629,6 @@
         "light": "Hell",
         "title": "Farbmodus"
       },
-      "language": {
-        "description": "Wählen Sie die Sprache für die Benutzeroberfläche.",
-        "title": "Sprache",
-        "updateFailed": "Die Spracheinstellung konnte nicht aktualisiert werden"
-      },
       "title": "Erscheinungsbild"
     },
     "chats": {
@@ -1738,6 +1733,16 @@
       "url": {
         "description": "Verwenden Sie diese Basis-URL mit kompatiblen OpenAI- und Anthropic-Clients.",
         "title": "Gateway-URL"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "Wählen Sie die Sprache für die Benutzeroberfläche.",
+        "title": "Anzeigesprache"
+      },
+      "title": "Sprache",
+      "toasts": {
+        "updateFailed": "Die Spracheinstellung konnte nicht aktualisiert werden"
       }
     },
     "memory": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -1629,11 +1629,6 @@
         "light": "Light",
         "title": "Color Mode"
       },
-      "language": {
-        "description": "Select the language for the UI.",
-        "title": "Language",
-        "updateFailed": "Failed to update language preference"
-      },
       "title": "Appearance"
     },
     "chats": {
@@ -1738,6 +1733,16 @@
       "url": {
         "description": "Use this base URL with compatible OpenAI and Anthropic clients.",
         "title": "Gateway URL"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "Select the language for the UI.",
+        "title": "Display Language"
+      },
+      "title": "Language",
+      "toasts": {
+        "updateFailed": "Failed to update language preference"
       }
     },
     "memory": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -1629,11 +1629,6 @@
         "light": "Claro",
         "title": "Modo de color"
       },
-      "language": {
-        "description": "Selecciona el idioma de la interfaz.",
-        "title": "Idioma",
-        "updateFailed": "No se pudo actualizar la preferencia de idioma"
-      },
       "title": "Apariencia"
     },
     "chats": {
@@ -1738,6 +1733,16 @@
       "url": {
         "description": "Usa esta URL base con clientes compatibles de OpenAI y Anthropic.",
         "title": "URL del Gateway"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "Selecciona el idioma de la interfaz.",
+        "title": "Idioma de la interfaz"
+      },
+      "title": "Idioma",
+      "toasts": {
+        "updateFailed": "No se pudo actualizar la preferencia de idioma"
       }
     },
     "memory": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -1629,11 +1629,6 @@
         "light": "Clair",
         "title": "Mode de couleur"
       },
-      "language": {
-        "description": "Sélectionnez la langue de l'interface.",
-        "title": "Langue",
-        "updateFailed": "Impossible de mettre à jour la préférence de langue"
-      },
       "title": "Apparence"
     },
     "chats": {
@@ -1738,6 +1733,16 @@
       "url": {
         "description": "Utilisez cette URL de base avec les clients OpenAI et Anthropic compatibles.",
         "title": "URL du Gateway"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "Sélectionnez la langue de l'interface.",
+        "title": "Langue d'affichage"
+      },
+      "title": "Langue",
+      "toasts": {
+        "updateFailed": "Impossible de mettre à jour la préférence de langue"
       }
     },
     "memory": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -1629,11 +1629,6 @@
         "light": "Claro",
         "title": "Modo de cor"
       },
-      "language": {
-        "description": "Selecione o idioma da interface.",
-        "title": "Idioma",
-        "updateFailed": "Não foi possível atualizar a preferência de idioma"
-      },
       "title": "Aparência"
     },
     "chats": {
@@ -1738,6 +1733,16 @@
       "url": {
         "description": "Use esta URL base com clientes compatíveis com OpenAI e Anthropic.",
         "title": "URL do gateway"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "Selecione o idioma da interface.",
+        "title": "Idioma da interface"
+      },
+      "title": "Idioma",
+      "toasts": {
+        "updateFailed": "Não foi possível atualizar a preferência de idioma"
       }
     },
     "memory": {

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -751,32 +751,6 @@ function GeneralSettings() {
                   </InputSelect.Content>
                 </InputSelect>
               </InputHorizontal>
-              <InputHorizontal
-                title={t("appearance.language.title")}
-                description={t("appearance.language.description")}
-                center
-                withLabel
-              >
-                <InputSelect
-                  value={currentLanguage}
-                  onValueChange={(value) => {
-                    // SAFETY: the items below only carry SUPPORTED_LOCALES
-                    // values, so the select can't emit anything else.
-                    updateUserLanguage(value as Locale).catch(() => {
-                      toast.error(t("appearance.language.updateFailed"));
-                    });
-                  }}
-                >
-                  <InputSelect.Trigger />
-                  <InputSelect.Content>
-                    {SUPPORTED_LOCALES.map((locale) => (
-                      <InputSelect.Item key={locale} value={locale}>
-                        {LOCALE_ENDONYMS[locale]}
-                      </InputSelect.Item>
-                    ))}
-                  </InputSelect.Content>
-                </InputSelect>
-              </InputHorizontal>
               <InputVertical title={t("appearance.chatBackground.title")}>
                 <div className="flex flex-wrap gap-2">
                   {CHAT_BACKGROUND_OPTIONS.map((bg) => {
@@ -829,6 +803,45 @@ function GeneralSettings() {
                   })}
                 </div>
               </InputVertical>
+            </Section>
+          </Card>
+        </Section>
+
+        <Section gap={3}>
+          <Content
+            title={t("language.title")}
+            sizePreset="main-content"
+            variant="section"
+            width="full"
+          />
+          <Card border="solid" rounding={4}>
+            <Section alignItems="start" height="fit">
+              <InputHorizontal
+                title={t("language.displayLanguage.title")}
+                description={t("language.displayLanguage.description")}
+                center
+                withLabel
+              >
+                <InputSelect
+                  value={currentLanguage}
+                  onValueChange={(value) => {
+                    // SAFETY: the items below only carry SUPPORTED_LOCALES
+                    // values, so the select can't emit anything else.
+                    updateUserLanguage(value as Locale).catch(() => {
+                      toast.error(t("language.toasts.updateFailed"));
+                    });
+                  }}
+                >
+                  <InputSelect.Trigger />
+                  <InputSelect.Content>
+                    {SUPPORTED_LOCALES.map((locale) => (
+                      <InputSelect.Item key={locale} value={locale}>
+                        {LOCALE_ENDONYMS[locale]}
+                      </InputSelect.Item>
+                    ))}
+                  </InputSelect.Content>
+                </InputSelect>
+              </InputHorizontal>
             </Section>
           </Card>
         </Section>


### PR DESCRIPTION
## Description

On `/app/settings/general`, the language switcher was the middle row of the **Appearance** card. Language is not an appearance preference, so it now gets its own section and card between Appearance and Danger Zone.

The message keys move from `settings.appearance.language.*` to a new `settings.language` section across all five locales:

- `language.title` — the card header
- `language.displayLanguage.{title,description}` — the row
- `language.toasts.updateFailed` — the error toast, matching the `toasts.*` convention the other settings sections use

One copy change: the row title is now "Display Language" instead of "Language", because the card header already reads "Language". The description and toast text are unchanged. The new string is translated for `es`/`pt`/`fr`/`de`.

## How Has This Been Tested?

- `pre-commit run --files <changed files>` — oxfmt, oxlint, and the TypeScript type check all pass. The type check covers the next-intl key augmentation and `keyParity.ts`, so it catches any missing or extra locale key.
- `bun run jest src/i18n/__tests__/catalog.test.ts` — 5 passed (ICU shape parity across locales).
- Manually checked the page in the browser: the Language card renders as its own section, and switching to Español translates the page and shows "Idioma" / "Idioma de la interfaz".

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1878" height="2085" alt="20260826_14h22m28s_grim" src="https://github.com/user-attachments/assets/ff5a4204-ada6-4609-98fd-4d9a0a8fcf83" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the language switcher out of the Appearance card on `/app/settings/general` and into its own card between Appearance and Danger Zone. Language isn't an appearance preference, so it gets a dedicated section; behavior is otherwise unchanged.

- Translation keys move from `settings.appearance.language.*` to a new `settings.language` section across all five locales.
- The row title becomes "Display Language" since the card header already reads "Language"; description and toast text stay the same.
- The error toast key moves under `toasts.*` to match how the other settings sections organize their toasts.

<sup>Written for commit f2737caa404d1b4c57a608acebe86aba4e13a06b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

