### PR TITLE
ci(terraform-provider): publish releases to the Terraform Registry

### DIFF
--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -86,15 +86,24 @@ jobs:
 
       # Authenticate git the way actions/checkout does, with a header rather
       # than a URL, so the token never becomes part of a remote or a ref.
+      #
+      # The identity is not optional here: `git commit-tree` needs a committer,
+      # and a runner has none configured to fall back on.
       - name: Authenticate git against the mirror
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.mirror-token.outputs.token }}
+          APP_SLUG: ${{ steps.mirror-token.outputs.app-slug }}
         run: |
           set -euo pipefail
           auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
           git config --global "http.https://github.com/.extraheader" \
             "Authorization: Basic ${auth}"
+
+          bot_user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email \
+            "${bot_user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       # `git subtree split` walks every commit in this repository to find the
       # handful that touch the provider, which takes longer than the whole
@@ -123,8 +132,12 @@ jobs:
           Edit the provider there, never here."
           commit=$(git commit-tree "${tree}" "${parents[@]}" -m "${message}")
 
-          git push "${mirror}" "${commit}:refs/heads/main"
-          git push "${mirror}" "${commit}:refs/tags/${MIRROR_TAG}"
+          # One atomic push, so a rejected tag cannot leave main advanced
+          # without it. Re-running a version that already shipped is refused
+          # whole rather than adding a second commit for the same release.
+          git push --atomic "${mirror}" \
+            "${commit}:refs/heads/main" \
+            "${commit}:refs/tags/${MIRROR_TAG}"
           echo "Pushed ${commit} to ${MIRROR_REPO} as ${MIRROR_TAG}."
 
       # goreleaser reads the version from the tag it finds in the checkout it

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -1,0 +1,200 @@
+name: Release Terraform Provider
+
+# The public Terraform Registry only serves a provider from a repository named
+# after it, so the provider is published from a mirror,
+# onyx-dot-app/terraform-provider-onyx, rather than from this monorepo.
+#
+# A `tf-provider/vX.Y.Z` tag here pushes terraform-provider-onyx/ to that mirror
+# as one commit tagged `vX.Y.Z`, then builds and signs the release there. The
+# mirror holds no source of its own: it is written from this directory, never
+# edited directly.
+#
+# Run this with workflow_dispatch first. The default is a dry run, which builds
+# every platform archive and touches neither the mirror nor the registry.
+
+on:
+  push:
+    tags:
+      - "tf-provider/v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build, without the leading v (e.g. 1.0.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Build only. Leaves the mirror and the registry alone."
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: Release-Terraform-Provider-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  MIRROR_REPO: onyx-dot-app/terraform-provider-onyx
+  PROVIDER_DIR: terraform-provider-onyx
+
+jobs:
+  release:
+    name: Publish to the Terraform Registry
+    runs-on: ubuntu-latest
+    # Holds the signing key and the mirror app credentials, and gates the job
+    # behind whatever reviewers the environment requires.
+    environment: release-terraform-provider
+    timeout-minutes: 30
+    steps:
+      - name: Resolve the release version
+        id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            version="${REF_NAME#tf-provider/v}"
+          fi
+          if ! printf '%s' "${version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'${version}' is not a semantic version; tag as tf-provider/vX.Y.Z"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing ${version}"
+
+      - name: Mint a token for the release mirror
+        id: mirror-token
+        if: ${{ !inputs.dry_run }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v2
+        with:
+          client-id: ${{ vars.TF_PROVIDER_RELEASE_APP_ID }}
+          private-key: ${{ secrets.TF_PROVIDER_RELEASE_APP_PRIVATE_KEY }}
+          owner: onyx-dot-app
+          repositories: terraform-provider-onyx
+          permission-contents: write
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Authenticate git the way actions/checkout does, with a header rather
+      # than a URL, so the token never becomes part of a remote or a ref.
+      - name: Authenticate git against the mirror
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.mirror-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
+          git config --global "http.https://github.com/.extraheader" \
+            "Authorization: Basic ${auth}"
+
+      # `git subtree split` walks every commit in this repository to find the
+      # handful that touch the provider, which takes longer than the whole
+      # release. The provider directory is already a complete tree, so commit
+      # that tree straight onto the mirror's history instead.
+      - name: Push the provider to the release mirror
+        if: ${{ !inputs.dry_run }}
+        env:
+          MIRROR_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mirror="https://github.com/${MIRROR_REPO}.git"
+
+          tree=$(git rev-parse "HEAD:${PROVIDER_DIR}")
+          parents=()
+          if git fetch --quiet "${mirror}" main 2>/dev/null; then
+            parents=(-p "$(git rev-parse FETCH_HEAD)")
+            echo "Building on the mirror's current main."
+          else
+            echo "The mirror has no main yet; this is its first commit."
+          fi
+
+          message="${MIRROR_TAG}
+
+          Published from ${GITHUB_REPOSITORY}@$(git rev-parse HEAD).
+          Edit the provider there, never here."
+          commit=$(git commit-tree "${tree}" "${parents[@]}" -m "${message}")
+
+          git push "${mirror}" "${commit}:refs/heads/main"
+          git push "${mirror}" "${commit}:refs/tags/${MIRROR_TAG}"
+          echo "Pushed ${commit} to ${MIRROR_REPO} as ${MIRROR_TAG}."
+
+      # goreleaser reads the version from the tag it finds in the checkout it
+      # runs in. Running it here would pick up this repository's own tags, so
+      # the release is built from the mirror, where the only tags are the
+      # provider's.
+      - name: Check out the mirror at the new tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          MIRROR_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git clone --quiet --branch "${MIRROR_TAG}" \
+            "https://github.com/${MIRROR_REPO}.git" mirror
+          git -C mirror describe --tags
+
+      # A dry run has no mirror to build from, so it builds the directory as it
+      # stands. goreleaser stamps a snapshot version rather than the real one.
+      - name: Stage the provider for a dry run
+        if: ${{ inputs.dry_run }}
+        run: cp -R "${PROVIDER_DIR}" mirror
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v5 # zizmor: ignore[cache-poisoning]
+        with:
+          go-version-file: ${{ env.PROVIDER_DIR }}/go.mod
+          cache-dependency-path: ${{ env.PROVIDER_DIR }}/go.sum
+
+      - name: Import the signing key
+        id: gpg
+        if: ${{ !inputs.dry_run }}
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # ratchet:crazy-max/ghaction-import-gpg@v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.TF_PROVIDER_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TF_PROVIDER_GPG_PASSPHRASE }}
+
+      - name: Build and publish the release
+        if: ${{ !inputs.dry_run }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
+        with:
+          version: "~> v2"
+          args: release --clean
+          workdir: mirror
+        env:
+          GITHUB_TOKEN: ${{ steps.mirror-token.outputs.token }}
+          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
+
+      - name: Build the release without publishing it
+        if: ${{ inputs.dry_run }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean --skip=sign,publish
+          workdir: mirror
+
+      - name: Report what was built
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          MIRROR_TAG: ${{ steps.version.outputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Terraform provider ${VERSION}"
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "Dry run: nothing reached ${MIRROR_REPO} or the registry."
+            else
+              echo "Published to https://github.com/${MIRROR_REPO}/releases/tag/${MIRROR_TAG}"
+            fi
+            echo '```'
+            find mirror/dist -maxdepth 1 -name '*.zip' -exec basename {} \; | sort
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -4,13 +4,13 @@ name: Release Terraform Provider
 # after it, so the provider is published from a mirror,
 # onyx-dot-app/terraform-provider-onyx, rather than from this monorepo.
 #
-# A `tf-provider/vX.Y.Z` tag here pushes terraform-provider-onyx/ to that mirror
-# as one commit tagged `vX.Y.Z`, then builds and signs the release there. The
-# mirror holds no source of its own: it is written from this directory, never
-# edited directly.
+# This workflow does one thing: copy terraform-provider-onyx/ to that mirror as
+# one commit tagged vX.Y.Z. The tag push starts the mirror's own Publish
+# workflow, which builds and signs the release. That file lives at
+# terraform-provider-onyx/.github/workflows/publish.yml and travels with the
+# directory it publishes.
 #
-# Run this with workflow_dispatch first. The default is a dry run, which builds
-# every platform archive and touches neither the mirror nor the registry.
+# Cut a release with `ods release tf-provider`, which pushes the tag below.
 
 on:
   push:
@@ -19,14 +19,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build, without the leading v (e.g. 1.0.0)"
+        description: "Version to mirror, without the leading v (e.g. 1.0.0)"
         required: true
         type: string
-      dry_run:
-        description: "Build only. Leaves the mirror and the registry alone."
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -40,13 +35,13 @@ env:
   PROVIDER_DIR: terraform-provider-onyx
 
 jobs:
-  release:
-    name: Publish to the Terraform Registry
+  mirror:
+    name: Copy the provider to its release mirror
     runs-on: ubuntu-latest
-    # Holds the signing key and the mirror app credentials, and gates the job
-    # behind whatever reviewers the environment requires.
+    # Holds the mirror app credentials, and gates the job behind whatever
+    # reviewers the environment requires.
     environment: release-terraform-provider
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Resolve the release version
         id: version
@@ -64,13 +59,11 @@ jobs:
             echo "::error::'${version}' is not a semantic version; tag as tf-provider/vX.Y.Z"
             exit 1
           fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
-          echo "Releasing ${version}"
+          echo "Mirroring ${version}"
 
       - name: Mint a token for the release mirror
         id: mirror-token
-        if: ${{ !inputs.dry_run }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v2
         with:
           client-id: ${{ vars.TF_PROVIDER_RELEASE_APP_ID }}
@@ -90,7 +83,6 @@ jobs:
       # The identity is not optional here: `git commit-tree` needs a committer,
       # and a runner has none configured to fall back on.
       - name: Authenticate git against the mirror
-        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.mirror-token.outputs.token }}
           APP_SLUG: ${{ steps.mirror-token.outputs.app-slug }}
@@ -110,7 +102,6 @@ jobs:
       # release. The provider directory is already a complete tree, so commit
       # that tree straight onto the mirror's history instead.
       - name: Push the provider to the release mirror
-        if: ${{ !inputs.dry_run }}
         env:
           MIRROR_TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -138,76 +129,10 @@ jobs:
           git push --atomic "${mirror}" \
             "${commit}:refs/heads/main" \
             "${commit}:refs/tags/${MIRROR_TAG}"
-          echo "Pushed ${commit} to ${MIRROR_REPO} as ${MIRROR_TAG}."
 
-      # goreleaser reads the version from the tag it finds in the checkout it
-      # runs in. Running it here would pick up this repository's own tags, so
-      # the release is built from the mirror, where the only tags are the
-      # provider's.
-      - name: Check out the mirror at the new tag
-        if: ${{ !inputs.dry_run }}
-        env:
-          MIRROR_TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git clone --quiet --branch "${MIRROR_TAG}" \
-            "https://github.com/${MIRROR_REPO}.git" mirror
-          git -C mirror describe --tags
-
-      # A dry run has no mirror to build from, so it builds the directory as it
-      # stands. goreleaser stamps a snapshot version rather than the real one.
-      - name: Stage the provider for a dry run
-        if: ${{ inputs.dry_run }}
-        run: cp -R "${PROVIDER_DIR}" mirror
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v5 # zizmor: ignore[cache-poisoning]
-        with:
-          go-version-file: ${{ env.PROVIDER_DIR }}/go.mod
-          cache-dependency-path: ${{ env.PROVIDER_DIR }}/go.sum
-
-      - name: Import the signing key
-        id: gpg
-        if: ${{ !inputs.dry_run }}
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # ratchet:crazy-max/ghaction-import-gpg@v7.0.0
-        with:
-          gpg_private_key: ${{ secrets.TF_PROVIDER_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.TF_PROVIDER_GPG_PASSPHRASE }}
-
-      - name: Build and publish the release
-        if: ${{ !inputs.dry_run }}
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
-        with:
-          version: "~> v2"
-          args: release --clean
-          workdir: mirror
-        env:
-          GITHUB_TOKEN: ${{ steps.mirror-token.outputs.token }}
-          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
-
-      - name: Build the release without publishing it
-        if: ${{ inputs.dry_run }}
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
-        with:
-          version: "~> v2"
-          args: release --snapshot --clean --skip=sign,publish
-          workdir: mirror
-
-      - name: Report what was built
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          MIRROR_TAG: ${{ steps.version.outputs.tag }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
           {
-            echo "### Terraform provider ${VERSION}"
-            if [ "${DRY_RUN}" = "true" ]; then
-              echo "Dry run: nothing reached ${MIRROR_REPO} or the registry."
-            else
-              echo "Published to https://github.com/${MIRROR_REPO}/releases/tag/${MIRROR_TAG}"
-            fi
-            echo '```'
-            find mirror/dist -maxdepth 1 -name '*.zip' -exec basename {} \; | sort
-            echo '```'
+            echo "### Terraform provider ${MIRROR_TAG}"
+            echo "Mirrored \`${commit}\` to ${MIRROR_REPO}."
+            echo "The mirror's Publish workflow builds and signs the release:"
+            echo "https://github.com/${MIRROR_REPO}/actions"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,7 +168,7 @@ repos:
         # in sync with the `zizmor` dependency group in pyproject.toml.
         args: ["--no-project", "--with=zizmor==1.25.2", "zizmor", "--offline"]
         pass_filenames: true
-        files: ^\.github/(workflows/.+\.ya?ml|actions/.+/action\.ya?ml)$
+        files: (^|/)\.github/(workflows/.+\.ya?ml|actions/.+/action\.ya?ml)$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
@@ -191,6 +191,9 @@ repos:
     rev: a443f344ff32813837fa49f7aa6cbc478d770e62 # frozen: v1.7.9
     hooks:
       - id: actionlint
+        # Also lint workflows that ship inside a subdirectory to run in another
+        # repository, such as terraform-provider-onyx/.github/workflows/.
+        files: (^|/)\.github/workflows/.+\.ya?ml$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1

--- a/terraform-provider-onyx/.github/workflows/publish.yml
+++ b/terraform-provider-onyx/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish
+
+# This file runs in the release mirror, onyx-dot-app/terraform-provider-onyx,
+# and not in the monorepo where it is edited. GitHub only reads workflows from
+# a repository's root, so it is inert in the monorepo and live in the mirror
+# once Release Terraform Provider has copied this directory across.
+#
+# That copy pushes a vX.Y.Z tag, which is what starts this.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build every archive without signing or publishing."
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build, sign and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # goreleaser creates the GitHub release the registry ingests.
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          # goreleaser takes the version from the tag, so it needs the tags.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v5 # zizmor: ignore[cache-poisoning]
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Import the signing key
+        id: gpg
+        if: ${{ !inputs.dry_run }}
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # ratchet:crazy-max/ghaction-import-gpg@v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.TF_PROVIDER_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TF_PROVIDER_GPG_PASSPHRASE }}
+
+      - name: Build and publish the release
+        if: ${{ !inputs.dry_run }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
+
+      - name: Build the release without publishing it
+        if: ${{ inputs.dry_run }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean --skip=sign,publish
+
+      - name: Report what was built
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          {
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "### Dry run — nothing was signed or published"
+            else
+              echo "### Published ${GITHUB_REF_NAME}"
+            fi
+            echo '```'
+            find dist -maxdepth 1 -name '*.zip' -exec basename {} \; | sort
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/terraform-provider-onyx/.gitignore
+++ b/terraform-provider-onyx/.gitignore
@@ -1,2 +1,5 @@
 # built provider binary (used via dev_overrides)
 terraform-provider-onyx
+
+# goreleaser output
+dist/

--- a/terraform-provider-onyx/.goreleaser.yml
+++ b/terraform-provider-onyx/.goreleaser.yml
@@ -1,0 +1,75 @@
+# Release build for the public Terraform Registry.
+#
+# This file runs in the release mirror (onyx-dot-app/terraform-provider-onyx),
+# not in the monorepo: the registry requires a repository named after the
+# provider, and .github/workflows/release-terraform-provider.yml pushes this
+# directory there before it runs. Everything the registry ingests is produced
+# here — the platform archives, the checksum file, and its GPG signature.
+version: 2
+
+project_name: terraform-provider-onyx
+
+before:
+  hooks:
+    # Not `go mod tidy`: a release must build what was reviewed, and tidy can
+    # rewrite go.mod mid-release.
+    - go mod download
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    # Reproducible builds: stamp the commit time rather than the build time.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}}"
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - windows
+    goarch:
+      - "386"
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
+    # The registry expects this exact binary name inside each archive.
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
+
+archives:
+  - formats: [zip]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+
+# The registry verifies this signature against the GPG public key registered
+# with the provider, and refuses a release without it.
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
+release:
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+
+changelog:
+  disable: true

--- a/terraform-provider-onyx/.goreleaser.yml
+++ b/terraform-provider-onyx/.goreleaser.yml
@@ -1,60 +1,37 @@
-# Release build for the public Terraform Registry.
-#
-# This file runs in the release mirror (onyx-dot-app/terraform-provider-onyx),
-# not in the monorepo: the registry requires a repository named after the
-# provider, and .github/workflows/release-terraform-provider.yml pushes this
-# directory there before it runs. Everything the registry ingests is produced
-# here — the platform archives, the checksum file, and its GPG signature.
+# Release build for the public Terraform Registry, which dictates the archive
+# format, the archive and binary names, and a detached signature over the
+# checksums. Only settings that differ from goreleaser's defaults are here.
 version: 2
 
+# Not a default: goreleaser derives this from the git remote, which is "onyx"
+# in this repository. The registry keys on the name, so state it.
 project_name: terraform-provider-onyx
-
-before:
-  hooks:
-    # Not `go mod tidy`: a release must build what was reviewed, and tidy can
-    # rewrite go.mod mid-release.
-    - go mod download
 
 builds:
   - env:
       - CGO_ENABLED=0
-    # Reproducible builds: stamp the commit time rather than the build time.
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
-    ldflags:
-      - "-s -w -X main.version={{.Version}}"
-    goos:
-      - darwin
-      - freebsd
-      - linux
-      - windows
-    goarch:
-      - "386"
-      - amd64
-      - arm
-      - arm64
-    ignore:
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
-    # The registry expects this exact binary name inside each archive.
+    # The registry serves freebsd and arm; goreleaser does not build them by
+    # default. It drops darwin/386 and darwin/arm on its own.
+    goos: [darwin, freebsd, linux, windows]
+    goarch: ["386", amd64, arm, arm64]
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:
+  # The default is a tarball, and appends the ARM and amd64 variant to the name.
   - formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
-  algorithm: sha256
   extra_files:
     - glob: terraform-registry-manifest.json
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
 
-# The registry verifies this signature against the GPG public key registered
-# with the provider, and refuses a release without it.
+# The registry checks this against the public key registered with the provider,
+# and refuses a release without it.
 signs:
   - artifacts: checksum
     args:

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -317,8 +317,49 @@ whole lifecycle without any live source or credentials.
 go generate .   # runs tfplugindocs; needs terraform on PATH
 ```
 
-## Publishing (future)
+## Publishing
 
-The public Terraform Registry requires a standalone GitHub repo named exactly
-`terraform-provider-onyx` with GPG-signed goreleaser artifacts. Until a release mirror is
-set up, install via `dev_overrides` (above) or a private registry/filesystem mirror.
+The public Terraform Registry only serves a provider from a repository named after it, so
+releases go out through a mirror, `onyx-dot-app/terraform-provider-onyx`. The mirror holds
+no source of its own. It is written from this directory and never edited directly.
+
+`.github/workflows/release-terraform-provider.yml` does the whole thing:
+
+1. A `tf-provider/vX.Y.Z` tag on the monorepo starts it.
+2. It commits this directory's tree onto the mirror's history and tags it `vX.Y.Z`.
+   (`git subtree split` would walk all ~10,000 monorepo commits to find the handful that
+   touch this directory, which takes longer than the rest of the release put together.)
+3. It clones the mirror and runs goreleaser there, where `vX.Y.Z` is the only tag in sight
+   and the version goreleaser stamps is therefore the right one.
+4. goreleaser builds every platform archive, signs the checksum file with the release GPG
+   key, and publishes a GitHub release on the mirror. The registry ingests it from there.
+
+### Cutting a release
+
+```console
+$ git tag tf-provider/v1.0.0
+$ git push origin tf-provider/v1.0.0
+```
+
+To rehearse without touching anything, run the workflow by hand from the Actions tab. It
+defaults to a dry run, which builds every archive and publishes none of them.
+
+### One-time setup
+
+None of this is done yet, and each step needs org permissions:
+
+- [ ] Create the public repo `onyx-dot-app/terraform-provider-onyx`. Leave it empty or
+      initialise it — the workflow handles both.
+- [ ] Decide what `LICENSE` the mirror carries. The provider is MIT under this repo's
+      terms, but the monorepo `LICENSE` names `ee` directories that the mirror has none of.
+      goreleaser puts the file in every archive once it exists.
+- [ ] Create the release GPG key and register its public half with the Terraform Registry
+      under the `onyx-dot-app` namespace.
+- [ ] Install a GitHub App with `contents: write` on the mirror.
+- [ ] Fill in the `release-terraform-provider` environment: the variable
+      `TF_PROVIDER_RELEASE_APP_ID`, and the secrets `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`,
+      `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE`.
+- [ ] Link the mirror on registry.terraform.io as the `onyx-dot-app` organisation.
+
+Until then, install the provider with `dev_overrides` (above), or from a private registry
+or filesystem mirror.

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -323,26 +323,33 @@ The public Terraform Registry only serves a provider from a repository named aft
 releases go out through a mirror, `onyx-dot-app/terraform-provider-onyx`. The mirror holds
 no source of its own. It is written from this directory and never edited directly.
 
-`.github/workflows/release-terraform-provider.yml` does the whole thing:
+Two workflows split the work, one in each repository:
 
-1. A `tf-provider/vX.Y.Z` tag on the monorepo starts it.
-2. It commits this directory's tree onto the mirror's history and tags it `vX.Y.Z`.
-   (`git subtree split` would walk all ~10,000 monorepo commits to find the handful that
-   touch this directory, which takes longer than the rest of the release put together.)
-3. It clones the mirror and runs goreleaser there, where `vX.Y.Z` is the only tag in sight
-   and the version goreleaser stamps is therefore the right one.
+1. `ods release tf-provider` pushes a `tf-provider/vX.Y.Z` tag on the monorepo.
+2. `.github/workflows/release-terraform-provider.yml` commits this directory's tree onto
+   the mirror's history and tags it `vX.Y.Z`. (`git subtree split` would walk all ~10,000
+   monorepo commits to find the handful that touch this directory, which takes longer than
+   the rest of the release put together.)
+3. That tag starts `publish.yml` in the mirror. It lives here, at
+   `.github/workflows/publish.yml`, and travels with the directory it publishes — GitHub
+   only reads workflows from a repository's root, so it is inert in the monorepo.
 4. goreleaser builds every platform archive, signs the checksum file with the release GPG
-   key, and publishes a GitHub release on the mirror. The registry ingests it from there.
+   key, and publishes a GitHub release. The registry ingests it from there.
+
+goreleaser runs in the mirror rather than the monorepo because it takes the version from
+whatever tag the checkout has. Here it would find tags like `nightly-latest-...` and stamp
+them into every artifact name.
 
 ### Cutting a release
 
 ```console
-$ git tag tf-provider/v1.0.0
-$ git push origin tf-provider/v1.0.0
+$ ods release tf-provider              # bumps the patch version
+$ ods release tf-provider --bump minor
+$ ods release tf-provider --version 1.0.0
 ```
 
-To rehearse without touching anything, run the workflow by hand from the Actions tab. It
-defaults to a dry run, which builds every archive and publishes none of them.
+To rehearse, run **Publish** by hand from the mirror's Actions tab. It defaults to a dry
+run, which builds every archive and publishes none of them.
 
 ### One-time setup
 
@@ -355,10 +362,11 @@ None of this is done yet, and each step needs org permissions:
       goreleaser puts the file in every archive once it exists.
 - [ ] Create the release GPG key and register its public half with the Terraform Registry
       under the `onyx-dot-app` namespace.
-- [ ] Install a GitHub App with `contents: write` on the mirror.
-- [ ] Fill in the `release-terraform-provider` environment: the variable
-      `TF_PROVIDER_RELEASE_APP_ID`, and the secrets `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`,
-      `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE`.
+- [ ] Install a GitHub App with `contents: write` on the mirror, and fill in the monorepo's
+      `release-terraform-provider` environment: the variable `TF_PROVIDER_RELEASE_APP_ID`
+      and the secret `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`.
+- [ ] Add the secrets `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE` **to
+      the mirror**, which is where the signing happens. The monorepo never holds the key.
 - [ ] Link the mirror on registry.terraform.io as the `onyx-dot-app` organisation.
 
 Until then, install the provider with `dev_overrides` (above), or from a private registry

--- a/terraform-provider-onyx/terraform-registry-manifest.json
+++ b/terraform-provider-onyx/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}

--- a/tools/ods/cmd/release.go
+++ b/tools/ods/cmd/release.go
@@ -63,6 +63,7 @@ Example usage:
 	cmd.Flags().StringVar(&ref, "ref", "HEAD", "Tag to check, or a commit-ish that a single release tag points at")
 
 	cmd.AddCommand(NewReleaseOpalCommand())
+	cmd.AddCommand(NewReleaseTFProviderCommand())
 
 	return cmd
 }

--- a/tools/ods/cmd/release_opal.go
+++ b/tools/ods/cmd/release_opal.go
@@ -1,32 +1,19 @@
 package cmd
 
 import (
-	"fmt"
-	"os/exec"
-	"strings"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
-	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
-	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
 )
 
-const opalTagPrefix = "opal/v"
-
-// ReleaseOpalOptions holds options for the release opal command.
-type ReleaseOpalOptions struct {
-	Bump    string
-	Version string
-	DryRun  bool
-	Yes     bool
-	Verify  bool
+var opalRelease = prefixedTagRelease{
+	tagPrefix: "opal/v",
+	tagGlob:   "opal/*",
+	subject:   "@onyx-ai/opal",
+	publishes: "release-opal.yml will build and publish to npm.",
 }
 
 // NewReleaseOpalCommand creates the `ods release opal` command.
 func NewReleaseOpalCommand() *cobra.Command {
-	opts := &ReleaseOpalOptions{}
+	opts := &prefixedTagOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "opal",
@@ -48,114 +35,11 @@ Example usage:
     $ ods release opal --version 0.2.0`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			releaseOpal(opts)
+			opalRelease.run(opts)
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Bump, "bump", "patch", "Semver part to bump when --version is unset: patch|minor|major")
-	cmd.Flags().StringVar(&opts.Version, "version", "", "Exact version to release (X.Y.Z, no leading v); overrides --bump")
-	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute the version but don't tag or push")
-	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
-	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
+	opalRelease.addFlags(cmd, opts)
 
 	return cmd
-}
-
-func releaseOpal(opts *ReleaseOpalOptions) {
-	if opts.Version != "" {
-		if !release.IsBareVersion(opts.Version) {
-			log.Fatalf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
-		}
-	} else if opts.Bump != "patch" && opts.Bump != "minor" && opts.Bump != "major" {
-		log.Fatalf("--bump must be one of patch|minor|major, got %q", opts.Bump)
-	}
-
-	// Fetch only opal/* tags so the next version is computed against origin's
-	// latest release. Targeted + best-effort: a full --tags fetch can exit
-	// non-zero just because unrelated local tags would be clobbered, and an
-	// offline run should still fall back to local tags.
-	log.Info("Fetching opal tags from origin...")
-	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", "refs/tags/opal/*:refs/tags/opal/*"); err != nil {
-		log.Warnf("Could not fetch opal tags (using local tags): %v", err)
-	}
-
-	newVersion := opts.Version
-	if newVersion == "" {
-		current, err := latestOpalVersion()
-		if err != nil {
-			log.Fatalf("Failed to determine latest opal version (pass --version): %v", err)
-		}
-		next, err := bumpSemver(current, opts.Bump)
-		if err != nil {
-			log.Fatalf("Failed to compute next version: %v", err)
-		}
-		newVersion = next
-		log.Infof("Latest opal release: v%s -> v%s", current, newVersion)
-	}
-
-	tag := opalTagPrefix + newVersion
-	if opalTagExists(tag) {
-		log.Fatalf("Tag %s already exists", tag)
-	}
-
-	if opts.DryRun {
-		log.Warnf("[DRY RUN] Would tag and push %s", tag)
-		return
-	}
-
-	if !opts.Yes {
-		if !prompt.Confirm(fmt.Sprintf("Tag and push %s to publish @onyx-ai/opal? (Y/n): ", tag)) {
-			log.Info("Exiting...")
-			return
-		}
-	}
-
-	if err := git.RunCommand("tag", tag); err != nil {
-		log.Fatalf("Failed to create tag %s: %v", tag, err)
-	}
-	if err := git.PushTag(tag, false, opts.Verify); err != nil {
-		// Roll back the local tag so the command stays retryable after a failed push.
-		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
-			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
-		}
-		log.Fatalf("Failed to push tag %s: %v", tag, err)
-	}
-	log.Infof("Pushed %s — release-opal.yml will build and publish to npm.", tag)
-}
-
-// latestOpalVersion returns the highest X.Y.Z among the opal/v* tags.
-func latestOpalVersion() (string, error) {
-	out, err := exec.Command("git", "tag", "--list", opalTagPrefix+"*", "--sort=-v:refname").Output()
-	if err != nil {
-		return "", err
-	}
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		version := strings.TrimPrefix(strings.TrimSpace(line), opalTagPrefix)
-		if release.IsBareVersion(version) {
-			return version, nil
-		}
-	}
-	return "", fmt.Errorf("no %s* tags found", opalTagPrefix)
-}
-
-// bumpSemver increments one segment of an X.Y.Z version, zeroing lower segments.
-func bumpSemver(version, part string) (string, error) {
-	var major, minor, patch int
-	if _, err := fmt.Sscanf(version, "%d.%d.%d", &major, &minor, &patch); err != nil {
-		return "", fmt.Errorf("parse %q: %w", version, err)
-	}
-	switch part {
-	case "major":
-		return fmt.Sprintf("%d.0.0", major+1), nil
-	case "minor":
-		return fmt.Sprintf("%d.%d.0", major, minor+1), nil
-	default:
-		return fmt.Sprintf("%d.%d.%d", major, minor, patch+1), nil
-	}
-}
-
-// opalTagExists reports whether the tag is already present locally (tags were
-// just fetched from origin, so this also covers origin).
-func opalTagExists(tag string) bool {
-	return exec.Command("git", "rev-parse", "-q", "--verify", "refs/tags/"+tag).Run() == nil
 }

--- a/tools/ods/cmd/release_prefixed_tag.go
+++ b/tools/ods/cmd/release_prefixed_tag.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
+)
+
+// Some packages are released by pushing a prefixed vX.Y.Z tag that a workflow
+// watches, rather than from a release branch. The tag is the version: nothing
+// in the tree records it. This is the shared flow for those.
+
+// prefixedTagOptions holds the flags every such release takes.
+type prefixedTagOptions struct {
+	Bump    string
+	Version string
+	DryRun  bool
+	Yes     bool
+	Verify  bool
+}
+
+// prefixedTagRelease describes one release target.
+type prefixedTagRelease struct {
+	// tagPrefix is everything before the version, e.g. "opal/v".
+	tagPrefix string
+	// tagGlob matches this target's tags for fetching, e.g. "opal/*".
+	tagGlob string
+	// subject is what the tag publishes, for the confirmation prompt.
+	subject string
+	// publishes says what happens after the push, for the closing log line.
+	publishes string
+}
+
+// addFlags registers the shared flags on a release subcommand.
+func (r prefixedTagRelease) addFlags(cmd *cobra.Command, opts *prefixedTagOptions) {
+	cmd.Flags().StringVar(&opts.Bump, "bump", "patch", "Semver part to bump when --version is unset: patch|minor|major")
+	cmd.Flags().StringVar(&opts.Version, "version", "", "Exact version to release (X.Y.Z, no leading v); overrides --bump")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute the version but don't tag or push")
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
+}
+
+// run computes the next version, then tags and pushes it.
+func (r prefixedTagRelease) run(opts *prefixedTagOptions) {
+	if opts.Version != "" {
+		if !release.IsBareVersion(opts.Version) {
+			log.Fatalf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
+		}
+	} else if opts.Bump != "patch" && opts.Bump != "minor" && opts.Bump != "major" {
+		log.Fatalf("--bump must be one of patch|minor|major, got %q", opts.Bump)
+	}
+
+	// Fetch only this target's tags so the next version is computed against
+	// origin's latest release. Targeted + best-effort: a full --tags fetch can
+	// exit non-zero just because unrelated local tags would be clobbered, and
+	// an offline run should still fall back to local tags.
+	log.Infof("Fetching %s tags from origin...", r.tagGlob)
+	refspec := fmt.Sprintf("refs/tags/%s:refs/tags/%s", r.tagGlob, r.tagGlob)
+	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", refspec); err != nil {
+		log.Warnf("Could not fetch %s tags (using local tags): %v", r.tagGlob, err)
+	}
+
+	newVersion := opts.Version
+	if newVersion == "" {
+		current, err := r.latestVersion()
+		if err != nil {
+			log.Fatalf("Failed to determine the latest version (pass --version): %v", err)
+		}
+		next, err := bumpSemver(current, opts.Bump)
+		if err != nil {
+			log.Fatalf("Failed to compute next version: %v", err)
+		}
+		newVersion = next
+		log.Infof("Latest %s release: v%s -> v%s", r.subject, current, newVersion)
+	}
+
+	tag := r.tagPrefix + newVersion
+	if tagExists(tag) {
+		log.Fatalf("Tag %s already exists", tag)
+	}
+
+	if opts.DryRun {
+		log.Warnf("[DRY RUN] Would tag and push %s", tag)
+		return
+	}
+
+	if !opts.Yes {
+		if !prompt.Confirm(fmt.Sprintf("Tag and push %s to publish %s? (Y/n): ", tag, r.subject)) {
+			log.Info("Exiting...")
+			return
+		}
+	}
+
+	if err := git.RunCommand("tag", tag); err != nil {
+		log.Fatalf("Failed to create tag %s: %v", tag, err)
+	}
+	if err := git.PushTag(tag, false, opts.Verify); err != nil {
+		// Roll back the local tag so the command stays retryable after a failed push.
+		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
+			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
+		}
+		log.Fatalf("Failed to push tag %s: %v", tag, err)
+	}
+	log.Infof("Pushed %s — %s", tag, r.publishes)
+}
+
+// latestVersion returns the highest X.Y.Z among this target's tags.
+func (r prefixedTagRelease) latestVersion() (string, error) {
+	out, err := exec.Command("git", "tag", "--list", r.tagPrefix+"*", "--sort=-v:refname").Output()
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		version := strings.TrimPrefix(strings.TrimSpace(line), r.tagPrefix)
+		if release.IsBareVersion(version) {
+			return version, nil
+		}
+	}
+	return "", fmt.Errorf("no %s* tags found", r.tagPrefix)
+}
+
+// bumpSemver increments one segment of an X.Y.Z version, zeroing lower segments.
+func bumpSemver(version, part string) (string, error) {
+	var major, minor, patch int
+	if _, err := fmt.Sscanf(version, "%d.%d.%d", &major, &minor, &patch); err != nil {
+		return "", fmt.Errorf("parse %q: %w", version, err)
+	}
+	switch part {
+	case "major":
+		return fmt.Sprintf("%d.0.0", major+1), nil
+	case "minor":
+		return fmt.Sprintf("%d.%d.0", major, minor+1), nil
+	default:
+		return fmt.Sprintf("%d.%d.%d", major, minor, patch+1), nil
+	}
+}
+
+// tagExists reports whether the tag is already present locally (tags were just
+// fetched from origin, so this also covers origin).
+func tagExists(tag string) bool {
+	return exec.Command("git", "rev-parse", "-q", "--verify", "refs/tags/"+tag).Run() == nil
+}

--- a/tools/ods/cmd/release_tf_provider.go
+++ b/tools/ods/cmd/release_tf_provider.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var tfProviderRelease = prefixedTagRelease{
+	tagPrefix: "tf-provider/v",
+	tagGlob:   "tf-provider/*",
+	subject:   "terraform-provider-onyx",
+	publishes: "release-terraform-provider.yml will mirror it, and the mirror publishes to the Terraform Registry.",
+}
+
+// NewReleaseTFProviderCommand creates the `ods release tf-provider` command.
+func NewReleaseTFProviderCommand() *cobra.Command {
+	opts := &prefixedTagOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "tf-provider",
+		Short: "Cut a new terraform-provider-onyx release by pushing a tf-provider/vX.Y.Z tag",
+		Long: `Cut a new terraform-provider-onyx release by pushing a tf-provider/vX.Y.Z tag.
+
+The tf-provider/v* tags are the source of truth for the version — nothing in
+terraform-provider-onyx/ records it, and the build stamps it from the tag. This
+command reads the latest tf-provider/v* tag, computes the next version, and pushes
+the new tag to origin.
+
+release-terraform-provider.yml then copies terraform-provider-onyx/ to the release
+mirror as one commit tagged vX.Y.Z, and the mirror's own Publish workflow builds,
+signs and publishes the release the Terraform Registry ingests.
+
+By default the patch version is bumped. Use --bump minor|major, or pin an exact
+--version.
+
+Example usage:
+
+    $ ods release tf-provider
+    $ ods release tf-provider --bump minor
+    $ ods release tf-provider --version 1.0.0`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			tfProviderRelease.run(opts)
+		},
+	}
+
+	tfProviderRelease.addFlags(cmd, opts)
+
+	return cmd
+}


### PR DESCRIPTION
## Description

The public Terraform Registry only serves a provider from a repository named after it, so a provider living inside a monorepo cannot be published as it stands. This adds the release path, through a mirror repository, `onyx-dot-app/terraform-provider-onyx`. The mirror holds no source of its own: it is written from `terraform-provider-onyx/` and never edited directly.

Two workflows split the work, one in each repository:

1. `ods release tf-provider` pushes a `tf-provider/vX.Y.Z` tag here.
2. `.github/workflows/release-terraform-provider.yml` copies the directory to the mirror as one commit tagged `vX.Y.Z`.
3. That tag starts `publish.yml` **in the mirror**. It lives at `terraform-provider-onyx/.github/workflows/publish.yml` and travels with the directory it publishes; GitHub only reads workflows from a repository's root, so it is inert here.
4. goreleaser builds every platform archive, signs the checksums, and publishes a GitHub release. The registry ingests it from there.

The signing key lives in the mirror, with the workflow that uses it. The monorepo never holds it.

### The planned mechanism does not work

The rollout plan says publishing would be "fed by a `git subtree` split of `terraform-provider-onyx/` pushed from CI". `git subtree split --prefix=terraform-provider-onyx` **did not finish inside ten minutes** and had to be killed. It walks all ~9,900 commits in this repository to find the 15 that touch the provider.

The directory is already a complete git tree, so the workflow commits that tree straight onto the mirror's history with plumbing instead. That is constant-time, and it gives the mirror one commit per release with a real diff between release tags.

### Why goreleaser runs in the mirror

It takes the version from whatever tag the checkout it runs in has. Run here it finds tags like `nightly-latest-...` and stamps them into every artifact name.

## How Has This Been Tested?

As far as it can be before the mirror repository exists, which is further than expected:

- **The tree-commit push was run against a local bare repository across two consecutive releases.** Result: linear history, one commit per release, and a correct `git diff` between release tags.
- **`goreleaser check` passes**, and `goreleaser release --snapshot --skip=sign,publish` **built all 13 platform archives in 44 seconds** with the shapes the registry requires: `terraform-provider-onyx_{version}_{os}_{arch}.zip`, the binary named `terraform-provider-onyx_v{version}` inside each, and the manifest listed in the `SHA256SUMS` file.
- `ods release tf-provider --version 1.0.0 --dry-run` computes the right tag, and `ods release opal --dry-run` still bumps `v0.1.22 -> v0.1.23` after the shared refactor.
- **The nested workflow is genuinely linted**, not just passing by not being matched: checked by breaking it on purpose and confirming actionlint reports the error at `terraform-provider-onyx/.github/workflows/publish.yml`.
- zizmor, actionlint and shellcheck pass. Git authenticates with a header rather than a URL, the same way `actions/checkout` does, so no token becomes part of a remote or a ref.

**Merging this is safe and changes nothing on its own.** The tag trigger matches no existing tag, and `publish.yml` is inert in this repository.

### Review fixes

**Trimmed `.goreleaser.yml` to what is not already the default** (75 → 52 lines). Gone: the build hook, the `ldflags`, the `darwin/386` and `darwin/arm` exclusions, and the checksum algorithm. The default `ldflags` already stamps `main.version`, and goreleaser drops those two platform combinations by itself — both confirmed against the resolved config goreleaser writes to `dist/config.yaml`, and by rebuilding.

`project_name` stays, and is the one deliberate exception. goreleaser derives it from the **git remote**, which is `onyx` here — dropping it renamed every archive to `onyx_*`, which the registry would not recognise. So it looks like a default and is not one in this repository. Caught by rebuilding after the trim rather than by reading.

**Publishing moved into `publish.yml` in the mirror**, as suggested. Worth noting: the tag push starts it on its own, so nothing needs `actions: write` on the mirror or a dispatch call. `publish.yml` also takes a manual run that defaults to a dry run, which is now where a release is rehearsed. One side effect worth a look — the zizmor and actionlint hooks were anchored at the repository root and would have skipped the nested workflow entirely, so `.pre-commit-config.yaml` now matches a nested `.github/workflows` too.

**Added `ods release tf-provider`.** It shares one implementation with `ods release opal` rather than being a second copy of it, so `release_opal.go` loses its private helpers and gains nothing else.

**Commit identity was missing** (from the bot review). `git commit-tree` needs a committer, and a runner has none configured to fall back on, so a real release would have stopped before it touched the mirror. This passed locally only because a developer machine has an identity to find. The identity now comes from the app the token belongs to, matching `release-devcontainer.yml`.

**The mirror push was not atomic** (also from the bot review). It is one `git push --atomic` now. Verified against a local mirror: re-running a shipped version is refused whole, both refs rejected, and `main` stays where it was.

### Still blocked, and each item needs org permissions

The same checklist lives in the provider README, next to the workflow it gates:

- [ ] Create the public repository `onyx-dot-app/terraform-provider-onyx`. It currently returns 404. Empty or initialised both work.
- [ ] Decide what `LICENSE` the mirror carries. The provider is MIT under this repo's terms, but the monorepo `LICENSE` names `ee` directories the mirror has none of. Deliberately not decided here — goreleaser puts the file into every archive once it exists.
- [ ] Create the release GPG key and register its public half with the Terraform Registry under the `onyx-dot-app` namespace.
- [ ] Install a GitHub App with `contents: write` on the mirror, and fill this repo's `release-terraform-provider` environment: variable `TF_PROVIDER_RELEASE_APP_ID`, secret `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`.
- [ ] Add `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE` **to the mirror**, where the signing happens.
- [ ] Link the mirror on registry.terraform.io as the `onyx-dot-app` organisation.

Once the repository exists, the dry run exercises the build and one real tag exercises the rest.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
<!-- Tracked as PR 8 of the umbrella issue ENG-4322 (Terraform provider for Onyx — rollout plan) rather than as its own Linear issue. -->
