### PR TITLE
chore(web): give Opal's hooks a barrel

### DIFF
--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -49,6 +49,10 @@
       "types": "./dist/logos/index.d.ts",
       "import": "./dist/logos/index.js"
     },
+    "./hooks": {
+      "types": "./dist/hooks/index.d.ts",
+      "import": "./dist/hooks/index.js"
+    },
     "./time": {
       "types": "./dist/time.d.ts",
       "import": "./dist/time.js"

--- a/web/lib/opal/src/hooks/index.ts
+++ b/web/lib/opal/src/hooks/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The entry point for Opal's hooks.
+ *
+ * Each hook is declared as a default export in its own file; this names them
+ * so callers outside Opal import from `@opal/hooks` rather than reaching for
+ * the file. Opal's own files keep importing each other directly — a sibling
+ * reaching back through the barrel is a cycle.
+ */
+
+export { default as useContainerCenter } from "@opal/hooks/useContainerCenter";
+export { default as useFocusOnMount } from "@opal/hooks/useFocusOnMount";
+export { default as useOnMount } from "@opal/hooks/useOnMount";
+export {
+  default as useScreenSize,
+  type ScreenSize,
+} from "@opal/hooks/useScreenSize";

--- a/web/lib/opal/tsup.config.ts
+++ b/web/lib/opal/tsup.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     "src/icons/index.ts",
     "src/illustrations/index.ts",
     "src/logos/index.ts",
+    "src/hooks/index.ts",
     "src/time.ts",
     "src/types.ts",
     "src/utils.ts",

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -2,7 +2,7 @@ import { SvgDownload, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { Interactive, Hoverable } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
 import { Button, InputTextArea } from "@opal/components";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import Text from "@/refresh-components/texts/Text";
 import { CopyButton } from "@opal/components";
 import { BasicModalFooter, Modal } from "@opal/components";

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import isEqual from "lodash/isEqual";
 import {
   Button,

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import { useRouter } from "next/navigation";
 import isEqual from "lodash/isEqual";
 import {

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -18,7 +18,7 @@ import type { Route } from "next";
 import { StandardAnswer, StandardAnswerCategory } from "@/lib/types";
 import { SvgSearch } from "@opal/icons";
 import { useState, JSX } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { deleteStandardAnswer } from "./lib";

--- a/web/src/lib/projects/components/FoldedProjectsPopover.tsx
+++ b/web/src/lib/projects/components/FoldedProjectsPopover.tsx
@@ -15,7 +15,7 @@ import {
   SidebarTab,
   useCreateModal,
 } from "@opal/components";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import { Section } from "@opal/layouts";
 import { SvgFolder, SvgFolderPlus } from "@opal/icons";
 import { useAppRouter } from "@/hooks/appNavigation";

--- a/web/src/lib/tools/components/SwitchList.tsx
+++ b/web/src/lib/tools/components/SwitchList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import {
   Button,
   InputTypeIn,

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -2,7 +2,7 @@
 
 import { FILE_READER_TOOL_ID, SEARCH_TOOL_ID } from "@/lib/tools/constants";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import { InputTypeIn, Button, Popover, PopoverMenu } from "@opal/components";
 import { SvgActions, SvgKey, SvgSliders, SvgSimpleLoader } from "@opal/icons";
 import SwitchList, { SwitchListItem } from "@/lib/tools/components/SwitchList";

--- a/web/src/refresh-components/buttons/ButtonRenaming.tsx
+++ b/web/src/refresh-components/buttons/ButtonRenaming.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import { handleEnterPress, useEscapePress } from "@/lib/typingUtils";
 import { UNNAMED_CHAT } from "@/lib/constants";
 import { cn } from "@opal/utils";

--- a/web/src/refresh-components/commandmenu/CommandMenu.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
   useMemo,
 } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import useContainerCenter from "@/hooks/useContainerCenter";

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { Modal } from "@opal/components";

--- a/web/src/sections/sidebar/ChatButton.tsx
+++ b/web/src/sections/sidebar/ChatButton.tsx
@@ -22,7 +22,7 @@ import ShareChatSessionModal from "@/sections/modals/ShareChatSessionModal";
 import { Button, LineItemButton, SidebarTab } from "@opal/components";
 import { InputTypeIn } from "@opal/components";
 import { Hoverable } from "@opal/core";
-import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useFocusOnMount } from "@opal/hooks";
 import { DRAG_TYPES, LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
 import {
   shouldShowMoveModal,


### PR DESCRIPTION
## Description

`hooks` was the only importable directory in Opal without a barrel, so `@opal/hooks`
resolved to nothing and every caller had to name the file:

```ts
import useFocusOnMount from "@opal/hooks/useFocusOnMount";
```

`components`, `core`, `icons`, `illustrations`, `layouts` and `logos` all have one.
This adds the seventh.

The hooks stay default exports in their own files, so the barrel names them on the way
out. `ScreenSize` comes along as `useScreenSize`'s return type; `ContainerCenter` does
not, since it is declared but never exported from its own file.

12 call sites in `src/` move to `import { useFocusOnMount } from "@opal/hooks"`.

Opal's own 8 imports are left alone. Two of them are `hooks/` siblings —
`useContainerCenter` reads `useScreenSize`, `useScreenSize` reads `useOnMount` — so
routing those through the barrel would be a cycle. The rest are Opal-internal, where a
package reaching through its own public entry buys nothing.

Worth setting expectations on the diff: `useFocusOnMount` is the only Opal hook anything
outside Opal uses today, so all 12 changed lines are the same import. The value is the
entry point existing, not the churn.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a barrel entry point for Opal's hooks and exports it as `@opal/hooks`, so callers can import from that subpath instead of naming the file directly. Migrates the 12 call sites that used `useFocusOnMount` to the new import; no runtime behavior changes.

- The barrel re-exports all four hooks, preserving their default exports and exporting `ScreenSize` as a type alongside `useScreenSize`.
- Opal's own hooks imports are left untouched to avoid a circular import between sibling hooks.

<sup>Written for commit d22ddf78d39446162d7c12d6c7517f2c0a479441. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

