### PR TITLE
feat(web): i18n extraction wave 3b — admin routes

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -113,6 +113,7 @@
         "src/sections/model-selector/**",
         "src/components/chat/**",
         "src/app/auth/**",
+        "src/app/admin/**",
         "src/app/app/page.tsx",
         "src/app/app/layout.tsx",
         "src/app/app/components/**",

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import { SourceCategory, SourceMetadata } from "@/lib/search/interfaces";
 import { listSourceMetadata } from "@/lib/sources";
@@ -30,6 +31,20 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
 const route = ADMIN_ROUTES.ADD_CONNECTOR;
 
+// The category headings come from the `SourceCategory` enum, whose values are
+// identifiers shared across the app. Map each one to a message key (inside the
+// `admin.addConnector` namespace) so the component can resolve it with `t`.
+const CATEGORY_LABEL_KEYS = {
+  [SourceCategory.Wiki]: "categories.wiki.label",
+  [SourceCategory.Storage]: "categories.storage.label",
+  [SourceCategory.TicketingAndTaskManagement]:
+    "categories.ticketingAndTaskManagement.label",
+  [SourceCategory.Messaging]: "categories.messaging.label",
+  [SourceCategory.Sales]: "categories.sales.label",
+  [SourceCategory.CodeRepository]: "categories.codeRepository.label",
+  [SourceCategory.Other]: "categories.other.label",
+} as const satisfies Record<SourceCategory, string>;
+
 function SourceTileTooltipWrapper({
   sourceMetadata,
   preSelect,
@@ -41,6 +56,8 @@ function SourceTileTooltipWrapper({
   federatedConnectors?: FederatedConnectorDetail[];
   slackCredentials?: Credential<any>[];
 }) {
+  const t = useTranslations("admin.addConnector");
+
   // Check if there's already a federated connector for this source
   const existingFederatedConnector = useMemo(() => {
     if (!sourceMetadata.federated || !federatedConnectors) {
@@ -95,13 +112,15 @@ function SourceTileTooltipWrapper({
       tooltip={
         existingFederatedConnector ? (
           <Text as="p" textLight05 secondaryBody>
-            <strong>Federated connector already configured.</strong> Click to
-            edit the existing connector.
+            {t.rich("sourceTile.tooltip.federatedConfigured", {
+              strong: (chunks) => <strong>{chunks}</strong>,
+            })}
           </Text>
         ) : hasExistingSlackCredentials ? (
           <Text as="p" textLight05 secondaryBody>
-            <strong>Existing Slack credentials found.</strong> Click to manage
-            your Slack connector.
+            {t.rich("sourceTile.tooltip.slackCredentialsFound", {
+              strong: (chunks) => <strong>{chunks}</strong>,
+            })}
           </Text>
         ) : undefined
       }
@@ -119,6 +138,7 @@ function SourceTileTooltipWrapper({
 }
 
 export default function Page() {
+  const t = useTranslations("admin.addConnector");
   const sources = useMemo(() => listSourceMetadata(), []);
 
   const [rawSearchTerm, setSearchTerm] = useState("");
@@ -243,14 +263,16 @@ export default function Page() {
         icon={route.icon}
         title={route.title}
         rightChildren={
-          <Button href="/admin/indexing/status">See Connectors</Button>
+          <Button href="/admin/indexing/status">
+            {t("seeConnectorsButton.label")}
+          </Button>
         }
         divider
       />
       <SettingsLayouts.Body>
         <InputTypeIn
           type="text"
-          placeholder="Search Connectors"
+          placeholder={t("search.placeholder")}
           ref={searchInputRef}
           value={rawSearchTerm} // keep the input bound to immediate state
           onChange={(event) => setSearchTerm(event.target.value)}
@@ -260,7 +282,7 @@ export default function Page() {
         {dedupedPopular.length > 0 && (
           <div className="pt-8">
             <Text as="p" headingH3>
-              Popular
+              {t("popular.title")}
             </Text>
             <div className="flex flex-wrap gap-4 p-4">
               {dedupedPopular.map((source) => (
@@ -281,7 +303,7 @@ export default function Page() {
           .map(([category, sources], categoryInd) => (
             <div key={category} className="pt-8">
               <Text as="p" headingH3>
-                {category}
+                {t(CATEGORY_LABEL_KEYS[category as SourceCategory])}
               </Text>
               <div className="flex flex-wrap gap-4 p-4">
                 {sources.map((source, sourceInd) => (

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { markdown } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
 import { Content, InputErrorText, InputVertical, toast } from "@opal/layouts";
@@ -46,13 +47,10 @@ import useUsers from "@/hooks/useUsers";
 const GRACE_PERIOD_DAYS = 30;
 const MS_PER_DAY = 86_400_000;
 
-/** How much of a trial is left, in words. Rounds up so a partial day still
- *  reads as a day, and floors at "today" so a lagging status cannot go negative. */
-function trialCountdown(trialEnd: Date, now: number = Date.now()): string {
-  const days = Math.ceil((trialEnd.getTime() - now) / MS_PER_DAY);
-  if (days <= 0) return "Trial ends today";
-  if (days === 1) return "Trial ends tomorrow";
-  return `Trial ends in ${days} days`;
+/** How many days of a trial are left. Rounds up so a partial day still counts
+ *  as a whole day; the caller reads a non-positive result as "today". */
+function trialDaysRemaining(trialEnd: Date, now: number = Date.now()): number {
+  return Math.ceil((trialEnd.getTime() - now) / MS_PER_DAY);
 }
 
 // ----------------------------------------------------------------------------
@@ -173,6 +171,7 @@ function SubscriptionCard({
   onReconnect?: () => Promise<void>;
   onRefresh?: () => Promise<void>;
 }) {
+  const t = useTranslations("admin.billing");
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [isEndingTrial, setIsEndingTrial] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -180,7 +179,9 @@ function SubscriptionCard({
   const settings = useSettings();
   const tier = settings.tier;
   const isEnterprise = tier === Tier.ENTERPRISE || tier == null;
-  const planName = isEnterprise ? "Enterprise Plan" : "Business Plan";
+  const planName = isEnterprise
+    ? t("subscription.enterprisePlan.name")
+    : t("subscription.businessPlan.name");
   const PlanIcon = isEnterprise ? SvgOrganization : SvgUsers;
   const expirationDate = billing?.current_period_end ?? license?.expires_at;
   const formattedDate = formatDateShort(expirationDate);
@@ -199,19 +200,27 @@ function SubscriptionCard({
   const isOnTrial = trialEnd !== null && trialEnd.getTime() > Date.now();
   let subtitle: string;
   if (isExpired) {
-    subtitle = `Expired on ${formattedDate}`;
+    subtitle = t("subscription.expired.subtitle", { date: formattedDate });
   } else if (isCanceling) {
-    subtitle = `Valid until ${formattedDate}`;
+    subtitle = t("subscription.validUntil.subtitle", { date: formattedDate });
   } else if (isOnTrial) {
     // The trial ending and the first charge are one event, so both halves of
     // this line have to come from the same date.
-    subtitle = `${trialCountdown(trialEnd)}. Payment required on ${formatDateShort(
-      license?.trial_end
-    )}`;
+    const trialDate = formatDateShort(license?.trial_end);
+    const daysLeft = trialDaysRemaining(trialEnd);
+    subtitle =
+      daysLeft <= 0
+        ? t("subscription.trialToday.subtitle", { date: trialDate })
+        : daysLeft === 1
+          ? t("subscription.trialTomorrow.subtitle", { date: trialDate })
+          : t("subscription.trialDays.subtitle", {
+              days: daysLeft,
+              date: trialDate,
+            });
   } else if (billing) {
-    subtitle = `Next payment on ${formattedDate}`;
+    subtitle = t("subscription.nextPayment.subtitle", { date: formattedDate });
   } else {
-    subtitle = `Valid until ${formattedDate}`;
+    subtitle = t("subscription.validUntil.subtitle", { date: formattedDate });
   }
 
   const handleManagePlan = async () => {
@@ -246,7 +255,7 @@ function SubscriptionCard({
       await onRefresh?.();
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to sync license"
+        error instanceof Error ? error.message : t("toasts.syncLicenseFailed")
       );
     } finally {
       setIsSyncing(false);
@@ -274,11 +283,11 @@ function SubscriptionCard({
           }
         } catch (portalError) {
           console.error("Failed to open customer portal:", portalError);
-          toast.error("Add a payment method first, then try upgrading again.");
+          toast.error(t("toasts.paymentMethodRequired"));
         }
       } else {
         toast.error(
-          error instanceof Error ? error.message : "Failed to end trial"
+          error instanceof Error ? error.message : t("toasts.endTrialFailed")
         );
       }
     } finally {
@@ -316,15 +325,17 @@ function SubscriptionCard({
         >
           {isManualLicenseOnly ? (
             <Text secondaryBody text03 className="text-right">
-              Your plan is managed through sales.
-              <br />
-              <a
-                href="mailto:support@onyx.app?subject=Billing%20change%20request"
-                className="underline"
-              >
-                Contact billing
-              </a>{" "}
-              to make changes.
+              {t.rich("subscription.managedBySales.text", {
+                br: () => <br />,
+                link: (chunks) => (
+                  <a
+                    href="mailto:support@onyx.app?subject=Billing%20change%20request"
+                    className="underline"
+                  >
+                    {chunks}
+                  </a>
+                ),
+              })}
             </Text>
           ) : disabled ? (
             <Button
@@ -333,7 +344,9 @@ function SubscriptionCard({
               onClick={handleReconnect}
               rightIcon={SvgArrowRight}
             >
-              {isReconnecting ? "Connecting..." : "Connect to Stripe"}
+              {isReconnecting
+                ? t("subscription.connecting.label")
+                : t("subscription.connectToStripe.label")}
             </Button>
           ) : (
             <Section
@@ -349,7 +362,9 @@ function SubscriptionCard({
                   onClick={handleEndTrial}
                   rightIcon={SvgArrowRight}
                 >
-                  {isEndingTrial ? "Upgrading..." : "Upgrade now"}
+                  {isEndingTrial
+                    ? t("subscription.upgrading.label")
+                    : t("subscription.upgradeNow.label")}
                 </Button>
               )}
               {/* Cloud has no local license to pull. Self-hosted refreshes
@@ -361,7 +376,9 @@ function SubscriptionCard({
                   prominence="secondary"
                   onClick={handleSyncLicense}
                 >
-                  {isSyncing ? "Syncing..." : "Sync License"}
+                  {isSyncing
+                    ? t("subscription.syncing.label")
+                    : t("subscription.syncLicense.label")}
                 </Button>
               )}
               <Button
@@ -369,12 +386,12 @@ function SubscriptionCard({
                 onClick={handleManagePlan}
                 rightIcon={SvgExternalLink}
               >
-                Manage Plan
+                {t("subscription.managePlan.label")}
               </Button>
             </Section>
           )}
           <Button prominence="tertiary" onClick={onViewPlans}>
-            View Plan Details
+            {t("subscription.viewPlanDetails.label")}
           </Button>
         </Section>
       </Section>
@@ -399,6 +416,7 @@ function SeatsCard({
   disabled?: boolean;
   hideUpdateSeats?: boolean;
 }) {
+  const t = useTranslations("admin.billing");
   const [isEditing, setIsEditing] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -455,7 +473,9 @@ function SeatsCard({
       await onRefresh?.();
       setIsEditing(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update seats");
+      setError(
+        err instanceof Error ? err.message : t("seats.updateFailed.error")
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -466,7 +486,6 @@ function SeatsCard({
   const isRemoving = seatDifference < 0;
   const nextBillingDate = formatDateShort(billing?.current_period_end);
   const seatCount = Math.abs(seatDifference);
-  const seatWord = seatCount === 1 ? "seat" : "seats";
 
   if (isEditing) {
     return (
@@ -484,8 +503,8 @@ function SeatsCard({
           height="auto"
         >
           <Content
-            title="Update Seats"
-            description="Add or remove seats to reflect your team size."
+            title={t("seats.updateSeats.title")}
+            description={t("seats.updateSeats.description")}
             sizePreset="main-content"
             variant="section"
           />
@@ -494,7 +513,7 @@ function SeatsCard({
             prominence="secondary"
             onClick={handleCancel}
           >
-            Cancel
+            {t("seats.cancel.label")}
           </Button>
         </Section>
 
@@ -506,7 +525,7 @@ function SeatsCard({
             padding={4}
             height="auto"
           >
-            <InputVertical title="Seats" withLabel>
+            <InputVertical title={t("seats.seatsField.title")} withLabel>
               <InputNumber
                 value={newSeatCount}
                 onChange={(v) => setNewSeatCount(v ?? 1)}
@@ -520,14 +539,14 @@ function SeatsCard({
             {isBelowMinimum ? (
               <InputErrorText type="error">
                 {markdown(
-                  `You cannot set seats below current **${minRequiredSeats}** seats in use/pending. [Remove users](/admin/users) first before adjusting seats.`
+                  t("seats.belowMinimum.error", { minimum: minRequiredSeats })
                 )}
               </InputErrorText>
             ) : seatDifference !== 0 ? (
               <Text secondaryBody text03>
-                {Math.abs(seatDifference)} seat
-                {Math.abs(seatDifference) !== 1 ? "s" : ""} to be{" "}
-                {isAdding ? "added" : "removed"}
+                {isAdding
+                  ? t("seats.delta.added", { count: seatCount })
+                  : t("seats.delta.removed", { count: seatCount })}
               </Text>
             ) : null}
 
@@ -548,26 +567,30 @@ function SeatsCard({
         >
           {isAdding ? (
             <Text secondaryBody text03>
-              You will be billed for the{" "}
-              <Text secondaryBody text04>
-                {seatCount}
-              </Text>{" "}
-              additional {seatWord} at a pro-rated amount.
+              {t.rich("seats.billing.added", {
+                count: seatCount,
+                value: (chunks) => (
+                  <Text secondaryBody text04>
+                    {chunks}
+                  </Text>
+                ),
+              })}
             </Text>
           ) : isRemoving ? (
             <Text secondaryBody text03>
-              <Text secondaryBody text04>
-                {seatCount}
-              </Text>{" "}
-              {seatWord} will be removed on{" "}
-              <Text secondaryBody text04>
-                {nextBillingDate}
-              </Text>{" "}
-              (after current billing cycle).
+              {t.rich("seats.billing.removed", {
+                count: seatCount,
+                date: nextBillingDate,
+                value: (chunks) => (
+                  <Text secondaryBody text04>
+                    {chunks}
+                  </Text>
+                ),
+              })}
             </Text>
           ) : (
             <Text secondaryBody text03>
-              No changes to your billing.
+              {t("seats.billing.unchanged")}
             </Text>
           )}
           <Button
@@ -576,7 +599,9 @@ function SeatsCard({
             }
             onClick={handleConfirm}
           >
-            {isSubmitting ? "Saving..." : "Confirm Change"}
+            {isSubmitting
+              ? t("seats.saving.label")
+              : t("seats.confirmChange.label")}
           </Button>
         </Section>
       </Card>
@@ -593,11 +618,14 @@ function SeatsCard({
       >
         <Section gap={1} alignItems="start" height="auto" width="auto">
           <Text mainContentMuted text04>
-            {totalSeats} Seats
+            {t("seats.total.label", { count: totalSeats })}
           </Text>
           <Text secondaryBody text03>
-            {usedSeats} in use • {pendingSeats} pending • {remainingSeats}{" "}
-            remaining
+            {t("seats.breakdown.label", {
+              used: usedSeats,
+              pending: pendingSeats,
+              remaining: remainingSeats,
+            })}
           </Text>
         </Section>
         <Section
@@ -612,7 +640,7 @@ function SeatsCard({
             href="/admin/users"
             icon={SvgExternalLink}
           >
-            View Users
+            {t("seats.viewUsers.label")}
           </Button>
           {!hideUpdateSeats && (
             <Button
@@ -621,7 +649,7 @@ function SeatsCard({
               onClick={handleStartEdit}
               icon={SvgPlus}
             >
-              Update Seats
+              {t("seats.updateSeats.label")}
             </Button>
           )}
         </Section>
@@ -635,6 +663,7 @@ function SeatsCard({
 // ----------------------------------------------------------------------------
 
 function PaymentSection({ billing }: { billing: BillingInformation }) {
+  const t = useTranslations("admin.billing");
   const handleOpenPortal = async () => {
     try {
       const response = await createCustomerPortalSession({
@@ -655,7 +684,7 @@ function PaymentSection({ billing }: { billing: BillingInformation }) {
   return (
     <div className="billing-payment-section">
       <Section alignItems="start" height="auto" width="full">
-        <Text mainContentEmphasis>Payment</Text>
+        <Text mainContentEmphasis>{t("payment.section.title")}</Text>
         <Section flexDirection="row" gap={2} alignItems="stretch" height="auto">
           <Card className="billing-payment-card">
             <Section
@@ -666,15 +695,15 @@ function PaymentSection({ billing }: { billing: BillingInformation }) {
             >
               <InfoBlock
                 icon={SvgWallet}
-                title="Visa ending in 1234"
-                description="Payment method"
+                title={t("payment.card.title")}
+                description={t("payment.card.description")}
               />
               <Button
                 prominence="tertiary"
                 onClick={handleOpenPortal}
                 rightIcon={SvgExternalLink}
               >
-                Update
+                {t("payment.update.label")}
               </Button>
             </Section>
           </Card>
@@ -689,14 +718,14 @@ function PaymentSection({ billing }: { billing: BillingInformation }) {
                 <InfoBlock
                   icon={SvgFileText}
                   title={lastPaymentDate}
-                  description="Last payment"
+                  description={t("payment.lastPayment.description")}
                 />
                 <Button
                   prominence="tertiary"
                   onClick={handleOpenPortal}
                   rightIcon={SvgExternalLink}
                 >
-                  View Invoice
+                  {t("payment.viewInvoice.label")}
                 </Button>
               </Section>
             </Card>
@@ -734,6 +763,7 @@ export default function BillingDetailsView({
   licenseCard,
   isGraceSyncing,
 }: BillingDetailsViewProps) {
+  const t = useTranslations("admin.billing");
   const expirationState = billing ? getExpirationState(billing, license) : null;
   const disableBillingActions =
     isAirGapped || hasStripeError || isManualLicenseOnly;
@@ -743,14 +773,14 @@ export default function BillingDetailsView({
       {/* Renewal fetched on arrival while expired. The page renders regardless:
           billing is the one route a lapsed instance must always reach. */}
       {isGraceSyncing && (
-        <MessageCard variant="info" title="Checking for a renewed license…" />
+        <MessageCard variant="info" title={t("banners.graceSync.title")} />
       )}
       {/* Stripe connection error banner */}
       {hasStripeError && (
         <MessageCard
           variant="warning"
-          title="Unable to connect to Stripe payment portal."
-          description="Check your internet connection or manually provide a license."
+          title={t("banners.stripeError.title")}
+          description={t("banners.stripeError.description")}
         />
       )}
 
@@ -758,8 +788,8 @@ export default function BillingDetailsView({
       {isAirGapped && !hasStripeError && !isManualLicenseOnly && (
         <MessageCard
           variant="info"
-          title="Air-gapped deployment"
-          description="Online billing management is disabled. Contact support to update your subscription."
+          title={t("banners.airGapped.title")}
+          description={t("banners.airGapped.description")}
         />
       )}
 
@@ -770,16 +800,24 @@ export default function BillingDetailsView({
           title={
             expirationState.variant === "error"
               ? expirationState.daysUntilDeletion
-                ? `Your subscription has expired. Data will be deleted in ${expirationState.daysUntilDeletion} days.`
-                : "Your subscription has expired."
-              : `Your subscription is expiring in ${expirationState.daysRemaining} days.`
+                ? t("banners.expired.withDeletion.title", {
+                    days: expirationState.daysUntilDeletion,
+                  })
+                : t("banners.expired.title")
+              : t("banners.expiring.title", {
+                  days: expirationState.daysRemaining,
+                })
           }
           description={
             expirationState.variant === "error"
               ? expirationState.expirationDate
-                ? `Renew your subscription by ${expirationState.expirationDate} to restore access.`
-                : "Renew your subscription to restore access to paid features."
-              : `Renew your subscription by ${expirationState.expirationDate} to avoid disruption.`
+                ? t("banners.expired.withDate.description", {
+                    date: expirationState.expirationDate,
+                  })
+                : t("banners.expired.description")
+              : t("banners.expiring.description", {
+                  date: expirationState.expirationDate,
+                })
           }
         />
       )}

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Section } from "@/layouts/general-layouts";
 import { InputHorizontal } from "@opal/layouts";
 import { Button, Divider } from "@opal/components";
@@ -33,6 +34,8 @@ function BillingOption({
   price,
   badge,
 }: BillingOptionProps) {
+  const t = useTranslations("admin.billing");
+
   return (
     <Card
       onClick={onClick}
@@ -59,10 +62,10 @@ function BillingOption({
           </Text>
           <div className="billing-option-price">
             <Text mainContentEmphasis text04>
-              ${price}
+              {t("checkout.price.label", { price })}
             </Text>
             <Text secondaryBody text03 nowrap>
-              per seat/month
+              {t("checkout.perSeatMonth.label")}
             </Text>
           </div>
         </Section>
@@ -95,6 +98,7 @@ interface CheckoutViewProps {
 }
 
 export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
+  const t = useTranslations("admin.billing");
   const { user } = useUser();
   const { data: usersData } = useUsers({ includeApiKeys: false });
 
@@ -146,7 +150,9 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
     } catch (err) {
       console.error("Error creating checkout session:", err);
       setError(
-        err instanceof Error ? err.message : "Failed to create checkout session"
+        err instanceof Error
+          ? err.message
+          : t("checkout.createSessionFailed.error")
       );
     } finally {
       setIsSubmitting(false);
@@ -172,11 +178,11 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
         >
           <SvgUsers size={24} />
           <Text headingH2 text04>
-            Business
+            {t("checkout.plan.title")}
           </Text>
         </Section>
         <Button prominence="secondary" onClick={onAdjustPlan}>
-          Adjust Plan
+          {t("checkout.adjustPlan.label")}
         </Button>
       </Section>
 
@@ -191,8 +197,8 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
         >
           {/* Billing Cycle */}
           <InputHorizontal
-            title="Billing Cycle"
-            description="after your 1-month free trial"
+            title={t("checkout.billingCycle.title")}
+            description={t("checkout.billingCycle.description")}
             withLabel
           >
             <Section
@@ -205,15 +211,15 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
               <BillingOption
                 selected={billingPeriod === "monthly"}
                 onClick={() => setBillingPeriod("monthly")}
-                title="Monthly"
+                title={t("checkout.monthly.label")}
                 price={monthlyPrice}
               />
               <BillingOption
                 selected={billingPeriod === "annual"}
                 onClick={() => setBillingPeriod("annual")}
-                title="Annual"
+                title={t("checkout.annual.label")}
                 price={annualPrice}
-                badge="Save 20%"
+                badge={t("checkout.annualBadge.label")}
               />
             </Section>
           </InputHorizontal>
@@ -222,10 +228,10 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
 
           {/* Seats */}
           <InputHorizontal
-            title="Seats"
-            description={`Minimum ${minRequiredSeats} seat${
-              minRequiredSeats !== 1 ? "s" : ""
-            } required for your current users and Slack accounts.`}
+            title={t("checkout.seats.title")}
+            description={t("checkout.seats.description", {
+              count: minRequiredSeats,
+            })}
             withLabel
           >
             <InputNumber
@@ -253,18 +259,23 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
           </Text>
         ) : !annualPriceSelected ? (
           <Text secondaryBody text03>
-            You will be billed on{" "}
-            <Text secondaryBody text04>
-              {trialEndDate}
-            </Text>{" "}
-            After your 1-month free trial ends.
+            {t.rich("checkout.trialBilling.text", {
+              date: trialEndDate,
+              value: (chunks) => (
+                <Text secondaryBody text04>
+                  {chunks}
+                </Text>
+              ),
+            })}
           </Text>
         ) : (
           // Empty div to maintain space-between alignment
           <div></div>
         )}
         <Button disabled={isSubmitting} onClick={handleSubmit}>
-          {isSubmitting ? "Loading..." : "Continue to Payment"}
+          {isSubmitting
+            ? t("checkout.loading.label")
+            : t("checkout.continueToPayment.label")}
         </Button>
       </Section>
     </Card>

--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button, Card } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import InputFile from "@/refresh-components/inputs/InputFile";
@@ -28,6 +29,7 @@ export default function LicenseActivationCard({
   license,
   hideClose,
 }: LicenseActivationCardProps) {
+  const t = useTranslations("admin.billing");
   const [licenseKey, setLicenseKey] = useState("");
   const [isActivating, setIsActivating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +50,7 @@ export default function LicenseActivationCard({
 
   const handleActivate = async () => {
     if (!licenseKey.trim()) {
-      setError("Please enter a license key");
+      setError(t("license.emptyKey.error"));
       return;
     }
 
@@ -65,7 +67,7 @@ export default function LicenseActivationCard({
     } catch (err) {
       console.error("Error activating license:", err);
       setError(
-        err instanceof Error ? err.message : "Failed to activate license"
+        err instanceof Error ? err.message : t("license.activateFailed.error")
       );
     } finally {
       setIsActivating(false);
@@ -109,25 +111,25 @@ export default function LicenseActivationCard({
                 />
               )}
               <Text secondaryBody text03>
-                {isExpired ? (
-                  <>License key expired</>
-                ) : (
-                  <>
-                    License key active until{" "}
-                    <Text secondaryBody text04>
-                      {expirationDate}
-                    </Text>
-                  </>
-                )}
+                {isExpired
+                  ? t("license.expired.label")
+                  : t.rich("license.activeUntil.label", {
+                      date: expirationDate ?? "",
+                      value: (chunks) => (
+                        <Text secondaryBody text04>
+                          {chunks}
+                        </Text>
+                      ),
+                    })}
               </Text>
             </Section>
             <Section flexDirection="row" gap={2} height="auto" width="auto">
               <Button prominence="secondary" onClick={() => setShowInput(true)}>
-                Update Key
+                {t("license.updateKey.label")}
               </Button>
               {!hideClose && (
                 <Button prominence="tertiary" onClick={handleClose}>
-                  Close
+                  {t("license.close.label")}
                 </Button>
               )}
             </Section>
@@ -154,18 +156,20 @@ export default function LicenseActivationCard({
             alignItems="center"
           >
             <Text headingH3>
-              {hasLicense ? "Update License Key" : "Activate License Key"}
+              {hasLicense
+                ? t("license.updateTitle.title")
+                : t("license.activateTitle.title")}
             </Text>
             <Button
               disabled={isActivating}
               prominence="secondary"
               onClick={handleClose}
             >
-              Cancel
+              {t("license.cancel.label")}
             </Button>
           </Section>
           <Text secondaryBody text03>
-            Manually add and activate a license for this Onyx instance.
+            {t("license.description")}
           </Text>
         </Section>
 
@@ -180,17 +184,17 @@ export default function LicenseActivationCard({
             {success && (
               <div className="billing-success-message">
                 <Text secondaryBody>
-                  License {hasLicense ? "updated" : "activated"} successfully!
+                  {hasLicense
+                    ? t("license.updateSuccess.message")
+                    : t("license.activateSuccess.message")}
                 </Text>
               </div>
             )}
 
             <InputVertical
-              title="License Key"
+              title={t("license.keyField.title")}
               subDescription={
-                error
-                  ? undefined
-                  : "Paste or attach your license key file you received from Onyx."
+                error ? undefined : t("license.keyField.description")
               }
               withLabel
             >
@@ -214,15 +218,19 @@ export default function LicenseActivationCard({
                     <SvgXCircle size={12} />
                   </div>
                   <Text secondaryBody text04>
-                    {error}.{" "}
-                    <a
-                      href={BILLING_HELP_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="billing-help-link"
-                    >
-                      Billing Help
-                    </a>
+                    {t.rich("license.error.text", {
+                      error,
+                      link: (chunks) => (
+                        <a
+                          href={BILLING_HELP_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="billing-help-link"
+                        >
+                          {chunks}
+                        </a>
+                      ),
+                    })}
                   </Text>
                 </Section>
               )}
@@ -237,10 +245,10 @@ export default function LicenseActivationCard({
             onClick={handleActivate}
           >
             {isActivating
-              ? "Activating..."
+              ? t("license.activating.label")
               : hasLicense
-                ? "Update License"
-                : "Activate License"}
+                ? t("license.updateLicense.label")
+                : t("license.activateLicense.label")}
           </Button>
         </Section>
       </Section>

--- a/web/src/app/admin/billing/PlansView.tsx
+++ b/web/src/app/admin/billing/PlansView.tsx
@@ -18,6 +18,7 @@ import {
   SvgUserManage,
   SvgUsers,
 } from "@opal/icons";
+import { useTranslations } from "next-intl";
 import "@/app/admin/billing/billing.css";
 import type { IconProps } from "@opal/types";
 import Card from "@/refresh-components/cards/Card";
@@ -52,31 +53,6 @@ interface PlanConfig {
 }
 
 // ----------------------------------------------------------------------------
-// Plan Features
-// ----------------------------------------------------------------------------
-
-const BUSINESS_FEATURES: PlanFeature[] = [
-  { icon: SvgFiles, text: "Inherit Document Permissions" },
-  { icon: SvgHistory, text: "Query History and Usage Dashboard" },
-  { icon: SvgShield, text: "Role Based Access Control (RBAC)" },
-  { icon: SvgLock, text: "Encryption of Secrets" },
-  { icon: SvgKey, text: "Service Account API Keys" },
-  { icon: SvgHardDrive, text: "Self-hosting (Optional)" },
-  { icon: SvgPaintBrush, text: "Custom Theming" },
-];
-
-const ENTERPRISE_FEATURES: PlanFeature[] = [
-  { icon: SvgUsers, text: "SCIM / Group Sync" },
-  { icon: SvgDashboard, text: "Full White-labeling" },
-  { icon: SvgUserManage, text: "Custom Roles and Permissions" },
-  { icon: SvgSliders, text: "Configurable Usage Limits" },
-  { icon: SvgShareWebhook, text: "Hook Extensions" },
-  { icon: SvgServer, text: "Custom Deployments" },
-  { icon: SvgGlobe, text: "Region-Specific Data Processing" },
-  { icon: SvgHeadsetMic, text: "Enterprise SLAs and Priority Support" },
-];
-
-// ----------------------------------------------------------------------------
 // PlanCard (inlined)
 // ----------------------------------------------------------------------------
 
@@ -94,12 +70,14 @@ function PlanCard({
   isCurrentPlan,
   hideFeatures,
 }: PlanConfig & { hideFeatures?: boolean }) {
+  const t = useTranslations("admin.billing");
+
   return (
     <Card
       padding={0}
       gap={0}
       alignItems="stretch"
-      aria-label={title + " plan card"}
+      aria-label={t("plans.card.ariaLabel", { plan: title })}
       className="plan-card"
     >
       <Section
@@ -148,7 +126,7 @@ function PlanCard({
             // the shared 2.25rem box now do directly.
             <div className="w-full flex items-center justify-center rounded-12 p-2 bg-background-tint-00">
               <Text mainUiAction text03>
-                Your Current Plan
+                {t("plans.currentPlan.label")}
               </Text>
             </div>
           ) : href ? (
@@ -170,7 +148,7 @@ function PlanCard({
             // the shared 2.25rem box now do directly.
             <div className="w-full flex items-center justify-center rounded-12 p-2 bg-background-tint-00">
               <Text mainUiAction text03>
-                Included in your plan
+                {t("plans.includedInPlan.label")}
               </Text>
             </div>
           )}
@@ -240,30 +218,60 @@ export default function PlansView({
   onCheckout,
   hideFeatures,
 }: PlansViewProps) {
+  const t = useTranslations("admin.billing");
+
+  const businessFeatures: PlanFeature[] = [
+    { icon: SvgFiles, text: t("plans.business.features.documentPermissions") },
+    { icon: SvgHistory, text: t("plans.business.features.queryHistory") },
+    { icon: SvgShield, text: t("plans.business.features.rbac") },
+    { icon: SvgLock, text: t("plans.business.features.encryption") },
+    { icon: SvgKey, text: t("plans.business.features.apiKeys") },
+    { icon: SvgHardDrive, text: t("plans.business.features.selfHosting") },
+    { icon: SvgPaintBrush, text: t("plans.business.features.theming") },
+  ];
+
+  const enterpriseFeatures: PlanFeature[] = [
+    { icon: SvgUsers, text: t("plans.enterprise.features.scim") },
+    { icon: SvgDashboard, text: t("plans.enterprise.features.whiteLabeling") },
+    { icon: SvgUserManage, text: t("plans.enterprise.features.customRoles") },
+    { icon: SvgSliders, text: t("plans.enterprise.features.usageLimits") },
+    {
+      icon: SvgShareWebhook,
+      text: t("plans.enterprise.features.hookExtensions"),
+    },
+    {
+      icon: SvgServer,
+      text: t("plans.enterprise.features.customDeployments"),
+    },
+    {
+      icon: SvgGlobe,
+      text: t("plans.enterprise.features.regionalProcessing"),
+    },
+    { icon: SvgHeadsetMic, text: t("plans.enterprise.features.support") },
+  ];
+
   const plans: PlanConfig[] = [
     {
       icon: SvgUsers,
-      title: "Business",
-      pricing: "$20",
-      description:
-        "per seat/month billed annually\nor $25 per seat if billed monthly",
-      buttonLabel: "Get Business Plan",
+      title: t("plans.business.title"),
+      pricing: t("plans.business.pricing"),
+      description: t("plans.business.description"),
+      buttonLabel: t("plans.business.button.label"),
       buttonVariant: "primary",
       onClick: hasLicense ? undefined : onCheckout,
-      features: BUSINESS_FEATURES,
-      featuresPrefix: "Get more work done with AI for your team.",
+      features: businessFeatures,
+      featuresPrefix: t("plans.business.featuresPrefix"),
       isCurrentPlan: !!hasSubscription,
     },
     {
       icon: SvgOrganization,
-      title: "Enterprise",
-      description:
-        "Flexible pricing & deployment options\nfor large organizations",
-      buttonLabel: "Contact Sales",
+      title: t("plans.enterprise.title"),
+      description: t("plans.enterprise.description"),
+      buttonLabel: t("plans.enterprise.button.label"),
       buttonVariant: "secondary",
       href: SALES_URL,
-      features: ENTERPRISE_FEATURES,
-      featuresPrefix: "Everything in Business Plan, plus:",
+      features: enterpriseFeatures,
+      featuresPrefix: t("plans.enterprise.featuresPrefix"),
       isCurrentPlan: !!hasLicense && !hasSubscription,
     },
   ];

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { mutate } from "swr";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
@@ -60,10 +61,11 @@ function FooterLinks({
   onActivateLicense?: () => void;
   hideLicenseLink?: boolean;
 }) {
+  const t = useTranslations("admin.billing");
   const { user } = useUser();
   const licenseText = hasSubscription
-    ? "Update License Key"
-    : "Activate License Key";
+    ? t("footer.updateLicenseKey.label")
+    : t("footer.activateLicenseKey.label");
   const billingHelpHref = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
     `[Billing] support for ${user?.email ?? "unknown"}`
   )}`;
@@ -73,14 +75,16 @@ function FooterLinks({
       {onActivateLicense && !hideLicenseLink && (
         <>
           <Text secondaryBody text03>
-            Have a license key?
+            {t("footer.licenseKeyPrompt.label")}
           </Text>
           <LinkButton onClick={onActivateLicense} external={false}>
             {licenseText}
           </LinkButton>
         </>
       )}
-      <LinkButton href={billingHelpHref}>Billing Help</LinkButton>
+      <LinkButton href={billingHelpHref}>
+        {t("footer.billingHelp.label")}
+      </LinkButton>
     </Section>
   );
 }
@@ -90,6 +94,7 @@ function FooterLinks({
 // ----------------------------------------------------------------------------
 
 export default function BillingPage() {
+  const t = useTranslations("admin.billing");
   const router = useRouter();
   const searchParams = useSearchParams();
   // Start with null view to prevent flash - will be set once data loads
@@ -337,11 +342,11 @@ export default function BillingPage() {
       .then(() => handleRefresh())
       .catch((error: unknown) =>
         toast.error(
-          error instanceof Error ? error.message : "License sync failed"
+          error instanceof Error ? error.message : t("toasts.licenseSyncFailed")
         )
       )
       .finally(() => setIsGraceSyncing(false));
-  }, [isSelfHosted, graceSyncAttempted, licenseData?.expiry_warning_stage]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isSelfHosted, graceSyncAttempted, licenseData?.expiry_warning_stage, t]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Hide license activation card when Stripe connection is restored (only if auto-opened)
   useEffect(() => {
@@ -382,7 +387,7 @@ export default function BillingPage() {
     if (isLoading || view === null) {
       return {
         icon: SvgWallet,
-        title: "Plans & Billing",
+        title: t("header.plansBilling.title"),
         showBackButton: false,
       };
     }
@@ -390,13 +395,15 @@ export default function BillingPage() {
       case "checkout":
         return {
           icon: SvgArrowUpCircle,
-          title: "Upgrade Plan",
+          title: t("header.upgradePlan.title"),
           showBackButton: false,
         };
       case "plans":
         return {
           icon: hasSubscription ? SvgWallet : SvgArrowUpCircle,
-          title: hasSubscription ? "View Plans" : "Upgrade Plan",
+          title: hasSubscription
+            ? t("header.viewPlans.title")
+            : t("header.upgradePlan.title"),
           showBackButton: !!(
             hasSubscription ||
             (isSelfHosted && licenseData?.has_license)
@@ -405,7 +412,7 @@ export default function BillingPage() {
       case "details":
         return {
           icon: SvgWallet,
-          title: "Plans & Billing",
+          title: t("header.plansBilling.title"),
           showBackButton: false,
         };
     }
@@ -536,8 +543,8 @@ export default function BillingPage() {
           {isActivating && (
             <MessageCard
               variant="warning"
-              title="Your license is still activating"
-              description="Your license is being processed. You'll be taken to billing details automatically once confirmed."
+              title={t("activatingBanner.title")}
+              description={t("activatingBanner.description")}
               onClose={() => {
                 sessionStorage.removeItem(BILLING_ACTIVATING_KEY);
                 setIsActivating(false);

--- a/web/src/app/admin/bots/SlackBotCreationForm.tsx
+++ b/web/src/app/admin/bots/SlackBotCreationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import CardSection from "@/components/admin/CardSection";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { SlackTokensForm } from "./SlackTokensForm";
@@ -8,6 +9,7 @@ import { SettingsLayouts } from "@opal/layouts";
 import { SvgSlack } from "@opal/logos";
 
 export function NewSlackBotForm() {
+  const t = useTranslations("admin.slackBots");
   const [formValues] = useState({
     name: "",
     enabled: true,
@@ -21,7 +23,7 @@ export function NewSlackBotForm() {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgSlack}
-        title="New Slack Bot"
+        title={t("newBot.header.title")}
         divider
         backButton
       />

--- a/web/src/app/admin/bots/SlackBotTable.tsx
+++ b/web/src/app/admin/bots/SlackBotTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PageSelector } from "@/components/PageSelector";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { useEffect, useState } from "react";
@@ -45,6 +46,7 @@ function ClickableTableRow({
 }
 
 export const SlackBotTable = ({ slackBots }: { slackBots: SlackBot[] }) => {
+  const t = useTranslations("admin.slackBots");
   const [page, setPage] = useState(1);
 
   // sort by id for consistent ordering
@@ -68,10 +70,10 @@ export const SlackBotTable = ({ slackBots }: { slackBots: SlackBot[] }) => {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Default Config</TableHead>
-            <TableHead>Channel Count</TableHead>
+            <TableHead>{t("table.name.header")}</TableHead>
+            <TableHead>{t("table.status.header")}</TableHead>
+            <TableHead>{t("table.defaultConfig.header")}</TableHead>
+            <TableHead>{t("table.channelCount.header")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -90,13 +92,17 @@ export const SlackBotTable = ({ slackBots }: { slackBots: SlackBot[] }) => {
                 </TableCell>
                 <TableCell>
                   {slackBot.enabled ? (
-                    <Badge variant="success">Enabled</Badge>
+                    <Badge variant="success">{t("table.enabled.badge")}</Badge>
                   ) : (
-                    <Badge variant="destructive">Disabled</Badge>
+                    <Badge variant="destructive">
+                      {t("table.disabled.badge")}
+                    </Badge>
                   )}
                 </TableCell>
                 <TableCell>
-                  <Badge variant="secondary">Default Set</Badge>
+                  <Badge variant="secondary">
+                    {t("table.defaultSet.badge")}
+                  </Badge>
                 </TableCell>
                 <TableCell>{slackBot.configs_count}</TableCell>
                 <TableCell>
@@ -111,7 +117,7 @@ export const SlackBotTable = ({ slackBots }: { slackBots: SlackBot[] }) => {
                 colSpan={5}
                 className="text-center text-muted-foreground"
               >
-                Please add a New Slack Bot to begin chatting with Onyx!
+                {t("table.empty.message")}
               </TableCell>
             </TableRow>
           )}

--- a/web/src/app/admin/bots/SlackBotUpdateForm.tsx
+++ b/web/src/app/admin/bots/SlackBotUpdateForm.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "@opal/layouts";
 import { SlackBot } from "@/lib/types";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 import { updateSlackBotField } from "@/lib/updateSlackBotField";
@@ -43,6 +44,7 @@ export const ExistingSlackBotForm = ({
   existingSlackBot: SlackBot;
   refreshSlackBot?: () => void;
 }) => {
+  const t = useTranslations("admin.slackBots");
   const [isExpanded, setIsExpanded] = useState(false);
   const [formValues, setFormValues] = useState(existingSlackBot);
   const router = useRouter();
@@ -62,9 +64,9 @@ export const ExistingSlackBotForm = ({
       if (!response.ok) {
         throw new Error(await response.text());
       }
-      toast.success(`Connector ${field} updated successfully`);
+      toast.success(t("updateForm.fieldUpdated.toast", { field }));
     } catch (error) {
-      toast.error(`Failed to update connector ${field}`);
+      toast.error(t("updateForm.fieldUpdateFailed.toast", { field }));
     }
     setFormValues((prev) => ({ ...prev, [field]: value }));
   };
@@ -111,14 +113,14 @@ export const ExistingSlackBotForm = ({
               )}
               onClick={() => setIsExpanded(!isExpanded)}
             >
-              Update Tokens
+              {t("updateForm.updateTokensButton.label")}
             </Button>
             <Button
               variant="danger"
               onClick={() => setShowDeleteModal(true)}
               icon={SvgTrash}
             >
-              Delete
+              {t("updateForm.deleteButton.label")}
             </Button>
           </div>
 
@@ -141,16 +143,16 @@ export const ExistingSlackBotForm = ({
       <div className="mt-2">
         <div className="inline-block border rounded-lg border-background-200 p-2">
           <Checkbox
-            label="Enabled"
+            label={t("updateForm.enabledCheckbox.label")}
             checked={formValues.enabled}
             onChange={(e) => handleUpdateField("enabled", e.target.checked)}
           />
         </div>
         {showDeleteModal && (
           <GenericConfirmModal
-            title="Delete Slack Bot"
-            message="Are you sure you want to delete this Slack bot? This action cannot be undone."
-            confirmText="Delete"
+            title={t("deleteModal.title")}
+            message={t("deleteModal.message")}
+            confirmText={t("deleteModal.confirmButton.label")}
             onClose={() => setShowDeleteModal(false)}
             onConfirm={async () => {
               try {
@@ -158,10 +160,10 @@ export const ExistingSlackBotForm = ({
                 if (!response.ok) {
                   throw new Error(await response.text());
                 }
-                toast.success("Slack bot deleted successfully");
+                toast.success(t("deleteModal.success.toast"));
                 router.push("/admin/bots");
               } catch (error) {
-                toast.error("Failed to delete Slack bot");
+                toast.error(t("deleteModal.error.toast"));
               }
               setShowDeleteModal(false);
             }}

--- a/web/src/app/admin/bots/SlackTokensForm.tsx
+++ b/web/src/app/admin/bots/SlackTokensForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TextFormField } from "@/components/Field";
+import { useTranslations } from "next-intl";
 import { Form, Formik } from "formik";
 import * as Yup from "yup";
 import { createSlackBot, updateSlackBot } from "./new/lib";
@@ -24,6 +25,8 @@ export const SlackTokensForm = ({
   router: any;
   onValuesChange?: (values: any) => void;
 }) => {
+  const t = useTranslations("admin.slackBots");
+
   useEffect(() => {
     if (onValuesChange) {
       onValuesChange(initialValues);
@@ -59,8 +62,8 @@ export const SlackTokensForm = ({
           const botId = isUpdate ? existingSlackBotId : responseJson.id;
           toast.success(
             isUpdate
-              ? "Successfully updated Slack Bot!"
-              : "Successfully created Slack Bot!"
+              ? t("tokensForm.updated.toast")
+              : t("tokensForm.created.toast")
           );
           router.push(`/admin/bots/${encodeURIComponent(botId)}`);
         } else {
@@ -68,14 +71,14 @@ export const SlackTokensForm = ({
           let errorMsg = responseJson.detail || responseJson.message;
 
           if (errorMsg.includes("Invalid bot token:")) {
-            errorMsg = "Slack Bot Token is invalid";
+            errorMsg = t("tokensForm.invalidBotToken.message");
           } else if (errorMsg.includes("Invalid app token:")) {
-            errorMsg = "Slack App Token is invalid";
+            errorMsg = t("tokensForm.invalidAppToken.message");
           }
           toast.error(
             isUpdate
-              ? `Error updating Slack Bot - ${errorMsg}`
-              : `Error creating Slack Bot - ${errorMsg}`
+              ? t("tokensForm.updateError.toast", { error: errorMsg })
+              : t("tokensForm.createError.toast", { error: errorMsg })
           );
         }
       }}
@@ -87,7 +90,7 @@ export const SlackTokensForm = ({
             <div className="">
               <TextFormField
                 name="name"
-                label="Name This Slack Bot:"
+                label={t("tokensForm.name.label")}
                 type="text"
               />
             </div>
@@ -96,33 +99,35 @@ export const SlackTokensForm = ({
           {!isUpdate && (
             <div className="mt-4">
               <Divider />
-              Please refer to our{" "}
-              <a
-                className="text-blue-500 hover:underline"
-                href={`${DOCS_ADMINS_PATH}/getting_started/slack_bot_setup`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                guide
-              </a>{" "}
-              if you are not sure how to get these tokens!
+              {t.rich("tokensForm.docsPrompt.text", {
+                link: (chunks) => (
+                  <a
+                    className="text-blue-500 hover:underline"
+                    href={`${DOCS_ADMINS_PATH}/getting_started/slack_bot_setup`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {chunks}
+                  </a>
+                ),
+              })}
             </div>
           )}
           <TextFormField
             name="bot_token"
-            label="Slack Bot Token"
+            label={t("tokensForm.botToken.label")}
             type="password"
           />
           <TextFormField
             name="app_token"
-            label="Slack App Token"
+            label={t("tokensForm.appToken.label")}
             type="password"
           />
           <TextFormField
             name="user_token"
-            label="Slack User Token (Optional)"
+            label={t("tokensForm.userToken.label")}
             type="password"
-            subtext="Optional: User OAuth token for enhanced private channel access"
+            subtext={t("tokensForm.userToken.subtext")}
           />
           <div className="flex justify-end w-full mt-4">
             <Button
@@ -134,7 +139,9 @@ export const SlackTokensForm = ({
               }
               type="submit"
             >
-              {isUpdate ? "Update" : "Create"}
+              {isUpdate
+                ? t("tokensForm.updateButton.label")
+                : t("tokensForm.createButton.label")}
             </Button>
           </div>
         </Form>

--- a/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
+++ b/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PageSelector } from "@/components/PageSelector";
+import { useTranslations } from "next-intl";
 import { toast } from "@opal/layouts";
 import { SvgEdit } from "@opal/icons";
 import { SlackChannelConfig } from "@/lib/types";
@@ -32,6 +33,7 @@ export default function SlackChannelConfigsTable({
   slackChannelConfigs,
   refresh,
 }: SlackChannelConfigsTableProps) {
+  const t = useTranslations("admin.slackBots");
   const [page, setPage] = useState(1);
 
   const defaultConfig = slackChannelConfigs.find((config) => config.is_default);
@@ -49,27 +51,27 @@ export default function SlackChannelConfigsTable({
           }}
           icon={SvgSettings}
         >
-          Edit Default Configuration
+          {t("channels.editDefaultButton.label")}
         </Button>
         <Button
           icon={SvgPlusCircle}
           prominence="secondary"
           href={`/admin/bots/${slackBotId}/channels/new`}
         >
-          New Channel Configuration
+          {t("channels.newConfigButton.label")}
         </Button>
       </div>
 
       <div>
-        <h2 className="text-2xl font- mb-4">Channel-Specific Configurations</h2>
+        <h2 className="text-2xl font- mb-4">{t("channels.section.title")}</h2>
         <Card>
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Channel</TableHead>
-                <TableHead>Assistant</TableHead>
-                <TableHead>Document Sets</TableHead>
-                <TableHead>Actions</TableHead>
+                <TableHead>{t("channels.table.channel.header")}</TableHead>
+                <TableHead>{t("channels.table.assistant.header")}</TableHead>
+                <TableHead>{t("channels.table.documentSets.header")}</TableHead>
+                <TableHead>{t("channels.table.actions.header")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -134,12 +136,16 @@ export default function SlackChannelConfigsTable({
                             );
                             if (response.ok) {
                               toast.success(
-                                `Slack bot config "${slackChannelConfig.id}" deleted`
+                                t("channels.deleted.toast", {
+                                  configId: slackChannelConfig.id,
+                                })
                               );
                             } else {
                               const errorMsg = await response.text();
                               toast.error(
-                                `Failed to delete Slack bot config - ${errorMsg}`
+                                t("channels.deleteError.toast", {
+                                  error: errorMsg,
+                                })
                               );
                             }
                             refresh();
@@ -159,8 +165,7 @@ export default function SlackChannelConfigsTable({
                     colSpan={4}
                     className="text-center text-muted-foreground"
                   >
-                    No channel-specific configurations. Add a new configuration
-                    to customize behavior for specific channels.
+                    {t("channels.table.empty.message")}
                   </TableCell>
                 </TableRow>
               )}

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { toast } from "@opal/layouts";
@@ -34,6 +35,7 @@ export const SlackChannelConfigCreationForm = ({
   standardAnswerCategoryResponse: StandardAnswerCategoryResponse;
   existingSlackChannelConfig?: SlackChannelConfig;
 }) => {
+  const t = useTranslations("admin.slackBots");
   const router = useRouter();
   const isUpdate = Boolean(existingSlackChannelConfig);
   const isDefault = existingSlackChannelConfig?.is_default || false;
@@ -126,7 +128,9 @@ export const SlackChannelConfigCreationForm = ({
           slack_bot_id: Yup.number().required(),
           channel_name: isDefault
             ? Yup.string()
-            : Yup.string().required("Channel Name is required"),
+            : Yup.string().required(
+                t("validation.channelNameRequired.message")
+              ),
           response_type: Yup.mixed<SlackBotResponseType>()
             .oneOf(["quotes", "citations"])
             .required(),
@@ -145,19 +149,14 @@ export const SlackChannelConfigCreationForm = ({
             .when("knowledge_source", {
               is: "document_sets",
               then: (schema) =>
-                schema.min(
-                  1,
-                  "At least one Document Set is required when using the 'Document Sets' knowledge source"
-                ),
+                schema.min(1, t("validation.documentSetRequired.message")),
             }),
           persona_id: Yup.number()
             .nullable()
             .when("knowledge_source", {
               is: "assistant",
               then: (schema) =>
-                schema.required(
-                  "An agent is required when using the 'Agent' knowledge source"
-                ),
+                schema.required(t("validation.agentRequired.message")),
             }),
           standard_answer_categories: Yup.array(),
           knowledge_source: Yup.string()
@@ -219,9 +218,9 @@ export const SlackChannelConfigCreationForm = ({
             const responseJson = await response.json();
             const errorMsg = responseJson.detail || responseJson.message;
             toast.error(
-              `Error ${
-                isUpdate ? "updating" : "creating"
-              } OnyxBot config - ${errorMsg}`
+              isUpdate
+                ? t("channelConfig.updateError.toast", { error: errorMsg })
+                : t("channelConfig.createError.toast", { error: errorMsg })
             );
           }
         }}

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { FieldArray, useFormikContext, ErrorMessage } from "formik";
 import { DocumentSetSummary } from "@/lib/types";
 import { toast } from "@opal/layouts";
@@ -57,6 +58,7 @@ export function SlackChannelConfigFormFields({
   slack_bot_id,
   formikProps,
 }: SlackChannelConfigFormFieldsProps) {
+  const t = useTranslations("admin.slackBots");
   const router = useRouter();
   const { values, setFieldValue } = useFormikContext<any>();
   const [viewUnselectableSets, setViewUnselectableSets] = useState(false);
@@ -150,11 +152,9 @@ export function SlackChannelConfigFormFields({
           (dsId: number) => !invalidSelected.includes(dsId)
         )
       );
-      toast.warning(
-        "We removed one or more document sets from your selection because they are no longer valid. Please review and update your configuration."
-      );
+      toast.warning(t("form.removedDocumentSets.toast"));
     }
-  }, [unselectableSets, values.document_sets, setFieldValue]);
+  }, [unselectableSets, values.document_sets, setFieldValue, t]);
 
   const shouldShowPrivacyAlert = useMemo(() => {
     if (values.knowledge_source === "document_sets") {
@@ -180,22 +180,19 @@ export function SlackChannelConfigFormFields({
         {isDefault && (
           <>
             <Badge variant="agent" className="bg-blue-100 text-blue-800">
-              Default Configuration
+              {t("form.defaultConfig.badge")}
             </Badge>
             <p className="mt-2 text-sm">
-              This default configuration will apply to all channels and direct
-              messages (DMs) in your Slack workspace.
+              {t("form.defaultConfig.description")}
             </p>
             <div className="mt-4 p-4 bg-background rounded-md border border-neutral-300">
               <CheckboxField
                 name="disabled"
-                label="Disable Default Configuration"
+                label={t("form.disableDefault.label")}
                 labelClassName="text-text"
               />
               <p className="mt-2 text-sm italic">
-                Warning: Disabling the default configuration means OnyxBot
-                won&apos;t respond in Slack channels unless they are explicitly
-                configured. Additionally, OnyxBot will not respond to DMs.
+                {t("form.disableDefault.warning")}
               </p>
             </div>
           </>
@@ -204,14 +201,14 @@ export function SlackChannelConfigFormFields({
           <>
             <TextFormField
               name="channel_name"
-              label="Slack Channel Name"
-              placeholder="Enter channel name (e.g., general, support)"
-              subtext="Enter the name of the Slack channel (without the # symbol)"
+              label={t("form.channelName.label")}
+              placeholder={t("form.channelName.placeholder")}
+              subtext={t("form.channelName.subtext")}
             />
           </>
         )}
         <div className="space-y-2 mt-4">
-          <Label>Knowledge Source</Label>
+          <Label>{t("form.knowledgeSource.label")}</Label>
           <RadioGroup
             className="flex flex-col gap-y-4"
             value={values.knowledge_source}
@@ -222,28 +219,28 @@ export function SlackChannelConfigFormFields({
             <RadioGroupItemField
               value="all_public"
               id="all_public"
-              label="All Public Knowledge"
-              sublabel="Let OnyxBot respond based on information from all public connectors"
+              label={t("form.knowledgeSource.allPublic.label")}
+              sublabel={t("form.knowledgeSource.allPublic.sublabel")}
             />
             {selectableSets.length + unselectableSets.length > 0 && (
               <RadioGroupItemField
                 value="document_sets"
                 id="document_sets"
-                label="Specific Document Sets"
-                sublabel="Control which documents to use for answering questions"
+                label={t("form.knowledgeSource.documentSets.label")}
+                sublabel={t("form.knowledgeSource.documentSets.sublabel")}
               />
             )}
             <RadioGroupItemField
               value="assistant"
               id="assistant"
-              label="Search Agent"
-              sublabel="Control both the documents and the prompt to use for answering questions"
+              label={t("form.knowledgeSource.searchAgent.label")}
+              sublabel={t("form.knowledgeSource.searchAgent.sublabel")}
             />
             <RadioGroupItemField
               value="non_search_agent"
               id="non_search_agent"
-              label="Non-Search Agent"
-              sublabel="Chat with an agent that does not use documents"
+              label={t("form.knowledgeSource.nonSearchAgent.label")}
+              sublabel={t("form.knowledgeSource.nonSearchAgent.sublabel")}
             />
           </RadioGroup>
         </div>
@@ -252,13 +249,13 @@ export function SlackChannelConfigFormFields({
             <div className="mt-4">
               <SubLabel>
                 <>
-                  Select the document sets OnyxBot will use while answering
-                  questions in Slack.
+                  {t("form.documentSets.description")}
                   <br />
                   {unselectableSets.length > 0 ? (
                     <span>
-                      Some incompatible document sets are{" "}
-                      {viewUnselectableSets ? "visible" : "hidden"}.{" "}
+                      {viewUnselectableSets
+                        ? t("form.documentSets.incompatibleVisible.text")
+                        : t("form.documentSets.incompatibleHidden.text")}{" "}
                       <button
                         type="button"
                         onClick={() =>
@@ -269,9 +266,8 @@ export function SlackChannelConfigFormFields({
                         className="text-sm text-action-selection-05"
                       >
                         {viewUnselectableSets
-                          ? "Hide un-selectable "
-                          : "View all "}
-                        document sets
+                          ? t("form.documentSets.hideUnselectableButton.label")
+                          : t("form.documentSets.viewAllButton.label")}
                       </button>
                     </span>
                   ) : (
@@ -309,8 +305,7 @@ export function SlackChannelConfigFormFields({
                     {viewUnselectableSets && unselectableSets.length > 0 && (
                       <div className="mt-4">
                         <p className="text-sm text-text-dark/80">
-                          These document sets cannot be attached as they have
-                          auto-synced docs:
+                          {t("form.documentSets.autoSyncedNote.text")}
                         </p>
                         <div className="mb-3 mt-2 flex gap-2 flex-wrap text-sm">
                           {unselectableSets.map((documentSet) => (
@@ -318,7 +313,9 @@ export function SlackChannelConfigFormFields({
                               key={documentSet.id}
                               documentSet={documentSet}
                               disabled
-                              disabledTooltip="Unable to use this document set because it contains a connector with auto-sync permissions. OnyxBot's responses in this channel are visible to all Slack users, so mirroring the asker's permissions could inadvertently expose private information."
+                              disabledTooltip={t(
+                                "form.documentSets.autoSyncedDisabled.tooltip"
+                              )}
                               isSelected={false}
                             />
                           ))}
@@ -339,15 +336,12 @@ export function SlackChannelConfigFormFields({
           <div className="mt-4">
             <SubLabel>
               <>
-                Select the search-enabled agent OnyxBot will use while answering
-                questions in Slack.
+                {t("form.searchAgent.description")}
                 {syncEnabledAgents.length > 0 && (
                   <>
                     <br />
                     <span className="text-sm text-text-dark/80">
-                      Note: Some of your agents have auto-synced connectors in
-                      their document sets. You cannot select these agents as
-                      they will not be able to answer questions in Slack.{" "}
+                      {t("form.syncEnabledAgents.note")}{" "}
                       <button
                         type="button"
                         onClick={() =>
@@ -358,9 +352,8 @@ export function SlackChannelConfigFormFields({
                         className="text-sm text-action-selection-05"
                       >
                         {viewSyncEnabledAgents
-                          ? "Hide un-selectable "
-                          : "View all "}
-                        agents
+                          ? t("form.syncEnabledAgents.hideButton.label")
+                          : t("form.syncEnabledAgents.viewAllButton.label")}
                       </button>
                     </span>
                   </>
@@ -369,7 +362,7 @@ export function SlackChannelConfigFormFields({
             </SubLabel>
 
             <InputComboBox
-              placeholder="Search for an agent..."
+              placeholder={t("form.agent.placeholder")}
               value={String(values.persona_id ?? "")}
               onValueChange={(val) =>
                 setFieldValue("persona_id", val ? Number(val) : null)
@@ -380,7 +373,7 @@ export function SlackChannelConfigFormFields({
             {viewSyncEnabledAgents && syncEnabledAgents.length > 0 && (
               <div className="mt-4">
                 <p className="text-sm text-text-dark/80">
-                  Un-selectable agents:
+                  {t("form.syncEnabledAgents.listLabel")}
                 </p>
                 <div className="mb-3 mt-2 flex gap-2 flex-wrap text-sm">
                   {syncEnabledAgents.map((persona: MinimalAgent) => (
@@ -405,15 +398,12 @@ export function SlackChannelConfigFormFields({
           <div className="mt-4">
             <SubLabel>
               <>
-                Select the non-search agent OnyxBot will use while answering
-                questions in Slack.
+                {t("form.nonSearchAgent.description")}
                 {syncEnabledAgents.length > 0 && (
                   <>
                     <br />
                     <span className="text-sm text-text-dark/80">
-                      Note: Some of your agents have auto-synced connectors in
-                      their document sets. You cannot select these agents as
-                      they will not be able to answer questions in Slack.{" "}
+                      {t("form.syncEnabledAgents.note")}{" "}
                       <button
                         type="button"
                         onClick={() =>
@@ -424,9 +414,8 @@ export function SlackChannelConfigFormFields({
                         className="text-sm text-action-selection-05"
                       >
                         {viewSyncEnabledAgents
-                          ? "Hide un-selectable "
-                          : "View all "}
-                        agents
+                          ? t("form.syncEnabledAgents.hideButton.label")
+                          : t("form.syncEnabledAgents.viewAllButton.label")}
                       </button>
                     </span>
                   </>
@@ -435,7 +424,7 @@ export function SlackChannelConfigFormFields({
             </SubLabel>
 
             <InputComboBox
-              placeholder="Search for an agent..."
+              placeholder={t("form.agent.placeholder")}
               value={String(values.persona_id ?? "")}
               onValueChange={(val) =>
                 setFieldValue("persona_id", val ? Number(val) : null)
@@ -451,25 +440,31 @@ export function SlackChannelConfigFormFields({
         {values.knowledge_source !== "non_search_agent" && (
           <AccordionItem value="search-options">
             <AccordionTrigger className="text-text">
-              Search Configuration
+              {t("form.searchConfig.section.title")}
             </AccordionTrigger>
             <AccordionContent>
               <div className="space-y-4 pb-3">
                 <div className="w-64">
                   <SelectorFormField
                     name="response_type"
-                    label="Answer Type"
-                    tooltip="Controls the format of OnyxBot's responses."
+                    label={t("form.responseType.label")}
+                    tooltip={t("form.responseType.tooltip")}
                     options={[
-                      { name: "Standard", value: "citations" },
-                      { name: "Detailed", value: "quotes" },
+                      {
+                        name: t("form.responseType.standard.label"),
+                        value: "citations",
+                      },
+                      {
+                        name: t("form.responseType.detailed.label"),
+                        value: "quotes",
+                      },
                     ]}
                   />
                 </div>
                 <CheckboxField
                   name="answer_validity_check_enabled"
-                  label="Only respond if citations found"
-                  tooltip="If set, will only answer questions where the model successfully produces citations"
+                  label={t("form.answerValidity.label")}
+                  tooltip={t("form.answerValidity.tooltip")}
                 />
               </div>
             </AccordionContent>
@@ -477,13 +472,15 @@ export function SlackChannelConfigFormFields({
         )}
 
         <AccordionItem className="mt-4" value="general-options">
-          <AccordionTrigger>General Configuration</AccordionTrigger>
+          <AccordionTrigger>
+            {t("form.generalConfig.section.title")}
+          </AccordionTrigger>
           <AccordionContent className="overflow-visible">
             <div className="space-y-4">
               <CheckboxField
                 name="show_continue_in_web_ui"
-                label="Show Continue in Web UI button"
-                tooltip="If set, will show a button at the bottom of the response that allows the user to continue the conversation in the Onyx Web UI"
+                label={t("form.showContinueInWebUi.label")}
+                tooltip={t("form.showContinueInWebUi.tooltip")}
               />
 
               <CheckboxField
@@ -494,66 +491,54 @@ export function SlackChannelConfigFormFields({
                     setFieldValue("follow_up_tags", []);
                   }
                 }}
-                label={'Give a "Still need help?" button'}
-                tooltip={`OnyxBot's response will include a button at the bottom
-                      of the response that asks the user if they still need help.`}
+                label={t("form.stillNeedHelp.label")}
+                tooltip={t("form.stillNeedHelp.tooltip")}
               />
               {values.still_need_help_enabled && (
-                <CollapsibleSection prompt="Configure Still Need Help Button">
+                <CollapsibleSection
+                  prompt={t("form.stillNeedHelp.section.prompt")}
+                >
                   <TextArrayField
                     name="follow_up_tags"
-                    label="(Optional) Users / Groups to Tag"
+                    label={t("form.followUpTags.label")}
                     values={values}
-                    subtext={
-                      <div>
-                        The Slack users / groups we should tag if the user
-                        clicks the &quot;Still need help?&quot; button. If no
-                        emails are provided, we will not tag anyone and will
-                        just react with a 🆘 emoji to the original message.
-                      </div>
-                    }
-                    placeholder="User email or user group name..."
+                    subtext={<div>{t("form.followUpTags.subtext")}</div>}
+                    placeholder={t("form.userOrGroup.placeholder")}
                   />
                 </CollapsibleSection>
               )}
 
               <CheckboxField
                 name="questionmark_prefilter_enabled"
-                label="Only respond to questions"
-                tooltip="If set, OnyxBot will only respond to messages that contain a question mark"
+                label={t("form.questionmarkPrefilter.label")}
+                tooltip={t("form.questionmarkPrefilter.tooltip")}
               />
               <CheckboxField
                 name="respond_tag_only"
-                label="Respond to @OnyxBot Only"
-                tooltip="If set, OnyxBot will only respond when directly tagged"
+                label={t("form.respondTagOnly.label")}
+                tooltip={t("form.respondTagOnly.tooltip")}
               />
               <CheckboxField
                 name="respond_to_bots"
-                label="Respond to Bot messages"
-                tooltip="If not set, OnyxBot will always ignore messages from Bots"
+                label={t("form.respondToBots.label")}
+                tooltip={t("form.respondToBots.tooltip")}
               />
               <CheckboxField
                 name="is_ephemeral"
-                label="Respond to user in a private (ephemeral) message"
-                tooltip="If set, OnyxBot will respond only to the user in a private (ephemeral) message. If you also
-                chose 'Search' Agent above, selecting this option will make documents that are private to the user
-                available for their queries."
+                label={t("form.isEphemeral.label")}
+                tooltip={t("form.isEphemeral.tooltip")}
               />
 
               <TextArrayField
                 name="respond_member_group_list"
-                label="(Optional) Respond to Certain Users / Groups"
-                subtext={
-                  "If specified, only these users / groups can invoke " +
-                  "OnyxBot in this channel, and responses are visible only " +
-                  "to them."
-                }
+                label={t("form.respondMemberGroupList.label")}
+                subtext={t("form.respondMemberGroupList.subtext")}
                 values={values}
-                placeholder="User email or user group name..."
+                placeholder={t("form.userOrGroup.placeholder")}
                 disabled={values.is_ephemeral}
                 tooltip={
                   values.is_ephemeral
-                    ? "Disabled while 'Respond to user in a private (ephemeral) message' is on — ephemeral responses target a single user only."
+                    ? t("form.respondMemberGroupList.disabled.tooltip")
                     : undefined
                 }
               />
@@ -577,21 +562,14 @@ export function SlackChannelConfigFormFields({
             tooltip={
               <div className="space-y-2">
                 <Label className="text-text mb-2 font-semibold">
-                  Privacy Alert
+                  {t("form.privacyAlert.title")}
                 </Label>
                 <p className="text-sm text-text-darker mb-4">
-                  Please note that if the private (ephemeral) response is *not
-                  selected*, only public documents within the selected document
-                  sets will be accessible for user queries. If the private
-                  (ephemeral) response *is selected*, user quries can also
-                  leverage documents that the user has already been granted
-                  access to. Note that users will be able to share the response
-                  with others in the channel, so please ensure that this is
-                  aligned with your company sharing policies.
+                  {t("form.privacyAlert.description")}
                 </p>
                 <div className="space-y-2">
                   <h4 className="text-sm text-text font-medium">
-                    Relevant Connectors:
+                    {t("form.privacyAlert.connectors.title")}
                   </h4>
                   <div className="max-h-40 overflow-y-auto border-t border-text-subtle flex-col gap-y-2">
                     {memoizedPrivateConnectors.map((ccpairinfo: any) => (
@@ -621,9 +599,13 @@ export function SlackChannelConfigFormFields({
             </div>
           </Tooltip>
         )}
-        <Button type="submit">{isUpdate ? "Update" : "Create"}</Button>
+        <Button type="submit">
+          {isUpdate
+            ? t("form.updateButton.label")
+            : t("form.createButton.label")}
+        </Button>
         <Button prominence="secondary" onClick={() => router.back()}>
-          Cancel
+          {t("form.cancelButton.label")}
         </Button>
       </div>
     </>

--- a/web/src/app/admin/bots/[bot-id]/channels/[id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use } from "react";
+import { useTranslations } from "next-intl";
 import { SlackChannelConfigCreationForm } from "@/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { SvgSimpleLoader } from "@opal/icons";
@@ -15,6 +16,7 @@ import { Tier } from "@/lib/settings/types";
 import type { StandardAnswerCategoryResponse } from "@/components/standardAnswers/getStandardAnswerCategoriesIfEE";
 
 function EditSlackChannelConfigContent({ id }: { id: string }) {
+  const t = useTranslations("admin.slackBots");
   const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
 
   const {
@@ -52,8 +54,8 @@ function EditSlackChannelConfigContent({ id }: { id: string }) {
   );
 
   const title = slackChannelConfig?.is_default
-    ? "Edit Default Slack Config"
-    : "Edit Slack Channel Config";
+    ? t("editChannel.default.header.title")
+    : t("editChannel.channel.header.title");
 
   return (
     <SettingsLayouts.Root>
@@ -68,29 +70,29 @@ function EditSlackChannelConfigContent({ id }: { id: string }) {
           <SvgSimpleLoader />
         ) : channelsError || !slackChannelConfigs ? (
           <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Failed to fetch Slack Channels - ${
-              channelsError?.message ?? "unknown error"
-            }`}
+            errorTitle={t("error.generic.title")}
+            errorMsg={t("error.fetchChannels.message", {
+              error: channelsError?.message ?? t("error.unknown.message"),
+            })}
           />
         ) : !slackChannelConfig ? (
           <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Did not find Slack Channel config with ID: ${id}`}
+            errorTitle={t("error.generic.title")}
+            errorMsg={t("error.channelConfigNotFound.message", { id })}
           />
         ) : docSetsError || !documentSets ? (
           <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Failed to fetch document sets - ${
-              docSetsError?.message ?? "unknown error"
-            }`}
+            errorTitle={t("error.generic.title")}
+            errorMsg={t("error.fetchDocumentSets.message", {
+              error: docSetsError?.message ?? t("error.unknown.message"),
+            })}
           />
         ) : agentsError ? (
           <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Failed to fetch agents - ${
-              agentsError?.message ?? "unknown error"
-            }`}
+            errorTitle={t("error.generic.title")}
+            errorMsg={t("error.fetchAgents.message", {
+              error: agentsError?.message ?? t("error.unknown.message"),
+            })}
           />
         ) : (
           <SlackChannelConfigCreationForm

--- a/web/src/app/admin/bots/[bot-id]/channels/new/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { SlackChannelConfigCreationForm } from "@/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { SvgSimpleLoader } from "@opal/icons";
@@ -15,6 +16,7 @@ import type { StandardAnswerCategoryResponse } from "@/components/standardAnswer
 import { useRouter } from "next/navigation";
 
 function NewChannelConfigContent({ slackBotId }: { slackBotId: number }) {
+  const t = useTranslations("admin.slackBots");
   const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
 
   const {
@@ -46,10 +48,10 @@ function NewChannelConfigContent({ slackBotId }: { slackBotId: number }) {
   if (docSetsError || !documentSets) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch document sets - ${
-          docSetsError?.message ?? "unknown error"
-        }`}
+        errorTitle={t("error.generic.title")}
+        errorMsg={t("error.fetchDocumentSets.message", {
+          error: docSetsError?.message ?? t("error.unknown.message"),
+        })}
       />
     );
   }
@@ -57,10 +59,10 @@ function NewChannelConfigContent({ slackBotId }: { slackBotId: number }) {
   if (agentsError) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch agents - ${
-          agentsError?.message ?? "unknown error"
-        }`}
+        errorTitle={t("error.generic.title")}
+        errorMsg={t("error.fetchAgents.message", {
+          error: agentsError?.message ?? t("error.unknown.message"),
+        })}
       />
     );
   }
@@ -87,6 +89,7 @@ function NewChannelConfigContent({ slackBotId }: { slackBotId: number }) {
 }
 
 export default function Page(props: { params: Promise<{ "bot-id": string }> }) {
+  const t = useTranslations("admin.slackBots");
   const unwrappedParams = use(props.params);
   const router = useRouter();
 
@@ -109,7 +112,7 @@ export default function Page(props: { params: Promise<{ "bot-id": string }> }) {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgSlack}
-        title="Configure OnyxBot for Slack Channel"
+        title={t("newChannel.header.title")}
         divider
         backButton
       />

--- a/web/src/app/admin/bots/[bot-id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use } from "react";
+import { useTranslations } from "next-intl";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { SvgSimpleLoader } from "@opal/icons";
 import SlackChannelConfigsTable from "./SlackChannelConfigsTable";
@@ -11,6 +12,7 @@ import { SvgSlack } from "@opal/logos";
 import { getErrorMsg } from "@/lib/error";
 
 function SlackBotEditContent({ botId }: { botId: string }) {
+  const t = useTranslations("admin.slackBots");
   const {
     data: slackBot,
     isLoading: isSlackBotLoading,
@@ -32,10 +34,11 @@ function SlackBotEditContent({ botId }: { botId: string }) {
   if (slackBotError || !slackBot) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch Slack Bot ${botId}: ${getErrorMsg(
-          slackBotError
-        )}`}
+        errorTitle={t("error.generic.title")}
+        errorMsg={t("error.fetchBot.message", {
+          botId,
+          error: getErrorMsg(slackBotError),
+        })}
       />
     );
   }
@@ -43,10 +46,11 @@ function SlackBotEditContent({ botId }: { botId: string }) {
   if (slackChannelConfigsError || !slackChannelConfigs) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch Slack Bot ${botId}: ${getErrorMsg(
-          slackChannelConfigsError
-        )}`}
+        errorTitle={t("error.generic.title")}
+        errorMsg={t("error.fetchBot.message", {
+          botId,
+          error: getErrorMsg(slackChannelConfigsError),
+        })}
       />
     );
   }
@@ -74,13 +78,14 @@ export default function Page({
 }: {
   params: Promise<{ "bot-id": string }>;
 }) {
+  const t = useTranslations("admin.slackBots");
   const unwrappedParams = use(params);
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgSlack}
-        title="Edit Slack Bot"
+        title={t("edit.header.title")}
         backButton
         divider
       />

--- a/web/src/app/admin/bots/page.tsx
+++ b/web/src/app/admin/bots/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { PageLoader } from "@opal/layouts";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
@@ -14,6 +15,7 @@ import { DOCS_ADMINS_PATH } from "@/lib/constants";
 const route = ADMIN_ROUTES.SLACK_BOTS;
 
 function Main() {
+  const t = useTranslations("admin.slackBots");
   const {
     data: slackBots,
     isLoading: isSlackBotsLoading,
@@ -28,46 +30,43 @@ function Main() {
     const errorMsg =
       slackBotsError?.info?.message ||
       slackBotsError?.info?.detail ||
-      "An unknown error occurred";
+      t("error.unknownOccurred.message");
 
     return (
-      <ErrorCallout errorTitle="Error loading apps" errorMsg={`${errorMsg}`} />
+      <ErrorCallout
+        errorTitle={t("list.error.title")}
+        errorMsg={`${errorMsg}`}
+      />
     );
   }
 
   return (
     <div className="mb-8">
       <p className="mb-2 text-sm text-muted-foreground">
-        Setup Slack bots that connect to Onyx. Once setup, you will be able to
-        ask questions to Onyx directly from Slack. Additionally, you can:
+        {t("intro.description")}
       </p>
 
       <div className="mb-2">
         <ul className="list-disc mt-2 ml-4 text-sm text-muted-foreground">
-          <li>
-            Setup OnyxBot to automatically answer questions in certain channels.
-          </li>
-          <li>
-            Choose which document sets OnyxBot should answer from, depending on
-            the channel the question is being asked.
-          </li>
-          <li>
-            Directly message OnyxBot to search just as you would in the web UI.
-          </li>
+          <li>{t("intro.autoAnswer.item")}</li>
+          <li>{t("intro.documentSets.item")}</li>
+          <li>{t("intro.directMessage.item")}</li>
         </ul>
       </div>
 
       <p className="mb-6 text-sm text-muted-foreground">
-        Follow the{" "}
-        <a
-          className="text-blue-500 hover:underline"
-          href={`${DOCS_ADMINS_PATH}/getting_started/slack_bot_setup`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          guide{" "}
-        </a>
-        found in the Onyx documentation to get started!
+        {t.rich("intro.docsPrompt.text", {
+          link: (chunks) => (
+            <a
+              className="text-blue-500 hover:underline"
+              href={`${DOCS_ADMINS_PATH}/getting_started/slack_bot_setup`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
       </p>
 
       <Button
@@ -75,7 +74,7 @@ function Main() {
         prominence="secondary"
         href="/admin/bots/new"
       >
-        New Slack Bot
+        {t("newBotButton.label")}
       </Button>
 
       <SlackBotTable slackBots={slackBots} />

--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 
 import { ValidSources } from "@/lib/types";
 import { Section } from "@/layouts/general-layouts";
@@ -47,6 +48,7 @@ interface ConfigItemProps {
 }
 
 function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
+  const t = useTranslations("admin.connector");
   const [isExpanded, setIsExpanded] = useState(false);
   const isExpandable = Array.isArray(value) && value.length > 5;
 
@@ -84,7 +86,7 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
     } else if (typeof value === "boolean") {
       return (
         <Text secondaryBody text03 className="text-right">
-          {value ? "True" : "False"}
+          {value ? t("configItem.booleanTrue") : t("configItem.booleanFalse")}
         </Text>
       );
     }
@@ -122,7 +124,9 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
             icon={isExpanded ? SvgChevronUp : SvgChevronDown}
             onClick={() => setIsExpanded(!isExpanded)}
           >
-            {isExpanded ? "Show less" : `Show all (${value.length} items)`}
+            {isExpanded
+              ? t("configItem.showLess.label")
+              : t("configItem.showAll.label", { count: value.length })}
           </Button>
         )}
         {onEdit && (
@@ -130,7 +134,7 @@ function ConfigItem({ label, value, onEdit }: ConfigItemProps) {
             prominence="tertiary"
             icon={SvgEdit}
             onClick={onEdit}
-            tooltip="Edit"
+            tooltip={t("configItem.edit.tooltip")}
           />
         )}
       </Section>
@@ -152,19 +156,24 @@ export function AdvancedConfigDisplay({
   onRefreshEdit?: () => void;
   onPruningEdit?: () => void;
 }) {
+  const t = useTranslations("admin.connector");
+  const locale = useLocale();
+
   const formatRefreshFrequency = (seconds: number | null): string => {
     if (seconds === null) return "-";
     const totalMinutes = seconds / 60;
 
     // If it's 60 minutes or more and evenly divisible by 60, show in hours
     if (totalMinutes >= 60 && totalMinutes % 60 === 0) {
-      const hours = totalMinutes / 60;
-      return `${hours} hour${hours !== 1 ? "s" : ""}`;
+      return t("advancedConfig.duration.hours", {
+        count: totalMinutes / 60,
+      });
     }
 
     // Otherwise show in minutes
-    const minutes = Math.round(totalMinutes);
-    return `${minutes} minute${minutes !== 1 ? "s" : ""}`;
+    return t("advancedConfig.duration.minutes", {
+      count: Math.round(totalMinutes),
+    });
   };
   const formatPruneFrequency = (seconds: number | null): string => {
     if (seconds === null) return "-";
@@ -172,25 +181,25 @@ export function AdvancedConfigDisplay({
 
     // If less than 1 hour, show in minutes
     if (totalHours < 1) {
-      const minutes = Math.round(seconds / 60);
-      return `${minutes} minute${minutes !== 1 ? "s" : ""}`;
+      return t("advancedConfig.duration.minutes", {
+        count: Math.round(seconds / 60),
+      });
     }
 
     const hours = Math.round(totalHours);
 
     // If it's 24 hours or more and evenly divisible by 24, show in days
     if (hours >= 24 && hours % 24 === 0) {
-      const days = hours / 24;
-      return `${days} day${days !== 1 ? "s" : ""}`;
+      return t("advancedConfig.duration.days", { count: hours / 24 });
     }
 
     // Otherwise show in hours
-    return `${hours} hour${hours !== 1 ? "s" : ""}`;
+    return t("advancedConfig.duration.hours", { count: hours });
   };
 
   const formatDate = (date: Date | null): string => {
     if (date === null) return "-";
-    return date.toLocaleString("en-US", {
+    return date.toLocaleString(locale, {
       year: "numeric",
       month: "long",
       day: "numeric",
@@ -202,17 +211,17 @@ export function AdvancedConfigDisplay({
 
   const items = [
     pruneFreq !== null && {
-      label: "Pruning Frequency",
+      label: t("advancedConfig.pruningFrequency.label"),
       value: formatPruneFrequency(pruneFreq),
       onEdit: onPruningEdit,
     },
     refreshFreq && {
-      label: "Refresh Frequency",
+      label: t("advancedConfig.refreshFrequency.label"),
       value: formatRefreshFrequency(refreshFreq),
       onEdit: onRefreshEdit,
     },
     indexingStart && {
-      label: "Indexing Start",
+      label: t("advancedConfig.indexingStart.label"),
       value: formatDate(indexingStart),
     },
   ].filter(Boolean) as ConfigItemProps[];

--- a/web/src/app/admin/connector/[ccPairId]/DeletionErrorStatus.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DeletionErrorStatus.tsx
@@ -1,19 +1,21 @@
 import { FiInfo } from "react-icons/fi";
+import { useTranslations } from "next-intl";
 
 export default function DeletionErrorStatus({
   deletion_failure_message,
 }: {
   deletion_failure_message: string;
 }) {
+  const t = useTranslations("admin.connector");
+
   return (
     <div className="mt-2 rounded-md border border-error-300 bg-error-50 p-4 text-error-600 max-w-3xl">
       <div className="flex items-center">
-        <h3 className="text-base font-medium">Deletion Error</h3>
+        <h3 className="text-base font-medium">{t("deletionError.title")}</h3>
         <div className="ml-2 relative group">
           <FiInfo className="h-4 w-4 text-error-600 cursor-help" />
           <div className="absolute z-10 w-64 p-2 mt-2 text-sm bg-white rounded-md shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 border border-background-200">
-            This error occurred while attempting to delete the connector. You
-            may re-attempt a deletion by clicking the &quot;Delete&quot; button.
+            {t("deletionError.description")}
           </div>
         </div>
       </div>

--- a/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   createTableColumns,
   EmptyMessageCard,
@@ -13,8 +14,6 @@ import { localizeAndPrettify } from "@opal/time";
 import ExceptionTraceModal from "@/sections/modals/PreviewModal/ExceptionTraceModal";
 import { PermissionSyncStatusBadge } from "./PermissionSyncStatusBadge";
 import type { DocPermissionSyncAttemptSnapshot } from "./types";
-
-const ERROR_MODAL_TITLE = "Document Permission Sync Error";
 
 /**
  * Renders one page of `DocPermissionSyncAttempt` rows for the
@@ -39,10 +38,22 @@ const tc = createTableColumns<DocPermissionSyncAttemptSnapshot>();
 // (e.g. "5/3/2026, 12:00:00 PM") stays on a single line at standard
 // 800px-wide admin layouts; the difference is taken from `Status` and
 // `Docs Synced`, which both render short content.
-function buildColumns(onErrorClick: (errorMessage: string) => void) {
+/** Translated column headers threaded in from the calling component. */
+interface ColumnHeaders {
+  timeStarted: string;
+  status: string;
+  docsSynced: string;
+  permissionErrors: string;
+  errorMessage: string;
+}
+
+function buildColumns(
+  onErrorClick: (errorMessage: string) => void,
+  headers: ColumnHeaders
+) {
   return [
     tc.column("time_started", {
-      header: "Time Started",
+      header: headers.timeStarted,
       weight: 28,
       enableSorting: false,
       cell: (value) => (
@@ -52,7 +63,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("status", {
-      header: "Status",
+      header: headers.status,
       weight: 14,
       enableSorting: false,
       cell: (value, row) => (
@@ -63,7 +74,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("total_docs_synced", {
-      header: "Docs Synced",
+      header: headers.docsSynced,
       weight: 12,
       enableSorting: false,
       cell: (value) => (
@@ -73,7 +84,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("docs_with_permission_errors", {
-      header: "Permission Errors",
+      header: headers.permissionErrors,
       weight: 18,
       enableSorting: false,
       cell: (value) => (
@@ -83,7 +94,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("error_message", {
-      header: "Error Message",
+      header: headers.errorMessage,
       weight: 28,
       enableSorting: false,
       cell: (value, row) => (
@@ -122,6 +133,8 @@ function ErrorMessageCell({
   modalContent,
   onErrorClick,
 }: ErrorMessageCellProps) {
+  const t = useTranslations("admin.connector");
+
   if (!errorMessage) {
     return (
       <Text as="span" font="secondary-body" color="text-03">
@@ -133,7 +146,7 @@ function ErrorMessageCell({
     <button
       type="button"
       onClick={() => onErrorClick(modalContent ?? errorMessage)}
-      aria-label="View full error message"
+      aria-label={t("syncTables.errorCell.ariaLabel")}
       className="text-left w-full cursor-pointer hover:underline"
     >
       <Text as="span" font="secondary-body" color="text-03" maxLines={2}>
@@ -157,22 +170,30 @@ export function DocPermissionSyncAttemptsTable({
   totalPages,
   onPageChange,
 }: DocPermissionSyncAttemptsTableProps) {
+  const t = useTranslations("admin.connector");
   const [openErrorMessage, setOpenErrorMessage] = useState<string | null>(null);
   const handleErrorClick = useCallback(
     (errorMessage: string) => setOpenErrorMessage(errorMessage),
     []
   );
   const columns = useMemo(
-    () => buildColumns(handleErrorClick),
-    [handleErrorClick]
+    () =>
+      buildColumns(handleErrorClick, {
+        timeStarted: t("docPermissionsTable.columns.timeStarted"),
+        status: t("docPermissionsTable.columns.status"),
+        docsSynced: t("docPermissionsTable.columns.docsSynced"),
+        permissionErrors: t("docPermissionsTable.columns.permissionErrors"),
+        errorMessage: t("docPermissionsTable.columns.errorMessage"),
+      }),
+    [handleErrorClick, t]
   );
 
   if (!attempts.length) {
     return (
       <EmptyMessageCard
         sizePreset="main-ui"
-        title="No document permission sync attempts yet"
-        description="Document-permission sync runs are scheduled in the background. They may take some time to appear — try refreshing in ~30 seconds."
+        title={t("docPermissionsTable.empty.title")}
+        description={t("docPermissionsTable.empty.description")}
       />
     );
   }
@@ -183,7 +204,7 @@ export function DocPermissionSyncAttemptsTable({
         <ExceptionTraceModal
           onOutsideClick={() => setOpenErrorMessage(null)}
           exceptionTrace={openErrorMessage}
-          title={ERROR_MODAL_TITLE}
+          title={t("docPermissionsTable.errorModal.title")}
         />
       )}
 

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   createTableColumns,
   EmptyMessageCard,
@@ -13,8 +14,6 @@ import { localizeAndPrettify } from "@opal/time";
 import ExceptionTraceModal from "@/sections/modals/PreviewModal/ExceptionTraceModal";
 import { PermissionSyncStatusBadge } from "./PermissionSyncStatusBadge";
 import type { ExternalGroupSyncAttemptSnapshot } from "./types";
-
-const ERROR_MODAL_TITLE = "Group Membership Sync Error";
 
 /**
  * Renders one page of `ExternalGroupPermissionSyncAttempt` rows for the
@@ -39,6 +38,16 @@ const ERROR_MODAL_TITLE = "Group Membership Sync Error";
 
 const tc = createTableColumns<ExternalGroupSyncAttemptSnapshot>();
 
+/** Translated column headers threaded in from the calling component. */
+interface ColumnHeaders {
+  timeStarted: string;
+  status: string;
+  users: string;
+  groups: string;
+  memberships: string;
+  errorMessage: string;
+}
+
 // Headers are intentionally short ("Users", not "Users Processed").
 // Opal's `TableHead` renders headers via `String(children)` (see
 // `web/lib/opal/src/components/table/TableHead.tsx:96`), which kills any
@@ -55,10 +64,13 @@ const tc = createTableColumns<ExternalGroupSyncAttemptSnapshot>();
 //
 // `Time Started` is bumped to 26 so `localizeAndPrettify` (e.g.
 // "5/3/2026, 12:00:00 PM") stays on a single line.
-function buildColumns(onErrorClick: (errorMessage: string) => void) {
+function buildColumns(
+  onErrorClick: (errorMessage: string) => void,
+  headers: ColumnHeaders
+) {
   return [
     tc.column("time_started", {
-      header: "Time Started",
+      header: headers.timeStarted,
       weight: 26,
       enableSorting: false,
       cell: (value) => (
@@ -68,7 +80,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("status", {
-      header: "Status",
+      header: headers.status,
       weight: 14,
       enableSorting: false,
       cell: (value, row) => (
@@ -79,7 +91,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("total_users_processed", {
-      header: "Users",
+      header: headers.users,
       weight: 10,
       enableSorting: false,
       cell: (value) => (
@@ -89,7 +101,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("total_groups_processed", {
-      header: "Groups",
+      header: headers.groups,
       weight: 10,
       enableSorting: false,
       cell: (value) => (
@@ -99,7 +111,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("total_group_memberships_synced", {
-      header: "Memberships",
+      header: headers.memberships,
       weight: 12,
       enableSorting: false,
       cell: (value) => (
@@ -109,7 +121,7 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       ),
     }),
     tc.column("error_message", {
-      header: "Error Message",
+      header: headers.errorMessage,
       weight: 28,
       enableSorting: false,
       cell: (value, row) => (
@@ -148,6 +160,8 @@ function ErrorMessageCell({
   modalContent,
   onErrorClick,
 }: ErrorMessageCellProps) {
+  const t = useTranslations("admin.connector");
+
   if (!errorMessage) {
     return (
       <Text as="span" font="secondary-body" color="text-03">
@@ -159,7 +173,7 @@ function ErrorMessageCell({
     <button
       type="button"
       onClick={() => onErrorClick(modalContent ?? errorMessage)}
-      aria-label="View full error message"
+      aria-label={t("syncTables.errorCell.ariaLabel")}
       className="text-left w-full cursor-pointer hover:underline"
     >
       <Text as="span" font="secondary-body" color="text-03" maxLines={2}>
@@ -183,22 +197,31 @@ export function ExternalGroupSyncAttemptsTable({
   totalPages,
   onPageChange,
 }: ExternalGroupSyncAttemptsTableProps) {
+  const t = useTranslations("admin.connector");
   const [openErrorMessage, setOpenErrorMessage] = useState<string | null>(null);
   const handleErrorClick = useCallback(
     (errorMessage: string) => setOpenErrorMessage(errorMessage),
     []
   );
   const columns = useMemo(
-    () => buildColumns(handleErrorClick),
-    [handleErrorClick]
+    () =>
+      buildColumns(handleErrorClick, {
+        timeStarted: t("groupMembershipTable.columns.timeStarted"),
+        status: t("groupMembershipTable.columns.status"),
+        users: t("groupMembershipTable.columns.users"),
+        groups: t("groupMembershipTable.columns.groups"),
+        memberships: t("groupMembershipTable.columns.memberships"),
+        errorMessage: t("groupMembershipTable.columns.errorMessage"),
+      }),
+    [handleErrorClick, t]
   );
 
   if (!attempts.length) {
     return (
       <EmptyMessageCard
         sizePreset="main-ui"
-        title="No group membership sync attempts yet"
-        description="Group-membership sync runs are scheduled in the background. They may take some time to appear — try refreshing in ~30 seconds."
+        title={t("groupMembershipTable.empty.title")}
+        description={t("groupMembershipTable.empty.description")}
       />
     );
   }
@@ -209,7 +232,7 @@ export function ExternalGroupSyncAttemptsTable({
         <ExceptionTraceModal
           onOutsideClick={() => setOpenErrorMessage(null)}
           exceptionTrace={openErrorMessage}
-          title={ERROR_MODAL_TITLE}
+          title={t("groupMembershipTable.errorModal.title")}
         />
       )}
 

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -12,6 +12,7 @@ import { localizeAndPrettify } from "@opal/time";
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { SvgAlertTriangle } from "@opal/icons";
 
 export interface IndexAttemptErrorsModalProps {
@@ -36,6 +37,7 @@ export default function IndexAttemptErrorsModal({
   onResolveAll,
   supportsTargetedReindex,
 }: IndexAttemptErrorsModalProps) {
+  const t = useTranslations("admin.connector");
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
     [errors.items]
@@ -52,20 +54,17 @@ export default function IndexAttemptErrorsModal({
       <Modal.Content width="full" height="full">
         <Modal.Header
           icon={SvgAlertTriangle}
-          title="Indexing Errors"
+          title={t("errorsModal.title")}
           onClose={onClose}
           height="fit"
         />
         <Modal.Body height="full">
           <div className="flex flex-col gap-2 shrink-0">
-            <Text as="p">
-              Below are the errors encountered during indexing. Each row
-              represents a failed document or entity.
-            </Text>
+            <Text as="p">{t("errorsModal.description")}</Text>
             <Text as="p">
               {supportsTargetedReindex
-                ? "Click the button below to re-fetch only the failing documents. Much faster than a full re-index."
-                : "Click the button below to kick off a full re-index to try and resolve these errors. This full re-index may take much longer than a normal update."}
+                ? t("errorsModal.targetedReindex.description")
+                : t("errorsModal.fullReindex.description")}
             </Text>
           </div>
 
@@ -73,10 +72,12 @@ export default function IndexAttemptErrorsModal({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Time</TableHead>
-                  <TableHead>Document ID</TableHead>
-                  <TableHead className="w-1/2">Error Message</TableHead>
-                  <TableHead>Status</TableHead>
+                  <TableHead>{t("errorsModal.columns.time")}</TableHead>
+                  <TableHead>{t("errorsModal.columns.documentId")}</TableHead>
+                  <TableHead className="w-1/2">
+                    {t("errorsModal.columns.errorMessage")}
+                  </TableHead>
+                  <TableHead>{t("errorsModal.columns.status")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -94,10 +95,14 @@ export default function IndexAttemptErrorsModal({
                             rel="noopener noreferrer"
                             className="text-link hover:underline"
                           >
-                            {error.document_id || error.entity_id || "Unknown"}
+                            {error.document_id ||
+                              error.entity_id ||
+                              t("errorsModal.unknownDocument")}
                           </a>
                         ) : (
-                          error.document_id || error.entity_id || "Unknown"
+                          error.document_id ||
+                          error.entity_id ||
+                          t("errorsModal.unknownDocument")
                         )}
                       </TableCell>
                       <TableCell>
@@ -113,7 +118,9 @@ export default function IndexAttemptErrorsModal({
                               : "bg-status-error-02 text-status-error-05"
                           }`}
                         >
-                          {error.is_resolved ? "Resolved" : "Unresolved"}
+                          {error.is_resolved
+                            ? t("errorsModal.status.resolved")
+                            : t("errorsModal.status.unresolved")}
                         </span>
                       </TableCell>
                     </TableRow>
@@ -124,7 +131,7 @@ export default function IndexAttemptErrorsModal({
                       colSpan={4}
                       className="text-center py-8 text-text-03"
                     >
-                      No errors found on this page
+                      {t("errorsModal.empty.description")}
                     </TableCell>
                   </TableRow>
                 )}
@@ -145,7 +152,9 @@ export default function IndexAttemptErrorsModal({
         <Modal.Footer>
           {hasUnresolvedErrors && (
             <div className="ml-4">
-              <Button onClick={onResolveAll}>Resolve All</Button>
+              <Button onClick={onResolveAll}>
+                {t("errorsModal.resolveAllButton.label")}
+              </Button>
             </div>
           )}
         </Modal.Footer>

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableHead,
@@ -36,6 +37,7 @@ export function IndexAttemptsTable({
   totalPages,
   onPageChange,
 }: IndexingAttemptsTableProps) {
+  const t = useTranslations("admin.connector");
   const [indexAttemptTracePopupId, setIndexAttemptTracePopupId] = useState<
     number | null
   >(null);
@@ -45,11 +47,10 @@ export function IndexAttemptsTable({
     return (
       <Callout
         className="mt-4"
-        title="No indexing attempts scheduled yet"
+        title={t("indexAttemptsTable.empty.title")}
         type="notice"
       >
-        Index attempts are scheduled in the background, and may take some time
-        to appear. Try refreshing the page in ~30 seconds!
+        {t("indexAttemptsTable.empty.description")}
       </Callout>
     );
   }
@@ -77,21 +78,25 @@ export function IndexAttemptsTable({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Time Started</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead className="whitespace-nowrap">New Docs</TableHead>
+            <TableHead>{t("indexAttemptsTable.columns.timeStarted")}</TableHead>
+            <TableHead>{t("indexAttemptsTable.columns.status")}</TableHead>
+            <TableHead className="whitespace-nowrap">
+              {t("indexAttemptsTable.columns.newDocs")}
+            </TableHead>
             <TableHead>
               <Tooltip
-                tooltip="Total number of documents replaced in the index during this indexing attempt"
+                tooltip={t("indexAttemptsTable.columns.totalDocsTooltip")}
                 side="top"
               >
                 <span className="flex items-center">
-                  Total Docs
+                  {t("indexAttemptsTable.columns.totalDocs")}
                   <SvgInfo className="ml-1 w-4 h-4" />
                 </span>
               </Tooltip>
             </TableHead>
-            <TableHead>Error Message</TableHead>
+            <TableHead>
+              {t("indexAttemptsTable.columns.errorMessage")}
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -101,11 +106,9 @@ export function IndexAttemptsTable({
             const isReindexInProgress =
               indexAttempt.status === "in_progress" ||
               indexAttempt.status === "not_started";
-            const reindexTooltip = `This index attempt ${
-              isReindexInProgress ? "is" : "was"
-            } a full re-index. All documents from the source ${
-              isReindexInProgress ? "are being" : "were"
-            } synced into the system.`;
+            const reindexTooltip = isReindexInProgress
+              ? t("indexAttemptsTable.reindexTooltip.inProgress")
+              : t("indexAttemptsTable.reindexTooltip.completed");
             return (
               <TableRow
                 key={indexAttempt.id}
@@ -139,20 +142,24 @@ export function IndexAttemptsTable({
                         className="relative z-content"
                       >
                         <Text font="secondary-body" color="text-03">
-                          {`${docsPerMinute} docs / min`}
+                          {t("indexAttemptsTable.docsPerMinute", {
+                            rate: docsPerMinute,
+                          })}
                         </Text>
                         <Button
                           icon={SvgBarChartSmall}
                           prominence="tertiary"
                           size="sm"
-                          tooltip="View stage metrics"
+                          tooltip={t(
+                            "indexAttemptsTable.stageMetricsButton.tooltip"
+                          )}
                           onClick={() => setMetricsAttemptId(indexAttempt.id)}
                         />
                       </Section>
                     ) : (
                       indexAttempt.status === "success" && (
                         <Text font="secondary-body" color="text-03">
-                          No additional docs processed
+                          {t("indexAttemptsTable.noAdditionalDocs")}
                         </Text>
                       )
                     )}
@@ -164,8 +171,9 @@ export function IndexAttemptsTable({
                       <div>{indexAttempt.new_docs_indexed}</div>
                       {indexAttempt.docs_removed_from_index > 0 && (
                         <div className="text-xs w-52 text-wrap flex italic overflow-hidden whitespace-normal px-1">
-                          (also removed {indexAttempt.docs_removed_from_index}{" "}
-                          docs that were detected as deleted in the source)
+                          {t("indexAttemptsTable.docsRemoved", {
+                            count: indexAttempt.docs_removed_from_index,
+                          })}
                         </div>
                       )}
                     </div>
@@ -195,7 +203,7 @@ export function IndexAttemptsTable({
                   {indexAttempt.full_exception_trace && (
                     <button
                       type="button"
-                      aria-label="View full trace"
+                      aria-label={t("indexAttemptsTable.viewTrace.ariaLabel")}
                       onClick={() =>
                         setIndexAttemptTracePopupId(indexAttempt.id)
                       }

--- a/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import {
   Table,
@@ -40,6 +41,7 @@ export default function InlineFileManagement({
   connectorId,
   onRefresh,
 }: InlineFileManagementProps) {
+  const t = useTranslations("admin.connector");
   const [isEditing, setIsEditing] = useState(false);
   const [selectedFilesToRemove, setSelectedFilesToRemove] = useState<
     Set<string>
@@ -97,9 +99,7 @@ export default function InlineFileManagement({
     ).length;
 
     if (remainingFiles === 0 && filesToAdd.length === 0) {
-      toast.error(
-        "Cannot remove all files from a connector. Delete the connector if this is desired."
-      );
+      toast.error(t("fileManagement.toasts.cannotRemoveAllFiles"));
       return;
     }
 
@@ -117,10 +117,7 @@ export default function InlineFileManagement({
         filesToAdd
       );
 
-      toast.success(
-        "Files updated successfully! Document index is being updated in the background. " +
-          "New files are being indexed and removed files will be pruned from the search results."
-      );
+      toast.success(t("fileManagement.toasts.filesUpdated"));
 
       // Reset editing state
       setIsEditing(false);
@@ -132,7 +129,9 @@ export default function InlineFileManagement({
       onRefresh();
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to update files"
+        error instanceof Error
+          ? error.message
+          : t("fileManagement.toasts.updateFailed")
       );
     } finally {
       setIsSaving(false);
@@ -156,7 +155,7 @@ export default function InlineFileManagement({
   if (error) {
     return (
       <Text as="p" className="text-error">
-        Error loading files: {error.message}
+        {t("fileManagement.loadError", { message: error.message })}
       </Text>
     );
   }
@@ -171,7 +170,7 @@ export default function InlineFileManagement({
       {/* Header with Edit/Save buttons */}
       <div className="flex justify-between items-center mb-4">
         <Text as="p" mainUiBody>
-          Files ({totalFiles} file{totalFiles !== 1 ? "s" : ""})
+          {t("fileManagement.header.title", { count: totalFiles })}
         </Text>
         <div className="flex gap-2">
           {!isEditing ? (
@@ -180,7 +179,7 @@ export default function InlineFileManagement({
               onClick={() => setIsEditing(true)}
               icon={SvgEdit}
             >
-              Edit
+              {t("fileManagement.editButton.label")}
             </Button>
           ) : (
             <>
@@ -190,7 +189,7 @@ export default function InlineFileManagement({
                 onClick={handleCancel}
                 icon={SvgX}
               >
-                Cancel
+                {t("fileManagement.cancelButton.label")}
               </Button>
               <Button
                 disabled={
@@ -200,7 +199,9 @@ export default function InlineFileManagement({
                 onClick={handleSaveClick}
                 icon={SvgCheck}
               >
-                {isSaving ? "Saving..." : "Save Changes"}
+                {isSaving
+                  ? t("fileManagement.saveButton.saving")
+                  : t("fileManagement.saveButton.label")}
               </Button>
             </>
           )}
@@ -210,7 +211,7 @@ export default function InlineFileManagement({
       {/* File List */}
       {files.length === 0 && filesToAdd.length === 0 ? (
         <Text as="p" mainUiMuted className="text-center py-8">
-          No files in this connector
+          {t("fileManagement.empty.description")}
         </Text>
       ) : (
         <div className="border rounded-lg overflow-hidden mb-4">
@@ -220,9 +221,11 @@ export default function InlineFileManagement({
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   {isEditing && <TableHead className="w-12"></TableHead>}
-                  <TableHead>File Name</TableHead>
-                  <TableHead>Size</TableHead>
-                  <TableHead>Upload Date</TableHead>
+                  <TableHead>{t("fileManagement.columns.fileName")}</TableHead>
+                  <TableHead>{t("fileManagement.columns.size")}</TableHead>
+                  <TableHead>
+                    {t("fileManagement.columns.uploadDate")}
+                  </TableHead>
                   {isEditing && <TableHead className="w-12"></TableHead>}
                 </TableRow>
               </TableHeader>
@@ -261,7 +264,7 @@ export default function InlineFileManagement({
                         </span>
                         {isMarkedForRemoval && (
                           <span className="ml-2 text-xs font-semibold text-red-600 dark:text-red-400">
-                            Removing
+                            {t("fileManagement.removingBadge.label")}
                           </span>
                         )}
                       </TableCell>
@@ -300,15 +303,15 @@ export default function InlineFileManagement({
                           prominence="tertiary"
                           size="sm"
                           onClick={() => handleRemoveNewFile(index)}
-                          tooltip="Remove file"
-                          title="Remove file"
+                          tooltip={t("fileManagement.removeFileButton.tooltip")}
+                          title={t("fileManagement.removeFileButton.tooltip")}
                         />
                       </TableCell>
                     )}
                     <TableCell className="font-medium">
                       {file.name}
                       <Text as="p" figureSmallValue>
-                        New
+                        {t("fileManagement.newBadge.label")}
                       </Text>
                     </TableCell>
                     <TableCell>{formatBytes(file.size)}</TableCell>
@@ -339,7 +342,7 @@ export default function InlineFileManagement({
             onClick={() => fileInputRef.current?.click()}
             icon={SvgPlusCircle}
           >
-            Add Files
+            {t("fileManagement.addFilesButton.label")}
           </Button>
         </div>
       )}
@@ -349,8 +352,8 @@ export default function InlineFileManagement({
         <Modal.Content width="sm">
           <Modal.Header
             icon={SvgFolderPlus}
-            title="Confirm File Changes"
-            description="When you save these changes, the following will happen:"
+            title={t("fileManagement.confirmModal.title")}
+            description={t("fileManagement.confirmModal.description")}
           />
 
           <Modal.Body>
@@ -361,15 +364,16 @@ export default function InlineFileManagement({
                   mainUiBody
                   className="font-semibold text-red-800 dark:text-red-200"
                 >
-                  🗑️ {selectedFilesToRemove.size} file(s) will be removed
+                  {t("fileManagement.confirmModal.removeSummary", {
+                    count: selectedFilesToRemove.size,
+                  })}
                 </Text>
                 <Text
                   as="p"
                   secondaryBody
                   className="text-red-700 dark:text-red-300 mt-1"
                 >
-                  Documents from these files will be pruned from the Document
-                  Index
+                  {t("fileManagement.confirmModal.removeDetails")}
                 </Text>
               </div>
             )}
@@ -381,15 +385,16 @@ export default function InlineFileManagement({
                   mainUiBody
                   className="font-semibold text-green-800 dark:text-green-200"
                 >
-                  {filesToAdd.length} file(s) will be added
+                  {t("fileManagement.confirmModal.addSummary", {
+                    count: filesToAdd.length,
+                  })}
                 </Text>
                 <Text
                   as="p"
                   secondaryBody
                   className="text-green-700 dark:text-green-300 mt-1"
                 >
-                  New files will be uploaded, chunked, embedded, and indexed in
-                  the Document Index
+                  {t("fileManagement.confirmModal.addDetails")}
                 </Text>
               </div>
             )}
@@ -401,10 +406,12 @@ export default function InlineFileManagement({
               prominence="secondary"
               onClick={() => setShowSaveConfirm(false)}
             >
-              Cancel
+              {t("fileManagement.cancelButton.label")}
             </Button>
             <Button disabled={isSaving} onClick={handleConfirmSave}>
-              {isSaving ? "Saving..." : "Confirm & Save"}
+              {isSaving
+                ? t("fileManagement.saveButton.saving")
+                : t("fileManagement.confirmModal.confirmButton.label")}
             </Button>
           </Modal.Footer>
         </Modal.Content>

--- a/web/src/app/admin/connector/[ccPairId]/PermissionSyncStatusBadge.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/PermissionSyncStatusBadge.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Tag, Tooltip } from "@opal/components";
 import type { TagColor } from "@opal/components";
 import type { IconFunctionComponent } from "@opal/types";
@@ -36,49 +37,59 @@ import { PermissionSyncStatusEnum } from "./types";
  * offered.
  */
 
+/** Message keys inside the `admin.connector` namespace. */
+type BadgeLabelKey =
+  | "permissionSyncStatus.success.label"
+  | "permissionSyncStatus.completedWithErrors.label"
+  | "permissionSyncStatus.failed.label"
+  | "permissionSyncStatus.inProgress.label"
+  | "permissionSyncStatus.notStarted.label"
+  | "permissionSyncStatus.canceled.label"
+  | "permissionSyncStatus.fallback.label";
+
 interface BadgeConfig {
   color: TagColor;
   icon: IconFunctionComponent;
-  label: string;
+  labelKey: BadgeLabelKey;
 }
 
 const STATUS_CONFIG: Record<PermissionSyncStatusEnum, BadgeConfig> = {
   [PermissionSyncStatusEnum.SUCCESS]: {
     color: "green",
     icon: SvgCheckCircle,
-    label: "Succeeded",
+    labelKey: "permissionSyncStatus.success.label",
   },
   [PermissionSyncStatusEnum.COMPLETED_WITH_ERRORS]: {
     color: "amber",
     icon: SvgAlertTriangle,
-    label: "Completed with errors",
+    labelKey: "permissionSyncStatus.completedWithErrors.label",
   },
   [PermissionSyncStatusEnum.FAILED]: {
     color: "amber",
     icon: SvgXOctagon,
-    label: "Failed",
+    labelKey: "permissionSyncStatus.failed.label",
   },
   [PermissionSyncStatusEnum.IN_PROGRESS]: {
     color: "blue",
     icon: SvgClock,
-    label: "In Progress",
+    labelKey: "permissionSyncStatus.inProgress.label",
   },
   [PermissionSyncStatusEnum.NOT_STARTED]: {
     color: "gray",
     icon: SvgClock,
-    label: "Scheduled",
+    labelKey: "permissionSyncStatus.notStarted.label",
   },
   [PermissionSyncStatusEnum.CANCELED]: {
     color: "gray",
     icon: SvgClock,
-    label: "Canceled",
+    labelKey: "permissionSyncStatus.canceled.label",
   },
 };
 
 const FALLBACK_CONFIG: BadgeConfig = {
   color: "gray",
   icon: SvgClock,
-  label: "Not Started",
+  labelKey: "permissionSyncStatus.fallback.label",
 };
 
 const STATUSES_WITH_ERROR_TOOLTIP: ReadonlySet<PermissionSyncStatusEnum> =
@@ -97,9 +108,10 @@ export function PermissionSyncStatusBadge({
   status,
   errorMsg,
 }: PermissionSyncStatusBadgeProps) {
+  const t = useTranslations("admin.connector");
   const config = (status && STATUS_CONFIG[status]) ?? FALLBACK_CONFIG;
   const tag = (
-    <Tag color={config.color} icon={config.icon} title={config.label} />
+    <Tag color={config.color} icon={config.icon} title={t(config.labelKey)} />
   );
 
   if (status && STATUSES_WITH_ERROR_TOOLTIP.has(status) && errorMsg) {

--- a/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Divider } from "@opal/components";
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "@opal/layouts";
 import { triggerIndexing } from "@/app/admin/connector/[ccPairId]/lib";
 import { Modal } from "@opal/components";
@@ -13,6 +14,7 @@ export function useReIndexModal(
   credentialId: number | null,
   ccPairId: number | null
 ) {
+  const t = useTranslations("admin.connector");
   const [reIndexPopupVisible, setReIndexPopupVisible] = useState(false);
 
   const showReIndexModal = () => {
@@ -42,18 +44,16 @@ export function useReIndexModal(
       // Show appropriate notification based on result
       if (result.success) {
         toast.success(
-          `${
-            fromBeginning ? "Complete re-indexing" : "Indexing update"
-          } started successfully`
+          fromBeginning
+            ? t("toasts.completeReindexStarted")
+            : t("toasts.indexingUpdateStarted")
         );
       } else {
-        toast.error(result.message || "Failed to start indexing");
+        toast.error(result.message || t("toasts.indexingStartFailed"));
       }
     } catch (error) {
       console.error("Failed to trigger indexing:", error);
-      toast.error(
-        "An unexpected error occurred while trying to start indexing"
-      );
+      toast.error(t("toasts.indexingStartUnexpectedError"));
     }
   };
 
@@ -77,6 +77,7 @@ export interface ReIndexModalProps {
 }
 
 export default function ReIndexModal({ hide, onRunIndex }: ReIndexModalProps) {
+  const t = useTranslations("admin.connector");
   const [isProcessing, setIsProcessing] = useState(false);
 
   const handleRunIndex = async (fromBeginning: boolean) => {
@@ -86,9 +87,9 @@ export default function ReIndexModal({ hide, onRunIndex }: ReIndexModalProps) {
     try {
       // First show immediate feedback with a toast
       toast.info(
-        `Starting ${
-          fromBeginning ? "complete re-indexing" : "indexing update"
-        }...`
+        fromBeginning
+          ? t("toasts.completeReindexStarting")
+          : t("toasts.indexingUpdateStarting")
       );
 
       // Then close the modal
@@ -99,7 +100,7 @@ export default function ReIndexModal({ hide, onRunIndex }: ReIndexModalProps) {
     } catch (error) {
       console.error("Error starting indexing:", error);
       // Show error in toast if needed
-      toast.error("Failed to start indexing process");
+      toast.error(t("toasts.indexingProcessStartFailed"));
     } finally {
       setIsProcessing(false);
     }
@@ -108,29 +109,28 @@ export default function ReIndexModal({ hide, onRunIndex }: ReIndexModalProps) {
   return (
     <Modal open onOpenChange={hide}>
       <Modal.Content width="sm" height="sm">
-        <Modal.Header icon={SvgRefreshCw} title="Run Indexing" onClose={hide} />
+        <Modal.Header
+          icon={SvgRefreshCw}
+          title={t("reIndexModal.title")}
+          onClose={hide}
+        />
         <Modal.Body>
-          <Text as="p">
-            This will pull in and index all documents that have changed and/or
-            have been added since the last successful indexing run.
-          </Text>
+          <Text as="p">{t("reIndexModal.update.description")}</Text>
           <Button disabled={isProcessing} onClick={() => handleRunIndex(false)}>
-            Run Update
+            {t("reIndexModal.updateButton.label")}
           </Button>
 
           <Divider />
 
+          <Text as="p">{t("reIndexModal.fullReindex.description")}</Text>
           <Text as="p">
-            This will cause a complete re-indexing of all documents from the
-            source.
-          </Text>
-          <Text as="p">
-            <strong>NOTE:</strong> depending on the number of documents stored
-            in the source, this may take a long time.
+            {t.rich("reIndexModal.fullReindex.note", {
+              strong: (chunks) => <strong>{chunks}</strong>,
+            })}
           </Text>
 
           <Button disabled={isProcessing} onClick={() => handleRunIndex(true)}>
-            Run Complete Re-Indexing
+            {t("reIndexModal.fullReindexButton.label")}
           </Button>
         </Modal.Body>
       </Modal.Content>

--- a/web/src/app/admin/connector/[ccPairId]/StageMetricsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/StageMetricsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Modal } from "@opal/components";
+import { useTranslations } from "next-intl";
 import { SvgBarChartSmall } from "@opal/icons";
 import StageMetricsPanel from "./stage-metrics/StageMetricsPanel";
 
@@ -13,13 +14,15 @@ export default function StageMetricsModal({
   indexAttemptId,
   onClose,
 }: StageMetricsModalProps) {
+  const t = useTranslations("admin.connector");
+
   return (
     <Modal open onOpenChange={(isOpen) => !isOpen && onClose()}>
       <Modal.Content width="lg" height="lg">
         <Modal.Header
           icon={SvgBarChartSmall}
-          title="Indexing stage metrics"
-          description="Per-batch and per-attempt timing for this index attempt."
+          title={t("stageMetricsModal.title")}
+          description={t("stageMetricsModal.description")}
           onClose={onClose}
         />
         <Modal.Body>

--- a/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { MessageCard, Tabs } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { SvgSimpleLoader } from "@opal/icons";
@@ -46,10 +47,6 @@ import useSyncAttemptsPaginatedFetch from "./useSyncAttemptsPaginatedFetch";
 
 const ITEMS_PER_PAGE = 8;
 const PAGES_PER_BATCH = 4;
-const NOT_APPLICABLE_DOC_PERMISSIONS_MESSAGE =
-  "This connector does not use a separate document-permission syncing job.";
-const NOT_APPLICABLE_GROUP_MEMBERSHIP_MESSAGE =
-  "This connector does not use a separate group-membership syncing job.";
 
 enum SyncAttemptsTab {
   INDEXING = "indexing",
@@ -77,6 +74,7 @@ export function SyncAttemptsTabs({
   indexTotalPages,
   onIndexPageChange,
 }: SyncAttemptsTabsProps) {
+  const t = useTranslations("admin.connector");
   const [tab, setTab] = useState<SyncAttemptsTab>(SyncAttemptsTab.INDEXING);
 
   return (
@@ -85,12 +83,14 @@ export function SyncAttemptsTabs({
       onValueChange={(value) => setTab(value as SyncAttemptsTab)}
     >
       <Tabs.List>
-        <Tabs.Trigger value={SyncAttemptsTab.INDEXING}>Indexing</Tabs.Trigger>
+        <Tabs.Trigger value={SyncAttemptsTab.INDEXING}>
+          {t("syncTabs.indexing.label")}
+        </Tabs.Trigger>
         <Tabs.Trigger value={SyncAttemptsTab.DOC_PERMISSIONS}>
-          Document Permission Sync
+          {t("syncTabs.docPermissions.label")}
         </Tabs.Trigger>
         <Tabs.Trigger value={SyncAttemptsTab.GROUP_MEMBERSHIP}>
-          Group Membership Sync
+          {t("syncTabs.groupMembership.label")}
         </Tabs.Trigger>
       </Tabs.List>
 
@@ -116,6 +116,7 @@ export function SyncAttemptsTabs({
 }
 
 function DocPermissionsTabBody({ ccPairId }: { ccPairId: number }) {
+  const t = useTranslations("admin.connector");
   const result =
     useSyncAttemptsPaginatedFetch<DocPermissionSyncAttemptSnapshot>({
       endpoint: SWR_KEYS.ccPairPermissionSyncAttempts(ccPairId),
@@ -124,7 +125,11 @@ function DocPermissionsTabBody({ ccPairId }: { ccPairId: number }) {
       pagesPerBatch: PAGES_PER_BATCH,
     });
 
-  const gate = renderTabGate(result, NOT_APPLICABLE_DOC_PERMISSIONS_MESSAGE);
+  const gate = renderTabGate(result, {
+    loadErrorTitle: t("syncTabs.loadError.title"),
+    notApplicableTitle: t("syncTabs.notApplicable.title"),
+    notApplicableMessage: t("syncTabs.docPermissions.notApplicableDescription"),
+  });
   if (gate !== null) return gate;
 
   return (
@@ -138,6 +143,7 @@ function DocPermissionsTabBody({ ccPairId }: { ccPairId: number }) {
 }
 
 function GroupMembershipTabBody({ ccPairId }: { ccPairId: number }) {
+  const t = useTranslations("admin.connector");
   const result =
     useSyncAttemptsPaginatedFetch<ExternalGroupSyncAttemptSnapshot>({
       endpoint: SWR_KEYS.ccPairExternalGroupSyncAttempts(ccPairId),
@@ -146,7 +152,13 @@ function GroupMembershipTabBody({ ccPairId }: { ccPairId: number }) {
       pagesPerBatch: PAGES_PER_BATCH,
     });
 
-  const gate = renderTabGate(result, NOT_APPLICABLE_GROUP_MEMBERSHIP_MESSAGE);
+  const gate = renderTabGate(result, {
+    loadErrorTitle: t("syncTabs.loadError.title"),
+    notApplicableTitle: t("syncTabs.notApplicable.title"),
+    notApplicableMessage: t(
+      "syncTabs.groupMembership.notApplicableDescription"
+    ),
+  });
   if (gate !== null) return gate;
 
   return (
@@ -168,6 +180,13 @@ interface TabGateInputs {
   currentPageData: unknown[] | null;
 }
 
+/** Translated copy threaded in from the calling component. */
+interface TabGateLabels {
+  loadErrorTitle: string;
+  notApplicableTitle: string;
+  notApplicableMessage: string;
+}
+
 /**
  * Compresses the loading / error / not-applicable / first-page-loading
  * branches both permission-sync tabs share into one place. Returns
@@ -175,7 +194,7 @@ interface TabGateInputs {
  */
 function renderTabGate(
   inputs: TabGateInputs,
-  notApplicableMessage: string
+  labels: TabGateLabels
 ): React.ReactElement | null {
   const {
     applicable,
@@ -190,7 +209,7 @@ function renderTabGate(
     return (
       <MessageCard
         variant="error"
-        title="Failed to load sync attempts"
+        title={labels.loadErrorTitle}
         description={applicableError.message}
       />
     );
@@ -202,8 +221,8 @@ function renderTabGate(
     return (
       <MessageCard
         variant="info"
-        title="Not applicable"
-        description={notApplicableMessage}
+        title={labels.notApplicableTitle}
+        description={labels.notApplicableMessage}
       />
     );
   }
@@ -214,7 +233,7 @@ function renderTabGate(
     return (
       <MessageCard
         variant="error"
-        title="Failed to load sync attempts"
+        title={labels.loadErrorTitle}
         description={error.message}
       />
     );

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -16,6 +16,7 @@ import { credentialTemplates } from "@/lib/connectors/credentials";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import Title from "@/components/ui/title";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState, use } from "react";
 import useSWR, { mutate } from "swr";
 import {
@@ -94,6 +95,7 @@ const ITEMS_PER_PAGE = 8;
 const PAGES_PER_BATCH = 8;
 
 function Main({ ccPairId }: { ccPairId: number }) {
+  const t = useTranslations("admin.connector");
   const router = useRouter();
   const { user } = useUser();
 
@@ -176,11 +178,11 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
     deleteCCPair(ccPair.connector.id, ccPair.credential.id).catch((error) => {
       toast.error(
-        "Failed to schedule deletion of connector - " + error.message
+        t("toasts.deletionScheduleFailed", { message: error.message })
       );
     });
     finishConnectorDeletion();
-  }, [ccPair, finishConnectorDeletion]);
+  }, [ccPair, finishConnectorDeletion, t]);
 
   const latestIndexAttempt = indexAttempts?.[0];
   const canManageInlineFileConnectorFiles =
@@ -218,18 +220,16 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
       if (result.success) {
         toast.success(
-          `${
-            fromBeginning ? "Complete re-indexing" : "Indexing update"
-          } started successfully`
+          fromBeginning
+            ? t("toasts.completeReindexStarted")
+            : t("toasts.indexingUpdateStarted")
         );
       } else {
-        toast.error(result.message || "Failed to start indexing");
+        toast.error(result.message || t("toasts.indexingStartFailed"));
       }
     } catch (error) {
       console.error("Failed to trigger indexing:", error);
-      toast.error(
-        "An unexpected error occurred while trying to start indexing"
-      );
+      toast.error(t("toasts.indexingStartUnexpectedError"));
     } finally {
       setShowIsResolvingKickoffLoader(false);
     }
@@ -270,9 +270,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
         throw new Error(await response.text());
       }
       mutate(buildCCPairInfoUrl(ccPairId));
-      toast.success("Connector name updated successfully");
+      toast.success(t("toasts.nameUpdated"));
     } catch (error) {
-      toast.error("Failed to update connector name");
+      toast.error(t("toasts.nameUpdateFailed"));
     }
   };
 
@@ -291,7 +291,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     const parsedRefreshFreqMinutes = parseInt(propertyValue, 10);
 
     if (isNaN(parsedRefreshFreqMinutes)) {
-      toast.error("Invalid refresh frequency: must be an integer");
+      toast.error(t("toasts.invalidRefreshFrequency"));
       return;
     }
 
@@ -308,9 +308,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
         throw new Error(await response.text());
       }
       mutate(buildCCPairInfoUrl(ccPairId));
-      toast.success("Connector refresh frequency updated successfully");
+      toast.success(t("toasts.refreshFrequencyUpdated"));
     } catch (error) {
-      toast.error("Failed to update connector refresh frequency");
+      toast.error(t("toasts.refreshFrequencyUpdateFailed"));
     }
   };
 
@@ -321,7 +321,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     const parsedFreqHours = parseFloat(propertyValue);
 
     if (isNaN(parsedFreqHours)) {
-      toast.error("Invalid pruning frequency: must be a valid number");
+      toast.error(t("toasts.invalidPruningFrequency"));
       return;
     }
 
@@ -338,9 +338,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
         throw new Error(await response.text());
       }
       mutate(buildCCPairInfoUrl(ccPairId));
-      toast.success("Connector pruning frequency updated successfully");
+      toast.success(t("toasts.pruningFrequencyUpdated"));
     } catch (error) {
-      toast.error("Failed to update connector pruning frequency");
+      toast.error(t("toasts.pruningFrequencyUpdateFailed"));
     }
   };
 
@@ -351,11 +351,11 @@ function Main({ ccPairId }: { ccPairId: number }) {
   if (!ccPair || (!hasLoadedOnce && ccPairError)) {
     return (
       <ErrorCallout
-        errorTitle={`Failed to fetch info on Connector with ID ${ccPairId}`}
+        errorTitle={t("loadError.title", { ccPairId: String(ccPairId) })}
         errorMsg={
           ccPairError?.info?.detail ||
           ccPairError?.toString() ||
-          "Unknown error"
+          t("loadError.unknownMessage")
         }
       />
     );
@@ -378,9 +378,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
       {showDeleteConnectorConfirmModal && (
         <ConfirmEntityModal
           danger
-          entityType="connector"
+          entityType={t("deleteModal.entityType")}
           entityName={ccPair.name}
-          additionalDetails="Deleting this connector schedules a deletion job that removes its indexed documents and deletes it for every user."
+          additionalDetails={t("deleteModal.additionalDetails")}
           onClose={() => {
             setShowDeleteConnectorConfirmModal(false);
           }}
@@ -390,8 +390,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
       {editingRefreshFrequency && (
         <EditPropertyModal
-          propertyTitle="Refresh Frequency"
-          propertyDetails="How often the connector should refresh (in minutes)"
+          propertyTitle={t("refreshFrequencyModal.title")}
+          propertyDetails={t("refreshFrequencyModal.description")}
           propertyName="refresh_frequency"
           propertyValue={String(Math.round((refreshFreq || 0) / 60))}
           validationSchema={RefreshFrequencySchema}
@@ -402,8 +402,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
       {editingPruningFrequency && (
         <EditPropertyModal
-          propertyTitle="Pruning Frequency"
-          propertyDetails="How often the connector should be pruned (in hours)"
+          propertyTitle={t("pruningFrequencyModal.title")}
+          propertyDetails={t("pruningFrequencyModal.description")}
           propertyName="pruning_frequency"
           propertyValue={String(
             ((pruneFreq || 0) / 3600).toFixed(3).replace(/\.?0+$/, "")
@@ -432,12 +432,12 @@ function Main({ ccPairId }: { ccPairId: number }) {
             try {
               const result = await resolveAllErrorsForCCPair(ccPairId);
               if (result.total_error_ids === 0) {
-                toast.success("No unresolved errors to retry.");
+                toast.success(t("toasts.noUnresolvedErrors"));
               } else {
                 toast.success(
-                  `Targeted reindex submitted for ${result.total_error_ids} ${
-                    result.total_error_ids === 1 ? "document" : "documents"
-                  }. Errors will clear from the list as documents finish reindexing.`
+                  t("toasts.targetedReindexSubmitted", {
+                    count: result.total_error_ids,
+                  })
                 );
               }
               mutate(
@@ -447,7 +447,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
               );
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
-              toast.error(`Targeted reindex failed: ${message}`);
+              toast.error(t("toasts.targetedReindexFailed", { message }));
             } finally {
               setShowIsResolvingKickoffLoader(false);
             }
@@ -485,7 +485,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button prominence="secondary" icon={SvgSettings}>
-                  Manage
+                  {t("manageMenu.trigger.label")}
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
@@ -507,17 +507,17 @@ function Main({ ccPairId }: { ccPairId: number }) {
                   className="flex items-center gap-x-2 cursor-pointer px-3 py-2"
                   tooltip={
                     ccPair.indexing
-                      ? "Cannot re-index while indexing is already in progress"
+                      ? t("manageMenu.reIndex.tooltip.indexing")
                       : ccPair.status === ConnectorCredentialPairStatus.PAUSED
-                        ? "Resume the connector before re-indexing"
+                        ? t("manageMenu.reIndex.tooltip.paused")
                         : ccPair.status ===
                             ConnectorCredentialPairStatus.INVALID
-                          ? "Fix the connector configuration before re-indexing"
+                          ? t("manageMenu.reIndex.tooltip.invalid")
                           : undefined
                   }
                 >
                   <RefreshCwIcon className="h-4 w-4" />
-                  <span>Re-Index</span>
+                  <span>{t("manageMenu.reIndex.label")}</span>
                 </DropdownMenuItemWithTooltip>
                 {!isDeleting && (
                   <DropdownMenuItemWithTooltip
@@ -531,7 +531,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
                     disabled={isStatusUpdating}
                     className="flex items-center gap-x-2 cursor-pointer px-3 py-2"
                     tooltip={
-                      isStatusUpdating ? "Status update in progress" : undefined
+                      isStatusUpdating
+                        ? t("manageMenu.toggleStatus.tooltip.updating")
+                        : undefined
                     }
                   >
                     {statusIsNotCurrentlyActive(ccPair.status) ? (
@@ -541,8 +543,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
                     )}
                     <span>
                       {statusIsNotCurrentlyActive(ccPair.status)
-                        ? "Resume"
-                        : "Pause"}
+                        ? t("manageMenu.toggleStatus.resume.label")
+                        : t("manageMenu.toggleStatus.pause.label")}
                     </span>
                   </DropdownMenuItemWithTooltip>
                 )}
@@ -555,12 +557,12 @@ function Main({ ccPairId }: { ccPairId: number }) {
                     className="flex items-center gap-x-2 cursor-pointer px-3 py-2 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
                     tooltip={
                       !statusIsNotCurrentlyActive(ccPair.status)
-                        ? "Pause the connector before deleting"
+                        ? t("manageMenu.delete.tooltip.active")
                         : undefined
                     }
                   >
                     <Trash2Icon className="h-4 w-4" />
-                    <span>Delete</span>
+                    <span>{t("manageMenu.delete.label")}</span>
                   </DropdownMenuItemWithTooltip>
                 )}
               </DropdownMenuContent>
@@ -581,9 +583,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
       {ccPair.status === ConnectorCredentialPairStatus.INVALID && (
         <div className="mt-6">
-          <Callout type="warning" title="Invalid Connector State">
-            This connector is in an invalid state. Please update your
-            credentials or create a new connector before re-indexing.
+          <Callout type="warning" title={t("invalidState.title")}>
+            {t("invalidState.description")}
           </Callout>
         </div>
       )}
@@ -592,39 +593,42 @@ function Main({ ccPairId }: { ccPairId: number }) {
         <Alert className="border-alert bg-yellow-50 dark:bg-yellow-800 my-2 mt-6">
           <AlertCircle className="h-4 w-4 text-yellow-700 dark:text-yellow-500" />
           <AlertTitle className="text-yellow-950 dark:text-yellow-200 font-semibold">
-            Some documents failed to index
+            {t("indexErrorsAlert.title")}
           </AlertTitle>
           <AlertDescription className="text-yellow-900 dark:text-yellow-300">
             {isResolvingErrors ? (
               <span>
                 <span className="text-sm text-yellow-700 dark:text-yellow-400 da animate-pulse">
-                  Resolving failures
+                  {t("indexErrorsAlert.resolvingStatus")}
                 </span>
               </span>
             ) : (
-              <>
-                We ran into some issues while processing some documents.{" "}
-                <button
-                  type="button"
-                  className="text-link cursor-pointer dark:text-blue-300 font-bold"
-                  onClick={() => setShowIndexAttemptErrors(true)}
-                >
-                  View details.
-                </button>
-              </>
+              t.rich("indexErrorsAlert.description", {
+                details: (chunks) => (
+                  <button
+                    type="button"
+                    className="text-link cursor-pointer dark:text-blue-300 font-bold"
+                    onClick={() => setShowIndexAttemptErrors(true)}
+                  >
+                    {chunks}
+                  </button>
+                ),
+              })
             )}
           </AlertDescription>
         </Alert>
       )}
 
       <Title className="mb-2 mt-6" size="md">
-        Indexing
+        {t("sections.indexing.title")}
       </Title>
 
       <Card className="px-8 py-12">
         <div className="flex">
           <div className="w-[200px]">
-            <div className="text-sm font-medium mb-1">Status</div>
+            <div className="text-sm font-medium mb-1">
+              {t("statusCard.status.label")}
+            </div>
             <CCPairStatus
               ccPairStatus={ccPair.status}
               inRepeatedErrorState={ccPair.in_repeated_error_state}
@@ -633,7 +637,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
           </div>
 
           <div className="w-[200px]">
-            <div className="text-sm font-medium mb-1">Documents Indexed</div>
+            <div className="text-sm font-medium mb-1">
+              {t("statusCard.documentsIndexed.label")}
+            </div>
             <div className="text-sm text-text-default flex items-center gap-x-1">
               {ccPair.num_docs_indexed.toLocaleString()}
               {ccPair.status ===
@@ -641,14 +647,18 @@ function Main({ ccPairId }: { ccPairId: number }) {
                 ccPair.overall_indexing_speed !== null &&
                 ccPair.num_docs_indexed > 0 && (
                   <div className="ml-0.5 text-xs font-medium">
-                    ({ccPair.overall_indexing_speed.toFixed(1)} docs / min)
+                    {t("statusCard.indexingSpeed", {
+                      speed: ccPair.overall_indexing_speed.toFixed(1),
+                    })}
                   </div>
                 )}
             </div>
           </div>
 
           <div className="w-[200px]">
-            <div className="text-sm font-medium mb-1">Last Indexed</div>
+            <div className="text-sm font-medium mb-1">
+              {t("statusCard.lastIndexed.label")}
+            </div>
             <div className="text-sm text-text-default">
               {timeAgo(ccPair?.last_indexed) ?? "-"}
             </div>
@@ -659,7 +669,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
               <div className="w-[200px]">
                 {/* TODO: Remove className and switch to text03 once Text is fully integrated across this page */}
                 <Text as="p" className="text-sm font-medium mb-1">
-                  Permission Syncing
+                  {t("statusCard.permissionSyncing.label")}
                 </Text>
                 {ccPair.permission_syncing ||
                 ccPair.last_permission_sync_attempt_status ? (
@@ -675,7 +685,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
               <div className="w-[200px]">
                 {/* TODO: Remove className and switch to text03 once Text is fully integrated across this page */}
                 <Text as="p" className="text-sm font-medium mb-1">
-                  Last Synced
+                  {t("statusCard.lastSynced.label")}
                 </Text>
                 <Text as="p" className="text-sm text-text-default">
                   {ccPair.last_permission_sync_attempt_finished
@@ -691,7 +701,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
       {credentialTemplates[ccPair.connector.source] && can(ccPair, "edit") && (
         <>
           <Title size="md" className="mt-10 mb-2">
-            Credential
+            {t("sections.credential.title")}
           </Title>
 
           <div className="mt-2">
@@ -708,7 +718,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
         Object.keys(ccPair.connector.connector_specific_config).length > 0 && (
           <>
             <Title size="md" className="mt-10 mb-2">
-              Connector Configuration
+              {t("sections.connectorConfiguration.title")}
             </Title>
 
             <Card className="px-8 py-4">
@@ -737,7 +747,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
           <AdvancedOptionsToggle
             showAdvancedOptions={showAdvancedOptions}
             setShowAdvancedOptions={setShowAdvancedOptions}
-            title="Advanced"
+            title={t("sections.advanced.title")}
           />
         </div>
         {showAdvancedOptions && (
@@ -745,7 +755,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
             {(pruneFreq || indexingStart || refreshFreq) && (
               <>
                 <Title size="md" className="mt-3 mb-2">
-                  Advanced Configuration
+                  {t("sections.advancedConfiguration.title")}
                 </Title>
                 <Card className="px-8 py-4">
                   <div>
@@ -780,7 +790,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
               ) : (
                 <>
                   <Title size="md" className="mt-6 mb-2">
-                    Indexing Attempts
+                    {t("sections.indexingAttempts.title")}
                   </Title>
                   <IndexAttemptsTable
                     ccPair={ccPair}

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/AttemptOverhead.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/AttemptOverhead.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { IndexAttemptStageMetric } from "@/lib/types";
 import { formatDurationMs } from "@opal/time";
-import { PIPELINE_ORDER, STAGE_LABELS } from "./constants";
+import { PIPELINE_ORDER, STAGE_LABEL_KEYS } from "./constants";
 
 interface AttemptOverheadProps {
   attemptStages: IndexAttemptStageMetric[];
@@ -17,6 +18,7 @@ interface AttemptOverheadProps {
 export default function AttemptOverhead({
   attemptStages,
 }: AttemptOverheadProps) {
+  const t = useTranslations("admin.connector");
   const [open, setOpen] = useState(false);
   const sorted = useMemo(() => {
     const copy = [...attemptStages];
@@ -33,7 +35,9 @@ export default function AttemptOverhead({
         size="sm"
         onClick={() => setOpen((o) => !o)}
       >
-        {open ? "Hide attempt overhead" : "Show attempt overhead"}
+        {open
+          ? t("stageMetrics.attemptOverhead.hideButton.label")
+          : t("stageMetrics.attemptOverhead.showButton.label")}
       </Button>
       {open && <AttemptOverheadList stages={sorted} />}
     </Section>
@@ -59,6 +63,8 @@ interface AttemptOverheadRowProps {
 }
 
 function AttemptOverheadRow({ stage }: AttemptOverheadRowProps) {
+  const t = useTranslations("admin.connector");
+
   return (
     <Section
       flexDirection="row"
@@ -69,7 +75,7 @@ function AttemptOverheadRow({ stage }: AttemptOverheadRowProps) {
       gap={4}
     >
       <Text font="secondary-body" color="text-04">
-        {STAGE_LABELS[stage.stage]}
+        {t(STAGE_LABEL_KEYS[stage.stage])}
       </Text>
       <Text font="secondary-body" color="text-03">
         {formatDurationMs(stage.total_duration_ms)}

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/BatchTotalHeader.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/BatchTotalHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import { IndexAttemptStageMetric } from "@/lib/types";
 import { formatDurationMs } from "@opal/time";
@@ -11,10 +12,12 @@ interface BatchTotalHeaderProps {
 export default function BatchTotalHeader({
   batchTotal,
 }: BatchTotalHeaderProps) {
+  const t = useTranslations("admin.connector");
+
   if (!batchTotal || batchTotal.event_count === 0) {
     return (
       <Text font="main-ui-action" color="text-04">
-        No completed batches yet
+        {t("stageMetrics.batchTotal.empty")}
       </Text>
     );
   }
@@ -30,9 +33,10 @@ export default function BatchTotalHeader({
 
   return (
     <Text font="main-ui-action" color="text-05">
-      {`Average batch: ${avgLabel}, ${batchTotal.event_count} ${
-        batchTotal.event_count === 1 ? "batch" : "batches"
-      } — distribution shown below.`}
+      {t("stageMetrics.batchTotal.summary", {
+        avgLabel,
+        count: batchTotal.event_count,
+      })}
     </Text>
   );
 }

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchSection.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { IndexAttemptStageMetric } from "@/lib/types";
@@ -18,10 +19,12 @@ export default function PerBatchSection({
   sortMode,
   onSortModeChange,
 }: PerBatchSectionProps) {
+  const t = useTranslations("admin.connector");
+
   if (perBatchStages.length === 0) {
     return (
       <Text font="secondary-body" color="text-03">
-        No per-batch stage data recorded.
+        {t("stageMetrics.perBatch.empty")}
       </Text>
     );
   }

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { Table, Text, createTableColumns } from "@opal/components";
 import { IndexAttemptStageMetric } from "@/lib/types";
 import { formatDurationMs } from "@opal/time";
@@ -34,6 +35,7 @@ export default function PerBatchTable({
   perBatchStages,
   sortMode,
 }: PerBatchTableProps) {
+  const t = useTranslations("admin.connector");
   const sorted = useMemo(
     () => sortPerBatchStages(perBatchStages, sortMode),
     [perBatchStages, sortMode]
@@ -59,13 +61,13 @@ export default function PerBatchTable({
     () => [
       tc.displayColumn({
         id: "stage",
-        header: "Stage",
+        header: t("stageMetrics.perBatch.columns.stage"),
         width: { weight: 32, minWidth: 220 },
         cell: (row) => <StageLabelCell stage={row.stage} />,
       }),
       tc.displayColumn({
         id: "avg",
-        header: "Avg time",
+        header: t("stageMetrics.perBatch.columns.avgTime"),
         // The Modal "lg" width minus body padding is ~768px. Other columns'
         // minWidths sum to 580, so capping avg at 170 keeps the total minWidth
         // under the modal's inner width and prevents a horizontal scrollbar.
@@ -76,7 +78,7 @@ export default function PerBatchTable({
       }),
       tc.displayColumn({
         id: "total",
-        header: "Total time",
+        header: t("stageMetrics.perBatch.columns.totalTime"),
         width: { weight: 14, minWidth: 110 },
         cell: (row) => (
           <TextCell>{formatDurationMs(row.total_duration_ms)}</TextCell>
@@ -84,13 +86,13 @@ export default function PerBatchTable({
       }),
       tc.displayColumn({
         id: "calls",
-        header: "Calls",
+        header: t("stageMetrics.perBatch.columns.calls"),
         width: { weight: 8, minWidth: 70 },
         cell: (row) => <TextCell>{row.event_count}</TextCell>,
       }),
       tc.displayColumn({
         id: "min",
-        header: "Min",
+        header: t("stageMetrics.perBatch.columns.min"),
         width: { weight: 8, minWidth: 90 },
         cell: (row) => (
           <TextCell>{formatOptionalMs(row.min_duration_ms)}</TextCell>
@@ -98,14 +100,14 @@ export default function PerBatchTable({
       }),
       tc.displayColumn({
         id: "max",
-        header: "Max",
+        header: t("stageMetrics.perBatch.columns.max"),
         width: { weight: 8, minWidth: 90 },
         cell: (row) => (
           <TextCell>{formatOptionalMs(row.max_duration_ms)}</TextCell>
         ),
       }),
     ],
-    [maxAvgMs]
+    [maxAvgMs, t]
   );
 
   // Use the default `cards` variant (matches the Agents page table) for

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/SortToggle.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/SortToggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { SortMode } from "./interfaces";
@@ -10,6 +11,8 @@ interface SortToggleProps {
 }
 
 export default function SortToggle({ sortMode, onChange }: SortToggleProps) {
+  const t = useTranslations("admin.connector");
+
   return (
     <Section
       flexDirection="row"
@@ -20,21 +23,21 @@ export default function SortToggle({ sortMode, onChange }: SortToggleProps) {
       gap={2}
     >
       <Text font="secondary-body" color="text-03">
-        Sort:
+        {t("stageMetrics.sort.label")}
       </Text>
       <Button
         prominence={sortMode === "pipeline" ? "secondary" : "tertiary"}
         size="sm"
         onClick={() => onChange("pipeline")}
       >
-        Pipeline order
+        {t("stageMetrics.sort.pipelineOrder.label")}
       </Button>
       <Button
         prominence={sortMode === "time-taken" ? "secondary" : "tertiary"}
         size="sm"
         onClick={() => onChange("time-taken")}
       >
-        Time taken
+        {t("stageMetrics.sort.timeTaken.label")}
       </Button>
     </Section>
   );

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageLabelCell.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageLabelCell.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { SvgInfoSmall } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { IndexAttemptStage } from "@/lib/types";
 import { cn } from "@opal/utils";
-import { STAGE_DESCRIPTIONS, STAGE_LABELS } from "./constants";
+import { STAGE_DESCRIPTION_KEYS, STAGE_LABEL_KEYS } from "./constants";
 import { colorClassForStage } from "./utils";
 
 interface StageLabelCellProps {
@@ -13,6 +14,8 @@ interface StageLabelCellProps {
 }
 
 export default function StageLabelCell({ stage }: StageLabelCellProps) {
+  const t = useTranslations("admin.connector");
+
   return (
     <Section
       flexDirection="row"
@@ -32,13 +35,13 @@ export default function StageLabelCell({ stage }: StageLabelCellProps) {
         )}
       />
       <Text font="secondary-body" color="text-05" nowrap>
-        {STAGE_LABELS[stage]}
+        {t(STAGE_LABEL_KEYS[stage])}
       </Text>
       <Button
         icon={SvgInfoSmall}
         prominence="tertiary"
         size="sm"
-        tooltip={STAGE_DESCRIPTIONS[stage]}
+        tooltip={t(STAGE_DESCRIPTION_KEYS[stage])}
       />
     </Section>
   );

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageMetricsPanel.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageMetricsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { MessageCard, Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import useIndexAttemptStageMetrics from "@/hooks/useIndexAttemptStageMetrics";
@@ -16,6 +17,7 @@ interface StageMetricsPanelProps {
 export default function StageMetricsPanel({
   indexAttemptId,
 }: StageMetricsPanelProps) {
+  const t = useTranslations("admin.connector");
   const [sortMode, setSortMode] = useState<SortMode>("pipeline");
 
   const { data, error, isLoading } =
@@ -38,7 +40,7 @@ export default function StageMetricsPanel({
   if (isLoading) {
     return (
       <Text font="secondary-body" color="text-03">
-        Loading stage metrics…
+        {t("stageMetrics.loading")}
       </Text>
     );
   }
@@ -47,8 +49,8 @@ export default function StageMetricsPanel({
     return (
       <MessageCard
         variant="warning"
-        title="Failed to load stage metrics"
-        description="Stage timing data could not be loaded for this attempt. The pipeline runs even when metric recording is unavailable, so this does not indicate a problem with the indexing run itself."
+        title={t("stageMetrics.loadError.title")}
+        description={t("stageMetrics.loadError.description")}
       />
     );
   }
@@ -56,9 +58,7 @@ export default function StageMetricsPanel({
   if (!data || data.stages.length === 0) {
     return (
       <Text font="secondary-body" color="text-03">
-        No stage timing data has been recorded for this attempt yet. Older
-        attempts that ran before stage instrumentation was deployed will not
-        have metrics.
+        {t("stageMetrics.empty.description")}
       </Text>
     );
   }

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/constants.ts
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/constants.ts
@@ -1,87 +1,68 @@
 import { INDEX_ATTEMPT_STAGES, IndexAttemptStage } from "@/lib/types";
 
-// Human-readable label per stage. Explicit (rather than auto-cased) so that
-// acronyms like DB / RAG render correctly.
-export const STAGE_LABELS: Record<IndexAttemptStage, string> = {
-  CONNECTOR_VALIDATION: "Connector validation",
-  PERMISSION_VALIDATION: "Permission validation",
-  CHECKPOINT_LOAD: "Checkpoint load",
-  CONNECTOR_FETCH: "Connector fetch",
-  HIERARCHY_UPSERT: "Hierarchy upsert",
-  DOC_BATCH_STORE: "Doc batch store",
-  DOC_BATCH_ENQUEUE: "Doc batch enqueue",
-  QUEUE_WAIT: "Queue wait",
-  DOCPROCESSING_SETUP: "Docprocessing setup",
-  BATCH_LOAD: "Batch load",
-  DOC_DB_PREPARE: "Doc DB prepare",
-  IMAGE_PROCESSING: "Image processing",
-  CHUNKING: "Chunking",
-  CONTEXTUAL_RAG: "Contextual RAG",
-  EMBEDDING: "Embedding",
-  DOC_LOCK_ACQUIRE_WAIT: "Doc lock acquire wait",
-  ENRICHMENT_PREP: "Enrichment prep",
-  VECTOR_DB_WRITE: "Vector DB write",
-  POST_INDEX_DB_UPDATE: "Post-index DB update",
-  COORD_LOCK_ACQUIRE_WAIT: "Coord lock acquire wait",
-  COORDINATION_UPDATE: "Coordination update",
-  FINALIZATION: "Finalization",
-  GC_COLLECT: "Garbage collection",
-  BATCH_UNACCOUNTED: "Unaccounted",
-  BATCH_TOTAL: "Batch total",
-};
+// Message key (inside the `admin.connector` namespace) for the human-readable
+// label of each stage. Labels are explicit (rather than auto-cased) so that
+// acronyms like DB / RAG render correctly. Modules cannot call hooks, so the
+// maps hold keys and the consuming component resolves them with `t`.
+export const STAGE_LABEL_KEYS = {
+  CONNECTOR_VALIDATION: "stageMetrics.stages.connectorValidation.label",
+  PERMISSION_VALIDATION: "stageMetrics.stages.permissionValidation.label",
+  CHECKPOINT_LOAD: "stageMetrics.stages.checkpointLoad.label",
+  CONNECTOR_FETCH: "stageMetrics.stages.connectorFetch.label",
+  HIERARCHY_UPSERT: "stageMetrics.stages.hierarchyUpsert.label",
+  DOC_BATCH_STORE: "stageMetrics.stages.docBatchStore.label",
+  DOC_BATCH_ENQUEUE: "stageMetrics.stages.docBatchEnqueue.label",
+  QUEUE_WAIT: "stageMetrics.stages.queueWait.label",
+  DOCPROCESSING_SETUP: "stageMetrics.stages.docprocessingSetup.label",
+  BATCH_LOAD: "stageMetrics.stages.batchLoad.label",
+  DOC_DB_PREPARE: "stageMetrics.stages.docDbPrepare.label",
+  IMAGE_PROCESSING: "stageMetrics.stages.imageProcessing.label",
+  CHUNKING: "stageMetrics.stages.chunking.label",
+  CONTEXTUAL_RAG: "stageMetrics.stages.contextualRag.label",
+  EMBEDDING: "stageMetrics.stages.embedding.label",
+  DOC_LOCK_ACQUIRE_WAIT: "stageMetrics.stages.docLockAcquireWait.label",
+  ENRICHMENT_PREP: "stageMetrics.stages.enrichmentPrep.label",
+  VECTOR_DB_WRITE: "stageMetrics.stages.vectorDbWrite.label",
+  POST_INDEX_DB_UPDATE: "stageMetrics.stages.postIndexDbUpdate.label",
+  COORD_LOCK_ACQUIRE_WAIT: "stageMetrics.stages.coordLockAcquireWait.label",
+  COORDINATION_UPDATE: "stageMetrics.stages.coordinationUpdate.label",
+  FINALIZATION: "stageMetrics.stages.finalization.label",
+  GC_COLLECT: "stageMetrics.stages.gcCollect.label",
+  BATCH_UNACCOUNTED: "stageMetrics.stages.batchUnaccounted.label",
+  BATCH_TOTAL: "stageMetrics.stages.batchTotal.label",
+} as const satisfies Record<IndexAttemptStage, string>;
 
-// Short explainer per stage, shown in a tooltip next to each row in the
-// per-batch table so admins can interpret the timings without leaving the
-// modal.
-export const STAGE_DESCRIPTIONS: Record<IndexAttemptStage, string> = {
-  CONNECTOR_VALIDATION:
-    "Validates that the connector is configured correctly and reachable before fetching begins.",
-  PERMISSION_VALIDATION:
-    "Verifies the credential has the permissions needed to read documents from the source.",
-  CHECKPOINT_LOAD:
-    "Loads any prior checkpoint so a resumed attempt can pick up where the last one left off.",
-  CONNECTOR_FETCH:
-    "Time spent calling the upstream source to retrieve a batch of raw documents.",
-  HIERARCHY_UPSERT:
-    "Records hierarchy and metadata relationships (folders, parents, etc.) for the batch in Postgres.",
-  DOC_BATCH_STORE:
-    "Persists the fetched batch to the file store so the docprocessing worker can consume it asynchronously.",
-  DOC_BATCH_ENQUEUE:
-    "Submits a docprocessing task for the batch onto the Celery queue.",
-  QUEUE_WAIT:
-    "Time the docprocessing task spent waiting in the Celery queue before a worker picked it up.",
-  DOCPROCESSING_SETUP:
-    "One-time setup the docprocessing worker performs before processing batches (DB session, embedder, etc.).",
-  BATCH_LOAD:
-    "Reads the batch back from the file store inside the docprocessing worker.",
-  DOC_DB_PREPARE:
-    "Cleans, dedupes, and prepares documents for indexing — includes the DB lookups against existing document state.",
-  IMAGE_PROCESSING:
-    "Extracts and processes images embedded in document sections.",
-  CHUNKING: "Splits documents into chunks sized for the embedding model.",
-  CONTEXTUAL_RAG:
-    "Optional LLM call that adds short contextual summaries to each chunk to improve retrieval quality.",
-  EMBEDDING: "Calls the embedding model to produce vectors for each chunk.",
-  DOC_LOCK_ACQUIRE_WAIT:
-    "Time spent waiting to acquire the per-document row locks before writing — the wait only, not the write done while holding them (that is Vector DB write / Post-index DB update). High values mean documents are contended across connectors.",
-  ENRICHMENT_PREP:
-    "Per-batch DB lookups that enrich chunks before writing — access info, document sets, ancestors, and prior chunk counts.",
-  VECTOR_DB_WRITE: "Writes the embedded chunks and their metadata to Vespa.",
-  POST_INDEX_DB_UPDATE:
-    "Updates Postgres with final document state after indexing (last-indexed timestamps, hashes, etc.).",
+// Message key for the short explainer per stage, shown in a tooltip next to
+// each row in the per-batch table so admins can interpret the timings without
+// leaving the modal.
+export const STAGE_DESCRIPTION_KEYS = {
+  CONNECTOR_VALIDATION: "stageMetrics.stages.connectorValidation.description",
+  PERMISSION_VALIDATION: "stageMetrics.stages.permissionValidation.description",
+  CHECKPOINT_LOAD: "stageMetrics.stages.checkpointLoad.description",
+  CONNECTOR_FETCH: "stageMetrics.stages.connectorFetch.description",
+  HIERARCHY_UPSERT: "stageMetrics.stages.hierarchyUpsert.description",
+  DOC_BATCH_STORE: "stageMetrics.stages.docBatchStore.description",
+  DOC_BATCH_ENQUEUE: "stageMetrics.stages.docBatchEnqueue.description",
+  QUEUE_WAIT: "stageMetrics.stages.queueWait.description",
+  DOCPROCESSING_SETUP: "stageMetrics.stages.docprocessingSetup.description",
+  BATCH_LOAD: "stageMetrics.stages.batchLoad.description",
+  DOC_DB_PREPARE: "stageMetrics.stages.docDbPrepare.description",
+  IMAGE_PROCESSING: "stageMetrics.stages.imageProcessing.description",
+  CHUNKING: "stageMetrics.stages.chunking.description",
+  CONTEXTUAL_RAG: "stageMetrics.stages.contextualRag.description",
+  EMBEDDING: "stageMetrics.stages.embedding.description",
+  DOC_LOCK_ACQUIRE_WAIT: "stageMetrics.stages.docLockAcquireWait.description",
+  ENRICHMENT_PREP: "stageMetrics.stages.enrichmentPrep.description",
+  VECTOR_DB_WRITE: "stageMetrics.stages.vectorDbWrite.description",
+  POST_INDEX_DB_UPDATE: "stageMetrics.stages.postIndexDbUpdate.description",
   COORD_LOCK_ACQUIRE_WAIT:
-    "Time spent waiting to acquire the connector-wide coordination lock that every batch serializes on — the wait only, not the update done while holding it (that is Coordination update). High values mean batch-level contention.",
-  COORDINATION_UPDATE:
-    "Bookkeeping updates after a batch — progress counters, checkpoint advances, and similar.",
-  FINALIZATION:
-    "Post-coordination bookkeeping — failure recording, progress telemetry, and batch storage cleanup.",
-  GC_COLLECT:
-    "Per-batch garbage-collection pass (stop-the-world for the worker process).",
-  BATCH_UNACCOUNTED:
-    "Wall-clock inside the batch not attributed to any measured stage (BATCH_TOTAL minus the measured stages). A high value signals lock contention or an un-instrumented hotspot.",
-  BATCH_TOTAL:
-    "Total wall-clock time elapsed processing a single batch end-to-end.",
-};
+    "stageMetrics.stages.coordLockAcquireWait.description",
+  COORDINATION_UPDATE: "stageMetrics.stages.coordinationUpdate.description",
+  FINALIZATION: "stageMetrics.stages.finalization.description",
+  GC_COLLECT: "stageMetrics.stages.gcCollect.description",
+  BATCH_UNACCOUNTED: "stageMetrics.stages.batchUnaccounted.description",
+  BATCH_TOTAL: "stageMetrics.stages.batchTotal.description",
+} as const satisfies Record<IndexAttemptStage, string>;
 
 // Distinct background classes for the per-row average-time bar. Cycled by
 // stage's pipeline-order index so the same stage gets the same color in both

--- a/web/src/app/admin/connector/[ccPairId]/useStatusChange.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/useStatusChange.tsx
@@ -5,10 +5,12 @@ import { mutate } from "swr";
 import { buildCCPairInfoUrl } from "./lib";
 import { setCCPairStatus } from "@/lib/ccPair";
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
 
 // Export the status change functionality separately
 export function useStatusChange(ccPair: CCPairFullInfo | null) {
+  const t = useTranslations("admin.connector");
   const [isUpdating, setIsUpdating] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
@@ -52,15 +54,15 @@ export function useStatusChange(ccPair: CCPairFullInfo | null) {
   const ConfirmModal =
     showConfirmModal && ccPair ? (
       <ConfirmEntityModal
-        entityType="Invalid Connector"
+        entityType={t("reEnableModal.entityType")}
         entityName={ccPair.name}
         onClose={() => setShowConfirmModal(false)}
         onSubmit={() => {
           setShowConfirmModal(false);
           updateStatus(ConnectorCredentialPairStatus.ACTIVE);
         }}
-        additionalDetails="This connector was previously marked as invalid. Please verify that your configuration is correct before re-enabling. Are you sure you want to proceed?"
-        actionButtonText="Re-Enable"
+        additionalDetails={t("reEnableModal.additionalDetails")}
+        actionButtonText={t("reEnableModal.actionButton.label")}
       />
     ) : null;
 

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -69,6 +69,7 @@ import Text from "@/refresh-components/texts/Text";
 import { SvgKey, SvgAlertCircle } from "@opal/icons";
 import { Tooltip } from "@opal/components";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 
 export interface AdvancedConfig {
   refreshFreq: number;
@@ -78,7 +79,6 @@ export interface AdvancedConfig {
 
 const BASE_CONNECTOR_URL = "/api/manage/admin/connector";
 const CONNECTOR_CREATION_TIMEOUT_MS = 10000; // ~10 seconds is reasonable for longer connector validation
-const OAUTH_REDIRECT_ERROR = "Unable to start OAuth";
 
 export async function submitConnector<T>(
   connector: ConnectorBase<T>,
@@ -139,6 +139,7 @@ export default function AddConnector({
 }: {
   connector: ConfigurableSources;
 }) {
+  const t = useTranslations("admin.connectorsList");
   const [currentPageUrl, setCurrentPageUrl] = useState<string | null>(null);
   const [oauthUrl, setOauthUrl] = useState<string | null>(null);
   const [isAuthorizing, setIsAuthorizing] = useState(false);
@@ -254,7 +255,7 @@ export default function AddConnector({
   const onDeleteCredential = async (credential: Credential<any | null>) => {
     const response = await deleteCredential(credential.id, true);
     if (response.ok) {
-      toast.success("Credential deleted successfully!");
+      toast.success(t("add.credentialDeleted.toast"));
     } else {
       const errorData = await response.json();
       toast.error(errorData.detail || errorData.message);
@@ -264,7 +265,7 @@ export default function AddConnector({
   const onSwap = async (selectedCredential: Credential<any>) => {
     setCurrentCredential(selectedCredential);
     setAllowCreate(true);
-    toast.success("Swapped credential successfully!");
+    toast.success(t("add.credentialSwapped.toast"));
     refresh();
   };
 
@@ -280,7 +281,7 @@ export default function AddConnector({
       window.location.href = redirectUrl;
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : OAUTH_REDIRECT_ERROR
+        error instanceof Error ? error.message : t("add.oauthStartFailed.toast")
       );
     }
   };
@@ -318,15 +319,15 @@ export default function AddConnector({
         setOauthUrl(response.url);
         window.open(response.url, "_blank", "noopener,noreferrer");
       } else {
-        toast.error("Failed to fetch OAuth URL");
+        toast.error(t("add.oauthUrlFailed.toast"));
       }
     } catch (error: unknown) {
       // Narrow the type of error
       if (error instanceof Error) {
-        toast.error(`Error: ${error.message}`);
+        toast.error(t("add.error.toast", { detail: error.message }));
       } else {
         // Handle non-standard errors
-        toast.error("An unknown error occurred");
+        toast.error(t("add.unknownError.toast"));
       }
     } finally {
       setIsAuthorizing(false);
@@ -425,7 +426,7 @@ export default function AddConnector({
               onSuccess();
             }
           } catch (error) {
-            toast.error("Error uploading files");
+            toast.error(t("add.fileUploadFailed.toast"));
           } finally {
             setUploading(false);
           }
@@ -518,9 +519,9 @@ export default function AddConnector({
           if (result.isTimeout) {
             timeoutErrorHappenedRef.current = true;
             toast.error(
-              `Operation timed out after ${
-                CONNECTOR_CREATION_TIMEOUT_MS / 1000
-              } seconds. Check your configuration for errors?`
+              t("add.timeout.toast", {
+                seconds: CONNECTOR_CREATION_TIMEOUT_MS / 1000,
+              })
             );
 
             if (connectorIdRef.current) {
@@ -551,15 +552,13 @@ export default function AddConnector({
                     tooltip={
                       <div className="flex flex-col gap-2">
                         <Text as="p" textLight05>
-                          A federated search option is available for this
-                          connector. It will result in greater latency and
-                          reduced search quality.
+                          {t("add.federated.tooltip.description")}
                         </Text>
                         <Link
                           href={`/admin/connectors/${connector}?mode=federated`}
                           className="text-action-selection-04 hover:underline text-sm"
                         >
-                          Use federated version instead →
+                          {t("add.federated.tooltip.link.label")}
                         </Link>
                       </div>
                     }
@@ -579,7 +578,7 @@ export default function AddConnector({
           {formStep == 0 && (
             <CardSection>
               <Text as="p" headingH3 className="pb-2">
-                Select a credential
+                {t("add.credentialStep.title")}
               </Text>
 
               <>
@@ -600,7 +599,9 @@ export default function AddConnector({
                     className="mt-6"
                   >
                     {oauthDetailsLoading ? (
-                      <Button disabled>Create New</Button>
+                      <Button disabled>
+                        {t("add.createCredentialButton.label")}
+                      </Button>
                     ) : (
                       credentialCreationMethods.map((method) => (
                         <Button
@@ -624,10 +625,10 @@ export default function AddConnector({
                           hidden={!isAuthorizeVisible}
                         >
                           {isAuthorizing
-                            ? "Authorizing..."
-                            : `Authorize with ${getSourceDisplayName(
-                                connector
-                              )}`}
+                            ? t("add.authorizeButton.pendingLabel")
+                            : t("add.authorizeButton.label", {
+                                source: displayName,
+                              })}
                         </Button>
                       )}
                   </Section>
@@ -638,9 +639,9 @@ export default function AddConnector({
                     <Modal.Content>
                       <Modal.Header
                         icon={SvgKey}
-                        title={`Create a ${getSourceDisplayName(
-                          connector
-                        )} credential`}
+                        title={t("add.credentialModal.title", {
+                          source: displayName,
+                        })}
                         onClose={closeCredentialModal}
                       />
                       <Modal.Body alignItems="stretch">
@@ -655,12 +656,12 @@ export default function AddConnector({
                                 font="main-ui-body"
                                 color="text-03"
                               >
-                                {`We couldn't redirect you to sign in with ${getSourceDisplayName(
-                                  connector
-                                )}. Please try again.`}
+                                {t("add.oauthRedirectFailed.message", {
+                                  source: displayName,
+                                })}
                               </OpalText>
                               <Button onClick={attemptOauthRedirect}>
-                                Retry
+                                {t("add.retryButton.label")}
                               </Button>
                             </Section>
                           ) : (

--- a/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
+++ b/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   ConfigurableSources,
   FederatedConnectorDetail,
@@ -30,12 +31,13 @@ export default function ConnectorWrapper({
 }: {
   connector: ConfigurableSources;
 }) {
+  const t = useTranslations("admin.connectorsList");
   const searchParams = useSearchParams();
   const mode = searchParams?.get("mode"); // 'federated' or 'regular'
 
   useToastFromQuery({
     oauth_failed: {
-      message: "OAuth authentication failed. Please try again.",
+      message: t("oauthFailed.toast"),
       type: "error",
     },
   });
@@ -50,13 +52,13 @@ export default function ConnectorWrapper({
         <div className="mt-12 w-full max-w-3xl mx-auto">
           <div className="mx-auto flex flex-col gap-y-2">
             <HeaderTitle>
-              <p>&lsquo;{connector}&rsquo; is not a valid Connector Type!</p>
+              <p>{t("invalidConnector.title", { connector })}</p>
             </HeaderTitle>
             <div className="mr-auto">
               <Button
                 onClick={() => window.open("/admin/indexing/status", "_self")}
               >
-                Go home
+                {t("invalidConnector.homeButton.label")}
               </Button>
             </div>
           </div>

--- a/web/src/app/admin/connectors/[connector]/NavigationRow.tsx
+++ b/web/src/app/admin/connectors/[connector]/NavigationRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useFormContext } from "@/components/context/FormContext";
 import { Button } from "@opal/components";
 import { SvgArrowLeft, SvgArrowRight, SvgPlusCircle } from "@opal/icons";
@@ -19,6 +20,7 @@ export default function NavigationRow({
   onSubmit,
   isValid,
 }: NavigationRowProps) {
+  const t = useTranslations("admin.connectorsList");
   const { formStep, prevFormStep, nextFormStep } = useFormContext();
 
   return (
@@ -31,7 +33,7 @@ export default function NavigationRow({
             onClick={prevFormStep}
             icon={SvgArrowLeft}
           >
-            Previous
+            {t("navigation.previousButton.label")}
           </Button>
         )}
       </div>
@@ -42,7 +44,7 @@ export default function NavigationRow({
             rightIcon={SvgPlusCircle}
             onClick={onSubmit}
           >
-            Create Connector
+            {t("navigation.createButton.label")}
           </Button>
         )}
       </div>
@@ -54,7 +56,7 @@ export default function NavigationRow({
             rightIcon={SvgArrowRight}
             onClick={() => nextFormStep()}
           >
-            Continue
+            {t("navigation.continueButton.label")}
           </Button>
         )}
         {!noAdvanced && formStep === 1 && (
@@ -64,7 +66,7 @@ export default function NavigationRow({
             rightIcon={SvgArrowRight}
             onClick={() => nextFormStep()}
           >
-            Advanced
+            {t("navigation.advancedButton.label")}
           </Button>
         )}
       </div>

--- a/web/src/app/admin/connectors/[connector]/oauth/callback/page.tsx
+++ b/web/src/app/admin/connectors/[connector]/oauth/callback/page.tsx
@@ -8,18 +8,21 @@ import { ValidSources } from "@/lib/types";
 import CardSection from "@/components/admin/CardSection";
 import { handleOAuthAuthorizationResponse } from "@/lib/oauth_utils";
 import { SvgKey } from "@opal/icons";
+import { useTranslations } from "next-intl";
+
 export default function OAuthCallbackPage() {
+  const t = useTranslations("admin.connectorsList");
   const searchParams = useSearchParams();
 
-  const [statusMessage, setStatusMessage] = useState("Processing...");
+  const [statusMessage, setStatusMessage] = useState(
+    t("oauth.processing.title")
+  );
   const [statusDetails, setStatusDetails] = useState(
-    "Please wait while we complete the setup."
+    t("oauth.processing.description")
   );
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
-  const [pageTitle, setPageTitle] = useState(
-    "Authorize with Third-Party service"
-  );
+  const [pageTitle, setPageTitle] = useState(t("oauthCallback.page.title"));
 
   // Extract query parameters
   const code = searchParams?.get("code");
@@ -35,9 +38,11 @@ export default function OAuthCallbackPage() {
       // sourceType (for looking up metadata) = "google_drive"
 
       if (!code || !state) {
-        setStatusMessage("Improperly formed OAuth authorization request.");
+        setStatusMessage(t("oauthCallback.malformed.title"));
         setStatusDetails(
-          !code ? "Missing authorization code." : "Missing state parameter."
+          !code
+            ? t("oauthCallback.malformed.missingCode")
+            : t("oauthCallback.malformed.missingState")
         );
         setIsError(true);
         return;
@@ -45,9 +50,13 @@ export default function OAuthCallbackPage() {
 
       if (!connector) {
         setStatusMessage(
-          `The specified connector source type ${connector} does not exist.`
+          t("oauth.invalidSource.title", { source: String(connector) })
         );
-        setStatusDetails(`${connector} is not a valid source type.`);
+        setStatusDetails(
+          t("oauth.invalidSource.description", {
+            source: String(connector),
+          })
+        );
         setIsError(true);
         return;
       }
@@ -55,18 +64,24 @@ export default function OAuthCallbackPage() {
       const sourceType = connector.replaceAll("-", "_");
       if (!isValidSource(sourceType)) {
         setStatusMessage(
-          `The specified connector source type ${sourceType} does not exist.`
+          t("oauth.invalidSource.title", { source: sourceType })
         );
-        setStatusDetails(`${sourceType} is not a valid source type.`);
+        setStatusDetails(
+          t("oauth.invalidSource.description", { source: sourceType })
+        );
         setIsError(true);
         return;
       }
 
       const sourceMetadata = getSourceMetadata(sourceType as ValidSources);
-      setPageTitle(`Authorize with ${sourceMetadata.displayName}`);
+      setPageTitle(
+        t("oauthCallback.authorize.title", {
+          source: sourceMetadata.displayName,
+        })
+      );
 
-      setStatusMessage("Processing...");
-      setStatusDetails("Please wait while we complete authorization.");
+      setStatusMessage(t("oauth.processing.title"));
+      setStatusDetails(t("oauthCallback.authorizing.description"));
       setIsError(false); // Ensure no error state during loading
 
       try {
@@ -80,33 +95,35 @@ export default function OAuthCallbackPage() {
           throw new Error("Empty response from OAuth server.");
         }
 
-        setStatusMessage("Success!");
+        setStatusMessage(t("oauthCallback.success.title"));
 
         // set the continuation link
         if (response.finalize_url) {
           setRedirectUrl(response.finalize_url);
           setStatusDetails(
-            `Your authorization with ${sourceMetadata.displayName} completed successfully. Additional steps are required to complete credential setup.`
+            t("oauthCallback.success.additionalSteps.description", {
+              source: sourceMetadata.displayName,
+            })
           );
         } else {
           setRedirectUrl(response.redirect_on_success);
           setStatusDetails(
-            `Your authorization with ${sourceMetadata.displayName} completed successfully.`
+            t("oauthCallback.success.description", {
+              source: sourceMetadata.displayName,
+            })
           );
         }
         setIsError(false);
       } catch (error) {
         console.error("OAuth error:", error);
-        setStatusMessage("Oops, something went wrong!");
-        setStatusDetails(
-          "An error occurred during the OAuth process. Please try again."
-        );
+        setStatusMessage(t("oauth.error.title"));
+        setStatusDetails(t("oauthCallback.error.description"));
         setIsError(true);
       }
     };
 
     onFirstLoad();
-  }, [code, state, connector]);
+  }, [code, state, connector, t]);
 
   return (
     <div className="mx-auto h-screen flex flex-col">
@@ -119,11 +136,13 @@ export default function OAuthCallbackPage() {
           {redirectUrl && !isError && (
             <div className="mt-4">
               <p className="text-sm">
-                Click{" "}
-                <a href={redirectUrl} className="text-blue-500 underline">
-                  here
-                </a>{" "}
-                to continue.
+                {t.rich("oauthCallback.continue.message", {
+                  link: (chunks) => (
+                    <a href={redirectUrl} className="text-blue-500 underline">
+                      {chunks}
+                    </a>
+                  ),
+                })}
               </p>
             </div>
           )}

--- a/web/src/app/admin/connectors/[connector]/oauth/finalize/page.tsx
+++ b/web/src/app/admin/connectors/[connector]/oauth/finalize/page.tsx
@@ -15,6 +15,7 @@ import { SelectorFormField } from "@/components/Field";
 import { ErrorMessage, Field, Form, Formik, useFormikContext } from "formik";
 import * as Yup from "yup";
 import { SvgKey } from "@opal/icons";
+import { useTranslations } from "next-intl";
 // Helper component to keep the effect logic clean:
 function UpdateCloudURLOnCloudIdChange({
   accessibleResources,
@@ -52,19 +53,20 @@ function UpdateCloudURLOnCloudIdChange({
 }
 
 export default function OAuthFinalizePage() {
+  const t = useTranslations("admin.connectorsList");
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [statusMessage, setStatusMessage] = useState("Processing...");
+  const [statusMessage, setStatusMessage] = useState(
+    t("oauth.processing.title")
+  );
   const [statusDetails, setStatusDetails] = useState(
-    "Please wait while we complete the setup."
+    t("oauth.processing.description")
   );
   const [redirectUrl, setRedirectUrl] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false); // New state
-  const [pageTitle, setPageTitle] = useState(
-    "Finalize Authorization with Third-Party service"
-  );
+  const [pageTitle, setPageTitle] = useState(t("oauthFinalize.page.title"));
 
   const [accessibleResources, setAccessibleResources] = useState<
     ConfluenceAccessibleResource[]
@@ -83,8 +85,8 @@ export default function OAuthFinalizePage() {
       // sourceType (for looking up metadata) = "google_drive"
 
       if (isNaN(credential) || !connector) {
-        setStatusMessage("Improperly formed OAuth finalization request.");
-        setStatusDetails("Invalid or missing credential id.");
+        setStatusMessage(t("oauthFinalize.malformed.title"));
+        setStatusDetails(t("oauthFinalize.malformed.description"));
         setIsError(true);
         return;
       }
@@ -92,20 +94,24 @@ export default function OAuthFinalizePage() {
       const sourceType = connector.replaceAll("-", "_");
       if (!isValidSource(sourceType)) {
         setStatusMessage(
-          `The specified connector source type ${sourceType} does not exist.`
+          t("oauth.invalidSource.title", { source: sourceType })
         );
-        setStatusDetails(`${sourceType} is not a valid source type.`);
+        setStatusDetails(
+          t("oauth.invalidSource.description", { source: sourceType })
+        );
         setIsError(true);
         return;
       }
 
       const sourceMetadata = getSourceMetadata(sourceType as ValidSources);
-      setPageTitle(`Finalize Authorization with ${sourceMetadata.displayName}`);
-
-      setStatusMessage("Processing...");
-      setStatusDetails(
-        "Please wait while we retrieve a list of your accessible sites."
+      setPageTitle(
+        t("oauthFinalize.authorize.title", {
+          source: sourceMetadata.displayName,
+        })
       );
+
+      setStatusMessage(t("oauth.processing.title"));
+      setStatusDetails(t("oauthFinalize.loadingSites.description"));
       setIsError(false); // Ensure no error state during loading
 
       try {
@@ -120,22 +126,20 @@ export default function OAuthFinalizePage() {
 
         setAccessibleResources(response.accessible_resources);
 
-        setStatusMessage("Select a Confluence site");
+        setStatusMessage(t("oauthFinalize.selectSite.title"));
         setStatusDetails("");
 
         setIsError(false);
       } catch (error) {
         console.error("OAuth finalization error:", error);
-        setStatusMessage("Oops, something went wrong!");
-        setStatusDetails(
-          "An error occurred during the OAuth finalization process. Please try again."
-        );
+        setStatusMessage(t("oauth.error.title"));
+        setStatusDetails(t("oauthFinalize.error.description"));
         setIsError(true);
       }
     };
 
     onFirstLoad();
-  }, [credential, connector]);
+  }, [credential, connector, t]);
 
   useEffect(() => {}, [redirectUrl]);
 
@@ -157,16 +161,16 @@ export default function OAuthFinalizePage() {
             }}
             validationSchema={Yup.object().shape({
               credential_id: Yup.number().required(
-                "Credential ID is required."
+                t("oauthFinalize.credentialId.required")
               ),
               cloud_id: Yup.string().required(
-                "You must select a Confluence site (id not found)."
+                t("oauthFinalize.cloudId.required")
               ),
               cloud_name: Yup.string().required(
-                "You must select a Confluence site (name not found)."
+                t("oauthFinalize.cloudName.required")
               ),
               cloud_url: Yup.string().required(
-                "You must select a Confluence site (url not found)."
+                t("oauthFinalize.cloudUrl.required")
               ),
             })}
             validateOnMount
@@ -195,16 +199,14 @@ export default function OAuthFinalizePage() {
 
                 if (response) {
                   setRedirectUrl(response.redirect_url);
-                  setStatusMessage("Confluence authorization finalized.");
+                  setStatusMessage(t("oauthFinalize.finalized.title"));
                 }
 
                 setIsSubmitted(true); // Mark as submitted
               } catch (error) {
                 console.error(error);
-                setStatusMessage("Error during submission.");
-                setStatusDetails(
-                  "An error occurred during the submission process. Please try again."
-                );
+                setStatusMessage(t("oauthFinalize.submitError.title"));
+                setStatusDetails(t("oauthFinalize.submitError.description"));
                 setIsError(true);
                 formikHelpers.setSubmitting(false);
               }
@@ -260,7 +262,9 @@ export default function OAuthFinalizePage() {
                 <br />
                 {!redirectUrl && (
                   <Button disabled={!isValid || isSubmitting} type="submit">
-                    {isSubmitting ? "Submitting..." : "Submit"}
+                    {isSubmitting
+                      ? t("oauthFinalize.submitButton.pendingLabel")
+                      : t("oauthFinalize.submitButton.label")}
                   </Button>
                 )}
               </Form>
@@ -270,11 +274,13 @@ export default function OAuthFinalizePage() {
           {redirectUrl && !isError && (
             <div className="mt-4">
               <p className="text-sm">
-                Authorization finalized. Click{" "}
-                <a href={redirectUrl} className="text-blue-500 underline">
-                  here
-                </a>{" "}
-                to continue.
+                {t.rich("oauthFinalize.continue.message", {
+                  link: (chunks) => (
+                    <a href={redirectUrl} className="text-blue-500 underline">
+                      {chunks}
+                    </a>
+                  ),
+                })}
               </p>
             </div>
           )}

--- a/web/src/app/admin/connectors/[connector]/pages/Advanced.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/Advanced.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslations } from "next-intl";
 import NumberInput from "./ConnectorInput/NumberInput";
 import { TextFormField } from "@/components/Field";
 import { Button } from "@opal/components";
@@ -10,41 +11,39 @@ interface AdvancedFormPageProps {
 export default function AdvancedFormPage({
   defaultPruneFreqHours = 600,
 }: AdvancedFormPageProps) {
+  const t = useTranslations("admin.connectorsList");
+
   return (
     <div className="py-4 flex flex-col gap-y-6 rounded-lg max-w-2xl mx-auto">
       <h2 className="text-2xl font-bold mb-4 text-text-800">
-        Advanced Configuration
+        {t("advanced.title")}
       </h2>
 
       <NumberInput
-        description={`
-          Checks all documents against the source to delete those that no longer exist.
-          Note: This process checks every document, so be cautious when increasing frequency.
-          Default is ${defaultPruneFreqHours} hours (${Math.round(
-            defaultPruneFreqHours / 24
-          )} days). Decimal hours are supported (e.g., 0.1 hours = 6 minutes).
-          Enter 0 to disable pruning for this connector.
-        `}
-        label="Prune Frequency (hours)"
+        description={t("advanced.pruneFrequency.description", {
+          hours: defaultPruneFreqHours,
+          days: Math.round(defaultPruneFreqHours / 24),
+        })}
+        label={t("advanced.pruneFrequency.label")}
         name="pruneFreq"
       />
 
       <NumberInput
-        description="This is how frequently we pull new documents from the source (in minutes). If you input 0, we will never pull new documents for this connector."
-        label="Refresh Frequency (minutes)"
+        description={t("advanced.refreshFrequency.description")}
+        label={t("advanced.refreshFrequency.label")}
         name="refreshFreq"
       />
 
       <TextFormField
         type="date"
-        subtext="Documents prior to this date will not be pulled in"
+        subtext={t("advanced.indexingStart.subtext")}
         optional
-        label="Indexing Start Date"
+        label={t("advanced.indexingStart.label")}
         name="indexingStart"
       />
       <div className="mt-4 flex w-full mx-auto max-w-2xl justify-start">
         <Button variant="danger" icon={SvgTrash} type="submit">
-          Reset
+          {t("advanced.resetButton.label")}
         </Button>
       </div>
     </div>

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/FileInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/FileInput.tsx
@@ -1,4 +1,5 @@
 import { useField } from "formik";
+import { useTranslations } from "next-intl";
 import { FileUpload } from "@/components/admin/connectors/FileUpload";
 import CredentialSubText from "@/lib/credentials/components/CredentialFields";
 
@@ -21,6 +22,7 @@ export default function FileInput({
   isZip = false, // Default to false for multiple file uploads
   hideError = false,
 }: FileInputProps) {
+  const t = useTranslations("admin.connectorsList");
   const [field, meta, helpers] = useField(name);
 
   return (
@@ -31,7 +33,11 @@ export default function FileInput({
           className="block text-sm font-medium text-text-700 mb-1"
         >
           {label}
-          {optional && <span className="text-text-500 ml-1">(optional)</span>}
+          {optional && (
+            <span className="text-text-500 ml-1">
+              {t("field.optional.label")}
+            </span>
+          )}
         </label>
       )}
       {description && <CredentialSubText>{description}</CredentialSubText>}

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/ListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/ListInput.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TextArrayField } from "@/components/Field";
 import { useFormikContext } from "formik";
+import { useTranslations } from "next-intl";
 
 interface ListInputProps {
   name: string;
@@ -9,6 +10,7 @@ interface ListInputProps {
 }
 
 const ListInput: React.FC<ListInputProps> = ({ name, label, description }) => {
+  const t = useTranslations("admin.connectorsList");
   const { values } = useFormikContext<any>();
   return (
     <TextArrayField
@@ -18,9 +20,9 @@ const ListInput: React.FC<ListInputProps> = ({ name, label, description }) => {
       subtext={
         typeof description === "function" ? description(null) : description
       }
-      placeholder={`Enter ${
-        typeof label === "function" ? label(null) : label.toLowerCase()
-      }`}
+      placeholder={t("listInput.placeholder", {
+        label: typeof label === "function" ? label(null) : label.toLowerCase(),
+      })}
     />
   );
 };

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/NumberInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/NumberInput.tsx
@@ -1,5 +1,6 @@
 import { Label, SubLabel } from "@/components/Field";
 import { ErrorMessage, useField } from "formik";
+import { useTranslations } from "next-intl";
 
 export default function NumberInput({
   label,
@@ -14,6 +15,7 @@ export default function NumberInput({
   description?: string;
   showNeverIfZero?: boolean;
 }) {
+  const t = useTranslations("admin.connectorsList");
   const [field, meta, helpers] = useField(name);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,7 +33,11 @@ export default function NumberInput({
       <Label>
         <>
           {label}
-          {optional && <span className="text-text-500 ml-1">(optional)</span>}
+          {optional && (
+            <span className="text-text-500 ml-1">
+              {t("field.optional.label")}
+            </span>
+          )}
         </>
       </Label>
       {description && <SubLabel>{description}</SubLabel>}

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/SelectInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/SelectInput.tsx
@@ -1,6 +1,7 @@
 import CredentialSubText from "@/lib/credentials/components/CredentialFields";
 import { StringWithDescription } from "@/lib/connectors/connectors";
 import { Field } from "formik";
+import { useTranslations } from "next-intl";
 
 export default function SelectInput({
   name,
@@ -15,6 +16,8 @@ export default function SelectInput({
   options: StringWithDescription[];
   label?: string;
 }) {
+  const t = useTranslations("admin.connectorsList");
+
   return (
     <>
       <label
@@ -22,7 +25,11 @@ export default function SelectInput({
         className="block text-sm font-medium text-text-700 mb-1"
       >
         {label}
-        {optional && <span className="text-text-500 ml-1">(optional)</span>}
+        {optional && (
+          <span className="text-text-500 ml-1">
+            {t("field.optional.label")}
+          </span>
+        )}
       </label>
       {description && <CredentialSubText>{description}</CredentialSubText>}
 
@@ -31,7 +38,7 @@ export default function SelectInput({
         name={name}
         className="w-full p-2 border border-border-03 rounded-08 bg-transparent text-text-04 focus:ring-2 focus:ring-lighter-agent focus:border-lighter-agent focus:outline-hidden"
       >
-        <option value="">Select an option</option>
+        <option value="">{t("selectInput.emptyOption.label")}</option>
         {options?.map((option: any) => (
           <option key={option.name} value={option.name}>
             {option.name}

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
@@ -5,6 +5,7 @@ import {
   FieldArray,
   useFormikContext,
 } from "formik";
+import { useTranslations } from "next-intl";
 import { Button, Spacer, Text } from "@opal/components";
 import { InputErrorText, InputVertical, Section } from "@opal/layouts";
 import { SvgMinusCircle, SvgPlusCircle } from "@opal/icons";
@@ -40,6 +41,7 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
   leftPlaceholder,
   rightPlaceholder,
 }) => {
+  const t = useTranslations("admin.connectorsList");
   const { values } = useFormikContext<Record<string, any>>();
   const pairs: Record<string, string>[] = values[name] || [];
 
@@ -134,7 +136,7 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
                     prominence="tertiary"
                     size="sm"
                     type="button"
-                    tooltip="Remove"
+                    tooltip={t("stringPairList.removeButton.tooltip")}
                     onClick={() => {
                       setRowKeys((prev) => ({
                         keys: prev.keys.filter((_, i) => i !== index),
@@ -161,7 +163,7 @@ const StringPairListInput: React.FC<StringPairListInputProps> = ({
                 arrayHelpers.push({ [leftKey]: "", [rightKey]: "" });
               }}
             >
-              Add New
+              {t("stringPairList.addButton.label")}
             </Button>
           </Section>
         )}

--- a/web/src/app/admin/connectors/[connector]/pages/DynamicConnectorCreationForm.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/DynamicConnectorCreationForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import CredentialSubText from "@/lib/credentials/components/CredentialFields";
 import { ConnectionConfiguration } from "@/lib/connectors/connectors";
 import { TextFormField } from "@/components/Field";
@@ -23,6 +24,7 @@ export default function DynamicConnectionForm({
   connector,
   currentCredential,
 }: DynamicConnectionFormProps) {
+  const t = useTranslations("admin.connectorsList");
   const { setFieldValue } = useFormikContext<any>(); // Get Formik's context functions
 
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
@@ -50,9 +52,9 @@ export default function DynamicConnectionForm({
       )}
 
       <TextFormField
-        subtext="A descriptive name for the connector."
+        subtext={t("connectorName.subtext")}
         type={"text"}
-        label={"Connector Name"}
+        label={t("connectorName.label")}
         name={"name"}
       />
 

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { TabOption } from "@/lib/connectors/connectors";
 import SelectInput from "./ConnectorInput/SelectInput";
 import NumberInput from "./ConnectorInput/NumberInput";
@@ -33,6 +34,7 @@ const TabsField: FC<TabsFieldProps> = ({
   connector,
   currentCredential,
 }) => {
+  const t = useTranslations("admin.connectorsList");
   const { setFieldValue } = useFormikContext<FormValues>();
 
   const resolvedLabel =
@@ -58,7 +60,7 @@ const TabsField: FC<TabsFieldProps> = ({
       {/* Ensure there's at least one tab before rendering */}
       {tabField.tabs.length === 0 ? (
         <Text text03 secondaryBody>
-          No tabs to display.
+          {t("tabs.empty.label")}
         </Text>
       ) : (
         <Tabs
@@ -128,6 +130,7 @@ export const RenderField: FC<RenderFieldProps> = ({
   connector,
   currentCredential,
 }) => {
+  const t = useTranslations("admin.connectorsList");
   const { setFieldValue } = useFormikContext<FormValues>(); // Get Formik's context functions
 
   const label =
@@ -240,7 +243,9 @@ export const RenderField: FC<RenderFieldProps> = ({
             withLabel={field.name}
             title={label}
             description={description}
-            suffix={field.optional ? "optional" : undefined}
+            suffix={
+              field.optional ? t("field.optionalSuffix.label") : undefined
+            }
           >
             <InputTextAreaField
               name={field.name}
@@ -268,7 +273,10 @@ export const RenderField: FC<RenderFieldProps> = ({
           </Text>
         </GeneralLayouts.Section>
       ) : (
-        <>INVALID FIELD TYPE</>
+        <>
+          {/* oxlint-disable-next-line i18n/no-raw-jsx-text -- developer diagnostic, not copy */}
+          INVALID FIELD TYPE
+        </>
       )}
     </>
   );

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import * as Yup from "yup";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
@@ -26,6 +27,7 @@ export const DriveAuthSection = ({
   refreshCredentials,
   user,
 }: DriveCredentialSectionProps) => {
+  const t = useTranslations("admin.connectorsList");
   const router = useRouter();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [justCreated, setJustCreated] = useState(false);
@@ -48,11 +50,10 @@ export const DriveAuthSection = ({
         className="mt-4 rounded-sm border border-border-02 bg-background-tint-02 px-4 py-3"
       >
         <Text as="p" font="main-ui-action">
-          Authentication Complete
+          {t("gdrive.authComplete.title")}
         </Text>
         <Text as="p" font="secondary-body" color="text-03">
-          Your Google Drive credential was created. Manage or revoke it from the
-          credential list.
+          {t("gdrive.authComplete.description")}
         </Text>
       </Section>
     );
@@ -61,20 +62,22 @@ export const DriveAuthSection = ({
   return (
     <Section alignItems="start" justifyContent="start" gap={4}>
       <Text as="h3" font="heading-h2">
-        Google Drive Authentication
+        {t("gdrive.section.title")}
       </Text>
       <Section alignItems="start" justifyContent="start" gap={4}>
         <Text as="p" font="main-ui-action">
-          Option 1: OAuth app
+          {t("gdrive.oauthOption.title")}
         </Text>
         <Text as="p" font="secondary-body" color="text-03">
           {markdown(
-            `Upload the OAuth app JSON from Google Cloud Console ([setup instructions](${DOCS_ADMINS_PATH}/connectors/official/google_drive/overview)), then authenticate with the Google account whose Drive you want to index.`
+            t("gdrive.oauthOption.description", {
+              docsUrl: `${DOCS_ADMINS_PATH}/connectors/official/google_drive/overview`,
+            })
           )}
         </Text>
         <InputFile
           accept="application/json"
-          placeholder="Upload or paste your OAuth app JSON"
+          placeholder={t("gdrive.oauthUpload.placeholder")}
           setValue={(value) => {
             setOauthAppCredential(
               value ? parseOauthAppCredentialJson(value) : null
@@ -103,23 +106,23 @@ export const DriveAuthSection = ({
                 }
               } catch (error) {
                 toast.error(
-                  `Failed to authenticate with Google Drive - ${error}`
+                  t("gdrive.authFailed.toast", { error: String(error) })
                 );
                 setIsAuthenticating(false);
               }
             }}
           >
             {isAuthenticating
-              ? "Authenticating..."
-              : "Authenticate with Google Drive"}
+              ? t("gdrive.authenticateButton.pendingLabel")
+              : t("gdrive.authenticateButton.label")}
           </Button>
         </Section>
         <Text as="p" font="main-ui-action">
-          Option 2: Service account
+          {t("gdrive.serviceAccountOption.title")}
         </Text>
         <InputFile
           accept="application/json"
-          placeholder="Upload or paste your service account JSON key"
+          placeholder={t("gdrive.serviceAccountUpload.placeholder")}
           setValue={(value) => {
             if (!value) {
               setServiceAccountKey(null);
@@ -128,15 +131,15 @@ export const DriveAuthSection = ({
             try {
               const parsed = JSON.parse(value) as Record<string, unknown>;
               if (parsed.type !== "service_account") {
-                toast.error(
-                  "Invalid file provided - expected a Service Account JSON key"
-                );
+                toast.error(t("gdrive.invalidServiceAccountFile.toast"));
                 setServiceAccountKey(null);
                 return;
               }
               setServiceAccountKey(parsed);
             } catch (error) {
-              toast.error(`Invalid file provided - ${error}`);
+              toast.error(
+                t("gdrive.invalidFile.toast", { error: String(error) })
+              );
               setServiceAccountKey(null);
             }
           }}
@@ -148,16 +151,14 @@ export const DriveAuthSection = ({
           }}
           validationSchema={Yup.object().shape({
             google_primary_admin: Yup.string()
-              .email("Must be a valid email")
-              .required("Required"),
+              .email(t("gdrive.primaryAdmin.invalidEmail"))
+              .required(t("gdrive.primaryAdmin.required")),
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
 
             if (!serviceAccountKey) {
-              toast.error(
-                "Please upload a service account key before creating a credential"
-              );
+              toast.error(t("gdrive.missingServiceAccountKey.toast"));
               formikHelpers.setSubmitting(false);
               return;
             }
@@ -178,20 +179,22 @@ export const DriveAuthSection = ({
               );
 
               if (response.ok) {
-                toast.success(
-                  "Successfully created service account credential"
-                );
+                toast.success(t("gdrive.serviceAccountCreated.toast"));
                 setJustCreated(true);
                 refreshCredentials();
               } else {
                 const errorMsg = await response.text();
                 toast.error(
-                  `Failed to create service account credential - ${errorMsg}`
+                  t("gdrive.serviceAccountCreateFailed.toast", {
+                    error: errorMsg,
+                  })
                 );
               }
             } catch (error) {
               toast.error(
-                `Failed to create service account credential - ${error}`
+                t("gdrive.serviceAccountCreateFailed.toast", {
+                  error: String(error),
+                })
               );
             } finally {
               formikHelpers.setSubmitting(false);
@@ -202,15 +205,14 @@ export const DriveAuthSection = ({
             <Form className="w-full">
               <Section alignItems="start" justifyContent="start" gap={1}>
                 <Text font="main-ui-body" color="text-03">
-                  Primary Admin Email
+                  {t("gdrive.primaryAdmin.label")}
                 </Text>
                 <InputTypeInField
                   name="google_primary_admin"
                   placeholder="admin@yourcompany.com"
                 />
                 <Text font="secondary-body" color="text-03">
-                  Enter the email of an admin or owner of the Google
-                  Organization that owns the Google Drive(s) you want to index.
+                  {t("gdrive.primaryAdmin.description")}
                 </Text>
               </Section>
               <Section
@@ -219,7 +221,9 @@ export const DriveAuthSection = ({
                 className="pt-2"
               >
                 <Button disabled={isSubmitting} type="submit">
-                  {isSubmitting ? "Creating..." : "Create Credential"}
+                  {isSubmitting
+                    ? t("gdrive.createButton.pendingLabel")
+                    : t("gdrive.createButton.label")}
                 </Button>
               </Section>
             </Form>

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { LoadingAnimation } from "@/components/Loading";
 import { ValidSources } from "@/lib/types";
@@ -15,6 +16,7 @@ import {
 } from "@/lib/googleConnector";
 
 const GDriveMain = () => {
+  const t = useTranslations("admin.connectorsList");
   const { user } = useUser();
   // Gated on the global holder, not isAdmin: managing connectors is what this
   // form does, and every endpoint behind it already enforces MANAGE_CONNECTORS.
@@ -57,13 +59,11 @@ const GDriveMain = () => {
 
   // Error states
   if (credentialsError || !credentialsData) {
-    return <ErrorCallout errorTitle="Failed to load credentials." />;
+    return <ErrorCallout errorTitle={t("credentialsLoadError.title")} />;
   }
 
   if (googleDriveCredentialsError || !googleDriveCredentials) {
-    return (
-      <ErrorCallout errorTitle="Failed to load Google Drive credentials." />
-    );
+    return <ErrorCallout errorTitle={t("gdrive.credentialsLoadError.title")} />;
   }
 
   return (

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
@@ -3,6 +3,7 @@ import { Section, toast } from "@opal/layouts";
 import InputFile from "@/refresh-components/inputs/InputFile";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import React, { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import * as Yup from "yup";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
@@ -32,6 +33,7 @@ export const GmailAuthSection = ({
   buildMode = false,
   onOAuthRedirect,
 }: GmailCredentialSectionProps) => {
+  const t = useTranslations("admin.connectorsList");
   const router = useRouter();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [justCreated, setJustCreated] = useState(false);
@@ -54,11 +56,10 @@ export const GmailAuthSection = ({
         className="mt-4 rounded-sm border border-border-02 bg-background-tint-02 px-4 py-3"
       >
         <Text as="p" font="main-ui-action">
-          Authentication Complete
+          {t("gmail.authComplete.title")}
         </Text>
         <Text as="p" font="secondary-body" color="text-03">
-          Your Gmail credential was created. Manage or revoke it from the
-          credential list.
+          {t("gmail.authComplete.description")}
         </Text>
       </Section>
     );
@@ -67,20 +68,22 @@ export const GmailAuthSection = ({
   return (
     <Section alignItems="start" justifyContent="start" gap={4}>
       <Text as="h3" font="heading-h2">
-        Gmail Authentication
+        {t("gmail.section.title")}
       </Text>
       <Section alignItems="start" justifyContent="start" gap={4}>
         <Text as="p" font="main-ui-action">
-          Option 1: OAuth app
+          {t("gmail.oauthOption.title")}
         </Text>
         <Text as="p" font="secondary-body" color="text-03">
           {markdown(
-            `Upload the OAuth app JSON from Google Cloud Console ([setup instructions](${DOCS_ADMINS_PATH}/connectors/official/gmail/overview)), then authenticate with the Google account whose Gmail you want to index.`
+            t("gmail.oauthOption.description", {
+              docsUrl: `${DOCS_ADMINS_PATH}/connectors/official/gmail/overview`,
+            })
           )}
         </Text>
         <InputFile
           accept="application/json"
-          placeholder="Upload or paste your OAuth app JSON"
+          placeholder={t("gmail.oauthUpload.placeholder")}
           setValue={(value) => {
             setOauthAppCredential(
               value ? parseOauthAppCredentialJson(value) : null
@@ -113,20 +116,24 @@ export const GmailAuthSection = ({
                   setIsAuthenticating(false);
                 }
               } catch (error) {
-                toast.error(`Failed to authenticate with Gmail - ${error}`);
+                toast.error(
+                  t("gmail.authFailed.toast", { error: String(error) })
+                );
                 setIsAuthenticating(false);
               }
             }}
           >
-            {isAuthenticating ? "Authenticating..." : "Authenticate with Gmail"}
+            {isAuthenticating
+              ? t("gmail.authenticateButton.pendingLabel")
+              : t("gmail.authenticateButton.label")}
           </Button>
         </Section>
         <Text as="p" font="main-ui-action">
-          Option 2: Service account
+          {t("gmail.serviceAccountOption.title")}
         </Text>
         <InputFile
           accept="application/json"
-          placeholder="Upload or paste your service account JSON key"
+          placeholder={t("gmail.serviceAccountUpload.placeholder")}
           setValue={(value) => {
             if (!value) {
               setServiceAccountKey(null);
@@ -135,15 +142,15 @@ export const GmailAuthSection = ({
             try {
               const parsed = JSON.parse(value) as Record<string, unknown>;
               if (parsed.type !== "service_account") {
-                toast.error(
-                  "Invalid file provided - expected a Service Account JSON key"
-                );
+                toast.error(t("gmail.invalidServiceAccountFile.toast"));
                 setServiceAccountKey(null);
                 return;
               }
               setServiceAccountKey(parsed);
             } catch (error) {
-              toast.error(`Invalid file provided - ${error}`);
+              toast.error(
+                t("gmail.invalidFile.toast", { error: String(error) })
+              );
               setServiceAccountKey(null);
             }
           }}
@@ -155,16 +162,14 @@ export const GmailAuthSection = ({
           }}
           validationSchema={Yup.object().shape({
             google_primary_admin: Yup.string()
-              .email("Must be a valid email")
-              .required("Required"),
+              .email(t("gmail.primaryAdmin.invalidEmail"))
+              .required(t("gmail.primaryAdmin.required")),
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
 
             if (!serviceAccountKey) {
-              toast.error(
-                "Please upload a service account key before creating a credential"
-              );
+              toast.error(t("gmail.missingServiceAccountKey.toast"));
               formikHelpers.setSubmitting(false);
               return;
             }
@@ -185,20 +190,22 @@ export const GmailAuthSection = ({
               );
 
               if (response.ok) {
-                toast.success(
-                  "Successfully created service account credential"
-                );
+                toast.success(t("gmail.serviceAccountCreated.toast"));
                 setJustCreated(true);
                 refreshCredentials();
               } else {
                 const errorMsg = await response.text();
                 toast.error(
-                  `Failed to create service account credential - ${errorMsg}`
+                  t("gmail.serviceAccountCreateFailed.toast", {
+                    error: errorMsg,
+                  })
                 );
               }
             } catch (error) {
               toast.error(
-                `Failed to create service account credential - ${error}`
+                t("gmail.serviceAccountCreateFailed.toast", {
+                  error: String(error),
+                })
               );
             } finally {
               formikHelpers.setSubmitting(false);
@@ -209,15 +216,14 @@ export const GmailAuthSection = ({
             <Form className="w-full">
               <Section alignItems="start" justifyContent="start" gap={1}>
                 <Text font="main-ui-body" color="text-03">
-                  Primary Admin Email
+                  {t("gmail.primaryAdmin.label")}
                 </Text>
                 <InputTypeInField
                   name="google_primary_admin"
                   placeholder="admin@yourcompany.com"
                 />
                 <Text font="secondary-body" color="text-03">
-                  Enter the email of an admin or owner of the Google
-                  Organization that owns the Gmail account(s) you want to index.
+                  {t("gmail.primaryAdmin.description")}
                 </Text>
               </Section>
               <Section
@@ -226,7 +232,9 @@ export const GmailAuthSection = ({
                 className="pt-2"
               >
                 <Button disabled={isSubmitting} type="submit">
-                  {isSubmitting ? "Creating..." : "Create Credential"}
+                  {isSubmitting
+                    ? t("gmail.createButton.pendingLabel")
+                    : t("gmail.createButton.label")}
                 </Button>
               </Section>
             </Form>

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/GmailPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/GmailPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { LoadingAnimation } from "@/components/Loading";
 import { toast } from "@opal/layouts";
@@ -29,6 +30,7 @@ export const GmailMain = ({
   buildMode = false,
   onOAuthRedirect,
 }: GmailMainProps) => {
+  const t = useTranslations("admin.connectorsList");
   const { user } = useUser();
   // See GoogleDrivePage — same gate, same reasoning.
   const { isGlobalHolder } = usePermissionAuthority(
@@ -65,11 +67,11 @@ export const GmailMain = ({
   }
 
   if (credentialsError || !credentialsData) {
-    return <ErrorCallout errorTitle="Failed to load credentials." />;
+    return <ErrorCallout errorTitle={t("credentialsLoadError.title")} />;
   }
 
   if (gmailCredentialsError || !gmailCredentials) {
-    return <ErrorCallout errorTitle="Failed to load Gmail credentials." />;
+    return <ErrorCallout errorTitle={t("gmail.credentialsLoadError.title")} />;
   }
 
   return (

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import { Button, Card, PasswordInputTypeIn } from "@opal/components";
@@ -17,6 +18,8 @@ import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
 import { getFormattedDateTime } from "@/lib/dateUtils";
 
 export function BotConfigCard() {
+  const t = useTranslations("admin.discordBot");
+  const locale = useLocale();
   const {
     data: botConfig,
     isLoading,
@@ -45,7 +48,7 @@ export function BotConfigCard() {
             alignItems="center"
           >
             <Text mainContentEmphasis text05>
-              Bot Token
+              {t("botToken.section.title")}
             </Text>
           </Section>
           <div className="flex justify-center">
@@ -61,7 +64,7 @@ export function BotConfigCard() {
 
   const handleSaveToken = async () => {
     if (!botToken.trim()) {
-      toast.error("Please enter a bot token");
+      toast.error(t("botToken.missing.toast"));
       return;
     }
 
@@ -70,10 +73,10 @@ export function BotConfigCard() {
       await createBotConfig(botToken.trim());
       setBotToken("");
       refreshBotConfig();
-      toast.success("Bot token saved successfully");
+      toast.success(t("botToken.saved.toast"));
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to save bot token"
+        err instanceof Error ? err.message : t("botToken.saveError.toast")
       );
     } finally {
       setIsSubmitting(false);
@@ -85,10 +88,10 @@ export function BotConfigCard() {
     try {
       await deleteBotConfig();
       refreshBotConfig();
-      toast.success("Bot token deleted");
+      toast.success(t("botToken.deleted.toast"));
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to delete bot token"
+        err instanceof Error ? err.message : t("botToken.deleteError.toast")
       );
     } finally {
       setIsSubmitting(false);
@@ -101,11 +104,11 @@ export function BotConfigCard() {
       {showDeleteConfirm && (
         <ConfirmEntityModal
           danger
-          entityType="Discord bot token"
-          entityName="Discord Bot Token"
+          entityType={t("botToken.deleteModal.entityType")}
+          entityName={t("botToken.deleteModal.entityName")}
           onClose={() => setShowDeleteConfirm(false)}
           onSubmit={handleDeleteToken}
-          additionalDetails="This will disconnect your Discord bot. You will need to re-enter the token to use the bot again."
+          additionalDetails={t("botToken.deleteModal.additionalDetails")}
         />
       )}
       <Card border="solid" rounding={4}>
@@ -113,18 +116,24 @@ export function BotConfigCard() {
           <Section flexDirection="row" justifyContent="between">
             <Section flexDirection="row" gap={2} width="fit">
               <Text mainContentEmphasis text05>
-                Bot Token
+                {t("botToken.section.title")}
               </Text>
               {isConfigured ? (
-                <Badge variant="success">Configured</Badge>
+                <Badge variant="success">
+                  {t("botToken.configured.badge")}
+                </Badge>
               ) : (
-                <Badge variant="secondary">Not Configured</Badge>
+                <Badge variant="secondary">
+                  {t("botToken.notConfigured.badge")}
+                </Badge>
               )}
             </Section>
             {isConfigured && (
               <Tooltip
                 tooltip={
-                  hasServerConfigs ? "Delete server configs first" : undefined
+                  hasServerConfigs
+                    ? t("botToken.deleteButton.blocked.tooltip")
+                    : undefined
                 }
               >
                 <Button
@@ -132,7 +141,7 @@ export function BotConfigCard() {
                   variant="danger"
                   onClick={() => setShowDeleteConfirm(true)}
                 >
-                  Delete Discord Token
+                  {t("botToken.deleteButton.label")}
                 </Button>
               </Tooltip>
             )}
@@ -141,37 +150,39 @@ export function BotConfigCard() {
           {isConfigured ? (
             <Section flexDirection="column" alignItems="start" gap={2}>
               <Text text03 secondaryBody>
-                Your Discord bot token is configured.
-                {botConfig?.created_at && (
-                  <>
-                    {" "}
-                    Added {getFormattedDateTime(new Date(botConfig.created_at))}
-                    .
-                  </>
-                )}
+                {botConfig?.created_at
+                  ? t("botToken.configuredWithDate.text", {
+                      date:
+                        getFormattedDateTime(
+                          new Date(botConfig.created_at),
+                          locale
+                        ) ?? "",
+                    })
+                  : t("botToken.configured.text")}
               </Text>
               <Text text03 secondaryBody>
-                To change the token, delete the current one and add a new one.
+                {t("botToken.changeInstructions.text")}
               </Text>
             </Section>
           ) : (
             <Section flexDirection="column" alignItems="start" gap={3}>
               <Text text03 secondaryBody>
-                Enter your Discord bot token to enable the bot. You can get this
-                from the Discord Developer Portal.
+                {t("botToken.enterInstructions.text")}
               </Text>
               <Section flexDirection="row" alignItems="end" gap={2}>
                 <PasswordInputTypeIn
                   value={botToken}
                   onChange={(e) => setBotToken(e.target.value)}
-                  placeholder="Enter bot token..."
+                  placeholder={t("botToken.input.placeholder")}
                   disabled={isSubmitting}
                 />
                 <Button
                   disabled={isSubmitting || !botToken.trim()}
                   onClick={handleSaveToken}
                 >
-                  {isSubmitting ? "Saving..." : "Save Token"}
+                  {isSubmitting
+                    ? t("botToken.saveButton.saving.label")
+                    : t("botToken.saveButton.label")}
                 </Button>
               </Section>
             </Section>

--- a/web/src/app/admin/discord-bot/DiscordGuildsTable.tsx
+++ b/web/src/app/admin/discord-bot/DiscordGuildsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import {
   Table,
@@ -30,6 +31,8 @@ interface Props {
 }
 
 export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
+  const t = useTranslations("admin.discordBot");
+  const locale = useLocale();
   const router = useRouter();
   const [guildToDelete, setGuildToDelete] = useState<DiscordGuildConfig | null>(
     null
@@ -42,10 +45,10 @@ export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
     try {
       await deleteGuildConfig(guildId);
       onRefresh();
-      toast.success("Server configuration deleted");
+      toast.success(t("guilds.deleted.toast"));
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to delete server config"
+        err instanceof Error ? err.message : t("guilds.deleteError.toast")
       );
     } finally {
       setGuildToDelete(null);
@@ -54,7 +57,7 @@ export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
 
   const handleToggleEnabled = async (guild: DiscordGuildConfig) => {
     if (!guild.guild_id) {
-      toast.error("Server must be registered before it can be enabled");
+      toast.error(t("guilds.notRegistered.toast"));
       return;
     }
 
@@ -65,10 +68,12 @@ export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
         default_persona_id: guild.default_persona_id,
       });
       onRefresh();
-      toast.success(`Server ${!guild.enabled ? "enabled" : "disabled"}`);
+      toast.success(
+        !guild.enabled ? t("guilds.enabled.toast") : t("guilds.disabled.toast")
+      );
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to update server"
+        err instanceof Error ? err.message : t("guilds.updateError.toast")
       );
     } finally {
       setUpdatingGuildIds((prev) => {
@@ -84,8 +89,8 @@ export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
       <EmptyMessageCard
         sizePreset="main-ui"
         icon={SvgServer}
-        title="No Discord servers configured yet"
-        description="Create a server configuration to get started."
+        title={t("guilds.empty.title")}
+        description={t("guilds.empty.description")}
       />
     );
   }
@@ -95,21 +100,24 @@ export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
       {guildToDelete && (
         <ConfirmEntityModal
           danger
-          entityType="Discord server configuration"
-          entityName={guildToDelete.guild_name || `Server #${guildToDelete.id}`}
+          entityType={t("guilds.deleteModal.entityType")}
+          entityName={
+            guildToDelete.guild_name ||
+            t("guilds.fallbackName", { id: guildToDelete.id })
+          }
           onClose={() => setGuildToDelete(null)}
           onSubmit={() => handleDelete(guildToDelete.id)}
-          additionalDetails="This will remove all settings for this Discord server."
+          additionalDetails={t("guilds.deleteModal.additionalDetails")}
         />
       )}
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Server</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Registered</TableHead>
-            <TableHead>Enabled</TableHead>
-            <TableHead>Actions</TableHead>
+            <TableHead>{t("guilds.table.server.header")}</TableHead>
+            <TableHead>{t("guilds.table.status.header")}</TableHead>
+            <TableHead>{t("guilds.table.registered.header")}</TableHead>
+            <TableHead>{t("guilds.table.enabled.header")}</TableHead>
+            <TableHead>{t("guilds.table.actions.header")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -122,19 +130,22 @@ export function DiscordGuildsTable({ guilds, onRefresh }: Props) {
                   onClick={() => router.push(`/admin/discord-bot/${guild.id}`)}
                   icon={SvgEdit}
                 >
-                  {guild.guild_name || `Server #${guild.id}`}
+                  {guild.guild_name ||
+                    t("guilds.fallbackName", { id: guild.id })}
                 </Button>
               </TableCell>
               <TableCell>
                 {guild.guild_id ? (
-                  <Badge variant="success">Registered</Badge>
+                  <Badge variant="success">
+                    {t("guilds.registered.badge")}
+                  </Badge>
                 ) : (
-                  <Badge variant="secondary">Pending</Badge>
+                  <Badge variant="secondary">{t("guilds.pending.badge")}</Badge>
                 )}
               </TableCell>
               <TableCell>
                 {guild.registered_at
-                  ? new Date(guild.registered_at).toLocaleDateString()
+                  ? new Date(guild.registered_at).toLocaleDateString(locale)
                   : "-"}
               </TableCell>
               <TableCell>

--- a/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -59,12 +60,14 @@ export function DiscordChannelsTable({
   onChannelUpdate,
   disabled = false,
 }: Props) {
+  const t = useTranslations("admin.discordBot");
+
   if (channels.length === 0) {
     return (
       <EmptyMessageCard
         sizePreset="main-ui"
-        title="No channels configured"
-        description="Run !sync-channels in Discord to add channels."
+        title={t("channels.empty.title")}
+        description={t("channels.empty.description")}
       />
     );
   }
@@ -73,11 +76,11 @@ export function DiscordChannelsTable({
     <Table>
       <TableHeader>
         <TableRow className="[&>th]:whitespace-nowrap">
-          <TableHead>Channel</TableHead>
-          <TableHead>Enabled</TableHead>
-          <TableHead>Require @mention</TableHead>
-          <TableHead>Thread Only Mode</TableHead>
-          <TableHead>Agent Override</TableHead>
+          <TableHead>{t("channels.table.channel.header")}</TableHead>
+          <TableHead>{t("channels.table.enabled.header")}</TableHead>
+          <TableHead>{t("channels.table.requireMention.header")}</TableHead>
+          <TableHead>{t("channels.table.threadOnly.header")}</TableHead>
+          <TableHead>{t("channels.table.agentOverride.header")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState, useEffect, useCallback, useMemo } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { PageLoader } from "@opal/layouts";
@@ -56,6 +57,7 @@ function GuildDetailContent({
   handleDisableAll: () => void;
   disabled: boolean;
 }) {
+  const t = useTranslations("admin.discordBot");
   const {
     data: guild,
     isLoading: guildLoading,
@@ -71,8 +73,8 @@ function GuildDetailContent({
   if (guildError || !guild) {
     return (
       <ErrorCallout
-        errorTitle="Failed to load server"
-        errorMsg={guildError?.info?.detail || "Server not found"}
+        errorTitle={t("error.loadServer.title")}
+        errorMsg={guildError?.info?.detail || t("error.serverNotFound.message")}
       />
     );
   }
@@ -82,16 +84,15 @@ function GuildDetailContent({
   return (
     <>
       {!isRegistered && (
-        <Callout type="notice" title="Waiting for Registration">
-          Use the !register command in your Discord server with the registration
-          key to complete setup.
+        <Callout type="notice" title={t("guildDetail.awaiting.title")}>
+          {t("guildDetail.awaiting.text")}
         </Callout>
       )}
 
       <Card variant={disabled ? "disabled" : "primary"}>
         <ContentAction
-          title="Channel Configuration"
-          description="Run !sync-channels in Discord to update the channel list."
+          title={t("channels.section.title")}
+          description={t("channels.section.description")}
           sizePreset="main-content"
           variant="section"
           rightChildren={
@@ -108,14 +109,14 @@ function GuildDetailContent({
                   prominence="secondary"
                   onClick={handleEnableAll}
                 >
-                  Enable All
+                  {t("channels.enableAllButton.label")}
                 </Button>
                 <Button
                   disabled={disabled}
                   prominence="secondary"
                   onClick={handleDisableAll}
                 >
-                  Disable All
+                  {t("channels.disableAllButton.label")}
                 </Button>
               </Section>
             ) : undefined
@@ -124,8 +125,7 @@ function GuildDetailContent({
 
         {!isRegistered ? (
           <Text text03 secondaryBody>
-            Channel configuration will be available after the server is
-            registered.
+            {t("channels.awaitingRegistration.text")}
           </Text>
         ) : channelsLoading ? (
           <div className="flex justify-center py-12">
@@ -133,8 +133,10 @@ function GuildDetailContent({
           </div>
         ) : channelsError ? (
           <ErrorCallout
-            errorTitle="Failed to load channels"
-            errorMsg={channelsError?.info?.detail || "Could not load channels"}
+            errorTitle={t("error.loadChannels.title")}
+            errorMsg={
+              channelsError?.info?.detail || t("error.loadChannels.message")
+            }
           />
         ) : (
           <DiscordChannelsTable
@@ -150,6 +152,8 @@ function GuildDetailContent({
 }
 
 export default function Page({ params }: Props) {
+  const t = useTranslations("admin.discordBot");
+  const locale = useLocale();
   const unwrappedParams = use(params);
   const guildId = Number(unwrappedParams["guild-id"]);
   const { data: guild, refreshGuild } = useDiscordGuild(guildId);
@@ -280,19 +284,17 @@ export default function Page({ params }: Props) {
       );
 
       if (failed > 0) {
-        toast.error(`Updated ${succeeded} channels, but ${failed} failed`);
+        toast.error(t("channels.partialUpdate.toast", { succeeded, failed }));
         // Refresh to get actual server state when some updates failed
         refreshChannels();
       } else {
-        toast.success(
-          `Updated ${succeeded} channel${succeeded !== 1 ? "s" : ""}`
-        );
+        toast.success(t("channels.updated.toast", { count: succeeded }));
         // Update original to match local (avoids flash from refresh)
         setOriginalChannels(localChannels);
       }
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to update channels"
+        err instanceof Error ? err.message : t("channels.updateError.toast")
       );
     } finally {
       setIsUpdating(false);
@@ -309,11 +311,13 @@ export default function Page({ params }: Props) {
       });
       refreshGuild();
       toast.success(
-        personaId ? "Default agent updated" : "Default agent cleared"
+        personaId
+          ? t("defaultAgent.updated.toast")
+          : t("defaultAgent.cleared.toast")
       );
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to update agent"
+        err instanceof Error ? err.message : t("defaultAgent.updateError.toast")
       );
     } finally {
       setIsUpdating(false);
@@ -321,8 +325,10 @@ export default function Page({ params }: Props) {
   };
 
   const registeredText = guild?.registered_at
-    ? `Registered: ${new Date(guild.registered_at).toLocaleString()}`
-    : "Pending registration";
+    ? t("guildDetail.registered.text", {
+        date: new Date(guild.registered_at).toLocaleString(locale),
+      })
+    : t("guildDetail.pending.text");
 
   const isRegistered = !!guild?.guild_id;
   const isUpdateDisabled =
@@ -337,12 +343,12 @@ export default function Page({ params }: Props) {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgServer}
-        title={guild?.guild_name || `Server #${guildId}`}
+        title={guild?.guild_name || t("guilds.fallbackName", { id: guildId })}
         description={registeredText}
         backButton
         rightChildren={
           <Button disabled={isUpdateDisabled} onClick={handleSaveChanges}>
-            Update Configuration
+            {t("guildDetail.updateButton.label")}
           </Button>
         }
       />
@@ -350,8 +356,8 @@ export default function Page({ params }: Props) {
         {/* Default Agent Selector */}
         <Card variant={!guild?.enabled ? "disabled" : "primary"}>
           <ContentAction
-            title="Default Agent"
-            description="The agent used by the bot in all channels unless overridden."
+            title={t("defaultAgent.section.title")}
+            description={t("defaultAgent.section.description")}
             sizePreset="main-content"
             variant="section"
             rightChildren={
@@ -364,10 +370,12 @@ export default function Page({ params }: Props) {
                 }
                 disabled={isUpdating || !guild?.enabled || personasLoading}
               >
-                <InputSelect.Trigger placeholder="Select agent" />
+                <InputSelect.Trigger
+                  placeholder={t("defaultAgent.select.placeholder")}
+                />
                 <InputSelect.Content>
                   <InputSelect.Item value="default">
-                    Default Agent
+                    {t("defaultAgent.select.default.label")}
                   </InputSelect.Item>
                   {agents.map((persona) => (
                     <InputSelect.Item
@@ -407,8 +415,8 @@ export default function Page({ params }: Props) {
         >
           <MessageCard
             variant="warning"
-            title="You have unsaved changes"
-            description="Click Update to save them."
+            title={t("unsavedChanges.title")}
+            description={t("unsavedChanges.description")}
           />
         </div>
       </SettingsLayouts.Body>

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { PageLoader } from "@opal/layouts";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { Section } from "@/layouts/general-layouts";
@@ -23,6 +24,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 const route = ADMIN_ROUTES.DISCORD_BOTS;
 
 function DiscordBotContent() {
+  const t = useTranslations("admin.discordBot");
   const { data: guilds, isLoading, error, refreshGuilds } = useDiscordGuilds();
   const { data: botConfig, isManaged } = useDiscordBotConfig();
   const [registrationKey, setRegistrationKey] = useState<string | null>(null);
@@ -39,10 +41,10 @@ function DiscordBotContent() {
       const result = await createGuildConfig();
       setRegistrationKey(result.registration_key);
       refreshGuilds();
-      toast.success("Server configuration created!");
+      toast.success(t("guilds.created.toast"));
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to create server"
+        err instanceof Error ? err.message : t("guilds.createError.toast")
       );
     } finally {
       setIsCreating(false);
@@ -56,8 +58,8 @@ function DiscordBotContent() {
   if (error || !guilds) {
     return (
       <ErrorCallout
-        errorTitle="Failed to load Discord servers"
-        errorMsg={error?.info?.detail || "An unknown error occurred"}
+        errorTitle={t("error.loadServers.title")}
+        errorMsg={error?.info?.detail || t("error.unknown.message")}
       />
     );
   }
@@ -69,14 +71,14 @@ function DiscordBotContent() {
       <Modal open={!!registrationKey}>
         <Modal.Content width="sm">
           <Modal.Header
-            title="Registration Key"
+            title={t("registrationKey.header.title")}
             icon={SvgKey}
             onClose={() => setRegistrationKey(null)}
-            description="This key will only be shown once!"
+            description={t("registrationKey.header.description")}
           />
           <Modal.Body>
             <Text text04 mainUiBody>
-              Copy the command and send it from any text channel in your server!
+              {t("registrationKey.instructions.text")}
             </Text>
             <Card variant="secondary">
               <Section
@@ -103,7 +105,7 @@ function DiscordBotContent() {
           alignItems="center"
         >
           <Text mainContentEmphasis text05>
-            Server Configurations
+            {t("serverConfigs.section.title")}
           </Text>
           <Button
             icon={SvgPlusCircle}
@@ -111,7 +113,9 @@ function DiscordBotContent() {
             onClick={handleCreateGuild}
             disabled={isCreating || !isBotAvailable}
           >
-            {isCreating ? "Creating..." : "Add Server"}
+            {isCreating
+              ? t("serverConfigs.addButton.creating.label")
+              : t("serverConfigs.addButton.label")}
           </Button>
         </Section>
         <DiscordGuildsTable guilds={guilds} onRefresh={refreshGuilds} />
@@ -121,12 +125,14 @@ function DiscordBotContent() {
 }
 
 export default function Page() {
+  const t = useTranslations("admin.discordBot");
+
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
         title={route.title}
-        description="Connect Onyx to your Discord servers. Users can ask questions directly in Discord channels."
+        description={t("page.header.description")}
       />
       <SettingsLayouts.Body>
         <DiscordBotContent />

--- a/web/src/app/admin/document-processing/page.tsx
+++ b/web/src/app/admin/document-processing/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import CardSection from "@/components/admin/CardSection";
 import { Button } from "@opal/components";
 import { InputTypeIn } from "@opal/components";
@@ -16,6 +17,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 const route = ADMIN_ROUTES.DOCUMENT_PROCESSING;
 
 function Main() {
+  const t = useTranslations("admin.documentProcessing");
   const {
     data: isApiKeySet,
     error,
@@ -68,31 +70,35 @@ function Main() {
             text05
             className="border-b border-border-01 pb-2"
           >
-            Process with Unstructured API
+            {t("unstructured.title")}
           </Text>
 
           <div className="flex flex-col gap-2">
             <Text as="p" mainContentBody text04 className="leading-relaxed">
-              Unstructured extracts and transforms complex data from formats
-              like .pdf, .docx, .png, .pptx, etc. into clean text for Onyx to
-              ingest. Provide an API key to enable Unstructured document
-              processing.
+              {t("unstructured.description")}
             </Text>
             <Text as="p" mainContentMuted text03>
-              <span className="font-main-ui-action text-text-03">Note:</span>{" "}
-              this will send documents to Unstructured servers for processing.
+              {t.rich("unstructured.note", {
+                label: (chunks) => (
+                  <span className="font-main-ui-action text-text-03">
+                    {chunks}
+                  </span>
+                ),
+              })}
             </Text>
             <Text as="p" mainContentBody text04 className="leading-relaxed">
-              Learn more about Unstructured{" "}
-              <a
-                href="https://docs.unstructured.io/welcome"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-action-selection-05 underline-offset-4 hover:underline"
-              >
-                here
-              </a>
-              .
+              {t.rich("unstructured.learnMore", {
+                link: (chunks) => (
+                  <a
+                    href="https://docs.unstructured.io/welcome"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-action-selection-05 underline-offset-4 hover:underline"
+                  >
+                    {chunks}
+                  </a>
+                ),
+              })}
             </Text>
             <div className="pt-1.5">
               {isApiKeySet ? (
@@ -121,7 +127,7 @@ function Main() {
                 </div>
               ) : (
                 <InputTypeIn
-                  placeholder="Enter API Key"
+                  placeholder={t("unstructured.apiKey.placeholder")}
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
                 />
@@ -131,15 +137,15 @@ function Main() {
               {isApiKeySet ? (
                 <>
                   <Button variant="danger" onClick={handleDelete}>
-                    Delete API Key
+                    {t("unstructured.deleteButton.label")}
                   </Button>
                   <Text as="p" mainContentBody text04 className="sm:mt-0">
-                    Delete the current API key before updating.
+                    {t("unstructured.deleteHint")}
                   </Text>
                 </>
               ) : (
                 <Button variant="action" onClick={handleSave}>
-                  Save API Key
+                  {t("unstructured.saveButton.label")}
                 </Button>
               )}
             </div>

--- a/web/src/app/admin/documents/ScoreEditor.tsx
+++ b/web/src/app/admin/documents/ScoreEditor.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { toast } from "@opal/layouts";
 import { updateBoost } from "./lib";
 import { EditableValue } from "@/components/EditableValue";
@@ -13,10 +14,12 @@ export const ScoreSection = ({
   refresh: () => void;
   consistentWidth?: boolean;
 }) => {
+  const t = useTranslations("admin.documents");
+
   const onSubmit = async (value: string) => {
     const numericScore = Number(value);
     if (isNaN(numericScore)) {
-      toast.error("Score must be a number");
+      toast.error(t("score.notANumber.toast"));
       return false;
     }
 
@@ -25,7 +28,7 @@ export const ScoreSection = ({
       toast.error(errorMsg);
       return false;
     } else {
-      toast.success("Updated score!");
+      toast.success(t("score.updated.toast"));
       refresh();
     }
 

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -2,6 +2,7 @@
 
 import { adminSearch } from "./lib";
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { OnyxDocument } from "@/lib/search/interfaces";
 import { buildDocumentSummaryDisplay } from "@/components/search/DocumentDisplay";
 import { Checkbox } from "@opal/components";
@@ -28,6 +29,8 @@ const DocumentDisplay = ({
   document: OnyxDocument;
   refresh: () => void;
 }) => {
+  const t = useTranslations("admin.documents");
+
   async function toggleHidden() {
     const response = await updateHiddenStatus(
       document.document_id,
@@ -36,7 +39,11 @@ const DocumentDisplay = ({
     if (response.ok) {
       refresh();
     } else {
-      toast.error(`Failed to update document - ${getErrorMsg(response)}`);
+      toast.error(
+        t("explorer.updateFailed.toast", {
+          detail: await getErrorMsg(response),
+        })
+      );
     }
   }
 
@@ -63,7 +70,7 @@ const DocumentDisplay = ({
       </div>
       <div className="flex flex-wrap gap-x-2 mt-1 text-xs">
         <div className="px-1 py-0.5 bg-accent-background-hovered rounded-sm flex">
-          <p className="mr-1 my-auto">Boost:</p>
+          <p className="mr-1 my-auto">{t("explorer.boost.label")}</p>
           <ScoreSection
             documentId={document.document_id}
             initialScore={document.boost}
@@ -74,16 +81,20 @@ const DocumentDisplay = ({
         <div
           role="button"
           tabIndex={0}
-          aria-label={document.hidden ? "Unhide document" : "Hide document"}
+          aria-label={
+            document.hidden
+              ? t("visibility.unhide.ariaLabel")
+              : t("visibility.hide.ariaLabel")
+          }
           onKeyDown={clickOnKeyDown(() => void toggleHidden())}
           onClick={() => void toggleHidden()}
           className="px-1 py-0.5 bg-accent-background-hovered hover:bg-accent-background rounded-sm flex cursor-pointer select-none"
         >
           <div className="my-auto">
             {document.hidden ? (
-              <div className="text-error">Hidden</div>
+              <div className="text-error">{t("visibility.hidden.label")}</div>
             ) : (
-              "Visible"
+              t("visibility.visible.label")
             )}
           </div>
           <div className="ml-1 my-auto">
@@ -112,6 +123,7 @@ export function Explorer({
   connectors: Connector<any>[];
   documentSets: DocumentSetSummary[];
 }) {
+  const t = useTranslations("admin.documents");
   const router = useRouter();
 
   const [query, setQuery] = useState(initialSearchValue || "");
@@ -169,7 +181,7 @@ export function Explorer({
     <div className="flex flex-col gap-6">
       <div className="flex flex-col justify-center gap-2">
         <InputTypeIn
-          placeholder="Find documents based on title / content..."
+          placeholder={t("explorer.search.placeholder")}
           value={query}
           onChange={(event) => {
             setQuery(event.target.value);

--- a/web/src/app/admin/documents/feedback/DocumentFeedbackTable.tsx
+++ b/web/src/app/admin/documents/feedback/DocumentFeedbackTable.tsx
@@ -1,5 +1,6 @@
 import { toast } from "@opal/layouts";
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableHead,
@@ -27,6 +28,8 @@ const IsVisibleSection = ({
   document: DocumentBoostStatus;
   onUpdate: (response: Response) => void;
 }) => {
+  const t = useTranslations("admin.documents");
+
   async function setHidden(hidden: boolean) {
     onUpdate(await updateHiddenStatus(document.document_id, hidden));
   }
@@ -38,12 +41,12 @@ const IsVisibleSection = ({
           <div
             role="button"
             tabIndex={0}
-            aria-label="Unhide document"
+            aria-label={t("visibility.unhide.ariaLabel")}
             onKeyDown={clickOnKeyDown(() => void setHidden(false))}
             onClick={() => void setHidden(false)}
             className="flex text-error cursor-pointer hover:bg-accent-background-hovered py-1 px-2 w-fit rounded-full"
           >
-            <div className="select-none">Hidden</div>
+            <div className="select-none">{t("visibility.hidden.label")}</div>
             <div className="ml-1 my-auto">
               <Checkbox checked={false} />
             </div>
@@ -52,12 +55,14 @@ const IsVisibleSection = ({
           <div
             role="button"
             tabIndex={0}
-            aria-label="Hide document"
+            aria-label={t("visibility.hide.ariaLabel")}
             onKeyDown={clickOnKeyDown(() => void setHidden(true))}
             onClick={() => void setHidden(true)}
             className="flex cursor-pointer hover:bg-accent-background-hovered py-1 px-2 w-fit rounded-full"
           >
-            <div className="my-auto select-none">Visible</div>
+            <div className="my-auto select-none">
+              {t("visibility.visible.label")}
+            </div>
             <div className="ml-1 my-auto">
               <Checkbox checked={true} />
             </div>
@@ -68,12 +73,12 @@ const IsVisibleSection = ({
         <div className="text-xs">
           {document.hidden ? (
             <div className="flex">
-              <FiEye className="my-auto mr-1" /> Unhide
+              <FiEye className="my-auto mr-1" /> {t("visibility.unhide.label")}
             </div>
           ) : (
             <div className="flex">
               <FiEyeOff className="my-auto mr-1" />
-              Hide
+              {t("visibility.hide.label")}
             </div>
           )}
         </div>
@@ -90,6 +95,7 @@ export const DocumentFeedbackTable = ({
   documents: DocumentBoostStatus[];
   refresh: () => void;
 }) => {
+  const t = useTranslations("admin.documents");
   const [page, setPage] = useState(1);
 
   return (
@@ -97,9 +103,9 @@ export const DocumentFeedbackTable = ({
       <Table className="overflow-visible">
         <TableHeader>
           <TableRow>
-            <TableHead>Document Name</TableHead>
-            <TableHead>Is Searchable?</TableHead>
-            <TableHead>Score</TableHead>
+            <TableHead>{t("feedback.table.name.header")}</TableHead>
+            <TableHead>{t("feedback.table.searchable.header")}</TableHead>
+            <TableHead>{t("feedback.table.score.header")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -126,9 +132,9 @@ export const DocumentFeedbackTable = ({
                           refresh();
                         } else {
                           toast.error(
-                            `Error updating hidden status - ${getErrorMsg(
-                              response
-                            )}`
+                            t("feedback.updateHiddenFailed.toast", {
+                              detail: await getErrorMsg(response),
+                            })
                           );
                         }
                       }}

--- a/web/src/app/admin/documents/feedback/page.tsx
+++ b/web/src/app/admin/documents/feedback/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { LoadingAnimation } from "@/components/Loading";
 import { useMostReactedToDocuments } from "@/lib/hooks";
 import { DocumentFeedbackTable } from "./DocumentFeedbackTable";
@@ -11,6 +12,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 const route = ADMIN_ROUTES.DOCUMENT_FEEDBACK;
 
 function Main() {
+  const t = useTranslations("admin.documents");
   const {
     data: mostLikedDocuments,
     isLoading: isMostLikedDocumentsLoading,
@@ -31,7 +33,7 @@ function Main() {
   };
 
   if (isMostLikedDocumentsLoading || isMostLikedDocumentLoading) {
-    return <LoadingAnimation text="Loading" />;
+    return <LoadingAnimation text={t("feedback.loading.label")} />;
   }
 
   if (
@@ -42,18 +44,19 @@ function Main() {
   ) {
     return (
       <div className="text-red-600">
-        Error loading documents -{" "}
-        {mostDislikedDocumentsError || mostLikedDocumentsError}
+        {t("feedback.loadError.message", {
+          detail: String(mostDislikedDocumentsError || mostLikedDocumentsError),
+        })}
       </div>
     );
   }
 
   return (
     <div>
-      <Title className="mb-2">Most Liked Documents</Title>
+      <Title className="mb-2">{t("feedback.mostLiked.title")}</Title>
       <DocumentFeedbackTable documents={mostLikedDocuments} refresh={refresh} />
 
-      <Title className="mb-2 mt-6">Most Disliked Documents</Title>
+      <Title className="mb-2 mt-6">{t("feedback.mostDisliked.title")}</Title>
       <DocumentFeedbackTable
         documents={mostDislikedDocuments}
         refresh={refresh}

--- a/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
+++ b/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Form, Formik } from "formik";
+import { useTranslations } from "next-intl";
 import { mutate } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import * as Yup from "yup";
@@ -40,6 +41,7 @@ export const DocumentSetCreationForm = ({
   onClose,
   existingDocumentSet,
 }: SetCreationPopupProps) => {
+  const t = useTranslations("admin.documents");
   const businessTier = useTierAtLeast(Tier.BUSINESS);
   const isUpdate = existingDocumentSet !== undefined;
   const [localCcPairs, setLocalCcPairs] = useState(ccPairs);
@@ -76,7 +78,7 @@ export const DocumentSetCreationForm = ({
         }}
         validationSchema={Yup.object()
           .shape({
-            name: Yup.string().required("Please enter a name for the set"),
+            name: Yup.string().required(t("sets.form.name.required")),
             description: Yup.string().optional(),
             cc_pair_ids: Yup.array().of(Yup.number().required()),
             federated_connectors: Yup.array().of(
@@ -88,7 +90,7 @@ export const DocumentSetCreationForm = ({
           })
           .test(
             "at-least-one-connector",
-            "Please select at least one connector (regular or federated)",
+            t("sets.form.connectors.required"),
             function (values) {
               const hasRegularConnectors =
                 values.cc_pair_ids && values.cc_pair_ids.length > 0;
@@ -120,8 +122,8 @@ export const DocumentSetCreationForm = ({
           if (response.ok) {
             toast.success(
               isUpdate
-                ? "Successfully updated document set!"
-                : "Successfully created document set!"
+                ? t("sets.form.updated.toast")
+                : t("sets.form.created.toast")
             );
             await Promise.all([
               mutate(SWR_KEYS.documentSets),
@@ -132,8 +134,8 @@ export const DocumentSetCreationForm = ({
             const errorMsg = await response.text();
             toast.error(
               isUpdate
-                ? `Error updating document set - ${errorMsg}`
-                : `Error creating document set - ${errorMsg}`
+                ? t("sets.form.updateFailed.toast", { detail: errorMsg })
+                : t("sets.form.createFailed.toast", { detail: errorMsg })
             );
           }
         }}
@@ -178,13 +180,13 @@ export const DocumentSetCreationForm = ({
               <div className="space-y-4 w-full">
                 <TextFormField
                   name="name"
-                  label="Name:"
-                  placeholder="A name for the document set"
+                  label={t("sets.form.name.label")}
+                  placeholder={t("sets.form.name.placeholder")}
                 />
                 <TextFormField
                   name="description"
-                  label="Description:"
-                  placeholder="Describe what the document set represents"
+                  label={t("sets.form.description.label")}
+                  placeholder={t("sets.form.description.placeholder")}
                   optional={true}
                 />
 
@@ -204,39 +206,37 @@ export const DocumentSetCreationForm = ({
                   <>
                     <ConnectorMultiSelect
                       name="cc_pair_ids"
-                      label={`Connectors available to ${
-                        props.values.groups.length > 1
-                          ? "the selected groups"
-                          : "the selected group"
-                      }`}
+                      label={t("sets.form.scopedConnectors.label", {
+                        count: props.values.groups.length,
+                      })}
                       connectors={visibleCcPairs}
                       selectedIds={props.values.cc_pair_ids}
                       onChange={(selectedIds) => {
                         props.setFieldValue("cc_pair_ids", selectedIds);
                       }}
-                      placeholder="Search for connectors..."
+                      placeholder={t("sets.form.connectors.placeholder")}
                     />
 
                     <NonSelectableConnectors
                       connectors={nonVisibleCcPairs}
-                      title={`Connectors not available to the ${
-                        props.values.groups.length > 1
-                          ? "groups you have selected"
-                          : "group you have selected"
-                      }`}
-                      description="Only connectors that are directly assigned to the group you are trying to add the document set to will be available."
+                      title={t("sets.form.unavailableConnectors.title", {
+                        count: props.values.groups.length,
+                      })}
+                      description={t(
+                        "sets.form.unavailableConnectors.description"
+                      )}
                     />
                   </>
                 ) : (
                   <ConnectorMultiSelect
                     name="cc_pair_ids"
-                    label="Pick your connectors"
+                    label={t("sets.form.connectors.label")}
                     connectors={visibleCcPairs}
                     selectedIds={props.values.cc_pair_ids}
                     onChange={(selectedIds) => {
                       props.setFieldValue("cc_pair_ids", selectedIds);
                     }}
-                    placeholder="Search for connectors..."
+                    placeholder={t("sets.form.connectors.placeholder")}
                   />
                 )}
 
@@ -246,7 +246,7 @@ export const DocumentSetCreationForm = ({
                     <div className="my-4 border-t border-border-02" />
                     <FederatedConnectorSelector
                       name="federated_connectors"
-                      label="Federated Connectors"
+                      label={t("sets.form.federatedConnectors.label")}
                       federatedConnectors={federatedConnectors}
                       selectedConfigs={props.values.federated_connectors}
                       onChange={(selectedConfigs) => {
@@ -255,7 +255,9 @@ export const DocumentSetCreationForm = ({
                           selectedConfigs
                         );
                       }}
-                      placeholder="Search for federated connectors..."
+                      placeholder={t(
+                        "sets.form.federatedConnectors.placeholder"
+                      )}
                     />
                   </>
                 )}
@@ -268,7 +270,9 @@ export const DocumentSetCreationForm = ({
                     disabled={props.isSubmitting}
                     width="full"
                   >
-                    {isUpdate ? "Update Document Set" : "Create Document Set"}
+                    {isUpdate
+                      ? t("sets.form.submitButton.updateLabel")
+                      : t("sets.form.submitButton.createLabel")}
                   </Button>
                 </div>
               </div>

--- a/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
+++ b/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { use } from "react";
+import { useTranslations } from "next-intl";
 
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { refreshDocumentSets, useDocumentSets } from "../hooks";
@@ -15,6 +16,7 @@ import { useSettings } from "@/lib/settings/hooks";
 const route = ADMIN_ROUTES.DOCUMENT_SETS;
 
 function Main({ documentSetId }: { documentSetId: number }) {
+  const t = useTranslations("admin.documents");
   const router = useRouter();
   const { vectorDbEnabled } = useSettings();
 
@@ -41,7 +43,7 @@ function Main({ documentSetId }: { documentSetId: number }) {
   if (documentSetsError || !documentSets) {
     return (
       <ErrorCallout
-        errorTitle="Failed to fetch document sets"
+        errorTitle={t("sets.fetchSetsFailed.title")}
         errorMsg={documentSetsError}
       />
     );
@@ -50,7 +52,7 @@ function Main({ documentSetId }: { documentSetId: number }) {
   if (vectorDbEnabled && (ccPairsError || !ccPairs)) {
     return (
       <ErrorCallout
-        errorTitle="Failed to fetch Connectors"
+        errorTitle={t("sets.fetchConnectorsFailed.title")}
         errorMsg={ccPairsError}
       />
     );
@@ -62,8 +64,8 @@ function Main({ documentSetId }: { documentSetId: number }) {
   if (!documentSet) {
     return (
       <ErrorCallout
-        errorTitle="Document set not found"
-        errorMsg={`Document set with id ${documentSetId} not found`}
+        errorTitle={t("sets.notFound.title")}
+        errorMsg={t("sets.notFound.message", { id: String(documentSetId) })}
       />
     );
   }
@@ -85,6 +87,7 @@ function Main({ documentSetId }: { documentSetId: number }) {
 export default function Page(props: {
   params: Promise<{ documentSetId: string }>;
 }) {
+  const t = useTranslations("admin.documents");
   const params = use(props.params);
   const documentSetId = parseInt(params.documentSetId);
 
@@ -92,7 +95,7 @@ export default function Page(props: {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title="Edit Document Set"
+        title={t("sets.edit.header.title")}
         divider
         backButton
       />

--- a/web/src/app/admin/documents/sets/new/page.tsx
+++ b/web/src/app/admin/documents/sets/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { DocumentSetCreationForm } from "../DocumentSetCreationForm";
@@ -14,6 +15,7 @@ import { useSettings } from "@/lib/settings/hooks";
 const route = ADMIN_ROUTES.DOCUMENT_SETS;
 
 function Main() {
+  const t = useTranslations("admin.documents");
   const router = useRouter();
   const { vectorDbEnabled } = useSettings();
 
@@ -34,7 +36,7 @@ function Main() {
   if (vectorDbEnabled && (ccPairsError || !ccPairs)) {
     return (
       <ErrorCallout
-        errorTitle="Failed to fetch Connectors"
+        errorTitle={t("sets.fetchConnectorsFailed.title")}
         errorMsg={ccPairsError}
       />
     );
@@ -56,11 +58,13 @@ function Main() {
 }
 
 export default function Page() {
+  const t = useTranslations("admin.documents");
+
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title="New Document Set"
+        title={t("sets.new.header.title")}
         divider
         backButton
       />

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { PageLoader } from "@opal/layouts";
 import { PageSelector } from "@/components/PageSelector";
 import { SvgInfo, SvgPlusCircle } from "@opal/icons";
@@ -51,6 +52,7 @@ const FederatedConnectorTitle = ({
   showMetadata?: boolean;
   isLink?: boolean;
 }) => {
+  const t = useTranslations("admin.documents");
   const sourceType = federatedConnector.source.replace(/^federated_/, "");
 
   const mainSectionClassName = "text-blue-500 dark:text-blue-100 flex w-fit";
@@ -61,7 +63,7 @@ const FederatedConnectorTitle = ({
         {federatedConnector.name}
       </div>
       <Badge variant="outline" className="text-xs ml-2">
-        Federated
+        {t("sets.federatedBadge.label")}
       </Badge>
     </>
   );
@@ -105,6 +107,7 @@ const EditRow = ({
   documentSet: DocumentSetSummary;
   isEditable: boolean;
 }) => {
+  const t = useTranslations("admin.documents");
   const router = useRouter();
 
   if (!isEditable) {
@@ -120,7 +123,7 @@ const EditRow = ({
       <Tooltip
         tooltip={
           !documentSet.is_up_to_date
-            ? "Cannot update while syncing! Wait for the sync to finish, then try again."
+            ? t("sets.editRow.syncing.tooltip")
             : undefined
         }
       >
@@ -156,6 +159,7 @@ const DocumentSetTable = ({
   documentSets,
   refresh,
 }: DocumentFeedbackTableProps) => {
+  const t = useTranslations("admin.documents");
   const [page, setPage] = useState(1);
 
   // editable rows first, then by name — editability now rides on each row's
@@ -167,15 +171,15 @@ const DocumentSetTable = ({
 
   return (
     <div>
-      <Title>Existing Document Sets</Title>
+      <Title>{t("sets.table.title")}</Title>
       <Table className="overflow-visible mt-2">
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Connectors</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Public</TableHead>
-            <TableHead>Delete</TableHead>
+            <TableHead>{t("sets.table.name.header")}</TableHead>
+            <TableHead>{t("sets.table.connectors.header")}</TableHead>
+            <TableHead>{t("sets.table.status.header")}</TableHead>
+            <TableHead>{t("sets.table.public.header")}</TableHead>
+            <TableHead>{t("sets.table.delete.header")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -213,7 +217,8 @@ const DocumentSetTable = ({
                                   iconSize={16}
                                 />
                                 <div className="ml-1 my-auto text-xs font-medium truncate">
-                                  {ccPairSummary.name || "Unnamed"}
+                                  {ccPairSummary.name ||
+                                    t("sets.connector.unnamed.label")}
                                 </div>
                               </div>
                             </div>
@@ -258,18 +263,18 @@ const DocumentSetTable = ({
                   <TableCell>
                     {documentSet.is_up_to_date ? (
                       <Badge variant="success" icon={FiCheckCircle}>
-                        Up to Date
+                        {t("sets.status.upToDate.label")}
                       </Badge>
                     ) : documentSet.cc_pair_summaries.length > 0 ||
                       (documentSet.federated_connector_summaries &&
                         documentSet.federated_connector_summaries.length >
                           0) ? (
                       <Badge variant="in_progress" icon={FiClock}>
-                        Syncing
+                        {t("sets.status.syncing.label")}
                       </Badge>
                     ) : (
                       <Badge variant="destructive" icon={FiAlertTriangle}>
-                        Deleting
+                        {t("sets.status.deleting.label")}
                       </Badge>
                     )}
                   </TableCell>
@@ -279,14 +284,14 @@ const DocumentSetTable = ({
                         variant={isEditable ? "success" : "default"}
                         icon={FiUnlock}
                       >
-                        Public
+                        {t("sets.access.public.label")}
                       </Badge>
                     ) : (
                       <Badge
                         variant={isEditable ? "private" : "default"}
                         icon={FiLock}
                       >
-                        Private
+                        {t("sets.access.private.label")}
                       </Badge>
                     )}
                   </TableCell>
@@ -299,12 +304,14 @@ const DocumentSetTable = ({
                           );
                           if (response.ok) {
                             toast.success(
-                              `Document set "${documentSet.name}" scheduled for deletion`
+                              t("sets.deleteScheduled.toast", {
+                                name: documentSet.name,
+                              })
                             );
                           } else {
                             const errorMsg = (await response.json()).detail;
                             toast.error(
-                              `Failed to schedule document set for deletion - ${errorMsg}`
+                              t("sets.deleteFailed.toast", { detail: errorMsg })
                             );
                           }
                           refresh();
@@ -334,6 +341,7 @@ const DocumentSetTable = ({
 };
 
 function Main() {
+  const t = useTranslations("admin.documents");
   const {
     data: documentSets,
     isLoading: isDocumentSetsLoading,
@@ -350,16 +358,16 @@ function Main() {
   }
 
   if (documentSetsError || !documentSets) {
-    return <div>Error: {documentSetsError}</div>;
+    return (
+      <div>
+        {t("sets.loadError.message", { detail: String(documentSetsError) })}
+      </div>
+    );
   }
 
   return (
     <div className="mb-8">
-      <Text as="p">
-        {markdown(
-          "**Document Sets** allow you to group logically connected documents into a single bundle. These can then be used as a filter when performing searches to control the scope of information Onyx searches over."
-        )}
-      </Text>
+      <Text as="p">{markdown(t("sets.description"))}</Text>
       <Spacer rem={0.75} />
 
       <div className="mb-3"></div>
@@ -370,7 +378,7 @@ function Main() {
           prominence="secondary"
           href="/admin/documents/sets/new"
         >
-          New Document Set
+          {t("sets.newButton.label")}
         </Button>
       </div>
 

--- a/web/src/app/admin/federated/[id]/page.tsx
+++ b/web/src/app/admin/federated/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { notFound } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { useFederatedConnector } from "./useFederatedConnector";
@@ -9,6 +10,7 @@ import { FederatedConnectorForm } from "@/components/admin/federated/FederatedCo
 export default function EditFederatedConnectorPage(props: {
   params: Promise<{ id: string }>;
 }) {
+  const t = useTranslations("admin.federated");
   const [params, setParams] = useState<{ id: string } | null>(null);
 
   useEffect(() => {
@@ -26,10 +28,10 @@ export default function EditFederatedConnectorPage(props: {
             <Loader2 className="h-8 w-8 animate-spin text-blue-500 mb-4" />
             <div className="text-center">
               <p className="text-lg font-medium text-gray-700 mb-2">
-                Loading connector configuration...
+                {t("loading.title")}
               </p>
               <p className="text-sm text-gray-500">
-                Retrieving connector details and credential schema
+                {t("loading.description")}
               </p>
             </div>
           </div>
@@ -43,7 +45,9 @@ export default function EditFederatedConnectorPage(props: {
       <div className="flex justify-center w-full h-full">
         <div className="mt-12 w-full max-w-4xl mx-auto">
           <div className="text-center">
-            <h1 className="text-2xl font-bold text-red-600 mb-4">Error</h1>
+            <h1 className="text-2xl font-bold text-red-600 mb-4">
+              {t("error.title")}
+            </h1>
             <p className="text-gray-600">{error}</p>
           </div>
         </div>

--- a/web/src/app/admin/federated/[id]/useFederatedConnector.ts
+++ b/web/src/app/admin/federated/[id]/useFederatedConnector.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import {
   ConfigurableSources,
   FederatedConnectorDetail,
@@ -16,6 +17,7 @@ interface UseFederatedConnectorResult {
 export function useFederatedConnector(
   connectorId: string
 ): UseFederatedConnectorResult {
+  const t = useTranslations("admin.federated");
   const [sourceType, setSourceType] = useState<ConfigurableSources | null>(
     null
   );
@@ -73,7 +75,7 @@ export function useFederatedConnector(
         setCredentialSchema(schemaData);
       } catch (error) {
         console.error("Error fetching federated connector data:", error);
-        setError(`Failed to load connector: ${error}`);
+        setError(t("error.loadFailed", { details: String(error) }));
       } finally {
         setIsLoading(false);
       }
@@ -82,7 +84,7 @@ export function useFederatedConnector(
     if (connectorId) {
       fetchData();
     }
-  }, [connectorId]);
+  }, [connectorId, t]);
 
   return {
     sourceType,

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableRow,
@@ -76,6 +77,7 @@ function SummaryRow({
   isOpen: boolean;
   onToggle: () => void;
 }) {
+  const t = useTranslations("admin.indexing");
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
   return (
@@ -99,14 +101,14 @@ function SummaryRow({
 
       <TableCell>
         <div className="text-sm text-neutral-500 dark:text-neutral-300">
-          Total Connectors
+          {t("status.summary.totalConnectors.label")}
         </div>
         <div className="text-xl font-semibold">{summary.total_connectors}</div>
       </TableCell>
 
       <TableCell>
         <div className="text-sm text-neutral-500 dark:text-neutral-300">
-          Active Connectors
+          {t("status.summary.activeConnectors.label")}
         </div>
         <p className="flex text-xl mx-auto font-semibold items-center text-lg mt-1">
           {summary.active_connectors}/{summary.total_connectors}
@@ -116,7 +118,7 @@ function SummaryRow({
       {businessTier && (
         <TableCell>
           <div className="text-sm text-neutral-500 dark:text-neutral-300">
-            Public Connectors
+            {t("status.summary.publicConnectors.label")}
           </div>
           <p className="flex text-xl mx-auto font-semibold items-center text-lg mt-1">
             {summary.public_connectors}/{summary.total_connectors}
@@ -126,7 +128,7 @@ function SummaryRow({
 
       <TableCell>
         <div className="text-sm text-neutral-500 dark:text-neutral-300">
-          Total Docs Indexed
+          {t("status.summary.totalDocsIndexed.label")}
         </div>
         <div className="text-xl font-semibold">
           {summary.total_docs_indexed.toLocaleString()}
@@ -147,6 +149,7 @@ function ConnectorRow({
   invisible?: boolean;
   isEditable: boolean;
 }) {
+  const t = useTranslations("admin.indexing");
   const router = useRouter();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
@@ -190,19 +193,21 @@ function ConnectorRow({
         <TableCell>
           {ccPairsIndexingStatus.access_type === "public" ? (
             <Badge variant={isEditable ? "success" : "default"} icon={FiUnlock}>
-              Organization Public
+              {t("status.access.organizationPublic.label")}
             </Badge>
           ) : ccPairsIndexingStatus.access_type === "sync" ? (
             <Badge
               variant={isEditable ? "auto-sync" : "default"}
               icon={FiRefreshCw}
             >
-              Inherited from{" "}
-              {getSourceDisplayName(ccPairsIndexingStatus.source)}
+              {t("status.access.inherited.label", {
+                source:
+                  getSourceDisplayName(ccPairsIndexingStatus.source) ?? "",
+              })}
             </Badge>
           ) : (
             <Badge variant={isEditable ? "private" : "default"} icon={FiLock}>
-              Private
+              {t("status.access.private.label")}
             </Badge>
           )}
         </TableCell>
@@ -210,7 +215,7 @@ function ConnectorRow({
       <TableCell>{ccPairsIndexingStatus.docs_indexed}</TableCell>
       <TableCell>
         {isEditable && (
-          <Tooltip tooltip="Manage Connector">
+          <Tooltip tooltip={t("status.manageConnector.tooltip")}>
             <Button icon={SvgSettings} prominence="tertiary" />
           </Tooltip>
         )}
@@ -226,6 +231,7 @@ function FederatedConnectorRow({
   federatedConnector: FederatedConnectorStatus;
   invisible?: boolean;
 }) {
+  const t = useTranslations("admin.indexing");
   const router = useRouter();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
@@ -249,18 +255,18 @@ function FederatedConnectorRow({
       <TableCell className="">
         <Truncated>{federatedConnector.name}</Truncated>
       </TableCell>
-      <TableCell>N/A</TableCell>
+      <TableCell>{t("status.federated.notApplicable.label")}</TableCell>
       <TableCell>
-        <Badge variant="success">Indexed</Badge>
+        <Badge variant="success">{t("status.federated.indexed.label")}</Badge>
       </TableCell>
       {businessTier && (
         <TableCell>
           <Badge variant="secondary" icon={FiRefreshCw}>
-            Federated Access
+            {t("status.federated.access.label")}
           </Badge>
         </TableCell>
       )}
-      <TableCell>N/A</TableCell>
+      <TableCell>{t("status.federated.notApplicable.label")}</TableCell>
       <TableCell>
         <Button
           icon={SvgSettings}
@@ -269,7 +275,7 @@ function FederatedConnectorRow({
             e.stopPropagation();
             navigateWithModifier(e, federatedUrl, router);
           }}
-          tooltip="Manage Federated Connector"
+          tooltip={t("status.manageFederatedConnector.tooltip")}
         />
       </TableCell>
     </TableRow>
@@ -289,6 +295,7 @@ export function CCPairIndexingStatusTable({
   onPageChange: (source: ValidSources, newPage: number) => void;
   sourceLoadingStates?: Record<ValidSources, boolean>;
 }) {
+  const t = useTranslations("admin.indexing");
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
   return (
@@ -340,13 +347,19 @@ export function CCPairIndexingStatusTable({
                 {!sourceLoadingStates[ccPairStatus.source] && (
                   <>
                     <TableRow className="border border-border dark:border-neutral-700">
-                      <TableHead>Name</TableHead>
-                      <TableHead>Last Indexed</TableHead>
-                      <TableHead>Status</TableHead>
+                      <TableHead>{t("status.table.name.header")}</TableHead>
+                      <TableHead>
+                        {t("status.table.lastIndexed.header")}
+                      </TableHead>
+                      <TableHead>{t("status.table.status.header")}</TableHead>
                       {businessTier && (
-                        <TableHead>Permissions / Access</TableHead>
+                        <TableHead>
+                          {t("status.table.permissions.header")}
+                        </TableHead>
                       )}
-                      <TableHead>Total Docs</TableHead>
+                      <TableHead>
+                        {t("status.table.totalDocs.header")}
+                      </TableHead>
                       <TableHead></TableHead>
                     </TableRow>
                     {ccPairStatus.indexing_statuses.map((indexingStatus) => {
@@ -413,7 +426,7 @@ export function CCPairIndexingStatusTable({
                                 className="h-[56px] text-center text-sm text-gray-400 dark:text-gray-500 border-b border-r border-l border-border dark:border-neutral-700"
                               >
                                 <span className="italic">
-                                  All caught up! No more connectors to show
+                                  {t("status.table.allCaughtUp.label")}
                                 </span>
                               </TableCell>
                             ) : (

--- a/web/src/app/admin/indexing/status/FilterComponent.tsx
+++ b/web/src/app/admin/indexing/status/FilterComponent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useImperativeHandle, forwardRef } from "react";
+import { useTranslations } from "next-intl";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,6 +33,7 @@ export const FilterComponent = forwardRef<
   { resetFilters: () => void },
   FilterComponentProps
 >(({ onFilterChange }, ref) => {
+  const t = useTranslations("admin.indexing");
   const [isOpen, setIsOpen] = useState(false);
   const [filters, setFilters] = useState<FilterOptions>({
     accessType: null,
@@ -140,14 +142,14 @@ export const FilterComponent = forwardRef<
         >
           <div className="flex items-center justify-between px-2 py-1.5">
             <DropdownMenuLabel className="text-base font-medium">
-              Filter Connectors
+              {t("status.filterMenu.title")}
             </DropdownMenuLabel>
           </div>
           <DropdownMenuSeparator />
 
           <DropdownMenuGroup>
             <DropdownMenuLabel className="px-2 py-1.5 text-xs text-muted-foreground">
-              Access Type
+              {t("status.filterMenu.accessType.title")}
             </DropdownMenuLabel>
             <div role="presentation" onClick={(e) => e.stopPropagation()}>
               <DropdownMenuCheckboxItem
@@ -156,7 +158,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Public
+                {t("status.filterMenu.accessType.public.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedAccessTypes.includes("private")}
@@ -164,7 +166,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Private
+                {t("status.filterMenu.accessType.private.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedAccessTypes.includes("sync")}
@@ -172,7 +174,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Auto-Sync
+                {t("status.filterMenu.accessType.autoSync.label")}
               </DropdownMenuCheckboxItem>
             </div>
           </DropdownMenuGroup>
@@ -181,7 +183,7 @@ export const FilterComponent = forwardRef<
 
           <DropdownMenuGroup>
             <DropdownMenuLabel className="px-2 py-1.5 text-xs text-muted-foreground">
-              Last Status
+              {t("status.filterMenu.lastStatus.title")}
             </DropdownMenuLabel>
             <div role="presentation" onClick={(e) => e.stopPropagation()}>
               <DropdownMenuCheckboxItem
@@ -190,7 +192,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Success
+                {t("status.filterMenu.lastStatus.success.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("failed")}
@@ -198,7 +200,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Failed
+                {t("status.filterMenu.lastStatus.failed.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("interrupted")}
@@ -206,7 +208,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Interrupted
+                {t("status.filterMenu.lastStatus.interrupted.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("in_progress")}
@@ -214,7 +216,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                In Progress
+                {t("status.filterMenu.lastStatus.inProgress.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("not_started")}
@@ -222,7 +224,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Not Started
+                {t("status.filterMenu.lastStatus.notStarted.label")}
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("completed_with_errors")}
@@ -232,7 +234,7 @@ export const FilterComponent = forwardRef<
                 className="flex items-center justify-between"
                 onSelect={(e) => e.preventDefault()}
               >
-                Completed with Errors
+                {t("status.filterMenu.lastStatus.completedWithErrors.label")}
               </DropdownMenuCheckboxItem>
             </div>
           </DropdownMenuGroup>
@@ -241,7 +243,7 @@ export const FilterComponent = forwardRef<
 
           <DropdownMenuGroup>
             <DropdownMenuLabel className="px-2 py-1.5 text-xs text-muted-foreground">
-              Document Count
+              {t("status.filterMenu.docCount.title")}
             </DropdownMenuLabel>
             <div
               role="presentation"
@@ -285,7 +287,7 @@ export const FilterComponent = forwardRef<
               </div>
               <Input
                 type="number"
-                placeholder="Count"
+                placeholder={t("status.filterMenu.docCount.placeholder")}
                 value={docsValue}
                 onChange={(e) => setDocsValue(e.target.value)}
                 className="h-8 w-full"
@@ -302,7 +304,7 @@ export const FilterComponent = forwardRef<
                 }}
                 type="button"
               >
-                Apply
+                {t("status.filterMenu.applyButton.label")}
               </Button>
             </div>
           </DropdownMenuGroup>

--- a/web/src/app/admin/indexing/status/SearchAndFilterControls.tsx
+++ b/web/src/app/admin/indexing/status/SearchAndFilterControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { Badge } from "@/components/ui/badge";
 import { FilterComponent, FilterOptions } from "./FilterComponent";
@@ -33,6 +34,7 @@ export function SearchAndFilterControls({
   filterComponentRef,
   resetPagination,
 }: SearchAndFilterControlsProps) {
+  const t = useTranslations("admin.indexing");
   const [localSearchValue, setLocalSearchValue] = useState(searchQuery);
 
   // Debounce the search query
@@ -53,14 +55,16 @@ export function SearchAndFilterControls({
   return (
     <div className="flex items-center gap-x-2">
       <InputTypeIn
-        placeholder="Search Connectors"
+        placeholder={t("status.search.placeholder")}
         type="text"
         value={localSearchValue}
         onChange={(event) => setLocalSearchValue(event.target.value)}
       />
 
       <Button onClick={hasExpandedSources ? onCollapseAll : onExpandAll}>
-        {hasExpandedSources ? "Collapse All" : "Expand All"}
+        {hasExpandedSources
+          ? t("status.toggleAll.collapse.label")
+          : t("status.toggleAll.expand.label")}
       </Button>
 
       <div className="flex items-center gap-2">
@@ -74,32 +78,39 @@ export function SearchAndFilterControls({
             {filterOptions.accessType &&
               filterOptions.accessType.length > 0 && (
                 <Badge variant="secondary" className="px-2 py-0.5 text-xs">
-                  Access: {filterOptions.accessType.join(", ")}
+                  {t("status.filters.accessBadge.label", {
+                    values: filterOptions.accessType.join(", "),
+                  })}
                 </Badge>
               )}
 
             {filterOptions.lastStatus &&
               filterOptions.lastStatus.length > 0 && (
                 <Badge variant="secondary" className="px-2 py-0.5 text-xs">
-                  Status:{" "}
-                  {filterOptions.lastStatus
-                    .map((s) => s.replace(/_/g, " "))
-                    .join(", ")}
+                  {t("status.filters.statusBadge.label", {
+                    values: filterOptions.lastStatus
+                      .map((s) => s.replace(/_/g, " "))
+                      .join(", "),
+                  })}
                 </Badge>
               )}
 
             {filterOptions.docsCountFilter.operator &&
               filterOptions.docsCountFilter.value !== null && (
                 <Badge variant="secondary" className="px-2 py-0.5 text-xs">
-                  Docs {filterOptions.docsCountFilter.operator}{" "}
-                  {filterOptions.docsCountFilter.value}
+                  {t("status.filters.docsBadge.label", {
+                    operator: filterOptions.docsCountFilter.operator,
+                    value: String(filterOptions.docsCountFilter.value),
+                  })}
                 </Badge>
               )}
 
             {filterOptions.docsCountFilter.operator &&
               filterOptions.docsCountFilter.value === null && (
                 <Badge variant="secondary" className="px-2 py-0.5 text-xs">
-                  Docs {filterOptions.docsCountFilter.operator} any
+                  {t("status.filters.docsAnyBadge.label", {
+                    operator: filterOptions.docsCountFilter.operator,
+                  })}
                 </Badge>
               )}
 
@@ -108,7 +119,9 @@ export function SearchAndFilterControls({
               className="px-2 py-0.5 text-xs border-red-400  bg-red-100 hover:border-red-600 cursor-pointer hover:bg-red-100 dark:hover:bg-red-900"
               onClick={onClearFilters}
             >
-              <span className="text-red-500 dark:text-red-400">Clear</span>
+              <span className="text-red-500 dark:text-red-400">
+                {t("status.filters.clearBadge.label")}
+              </span>
             </Badge>
           </div>
         )}

--- a/web/src/app/admin/indexing/status/page.tsx
+++ b/web/src/app/admin/indexing/status/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { CCPairIndexingStatusTable } from "./CCPairIndexingStatusTable";
 import { SearchAndFilterControls } from "./SearchAndFilterControls";
 import { SettingsLayouts, useToastFromQuery } from "@opal/layouts";
@@ -22,6 +23,7 @@ import { IndexingStatusRequest } from "@/lib/types";
 const route = ADMIN_ROUTES.INDEXING_STATUS;
 
 function Main() {
+  const t = useTranslations("admin.indexing");
   const { vectorDbEnabled } = useSettings();
 
   // State for filter management
@@ -156,7 +158,7 @@ function Main() {
     return (
       <div className="text-error">
         {ccPairsIndexingStatusesError?.info?.detail ||
-          "Error loading indexing status."}
+          t("status.loadError.message")}
       </div>
     );
   }
@@ -188,11 +190,7 @@ function Main() {
       ) : !ccPairsIndexingStatuses || ccPairsIndexingStatuses.length === 0 ? (
         <div>
           <Spacer rem={3} />
-          <Text as="p">
-            {markdown(
-              "It looks like you don't have any connectors setup yet. Visit the [Add Connector](/admin/add-connector) page to get started!"
-            )}
-          </Text>
+          <Text as="p">{markdown(t("status.empty.message"))}</Text>
         </div>
       ) : (
         <CCPairIndexingStatusTable
@@ -208,9 +206,11 @@ function Main() {
 }
 
 export default function Status() {
+  const t = useTranslations("admin.indexing");
+
   useToastFromQuery({
     "connector-created": {
-      message: "Connector created successfully",
+      message: t("status.connectorCreated.toast"),
       type: "success",
     },
   });
@@ -221,7 +221,9 @@ export default function Status() {
         icon={route.icon}
         title={route.title}
         rightChildren={
-          <Button href="/admin/add-connector">Add Connector</Button>
+          <Button href="/admin/add-connector">
+            {t("status.addConnectorButton.label")}
+          </Button>
         }
         divider
       />

--- a/web/src/app/admin/mcp-actions/page.tsx
+++ b/web/src/app/admin/mcp-actions/page.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 import MCPPageContent from "@/sections/actions/MCPPageContent";
+import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
 const route = ADMIN_ROUTES.MCP_ACTIONS;
 
 export default function Main() {
+  const t = useTranslations("admin.mcpActions");
+
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
         title={route.title}
-        description="Connect MCP (Model Context Protocol) servers to add custom actions and tools for your agents."
+        description={t("header.description")}
         divider
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/oauth-test/page.tsx
+++ b/web/src/app/admin/oauth-test/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { PageLoader } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SettingsLayouts } from "@opal/layouts";
@@ -56,6 +57,7 @@ function ClaimsTable({
   subtitle: string;
   claims: Record<string, unknown>;
 }) {
+  const t = useTranslations("admin.oauthTest");
   const entries = Object.entries(claims);
   return (
     <div className="flex flex-col gap-2">
@@ -65,14 +67,16 @@ function ClaimsTable({
       </Text>
       {entries.length === 0 ? (
         <Text font="main-ui-body" color="text-03">
-          No claims received.
+          {t("claims.empty.message")}
         </Text>
       ) : (
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-64">Claim</TableHead>
-              <TableHead>Value</TableHead>
+              <TableHead className="w-64">
+                {t("claims.table.claim.header")}
+              </TableHead>
+              <TableHead>{t("claims.table.value.header")}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -94,6 +98,7 @@ function ClaimsTable({
 }
 
 function Main() {
+  const t = useTranslations("admin.oauthTest");
   const {
     data: snapshot,
     error,
@@ -110,7 +115,7 @@ function Main() {
   if (error || !snapshot) {
     return (
       <ErrorCallout
-        errorTitle="Failed to load OAuth claims"
+        errorTitle={t("loadFailed.title")}
         errorMsg={error?.info?.detail || String(error)}
       />
     );
@@ -120,64 +125,70 @@ function Main() {
     <div className="flex flex-col gap-6 pb-8">
       <div className="flex flex-col gap-2">
         <Text font="main-ui-body" color="text-03">
-          Shows the raw fields your identity provider sent about you during your
-          last OAuth/OIDC login: the id_token claims and the userinfo endpoint
-          response. Use it to verify which attributes the IdP is configured to
-          release. Claims are captured at every login.
+          {t("intro.description")}
         </Text>
         <div>
           <Button onClick={() => (window.location.href = RERUN_URL)}>
-            Re-run OAuth login
+            {t("rerun.label")}
           </Button>
         </div>
       </div>
 
       {!snapshot.found ? (
         <ErrorCallout
-          errorTitle="No captured claims yet"
-          errorMsg={`No OAuth login snapshot found for ${snapshot.email}. Log in through the identity provider (button above) and reload this page.`}
+          errorTitle={t("noSnapshot.title")}
+          errorMsg={t("noSnapshot.description", { email: snapshot.email })}
         />
       ) : (
         <>
           <div className="flex flex-col gap-1">
             <Text font="main-ui-body" color="text-03">
-              {`User: ${snapshot.email}`}
+              {t("snapshot.user.label", { email: snapshot.email })}
             </Text>
             <Text font="main-ui-body" color="text-03">
-              {`Provider: ${snapshot.oauth_name ?? "-"}`}
+              {t("snapshot.provider.label", {
+                provider: snapshot.oauth_name ?? "-",
+              })}
             </Text>
             <Text font="main-ui-body" color="text-03">
-              {`Captured at: ${snapshot.captured_at ?? "-"}`}
+              {t("snapshot.capturedAt.label", {
+                timestamp: snapshot.captured_at ?? "-",
+              })}
             </Text>
             <Text font="main-ui-body" color="text-03">
-              {`Token response fields: ${formatClaimValue(
-                snapshot.token_meta?.keys ?? []
-              )}`}
+              {t("snapshot.tokenFields.label", {
+                fields: formatClaimValue(snapshot.token_meta?.keys ?? []),
+              })}
             </Text>
           </div>
 
           <ClaimsTable
-            title="id_token claims"
-            subtitle="Decoded from the id_token JWT returned by the token endpoint."
+            title={t("idToken.title")}
+            subtitle={t("idToken.subtitle")}
             claims={snapshot.id_token_claims ?? {}}
           />
           <ClaimsTable
-            title="userinfo claims"
-            subtitle="Response of the OIDC userinfo endpoint for your access token."
+            title={t("userinfo.title")}
+            subtitle={t("userinfo.subtitle")}
             claims={snapshot.userinfo ?? {}}
           />
           {snapshot.directory_profile && (
             <ClaimsTable
-              title={`Directory profile (${snapshot.directory_source ?? "provider API"})`}
-              subtitle="Directory fields fetched from the provider API — e.g. Microsoft Graph /me for Entra ID, which carries country/usageLocation that the id_token omits unless the ctry optional claim is configured."
+              title={t("directory.title", {
+                source:
+                  snapshot.directory_source ?? t("directory.fallbackSource"),
+              })}
+              subtitle={t("directory.subtitle")}
               claims={snapshot.directory_profile}
             />
           )}
           {snapshot.resolved_profile &&
             Object.keys(snapshot.resolved_profile).length > 0 && (
               <ClaimsTable
-                title="Resolved profile (used for prompts)"
-                subtitle="The claim-mapped directory profile that actually feeds the Organization Profile prompt block and {{user.*}} placeholders."
+                title={t("resolved.title")}
+                subtitle={t("resolved.subtitle", {
+                  placeholder: "{{user.*}}",
+                })}
                 claims={snapshot.resolved_profile}
               />
             )}

--- a/web/src/app/admin/openapi-actions/page.tsx
+++ b/web/src/app/admin/openapi-actions/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import OpenApiPageContent from "@/sections/actions/OpenApiPageContent";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -7,12 +8,14 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 const route = ADMIN_ROUTES.OPENAPI_ACTIONS;
 
 export default function Main() {
+  const t = useTranslations("admin.openapiActions");
+
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
         title={route.title}
-        description="Connect OpenAPI servers to add custom actions and tools for your agents."
+        description={t("header.description")}
         divider
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { SvgDownload, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { Interactive, Hoverable } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
@@ -24,19 +25,6 @@ interface ScimModalProps {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function copyToClipboard(text: string) {
-  try {
-    await navigator.clipboard.writeText(text);
-    toast.success("Token copied to clipboard");
-  } catch {
-    toast.error("Failed to copy token");
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -46,14 +34,24 @@ export default function ScimModal({
   onRegenerate,
   onClose,
 }: ScimModalProps) {
+  const t = useTranslations("admin.scim");
   const focusOnMount = useFocusOnMount<HTMLElement>();
+
+  async function copyToClipboard(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(t("modal.copied.message"));
+    } catch {
+      toast.error(t("modal.copyFailed.error"));
+    }
+  }
 
   switch (view.kind) {
     case "regenerate":
       return (
         <ConfirmationModalLayout
           icon={SvgRefreshCw}
-          title="Regenerate SCIM Token"
+          title={t("modal.regenerate.title")}
           onClose={onClose}
           submit={
             <Button
@@ -61,15 +59,13 @@ export default function ScimModal({
               variant="danger"
               onClick={onRegenerate}
             >
-              Regenerate Token
+              {t("modal.regenerate.submit.label")}
             </Button>
           }
         >
           <Section alignItems="start" gap={2}>
             <Text as="p" text03>
-              Your current SCIM token will be revoked and a new token will be
-              generated. You will need to update the token on your identity
-              provider before SCIM provisioning will resume.
+              {t("modal.regenerate.description")}
             </Text>
           </Section>
         </ConfirmationModalLayout>
@@ -81,8 +77,8 @@ export default function ScimModal({
           <Modal.Content width="sm">
             <Modal.Header
               icon={SvgKey}
-              title="SCIM Token"
-              description="Save this key before continuing. It won't be shown again."
+              title={t("modal.token.title")}
+              description={t("modal.token.description")}
               onClose={onClose}
             />
             <Modal.Body>
@@ -127,7 +123,7 @@ export default function ScimModal({
                       })
                     }
                   >
-                    Download
+                    {t("modal.token.download.label")}
                   </Button>
                 }
                 submit={
@@ -135,7 +131,7 @@ export default function ScimModal({
                     ref={focusOnMount}
                     onClick={() => copyToClipboard(view.rawToken)}
                   >
-                    Copy Token
+                    {t("modal.token.copy.label")}
                   </Button>
                 }
               />

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { SvgCheckCircle, SvgClock, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
@@ -32,12 +33,14 @@ export default function ScimSyncCard({
   onGenerate,
   onRegenerate,
 }: ScimSyncCardProps) {
+  const t = useTranslations("admin.scim");
+
   return (
     <Card border="solid" rounding={4}>
       <Section alignItems="start" height="fit" gap={3}>
         <ContentAction
-          title="SCIM Sync"
-          description="Connect your identity provider to import and sync users and groups."
+          title={t("card.title")}
+          description={t("card.description")}
           sizePreset="main-ui"
           variant="section"
           padding={0}
@@ -49,7 +52,7 @@ export default function ScimSyncCard({
                 onClick={onRegenerate}
                 icon={SvgRefreshCw}
               >
-                Regenerate Token
+                {t("card.regenerate.label")}
               </Button>
             ) : (
               <Button
@@ -57,7 +60,7 @@ export default function ScimSyncCard({
                 rightIcon={SvgKey}
                 onClick={onGenerate}
               >
-                Generate SCIM Token
+                {t("card.generate.label")}
               </Button>
             )
           }
@@ -83,7 +86,9 @@ export default function ScimSyncCard({
                   <SvgClock size={15} className="text-theme-amber-05" />
                 )}
                 <Text as="p" mainUiBody text04>
-                  {isConnected ? "Connected" : "Waiting for Connection"}
+                  {isConnected
+                    ? t("card.connected.label")
+                    : t("card.waiting.label")}
                 </Text>
               </Section>
 
@@ -106,8 +111,7 @@ export default function ScimSyncCard({
                     text03
                     className="max-w-[240px] text-right"
                   >
-                    Provide the SCIM key to your identity provider to begin
-                    syncing users and groups.
+                    {t("card.waiting.description")}
                   </Text>
                 )}
               </Section>

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 
 import { SvgUserSync } from "@opal/icons";
 import { useScimToken } from "@/hooks/useScimToken";
@@ -19,6 +20,7 @@ import ScimModal from "./ScimModal";
 // ---------------------------------------------------------------------------
 
 function ScimContent() {
+  const t = useTranslations("admin.scim");
   const { data: token, error: tokenError, isLoading, mutate } = useScimToken();
 
   const modal = useCreateModal();
@@ -36,7 +38,7 @@ function ScimContent() {
   if (tokenError) {
     return (
       <Text as="p" text03>
-        Failed to load SCIM token status.
+        {t("loadFailed.error")}
       </Text>
     );
   }
@@ -67,15 +69,15 @@ function ScimContent() {
         } catch {
           detail = await response.text();
         }
-        toast.error(`Failed to generate token: ${detail}`);
+        toast.error(t("toasts.generateFailed", { detail }));
         return;
       }
       const created: ScimTokenCreatedResponse = await response.json();
       await mutate();
       openModal({ kind: "token", rawToken: created.raw_token });
-      if (hasToken) toast.success("Token regenerated");
+      if (hasToken) toast.success(t("toasts.regenerated"));
     } catch {
-      toast.error("Something went wrong. Please try again.");
+      toast.error(t("toasts.genericError"));
     } finally {
       setIsSubmitting(false);
     }
@@ -116,12 +118,14 @@ function ScimContent() {
 // ---------------------------------------------------------------------------
 
 export default function Page() {
+  const t = useTranslations("admin.scim");
+
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgUserSync}
-        title="SCIM"
-        description="Sync users and groups via System for Cross-domain Identity Management (SCIM) protocol."
+        title={t("header.title")}
+        description={t("header.description")}
         divider
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/systeminfo/page.tsx
+++ b/web/src/app/admin/systeminfo/page.tsx
@@ -1,7 +1,9 @@
+import { getTranslations } from "next-intl/server";
 import { getWebVersion, getBackendVersion } from "@/lib/version";
 import { SvgBook } from "@opal/icons";
 
 const Page = async () => {
+  const t = await getTranslations("admin.systemInfo");
   let web_version: string | null = null;
   let backend_version: string | null = null;
   try {
@@ -17,18 +19,18 @@ const Page = async () => {
     <div>
       <div className="border-solid border-background-600 border-b pb-2 mb-4 flex">
         <SvgBook size={32} />
-        <h1 className="text-3xl font-bold pl-2">Version</h1>
+        <h1 className="text-3xl font-bold pl-2">{t("version.title")}</h1>
       </div>
 
       <div>
         <div className="flex mb-2">
-          <p className="my-auto mr-1">Backend Version: </p>
+          <p className="my-auto mr-1">{t("backendVersion.label")}</p>
           <p className="text-base my-auto text-slate-400 italic">
             {backend_version}
           </p>
         </div>
         <div className="flex mb-2">
-          <p className="my-auto mr-1">Web Version: </p>
+          <p className="my-auto mr-1">{t("webVersion.label")}</p>
           <p className="text-base my-auto text-slate-400 italic">
             {web_version}
           </p>

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "@opal/components";
 import React, { useRef } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { Form, Formik, useField, useFormikContext } from "formik";
 import { Scope } from "./types";
 import {
@@ -44,18 +45,6 @@ interface ScopeOptionConfig {
   value: Scope;
   icon: IconFunctionComponent;
   title: string;
-}
-
-const SCOPE_OPTIONS: ScopeOptionConfig[] = [
-  { value: Scope.GLOBAL, icon: SvgGlobe, title: "Workspace" },
-  { value: Scope.USER, icon: SvgUser, title: "Per user" },
-  { value: Scope.USER_GROUP, icon: SvgUsers, title: "User group" },
-];
-
-function scopeSubject(scope: Scope, groupName?: string): string {
-  if (scope === Scope.GLOBAL) return "Everyone in the workspace";
-  if (scope === Scope.USER) return "Each user";
-  return groupName ? `Members of ${groupName}` : "Members of the chosen group";
 }
 
 function handleRadioOptionKeyDown(
@@ -170,6 +159,8 @@ function GroupMenuContent({
   selectedGroupId,
   onSelectGroup,
 }: GroupMenuContentProps) {
+  const t = useTranslations("admin.tokenRateLimits");
+
   return (
     <Popover.Content align="start" side="bottom" width="lg">
       <Popover.Menu>
@@ -177,7 +168,7 @@ function GroupMenuContent({
           ? [
               <div className="p-2" key="empty">
                 <Text font="secondary-body" color="text-03" as="p">
-                  No user groups yet. Create one under Users &amp; Groups.
+                  {t("modal.groupMenu.empty")}
                 </Text>
               </div>,
             ]
@@ -227,14 +218,14 @@ function GroupScopeOption({
 }
 
 function TokenBudgetField() {
+  const t = useTranslations("admin.tokenRateLimits");
+  const locale = useLocale();
   const [field, meta, helpers] = useField<string>("token_budget");
   const inputRef = useRef<HTMLInputElement>(null);
   const digits = String(field.value ?? "")
     .replace(/\D/g, "")
     .slice(0, 15);
-  const formattedValue = digits
-    ? new Intl.NumberFormat("en-US").format(Number(digits))
-    : "";
+  const formattedValue = digits ? formatTokenCount(Number(digits), locale) : "";
 
   return (
     <InputTypeIn
@@ -245,7 +236,7 @@ function TokenBudgetField() {
       inputMode="numeric"
       pattern="[0-9,]*"
       maxLength={19}
-      placeholder="No token limit"
+      placeholder={t("modal.tokenBudget.placeholder")}
       onChange={(event) => {
         const input = event.target;
         const cursorPosition = input.selectionStart ?? input.value.length;
@@ -257,7 +248,7 @@ function TokenBudgetField() {
         void helpers.setValue(nextDigits);
 
         const nextFormatted = nextDigits
-          ? new Intl.NumberFormat("en-US").format(Number(nextDigits))
+          ? formatTokenCount(Number(nextDigits), locale)
           : "";
         let seenDigits = 0;
         let nextCursorPosition = nextFormatted.length;
@@ -280,7 +271,7 @@ function TokenBudgetField() {
       rightChildren={
         <div className="pr-1">
           <Text font="secondary-action" color="text-03" nowrap>
-            tokens
+            {t("modal.tokenBudget.unit")}
           </Text>
         </div>
       }
@@ -288,16 +279,11 @@ function TokenBudgetField() {
   );
 }
 
-function formatDollarBudgetInput(raw: string): string | null {
+/** Reads a budget field, ignoring blank, malformed, and non-positive input. */
+function parseBudgetInput(raw: string): number | null {
   const amount = Number(raw);
   if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
-  return formatCurrency(amount);
-}
-
-function formatTokenBudgetInput(raw: string): string | null {
-  const amount = Number(raw);
-  if (raw === "" || !Number.isFinite(amount) || amount <= 0) return null;
-  return `${formatTokenCount(amount)} tokens`;
+  return amount;
 }
 
 interface GroupPickerProps {
@@ -311,13 +297,14 @@ function GroupPicker({
   selectedGroupId,
   onSelectGroup,
 }: GroupPickerProps) {
+  const t = useTranslations("admin.tokenRateLimits");
   const selectedGroup = groups.find((group) => group.value === selectedGroupId);
 
   return (
     <Popover>
       <Popover.Trigger asChild>
         <Button prominence="secondary" width="full">
-          {selectedGroup?.name ?? "Choose a group"}
+          {selectedGroup?.name ?? t("modal.groupPicker.placeholder")}
         </Button>
       </Popover.Trigger>
       <GroupMenuContent
@@ -334,27 +321,38 @@ interface LimitSummaryProps {
 }
 
 function LimitSummary({ groupName }: LimitSummaryProps) {
+  const t = useTranslations("admin.tokenRateLimits");
+  const locale = useLocale();
   const { values } = useFormikContext<RateLimitFormValues>();
 
   const period = Number(values.period_days);
   if (!Number.isInteger(period) || period < 1) return null;
 
-  const budgets = [
-    formatDollarBudgetInput(values.cost_budget_dollars),
-    formatTokenBudgetInput(values.token_budget),
-  ].filter((budget): budget is string => budget !== null);
-  if (budgets.length === 0) return null;
+  const costAmount = parseBudgetInput(values.cost_budget_dollars);
+  const tokenAmount = parseBudgetInput(values.token_budget);
+  const cost = costAmount === null ? null : formatCurrency(costAmount, locale);
+  const tokens =
+    tokenAmount === null ? null : formatTokenCount(tokenAmount, locale);
 
-  const budgetText = budgets.join(" or ");
-  const periodText = period === 1 ? "every day" : `every ${period} days`;
+  let budget: string;
+  if (cost !== null && tokens !== null) {
+    budget = t("modal.summary.budget.both", { cost, tokens });
+  } else if (cost !== null) {
+    budget = cost;
+  } else if (tokens !== null) {
+    budget = t("modal.summary.budget.tokens", { tokens });
+  } else {
+    return null;
+  }
 
-  const subject = scopeSubject(values.target_scope, groupName);
-  const subjectText =
-    values.target_scope === Scope.USER
-      ? `${subject} can spend`
-      : `${subject} share${values.target_scope === Scope.GLOBAL ? "s" : ""}`;
-
-  const summary = `${subjectText} up to ${budgetText} ${periodText}. Usage is blocked until the period resets.`;
+  const summary =
+    values.target_scope === Scope.GLOBAL
+      ? t("modal.summary.global", { days: period, budget })
+      : values.target_scope === Scope.USER
+        ? t("modal.summary.user", { days: period, budget })
+        : groupName
+          ? t("modal.summary.group", { days: period, budget, group: groupName })
+          : t("modal.summary.groupUnchosen", { days: period, budget });
 
   return (
     <div className="rounded-08 bg-background-tint-01 p-2">
@@ -386,17 +384,36 @@ export default function CreateRateLimitModal({
   forSpecificScope,
   forSpecificUserGroup,
 }: CreateRateLimitModalProps) {
+  const t = useTranslations("admin.tokenRateLimits");
   const { data: shareableGroupsData } = useShareableGroups();
   const modalUserGroups = (shareableGroupsData ?? []).map((userGroup) => ({
     name: userGroup.name,
     value: userGroup.id,
   }));
 
+  const scopeOptions: ScopeOptionConfig[] = [
+    {
+      value: Scope.GLOBAL,
+      icon: SvgGlobe,
+      title: t("modal.scopeOptions.global.title"),
+    },
+    {
+      value: Scope.USER,
+      icon: SvgUser,
+      title: t("modal.scopeOptions.user.title"),
+    },
+    {
+      value: Scope.USER_GROUP,
+      icon: SvgUsers,
+      title: t("modal.scopeOptions.userGroup.title"),
+    },
+  ];
+
   return (
     <Modal open={isOpen} onOpenChange={setIsOpen}>
       <Modal.Content width="sm" height="fit">
         <Modal.Header
-          title="Create spending limit"
+          title={t("modal.header.title")}
           onClose={() => setIsOpen(false)}
         />
         <Formik<RateLimitFormValues>
@@ -410,30 +427,28 @@ export default function CreateRateLimitModal({
           }}
           validationSchema={Yup.object().shape({
             period_days: Yup.number()
-              .required("Enter a reset period")
-              .integer("Enter a whole number of days")
-              .min(1, "Use at least 1 day"),
+              .required(t("modal.errors.periodRequired"))
+              .integer(t("modal.errors.periodInteger"))
+              .min(1, t("modal.errors.periodMin")),
             cost_budget_dollars: Yup.number()
               .transform((value, original) =>
                 original === "" ? undefined : value
               )
-              .moreThan(0, "Cost budget must be greater than 0")
+              .moreThan(0, t("modal.errors.costMoreThanZero"))
               .max(
                 MAX_COST_BUDGET_DOLLARS,
-                `The maximum cost budget is $${new Intl.NumberFormat("en-US").format(MAX_COST_BUDGET_DOLLARS)}`
+                t("modal.errors.costMax", { amount: MAX_COST_BUDGET_DOLLARS })
               )
               .test(
                 "minimum-cents",
-                "Cost budget must be at least $0.01",
+                t("modal.errors.costMinCents"),
                 (value) => value == null || Math.round(value * 100) > 0
               )
               .when("token_budget", {
                 is: (value: string | undefined) =>
                   value === undefined || value === "",
                 then: (schema) =>
-                  schema.required(
-                    "Enter a cost budget, a token budget, or both"
-                  ),
+                  schema.required(t("modal.errors.budgetRequired")),
                 otherwise: (schema) => schema.notRequired(),
               }),
             token_budget: Yup.number()
@@ -441,20 +456,20 @@ export default function CreateRateLimitModal({
                 original === "" ? undefined : value
               )
               .notRequired()
-              .integer("Enter a whole number of tokens")
-              .min(1_000, "Use at least 1,000 tokens")
-              .max(MAX_TOKEN_BUDGET, "The maximum token budget is 1 trillion")
+              .integer(t("modal.errors.tokenInteger"))
+              .min(1_000, t("modal.errors.tokenMin"))
+              .max(MAX_TOKEN_BUDGET, t("modal.errors.tokenMax"))
               .test(
                 "whole-thousands",
-                "Use increments of 1,000 tokens",
+                t("modal.errors.tokenIncrement"),
                 (value) => value == null || value % 1_000 === 0
               ),
             target_scope: Yup.string().required(
-              "Target Scope is a required field"
+              t("modal.errors.scopeRequired")
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
-              "Select a user group",
+              t("modal.errors.groupRequired"),
               (value, context) => {
                 return (
                   context.parent.target_scope !== "user_group" ||
@@ -488,16 +503,16 @@ export default function CreateRateLimitModal({
             const selectedGroupName = modalUserGroups.find(
               (group) => group.value === values.user_group_id
             )?.name;
-            const scopeSubjectLabel = scopeSubject(
-              values.target_scope,
-              selectedGroupName
-            );
             const scopeCaption =
-              values.target_scope === Scope.USER
-                ? `${scopeSubjectLabel} gets their own budget.`
-                : `${scopeSubjectLabel} share${
-                    values.target_scope === Scope.GLOBAL ? "s" : ""
-                  } one budget.`;
+              values.target_scope === Scope.GLOBAL
+                ? t("modal.scope.caption.global")
+                : values.target_scope === Scope.USER
+                  ? t("modal.scope.caption.user")
+                  : selectedGroupName
+                    ? t("modal.scope.caption.group", {
+                        group: selectedGroupName,
+                      })
+                    : t("modal.scope.caption.groupUnchosen");
 
             return (
               <Form className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -505,15 +520,15 @@ export default function CreateRateLimitModal({
                   <Section alignItems="stretch" height="auto" gap={4}>
                     {!forSpecificScope && (
                       <InputVertical
-                        title="Applies to"
+                        title={t("modal.scope.title")}
                         subDescription={scopeCaption}
                       >
                         <div
                           role="radiogroup"
-                          aria-label="Applies to"
+                          aria-label={t("modal.scope.title")}
                           className="grid w-full grid-cols-3 gap-1"
                         >
-                          {SCOPE_OPTIONS.map((option) =>
+                          {scopeOptions.map((option) =>
                             option.value === Scope.USER_GROUP &&
                             forSpecificUserGroup === undefined ? (
                               <GroupScopeOption
@@ -558,8 +573,8 @@ export default function CreateRateLimitModal({
                     {forSpecificScope === Scope.USER_GROUP &&
                       forSpecificUserGroup === undefined && (
                         <InputVertical
-                          title="User group"
-                          description="Choose which group shares this budget"
+                          title={t("modal.userGroup.title")}
+                          description={t("modal.userGroup.description")}
                         >
                           <GroupPicker
                             groups={modalUserGroups}
@@ -578,14 +593,14 @@ export default function CreateRateLimitModal({
 
                     <InputVertical
                       withLabel="cost_budget_dollars"
-                      title="Cost budget"
-                      description="Maximum spend per reset period. Set a cost budget, a token budget, or both."
+                      title={t("modal.costBudget.title")}
+                      description={t("modal.costBudget.description")}
                     >
                       <InputTypeInField
                         name="cost_budget_dollars"
                         inputMode="decimal"
                         prefixText="$"
-                        placeholder="No cost limit"
+                        placeholder={t("modal.costBudget.placeholder")}
                         rightChildren={
                           <div className="pr-1">
                             <Text
@@ -593,7 +608,7 @@ export default function CreateRateLimitModal({
                               color="text-03"
                               nowrap
                             >
-                              USD
+                              {t("modal.costBudget.unit")}
                             </Text>
                           </div>
                         }
@@ -602,16 +617,16 @@ export default function CreateRateLimitModal({
 
                     <InputVertical
                       withLabel="token_budget"
-                      title="Token budget"
-                      description="Maximum tokens per reset period"
+                      title={t("modal.tokenBudget.title")}
+                      description={t("modal.tokenBudget.description")}
                     >
                       <TokenBudgetField />
                     </InputVertical>
 
                     <InputVertical
                       withLabel="period_days"
-                      title="Reset period"
-                      description="Budgets reset at midnight UTC"
+                      title={t("modal.period.title")}
+                      description={t("modal.period.description")}
                     >
                       <InputTypeInField
                         name="period_days"
@@ -624,7 +639,7 @@ export default function CreateRateLimitModal({
                               color="text-03"
                               nowrap
                             >
-                              days
+                              {t("modal.period.unit")}
                             </Text>
                           </div>
                         }
@@ -641,10 +656,10 @@ export default function CreateRateLimitModal({
                     type="button"
                     onClick={() => setIsOpen(false)}
                   >
-                    Cancel
+                    {t("modal.cancel.label")}
                   </Button>
                   <Button disabled={isSubmitting} type="submit">
-                    Create limit
+                    {t("modal.submit.label")}
                   </Button>
                 </Modal.Footer>
               </Form>

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocale, useTranslations } from "next-intl";
 import { deleteTokenRateLimit, updateTokenRateLimit } from "./lib";
 import { ContentAction, PageLoader, Section, toast } from "@opal/layouts";
 import { TokenRateLimitDisplay } from "./types";
@@ -10,26 +11,6 @@ import { SvgTrash, SvgUsers, SvgWallet } from "@opal/icons";
 import { formatCurrencyFromCents, formatTokenCount } from "@/lib/format";
 
 const HOURS_PER_DAY = 24;
-const UPDATE_ERROR_MESSAGE = "Failed to update token rate limit";
-const DELETE_ERROR_MESSAGE = "Failed to delete token rate limit";
-
-function formatBudget(limit: TokenRateLimitDisplay): string {
-  const parts: string[] = [];
-  if (limit.cost_budget_cents != null) {
-    parts.push(formatCurrencyFromCents(limit.cost_budget_cents));
-  }
-  if (limit.token_budget != null) {
-    parts.push(`${formatTokenCount(limit.token_budget * 1000)} tokens`);
-  }
-  if (parts.length === 0) return "No budget set";
-  return `Up to ${parts.join(" or ")}`;
-}
-
-function formatCadence(limit: TokenRateLimitDisplay): string {
-  const days = limit.period_hours / HOURS_PER_DAY;
-  const period = days === 1 ? "every day" : `every ${days} days`;
-  return `Resets ${period} at midnight UTC`;
-}
 
 interface LimitRowProps {
   limit: TokenRateLimitDisplay;
@@ -39,7 +20,30 @@ interface LimitRowProps {
 }
 
 function LimitRow({ limit, isAdmin, onToggle, onDelete }: LimitRowProps) {
-  const limitLabel = `${formatBudget(limit)}, ${formatCadence(limit)}`;
+  const t = useTranslations("admin.tokenRateLimits");
+  const locale = useLocale();
+
+  const cost =
+    limit.cost_budget_cents != null
+      ? formatCurrencyFromCents(limit.cost_budget_cents, locale)
+      : null;
+  const tokens =
+    limit.token_budget != null
+      ? formatTokenCount(limit.token_budget * 1000, locale)
+      : null;
+
+  const budget =
+    cost !== null && tokens !== null
+      ? t("limits.budget.both", { cost, tokens })
+      : cost !== null
+        ? t("limits.budget.cost", { cost })
+        : tokens !== null
+          ? t("limits.budget.tokens", { tokens })
+          : t("limits.budget.none");
+  const cadence = t("limits.cadence.label", {
+    days: limit.period_hours / HOURS_PER_DAY,
+  });
+  const limitLabel = t("limits.row.label", { budget, cadence });
 
   return (
     <div className="rounded-12 border border-border-01 bg-background-neutral-00">
@@ -47,8 +51,8 @@ function LimitRow({ limit, isAdmin, onToggle, onDelete }: LimitRowProps) {
         sizePreset="main-ui"
         variant="section"
         icon={limit.group_name !== undefined ? SvgUsers : SvgWallet}
-        title={formatBudget(limit)}
-        description={formatCadence(limit)}
+        title={budget}
+        description={cadence}
         tag={
           limit.group_name !== undefined
             ? { title: limit.group_name }
@@ -63,7 +67,9 @@ function LimitRow({ limit, isAdmin, onToggle, onDelete }: LimitRowProps) {
               disabled={!isAdmin}
               onCheckedChange={() => onToggle(limit.token_id)}
               aria-label={
-                limit.enabled ? `Disable ${limitLabel}` : `Enable ${limitLabel}`
+                limit.enabled
+                  ? t("limits.row.disable.ariaLabel", { label: limitLabel })
+                  : t("limits.row.enable.ariaLabel", { label: limitLabel })
               }
             />
             {isAdmin && (
@@ -72,8 +78,10 @@ function LimitRow({ limit, isAdmin, onToggle, onDelete }: LimitRowProps) {
                 prominence="tertiary"
                 icon={SvgTrash}
                 size="sm"
-                tooltip="Delete limit"
-                aria-label={`Delete ${limitLabel}`}
+                tooltip={t("limits.row.delete.tooltip")}
+                aria-label={t("limits.row.delete.ariaLabel", {
+                  label: limitLabel,
+                })}
                 onClick={() => onDelete(limit.token_id)}
               />
             )}
@@ -99,6 +107,8 @@ export const TokenRateLimitTable = ({
   hideHeading,
   isAdmin,
 }: TokenRateLimitTableArgs) => {
+  const t = useTranslations("admin.tokenRateLimits");
+
   const handleEnabledChange = async (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
       (tokenRateLimit) => tokenRateLimit.token_id === id
@@ -118,7 +128,7 @@ export const TokenRateLimitTable = ({
       await mutate(fetchUrl);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : UPDATE_ERROR_MESSAGE
+        error instanceof Error ? error.message : t("limits.updateFailed.error")
       );
     }
   };
@@ -129,7 +139,7 @@ export const TokenRateLimitTable = ({
       await mutate(fetchUrl);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : DELETE_ERROR_MESSAGE
+        error instanceof Error ? error.message : t("limits.deleteFailed.error")
       );
     }
   };
@@ -144,7 +154,7 @@ export const TokenRateLimitTable = ({
       {tokenRateLimits.length === 0 ? (
         <div className="rounded-12 border border-dashed border-border-02 p-4">
           <Text font="secondary-body" color="text-03" as="p">
-            No limits yet. Create a spending limit to cap usage.
+            {t("limits.empty.message")}
           </Text>
         </div>
       ) : (
@@ -175,6 +185,7 @@ export const GenericTokenRateLimitTable = ({
   responseMapper?: (data: any) => TokenRateLimitDisplay[];
   isAdmin?: boolean;
 }) => {
+  const t = useTranslations("admin.tokenRateLimits");
   const { data, isLoading, error } = useSWR<TokenRateLimitDisplay[]>(
     fetchUrl,
     errorHandlingFetcher
@@ -185,7 +196,7 @@ export const GenericTokenRateLimitTable = ({
   }
 
   if (!isLoading && error) {
-    return <Text as="p">Failed to load token rate limits</Text>;
+    return <Text as="p">{t("limits.loadFailed.error")}</Text>;
   }
 
   let processedData = data;

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import SimpleTabs from "@/refresh-components/SimpleTabs";
+import { useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { toast } from "@opal/layouts";
 import { useState } from "react";
@@ -22,14 +23,6 @@ import CreateRateLimitModal from "./CreateRateLimitModal";
 const GLOBAL_TOKEN_FETCH_URL = SWR_KEYS.globalTokenRateLimits;
 const USER_TOKEN_FETCH_URL = SWR_KEYS.userTokenRateLimits;
 const USER_GROUP_FETCH_URL = SWR_KEYS.userGroupTokenRateLimits;
-
-const GLOBAL_DESCRIPTION =
-  "Global limits apply to all users, user groups, and API keys. When the global limit is reached, no more tokens can be spent.";
-const USER_DESCRIPTION =
-  "User limits apply to each user individually. When a user reaches a limit, they are temporarily blocked from spending tokens.";
-const USER_GROUP_DESCRIPTION =
-  "Group limits apply to all users in a group. If a user belongs to multiple groups, the most permissive limit applies.";
-const CREATE_ERROR_MESSAGE = "Failed to create spending limit";
 
 async function createTokenRateLimit(
   targetScope: Scope,
@@ -63,6 +56,7 @@ interface TokenRateLimitsPanelProps {
 export default function TokenRateLimitsPanel({
   embedded = false,
 }: TokenRateLimitsPanelProps) {
+  const t = useTranslations("admin.tokenRateLimits");
   const [tabIndex, setTabIndex] = useState(0);
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
@@ -96,12 +90,12 @@ export default function TokenRateLimitsPanel({
         groupId
       );
       setModalIsOpen(false);
-      toast.success("Spending limit created!");
+      toast.success(t("panel.created.message"));
       updateTable(targetScope);
     } catch (error) {
       console.error("Failed to create spending limit:", error);
       toast.error(
-        error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
+        error instanceof Error ? error.message : t("panel.createFailed.error")
       );
     }
   }
@@ -110,40 +104,30 @@ export default function TokenRateLimitsPanel({
     <Section alignItems="stretch" justifyContent="start" height="auto">
       {embedded ? (
         <Section gap={1} alignItems="start" justifyContent="start">
-          <Text font="heading-h3">Manage spending limits</Text>
+          <Text font="heading-h3">{t("panel.embedded.title")}</Text>
           <Text font="secondary-body" color="text-03">
-            Set guardrails for workspace, user, and group usage. Limits can be
-            enabled or disabled without deleting their configuration.
+            {t("panel.embedded.description")}
           </Text>
         </Section>
       ) : (
         <>
-          <Text as="p">
-            Spending limits help you control how many tokens can be spent in a
-            given time period.
-          </Text>
+          <Text as="p">{t("panel.intro.description")}</Text>
           <ul className="list-disc ml-4">
             <li>
-              <Text as="p">
-                Set a workspace-wide limit for your team&apos;s overall spend.
-              </Text>
+              <Text as="p">{t("panel.intro.workspaceLimit")}</Text>
             </li>
             {enterpriseTier && (
               <>
                 <li>
-                  <Text as="p">
-                    Set limits for users so no single user can spend too much.
-                  </Text>
+                  <Text as="p">{t("panel.intro.userLimit")}</Text>
                 </li>
                 <li>
-                  <Text as="p">
-                    Set limits for user groups to control spend for teams.
-                  </Text>
+                  <Text as="p">{t("panel.intro.groupLimit")}</Text>
                 </li>
               </>
             )}
             <li>
-              <Text as="p">Enable and disable limits as needed.</Text>
+              <Text as="p">{t("panel.intro.toggleLimit")}</Text>
             </li>
           </ul>
         </>
@@ -154,39 +138,39 @@ export default function TokenRateLimitsPanel({
         prominence="secondary"
         onClick={() => setModalIsOpen(true)}
       >
-        Create spending limit
+        {t("panel.create.label")}
       </Button>
 
       {enterpriseTier ? (
         <SimpleTabs
           tabs={{
             "0": {
-              name: "Global",
+              name: t("panel.tabs.global.name"),
               icon: SvgGlobe,
               content: (
                 <GenericTokenRateLimitTable
                   fetchUrl={GLOBAL_TOKEN_FETCH_URL}
-                  description={GLOBAL_DESCRIPTION}
+                  description={t("panel.global.description")}
                 />
               ),
             },
             "1": {
-              name: "Users",
+              name: t("panel.tabs.users.name"),
               icon: SvgUser,
               content: (
                 <GenericTokenRateLimitTable
                   fetchUrl={USER_TOKEN_FETCH_URL}
-                  description={USER_DESCRIPTION}
+                  description={t("panel.user.description")}
                 />
               ),
             },
             "2": {
-              name: "Groups",
+              name: t("panel.tabs.groups.name"),
               icon: SvgUsers,
               content: (
                 <GenericTokenRateLimitTable
                   fetchUrl={USER_GROUP_FETCH_URL}
-                  description={USER_GROUP_DESCRIPTION}
+                  description={t("panel.userGroup.description")}
                   responseMapper={(data: Record<string, TokenRateLimit[]>) =>
                     Object.entries(data).flatMap(([groupName, elements]) =>
                       elements.map((element) => ({
@@ -205,7 +189,7 @@ export default function TokenRateLimitsPanel({
       ) : (
         <GenericTokenRateLimitTable
           fetchUrl={GLOBAL_TOKEN_FETCH_URL}
-          description={GLOBAL_DESCRIPTION}
+          description={t("panel.global.description")}
         />
       )}
 

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -26,6 +26,46 @@
     }
   },
   "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "Code-Repository"
+        },
+        "messaging": {
+          "label": "Messaging"
+        },
+        "other": {
+          "label": "Sonstige"
+        },
+        "sales": {
+          "label": "Vertrieb"
+        },
+        "storage": {
+          "label": "Cloud-Speicher"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "Ticketing & Aufgabenverwaltung"
+        },
+        "wiki": {
+          "label": "Wissensbasis & Wikis"
+        }
+      },
+      "popular": {
+        "title": "Beliebt"
+      },
+      "search": {
+        "placeholder": "Konnektoren suchen"
+      },
+      "seeConnectorsButton": {
+        "label": "Konnektoren anzeigen"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>Föderierter Konnektor bereits konfiguriert.</strong> Klicken Sie, um den vorhandenen Konnektor zu bearbeiten.",
+          "slackCredentialsFound": "<strong>Vorhandene Slack-Anmeldedaten gefunden.</strong> Klicken Sie, um Ihren Slack-Konnektor zu verwalten."
+        }
+      }
+    },
     "agents": {
       "deleteModal": {
         "confirmation": {
@@ -298,6 +338,326 @@
           }
         },
         "title": "Nutzung"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "Ihre Lizenz wird verarbeitet. Nach der Bestätigung gelangen Sie automatisch zu den Abrechnungsdetails.",
+        "title": "Ihre Lizenz wird noch aktiviert"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "Die Online-Abrechnungsverwaltung ist deaktiviert. Wenden Sie sich an den Support, um Ihr Abonnement zu aktualisieren.",
+          "title": "Air-Gap-Bereitstellung"
+        },
+        "expired": {
+          "description": "Erneuern Sie Ihr Abonnement, um den Zugriff auf kostenpflichtige Funktionen wiederherzustellen.",
+          "title": "Ihr Abonnement ist abgelaufen.",
+          "withDate": {
+            "description": "Erneuern Sie Ihr Abonnement bis zum {date}, um den Zugriff wiederherzustellen."
+          },
+          "withDeletion": {
+            "title": "Ihr Abonnement ist abgelaufen. Die Daten werden in {days} Tagen gelöscht."
+          }
+        },
+        "expiring": {
+          "description": "Erneuern Sie Ihr Abonnement bis zum {date}, um Unterbrechungen zu vermeiden.",
+          "title": "Ihr Abonnement läuft in {days} Tagen ab."
+        },
+        "graceSync": {
+          "title": "Es wird nach einer erneuerten Lizenz gesucht…"
+        },
+        "stripeError": {
+          "description": "Prüfen Sie Ihre Internetverbindung oder geben Sie eine Lizenz manuell an.",
+          "title": "Die Verbindung zum Stripe-Zahlungsportal ist nicht möglich."
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "Tarif anpassen"
+        },
+        "annual": {
+          "label": "Jährlich"
+        },
+        "annualBadge": {
+          "label": "20 % sparen"
+        },
+        "billingCycle": {
+          "description": "nach Ihrer einmonatigen kostenlosen Testphase",
+          "title": "Abrechnungszeitraum"
+        },
+        "continueToPayment": {
+          "label": "Weiter zur Zahlung"
+        },
+        "createSessionFailed": {
+          "error": "Die Checkout-Sitzung konnte nicht erstellt werden"
+        },
+        "loading": {
+          "label": "Wird geladen..."
+        },
+        "monthly": {
+          "label": "Monatlich"
+        },
+        "perSeatMonth": {
+          "label": "pro Platz/Monat"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "{price} $"
+        },
+        "seats": {
+          "description": "{count, plural, one {Mindestens # Platz für Ihre aktuellen Benutzer und Slack-Konten erforderlich.} other {Mindestens # Plätze für Ihre aktuellen Benutzer und Slack-Konten erforderlich.}}",
+          "title": "Plätze"
+        },
+        "trialBilling": {
+          "text": "Ihnen wird am <value>{date}</value> in Rechnung gestellt, nachdem Ihre einmonatige kostenlose Testphase endet."
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "Lizenzschlüssel aktivieren"
+        },
+        "billingHelp": {
+          "label": "Hilfe zur Abrechnung"
+        },
+        "licenseKeyPrompt": {
+          "label": "Haben Sie einen Lizenzschlüssel?"
+        },
+        "updateLicenseKey": {
+          "label": "Lizenzschlüssel aktualisieren"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "Tarife & Abrechnung"
+        },
+        "upgradePlan": {
+          "title": "Tarif upgraden"
+        },
+        "viewPlans": {
+          "title": "Tarife anzeigen"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "Die Lizenz konnte nicht aktiviert werden"
+        },
+        "activateLicense": {
+          "label": "Lizenz aktivieren"
+        },
+        "activateSuccess": {
+          "message": "Lizenz erfolgreich aktiviert!"
+        },
+        "activateTitle": {
+          "title": "Lizenzschlüssel aktivieren"
+        },
+        "activating": {
+          "label": "Wird aktiviert..."
+        },
+        "activeUntil": {
+          "label": "Lizenzschlüssel aktiv bis <value>{date}</value>"
+        },
+        "cancel": {
+          "label": "Abbrechen"
+        },
+        "close": {
+          "label": "Schließen"
+        },
+        "description": "Fügen Sie manuell eine Lizenz für diese Onyx-Instanz hinzu und aktivieren Sie sie.",
+        "emptyKey": {
+          "error": "Bitte geben Sie einen Lizenzschlüssel ein"
+        },
+        "error": {
+          "text": "{error}. <link>Hilfe zur Abrechnung</link>"
+        },
+        "expired": {
+          "label": "Lizenzschlüssel abgelaufen"
+        },
+        "keyField": {
+          "description": "Fügen Sie Ihre von Onyx erhaltene Lizenzschlüsseldatei ein oder hängen Sie sie an.",
+          "title": "Lizenzschlüssel"
+        },
+        "updateKey": {
+          "label": "Schlüssel aktualisieren"
+        },
+        "updateLicense": {
+          "label": "Lizenz aktualisieren"
+        },
+        "updateSuccess": {
+          "message": "Lizenz erfolgreich aktualisiert!"
+        },
+        "updateTitle": {
+          "title": "Lizenzschlüssel aktualisieren"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "Zahlungsmethode",
+          "title": "Visa mit Endung 1234"
+        },
+        "lastPayment": {
+          "description": "Letzte Zahlung"
+        },
+        "section": {
+          "title": "Zahlung"
+        },
+        "update": {
+          "label": "Aktualisieren"
+        },
+        "viewInvoice": {
+          "label": "Rechnung anzeigen"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Business-Tarif wählen"
+          },
+          "description": "pro Platz/Monat bei jährlicher Abrechnung\noder 25 $ pro Platz bei monatlicher Abrechnung",
+          "features": {
+            "apiKeys": "API-Schlüssel für Dienstkonten",
+            "documentPermissions": "Dokumentberechtigungen übernehmen",
+            "encryption": "Verschlüsselung von Geheimnissen",
+            "queryHistory": "Abfrageverlauf und Nutzungs-Dashboard",
+            "rbac": "Rollenbasierte Zugriffskontrolle (RBAC)",
+            "selfHosting": "Self-Hosting (optional)",
+            "theming": "Individuelles Design"
+          },
+          "featuresPrefix": "Erledigen Sie mehr mit KI für Ihr Team.",
+          "pricing": "20 $",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "Tarifkarte {plan}"
+        },
+        "currentPlan": {
+          "label": "Ihr aktueller Tarif"
+        },
+        "enterprise": {
+          "button": {
+            "label": "Vertrieb kontaktieren"
+          },
+          "description": "Flexible Preis- & Bereitstellungsoptionen\nfür große Organisationen",
+          "features": {
+            "customDeployments": "Individuelle Bereitstellungen",
+            "customRoles": "Individuelle Rollen und Berechtigungen",
+            "hookExtensions": "Hook-Erweiterungen",
+            "regionalProcessing": "Regionsspezifische Datenverarbeitung",
+            "scim": "SCIM / Gruppensynchronisierung",
+            "support": "Enterprise-SLAs und Priority Support",
+            "usageLimits": "Konfigurierbare Nutzungslimits",
+            "whiteLabeling": "Vollständiges White-Labeling"
+          },
+          "featuresPrefix": "Alles aus dem Business-Tarif, zusätzlich:",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "In Ihrem Tarif enthalten"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "Sie können die Plätze nicht unter die aktuell genutzten/ausstehenden **{minimum}** Plätze senken. [Entfernen Sie zuerst Benutzer](/admin/users), bevor Sie die Plätze anpassen."
+        },
+        "billing": {
+          "added": "{count, plural, one {Der <value>{count}</value> zusätzliche Platz wird Ihnen anteilig in Rechnung gestellt.} other {Die <value>{count}</value> zusätzlichen Plätze werden Ihnen anteilig in Rechnung gestellt.}}",
+          "removed": "{count, plural, one {<value>{count}</value> Platz wird am <value>{date}</value> entfernt (nach dem aktuellen Abrechnungszeitraum).} other {<value>{count}</value> Plätze werden am <value>{date}</value> entfernt (nach dem aktuellen Abrechnungszeitraum).}}",
+          "unchanged": "Keine Änderungen an Ihrer Abrechnung."
+        },
+        "breakdown": {
+          "label": "{used} in Verwendung • {pending} ausstehend • {remaining} verbleibend"
+        },
+        "cancel": {
+          "label": "Abbrechen"
+        },
+        "confirmChange": {
+          "label": "Änderung bestätigen"
+        },
+        "delta": {
+          "added": "{count, plural, one {# Platz wird hinzugefügt} other {# Plätze werden hinzugefügt}}",
+          "removed": "{count, plural, one {# Platz wird entfernt} other {# Plätze werden entfernt}}"
+        },
+        "saving": {
+          "label": "Wird gespeichert..."
+        },
+        "seatsField": {
+          "title": "Plätze"
+        },
+        "total": {
+          "label": "{count} Plätze"
+        },
+        "updateFailed": {
+          "error": "Die Plätze konnten nicht aktualisiert werden"
+        },
+        "updateSeats": {
+          "description": "Fügen Sie Plätze hinzu oder entfernen Sie sie, um Ihre Teamgröße abzubilden.",
+          "label": "Plätze aktualisieren",
+          "title": "Plätze aktualisieren"
+        },
+        "viewUsers": {
+          "label": "Benutzer anzeigen"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Business-Tarif"
+        },
+        "connectToStripe": {
+          "label": "Mit Stripe verbinden"
+        },
+        "connecting": {
+          "label": "Wird verbunden..."
+        },
+        "enterprisePlan": {
+          "name": "Enterprise-Tarif"
+        },
+        "expired": {
+          "subtitle": "Abgelaufen am {date}"
+        },
+        "managePlan": {
+          "label": "Tarif verwalten"
+        },
+        "managedBySales": {
+          "text": "Ihr Tarif wird über den Vertrieb verwaltet.<br></br><link>Kontaktieren Sie die Abrechnung</link>, um Änderungen vorzunehmen."
+        },
+        "nextPayment": {
+          "subtitle": "Nächste Zahlung am {date}"
+        },
+        "syncLicense": {
+          "label": "Lizenz synchronisieren"
+        },
+        "syncing": {
+          "label": "Wird synchronisiert..."
+        },
+        "trialDays": {
+          "subtitle": "Die Testphase endet in {days} Tagen. Zahlung erforderlich am {date}"
+        },
+        "trialToday": {
+          "subtitle": "Die Testphase endet heute. Zahlung erforderlich am {date}"
+        },
+        "trialTomorrow": {
+          "subtitle": "Die Testphase endet morgen. Zahlung erforderlich am {date}"
+        },
+        "upgradeNow": {
+          "label": "Jetzt upgraden"
+        },
+        "upgrading": {
+          "label": "Upgrade läuft..."
+        },
+        "validUntil": {
+          "subtitle": "Gültig bis {date}"
+        },
+        "viewPlanDetails": {
+          "label": "Tarifdetails anzeigen"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "Die Testphase konnte nicht beendet werden",
+        "licenseSyncFailed": "Die Lizenzsynchronisierung ist fehlgeschlagen",
+        "paymentMethodRequired": "Fügen Sie zuerst eine Zahlungsmethode hinzu und versuchen Sie das Upgrade dann erneut.",
+        "syncLicenseFailed": "Die Lizenz konnte nicht synchronisiert werden"
       }
     },
     "chatPreferences": {
@@ -591,6 +951,847 @@
         }
       }
     },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# Tag} other {# Tage}}",
+          "hours": "{count, plural, one {# Stunde} other {# Stunden}}",
+          "minutes": "{count, plural, one {# Minute} other {# Minuten}}"
+        },
+        "indexingStart": {
+          "label": "Beginn der Indizierung"
+        },
+        "pruningFrequency": {
+          "label": "Bereinigungsintervall"
+        },
+        "refreshFrequency": {
+          "label": "Aktualisierungsintervall"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "Falsch",
+        "booleanTrue": "Wahr",
+        "edit": {
+          "tooltip": "Bearbeiten"
+        },
+        "showAll": {
+          "label": "Alle anzeigen ({count} Einträge)"
+        },
+        "showLess": {
+          "label": "Weniger anzeigen"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "Beim Löschen dieses Konnektors wird ein Löschauftrag geplant, der seine indizierten Dokumente entfernt und ihn für alle Benutzer löscht.",
+        "entityType": "Konnektor"
+      },
+      "deletionError": {
+        "description": "Dieser Fehler ist beim Versuch aufgetreten, den Konnektor zu löschen. Sie können das Löschen erneut versuchen, indem Sie auf die Schaltfläche \"Löschen\" klicken.",
+        "title": "Löschfehler"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "Synchronisierte Dokumente",
+          "errorMessage": "Fehlermeldung",
+          "permissionErrors": "Berechtigungsfehler",
+          "status": "Status",
+          "timeStarted": "Startzeit"
+        },
+        "empty": {
+          "description": "Synchronisierungsläufe für Dokumentberechtigungen werden im Hintergrund geplant. Es kann etwas dauern, bis sie erscheinen — laden Sie die Seite in etwa 30 Sekunden neu.",
+          "title": "Noch keine Synchronisierungsversuche für Dokumentberechtigungen"
+        },
+        "errorModal": {
+          "title": "Fehler bei der Synchronisierung der Dokumentberechtigungen"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "Dokument-ID",
+          "errorMessage": "Fehlermeldung",
+          "status": "Status",
+          "time": "Zeit"
+        },
+        "description": "Unten sehen Sie die Fehler, die während der Indizierung aufgetreten sind. Jede Zeile steht für ein fehlgeschlagenes Dokument oder Objekt.",
+        "empty": {
+          "description": "Auf dieser Seite wurden keine Fehler gefunden"
+        },
+        "fullReindex": {
+          "description": "Klicken Sie auf die Schaltfläche unten, um eine vollständige Neuindizierung zu starten und diese Fehler zu beheben. Diese vollständige Neuindizierung kann viel länger dauern als eine normale Aktualisierung."
+        },
+        "resolveAllButton": {
+          "label": "Alle beheben"
+        },
+        "status": {
+          "resolved": "Behoben",
+          "unresolved": "Nicht behoben"
+        },
+        "targetedReindex": {
+          "description": "Klicken Sie auf die Schaltfläche unten, um nur die fehlgeschlagenen Dokumente erneut abzurufen. Das ist viel schneller als eine vollständige Neuindizierung."
+        },
+        "title": "Indizierungsfehler",
+        "unknownDocument": "Unbekannt"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "Dateien hinzufügen"
+        },
+        "cancelButton": {
+          "label": "Abbrechen"
+        },
+        "columns": {
+          "fileName": "Dateiname",
+          "size": "Größe",
+          "uploadDate": "Hochladedatum"
+        },
+        "confirmModal": {
+          "addDetails": "Neue Dateien werden hochgeladen, in Chunks zerlegt, eingebettet und im Dokumentenindex indiziert",
+          "addSummary": "{count} Datei(en) werden hinzugefügt",
+          "confirmButton": {
+            "label": "Bestätigen & speichern"
+          },
+          "description": "Wenn Sie diese Änderungen speichern, geschieht Folgendes:",
+          "removeDetails": "Dokumente aus diesen Dateien werden aus dem Dokumentenindex entfernt",
+          "removeSummary": "🗑️ {count} Datei(en) werden entfernt",
+          "title": "Dateiänderungen bestätigen"
+        },
+        "editButton": {
+          "label": "Bearbeiten"
+        },
+        "empty": {
+          "description": "Keine Dateien in diesem Konnektor"
+        },
+        "header": {
+          "title": "Dateien ({count, plural, one {# Datei} other {# Dateien}})"
+        },
+        "loadError": "Fehler beim Laden der Dateien: {message}",
+        "newBadge": {
+          "label": "Neu"
+        },
+        "removeFileButton": {
+          "tooltip": "Datei entfernen"
+        },
+        "removingBadge": {
+          "label": "Wird entfernt"
+        },
+        "saveButton": {
+          "label": "Änderungen speichern",
+          "saving": "Wird gespeichert..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "Es können nicht alle Dateien aus einem Konnektor entfernt werden. Löschen Sie den Konnektor, wenn Sie das möchten.",
+          "filesUpdated": "Dateien erfolgreich aktualisiert! Der Dokumentenindex wird im Hintergrund aktualisiert. Neue Dateien werden indiziert und entfernte Dateien werden aus den Suchergebnissen bereinigt.",
+          "updateFailed": "Die Dateien konnten nicht aktualisiert werden"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "Fehlermeldung",
+          "groups": "Gruppen",
+          "memberships": "Mitgliedschaften",
+          "status": "Status",
+          "timeStarted": "Startzeit",
+          "users": "Benutzer"
+        },
+        "empty": {
+          "description": "Synchronisierungsläufe für Gruppenmitgliedschaften werden im Hintergrund geplant. Es kann etwas dauern, bis sie erscheinen — laden Sie die Seite in etwa 30 Sekunden neu.",
+          "title": "Noch keine Synchronisierungsversuche für Gruppenmitgliedschaften"
+        },
+        "errorModal": {
+          "title": "Fehler bei der Synchronisierung der Gruppenmitgliedschaften"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "Fehlermeldung",
+          "newDocs": "Neue Dok.",
+          "status": "Status",
+          "timeStarted": "Startzeit",
+          "totalDocs": "Dok. gesamt",
+          "totalDocsTooltip": "Gesamtzahl der Dokumente, die bei diesem Indizierungsversuch im Index ersetzt wurden"
+        },
+        "docsPerMinute": "{rate} Dok. / Min.",
+        "docsRemoved": "(außerdem wurden {count} Dokumente entfernt, die in der Quelle als gelöscht erkannt wurden)",
+        "empty": {
+          "description": "Indizierungsversuche werden im Hintergrund geplant, und es kann etwas dauern, bis sie erscheinen. Laden Sie die Seite in etwa 30 Sekunden neu!",
+          "title": "Noch keine Indizierungsversuche geplant"
+        },
+        "noAdditionalDocs": "Keine weiteren Dokumente verarbeitet",
+        "reindexTooltip": {
+          "completed": "Dieser Indizierungsversuch war eine vollständige Neuindizierung. Alle Dokumente aus der Quelle wurden in das System synchronisiert.",
+          "inProgress": "Dieser Indizierungsversuch ist eine vollständige Neuindizierung. Alle Dokumente aus der Quelle werden in das System synchronisiert."
+        },
+        "stageMetricsButton": {
+          "tooltip": "Phasenmetriken anzeigen"
+        },
+        "viewTrace": {
+          "ariaLabel": "Vollständige Ablaufverfolgung anzeigen"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "Bei der Verarbeitung einiger Dokumente sind Probleme aufgetreten. <details>Details anzeigen.</details>",
+        "resolvingStatus": "Fehler werden behoben",
+        "title": "Einige Dokumente konnten nicht indiziert werden"
+      },
+      "invalidState": {
+        "description": "Dieser Konnektor befindet sich in einem ungültigen Zustand. Bitte aktualisieren Sie Ihre Anmeldedaten oder erstellen Sie einen neuen Konnektor, bevor Sie neu indizieren.",
+        "title": "Ungültiger Konnektorzustand"
+      },
+      "loadError": {
+        "title": "Die Informationen zum Konnektor mit der ID {ccPairId} konnten nicht abgerufen werden",
+        "unknownMessage": "Unbekannter Fehler"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "Löschen",
+          "tooltip": {
+            "active": "Pausieren Sie den Konnektor vor dem Löschen"
+          }
+        },
+        "reIndex": {
+          "label": "Neu indizieren",
+          "tooltip": {
+            "indexing": "Eine Neuindizierung ist nicht möglich, während bereits eine Indizierung läuft",
+            "invalid": "Korrigieren Sie die Konnektorkonfiguration vor der Neuindizierung",
+            "paused": "Setzen Sie den Konnektor vor der Neuindizierung fort"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "Pausieren"
+          },
+          "resume": {
+            "label": "Fortsetzen"
+          },
+          "tooltip": {
+            "updating": "Statusaktualisierung läuft"
+          }
+        },
+        "trigger": {
+          "label": "Verwalten"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "Abgebrochen"
+        },
+        "completedWithErrors": {
+          "label": "Mit Fehlern abgeschlossen"
+        },
+        "failed": {
+          "label": "Fehlgeschlagen"
+        },
+        "fallback": {
+          "label": "Nicht gestartet"
+        },
+        "inProgress": {
+          "label": "Läuft"
+        },
+        "notStarted": {
+          "label": "Geplant"
+        },
+        "success": {
+          "label": "Erfolgreich"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "Wie oft der Konnektor bereinigt werden soll (in Stunden)",
+        "title": "Bereinigungsintervall"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "Wieder aktivieren"
+        },
+        "additionalDetails": "Dieser Konnektor wurde zuvor als ungültig markiert. Bitte prüfen Sie, ob Ihre Konfiguration korrekt ist, bevor Sie ihn wieder aktivieren. Möchten Sie wirklich fortfahren?",
+        "entityType": "Ungültiger Konnektor"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "Dadurch werden alle Dokumente aus der Quelle vollständig neu indiziert.",
+          "note": "<strong>HINWEIS:</strong> Je nach Anzahl der in der Quelle gespeicherten Dokumente kann dies lange dauern."
+        },
+        "fullReindexButton": {
+          "label": "Vollständige Neuindizierung ausführen"
+        },
+        "title": "Indizierung ausführen",
+        "update": {
+          "description": "Dadurch werden alle Dokumente abgerufen und indiziert, die sich seit dem letzten erfolgreichen Indizierungslauf geändert haben und/oder hinzugekommen sind."
+        },
+        "updateButton": {
+          "label": "Aktualisierung ausführen"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "Wie oft der Konnektor aktualisiert werden soll (in Minuten)",
+        "title": "Aktualisierungsintervall"
+      },
+      "sections": {
+        "advanced": {
+          "title": "Erweitert"
+        },
+        "advancedConfiguration": {
+          "title": "Erweiterte Konfiguration"
+        },
+        "connectorConfiguration": {
+          "title": "Konnektorkonfiguration"
+        },
+        "credential": {
+          "title": "Anmeldedaten"
+        },
+        "indexing": {
+          "title": "Indizierung"
+        },
+        "indexingAttempts": {
+          "title": "Indizierungsversuche"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "Zusatzaufwand des Versuchs ausblenden"
+          },
+          "showButton": {
+            "label": "Zusatzaufwand des Versuchs anzeigen"
+          }
+        },
+        "batchTotal": {
+          "empty": "Noch keine abgeschlossenen Batches",
+          "summary": "Durchschnittlicher Batch: {avgLabel}, {count, plural, one {# Batch} other {# Batches}} — Verteilung siehe unten."
+        },
+        "empty": {
+          "description": "Für diesen Versuch wurden noch keine Phasenzeiten aufgezeichnet. Ältere Versuche, die vor der Einführung der Phasenmessung liefen, haben keine Metriken."
+        },
+        "loadError": {
+          "description": "Die Phasenzeiten für diesen Versuch konnten nicht geladen werden. Die Pipeline läuft auch dann, wenn die Aufzeichnung der Metriken nicht verfügbar ist. Das weist also nicht auf ein Problem mit dem Indizierungslauf selbst hin.",
+          "title": "Die Phasenmetriken konnten nicht geladen werden"
+        },
+        "loading": "Phasenmetriken werden geladen…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "Durchschn. Zeit",
+            "calls": "Aufrufe",
+            "max": "Max.",
+            "min": "Min.",
+            "stage": "Phase",
+            "totalTime": "Gesamtzeit"
+          },
+          "empty": "Keine Phasendaten pro Batch aufgezeichnet."
+        },
+        "sort": {
+          "label": "Sortieren:",
+          "pipelineOrder": {
+            "label": "Pipeline-Reihenfolge"
+          },
+          "timeTaken": {
+            "label": "Benötigte Zeit"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "Liest den Batch aus dem Objektspeicher zurück in den Speicher des Workers.",
+            "label": "Batch laden"
+          },
+          "batchTotal": {
+            "description": "Gesamte tatsächliche Zeit für die Verarbeitung eines einzelnen Batches von Anfang bis Ende.",
+            "label": "Batch gesamt"
+          },
+          "batchUnaccounted": {
+            "description": "Batch-Zeit, die keiner benannten Phase zugeordnet ist. Ein hoher Wert deutet auf fehlende Messpunkte hin.",
+            "label": "Nicht zugeordnet"
+          },
+          "checkpointLoad": {
+            "description": "Lädt den gespeicherten Checkpoint, damit der Versuch dort fortfährt, wo der vorherige Lauf endete.",
+            "label": "Checkpoint laden"
+          },
+          "chunking": {
+            "description": "Teilt jedes Dokument in die Chunks auf, die eingebettet und indiziert werden.",
+            "label": "Chunking"
+          },
+          "connectorFetch": {
+            "description": "Zeit, die der Konnektor mit Aufrufen der Quell-API und der Ausgabe von Rohdokumenten verbringt.",
+            "label": "Konnektor-Abruf"
+          },
+          "connectorValidation": {
+            "description": "Prüft vor dem Abruf, ob der Konnektor korrekt konfiguriert und erreichbar ist.",
+            "label": "Konnektor-Prüfung"
+          },
+          "contextualRag": {
+            "description": "Erzeugt mit einem LLM Kontextzusammenfassungen pro Chunk, um die Retrieval-Qualität zu verbessern.",
+            "label": "Contextual RAG"
+          },
+          "coordLockAcquireWait": {
+            "description": "Wartet auf die Koordinationssperre, die die gemeinsamen Fortschrittszähler des Versuchs schützt.",
+            "label": "Wartezeit auf Koordinationssperre"
+          },
+          "coordinationUpdate": {
+            "description": "Aktualisiert die Fortschrittszähler des Versuchs, damit die Oberfläche den abgeschlossenen Batch anzeigt.",
+            "label": "Koordinationsaktualisierung"
+          },
+          "docBatchEnqueue": {
+            "description": "Stellt den gespeicherten Batch in die Celery-Warteschlange, damit ein Docprocessing-Worker ihn übernimmt.",
+            "label": "Dokument-Batch einreihen"
+          },
+          "docBatchStore": {
+            "description": "Speichert einen abgerufenen Dokument-Batch für die Docprocessing-Worker im Objektspeicher.",
+            "label": "Dokument-Batch speichern"
+          },
+          "docDbPrepare": {
+            "description": "Ermittelt, welche Dokumente neu oder aktualisiert sind, und bereitet die Datenbankzeilen vor.",
+            "label": "Dokument-DB vorbereiten"
+          },
+          "docLockAcquireWait": {
+            "description": "Wartet auf Sperren pro Dokument, damit parallele Versuche nicht dasselbe Dokument schreiben.",
+            "label": "Wartezeit auf Dokumentsperre"
+          },
+          "docprocessingSetup": {
+            "description": "Bereitet den Worker vor: lädt Sucheinstellungen, Embedding-Modell und Index-Clients.",
+            "label": "Docprocessing-Einrichtung"
+          },
+          "embedding": {
+            "description": "Ruft das Embedding-Modell auf, um Chunks in Vektoren umzuwandeln. Meist die langsamste Phase.",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "Hängt vor dem Schreiben Zugriffssteuerung, Boosts und weitere Metadaten an jeden Chunk an.",
+            "label": "Anreicherung vorbereiten"
+          },
+          "finalization": {
+            "description": "Räumt die Worker-Ressourcen auf und gibt den Batch frei, sobald die Verarbeitung endet.",
+            "label": "Abschluss"
+          },
+          "gcCollect": {
+            "description": "Zeit für die ausdrückliche Garbage Collection zwischen Batches.",
+            "label": "Garbage Collection"
+          },
+          "hierarchyUpsert": {
+            "description": "Schreibt die Ordner- oder Space-Hierarchie der Quelle, damit Dokumente nach Ort gefiltert werden können.",
+            "label": "Hierarchie-Upsert"
+          },
+          "imageProcessing": {
+            "description": "Extrahiert Bilder und fasst sie zusammen, damit ihr Inhalt zu durchsuchbarem Text wird.",
+            "label": "Bildverarbeitung"
+          },
+          "permissionValidation": {
+            "description": "Bestätigt, dass die Anmeldedaten die nötigen Berechtigungen haben, um die Dokumente der Quelle zu lesen.",
+            "label": "Berechtigungsprüfung"
+          },
+          "postIndexDbUpdate": {
+            "description": "Aktualisiert die Dokumentzeilen in Postgres, nachdem das Schreiben in den Index erfolgreich war.",
+            "label": "DB-Aktualisierung nach Indizierung"
+          },
+          "queueWait": {
+            "description": "Zeit, die ein Batch in der Warteschlange wartet, bis ein Docprocessing-Worker ihn startet.",
+            "label": "Warteschlangenzeit"
+          },
+          "vectorDbWrite": {
+            "description": "Schreibt die eingebetteten Chunks in den Dokumentenindex.",
+            "label": "Schreiben in Vektor-DB"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "Zeiten pro Batch und pro Versuch für diesen Indizierungsversuch.",
+        "title": "Metriken der Indizierungsphasen"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "Indizierte Dokumente"
+        },
+        "indexingSpeed": "({speed} Dok. / Min.)",
+        "lastIndexed": {
+          "label": "Zuletzt indiziert"
+        },
+        "lastSynced": {
+          "label": "Zuletzt synchronisiert"
+        },
+        "permissionSyncing": {
+          "label": "Berechtigungssynchronisierung"
+        },
+        "status": {
+          "label": "Status"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "Vollständige Fehlermeldung anzeigen"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "Synchronisierung der Dokumentberechtigungen",
+          "notApplicableDescription": "Dieser Konnektor verwendet keinen separaten Auftrag zur Synchronisierung der Dokumentberechtigungen."
+        },
+        "groupMembership": {
+          "label": "Synchronisierung der Gruppenmitgliedschaften",
+          "notApplicableDescription": "Dieser Konnektor verwendet keinen separaten Auftrag zur Synchronisierung der Gruppenmitgliedschaften."
+        },
+        "indexing": {
+          "label": "Indizierung"
+        },
+        "loadError": {
+          "title": "Die Synchronisierungsversuche konnten nicht geladen werden"
+        },
+        "notApplicable": {
+          "title": "Nicht zutreffend"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "Vollständige Neuindizierung erfolgreich gestartet",
+        "completeReindexStarting": "Vollständige Neuindizierung wird gestartet...",
+        "deletionScheduleFailed": "Das Löschen des Konnektors konnte nicht geplant werden - {message}",
+        "indexingProcessStartFailed": "Der Indizierungsprozess konnte nicht gestartet werden",
+        "indexingStartFailed": "Die Indizierung konnte nicht gestartet werden",
+        "indexingStartUnexpectedError": "Beim Starten der Indizierung ist ein unerwarteter Fehler aufgetreten",
+        "indexingUpdateStarted": "Indizierungsaktualisierung erfolgreich gestartet",
+        "indexingUpdateStarting": "Indizierungsaktualisierung wird gestartet...",
+        "invalidPruningFrequency": "Ungültiges Bereinigungsintervall: muss eine gültige Zahl sein",
+        "invalidRefreshFrequency": "Ungültiges Aktualisierungsintervall: muss eine ganze Zahl sein",
+        "nameUpdateFailed": "Der Konnektorname konnte nicht aktualisiert werden",
+        "nameUpdated": "Konnektorname erfolgreich aktualisiert",
+        "noUnresolvedErrors": "Keine nicht behobenen Fehler für einen erneuten Versuch.",
+        "pruningFrequencyUpdateFailed": "Das Bereinigungsintervall des Konnektors konnte nicht aktualisiert werden",
+        "pruningFrequencyUpdated": "Bereinigungsintervall des Konnektors erfolgreich aktualisiert",
+        "refreshFrequencyUpdateFailed": "Das Aktualisierungsintervall des Konnektors konnte nicht aktualisiert werden",
+        "refreshFrequencyUpdated": "Aktualisierungsintervall des Konnektors erfolgreich aktualisiert",
+        "targetedReindexFailed": "Die gezielte Neuindizierung ist fehlgeschlagen: {message}",
+        "targetedReindexSubmitted": "Gezielte Neuindizierung für {count, plural, one {# Dokument} other {# Dokumente}} übermittelt. Die Fehler verschwinden aus der Liste, sobald die Dokumente neu indiziert sind."
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "Mit {source} autorisieren",
+          "pendingLabel": "Wird autorisiert..."
+        },
+        "createCredentialButton": {
+          "label": "Neu erstellen"
+        },
+        "credentialDeleted": {
+          "toast": "Anmeldedaten erfolgreich gelöscht!"
+        },
+        "credentialModal": {
+          "title": "Anmeldedaten für {source} erstellen"
+        },
+        "credentialStep": {
+          "title": "Anmeldedaten auswählen"
+        },
+        "credentialSwapped": {
+          "toast": "Anmeldedaten erfolgreich gewechselt!"
+        },
+        "error": {
+          "toast": "Fehler: {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "Für diesen Konnektor ist eine föderierte Suchoption verfügbar. Sie führt zu höherer Latenz und geringerer Suchqualität.",
+            "link": {
+              "label": "Stattdessen die föderierte Version verwenden →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "Fehler beim Hochladen der Dateien"
+        },
+        "oauthRedirectFailed": {
+          "message": "Wir konnten Sie nicht zur Anmeldung bei {source} weiterleiten. Bitte versuchen Sie es erneut."
+        },
+        "oauthStartFailed": {
+          "toast": "OAuth kann nicht gestartet werden"
+        },
+        "oauthUrlFailed": {
+          "toast": "Die OAuth-URL konnte nicht abgerufen werden"
+        },
+        "retryButton": {
+          "label": "Erneut versuchen"
+        },
+        "timeout": {
+          "toast": "Zeitüberschreitung des Vorgangs nach {seconds} Sekunden. Prüfen Sie Ihre Konfiguration auf Fehler."
+        },
+        "unknownError": {
+          "toast": "Ein unbekannter Fehler ist aufgetreten"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "Startdatum der Indizierung",
+          "subtext": "Dokumente vor diesem Datum werden nicht abgerufen"
+        },
+        "pruneFrequency": {
+          "description": "Prüft alle Dokumente gegen die Quelle, um jene zu löschen, die nicht mehr vorhanden sind. Hinweis: Dieser Vorgang prüft jedes Dokument. Erhöhen Sie die Häufigkeit daher mit Bedacht. Standard sind {hours} Stunden ({days} Tage). Dezimalstunden werden unterstützt (z. B. 0,1 Stunden = 6 Minuten). Geben Sie 0 ein, um die Bereinigung für diesen Konnektor zu deaktivieren.",
+          "label": "Bereinigungsintervall (Stunden)"
+        },
+        "refreshFrequency": {
+          "description": "So oft rufen wir neue Dokumente aus der Quelle ab (in Minuten). Wenn Sie 0 eingeben, rufen wir für diesen Konnektor nie neue Dokumente ab.",
+          "label": "Aktualisierungsintervall (Minuten)"
+        },
+        "resetButton": {
+          "label": "Zurücksetzen"
+        },
+        "title": "Erweiterte Konfiguration"
+      },
+      "connectorName": {
+        "label": "Konnektorname",
+        "subtext": "Ein aussagekräftiger Name für den Konnektor."
+      },
+      "credentialsLoadError": {
+        "title": "Die Anmeldedaten konnten nicht geladen werden."
+      },
+      "field": {
+        "optional": {
+          "label": "(optional)"
+        },
+        "optionalSuffix": {
+          "label": "optional"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Ihre Google Drive-Anmeldedaten wurden erstellt. Sie können sie in der Liste der Anmeldedaten verwalten oder widerrufen.",
+          "title": "Authentifizierung abgeschlossen"
+        },
+        "authFailed": {
+          "toast": "Die Authentifizierung bei Google Drive ist fehlgeschlagen - {error}"
+        },
+        "authenticateButton": {
+          "label": "Bei Google Drive authentifizieren",
+          "pendingLabel": "Wird authentifiziert..."
+        },
+        "createButton": {
+          "label": "Anmeldedaten erstellen",
+          "pendingLabel": "Wird erstellt..."
+        },
+        "credentialsLoadError": {
+          "title": "Die Google Drive-Anmeldedaten konnten nicht geladen werden."
+        },
+        "invalidFile": {
+          "toast": "Ungültige Datei angegeben - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Ungültige Datei angegeben - erwartet wurde ein JSON-Schlüssel für ein Dienstkonto"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Bitte laden Sie einen Dienstkontoschlüssel hoch, bevor Sie Anmeldedaten erstellen"
+        },
+        "oauthOption": {
+          "description": "Laden Sie die JSON-Datei der OAuth-App aus der Google Cloud Console hoch ([Einrichtungsanleitung]({docsUrl})) und authentifizieren Sie sich dann mit dem Google-Konto, dessen Drive Sie indizieren möchten.",
+          "title": "Option 1: OAuth-App"
+        },
+        "oauthUpload": {
+          "placeholder": "Laden Sie die JSON-Datei Ihrer OAuth-App hoch oder fügen Sie sie ein"
+        },
+        "primaryAdmin": {
+          "description": "Geben Sie die E-Mail-Adresse eines Administrators oder Eigentümers der Google-Organisation ein, der die Google Drives gehören, die Sie indizieren möchten.",
+          "invalidEmail": "Muss eine gültige E-Mail-Adresse sein",
+          "label": "E-Mail-Adresse des Hauptadministrators",
+          "required": "Erforderlich"
+        },
+        "section": {
+          "title": "Google Drive-Authentifizierung"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Die Anmeldedaten für das Dienstkonto konnten nicht erstellt werden - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Anmeldedaten für das Dienstkonto erfolgreich erstellt"
+        },
+        "serviceAccountOption": {
+          "title": "Option 2: Dienstkonto"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Laden Sie den JSON-Schlüssel Ihres Dienstkontos hoch oder fügen Sie ihn ein"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Ihre Gmail-Anmeldedaten wurden erstellt. Sie können sie in der Liste der Anmeldedaten verwalten oder widerrufen.",
+          "title": "Authentifizierung abgeschlossen"
+        },
+        "authFailed": {
+          "toast": "Die Authentifizierung bei Gmail ist fehlgeschlagen - {error}"
+        },
+        "authenticateButton": {
+          "label": "Bei Gmail authentifizieren",
+          "pendingLabel": "Wird authentifiziert..."
+        },
+        "createButton": {
+          "label": "Anmeldedaten erstellen",
+          "pendingLabel": "Wird erstellt..."
+        },
+        "credentialsLoadError": {
+          "title": "Die Gmail-Anmeldedaten konnten nicht geladen werden."
+        },
+        "invalidFile": {
+          "toast": "Ungültige Datei angegeben - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Ungültige Datei angegeben - erwartet wurde ein JSON-Schlüssel für ein Dienstkonto"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Bitte laden Sie einen Dienstkontoschlüssel hoch, bevor Sie Anmeldedaten erstellen"
+        },
+        "oauthOption": {
+          "description": "Laden Sie die JSON-Datei der OAuth-App aus der Google Cloud Console hoch ([Einrichtungsanleitung]({docsUrl})) und authentifizieren Sie sich dann mit dem Google-Konto, dessen Gmail Sie indizieren möchten.",
+          "title": "Option 1: OAuth-App"
+        },
+        "oauthUpload": {
+          "placeholder": "Laden Sie die JSON-Datei Ihrer OAuth-App hoch oder fügen Sie sie ein"
+        },
+        "primaryAdmin": {
+          "description": "Geben Sie die E-Mail-Adresse eines Administrators oder Eigentümers der Google-Organisation ein, der die Gmail-Konten gehören, die Sie indizieren möchten.",
+          "invalidEmail": "Muss eine gültige E-Mail-Adresse sein",
+          "label": "E-Mail-Adresse des Hauptadministrators",
+          "required": "Erforderlich"
+        },
+        "section": {
+          "title": "Gmail-Authentifizierung"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Die Anmeldedaten für das Dienstkonto konnten nicht erstellt werden - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Anmeldedaten für das Dienstkonto erfolgreich erstellt"
+        },
+        "serviceAccountOption": {
+          "title": "Option 2: Dienstkonto"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Laden Sie den JSON-Schlüssel Ihres Dienstkontos hoch oder fügen Sie ihn ein"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "Zur Startseite"
+        },
+        "title": "‘{connector}’ ist kein gültiger Konnektortyp!"
+      },
+      "listInput": {
+        "placeholder": "{label} eingeben"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "Erweitert"
+        },
+        "continueButton": {
+          "label": "Weiter"
+        },
+        "createButton": {
+          "label": "Konnektor erstellen"
+        },
+        "previousButton": {
+          "label": "Zurück"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "Ups, etwas ist schiefgelaufen!"
+        },
+        "invalidSource": {
+          "description": "{source} ist kein gültiger Quelltyp.",
+          "title": "Der angegebene Konnektor-Quelltyp {source} existiert nicht."
+        },
+        "processing": {
+          "description": "Bitte warten Sie, während wir die Einrichtung abschließen.",
+          "title": "Wird verarbeitet..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "Mit {source} autorisieren"
+        },
+        "authorizing": {
+          "description": "Bitte warten Sie, während wir die Autorisierung abschließen."
+        },
+        "continue": {
+          "message": "Klicken Sie <link>hier</link>, um fortzufahren."
+        },
+        "error": {
+          "description": "Während des OAuth-Vorgangs ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+        },
+        "malformed": {
+          "missingCode": "Der Autorisierungscode fehlt.",
+          "missingState": "Der Parameter state fehlt.",
+          "title": "Falsch aufgebaute OAuth-Autorisierungsanfrage."
+        },
+        "page": {
+          "title": "Mit Drittanbieterdienst autorisieren"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "Ihre Autorisierung mit {source} war erfolgreich. Für die Einrichtung der Anmeldedaten sind weitere Schritte nötig."
+          },
+          "description": "Ihre Autorisierung mit {source} war erfolgreich.",
+          "title": "Erfolg!"
+        }
+      },
+      "oauthFailed": {
+        "toast": "Die OAuth-Authentifizierung ist fehlgeschlagen. Bitte versuchen Sie es erneut."
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "Autorisierung mit {source} abschließen"
+        },
+        "cloudId": {
+          "required": "Sie müssen eine Confluence-Site auswählen (id nicht gefunden)."
+        },
+        "cloudName": {
+          "required": "Sie müssen eine Confluence-Site auswählen (Name nicht gefunden)."
+        },
+        "cloudUrl": {
+          "required": "Sie müssen eine Confluence-Site auswählen (URL nicht gefunden)."
+        },
+        "continue": {
+          "message": "Autorisierung abgeschlossen. Klicken Sie <link>hier</link>, um fortzufahren."
+        },
+        "credentialId": {
+          "required": "Die ID der Anmeldedaten ist erforderlich."
+        },
+        "error": {
+          "description": "Beim Abschluss des OAuth-Vorgangs ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+        },
+        "finalized": {
+          "title": "Confluence-Autorisierung abgeschlossen."
+        },
+        "loadingSites": {
+          "description": "Bitte warten Sie, während wir eine Liste Ihrer zugänglichen Sites abrufen."
+        },
+        "malformed": {
+          "description": "Ungültige oder fehlende ID der Anmeldedaten.",
+          "title": "Falsch aufgebaute OAuth-Abschlussanfrage."
+        },
+        "page": {
+          "title": "Autorisierung mit Drittanbieterdienst abschließen"
+        },
+        "selectSite": {
+          "title": "Wählen Sie eine Confluence-Site"
+        },
+        "submitButton": {
+          "label": "Absenden",
+          "pendingLabel": "Wird gesendet..."
+        },
+        "submitError": {
+          "description": "Beim Senden ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+          "title": "Fehler beim Senden."
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "Option auswählen"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "Neu hinzufügen"
+        },
+        "removeButton": {
+          "tooltip": "Entfernen"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "Keine Tabs zum Anzeigen."
+        }
+      }
+    },
     "costOverrides": {
       "allProviders": {
         "label": "Alle Anbieter"
@@ -813,6 +2014,461 @@
         "title": "Craft ist in dieser Bereitstellung nicht verfügbar"
       }
     },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "Um den Token zu ändern, löschen Sie den aktuellen und fügen Sie einen neuen hinzu."
+        },
+        "configured": {
+          "badge": "Konfiguriert",
+          "text": "Ihr Discord-Bot-Token ist konfiguriert."
+        },
+        "configuredWithDate": {
+          "text": "Ihr Discord-Bot-Token ist konfiguriert. Hinzugefügt am {date}."
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "Löschen Sie zuerst die Serverkonfigurationen"
+          },
+          "label": "Discord-Token löschen"
+        },
+        "deleteError": {
+          "toast": "Der Bot-Token konnte nicht gelöscht werden"
+        },
+        "deleteModal": {
+          "additionalDetails": "Dadurch wird Ihr Discord-Bot getrennt. Sie müssen den Token erneut eingeben, um den Bot wieder zu verwenden.",
+          "entityName": "Discord-Bot-Token",
+          "entityType": "Discord-Bot-Token"
+        },
+        "deleted": {
+          "toast": "Bot-Token gelöscht"
+        },
+        "enterInstructions": {
+          "text": "Geben Sie Ihren Discord-Bot-Token ein, um den Bot zu aktivieren. Sie erhalten ihn im Discord Developer Portal."
+        },
+        "input": {
+          "placeholder": "Bot-Token eingeben..."
+        },
+        "missing": {
+          "toast": "Bitte geben Sie einen Bot-Token ein"
+        },
+        "notConfigured": {
+          "badge": "Nicht konfiguriert"
+        },
+        "saveButton": {
+          "label": "Token speichern",
+          "saving": {
+            "label": "Wird gespeichert..."
+          }
+        },
+        "saveError": {
+          "toast": "Der Bot-Token konnte nicht gespeichert werden"
+        },
+        "saved": {
+          "toast": "Bot-Token erfolgreich gespeichert"
+        },
+        "section": {
+          "title": "Bot-Token"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "Die Kanalkonfiguration ist verfügbar, sobald der Server registriert ist."
+        },
+        "disableAllButton": {
+          "label": "Alle deaktivieren"
+        },
+        "empty": {
+          "description": "Führen Sie !sync-channels in Discord aus, um Kanäle hinzuzufügen.",
+          "title": "Keine Kanäle konfiguriert"
+        },
+        "enableAllButton": {
+          "label": "Alle aktivieren"
+        },
+        "partialUpdate": {
+          "toast": "{succeeded} Kanäle wurden aktualisiert, {failed} sind fehlgeschlagen"
+        },
+        "section": {
+          "description": "Führen Sie !sync-channels in Discord aus, um die Kanalliste zu aktualisieren.",
+          "title": "Kanalkonfiguration"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "Agent-Überschreibung"
+          },
+          "channel": {
+            "header": "Kanal"
+          },
+          "enabled": {
+            "header": "Aktiviert"
+          },
+          "requireMention": {
+            "header": "@Erwähnung erforderlich"
+          },
+          "threadOnly": {
+            "header": "Nur-Thread-Modus"
+          }
+        },
+        "updateError": {
+          "toast": "Die Kanäle konnten nicht aktualisiert werden"
+        },
+        "updated": {
+          "toast": "{count, plural, one {# Kanal aktualisiert} other {# Kanäle aktualisiert}}"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "Standardagent zurückgesetzt"
+        },
+        "section": {
+          "description": "Der Agent, den der Bot in allen Kanälen verwendet, sofern er nicht überschrieben wird.",
+          "title": "Standardagent"
+        },
+        "select": {
+          "default": {
+            "label": "Standardagent"
+          },
+          "placeholder": "Agent auswählen"
+        },
+        "updateError": {
+          "toast": "Der Agent konnte nicht aktualisiert werden"
+        },
+        "updated": {
+          "toast": "Standardagent aktualisiert"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "Die Kanäle konnten nicht geladen werden",
+          "title": "Die Kanäle konnten nicht geladen werden"
+        },
+        "loadServer": {
+          "title": "Der Server konnte nicht geladen werden"
+        },
+        "loadServers": {
+          "title": "Die Discord-Server konnten nicht geladen werden"
+        },
+        "serverNotFound": {
+          "message": "Server nicht gefunden"
+        },
+        "unknown": {
+          "message": "Ein unbekannter Fehler ist aufgetreten"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "Verwenden Sie den Befehl !register mit dem Registrierungsschlüssel in Ihrem Discord-Server, um die Einrichtung abzuschließen.",
+          "title": "Warten auf Registrierung"
+        },
+        "pending": {
+          "text": "Registrierung ausstehend"
+        },
+        "registered": {
+          "text": "Registriert: {date}"
+        },
+        "updateButton": {
+          "label": "Konfiguration aktualisieren"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "Der Server konnte nicht erstellt werden"
+        },
+        "created": {
+          "toast": "Serverkonfiguration erstellt!"
+        },
+        "deleteError": {
+          "toast": "Die Serverkonfiguration konnte nicht gelöscht werden"
+        },
+        "deleteModal": {
+          "additionalDetails": "Dadurch werden alle Einstellungen für diesen Discord-Server entfernt.",
+          "entityType": "Discord-Serverkonfiguration"
+        },
+        "deleted": {
+          "toast": "Serverkonfiguration gelöscht"
+        },
+        "disabled": {
+          "toast": "Server deaktiviert"
+        },
+        "empty": {
+          "description": "Erstellen Sie eine Serverkonfiguration, um zu beginnen.",
+          "title": "Noch keine Discord-Server konfiguriert"
+        },
+        "enabled": {
+          "toast": "Server aktiviert"
+        },
+        "fallbackName": "Server #{id}",
+        "notRegistered": {
+          "toast": "Der Server muss registriert sein, bevor er aktiviert werden kann"
+        },
+        "pending": {
+          "badge": "Ausstehend"
+        },
+        "registered": {
+          "badge": "Registriert"
+        },
+        "table": {
+          "actions": {
+            "header": "Aktionen"
+          },
+          "enabled": {
+            "header": "Aktiviert"
+          },
+          "registered": {
+            "header": "Registriert"
+          },
+          "server": {
+            "header": "Server"
+          },
+          "status": {
+            "header": "Status"
+          }
+        },
+        "updateError": {
+          "toast": "Der Server konnte nicht aktualisiert werden"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Verbinden Sie Onyx mit Ihren Discord-Servern. Benutzer können Fragen direkt in Discord-Kanälen stellen."
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "Dieser Schlüssel wird nur einmal angezeigt!",
+          "title": "Registrierungsschlüssel"
+        },
+        "instructions": {
+          "text": "Kopieren Sie den Befehl und senden Sie ihn aus einem beliebigen Textkanal in Ihrem Server!"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "Wird erstellt..."
+          },
+          "label": "Server hinzufügen"
+        },
+        "section": {
+          "title": "Serverkonfigurationen"
+        }
+      },
+      "unsavedChanges": {
+        "description": "Klicken Sie auf Aktualisieren, um sie zu speichern.",
+        "title": "Sie haben ungespeicherte Änderungen"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "API-Schlüssel eingeben"
+        },
+        "deleteButton": {
+          "label": "API-Schlüssel löschen"
+        },
+        "deleteHint": "Löschen Sie den aktuellen API-Schlüssel, bevor Sie ihn aktualisieren.",
+        "description": "Unstructured extrahiert komplexe Daten aus Formaten wie .pdf, .docx, .png, .pptx usw. und wandelt sie in sauberen Text um, den Onyx aufnehmen kann. Geben Sie einen API-Schlüssel an, um die Dokumentverarbeitung mit Unstructured zu aktivieren.",
+        "learnMore": "Erfahren Sie <link>hier</link> mehr über Unstructured.",
+        "note": "<label>Hinweis:</label> Dadurch werden Dokumente zur Verarbeitung an die Server von Unstructured gesendet.",
+        "saveButton": {
+          "label": "API-Schlüssel speichern"
+        },
+        "title": "Mit der Unstructured-API verarbeiten"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "Boost:"
+        },
+        "search": {
+          "placeholder": "Dokumente nach Titel / Inhalt finden..."
+        },
+        "updateFailed": {
+          "toast": "Das Dokument konnte nicht aktualisiert werden - {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "Fehler beim Laden der Dokumente - {detail}"
+        },
+        "loading": {
+          "label": "Wird geladen"
+        },
+        "mostDisliked": {
+          "title": "Am schlechtesten bewertete Dokumente"
+        },
+        "mostLiked": {
+          "title": "Am besten bewertete Dokumente"
+        },
+        "table": {
+          "name": {
+            "header": "Dokumentname"
+          },
+          "score": {
+            "header": "Bewertung"
+          },
+          "searchable": {
+            "header": "Durchsuchbar?"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "Fehler beim Aktualisieren des Status \"Ausgeblendet\" - {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "Die Bewertung muss eine Zahl sein"
+        },
+        "updated": {
+          "toast": "Bewertung aktualisiert!"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "Privat"
+          },
+          "public": {
+            "label": "Öffentlich"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "Unbenannt"
+          }
+        },
+        "deleteFailed": {
+          "toast": "Das Löschen des Dokumentensatzes konnte nicht geplant werden - {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "Löschen des Dokumentensatzes \"{name}\" geplant"
+        },
+        "description": "Mit **Dokumentensätzen** können Sie logisch zusammengehörende Dokumente zu einem Paket bündeln. Diese können Sie dann bei der Suche als Filter verwenden, um den Umfang der von Onyx durchsuchten Informationen zu steuern.",
+        "edit": {
+          "header": {
+            "title": "Dokumentensatz bearbeiten"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "Während der Synchronisierung ist keine Aktualisierung möglich! Warten Sie das Ende der Synchronisierung ab und versuchen Sie es erneut."
+          }
+        },
+        "federatedBadge": {
+          "label": "Föderiert"
+        },
+        "fetchConnectorsFailed": {
+          "title": "Die Konnektoren konnten nicht abgerufen werden"
+        },
+        "fetchSetsFailed": {
+          "title": "Die Dokumentensätze konnten nicht abgerufen werden"
+        },
+        "form": {
+          "connectors": {
+            "label": "Wählen Sie Ihre Konnektoren",
+            "placeholder": "Nach Konnektoren suchen...",
+            "required": "Bitte wählen Sie mindestens einen Konnektor aus (regulär oder föderiert)"
+          },
+          "createFailed": {
+            "toast": "Fehler beim Erstellen des Dokumentensatzes - {detail}"
+          },
+          "created": {
+            "toast": "Dokumentensatz erfolgreich erstellt!"
+          },
+          "description": {
+            "label": "Beschreibung:",
+            "placeholder": "Beschreiben Sie, wofür der Dokumentensatz steht"
+          },
+          "federatedConnectors": {
+            "label": "Föderierte Konnektoren",
+            "placeholder": "Nach föderierten Konnektoren suchen..."
+          },
+          "name": {
+            "label": "Name:",
+            "placeholder": "Ein Name für den Dokumentensatz",
+            "required": "Bitte geben Sie einen Namen für den Satz ein"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {Konnektoren, die für die ausgewählte Gruppe verfügbar sind} one {Konnektoren, die für die ausgewählte Gruppe verfügbar sind} other {Konnektoren, die für die ausgewählten Gruppen verfügbar sind}}"
+          },
+          "submitButton": {
+            "createLabel": "Dokumentensatz erstellen",
+            "updateLabel": "Dokumentensatz aktualisieren"
+          },
+          "unavailableConnectors": {
+            "description": "Es sind nur Konnektoren verfügbar, die der Gruppe direkt zugewiesen sind, zu der Sie den Dokumentensatz hinzufügen möchten.",
+            "title": "{count, plural, =0 {Konnektoren, die für die ausgewählte Gruppe nicht verfügbar sind} one {Konnektoren, die für die ausgewählte Gruppe nicht verfügbar sind} other {Konnektoren, die für die ausgewählten Gruppen nicht verfügbar sind}}"
+          },
+          "updateFailed": {
+            "toast": "Fehler beim Aktualisieren des Dokumentensatzes - {detail}"
+          },
+          "updated": {
+            "toast": "Dokumentensatz erfolgreich aktualisiert!"
+          }
+        },
+        "loadError": {
+          "message": "Fehler: {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "Neuer Dokumentensatz"
+          }
+        },
+        "newButton": {
+          "label": "Neuer Dokumentensatz"
+        },
+        "notFound": {
+          "message": "Dokumentensatz mit der ID {id} nicht gefunden",
+          "title": "Dokumentensatz nicht gefunden"
+        },
+        "status": {
+          "deleting": {
+            "label": "Wird gelöscht"
+          },
+          "syncing": {
+            "label": "Wird synchronisiert"
+          },
+          "upToDate": {
+            "label": "Aktuell"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "Konnektoren"
+          },
+          "delete": {
+            "header": "Löschen"
+          },
+          "name": {
+            "header": "Name"
+          },
+          "public": {
+            "header": "Öffentlich"
+          },
+          "status": {
+            "header": "Status"
+          },
+          "title": "Vorhandene Dokumentensätze"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "Ausgeblendet"
+        },
+        "hide": {
+          "ariaLabel": "Dokument ausblenden",
+          "label": "Ausblenden"
+        },
+        "unhide": {
+          "ariaLabel": "Dokument einblenden",
+          "label": "Einblenden"
+        },
+        "visible": {
+          "label": "Sichtbar"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -912,6 +2568,16 @@
       "warnings": {
         "invalidSkill": "ungültiger Skill",
         "providerUnavailable": "Anbieter nicht verfügbar"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "Der Konnektor konnte nicht geladen werden: {details}",
+        "title": "Fehler"
+      },
+      "loading": {
+        "description": "Konnektordetails und Schema der Anmeldedaten werden abgerufen",
+        "title": "Konnektorkonfiguration wird geladen..."
       }
     },
     "groups": {
@@ -1734,6 +3400,155 @@
         "urlInvalid": "Muss eine gültige URL sein"
       }
     },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "Von {source} übernommen"
+          },
+          "organizationPublic": {
+            "label": "Organisationsweit öffentlich"
+          },
+          "private": {
+            "label": "Privat"
+          }
+        },
+        "addConnectorButton": {
+          "label": "Konnektor hinzufügen"
+        },
+        "connectorCreated": {
+          "toast": "Konnektor erfolgreich erstellt"
+        },
+        "empty": {
+          "message": "Sie haben anscheinend noch keine Konnektoren eingerichtet. Öffnen Sie die Seite [Konnektor hinzufügen](/admin/add-connector), um zu beginnen!"
+        },
+        "federated": {
+          "access": {
+            "label": "Föderierter Zugriff"
+          },
+          "indexed": {
+            "label": "Indiziert"
+          },
+          "notApplicable": {
+            "label": "Nicht zutreffend"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "Automatische Synchronisierung"
+            },
+            "private": {
+              "label": "Privat"
+            },
+            "public": {
+              "label": "Öffentlich"
+            },
+            "title": "Zugriffstyp"
+          },
+          "applyButton": {
+            "label": "Anwenden"
+          },
+          "docCount": {
+            "placeholder": "Anzahl",
+            "title": "Anzahl der Dokumente"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "Mit Fehlern abgeschlossen"
+            },
+            "failed": {
+              "label": "Fehlgeschlagen"
+            },
+            "inProgress": {
+              "label": "Läuft"
+            },
+            "interrupted": {
+              "label": "Unterbrochen"
+            },
+            "notStarted": {
+              "label": "Nicht gestartet"
+            },
+            "success": {
+              "label": "Erfolgreich"
+            },
+            "title": "Letzter Status"
+          },
+          "title": "Konnektoren filtern"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "Zugriff: {values}"
+          },
+          "clearBadge": {
+            "label": "Löschen"
+          },
+          "docsAnyBadge": {
+            "label": "Dok. {operator} beliebig"
+          },
+          "docsBadge": {
+            "label": "Dok. {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "Status: {values}"
+          }
+        },
+        "loadError": {
+          "message": "Fehler beim Laden des Indizierungsstatus."
+        },
+        "manageConnector": {
+          "tooltip": "Konnektor verwalten"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "Föderierten Konnektor verwalten"
+        },
+        "search": {
+          "placeholder": "Konnektoren suchen"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "Aktive Konnektoren"
+          },
+          "publicConnectors": {
+            "label": "Öffentliche Konnektoren"
+          },
+          "totalConnectors": {
+            "label": "Konnektoren gesamt"
+          },
+          "totalDocsIndexed": {
+            "label": "Indizierte Dokumente gesamt"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "Alles erledigt! Keine weiteren Konnektoren vorhanden"
+          },
+          "lastIndexed": {
+            "header": "Zuletzt indiziert"
+          },
+          "name": {
+            "header": "Name"
+          },
+          "permissions": {
+            "header": "Berechtigungen / Zugriff"
+          },
+          "status": {
+            "header": "Status"
+          },
+          "totalDocs": {
+            "header": "Dok. gesamt"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "Alle einklappen"
+          },
+          "expand": {
+            "label": "Alle ausklappen"
+          }
+        }
+      }
+    },
     "languageModels": {
       "availableProviders": {
         "title": "Verfügbare Anbieter"
@@ -1798,6 +3613,75 @@
         "unknownError": "Unbekannter Fehler"
       }
     },
+    "mcpActions": {
+      "header": {
+        "description": "Verbinden Sie MCP-Server (Model Context Protocol), um benutzerdefinierte Aktionen und Tools für Ihre Agenten hinzuzufügen."
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "Keine Claims empfangen."
+        },
+        "table": {
+          "claim": {
+            "header": "Claim"
+          },
+          "value": {
+            "header": "Wert"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "Anbieter-API",
+        "subtitle": "Verzeichnisfelder, die über die Anbieter-API abgerufen wurden — z. B. Microsoft Graph /me für Entra ID. Diese liefert country/usageLocation, die das id_token auslässt, sofern der optionale Claim ctry nicht konfiguriert ist.",
+        "title": "Verzeichnisprofil ({source})"
+      },
+      "idToken": {
+        "subtitle": "Dekodiert aus dem id_token-JWT, das der Token-Endpunkt zurückgegeben hat.",
+        "title": "id_token-Claims"
+      },
+      "intro": {
+        "description": "Zeigt die Rohfelder, die Ihr Identitätsanbieter bei Ihrer letzten OAuth-/OIDC-Anmeldung über Sie gesendet hat: die id_token-Claims und die Antwort des userinfo-Endpunkts. Damit prüfen Sie, welche Attribute der IdP freigeben soll. Die Claims werden bei jeder Anmeldung erfasst."
+      },
+      "loadFailed": {
+        "title": "Die OAuth-Claims konnten nicht geladen werden"
+      },
+      "noSnapshot": {
+        "description": "Für {email} wurde keine Momentaufnahme einer OAuth-Anmeldung gefunden. Melden Sie sich über den Identitätsanbieter an (Schaltfläche oben) und laden Sie diese Seite neu.",
+        "title": "Noch keine Claims erfasst"
+      },
+      "rerun": {
+        "label": "OAuth-Anmeldung erneut ausführen"
+      },
+      "resolved": {
+        "subtitle": "Das über Claims zugeordnete Verzeichnisprofil, das tatsächlich den Prompt-Block „Organisationsprofil“ und die Platzhalter {placeholder} speist.",
+        "title": "Aufgelöstes Profil (für Prompts verwendet)"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "Erfasst am: {timestamp}"
+        },
+        "provider": {
+          "label": "Anbieter: {provider}"
+        },
+        "tokenFields": {
+          "label": "Felder der Token-Antwort: {fields}"
+        },
+        "user": {
+          "label": "Benutzer: {email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "Antwort des OIDC-userinfo-Endpunkts für Ihr Zugriffstoken.",
+        "title": "userinfo-Claims"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "Verbinden Sie OpenAPI-Server, um benutzerdefinierte Aktionen und Tools für Ihre Agenten hinzuzufügen."
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Die Kosten werden aus der erfassten Modellnutzung berechnet.",
@@ -1831,6 +3715,62 @@
           "description": "Für diesen Zeitraum wurde keine Nutzung erfasst."
         },
         "title": "Benutzer"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "Verbunden"
+        },
+        "description": "Verbinden Sie Ihren Identitätsanbieter, um Benutzer und Gruppen zu importieren und zu synchronisieren.",
+        "generate": {
+          "label": "SCIM-Token erzeugen"
+        },
+        "regenerate": {
+          "label": "Token neu erzeugen"
+        },
+        "title": "SCIM-Synchronisierung",
+        "waiting": {
+          "description": "Geben Sie den SCIM-Schlüssel an Ihren Identitätsanbieter weiter, um mit der Synchronisierung von Benutzern und Gruppen zu beginnen.",
+          "label": "Warten auf Verbindung"
+        }
+      },
+      "header": {
+        "description": "Synchronisieren Sie Benutzer und Gruppen über das Protokoll System for Cross-domain Identity Management (SCIM).",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "Der Status des SCIM-Tokens konnte nicht geladen werden."
+      },
+      "modal": {
+        "copied": {
+          "message": "Token in die Zwischenablage kopiert"
+        },
+        "copyFailed": {
+          "error": "Der Token konnte nicht kopiert werden"
+        },
+        "regenerate": {
+          "description": "Ihr aktueller SCIM-Token wird widerrufen und ein neuer Token wird erzeugt. Sie müssen den Token bei Ihrem Identitätsanbieter aktualisieren, bevor die SCIM-Bereitstellung fortgesetzt wird.",
+          "submit": {
+            "label": "Token neu erzeugen"
+          },
+          "title": "SCIM-Token neu erzeugen"
+        },
+        "token": {
+          "copy": {
+            "label": "Token kopieren"
+          },
+          "description": "Speichern Sie diesen Schlüssel, bevor Sie fortfahren. Er wird nicht erneut angezeigt.",
+          "download": {
+            "label": "Herunterladen"
+          },
+          "title": "SCIM-Token"
+        }
+      },
+      "toasts": {
+        "generateFailed": "Der Token konnte nicht erzeugt werden: {detail}",
+        "genericError": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
+        "regenerated": "Token neu erzeugt"
       }
     },
     "security": {
@@ -2213,6 +4153,393 @@
         }
       }
     },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "Fehler beim Erstellen der OnyxBot-Konfiguration - {error}"
+        },
+        "updateError": {
+          "toast": "Fehler beim Aktualisieren der OnyxBot-Konfiguration - {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "Die Slack-Bot-Konfiguration konnte nicht gelöscht werden - {error}"
+        },
+        "deleted": {
+          "toast": "Slack-Bot-Konfiguration \"{configId}\" gelöscht"
+        },
+        "editDefaultButton": {
+          "label": "Standardkonfiguration bearbeiten"
+        },
+        "newConfigButton": {
+          "label": "Neue Kanalkonfiguration"
+        },
+        "section": {
+          "title": "Kanalspezifische Konfigurationen"
+        },
+        "table": {
+          "actions": {
+            "header": "Aktionen"
+          },
+          "assistant": {
+            "header": "Assistent"
+          },
+          "channel": {
+            "header": "Kanal"
+          },
+          "documentSets": {
+            "header": "Dokumentensätze"
+          },
+          "empty": {
+            "message": "Keine kanalspezifischen Konfigurationen. Fügen Sie eine neue Konfiguration hinzu, um das Verhalten für bestimmte Kanäle anzupassen."
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "Löschen"
+        },
+        "error": {
+          "toast": "Der Slack-Bot konnte nicht gelöscht werden"
+        },
+        "message": "Möchten Sie diesen Slack-Bot wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "success": {
+          "toast": "Slack-Bot erfolgreich gelöscht"
+        },
+        "title": "Slack-Bot löschen"
+      },
+      "edit": {
+        "header": {
+          "title": "Slack-Bot bearbeiten"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Slack-Kanalkonfiguration bearbeiten"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "Slack-Standardkonfiguration bearbeiten"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "Slack-Kanalkonfiguration mit der ID {id} wurde nicht gefunden"
+        },
+        "fetchAgents": {
+          "message": "Die Agenten konnten nicht abgerufen werden - {error}"
+        },
+        "fetchBot": {
+          "message": "Der Slack-Bot {botId} konnte nicht abgerufen werden: {error}"
+        },
+        "fetchChannels": {
+          "message": "Die Slack-Kanäle konnten nicht abgerufen werden - {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "Die Dokumentensätze konnten nicht abgerufen werden - {error}"
+        },
+        "generic": {
+          "title": "Etwas ist schiefgelaufen :("
+        },
+        "unknown": {
+          "message": "unbekannter Fehler"
+        },
+        "unknownOccurred": {
+          "message": "Ein unbekannter Fehler ist aufgetreten"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "Nach einem Agenten suchen..."
+        },
+        "answerValidity": {
+          "label": "Nur antworten, wenn Quellenangaben gefunden werden",
+          "tooltip": "Wenn aktiviert, werden nur Fragen beantwortet, bei denen das Modell erfolgreich Quellenangaben erzeugt"
+        },
+        "cancelButton": {
+          "label": "Abbrechen"
+        },
+        "channelName": {
+          "label": "Name des Slack-Kanals",
+          "placeholder": "Kanalnamen eingeben (z. B. general, support)",
+          "subtext": "Geben Sie den Namen des Slack-Kanals ein (ohne das Zeichen #)"
+        },
+        "createButton": {
+          "label": "Erstellen"
+        },
+        "defaultConfig": {
+          "badge": "Standardkonfiguration",
+          "description": "Diese Standardkonfiguration gilt für alle Kanäle und Direktnachrichten (DMs) in Ihrem Slack-Arbeitsbereich."
+        },
+        "disableDefault": {
+          "label": "Standardkonfiguration deaktivieren",
+          "warning": "Warnung: Wenn Sie die Standardkonfiguration deaktivieren, antwortet OnyxBot nur in Slack-Kanälen, die ausdrücklich konfiguriert sind. Außerdem antwortet OnyxBot nicht auf Direktnachrichten."
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "Dieser Dokumentensatz kann nicht verwendet werden, weil er einen Konnektor mit automatisch synchronisierten Berechtigungen enthält. Die Antworten von OnyxBot in diesem Kanal sind für alle Slack-Benutzer sichtbar. Die Berechtigungen der fragenden Person zu spiegeln, könnte daher versehentlich private Informationen offenlegen."
+          },
+          "autoSyncedNote": {
+            "text": "Diese Dokumentensätze können nicht angehängt werden, da sie automatisch synchronisierte Dokumente enthalten:"
+          },
+          "description": "Wählen Sie die Dokumentensätze aus, die OnyxBot beim Beantworten von Fragen in Slack verwendet.",
+          "hideUnselectableButton": {
+            "label": "Nicht auswählbare Dokumentensätze ausblenden"
+          },
+          "incompatibleHidden": {
+            "text": "Einige nicht kompatible Dokumentensätze sind ausgeblendet."
+          },
+          "incompatibleVisible": {
+            "text": "Einige nicht kompatible Dokumentensätze sind sichtbar."
+          },
+          "viewAllButton": {
+            "label": "Alle Dokumentensätze anzeigen"
+          }
+        },
+        "followUpTags": {
+          "label": "(Optional) Zu markierende Benutzer / Gruppen",
+          "subtext": "Die Slack-Benutzer / -Gruppen, die wir markieren sollen, wenn der Benutzer auf die Schaltfläche \"Brauchen Sie noch Hilfe?\" klickt. Wenn keine E-Mail-Adressen angegeben sind, markieren wir niemanden und reagieren nur mit einem 🆘-Emoji auf die ursprüngliche Nachricht."
+        },
+        "generalConfig": {
+          "section": {
+            "title": "Allgemeine Konfiguration"
+          }
+        },
+        "isEphemeral": {
+          "label": "Dem Benutzer in einer privaten (kurzlebigen) Nachricht antworten",
+          "tooltip": "Wenn aktiviert, antwortet OnyxBot nur dem Benutzer in einer privaten (kurzlebigen) Nachricht. Wenn Sie oben außerdem den Agenten „Suche“ gewählt haben, macht diese Option auch Dokumente verfügbar, die für den Benutzer privat sind."
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "Gesamtes öffentliches Wissen",
+            "sublabel": "OnyxBot antwortet auf Basis der Informationen aus allen öffentlichen Konnektoren"
+          },
+          "documentSets": {
+            "label": "Bestimmte Dokumentensätze",
+            "sublabel": "Steuern Sie, welche Dokumente zur Beantwortung von Fragen verwendet werden"
+          },
+          "label": "Wissensquelle",
+          "nonSearchAgent": {
+            "label": "Agent ohne Suche",
+            "sublabel": "Chatten Sie mit einem Agenten, der keine Dokumente verwendet"
+          },
+          "searchAgent": {
+            "label": "Such-Agent",
+            "sublabel": "Steuern Sie sowohl die Dokumente als auch den Prompt zur Beantwortung von Fragen"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "Wählen Sie den Agenten ohne Suche aus, den OnyxBot beim Beantworten von Fragen in Slack verwendet."
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "Relevante Konnektoren:"
+          },
+          "description": "Bitte beachten Sie: Wenn die private (kurzlebige) Antwort *nicht ausgewählt* ist, sind für Benutzeranfragen nur öffentliche Dokumente innerhalb der ausgewählten Dokumentensätze zugänglich. Wenn die private (kurzlebige) Antwort *ausgewählt* ist, können die Anfragen der Benutzer auch Dokumente nutzen, für die der Benutzer bereits Zugriff erhalten hat. Beachten Sie, dass Benutzer die Antwort mit anderen im Kanal teilen können. Stellen Sie daher sicher, dass dies mit den Freigaberichtlinien Ihres Unternehmens vereinbar ist.",
+          "title": "Datenschutzhinweis"
+        },
+        "questionmarkPrefilter": {
+          "label": "Nur auf Fragen antworten",
+          "tooltip": "Wenn aktiviert, antwortet OnyxBot nur auf Nachrichten, die ein Fragezeichen enthalten"
+        },
+        "removedDocumentSets": {
+          "toast": "Wir haben einen oder mehrere Dokumentensätze aus Ihrer Auswahl entfernt, weil sie nicht mehr gültig sind. Bitte prüfen und aktualisieren Sie Ihre Konfiguration."
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "Deaktiviert, solange „Dem Benutzer in einer privaten (kurzlebigen) Nachricht antworten“ aktiv ist — kurzlebige Antworten richten sich nur an einen einzelnen Benutzer."
+          },
+          "label": "(Optional) Nur bestimmten Benutzern / Gruppen antworten",
+          "subtext": "Wenn angegeben, können nur diese Benutzer / Gruppen OnyxBot in diesem Kanal aufrufen, und die Antworten sind nur für sie sichtbar."
+        },
+        "respondTagOnly": {
+          "label": "Nur auf @OnyxBot antworten",
+          "tooltip": "Wenn aktiviert, antwortet OnyxBot nur, wenn er direkt markiert wird"
+        },
+        "respondToBots": {
+          "label": "Auf Bot-Nachrichten antworten",
+          "tooltip": "Wenn nicht aktiviert, ignoriert OnyxBot Nachrichten von Bots immer"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "Ausführlich"
+          },
+          "label": "Antworttyp",
+          "standard": {
+            "label": "Standard"
+          },
+          "tooltip": "Steuert das Format der Antworten von OnyxBot."
+        },
+        "searchAgent": {
+          "description": "Wählen Sie den suchfähigen Agenten aus, den OnyxBot beim Beantworten von Fragen in Slack verwendet."
+        },
+        "searchConfig": {
+          "section": {
+            "title": "Suchkonfiguration"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "Schaltfläche zum Fortsetzen in der Weboberfläche anzeigen",
+          "tooltip": "Wenn aktiviert, wird am Ende der Antwort eine Schaltfläche angezeigt, mit der der Benutzer das Gespräch in der Onyx-Weboberfläche fortsetzen kann"
+        },
+        "stillNeedHelp": {
+          "label": "Schaltfläche \"Brauchen Sie noch Hilfe?\" anzeigen",
+          "section": {
+            "prompt": "Schaltfläche \"Brauchen Sie noch Hilfe?\" konfigurieren"
+          },
+          "tooltip": "Die Antwort von OnyxBot enthält am Ende eine Schaltfläche, die den Benutzer fragt, ob er noch Hilfe braucht."
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "Nicht auswählbare Agenten ausblenden"
+          },
+          "listLabel": "Nicht auswählbare Agenten:",
+          "note": "Hinweis: Einige Ihrer Agenten haben in ihren Dokumentensätzen automatisch synchronisierte Konnektoren. Sie können diese Agenten nicht auswählen, da sie in Slack keine Fragen beantworten können.",
+          "viewAllButton": {
+            "label": "Alle Agenten anzeigen"
+          }
+        },
+        "updateButton": {
+          "label": "Aktualisieren"
+        },
+        "userOrGroup": {
+          "placeholder": "E-Mail-Adresse des Benutzers oder Name der Benutzergruppe..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "Richten Sie OnyxBot so ein, dass er Fragen in bestimmten Kanälen automatisch beantwortet."
+        },
+        "description": "Richten Sie Slack-Bots ein, die sich mit Onyx verbinden. Nach der Einrichtung können Sie Onyx direkt aus Slack Fragen stellen. Außerdem können Sie:",
+        "directMessage": {
+          "item": "Schreiben Sie OnyxBot direkt eine Nachricht, um wie in der Weboberfläche zu suchen."
+        },
+        "docsPrompt": {
+          "text": "Folgen Sie der <link>Anleitung</link> in der Onyx-Dokumentation, um zu beginnen!"
+        },
+        "documentSets": {
+          "item": "Wählen Sie je nach Kanal, in dem die Frage gestellt wird, aus welchen Dokumentensätzen OnyxBot antworten soll."
+        }
+      },
+      "list": {
+        "error": {
+          "title": "Fehler beim Laden der Apps"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "Neuer Slack-Bot"
+        }
+      },
+      "newBotButton": {
+        "label": "Neuer Slack-Bot"
+      },
+      "newChannel": {
+        "header": {
+          "title": "OnyxBot für Slack-Kanal konfigurieren"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "Anzahl der Kanäle"
+        },
+        "defaultConfig": {
+          "header": "Standardkonfiguration"
+        },
+        "defaultSet": {
+          "badge": "Standard festgelegt"
+        },
+        "disabled": {
+          "badge": "Deaktiviert"
+        },
+        "empty": {
+          "message": "Bitte fügen Sie einen neuen Slack-Bot hinzu, um mit Onyx zu chatten!"
+        },
+        "enabled": {
+          "badge": "Aktiviert"
+        },
+        "name": {
+          "header": "Name"
+        },
+        "status": {
+          "header": "Status"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Slack-App-Token"
+        },
+        "botToken": {
+          "label": "Slack-Bot-Token"
+        },
+        "createButton": {
+          "label": "Erstellen"
+        },
+        "createError": {
+          "toast": "Fehler beim Erstellen des Slack-Bots - {error}"
+        },
+        "created": {
+          "toast": "Slack-Bot erfolgreich erstellt!"
+        },
+        "docsPrompt": {
+          "text": "Bitte lesen Sie unsere <link>Anleitung</link>, wenn Sie nicht sicher sind, wie Sie diese Token erhalten!"
+        },
+        "invalidAppToken": {
+          "message": "Der Slack-App-Token ist ungültig"
+        },
+        "invalidBotToken": {
+          "message": "Der Slack-Bot-Token ist ungültig"
+        },
+        "name": {
+          "label": "Benennen Sie diesen Slack-Bot:"
+        },
+        "updateButton": {
+          "label": "Aktualisieren"
+        },
+        "updateError": {
+          "toast": "Fehler beim Aktualisieren des Slack-Bots - {error}"
+        },
+        "updated": {
+          "toast": "Slack-Bot erfolgreich aktualisiert!"
+        },
+        "userToken": {
+          "label": "Slack-Benutzer-Token (optional)",
+          "subtext": "Optional: OAuth-Token des Benutzers für erweiterten Zugriff auf private Kanäle"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "Löschen"
+        },
+        "enabledCheckbox": {
+          "label": "Aktiviert"
+        },
+        "fieldUpdateFailed": {
+          "toast": "{field} des Konnektors konnte nicht aktualisiert werden"
+        },
+        "fieldUpdated": {
+          "toast": "{field} des Konnektors erfolgreich aktualisiert"
+        },
+        "updateTokensButton": {
+          "label": "Token aktualisieren"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "Bei der Wissensquelle „Agent“ ist ein Agent erforderlich"
+        },
+        "channelNameRequired": {
+          "message": "Der Kanalname ist erforderlich"
+        },
+        "documentSetRequired": {
+          "message": "Bei der Wissensquelle „Dokumentensätze“ ist mindestens ein Dokumentensatz erforderlich"
+        }
+      }
+    },
     "ssoProviders": {
       "addProvider": {
         "button": {
@@ -2239,6 +4566,180 @@
       },
       "toasts": {
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten."
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "Backend-Version: "
+      },
+      "version": {
+        "title": "Version"
+      },
+      "webVersion": {
+        "label": "Web-Version: "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "Bis zu {cost} oder {tokens} Token",
+          "cost": "Bis zu {cost}",
+          "none": "Kein Budget festgelegt",
+          "tokens": "Bis zu {tokens} Token"
+        },
+        "cadence": {
+          "label": "{days, plural, one {Wird jeden Tag um Mitternacht UTC zurückgesetzt} other {Wird alle # Tage um Mitternacht UTC zurückgesetzt}}"
+        },
+        "deleteFailed": {
+          "error": "Das Token-Ratenlimit konnte nicht gelöscht werden"
+        },
+        "empty": {
+          "message": "Noch keine Limits. Erstellen Sie ein Ausgabenlimit, um die Nutzung zu begrenzen."
+        },
+        "loadFailed": {
+          "error": "Die Token-Ratenlimits konnten nicht geladen werden"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "{label} löschen",
+            "tooltip": "Limit löschen"
+          },
+          "disable": {
+            "ariaLabel": "{label} deaktivieren"
+          },
+          "enable": {
+            "ariaLabel": "{label} aktivieren"
+          },
+          "label": "{budget}, {cadence}"
+        },
+        "updateFailed": {
+          "error": "Das Token-Ratenlimit konnte nicht aktualisiert werden"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "Abbrechen"
+        },
+        "costBudget": {
+          "description": "Maximale Ausgaben pro Zurücksetzungszeitraum. Legen Sie ein Kostenbudget, ein Token-Budget oder beides fest.",
+          "placeholder": "Kein Kostenlimit",
+          "title": "Kostenbudget",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "Geben Sie ein Kostenbudget, ein Token-Budget oder beides ein",
+          "costMax": "Das maximale Kostenbudget beträgt {amount, number} $",
+          "costMinCents": "Das Kostenbudget muss mindestens 0,01 $ betragen",
+          "costMoreThanZero": "Das Kostenbudget muss größer als 0 sein",
+          "groupRequired": "Wählen Sie eine Benutzergruppe aus",
+          "periodInteger": "Geben Sie eine ganze Anzahl von Tagen ein",
+          "periodMin": "Verwenden Sie mindestens 1 Tag",
+          "periodRequired": "Geben Sie einen Zurücksetzungszeitraum ein",
+          "scopeRequired": "Der Zielbereich ist ein Pflichtfeld",
+          "tokenIncrement": "Verwenden Sie Schritte von 1.000 Token",
+          "tokenInteger": "Geben Sie eine ganze Anzahl von Token ein",
+          "tokenMax": "Das maximale Token-Budget beträgt 1 Billion",
+          "tokenMin": "Verwenden Sie mindestens 1.000 Token"
+        },
+        "groupMenu": {
+          "empty": "Noch keine Benutzergruppen. Erstellen Sie eine unter Benutzer & Gruppen."
+        },
+        "groupPicker": {
+          "placeholder": "Gruppe auswählen"
+        },
+        "header": {
+          "title": "Ausgabenlimit erstellen"
+        },
+        "period": {
+          "description": "Budgets werden um Mitternacht UTC zurückgesetzt",
+          "title": "Zurücksetzungszeitraum",
+          "unit": "Tage"
+        },
+        "scope": {
+          "caption": {
+            "global": "Alle im Arbeitsbereich teilen sich ein Budget.",
+            "group": "Die Mitglieder von {group} teilen sich ein Budget.",
+            "groupUnchosen": "Die Mitglieder der gewählten Gruppe teilen sich ein Budget.",
+            "user": "Jeder Benutzer erhält ein eigenes Budget."
+          },
+          "title": "Gilt für"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "Arbeitsbereich"
+          },
+          "user": {
+            "title": "Pro Benutzer"
+          },
+          "userGroup": {
+            "title": "Benutzergruppe"
+          }
+        },
+        "submit": {
+          "label": "Limit erstellen"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} oder {tokens} Token",
+            "tokens": "{tokens} Token"
+          },
+          "global": "{days, plural, one {Alle im Arbeitsbereich teilen sich täglich bis zu {budget}. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.} other {Alle im Arbeitsbereich teilen sich alle # Tage bis zu {budget}. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.}}",
+          "group": "{days, plural, one {Die Mitglieder von {group} teilen sich täglich bis zu {budget}. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.} other {Die Mitglieder von {group} teilen sich alle # Tage bis zu {budget}. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.}}",
+          "groupUnchosen": "{days, plural, one {Die Mitglieder der gewählten Gruppe teilen sich täglich bis zu {budget}. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.} other {Die Mitglieder der gewählten Gruppe teilen sich alle # Tage bis zu {budget}. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.}}",
+          "user": "{days, plural, one {Jeder Benutzer kann täglich bis zu {budget} ausgeben. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.} other {Jeder Benutzer kann alle # Tage bis zu {budget} ausgeben. Die Nutzung wird blockiert, bis der Zeitraum zurückgesetzt wird.}}"
+        },
+        "tokenBudget": {
+          "description": "Maximale Anzahl an Token pro Zurücksetzungszeitraum",
+          "placeholder": "Kein Token-Limit",
+          "title": "Token-Budget",
+          "unit": "Token"
+        },
+        "userGroup": {
+          "description": "Wählen Sie, welche Gruppe sich dieses Budget teilt",
+          "title": "Benutzergruppe"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "Ausgabenlimit erstellen"
+        },
+        "createFailed": {
+          "error": "Das Ausgabenlimit konnte nicht erstellt werden"
+        },
+        "created": {
+          "message": "Ausgabenlimit erstellt!"
+        },
+        "embedded": {
+          "description": "Legen Sie Leitplanken für die Nutzung durch den Arbeitsbereich, Benutzer und Gruppen fest. Limits können aktiviert oder deaktiviert werden, ohne ihre Konfiguration zu löschen.",
+          "title": "Ausgabenlimits verwalten"
+        },
+        "global": {
+          "description": "Globale Limits gelten für alle Benutzer, Benutzergruppen und API-Schlüssel. Wenn das globale Limit erreicht ist, können keine weiteren Token verbraucht werden."
+        },
+        "intro": {
+          "description": "Mit Ausgabenlimits steuern Sie, wie viele Token in einem bestimmten Zeitraum verbraucht werden dürfen.",
+          "groupLimit": "Legen Sie Limits für Benutzergruppen fest, um die Ausgaben von Teams zu steuern.",
+          "toggleLimit": "Aktivieren und deaktivieren Sie Limits nach Bedarf.",
+          "userLimit": "Legen Sie Limits für Benutzer fest, damit kein einzelner Benutzer zu viel verbraucht.",
+          "workspaceLimit": "Legen Sie ein arbeitsbereichsweites Limit für die Gesamtausgaben Ihres Teams fest."
+        },
+        "tabs": {
+          "global": {
+            "name": "Global"
+          },
+          "groups": {
+            "name": "Gruppen"
+          },
+          "users": {
+            "name": "Benutzer"
+          }
+        },
+        "user": {
+          "description": "Benutzerlimits gelten für jeden Benutzer einzeln. Wenn ein Benutzer ein Limit erreicht, kann er vorübergehend keine Token mehr verbrauchen."
+        },
+        "userGroup": {
+          "description": "Gruppenlimits gelten für alle Benutzer einer Gruppe. Gehört ein Benutzer mehreren Gruppen an, gilt das großzügigste Limit."
+        }
       }
     },
     "tracing": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -26,6 +26,46 @@
     }
   },
   "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "Code Repository"
+        },
+        "messaging": {
+          "label": "Messaging"
+        },
+        "other": {
+          "label": "Others"
+        },
+        "sales": {
+          "label": "Sales"
+        },
+        "storage": {
+          "label": "Cloud Storage"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "Ticketing & Task Management"
+        },
+        "wiki": {
+          "label": "Knowledge Base & Wikis"
+        }
+      },
+      "popular": {
+        "title": "Popular"
+      },
+      "search": {
+        "placeholder": "Search Connectors"
+      },
+      "seeConnectorsButton": {
+        "label": "See Connectors"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>Federated connector already configured.</strong> Click to edit the existing connector.",
+          "slackCredentialsFound": "<strong>Existing Slack credentials found.</strong> Click to manage your Slack connector."
+        }
+      }
+    },
     "agents": {
       "deleteModal": {
         "confirmation": {
@@ -298,6 +338,326 @@
           }
         },
         "title": "Usage"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "Your license is being processed. You'll be taken to billing details automatically once confirmed.",
+        "title": "Your license is still activating"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "Online billing management is disabled. Contact support to update your subscription.",
+          "title": "Air-gapped deployment"
+        },
+        "expired": {
+          "description": "Renew your subscription to restore access to paid features.",
+          "title": "Your subscription has expired.",
+          "withDate": {
+            "description": "Renew your subscription by {date} to restore access."
+          },
+          "withDeletion": {
+            "title": "Your subscription has expired. Data will be deleted in {days} days."
+          }
+        },
+        "expiring": {
+          "description": "Renew your subscription by {date} to avoid disruption.",
+          "title": "Your subscription is expiring in {days} days."
+        },
+        "graceSync": {
+          "title": "Checking for a renewed license…"
+        },
+        "stripeError": {
+          "description": "Check your internet connection or manually provide a license.",
+          "title": "Unable to connect to Stripe payment portal."
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "Adjust Plan"
+        },
+        "annual": {
+          "label": "Annual"
+        },
+        "annualBadge": {
+          "label": "Save 20%"
+        },
+        "billingCycle": {
+          "description": "after your 1-month free trial",
+          "title": "Billing Cycle"
+        },
+        "continueToPayment": {
+          "label": "Continue to Payment"
+        },
+        "createSessionFailed": {
+          "error": "Failed to create checkout session"
+        },
+        "loading": {
+          "label": "Loading..."
+        },
+        "monthly": {
+          "label": "Monthly"
+        },
+        "perSeatMonth": {
+          "label": "per seat/month"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "${price}"
+        },
+        "seats": {
+          "description": "{count, plural, one {Minimum # seat required for your current users and Slack accounts.} other {Minimum # seats required for your current users and Slack accounts.}}",
+          "title": "Seats"
+        },
+        "trialBilling": {
+          "text": "You will be billed on <value>{date}</value> After your 1-month free trial ends."
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "Activate License Key"
+        },
+        "billingHelp": {
+          "label": "Billing Help"
+        },
+        "licenseKeyPrompt": {
+          "label": "Have a license key?"
+        },
+        "updateLicenseKey": {
+          "label": "Update License Key"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "Plans & Billing"
+        },
+        "upgradePlan": {
+          "title": "Upgrade Plan"
+        },
+        "viewPlans": {
+          "title": "View Plans"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "Failed to activate license"
+        },
+        "activateLicense": {
+          "label": "Activate License"
+        },
+        "activateSuccess": {
+          "message": "License activated successfully!"
+        },
+        "activateTitle": {
+          "title": "Activate License Key"
+        },
+        "activating": {
+          "label": "Activating..."
+        },
+        "activeUntil": {
+          "label": "License key active until <value>{date}</value>"
+        },
+        "cancel": {
+          "label": "Cancel"
+        },
+        "close": {
+          "label": "Close"
+        },
+        "description": "Manually add and activate a license for this Onyx instance.",
+        "emptyKey": {
+          "error": "Please enter a license key"
+        },
+        "error": {
+          "text": "{error}. <link>Billing Help</link>"
+        },
+        "expired": {
+          "label": "License key expired"
+        },
+        "keyField": {
+          "description": "Paste or attach your license key file you received from Onyx.",
+          "title": "License Key"
+        },
+        "updateKey": {
+          "label": "Update Key"
+        },
+        "updateLicense": {
+          "label": "Update License"
+        },
+        "updateSuccess": {
+          "message": "License updated successfully!"
+        },
+        "updateTitle": {
+          "title": "Update License Key"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "Payment method",
+          "title": "Visa ending in 1234"
+        },
+        "lastPayment": {
+          "description": "Last payment"
+        },
+        "section": {
+          "title": "Payment"
+        },
+        "update": {
+          "label": "Update"
+        },
+        "viewInvoice": {
+          "label": "View Invoice"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Get Business Plan"
+          },
+          "description": "per seat/month billed annually\nor $25 per seat if billed monthly",
+          "features": {
+            "apiKeys": "Service Account API Keys",
+            "documentPermissions": "Inherit Document Permissions",
+            "encryption": "Encryption of Secrets",
+            "queryHistory": "Query History and Usage Dashboard",
+            "rbac": "Role Based Access Control (RBAC)",
+            "selfHosting": "Self-hosting (Optional)",
+            "theming": "Custom Theming"
+          },
+          "featuresPrefix": "Get more work done with AI for your team.",
+          "pricing": "$20",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "{plan} plan card"
+        },
+        "currentPlan": {
+          "label": "Your Current Plan"
+        },
+        "enterprise": {
+          "button": {
+            "label": "Contact Sales"
+          },
+          "description": "Flexible pricing & deployment options\nfor large organizations",
+          "features": {
+            "customDeployments": "Custom Deployments",
+            "customRoles": "Custom Roles and Permissions",
+            "hookExtensions": "Hook Extensions",
+            "regionalProcessing": "Region-Specific Data Processing",
+            "scim": "SCIM / Group Sync",
+            "support": "Enterprise SLAs and Priority Support",
+            "usageLimits": "Configurable Usage Limits",
+            "whiteLabeling": "Full White-labeling"
+          },
+          "featuresPrefix": "Everything in Business Plan, plus:",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "Included in your plan"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "You cannot set seats below current **{minimum}** seats in use/pending. [Remove users](/admin/users) first before adjusting seats."
+        },
+        "billing": {
+          "added": "{count, plural, one {You will be billed for the <value>{count}</value> additional seat at a pro-rated amount.} other {You will be billed for the <value>{count}</value> additional seats at a pro-rated amount.}}",
+          "removed": "{count, plural, one {<value>{count}</value> seat will be removed on <value>{date}</value> (after current billing cycle).} other {<value>{count}</value> seats will be removed on <value>{date}</value> (after current billing cycle).}}",
+          "unchanged": "No changes to your billing."
+        },
+        "breakdown": {
+          "label": "{used} in use • {pending} pending • {remaining} remaining"
+        },
+        "cancel": {
+          "label": "Cancel"
+        },
+        "confirmChange": {
+          "label": "Confirm Change"
+        },
+        "delta": {
+          "added": "{count, plural, one {# seat to be added} other {# seats to be added}}",
+          "removed": "{count, plural, one {# seat to be removed} other {# seats to be removed}}"
+        },
+        "saving": {
+          "label": "Saving..."
+        },
+        "seatsField": {
+          "title": "Seats"
+        },
+        "total": {
+          "label": "{count} Seats"
+        },
+        "updateFailed": {
+          "error": "Failed to update seats"
+        },
+        "updateSeats": {
+          "description": "Add or remove seats to reflect your team size.",
+          "label": "Update Seats",
+          "title": "Update Seats"
+        },
+        "viewUsers": {
+          "label": "View Users"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Business Plan"
+        },
+        "connectToStripe": {
+          "label": "Connect to Stripe"
+        },
+        "connecting": {
+          "label": "Connecting..."
+        },
+        "enterprisePlan": {
+          "name": "Enterprise Plan"
+        },
+        "expired": {
+          "subtitle": "Expired on {date}"
+        },
+        "managePlan": {
+          "label": "Manage Plan"
+        },
+        "managedBySales": {
+          "text": "Your plan is managed through sales.<br></br><link>Contact billing</link> to make changes."
+        },
+        "nextPayment": {
+          "subtitle": "Next payment on {date}"
+        },
+        "syncLicense": {
+          "label": "Sync License"
+        },
+        "syncing": {
+          "label": "Syncing..."
+        },
+        "trialDays": {
+          "subtitle": "Trial ends in {days} days. Payment required on {date}"
+        },
+        "trialToday": {
+          "subtitle": "Trial ends today. Payment required on {date}"
+        },
+        "trialTomorrow": {
+          "subtitle": "Trial ends tomorrow. Payment required on {date}"
+        },
+        "upgradeNow": {
+          "label": "Upgrade now"
+        },
+        "upgrading": {
+          "label": "Upgrading..."
+        },
+        "validUntil": {
+          "subtitle": "Valid until {date}"
+        },
+        "viewPlanDetails": {
+          "label": "View Plan Details"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "Failed to end trial",
+        "licenseSyncFailed": "License sync failed",
+        "paymentMethodRequired": "Add a payment method first, then try upgrading again.",
+        "syncLicenseFailed": "Failed to sync license"
       }
     },
     "chatPreferences": {
@@ -591,6 +951,847 @@
         }
       }
     },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# day} other {# days}}",
+          "hours": "{count, plural, one {# hour} other {# hours}}",
+          "minutes": "{count, plural, one {# minute} other {# minutes}}"
+        },
+        "indexingStart": {
+          "label": "Indexing Start"
+        },
+        "pruningFrequency": {
+          "label": "Pruning Frequency"
+        },
+        "refreshFrequency": {
+          "label": "Refresh Frequency"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "False",
+        "booleanTrue": "True",
+        "edit": {
+          "tooltip": "Edit"
+        },
+        "showAll": {
+          "label": "Show all ({count} items)"
+        },
+        "showLess": {
+          "label": "Show less"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "Deleting this connector schedules a deletion job that removes its indexed documents and deletes it for every user.",
+        "entityType": "connector"
+      },
+      "deletionError": {
+        "description": "This error occurred while attempting to delete the connector. You may re-attempt a deletion by clicking the \"Delete\" button.",
+        "title": "Deletion Error"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "Docs Synced",
+          "errorMessage": "Error Message",
+          "permissionErrors": "Permission Errors",
+          "status": "Status",
+          "timeStarted": "Time Started"
+        },
+        "empty": {
+          "description": "Document-permission sync runs are scheduled in the background. They may take some time to appear — try refreshing in ~30 seconds.",
+          "title": "No document permission sync attempts yet"
+        },
+        "errorModal": {
+          "title": "Document Permission Sync Error"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "Document ID",
+          "errorMessage": "Error Message",
+          "status": "Status",
+          "time": "Time"
+        },
+        "description": "Below are the errors encountered during indexing. Each row represents a failed document or entity.",
+        "empty": {
+          "description": "No errors found on this page"
+        },
+        "fullReindex": {
+          "description": "Click the button below to kick off a full re-index to try and resolve these errors. This full re-index may take much longer than a normal update."
+        },
+        "resolveAllButton": {
+          "label": "Resolve All"
+        },
+        "status": {
+          "resolved": "Resolved",
+          "unresolved": "Unresolved"
+        },
+        "targetedReindex": {
+          "description": "Click the button below to re-fetch only the failing documents. Much faster than a full re-index."
+        },
+        "title": "Indexing Errors",
+        "unknownDocument": "Unknown"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "Add Files"
+        },
+        "cancelButton": {
+          "label": "Cancel"
+        },
+        "columns": {
+          "fileName": "File Name",
+          "size": "Size",
+          "uploadDate": "Upload Date"
+        },
+        "confirmModal": {
+          "addDetails": "New files will be uploaded, chunked, embedded, and indexed in the Document Index",
+          "addSummary": "{count} file(s) will be added",
+          "confirmButton": {
+            "label": "Confirm & Save"
+          },
+          "description": "When you save these changes, the following will happen:",
+          "removeDetails": "Documents from these files will be pruned from the Document Index",
+          "removeSummary": "🗑️ {count} file(s) will be removed",
+          "title": "Confirm File Changes"
+        },
+        "editButton": {
+          "label": "Edit"
+        },
+        "empty": {
+          "description": "No files in this connector"
+        },
+        "header": {
+          "title": "Files ({count, plural, one {# file} other {# files}})"
+        },
+        "loadError": "Error loading files: {message}",
+        "newBadge": {
+          "label": "New"
+        },
+        "removeFileButton": {
+          "tooltip": "Remove file"
+        },
+        "removingBadge": {
+          "label": "Removing"
+        },
+        "saveButton": {
+          "label": "Save Changes",
+          "saving": "Saving..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "Cannot remove all files from a connector. Delete the connector if this is desired.",
+          "filesUpdated": "Files updated successfully! Document index is being updated in the background. New files are being indexed and removed files will be pruned from the search results.",
+          "updateFailed": "Failed to update files"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "Error Message",
+          "groups": "Groups",
+          "memberships": "Memberships",
+          "status": "Status",
+          "timeStarted": "Time Started",
+          "users": "Users"
+        },
+        "empty": {
+          "description": "Group-membership sync runs are scheduled in the background. They may take some time to appear — try refreshing in ~30 seconds.",
+          "title": "No group membership sync attempts yet"
+        },
+        "errorModal": {
+          "title": "Group Membership Sync Error"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "Error Message",
+          "newDocs": "New Docs",
+          "status": "Status",
+          "timeStarted": "Time Started",
+          "totalDocs": "Total Docs",
+          "totalDocsTooltip": "Total number of documents replaced in the index during this indexing attempt"
+        },
+        "docsPerMinute": "{rate} docs / min",
+        "docsRemoved": "(also removed {count} docs that were detected as deleted in the source)",
+        "empty": {
+          "description": "Index attempts are scheduled in the background, and may take some time to appear. Try refreshing the page in ~30 seconds!",
+          "title": "No indexing attempts scheduled yet"
+        },
+        "noAdditionalDocs": "No additional docs processed",
+        "reindexTooltip": {
+          "completed": "This index attempt was a full re-index. All documents from the source were synced into the system.",
+          "inProgress": "This index attempt is a full re-index. All documents from the source are being synced into the system."
+        },
+        "stageMetricsButton": {
+          "tooltip": "View stage metrics"
+        },
+        "viewTrace": {
+          "ariaLabel": "View full trace"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "We ran into some issues while processing some documents. <details>View details.</details>",
+        "resolvingStatus": "Resolving failures",
+        "title": "Some documents failed to index"
+      },
+      "invalidState": {
+        "description": "This connector is in an invalid state. Please update your credentials or create a new connector before re-indexing.",
+        "title": "Invalid Connector State"
+      },
+      "loadError": {
+        "title": "Failed to fetch info on Connector with ID {ccPairId}",
+        "unknownMessage": "Unknown error"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "Delete",
+          "tooltip": {
+            "active": "Pause the connector before deleting"
+          }
+        },
+        "reIndex": {
+          "label": "Re-Index",
+          "tooltip": {
+            "indexing": "Cannot re-index while indexing is already in progress",
+            "invalid": "Fix the connector configuration before re-indexing",
+            "paused": "Resume the connector before re-indexing"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "Pause"
+          },
+          "resume": {
+            "label": "Resume"
+          },
+          "tooltip": {
+            "updating": "Status update in progress"
+          }
+        },
+        "trigger": {
+          "label": "Manage"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "Canceled"
+        },
+        "completedWithErrors": {
+          "label": "Completed with errors"
+        },
+        "failed": {
+          "label": "Failed"
+        },
+        "fallback": {
+          "label": "Not Started"
+        },
+        "inProgress": {
+          "label": "In Progress"
+        },
+        "notStarted": {
+          "label": "Scheduled"
+        },
+        "success": {
+          "label": "Succeeded"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "How often the connector should be pruned (in hours)",
+        "title": "Pruning Frequency"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "Re-Enable"
+        },
+        "additionalDetails": "This connector was previously marked as invalid. Please verify that your configuration is correct before re-enabling. Are you sure you want to proceed?",
+        "entityType": "Invalid Connector"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "This will cause a complete re-indexing of all documents from the source.",
+          "note": "<strong>NOTE:</strong> depending on the number of documents stored in the source, this may take a long time."
+        },
+        "fullReindexButton": {
+          "label": "Run Complete Re-Indexing"
+        },
+        "title": "Run Indexing",
+        "update": {
+          "description": "This will pull in and index all documents that have changed and/or have been added since the last successful indexing run."
+        },
+        "updateButton": {
+          "label": "Run Update"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "How often the connector should refresh (in minutes)",
+        "title": "Refresh Frequency"
+      },
+      "sections": {
+        "advanced": {
+          "title": "Advanced"
+        },
+        "advancedConfiguration": {
+          "title": "Advanced Configuration"
+        },
+        "connectorConfiguration": {
+          "title": "Connector Configuration"
+        },
+        "credential": {
+          "title": "Credential"
+        },
+        "indexing": {
+          "title": "Indexing"
+        },
+        "indexingAttempts": {
+          "title": "Indexing Attempts"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "Hide attempt overhead"
+          },
+          "showButton": {
+            "label": "Show attempt overhead"
+          }
+        },
+        "batchTotal": {
+          "empty": "No completed batches yet",
+          "summary": "Average batch: {avgLabel}, {count, plural, one {# batch} other {# batches}} — distribution shown below."
+        },
+        "empty": {
+          "description": "No stage timing data has been recorded for this attempt yet. Older attempts that ran before stage instrumentation was deployed will not have metrics."
+        },
+        "loadError": {
+          "description": "Stage timing data could not be loaded for this attempt. The pipeline runs even when metric recording is unavailable, so this does not indicate a problem with the indexing run itself.",
+          "title": "Failed to load stage metrics"
+        },
+        "loading": "Loading stage metrics…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "Avg time",
+            "calls": "Calls",
+            "max": "Max",
+            "min": "Min",
+            "stage": "Stage",
+            "totalTime": "Total time"
+          },
+          "empty": "No per-batch stage data recorded."
+        },
+        "sort": {
+          "label": "Sort:",
+          "pipelineOrder": {
+            "label": "Pipeline order"
+          },
+          "timeTaken": {
+            "label": "Time taken"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "Reads the batch back from object storage into worker memory.",
+            "label": "Batch load"
+          },
+          "batchTotal": {
+            "description": "Total wall-clock time elapsed processing a single batch end-to-end.",
+            "label": "Batch total"
+          },
+          "batchUnaccounted": {
+            "description": "Batch time not attributed to any named stage. A large value suggests missing instrumentation.",
+            "label": "Unaccounted"
+          },
+          "checkpointLoad": {
+            "description": "Loads the saved checkpoint so the attempt resumes where the previous run stopped.",
+            "label": "Checkpoint load"
+          },
+          "chunking": {
+            "description": "Splits each document into the chunks that get embedded and indexed.",
+            "label": "Chunking"
+          },
+          "connectorFetch": {
+            "description": "Time the connector spends calling the source API and yielding raw documents.",
+            "label": "Connector fetch"
+          },
+          "connectorValidation": {
+            "description": "Validates that the connector is configured correctly and reachable before fetching begins.",
+            "label": "Connector validation"
+          },
+          "contextualRag": {
+            "description": "Generates per-chunk context summaries with an LLM to improve retrieval quality.",
+            "label": "Contextual RAG"
+          },
+          "coordLockAcquireWait": {
+            "description": "Waits for the coordination lock that guards the attempt's shared progress counters.",
+            "label": "Coord lock acquire wait"
+          },
+          "coordinationUpdate": {
+            "description": "Updates the attempt's progress counters so the UI reflects the completed batch.",
+            "label": "Coordination update"
+          },
+          "docBatchEnqueue": {
+            "description": "Publishes the stored batch onto the Celery queue for a docprocessing worker to pick up.",
+            "label": "Doc batch enqueue"
+          },
+          "docBatchStore": {
+            "description": "Persists a fetched batch of documents to object storage for the docprocessing workers.",
+            "label": "Doc batch store"
+          },
+          "docDbPrepare": {
+            "description": "Resolves which documents are new or updated and prepares the database rows.",
+            "label": "Doc DB prepare"
+          },
+          "docLockAcquireWait": {
+            "description": "Waits for per-document locks so concurrent attempts do not write the same document.",
+            "label": "Doc lock acquire wait"
+          },
+          "docprocessingSetup": {
+            "description": "Prepares the worker: loads search settings, embedding model, and index clients.",
+            "label": "Docprocessing setup"
+          },
+          "embedding": {
+            "description": "Calls the embedding model to turn chunks into vectors. Usually the slowest stage.",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "Attaches access control, boosts, and other metadata to each chunk before writing.",
+            "label": "Enrichment prep"
+          },
+          "finalization": {
+            "description": "Cleans up worker resources and releases the batch once processing completes.",
+            "label": "Finalization"
+          },
+          "gcCollect": {
+            "description": "Time spent in explicit garbage collection between batches.",
+            "label": "Garbage collection"
+          },
+          "hierarchyUpsert": {
+            "description": "Writes the source's folder or space hierarchy so documents can be filtered by location.",
+            "label": "Hierarchy upsert"
+          },
+          "imageProcessing": {
+            "description": "Extracts and summarizes images so their content becomes searchable text.",
+            "label": "Image processing"
+          },
+          "permissionValidation": {
+            "description": "Confirms the credential has the permissions required to read the source's documents.",
+            "label": "Permission validation"
+          },
+          "postIndexDbUpdate": {
+            "description": "Updates document rows in Postgres after the index write succeeds.",
+            "label": "Post-index DB update"
+          },
+          "queueWait": {
+            "description": "Time a batch waits in the queue before a docprocessing worker starts it.",
+            "label": "Queue wait"
+          },
+          "vectorDbWrite": {
+            "description": "Writes the embedded chunks into the document index.",
+            "label": "Vector DB write"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "Per-batch and per-attempt timing for this index attempt.",
+        "title": "Indexing stage metrics"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "Documents Indexed"
+        },
+        "indexingSpeed": "({speed} docs / min)",
+        "lastIndexed": {
+          "label": "Last Indexed"
+        },
+        "lastSynced": {
+          "label": "Last Synced"
+        },
+        "permissionSyncing": {
+          "label": "Permission Syncing"
+        },
+        "status": {
+          "label": "Status"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "View full error message"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "Document Permission Sync",
+          "notApplicableDescription": "This connector does not use a separate document-permission syncing job."
+        },
+        "groupMembership": {
+          "label": "Group Membership Sync",
+          "notApplicableDescription": "This connector does not use a separate group-membership syncing job."
+        },
+        "indexing": {
+          "label": "Indexing"
+        },
+        "loadError": {
+          "title": "Failed to load sync attempts"
+        },
+        "notApplicable": {
+          "title": "Not applicable"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "Complete re-indexing started successfully",
+        "completeReindexStarting": "Starting complete re-indexing...",
+        "deletionScheduleFailed": "Failed to schedule deletion of connector - {message}",
+        "indexingProcessStartFailed": "Failed to start indexing process",
+        "indexingStartFailed": "Failed to start indexing",
+        "indexingStartUnexpectedError": "An unexpected error occurred while trying to start indexing",
+        "indexingUpdateStarted": "Indexing update started successfully",
+        "indexingUpdateStarting": "Starting indexing update...",
+        "invalidPruningFrequency": "Invalid pruning frequency: must be a valid number",
+        "invalidRefreshFrequency": "Invalid refresh frequency: must be an integer",
+        "nameUpdateFailed": "Failed to update connector name",
+        "nameUpdated": "Connector name updated successfully",
+        "noUnresolvedErrors": "No unresolved errors to retry.",
+        "pruningFrequencyUpdateFailed": "Failed to update connector pruning frequency",
+        "pruningFrequencyUpdated": "Connector pruning frequency updated successfully",
+        "refreshFrequencyUpdateFailed": "Failed to update connector refresh frequency",
+        "refreshFrequencyUpdated": "Connector refresh frequency updated successfully",
+        "targetedReindexFailed": "Targeted reindex failed: {message}",
+        "targetedReindexSubmitted": "Targeted reindex submitted for {count, plural, one {# document} other {# documents}}. Errors will clear from the list as documents finish reindexing."
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "Authorize with {source}",
+          "pendingLabel": "Authorizing..."
+        },
+        "createCredentialButton": {
+          "label": "Create New"
+        },
+        "credentialDeleted": {
+          "toast": "Credential deleted successfully!"
+        },
+        "credentialModal": {
+          "title": "Create a {source} credential"
+        },
+        "credentialStep": {
+          "title": "Select a credential"
+        },
+        "credentialSwapped": {
+          "toast": "Swapped credential successfully!"
+        },
+        "error": {
+          "toast": "Error: {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "A federated search option is available for this connector. It will result in greater latency and reduced search quality.",
+            "link": {
+              "label": "Use federated version instead →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "Error uploading files"
+        },
+        "oauthRedirectFailed": {
+          "message": "We couldn't redirect you to sign in with {source}. Please try again."
+        },
+        "oauthStartFailed": {
+          "toast": "Unable to start OAuth"
+        },
+        "oauthUrlFailed": {
+          "toast": "Failed to fetch OAuth URL"
+        },
+        "retryButton": {
+          "label": "Retry"
+        },
+        "timeout": {
+          "toast": "Operation timed out after {seconds} seconds. Check your configuration for errors?"
+        },
+        "unknownError": {
+          "toast": "An unknown error occurred"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "Indexing Start Date",
+          "subtext": "Documents prior to this date will not be pulled in"
+        },
+        "pruneFrequency": {
+          "description": "Checks all documents against the source to delete those that no longer exist. Note: This process checks every document, so be cautious when increasing frequency. Default is {hours} hours ({days} days). Decimal hours are supported (e.g., 0.1 hours = 6 minutes). Enter 0 to disable pruning for this connector.",
+          "label": "Prune Frequency (hours)"
+        },
+        "refreshFrequency": {
+          "description": "This is how frequently we pull new documents from the source (in minutes). If you input 0, we will never pull new documents for this connector.",
+          "label": "Refresh Frequency (minutes)"
+        },
+        "resetButton": {
+          "label": "Reset"
+        },
+        "title": "Advanced Configuration"
+      },
+      "connectorName": {
+        "label": "Connector Name",
+        "subtext": "A descriptive name for the connector."
+      },
+      "credentialsLoadError": {
+        "title": "Failed to load credentials."
+      },
+      "field": {
+        "optional": {
+          "label": "(optional)"
+        },
+        "optionalSuffix": {
+          "label": "optional"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Your Google Drive credential was created. Manage or revoke it from the credential list.",
+          "title": "Authentication Complete"
+        },
+        "authFailed": {
+          "toast": "Failed to authenticate with Google Drive - {error}"
+        },
+        "authenticateButton": {
+          "label": "Authenticate with Google Drive",
+          "pendingLabel": "Authenticating..."
+        },
+        "createButton": {
+          "label": "Create Credential",
+          "pendingLabel": "Creating..."
+        },
+        "credentialsLoadError": {
+          "title": "Failed to load Google Drive credentials."
+        },
+        "invalidFile": {
+          "toast": "Invalid file provided - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Invalid file provided - expected a Service Account JSON key"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Please upload a service account key before creating a credential"
+        },
+        "oauthOption": {
+          "description": "Upload the OAuth app JSON from Google Cloud Console ([setup instructions]({docsUrl})), then authenticate with the Google account whose Drive you want to index.",
+          "title": "Option 1: OAuth app"
+        },
+        "oauthUpload": {
+          "placeholder": "Upload or paste your OAuth app JSON"
+        },
+        "primaryAdmin": {
+          "description": "Enter the email of an admin or owner of the Google Organization that owns the Google Drive(s) you want to index.",
+          "invalidEmail": "Must be a valid email",
+          "label": "Primary Admin Email",
+          "required": "Required"
+        },
+        "section": {
+          "title": "Google Drive Authentication"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Failed to create service account credential - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Successfully created service account credential"
+        },
+        "serviceAccountOption": {
+          "title": "Option 2: Service account"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Upload or paste your service account JSON key"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Your Gmail credential was created. Manage or revoke it from the credential list.",
+          "title": "Authentication Complete"
+        },
+        "authFailed": {
+          "toast": "Failed to authenticate with Gmail - {error}"
+        },
+        "authenticateButton": {
+          "label": "Authenticate with Gmail",
+          "pendingLabel": "Authenticating..."
+        },
+        "createButton": {
+          "label": "Create Credential",
+          "pendingLabel": "Creating..."
+        },
+        "credentialsLoadError": {
+          "title": "Failed to load Gmail credentials."
+        },
+        "invalidFile": {
+          "toast": "Invalid file provided - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Invalid file provided - expected a Service Account JSON key"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Please upload a service account key before creating a credential"
+        },
+        "oauthOption": {
+          "description": "Upload the OAuth app JSON from Google Cloud Console ([setup instructions]({docsUrl})), then authenticate with the Google account whose Gmail you want to index.",
+          "title": "Option 1: OAuth app"
+        },
+        "oauthUpload": {
+          "placeholder": "Upload or paste your OAuth app JSON"
+        },
+        "primaryAdmin": {
+          "description": "Enter the email of an admin or owner of the Google Organization that owns the Gmail account(s) you want to index.",
+          "invalidEmail": "Must be a valid email",
+          "label": "Primary Admin Email",
+          "required": "Required"
+        },
+        "section": {
+          "title": "Gmail Authentication"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Failed to create service account credential - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Successfully created service account credential"
+        },
+        "serviceAccountOption": {
+          "title": "Option 2: Service account"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Upload or paste your service account JSON key"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "Go home"
+        },
+        "title": "‘{connector}’ is not a valid Connector Type!"
+      },
+      "listInput": {
+        "placeholder": "Enter {label}"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "Advanced"
+        },
+        "continueButton": {
+          "label": "Continue"
+        },
+        "createButton": {
+          "label": "Create Connector"
+        },
+        "previousButton": {
+          "label": "Previous"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "Oops, something went wrong!"
+        },
+        "invalidSource": {
+          "description": "{source} is not a valid source type.",
+          "title": "The specified connector source type {source} does not exist."
+        },
+        "processing": {
+          "description": "Please wait while we complete the setup.",
+          "title": "Processing..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "Authorize with {source}"
+        },
+        "authorizing": {
+          "description": "Please wait while we complete authorization."
+        },
+        "continue": {
+          "message": "Click <link>here</link> to continue."
+        },
+        "error": {
+          "description": "An error occurred during the OAuth process. Please try again."
+        },
+        "malformed": {
+          "missingCode": "Missing authorization code.",
+          "missingState": "Missing state parameter.",
+          "title": "Improperly formed OAuth authorization request."
+        },
+        "page": {
+          "title": "Authorize with Third-Party service"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "Your authorization with {source} completed successfully. Additional steps are required to complete credential setup."
+          },
+          "description": "Your authorization with {source} completed successfully.",
+          "title": "Success!"
+        }
+      },
+      "oauthFailed": {
+        "toast": "OAuth authentication failed. Please try again."
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "Finalize Authorization with {source}"
+        },
+        "cloudId": {
+          "required": "You must select a Confluence site (id not found)."
+        },
+        "cloudName": {
+          "required": "You must select a Confluence site (name not found)."
+        },
+        "cloudUrl": {
+          "required": "You must select a Confluence site (url not found)."
+        },
+        "continue": {
+          "message": "Authorization finalized. Click <link>here</link> to continue."
+        },
+        "credentialId": {
+          "required": "Credential ID is required."
+        },
+        "error": {
+          "description": "An error occurred during the OAuth finalization process. Please try again."
+        },
+        "finalized": {
+          "title": "Confluence authorization finalized."
+        },
+        "loadingSites": {
+          "description": "Please wait while we retrieve a list of your accessible sites."
+        },
+        "malformed": {
+          "description": "Invalid or missing credential id.",
+          "title": "Improperly formed OAuth finalization request."
+        },
+        "page": {
+          "title": "Finalize Authorization with Third-Party service"
+        },
+        "selectSite": {
+          "title": "Select a Confluence site"
+        },
+        "submitButton": {
+          "label": "Submit",
+          "pendingLabel": "Submitting..."
+        },
+        "submitError": {
+          "description": "An error occurred during the submission process. Please try again.",
+          "title": "Error during submission."
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "Select an option"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "Add New"
+        },
+        "removeButton": {
+          "tooltip": "Remove"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "No tabs to display."
+        }
+      }
+    },
     "costOverrides": {
       "allProviders": {
         "label": "All providers"
@@ -813,6 +2014,461 @@
         "title": "Craft isn't available on this deployment"
       }
     },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "To change the token, delete the current one and add a new one."
+        },
+        "configured": {
+          "badge": "Configured",
+          "text": "Your Discord bot token is configured."
+        },
+        "configuredWithDate": {
+          "text": "Your Discord bot token is configured. Added {date}."
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "Delete server configs first"
+          },
+          "label": "Delete Discord Token"
+        },
+        "deleteError": {
+          "toast": "Failed to delete bot token"
+        },
+        "deleteModal": {
+          "additionalDetails": "This will disconnect your Discord bot. You will need to re-enter the token to use the bot again.",
+          "entityName": "Discord Bot Token",
+          "entityType": "Discord bot token"
+        },
+        "deleted": {
+          "toast": "Bot token deleted"
+        },
+        "enterInstructions": {
+          "text": "Enter your Discord bot token to enable the bot. You can get this from the Discord Developer Portal."
+        },
+        "input": {
+          "placeholder": "Enter bot token..."
+        },
+        "missing": {
+          "toast": "Please enter a bot token"
+        },
+        "notConfigured": {
+          "badge": "Not Configured"
+        },
+        "saveButton": {
+          "label": "Save Token",
+          "saving": {
+            "label": "Saving..."
+          }
+        },
+        "saveError": {
+          "toast": "Failed to save bot token"
+        },
+        "saved": {
+          "toast": "Bot token saved successfully"
+        },
+        "section": {
+          "title": "Bot Token"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "Channel configuration will be available after the server is registered."
+        },
+        "disableAllButton": {
+          "label": "Disable All"
+        },
+        "empty": {
+          "description": "Run !sync-channels in Discord to add channels.",
+          "title": "No channels configured"
+        },
+        "enableAllButton": {
+          "label": "Enable All"
+        },
+        "partialUpdate": {
+          "toast": "Updated {succeeded} channels, but {failed} failed"
+        },
+        "section": {
+          "description": "Run !sync-channels in Discord to update the channel list.",
+          "title": "Channel Configuration"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "Agent Override"
+          },
+          "channel": {
+            "header": "Channel"
+          },
+          "enabled": {
+            "header": "Enabled"
+          },
+          "requireMention": {
+            "header": "Require @mention"
+          },
+          "threadOnly": {
+            "header": "Thread Only Mode"
+          }
+        },
+        "updateError": {
+          "toast": "Failed to update channels"
+        },
+        "updated": {
+          "toast": "Updated {count, plural, one {# channel} other {# channels}}"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "Default agent cleared"
+        },
+        "section": {
+          "description": "The agent used by the bot in all channels unless overridden.",
+          "title": "Default Agent"
+        },
+        "select": {
+          "default": {
+            "label": "Default Agent"
+          },
+          "placeholder": "Select agent"
+        },
+        "updateError": {
+          "toast": "Failed to update agent"
+        },
+        "updated": {
+          "toast": "Default agent updated"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "Could not load channels",
+          "title": "Failed to load channels"
+        },
+        "loadServer": {
+          "title": "Failed to load server"
+        },
+        "loadServers": {
+          "title": "Failed to load Discord servers"
+        },
+        "serverNotFound": {
+          "message": "Server not found"
+        },
+        "unknown": {
+          "message": "An unknown error occurred"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "Use the !register command in your Discord server with the registration key to complete setup.",
+          "title": "Waiting for Registration"
+        },
+        "pending": {
+          "text": "Pending registration"
+        },
+        "registered": {
+          "text": "Registered: {date}"
+        },
+        "updateButton": {
+          "label": "Update Configuration"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "Failed to create server"
+        },
+        "created": {
+          "toast": "Server configuration created!"
+        },
+        "deleteError": {
+          "toast": "Failed to delete server config"
+        },
+        "deleteModal": {
+          "additionalDetails": "This will remove all settings for this Discord server.",
+          "entityType": "Discord server configuration"
+        },
+        "deleted": {
+          "toast": "Server configuration deleted"
+        },
+        "disabled": {
+          "toast": "Server disabled"
+        },
+        "empty": {
+          "description": "Create a server configuration to get started.",
+          "title": "No Discord servers configured yet"
+        },
+        "enabled": {
+          "toast": "Server enabled"
+        },
+        "fallbackName": "Server #{id}",
+        "notRegistered": {
+          "toast": "Server must be registered before it can be enabled"
+        },
+        "pending": {
+          "badge": "Pending"
+        },
+        "registered": {
+          "badge": "Registered"
+        },
+        "table": {
+          "actions": {
+            "header": "Actions"
+          },
+          "enabled": {
+            "header": "Enabled"
+          },
+          "registered": {
+            "header": "Registered"
+          },
+          "server": {
+            "header": "Server"
+          },
+          "status": {
+            "header": "Status"
+          }
+        },
+        "updateError": {
+          "toast": "Failed to update server"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Connect Onyx to your Discord servers. Users can ask questions directly in Discord channels."
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "This key will only be shown once!",
+          "title": "Registration Key"
+        },
+        "instructions": {
+          "text": "Copy the command and send it from any text channel in your server!"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "Creating..."
+          },
+          "label": "Add Server"
+        },
+        "section": {
+          "title": "Server Configurations"
+        }
+      },
+      "unsavedChanges": {
+        "description": "Click Update to save them.",
+        "title": "You have unsaved changes"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "Enter API Key"
+        },
+        "deleteButton": {
+          "label": "Delete API Key"
+        },
+        "deleteHint": "Delete the current API key before updating.",
+        "description": "Unstructured extracts and transforms complex data from formats like .pdf, .docx, .png, .pptx, etc. into clean text for Onyx to ingest. Provide an API key to enable Unstructured document processing.",
+        "learnMore": "Learn more about Unstructured <link>here</link>.",
+        "note": "<label>Note:</label> this will send documents to Unstructured servers for processing.",
+        "saveButton": {
+          "label": "Save API Key"
+        },
+        "title": "Process with Unstructured API"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "Boost:"
+        },
+        "search": {
+          "placeholder": "Find documents based on title / content..."
+        },
+        "updateFailed": {
+          "toast": "Failed to update document - {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "Error loading documents - {detail}"
+        },
+        "loading": {
+          "label": "Loading"
+        },
+        "mostDisliked": {
+          "title": "Most Disliked Documents"
+        },
+        "mostLiked": {
+          "title": "Most Liked Documents"
+        },
+        "table": {
+          "name": {
+            "header": "Document Name"
+          },
+          "score": {
+            "header": "Score"
+          },
+          "searchable": {
+            "header": "Is Searchable?"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "Error updating hidden status - {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "Score must be a number"
+        },
+        "updated": {
+          "toast": "Updated score!"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "Private"
+          },
+          "public": {
+            "label": "Public"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "Unnamed"
+          }
+        },
+        "deleteFailed": {
+          "toast": "Failed to schedule document set for deletion - {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "Document set \"{name}\" scheduled for deletion"
+        },
+        "description": "**Document Sets** allow you to group logically connected documents into a single bundle. These can then be used as a filter when performing searches to control the scope of information Onyx searches over.",
+        "edit": {
+          "header": {
+            "title": "Edit Document Set"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "Cannot update while syncing! Wait for the sync to finish, then try again."
+          }
+        },
+        "federatedBadge": {
+          "label": "Federated"
+        },
+        "fetchConnectorsFailed": {
+          "title": "Failed to fetch Connectors"
+        },
+        "fetchSetsFailed": {
+          "title": "Failed to fetch document sets"
+        },
+        "form": {
+          "connectors": {
+            "label": "Pick your connectors",
+            "placeholder": "Search for connectors...",
+            "required": "Please select at least one connector (regular or federated)"
+          },
+          "createFailed": {
+            "toast": "Error creating document set - {detail}"
+          },
+          "created": {
+            "toast": "Successfully created document set!"
+          },
+          "description": {
+            "label": "Description:",
+            "placeholder": "Describe what the document set represents"
+          },
+          "federatedConnectors": {
+            "label": "Federated Connectors",
+            "placeholder": "Search for federated connectors..."
+          },
+          "name": {
+            "label": "Name:",
+            "placeholder": "A name for the document set",
+            "required": "Please enter a name for the set"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {Connectors available to the selected group} one {Connectors available to the selected group} other {Connectors available to the selected groups}}"
+          },
+          "submitButton": {
+            "createLabel": "Create Document Set",
+            "updateLabel": "Update Document Set"
+          },
+          "unavailableConnectors": {
+            "description": "Only connectors that are directly assigned to the group you are trying to add the document set to will be available.",
+            "title": "{count, plural, =0 {Connectors not available to the group you have selected} one {Connectors not available to the group you have selected} other {Connectors not available to the groups you have selected}}"
+          },
+          "updateFailed": {
+            "toast": "Error updating document set - {detail}"
+          },
+          "updated": {
+            "toast": "Successfully updated document set!"
+          }
+        },
+        "loadError": {
+          "message": "Error: {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "New Document Set"
+          }
+        },
+        "newButton": {
+          "label": "New Document Set"
+        },
+        "notFound": {
+          "message": "Document set with id {id} not found",
+          "title": "Document set not found"
+        },
+        "status": {
+          "deleting": {
+            "label": "Deleting"
+          },
+          "syncing": {
+            "label": "Syncing"
+          },
+          "upToDate": {
+            "label": "Up to Date"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "Connectors"
+          },
+          "delete": {
+            "header": "Delete"
+          },
+          "name": {
+            "header": "Name"
+          },
+          "public": {
+            "header": "Public"
+          },
+          "status": {
+            "header": "Status"
+          },
+          "title": "Existing Document Sets"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "Hidden"
+        },
+        "hide": {
+          "ariaLabel": "Hide document",
+          "label": "Hide"
+        },
+        "unhide": {
+          "ariaLabel": "Unhide document",
+          "label": "Unhide"
+        },
+        "visible": {
+          "label": "Visible"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -912,6 +2568,16 @@
       "warnings": {
         "invalidSkill": "invalid skill",
         "providerUnavailable": "provider unavailable"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "Failed to load connector: {details}",
+        "title": "Error"
+      },
+      "loading": {
+        "description": "Retrieving connector details and credential schema",
+        "title": "Loading connector configuration..."
       }
     },
     "groups": {
@@ -1734,6 +3400,155 @@
         "urlInvalid": "Must be a valid URL"
       }
     },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "Inherited from {source}"
+          },
+          "organizationPublic": {
+            "label": "Organization Public"
+          },
+          "private": {
+            "label": "Private"
+          }
+        },
+        "addConnectorButton": {
+          "label": "Add Connector"
+        },
+        "connectorCreated": {
+          "toast": "Connector created successfully"
+        },
+        "empty": {
+          "message": "It looks like you don't have any connectors setup yet. Visit the [Add Connector](/admin/add-connector) page to get started!"
+        },
+        "federated": {
+          "access": {
+            "label": "Federated Access"
+          },
+          "indexed": {
+            "label": "Indexed"
+          },
+          "notApplicable": {
+            "label": "N/A"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "Auto-Sync"
+            },
+            "private": {
+              "label": "Private"
+            },
+            "public": {
+              "label": "Public"
+            },
+            "title": "Access Type"
+          },
+          "applyButton": {
+            "label": "Apply"
+          },
+          "docCount": {
+            "placeholder": "Count",
+            "title": "Document Count"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "Completed with Errors"
+            },
+            "failed": {
+              "label": "Failed"
+            },
+            "inProgress": {
+              "label": "In Progress"
+            },
+            "interrupted": {
+              "label": "Interrupted"
+            },
+            "notStarted": {
+              "label": "Not Started"
+            },
+            "success": {
+              "label": "Success"
+            },
+            "title": "Last Status"
+          },
+          "title": "Filter Connectors"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "Access: {values}"
+          },
+          "clearBadge": {
+            "label": "Clear"
+          },
+          "docsAnyBadge": {
+            "label": "Docs {operator} any"
+          },
+          "docsBadge": {
+            "label": "Docs {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "Status: {values}"
+          }
+        },
+        "loadError": {
+          "message": "Error loading indexing status."
+        },
+        "manageConnector": {
+          "tooltip": "Manage Connector"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "Manage Federated Connector"
+        },
+        "search": {
+          "placeholder": "Search Connectors"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "Active Connectors"
+          },
+          "publicConnectors": {
+            "label": "Public Connectors"
+          },
+          "totalConnectors": {
+            "label": "Total Connectors"
+          },
+          "totalDocsIndexed": {
+            "label": "Total Docs Indexed"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "All caught up! No more connectors to show"
+          },
+          "lastIndexed": {
+            "header": "Last Indexed"
+          },
+          "name": {
+            "header": "Name"
+          },
+          "permissions": {
+            "header": "Permissions / Access"
+          },
+          "status": {
+            "header": "Status"
+          },
+          "totalDocs": {
+            "header": "Total Docs"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "Collapse All"
+          },
+          "expand": {
+            "label": "Expand All"
+          }
+        }
+      }
+    },
     "languageModels": {
       "availableProviders": {
         "title": "Available Providers"
@@ -1798,6 +3613,75 @@
         "unknownError": "Unknown error"
       }
     },
+    "mcpActions": {
+      "header": {
+        "description": "Connect MCP (Model Context Protocol) servers to add custom actions and tools for your agents."
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "No claims received."
+        },
+        "table": {
+          "claim": {
+            "header": "Claim"
+          },
+          "value": {
+            "header": "Value"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "provider API",
+        "subtitle": "Directory fields fetched from the provider API — e.g. Microsoft Graph /me for Entra ID, which carries country/usageLocation that the id_token omits unless the ctry optional claim is configured.",
+        "title": "Directory profile ({source})"
+      },
+      "idToken": {
+        "subtitle": "Decoded from the id_token JWT returned by the token endpoint.",
+        "title": "id_token claims"
+      },
+      "intro": {
+        "description": "Shows the raw fields your identity provider sent about you during your last OAuth/OIDC login: the id_token claims and the userinfo endpoint response. Use it to verify which attributes the IdP is configured to release. Claims are captured at every login."
+      },
+      "loadFailed": {
+        "title": "Failed to load OAuth claims"
+      },
+      "noSnapshot": {
+        "description": "No OAuth login snapshot found for {email}. Log in through the identity provider (button above) and reload this page.",
+        "title": "No captured claims yet"
+      },
+      "rerun": {
+        "label": "Re-run OAuth login"
+      },
+      "resolved": {
+        "subtitle": "The claim-mapped directory profile that actually feeds the Organization Profile prompt block and {placeholder} placeholders.",
+        "title": "Resolved profile (used for prompts)"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "Captured at: {timestamp}"
+        },
+        "provider": {
+          "label": "Provider: {provider}"
+        },
+        "tokenFields": {
+          "label": "Token response fields: {fields}"
+        },
+        "user": {
+          "label": "User: {email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "Response of the OIDC userinfo endpoint for your access token.",
+        "title": "userinfo claims"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "Connect OpenAPI servers to add custom actions and tools for your agents."
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Costs are calculated from recorded model usage.",
@@ -1831,6 +3715,62 @@
           "description": "No usage recorded for this period."
         },
         "title": "Users"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "Connected"
+        },
+        "description": "Connect your identity provider to import and sync users and groups.",
+        "generate": {
+          "label": "Generate SCIM Token"
+        },
+        "regenerate": {
+          "label": "Regenerate Token"
+        },
+        "title": "SCIM Sync",
+        "waiting": {
+          "description": "Provide the SCIM key to your identity provider to begin syncing users and groups.",
+          "label": "Waiting for Connection"
+        }
+      },
+      "header": {
+        "description": "Sync users and groups via System for Cross-domain Identity Management (SCIM) protocol.",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "Failed to load SCIM token status."
+      },
+      "modal": {
+        "copied": {
+          "message": "Token copied to clipboard"
+        },
+        "copyFailed": {
+          "error": "Failed to copy token"
+        },
+        "regenerate": {
+          "description": "Your current SCIM token will be revoked and a new token will be generated. You will need to update the token on your identity provider before SCIM provisioning will resume.",
+          "submit": {
+            "label": "Regenerate Token"
+          },
+          "title": "Regenerate SCIM Token"
+        },
+        "token": {
+          "copy": {
+            "label": "Copy Token"
+          },
+          "description": "Save this key before continuing. It won't be shown again.",
+          "download": {
+            "label": "Download"
+          },
+          "title": "SCIM Token"
+        }
+      },
+      "toasts": {
+        "generateFailed": "Failed to generate token: {detail}",
+        "genericError": "Something went wrong. Please try again.",
+        "regenerated": "Token regenerated"
       }
     },
     "security": {
@@ -2213,6 +4153,393 @@
         }
       }
     },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "Error creating OnyxBot config - {error}"
+        },
+        "updateError": {
+          "toast": "Error updating OnyxBot config - {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "Failed to delete Slack bot config - {error}"
+        },
+        "deleted": {
+          "toast": "Slack bot config \"{configId}\" deleted"
+        },
+        "editDefaultButton": {
+          "label": "Edit Default Configuration"
+        },
+        "newConfigButton": {
+          "label": "New Channel Configuration"
+        },
+        "section": {
+          "title": "Channel-Specific Configurations"
+        },
+        "table": {
+          "actions": {
+            "header": "Actions"
+          },
+          "assistant": {
+            "header": "Assistant"
+          },
+          "channel": {
+            "header": "Channel"
+          },
+          "documentSets": {
+            "header": "Document Sets"
+          },
+          "empty": {
+            "message": "No channel-specific configurations. Add a new configuration to customize behavior for specific channels."
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "Delete"
+        },
+        "error": {
+          "toast": "Failed to delete Slack bot"
+        },
+        "message": "Are you sure you want to delete this Slack bot? This action cannot be undone.",
+        "success": {
+          "toast": "Slack bot deleted successfully"
+        },
+        "title": "Delete Slack Bot"
+      },
+      "edit": {
+        "header": {
+          "title": "Edit Slack Bot"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Edit Slack Channel Config"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "Edit Default Slack Config"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "Did not find Slack Channel config with ID: {id}"
+        },
+        "fetchAgents": {
+          "message": "Failed to fetch agents - {error}"
+        },
+        "fetchBot": {
+          "message": "Failed to fetch Slack Bot {botId}: {error}"
+        },
+        "fetchChannels": {
+          "message": "Failed to fetch Slack Channels - {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "Failed to fetch document sets - {error}"
+        },
+        "generic": {
+          "title": "Something went wrong :("
+        },
+        "unknown": {
+          "message": "unknown error"
+        },
+        "unknownOccurred": {
+          "message": "An unknown error occurred"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "Search for an agent..."
+        },
+        "answerValidity": {
+          "label": "Only respond if citations found",
+          "tooltip": "If set, will only answer questions where the model successfully produces citations"
+        },
+        "cancelButton": {
+          "label": "Cancel"
+        },
+        "channelName": {
+          "label": "Slack Channel Name",
+          "placeholder": "Enter channel name (e.g., general, support)",
+          "subtext": "Enter the name of the Slack channel (without the # symbol)"
+        },
+        "createButton": {
+          "label": "Create"
+        },
+        "defaultConfig": {
+          "badge": "Default Configuration",
+          "description": "This default configuration will apply to all channels and direct messages (DMs) in your Slack workspace."
+        },
+        "disableDefault": {
+          "label": "Disable Default Configuration",
+          "warning": "Warning: Disabling the default configuration means OnyxBot won't respond in Slack channels unless they are explicitly configured. Additionally, OnyxBot will not respond to DMs."
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "Unable to use this document set because it contains a connector with auto-sync permissions. OnyxBot's responses in this channel are visible to all Slack users, so mirroring the asker's permissions could inadvertently expose private information."
+          },
+          "autoSyncedNote": {
+            "text": "These document sets cannot be attached as they have auto-synced docs:"
+          },
+          "description": "Select the document sets OnyxBot will use while answering questions in Slack.",
+          "hideUnselectableButton": {
+            "label": "Hide un-selectable document sets"
+          },
+          "incompatibleHidden": {
+            "text": "Some incompatible document sets are hidden."
+          },
+          "incompatibleVisible": {
+            "text": "Some incompatible document sets are visible."
+          },
+          "viewAllButton": {
+            "label": "View all document sets"
+          }
+        },
+        "followUpTags": {
+          "label": "(Optional) Users / Groups to Tag",
+          "subtext": "The Slack users / groups we should tag if the user clicks the \"Still need help?\" button. If no emails are provided, we will not tag anyone and will just react with a 🆘 emoji to the original message."
+        },
+        "generalConfig": {
+          "section": {
+            "title": "General Configuration"
+          }
+        },
+        "isEphemeral": {
+          "label": "Respond to user in a private (ephemeral) message",
+          "tooltip": "If set, OnyxBot will respond only to the user in a private (ephemeral) message. If you also chose 'Search' Agent above, selecting this option will make documents that are private to the user available for their queries."
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "All Public Knowledge",
+            "sublabel": "Let OnyxBot respond based on information from all public connectors"
+          },
+          "documentSets": {
+            "label": "Specific Document Sets",
+            "sublabel": "Control which documents to use for answering questions"
+          },
+          "label": "Knowledge Source",
+          "nonSearchAgent": {
+            "label": "Non-Search Agent",
+            "sublabel": "Chat with an agent that does not use documents"
+          },
+          "searchAgent": {
+            "label": "Search Agent",
+            "sublabel": "Control both the documents and the prompt to use for answering questions"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "Select the non-search agent OnyxBot will use while answering questions in Slack."
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "Relevant Connectors:"
+          },
+          "description": "Please note that if the private (ephemeral) response is *not selected*, only public documents within the selected document sets will be accessible for user queries. If the private (ephemeral) response *is selected*, user quries can also leverage documents that the user has already been granted access to. Note that users will be able to share the response with others in the channel, so please ensure that this is aligned with your company sharing policies.",
+          "title": "Privacy Alert"
+        },
+        "questionmarkPrefilter": {
+          "label": "Only respond to questions",
+          "tooltip": "If set, OnyxBot will only respond to messages that contain a question mark"
+        },
+        "removedDocumentSets": {
+          "toast": "We removed one or more document sets from your selection because they are no longer valid. Please review and update your configuration."
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "Disabled while 'Respond to user in a private (ephemeral) message' is on — ephemeral responses target a single user only."
+          },
+          "label": "(Optional) Respond to Certain Users / Groups",
+          "subtext": "If specified, only these users / groups can invoke OnyxBot in this channel, and responses are visible only to them."
+        },
+        "respondTagOnly": {
+          "label": "Respond to @OnyxBot Only",
+          "tooltip": "If set, OnyxBot will only respond when directly tagged"
+        },
+        "respondToBots": {
+          "label": "Respond to Bot messages",
+          "tooltip": "If not set, OnyxBot will always ignore messages from Bots"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "Detailed"
+          },
+          "label": "Answer Type",
+          "standard": {
+            "label": "Standard"
+          },
+          "tooltip": "Controls the format of OnyxBot's responses."
+        },
+        "searchAgent": {
+          "description": "Select the search-enabled agent OnyxBot will use while answering questions in Slack."
+        },
+        "searchConfig": {
+          "section": {
+            "title": "Search Configuration"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "Show Continue in Web UI button",
+          "tooltip": "If set, will show a button at the bottom of the response that allows the user to continue the conversation in the Onyx Web UI"
+        },
+        "stillNeedHelp": {
+          "label": "Give a \"Still need help?\" button",
+          "section": {
+            "prompt": "Configure Still Need Help Button"
+          },
+          "tooltip": "OnyxBot's response will include a button at the bottom of the response that asks the user if they still need help."
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "Hide un-selectable agents"
+          },
+          "listLabel": "Un-selectable agents:",
+          "note": "Note: Some of your agents have auto-synced connectors in their document sets. You cannot select these agents as they will not be able to answer questions in Slack.",
+          "viewAllButton": {
+            "label": "View all agents"
+          }
+        },
+        "updateButton": {
+          "label": "Update"
+        },
+        "userOrGroup": {
+          "placeholder": "User email or user group name..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "Setup OnyxBot to automatically answer questions in certain channels."
+        },
+        "description": "Setup Slack bots that connect to Onyx. Once setup, you will be able to ask questions to Onyx directly from Slack. Additionally, you can:",
+        "directMessage": {
+          "item": "Directly message OnyxBot to search just as you would in the web UI."
+        },
+        "docsPrompt": {
+          "text": "Follow the <link>guide</link> found in the Onyx documentation to get started!"
+        },
+        "documentSets": {
+          "item": "Choose which document sets OnyxBot should answer from, depending on the channel the question is being asked."
+        }
+      },
+      "list": {
+        "error": {
+          "title": "Error loading apps"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "New Slack Bot"
+        }
+      },
+      "newBotButton": {
+        "label": "New Slack Bot"
+      },
+      "newChannel": {
+        "header": {
+          "title": "Configure OnyxBot for Slack Channel"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "Channel Count"
+        },
+        "defaultConfig": {
+          "header": "Default Config"
+        },
+        "defaultSet": {
+          "badge": "Default Set"
+        },
+        "disabled": {
+          "badge": "Disabled"
+        },
+        "empty": {
+          "message": "Please add a New Slack Bot to begin chatting with Onyx!"
+        },
+        "enabled": {
+          "badge": "Enabled"
+        },
+        "name": {
+          "header": "Name"
+        },
+        "status": {
+          "header": "Status"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Slack App Token"
+        },
+        "botToken": {
+          "label": "Slack Bot Token"
+        },
+        "createButton": {
+          "label": "Create"
+        },
+        "createError": {
+          "toast": "Error creating Slack Bot - {error}"
+        },
+        "created": {
+          "toast": "Successfully created Slack Bot!"
+        },
+        "docsPrompt": {
+          "text": "Please refer to our <link>guide</link> if you are not sure how to get these tokens!"
+        },
+        "invalidAppToken": {
+          "message": "Slack App Token is invalid"
+        },
+        "invalidBotToken": {
+          "message": "Slack Bot Token is invalid"
+        },
+        "name": {
+          "label": "Name This Slack Bot:"
+        },
+        "updateButton": {
+          "label": "Update"
+        },
+        "updateError": {
+          "toast": "Error updating Slack Bot - {error}"
+        },
+        "updated": {
+          "toast": "Successfully updated Slack Bot!"
+        },
+        "userToken": {
+          "label": "Slack User Token (Optional)",
+          "subtext": "Optional: User OAuth token for enhanced private channel access"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "Delete"
+        },
+        "enabledCheckbox": {
+          "label": "Enabled"
+        },
+        "fieldUpdateFailed": {
+          "toast": "Failed to update connector {field}"
+        },
+        "fieldUpdated": {
+          "toast": "Connector {field} updated successfully"
+        },
+        "updateTokensButton": {
+          "label": "Update Tokens"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "An agent is required when using the 'Agent' knowledge source"
+        },
+        "channelNameRequired": {
+          "message": "Channel Name is required"
+        },
+        "documentSetRequired": {
+          "message": "At least one Document Set is required when using the 'Document Sets' knowledge source"
+        }
+      }
+    },
     "ssoProviders": {
       "addProvider": {
         "button": {
@@ -2239,6 +4566,180 @@
       },
       "toasts": {
         "unexpectedError": "Unexpected error occurred."
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "Backend Version: "
+      },
+      "version": {
+        "title": "Version"
+      },
+      "webVersion": {
+        "label": "Web Version: "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "Up to {cost} or {tokens} tokens",
+          "cost": "Up to {cost}",
+          "none": "No budget set",
+          "tokens": "Up to {tokens} tokens"
+        },
+        "cadence": {
+          "label": "{days, plural, one {Resets every day at midnight UTC} other {Resets every # days at midnight UTC}}"
+        },
+        "deleteFailed": {
+          "error": "Failed to delete token rate limit"
+        },
+        "empty": {
+          "message": "No limits yet. Create a spending limit to cap usage."
+        },
+        "loadFailed": {
+          "error": "Failed to load token rate limits"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "Delete {label}",
+            "tooltip": "Delete limit"
+          },
+          "disable": {
+            "ariaLabel": "Disable {label}"
+          },
+          "enable": {
+            "ariaLabel": "Enable {label}"
+          },
+          "label": "{budget}, {cadence}"
+        },
+        "updateFailed": {
+          "error": "Failed to update token rate limit"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "Cancel"
+        },
+        "costBudget": {
+          "description": "Maximum spend per reset period. Set a cost budget, a token budget, or both.",
+          "placeholder": "No cost limit",
+          "title": "Cost budget",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "Enter a cost budget, a token budget, or both",
+          "costMax": "The maximum cost budget is ${amount, number}",
+          "costMinCents": "Cost budget must be at least $0.01",
+          "costMoreThanZero": "Cost budget must be greater than 0",
+          "groupRequired": "Select a user group",
+          "periodInteger": "Enter a whole number of days",
+          "periodMin": "Use at least 1 day",
+          "periodRequired": "Enter a reset period",
+          "scopeRequired": "Target Scope is a required field",
+          "tokenIncrement": "Use increments of 1,000 tokens",
+          "tokenInteger": "Enter a whole number of tokens",
+          "tokenMax": "The maximum token budget is 1 trillion",
+          "tokenMin": "Use at least 1,000 tokens"
+        },
+        "groupMenu": {
+          "empty": "No user groups yet. Create one under Users & Groups."
+        },
+        "groupPicker": {
+          "placeholder": "Choose a group"
+        },
+        "header": {
+          "title": "Create spending limit"
+        },
+        "period": {
+          "description": "Budgets reset at midnight UTC",
+          "title": "Reset period",
+          "unit": "days"
+        },
+        "scope": {
+          "caption": {
+            "global": "Everyone in the workspace shares one budget.",
+            "group": "Members of {group} share one budget.",
+            "groupUnchosen": "Members of the chosen group share one budget.",
+            "user": "Each user gets their own budget."
+          },
+          "title": "Applies to"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "Workspace"
+          },
+          "user": {
+            "title": "Per user"
+          },
+          "userGroup": {
+            "title": "User group"
+          }
+        },
+        "submit": {
+          "label": "Create limit"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} or {tokens} tokens",
+            "tokens": "{tokens} tokens"
+          },
+          "global": "{days, plural, one {Everyone in the workspace shares up to {budget} every day. Usage is blocked until the period resets.} other {Everyone in the workspace shares up to {budget} every # days. Usage is blocked until the period resets.}}",
+          "group": "{days, plural, one {Members of {group} share up to {budget} every day. Usage is blocked until the period resets.} other {Members of {group} share up to {budget} every # days. Usage is blocked until the period resets.}}",
+          "groupUnchosen": "{days, plural, one {Members of the chosen group share up to {budget} every day. Usage is blocked until the period resets.} other {Members of the chosen group share up to {budget} every # days. Usage is blocked until the period resets.}}",
+          "user": "{days, plural, one {Each user can spend up to {budget} every day. Usage is blocked until the period resets.} other {Each user can spend up to {budget} every # days. Usage is blocked until the period resets.}}"
+        },
+        "tokenBudget": {
+          "description": "Maximum tokens per reset period",
+          "placeholder": "No token limit",
+          "title": "Token budget",
+          "unit": "tokens"
+        },
+        "userGroup": {
+          "description": "Choose which group shares this budget",
+          "title": "User group"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "Create spending limit"
+        },
+        "createFailed": {
+          "error": "Failed to create spending limit"
+        },
+        "created": {
+          "message": "Spending limit created!"
+        },
+        "embedded": {
+          "description": "Set guardrails for workspace, user, and group usage. Limits can be enabled or disabled without deleting their configuration.",
+          "title": "Manage spending limits"
+        },
+        "global": {
+          "description": "Global limits apply to all users, user groups, and API keys. When the global limit is reached, no more tokens can be spent."
+        },
+        "intro": {
+          "description": "Spending limits help you control how many tokens can be spent in a given time period.",
+          "groupLimit": "Set limits for user groups to control spend for teams.",
+          "toggleLimit": "Enable and disable limits as needed.",
+          "userLimit": "Set limits for users so no single user can spend too much.",
+          "workspaceLimit": "Set a workspace-wide limit for your team's overall spend."
+        },
+        "tabs": {
+          "global": {
+            "name": "Global"
+          },
+          "groups": {
+            "name": "Groups"
+          },
+          "users": {
+            "name": "Users"
+          }
+        },
+        "user": {
+          "description": "User limits apply to each user individually. When a user reaches a limit, they are temporarily blocked from spending tokens."
+        },
+        "userGroup": {
+          "description": "Group limits apply to all users in a group. If a user belongs to multiple groups, the most permissive limit applies."
+        }
       }
     },
     "tracing": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -26,6 +26,46 @@
     }
   },
   "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "Repositorio de código"
+        },
+        "messaging": {
+          "label": "Mensajería"
+        },
+        "other": {
+          "label": "Otros"
+        },
+        "sales": {
+          "label": "Ventas"
+        },
+        "storage": {
+          "label": "Almacenamiento en la nube"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "Tickets y gestión de tareas"
+        },
+        "wiki": {
+          "label": "Bases de conocimiento y wikis"
+        }
+      },
+      "popular": {
+        "title": "Populares"
+      },
+      "search": {
+        "placeholder": "Buscar conectores"
+      },
+      "seeConnectorsButton": {
+        "label": "Ver los conectores"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>El conector federado ya está configurado.</strong> Haz clic para editar el conector existente.",
+          "slackCredentialsFound": "<strong>Se encontraron credenciales de Slack existentes.</strong> Haz clic para gestionar tu conector de Slack."
+        }
+      }
+    },
     "agents": {
       "deleteModal": {
         "confirmation": {
@@ -298,6 +338,326 @@
           }
         },
         "title": "Uso"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "Tu licencia se está procesando. Te llevaremos a los detalles de facturación en cuanto se confirme.",
+        "title": "Tu licencia aún se está activando"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "La gestión de la facturación en línea está desactivada. Contacta con el soporte para actualizar tu suscripción.",
+          "title": "Instalación aislada de la red"
+        },
+        "expired": {
+          "description": "Renueva tu suscripción para recuperar el acceso a las funciones de pago.",
+          "title": "Tu suscripción ha caducado.",
+          "withDate": {
+            "description": "Renueva tu suscripción antes del {date} para recuperar el acceso."
+          },
+          "withDeletion": {
+            "title": "Tu suscripción ha caducado. Los datos se eliminarán en {days} días."
+          }
+        },
+        "expiring": {
+          "description": "Renueva tu suscripción antes del {date} para evitar interrupciones.",
+          "title": "Tu suscripción caduca en {days} días."
+        },
+        "graceSync": {
+          "title": "Comprobando si hay una licencia renovada…"
+        },
+        "stripeError": {
+          "description": "Comprueba tu conexión a Internet o proporciona una licencia manualmente.",
+          "title": "No se pudo conectar con el portal de pagos de Stripe."
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "Ajustar el plan"
+        },
+        "annual": {
+          "label": "Anual"
+        },
+        "annualBadge": {
+          "label": "Ahorra un 20%"
+        },
+        "billingCycle": {
+          "description": "tras tu prueba gratuita de 1 mes",
+          "title": "Ciclo de facturación"
+        },
+        "continueToPayment": {
+          "label": "Continuar al pago"
+        },
+        "createSessionFailed": {
+          "error": "No se pudo crear la sesión de pago"
+        },
+        "loading": {
+          "label": "Cargando..."
+        },
+        "monthly": {
+          "label": "Mensual"
+        },
+        "perSeatMonth": {
+          "label": "por puesto/mes"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "${price}"
+        },
+        "seats": {
+          "description": "{count, plural, one {Se requiere un mínimo de # puesto para tus usuarios y cuentas de Slack actuales.} other {Se requiere un mínimo de # puestos para tus usuarios y cuentas de Slack actuales.}}",
+          "title": "Puestos"
+        },
+        "trialBilling": {
+          "text": "Se te facturará el <value>{date}</value>, cuando termine tu prueba gratuita de 1 mes."
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "Activar la clave de licencia"
+        },
+        "billingHelp": {
+          "label": "Ayuda con la facturación"
+        },
+        "licenseKeyPrompt": {
+          "label": "¿Tienes una clave de licencia?"
+        },
+        "updateLicenseKey": {
+          "label": "Actualizar la clave de licencia"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "Planes y facturación"
+        },
+        "upgradePlan": {
+          "title": "Mejorar el plan"
+        },
+        "viewPlans": {
+          "title": "Ver los planes"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "No se pudo activar la licencia"
+        },
+        "activateLicense": {
+          "label": "Activar la licencia"
+        },
+        "activateSuccess": {
+          "message": "¡Licencia activada!"
+        },
+        "activateTitle": {
+          "title": "Activar la clave de licencia"
+        },
+        "activating": {
+          "label": "Activando..."
+        },
+        "activeUntil": {
+          "label": "Clave de licencia activa hasta el <value>{date}</value>"
+        },
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "close": {
+          "label": "Cerrar"
+        },
+        "description": "Añade y activa manualmente una licencia para esta instancia de Onyx.",
+        "emptyKey": {
+          "error": "Introduce una clave de licencia"
+        },
+        "error": {
+          "text": "{error}. <link>Ayuda con la facturación</link>"
+        },
+        "expired": {
+          "label": "Clave de licencia caducada"
+        },
+        "keyField": {
+          "description": "Pega o adjunta el archivo de clave de licencia que recibiste de Onyx.",
+          "title": "Clave de licencia"
+        },
+        "updateKey": {
+          "label": "Actualizar la clave"
+        },
+        "updateLicense": {
+          "label": "Actualizar la licencia"
+        },
+        "updateSuccess": {
+          "message": "¡Licencia actualizada!"
+        },
+        "updateTitle": {
+          "title": "Actualizar la clave de licencia"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "Método de pago",
+          "title": "Visa terminada en 1234"
+        },
+        "lastPayment": {
+          "description": "Último pago"
+        },
+        "section": {
+          "title": "Pago"
+        },
+        "update": {
+          "label": "Actualizar"
+        },
+        "viewInvoice": {
+          "label": "Ver la factura"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Obtener el plan Business"
+          },
+          "description": "por puesto/mes con facturación anual\no $25 por puesto con facturación mensual",
+          "features": {
+            "apiKeys": "Claves de API para cuentas de servicio",
+            "documentPermissions": "Herencia de los permisos de los documentos",
+            "encryption": "Cifrado de los secretos",
+            "queryHistory": "Historial de consultas y panel de uso",
+            "rbac": "Control de acceso basado en roles (RBAC)",
+            "selfHosting": "Autoalojamiento (opcional)",
+            "theming": "Temas personalizados"
+          },
+          "featuresPrefix": "Trabaja mejor con la IA para tu equipo.",
+          "pricing": "$20",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "Tarjeta del plan {plan}"
+        },
+        "currentPlan": {
+          "label": "Tu plan actual"
+        },
+        "enterprise": {
+          "button": {
+            "label": "Contactar con ventas"
+          },
+          "description": "Precios y opciones de instalación flexibles\npara organizaciones grandes",
+          "features": {
+            "customDeployments": "Instalaciones personalizadas",
+            "customRoles": "Roles y permisos personalizados",
+            "hookExtensions": "Extensiones con hooks",
+            "regionalProcessing": "Procesamiento de datos por región",
+            "scim": "SCIM / sincronización de grupos",
+            "support": "SLA empresariales y soporte prioritario",
+            "usageLimits": "Límites de uso configurables",
+            "whiteLabeling": "Marca blanca completa"
+          },
+          "featuresPrefix": "Todo lo del plan Business, y además:",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "Incluido en tu plan"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "No puedes fijar menos de los **{minimum}** puestos actuales en uso o pendientes. [Quita usuarios](/admin/users) antes de ajustar los puestos."
+        },
+        "billing": {
+          "added": "{count, plural, one {Se te facturará el <value>{count}</value> puesto adicional con un importe prorrateado.} other {Se te facturarán los <value>{count}</value> puestos adicionales con un importe prorrateado.}}",
+          "removed": "{count, plural, one {Se quitará <value>{count}</value> puesto el <value>{date}</value> (después del ciclo de facturación actual).} other {Se quitarán <value>{count}</value> puestos el <value>{date}</value> (después del ciclo de facturación actual).}}",
+          "unchanged": "No hay cambios en tu facturación."
+        },
+        "breakdown": {
+          "label": "{used} en uso • {pending} pendientes • {remaining} disponibles"
+        },
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "confirmChange": {
+          "label": "Confirmar el cambio"
+        },
+        "delta": {
+          "added": "{count, plural, one {# puesto por añadir} other {# puestos por añadir}}",
+          "removed": "{count, plural, one {# puesto por quitar} other {# puestos por quitar}}"
+        },
+        "saving": {
+          "label": "Guardando..."
+        },
+        "seatsField": {
+          "title": "Puestos"
+        },
+        "total": {
+          "label": "{count} puestos"
+        },
+        "updateFailed": {
+          "error": "No se pudieron actualizar los puestos"
+        },
+        "updateSeats": {
+          "description": "Añade o quita puestos para reflejar el tamaño de tu equipo.",
+          "label": "Actualizar los puestos",
+          "title": "Actualizar los puestos"
+        },
+        "viewUsers": {
+          "label": "Ver los usuarios"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Plan Business"
+        },
+        "connectToStripe": {
+          "label": "Conectar con Stripe"
+        },
+        "connecting": {
+          "label": "Conectando..."
+        },
+        "enterprisePlan": {
+          "name": "Plan Enterprise"
+        },
+        "expired": {
+          "subtitle": "Caducó el {date}"
+        },
+        "managePlan": {
+          "label": "Gestionar el plan"
+        },
+        "managedBySales": {
+          "text": "Tu plan se gestiona a través del equipo de ventas.<br></br><link>Contacta con facturación</link> para hacer cambios."
+        },
+        "nextPayment": {
+          "subtitle": "Próximo pago el {date}"
+        },
+        "syncLicense": {
+          "label": "Sincronizar la licencia"
+        },
+        "syncing": {
+          "label": "Sincronizando..."
+        },
+        "trialDays": {
+          "subtitle": "La prueba termina en {days} días. El pago se requiere el {date}"
+        },
+        "trialToday": {
+          "subtitle": "La prueba termina hoy. El pago se requiere el {date}"
+        },
+        "trialTomorrow": {
+          "subtitle": "La prueba termina mañana. El pago se requiere el {date}"
+        },
+        "upgradeNow": {
+          "label": "Mejorar ahora"
+        },
+        "upgrading": {
+          "label": "Mejorando..."
+        },
+        "validUntil": {
+          "subtitle": "Válida hasta el {date}"
+        },
+        "viewPlanDetails": {
+          "label": "Ver los detalles del plan"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "No se pudo terminar la prueba",
+        "licenseSyncFailed": "Falló la sincronización de la licencia",
+        "paymentMethodRequired": "Añade primero un método de pago y luego vuelve a intentar la mejora.",
+        "syncLicenseFailed": "No se pudo sincronizar la licencia"
       }
     },
     "chatPreferences": {
@@ -591,6 +951,847 @@
         }
       }
     },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# día} other {# días}}",
+          "hours": "{count, plural, one {# hora} other {# horas}}",
+          "minutes": "{count, plural, one {# minuto} other {# minutos}}"
+        },
+        "indexingStart": {
+          "label": "Inicio de la indexación"
+        },
+        "pruningFrequency": {
+          "label": "Frecuencia de purga"
+        },
+        "refreshFrequency": {
+          "label": "Frecuencia de actualización"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "Falso",
+        "booleanTrue": "Verdadero",
+        "edit": {
+          "tooltip": "Editar"
+        },
+        "showAll": {
+          "label": "Mostrar todo ({count} elementos)"
+        },
+        "showLess": {
+          "label": "Mostrar menos"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "Al eliminar este conector se programa una tarea de eliminación que quita sus documentos indexados y lo elimina para todos los usuarios.",
+        "entityType": "conector"
+      },
+      "deletionError": {
+        "description": "Este error ocurrió al intentar eliminar el conector. Puedes volver a intentar la eliminación con el botón \"Eliminar\".",
+        "title": "Error de eliminación"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "Documentos sincronizados",
+          "errorMessage": "Mensaje de error",
+          "permissionErrors": "Errores de permisos",
+          "status": "Estado",
+          "timeStarted": "Hora de inicio"
+        },
+        "empty": {
+          "description": "Las sincronizaciones de permisos de documentos se programan en segundo plano. Pueden tardar un poco en aparecer: prueba a actualizar en unos 30 segundos.",
+          "title": "Todavía no hay intentos de sincronización de permisos de documentos"
+        },
+        "errorModal": {
+          "title": "Error de sincronización de permisos de documentos"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "ID del documento",
+          "errorMessage": "Mensaje de error",
+          "status": "Estado",
+          "time": "Hora"
+        },
+        "description": "Abajo están los errores que ocurrieron durante la indexación. Cada fila representa un documento o una entidad que falló.",
+        "empty": {
+          "description": "No se encontraron errores en esta página"
+        },
+        "fullReindex": {
+          "description": "Haz clic en el botón de abajo para iniciar una reindexación completa e intentar resolver estos errores. Esta reindexación completa puede tardar mucho más que una actualización normal."
+        },
+        "resolveAllButton": {
+          "label": "Resolver todo"
+        },
+        "status": {
+          "resolved": "Resuelto",
+          "unresolved": "Sin resolver"
+        },
+        "targetedReindex": {
+          "description": "Haz clic en el botón de abajo para volver a obtener solo los documentos que fallan. Es mucho más rápido que una reindexación completa."
+        },
+        "title": "Errores de indexación",
+        "unknownDocument": "Desconocido"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "Añadir archivos"
+        },
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "columns": {
+          "fileName": "Nombre del archivo",
+          "size": "Tamaño",
+          "uploadDate": "Fecha de subida"
+        },
+        "confirmModal": {
+          "addDetails": "Los archivos nuevos se subirán, se dividirán en fragmentos, se convertirán en embeddings y se indexarán en el índice de documentos",
+          "addSummary": "Se añadirán {count} archivo(s)",
+          "confirmButton": {
+            "label": "Confirmar y guardar"
+          },
+          "description": "Cuando guardes estos cambios, ocurrirá lo siguiente:",
+          "removeDetails": "Los documentos de estos archivos se purgarán del índice de documentos",
+          "removeSummary": "🗑️ Se quitarán {count} archivo(s)",
+          "title": "Confirmar los cambios en los archivos"
+        },
+        "editButton": {
+          "label": "Editar"
+        },
+        "empty": {
+          "description": "No hay archivos en este conector"
+        },
+        "header": {
+          "title": "Archivos ({count, plural, one {# archivo} other {# archivos}})"
+        },
+        "loadError": "Error al cargar los archivos: {message}",
+        "newBadge": {
+          "label": "Nuevo"
+        },
+        "removeFileButton": {
+          "tooltip": "Quitar el archivo"
+        },
+        "removingBadge": {
+          "label": "Quitando"
+        },
+        "saveButton": {
+          "label": "Guardar los cambios",
+          "saving": "Guardando..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "No se pueden quitar todos los archivos de un conector. Si es lo que quieres, elimina el conector.",
+          "filesUpdated": "¡Archivos actualizados! El índice de documentos se está actualizando en segundo plano. Los archivos nuevos se están indexando y los archivos quitados se purgarán de los resultados de búsqueda.",
+          "updateFailed": "No se pudieron actualizar los archivos"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "Mensaje de error",
+          "groups": "Grupos",
+          "memberships": "Pertenencias",
+          "status": "Estado",
+          "timeStarted": "Hora de inicio",
+          "users": "Usuarios"
+        },
+        "empty": {
+          "description": "Las sincronizaciones de pertenencia a grupos se programan en segundo plano. Pueden tardar un poco en aparecer: prueba a actualizar en unos 30 segundos.",
+          "title": "Todavía no hay intentos de sincronización de pertenencia a grupos"
+        },
+        "errorModal": {
+          "title": "Error de sincronización de pertenencia a grupos"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "Mensaje de error",
+          "newDocs": "Documentos nuevos",
+          "status": "Estado",
+          "timeStarted": "Hora de inicio",
+          "totalDocs": "Documentos totales",
+          "totalDocsTooltip": "Número total de documentos reemplazados en el índice durante este intento de indexación"
+        },
+        "docsPerMinute": "{rate} documentos/min",
+        "docsRemoved": "(también se quitaron {count} documentos que se detectaron como eliminados en la fuente)",
+        "empty": {
+          "description": "Los intentos de indexación se programan en segundo plano y pueden tardar un poco en aparecer. ¡Prueba a actualizar la página en unos 30 segundos!",
+          "title": "Todavía no hay intentos de indexación programados"
+        },
+        "noAdditionalDocs": "No se procesaron documentos adicionales",
+        "reindexTooltip": {
+          "completed": "Este intento de indexación fue una reindexación completa. Todos los documentos de la fuente se sincronizaron con el sistema.",
+          "inProgress": "Este intento de indexación es una reindexación completa. Todos los documentos de la fuente se están sincronizando con el sistema."
+        },
+        "stageMetricsButton": {
+          "tooltip": "Ver las métricas por etapa"
+        },
+        "viewTrace": {
+          "ariaLabel": "Ver la traza completa"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "Tuvimos problemas al procesar algunos documentos. <details>Ver los detalles.</details>",
+        "resolvingStatus": "Resolviendo los fallos",
+        "title": "Algunos documentos no se pudieron indexar"
+      },
+      "invalidState": {
+        "description": "Este conector está en un estado no válido. Actualiza tus credenciales o crea un conector nuevo antes de reindexar.",
+        "title": "Estado del conector no válido"
+      },
+      "loadError": {
+        "title": "No se pudo obtener la información del conector con el ID {ccPairId}",
+        "unknownMessage": "Error desconocido"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "Eliminar",
+          "tooltip": {
+            "active": "Pausa el conector antes de eliminarlo"
+          }
+        },
+        "reIndex": {
+          "label": "Reindexar",
+          "tooltip": {
+            "indexing": "No se puede reindexar mientras la indexación está en curso",
+            "invalid": "Corrige la configuración del conector antes de reindexar",
+            "paused": "Reanuda el conector antes de reindexar"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "Pausar"
+          },
+          "resume": {
+            "label": "Reanudar"
+          },
+          "tooltip": {
+            "updating": "Actualización de estado en curso"
+          }
+        },
+        "trigger": {
+          "label": "Gestionar"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "Cancelado"
+        },
+        "completedWithErrors": {
+          "label": "Completado con errores"
+        },
+        "failed": {
+          "label": "Fallido"
+        },
+        "fallback": {
+          "label": "No iniciado"
+        },
+        "inProgress": {
+          "label": "En curso"
+        },
+        "notStarted": {
+          "label": "Programado"
+        },
+        "success": {
+          "label": "Correcto"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "Cada cuánto se debe purgar el conector (en horas)",
+        "title": "Frecuencia de purga"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "Volver a activar"
+        },
+        "additionalDetails": "Este conector se marcó antes como no válido. Comprueba que la configuración es correcta antes de volver a activarlo. ¿Seguro que quieres continuar?",
+        "entityType": "Conector no válido"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "Esto provocará una reindexación completa de todos los documentos de la fuente.",
+          "note": "<strong>NOTA:</strong> según el número de documentos que haya en la fuente, esto puede tardar mucho tiempo."
+        },
+        "fullReindexButton": {
+          "label": "Ejecutar la reindexación completa"
+        },
+        "title": "Ejecutar la indexación",
+        "update": {
+          "description": "Esto obtendrá e indexará todos los documentos que hayan cambiado o se hayan añadido desde la última indexación correcta."
+        },
+        "updateButton": {
+          "label": "Ejecutar la actualización"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "Cada cuánto se debe actualizar el conector (en minutos)",
+        "title": "Frecuencia de actualización"
+      },
+      "sections": {
+        "advanced": {
+          "title": "Avanzado"
+        },
+        "advancedConfiguration": {
+          "title": "Configuración avanzada"
+        },
+        "connectorConfiguration": {
+          "title": "Configuración del conector"
+        },
+        "credential": {
+          "title": "Credencial"
+        },
+        "indexing": {
+          "title": "Indexación"
+        },
+        "indexingAttempts": {
+          "title": "Intentos de indexación"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "Ocultar la sobrecarga del intento"
+          },
+          "showButton": {
+            "label": "Mostrar la sobrecarga del intento"
+          }
+        },
+        "batchTotal": {
+          "empty": "Todavía no hay lotes completados",
+          "summary": "Lote medio: {avgLabel}, {count, plural, one {# lote} other {# lotes}} — la distribución se muestra abajo."
+        },
+        "empty": {
+          "description": "Todavía no se han registrado datos de tiempo por etapa para este intento. Los intentos antiguos, anteriores a la instrumentación de etapas, no tienen métricas."
+        },
+        "loadError": {
+          "description": "No se pudieron cargar los datos de tiempo por etapa de este intento. El pipeline se ejecuta aunque el registro de métricas no esté disponible, así que esto no indica un problema con la indexación en sí.",
+          "title": "No se pudieron cargar las métricas por etapa"
+        },
+        "loading": "Cargando las métricas por etapa…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "Tiempo medio",
+            "calls": "Llamadas",
+            "max": "Máx.",
+            "min": "Mín.",
+            "stage": "Etapa",
+            "totalTime": "Tiempo total"
+          },
+          "empty": "No se registraron datos de etapa por lote."
+        },
+        "sort": {
+          "label": "Ordenar:",
+          "pipelineOrder": {
+            "label": "Orden del pipeline"
+          },
+          "timeTaken": {
+            "label": "Tiempo empleado"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "Lee de vuelta el lote desde el almacenamiento de objetos a la memoria del worker.",
+            "label": "Carga del lote"
+          },
+          "batchTotal": {
+            "description": "Tiempo real total transcurrido al procesar un solo lote de principio a fin.",
+            "label": "Total del lote"
+          },
+          "batchUnaccounted": {
+            "description": "Tiempo del lote no atribuido a ninguna etapa con nombre. Un valor alto indica que falta instrumentación.",
+            "label": "Sin asignar"
+          },
+          "checkpointLoad": {
+            "description": "Carga el checkpoint guardado para que el intento continúe donde se detuvo la ejecución anterior.",
+            "label": "Carga del checkpoint"
+          },
+          "chunking": {
+            "description": "Divide cada documento en los fragmentos que se convierten en embeddings y se indexan.",
+            "label": "División en fragmentos"
+          },
+          "connectorFetch": {
+            "description": "Tiempo que el conector dedica a llamar a la API de la fuente y entregar los documentos sin procesar.",
+            "label": "Obtención del conector"
+          },
+          "connectorValidation": {
+            "description": "Comprueba que el conector está bien configurado y es accesible antes de empezar la obtención.",
+            "label": "Validación del conector"
+          },
+          "contextualRag": {
+            "description": "Genera resúmenes de contexto por fragmento con un LLM para mejorar la calidad de la recuperación.",
+            "label": "RAG contextual"
+          },
+          "coordLockAcquireWait": {
+            "description": "Espera al bloqueo de coordinación que protege los contadores de progreso compartidos del intento.",
+            "label": "Espera del bloqueo de coordinación"
+          },
+          "coordinationUpdate": {
+            "description": "Actualiza los contadores de progreso del intento para que la interfaz refleje el lote completado.",
+            "label": "Actualización de coordinación"
+          },
+          "docBatchEnqueue": {
+            "description": "Publica el lote guardado en la cola de Celery para que un worker de docprocessing lo recoja.",
+            "label": "Encolado del lote de documentos"
+          },
+          "docBatchStore": {
+            "description": "Guarda un lote de documentos obtenidos en el almacenamiento de objetos para los workers de docprocessing.",
+            "label": "Almacenamiento del lote de documentos"
+          },
+          "docDbPrepare": {
+            "description": "Determina qué documentos son nuevos o están actualizados y prepara las filas de la base de datos.",
+            "label": "Preparación de la BD de documentos"
+          },
+          "docLockAcquireWait": {
+            "description": "Espera a los bloqueos por documento para que dos intentos simultáneos no escriban el mismo documento.",
+            "label": "Espera del bloqueo de documento"
+          },
+          "docprocessingSetup": {
+            "description": "Prepara el worker: carga la configuración de búsqueda, el modelo de embeddings y los clientes del índice.",
+            "label": "Preparación de docprocessing"
+          },
+          "embedding": {
+            "description": "Llama al modelo de embeddings para convertir los fragmentos en vectores. Suele ser la etapa más lenta.",
+            "label": "Embeddings"
+          },
+          "enrichmentPrep": {
+            "description": "Añade el control de acceso, los impulsos y otros metadatos a cada fragmento antes de escribirlo.",
+            "label": "Preparación del enriquecimiento"
+          },
+          "finalization": {
+            "description": "Libera los recursos del worker y el lote cuando termina el procesamiento.",
+            "label": "Finalización"
+          },
+          "gcCollect": {
+            "description": "Tiempo dedicado a la recolección de basura explícita entre lotes.",
+            "label": "Recolección de basura"
+          },
+          "hierarchyUpsert": {
+            "description": "Escribe la jerarquía de carpetas o espacios de la fuente para poder filtrar los documentos por ubicación.",
+            "label": "Escritura de la jerarquía"
+          },
+          "imageProcessing": {
+            "description": "Extrae y resume las imágenes para que su contenido sea texto que se pueda buscar.",
+            "label": "Procesamiento de imágenes"
+          },
+          "permissionValidation": {
+            "description": "Confirma que la credencial tiene los permisos necesarios para leer los documentos de la fuente.",
+            "label": "Validación de permisos"
+          },
+          "postIndexDbUpdate": {
+            "description": "Actualiza las filas de documentos en Postgres después de que la escritura en el índice sea correcta.",
+            "label": "Actualización de la BD tras la indexación"
+          },
+          "queueWait": {
+            "description": "Tiempo que un lote espera en la cola antes de que un worker de docprocessing lo empiece.",
+            "label": "Espera en la cola"
+          },
+          "vectorDbWrite": {
+            "description": "Escribe en el índice de documentos los fragmentos convertidos en embeddings.",
+            "label": "Escritura en la BD vectorial"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "Tiempos por lote y por intento de este intento de indexación.",
+        "title": "Métricas por etapa de la indexación"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "Documentos indexados"
+        },
+        "indexingSpeed": "({speed} documentos/min)",
+        "lastIndexed": {
+          "label": "Última indexación"
+        },
+        "lastSynced": {
+          "label": "Última sincronización"
+        },
+        "permissionSyncing": {
+          "label": "Sincronización de permisos"
+        },
+        "status": {
+          "label": "Estado"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "Ver el mensaje de error completo"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "Sincronización de permisos de documentos",
+          "notApplicableDescription": "Este conector no usa una tarea aparte de sincronización de permisos de documentos."
+        },
+        "groupMembership": {
+          "label": "Sincronización de pertenencia a grupos",
+          "notApplicableDescription": "Este conector no usa una tarea aparte de sincronización de pertenencia a grupos."
+        },
+        "indexing": {
+          "label": "Indexación"
+        },
+        "loadError": {
+          "title": "No se pudieron cargar los intentos de sincronización"
+        },
+        "notApplicable": {
+          "title": "No aplicable"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "La reindexación completa se inició correctamente",
+        "completeReindexStarting": "Iniciando la reindexación completa...",
+        "deletionScheduleFailed": "No se pudo programar la eliminación del conector: {message}",
+        "indexingProcessStartFailed": "No se pudo iniciar el proceso de indexación",
+        "indexingStartFailed": "No se pudo iniciar la indexación",
+        "indexingStartUnexpectedError": "Ocurrió un error inesperado al intentar iniciar la indexación",
+        "indexingUpdateStarted": "La actualización de la indexación se inició correctamente",
+        "indexingUpdateStarting": "Iniciando la actualización de la indexación...",
+        "invalidPruningFrequency": "Frecuencia de purga no válida: debe ser un número válido",
+        "invalidRefreshFrequency": "Frecuencia de actualización no válida: debe ser un número entero",
+        "nameUpdateFailed": "No se pudo actualizar el nombre del conector",
+        "nameUpdated": "El nombre del conector se actualizó correctamente",
+        "noUnresolvedErrors": "No hay errores sin resolver que reintentar.",
+        "pruningFrequencyUpdateFailed": "No se pudo actualizar la frecuencia de purga del conector",
+        "pruningFrequencyUpdated": "La frecuencia de purga del conector se actualizó correctamente",
+        "refreshFrequencyUpdateFailed": "No se pudo actualizar la frecuencia de actualización del conector",
+        "refreshFrequencyUpdated": "La frecuencia de actualización del conector se actualizó correctamente",
+        "targetedReindexFailed": "Falló la reindexación selectiva: {message}",
+        "targetedReindexSubmitted": "Se envió la reindexación selectiva de {count, plural, one {# documento} other {# documentos}}. Los errores desaparecerán de la lista a medida que los documentos terminen de reindexarse."
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "Autorizar con {source}",
+          "pendingLabel": "Autorizando..."
+        },
+        "createCredentialButton": {
+          "label": "Crear una nueva"
+        },
+        "credentialDeleted": {
+          "toast": "¡Credencial eliminada!"
+        },
+        "credentialModal": {
+          "title": "Crear una credencial de {source}"
+        },
+        "credentialStep": {
+          "title": "Selecciona una credencial"
+        },
+        "credentialSwapped": {
+          "toast": "¡Credencial cambiada!"
+        },
+        "error": {
+          "toast": "Error: {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "Este conector tiene una opción de búsqueda federada. Aumentará la latencia y reducirá la calidad de la búsqueda.",
+            "link": {
+              "label": "Usar la versión federada →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "Error al subir los archivos"
+        },
+        "oauthRedirectFailed": {
+          "message": "No pudimos redirigirte para iniciar sesión con {source}. Inténtalo de nuevo."
+        },
+        "oauthStartFailed": {
+          "toast": "No se pudo iniciar OAuth"
+        },
+        "oauthUrlFailed": {
+          "toast": "No se pudo obtener la URL de OAuth"
+        },
+        "retryButton": {
+          "label": "Reintentar"
+        },
+        "timeout": {
+          "toast": "La operación agotó el tiempo de espera tras {seconds} segundos. ¿Quieres revisar tu configuración por si hay errores?"
+        },
+        "unknownError": {
+          "toast": "Ocurrió un error desconocido"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "Fecha de inicio de la indexación",
+          "subtext": "Los documentos anteriores a esta fecha no se obtendrán"
+        },
+        "pruneFrequency": {
+          "description": "Comprueba todos los documentos con la fuente para eliminar los que ya no existen. Nota: este proceso revisa todos los documentos, así que ten cuidado al aumentar la frecuencia. El valor predeterminado es {hours} horas ({days} días). Se admiten horas decimales (p. ej., 0.1 horas = 6 minutos). Introduce 0 para desactivar la purga de este conector.",
+          "label": "Frecuencia de purga (horas)"
+        },
+        "refreshFrequency": {
+          "description": "Es la frecuencia con la que obtenemos documentos nuevos de la fuente (en minutos). Si introduces 0, nunca obtendremos documentos nuevos para este conector.",
+          "label": "Frecuencia de actualización (minutos)"
+        },
+        "resetButton": {
+          "label": "Restablecer"
+        },
+        "title": "Configuración avanzada"
+      },
+      "connectorName": {
+        "label": "Nombre del conector",
+        "subtext": "Un nombre descriptivo para el conector."
+      },
+      "credentialsLoadError": {
+        "title": "No se pudieron cargar las credenciales."
+      },
+      "field": {
+        "optional": {
+          "label": "(opcional)"
+        },
+        "optionalSuffix": {
+          "label": "opcional"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Se creó tu credencial de Google Drive. Puedes gestionarla o revocarla desde la lista de credenciales.",
+          "title": "Autenticación completada"
+        },
+        "authFailed": {
+          "toast": "No se pudo autenticar con Google Drive: {error}"
+        },
+        "authenticateButton": {
+          "label": "Autenticar con Google Drive",
+          "pendingLabel": "Autenticando..."
+        },
+        "createButton": {
+          "label": "Crear la credencial",
+          "pendingLabel": "Creando..."
+        },
+        "credentialsLoadError": {
+          "title": "No se pudieron cargar las credenciales de Google Drive."
+        },
+        "invalidFile": {
+          "toast": "El archivo no es válido: {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "El archivo no es válido: se esperaba una clave JSON de cuenta de servicio"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Sube una clave de cuenta de servicio antes de crear una credencial"
+        },
+        "oauthOption": {
+          "description": "Sube el JSON de la app de OAuth desde la consola de Google Cloud ([instrucciones de configuración]({docsUrl})) y luego autentícate con la cuenta de Google cuyo Drive quieres indexar.",
+          "title": "Opción 1: app de OAuth"
+        },
+        "oauthUpload": {
+          "placeholder": "Sube o pega el JSON de tu app de OAuth"
+        },
+        "primaryAdmin": {
+          "description": "Introduce el correo de un administrador o propietario de la organización de Google que posee los Google Drive que quieres indexar.",
+          "invalidEmail": "Debe ser un correo válido",
+          "label": "Correo del administrador principal",
+          "required": "Obligatorio"
+        },
+        "section": {
+          "title": "Autenticación de Google Drive"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "No se pudo crear la credencial de cuenta de servicio: {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "La credencial de cuenta de servicio se creó correctamente"
+        },
+        "serviceAccountOption": {
+          "title": "Opción 2: cuenta de servicio"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Sube o pega la clave JSON de tu cuenta de servicio"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Se creó tu credencial de Gmail. Puedes gestionarla o revocarla desde la lista de credenciales.",
+          "title": "Autenticación completada"
+        },
+        "authFailed": {
+          "toast": "No se pudo autenticar con Gmail: {error}"
+        },
+        "authenticateButton": {
+          "label": "Autenticar con Gmail",
+          "pendingLabel": "Autenticando..."
+        },
+        "createButton": {
+          "label": "Crear la credencial",
+          "pendingLabel": "Creando..."
+        },
+        "credentialsLoadError": {
+          "title": "No se pudieron cargar las credenciales de Gmail."
+        },
+        "invalidFile": {
+          "toast": "El archivo no es válido: {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "El archivo no es válido: se esperaba una clave JSON de cuenta de servicio"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Sube una clave de cuenta de servicio antes de crear una credencial"
+        },
+        "oauthOption": {
+          "description": "Sube el JSON de la app de OAuth desde la consola de Google Cloud ([instrucciones de configuración]({docsUrl})) y luego autentícate con la cuenta de Google cuyo Gmail quieres indexar.",
+          "title": "Opción 1: app de OAuth"
+        },
+        "oauthUpload": {
+          "placeholder": "Sube o pega el JSON de tu app de OAuth"
+        },
+        "primaryAdmin": {
+          "description": "Introduce el correo de un administrador o propietario de la organización de Google que posee las cuentas de Gmail que quieres indexar.",
+          "invalidEmail": "Debe ser un correo válido",
+          "label": "Correo del administrador principal",
+          "required": "Obligatorio"
+        },
+        "section": {
+          "title": "Autenticación de Gmail"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "No se pudo crear la credencial de cuenta de servicio: {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "La credencial de cuenta de servicio se creó correctamente"
+        },
+        "serviceAccountOption": {
+          "title": "Opción 2: cuenta de servicio"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Sube o pega la clave JSON de tu cuenta de servicio"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "Ir al inicio"
+        },
+        "title": "¡‘{connector}’ no es un tipo de conector válido!"
+      },
+      "listInput": {
+        "placeholder": "Introduce {label}"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "Avanzado"
+        },
+        "continueButton": {
+          "label": "Continuar"
+        },
+        "createButton": {
+          "label": "Crear el conector"
+        },
+        "previousButton": {
+          "label": "Anterior"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "¡Vaya, algo salió mal!"
+        },
+        "invalidSource": {
+          "description": "{source} no es un tipo de fuente válido.",
+          "title": "El tipo de fuente de conector indicado, {source}, no existe."
+        },
+        "processing": {
+          "description": "Espera mientras completamos la configuración.",
+          "title": "Procesando..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "Autorizar con {source}"
+        },
+        "authorizing": {
+          "description": "Espera mientras completamos la autorización."
+        },
+        "continue": {
+          "message": "Haz clic <link>aquí</link> para continuar."
+        },
+        "error": {
+          "description": "Ocurrió un error durante el proceso de OAuth. Inténtalo de nuevo."
+        },
+        "malformed": {
+          "missingCode": "Falta el código de autorización.",
+          "missingState": "Falta el parámetro de estado.",
+          "title": "La solicitud de autorización de OAuth está mal formada."
+        },
+        "page": {
+          "title": "Autorizar con un servicio de terceros"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "Tu autorización con {source} se completó correctamente. Hacen falta pasos adicionales para terminar la configuración de la credencial."
+          },
+          "description": "Tu autorización con {source} se completó correctamente.",
+          "title": "¡Listo!"
+        }
+      },
+      "oauthFailed": {
+        "toast": "Falló la autenticación con OAuth. Inténtalo de nuevo."
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "Finalizar la autorización con {source}"
+        },
+        "cloudId": {
+          "required": "Debes seleccionar un sitio de Confluence (no se encontró el id)."
+        },
+        "cloudName": {
+          "required": "Debes seleccionar un sitio de Confluence (no se encontró el nombre)."
+        },
+        "cloudUrl": {
+          "required": "Debes seleccionar un sitio de Confluence (no se encontró la url)."
+        },
+        "continue": {
+          "message": "Autorización finalizada. Haz clic <link>aquí</link> para continuar."
+        },
+        "credentialId": {
+          "required": "El ID de la credencial es obligatorio."
+        },
+        "error": {
+          "description": "Ocurrió un error durante la finalización de OAuth. Inténtalo de nuevo."
+        },
+        "finalized": {
+          "title": "Autorización de Confluence finalizada."
+        },
+        "loadingSites": {
+          "description": "Espera mientras obtenemos la lista de los sitios a los que tienes acceso."
+        },
+        "malformed": {
+          "description": "El id de la credencial falta o no es válido.",
+          "title": "La solicitud de finalización de OAuth está mal formada."
+        },
+        "page": {
+          "title": "Finalizar la autorización con un servicio de terceros"
+        },
+        "selectSite": {
+          "title": "Selecciona un sitio de Confluence"
+        },
+        "submitButton": {
+          "label": "Enviar",
+          "pendingLabel": "Enviando..."
+        },
+        "submitError": {
+          "description": "Ocurrió un error durante el envío. Inténtalo de nuevo.",
+          "title": "Error durante el envío."
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "Selecciona una opción"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "Añadir uno nuevo"
+        },
+        "removeButton": {
+          "tooltip": "Quitar"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "No hay pestañas que mostrar."
+        }
+      }
+    },
     "costOverrides": {
       "allProviders": {
         "label": "Todos los proveedores"
@@ -813,6 +2014,461 @@
         "title": "Craft no está disponible en esta instalación"
       }
     },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "Para cambiar el token, elimina el actual y añade uno nuevo."
+        },
+        "configured": {
+          "badge": "Configurado",
+          "text": "El token de tu bot de Discord está configurado."
+        },
+        "configuredWithDate": {
+          "text": "El token de tu bot de Discord está configurado. Se añadió el {date}."
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "Elimina antes las configuraciones de servidor"
+          },
+          "label": "Eliminar el token de Discord"
+        },
+        "deleteError": {
+          "toast": "No se pudo eliminar el token del bot"
+        },
+        "deleteModal": {
+          "additionalDetails": "Esto desconectará tu bot de Discord. Tendrás que volver a introducir el token para usar el bot otra vez.",
+          "entityName": "Token del bot de Discord",
+          "entityType": "token del bot de Discord"
+        },
+        "deleted": {
+          "toast": "Token del bot eliminado"
+        },
+        "enterInstructions": {
+          "text": "Introduce el token de tu bot de Discord para activarlo. Puedes obtenerlo en el Discord Developer Portal."
+        },
+        "input": {
+          "placeholder": "Introduce el token del bot..."
+        },
+        "missing": {
+          "toast": "Introduce un token de bot"
+        },
+        "notConfigured": {
+          "badge": "Sin configurar"
+        },
+        "saveButton": {
+          "label": "Guardar el token",
+          "saving": {
+            "label": "Guardando..."
+          }
+        },
+        "saveError": {
+          "toast": "No se pudo guardar el token del bot"
+        },
+        "saved": {
+          "toast": "El token del bot se guardó correctamente"
+        },
+        "section": {
+          "title": "Token del bot"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "La configuración de los canales estará disponible cuando se registre el servidor."
+        },
+        "disableAllButton": {
+          "label": "Desactivar todos"
+        },
+        "empty": {
+          "description": "Ejecuta !sync-channels en Discord para añadir canales.",
+          "title": "No hay canales configurados"
+        },
+        "enableAllButton": {
+          "label": "Activar todos"
+        },
+        "partialUpdate": {
+          "toast": "Se actualizaron {succeeded} canales, pero {failed} fallaron"
+        },
+        "section": {
+          "description": "Ejecuta !sync-channels en Discord para actualizar la lista de canales.",
+          "title": "Configuración de los canales"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "Agente específico"
+          },
+          "channel": {
+            "header": "Canal"
+          },
+          "enabled": {
+            "header": "Activado"
+          },
+          "requireMention": {
+            "header": "Requerir @mención"
+          },
+          "threadOnly": {
+            "header": "Modo solo hilos"
+          }
+        },
+        "updateError": {
+          "toast": "No se pudieron actualizar los canales"
+        },
+        "updated": {
+          "toast": "{count, plural, one {Se actualizó # canal} other {Se actualizaron # canales}}"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "Se quitó el agente predeterminado"
+        },
+        "section": {
+          "description": "El agente que usa el bot en todos los canales, salvo que se defina otro.",
+          "title": "Agente predeterminado"
+        },
+        "select": {
+          "default": {
+            "label": "Agente predeterminado"
+          },
+          "placeholder": "Selecciona un agente"
+        },
+        "updateError": {
+          "toast": "No se pudo actualizar el agente"
+        },
+        "updated": {
+          "toast": "Agente predeterminado actualizado"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "No se pudieron cargar los canales",
+          "title": "No se pudieron cargar los canales"
+        },
+        "loadServer": {
+          "title": "No se pudo cargar el servidor"
+        },
+        "loadServers": {
+          "title": "No se pudieron cargar los servidores de Discord"
+        },
+        "serverNotFound": {
+          "message": "Servidor no encontrado"
+        },
+        "unknown": {
+          "message": "Ocurrió un error desconocido"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "Usa el comando !register en tu servidor de Discord con la clave de registro para terminar la configuración.",
+          "title": "Esperando el registro"
+        },
+        "pending": {
+          "text": "Registro pendiente"
+        },
+        "registered": {
+          "text": "Registrado: {date}"
+        },
+        "updateButton": {
+          "label": "Actualizar la configuración"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "No se pudo crear el servidor"
+        },
+        "created": {
+          "toast": "¡Configuración del servidor creada!"
+        },
+        "deleteError": {
+          "toast": "No se pudo eliminar la configuración del servidor"
+        },
+        "deleteModal": {
+          "additionalDetails": "Esto quitará todos los ajustes de este servidor de Discord.",
+          "entityType": "configuración del servidor de Discord"
+        },
+        "deleted": {
+          "toast": "Configuración del servidor eliminada"
+        },
+        "disabled": {
+          "toast": "Servidor desactivado"
+        },
+        "empty": {
+          "description": "Crea una configuración de servidor para empezar.",
+          "title": "Todavía no hay servidores de Discord configurados"
+        },
+        "enabled": {
+          "toast": "Servidor activado"
+        },
+        "fallbackName": "Servidor n.º {id}",
+        "notRegistered": {
+          "toast": "El servidor debe estar registrado antes de poder activarlo"
+        },
+        "pending": {
+          "badge": "Pendiente"
+        },
+        "registered": {
+          "badge": "Registrado"
+        },
+        "table": {
+          "actions": {
+            "header": "Acciones"
+          },
+          "enabled": {
+            "header": "Activado"
+          },
+          "registered": {
+            "header": "Registrado"
+          },
+          "server": {
+            "header": "Servidor"
+          },
+          "status": {
+            "header": "Estado"
+          }
+        },
+        "updateError": {
+          "toast": "No se pudo actualizar el servidor"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Conecta Onyx con tus servidores de Discord. Los usuarios pueden hacer preguntas directamente en los canales de Discord."
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "¡Esta clave solo se mostrará una vez!",
+          "title": "Clave de registro"
+        },
+        "instructions": {
+          "text": "¡Copia el comando y envíalo desde cualquier canal de texto de tu servidor!"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "Creando..."
+          },
+          "label": "Añadir un servidor"
+        },
+        "section": {
+          "title": "Configuraciones de servidor"
+        }
+      },
+      "unsavedChanges": {
+        "description": "Haz clic en Actualizar para guardarlos.",
+        "title": "Tienes cambios sin guardar"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "Introduce la clave de API"
+        },
+        "deleteButton": {
+          "label": "Eliminar la clave de API"
+        },
+        "deleteHint": "Elimina la clave de API actual antes de actualizarla.",
+        "description": "Unstructured extrae y transforma datos complejos de formatos como .pdf, .docx, .png, .pptx, etc. en texto limpio para que Onyx lo procese. Proporciona una clave de API para activar el procesamiento de documentos con Unstructured.",
+        "learnMore": "Más información sobre Unstructured <link>aquí</link>.",
+        "note": "<label>Nota:</label> esto enviará los documentos a los servidores de Unstructured para procesarlos.",
+        "saveButton": {
+          "label": "Guardar la clave de API"
+        },
+        "title": "Procesar con la API de Unstructured"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "Impulso:"
+        },
+        "search": {
+          "placeholder": "Busca documentos por título o contenido..."
+        },
+        "updateFailed": {
+          "toast": "No se pudo actualizar el documento: {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "Error al cargar los documentos: {detail}"
+        },
+        "loading": {
+          "label": "Cargando"
+        },
+        "mostDisliked": {
+          "title": "Documentos con más valoraciones negativas"
+        },
+        "mostLiked": {
+          "title": "Documentos con más valoraciones positivas"
+        },
+        "table": {
+          "name": {
+            "header": "Nombre del documento"
+          },
+          "score": {
+            "header": "Puntuación"
+          },
+          "searchable": {
+            "header": "¿Se puede buscar?"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "Error al actualizar el estado de ocultación: {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "La puntuación debe ser un número"
+        },
+        "updated": {
+          "toast": "¡Puntuación actualizada!"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "Privado"
+          },
+          "public": {
+            "label": "Público"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "Sin nombre"
+          }
+        },
+        "deleteFailed": {
+          "toast": "No se pudo programar la eliminación del conjunto de documentos: {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "Se programó la eliminación del conjunto de documentos \"{name}\""
+        },
+        "description": "Los **conjuntos de documentos** te permiten agrupar documentos relacionados en un solo paquete. Después puedes usarlos como filtro en las búsquedas para controlar el ámbito de información en el que busca Onyx.",
+        "edit": {
+          "header": {
+            "title": "Editar el conjunto de documentos"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "¡No se puede actualizar mientras se sincroniza! Espera a que termine la sincronización e inténtalo de nuevo."
+          }
+        },
+        "federatedBadge": {
+          "label": "Federado"
+        },
+        "fetchConnectorsFailed": {
+          "title": "No se pudieron obtener los conectores"
+        },
+        "fetchSetsFailed": {
+          "title": "No se pudieron obtener los conjuntos de documentos"
+        },
+        "form": {
+          "connectors": {
+            "label": "Elige tus conectores",
+            "placeholder": "Buscar conectores...",
+            "required": "Selecciona al menos un conector (normal o federado)"
+          },
+          "createFailed": {
+            "toast": "Error al crear el conjunto de documentos: {detail}"
+          },
+          "created": {
+            "toast": "¡El conjunto de documentos se creó correctamente!"
+          },
+          "description": {
+            "label": "Descripción:",
+            "placeholder": "Describe qué representa el conjunto de documentos"
+          },
+          "federatedConnectors": {
+            "label": "Conectores federados",
+            "placeholder": "Buscar conectores federados..."
+          },
+          "name": {
+            "label": "Nombre:",
+            "placeholder": "Un nombre para el conjunto de documentos",
+            "required": "Introduce un nombre para el conjunto"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {Conectores disponibles para el grupo seleccionado} one {Conectores disponibles para el grupo seleccionado} other {Conectores disponibles para los grupos seleccionados}}"
+          },
+          "submitButton": {
+            "createLabel": "Crear el conjunto de documentos",
+            "updateLabel": "Actualizar el conjunto de documentos"
+          },
+          "unavailableConnectors": {
+            "description": "Solo estarán disponibles los conectores asignados directamente al grupo al que intentas añadir el conjunto de documentos.",
+            "title": "{count, plural, =0 {Conectores no disponibles para el grupo que has seleccionado} one {Conectores no disponibles para el grupo que has seleccionado} other {Conectores no disponibles para los grupos que has seleccionado}}"
+          },
+          "updateFailed": {
+            "toast": "Error al actualizar el conjunto de documentos: {detail}"
+          },
+          "updated": {
+            "toast": "¡El conjunto de documentos se actualizó correctamente!"
+          }
+        },
+        "loadError": {
+          "message": "Error: {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "Nuevo conjunto de documentos"
+          }
+        },
+        "newButton": {
+          "label": "Nuevo conjunto de documentos"
+        },
+        "notFound": {
+          "message": "No se encontró el conjunto de documentos con el id {id}",
+          "title": "Conjunto de documentos no encontrado"
+        },
+        "status": {
+          "deleting": {
+            "label": "Eliminando"
+          },
+          "syncing": {
+            "label": "Sincronizando"
+          },
+          "upToDate": {
+            "label": "Actualizado"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "Conectores"
+          },
+          "delete": {
+            "header": "Eliminar"
+          },
+          "name": {
+            "header": "Nombre"
+          },
+          "public": {
+            "header": "Público"
+          },
+          "status": {
+            "header": "Estado"
+          },
+          "title": "Conjuntos de documentos existentes"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "Oculto"
+        },
+        "hide": {
+          "ariaLabel": "Ocultar el documento",
+          "label": "Ocultar"
+        },
+        "unhide": {
+          "ariaLabel": "Mostrar el documento",
+          "label": "Mostrar"
+        },
+        "visible": {
+          "label": "Visible"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -912,6 +2568,16 @@
       "warnings": {
         "invalidSkill": "habilidad no válida",
         "providerUnavailable": "proveedor no disponible"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "No se pudo cargar el conector: {details}",
+        "title": "Error"
+      },
+      "loading": {
+        "description": "Obteniendo los detalles del conector y el esquema de credenciales",
+        "title": "Cargando la configuración del conector..."
       }
     },
     "groups": {
@@ -1734,6 +3400,155 @@
         "urlInvalid": "Debe ser una URL válida"
       }
     },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "Heredado de {source}"
+          },
+          "organizationPublic": {
+            "label": "Público en la organización"
+          },
+          "private": {
+            "label": "Privado"
+          }
+        },
+        "addConnectorButton": {
+          "label": "Añadir un conector"
+        },
+        "connectorCreated": {
+          "toast": "El conector se creó correctamente"
+        },
+        "empty": {
+          "message": "Parece que aún no tienes ningún conector configurado. ¡Ve a la página [Añadir conector](/admin/add-connector) para empezar!"
+        },
+        "federated": {
+          "access": {
+            "label": "Acceso federado"
+          },
+          "indexed": {
+            "label": "Indexado"
+          },
+          "notApplicable": {
+            "label": "N/D"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "Sincronización automática"
+            },
+            "private": {
+              "label": "Privado"
+            },
+            "public": {
+              "label": "Público"
+            },
+            "title": "Tipo de acceso"
+          },
+          "applyButton": {
+            "label": "Aplicar"
+          },
+          "docCount": {
+            "placeholder": "Cantidad",
+            "title": "Número de documentos"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "Completado con errores"
+            },
+            "failed": {
+              "label": "Fallido"
+            },
+            "inProgress": {
+              "label": "En curso"
+            },
+            "interrupted": {
+              "label": "Interrumpido"
+            },
+            "notStarted": {
+              "label": "No iniciado"
+            },
+            "success": {
+              "label": "Correcto"
+            },
+            "title": "Último estado"
+          },
+          "title": "Filtrar los conectores"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "Acceso: {values}"
+          },
+          "clearBadge": {
+            "label": "Borrar"
+          },
+          "docsAnyBadge": {
+            "label": "Documentos {operator} cualquier valor"
+          },
+          "docsBadge": {
+            "label": "Documentos {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "Estado: {values}"
+          }
+        },
+        "loadError": {
+          "message": "Error al cargar el estado de la indexación."
+        },
+        "manageConnector": {
+          "tooltip": "Gestionar el conector"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "Gestionar el conector federado"
+        },
+        "search": {
+          "placeholder": "Buscar conectores"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "Conectores activos"
+          },
+          "publicConnectors": {
+            "label": "Conectores públicos"
+          },
+          "totalConnectors": {
+            "label": "Conectores totales"
+          },
+          "totalDocsIndexed": {
+            "label": "Documentos indexados en total"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "¡Todo al día! No hay más conectores que mostrar"
+          },
+          "lastIndexed": {
+            "header": "Última indexación"
+          },
+          "name": {
+            "header": "Nombre"
+          },
+          "permissions": {
+            "header": "Permisos / acceso"
+          },
+          "status": {
+            "header": "Estado"
+          },
+          "totalDocs": {
+            "header": "Documentos totales"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "Contraer todo"
+          },
+          "expand": {
+            "label": "Expandir todo"
+          }
+        }
+      }
+    },
     "languageModels": {
       "availableProviders": {
         "title": "Proveedores disponibles"
@@ -1798,6 +3613,75 @@
         "unknownError": "Error desconocido"
       }
     },
+    "mcpActions": {
+      "header": {
+        "description": "Conecta servidores MCP (Model Context Protocol) para añadir acciones y herramientas personalizadas a tus agentes."
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "No se recibió ningún claim."
+        },
+        "table": {
+          "claim": {
+            "header": "Claim"
+          },
+          "value": {
+            "header": "Valor"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "API del proveedor",
+        "subtitle": "Campos del directorio obtenidos de la API del proveedor; p. ej., Microsoft Graph /me para Entra ID, que incluye country/usageLocation, algo que el id_token omite salvo que se configure el claim opcional ctry.",
+        "title": "Perfil del directorio ({source})"
+      },
+      "idToken": {
+        "subtitle": "Decodificado del JWT id_token que devuelve el endpoint de token.",
+        "title": "Claims del id_token"
+      },
+      "intro": {
+        "description": "Muestra los campos sin procesar que tu proveedor de identidad envió sobre ti en tu último inicio de sesión con OAuth/OIDC: los claims del id_token y la respuesta del endpoint userinfo. Úsalo para comprobar qué atributos está configurado para entregar el IdP. Los claims se capturan en cada inicio de sesión."
+      },
+      "loadFailed": {
+        "title": "No se pudieron cargar los claims de OAuth"
+      },
+      "noSnapshot": {
+        "description": "No se encontró ninguna captura de inicio de sesión con OAuth para {email}. Inicia sesión con el proveedor de identidad (el botón de arriba) y vuelve a cargar esta página.",
+        "title": "Todavía no hay claims capturados"
+      },
+      "rerun": {
+        "label": "Repetir el inicio de sesión con OAuth"
+      },
+      "resolved": {
+        "subtitle": "El perfil del directorio con los claims asignados que alimenta de verdad el bloque de prompt Perfil de la organización y los marcadores {placeholder}.",
+        "title": "Perfil resuelto (se usa en los prompts)"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "Capturado a las: {timestamp}"
+        },
+        "provider": {
+          "label": "Proveedor: {provider}"
+        },
+        "tokenFields": {
+          "label": "Campos de la respuesta del token: {fields}"
+        },
+        "user": {
+          "label": "Usuario: {email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "Respuesta del endpoint userinfo de OIDC para tu token de acceso.",
+        "title": "Claims de userinfo"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "Conecta servidores de OpenAPI para añadir acciones y herramientas personalizadas a tus agentes."
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Los costes se calculan a partir del uso registrado de los modelos.",
@@ -1831,6 +3715,62 @@
           "description": "No hay uso registrado en este periodo."
         },
         "title": "Usuarios"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "Conectado"
+        },
+        "description": "Conecta tu proveedor de identidad para importar y sincronizar usuarios y grupos.",
+        "generate": {
+          "label": "Generar un token de SCIM"
+        },
+        "regenerate": {
+          "label": "Regenerar el token"
+        },
+        "title": "Sincronización con SCIM",
+        "waiting": {
+          "description": "Proporciona la clave de SCIM a tu proveedor de identidad para empezar a sincronizar usuarios y grupos.",
+          "label": "Esperando la conexión"
+        }
+      },
+      "header": {
+        "description": "Sincroniza usuarios y grupos con el protocolo SCIM (System for Cross-domain Identity Management).",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "No se pudo cargar el estado del token de SCIM."
+      },
+      "modal": {
+        "copied": {
+          "message": "Token copiado al portapapeles"
+        },
+        "copyFailed": {
+          "error": "No se pudo copiar el token"
+        },
+        "regenerate": {
+          "description": "Tu token de SCIM actual se revocará y se generará uno nuevo. Tendrás que actualizar el token en tu proveedor de identidad antes de que se reanude el aprovisionamiento con SCIM.",
+          "submit": {
+            "label": "Regenerar el token"
+          },
+          "title": "Regenerar el token de SCIM"
+        },
+        "token": {
+          "copy": {
+            "label": "Copiar el token"
+          },
+          "description": "Guarda esta clave antes de continuar. No se volverá a mostrar.",
+          "download": {
+            "label": "Descargar"
+          },
+          "title": "Token de SCIM"
+        }
+      },
+      "toasts": {
+        "generateFailed": "No se pudo generar el token: {detail}",
+        "genericError": "Algo salió mal. Inténtalo de nuevo.",
+        "regenerated": "Token regenerado"
       }
     },
     "security": {
@@ -2213,6 +4153,393 @@
         }
       }
     },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "Error al crear la configuración de OnyxBot: {error}"
+        },
+        "updateError": {
+          "toast": "Error al actualizar la configuración de OnyxBot: {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "No se pudo eliminar la configuración del bot de Slack: {error}"
+        },
+        "deleted": {
+          "toast": "Se eliminó la configuración \"{configId}\" del bot de Slack"
+        },
+        "editDefaultButton": {
+          "label": "Editar la configuración predeterminada"
+        },
+        "newConfigButton": {
+          "label": "Nueva configuración de canal"
+        },
+        "section": {
+          "title": "Configuraciones por canal"
+        },
+        "table": {
+          "actions": {
+            "header": "Acciones"
+          },
+          "assistant": {
+            "header": "Agente"
+          },
+          "channel": {
+            "header": "Canal"
+          },
+          "documentSets": {
+            "header": "Conjuntos de documentos"
+          },
+          "empty": {
+            "message": "No hay configuraciones por canal. Añade una configuración nueva para personalizar el comportamiento en canales concretos."
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "Eliminar"
+        },
+        "error": {
+          "toast": "No se pudo eliminar el bot de Slack"
+        },
+        "message": "¿Seguro que quieres eliminar este bot de Slack? Esta acción no se puede deshacer.",
+        "success": {
+          "toast": "El bot de Slack se eliminó correctamente"
+        },
+        "title": "Eliminar el bot de Slack"
+      },
+      "edit": {
+        "header": {
+          "title": "Editar el bot de Slack"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Editar la configuración del canal de Slack"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "Editar la configuración predeterminada de Slack"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "No se encontró la configuración del canal de Slack con el ID: {id}"
+        },
+        "fetchAgents": {
+          "message": "No se pudieron obtener los agentes: {error}"
+        },
+        "fetchBot": {
+          "message": "No se pudo obtener el bot de Slack {botId}: {error}"
+        },
+        "fetchChannels": {
+          "message": "No se pudieron obtener los canales de Slack: {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "No se pudieron obtener los conjuntos de documentos: {error}"
+        },
+        "generic": {
+          "title": "Algo salió mal :("
+        },
+        "unknown": {
+          "message": "error desconocido"
+        },
+        "unknownOccurred": {
+          "message": "Ocurrió un error desconocido"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "Buscar un agente..."
+        },
+        "answerValidity": {
+          "label": "Responder solo si se encuentran citas",
+          "tooltip": "Si se activa, solo responderá a las preguntas en las que el modelo consiga generar citas"
+        },
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "channelName": {
+          "label": "Nombre del canal de Slack",
+          "placeholder": "Introduce el nombre del canal (p. ej., general, soporte)",
+          "subtext": "Introduce el nombre del canal de Slack (sin el símbolo #)"
+        },
+        "createButton": {
+          "label": "Crear"
+        },
+        "defaultConfig": {
+          "badge": "Configuración predeterminada",
+          "description": "Esta configuración predeterminada se aplicará a todos los canales y mensajes directos (DM) de tu espacio de trabajo de Slack."
+        },
+        "disableDefault": {
+          "label": "Desactivar la configuración predeterminada",
+          "warning": "Advertencia: si desactivas la configuración predeterminada, OnyxBot no responderá en los canales de Slack salvo que se configuren de forma explícita. Además, OnyxBot no responderá a los mensajes directos."
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "No se puede usar este conjunto de documentos porque contiene un conector con permisos de sincronización automática. Las respuestas de OnyxBot en este canal son visibles para todos los usuarios de Slack, así que replicar los permisos de quien pregunta podría exponer información privada sin querer."
+          },
+          "autoSyncedNote": {
+            "text": "Estos conjuntos de documentos no se pueden adjuntar porque tienen documentos con sincronización automática:"
+          },
+          "description": "Selecciona los conjuntos de documentos que usará OnyxBot al responder preguntas en Slack.",
+          "hideUnselectableButton": {
+            "label": "Ocultar los conjuntos de documentos no seleccionables"
+          },
+          "incompatibleHidden": {
+            "text": "Algunos conjuntos de documentos incompatibles están ocultos."
+          },
+          "incompatibleVisible": {
+            "text": "Algunos conjuntos de documentos incompatibles están visibles."
+          },
+          "viewAllButton": {
+            "label": "Ver todos los conjuntos de documentos"
+          }
+        },
+        "followUpTags": {
+          "label": "(Opcional) Usuarios o grupos a los que mencionar",
+          "subtext": "Los usuarios o grupos de Slack a los que mencionaremos si el usuario hace clic en el botón \"¿Necesitas más ayuda?\". Si no indicas ningún correo, no mencionaremos a nadie y solo reaccionaremos al mensaje original con el emoji 🆘."
+        },
+        "generalConfig": {
+          "section": {
+            "title": "Configuración general"
+          }
+        },
+        "isEphemeral": {
+          "label": "Responder al usuario con un mensaje privado (efímero)",
+          "tooltip": "Si se activa, OnyxBot responderá solo al usuario con un mensaje privado (efímero). Si además elegiste arriba el agente de 'Búsqueda', esta opción hará que los documentos privados del usuario estén disponibles para sus consultas."
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "Todo el conocimiento público",
+            "sublabel": "Deja que OnyxBot responda con la información de todos los conectores públicos"
+          },
+          "documentSets": {
+            "label": "Conjuntos de documentos concretos",
+            "sublabel": "Controla qué documentos se usan para responder preguntas"
+          },
+          "label": "Fuente de conocimiento",
+          "nonSearchAgent": {
+            "label": "Agente sin búsqueda",
+            "sublabel": "Chatea con un agente que no usa documentos"
+          },
+          "searchAgent": {
+            "label": "Agente de búsqueda",
+            "sublabel": "Controla tanto los documentos como el prompt que se usan para responder preguntas"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "Selecciona el agente sin búsqueda que usará OnyxBot al responder preguntas en Slack."
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "Conectores implicados:"
+          },
+          "description": "Ten en cuenta que si la respuesta privada (efímera) *no está seleccionada*, solo los documentos públicos de los conjuntos de documentos seleccionados estarán disponibles para las consultas de los usuarios. Si la respuesta privada (efímera) *sí está seleccionada*, las consultas de los usuarios también pueden aprovechar los documentos a los que ya tienen acceso. Ten en cuenta que los usuarios podrán compartir la respuesta con otras personas del canal, así que asegúrate de que esto encaja con las políticas de uso compartido de tu empresa.",
+          "title": "Aviso de privacidad"
+        },
+        "questionmarkPrefilter": {
+          "label": "Responder solo a preguntas",
+          "tooltip": "Si se activa, OnyxBot solo responderá a los mensajes que contengan un signo de interrogación"
+        },
+        "removedDocumentSets": {
+          "toast": "Quitamos uno o más conjuntos de documentos de tu selección porque ya no son válidos. Revisa y actualiza tu configuración."
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "Desactivado mientras 'Responder al usuario con un mensaje privado (efímero)' esté activo: las respuestas efímeras se dirigen a un solo usuario."
+          },
+          "label": "(Opcional) Responder solo a ciertos usuarios o grupos",
+          "subtext": "Si lo indicas, solo estos usuarios o grupos pueden invocar a OnyxBot en este canal, y las respuestas solo son visibles para ellos."
+        },
+        "respondTagOnly": {
+          "label": "Responder solo a @OnyxBot",
+          "tooltip": "Si se activa, OnyxBot solo responderá cuando se le mencione directamente"
+        },
+        "respondToBots": {
+          "label": "Responder a los mensajes de bots",
+          "tooltip": "Si no se activa, OnyxBot siempre ignorará los mensajes de los bots"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "Detallada"
+          },
+          "label": "Tipo de respuesta",
+          "standard": {
+            "label": "Estándar"
+          },
+          "tooltip": "Controla el formato de las respuestas de OnyxBot."
+        },
+        "searchAgent": {
+          "description": "Selecciona el agente con búsqueda que usará OnyxBot al responder preguntas en Slack."
+        },
+        "searchConfig": {
+          "section": {
+            "title": "Configuración de la búsqueda"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "Mostrar el botón Continuar en la interfaz web",
+          "tooltip": "Si se activa, se mostrará un botón al final de la respuesta que permite al usuario continuar la conversación en la interfaz web de Onyx"
+        },
+        "stillNeedHelp": {
+          "label": "Mostrar un botón \"¿Necesitas más ayuda?\"",
+          "section": {
+            "prompt": "Configurar el botón ¿Necesitas más ayuda?"
+          },
+          "tooltip": "La respuesta de OnyxBot incluirá un botón al final que pregunta al usuario si todavía necesita ayuda."
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "Ocultar los agentes no seleccionables"
+          },
+          "listLabel": "Agentes no seleccionables:",
+          "note": "Nota: algunos de tus agentes tienen conectores con sincronización automática en sus conjuntos de documentos. No puedes seleccionar estos agentes porque no podrán responder preguntas en Slack.",
+          "viewAllButton": {
+            "label": "Ver todos los agentes"
+          }
+        },
+        "updateButton": {
+          "label": "Actualizar"
+        },
+        "userOrGroup": {
+          "placeholder": "Correo del usuario o nombre del grupo de usuarios..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "Configura OnyxBot para que responda automáticamente a las preguntas en ciertos canales."
+        },
+        "description": "Configura bots de Slack que se conecten a Onyx. Una vez configurados, podrás hacer preguntas a Onyx directamente desde Slack. Además, puedes:",
+        "directMessage": {
+          "item": "Enviar un mensaje directo a OnyxBot para buscar igual que lo harías en la interfaz web."
+        },
+        "docsPrompt": {
+          "text": "¡Sigue la <link>guía</link> de la documentación de Onyx para empezar!"
+        },
+        "documentSets": {
+          "item": "Elegir de qué conjuntos de documentos debe responder OnyxBot según el canal en el que se haga la pregunta."
+        }
+      },
+      "list": {
+        "error": {
+          "title": "Error al cargar las apps"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "Nuevo bot de Slack"
+        }
+      },
+      "newBotButton": {
+        "label": "Nuevo bot de Slack"
+      },
+      "newChannel": {
+        "header": {
+          "title": "Configurar OnyxBot para un canal de Slack"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "Número de canales"
+        },
+        "defaultConfig": {
+          "header": "Configuración predeterminada"
+        },
+        "defaultSet": {
+          "badge": "Predeterminada definida"
+        },
+        "disabled": {
+          "badge": "Desactivado"
+        },
+        "empty": {
+          "message": "¡Añade un nuevo bot de Slack para empezar a chatear con Onyx!"
+        },
+        "enabled": {
+          "badge": "Activado"
+        },
+        "name": {
+          "header": "Nombre"
+        },
+        "status": {
+          "header": "Estado"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Token de la app de Slack"
+        },
+        "botToken": {
+          "label": "Token del bot de Slack"
+        },
+        "createButton": {
+          "label": "Crear"
+        },
+        "createError": {
+          "toast": "Error al crear el bot de Slack: {error}"
+        },
+        "created": {
+          "toast": "¡El bot de Slack se creó correctamente!"
+        },
+        "docsPrompt": {
+          "text": "¡Consulta nuestra <link>guía</link> si no sabes cómo obtener estos tokens!"
+        },
+        "invalidAppToken": {
+          "message": "El token de la app de Slack no es válido"
+        },
+        "invalidBotToken": {
+          "message": "El token del bot de Slack no es válido"
+        },
+        "name": {
+          "label": "Ponle un nombre a este bot de Slack:"
+        },
+        "updateButton": {
+          "label": "Actualizar"
+        },
+        "updateError": {
+          "toast": "Error al actualizar el bot de Slack: {error}"
+        },
+        "updated": {
+          "toast": "¡El bot de Slack se actualizó correctamente!"
+        },
+        "userToken": {
+          "label": "Token de usuario de Slack (opcional)",
+          "subtext": "Opcional: token de OAuth de usuario para ampliar el acceso a los canales privados"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "Eliminar"
+        },
+        "enabledCheckbox": {
+          "label": "Activado"
+        },
+        "fieldUpdateFailed": {
+          "toast": "No se pudo actualizar {field} del conector"
+        },
+        "fieldUpdated": {
+          "toast": "{field} del conector se actualizó correctamente"
+        },
+        "updateTokensButton": {
+          "label": "Actualizar los tokens"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "Hace falta un agente cuando se usa la fuente de conocimiento 'Agente'"
+        },
+        "channelNameRequired": {
+          "message": "El nombre del canal es obligatorio"
+        },
+        "documentSetRequired": {
+          "message": "Hace falta al menos un conjunto de documentos cuando se usa la fuente de conocimiento 'Conjuntos de documentos'"
+        }
+      }
+    },
     "ssoProviders": {
       "addProvider": {
         "button": {
@@ -2239,6 +4566,180 @@
       },
       "toasts": {
         "unexpectedError": "Ocurrió un error inesperado."
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "Versión del backend: "
+      },
+      "version": {
+        "title": "Versión"
+      },
+      "webVersion": {
+        "label": "Versión web: "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "Hasta {cost} o {tokens} tokens",
+          "cost": "Hasta {cost}",
+          "none": "Sin presupuesto definido",
+          "tokens": "Hasta {tokens} tokens"
+        },
+        "cadence": {
+          "label": "{days, plural, one {Se restablece cada día a medianoche UTC} other {Se restablece cada # días a medianoche UTC}}"
+        },
+        "deleteFailed": {
+          "error": "No se pudo eliminar el límite de frecuencia de tokens"
+        },
+        "empty": {
+          "message": "Todavía no hay límites. Crea un límite de gasto para acotar el uso."
+        },
+        "loadFailed": {
+          "error": "No se pudieron cargar los límites de frecuencia de tokens"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "Eliminar {label}",
+            "tooltip": "Eliminar el límite"
+          },
+          "disable": {
+            "ariaLabel": "Desactivar {label}"
+          },
+          "enable": {
+            "ariaLabel": "Activar {label}"
+          },
+          "label": "{budget}, {cadence}"
+        },
+        "updateFailed": {
+          "error": "No se pudo actualizar el límite de frecuencia de tokens"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "costBudget": {
+          "description": "Gasto máximo por periodo de restablecimiento. Define un presupuesto de coste, uno de tokens o ambos.",
+          "placeholder": "Sin límite de coste",
+          "title": "Presupuesto de coste",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "Introduce un presupuesto de coste, uno de tokens o ambos",
+          "costMax": "El presupuesto de coste máximo es de ${amount, number}",
+          "costMinCents": "El presupuesto de coste debe ser de al menos $0.01",
+          "costMoreThanZero": "El presupuesto de coste debe ser mayor que 0",
+          "groupRequired": "Selecciona un grupo de usuarios",
+          "periodInteger": "Introduce un número entero de días",
+          "periodMin": "Usa al menos 1 día",
+          "periodRequired": "Introduce un periodo de restablecimiento",
+          "scopeRequired": "El ámbito de destino es un campo obligatorio",
+          "tokenIncrement": "Usa incrementos de 1.000 tokens",
+          "tokenInteger": "Introduce un número entero de tokens",
+          "tokenMax": "El presupuesto máximo de tokens es de un billón",
+          "tokenMin": "Usa al menos 1.000 tokens"
+        },
+        "groupMenu": {
+          "empty": "Todavía no hay grupos de usuarios. Crea uno en Usuarios y grupos."
+        },
+        "groupPicker": {
+          "placeholder": "Elige un grupo"
+        },
+        "header": {
+          "title": "Crear un límite de gasto"
+        },
+        "period": {
+          "description": "Los presupuestos se restablecen a medianoche UTC",
+          "title": "Periodo de restablecimiento",
+          "unit": "días"
+        },
+        "scope": {
+          "caption": {
+            "global": "Todo el espacio de trabajo comparte un solo presupuesto.",
+            "group": "Los miembros de {group} comparten un solo presupuesto.",
+            "groupUnchosen": "Los miembros del grupo elegido comparten un solo presupuesto.",
+            "user": "Cada usuario tiene su propio presupuesto."
+          },
+          "title": "Se aplica a"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "Espacio de trabajo"
+          },
+          "user": {
+            "title": "Por usuario"
+          },
+          "userGroup": {
+            "title": "Grupo de usuarios"
+          }
+        },
+        "submit": {
+          "label": "Crear el límite"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} o {tokens} tokens",
+            "tokens": "{tokens} tokens"
+          },
+          "global": "{days, plural, one {Todo el espacio de trabajo comparte hasta {budget} cada día. El uso se bloquea hasta que se restablece el periodo.} other {Todo el espacio de trabajo comparte hasta {budget} cada # días. El uso se bloquea hasta que se restablece el periodo.}}",
+          "group": "{days, plural, one {Los miembros de {group} comparten hasta {budget} cada día. El uso se bloquea hasta que se restablece el periodo.} other {Los miembros de {group} comparten hasta {budget} cada # días. El uso se bloquea hasta que se restablece el periodo.}}",
+          "groupUnchosen": "{days, plural, one {Los miembros del grupo elegido comparten hasta {budget} cada día. El uso se bloquea hasta que se restablece el periodo.} other {Los miembros del grupo elegido comparten hasta {budget} cada # días. El uso se bloquea hasta que se restablece el periodo.}}",
+          "user": "{days, plural, one {Cada usuario puede gastar hasta {budget} cada día. El uso se bloquea hasta que se restablece el periodo.} other {Cada usuario puede gastar hasta {budget} cada # días. El uso se bloquea hasta que se restablece el periodo.}}"
+        },
+        "tokenBudget": {
+          "description": "Tokens máximos por periodo de restablecimiento",
+          "placeholder": "Sin límite de tokens",
+          "title": "Presupuesto de tokens",
+          "unit": "tokens"
+        },
+        "userGroup": {
+          "description": "Elige qué grupo comparte este presupuesto",
+          "title": "Grupo de usuarios"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "Crear un límite de gasto"
+        },
+        "createFailed": {
+          "error": "No se pudo crear el límite de gasto"
+        },
+        "created": {
+          "message": "¡Límite de gasto creado!"
+        },
+        "embedded": {
+          "description": "Define límites de seguridad para el uso del espacio de trabajo, de los usuarios y de los grupos. Los límites se pueden activar o desactivar sin eliminar su configuración.",
+          "title": "Gestionar los límites de gasto"
+        },
+        "global": {
+          "description": "Los límites globales se aplican a todos los usuarios, grupos de usuarios y claves de API. Cuando se alcanza el límite global, no se pueden gastar más tokens."
+        },
+        "intro": {
+          "description": "Los límites de gasto te ayudan a controlar cuántos tokens se pueden gastar en un periodo de tiempo determinado.",
+          "groupLimit": "Define límites para los grupos de usuarios y controla el gasto de los equipos.",
+          "toggleLimit": "Activa y desactiva los límites cuando lo necesites.",
+          "userLimit": "Define límites por usuario para que nadie gaste demasiado.",
+          "workspaceLimit": "Define un límite para todo el espacio de trabajo sobre el gasto total de tu equipo."
+        },
+        "tabs": {
+          "global": {
+            "name": "Global"
+          },
+          "groups": {
+            "name": "Grupos"
+          },
+          "users": {
+            "name": "Usuarios"
+          }
+        },
+        "user": {
+          "description": "Los límites de usuario se aplican a cada usuario por separado. Cuando un usuario alcanza un límite, se le bloquea temporalmente el gasto de tokens."
+        },
+        "userGroup": {
+          "description": "Los límites de grupo se aplican a todos los usuarios de un grupo. Si un usuario pertenece a varios grupos, se aplica el límite más permisivo."
+        }
       }
     },
     "tracing": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -26,6 +26,46 @@
     }
   },
   "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "Dépôt de code"
+        },
+        "messaging": {
+          "label": "Messagerie"
+        },
+        "other": {
+          "label": "Autres"
+        },
+        "sales": {
+          "label": "Ventes"
+        },
+        "storage": {
+          "label": "Stockage cloud"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "Tickets et gestion des tâches"
+        },
+        "wiki": {
+          "label": "Bases de connaissances et wikis"
+        }
+      },
+      "popular": {
+        "title": "Populaires"
+      },
+      "search": {
+        "placeholder": "Rechercher des connecteurs"
+      },
+      "seeConnectorsButton": {
+        "label": "Voir les connecteurs"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>Connecteur fédéré déjà configuré.</strong> Cliquez pour modifier le connecteur existant.",
+          "slackCredentialsFound": "<strong>Identifiants Slack existants trouvés.</strong> Cliquez pour gérer votre connecteur Slack."
+        }
+      }
+    },
     "agents": {
       "deleteModal": {
         "confirmation": {
@@ -298,6 +338,326 @@
           }
         },
         "title": "Utilisation"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "Votre licence est en cours de traitement. Vous serez redirigé automatiquement vers les détails de facturation après confirmation.",
+        "title": "Votre licence est encore en cours d'activation"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "La gestion de la facturation en ligne est désactivée. Contactez l'assistance pour mettre à jour votre abonnement.",
+          "title": "Déploiement isolé du réseau"
+        },
+        "expired": {
+          "description": "Renouvelez votre abonnement pour rétablir l'accès aux fonctionnalités payantes.",
+          "title": "Votre abonnement a expiré.",
+          "withDate": {
+            "description": "Renouvelez votre abonnement avant le {date} pour rétablir l'accès."
+          },
+          "withDeletion": {
+            "title": "Votre abonnement a expiré. Les données seront supprimées dans {days} jours."
+          }
+        },
+        "expiring": {
+          "description": "Renouvelez votre abonnement avant le {date} pour éviter toute interruption.",
+          "title": "Votre abonnement expire dans {days} jours."
+        },
+        "graceSync": {
+          "title": "Recherche d'une licence renouvelée…"
+        },
+        "stripeError": {
+          "description": "Vérifiez votre connexion Internet ou fournissez une licence manuellement.",
+          "title": "Impossible de se connecter au portail de paiement Stripe."
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "Ajuster le forfait"
+        },
+        "annual": {
+          "label": "Annuel"
+        },
+        "annualBadge": {
+          "label": "Économisez 20 %"
+        },
+        "billingCycle": {
+          "description": "après votre essai gratuit d'un mois",
+          "title": "Cycle de facturation"
+        },
+        "continueToPayment": {
+          "label": "Passer au paiement"
+        },
+        "createSessionFailed": {
+          "error": "Échec de la création de la session de paiement"
+        },
+        "loading": {
+          "label": "Chargement..."
+        },
+        "monthly": {
+          "label": "Mensuel"
+        },
+        "perSeatMonth": {
+          "label": "par place/mois"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "{price} $"
+        },
+        "seats": {
+          "description": "{count, plural, one {# place minimum requise pour vos utilisateurs et vos comptes Slack actuels.} other {# places minimum requises pour vos utilisateurs et vos comptes Slack actuels.}}",
+          "title": "Places"
+        },
+        "trialBilling": {
+          "text": "Vous serez facturé le <value>{date}</value> après la fin de votre essai gratuit d'un mois."
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "Activer la clé de licence"
+        },
+        "billingHelp": {
+          "label": "Aide à la facturation"
+        },
+        "licenseKeyPrompt": {
+          "label": "Vous avez une clé de licence ?"
+        },
+        "updateLicenseKey": {
+          "label": "Mettre à jour la clé de licence"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "Forfaits et facturation"
+        },
+        "upgradePlan": {
+          "title": "Mettre à niveau le forfait"
+        },
+        "viewPlans": {
+          "title": "Voir les forfaits"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "Échec de l'activation de la licence"
+        },
+        "activateLicense": {
+          "label": "Activer la licence"
+        },
+        "activateSuccess": {
+          "message": "Licence activée avec succès !"
+        },
+        "activateTitle": {
+          "title": "Activer la clé de licence"
+        },
+        "activating": {
+          "label": "Activation..."
+        },
+        "activeUntil": {
+          "label": "Clé de licence active jusqu'au <value>{date}</value>"
+        },
+        "cancel": {
+          "label": "Annuler"
+        },
+        "close": {
+          "label": "Fermer"
+        },
+        "description": "Ajoutez et activez manuellement une licence pour cette instance Onyx.",
+        "emptyKey": {
+          "error": "Saisissez une clé de licence"
+        },
+        "error": {
+          "text": "{error}. <link>Aide à la facturation</link>"
+        },
+        "expired": {
+          "label": "Clé de licence expirée"
+        },
+        "keyField": {
+          "description": "Collez ou joignez le fichier de clé de licence que vous avez reçu d'Onyx.",
+          "title": "Clé de licence"
+        },
+        "updateKey": {
+          "label": "Mettre à jour la clé"
+        },
+        "updateLicense": {
+          "label": "Mettre à jour la licence"
+        },
+        "updateSuccess": {
+          "message": "Licence mise à jour avec succès !"
+        },
+        "updateTitle": {
+          "title": "Mettre à jour la clé de licence"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "Moyen de paiement",
+          "title": "Visa se terminant par 1234"
+        },
+        "lastPayment": {
+          "description": "Dernier paiement"
+        },
+        "section": {
+          "title": "Paiement"
+        },
+        "update": {
+          "label": "Mettre à jour"
+        },
+        "viewInvoice": {
+          "label": "Voir la facture"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Choisir le forfait Business"
+          },
+          "description": "par place/mois avec facturation annuelle\nou 25 $ par place avec facturation mensuelle",
+          "features": {
+            "apiKeys": "Clés d'API de compte de service",
+            "documentPermissions": "Héritage des autorisations des documents",
+            "encryption": "Chiffrement des secrets",
+            "queryHistory": "Historique des requêtes et tableau de bord d'utilisation",
+            "rbac": "Contrôle d'accès basé sur les rôles (RBAC)",
+            "selfHosting": "Auto-hébergement (facultatif)",
+            "theming": "Thèmes personnalisés"
+          },
+          "featuresPrefix": "Accomplissez plus de travail grâce à l'IA pour votre équipe.",
+          "pricing": "20 $",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "Carte du forfait {plan}"
+        },
+        "currentPlan": {
+          "label": "Votre forfait actuel"
+        },
+        "enterprise": {
+          "button": {
+            "label": "Contacter le service commercial"
+          },
+          "description": "Tarifs et options de déploiement flexibles\npour les grandes organisations",
+          "features": {
+            "customDeployments": "Déploiements personnalisés",
+            "customRoles": "Rôles et autorisations personnalisés",
+            "hookExtensions": "Extensions de hooks",
+            "regionalProcessing": "Traitement des données par région",
+            "scim": "SCIM / Synchronisation des groupes",
+            "support": "SLA Enterprise et assistance prioritaire",
+            "usageLimits": "Limites d'utilisation configurables",
+            "whiteLabeling": "Marque blanche complète"
+          },
+          "featuresPrefix": "Tout ce qui est inclus dans le forfait Business, plus :",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "Inclus dans votre forfait"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "Vous ne pouvez pas définir un nombre de places inférieur aux **{minimum}** places actuellement utilisées ou en attente. [Retirez des utilisateurs](/admin/users) avant d'ajuster les places."
+        },
+        "billing": {
+          "added": "{count, plural, one {Vous serez facturé au prorata pour <value>{count}</value> place supplémentaire.} other {Vous serez facturé au prorata pour <value>{count}</value> places supplémentaires.}}",
+          "removed": "{count, plural, one {<value>{count}</value> place sera retirée le <value>{date}</value> (après le cycle de facturation actuel).} other {<value>{count}</value> places seront retirées le <value>{date}</value> (après le cycle de facturation actuel).}}",
+          "unchanged": "Aucun changement pour votre facturation."
+        },
+        "breakdown": {
+          "label": "{used} utilisées • {pending} en attente • {remaining} restantes"
+        },
+        "cancel": {
+          "label": "Annuler"
+        },
+        "confirmChange": {
+          "label": "Confirmer la modification"
+        },
+        "delta": {
+          "added": "{count, plural, one {# place à ajouter} other {# places à ajouter}}",
+          "removed": "{count, plural, one {# place à retirer} other {# places à retirer}}"
+        },
+        "saving": {
+          "label": "Enregistrement..."
+        },
+        "seatsField": {
+          "title": "Places"
+        },
+        "total": {
+          "label": "{count} places"
+        },
+        "updateFailed": {
+          "error": "Échec de la mise à jour des places"
+        },
+        "updateSeats": {
+          "description": "Ajoutez ou retirez des places pour refléter la taille de votre équipe.",
+          "label": "Mettre à jour les places",
+          "title": "Mettre à jour les places"
+        },
+        "viewUsers": {
+          "label": "Voir les utilisateurs"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Forfait Business"
+        },
+        "connectToStripe": {
+          "label": "Se connecter à Stripe"
+        },
+        "connecting": {
+          "label": "Connexion..."
+        },
+        "enterprisePlan": {
+          "name": "Forfait Enterprise"
+        },
+        "expired": {
+          "subtitle": "Expiré le {date}"
+        },
+        "managePlan": {
+          "label": "Gérer le forfait"
+        },
+        "managedBySales": {
+          "text": "Votre forfait est géré par le service commercial.<br></br><link>Contactez la facturation</link> pour apporter des modifications."
+        },
+        "nextPayment": {
+          "subtitle": "Prochain paiement le {date}"
+        },
+        "syncLicense": {
+          "label": "Synchroniser la licence"
+        },
+        "syncing": {
+          "label": "Synchronisation..."
+        },
+        "trialDays": {
+          "subtitle": "L'essai se termine dans {days} jours. Paiement requis le {date}"
+        },
+        "trialToday": {
+          "subtitle": "L'essai se termine aujourd'hui. Paiement requis le {date}"
+        },
+        "trialTomorrow": {
+          "subtitle": "L'essai se termine demain. Paiement requis le {date}"
+        },
+        "upgradeNow": {
+          "label": "Mettre à niveau maintenant"
+        },
+        "upgrading": {
+          "label": "Mise à niveau..."
+        },
+        "validUntil": {
+          "subtitle": "Valable jusqu'au {date}"
+        },
+        "viewPlanDetails": {
+          "label": "Voir les détails du forfait"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "Échec de la fin de l'essai",
+        "licenseSyncFailed": "La synchronisation de la licence a échoué",
+        "paymentMethodRequired": "Ajoutez d'abord un moyen de paiement, puis réessayez la mise à niveau.",
+        "syncLicenseFailed": "Échec de la synchronisation de la licence"
       }
     },
     "chatPreferences": {
@@ -591,6 +951,847 @@
         }
       }
     },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# jour} other {# jours}}",
+          "hours": "{count, plural, one {# heure} other {# heures}}",
+          "minutes": "{count, plural, one {# minute} other {# minutes}}"
+        },
+        "indexingStart": {
+          "label": "Début de l'indexation"
+        },
+        "pruningFrequency": {
+          "label": "Fréquence d'élagage"
+        },
+        "refreshFrequency": {
+          "label": "Fréquence d'actualisation"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "Faux",
+        "booleanTrue": "Vrai",
+        "edit": {
+          "tooltip": "Modifier"
+        },
+        "showAll": {
+          "label": "Tout afficher ({count} éléments)"
+        },
+        "showLess": {
+          "label": "Afficher moins"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "La suppression de ce connecteur planifie une tâche de suppression qui retire ses documents indexés et le supprime pour tous les utilisateurs.",
+        "entityType": "le connecteur"
+      },
+      "deletionError": {
+        "description": "Cette erreur s'est produite lors de la tentative de suppression du connecteur. Vous pouvez réessayer la suppression en cliquant sur le bouton \"Supprimer\".",
+        "title": "Erreur de suppression"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "Documents synchronisés",
+          "errorMessage": "Message d'erreur",
+          "permissionErrors": "Erreurs d'autorisation",
+          "status": "Statut",
+          "timeStarted": "Heure de début"
+        },
+        "empty": {
+          "description": "Les synchronisations des autorisations des documents sont planifiées en arrière-plan. Elles peuvent mettre un certain temps à apparaître — actualisez la page dans environ 30 secondes.",
+          "title": "Aucune tentative de synchronisation des autorisations des documents pour l'instant"
+        },
+        "errorModal": {
+          "title": "Erreur de synchronisation des autorisations des documents"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "ID du document",
+          "errorMessage": "Message d'erreur",
+          "status": "Statut",
+          "time": "Heure"
+        },
+        "description": "Voici les erreurs rencontrées pendant l'indexation. Chaque ligne représente un document ou une entité en échec.",
+        "empty": {
+          "description": "Aucune erreur trouvée sur cette page"
+        },
+        "fullReindex": {
+          "description": "Cliquez sur le bouton ci-dessous pour lancer une réindexation complète et tenter de résoudre ces erreurs. Cette réindexation complète peut prendre beaucoup plus de temps qu'une mise à jour normale."
+        },
+        "resolveAllButton": {
+          "label": "Tout résoudre"
+        },
+        "status": {
+          "resolved": "Résolue",
+          "unresolved": "Non résolue"
+        },
+        "targetedReindex": {
+          "description": "Cliquez sur le bouton ci-dessous pour récupérer à nouveau uniquement les documents en échec. Bien plus rapide qu'une réindexation complète."
+        },
+        "title": "Erreurs d'indexation",
+        "unknownDocument": "Inconnu"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "Ajouter des fichiers"
+        },
+        "cancelButton": {
+          "label": "Annuler"
+        },
+        "columns": {
+          "fileName": "Nom du fichier",
+          "size": "Taille",
+          "uploadDate": "Date de téléversement"
+        },
+        "confirmModal": {
+          "addDetails": "Les nouveaux fichiers seront téléversés, découpés, transformés en embeddings et indexés dans l'index de documents",
+          "addSummary": "{count} fichier(s) seront ajoutés",
+          "confirmButton": {
+            "label": "Confirmer et enregistrer"
+          },
+          "description": "Quand vous enregistrerez ces modifications, voici ce qui se passera :",
+          "removeDetails": "Les documents issus de ces fichiers seront élagués de l'index de documents",
+          "removeSummary": "🗑️ {count} fichier(s) seront retirés",
+          "title": "Confirmer les modifications des fichiers"
+        },
+        "editButton": {
+          "label": "Modifier"
+        },
+        "empty": {
+          "description": "Aucun fichier dans ce connecteur"
+        },
+        "header": {
+          "title": "Fichiers ({count, plural, one {# fichier} other {# fichiers}})"
+        },
+        "loadError": "Erreur lors du chargement des fichiers : {message}",
+        "newBadge": {
+          "label": "Nouveau"
+        },
+        "removeFileButton": {
+          "tooltip": "Retirer le fichier"
+        },
+        "removingBadge": {
+          "label": "Retrait en cours"
+        },
+        "saveButton": {
+          "label": "Enregistrer les modifications",
+          "saving": "Enregistrement..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "Impossible de retirer tous les fichiers d'un connecteur. Supprimez le connecteur si c'est ce que vous voulez.",
+          "filesUpdated": "Fichiers mis à jour avec succès ! L'index de documents est mis à jour en arrière-plan. Les nouveaux fichiers sont en cours d'indexation et les fichiers retirés seront élagués des résultats de recherche.",
+          "updateFailed": "Échec de la mise à jour des fichiers"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "Message d'erreur",
+          "groups": "Groupes",
+          "memberships": "Appartenances",
+          "status": "Statut",
+          "timeStarted": "Heure de début",
+          "users": "Utilisateurs"
+        },
+        "empty": {
+          "description": "Les synchronisations de l'appartenance aux groupes sont planifiées en arrière-plan. Elles peuvent mettre un certain temps à apparaître — actualisez la page dans environ 30 secondes.",
+          "title": "Aucune tentative de synchronisation de l'appartenance aux groupes pour l'instant"
+        },
+        "errorModal": {
+          "title": "Erreur de synchronisation de l'appartenance aux groupes"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "Message d'erreur",
+          "newDocs": "Nouveaux docs",
+          "status": "Statut",
+          "timeStarted": "Heure de début",
+          "totalDocs": "Total des docs",
+          "totalDocsTooltip": "Nombre total de documents remplacés dans l'index pendant cette tentative d'indexation"
+        },
+        "docsPerMinute": "{rate} docs / min",
+        "docsRemoved": "(a également supprimé {count} docs détectés comme supprimés dans la source)",
+        "empty": {
+          "description": "Les tentatives d'indexation sont planifiées en arrière-plan et peuvent mettre un certain temps à apparaître. Actualisez la page dans environ 30 secondes !",
+          "title": "Aucune tentative d'indexation planifiée pour l'instant"
+        },
+        "noAdditionalDocs": "Aucun doc supplémentaire traité",
+        "reindexTooltip": {
+          "completed": "Cette tentative d'indexation était une réindexation complète. Tous les documents de la source ont été synchronisés dans le système.",
+          "inProgress": "Cette tentative d'indexation est une réindexation complète. Tous les documents de la source sont en cours de synchronisation dans le système."
+        },
+        "stageMetricsButton": {
+          "tooltip": "Voir les métriques des étapes"
+        },
+        "viewTrace": {
+          "ariaLabel": "Voir la trace complète"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "Nous avons rencontré des problèmes lors du traitement de certains documents. <details>Voir les détails.</details>",
+        "resolvingStatus": "Résolution des échecs",
+        "title": "L'indexation de certains documents a échoué"
+      },
+      "invalidState": {
+        "description": "Ce connecteur est dans un état non valide. Mettez à jour vos identifiants ou créez un nouveau connecteur avant de réindexer.",
+        "title": "État du connecteur non valide"
+      },
+      "loadError": {
+        "title": "Échec de la récupération des informations du connecteur portant l'ID {ccPairId}",
+        "unknownMessage": "Erreur inconnue"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "Supprimer",
+          "tooltip": {
+            "active": "Mettez le connecteur en pause avant de le supprimer"
+          }
+        },
+        "reIndex": {
+          "label": "Réindexer",
+          "tooltip": {
+            "indexing": "Impossible de réindexer pendant qu'une indexation est déjà en cours",
+            "invalid": "Corrigez la configuration du connecteur avant de réindexer",
+            "paused": "Reprenez le connecteur avant de réindexer"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "Mettre en pause"
+          },
+          "resume": {
+            "label": "Reprendre"
+          },
+          "tooltip": {
+            "updating": "Mise à jour du statut en cours"
+          }
+        },
+        "trigger": {
+          "label": "Gérer"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "Annulé"
+        },
+        "completedWithErrors": {
+          "label": "Terminé avec des erreurs"
+        },
+        "failed": {
+          "label": "En échec"
+        },
+        "fallback": {
+          "label": "Non démarré"
+        },
+        "inProgress": {
+          "label": "En cours"
+        },
+        "notStarted": {
+          "label": "Planifié"
+        },
+        "success": {
+          "label": "Réussi"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "Fréquence à laquelle le connecteur doit être élagué (en heures)",
+        "title": "Fréquence d'élagage"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "Réactiver"
+        },
+        "additionalDetails": "Ce connecteur a été marqué comme non valide précédemment. Vérifiez que votre configuration est correcte avant de le réactiver. Voulez-vous vraiment continuer ?",
+        "entityType": "le connecteur non valide"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "Cela entraînera une réindexation complète de tous les documents de la source.",
+          "note": "<strong>REMARQUE :</strong> selon le nombre de documents stockés dans la source, cela peut prendre beaucoup de temps."
+        },
+        "fullReindexButton": {
+          "label": "Lancer une réindexation complète"
+        },
+        "title": "Lancer l'indexation",
+        "update": {
+          "description": "Cela récupérera et indexera tous les documents qui ont changé et/ou qui ont été ajoutés depuis la dernière indexation réussie."
+        },
+        "updateButton": {
+          "label": "Lancer la mise à jour"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "Fréquence à laquelle le connecteur doit s'actualiser (en minutes)",
+        "title": "Fréquence d'actualisation"
+      },
+      "sections": {
+        "advanced": {
+          "title": "Avancé"
+        },
+        "advancedConfiguration": {
+          "title": "Configuration avancée"
+        },
+        "connectorConfiguration": {
+          "title": "Configuration du connecteur"
+        },
+        "credential": {
+          "title": "Identifiants"
+        },
+        "indexing": {
+          "title": "Indexation"
+        },
+        "indexingAttempts": {
+          "title": "Tentatives d'indexation"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "Masquer le surcoût de la tentative"
+          },
+          "showButton": {
+            "label": "Afficher le surcoût de la tentative"
+          }
+        },
+        "batchTotal": {
+          "empty": "Aucun lot terminé pour l'instant",
+          "summary": "Lot moyen : {avgLabel}, {count, plural, one {# lot} other {# lots}} — distribution affichée ci-dessous."
+        },
+        "empty": {
+          "description": "Aucune donnée de durée des étapes n'a encore été enregistrée pour cette tentative. Les anciennes tentatives exécutées avant le déploiement de l'instrumentation des étapes n'ont pas de métriques."
+        },
+        "loadError": {
+          "description": "Impossible de charger les données de durée des étapes pour cette tentative. Le pipeline s'exécute même quand l'enregistrement des métriques est indisponible ; cela n'indique donc pas un problème avec l'indexation elle-même.",
+          "title": "Échec du chargement des métriques des étapes"
+        },
+        "loading": "Chargement des métriques des étapes…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "Durée moy.",
+            "calls": "Appels",
+            "max": "Max",
+            "min": "Min",
+            "stage": "Étape",
+            "totalTime": "Durée totale"
+          },
+          "empty": "Aucune donnée d'étape par lot enregistrée."
+        },
+        "sort": {
+          "label": "Trier :",
+          "pipelineOrder": {
+            "label": "Ordre du pipeline"
+          },
+          "timeTaken": {
+            "label": "Durée écoulée"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "Relit le lot depuis le stockage objet vers la mémoire du worker.",
+            "label": "Chargement du lot"
+          },
+          "batchTotal": {
+            "description": "Temps réel écoulé total pour traiter un seul lot de bout en bout.",
+            "label": "Total du lot"
+          },
+          "batchUnaccounted": {
+            "description": "Temps du lot non attribué à une étape nommée. Une valeur élevée indique une instrumentation manquante.",
+            "label": "Non attribué"
+          },
+          "checkpointLoad": {
+            "description": "Charge le point de reprise enregistré pour que la tentative reprenne là où l'exécution précédente s'est arrêtée.",
+            "label": "Chargement du point de reprise"
+          },
+          "chunking": {
+            "description": "Découpe chaque document en segments qui sont ensuite transformés en embeddings et indexés.",
+            "label": "Segmentation"
+          },
+          "connectorFetch": {
+            "description": "Temps passé par le connecteur à appeler l'API de la source et à produire les documents bruts.",
+            "label": "Récupération par le connecteur"
+          },
+          "connectorValidation": {
+            "description": "Vérifie que le connecteur est configuré correctement et joignable avant le début de la récupération.",
+            "label": "Validation du connecteur"
+          },
+          "contextualRag": {
+            "description": "Génère des résumés de contexte par segment avec un LLM pour améliorer la qualité de la récupération.",
+            "label": "RAG contextuel"
+          },
+          "coordLockAcquireWait": {
+            "description": "Attend le verrou de coordination qui protège les compteurs de progression partagés de la tentative.",
+            "label": "Attente du verrou de coordination"
+          },
+          "coordinationUpdate": {
+            "description": "Met à jour les compteurs de progression de la tentative pour que l'interface reflète le lot terminé.",
+            "label": "Mise à jour de la coordination"
+          },
+          "docBatchEnqueue": {
+            "description": "Publie le lot enregistré dans la file Celery pour qu'un worker docprocessing le prenne en charge.",
+            "label": "Mise en file du lot de documents"
+          },
+          "docBatchStore": {
+            "description": "Enregistre un lot de documents récupérés dans le stockage objet pour les workers docprocessing.",
+            "label": "Enregistrement du lot de documents"
+          },
+          "docDbPrepare": {
+            "description": "Détermine quels documents sont nouveaux ou mis à jour et prépare les lignes de la base de données.",
+            "label": "Préparation DB des documents"
+          },
+          "docLockAcquireWait": {
+            "description": "Attend les verrous par document pour que des tentatives simultanées n'écrivent pas le même document.",
+            "label": "Attente du verrou de document"
+          },
+          "docprocessingSetup": {
+            "description": "Prépare le worker : charge les paramètres de recherche, le modèle d'embedding et les clients d'index.",
+            "label": "Configuration du docprocessing"
+          },
+          "embedding": {
+            "description": "Appelle le modèle d'embedding pour convertir les segments en vecteurs. Généralement l'étape la plus lente.",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "Attache le contrôle d'accès, les boosts et les autres métadonnées à chaque segment avant l'écriture.",
+            "label": "Préparation de l'enrichissement"
+          },
+          "finalization": {
+            "description": "Libère les ressources du worker et relâche le lot une fois le traitement terminé.",
+            "label": "Finalisation"
+          },
+          "gcCollect": {
+            "description": "Temps passé en garbage collection explicite entre les lots.",
+            "label": "Garbage collection"
+          },
+          "hierarchyUpsert": {
+            "description": "Écrit la hiérarchie des dossiers ou des espaces de la source pour permettre de filtrer les documents par emplacement.",
+            "label": "Upsert de la hiérarchie"
+          },
+          "imageProcessing": {
+            "description": "Extrait et résume les images pour que leur contenu devienne du texte consultable.",
+            "label": "Traitement des images"
+          },
+          "permissionValidation": {
+            "description": "Confirme que l'identifiant dispose des autorisations requises pour lire les documents de la source.",
+            "label": "Validation des autorisations"
+          },
+          "postIndexDbUpdate": {
+            "description": "Met à jour les lignes des documents dans Postgres après la réussite de l'écriture dans l'index.",
+            "label": "Mise à jour DB après indexation"
+          },
+          "queueWait": {
+            "description": "Temps d'attente d'un lot dans la file avant qu'un worker docprocessing ne le démarre.",
+            "label": "Attente en file"
+          },
+          "vectorDbWrite": {
+            "description": "Écrit les segments et leurs embeddings dans l'index des documents.",
+            "label": "Écriture DB vectorielle"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "Durées par lot et par tentative pour cette tentative d'indexation.",
+        "title": "Métriques des étapes d'indexation"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "Documents indexés"
+        },
+        "indexingSpeed": "({speed} docs / min)",
+        "lastIndexed": {
+          "label": "Dernière indexation"
+        },
+        "lastSynced": {
+          "label": "Dernière synchronisation"
+        },
+        "permissionSyncing": {
+          "label": "Synchronisation des autorisations"
+        },
+        "status": {
+          "label": "Statut"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "Voir le message d'erreur complet"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "Synchronisation des autorisations de documents",
+          "notApplicableDescription": "Ce connecteur n'utilise pas de tâche distincte de synchronisation des autorisations de documents."
+        },
+        "groupMembership": {
+          "label": "Synchronisation des appartenances aux groupes",
+          "notApplicableDescription": "Ce connecteur n'utilise pas de tâche distincte de synchronisation des appartenances aux groupes."
+        },
+        "indexing": {
+          "label": "Indexation"
+        },
+        "loadError": {
+          "title": "Échec du chargement des tentatives de synchronisation"
+        },
+        "notApplicable": {
+          "title": "Non applicable"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "Réindexation complète démarrée avec succès",
+        "completeReindexStarting": "Démarrage de la réindexation complète...",
+        "deletionScheduleFailed": "Échec de la planification de la suppression du connecteur - {message}",
+        "indexingProcessStartFailed": "Échec du démarrage du processus d'indexation",
+        "indexingStartFailed": "Échec du démarrage de l'indexation",
+        "indexingStartUnexpectedError": "Une erreur inattendue est survenue lors du démarrage de l'indexation",
+        "indexingUpdateStarted": "Mise à jour de l'indexation démarrée avec succès",
+        "indexingUpdateStarting": "Démarrage de la mise à jour de l'indexation...",
+        "invalidPruningFrequency": "Fréquence d'élagage non valide : doit être un nombre valide",
+        "invalidRefreshFrequency": "Fréquence d'actualisation non valide : doit être un entier",
+        "nameUpdateFailed": "Échec de la mise à jour du nom du connecteur",
+        "nameUpdated": "Nom du connecteur mis à jour avec succès",
+        "noUnresolvedErrors": "Aucune erreur non résolue à réessayer.",
+        "pruningFrequencyUpdateFailed": "Échec de la mise à jour de la fréquence d'élagage du connecteur",
+        "pruningFrequencyUpdated": "Fréquence d'élagage du connecteur mise à jour avec succès",
+        "refreshFrequencyUpdateFailed": "Échec de la mise à jour de la fréquence d'actualisation du connecteur",
+        "refreshFrequencyUpdated": "Fréquence d'actualisation du connecteur mise à jour avec succès",
+        "targetedReindexFailed": "Échec de la réindexation ciblée : {message}",
+        "targetedReindexSubmitted": "Réindexation ciblée envoyée pour {count, plural, one {# document} other {# documents}}. Les erreurs disparaîtront de la liste au fur et à mesure de la réindexation des documents."
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "Autoriser avec {source}",
+          "pendingLabel": "Autorisation en cours..."
+        },
+        "createCredentialButton": {
+          "label": "Créer"
+        },
+        "credentialDeleted": {
+          "toast": "Identifiant supprimé avec succès !"
+        },
+        "credentialModal": {
+          "title": "Créer un identifiant pour {source}"
+        },
+        "credentialStep": {
+          "title": "Sélectionnez un identifiant"
+        },
+        "credentialSwapped": {
+          "toast": "Identifiant remplacé avec succès !"
+        },
+        "error": {
+          "toast": "Erreur : {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "Une option de recherche fédérée est disponible pour ce connecteur. Elle entraîne une latence plus élevée et une qualité de recherche réduite.",
+            "link": {
+              "label": "Utiliser la version fédérée à la place →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "Erreur lors du téléversement des fichiers"
+        },
+        "oauthRedirectFailed": {
+          "message": "Nous n'avons pas pu vous rediriger pour vous connecter avec {source}. Veuillez réessayer."
+        },
+        "oauthStartFailed": {
+          "toast": "Impossible de démarrer OAuth"
+        },
+        "oauthUrlFailed": {
+          "toast": "Échec de la récupération de l'URL OAuth"
+        },
+        "retryButton": {
+          "label": "Réessayer"
+        },
+        "timeout": {
+          "toast": "L'opération a expiré après {seconds} secondes. Vérifiez si votre configuration contient des erreurs ?"
+        },
+        "unknownError": {
+          "toast": "Une erreur inconnue est survenue"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "Date de début de l'indexation",
+          "subtext": "Les documents antérieurs à cette date ne seront pas récupérés"
+        },
+        "pruneFrequency": {
+          "description": "Vérifie tous les documents par rapport à la source pour supprimer ceux qui n'existent plus. Remarque : ce processus vérifie chaque document, soyez donc prudent lorsque vous augmentez la fréquence. La valeur par défaut est de {hours} heures ({days} jours). Les heures décimales sont prises en charge (ex. : 0.1 heure = 6 minutes). Saisissez 0 pour désactiver l'élagage pour ce connecteur.",
+          "label": "Fréquence d'élagage (heures)"
+        },
+        "refreshFrequency": {
+          "description": "Indique la fréquence à laquelle nous récupérons de nouveaux documents depuis la source (en minutes). Si vous saisissez 0, nous ne récupérerons jamais de nouveaux documents pour ce connecteur.",
+          "label": "Fréquence d'actualisation (minutes)"
+        },
+        "resetButton": {
+          "label": "Réinitialiser"
+        },
+        "title": "Configuration avancée"
+      },
+      "connectorName": {
+        "label": "Nom du connecteur",
+        "subtext": "Un nom descriptif pour le connecteur."
+      },
+      "credentialsLoadError": {
+        "title": "Échec du chargement des identifiants."
+      },
+      "field": {
+        "optional": {
+          "label": "(facultatif)"
+        },
+        "optionalSuffix": {
+          "label": "facultatif"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Votre identifiant Google Drive a été créé. Gérez-le ou révoquez-le depuis la liste des identifiants.",
+          "title": "Authentification terminée"
+        },
+        "authFailed": {
+          "toast": "Échec de l'authentification avec Google Drive : {error}"
+        },
+        "authenticateButton": {
+          "label": "S'authentifier avec Google Drive",
+          "pendingLabel": "Authentification en cours..."
+        },
+        "createButton": {
+          "label": "Créer l'identifiant",
+          "pendingLabel": "Création..."
+        },
+        "credentialsLoadError": {
+          "title": "Échec du chargement des identifiants Google Drive."
+        },
+        "invalidFile": {
+          "toast": "Fichier fourni non valide : {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Fichier fourni non valide : une clé JSON de compte de service est attendue"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Téléversez une clé de compte de service avant de créer un identifiant"
+        },
+        "oauthOption": {
+          "description": "Téléversez le JSON de l'application OAuth depuis Google Cloud Console ([instructions de configuration]({docsUrl})), puis authentifiez-vous avec le compte Google dont vous voulez indexer le Drive.",
+          "title": "Option 1 : application OAuth"
+        },
+        "oauthUpload": {
+          "placeholder": "Téléversez ou collez le JSON de votre application OAuth"
+        },
+        "primaryAdmin": {
+          "description": "Saisissez l'e-mail d'un administrateur ou d'un propriétaire de l'organisation Google qui possède le ou les Google Drive que vous voulez indexer.",
+          "invalidEmail": "Doit être un e-mail valide",
+          "label": "E-mail de l'administrateur principal",
+          "required": "Obligatoire"
+        },
+        "section": {
+          "title": "Authentification Google Drive"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Échec de la création de l'identifiant du compte de service : {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Identifiant du compte de service créé avec succès"
+        },
+        "serviceAccountOption": {
+          "title": "Option 2 : compte de service"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Téléversez ou collez la clé JSON de votre compte de service"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Votre identifiant Gmail a été créé. Gérez-le ou révoquez-le depuis la liste des identifiants.",
+          "title": "Authentification terminée"
+        },
+        "authFailed": {
+          "toast": "Échec de l'authentification avec Gmail : {error}"
+        },
+        "authenticateButton": {
+          "label": "S'authentifier avec Gmail",
+          "pendingLabel": "Authentification en cours..."
+        },
+        "createButton": {
+          "label": "Créer l'identifiant",
+          "pendingLabel": "Création..."
+        },
+        "credentialsLoadError": {
+          "title": "Échec du chargement des identifiants Gmail."
+        },
+        "invalidFile": {
+          "toast": "Fichier fourni non valide : {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Fichier fourni non valide : une clé JSON de compte de service est attendue"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Téléversez une clé de compte de service avant de créer un identifiant"
+        },
+        "oauthOption": {
+          "description": "Téléversez le JSON de l'application OAuth depuis Google Cloud Console ([instructions de configuration]({docsUrl})), puis authentifiez-vous avec le compte Google dont vous voulez indexer la messagerie Gmail.",
+          "title": "Option 1 : application OAuth"
+        },
+        "oauthUpload": {
+          "placeholder": "Téléversez ou collez le JSON de votre application OAuth"
+        },
+        "primaryAdmin": {
+          "description": "Saisissez l'e-mail d'un administrateur ou d'un propriétaire de l'organisation Google qui possède le ou les comptes Gmail que vous voulez indexer.",
+          "invalidEmail": "Doit être un e-mail valide",
+          "label": "E-mail de l'administrateur principal",
+          "required": "Obligatoire"
+        },
+        "section": {
+          "title": "Authentification Gmail"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Échec de la création de l'identifiant du compte de service : {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Identifiant du compte de service créé avec succès"
+        },
+        "serviceAccountOption": {
+          "title": "Option 2 : compte de service"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Téléversez ou collez la clé JSON de votre compte de service"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "Retour à l'accueil"
+        },
+        "title": "‘{connector}’ n'est pas un type de connecteur valide !"
+      },
+      "listInput": {
+        "placeholder": "Saisissez {label}"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "Avancé"
+        },
+        "continueButton": {
+          "label": "Continuer"
+        },
+        "createButton": {
+          "label": "Créer le connecteur"
+        },
+        "previousButton": {
+          "label": "Précédent"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "Oups, une erreur s'est produite !"
+        },
+        "invalidSource": {
+          "description": "{source} n'est pas un type de source valide.",
+          "title": "Le type de source de connecteur {source} spécifié n'existe pas."
+        },
+        "processing": {
+          "description": "Veuillez patienter pendant que nous terminons la configuration.",
+          "title": "Traitement en cours..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "Autoriser avec {source}"
+        },
+        "authorizing": {
+          "description": "Veuillez patienter pendant que nous terminons l'autorisation."
+        },
+        "continue": {
+          "message": "Cliquez <link>ici</link> pour continuer."
+        },
+        "error": {
+          "description": "Une erreur est survenue pendant le processus OAuth. Veuillez réessayer."
+        },
+        "malformed": {
+          "missingCode": "Code d'autorisation manquant.",
+          "missingState": "Paramètre state manquant.",
+          "title": "Requête d'autorisation OAuth mal formée."
+        },
+        "page": {
+          "title": "Autoriser avec un service tiers"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "Votre autorisation avec {source} a réussi. Des étapes supplémentaires sont nécessaires pour terminer la configuration de l'identifiant."
+          },
+          "description": "Votre autorisation avec {source} a réussi.",
+          "title": "Succès !"
+        }
+      },
+      "oauthFailed": {
+        "toast": "L'authentification OAuth a échoué. Veuillez réessayer."
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "Finaliser l'autorisation avec {source}"
+        },
+        "cloudId": {
+          "required": "Vous devez sélectionner un site Confluence (id introuvable)."
+        },
+        "cloudName": {
+          "required": "Vous devez sélectionner un site Confluence (nom introuvable)."
+        },
+        "cloudUrl": {
+          "required": "Vous devez sélectionner un site Confluence (url introuvable)."
+        },
+        "continue": {
+          "message": "Autorisation finalisée. Cliquez <link>ici</link> pour continuer."
+        },
+        "credentialId": {
+          "required": "L'ID de l'identifiant est obligatoire."
+        },
+        "error": {
+          "description": "Une erreur est survenue pendant le processus de finalisation OAuth. Veuillez réessayer."
+        },
+        "finalized": {
+          "title": "Autorisation Confluence finalisée."
+        },
+        "loadingSites": {
+          "description": "Veuillez patienter pendant que nous récupérons la liste de vos sites accessibles."
+        },
+        "malformed": {
+          "description": "ID d'identifiant non valide ou manquant.",
+          "title": "Requête de finalisation OAuth mal formée."
+        },
+        "page": {
+          "title": "Finaliser l'autorisation avec un service tiers"
+        },
+        "selectSite": {
+          "title": "Sélectionnez un site Confluence"
+        },
+        "submitButton": {
+          "label": "Envoyer",
+          "pendingLabel": "Envoi en cours..."
+        },
+        "submitError": {
+          "description": "Une erreur est survenue pendant l'envoi. Veuillez réessayer.",
+          "title": "Erreur lors de l'envoi."
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "Sélectionnez une option"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "Ajouter"
+        },
+        "removeButton": {
+          "tooltip": "Retirer"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "Aucun onglet à afficher."
+        }
+      }
+    },
     "costOverrides": {
       "allProviders": {
         "label": "Tous les fournisseurs"
@@ -813,6 +2014,461 @@
         "title": "Craft n'est pas disponible sur ce déploiement"
       }
     },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "Pour changer le jeton, supprimez le jeton actuel et ajoutez-en un nouveau."
+        },
+        "configured": {
+          "badge": "Configuré",
+          "text": "Votre jeton de bot Discord est configuré."
+        },
+        "configuredWithDate": {
+          "text": "Votre jeton de bot Discord est configuré. Ajouté le {date}."
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "Supprimez d'abord les configurations de serveur"
+          },
+          "label": "Supprimer le jeton Discord"
+        },
+        "deleteError": {
+          "toast": "Échec de la suppression du jeton de bot"
+        },
+        "deleteModal": {
+          "additionalDetails": "Cela déconnectera votre bot Discord. Vous devrez saisir à nouveau le jeton pour réutiliser le bot.",
+          "entityName": "le jeton de bot Discord",
+          "entityType": "le jeton de bot Discord"
+        },
+        "deleted": {
+          "toast": "Jeton de bot supprimé"
+        },
+        "enterInstructions": {
+          "text": "Saisissez votre jeton de bot Discord pour activer le bot. Vous pouvez l'obtenir depuis le Discord Developer Portal."
+        },
+        "input": {
+          "placeholder": "Saisissez le jeton de bot..."
+        },
+        "missing": {
+          "toast": "Veuillez saisir un jeton de bot"
+        },
+        "notConfigured": {
+          "badge": "Non configuré"
+        },
+        "saveButton": {
+          "label": "Enregistrer le jeton",
+          "saving": {
+            "label": "Enregistrement..."
+          }
+        },
+        "saveError": {
+          "toast": "Échec de l'enregistrement du jeton de bot"
+        },
+        "saved": {
+          "toast": "Jeton de bot enregistré avec succès"
+        },
+        "section": {
+          "title": "Jeton du bot"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "La configuration des canaux sera disponible après l'enregistrement du serveur."
+        },
+        "disableAllButton": {
+          "label": "Tout désactiver"
+        },
+        "empty": {
+          "description": "Exécutez !sync-channels dans Discord pour ajouter des canaux.",
+          "title": "Aucun canal configuré"
+        },
+        "enableAllButton": {
+          "label": "Tout activer"
+        },
+        "partialUpdate": {
+          "toast": "{succeeded} canaux mis à jour, mais {failed} ont échoué"
+        },
+        "section": {
+          "description": "Exécutez !sync-channels dans Discord pour mettre à jour la liste des canaux.",
+          "title": "Configuration des canaux"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "Remplacement d'agent"
+          },
+          "channel": {
+            "header": "Canal"
+          },
+          "enabled": {
+            "header": "Activé"
+          },
+          "requireMention": {
+            "header": "Exiger une @mention"
+          },
+          "threadOnly": {
+            "header": "Mode fil uniquement"
+          }
+        },
+        "updateError": {
+          "toast": "Échec de la mise à jour des canaux"
+        },
+        "updated": {
+          "toast": "{count, plural, one {# canal mis à jour} other {# canaux mis à jour}}"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "Agent par défaut effacé"
+        },
+        "section": {
+          "description": "L'agent utilisé par le bot dans tous les canaux, sauf remplacement.",
+          "title": "Agent par défaut"
+        },
+        "select": {
+          "default": {
+            "label": "Agent par défaut"
+          },
+          "placeholder": "Sélectionner un agent"
+        },
+        "updateError": {
+          "toast": "Échec de la mise à jour de l'agent"
+        },
+        "updated": {
+          "toast": "Agent par défaut mis à jour"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "Impossible de charger les canaux",
+          "title": "Échec du chargement des canaux"
+        },
+        "loadServer": {
+          "title": "Échec du chargement du serveur"
+        },
+        "loadServers": {
+          "title": "Échec du chargement des serveurs Discord"
+        },
+        "serverNotFound": {
+          "message": "Serveur introuvable"
+        },
+        "unknown": {
+          "message": "Une erreur inconnue est survenue"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "Utilisez la commande !register dans votre serveur Discord avec la clé d'enregistrement pour terminer la configuration.",
+          "title": "En attente d'enregistrement"
+        },
+        "pending": {
+          "text": "Enregistrement en attente"
+        },
+        "registered": {
+          "text": "Enregistré : {date}"
+        },
+        "updateButton": {
+          "label": "Mettre à jour la configuration"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "Échec de la création du serveur"
+        },
+        "created": {
+          "toast": "Configuration du serveur créée !"
+        },
+        "deleteError": {
+          "toast": "Échec de la suppression de la configuration du serveur"
+        },
+        "deleteModal": {
+          "additionalDetails": "Cela supprimera tous les paramètres de ce serveur Discord.",
+          "entityType": "la configuration du serveur Discord"
+        },
+        "deleted": {
+          "toast": "Configuration du serveur supprimée"
+        },
+        "disabled": {
+          "toast": "Serveur désactivé"
+        },
+        "empty": {
+          "description": "Créez une configuration de serveur pour commencer.",
+          "title": "Aucun serveur Discord configuré pour l'instant"
+        },
+        "enabled": {
+          "toast": "Serveur activé"
+        },
+        "fallbackName": "Serveur #{id}",
+        "notRegistered": {
+          "toast": "Le serveur doit être enregistré avant de pouvoir être activé"
+        },
+        "pending": {
+          "badge": "En attente"
+        },
+        "registered": {
+          "badge": "Enregistré"
+        },
+        "table": {
+          "actions": {
+            "header": "Actions"
+          },
+          "enabled": {
+            "header": "Activé"
+          },
+          "registered": {
+            "header": "Enregistré"
+          },
+          "server": {
+            "header": "Serveur"
+          },
+          "status": {
+            "header": "Statut"
+          }
+        },
+        "updateError": {
+          "toast": "Échec de la mise à jour du serveur"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Connectez Onyx à vos serveurs Discord. Les utilisateurs peuvent poser des questions directement dans les canaux Discord."
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "Cette clé ne sera affichée qu'une seule fois !",
+          "title": "Clé d'enregistrement"
+        },
+        "instructions": {
+          "text": "Copiez la commande et envoyez-la depuis n'importe quel canal textuel de votre serveur !"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "Création..."
+          },
+          "label": "Ajouter un serveur"
+        },
+        "section": {
+          "title": "Configurations de serveur"
+        }
+      },
+      "unsavedChanges": {
+        "description": "Cliquez sur Mettre à jour pour les enregistrer.",
+        "title": "Vous avez des modifications non enregistrées"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "Saisissez la clé d'API"
+        },
+        "deleteButton": {
+          "label": "Supprimer la clé d'API"
+        },
+        "deleteHint": "Supprimez la clé d'API actuelle avant de la mettre à jour.",
+        "description": "Unstructured extrait et transforme les données complexes de formats comme .pdf, .docx, .png, .pptx, etc. en texte propre qu'Onyx peut ingérer. Fournissez une clé d'API pour activer le traitement des documents par Unstructured.",
+        "learnMore": "En savoir plus sur Unstructured <link>ici</link>.",
+        "note": "<label>Remarque :</label> les documents seront envoyés aux serveurs Unstructured pour traitement.",
+        "saveButton": {
+          "label": "Enregistrer la clé d'API"
+        },
+        "title": "Traiter avec l'API Unstructured"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "Boost :"
+        },
+        "search": {
+          "placeholder": "Rechercher des documents par titre / contenu..."
+        },
+        "updateFailed": {
+          "toast": "Échec de la mise à jour du document : {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "Erreur lors du chargement des documents : {detail}"
+        },
+        "loading": {
+          "label": "Chargement"
+        },
+        "mostDisliked": {
+          "title": "Documents les moins appréciés"
+        },
+        "mostLiked": {
+          "title": "Documents les plus appréciés"
+        },
+        "table": {
+          "name": {
+            "header": "Nom du document"
+          },
+          "score": {
+            "header": "Score"
+          },
+          "searchable": {
+            "header": "Visible dans la recherche ?"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "Erreur lors de la mise à jour du statut masqué : {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "Le score doit être un nombre"
+        },
+        "updated": {
+          "toast": "Score mis à jour !"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "Privé"
+          },
+          "public": {
+            "label": "Public"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "Sans nom"
+          }
+        },
+        "deleteFailed": {
+          "toast": "Échec de la planification de la suppression de l'ensemble de documents : {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "Ensemble de documents \"{name}\" planifié pour suppression"
+        },
+        "description": "Les **ensembles de documents** vous permettent de regrouper des documents liés logiquement en un seul lot. Vous pouvez ensuite les utiliser comme filtre lors des recherches pour contrôler l'étendue des informations sur lesquelles Onyx effectue ses recherches.",
+        "edit": {
+          "header": {
+            "title": "Modifier l'ensemble de documents"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "Impossible de mettre à jour pendant la synchronisation ! Attendez la fin de la synchronisation, puis réessayez."
+          }
+        },
+        "federatedBadge": {
+          "label": "Fédéré"
+        },
+        "fetchConnectorsFailed": {
+          "title": "Échec de la récupération des connecteurs"
+        },
+        "fetchSetsFailed": {
+          "title": "Échec de la récupération des ensembles de documents"
+        },
+        "form": {
+          "connectors": {
+            "label": "Choisissez vos connecteurs",
+            "placeholder": "Rechercher des connecteurs...",
+            "required": "Veuillez sélectionner au moins un connecteur (standard ou fédéré)"
+          },
+          "createFailed": {
+            "toast": "Erreur lors de la création de l'ensemble de documents : {detail}"
+          },
+          "created": {
+            "toast": "Ensemble de documents créé avec succès !"
+          },
+          "description": {
+            "label": "Description :",
+            "placeholder": "Décrivez ce que représente l'ensemble de documents"
+          },
+          "federatedConnectors": {
+            "label": "Connecteurs fédérés",
+            "placeholder": "Rechercher des connecteurs fédérés..."
+          },
+          "name": {
+            "label": "Nom :",
+            "placeholder": "Un nom pour l'ensemble de documents",
+            "required": "Veuillez saisir un nom pour l'ensemble"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {Connecteurs disponibles pour le groupe sélectionné} one {Connecteurs disponibles pour le groupe sélectionné} other {Connecteurs disponibles pour les groupes sélectionnés}}"
+          },
+          "submitButton": {
+            "createLabel": "Créer l'ensemble de documents",
+            "updateLabel": "Mettre à jour l'ensemble de documents"
+          },
+          "unavailableConnectors": {
+            "description": "Seuls les connecteurs directement attribués au groupe auquel vous essayez d'ajouter l'ensemble de documents seront disponibles.",
+            "title": "{count, plural, =0 {Connecteurs non disponibles pour le groupe que vous avez sélectionné} one {Connecteurs non disponibles pour le groupe que vous avez sélectionné} other {Connecteurs non disponibles pour les groupes que vous avez sélectionnés}}"
+          },
+          "updateFailed": {
+            "toast": "Erreur lors de la mise à jour de l'ensemble de documents : {detail}"
+          },
+          "updated": {
+            "toast": "Ensemble de documents mis à jour avec succès !"
+          }
+        },
+        "loadError": {
+          "message": "Erreur : {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "Nouvel ensemble de documents"
+          }
+        },
+        "newButton": {
+          "label": "Nouvel ensemble de documents"
+        },
+        "notFound": {
+          "message": "Ensemble de documents avec l'id {id} introuvable",
+          "title": "Ensemble de documents introuvable"
+        },
+        "status": {
+          "deleting": {
+            "label": "Suppression"
+          },
+          "syncing": {
+            "label": "Synchronisation"
+          },
+          "upToDate": {
+            "label": "À jour"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "Connecteurs"
+          },
+          "delete": {
+            "header": "Supprimer"
+          },
+          "name": {
+            "header": "Nom"
+          },
+          "public": {
+            "header": "Public"
+          },
+          "status": {
+            "header": "Statut"
+          },
+          "title": "Ensembles de documents existants"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "Masqué"
+        },
+        "hide": {
+          "ariaLabel": "Masquer le document",
+          "label": "Masquer"
+        },
+        "unhide": {
+          "ariaLabel": "Afficher le document",
+          "label": "Afficher"
+        },
+        "visible": {
+          "label": "Visible"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -912,6 +2568,16 @@
       "warnings": {
         "invalidSkill": "compétence non valide",
         "providerUnavailable": "fournisseur indisponible"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "Échec du chargement du connecteur : {details}",
+        "title": "Erreur"
+      },
+      "loading": {
+        "description": "Récupération des détails du connecteur et du schéma des identifiants",
+        "title": "Chargement de la configuration du connecteur..."
       }
     },
     "groups": {
@@ -1734,6 +3400,155 @@
         "urlInvalid": "Doit être une URL valide"
       }
     },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "Hérité de {source}"
+          },
+          "organizationPublic": {
+            "label": "Public dans l'organisation"
+          },
+          "private": {
+            "label": "Privé"
+          }
+        },
+        "addConnectorButton": {
+          "label": "Ajouter un connecteur"
+        },
+        "connectorCreated": {
+          "toast": "Connecteur créé avec succès"
+        },
+        "empty": {
+          "message": "Il semble que vous n'ayez pas encore configuré de connecteurs. Consultez la page [Ajouter un connecteur](/admin/add-connector) pour commencer !"
+        },
+        "federated": {
+          "access": {
+            "label": "Accès fédéré"
+          },
+          "indexed": {
+            "label": "Indexé"
+          },
+          "notApplicable": {
+            "label": "N/D"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "Synchronisation automatique"
+            },
+            "private": {
+              "label": "Privé"
+            },
+            "public": {
+              "label": "Public"
+            },
+            "title": "Type d'accès"
+          },
+          "applyButton": {
+            "label": "Appliquer"
+          },
+          "docCount": {
+            "placeholder": "Nombre",
+            "title": "Nombre de documents"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "Terminé avec des erreurs"
+            },
+            "failed": {
+              "label": "En échec"
+            },
+            "inProgress": {
+              "label": "En cours"
+            },
+            "interrupted": {
+              "label": "Interrompu"
+            },
+            "notStarted": {
+              "label": "Non démarré"
+            },
+            "success": {
+              "label": "Réussi"
+            },
+            "title": "Dernier statut"
+          },
+          "title": "Filtrer les connecteurs"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "Accès : {values}"
+          },
+          "clearBadge": {
+            "label": "Effacer"
+          },
+          "docsAnyBadge": {
+            "label": "Documents {operator} toute valeur"
+          },
+          "docsBadge": {
+            "label": "Documents {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "Statut : {values}"
+          }
+        },
+        "loadError": {
+          "message": "Erreur lors du chargement de l'état de l'indexation."
+        },
+        "manageConnector": {
+          "tooltip": "Gérer le connecteur"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "Gérer le connecteur fédéré"
+        },
+        "search": {
+          "placeholder": "Rechercher des connecteurs"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "Connecteurs actifs"
+          },
+          "publicConnectors": {
+            "label": "Connecteurs publics"
+          },
+          "totalConnectors": {
+            "label": "Total des connecteurs"
+          },
+          "totalDocsIndexed": {
+            "label": "Total des documents indexés"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "Tout est à jour ! Aucun autre connecteur à afficher"
+          },
+          "lastIndexed": {
+            "header": "Dernière indexation"
+          },
+          "name": {
+            "header": "Nom"
+          },
+          "permissions": {
+            "header": "Autorisations / Accès"
+          },
+          "status": {
+            "header": "Statut"
+          },
+          "totalDocs": {
+            "header": "Total des docs"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "Tout réduire"
+          },
+          "expand": {
+            "label": "Tout développer"
+          }
+        }
+      }
+    },
     "languageModels": {
       "availableProviders": {
         "title": "Fournisseurs disponibles"
@@ -1798,6 +3613,75 @@
         "unknownError": "Erreur inconnue"
       }
     },
+    "mcpActions": {
+      "header": {
+        "description": "Connectez des serveurs MCP (Model Context Protocol) pour ajouter des actions et des outils personnalisés à vos agents."
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "Aucune revendication reçue."
+        },
+        "table": {
+          "claim": {
+            "header": "Revendication"
+          },
+          "value": {
+            "header": "Valeur"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "API du fournisseur",
+        "subtitle": "Champs d'annuaire récupérés depuis l'API du fournisseur — par exemple Microsoft Graph /me pour Entra ID, qui contient country/usageLocation que l'id_token omet, sauf si la revendication facultative ctry est configurée.",
+        "title": "Profil d'annuaire ({source})"
+      },
+      "idToken": {
+        "subtitle": "Décodé depuis le JWT id_token renvoyé par le point de terminaison de jeton.",
+        "title": "Revendications de l'id_token"
+      },
+      "intro": {
+        "description": "Affiche les champs bruts que votre fournisseur d'identité a envoyés à votre sujet lors de votre dernière connexion OAuth/OIDC : les revendications de l'id_token et la réponse du point de terminaison userinfo. Utilisez cette page pour vérifier quels attributs l'IdP est configuré pour transmettre. Les revendications sont capturées à chaque connexion."
+      },
+      "loadFailed": {
+        "title": "Échec du chargement des revendications OAuth"
+      },
+      "noSnapshot": {
+        "description": "Aucun instantané de connexion OAuth trouvé pour {email}. Connectez-vous via le fournisseur d'identité (bouton ci-dessus), puis rechargez cette page.",
+        "title": "Aucune revendication capturée pour l'instant"
+      },
+      "rerun": {
+        "label": "Relancer la connexion OAuth"
+      },
+      "resolved": {
+        "subtitle": "Le profil d'annuaire issu du mappage des revendications, qui alimente réellement le bloc de prompt Profil de l'organisation et les espaces réservés {placeholder}.",
+        "title": "Profil résolu (utilisé pour les prompts)"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "Capturé le : {timestamp}"
+        },
+        "provider": {
+          "label": "Fournisseur : {provider}"
+        },
+        "tokenFields": {
+          "label": "Champs de la réponse de jeton : {fields}"
+        },
+        "user": {
+          "label": "Utilisateur : {email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "Réponse du point de terminaison userinfo OIDC pour votre jeton d'accès.",
+        "title": "Revendications de userinfo"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "Connectez des serveurs OpenAPI pour ajouter des actions et des outils personnalisés à vos agents."
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Les coûts sont calculés à partir de l'utilisation enregistrée des modèles.",
@@ -1831,6 +3715,62 @@
           "description": "Aucune utilisation enregistrée pour cette période."
         },
         "title": "Utilisateurs"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "Connecté"
+        },
+        "description": "Connectez votre fournisseur d'identité pour importer et synchroniser les utilisateurs et les groupes.",
+        "generate": {
+          "label": "Générer un jeton SCIM"
+        },
+        "regenerate": {
+          "label": "Régénérer le jeton"
+        },
+        "title": "Synchronisation SCIM",
+        "waiting": {
+          "description": "Fournissez la clé SCIM à votre fournisseur d'identité pour commencer à synchroniser les utilisateurs et les groupes.",
+          "label": "En attente de connexion"
+        }
+      },
+      "header": {
+        "description": "Synchronisez les utilisateurs et les groupes via le protocole SCIM (System for Cross-domain Identity Management).",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "Échec du chargement de l'état du jeton SCIM."
+      },
+      "modal": {
+        "copied": {
+          "message": "Jeton copié dans le presse-papiers"
+        },
+        "copyFailed": {
+          "error": "Échec de la copie du jeton"
+        },
+        "regenerate": {
+          "description": "Votre jeton SCIM actuel sera révoqué et un nouveau jeton sera généré. Vous devrez mettre à jour le jeton chez votre fournisseur d'identité avant que le provisionnement SCIM ne reprenne.",
+          "submit": {
+            "label": "Régénérer le jeton"
+          },
+          "title": "Régénérer le jeton SCIM"
+        },
+        "token": {
+          "copy": {
+            "label": "Copier le jeton"
+          },
+          "description": "Enregistrez cette clé avant de continuer. Elle ne sera plus affichée.",
+          "download": {
+            "label": "Télécharger"
+          },
+          "title": "Jeton SCIM"
+        }
+      },
+      "toasts": {
+        "generateFailed": "Échec de la génération du jeton : {detail}",
+        "genericError": "Une erreur s'est produite. Veuillez réessayer.",
+        "regenerated": "Jeton régénéré"
       }
     },
     "security": {
@@ -2213,6 +4153,393 @@
         }
       }
     },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "Erreur lors de la création de la configuration OnyxBot : {error}"
+        },
+        "updateError": {
+          "toast": "Erreur lors de la mise à jour de la configuration OnyxBot : {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "Échec de la suppression de la configuration du bot Slack : {error}"
+        },
+        "deleted": {
+          "toast": "Configuration du bot Slack \"{configId}\" supprimée"
+        },
+        "editDefaultButton": {
+          "label": "Modifier la configuration par défaut"
+        },
+        "newConfigButton": {
+          "label": "Nouvelle configuration de canal"
+        },
+        "section": {
+          "title": "Configurations spécifiques aux canaux"
+        },
+        "table": {
+          "actions": {
+            "header": "Actions"
+          },
+          "assistant": {
+            "header": "Agent"
+          },
+          "channel": {
+            "header": "Canal"
+          },
+          "documentSets": {
+            "header": "Ensembles de documents"
+          },
+          "empty": {
+            "message": "Aucune configuration spécifique aux canaux. Ajoutez une nouvelle configuration pour personnaliser le comportement de canaux précis."
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "Supprimer"
+        },
+        "error": {
+          "toast": "Échec de la suppression du bot Slack"
+        },
+        "message": "Voulez-vous vraiment supprimer ce bot Slack ? Cette action est irréversible.",
+        "success": {
+          "toast": "Bot Slack supprimé avec succès"
+        },
+        "title": "Supprimer le bot Slack"
+      },
+      "edit": {
+        "header": {
+          "title": "Modifier le bot Slack"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Modifier la configuration du canal Slack"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "Modifier la configuration Slack par défaut"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "Configuration de canal Slack introuvable pour l'ID : {id}"
+        },
+        "fetchAgents": {
+          "message": "Échec de la récupération des agents : {error}"
+        },
+        "fetchBot": {
+          "message": "Échec de la récupération du bot Slack {botId} : {error}"
+        },
+        "fetchChannels": {
+          "message": "Échec de la récupération des canaux Slack : {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "Échec de la récupération des ensembles de documents : {error}"
+        },
+        "generic": {
+          "title": "Une erreur s'est produite :("
+        },
+        "unknown": {
+          "message": "erreur inconnue"
+        },
+        "unknownOccurred": {
+          "message": "Une erreur inconnue est survenue"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "Rechercher un agent..."
+        },
+        "answerValidity": {
+          "label": "Répondre uniquement si des citations sont trouvées",
+          "tooltip": "Si activé, OnyxBot ne répond qu'aux questions pour lesquelles le modèle produit des citations"
+        },
+        "cancelButton": {
+          "label": "Annuler"
+        },
+        "channelName": {
+          "label": "Nom du canal Slack",
+          "placeholder": "Saisissez le nom du canal (ex. : general, support)",
+          "subtext": "Saisissez le nom du canal Slack (sans le symbole #)"
+        },
+        "createButton": {
+          "label": "Créer"
+        },
+        "defaultConfig": {
+          "badge": "Configuration par défaut",
+          "description": "Cette configuration par défaut s'applique à tous les canaux et à tous les messages directs (DM) de votre espace de travail Slack."
+        },
+        "disableDefault": {
+          "label": "Désactiver la configuration par défaut",
+          "warning": "Avertissement : si vous désactivez la configuration par défaut, OnyxBot ne répond pas dans les canaux Slack, sauf s'ils sont explicitement configurés. De plus, OnyxBot ne répond pas aux DM."
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "Impossible d'utiliser cet ensemble de documents car il contient un connecteur avec des autorisations de synchronisation automatique. Les réponses d'OnyxBot dans ce canal sont visibles par tous les utilisateurs Slack : reproduire les autorisations de l'auteur de la question pourrait donc exposer par inadvertance des informations privées."
+          },
+          "autoSyncedNote": {
+            "text": "Ces ensembles de documents ne peuvent pas être joints car ils contiennent des documents synchronisés automatiquement :"
+          },
+          "description": "Sélectionnez les ensembles de documents qu'OnyxBot utilisera pour répondre aux questions dans Slack.",
+          "hideUnselectableButton": {
+            "label": "Masquer les ensembles de documents non sélectionnables"
+          },
+          "incompatibleHidden": {
+            "text": "Certains ensembles de documents incompatibles sont masqués."
+          },
+          "incompatibleVisible": {
+            "text": "Certains ensembles de documents incompatibles sont visibles."
+          },
+          "viewAllButton": {
+            "label": "Voir tous les ensembles de documents"
+          }
+        },
+        "followUpTags": {
+          "label": "(Facultatif) Utilisateurs / groupes à mentionner",
+          "subtext": "Les utilisateurs / groupes Slack à mentionner si l'utilisateur clique sur le bouton \"Toujours besoin d'aide ?\". Si aucune adresse e-mail n'est fournie, nous ne mentionnerons personne et réagirons simplement au message d'origine avec l'emoji 🆘."
+        },
+        "generalConfig": {
+          "section": {
+            "title": "Configuration générale"
+          }
+        },
+        "isEphemeral": {
+          "label": "Répondre à l'utilisateur dans un message privé (éphémère)",
+          "tooltip": "Si activé, OnyxBot répond uniquement à l'utilisateur dans un message privé (éphémère). Si vous avez aussi choisi l'agent 'Recherche' ci-dessus, cette option rend les documents privés de l'utilisateur disponibles pour ses requêtes."
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "Toutes les connaissances publiques",
+            "sublabel": "Laissez OnyxBot répondre à partir des informations de tous les connecteurs publics"
+          },
+          "documentSets": {
+            "label": "Ensembles de documents précis",
+            "sublabel": "Contrôlez les documents à utiliser pour répondre aux questions"
+          },
+          "label": "Source de connaissances",
+          "nonSearchAgent": {
+            "label": "Agent sans recherche",
+            "sublabel": "Discutez avec un agent qui n'utilise pas de documents"
+          },
+          "searchAgent": {
+            "label": "Agent de recherche",
+            "sublabel": "Contrôlez à la fois les documents et le prompt à utiliser pour répondre aux questions"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "Sélectionnez l'agent sans recherche qu'OnyxBot utilisera pour répondre aux questions dans Slack."
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "Connecteurs concernés :"
+          },
+          "description": "Veuillez noter que si la réponse privée (éphémère) n'est *pas sélectionnée*, seuls les documents publics des ensembles de documents sélectionnés seront accessibles pour les requêtes des utilisateurs. Si la réponse privée (éphémère) *est sélectionnée*, les requêtes des utilisateurs peuvent aussi exploiter les documents auxquels l'utilisateur a déjà reçu l'accès. Notez que les utilisateurs pourront partager la réponse avec les autres membres du canal : assurez-vous donc que cela correspond aux politiques de partage de votre entreprise.",
+          "title": "Alerte de confidentialité"
+        },
+        "questionmarkPrefilter": {
+          "label": "Répondre uniquement aux questions",
+          "tooltip": "Si activé, OnyxBot ne répond qu'aux messages qui contiennent un point d'interrogation"
+        },
+        "removedDocumentSets": {
+          "toast": "Nous avons retiré un ou plusieurs ensembles de documents de votre sélection car ils ne sont plus valides. Veuillez vérifier et mettre à jour votre configuration."
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "Désactivé tant que l'option 'Répondre à l'utilisateur dans un message privé (éphémère)' est active — les réponses éphémères ne ciblent qu'un seul utilisateur."
+          },
+          "label": "(Facultatif) Répondre à certains utilisateurs / groupes",
+          "subtext": "Si vous en indiquez, seuls ces utilisateurs / groupes peuvent solliciter OnyxBot dans ce canal, et les réponses ne sont visibles que par eux."
+        },
+        "respondTagOnly": {
+          "label": "Répondre uniquement à @OnyxBot",
+          "tooltip": "Si activé, OnyxBot ne répond que lorsqu'il est directement mentionné"
+        },
+        "respondToBots": {
+          "label": "Répondre aux messages des bots",
+          "tooltip": "Si désactivé, OnyxBot ignore toujours les messages des bots"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "Détaillée"
+          },
+          "label": "Type de réponse",
+          "standard": {
+            "label": "Standard"
+          },
+          "tooltip": "Contrôle le format des réponses d'OnyxBot."
+        },
+        "searchAgent": {
+          "description": "Sélectionnez l'agent avec recherche qu'OnyxBot utilisera pour répondre aux questions dans Slack."
+        },
+        "searchConfig": {
+          "section": {
+            "title": "Configuration de la recherche"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "Afficher le bouton Continuer dans l'interface web",
+          "tooltip": "Si activé, affiche en bas de la réponse un bouton qui permet à l'utilisateur de poursuivre la conversation dans l'interface web Onyx"
+        },
+        "stillNeedHelp": {
+          "label": "Afficher un bouton \"Toujours besoin d'aide ?\"",
+          "section": {
+            "prompt": "Configurer le bouton Toujours besoin d'aide"
+          },
+          "tooltip": "La réponse d'OnyxBot inclura en bas un bouton qui demande à l'utilisateur s'il a encore besoin d'aide."
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "Masquer les agents non sélectionnables"
+          },
+          "listLabel": "Agents non sélectionnables :",
+          "note": "Remarque : certains de vos agents ont des connecteurs synchronisés automatiquement dans leurs ensembles de documents. Vous ne pouvez pas sélectionner ces agents car ils ne pourront pas répondre aux questions dans Slack.",
+          "viewAllButton": {
+            "label": "Voir tous les agents"
+          }
+        },
+        "updateButton": {
+          "label": "Mettre à jour"
+        },
+        "userOrGroup": {
+          "placeholder": "E-mail d'utilisateur ou nom de groupe d'utilisateurs..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "Configurer OnyxBot pour répondre automatiquement aux questions dans certains canaux."
+        },
+        "description": "Configurez des bots Slack connectés à Onyx. Une fois la configuration terminée, vous pourrez poser des questions à Onyx directement depuis Slack. Vous pouvez aussi :",
+        "directMessage": {
+          "item": "Envoyer un message direct à OnyxBot pour faire une recherche, comme dans l'interface web."
+        },
+        "docsPrompt": {
+          "text": "Suivez le <link>guide</link> de la documentation Onyx pour commencer !"
+        },
+        "documentSets": {
+          "item": "Choisir les ensembles de documents à partir desquels OnyxBot doit répondre, selon le canal où la question est posée."
+        }
+      },
+      "list": {
+        "error": {
+          "title": "Erreur lors du chargement des applications"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "Nouveau bot Slack"
+        }
+      },
+      "newBotButton": {
+        "label": "Nouveau bot Slack"
+      },
+      "newChannel": {
+        "header": {
+          "title": "Configurer OnyxBot pour un canal Slack"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "Nombre de canaux"
+        },
+        "defaultConfig": {
+          "header": "Config par défaut"
+        },
+        "defaultSet": {
+          "badge": "Définie"
+        },
+        "disabled": {
+          "badge": "Désactivé"
+        },
+        "empty": {
+          "message": "Ajoutez un nouveau bot Slack pour commencer à discuter avec Onyx !"
+        },
+        "enabled": {
+          "badge": "Activé"
+        },
+        "name": {
+          "header": "Nom"
+        },
+        "status": {
+          "header": "Statut"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Slack App Token"
+        },
+        "botToken": {
+          "label": "Slack Bot Token"
+        },
+        "createButton": {
+          "label": "Créer"
+        },
+        "createError": {
+          "toast": "Erreur lors de la création du bot Slack : {error}"
+        },
+        "created": {
+          "toast": "Bot Slack créé avec succès !"
+        },
+        "docsPrompt": {
+          "text": "Consultez notre <link>guide</link> si vous ne savez pas comment obtenir ces jetons !"
+        },
+        "invalidAppToken": {
+          "message": "Le Slack App Token n'est pas valide"
+        },
+        "invalidBotToken": {
+          "message": "Le Slack Bot Token n'est pas valide"
+        },
+        "name": {
+          "label": "Nommez ce bot Slack :"
+        },
+        "updateButton": {
+          "label": "Mettre à jour"
+        },
+        "updateError": {
+          "toast": "Erreur lors de la mise à jour du bot Slack : {error}"
+        },
+        "updated": {
+          "toast": "Bot Slack mis à jour avec succès !"
+        },
+        "userToken": {
+          "label": "Slack User Token (facultatif)",
+          "subtext": "Facultatif : jeton OAuth utilisateur pour un meilleur accès aux canaux privés"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "Supprimer"
+        },
+        "enabledCheckbox": {
+          "label": "Activé"
+        },
+        "fieldUpdateFailed": {
+          "toast": "Échec de la mise à jour du champ {field} du connecteur"
+        },
+        "fieldUpdated": {
+          "toast": "Champ {field} du connecteur mis à jour avec succès"
+        },
+        "updateTokensButton": {
+          "label": "Mettre à jour les jetons"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "Un agent est obligatoire avec la source de connaissances 'Agent'"
+        },
+        "channelNameRequired": {
+          "message": "Le nom du canal est obligatoire"
+        },
+        "documentSetRequired": {
+          "message": "Au moins un ensemble de documents est obligatoire avec la source de connaissances 'Ensembles de documents'"
+        }
+      }
+    },
     "ssoProviders": {
       "addProvider": {
         "button": {
@@ -2239,6 +4566,180 @@
       },
       "toasts": {
         "unexpectedError": "Une erreur inattendue est survenue."
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "Version du backend : "
+      },
+      "version": {
+        "title": "Version"
+      },
+      "webVersion": {
+        "label": "Version web : "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "Jusqu'à {cost} ou {tokens} jetons",
+          "cost": "Jusqu'à {cost}",
+          "none": "Aucun budget défini",
+          "tokens": "Jusqu'à {tokens} jetons"
+        },
+        "cadence": {
+          "label": "{days, plural, one {Réinitialisation chaque jour à minuit UTC} other {Réinitialisation tous les # jours à minuit UTC}}"
+        },
+        "deleteFailed": {
+          "error": "Échec de la suppression de la limite de débit de jetons"
+        },
+        "empty": {
+          "message": "Aucune limite pour l'instant. Créez une limite de dépenses pour plafonner l'utilisation."
+        },
+        "loadFailed": {
+          "error": "Échec du chargement des limites de débit de jetons"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "Supprimer {label}",
+            "tooltip": "Supprimer la limite"
+          },
+          "disable": {
+            "ariaLabel": "Désactiver {label}"
+          },
+          "enable": {
+            "ariaLabel": "Activer {label}"
+          },
+          "label": "{budget}, {cadence}"
+        },
+        "updateFailed": {
+          "error": "Échec de la mise à jour de la limite de débit de jetons"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "Annuler"
+        },
+        "costBudget": {
+          "description": "Dépense maximale par période de réinitialisation. Définissez un budget de coût, un budget de jetons, ou les deux.",
+          "placeholder": "Aucune limite de coût",
+          "title": "Budget de coût",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "Saisissez un budget de coût, un budget de jetons, ou les deux",
+          "costMax": "Le budget de coût maximal est de {amount, number} $",
+          "costMinCents": "Le budget de coût doit être d'au moins 0,01 $",
+          "costMoreThanZero": "Le budget de coût doit être supérieur à 0",
+          "groupRequired": "Sélectionnez un groupe d'utilisateurs",
+          "periodInteger": "Saisissez un nombre entier de jours",
+          "periodMin": "Utilisez au moins 1 jour",
+          "periodRequired": "Saisissez une période de réinitialisation",
+          "scopeRequired": "La portée cible est un champ obligatoire",
+          "tokenIncrement": "Utilisez des incréments de 1 000 jetons",
+          "tokenInteger": "Saisissez un nombre entier de jetons",
+          "tokenMax": "Le budget de jetons maximal est de 1 000 milliards",
+          "tokenMin": "Utilisez au moins 1 000 jetons"
+        },
+        "groupMenu": {
+          "empty": "Aucun groupe d'utilisateurs pour l'instant. Créez-en un dans Utilisateurs et groupes."
+        },
+        "groupPicker": {
+          "placeholder": "Choisissez un groupe"
+        },
+        "header": {
+          "title": "Créer une limite de dépenses"
+        },
+        "period": {
+          "description": "Les budgets sont réinitialisés à minuit UTC",
+          "title": "Période de réinitialisation",
+          "unit": "jours"
+        },
+        "scope": {
+          "caption": {
+            "global": "Tout le monde dans l'espace de travail partage un seul budget.",
+            "group": "Les membres de {group} partagent un seul budget.",
+            "groupUnchosen": "Les membres du groupe choisi partagent un seul budget.",
+            "user": "Chaque utilisateur dispose de son propre budget."
+          },
+          "title": "S'applique à"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "Espace de travail"
+          },
+          "user": {
+            "title": "Par utilisateur"
+          },
+          "userGroup": {
+            "title": "Groupe d'utilisateurs"
+          }
+        },
+        "submit": {
+          "label": "Créer la limite"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} ou {tokens} jetons",
+            "tokens": "{tokens} jetons"
+          },
+          "global": "{days, plural, one {Tout le monde dans l'espace de travail partage jusqu'à {budget} chaque jour. L'utilisation est bloquée jusqu'à la réinitialisation de la période.} other {Tout le monde dans l'espace de travail partage jusqu'à {budget} tous les # jours. L'utilisation est bloquée jusqu'à la réinitialisation de la période.}}",
+          "group": "{days, plural, one {Les membres de {group} partagent jusqu'à {budget} chaque jour. L'utilisation est bloquée jusqu'à la réinitialisation de la période.} other {Les membres de {group} partagent jusqu'à {budget} tous les # jours. L'utilisation est bloquée jusqu'à la réinitialisation de la période.}}",
+          "groupUnchosen": "{days, plural, one {Les membres du groupe choisi partagent jusqu'à {budget} chaque jour. L'utilisation est bloquée jusqu'à la réinitialisation de la période.} other {Les membres du groupe choisi partagent jusqu'à {budget} tous les # jours. L'utilisation est bloquée jusqu'à la réinitialisation de la période.}}",
+          "user": "{days, plural, one {Chaque utilisateur peut dépenser jusqu'à {budget} chaque jour. L'utilisation est bloquée jusqu'à la réinitialisation de la période.} other {Chaque utilisateur peut dépenser jusqu'à {budget} tous les # jours. L'utilisation est bloquée jusqu'à la réinitialisation de la période.}}"
+        },
+        "tokenBudget": {
+          "description": "Nombre maximal de jetons par période de réinitialisation",
+          "placeholder": "Aucune limite de jetons",
+          "title": "Budget de jetons",
+          "unit": "jetons"
+        },
+        "userGroup": {
+          "description": "Choisissez le groupe qui partage ce budget",
+          "title": "Groupe d'utilisateurs"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "Créer une limite de dépenses"
+        },
+        "createFailed": {
+          "error": "Échec de la création de la limite de dépenses"
+        },
+        "created": {
+          "message": "Limite de dépenses créée !"
+        },
+        "embedded": {
+          "description": "Définissez des garde-fous pour l'utilisation de l'espace de travail, des utilisateurs et des groupes. Les limites peuvent être activées ou désactivées sans supprimer leur configuration.",
+          "title": "Gérer les limites de dépenses"
+        },
+        "global": {
+          "description": "Les limites globales s'appliquent à tous les utilisateurs, groupes d'utilisateurs et clés d'API. Quand la limite globale est atteinte, plus aucun jeton ne peut être dépensé."
+        },
+        "intro": {
+          "description": "Les limites de dépenses vous aident à contrôler le nombre de jetons dépensés sur une période donnée.",
+          "groupLimit": "Définissez des limites pour les groupes d'utilisateurs afin de contrôler les dépenses des équipes.",
+          "toggleLimit": "Activez et désactivez les limites selon vos besoins.",
+          "userLimit": "Définissez des limites pour les utilisateurs afin qu'aucun utilisateur ne dépense trop.",
+          "workspaceLimit": "Définissez une limite pour tout l'espace de travail afin d'encadrer les dépenses globales de votre équipe."
+        },
+        "tabs": {
+          "global": {
+            "name": "Global"
+          },
+          "groups": {
+            "name": "Groupes"
+          },
+          "users": {
+            "name": "Utilisateurs"
+          }
+        },
+        "user": {
+          "description": "Les limites par utilisateur s'appliquent à chaque utilisateur individuellement. Quand un utilisateur atteint une limite, il ne peut temporairement plus dépenser de jetons."
+        },
+        "userGroup": {
+          "description": "Les limites de groupe s'appliquent à tous les utilisateurs d'un groupe. Si un utilisateur appartient à plusieurs groupes, la limite la plus permissive s'applique."
+        }
       }
     },
     "tracing": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -26,6 +26,46 @@
     }
   },
   "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "Repositório de código"
+        },
+        "messaging": {
+          "label": "Mensagens"
+        },
+        "other": {
+          "label": "Outros"
+        },
+        "sales": {
+          "label": "Vendas"
+        },
+        "storage": {
+          "label": "Armazenamento em nuvem"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "Tíquetes e gestão de tarefas"
+        },
+        "wiki": {
+          "label": "Base de conhecimento e wikis"
+        }
+      },
+      "popular": {
+        "title": "Populares"
+      },
+      "search": {
+        "placeholder": "Pesquisar conectores"
+      },
+      "seeConnectorsButton": {
+        "label": "Ver conectores"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>Conector federado já configurado.</strong> Clique para editar o conector existente.",
+          "slackCredentialsFound": "<strong>Credenciais do Slack existentes encontradas.</strong> Clique para gerenciar seu conector do Slack."
+        }
+      }
+    },
     "agents": {
       "deleteModal": {
         "confirmation": {
@@ -298,6 +338,326 @@
           }
         },
         "title": "Uso"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "Sua licença está sendo processada. Você será levado aos detalhes de cobrança automaticamente após a confirmação.",
+        "title": "Sua licença ainda está sendo ativada"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "O gerenciamento de cobrança on-line está desativado. Entre em contato com o suporte para atualizar sua assinatura.",
+          "title": "Implantação isolada da internet"
+        },
+        "expired": {
+          "description": "Renove sua assinatura para restaurar o acesso aos recursos pagos.",
+          "title": "Sua assinatura expirou.",
+          "withDate": {
+            "description": "Renove sua assinatura até {date} para restaurar o acesso."
+          },
+          "withDeletion": {
+            "title": "Sua assinatura expirou. Os dados serão excluídos em {days} dias."
+          }
+        },
+        "expiring": {
+          "description": "Renove sua assinatura até {date} para evitar interrupções.",
+          "title": "Sua assinatura expira em {days} dias."
+        },
+        "graceSync": {
+          "title": "Procurando uma licença renovada…"
+        },
+        "stripeError": {
+          "description": "Verifique sua conexão com a internet ou forneça uma licença manualmente.",
+          "title": "Não foi possível conectar ao portal de pagamento do Stripe."
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "Ajustar plano"
+        },
+        "annual": {
+          "label": "Anual"
+        },
+        "annualBadge": {
+          "label": "Economize 20%"
+        },
+        "billingCycle": {
+          "description": "após sua avaliação gratuita de 1 mês",
+          "title": "Ciclo de cobrança"
+        },
+        "continueToPayment": {
+          "label": "Continuar para o pagamento"
+        },
+        "createSessionFailed": {
+          "error": "Falha ao criar a sessão de checkout"
+        },
+        "loading": {
+          "label": "Carregando..."
+        },
+        "monthly": {
+          "label": "Mensal"
+        },
+        "perSeatMonth": {
+          "label": "por assento/mês"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "${price}"
+        },
+        "seats": {
+          "description": "{count, plural, one {Mínimo de # assento necessário para seus usuários atuais e contas do Slack.} other {Mínimo de # assentos necessários para seus usuários atuais e contas do Slack.}}",
+          "title": "Assentos"
+        },
+        "trialBilling": {
+          "text": "Você será cobrado em <value>{date}</value> após o fim da sua avaliação gratuita de 1 mês."
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "Ativar chave de licença"
+        },
+        "billingHelp": {
+          "label": "Ajuda com cobrança"
+        },
+        "licenseKeyPrompt": {
+          "label": "Tem uma chave de licença?"
+        },
+        "updateLicenseKey": {
+          "label": "Atualizar chave de licença"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "Planos e cobrança"
+        },
+        "upgradePlan": {
+          "title": "Fazer upgrade do plano"
+        },
+        "viewPlans": {
+          "title": "Ver planos"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "Falha ao ativar a licença"
+        },
+        "activateLicense": {
+          "label": "Ativar licença"
+        },
+        "activateSuccess": {
+          "message": "Licença ativada com sucesso!"
+        },
+        "activateTitle": {
+          "title": "Ativar chave de licença"
+        },
+        "activating": {
+          "label": "Ativando..."
+        },
+        "activeUntil": {
+          "label": "Chave de licença ativa até <value>{date}</value>"
+        },
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "close": {
+          "label": "Fechar"
+        },
+        "description": "Adicione e ative manualmente uma licença para esta instância do Onyx.",
+        "emptyKey": {
+          "error": "Digite uma chave de licença"
+        },
+        "error": {
+          "text": "{error}. <link>Ajuda com cobrança</link>"
+        },
+        "expired": {
+          "label": "Chave de licença expirada"
+        },
+        "keyField": {
+          "description": "Cole ou anexe o arquivo da chave de licença que você recebeu da Onyx.",
+          "title": "Chave de licença"
+        },
+        "updateKey": {
+          "label": "Atualizar chave"
+        },
+        "updateLicense": {
+          "label": "Atualizar licença"
+        },
+        "updateSuccess": {
+          "message": "Licença atualizada com sucesso!"
+        },
+        "updateTitle": {
+          "title": "Atualizar chave de licença"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "Forma de pagamento",
+          "title": "Visa terminado em 1234"
+        },
+        "lastPayment": {
+          "description": "Último pagamento"
+        },
+        "section": {
+          "title": "Pagamento"
+        },
+        "update": {
+          "label": "Atualizar"
+        },
+        "viewInvoice": {
+          "label": "Ver fatura"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Obter o plano Business"
+          },
+          "description": "por assento/mês com cobrança anual\nou US$ 25 por assento com cobrança mensal",
+          "features": {
+            "apiKeys": "Chaves de API para contas de serviço",
+            "documentPermissions": "Herança das permissões dos documentos",
+            "encryption": "Criptografia de segredos",
+            "queryHistory": "Histórico de consultas e painel de uso",
+            "rbac": "Controle de acesso por função (RBAC)",
+            "selfHosting": "Hospedagem própria (opcional)",
+            "theming": "Temas personalizados"
+          },
+          "featuresPrefix": "Faça mais com IA para a sua equipe.",
+          "pricing": "$20",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "Cartão do plano {plan}"
+        },
+        "currentPlan": {
+          "label": "Seu plano atual"
+        },
+        "enterprise": {
+          "button": {
+            "label": "Falar com vendas"
+          },
+          "description": "Preços flexíveis e opções de implantação\npara grandes organizações",
+          "features": {
+            "customDeployments": "Implantações personalizadas",
+            "customRoles": "Funções e permissões personalizadas",
+            "hookExtensions": "Extensões de hooks",
+            "regionalProcessing": "Processamento de dados por região",
+            "scim": "SCIM / sincronização de grupos",
+            "support": "SLAs Enterprise e suporte prioritário",
+            "usageLimits": "Limites de uso configuráveis",
+            "whiteLabeling": "White-label completo"
+          },
+          "featuresPrefix": "Tudo do plano Business, mais:",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "Incluído no seu plano"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "Você não pode definir menos assentos do que os **{minimum}** assentos em uso/pendentes. [Remova usuários](/admin/users) antes de ajustar os assentos."
+        },
+        "billing": {
+          "added": "{count, plural, one {Você será cobrado pelo <value>{count}</value> assento adicional em valor proporcional.} other {Você será cobrado pelos <value>{count}</value> assentos adicionais em valor proporcional.}}",
+          "removed": "{count, plural, one {<value>{count}</value> assento será removido em <value>{date}</value> (após o ciclo de cobrança atual).} other {<value>{count}</value> assentos serão removidos em <value>{date}</value> (após o ciclo de cobrança atual).}}",
+          "unchanged": "Nenhuma mudança na sua cobrança."
+        },
+        "breakdown": {
+          "label": "{used} em uso • {pending} pendentes • {remaining} restantes"
+        },
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "confirmChange": {
+          "label": "Confirmar mudança"
+        },
+        "delta": {
+          "added": "{count, plural, one {# assento a ser adicionado} other {# assentos a serem adicionados}}",
+          "removed": "{count, plural, one {# assento a ser removido} other {# assentos a serem removidos}}"
+        },
+        "saving": {
+          "label": "Salvando..."
+        },
+        "seatsField": {
+          "title": "Assentos"
+        },
+        "total": {
+          "label": "{count} assentos"
+        },
+        "updateFailed": {
+          "error": "Falha ao atualizar os assentos"
+        },
+        "updateSeats": {
+          "description": "Adicione ou remova assentos para refletir o tamanho da sua equipe.",
+          "label": "Atualizar assentos",
+          "title": "Atualizar assentos"
+        },
+        "viewUsers": {
+          "label": "Ver usuários"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Plano Business"
+        },
+        "connectToStripe": {
+          "label": "Conectar ao Stripe"
+        },
+        "connecting": {
+          "label": "Conectando..."
+        },
+        "enterprisePlan": {
+          "name": "Plano Enterprise"
+        },
+        "expired": {
+          "subtitle": "Expirou em {date}"
+        },
+        "managePlan": {
+          "label": "Gerenciar plano"
+        },
+        "managedBySales": {
+          "text": "Seu plano é gerenciado pela equipe de vendas.<br></br><link>Fale com a equipe de cobrança</link> para fazer alterações."
+        },
+        "nextPayment": {
+          "subtitle": "Próximo pagamento em {date}"
+        },
+        "syncLicense": {
+          "label": "Sincronizar licença"
+        },
+        "syncing": {
+          "label": "Sincronizando..."
+        },
+        "trialDays": {
+          "subtitle": "A avaliação termina em {days} dias. Pagamento necessário em {date}"
+        },
+        "trialToday": {
+          "subtitle": "A avaliação termina hoje. Pagamento necessário em {date}"
+        },
+        "trialTomorrow": {
+          "subtitle": "A avaliação termina amanhã. Pagamento necessário em {date}"
+        },
+        "upgradeNow": {
+          "label": "Fazer upgrade agora"
+        },
+        "upgrading": {
+          "label": "Fazendo upgrade..."
+        },
+        "validUntil": {
+          "subtitle": "Válida até {date}"
+        },
+        "viewPlanDetails": {
+          "label": "Ver detalhes do plano"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "Falha ao encerrar a avaliação",
+        "licenseSyncFailed": "Falha na sincronização da licença",
+        "paymentMethodRequired": "Adicione uma forma de pagamento primeiro e tente fazer o upgrade novamente.",
+        "syncLicenseFailed": "Falha ao sincronizar a licença"
       }
     },
     "chatPreferences": {
@@ -591,6 +951,847 @@
         }
       }
     },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# dia} other {# dias}}",
+          "hours": "{count, plural, one {# hora} other {# horas}}",
+          "minutes": "{count, plural, one {# minuto} other {# minutos}}"
+        },
+        "indexingStart": {
+          "label": "Início da indexação"
+        },
+        "pruningFrequency": {
+          "label": "Frequência de limpeza"
+        },
+        "refreshFrequency": {
+          "label": "Frequência de atualização"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "Falso",
+        "booleanTrue": "Verdadeiro",
+        "edit": {
+          "tooltip": "Editar"
+        },
+        "showAll": {
+          "label": "Mostrar tudo ({count} itens)"
+        },
+        "showLess": {
+          "label": "Mostrar menos"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "Excluir este conector agenda uma tarefa de exclusão que remove os documentos indexados e o exclui para todos os usuários.",
+        "entityType": "conector"
+      },
+      "deletionError": {
+        "description": "Este erro ocorreu durante a tentativa de exclusão do conector. Você pode tentar excluir novamente clicando no botão \"Excluir\".",
+        "title": "Erro de exclusão"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "Documentos sincronizados",
+          "errorMessage": "Mensagem de erro",
+          "permissionErrors": "Erros de permissão",
+          "status": "Status",
+          "timeStarted": "Horário de início"
+        },
+        "empty": {
+          "description": "As execuções de sincronização das permissões dos documentos são agendadas em segundo plano. Elas podem demorar a aparecer — tente atualizar em cerca de 30 segundos.",
+          "title": "Ainda não há tentativas de sincronização das permissões dos documentos"
+        },
+        "errorModal": {
+          "title": "Erro na sincronização das permissões dos documentos"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "ID do documento",
+          "errorMessage": "Mensagem de erro",
+          "status": "Status",
+          "time": "Horário"
+        },
+        "description": "Veja abaixo os erros encontrados durante a indexação. Cada linha representa um documento ou entidade com falha.",
+        "empty": {
+          "description": "Nenhum erro encontrado nesta página"
+        },
+        "fullReindex": {
+          "description": "Clique no botão abaixo para iniciar uma reindexação completa e tentar resolver estes erros. Esta reindexação completa pode demorar muito mais do que uma atualização normal."
+        },
+        "resolveAllButton": {
+          "label": "Resolver tudo"
+        },
+        "status": {
+          "resolved": "Resolvido",
+          "unresolved": "Não resolvido"
+        },
+        "targetedReindex": {
+          "description": "Clique no botão abaixo para buscar novamente apenas os documentos com falha. É muito mais rápido do que uma reindexação completa."
+        },
+        "title": "Erros de indexação",
+        "unknownDocument": "Desconhecido"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "Adicionar arquivos"
+        },
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "columns": {
+          "fileName": "Nome do arquivo",
+          "size": "Tamanho",
+          "uploadDate": "Data de envio"
+        },
+        "confirmModal": {
+          "addDetails": "Os novos arquivos serão enviados, divididos em chunks, transformados em embeddings e indexados no índice de documentos",
+          "addSummary": "{count} arquivo(s) serão adicionados",
+          "confirmButton": {
+            "label": "Confirmar e salvar"
+          },
+          "description": "Quando você salvar estas alterações, o seguinte vai acontecer:",
+          "removeDetails": "Os documentos destes arquivos serão removidos do índice de documentos",
+          "removeSummary": "🗑️ {count} arquivo(s) serão removidos",
+          "title": "Confirmar alterações nos arquivos"
+        },
+        "editButton": {
+          "label": "Editar"
+        },
+        "empty": {
+          "description": "Nenhum arquivo neste conector"
+        },
+        "header": {
+          "title": "Arquivos ({count, plural, one {# arquivo} other {# arquivos}})"
+        },
+        "loadError": "Erro ao carregar os arquivos: {message}",
+        "newBadge": {
+          "label": "Novo"
+        },
+        "removeFileButton": {
+          "tooltip": "Remover arquivo"
+        },
+        "removingBadge": {
+          "label": "Removendo"
+        },
+        "saveButton": {
+          "label": "Salvar alterações",
+          "saving": "Salvando..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "Não é possível remover todos os arquivos de um conector. Exclua o conector se for isso que você quer.",
+          "filesUpdated": "Arquivos atualizados com sucesso! O índice de documentos está sendo atualizado em segundo plano. Os novos arquivos estão sendo indexados e os arquivos removidos serão retirados dos resultados de pesquisa.",
+          "updateFailed": "Falha ao atualizar os arquivos"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "Mensagem de erro",
+          "groups": "Grupos",
+          "memberships": "Associações",
+          "status": "Status",
+          "timeStarted": "Horário de início",
+          "users": "Usuários"
+        },
+        "empty": {
+          "description": "As execuções de sincronização das associações de grupo são agendadas em segundo plano. Elas podem demorar a aparecer — tente atualizar em cerca de 30 segundos.",
+          "title": "Ainda não há tentativas de sincronização das associações de grupo"
+        },
+        "errorModal": {
+          "title": "Erro na sincronização das associações de grupo"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "Mensagem de erro",
+          "newDocs": "Novos documentos",
+          "status": "Status",
+          "timeStarted": "Horário de início",
+          "totalDocs": "Total de documentos",
+          "totalDocsTooltip": "Número total de documentos substituídos no índice durante esta tentativa de indexação"
+        },
+        "docsPerMinute": "{rate} documentos / min",
+        "docsRemoved": "(também removeu {count} documentos detectados como excluídos na origem)",
+        "empty": {
+          "description": "As tentativas de indexação são agendadas em segundo plano e podem demorar a aparecer. Tente atualizar a página em cerca de 30 segundos!",
+          "title": "Nenhuma tentativa de indexação agendada ainda"
+        },
+        "noAdditionalDocs": "Nenhum documento adicional processado",
+        "reindexTooltip": {
+          "completed": "Esta tentativa de indexação foi uma reindexação completa. Todos os documentos da origem foram sincronizados com o sistema.",
+          "inProgress": "Esta tentativa de indexação é uma reindexação completa. Todos os documentos da origem estão sendo sincronizados com o sistema."
+        },
+        "stageMetricsButton": {
+          "tooltip": "Ver métricas por etapa"
+        },
+        "viewTrace": {
+          "ariaLabel": "Ver rastreamento completo"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "Encontramos alguns problemas ao processar alguns documentos. <details>Ver detalhes.</details>",
+        "resolvingStatus": "Resolvendo as falhas",
+        "title": "Alguns documentos não foram indexados"
+      },
+      "invalidState": {
+        "description": "Este conector está em um estado inválido. Atualize suas credenciais ou crie um novo conector antes de reindexar.",
+        "title": "Estado inválido do conector"
+      },
+      "loadError": {
+        "title": "Falha ao buscar as informações do conector com ID {ccPairId}",
+        "unknownMessage": "Erro desconhecido"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "Excluir",
+          "tooltip": {
+            "active": "Pause o conector antes de excluir"
+          }
+        },
+        "reIndex": {
+          "label": "Reindexar",
+          "tooltip": {
+            "indexing": "Não é possível reindexar enquanto uma indexação está em andamento",
+            "invalid": "Corrija a configuração do conector antes de reindexar",
+            "paused": "Retome o conector antes de reindexar"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "Pausar"
+          },
+          "resume": {
+            "label": "Retomar"
+          },
+          "tooltip": {
+            "updating": "Atualização de status em andamento"
+          }
+        },
+        "trigger": {
+          "label": "Gerenciar"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "Cancelada"
+        },
+        "completedWithErrors": {
+          "label": "Concluída com erros"
+        },
+        "failed": {
+          "label": "Falhou"
+        },
+        "fallback": {
+          "label": "Não iniciada"
+        },
+        "inProgress": {
+          "label": "Em andamento"
+        },
+        "notStarted": {
+          "label": "Agendada"
+        },
+        "success": {
+          "label": "Concluída com sucesso"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "Com que frequência o conector deve fazer a limpeza (em horas)",
+        "title": "Frequência de limpeza"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "Reativar"
+        },
+        "additionalDetails": "Este conector foi marcado como inválido anteriormente. Confirme que sua configuração está correta antes de reativar. Tem certeza de que deseja continuar?",
+        "entityType": "Conector inválido"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "Isso vai causar uma reindexação completa de todos os documentos da origem.",
+          "note": "<strong>OBSERVAÇÃO:</strong> dependendo do número de documentos armazenados na origem, isso pode demorar muito."
+        },
+        "fullReindexButton": {
+          "label": "Executar reindexação completa"
+        },
+        "title": "Executar indexação",
+        "update": {
+          "description": "Isso vai buscar e indexar todos os documentos que mudaram e/ou foram adicionados desde a última indexação bem-sucedida."
+        },
+        "updateButton": {
+          "label": "Executar atualização"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "Com que frequência o conector deve atualizar (em minutos)",
+        "title": "Frequência de atualização"
+      },
+      "sections": {
+        "advanced": {
+          "title": "Avançado"
+        },
+        "advancedConfiguration": {
+          "title": "Configuração avançada"
+        },
+        "connectorConfiguration": {
+          "title": "Configuração do conector"
+        },
+        "credential": {
+          "title": "Credencial"
+        },
+        "indexing": {
+          "title": "Indexação"
+        },
+        "indexingAttempts": {
+          "title": "Tentativas de indexação"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "Ocultar o overhead da tentativa"
+          },
+          "showButton": {
+            "label": "Mostrar o overhead da tentativa"
+          }
+        },
+        "batchTotal": {
+          "empty": "Nenhum lote concluído ainda",
+          "summary": "Lote médio: {avgLabel}, {count, plural, one {# lote} other {# lotes}} — distribuição mostrada abaixo."
+        },
+        "empty": {
+          "description": "Nenhum dado de tempo por etapa foi registrado para esta tentativa ainda. Tentativas antigas, executadas antes da instrumentação de etapas, não têm métricas."
+        },
+        "loadError": {
+          "description": "Não foi possível carregar os dados de tempo por etapa desta tentativa. O pipeline é executado mesmo quando o registro de métricas não está disponível, portanto isso não indica um problema na indexação em si.",
+          "title": "Falha ao carregar as métricas por etapa"
+        },
+        "loading": "Carregando as métricas por etapa…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "Tempo médio",
+            "calls": "Chamadas",
+            "max": "Máx",
+            "min": "Mín",
+            "stage": "Etapa",
+            "totalTime": "Tempo total"
+          },
+          "empty": "Nenhum dado de etapa por lote registrado."
+        },
+        "sort": {
+          "label": "Ordenar:",
+          "pipelineOrder": {
+            "label": "Ordem do pipeline"
+          },
+          "timeTaken": {
+            "label": "Tempo gasto"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "Lê o lote de volta do armazenamento de objetos para a memória do worker.",
+            "label": "Carga do lote"
+          },
+          "batchTotal": {
+            "description": "Tempo total decorrido no processamento de um único lote do início ao fim.",
+            "label": "Total do lote"
+          },
+          "batchUnaccounted": {
+            "description": "Tempo do lote não atribuído a nenhuma etapa nomeada. Um valor alto sugere falta de instrumentação.",
+            "label": "Não contabilizado"
+          },
+          "checkpointLoad": {
+            "description": "Carrega o checkpoint salvo para que a tentativa continue de onde a execução anterior parou.",
+            "label": "Carga do checkpoint"
+          },
+          "chunking": {
+            "description": "Divide cada documento nos chunks que são transformados em embeddings e indexados.",
+            "label": "Divisão em chunks"
+          },
+          "connectorFetch": {
+            "description": "Tempo que o conector gasta chamando a API da origem e entregando os documentos brutos.",
+            "label": "Busca do conector"
+          },
+          "connectorValidation": {
+            "description": "Verifica se o conector está configurado corretamente e acessível antes de começar a busca.",
+            "label": "Validação do conector"
+          },
+          "contextualRag": {
+            "description": "Gera resumos de contexto por chunk com um LLM para melhorar a qualidade da recuperação.",
+            "label": "RAG contextual"
+          },
+          "coordLockAcquireWait": {
+            "description": "Aguarda o bloqueio de coordenação que protege os contadores de progresso compartilhados da tentativa.",
+            "label": "Espera pelo bloqueio de coordenação"
+          },
+          "coordinationUpdate": {
+            "description": "Atualiza os contadores de progresso da tentativa para que a interface reflita o lote concluído.",
+            "label": "Atualização da coordenação"
+          },
+          "docBatchEnqueue": {
+            "description": "Publica o lote armazenado na fila do Celery para que um worker de docprocessing o processe.",
+            "label": "Enfileiramento do lote de documentos"
+          },
+          "docBatchStore": {
+            "description": "Grava um lote de documentos buscados no armazenamento de objetos para os workers de docprocessing.",
+            "label": "Armazenamento do lote de documentos"
+          },
+          "docDbPrepare": {
+            "description": "Determina quais documentos são novos ou atualizados e prepara as linhas do banco de dados.",
+            "label": "Preparação do banco de documentos"
+          },
+          "docLockAcquireWait": {
+            "description": "Aguarda os bloqueios por documento para que tentativas simultâneas não gravem o mesmo documento.",
+            "label": "Espera pelo bloqueio de documento"
+          },
+          "docprocessingSetup": {
+            "description": "Prepara o worker: carrega as configurações de pesquisa, o modelo de embedding e os clientes de índice.",
+            "label": "Configuração do docprocessing"
+          },
+          "embedding": {
+            "description": "Chama o modelo de embedding para transformar os chunks em vetores. Normalmente é a etapa mais lenta.",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "Anexa o controle de acesso, os boosts e outros metadados a cada chunk antes da gravação.",
+            "label": "Preparação do enriquecimento"
+          },
+          "finalization": {
+            "description": "Libera os recursos do worker e o lote assim que o processamento termina.",
+            "label": "Finalização"
+          },
+          "gcCollect": {
+            "description": "Tempo gasto na coleta de lixo explícita entre os lotes.",
+            "label": "Coleta de lixo"
+          },
+          "hierarchyUpsert": {
+            "description": "Grava a hierarquia de pastas ou espaços da origem para que os documentos possam ser filtrados por local.",
+            "label": "Upsert da hierarquia"
+          },
+          "imageProcessing": {
+            "description": "Extrai e resume as imagens para que o conteúdo delas vire texto pesquisável.",
+            "label": "Processamento de imagens"
+          },
+          "permissionValidation": {
+            "description": "Confirma que a credencial tem as permissões necessárias para ler os documentos da origem.",
+            "label": "Validação de permissões"
+          },
+          "postIndexDbUpdate": {
+            "description": "Atualiza as linhas dos documentos no Postgres depois que a gravação no índice é concluída.",
+            "label": "Atualização do banco após a indexação"
+          },
+          "queueWait": {
+            "description": "Tempo que um lote espera na fila até um worker de docprocessing começar.",
+            "label": "Espera na fila"
+          },
+          "vectorDbWrite": {
+            "description": "Grava os chunks com embeddings no índice de documentos.",
+            "label": "Gravação no banco vetorial"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "Tempos por lote e por tentativa desta tentativa de indexação.",
+        "title": "Métricas por etapa da indexação"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "Documentos indexados"
+        },
+        "indexingSpeed": "({speed} documentos / min)",
+        "lastIndexed": {
+          "label": "Última indexação"
+        },
+        "lastSynced": {
+          "label": "Última sincronização"
+        },
+        "permissionSyncing": {
+          "label": "Sincronização de permissões"
+        },
+        "status": {
+          "label": "Status"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "Ver a mensagem de erro completa"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "Sincronização das permissões dos documentos",
+          "notApplicableDescription": "Este conector não usa uma tarefa separada de sincronização das permissões dos documentos."
+        },
+        "groupMembership": {
+          "label": "Sincronização das associações de grupo",
+          "notApplicableDescription": "Este conector não usa uma tarefa separada de sincronização das associações de grupo."
+        },
+        "indexing": {
+          "label": "Indexação"
+        },
+        "loadError": {
+          "title": "Falha ao carregar as tentativas de sincronização"
+        },
+        "notApplicable": {
+          "title": "Não se aplica"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "Reindexação completa iniciada com sucesso",
+        "completeReindexStarting": "Iniciando a reindexação completa...",
+        "deletionScheduleFailed": "Falha ao agendar a exclusão do conector - {message}",
+        "indexingProcessStartFailed": "Falha ao iniciar o processo de indexação",
+        "indexingStartFailed": "Falha ao iniciar a indexação",
+        "indexingStartUnexpectedError": "Ocorreu um erro inesperado ao tentar iniciar a indexação",
+        "indexingUpdateStarted": "Atualização da indexação iniciada com sucesso",
+        "indexingUpdateStarting": "Iniciando a atualização da indexação...",
+        "invalidPruningFrequency": "Frequência de limpeza inválida: precisa ser um número válido",
+        "invalidRefreshFrequency": "Frequência de atualização inválida: precisa ser um número inteiro",
+        "nameUpdateFailed": "Falha ao atualizar o nome do conector",
+        "nameUpdated": "Nome do conector atualizado com sucesso",
+        "noUnresolvedErrors": "Nenhum erro não resolvido para tentar novamente.",
+        "pruningFrequencyUpdateFailed": "Falha ao atualizar a frequência de limpeza do conector",
+        "pruningFrequencyUpdated": "Frequência de limpeza do conector atualizada com sucesso",
+        "refreshFrequencyUpdateFailed": "Falha ao atualizar a frequência de atualização do conector",
+        "refreshFrequencyUpdated": "Frequência de atualização do conector atualizada com sucesso",
+        "targetedReindexFailed": "Falha na reindexação direcionada: {message}",
+        "targetedReindexSubmitted": "Reindexação direcionada enviada para {count, plural, one {# documento} other {# documentos}}. Os erros vão sair da lista conforme os documentos terminarem de ser reindexados."
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "Autorizar com {source}",
+          "pendingLabel": "Autorizando..."
+        },
+        "createCredentialButton": {
+          "label": "Criar nova"
+        },
+        "credentialDeleted": {
+          "toast": "Credencial excluída com sucesso!"
+        },
+        "credentialModal": {
+          "title": "Criar uma credencial do {source}"
+        },
+        "credentialStep": {
+          "title": "Selecione uma credencial"
+        },
+        "credentialSwapped": {
+          "toast": "Credencial trocada com sucesso!"
+        },
+        "error": {
+          "toast": "Erro: {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "Uma opção de pesquisa federada está disponível para este conector. Ela resulta em maior latência e menor qualidade de pesquisa.",
+            "link": {
+              "label": "Usar a versão federada →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "Erro ao enviar os arquivos"
+        },
+        "oauthRedirectFailed": {
+          "message": "Não foi possível redirecionar você para entrar com {source}. Tente novamente."
+        },
+        "oauthStartFailed": {
+          "toast": "Não foi possível iniciar o OAuth"
+        },
+        "oauthUrlFailed": {
+          "toast": "Falha ao buscar a URL do OAuth"
+        },
+        "retryButton": {
+          "label": "Tentar novamente"
+        },
+        "timeout": {
+          "toast": "A operação expirou após {seconds} segundos. Verifique se há erros na sua configuração."
+        },
+        "unknownError": {
+          "toast": "Ocorreu um erro desconhecido"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "Data de início da indexação",
+          "subtext": "Documentos anteriores a esta data não serão buscados"
+        },
+        "pruneFrequency": {
+          "description": "Verifica todos os documentos na origem para excluir os que não existem mais. Observação: este processo verifica cada documento, portanto tenha cuidado ao aumentar a frequência. O padrão é {hours} horas ({days} dias). São aceitas horas decimais (por exemplo, 0,1 hora = 6 minutos). Digite 0 para desativar a limpeza deste conector.",
+          "label": "Frequência de limpeza (horas)"
+        },
+        "refreshFrequency": {
+          "description": "É com esta frequência que buscamos novos documentos na origem (em minutos). Se você digitar 0, nunca vamos buscar novos documentos para este conector.",
+          "label": "Frequência de atualização (minutos)"
+        },
+        "resetButton": {
+          "label": "Redefinir"
+        },
+        "title": "Configuração avançada"
+      },
+      "connectorName": {
+        "label": "Nome do conector",
+        "subtext": "Um nome descritivo para o conector."
+      },
+      "credentialsLoadError": {
+        "title": "Falha ao carregar as credenciais."
+      },
+      "field": {
+        "optional": {
+          "label": "(opcional)"
+        },
+        "optionalSuffix": {
+          "label": "opcional"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Sua credencial do Google Drive foi criada. Gerencie ou revogue essa credencial na lista de credenciais.",
+          "title": "Autenticação concluída"
+        },
+        "authFailed": {
+          "toast": "Falha na autenticação com o Google Drive - {error}"
+        },
+        "authenticateButton": {
+          "label": "Autenticar com o Google Drive",
+          "pendingLabel": "Autenticando..."
+        },
+        "createButton": {
+          "label": "Criar credencial",
+          "pendingLabel": "Criando..."
+        },
+        "credentialsLoadError": {
+          "title": "Falha ao carregar as credenciais do Google Drive."
+        },
+        "invalidFile": {
+          "toast": "Arquivo inválido - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Arquivo inválido - era esperada uma chave JSON de conta de serviço"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Envie uma chave de conta de serviço antes de criar uma credencial"
+        },
+        "oauthOption": {
+          "description": "Envie o JSON do app OAuth do Google Cloud Console ([instruções de configuração]({docsUrl})) e depois autentique com a conta Google cujo Drive você quer indexar.",
+          "title": "Opção 1: app OAuth"
+        },
+        "oauthUpload": {
+          "placeholder": "Envie ou cole o JSON do seu app OAuth"
+        },
+        "primaryAdmin": {
+          "description": "Digite o e-mail de um administrador ou proprietário da organização Google que é dona dos Google Drives que você quer indexar.",
+          "invalidEmail": "Precisa ser um e-mail válido",
+          "label": "E-mail do administrador principal",
+          "required": "Obrigatório"
+        },
+        "section": {
+          "title": "Autenticação do Google Drive"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Falha ao criar a credencial de conta de serviço - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Credencial de conta de serviço criada com sucesso"
+        },
+        "serviceAccountOption": {
+          "title": "Opção 2: conta de serviço"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Envie ou cole a chave JSON da sua conta de serviço"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Sua credencial do Gmail foi criada. Gerencie ou revogue essa credencial na lista de credenciais.",
+          "title": "Autenticação concluída"
+        },
+        "authFailed": {
+          "toast": "Falha na autenticação com o Gmail - {error}"
+        },
+        "authenticateButton": {
+          "label": "Autenticar com o Gmail",
+          "pendingLabel": "Autenticando..."
+        },
+        "createButton": {
+          "label": "Criar credencial",
+          "pendingLabel": "Criando..."
+        },
+        "credentialsLoadError": {
+          "title": "Falha ao carregar as credenciais do Gmail."
+        },
+        "invalidFile": {
+          "toast": "Arquivo inválido - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "Arquivo inválido - era esperada uma chave JSON de conta de serviço"
+        },
+        "missingServiceAccountKey": {
+          "toast": "Envie uma chave de conta de serviço antes de criar uma credencial"
+        },
+        "oauthOption": {
+          "description": "Envie o JSON do app OAuth do Google Cloud Console ([instruções de configuração]({docsUrl})) e depois autentique com a conta Google cujo Gmail você quer indexar.",
+          "title": "Opção 1: app OAuth"
+        },
+        "oauthUpload": {
+          "placeholder": "Envie ou cole o JSON do seu app OAuth"
+        },
+        "primaryAdmin": {
+          "description": "Digite o e-mail de um administrador ou proprietário da organização Google que é dona das contas do Gmail que você quer indexar.",
+          "invalidEmail": "Precisa ser um e-mail válido",
+          "label": "E-mail do administrador principal",
+          "required": "Obrigatório"
+        },
+        "section": {
+          "title": "Autenticação do Gmail"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "Falha ao criar a credencial de conta de serviço - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "Credencial de conta de serviço criada com sucesso"
+        },
+        "serviceAccountOption": {
+          "title": "Opção 2: conta de serviço"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "Envie ou cole a chave JSON da sua conta de serviço"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "Ir para o início"
+        },
+        "title": "‘{connector}’ não é um tipo de conector válido!"
+      },
+      "listInput": {
+        "placeholder": "Digite {label}"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "Avançado"
+        },
+        "continueButton": {
+          "label": "Continuar"
+        },
+        "createButton": {
+          "label": "Criar conector"
+        },
+        "previousButton": {
+          "label": "Anterior"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "Ops, algo deu errado!"
+        },
+        "invalidSource": {
+          "description": "{source} não é um tipo de origem válido.",
+          "title": "O tipo de origem do conector {source} não existe."
+        },
+        "processing": {
+          "description": "Aguarde enquanto concluímos a configuração.",
+          "title": "Processando..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "Autorizar com {source}"
+        },
+        "authorizing": {
+          "description": "Aguarde enquanto concluímos a autorização."
+        },
+        "continue": {
+          "message": "Clique <link>aqui</link> para continuar."
+        },
+        "error": {
+          "description": "Ocorreu um erro durante o processo de OAuth. Tente novamente."
+        },
+        "malformed": {
+          "missingCode": "Código de autorização ausente.",
+          "missingState": "Parâmetro state ausente.",
+          "title": "Solicitação de autorização OAuth mal formada."
+        },
+        "page": {
+          "title": "Autorizar com um serviço de terceiros"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "Sua autorização com {source} foi concluída com sucesso. São necessárias etapas adicionais para concluir a configuração da credencial."
+          },
+          "description": "Sua autorização com {source} foi concluída com sucesso.",
+          "title": "Tudo certo!"
+        }
+      },
+      "oauthFailed": {
+        "toast": "Falha na autenticação OAuth. Tente novamente."
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "Finalizar a autorização com {source}"
+        },
+        "cloudId": {
+          "required": "Você precisa selecionar um site do Confluence (id não encontrado)."
+        },
+        "cloudName": {
+          "required": "Você precisa selecionar um site do Confluence (nome não encontrado)."
+        },
+        "cloudUrl": {
+          "required": "Você precisa selecionar um site do Confluence (url não encontrada)."
+        },
+        "continue": {
+          "message": "Autorização finalizada. Clique <link>aqui</link> para continuar."
+        },
+        "credentialId": {
+          "required": "O ID da credencial é obrigatório."
+        },
+        "error": {
+          "description": "Ocorreu um erro durante a finalização do OAuth. Tente novamente."
+        },
+        "finalized": {
+          "title": "Autorização do Confluence finalizada."
+        },
+        "loadingSites": {
+          "description": "Aguarde enquanto buscamos a lista dos sites que você pode acessar."
+        },
+        "malformed": {
+          "description": "ID da credencial inválido ou ausente.",
+          "title": "Solicitação de finalização do OAuth mal formada."
+        },
+        "page": {
+          "title": "Finalizar a autorização com um serviço de terceiros"
+        },
+        "selectSite": {
+          "title": "Selecione um site do Confluence"
+        },
+        "submitButton": {
+          "label": "Enviar",
+          "pendingLabel": "Enviando..."
+        },
+        "submitError": {
+          "description": "Ocorreu um erro durante o envio. Tente novamente.",
+          "title": "Erro durante o envio."
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "Selecione uma opção"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "Adicionar novo"
+        },
+        "removeButton": {
+          "tooltip": "Remover"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "Nenhuma aba para mostrar."
+        }
+      }
+    },
     "costOverrides": {
       "allProviders": {
         "label": "Todos os provedores"
@@ -813,6 +2014,461 @@
         "title": "O Craft não está disponível nesta implantação"
       }
     },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "Para trocar o token, exclua o atual e adicione um novo."
+        },
+        "configured": {
+          "badge": "Configurado",
+          "text": "Seu token do bot do Discord está configurado."
+        },
+        "configuredWithDate": {
+          "text": "Seu token do bot do Discord está configurado. Adicionado em {date}."
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "Exclua primeiro as configurações dos servidores"
+          },
+          "label": "Excluir o token do Discord"
+        },
+        "deleteError": {
+          "toast": "Falha ao excluir o token do bot"
+        },
+        "deleteModal": {
+          "additionalDetails": "Isso vai desconectar seu bot do Discord. Você vai precisar digitar o token novamente para usar o bot de novo.",
+          "entityName": "Token do bot do Discord",
+          "entityType": "token do bot do Discord"
+        },
+        "deleted": {
+          "toast": "Token do bot excluído"
+        },
+        "enterInstructions": {
+          "text": "Digite o token do seu bot do Discord para ativar o bot. Você consegue esse token no Discord Developer Portal."
+        },
+        "input": {
+          "placeholder": "Digite o token do bot..."
+        },
+        "missing": {
+          "toast": "Digite um token do bot"
+        },
+        "notConfigured": {
+          "badge": "Não configurado"
+        },
+        "saveButton": {
+          "label": "Salvar token",
+          "saving": {
+            "label": "Salvando..."
+          }
+        },
+        "saveError": {
+          "toast": "Falha ao salvar o token do bot"
+        },
+        "saved": {
+          "toast": "Token do bot salvo com sucesso"
+        },
+        "section": {
+          "title": "Token do bot"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "A configuração dos canais fica disponível depois que o servidor for registrado."
+        },
+        "disableAllButton": {
+          "label": "Desativar todos"
+        },
+        "empty": {
+          "description": "Execute !sync-channels no Discord para adicionar canais.",
+          "title": "Nenhum canal configurado"
+        },
+        "enableAllButton": {
+          "label": "Ativar todos"
+        },
+        "partialUpdate": {
+          "toast": "{succeeded} canais atualizados, mas {failed} falharam"
+        },
+        "section": {
+          "description": "Execute !sync-channels no Discord para atualizar a lista de canais.",
+          "title": "Configuração dos canais"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "Agente específico"
+          },
+          "channel": {
+            "header": "Canal"
+          },
+          "enabled": {
+            "header": "Ativado"
+          },
+          "requireMention": {
+            "header": "Exigir @menção"
+          },
+          "threadOnly": {
+            "header": "Modo apenas em threads"
+          }
+        },
+        "updateError": {
+          "toast": "Falha ao atualizar os canais"
+        },
+        "updated": {
+          "toast": "{count, plural, one {# canal atualizado} other {# canais atualizados}}"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "Agente padrão removido"
+        },
+        "section": {
+          "description": "O agente usado pelo bot em todos os canais, a menos que seja substituído.",
+          "title": "Agente padrão"
+        },
+        "select": {
+          "default": {
+            "label": "Agente padrão"
+          },
+          "placeholder": "Selecione um agente"
+        },
+        "updateError": {
+          "toast": "Falha ao atualizar o agente"
+        },
+        "updated": {
+          "toast": "Agente padrão atualizado"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "Não foi possível carregar os canais",
+          "title": "Falha ao carregar os canais"
+        },
+        "loadServer": {
+          "title": "Falha ao carregar o servidor"
+        },
+        "loadServers": {
+          "title": "Falha ao carregar os servidores do Discord"
+        },
+        "serverNotFound": {
+          "message": "Servidor não encontrado"
+        },
+        "unknown": {
+          "message": "Ocorreu um erro desconhecido"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "Use o comando !register no seu servidor do Discord com a chave de registro para concluir a configuração.",
+          "title": "Aguardando o registro"
+        },
+        "pending": {
+          "text": "Registro pendente"
+        },
+        "registered": {
+          "text": "Registrado: {date}"
+        },
+        "updateButton": {
+          "label": "Atualizar configuração"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "Falha ao criar o servidor"
+        },
+        "created": {
+          "toast": "Configuração do servidor criada!"
+        },
+        "deleteError": {
+          "toast": "Falha ao excluir a configuração do servidor"
+        },
+        "deleteModal": {
+          "additionalDetails": "Isso vai remover todas as configurações deste servidor do Discord.",
+          "entityType": "configuração do servidor do Discord"
+        },
+        "deleted": {
+          "toast": "Configuração do servidor excluída"
+        },
+        "disabled": {
+          "toast": "Servidor desativado"
+        },
+        "empty": {
+          "description": "Crie uma configuração de servidor para começar.",
+          "title": "Nenhum servidor do Discord configurado ainda"
+        },
+        "enabled": {
+          "toast": "Servidor ativado"
+        },
+        "fallbackName": "Servidor #{id}",
+        "notRegistered": {
+          "toast": "O servidor precisa ser registrado antes de ser ativado"
+        },
+        "pending": {
+          "badge": "Pendente"
+        },
+        "registered": {
+          "badge": "Registrado"
+        },
+        "table": {
+          "actions": {
+            "header": "Ações"
+          },
+          "enabled": {
+            "header": "Ativado"
+          },
+          "registered": {
+            "header": "Registrado"
+          },
+          "server": {
+            "header": "Servidor"
+          },
+          "status": {
+            "header": "Status"
+          }
+        },
+        "updateError": {
+          "toast": "Falha ao atualizar o servidor"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Conecte o Onyx aos seus servidores do Discord. Os usuários podem fazer perguntas diretamente nos canais do Discord."
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "Esta chave será mostrada apenas uma vez!",
+          "title": "Chave de registro"
+        },
+        "instructions": {
+          "text": "Copie o comando e envie-o de qualquer canal de texto do seu servidor!"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "Criando..."
+          },
+          "label": "Adicionar servidor"
+        },
+        "section": {
+          "title": "Configurações dos servidores"
+        }
+      },
+      "unsavedChanges": {
+        "description": "Clique em Atualizar para salvá-las.",
+        "title": "Você tem alterações não salvas"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "Digite a chave de API"
+        },
+        "deleteButton": {
+          "label": "Excluir chave de API"
+        },
+        "deleteHint": "Exclua a chave de API atual antes de atualizar.",
+        "description": "O Unstructured extrai e transforma dados complexos de formatos como .pdf, .docx, .png, .pptx, etc. em texto limpo para o Onyx processar. Forneça uma chave de API para ativar o processamento de documentos com o Unstructured.",
+        "learnMore": "Saiba mais sobre o Unstructured <link>aqui</link>.",
+        "note": "<label>Observação:</label> isso vai enviar os documentos para os servidores do Unstructured para processamento.",
+        "saveButton": {
+          "label": "Salvar chave de API"
+        },
+        "title": "Processar com a API do Unstructured"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "Boost:"
+        },
+        "search": {
+          "placeholder": "Encontre documentos por título / conteúdo..."
+        },
+        "updateFailed": {
+          "toast": "Falha ao atualizar o documento - {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "Erro ao carregar os documentos - {detail}"
+        },
+        "loading": {
+          "label": "Carregando"
+        },
+        "mostDisliked": {
+          "title": "Documentos com mais avaliações negativas"
+        },
+        "mostLiked": {
+          "title": "Documentos com mais avaliações positivas"
+        },
+        "table": {
+          "name": {
+            "header": "Nome do documento"
+          },
+          "score": {
+            "header": "Pontuação"
+          },
+          "searchable": {
+            "header": "É pesquisável?"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "Erro ao atualizar o status de ocultação - {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "A pontuação precisa ser um número"
+        },
+        "updated": {
+          "toast": "Pontuação atualizada!"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "Privado"
+          },
+          "public": {
+            "label": "Público"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "Sem nome"
+          }
+        },
+        "deleteFailed": {
+          "toast": "Falha ao agendar a exclusão do conjunto de documentos - {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "Exclusão do conjunto de documentos \"{name}\" agendada"
+        },
+        "description": "Os **conjuntos de documentos** permitem agrupar documentos logicamente relacionados em um único pacote. Depois eles podem ser usados como filtro nas pesquisas para controlar o escopo das informações em que o Onyx pesquisa.",
+        "edit": {
+          "header": {
+            "title": "Editar conjunto de documentos"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "Não é possível atualizar durante a sincronização! Espere a sincronização terminar e tente novamente."
+          }
+        },
+        "federatedBadge": {
+          "label": "Federado"
+        },
+        "fetchConnectorsFailed": {
+          "title": "Falha ao buscar os conectores"
+        },
+        "fetchSetsFailed": {
+          "title": "Falha ao buscar os conjuntos de documentos"
+        },
+        "form": {
+          "connectors": {
+            "label": "Escolha seus conectores",
+            "placeholder": "Pesquisar conectores...",
+            "required": "Selecione pelo menos um conector (comum ou federado)"
+          },
+          "createFailed": {
+            "toast": "Erro ao criar o conjunto de documentos - {detail}"
+          },
+          "created": {
+            "toast": "Conjunto de documentos criado com sucesso!"
+          },
+          "description": {
+            "label": "Descrição:",
+            "placeholder": "Descreva o que o conjunto de documentos representa"
+          },
+          "federatedConnectors": {
+            "label": "Conectores federados",
+            "placeholder": "Pesquisar conectores federados..."
+          },
+          "name": {
+            "label": "Nome:",
+            "placeholder": "Um nome para o conjunto de documentos",
+            "required": "Digite um nome para o conjunto"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {Conectores disponíveis para o grupo selecionado} one {Conectores disponíveis para o grupo selecionado} other {Conectores disponíveis para os grupos selecionados}}"
+          },
+          "submitButton": {
+            "createLabel": "Criar conjunto de documentos",
+            "updateLabel": "Atualizar conjunto de documentos"
+          },
+          "unavailableConnectors": {
+            "description": "Só ficam disponíveis os conectores atribuídos diretamente ao grupo ao qual você quer adicionar o conjunto de documentos.",
+            "title": "{count, plural, =0 {Conectores não disponíveis para o grupo que você selecionou} one {Conectores não disponíveis para o grupo que você selecionou} other {Conectores não disponíveis para os grupos que você selecionou}}"
+          },
+          "updateFailed": {
+            "toast": "Erro ao atualizar o conjunto de documentos - {detail}"
+          },
+          "updated": {
+            "toast": "Conjunto de documentos atualizado com sucesso!"
+          }
+        },
+        "loadError": {
+          "message": "Erro: {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "Novo conjunto de documentos"
+          }
+        },
+        "newButton": {
+          "label": "Novo conjunto de documentos"
+        },
+        "notFound": {
+          "message": "Conjunto de documentos com id {id} não encontrado",
+          "title": "Conjunto de documentos não encontrado"
+        },
+        "status": {
+          "deleting": {
+            "label": "Excluindo"
+          },
+          "syncing": {
+            "label": "Sincronizando"
+          },
+          "upToDate": {
+            "label": "Atualizado"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "Conectores"
+          },
+          "delete": {
+            "header": "Excluir"
+          },
+          "name": {
+            "header": "Nome"
+          },
+          "public": {
+            "header": "Público"
+          },
+          "status": {
+            "header": "Status"
+          },
+          "title": "Conjuntos de documentos existentes"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "Oculto"
+        },
+        "hide": {
+          "ariaLabel": "Ocultar documento",
+          "label": "Ocultar"
+        },
+        "unhide": {
+          "ariaLabel": "Mostrar documento",
+          "label": "Mostrar"
+        },
+        "visible": {
+          "label": "Visível"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -912,6 +2568,16 @@
       "warnings": {
         "invalidSkill": "habilidade inválida",
         "providerUnavailable": "provedor indisponível"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "Falha ao carregar o conector: {details}",
+        "title": "Erro"
+      },
+      "loading": {
+        "description": "Buscando os detalhes do conector e o esquema da credencial",
+        "title": "Carregando a configuração do conector..."
       }
     },
     "groups": {
@@ -1734,6 +3400,155 @@
         "urlInvalid": "Deve ser uma URL válida"
       }
     },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "Herdado de {source}"
+          },
+          "organizationPublic": {
+            "label": "Público na organização"
+          },
+          "private": {
+            "label": "Privado"
+          }
+        },
+        "addConnectorButton": {
+          "label": "Adicionar conector"
+        },
+        "connectorCreated": {
+          "toast": "Conector criado com sucesso"
+        },
+        "empty": {
+          "message": "Parece que você ainda não configurou nenhum conector. Acesse a página [Adicionar conector](/admin/add-connector) para começar!"
+        },
+        "federated": {
+          "access": {
+            "label": "Acesso federado"
+          },
+          "indexed": {
+            "label": "Indexado"
+          },
+          "notApplicable": {
+            "label": "N/D"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "Sincronização automática"
+            },
+            "private": {
+              "label": "Privado"
+            },
+            "public": {
+              "label": "Público"
+            },
+            "title": "Tipo de acesso"
+          },
+          "applyButton": {
+            "label": "Aplicar"
+          },
+          "docCount": {
+            "placeholder": "Quantidade",
+            "title": "Quantidade de documentos"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "Concluído com erros"
+            },
+            "failed": {
+              "label": "Falhou"
+            },
+            "inProgress": {
+              "label": "Em andamento"
+            },
+            "interrupted": {
+              "label": "Interrompido"
+            },
+            "notStarted": {
+              "label": "Não iniciado"
+            },
+            "success": {
+              "label": "Sucesso"
+            },
+            "title": "Último status"
+          },
+          "title": "Filtrar conectores"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "Acesso: {values}"
+          },
+          "clearBadge": {
+            "label": "Limpar"
+          },
+          "docsAnyBadge": {
+            "label": "Documentos {operator} qualquer"
+          },
+          "docsBadge": {
+            "label": "Documentos {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "Status: {values}"
+          }
+        },
+        "loadError": {
+          "message": "Erro ao carregar o status da indexação."
+        },
+        "manageConnector": {
+          "tooltip": "Gerenciar conector"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "Gerenciar conector federado"
+        },
+        "search": {
+          "placeholder": "Pesquisar conectores"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "Conectores ativos"
+          },
+          "publicConnectors": {
+            "label": "Conectores públicos"
+          },
+          "totalConnectors": {
+            "label": "Total de conectores"
+          },
+          "totalDocsIndexed": {
+            "label": "Total de documentos indexados"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "Tudo em dia! Não há mais conectores para mostrar"
+          },
+          "lastIndexed": {
+            "header": "Última indexação"
+          },
+          "name": {
+            "header": "Nome"
+          },
+          "permissions": {
+            "header": "Permissões / acesso"
+          },
+          "status": {
+            "header": "Status"
+          },
+          "totalDocs": {
+            "header": "Total de documentos"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "Recolher tudo"
+          },
+          "expand": {
+            "label": "Expandir tudo"
+          }
+        }
+      }
+    },
     "languageModels": {
       "availableProviders": {
         "title": "Provedores disponíveis"
@@ -1798,6 +3613,75 @@
         "unknownError": "Erro desconhecido"
       }
     },
+    "mcpActions": {
+      "header": {
+        "description": "Conecte servidores MCP (Model Context Protocol) para adicionar ações e ferramentas personalizadas aos seus agentes."
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "Nenhuma claim recebida."
+        },
+        "table": {
+          "claim": {
+            "header": "Claim"
+          },
+          "value": {
+            "header": "Valor"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "API do provedor",
+        "subtitle": "Campos de diretório buscados na API do provedor — por exemplo, o Microsoft Graph /me para o Entra ID, que traz country/usageLocation, campos que o id_token omite a menos que a claim opcional ctry esteja configurada.",
+        "title": "Perfil do diretório ({source})"
+      },
+      "idToken": {
+        "subtitle": "Decodificadas do JWT id_token retornado pelo endpoint de token.",
+        "title": "Claims do id_token"
+      },
+      "intro": {
+        "description": "Mostra os campos brutos que seu provedor de identidade enviou sobre você no último login OAuth/OIDC: as claims do id_token e a resposta do endpoint userinfo. Use isso para verificar quais atributos o IdP está configurado para liberar. As claims são capturadas em todos os logins."
+      },
+      "loadFailed": {
+        "title": "Falha ao carregar as claims do OAuth"
+      },
+      "noSnapshot": {
+        "description": "Nenhum snapshot de login OAuth encontrado para {email}. Faça login pelo provedor de identidade (botão acima) e recarregue esta página.",
+        "title": "Nenhuma claim capturada ainda"
+      },
+      "rerun": {
+        "label": "Refazer o login OAuth"
+      },
+      "resolved": {
+        "subtitle": "O perfil de diretório mapeado pelas claims que realmente alimenta o bloco de prompt do perfil da organização e os espaços reservados {placeholder}.",
+        "title": "Perfil resolvido (usado nos prompts)"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "Capturado em: {timestamp}"
+        },
+        "provider": {
+          "label": "Provedor: {provider}"
+        },
+        "tokenFields": {
+          "label": "Campos da resposta do token: {fields}"
+        },
+        "user": {
+          "label": "Usuário: {email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "Resposta do endpoint userinfo do OIDC para o seu token de acesso.",
+        "title": "Claims do userinfo"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "Conecte servidores OpenAPI para adicionar ações e ferramentas personalizadas aos seus agentes."
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Os custos são calculados a partir do uso registrado do modelo.",
@@ -1831,6 +3715,62 @@
           "description": "Nenhum uso registrado neste período."
         },
         "title": "Usuários"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "Conectado"
+        },
+        "description": "Conecte seu provedor de identidade para importar e sincronizar usuários e grupos.",
+        "generate": {
+          "label": "Gerar token SCIM"
+        },
+        "regenerate": {
+          "label": "Gerar novo token"
+        },
+        "title": "Sincronização SCIM",
+        "waiting": {
+          "description": "Forneça a chave SCIM ao seu provedor de identidade para começar a sincronizar usuários e grupos.",
+          "label": "Aguardando a conexão"
+        }
+      },
+      "header": {
+        "description": "Sincronize usuários e grupos pelo protocolo System for Cross-domain Identity Management (SCIM).",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "Falha ao carregar o status do token SCIM."
+      },
+      "modal": {
+        "copied": {
+          "message": "Token copiado para a área de transferência"
+        },
+        "copyFailed": {
+          "error": "Falha ao copiar o token"
+        },
+        "regenerate": {
+          "description": "Seu token SCIM atual será revogado e um novo token será gerado. Você vai precisar atualizar o token no seu provedor de identidade antes que o provisionamento SCIM continue.",
+          "submit": {
+            "label": "Gerar novo token"
+          },
+          "title": "Gerar novo token SCIM"
+        },
+        "token": {
+          "copy": {
+            "label": "Copiar token"
+          },
+          "description": "Salve esta chave antes de continuar. Ela não será mostrada de novo.",
+          "download": {
+            "label": "Baixar"
+          },
+          "title": "Token SCIM"
+        }
+      },
+      "toasts": {
+        "generateFailed": "Falha ao gerar o token: {detail}",
+        "genericError": "Algo deu errado. Tente novamente.",
+        "regenerated": "Novo token gerado"
       }
     },
     "security": {
@@ -2213,6 +4153,393 @@
         }
       }
     },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "Erro ao criar a configuração do OnyxBot - {error}"
+        },
+        "updateError": {
+          "toast": "Erro ao atualizar a configuração do OnyxBot - {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "Falha ao excluir a configuração do bot do Slack - {error}"
+        },
+        "deleted": {
+          "toast": "Configuração do bot do Slack \"{configId}\" excluída"
+        },
+        "editDefaultButton": {
+          "label": "Editar a configuração padrão"
+        },
+        "newConfigButton": {
+          "label": "Nova configuração de canal"
+        },
+        "section": {
+          "title": "Configurações por canal"
+        },
+        "table": {
+          "actions": {
+            "header": "Ações"
+          },
+          "assistant": {
+            "header": "Assistente"
+          },
+          "channel": {
+            "header": "Canal"
+          },
+          "documentSets": {
+            "header": "Conjuntos de documentos"
+          },
+          "empty": {
+            "message": "Nenhuma configuração por canal. Adicione uma nova configuração para personalizar o comportamento em canais específicos."
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "Excluir"
+        },
+        "error": {
+          "toast": "Falha ao excluir o bot do Slack"
+        },
+        "message": "Tem certeza de que deseja excluir este bot do Slack? Esta ação não pode ser desfeita.",
+        "success": {
+          "toast": "Bot do Slack excluído com sucesso"
+        },
+        "title": "Excluir bot do Slack"
+      },
+      "edit": {
+        "header": {
+          "title": "Editar bot do Slack"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Editar a configuração do canal do Slack"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "Editar a configuração padrão do Slack"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "Não encontramos a configuração do canal do Slack com o ID: {id}"
+        },
+        "fetchAgents": {
+          "message": "Falha ao buscar os agentes - {error}"
+        },
+        "fetchBot": {
+          "message": "Falha ao buscar o bot do Slack {botId}: {error}"
+        },
+        "fetchChannels": {
+          "message": "Falha ao buscar os canais do Slack - {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "Falha ao buscar os conjuntos de documentos - {error}"
+        },
+        "generic": {
+          "title": "Algo deu errado :("
+        },
+        "unknown": {
+          "message": "erro desconhecido"
+        },
+        "unknownOccurred": {
+          "message": "Ocorreu um erro desconhecido"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "Pesquisar um agente..."
+        },
+        "answerValidity": {
+          "label": "Responder apenas se houver citações",
+          "tooltip": "Se ativado, só vai responder às perguntas em que o modelo produzir citações com sucesso"
+        },
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "channelName": {
+          "label": "Nome do canal do Slack",
+          "placeholder": "Digite o nome do canal (por exemplo, general, support)",
+          "subtext": "Digite o nome do canal do Slack (sem o símbolo #)"
+        },
+        "createButton": {
+          "label": "Criar"
+        },
+        "defaultConfig": {
+          "badge": "Configuração padrão",
+          "description": "Esta configuração padrão se aplica a todos os canais e mensagens diretas (DMs) do seu espaço de trabalho do Slack."
+        },
+        "disableDefault": {
+          "label": "Desativar a configuração padrão",
+          "warning": "Aviso: se você desativar a configuração padrão, o OnyxBot não vai responder nos canais do Slack, a menos que eles sejam configurados explicitamente. Além disso, o OnyxBot não vai responder às DMs."
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "Não é possível usar este conjunto de documentos porque ele contém um conector com permissões de sincronização automática. As respostas do OnyxBot neste canal ficam visíveis para todos os usuários do Slack, portanto espelhar as permissões de quem pergunta poderia expor informações privadas sem querer."
+          },
+          "autoSyncedNote": {
+            "text": "Estes conjuntos de documentos não podem ser anexados porque têm documentos sincronizados automaticamente:"
+          },
+          "description": "Selecione os conjuntos de documentos que o OnyxBot vai usar ao responder às perguntas no Slack.",
+          "hideUnselectableButton": {
+            "label": "Ocultar os conjuntos de documentos não selecionáveis"
+          },
+          "incompatibleHidden": {
+            "text": "Alguns conjuntos de documentos incompatíveis estão ocultos."
+          },
+          "incompatibleVisible": {
+            "text": "Alguns conjuntos de documentos incompatíveis estão visíveis."
+          },
+          "viewAllButton": {
+            "label": "Ver todos os conjuntos de documentos"
+          }
+        },
+        "followUpTags": {
+          "label": "(Opcional) Usuários / grupos a marcar",
+          "subtext": "Os usuários / grupos do Slack que devemos marcar se a pessoa clicar no botão \"Ainda precisa de ajuda?\". Se nenhum e-mail for informado, não vamos marcar ninguém e apenas vamos reagir à mensagem original com o emoji 🆘."
+        },
+        "generalConfig": {
+          "section": {
+            "title": "Configuração geral"
+          }
+        },
+        "isEphemeral": {
+          "label": "Responder ao usuário em uma mensagem privada (efêmera)",
+          "tooltip": "Se ativado, o OnyxBot vai responder apenas ao usuário em uma mensagem privada (efêmera). Se você também escolheu o agente de 'Pesquisa' acima, esta opção torna os documentos privados do usuário disponíveis para as consultas dele."
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "Todo o conhecimento público",
+            "sublabel": "Permite que o OnyxBot responda com base nas informações de todos os conectores públicos"
+          },
+          "documentSets": {
+            "label": "Conjuntos de documentos específicos",
+            "sublabel": "Controle quais documentos usar para responder às perguntas"
+          },
+          "label": "Fonte de conhecimento",
+          "nonSearchAgent": {
+            "label": "Agente sem pesquisa",
+            "sublabel": "Converse com um agente que não usa documentos"
+          },
+          "searchAgent": {
+            "label": "Agente de pesquisa",
+            "sublabel": "Controle os documentos e o prompt usados para responder às perguntas"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "Selecione o agente sem pesquisa que o OnyxBot vai usar ao responder às perguntas no Slack."
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "Conectores relevantes:"
+          },
+          "description": "Observe que, se a resposta privada (efêmera) *não estiver selecionada*, apenas os documentos públicos dos conjuntos de documentos selecionados ficam acessíveis para as consultas dos usuários. Se a resposta privada (efêmera) *estiver selecionada*, as consultas dos usuários também podem usar documentos aos quais o usuário já recebeu acesso. Lembre-se de que os usuários podem compartilhar a resposta com outras pessoas no canal, portanto confirme que isso está alinhado com as políticas de compartilhamento da sua empresa.",
+          "title": "Alerta de privacidade"
+        },
+        "questionmarkPrefilter": {
+          "label": "Responder apenas a perguntas",
+          "tooltip": "Se ativado, o OnyxBot só vai responder às mensagens que contêm um ponto de interrogação"
+        },
+        "removedDocumentSets": {
+          "toast": "Removemos um ou mais conjuntos de documentos da sua seleção porque eles não são mais válidos. Revise e atualize sua configuração."
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "Desativado enquanto 'Responder ao usuário em uma mensagem privada (efêmera)' estiver ativo — as respostas efêmeras vão para um único usuário."
+          },
+          "label": "(Opcional) Responder a certos usuários / grupos",
+          "subtext": "Se especificado, apenas estes usuários / grupos podem acionar o OnyxBot neste canal, e as respostas ficam visíveis somente para eles."
+        },
+        "respondTagOnly": {
+          "label": "Responder apenas a @OnyxBot",
+          "tooltip": "Se ativado, o OnyxBot só vai responder quando for marcado diretamente"
+        },
+        "respondToBots": {
+          "label": "Responder a mensagens de bots",
+          "tooltip": "Se não estiver ativado, o OnyxBot sempre vai ignorar as mensagens de bots"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "Detalhada"
+          },
+          "label": "Tipo de resposta",
+          "standard": {
+            "label": "Padrão"
+          },
+          "tooltip": "Controla o formato das respostas do OnyxBot."
+        },
+        "searchAgent": {
+          "description": "Selecione o agente com pesquisa que o OnyxBot vai usar ao responder às perguntas no Slack."
+        },
+        "searchConfig": {
+          "section": {
+            "title": "Configuração da pesquisa"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "Mostrar o botão Continuar na interface web",
+          "tooltip": "Se ativado, mostra um botão no fim da resposta que permite ao usuário continuar a conversa na interface web do Onyx"
+        },
+        "stillNeedHelp": {
+          "label": "Mostrar um botão \"Ainda precisa de ajuda?\"",
+          "section": {
+            "prompt": "Configurar o botão Ainda precisa de ajuda"
+          },
+          "tooltip": "A resposta do OnyxBot vai incluir, no fim, um botão que pergunta ao usuário se ele ainda precisa de ajuda."
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "Ocultar os agentes não selecionáveis"
+          },
+          "listLabel": "Agentes não selecionáveis:",
+          "note": "Observação: alguns dos seus agentes têm conectores com sincronização automática nos conjuntos de documentos deles. Você não pode selecionar esses agentes porque eles não conseguem responder às perguntas no Slack.",
+          "viewAllButton": {
+            "label": "Ver todos os agentes"
+          }
+        },
+        "updateButton": {
+          "label": "Atualizar"
+        },
+        "userOrGroup": {
+          "placeholder": "E-mail do usuário ou nome do grupo de usuários..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "Configure o OnyxBot para responder automaticamente às perguntas em certos canais."
+        },
+        "description": "Configure bots do Slack que se conectam ao Onyx. Depois da configuração, você vai poder fazer perguntas ao Onyx direto do Slack. Além disso, você pode:",
+        "directMessage": {
+          "item": "Enviar uma mensagem direta ao OnyxBot para pesquisar como você faria na interface web."
+        },
+        "docsPrompt": {
+          "text": "Siga o <link>guia</link> da documentação do Onyx para começar!"
+        },
+        "documentSets": {
+          "item": "Escolher de quais conjuntos de documentos o OnyxBot deve responder, conforme o canal em que a pergunta é feita."
+        }
+      },
+      "list": {
+        "error": {
+          "title": "Erro ao carregar os aplicativos"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "Novo bot do Slack"
+        }
+      },
+      "newBotButton": {
+        "label": "Novo bot do Slack"
+      },
+      "newChannel": {
+        "header": {
+          "title": "Configurar o OnyxBot para um canal do Slack"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "Quantidade de canais"
+        },
+        "defaultConfig": {
+          "header": "Configuração padrão"
+        },
+        "defaultSet": {
+          "badge": "Padrão definido"
+        },
+        "disabled": {
+          "badge": "Desativado"
+        },
+        "empty": {
+          "message": "Adicione um novo bot do Slack para começar a conversar com o Onyx!"
+        },
+        "enabled": {
+          "badge": "Ativado"
+        },
+        "name": {
+          "header": "Nome"
+        },
+        "status": {
+          "header": "Status"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Token do app do Slack"
+        },
+        "botToken": {
+          "label": "Token do bot do Slack"
+        },
+        "createButton": {
+          "label": "Criar"
+        },
+        "createError": {
+          "toast": "Erro ao criar o bot do Slack - {error}"
+        },
+        "created": {
+          "toast": "Bot do Slack criado com sucesso!"
+        },
+        "docsPrompt": {
+          "text": "Consulte nosso <link>guia</link> se você não tiver certeza de como obter estes tokens!"
+        },
+        "invalidAppToken": {
+          "message": "O token do app do Slack é inválido"
+        },
+        "invalidBotToken": {
+          "message": "O token do bot do Slack é inválido"
+        },
+        "name": {
+          "label": "Dê um nome a este bot do Slack:"
+        },
+        "updateButton": {
+          "label": "Atualizar"
+        },
+        "updateError": {
+          "toast": "Erro ao atualizar o bot do Slack - {error}"
+        },
+        "updated": {
+          "toast": "Bot do Slack atualizado com sucesso!"
+        },
+        "userToken": {
+          "label": "Token de usuário do Slack (opcional)",
+          "subtext": "Opcional: token OAuth de usuário para ampliar o acesso a canais privados"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "Excluir"
+        },
+        "enabledCheckbox": {
+          "label": "Ativado"
+        },
+        "fieldUpdateFailed": {
+          "toast": "Falha ao atualizar {field} do conector"
+        },
+        "fieldUpdated": {
+          "toast": "{field} do conector atualizado com sucesso"
+        },
+        "updateTokensButton": {
+          "label": "Atualizar tokens"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "É necessário um agente quando você usa a fonte de conhecimento 'Agente'"
+        },
+        "channelNameRequired": {
+          "message": "O nome do canal é obrigatório"
+        },
+        "documentSetRequired": {
+          "message": "É necessário pelo menos um conjunto de documentos quando você usa a fonte de conhecimento 'Conjuntos de documentos'"
+        }
+      }
+    },
     "ssoProviders": {
       "addProvider": {
         "button": {
@@ -2239,6 +4566,180 @@
       },
       "toasts": {
         "unexpectedError": "Ocorreu um erro inesperado."
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "Versão do backend: "
+      },
+      "version": {
+        "title": "Versão"
+      },
+      "webVersion": {
+        "label": "Versão da web: "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "Até {cost} ou {tokens} tokens",
+          "cost": "Até {cost}",
+          "none": "Nenhum orçamento definido",
+          "tokens": "Até {tokens} tokens"
+        },
+        "cadence": {
+          "label": "{days, plural, one {Reinicia todo dia à meia-noite UTC} other {Reinicia a cada # dias à meia-noite UTC}}"
+        },
+        "deleteFailed": {
+          "error": "Falha ao excluir o limite de taxa de tokens"
+        },
+        "empty": {
+          "message": "Nenhum limite ainda. Crie um limite de gastos para restringir o uso."
+        },
+        "loadFailed": {
+          "error": "Falha ao carregar os limites de taxa de tokens"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "Excluir {label}",
+            "tooltip": "Excluir limite"
+          },
+          "disable": {
+            "ariaLabel": "Desativar {label}"
+          },
+          "enable": {
+            "ariaLabel": "Ativar {label}"
+          },
+          "label": "{budget}, {cadence}"
+        },
+        "updateFailed": {
+          "error": "Falha ao atualizar o limite de taxa de tokens"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "costBudget": {
+          "description": "Gasto máximo por período de reinício. Defina um orçamento de custo, um orçamento de tokens ou ambos.",
+          "placeholder": "Sem limite de custo",
+          "title": "Orçamento de custo",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "Digite um orçamento de custo, um orçamento de tokens ou ambos",
+          "costMax": "O orçamento de custo máximo é US$ {amount, number}",
+          "costMinCents": "O orçamento de custo precisa ser de pelo menos US$ 0,01",
+          "costMoreThanZero": "O orçamento de custo precisa ser maior que 0",
+          "groupRequired": "Selecione um grupo de usuários",
+          "periodInteger": "Digite um número inteiro de dias",
+          "periodMin": "Use pelo menos 1 dia",
+          "periodRequired": "Digite um período de reinício",
+          "scopeRequired": "O escopo de destino é um campo obrigatório",
+          "tokenIncrement": "Use incrementos de 1.000 tokens",
+          "tokenInteger": "Digite um número inteiro de tokens",
+          "tokenMax": "O orçamento máximo é de 1 trilhão de tokens",
+          "tokenMin": "Use pelo menos 1.000 tokens"
+        },
+        "groupMenu": {
+          "empty": "Nenhum grupo de usuários ainda. Crie um em Usuários e grupos."
+        },
+        "groupPicker": {
+          "placeholder": "Escolha um grupo"
+        },
+        "header": {
+          "title": "Criar limite de gastos"
+        },
+        "period": {
+          "description": "Os orçamentos reiniciam à meia-noite UTC",
+          "title": "Período de reinício",
+          "unit": "dias"
+        },
+        "scope": {
+          "caption": {
+            "global": "Todos no espaço de trabalho compartilham um orçamento.",
+            "group": "Os membros de {group} compartilham um orçamento.",
+            "groupUnchosen": "Os membros do grupo escolhido compartilham um orçamento.",
+            "user": "Cada usuário tem o próprio orçamento."
+          },
+          "title": "Aplica-se a"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "Espaço de trabalho"
+          },
+          "user": {
+            "title": "Por usuário"
+          },
+          "userGroup": {
+            "title": "Grupo de usuários"
+          }
+        },
+        "submit": {
+          "label": "Criar limite"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} ou {tokens} tokens",
+            "tokens": "{tokens} tokens"
+          },
+          "global": "{days, plural, one {Todos no espaço de trabalho compartilham até {budget} por dia. O uso fica bloqueado até o período reiniciar.} other {Todos no espaço de trabalho compartilham até {budget} a cada # dias. O uso fica bloqueado até o período reiniciar.}}",
+          "group": "{days, plural, one {Os membros de {group} compartilham até {budget} por dia. O uso fica bloqueado até o período reiniciar.} other {Os membros de {group} compartilham até {budget} a cada # dias. O uso fica bloqueado até o período reiniciar.}}",
+          "groupUnchosen": "{days, plural, one {Os membros do grupo escolhido compartilham até {budget} por dia. O uso fica bloqueado até o período reiniciar.} other {Os membros do grupo escolhido compartilham até {budget} a cada # dias. O uso fica bloqueado até o período reiniciar.}}",
+          "user": "{days, plural, one {Cada usuário pode gastar até {budget} por dia. O uso fica bloqueado até o período reiniciar.} other {Cada usuário pode gastar até {budget} a cada # dias. O uso fica bloqueado até o período reiniciar.}}"
+        },
+        "tokenBudget": {
+          "description": "Máximo de tokens por período de reinício",
+          "placeholder": "Sem limite de tokens",
+          "title": "Orçamento de tokens",
+          "unit": "tokens"
+        },
+        "userGroup": {
+          "description": "Escolha qual grupo compartilha este orçamento",
+          "title": "Grupo de usuários"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "Criar limite de gastos"
+        },
+        "createFailed": {
+          "error": "Falha ao criar o limite de gastos"
+        },
+        "created": {
+          "message": "Limite de gastos criado!"
+        },
+        "embedded": {
+          "description": "Defina limites de proteção para o uso do espaço de trabalho, dos usuários e dos grupos. Os limites podem ser ativados ou desativados sem excluir a configuração deles.",
+          "title": "Gerenciar os limites de gastos"
+        },
+        "global": {
+          "description": "Os limites globais se aplicam a todos os usuários, grupos de usuários e chaves de API. Quando o limite global é atingido, não é possível gastar mais tokens."
+        },
+        "intro": {
+          "description": "Os limites de gastos ajudam você a controlar quantos tokens podem ser gastos em um determinado período.",
+          "groupLimit": "Defina limites para grupos de usuários para controlar os gastos das equipes.",
+          "toggleLimit": "Ative e desative os limites conforme a necessidade.",
+          "userLimit": "Defina limites para os usuários para que nenhum usuário gaste demais.",
+          "workspaceLimit": "Defina um limite para todo o espaço de trabalho e controle os gastos totais da sua equipe."
+        },
+        "tabs": {
+          "global": {
+            "name": "Global"
+          },
+          "groups": {
+            "name": "Grupos"
+          },
+          "users": {
+            "name": "Usuários"
+          }
+        },
+        "user": {
+          "description": "Os limites de usuário se aplicam a cada usuário individualmente. Quando um usuário atinge um limite, ele fica temporariamente impedido de gastar tokens."
+        },
+        "userGroup": {
+          "description": "Os limites de grupo se aplicam a todos os usuários de um grupo. Se um usuário pertence a vários grupos, vale o limite mais permissivo."
+        }
       }
     },
     "tracing": {


### PR DESCRIPTION
## Summary

Second admin slice, following #14300 (merged): the `app/admin` route pages.

- Migrate `app/admin/**` — connector detail (incl. indexing stage metrics), add-connector, connector setup + OAuth flows, indexing status, documents & document sets, document processing, Slack & Discord bots, billing & plans, token rate limits, SCIM, OAuth test, system info, federated. This adds **943 keys** under `admin.*`.
- Stage-metric labels/descriptions, permission-sync statuses, and connector categories store typed message-key unions — adding an enum member without copy fails compilation.
- Bug fix the typed ICU args caught: two document-admin toasts interpolated an **un-awaited Promise** from `getErrorMsg` (rendered `[object Promise]`); both now await.
- Every new key translated in `es/pt/fr/de`, one agent per locale, each validated for identical ICU shapes (arguments, plural branch sets incl. explicit `=0`, tags, markdown markers). Locale niceties handled: German/French long-scale "trillion", localized currency ordering, article insertion in shared confirm-modal templates.
- Ratchet: `src/app/admin/**` added to the `i18n/no-raw-jsx-text` override.

## Left English on purpose (follow-ups)

- Plain-module helpers surfacing toasts: `connectors/[connector]/pages/utils/{files,google_site}.ts`, `AddConnectorPage.submitConnector`, `documents/lib.ts`, `token-rate-limits/lib.ts` error constants.
- Shared out-of-scope modules: `lib/credentials/credentialCreation.ts`, `lib/search/interfaces.ts` `SourceCategory` enum (copy now duplicated in catalog; enum edits must update the catalog), `admin-routes.ts` titles (dedicated pass planned).
- One behavior note: the prune-frequency description lost its hard line breaks (single-line ICU message; `SubLabel` only pre-wraps multi-line strings).

## Test plan

- `bun run types:check` — parity across all five catalogs; every `t()` key resolves.
- Catalog Jest test — valid ICU + identical placeholders per locale (5/5).
- `bun run lint` — clean with the extended ratchet.
- `bun run test` — 1181/1182; only the known `CustomModal` load-flake (passes in isolation, pre-dates the wave).
- `pre-commit run` on all touched files passes.

Next: wave 3c (actions/tools, remaining modals, small sections) — the final extraction wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates all `app/admin` routes to `next-intl`, adding 943 keys under `admin.*` translated in es/pt/fr/de. Also fixes two document toasts that rendered `[object Promise]` by now awaiting `getErrorMsg`.

**Refactors**
- Stage-metric labels, permission-sync statuses, and connector categories use typed message-key unions so adding an enum member without a translation fails compilation.
- Extends the i18n lint ratchet to `src/app/admin/**`.
- Plain-module toast helpers and shared modules stay in English for follow-ups.
- Prune-frequency description lost its hard line breaks (now a single-line ICU message).

<sup>Written for commit 5ac48eb040541c8d3d3445ce8398a2e268647951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

