### PR TITLE
feat(chat): answer-completeness reminder for search-backed turns

### DIFF
--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -8,6 +8,7 @@ from onyx.db.persona import get_default_behavior_persona
 from onyx.db.user_file import calculate_user_files_token_count
 from onyx.file_store.models import FileDescriptor
 from onyx.prompts.chat_prompts import (
+    ANSWER_COMPLETENESS_REMINDER,
     CITATION_REMINDER,
     DEFAULT_SYSTEM_PROMPT,
     FILE_REMINDER,
@@ -135,6 +136,7 @@ def build_reminder_message(
         reminder += "\n\n" + LAST_CYCLE_CITATION_REMINDER
     if include_citation_reminder:
         reminder += "\n\n" + CITATION_REMINDER
+        reminder += "\n\n" + ANSWER_COMPLETENESS_REMINDER
     if include_file_reminder:
         reminder += "\n\n" + FILE_REMINDER
     reminder = reminder.strip()

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -49,6 +49,16 @@ CITATION_REMINDER = """
 Remember to provide inline citations in the format [1], [2], [3], etc. based on the "document" field of the documents.
 """.strip()
 
+# Pushes the answer to cover every part of the question with the concrete
+# values the sources state. Benchmarked on EnterpriseRAG-Bench (500 questions):
+# +3.3 combined score on the default pipeline, driven by answer completeness
+# (77% -> 80%) with correctness flat. The final sentence keeps
+# "information not found" answers short; broader brevity or hedging clauses
+# tested worse.
+ANSWER_COMPLETENESS_REMINDER = """
+Address every part of the question explicitly. When the source documents state specific values, limits, dates, names, commands, or steps relevant to the question, include them exactly rather than summarizing them away. Before finishing, check the question for sub-parts you have not answered. If the requested information is not available, state that briefly without adding related background.
+""".strip()
+
 LAST_CYCLE_CITATION_REMINDER = """
 You are on your last cycle and no longer have any tool calls available. You must answer the query now to the best of your ability.
 """.strip()

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -49,12 +49,9 @@ CITATION_REMINDER = """
 Remember to provide inline citations in the format [1], [2], [3], etc. based on the "document" field of the documents.
 """.strip()
 
-# Pushes the answer to cover every part of the question with the concrete
-# values the sources state. Benchmarked on EnterpriseRAG-Bench (500 questions):
-# +3.3 combined score on the default pipeline, driven by answer completeness
-# (77% -> 80%) with correctness flat. The final sentence keeps
-# "information not found" answers short; broader brevity or hedging clauses
-# tested worse.
+# Pushes answers to cover every part of the question with the exact values the
+# sources state. +3.3 combined score on EnterpriseRAG-Bench (500 questions);
+# broader brevity or hedging variants tested worse.
 ANSWER_COMPLETENESS_REMINDER = """
 Address every part of the question explicitly. When the source documents state specific values, limits, dates, names, commands, or steps relevant to the question, include them exactly rather than summarizing them away. Before finishing, check the question for sub-parts you have not answered. If the requested information is not available, state that briefly without adding related background.
 """.strip()


### PR DESCRIPTION
## Description

Adds an answer-completeness reminder alongside the citation reminder on search-backed turns: address every sub-part of the question, include the exact values/limits/names/steps the sources state, and keep "information not found" answers brief.

Benchmarked on EnterpriseRAG-Bench (500 questions, gpt-5.6-luna, judged with gpt-5.4): +3.3 combined score on the current pipeline (70.2 → 73.5), driven by answer completeness (77.2% → 80.3%) with correctness flat; +2.6 on top of the `search-update` branch (79.3 → 81.9 on the 107-question subset). Variants with a general brevity clause or an uncertainty-hedging clause both scored materially worse, so the instruction is deliberately scoped. Full experiment series is on the agent-wiki page "Benchmark Speed Cost and Quality".

## How Has This Been Tested?

Live A/B on the eRAG benchmark against yuhong.onyx.app (persona task-prompt injection, identical placement to this change): 500-question runs for the with/without comparison plus 4 prompt variants on the 107-question subset. Pre-commit (ty, ruff) passes; no behavior change when no search ran (`include_citation_reminder` false).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an answer-completeness reminder alongside the citation reminder on search-backed turns so the model addresses every sub-part of the question, includes the exact values the sources state, and keeps "information not found" answers brief. No behavior change when no search ran.

**Benchmarks**
- +3.3 combined score on EnterpriseRAG-Bench (70.2 → 73.5), driven by answer completeness (77.2% → 80.3%) with correctness flat.
- +2.6 on top of the `search-update` branch (79.3 → 81.9).
- Broader brevity or uncertainty-hedging clauses scored worse, so the instruction is deliberately scoped.

<sup>Written for commit 6e25a5ced7834aff2b81b6ea2affd78ce8605204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

