### PR TITLE
feat(craft): artifact index and action receipt schema with DAL

### DIFF
--- a/backend/alembic/versions/34fe28843029_craft_artifact_index_and_receipts.py
+++ b/backend/alembic/versions/34fe28843029_craft_artifact_index_and_receipts.py
@@ -1,0 +1,146 @@
+"""Craft artifact index columns and action receipts
+
+The artifact table becomes the index the output panel renders from, with an
+upsert key on (session, path). action_receipt records external actions with a
+pending/confirmed/failed/unknown lifecycle for receipt cards.
+
+Revision ID: 34fe28843029
+Revises: 66a70ddc0652
+Create Date: 2026-08-26
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "34fe28843029"
+down_revision = "66a70ddc0652"
+branch_labels = None
+depends_on = None
+
+# Non-native enums store member NAMES in a VARCHAR sized to the longest one.
+# The original artifact.type was sized for six members (VARCHAR(8)), too narrow
+# for DIRECTORY, so upgrade widens it to the full member set.
+_ARTIFACT_TYPE_OLD = sa.Enum(
+    "WEB_APP",
+    "PPTX",
+    "DOCX",
+    "IMAGE",
+    "MARKDOWN",
+    "EXCEL",
+    native_enum=False,
+    name="artifacttype",
+)
+_ARTIFACT_TYPE_NEW = sa.Enum(
+    "WEB_APP",
+    "PPTX",
+    "DOCX",
+    "IMAGE",
+    "MARKDOWN",
+    "EXCEL",
+    "PDF",
+    "CSV",
+    "CODE",
+    "DIRECTORY",
+    "AUDIO",
+    "VIDEO",
+    "ARCHIVE",
+    "FILE",
+    native_enum=False,
+    name="artifacttype",
+)
+_RECEIPT_STATUS = sa.Enum(
+    "PENDING",
+    "CONFIRMED",
+    "FAILED",
+    "UNKNOWN",
+    native_enum=False,
+    name="receiptstatus",
+)
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "artifact",
+        "type",
+        existing_type=_ARTIFACT_TYPE_OLD,
+        type_=_ARTIFACT_TYPE_NEW,
+        existing_nullable=False,
+    )
+    op.add_column("artifact", sa.Column("turn_index", sa.Integer(), nullable=True))
+    op.add_column("artifact", sa.Column("size_bytes", sa.BigInteger(), nullable=True))
+    op.add_column("artifact", sa.Column("content_hash", sa.String(), nullable=True))
+    op.add_column(
+        "artifact",
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "artifact",
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column("artifact", sa.Column("archive_file_id", sa.String(), nullable=True))
+    op.create_index(
+        "uq_artifact_session_path",
+        "artifact",
+        ["session_id", "path"],
+        unique=True,
+    )
+
+    op.create_table(
+        "action_receipt",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("gated_app_id", sa.Integer(), nullable=True),
+        sa.Column("approval_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("action_type", sa.String(), nullable=False),
+        sa.Column("effect", sa.String(), nullable=False),
+        sa.Column("destination", sa.String(), nullable=False),
+        sa.Column("link", sa.String(), nullable=True),
+        sa.Column("operation_key", sa.String(), nullable=True),
+        sa.Column("status", _RECEIPT_STATUS, server_default="PENDING", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"], ["build_session.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["gated_app_id"], ["gated_app.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["approval_id"], ["action_approval.approval_id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_action_receipt_session_created",
+        "action_receipt",
+        ["session_id", sa.text("created_at DESC")],
+    )
+    op.create_index(
+        "uq_action_receipt_session_operation",
+        "action_receipt",
+        ["session_id", "operation_key"],
+        unique=True,
+        postgresql_where=sa.text("operation_key IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_action_receipt_session_operation", table_name="action_receipt")
+    op.drop_index("ix_action_receipt_session_created", table_name="action_receipt")
+    op.drop_table("action_receipt")
+    op.drop_index("uq_artifact_session_path", table_name="artifact")
+    op.drop_column("artifact", "archive_file_id")
+    op.drop_column("artifact", "deleted")
+    op.drop_column("artifact", "version")
+    op.drop_column("artifact", "content_hash")
+    op.drop_column("artifact", "size_bytes")
+    op.drop_column("artifact", "turn_index")
+    # type stays wide on downgrade: narrowing would fail on rows holding the
+    # new values, and a wider varchar is harmless to the old code.

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -540,6 +540,25 @@ class ArtifactType(str, PyEnum):
     IMAGE = "image"
     MARKDOWN = "markdown"
     EXCEL = "excel"
+    PDF = "pdf"
+    CSV = "csv"
+    CODE = "code"
+    DIRECTORY = "directory"
+    AUDIO = "audio"
+    VIDEO = "video"
+    ARCHIVE = "archive"
+    # Generic file type used when no specific type applies.
+    FILE = "file"
+
+
+class ReceiptStatus(str, PyEnum):
+    """Lifecycle of an external-action receipt. The full contract lives on
+    ActionReceipt."""
+
+    PENDING = "pending"
+    CONFIRMED = "confirmed"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
 
 
 class HierarchyNodeType(str, PyEnum):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -105,6 +105,7 @@ from onyx.db.enums import (
     PersonaSharePermission,
     PortAttemptStatus,
     ProcessingMode,
+    ReceiptStatus,
     SandboxStatus,
     ScheduledTaskRunStatus,
     ScheduledTaskStatus,
@@ -6357,6 +6358,9 @@ class BuildSession(Base):
     artifacts: Mapped[list["Artifact"]] = relationship(
         "Artifact", back_populates="session", cascade="all, delete-orphan"
     )
+    receipts: Mapped[list["ActionReceipt"]] = relationship(
+        "ActionReceipt", back_populates="session", cascade="all, delete-orphan"
+    )
     messages: Mapped[list["BuildMessage"]] = relationship(
         "BuildMessage", back_populates="session", cascade="all, delete-orphan"
     )
@@ -6467,6 +6471,23 @@ class Artifact(Base):
     # path of artifact in sandbox relative to outputs/
     path: Mapped[str] = mapped_column(String, nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
+    # Turn that last produced or changed this artifact. NULL when the
+    # producing turn is unknown.
+    turn_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # Content hash from the sandbox manifest. Drives change detection: an
+    # upsert with a different hash bumps version and invalidates the archive.
+    content_hash: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Bumped on every content change so a consumer holding an earlier
+    # version can detect that it was superseded.
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    # Deleted artifacts keep their row so stale cards grey out instead of 404ing.
+    deleted: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    # Reserved for archived bytes served without the sandbox. NULL until an
+    # archive exists.
+    archive_file_id: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -6485,6 +6506,82 @@ class Artifact(Base):
     __table_args__ = (
         Index("ix_artifact_session_created", "session_id", desc("created_at")),
         Index("ix_artifact_type", "type"),
+        # Upsert key: one row per file, edits update in place instead of
+        # duplicating.
+        Index("uq_artifact_session_path", "session_id", "path", unique=True),
+    )
+
+
+class ActionReceipt(Base):
+    """Record of one external action a session performed, covering
+    write-effect actions and anything that went through an approval.
+
+    Written PENDING before the action executes, finalized CONFIRMED or FAILED
+    by the recorder's response and error handling, swept to UNKNOWN when
+    orphaned. Only CONFIRMED rows are presented as proof.
+    """
+
+    __tablename__ = "action_receipt"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    session_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("build_session.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # The gated target this action hit, via the polymorphic ``gated_app``
+    # identity row. Goes NULL when that target is deleted, the receipt stays
+    # as a record of what happened.
+    gated_app_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("gated_app.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # The approval that authorized this action, when it went through one.
+    approval_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("action_approval.approval_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Typed action id, e.g. ``slack.messages.write`` or an MCP tool name.
+    action_type: Mapped[str] = mapped_column(String, nullable=False)
+    # Catalog effect kind (read/write) captured at record time, so the row is
+    # self-contained even if the catalog reclassifies later.
+    effect: Mapped[str] = mapped_column(String, nullable=False)
+    # Human-readable destination, e.g. ``#exec-team`` or ``Google Drive``.
+    destination: Mapped[str] = mapped_column(String, nullable=False)
+    # Deep link into the destination, when a provider extractor could read one
+    # from the response.
+    link: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Coalescing key so multi-request provider flows (a Slack upload spans
+    # several matched requests) collapse into one receipt.
+    operation_key: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[ReceiptStatus] = mapped_column(
+        Enum(ReceiptStatus, native_enum=False, name="receiptstatus"),
+        nullable=False,
+        # Non-native enums store the member NAME, so the default must match it.
+        server_default=ReceiptStatus.PENDING.name,
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    session: Mapped[BuildSession] = relationship(
+        "BuildSession", back_populates="receipts"
+    )
+
+    __table_args__ = (
+        Index("ix_action_receipt_session_created", "session_id", desc("created_at")),
+        # One receipt per logical operation. NULL keys stay independent rows.
+        Index(
+            "uq_action_receipt_session_operation",
+            "session_id",
+            "operation_key",
+            unique=True,
+            postgresql_where=text("operation_key IS NOT NULL"),
+        ),
     )
 
 

--- a/backend/onyx/server/features/build/db/artifact.py
+++ b/backend/onyx/server/features/build/db/artifact.py
@@ -1,0 +1,106 @@
+"""Artifact index DAL.
+
+One mutable row per (session, path), upserted at turn end. Content-hash
+comparison decides whether an upsert is a content change (version bump,
+archive invalidated) or a metadata touch. Helpers flush and never commit,
+the caller owns the transaction so rows land before the turn's terminal
+event.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import case, desc, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ArtifactType
+from onyx.db.models import Artifact
+
+
+def upsert_artifact(
+    db_session: Session,
+    *,
+    session_id: UUID,
+    artifact_type: ArtifactType,
+    path: str,
+    name: str,
+    turn_index: int | None,
+    size_bytes: int | None,
+    content_hash: str | None,
+) -> Artifact:
+    """Insert or update the row for (session, path).
+
+    A changed content hash bumps the version and clears the archive reference
+    (the archived bytes no longer match). An unchanged hash only refreshes
+    metadata. Either way the row is undeleted, a resurrected path is live
+    again.
+    """
+    changed = Artifact.content_hash.is_distinct_from(content_hash)
+    stmt = (
+        pg_insert(Artifact)
+        .values(
+            session_id=session_id,
+            type=artifact_type,
+            path=path,
+            name=name,
+            turn_index=turn_index,
+            size_bytes=size_bytes,
+            content_hash=content_hash,
+            version=1,
+            deleted=False,
+        )
+        .on_conflict_do_update(
+            index_elements=[Artifact.session_id, Artifact.path],
+            set_={
+                "type": artifact_type,
+                "name": name,
+                "turn_index": turn_index,
+                "size_bytes": size_bytes,
+                "content_hash": content_hash,
+                "deleted": False,
+                "version": case(
+                    (changed, Artifact.version + 1), else_=Artifact.version
+                ),
+                "archive_file_id": case(
+                    (changed, None), else_=Artifact.archive_file_id
+                ),
+                # ON CONFLICT bypasses the column's onupdate, so bump manually.
+                "updated_at": func.now(),
+            },
+        )
+        .returning(Artifact)
+    )
+    # populate_existing: the row changes via Core SQL, so an identity-map hit
+    # must be refreshed rather than returned with stale attributes.
+    return db_session.execute(
+        select(Artifact).from_statement(stmt).execution_options(populate_existing=True)
+    ).scalar_one()
+
+
+def mark_artifact_deleted(
+    db_session: Session,
+    *,
+    session_id: UUID,
+    path: str,
+) -> Artifact | None:
+    """Flag the row for a path the manifest no longer contains."""
+    artifact = db_session.scalar(
+        select(Artifact).where(Artifact.session_id == session_id, Artifact.path == path)
+    )
+    if artifact is None or artifact.deleted:
+        return artifact
+    artifact.deleted = True
+    db_session.flush()
+    return artifact
+
+
+def get_session_artifacts(
+    db_session: Session,
+    *,
+    session_id: UUID,
+    include_deleted: bool = False,
+) -> list[Artifact]:
+    query = select(Artifact).where(Artifact.session_id == session_id)
+    if not include_deleted:
+        query = query.where(Artifact.deleted.is_(False))
+    return list(db_session.scalars(query.order_by(desc(Artifact.created_at))))

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.constants import MessageType
 from onyx.db.enums import BuildSessionStatus, SessionOrigin, SharingScope
-from onyx.db.models import Artifact, BuildMessage, BuildSession, Sandbox
+from onyx.db.models import BuildMessage, BuildSession, Sandbox
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.configs import (
@@ -316,62 +316,6 @@ def update_sandbox_heartbeat(
     if sandbox:
         sandbox.last_heartbeat = datetime.now(tz=timezone.utc)
         db_session.commit()
-
-
-# Artifact operations
-def create_artifact(
-    session_id: UUID,
-    artifact_type: str,
-    path: str,
-    name: str,
-    db_session: Session,
-) -> Artifact:
-    """Create a new artifact record."""
-    artifact = Artifact(
-        session_id=session_id,
-        type=artifact_type,
-        path=path,
-        name=name,
-    )
-    db_session.add(artifact)
-    db_session.commit()
-    db_session.refresh(artifact)
-
-    logger.info("Created artifact %s for session %s", artifact.id, session_id)
-    return artifact
-
-
-def get_session_artifacts(
-    session_id: UUID,
-    db_session: Session,
-) -> list[Artifact]:
-    """Get all artifacts for a session."""
-    return (
-        db_session.query(Artifact)
-        .filter(Artifact.session_id == session_id)
-        .order_by(desc(Artifact.created_at))
-        .all()
-    )
-
-
-def update_artifact(
-    artifact_id: UUID,
-    db_session: Session,
-    path: str | None = None,
-    name: str | None = None,
-) -> None:
-    """Update artifact metadata."""
-    artifact = (
-        db_session.query(Artifact).filter(Artifact.id == artifact_id).one_or_none()
-    )
-    if artifact:
-        if path is not None:
-            artifact.path = path
-        if name is not None:
-            artifact.name = name
-        artifact.updated_at = datetime.now(tz=timezone.utc)
-        db_session.commit()
-        logger.info("Updated artifact %s", artifact_id)
 
 
 # Message operations

--- a/backend/onyx/server/features/build/db/receipt.py
+++ b/backend/onyx/server/features/build/db/receipt.py
@@ -1,0 +1,148 @@
+"""Action receipt DAL.
+
+The shared persistence primitive receipts flow through, independent of which
+layer records them. The lifecycle contract lives on ActionReceipt. Helpers
+flush and never commit, the caller owns the transaction.
+"""
+
+from datetime import timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import desc, func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ReceiptStatus
+from onyx.db.models import ActionReceipt
+
+# A PENDING row older than this lost its recorder mid-flight. The sweeper
+# moves it to UNKNOWN so it can never linger as an implied in-progress send.
+PENDING_RECEIPT_TTL = timedelta(minutes=10)
+
+
+def insert_pending_receipt(
+    db_session: Session,
+    *,
+    session_id: UUID,
+    action_type: str,
+    effect: str,
+    destination: str,
+    gated_app_id: int | None,
+    approval_id: UUID | None,
+    operation_key: str | None,
+) -> ActionReceipt:
+    """Record the attempt before the action executes.
+
+    A repeated operation_key returns the existing row instead of a duplicate,
+    which is how multi-request provider flows coalesce into one receipt. NULL
+    keys always insert, the conflict target is the partial unique index.
+    """
+    stmt = (
+        pg_insert(ActionReceipt)
+        .values(
+            session_id=session_id,
+            action_type=action_type,
+            effect=effect,
+            destination=destination,
+            gated_app_id=gated_app_id,
+            approval_id=approval_id,
+            operation_key=operation_key,
+            status=ReceiptStatus.PENDING,
+        )
+        .on_conflict_do_nothing(
+            index_elements=[ActionReceipt.session_id, ActionReceipt.operation_key],
+            index_where=ActionReceipt.operation_key.isnot(None),
+        )
+        .returning(ActionReceipt)
+    )
+    receipt = db_session.execute(
+        select(ActionReceipt)
+        .from_statement(stmt)
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if receipt is not None:
+        return receipt
+    return db_session.execute(
+        select(ActionReceipt)
+        .where(
+            ActionReceipt.session_id == session_id,
+            ActionReceipt.operation_key == operation_key,
+        )
+        .execution_options(populate_existing=True)
+    ).scalar_one()
+
+
+def finalize_receipt(
+    db_session: Session,
+    *,
+    receipt_id: UUID,
+    status: ReceiptStatus,
+    link: str | None = None,
+) -> ActionReceipt | None:
+    """Move a PENDING row to its terminal state.
+
+    The conditional UPDATE is the race arbiter: concurrent finalizes cannot
+    flip an already-recorded verdict. Returns the row (already-terminal
+    included) or None when it does not exist.
+    """
+    if status not in (ReceiptStatus.CONFIRMED, ReceiptStatus.FAILED):
+        raise ValueError("finalize_receipt only records CONFIRMED or FAILED")
+    values: dict[str, Any] = {"status": status}
+    if link is not None:
+        values["link"] = link
+    row = db_session.execute(
+        update(ActionReceipt)
+        .where(
+            ActionReceipt.id == receipt_id,
+            ActionReceipt.status == ReceiptStatus.PENDING,
+        )
+        .values(**values)
+        .returning(ActionReceipt)
+        .execution_options(synchronize_session=False)
+    ).scalar_one_or_none()
+    db_session.flush()
+    if row is None:
+        # Lost the race or already terminal. Read fresh, an identity-map hit
+        # here could still say PENDING.
+        return db_session.execute(
+            select(ActionReceipt)
+            .where(ActionReceipt.id == receipt_id)
+            .execution_options(populate_existing=True)
+        ).scalar_one_or_none()
+    db_session.refresh(row)
+    return row
+
+
+def sweep_stale_pending_receipts(db_session: Session) -> int:
+    """Mark orphaned PENDING rows UNKNOWN. Returns the number swept."""
+    # DB clock on both sides, created_at is server-generated.
+    cutoff = func.now() - PENDING_RECEIPT_TTL
+    swept_ids = (
+        db_session.execute(
+            update(ActionReceipt)
+            .where(
+                ActionReceipt.status == ReceiptStatus.PENDING,
+                ActionReceipt.created_at < cutoff,
+            )
+            .values(status=ReceiptStatus.UNKNOWN)
+            .returning(ActionReceipt.id)
+            .execution_options(synchronize_session=False)
+        )
+        .scalars()
+        .all()
+    )
+    db_session.flush()
+    return len(swept_ids)
+
+
+def get_session_receipts(
+    db_session: Session,
+    *,
+    session_id: UUID,
+    statuses: list[ReceiptStatus] | None = None,
+) -> list[ActionReceipt]:
+    query = select(ActionReceipt).where(ActionReceipt.session_id == session_id)
+    if statuses is not None:
+        query = query.where(ActionReceipt.status.in_(statuses))
+    return list(db_session.scalars(query.order_by(desc(ActionReceipt.created_at))))

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -38,6 +38,7 @@ from onyx.db.enums import (
 from onyx.db.gated_app import get_or_create_gated_app_id
 from onyx.db.models import (
     ActionApproval,
+    ActionReceipt,
     Connector,
     ConnectorCredentialPair,
     Credential,
@@ -66,6 +67,20 @@ def force_approval_created_at(
     db_session.execute(
         update(ActionApproval)
         .where(ActionApproval.approval_id == approval_id)
+        .values(created_at=when)
+    )
+    db_session.commit()
+
+
+def force_receipt_created_at(
+    db_session: Session,
+    receipt_id: UUID,
+    when: datetime,
+) -> None:
+    """Force an ``ActionReceipt`` row's ``created_at`` timestamp."""
+    db_session.execute(
+        update(ActionReceipt)
+        .where(ActionReceipt.id == receipt_id)
         .values(created_at=when)
     )
     db_session.commit()

--- a/backend/tests/external_dependency_unit/craft/test_artifact_receipt_dal.py
+++ b/backend/tests/external_dependency_unit/craft/test_artifact_receipt_dal.py
@@ -1,0 +1,224 @@
+"""External-dependency-unit tests for the artifact and receipt DALs.
+
+Runs real ORM/SQL against Postgres so the upsert semantics the reconciler
+depends on (hash-driven version bumps, archive invalidation, operation-key
+coalescing, terminal receipt states) actually fail on regression.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ArtifactType, ReceiptStatus
+from onyx.db.models import ActionReceipt, Artifact, BuildSession
+from onyx.server.features.build.db.artifact import (
+    get_session_artifacts,
+    mark_artifact_deleted,
+    upsert_artifact,
+)
+from onyx.server.features.build.db.receipt import (
+    finalize_receipt,
+    get_session_receipts,
+    insert_pending_receipt,
+    sweep_stale_pending_receipts,
+)
+from tests.external_dependency_unit.craft.db_helpers import force_receipt_created_at
+
+
+def _upsert(
+    db_session: Session,
+    session: BuildSession,
+    *,
+    path: str = "q3_board_deck.pptx",
+    content_hash: str | None = "hash-a",
+    turn_index: int | None = 1,
+) -> Artifact:
+    return upsert_artifact(
+        db_session,
+        session_id=session.id,
+        artifact_type=ArtifactType.PPTX,
+        path=path,
+        name=path,
+        turn_index=turn_index,
+        size_bytes=1024,
+        content_hash=content_hash,
+    )
+
+
+def test_upsert_same_hash_touches_without_version_bump(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    first = _upsert(db_session, session)
+    db_session.commit()
+    assert first.version == 1
+
+    second = _upsert(db_session, session, turn_index=2)
+    db_session.commit()
+    assert second.id == first.id
+    assert second.version == 1
+    assert second.turn_index == 2
+
+
+def test_upsert_content_change_bumps_version_and_clears_archive(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    first = _upsert(db_session, session)
+    first.archive_file_id = "file-store-id"
+    db_session.commit()
+
+    second = _upsert(db_session, session, content_hash="hash-b")
+    db_session.commit()
+    assert second.id == first.id
+    assert second.version == 2
+    assert second.archive_file_id is None
+
+
+def test_deleted_artifact_hidden_then_resurrected(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _upsert(db_session, session)
+    db_session.commit()
+
+    deleted = mark_artifact_deleted(
+        db_session, session_id=session.id, path="q3_board_deck.pptx"
+    )
+    db_session.commit()
+    assert deleted is not None and deleted.deleted
+
+    assert get_session_artifacts(db_session, session_id=session.id) == []
+    assert (
+        len(
+            get_session_artifacts(
+                db_session, session_id=session.id, include_deleted=True
+            )
+        )
+        == 1
+    )
+
+    resurrected = _upsert(db_session, session, turn_index=3)
+    db_session.commit()
+    assert not resurrected.deleted
+    assert len(get_session_artifacts(db_session, session_id=session.id)) == 1
+
+
+def test_same_path_isolated_per_session(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session_a = build_session_with_user()
+    session_b = build_session_with_user()
+    _upsert(db_session, session_a)
+    _upsert(db_session, session_b)
+    db_session.commit()
+
+    assert len(get_session_artifacts(db_session, session_id=session_a.id)) == 1
+    assert len(get_session_artifacts(db_session, session_id=session_b.id)) == 1
+
+
+def _pending(
+    db_session: Session,
+    session: BuildSession,
+    *,
+    operation_key: str | None = None,
+    action_type: str = "slack.messages.write",
+) -> ActionReceipt:
+    return insert_pending_receipt(
+        db_session,
+        session_id=session.id,
+        action_type=action_type,
+        effect="write",
+        destination="#exec-team",
+        gated_app_id=None,
+        approval_id=None,
+        operation_key=operation_key,
+    )
+
+
+def test_pending_receipt_coalesces_on_operation_key(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    first = _pending(db_session, session, operation_key="upload-1")
+    second = _pending(db_session, session, operation_key="upload-1")
+    third = _pending(db_session, session, operation_key="upload-2")
+    db_session.commit()
+
+    assert second.id == first.id
+    assert third.id != first.id
+    assert len(get_session_receipts(db_session, session_id=session.id)) == 2
+
+
+def test_finalize_is_terminal_and_rejects_pending(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    receipt = _pending(db_session, session)
+    db_session.commit()
+
+    confirmed = finalize_receipt(
+        db_session,
+        receipt_id=receipt.id,
+        status=ReceiptStatus.CONFIRMED,
+        link="https://slack.com/archives/C1/p1",
+    )
+    db_session.commit()
+    assert confirmed is not None
+    assert confirmed.status == ReceiptStatus.CONFIRMED
+    assert confirmed.link is not None
+
+    flipped = finalize_receipt(
+        db_session, receipt_id=receipt.id, status=ReceiptStatus.FAILED
+    )
+    db_session.commit()
+    assert flipped is not None
+    assert flipped.status == ReceiptStatus.CONFIRMED
+
+    for non_terminal in (ReceiptStatus.PENDING, ReceiptStatus.UNKNOWN):
+        with pytest.raises(ValueError):
+            finalize_receipt(db_session, receipt_id=receipt.id, status=non_terminal)
+
+
+def test_sweep_marks_only_stale_pending_unknown(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    stale = _pending(db_session, session, action_type="drive.files.upload")
+    fresh = _pending(db_session, session)
+    db_session.commit()
+
+    force_receipt_created_at(
+        db_session, stale.id, datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    )
+
+    swept = sweep_stale_pending_receipts(db_session)
+    db_session.commit()
+    assert swept == 1
+    db_session.refresh(stale)
+    db_session.refresh(fresh)
+    assert stale.status == ReceiptStatus.UNKNOWN
+    assert fresh.status == ReceiptStatus.PENDING
+
+    confirmed_only = get_session_receipts(
+        db_session, session_id=session.id, statuses=[ReceiptStatus.CONFIRMED]
+    )
+    assert confirmed_only == []


### PR DESCRIPTION
## Description

**Why.** The output panel redesign needs a backend that actually knows what Craft produced. Today the `artifact` table is dead weight: its DAL has zero callers and `SessionManager.list_artifacts` fabricates a single hardcoded webapp entry with an unstable UUID, so cards, versioning, and deletion state have nowhere to live. External side effects (a deck posted to Slack) leave no record at all. This PR lays the schema and data-access layer that PRs 2-7 build on.

**What.**
- `artifact` becomes a real index: unique key on (session, path) so edits update in place, `content_hash` for change detection, `version` bumped only on hash change (same upsert clears `archive_file_id`, since archived bytes no longer match), `deleted` flag so stale cards grey out instead of 404ing, `turn_index` and `size_bytes` for cards, reserved nullable `archive_file_id` so the archive fast-follow needs no second migration.
- `ArtifactType` gains pdf/csv/code/directory/audio/video/archive and a generic `file` fallback. The migration widens the VARCHAR(8) `type` column that `DIRECTORY` would overflow.
- New `action_receipt` table: PENDING written before an external action executes, a conditional UPDATE (the race arbiter, mirroring `action_approval.try_record_decision`) finalizes CONFIRMED/FAILED, stale PENDING sweeps to UNKNOWN. `operation_key` partial unique index coalesces multi-request provider flows into one receipt.
- Removes the never-called artifact DAL from `build_session.py`.

Everything is additive and backwards compatible. The tables are empty in every deployment until the reconciler (PR4) and receipt recorder (PR6) write to them.

## How Has This Been Tested?

- External-dependency-unit tests (`test_artifact_receipt_dal.py`, real ORM/SQL against a Postgres migrated with this revision): same-hash upsert refreshes metadata without a version bump, changed hash bumps version and clears the archive ref, deleted paths flag and resurrect, receipt lifecycle through PENDING → CONFIRMED/FAILED including the conditional-UPDATE race arbiter, stale-PENDING sweep to UNKNOWN, and operation-key coalescing.
- Migration applied and verified against a scratch database at main's alembic head; single-head chain preserved.
- Full CI matrix green (160 checks).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check