### PR TITLE
feat(indexing): bake tree-sitter grammars into the image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -157,6 +157,17 @@ RUN python -c "import nltk; \
 RUN python -c "import tiktoken; \
 tiktoken.get_encoding('cl100k_base')"
 
+# Pre-downloading tree-sitter grammars for setups with limited egress. One
+# request caches an archive of every language, and each grammar is extracted
+# from it on demand, so a read-only /app/.cache needs a volume mounted there.
+# get_parser is the check: it raises if the archive did not arrive.
+RUN python -c "from tree_sitter_language_pack import get_parser, prefetch; \
+prefetch(['python']); \
+get_parser('python')"
+
+# The runtime user (uid 1001) reads everything cached above.
+RUN chown -R onyx:onyx /app/.cache /app/nltk_data
+
 # Set up application files
 WORKDIR /app
 
@@ -187,20 +198,6 @@ RUN chmod +x /app/scripts/supervisord_entrypoint.sh
 COPY --chown=onyx:onyx ./assets /app/assets
 
 ENV PYTHONPATH=/app
-
-# Pre-downloading tree-sitter grammars for setups with limited egress.
-# tree-sitter-language-pack ships none: the first call fetches one bundle for
-# every language, then extracts from it offline. The cache path embeds the
-# pack version, so the assertion fails the build when a bump leaves it stale.
-RUN python -c "import sys; \
-from onyx.connectors.cross_connector_utils.code_file_utils import DEFAULT_CODE_GRAMMARS; \
-from tree_sitter_language_pack import prefetch, downloaded_languages, cache_dir; \
-wanted = set(DEFAULT_CODE_GRAMMARS); \
-prefetch(sorted(wanted)); \
-missing = sorted(wanted - set(downloaded_languages())); \
-sys.exit(f'grammars missing from {cache_dir()}: {missing}') if missing else \
-print(f'cached {len(wanted)} grammars in {cache_dir()}')" && \
-    chown -R onyx:onyx /app/.cache /app/nltk_data
 
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -133,6 +133,16 @@ RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
+# Deployments run this image as uid 1001, and the default caches land under
+# /root (mode 700). Pin them to /app so one chown at the end covers them.
+# XDG_CACHE_HOME also drives huggingface_hub and tree-sitter-language-pack.
+ENV XDG_CACHE_HOME=/app/.cache \
+    NLTK_DATA=/app/nltk_data
+
+# nltk.download() only writes to a search path that already exists, and
+# silently falls back to /root/nltk_data otherwise.
+RUN mkdir -p /app/.cache /app/nltk_data
+
 # Pre-downloading models for setups with limited egress
 RUN python -c "from tokenizers import Tokenizer; \
 Tokenizer.from_pretrained('nomic-ai/nomic-embed-text-v1')"
@@ -177,6 +187,20 @@ RUN chmod +x /app/scripts/supervisord_entrypoint.sh
 COPY --chown=onyx:onyx ./assets /app/assets
 
 ENV PYTHONPATH=/app
+
+# Pre-downloading tree-sitter grammars for setups with limited egress.
+# tree-sitter-language-pack ships none: the first call fetches one bundle for
+# every language, then extracts from it offline. The cache path embeds the
+# pack version, so the assertion fails the build when a bump leaves it stale.
+RUN python -c "import sys; \
+from onyx.connectors.cross_connector_utils.code_file_utils import DEFAULT_CODE_GRAMMARS; \
+from tree_sitter_language_pack import prefetch, downloaded_languages, cache_dir; \
+wanted = set(DEFAULT_CODE_GRAMMARS); \
+prefetch(sorted(wanted)); \
+missing = sorted(wanted - set(downloaded_languages())); \
+sys.exit(f'grammars missing from {cache_dir()}: {missing}') if missing else \
+print(f'cached {len(wanted)} grammars in {cache_dir()}')" && \
+    chown -R onyx:onyx /app/.cache /app/nltk_data
 
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -134,39 +134,35 @@ RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     apt-get clean
 
 # Deployments run this image as uid 1001, and the default caches land under
-# /root (mode 700). Pin them to /app so one chown at the end covers them.
+# /root (mode 700). Pin them to /app so the runtime user can read them.
 # XDG_CACHE_HOME also drives huggingface_hub and tree-sitter-language-pack.
 ENV XDG_CACHE_HOME=/app/.cache \
     NLTK_DATA=/app/nltk_data
 
-# nltk.download() only writes to a search path that already exists, and
+# Pre-downloading models, NLTK data, and tree-sitter grammars for setups with
+# limited egress. One layer, ending in the chown that hands them to the runtime
+# user: chowning in a later layer rewrites every file, so the image would carry
+# a second copy of all of them.
+# mkdir: nltk.download() only writes to a search path that already exists, and
 # silently falls back to /root/nltk_data otherwise.
-RUN mkdir -p /app/.cache /app/nltk_data
-
-# Pre-downloading models for setups with limited egress
-RUN python -c "from tokenizers import Tokenizer; \
-Tokenizer.from_pretrained('nomic-ai/nomic-embed-text-v1')"
-
-# Pre-downloading NLTK for setups with limited egress
-RUN python -c "import nltk; \
-    nltk.download('stopwords', quiet=True); \
-    nltk.download('punkt_tab', quiet=True);"
+# tree-sitter caches one archive covering every language and extracts grammars
+# from it on demand, so a read-only /app/.cache needs a volume mounted there.
+# get_parser is the check: it raises if the archive did not arrive.
 # nltk.download('wordnet', quiet=True); introduce this back if lemmatization is needed
+RUN mkdir -p /app/.cache /app/nltk_data && \
+python -c "from tokenizers import Tokenizer; \
+Tokenizer.from_pretrained('nomic-ai/nomic-embed-text-v1')" && \
+python -c "import nltk; \
+nltk.download('stopwords', quiet=True); \
+nltk.download('punkt_tab', quiet=True);" && \
+python -c "from tree_sitter_language_pack import get_parser, prefetch; \
+prefetch(['python']); \
+get_parser('python')" && \
+chown -R onyx:onyx /app/.cache /app/nltk_data
 
 # Pre-downloading tiktoken for setups with limited egress
 RUN python -c "import tiktoken; \
 tiktoken.get_encoding('cl100k_base')"
-
-# Pre-downloading tree-sitter grammars for setups with limited egress. One
-# request caches an archive of every language, and each grammar is extracted
-# from it on demand, so a read-only /app/.cache needs a volume mounted there.
-# get_parser is the check: it raises if the archive did not arrive.
-RUN python -c "from tree_sitter_language_pack import get_parser, prefetch; \
-prefetch(['python']); \
-get_parser('python')"
-
-# The runtime user (uid 1001) reads everything cached above.
-RUN chown -R onyx:onyx /app/.cache /app/nltk_data
 
 # Set up application files
 WORKDIR /app

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -62,10 +62,13 @@ def infer_code_language(file_path: str | None) -> str | None:
     registry plus the extensionless names it does not cover. None when the
     path is empty or nothing matches.
 
-    A grammar lookup, not a code-vs-prose judgment: prose formats with
-    grammars (e.g. .md -> markdown) return that grammar. Callers decide what
-    to exclude — they subtract their own document extensions and
-    NON_CODE_LANGUAGES, and call `is_sensitive_code_file` themselves.
+    The prose and tabular grammars in NON_CODE_LANGUAGES are subtracted, so
+    the answer is a code language. Everything else is a grammar lookup rather
+    than a code-vs-prose judgment: markdown has a grammar and returns it, so
+    connectors that keep prose out of code indexing still subtract their own
+    document extensions (e.g. the GitHub connector's docs set). Whether the
+    file holds credentials is a separate question — ask
+    `is_sensitive_code_file`.
     """
     if not file_path:
         return None
@@ -78,7 +81,8 @@ def infer_code_language(file_path: str | None) -> str | None:
     # Local import: keeps the language pack off the connector import path.
     from tree_sitter_language_pack import detect_language_from_path
 
-    return detect_language_from_path(file_path)
+    language = detect_language_from_path(file_path)
+    return None if language in NON_CODE_LANGUAGES else language
 
 
 def is_sensitive_code_file(file_path: str | None) -> bool:

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -39,15 +39,12 @@ SENSITIVE_FILE_PATTERNS = (
     "*.kdbx",
 )
 
-# Grammars the pack resolves for prose and tabular formats. They parse, but
-# their chunk boundaries mean nothing for retrieval, and .csv/.tsv have a
-# TabularSection path built for them. Subtracted so each connector does not
-# have to rediscover that .txt resolves to the Vim help-file grammar.
+# Formats the pack has grammars for but that are not code: .txt resolves to
+# the Vim help-file grammar, and .csv/.tsv have a TabularSection path.
 NON_CODE_LANGUAGES = frozenset({"vimdoc", "rst", "csv", "tsv"})
 
 
-# The pack's registry is extension-only, so the canonical extensionless names
-# resolve to nothing even though their grammars ship with it.
+# The pack's registry is extension-only, so these resolve to nothing.
 BASENAME_LANGUAGES = {
     "makefile": "make",
     "gnumakefile": "make",
@@ -76,7 +73,6 @@ def infer_code_language(file_path: str | None) -> str | None:
     known = BASENAME_LANGUAGES.get(basename)
     if known is not None:
         return known
-    # Dockerfile.dev / Dockerfile.prod and the like.
     if basename.startswith("dockerfile."):
         return "dockerfile"
     # Local import: keeps the language pack off the connector import path.

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -39,6 +39,47 @@ SENSITIVE_FILE_PATTERNS = (
     "*.kdbx",
 )
 
+# Grammars the image build extracts ahead of time. Anything outside this set
+# still extracts on demand from the same bundle. Names are checked against the
+# pack's manifest by a unit test.
+DEFAULT_CODE_GRAMMARS = (
+    "bash",
+    "c",
+    "cpp",
+    "csharp",
+    "css",
+    "dockerfile",
+    "go",
+    "gomod",
+    "graphql",
+    "hcl",
+    "html",
+    "ini",
+    "java",
+    "javascript",
+    "json",
+    "kotlin",
+    "lua",
+    "make",
+    "markdown",
+    "php",
+    "powershell",
+    "proto",
+    "python",
+    "ruby",
+    "rust",
+    "scala",
+    "scss",
+    "sql",
+    "swift",
+    "terraform",
+    "toml",
+    "tsx",
+    "typescript",
+    "xml",
+    "yaml",
+)
+
 
 def infer_code_language(file_path: str | None) -> str | None:
     """Grammar name for a path, from tree-sitter-language-pack's extension

--- a/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/code_file_utils.py
@@ -39,59 +39,46 @@ SENSITIVE_FILE_PATTERNS = (
     "*.kdbx",
 )
 
-# Grammars the image build extracts ahead of time. Anything outside this set
-# still extracts on demand from the same bundle. Names are checked against the
-# pack's manifest by a unit test.
-DEFAULT_CODE_GRAMMARS = (
-    "bash",
-    "c",
-    "cpp",
-    "csharp",
-    "css",
-    "dockerfile",
-    "go",
-    "gomod",
-    "graphql",
-    "hcl",
-    "html",
-    "ini",
-    "java",
-    "javascript",
-    "json",
-    "kotlin",
-    "lua",
-    "make",
-    "markdown",
-    "php",
-    "powershell",
-    "proto",
-    "python",
-    "ruby",
-    "rust",
-    "scala",
-    "scss",
-    "sql",
-    "swift",
-    "terraform",
-    "toml",
-    "tsx",
-    "typescript",
-    "xml",
-    "yaml",
-)
+# Grammars the pack resolves for prose and tabular formats. They parse, but
+# their chunk boundaries mean nothing for retrieval, and .csv/.tsv have a
+# TabularSection path built for them. Subtracted so each connector does not
+# have to rediscover that .txt resolves to the Vim help-file grammar.
+NON_CODE_LANGUAGES = frozenset({"vimdoc", "rst", "csv", "tsv"})
+
+
+# The pack's registry is extension-only, so the canonical extensionless names
+# resolve to nothing even though their grammars ship with it.
+BASENAME_LANGUAGES = {
+    "makefile": "make",
+    "gnumakefile": "make",
+    "dockerfile": "dockerfile",
+    "containerfile": "dockerfile",
+    "cmakelists.txt": "cmake",
+    "gemfile": "ruby",
+    "rakefile": "ruby",
+    "brewfile": "ruby",
+}
 
 
 def infer_code_language(file_path: str | None) -> str | None:
     """Grammar name for a path, from tree-sitter-language-pack's extension
-    registry. None when the path is empty or the extension is unknown.
+    registry plus the extensionless names it does not cover. None when the
+    path is empty or nothing matches.
 
     A grammar lookup, not a code-vs-prose judgment: prose formats with
     grammars (e.g. .md -> markdown) return that grammar. Callers decide what
-    to exclude — connectors subtract their own document extensions, and both
-    connectors and the chunker call `is_sensitive_code_file` themselves.
+    to exclude — they subtract their own document extensions and
+    NON_CODE_LANGUAGES, and call `is_sensitive_code_file` themselves.
     """
     if not file_path:
         return None
+    basename = PurePosixPath(file_path.replace("\\", "/")).name.lower()
+    known = BASENAME_LANGUAGES.get(basename)
+    if known is not None:
+        return known
+    # Dockerfile.dev / Dockerfile.prod and the like.
+    if basename.startswith("dockerfile."):
+        return "dockerfile"
     # Local import: keeps the language pack off the connector import path.
     from tree_sitter_language_pack import detect_language_from_path
 

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -22,15 +22,10 @@ from onyx.utils.text_processing import clean_code_text
 
 logger = setup_logger()
 
-# Loading a grammar the pack has not cached makes it fetch its bundle, and a
-# firewalled network drops those packets rather than refusing them, so the
-# attempt blocks until timeout (60s in testing). That cost is per call and the
-# cause is shared — one unreachable bundle fails every language — so back off
-# across all of them rather than per language. A grammar that is merely absent
-# fails fast and locally, and has_language() already filters unknown names.
-#
-# Module-level because a Chunker is built per document batch, and shared
-# across worker threads, which the breaker is built for.
+# An uncached grammar makes the pack fetch its archive, which on a firewalled
+# network blocks until timeout (60s in testing). One archive serves every
+# language, so the failure is shared and the breaker covers all loads.
+# Module-level: a Chunker is built per document batch.
 _GRAMMAR_LOADS = CircuitBreaker()
 
 

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -21,6 +21,14 @@ from onyx.utils.text_processing import clean_code_text
 
 logger = setup_logger()
 
+# Grammars whose load already failed in this process. The pack fetches its
+# bundle on the first miss, and a firewalled network drops those packets
+# rather than refusing them, so each attempt blocks until timeout (60s in
+# testing). Without this an unreachable bundle costs one timeout per file.
+# Process-wide because a Chunker is built per document batch. Holds only
+# language names, so unlike the splitter cache it is safe to share.
+_UNAVAILABLE_GRAMMARS: set[str] = set()
+
 
 class _CodeSpan(NamedTuple):
     """One syntax-bounded slice of a code section, and the 1-based line range
@@ -203,6 +211,9 @@ class CodeChunker(SectionChunker):
             )
             return None
 
+        if language in _UNAVAILABLE_GRAMMARS:
+            return None
+
         try:
             splitter = ChonkieCodeChunker(
                 tokenizer_or_token_counter=(
@@ -213,9 +224,12 @@ class CodeChunker(SectionChunker):
                 return_type="texts",
             )
         except Exception:
+            _UNAVAILABLE_GRAMMARS.add(language)
             logger.warning(
-                "Could not load the tree-sitter grammar for language=%s; "
-                "falling back to token splitting.",
+                "Could not load the tree-sitter grammar for language=%s; falling "
+                "back to token splitting for the rest of this process. Grammars "
+                "are extracted from a bundle the image build caches, so this "
+                "means that cache is missing or not writable.",
                 language,
                 exc_info=True,
             )

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -16,18 +16,22 @@ from onyx.indexing.chunking.section_chunker import (
     build_payloads,
 )
 from onyx.natural_language_processing.utils import BaseTokenizer, count_tokens
+from onyx.utils.circuit_breaker import CircuitBreaker
 from onyx.utils.logger import setup_logger
 from onyx.utils.text_processing import clean_code_text
 
 logger = setup_logger()
 
-# Grammars whose load already failed in this process. The pack fetches its
-# bundle on the first miss, and a firewalled network drops those packets
-# rather than refusing them, so each attempt blocks until timeout (60s in
-# testing). Without this an unreachable bundle costs one timeout per file.
-# Process-wide because a Chunker is built per document batch. Holds only
-# language names, so unlike the splitter cache it is safe to share.
-_UNAVAILABLE_GRAMMARS: set[str] = set()
+# Loading a grammar the pack has not cached makes it fetch its bundle, and a
+# firewalled network drops those packets rather than refusing them, so the
+# attempt blocks until timeout (60s in testing). That cost is per call and the
+# cause is shared — one unreachable bundle fails every language — so back off
+# across all of them rather than per language. A grammar that is merely absent
+# fails fast and locally, and has_language() already filters unknown names.
+#
+# Module-level because a Chunker is built per document batch, and shared
+# across worker threads, which the breaker is built for.
+_GRAMMAR_LOADS = CircuitBreaker()
 
 
 class _CodeSpan(NamedTuple):
@@ -211,7 +215,7 @@ class CodeChunker(SectionChunker):
             )
             return None
 
-        if language in _UNAVAILABLE_GRAMMARS:
+        if _GRAMMAR_LOADS.is_open:
             return None
 
         try:
@@ -224,16 +228,18 @@ class CodeChunker(SectionChunker):
                 return_type="texts",
             )
         except Exception:
-            _UNAVAILABLE_GRAMMARS.add(language)
-            logger.warning(
+            failures = _GRAMMAR_LOADS.record_failure()
+            log = logger.warning if failures == 1 else logger.debug
+            log(
                 "Could not load the tree-sitter grammar for language=%s; falling "
-                "back to token splitting for the rest of this process. Grammars "
+                "back to token splitting for now. Grammars "
                 "are extracted from a bundle the image build caches, so this "
                 "means that cache is missing or not writable.",
                 language,
-                exc_info=True,
+                exc_info=failures == 1,
             )
             return None
 
+        _GRAMMAR_LOADS.record_success()
         self._splitters[language] = _CachedSplitter(content_token_limit, splitter)
         return splitter

--- a/backend/onyx/indexing/chunking/code_section_chunker.py
+++ b/backend/onyx/indexing/chunking/code_section_chunker.py
@@ -211,6 +211,11 @@ class CodeChunker(SectionChunker):
             return None
 
         if _GRAMMAR_LOADS.is_open:
+            logger.debug(
+                "Grammar loading is suppressed after repeated failures; "
+                "token splitting language=%s",
+                language,
+            )
             return None
 
         try:
@@ -224,7 +229,13 @@ class CodeChunker(SectionChunker):
             )
         except Exception:
             failures = _GRAMMAR_LOADS.record_failure()
-            log = logger.warning if failures == 1 else logger.debug
+            # Warn on the first failure and again when the breaker opens: an
+            # open breaker degrades every language to token splitting.
+            log = (
+                logger.warning
+                if failures in (1, _GRAMMAR_LOADS.failures_before_open)
+                else logger.debug
+            )
             log(
                 "Could not load the tree-sitter grammar for language=%s; falling "
                 "back to token splitting for now. Grammars "

--- a/backend/onyx/utils/circuit_breaker.py
+++ b/backend/onyx/utils/circuit_breaker.py
@@ -1,0 +1,57 @@
+import threading
+import time
+
+
+class CircuitBreaker:
+    """Stops calling something that keeps failing, backing off exponentially.
+
+    For work that is expensive to fail rather than expensive to do: an
+    unreachable host that drops packets costs a full timeout per attempt, so
+    the useful thing is to stop asking for a while, not to retry harder.
+
+    Opens after `failures_before_open` consecutive failures and stays open for
+    a delay that doubles with each further failure, capped at `max_delay`. Any
+    success closes it, so an isolated failure among healthy calls never opens
+    it. Callers decide what to do while it is open; the breaker only answers
+    whether to try.
+
+    Thread-safe, so one instance can be shared across a worker's threads.
+    """
+
+    def __init__(
+        self,
+        *,
+        failures_before_open: int = 3,
+        base_delay: float = 60.0,
+        max_delay: float = 6 * 60 * 60,
+    ) -> None:
+        self._failures_before_open = failures_before_open
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._last_failure_at = 0.0
+
+    @property
+    def is_open(self) -> bool:
+        """True while the caller should skip the call rather than retry it."""
+        with self._lock:
+            if self._consecutive_failures < self._failures_before_open:
+                return False
+            return time.monotonic() - self._last_failure_at < self._delay()
+
+    def record_failure(self) -> int:
+        """Count a failure; return how many have happened in a row."""
+        with self._lock:
+            self._consecutive_failures += 1
+            self._last_failure_at = time.monotonic()
+            return self._consecutive_failures
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._consecutive_failures = 0
+
+    def _delay(self) -> float:
+        """Backoff for the current failure count. Caller holds the lock."""
+        doublings = self._consecutive_failures - self._failures_before_open
+        return min(self._base_delay * 2**doublings, self._max_delay)

--- a/backend/onyx/utils/circuit_breaker.py
+++ b/backend/onyx/utils/circuit_breaker.py
@@ -25,7 +25,7 @@ class CircuitBreaker:
         base_delay: float = 60.0,
         max_delay: float = 6 * 60 * 60,
     ) -> None:
-        self._failures_before_open = failures_before_open
+        self.failures_before_open = failures_before_open
         self._base_delay = base_delay
         self._max_delay = max_delay
         self._lock = threading.Lock()
@@ -36,7 +36,7 @@ class CircuitBreaker:
     def is_open(self) -> bool:
         """True while the caller should skip the call rather than retry it."""
         with self._lock:
-            if self._consecutive_failures < self._failures_before_open:
+            if self._consecutive_failures < self.failures_before_open:
                 return False
             return time.monotonic() - self._last_failure_at < self._delay()
 
@@ -53,5 +53,5 @@ class CircuitBreaker:
 
     def _delay(self) -> float:
         """Backoff for the current failure count. Caller holds the lock."""
-        doublings = self._consecutive_failures - self._failures_before_open
+        doublings = self._consecutive_failures - self.failures_before_open
         return min(self._base_delay * 2**doublings, self._max_delay)

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
@@ -2,6 +2,7 @@ import pytest
 from tree_sitter_language_pack import manifest_languages
 
 from onyx.connectors.cross_connector_utils.code_file_utils import (
+    DEFAULT_CODE_GRAMMARS,
     SENSITIVE_FILE_LANGUAGES,
     infer_code_language,
     is_sensitive_code_file,
@@ -14,6 +15,19 @@ def test_sensitive_languages_are_real_grammars() -> None:
     manifest = set(manifest_languages())
     unknown = SENSITIVE_FILE_LANGUAGES - manifest
     assert not unknown, f"Not grammars in tree-sitter-language-pack: {unknown}"
+
+
+def test_default_grammars_are_real_grammars() -> None:
+    """A name that is not a grammar is prefetched as a no-op, so the worker
+    would still download that language at index time. Fail here instead."""
+    manifest = set(manifest_languages())
+    unknown = set(DEFAULT_CODE_GRAMMARS) - manifest
+    assert not unknown, f"Not grammars in tree-sitter-language-pack: {unknown}"
+
+
+def test_default_grammars_exclude_credential_formats() -> None:
+    """Prefetching a guarded grammar would suggest those files are indexable."""
+    assert not set(DEFAULT_CODE_GRAMMARS) & SENSITIVE_FILE_LANGUAGES
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_code_file_utils.py
@@ -2,7 +2,6 @@ import pytest
 from tree_sitter_language_pack import manifest_languages
 
 from onyx.connectors.cross_connector_utils.code_file_utils import (
-    DEFAULT_CODE_GRAMMARS,
     SENSITIVE_FILE_LANGUAGES,
     infer_code_language,
     is_sensitive_code_file,
@@ -12,22 +11,8 @@ from onyx.connectors.cross_connector_utils.code_file_utils import (
 def test_sensitive_languages_are_real_grammars() -> None:
     """A pack upgrade that renames a guarded grammar would make its entry
     dead — and credential files would silently start indexing. Fail here."""
-    manifest = set(manifest_languages())
-    unknown = SENSITIVE_FILE_LANGUAGES - manifest
+    unknown = SENSITIVE_FILE_LANGUAGES - set(manifest_languages())
     assert not unknown, f"Not grammars in tree-sitter-language-pack: {unknown}"
-
-
-def test_default_grammars_are_real_grammars() -> None:
-    """A name that is not a grammar is prefetched as a no-op, so the worker
-    would still download that language at index time. Fail here instead."""
-    manifest = set(manifest_languages())
-    unknown = set(DEFAULT_CODE_GRAMMARS) - manifest
-    assert not unknown, f"Not grammars in tree-sitter-language-pack: {unknown}"
-
-
-def test_default_grammars_exclude_credential_formats() -> None:
-    """Prefetching a guarded grammar would suggest those files are indexable."""
-    assert not set(DEFAULT_CODE_GRAMMARS) & SENSITIVE_FILE_LANGUAGES
 
 
 @pytest.mark.parametrize(
@@ -104,3 +89,32 @@ def test_credential_files_are_refused(path: str) -> None:
 def test_ordinary_files_are_not_refused(path: str) -> None:
     """The patterns must not swallow normal source files."""
     assert is_sensitive_code_file(path) is False
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("Makefile", "make"),
+        ("GNUmakefile", "make"),
+        ("Dockerfile", "dockerfile"),
+        ("Dockerfile.dev", "dockerfile"),
+        ("Containerfile", "dockerfile"),
+        ("CMakeLists.txt", "cmake"),
+        ("Gemfile", "ruby"),
+        ("deep/dir/Makefile", "make"),
+    ],
+)
+def test_extensionless_code_files_resolve(path: str, expected: str) -> None:
+    """The pack's registry is extension-only, so these canonical names —
+    which is how repositories actually spell them — resolve to nothing
+    without the basename map."""
+    assert infer_code_language(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path", ["a.txt", "requirements.txt", "a.csv", "a.tsv", "a.rst"]
+)
+def test_prose_and_tabular_files_are_not_code(path: str) -> None:
+    """.txt resolves to the Vim help-file grammar and .csv/.tsv have their own
+    tabular path; chunking them as code produces meaningless boundaries."""
+    assert infer_code_language(path) is None

--- a/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
@@ -8,6 +8,7 @@ from onyx.connectors.models import (
 )
 from onyx.indexing.chunking import DocumentChunker, code_section_chunker
 from onyx.indexing.chunking.code_section_chunker import _line_anchored_link
+from onyx.utils.circuit_breaker import CircuitBreaker
 from tests.unit.onyx.indexing.conftest import CHUNK_LIMIT, make_doc
 from tests.unit.onyx.indexing.conftest import (
     make_document_chunker as _make_document_chunker,
@@ -143,12 +144,13 @@ def test_code_text_keeps_punctuation_and_emoji() -> None:
     assert "✅" in chunks[0].content
 
 
-def test_unreachable_grammar_is_attempted_once_per_process(
+def test_unreachable_bundle_is_attempted_a_few_times_not_once_per_file(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A firewalled network blocks each bundle fetch until timeout, so the
-    failure must be remembered rather than repaid for every file."""
-    monkeypatch.setattr(code_section_chunker, "_UNAVAILABLE_GRAMMARS", set())
+    """Each failed load blocks until the fetch times out, and one unreachable
+    bundle fails every language — so the attempts must stop, not repeat per
+    file or per language."""
+    monkeypatch.setattr(code_section_chunker, "_GRAMMAR_LOADS", CircuitBreaker())
     attempts = 0
 
     def _blocked(**_kwargs: object) -> None:
@@ -158,18 +160,26 @@ def test_unreachable_grammar_is_attempted_once_per_process(
 
     monkeypatch.setattr(code_section_chunker, "ChonkieCodeChunker", _blocked)
 
-    section = CodeSection(
-        text="x " * 300,
-        language="python",
-        file_path="a.py",
-        link="https://git.example.com/blob/main/a.py",
-    )
-    for _ in range(3):
-        chunks = _chunk(_make_document_chunker(), [section])
-        assert len(chunks) > 1  # still indexed, via token splitting
+    for language in ["python", "go", "rust", "java", "ruby", "php", "scala"]:
+        _chunk(
+            _make_document_chunker(),
+            [
+                CodeSection(
+                    text="x " * 300,
+                    language=language,
+                    file_path=f"a.{language}",
+                    link=f"https://git.example.com/blob/main/a.{language}",
+                )
+            ],
+        )
 
-    assert attempts == 1
-    assert "python" in code_section_chunker._UNAVAILABLE_GRAMMARS
+    assert attempts == 3  # CircuitBreaker's default failures_before_open
+    # Still indexed, just without syntax boundaries.
+    chunks = _chunk(
+        _make_document_chunker(),
+        [CodeSection(text="x " * 300, language="python", file_path="a.py", link="")],
+    )
+    assert len(chunks) > 1
 
 
 # --- Interaction with other sections ----------------------------------------------

--- a/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_code_section_chunker.py
@@ -6,7 +6,7 @@ from onyx.connectors.models import (
     Section,
     TextSection,
 )
-from onyx.indexing.chunking import DocumentChunker
+from onyx.indexing.chunking import DocumentChunker, code_section_chunker
 from onyx.indexing.chunking.code_section_chunker import _line_anchored_link
 from tests.unit.onyx.indexing.conftest import CHUNK_LIMIT, make_doc
 from tests.unit.onyx.indexing.conftest import (
@@ -141,6 +141,35 @@ def test_code_text_keeps_punctuation_and_emoji() -> None:
 
     assert "—" in chunks[0].content
     assert "✅" in chunks[0].content
+
+
+def test_unreachable_grammar_is_attempted_once_per_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A firewalled network blocks each bundle fetch until timeout, so the
+    failure must be remembered rather than repaid for every file."""
+    monkeypatch.setattr(code_section_chunker, "_UNAVAILABLE_GRAMMARS", set())
+    attempts = 0
+
+    def _blocked(**_kwargs: object) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("bundle unreachable")
+
+    monkeypatch.setattr(code_section_chunker, "ChonkieCodeChunker", _blocked)
+
+    section = CodeSection(
+        text="x " * 300,
+        language="python",
+        file_path="a.py",
+        link="https://git.example.com/blob/main/a.py",
+    )
+    for _ in range(3):
+        chunks = _chunk(_make_document_chunker(), [section])
+        assert len(chunks) > 1  # still indexed, via token splitting
+
+    assert attempts == 1
+    assert "python" in code_section_chunker._UNAVAILABLE_GRAMMARS
 
 
 # --- Interaction with other sections ----------------------------------------------

--- a/backend/tests/unit/onyx/utils/test_circuit_breaker.py
+++ b/backend/tests/unit/onyx/utils/test_circuit_breaker.py
@@ -1,0 +1,97 @@
+import time
+
+from onyx.utils.circuit_breaker import CircuitBreaker
+
+
+def _age(breaker: CircuitBreaker, seconds: float) -> None:
+    """Move the last failure into the past instead of sleeping."""
+    breaker._last_failure_at -= seconds
+
+
+def test_stays_closed_below_the_threshold() -> None:
+    breaker = CircuitBreaker(failures_before_open=3)
+
+    breaker.record_failure()
+    breaker.record_failure()
+
+    assert breaker.is_open is False
+
+
+def test_opens_on_the_threshold_failure() -> None:
+    breaker = CircuitBreaker(failures_before_open=3)
+
+    for _ in range(3):
+        breaker.record_failure()
+
+    assert breaker.is_open is True
+
+
+def test_a_success_among_failures_keeps_it_closed() -> None:
+    """An isolated failure between healthy calls must not open the breaker."""
+    breaker = CircuitBreaker(failures_before_open=3)
+
+    for _ in range(10):
+        breaker.record_failure()
+        breaker.record_success()
+
+    assert breaker.is_open is False
+
+
+def test_closes_once_the_delay_passes() -> None:
+    breaker = CircuitBreaker(failures_before_open=3, base_delay=60)
+
+    for _ in range(3):
+        breaker.record_failure()
+    assert breaker.is_open is True
+
+    _age(breaker, 61)
+
+    assert breaker.is_open is False
+
+
+def test_delay_doubles_per_failure_and_is_capped() -> None:
+    """Persistent failure has to decay to a negligible cost, so the wait
+    doubles — but stays bounded so it can still recover."""
+    breaker = CircuitBreaker(failures_before_open=1, base_delay=10, max_delay=40)
+
+    waits = []
+    for _ in range(5):
+        breaker.record_failure()
+        waits.append(breaker._delay())
+
+    assert waits == [10, 20, 40, 40, 40]
+
+
+def test_success_resets_the_backoff() -> None:
+    breaker = CircuitBreaker(failures_before_open=1, base_delay=10, max_delay=40)
+
+    for _ in range(4):
+        breaker.record_failure()
+    breaker.record_success()
+    breaker.record_failure()
+
+    assert breaker._delay() == 10
+
+
+def test_record_failure_reports_the_run_length() -> None:
+    """Callers log the first failure loudly and the rest quietly."""
+    breaker = CircuitBreaker()
+
+    assert [breaker.record_failure() for _ in range(3)] == [1, 2, 3]
+    breaker.record_success()
+    assert breaker.record_failure() == 1
+
+
+def test_is_open_is_a_read_not_a_countdown() -> None:
+    """Checking the breaker must not extend the wait, or a busy caller would
+    hold it open forever."""
+    breaker = CircuitBreaker(failures_before_open=1, base_delay=1)
+
+    breaker.record_failure()
+    deadline = time.monotonic() + 1.1
+    checks = 0
+    while time.monotonic() < deadline:
+        checks += breaker.is_open
+
+    assert checks > 0  # it really was open for a while
+    assert breaker.is_open is False


### PR DESCRIPTION
## Description

Part 3/10 of the code-indexing stack. Stacked on #14225, which adds the code chunker this serves.

`tree-sitter-language-pack` ships no grammars. The first call fetches one bundle covering every language, then extracts individual grammars from it offline. Without that bundle a deployment with no egress indexes every source file by plain token splitting — losing syntax boundaries, line anchors and the `language` metadata — and says so only in a warning that names the language rather than the cause.

So the image build caches that bundle. It deliberately does *not* pre-extract a chosen set of grammars: the bundle is the whole air-gapped guarantee, and extraction from it is local. The build calls `get_parser` afterwards, which raises if the bundle never arrived, so a dependency bump that leaves the cache stale fails the build instead of silently reverting to runtime downloads.

Two things ride along because they are the same defect:

- **The caches are pinned where the runtime user can read them.** Deployments run this image as uid 1001 (`runAsNonRoot` in the Helm chart), but the tokenizer and NLTK pre-downloads were landing under `/root`, which is mode 700 — so those "limited egress" steps have never been reachable in that configuration. `XDG_CACHE_HOME` and `NLTK_DATA` now point at `/app`, with one `chown`. `nltk.download()` also only writes to a search path that already exists, so the directory is created first.
- **A grammar whose load fails is remembered.** `--network none` fails instantly, but a firewalled network that drops packets blocks ~60s per attempt, and that was paid per file. A 500-file repo would have stalled for hours.

## Impact on image size and memory

Measured, not estimated.

**Image.** The bundle is a single per-platform `.tar.zst` holding all 371 grammars — 21 MB in the image, 479 MB uncompressed (≈20× compression; grammars are large, repetitive parser tables). Caching it and extracting one grammar costs **21 MB + 0.8 MB**. An earlier revision of this PR pre-extracted 51 named grammars instead, which added ~59 MB of `libs/` for no offline benefit, so dropping that list took **about 58 MB out of the image** and widened offline coverage from those 51 languages to all 371.

**Memory.** Grammars are `dlopen`ed shared objects, and the resident cost is small: importing the pack adds ~5.9 MB, and each loaded grammar adds **~0.09 MB** (20 grammars measured at +1.9 MB total). A docprocessing worker touching a dozen languages therefore carries well under 10 MB for this. Grammars are loaded lazily, so a worker only pays for what it actually sees; the `Chunker`'s splitter cache is per document batch and released with it.

**Runtime disk.** The trade-off of not pre-extracting is that `libs/` grows as new languages appear, at ~1.5 MB per grammar. A worker that saw every language the pack supports would reach ~479 MB, and a realistic repository mix is a few dozen MB. This lands on the pod's ephemeral storage, so it is worth knowing for tightly-sized deployments. Extraction also needs the cache to be writable — a deployment running with `readOnlyRootFilesystem` should mount a volume at `/app/.cache`, otherwise only the one pre-extracted grammar loads and the rest fall back to token splitting.

## How Has This Been Tested?

Built the real image and ran it with `--network none --user 1001:1001`. With a single grammar pre-extracted, 18/18 languages built parsers offline — including `vue`, `elixir`, `solidity`, `zig` and `cmake` — and the on-disk `.so` count rose 1 → 18, confirming extraction from the cached bundle rather than the network. The HF tokenizer, NLTK and tiktoken caches all resolve as uid 1001.

Negative controls confirm the cache is load-bearing: point `XDG_CACHE_HOME` at an empty directory offline and the build's own check fails with `Download error: Failed to fetch manifest`; point it at the old root-only layout as uid 1001 and the tokenizer fails with `PermissionError`. Touching a backend source file and rebuilding leaves both grammar layers `CACHED`, which is the point of moving them above the source `COPY`s.

Unit tests cover the circuit breaker as a unit (threshold, reset-on-success, doubling, cap), that an unreachable bundle stops after a few attempts rather than one per file, that credential filenames are refused, and that extensionless and prose/tabular paths resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bakes the `tree-sitter-language-pack` grammar bundle into the Docker image so deployments without egress index code with syntax-aware splitting instead of falling back to plain token splitting. Shipping the whole bundle instead of a fixed set of grammars keeps every supported language available offline; the build prefetches python and fails if the bundle did not arrive. The step sits above the source `COPY`s, so backend commits do not re-download the archive.

Detection now resolves extensionless canonical names (`Makefile`, `Dockerfile`, `CMakeLists.txt`) to their grammars, and refuses prose and tabular formats (`.txt`, `.csv`, `.tsv`, `.rst`) that were being chunked as code.

Two related defects ride along: the tokenizer and NLTK caches landed under `/root` (mode 700), unreachable to the runtime user (uid 1001), and now point at `/app`; the download and chown share one image layer, so the image does not carry a second copy of the cached files. A grammar whose load fails is remembered across all languages, so a firewalled network no longer pays a ~60s timeout per file; the first failure and the one that opens the breaker warn, and suppressed loads log at debug.

<sup>Written for commit 90ae8e4d1439a0e99845848319e65a64b5f2fa2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
