### PR TITLE
ci(terraform-provider): run the acceptance suite against a real stack

### DIFF
--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -24,7 +24,7 @@
 name: Terraform Provider Tests
 
 concurrency:
-  group: Terraform-Provider-Tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: Terraform-Provider-Tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:
@@ -306,12 +306,20 @@ jobs:
           AUTH_MODE: ${{ matrix.auth }}
           TF_ACC: "1"
           ONYX_TF_ACC_SERVER_URL: http://localhost:8080
+          # mint_api_key.sh requires these rather than defaulting them, so that
+          # it cannot quietly create a known-password admin on a real
+          # deployment. Here they match the harness's own defaults, against a
+          # throwaway stack this job tears down with `down -v`.
+          ACC_ADMIN_EMAIL: admin_user@example.com
+          ACC_ADMIN_PASSWORD: TestPassword123!
         run: |
           set -uo pipefail
           # Mint the key in this step so the material never lands in the job
           # environment or a step output.
           if [ "${AUTH_MODE}" = "api-key" ]; then
             key=$(ONYX_SERVER_URL="${ONYX_TF_ACC_SERVER_URL}" \
+              ONYX_ADMIN_EMAIL="${ACC_ADMIN_EMAIL}" \
+              ONYX_ADMIN_PASSWORD="${ACC_ADMIN_PASSWORD}" \
               ONYX_API_KEY_NAME=terraform-provider-ci \
               ./examples/bootstrap/mint_api_key.sh)
             # An empty key would send the harness down its own bootstrap path,

--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -279,6 +279,12 @@ jobs:
         run: |
           set -uo pipefail
           programs="celery_beat celery_worker_primary celery_worker_light"
+          # -c is required. supervisorctl only searches <exec>/etc, ./etc,
+          # /etc/supervisord.conf and /etc/supervisor/supervisord.conf, and the
+          # image puts the file in /etc/supervisor/conf.d/ -- so without this it
+          # silently falls back to its built-in http://localhost:9001 and
+          # reports a refused connection. Same path the entrypoint uses.
+          supervisor_conf=/etc/supervisor/conf.d/supervisord.conf
           # `background` declares no healthcheck, so `--wait` returns as soon as
           # the container starts and every worker still has the whole app to
           # import. 150 x 2s covers a cold runner; a healthy stack exits in
@@ -286,7 +292,8 @@ jobs:
           for _ in $(seq 150); do
             status=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml \
               --env-file env.template \
-              exec -T background supervisorctl status ${programs} 2>/dev/null || true)
+              exec -T background \
+              supervisorctl -c "${supervisor_conf}" status ${programs} 2>&1 || true)
             if [ "$(echo "${status}" | grep -c RUNNING)" -eq 3 ]; then
               echo "${status}"
               exit 0

--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -1,0 +1,375 @@
+# Runs the Terraform provider acceptance suite against a real Onyx stack.
+#
+# The provider's unit tests run in pr-golang-tests.yml, which discovers every
+# go.mod and runs `go test -race ./...`. That lane leaves TF_ACC unset, so the
+# acceptance tests skip there and the provider's real coverage — every resource
+# driven end to end through terraform plan/apply/destroy against live API
+# routes — never ran in CI. This lane runs it.
+#
+# The suite needs Enterprise Edition (user groups, private agents and document
+# sets) and needs celery: several resources only settle once the sync gate
+# marks them up to date, and that gate is driven by beat-scheduled tasks. So
+# the stack here is api_server + background (supervisord runs the workers and
+# beat), not the in-process TestClient the python integration lane uses.
+#
+# Two auth legs run in parallel. `bootstrap` lets the harness register an admin
+# and mint its own key. `api-key` mints a key first with the documented
+# examples/bootstrap/mint_api_key.sh and passes it in, which covers the
+# ONYX_TF_ACC_API_KEY path a user actually takes.
+#
+# PRs only trigger the suite for provider and compose changes: it is a heavy
+# lane and the provider changes far less often than the routes it calls. The
+# nightly run is what catches a backend change that breaks the provider.
+
+name: Terraform Provider Tests
+
+concurrency:
+  group: Terraform-Provider-Tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 08:00 UTC nightly
+  merge_group:
+  pull_request:
+    branches: [main]
+    # NOTE: Intentionally no `paths:` filter. We always trigger and let the
+    # `changes` job below decide whether the real test job runs. This avoids
+    # the dual-workflow skip pattern where a `paths-ignore`'d skip workflow can
+    # race the real workflow's same-named status check under branch protection.
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.26.5"
+  IMAGE_TAG: "latest"
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "password"
+  # Pin defensively. Compose's ${VAR:-default} prefers a leaked host value over
+  # the --env-file one.
+  S3_ENDPOINT_URL: "http://minio:9000"
+
+jobs:
+  changes:
+    # Decides whether the heavy acceptance job runs. On pull_request /
+    # merge_group we use paths-filter; on schedule / push (tags) /
+    # workflow_dispatch the filter is skipped and the output defaults to
+    # `true` so everything runs.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # paths-filter needs pull-requests:read to list PR files on private repos.
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      provider: ${{ steps.filter.outputs.provider || 'true' }}
+    steps:
+      - name: Checkout code
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # ratchet:dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          filters: |
+            provider:
+              - 'terraform-provider-onyx/**'
+              - 'backend/Dockerfile'
+              - 'deployment/docker_compose/docker-compose.yml'
+              - 'deployment/docker_compose/docker-compose.dev.yml'
+              - 'deployment/docker_compose/env.template'
+              - '.github/workflows/pr-terraform-provider-tests.yml'
+              - '.github/actions/login-ecr-pullthrough-cache/**'
+
+  docs-check:
+    # docs/ is generated from the schema descriptions and examples/. A hand-edited
+    # page silently drifts from the schema, so regenerate and fail on any diff.
+    # tfplugindocs needs the terraform CLI, and is version-pinned in main.go so
+    # this check only moves when someone moves it.
+    needs: changes
+    if: needs.changes.outputs.provider == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v5 # zizmor: ignore[cache-poisoning]
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: terraform-provider-onyx/go.sum
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # ratchet:hashicorp/setup-terraform@v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Regenerate docs
+        working-directory: terraform-provider-onyx
+        run: go generate .
+
+      - name: Fail on uncommitted docs changes
+        working-directory: terraform-provider-onyx
+        run: |
+          if ! git diff --exit-code docs/; then
+            echo "::error::docs/ is out of date -- run 'go generate .' in terraform-provider-onyx/ and commit the result"
+            exit 1
+          fi
+
+  build-backend-image:
+    # Built once and pushed to the shared ECR repo so both auth legs pull a
+    # prebuilt image instead of cold-building.
+    needs: changes
+    if: needs.changes.outputs.provider == 'true'
+    runs-on:
+      - runs-on
+      - runner=8cpu-linux-x64
+      - spot=false
+      - volume=100gb
+      - ${{ format('run-id={0}-tf-provider-build', github.run_id) }}
+      - extras=ecr-cache
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # ratchet:runs-on/action@v1
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Log in to ECR pull-through cache
+        uses: ./.github/actions/login-ecr-pullthrough-cache
+        with:
+          ecr-registry: ${{ vars.ECR_REGISTRY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # ratchet:docker/setup-buildx-action@v4
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # ratchet:docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          # The production image; the Dockerfile's default (last) stage is the
+          # dev variant.
+          target: runtime
+          platforms: linux/amd64
+          build-args: |
+            BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
+          tags: ${{ env.RUNS_ON_ECR_CACHE }}:tf-provider-backend-${{ github.run_id }}
+          push: true
+          # Attestations attach as ECR referrers to the image digest, which is
+          # stable across runs and caps out at 100 per subject.
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=tf-provider-backend
+          cache-to: type=gha,scope=tf-provider-backend,mode=max
+
+  acceptance:
+    name: acceptance (${{ matrix.auth }})
+    needs: [changes, build-backend-image]
+    if: needs.changes.outputs.provider == 'true'
+    permissions:
+      contents: read
+    runs-on:
+      - runs-on
+      - runner=4cpu-linux-x64
+      - spot=false
+      - volume=100gb
+      - ${{ format('run-id={0}-tf-provider-acceptance-{1}', github.run_id, matrix.auth) }}
+      - extras=ecr-cache
+    timeout-minutes: 45
+
+    strategy:
+      # fail-fast off so one leg's failure does not cancel the other.
+      fail-fast: false
+      matrix:
+        auth: [bootstrap, api-key]
+
+    steps:
+      - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # ratchet:runs-on/action@v1
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v5 # zizmor: ignore[cache-poisoning]
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: terraform-provider-onyx/go.sum
+
+      - name: Log in to ECR pull-through cache
+        uses: ./.github/actions/login-ecr-pullthrough-cache
+        with:
+          ecr-registry: ${{ vars.ECR_REGISTRY }}
+
+      # Retag the prebuilt image to the local name compose expects (compose
+      # consumes local docker images directly, so pull+tag is enough).
+      - name: Pull and tag the backend image
+        env:
+          ECR_CACHE: ${{ env.RUNS_ON_ECR_CACHE }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -eo pipefail
+          docker pull "${ECR_CACHE}:tf-provider-backend-${RUN_ID}"
+          docker tag "${ECR_CACHE}:tf-provider-backend-${RUN_ID}" \
+            "onyxdotapp/onyx-backend:latest"
+
+      # LICENSE_ENFORCEMENT_ENABLED already defaults to false; it is set here so
+      # the lane keeps working if that default changes, and so it needs no
+      # license and no AWS credentials.
+      - name: Write compose .env
+        working-directory: deployment/docker_compose
+        run: |
+          cat <<'EOF' > .env
+          AUTH_TYPE=basic
+          REQUIRE_EMAIL_VERIFICATION=false
+          DISABLE_TELEMETRY=true
+          ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
+          LICENSE_ENFORCEMENT_ENABLED=false
+          USER_AUTH_SECRET=tf-provider-ci-only-dummy-secret
+          POSTGRES_POOL_PRE_PING=true
+          POSTGRES_USE_NULL_POOL=true
+          EOF
+
+      # api_server and background are named; depends_on pulls in db / cache /
+      # opensearch / model servers / minio. web_server + nginx are omitted.
+      - name: Bring up the stack
+        working-directory: deployment/docker_compose
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.dev.yml \
+            --env-file env.template \
+            up -d --wait --wait-timeout 600 \
+            api_server background
+
+      - name: Check the api_server is serving
+        # --fail: without it curl exits 0 on 4xx/5xx and this step would accept
+        # an unhealthy api_server. -w still emits on --fail.
+        run: |
+          docker ps --format 'table {{.Names}}\t{{.Status}}'
+          curl --fail -sS -o /dev/null -w "api_server /health -> %{http_code}\n" \
+            http://localhost:8080/health
+
+      # Several resources only settle once the sync gate marks them up to date,
+      # and beat is what schedules the task that moves the gate. Without this
+      # check a missing beat surfaces much later as an unexplained test timeout.
+      - name: Check celery beat and workers are running
+        working-directory: deployment/docker_compose
+        run: |
+          set -uo pipefail
+          programs="celery_beat celery_worker_primary celery_worker_light"
+          for _ in $(seq 60); do
+            status=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+              --env-file env.template \
+              exec -T background supervisorctl status ${programs} 2>/dev/null || true)
+            if [ "$(echo "${status}" | grep -c RUNNING)" -eq 3 ]; then
+              echo "${status}"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "celery did not reach RUNNING for: ${programs}"
+          echo "${status:-<no supervisorctl output>}"
+          exit 1
+
+      - name: Run acceptance tests (${{ matrix.auth }})
+        working-directory: terraform-provider-onyx
+        timeout-minutes: 30
+        env:
+          AUTH_MODE: ${{ matrix.auth }}
+          TF_ACC: "1"
+          ONYX_TF_ACC_SERVER_URL: http://localhost:8080
+        run: |
+          set -uo pipefail
+          # Mint the key in this step so the material never lands in the job
+          # environment or a step output.
+          if [ "${AUTH_MODE}" = "api-key" ]; then
+            key=$(ONYX_SERVER_URL="${ONYX_TF_ACC_SERVER_URL}" \
+              ONYX_API_KEY_NAME=terraform-provider-ci \
+              ./examples/bootstrap/mint_api_key.sh)
+            # An empty key would send the harness down its own bootstrap path,
+            # so this leg would pass while testing the other one.
+            if [ -z "${key}" ]; then
+              echo "::error::mint_api_key.sh returned no key; this leg cannot test the API key path"
+              exit 1
+            fi
+            echo "::add-mask::${key}"
+            export ONYX_TF_ACC_API_KEY="${key}"
+          fi
+          go test ./internal/provider/... -count=1 -timeout 30m
+
+      - name: Collect compose logs
+        if: ${{ !success() }}
+        working-directory: deployment/docker_compose
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/compose-logs"
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+            --env-file env.template \
+            logs --no-color > "${GITHUB_WORKSPACE}/compose-logs/compose.log" || true
+
+      - name: Upload logs
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v4
+        with:
+          name: tf-provider-compose-logs-${{ matrix.auth }}
+          path: compose-logs/
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        working-directory: deployment/docker_compose
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+            --env-file env.template down -v || true
+
+  terraform-provider-required:
+    # Single required status check for this suite. Always runs so branch
+    # protection has a stable target, and passes cleanly when `changes` reports
+    # no relevant paths changed (i.e. the test job was legitimately skipped).
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes, docs-check, build-backend-image, acceptance]
+    if: ${{ always() }}
+    steps:
+      - name: Check job status
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          RUN_TESTS: ${{ needs.changes.outputs.provider }}
+          DOCS_RESULT: ${{ needs.docs-check.result }}
+          BUILD_RESULT: ${{ needs.build-backend-image.result }}
+          TEST_RESULT: ${{ needs.acceptance.result }}
+        run: |
+          # Fail closed if `changes` didn't succeed. Otherwise an empty
+          # RUN_TESTS (what we'd see when `changes` failed or was cancelled)
+          # would be indistinguishable from "no relevant paths changed" and we
+          # would incorrectly pass the required check.
+          if [ "${CHANGES_RESULT}" != "success" ]; then
+            echo "changes job did not succeed (result: ${CHANGES_RESULT})"
+            exit 1
+          fi
+          if [ "${RUN_TESTS}" != "true" ]; then
+            echo "No relevant paths changed -- required check passes."
+            exit 0
+          fi
+          if [ "${DOCS_RESULT}" != "success" ] || [ "${BUILD_RESULT}" != "success" ]; then
+            echo "Setup results: docs-check=${DOCS_RESULT}, build-backend-image=${BUILD_RESULT}"
+            exit 1
+          fi
+          if [ "${TEST_RESULT}" != "success" ]; then
+            echo "Test result: ${TEST_RESULT}"
+            exit 1
+          fi
+          echo "All acceptance tests passed."

--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -224,7 +224,7 @@ jobs:
 
       # Retag the prebuilt image to the local name compose expects (compose
       # consumes local docker images directly, so pull+tag is enough).
-      - name: Pull and tag the backend image
+      - name: Pull the backend image and pin the model server to the cache
         env:
           ECR_CACHE: ${{ env.RUNS_ON_ECR_CACHE }}
           RUN_ID: ${{ github.run_id }}
@@ -233,6 +233,15 @@ jobs:
           docker pull "${ECR_CACHE}:tf-provider-backend-${RUN_ID}"
           docker tag "${ECR_CACHE}:tf-provider-backend-${RUN_ID}" \
             "onyxdotapp/onyx-backend:latest"
+
+          # Every other image already resolves through the pull-through cache:
+          # compose writes them as ${BASE_IMAGE_REGISTRY:-docker.io}/... and the
+          # ECR login step exports that. The model servers are the exception --
+          # their default carries no registry, so they would come straight from
+          # Docker Hub, anonymously and rate-limited, and they are the largest
+          # images in the stack.
+          echo "ONYX_MODEL_SERVER_IMAGE=${BASE_IMAGE_REGISTRY}/onyxdotapp/onyx-model-server:${IMAGE_TAG}" \
+            >> "$GITHUB_ENV"
 
       # LICENSE_ENFORCEMENT_ENABLED already defaults to false; it is set here so
       # the lane keeps working if that default changes, and so it needs no
@@ -262,14 +271,6 @@ jobs:
             --env-file env.template \
             up -d --wait --wait-timeout 600 \
             api_server background
-
-      - name: Check the api_server is serving
-        # --fail: without it curl exits 0 on 4xx/5xx and this step would accept
-        # an unhealthy api_server. -w still emits on --fail.
-        run: |
-          docker ps --format 'table {{.Names}}\t{{.Status}}'
-          curl --fail -sS -o /dev/null -w "api_server /health -> %{http_code}\n" \
-            http://localhost:8080/health
 
       # Several resources only settle once the sync gate marks them up to date,
       # and beat is what schedules the task that moves the gate. Without this

--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -118,8 +118,14 @@ jobs:
 
       - name: Fail on uncommitted docs changes
         working-directory: terraform-provider-onyx
+        # `git status --porcelain`, not `git diff`: a new resource's page is
+        # generated untracked, and git diff does not see untracked files, so the
+        # likeliest drift of all would pass silently.
         run: |
-          if ! git diff --exit-code docs/; then
+          drift=$(git status --porcelain -- docs/)
+          if [ -n "${drift}" ]; then
+            echo "${drift}"
+            git diff -- docs/ || true
             echo "::error::docs/ is out of date -- run 'go generate .' in terraform-provider-onyx/ and commit the result"
             exit 1
           fi
@@ -188,7 +194,9 @@ jobs:
       - volume=100gb
       - ${{ format('run-id={0}-tf-provider-acceptance-{1}', github.run_id, matrix.auth) }}
       - extras=ecr-cache
-    timeout-minutes: 45
+    # Bounds the steps below rather than cutting across them: stack-up (10m) +
+    # celery readiness (5m) + the test step (35m) have to fit inside it.
+    timeout-minutes: 60
 
     strategy:
       # fail-fast off so one leg's failure does not cancel the other.
@@ -271,7 +279,11 @@ jobs:
         run: |
           set -uo pipefail
           programs="celery_beat celery_worker_primary celery_worker_light"
-          for _ in $(seq 60); do
+          # `background` declares no healthcheck, so `--wait` returns as soon as
+          # the container starts and every worker still has the whole app to
+          # import. 150 x 2s covers a cold runner; a healthy stack exits in
+          # seconds.
+          for _ in $(seq 150); do
             status=$(docker compose -f docker-compose.yml -f docker-compose.dev.yml \
               --env-file env.template \
               exec -T background supervisorctl status ${programs} 2>/dev/null || true)
@@ -287,7 +299,9 @@ jobs:
 
       - name: Run acceptance tests (${{ matrix.auth }})
         working-directory: terraform-provider-onyx
-        timeout-minutes: 30
+        # Deliberately above the -timeout below: go test's own timeout dumps
+        # every goroutine, while a step timeout kills the job with no diagnosis.
+        timeout-minutes: 35
         env:
           AUTH_MODE: ${{ matrix.auth }}
           TF_ACC: "1"

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -32,6 +32,9 @@ providers.
 
 Generated per-resource docs live in [`docs/`](./docs/).
 
+[`examples/bootstrap/`](./examples/bootstrap/) is a runnable day-one configuration: a chat
+model, one indexed site, a document set built from it, and an agent that answers from it.
+
 ## Authentication
 
 The provider needs an API key in the seeded **Admin** group (or an unrestricted PAT created
@@ -44,6 +47,9 @@ curl -X POST https://your-onyx/api/admin/api-key \
   -H "Content-Type: application/json" \
   -d '{"name": "terraform", "group_ids": [<admin group id>]}'
 ```
+
+[`examples/bootstrap/mint_api_key.sh`](./examples/bootstrap/mint_api_key.sh) does the whole
+sequence — register, log in, resolve the Admin group, mint the key — for a scripted setup.
 
 This first key is inherently chicken-and-egg: it must exist before Terraform can run, so
 either leave it unmanaged, or `terraform import` it afterwards (its `api_key` attribute
@@ -240,8 +246,16 @@ TF_ACC=1 ONYX_TF_ACC_SERVER_URL=http://localhost:8080 go test ./internal/provide
   `admin_user@example.com` / `TestPassword123!`; on a fresh deployment the first
   registered user becomes admin automatically).
 
-Without `TF_ACC` these tests skip, so plain `go test ./...` (and the repo's Go CI) stays
-green with no Onyx running.
+Without `TF_ACC` these tests skip, so plain `go test ./...` stays green with no Onyx
+running. That is also what `pr-golang-tests.yml` runs, so the acceptance suite does not
+run there.
+
+`pr-terraform-provider-tests.yml` is the lane that does run it. It stands up api_server
+and background from docker compose, so the workers and beat below come with it, and runs
+the suite twice: once letting the harness bootstrap its own key, and once against a key
+minted first by `examples/bootstrap/mint_api_key.sh`. On pull requests it only triggers
+for provider and compose changes; the nightly run is what catches a backend change that
+breaks the provider.
 
 To test against an API server that does not touch your dev database, give it a database of
 its own. This reuses the running Postgres, Redis, OpenSearch and MinIO containers (the

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -49,7 +49,10 @@ curl -X POST https://your-onyx/api/admin/api-key \
 ```
 
 [`examples/bootstrap/mint_api_key.sh`](./examples/bootstrap/mint_api_key.sh) does the whole
-sequence — register, log in, resolve the Admin group, mint the key — for a scripted setup.
+sequence — register, log in, resolve the Admin group, mint the key — for a scripted setup. It
+requires `ONYX_ADMIN_EMAIL` and `ONYX_ADMIN_PASSWORD` rather than defaulting them: on a
+deployment with no users it registers that account, and the first user to register becomes an
+admin.
 
 This first key is inherently chicken-and-egg: it must exist before Terraform can run, so
 either leave it unmanaged, or `terraform import` it afterwards (its `api_key` attribute

--- a/terraform-provider-onyx/docs/resources/api_key.md
+++ b/terraform-provider-onyx/docs/resources/api_key.md
@@ -31,8 +31,8 @@ resource "onyx_api_key" "ingest" {
 
 ### Optional
 
-- `name` (String) Display name for the key.
 - `group_ids` (Set of Number) Ids of the user groups the backing service account belongs to. The key resolves the union of those groups' permissions. Omit for a key with no group permissions. This replaces the whole group set on every apply.
+- `name` (String) Display name for the key.
 
 ### Read-Only
 

--- a/terraform-provider-onyx/examples/bootstrap/README.md
+++ b/terraform-provider-onyx/examples/bootstrap/README.md
@@ -1,0 +1,72 @@
+# Bootstrap example
+
+A day-one Onyx configuration. It creates a chat model, indexes one public
+documentation site, groups the result into a document set, and adds an agent
+that answers from it.
+
+Everything here works on Community Edition. The `onyx_user_group` resource is
+the one exception and stays off unless you set
+`enable_enterprise_features = true`.
+
+## Get an API key
+
+The provider authenticates with an Onyx API key. A key's access comes from the
+groups it belongs to, so the key must be in the `Admin` group.
+
+Create one in the admin panel under **Settings -> Service Accounts**, or run:
+
+```bash
+ONYX_SERVER_URL=http://localhost:8080 ./mint_api_key.sh
+```
+
+The script registers an admin, logs in, and mints a key in the `Admin` group.
+It reads `ONYX_ADMIN_EMAIL` and `ONYX_ADMIN_PASSWORD`, and needs `curl` and
+`jq`. Listing groups needs the same Enterprise Edition route the admin panel
+uses.
+
+## Apply
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars
+
+terraform init
+terraform plan
+terraform apply
+```
+
+Credentials can also come from the environment, which keeps them out of
+`terraform.tfvars`:
+
+```bash
+export ONYX_SERVER_URL=http://localhost:8080
+export ONYX_API_KEY="$(./mint_api_key.sh)"
+```
+
+## What it creates
+
+| Resource | Purpose |
+| --- | --- |
+| `onyx_settings.workspace` | Workspace name |
+| `onyx_llm_provider.openai` | The chat model provider |
+| `onyx_llm_provider_default.this` | Picks the deployment-wide default model |
+| `onyx_credential.web` | An empty credential, which is what the web connector takes |
+| `onyx_connector.docs` | Says what to index and how often |
+| `onyx_cc_pair.docs` | Joins connector to credential and indexes |
+| `onyx_document_set.docs` | Groups the indexed pair for search |
+| `onyx_persona.docs` | The agent that answers from the set |
+| `onyx_user_group.platform` | Enterprise Edition only, off by default |
+
+Indexing starts after apply and runs in the background, so the agent answers
+from the site only once the first index run finishes. Watch progress in the
+admin panel under **Connectors**.
+
+## Clean up
+
+```bash
+terraform destroy
+```
+
+Destroying the pair also removes the documents it indexed, which Onyx does in
+the background. `onyx_settings` is the exception: destroying it stops managing
+the settings but does not reset them.

--- a/terraform-provider-onyx/examples/bootstrap/README.md
+++ b/terraform-provider-onyx/examples/bootstrap/README.md
@@ -16,13 +16,20 @@ groups it belongs to, so the key must be in the `Admin` group.
 Create one in the admin panel under **Settings -> Service Accounts**, or run:
 
 ```bash
-ONYX_SERVER_URL=http://localhost:8080 ./mint_api_key.sh
+ONYX_SERVER_URL=http://localhost:8080 \
+ONYX_ADMIN_EMAIL=admin@example.com \
+ONYX_ADMIN_PASSWORD='...' \
+./mint_api_key.sh
 ```
 
-The script registers an admin, logs in, and mints a key in the `Admin` group.
-It reads `ONYX_ADMIN_EMAIL` and `ONYX_ADMIN_PASSWORD`, and needs `curl` and
-`jq`. Listing groups needs the same Enterprise Edition route the admin panel
-uses.
+The script logs in as that account and mints a key in the `Admin` group. It
+needs `curl` and `jq`, and listing groups needs the same Enterprise Edition
+route the admin panel uses.
+
+The credentials are required rather than defaulted, deliberately. On a
+deployment with no users the script registers the account, and the first user
+to register becomes an admin — so a default password here would quietly create
+a known-password administrator on any reachable deployment.
 
 ## Apply
 
@@ -40,7 +47,9 @@ Credentials can also come from the environment, which keeps them out of
 
 ```bash
 export ONYX_SERVER_URL=http://localhost:8080
-export ONYX_API_KEY="$(./mint_api_key.sh)"
+export ONYX_API_KEY="$(ONYX_ADMIN_EMAIL=admin@example.com \
+  ONYX_ADMIN_PASSWORD='...' ./mint_api_key.sh)"
+export TF_VAR_openai_api_key="sk-..."
 ```
 
 ## What it creates

--- a/terraform-provider-onyx/examples/bootstrap/main.tf
+++ b/terraform-provider-onyx/examples/bootstrap/main.tf
@@ -1,0 +1,134 @@
+# A day-one Onyx configuration: a chat model, one indexed source, a document
+# set built from it, and an agent that answers from that set.
+#
+# Everything here works on Community Edition. The user group at the bottom is
+# the one exception and stays off unless you enable it.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    onyx = {
+      source = "onyx-dot-app/onyx"
+    }
+  }
+}
+
+# Reads ONYX_SERVER_URL and ONYX_API_KEY when the variables are unset.
+provider "onyx" {
+  endpoint = var.onyx_server_url
+  api_key  = var.onyx_api_key
+}
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+
+# Only the attributes set here are managed. Destroying this resource does not
+# reset the settings it wrote.
+resource "onyx_settings" "workspace" {
+  company_name = var.company_name
+}
+
+# ---------------------------------------------------------------------------
+# Chat model
+# ---------------------------------------------------------------------------
+
+resource "onyx_llm_provider" "openai" {
+  name          = "openai"
+  provider_type = "openai"
+  api_key       = var.openai_api_key
+
+  # The complete set of enabled models: anything omitted is removed on apply.
+  model_configurations = [
+    { name = "gpt-5" },
+    { name = "gpt-5-mini" },
+  ]
+}
+
+# Referencing the provider id also orders destroys correctly: the default is
+# released before the provider holding it is deleted.
+resource "onyx_llm_provider_default" "this" {
+  provider_id = onyx_llm_provider.openai.id
+  model_name  = "gpt-5"
+}
+
+# ---------------------------------------------------------------------------
+# Knowledge
+# ---------------------------------------------------------------------------
+
+# The web connector reads public pages, so its credential holds no secret.
+resource "onyx_credential" "web" {
+  source          = "web"
+  name            = "public-web"
+  credential_json = jsonencode({})
+}
+
+resource "onyx_connector" "docs" {
+  name       = "docs-site"
+  source     = "web"
+  input_type = "load_state"
+
+  # Re-index once a day.
+  refresh_freq = 24 * 60 * 60
+
+  connector_specific_config = jsonencode({
+    base_url           = var.docs_base_url
+    web_connector_type = "recursive"
+  })
+}
+
+# The pair is the object that indexes. It also carries the access control for
+# the documents it produces.
+resource "onyx_cc_pair" "docs" {
+  name          = "docs-site"
+  connector_id  = onyx_connector.docs.id
+  credential_id = onyx_credential.web.id
+  access_type   = "public"
+}
+
+resource "onyx_document_set" "docs" {
+  name        = "docs"
+  description = "Public product documentation"
+  cc_pair_ids = [onyx_cc_pair.docs.id]
+}
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+resource "onyx_persona" "docs" {
+  name        = "Docs"
+  description = "Answers product questions from the documentation"
+
+  system_prompt = <<-EOT
+    You answer questions from the product documentation.
+    If the documentation does not cover the question, say so.
+  EOT
+
+  document_set_ids = [onyx_document_set.docs.id]
+
+  starter_messages = [
+    {
+      name    = "Getting started"
+      message = "How do I get started?"
+    },
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Access control (Enterprise Edition)
+# ---------------------------------------------------------------------------
+
+# User groups need Enterprise Edition. Leave enable_enterprise_features off on
+# Community Edition: Onyx rejects these routes there.
+resource "onyx_user_group" "platform" {
+  count = var.enable_enterprise_features ? 1 : 0
+
+  name = "Platform"
+
+  # Permissions use Onyx's own tokens, not the enum names.
+  permissions = [
+    "manage:connectors",
+    "manage:document_sets",
+  ]
+}

--- a/terraform-provider-onyx/examples/bootstrap/mint_api_key.sh
+++ b/terraform-provider-onyx/examples/bootstrap/mint_api_key.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Mints an Onyx API key in the seeded "Admin" group and prints it.
+#
+# This is the scripted form of what the admin panel does under
+# Settings -> Service Accounts. Use it for CI or a scripted first setup. A
+# person setting up by hand can create the key in the panel instead.
+#
+# A key's access comes from its groups, so a key with no group is refused by
+# every admin route. Listing groups needs the same Enterprise Edition route
+# the admin panel uses.
+#
+# Usage:
+#   ONYX_SERVER_URL=http://localhost:8080 \
+#   ONYX_ADMIN_EMAIL=admin@example.com \
+#   ONYX_ADMIN_PASSWORD='...' \
+#   ./mint_api_key.sh
+set -euo pipefail
+
+server_url="${ONYX_SERVER_URL:-http://localhost:8080}"
+email="${ONYX_ADMIN_EMAIL:-admin_user@example.com}"
+password="${ONYX_ADMIN_PASSWORD:-TestPassword123!}"
+key_name="${ONYX_API_KEY_NAME:-terraform}"
+
+base="${server_url%/}"
+if [ -n "${ONYX_API_PREFIX:-}" ]; then
+  base="${base}/${ONYX_API_PREFIX#/}"
+fi
+
+for tool in curl jq; do
+  command -v "$tool" > /dev/null 2>&1 || {
+    echo "$tool is required" >&2
+    exit 1
+  }
+done
+
+cookie_jar="$(mktemp)"
+trap 'rm -f "$cookie_jar"' EXIT
+
+# Register. The first user on an empty deployment becomes admin. An existing
+# account fails here, which is fine: the login below is the real gate.
+curl -fsS -X POST "${base}/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -cn --arg e "$email" --arg p "$password" \
+    '{email: $e, username: $e, password: $p}')" \
+  > /dev/null 2>&1 || true
+
+if ! curl -fsS -X POST "${base}/auth/login" \
+  -c "$cookie_jar" \
+  --data-urlencode "username=${email}" \
+  --data-urlencode "password=${password}" \
+  > /dev/null; then
+  echo "login as ${email} failed at ${base}" >&2
+  exit 1
+fi
+
+# The seeded "Admin" group is hidden from the default listing.
+admin_group_id="$(curl -fsS -b "$cookie_jar" \
+  "${base}/manage/admin/user-group?include_default=true" \
+  | jq -r '[.[] | select(.name == "Admin")][0].id // empty')"
+
+if [ -z "$admin_group_id" ]; then
+  echo "no seeded \"Admin\" group found at ${base}" >&2
+  echo "the group listing route needs Enterprise Edition, same as the admin panel" >&2
+  exit 1
+fi
+
+api_key="$(curl -fsS -X POST "${base}/admin/api-key" \
+  -b "$cookie_jar" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -cn --arg n "$key_name" --argjson g "[$admin_group_id]" \
+    '{name: $n, group_ids: $g}')" \
+  | jq -r '.api_key // empty')"
+
+if [ -z "$api_key" ]; then
+  echo "API key creation did not return key material" >&2
+  exit 1
+fi
+
+echo "$api_key"

--- a/terraform-provider-onyx/examples/bootstrap/mint_api_key.sh
+++ b/terraform-provider-onyx/examples/bootstrap/mint_api_key.sh
@@ -9,6 +9,11 @@
 # every admin route. Listing groups needs the same Enterprise Edition route
 # the admin panel uses.
 #
+# The account credentials are required, deliberately. On a deployment with no
+# users the register call below succeeds and the first user becomes an admin,
+# so a default password here would quietly create a known-password
+# administrator on any reachable deployment.
+#
 # Usage:
 #   ONYX_SERVER_URL=http://localhost:8080 \
 #   ONYX_ADMIN_EMAIL=admin@example.com \
@@ -17,9 +22,15 @@
 set -euo pipefail
 
 server_url="${ONYX_SERVER_URL:-http://localhost:8080}"
-email="${ONYX_ADMIN_EMAIL:-admin_user@example.com}"
-password="${ONYX_ADMIN_PASSWORD:-TestPassword123!}"
+email="${ONYX_ADMIN_EMAIL:-}"
+password="${ONYX_ADMIN_PASSWORD:-}"
 key_name="${ONYX_API_KEY_NAME:-terraform}"
+
+if [ -z "$email" ] || [ -z "$password" ]; then
+  echo "set ONYX_ADMIN_EMAIL and ONYX_ADMIN_PASSWORD" >&2
+  echo "they are required rather than defaulted: on a deployment with no users this script registers the account, and the first user becomes an admin" >&2
+  exit 1
+fi
 
 base="${server_url%/}"
 if [ -n "${ONYX_API_PREFIX:-}" ]; then
@@ -34,15 +45,27 @@ for tool in curl jq; do
 done
 
 cookie_jar="$(mktemp)"
-trap 'rm -f "$cookie_jar"' EXIT
+register_body="$(mktemp)"
+trap 'rm -f "$cookie_jar" "$register_body"' EXIT
 
-# Register. The first user on an empty deployment becomes admin. An existing
-# account fails here, which is fine: the login below is the real gate.
-curl -fsS -X POST "${base}/auth/register" \
+# Register. The first user on an empty deployment becomes admin. An account that
+# already exists answers 400 and is fine -- the login below is the real gate.
+# Any other status is reported rather than swallowed, so a deployment problem
+# does not resurface later as a confusing login failure.
+register_code="$(curl -sS -o "$register_body" -w '%{http_code}' \
+  -X POST "${base}/auth/register" \
   -H 'Content-Type: application/json' \
   -d "$(jq -cn --arg e "$email" --arg p "$password" \
-    '{email: $e, username: $e, password: $p}')" \
-  > /dev/null 2>&1 || true
+    '{email: $e, username: $e, password: $p}')" 2> /dev/null || echo 000)"
+
+case "$register_code" in
+  2*| 400) ;;
+  *)
+    echo "warning: registering ${email} answered HTTP ${register_code}" >&2
+    head -c 500 "$register_body" >&2
+    echo >&2
+    ;;
+esac
 
 if ! curl -fsS -X POST "${base}/auth/login" \
   -c "$cookie_jar" \

--- a/terraform-provider-onyx/examples/bootstrap/outputs.tf
+++ b/terraform-provider-onyx/examples/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "agent_id" {
+  description = "Id of the documentation agent."
+  value       = onyx_persona.docs.id
+}
+
+output "cc_pair_id" {
+  description = "Id of the indexing connector-credential pair."
+  value       = onyx_cc_pair.docs.id
+}

--- a/terraform-provider-onyx/examples/bootstrap/terraform.tfvars.example
+++ b/terraform-provider-onyx/examples/bootstrap/terraform.tfvars.example
@@ -2,9 +2,18 @@
 # control: it holds secrets.
 
 onyx_server_url = "http://localhost:8080"
-onyx_api_key    = "on_..."
 
-openai_api_key = "sk-..."
+# The secrets stay commented so the environment wins by default. A value set
+# here overrides ONYX_API_KEY / TF_VAR_openai_api_key, so a placeholder left
+# in place would be sent as though it were a real key.
+#
+#   export ONYX_API_KEY="$(./mint_api_key.sh)"
+#   export TF_VAR_openai_api_key="sk-..."
+#
+# Uncomment instead to keep them in this file.
+#
+# onyx_api_key   = "on_..."
+# openai_api_key = "sk-..."
 
 company_name  = "ACME Corp"
 docs_base_url = "https://docs.onyx.app"

--- a/terraform-provider-onyx/examples/bootstrap/terraform.tfvars.example
+++ b/terraform-provider-onyx/examples/bootstrap/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Copy to terraform.tfvars and fill in. Keep terraform.tfvars out of version
+# control: it holds secrets.
+
+onyx_server_url = "http://localhost:8080"
+onyx_api_key    = "on_..."
+
+openai_api_key = "sk-..."
+
+company_name  = "ACME Corp"
+docs_base_url = "https://docs.onyx.app"
+
+# Enterprise Edition only.
+enable_enterprise_features = false

--- a/terraform-provider-onyx/examples/bootstrap/variables.tf
+++ b/terraform-provider-onyx/examples/bootstrap/variables.tf
@@ -1,0 +1,36 @@
+variable "onyx_server_url" {
+  type        = string
+  description = "Base URL of the Onyx deployment, for example https://onyx.example.com. Falls back to ONYX_SERVER_URL."
+  default     = null
+}
+
+variable "onyx_api_key" {
+  type        = string
+  description = "An Onyx API key in the Admin group. Falls back to ONYX_API_KEY. Run ./mint_api_key.sh to create one."
+  sensitive   = true
+  default     = null
+}
+
+variable "openai_api_key" {
+  type        = string
+  description = "OpenAI API key for the chat model."
+  sensitive   = true
+}
+
+variable "company_name" {
+  type        = string
+  description = "Workspace name shown in the Onyx UI."
+  default     = "ACME Corp"
+}
+
+variable "docs_base_url" {
+  type        = string
+  description = "Public documentation site to index."
+  default     = "https://docs.onyx.app"
+}
+
+variable "enable_enterprise_features" {
+  type        = bool
+  description = "Set true only on a deployment with Enterprise Edition enabled. Community Edition rejects the user group routes."
+  default     = false
+}

--- a/terraform-provider-onyx/main.go
+++ b/terraform-provider-onyx/main.go
@@ -12,7 +12,9 @@ import (
 )
 
 // Docs generate from schema descriptions + examples/ (needs terraform CLI).
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest generate
+// Pinned: CI fails on any docs/ diff, and an unpinned generator would move that
+// output on its own.
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 generate
 
 // version is set via ldflags on release builds.
 var version = "dev"


### PR DESCRIPTION
## Description

The provider's acceptance suite has never run in CI.

`pr-golang-tests.yml` discovers every `go.mod` and runs `go test -race ./...`, which leaves `TF_ACC` unset — so every acceptance test skips there. Six PRs' worth of real coverage, each resource driven end to end through plan/apply/destroy against live API routes, has only ever run locally against one dev stack. This adds the lane that runs it.

`pr-terraform-provider-tests.yml` follows the shape of `pr-craft-compose-integration.yml`: a `changes` gate, a prebuilt backend image, the test matrix, and one `terraform-provider-required` status check that always runs so branch protection has a stable target.

**The stack is `api_server` + `background` from docker compose.** The suite needs Enterprise Edition and it needs celery — several resources only settle once the sync gate marks them up to date, and beat schedules the task that moves that gate. `background` runs supervisord, which already starts `celery_beat`, `celery_worker_primary` and `celery_worker_light`, so no worker is launched by hand. A readiness step asserts all three report `RUNNING`, because a missing beat otherwise surfaces much later as an unexplained test timeout rather than a clear failure.

**Two auth legs.** `bootstrap` lets the harness mint its own key. `api-key` mints one first with the new `examples/bootstrap/mint_api_key.sh` and passes it in, covering the `ONYX_TF_ACC_API_KEY` path a user actually takes — the path nothing exercised, and the one that let #14299 ship a test that failed outright under it. The leg fails closed if minting returns nothing, since an empty key would send the harness down its own bootstrap path and pass while testing the other leg.

**Also here:**

- `examples/bootstrap/` — a day-one configuration that applies as it stands: settings, an LLM provider and default, a web credential/connector/pair, a document set, and an agent that answers from it. The EE user group sits behind a variable that is off by default. `mint_api_key.sh` documents the register → log in → resolve the Admin group → mint sequence, since a key with no group is refused by every admin route.
- `go:generate` ran `tfplugindocs@latest`, so the generated pages could move with no change on our side. Pinned to `v0.25.0`, which is what makes the new `docs-check` job meaningful. It immediately caught real drift: `docs/resources/api_key.md` was hand-edited by #14029 rather than regenerated, leaving `group_ids` outside the generator's sort order.

**Two things worth knowing before merging:**

- This PR is the lane's first real execution. The compose recipe was verified by resolving the config rather than by `up`, so image build, runner labels and ECR access get tested here for the first time.
- Merging does not make the check gate anything. Adding `terraform-provider-required` does not add it to branch protection — that is a separate repo-admin setting. Until someone adds it, the lane reports but cannot block a merge.

## How Has This Been Tested?

- **The whole 35-test acceptance suite run locally through the `ONYX_TF_ACC_API_KEY` path** — the leg this PR adds — green in 203s, using a key minted by the new script.
- `mint_api_key.sh` run against a live deployment; the resulting key verified against two admin routes to confirm the group assignment actually carries permission, which is the part that fails silently.
- The compose recipe verified by resolving the config both with and without the lane's `.env`, confirming the EE flag reaches **both** `api_server` and `background`. `env.template` sets it to `false`, so this was worth proving rather than assuming.
- `docs-check` simulated locally against three states: clean, an edited page, and an untracked new page.
- `examples/bootstrap/` validated against the real provider schema via `dev_overrides`.
- `go build`, `go test ./...` and `go mod tidy` all clean; pre-commit passes, including actionlint, zizmor, shellcheck, terraform fmt and ripsecrets.

A re-review pass before opening found four gaps, the worst of them in the new check itself: `git diff --exit-code docs/` does not see untracked files, so a new resource's generated page — the likeliest drift of all — passed silently. Fixed to `git status --porcelain` and verified against all three states. The other three were timing: the celery loop was too short (`background` declares no healthcheck, so `--wait` returns on container start), the step timeout raced `go test -timeout`, and the job timeout sat below the sum of its own steps.

Linear: [ENG-4322](https://linear.app/onyx-app/issue/ENG-4322/terraform-provider-for-onyx-rollout-plan)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- Override Linear Check: this is PR 7 of the nine-PR rollout tracked by the
     umbrella issue ENG-4322, which covers the whole series rather than one
     issue per PR. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI lane that runs the Terraform provider's acceptance suite against a real Onyx stack; the existing Go test lane leaves `TF_ACC` unset, so the acceptance tests only ever ran locally before.

**CI**
- New `pr-terraform-provider-tests.yml` stands up `api_server` and `background` from docker compose and runs the suite under two auth legs: harness-bootstrapped key and a key minted first via `examples/bootstrap/mint_api_key.sh`.
- The model server image now pulls through the ECR cache instead of Docker Hub, and a redundant `api_server` health probe was dropped since compose's `up --wait` already guarantees it.
- A `docs-check` job regenerates `docs/` and fails on any drift; its first run caught hand-edit drift in `docs/resources/api_key.md`.
- The `terraform-provider-required` status check reports but does not gate merges until branch protection is updated separately.
- PRs only trigger the suite for provider and compose changes; the nightly run catches backend changes that break the provider.

**Bootstrap example**
- `examples/bootstrap/` is a runnable day-one config — chat model, one indexed site, document set, and agent — that applies as it stands; the Enterprise user group stays behind an off-by-default variable.
- `mint_api_key.sh` now requires admin credentials instead of defaulting them, since the first user on an empty deployment becomes an admin; `terraform.tfvars.example` leaves secrets commented out so a placeholder can't be sent as a real key.
- The API-key CI leg fails closed on an empty key; `supervisorctl` is now passed `-c` explicitly after the first run's false celery-readiness failure.
- `tfplugindocs` is pinned to `v0.25.0` so the docs generator can't move generated output on its own.

Part of the ENG-4322 Terraform provider rollout.

<sup>Written for commit f7acb41b88d7c7d1f207d6ec7ea0710d0f7512ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Review response

**Taken (4 of 5).**

- **`mint_api_key.sh` defaulted to the repo's e2e credentials.** Right for CI, wrong for the path the README shows users: against an empty, reachable deployment it registered `admin_user@example.com` with a published password, and the first user to register becomes an admin. Both credentials are now required, with the reason given at the point of failure; CI passes them explicitly.
- **The same script swallowed every registration failure,** so a deployment problem resurfaced later as a misleading "login failed". An existing account still answers 400 and is still ignored; anything else is reported with its body.
- **`terraform.tfvars.example` shipped live placeholder secrets.** A value there beats the `ONYX_API_KEY` the README tells you to export, so a leftover `on_...` would be sent as if it were a real key. The secrets are commented out, so the environment wins until someone deliberately fills them in.
- **The concurrency group fell back to `github.run_id`,** unique per run, so nightly, tag and dispatch runs never cancelled a duplicate of a heavy suite. `github.ref_name` is stable for those.

**Not taken (1 of 5): enumerating every `celery_worker_*` in the readiness gate.**

The suite needs exactly three programs, and the gate names them deliberately. `celery_beat` clears the sync gate that `onyx_user_group` and `onyx_document_set` wait on; `celery_worker_primary` dispatches the deletion checks the api_server queues; `celery_worker_light` runs the deletions and the document-set sync. The other five cover indexing, docfetching and permission sync, which these tests never reach — the pair tests use `mock_connector`, which short-circuits connector validation. The full suite passes locally against exactly these three with no other worker running, so gating on all eight would fail this lane for workers it does not use.

The accompanying claim that the gate "can pass with workers still starting" is also not the case: it requires all three to report `RUNNING`, so a `STARTING` program keeps it looping.

The gate did, however, have a real bug of its own, which the first CI run exposed — see below.

## First CI run

The stack came up correctly on the first attempt: image pull and retag, compose `up --wait`, migrations, api_server healthy, and all nine supervisord programs `RUNNING` at 21:45:20.

The readiness gate then failed it anyway, for five minutes, on a perfectly healthy stack — a false negative, and worse than no gate. `supervisorctl` answered `http://localhost:9001 refused connection` because it searches `<exec>/etc/supervisord.conf`, `./supervisord.conf`, `./etc/supervisord.conf`, `/etc/supervisord.conf` and `/etc/supervisor/supervisord.conf`, while the image installs the file at `/etc/supervisor/conf.d/supervisord.conf`. It is also not symlinked into `/usr/bin` the way `supervisord` is, so the `/usr/etc` copy is unreachable too. With no config it falls back to its built-in inet server, which nothing listens on. Now passed `-c` explicitly, the same path the entrypoint uses, with stderr folded into the captured output.


## Second review round

Both points taken.

**@jmelahman — the api_server health check was redundant.** `up --wait` cannot return until that service is healthy, and its healthcheck is literally `python -c "urllib.request.urlopen('http://localhost:8080/health')"` — the same endpoint the step was curling. Removed.

**The model servers were the one part of the stack still pulling from Docker Hub.** Everything else in the compose file is written as `${BASE_IMAGE_REGISTRY:-docker.io}/...`, and the ECR login step exports that variable, so postgres, redis, opensearch, minio and nginx already resolve through the pull-through cache. The model server default carries no registry at all, so the two largest images in the stack came down anonymously against a shared rate limit — about a minute per leg in the run above. `ONYX_MODEL_SERVER_IMAGE` now points at the cache.

For the record, the lane went green before these two changes: both acceptance legs passed, `internal/provider` in 246s (bootstrap) and 273s (api-key), with the celery gate clearing in under a second.
