### PR TITLE
feat: add Japanese, Simplified Chinese, and Korean UI locales

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -311,6 +311,9 @@ class SupportedLanguage(str, PyEnum):
     PT = "pt"
     FR = "fr"
     DE = "de"
+    JA = "ja"
+    ZH = "zh"
+    KO = "ko"
 
 
 class DefaultAppMode(str, PyEnum):

--- a/web/src/i18n/__tests__/catalog.test.ts
+++ b/web/src/i18n/__tests__/catalog.test.ts
@@ -17,11 +17,22 @@ import de from "@/i18n/messages/de.json";
 import en from "@/i18n/messages/en.json";
 import es from "@/i18n/messages/es.json";
 import fr from "@/i18n/messages/fr.json";
+import ja from "@/i18n/messages/ja.json";
+import ko from "@/i18n/messages/ko.json";
 import pt from "@/i18n/messages/pt.json";
+import zh from "@/i18n/messages/zh.json";
 
 type MessageTree = { [key: string]: string | MessageTree };
 
-const TARGET_LOCALES: Record<string, MessageTree> = { de, es, fr, pt };
+const TARGET_LOCALES: Record<string, MessageTree> = {
+  de,
+  es,
+  fr,
+  ja,
+  ko,
+  pt,
+  zh,
+};
 
 function flatten(tree: MessageTree, prefix = ""): Record<string, string> {
   const flat: Record<string, string> = {};

--- a/web/src/i18n/config.test.ts
+++ b/web/src/i18n/config.test.ts
@@ -5,6 +5,15 @@ describe("SUPPORTED_LOCALES", () => {
     // Pin the locale list that mirrors the backend `SupportedLanguage` enum
     // (backend/onyx/db/enums.py). If this test fails, update both places
     // together.
-    expect([...SUPPORTED_LOCALES]).toEqual(["en", "es", "pt", "fr", "de"]);
+    expect([...SUPPORTED_LOCALES]).toEqual([
+      "en",
+      "es",
+      "pt",
+      "fr",
+      "de",
+      "ja",
+      "zh",
+      "ko",
+    ]);
   });
 });

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -3,7 +3,16 @@
 // Must stay in sync with the backend `SupportedLanguage` enum in
 // backend/onyx/db/enums.py — config.test.ts pins this list, and
 // `PATCH /user/language` rejects values outside that enum.
-export const SUPPORTED_LOCALES = ["en", "es", "pt", "fr", "de"] as const;
+export const SUPPORTED_LOCALES = [
+  "en",
+  "es",
+  "pt",
+  "fr",
+  "de",
+  "ja",
+  "zh",
+  "ko",
+] as const;
 
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
@@ -23,6 +32,9 @@ export const LOCALE_ENDONYMS = {
   pt: "Português",
   fr: "Français",
   de: "Deutsch",
+  ja: "日本語",
+  zh: "简体中文",
+  ko: "한국어",
 } satisfies Record<Locale, string>;
 
 export function isSupportedLocale(

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -1,0 +1,9561 @@
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "アカウント"
+    },
+    "helpFaq": {
+      "label": "ヘルプと FAQ"
+    },
+    "logIn": {
+      "label": "ログイン"
+    },
+    "logoutFailed": {
+      "message": "ログアウトに失敗しました"
+    },
+    "notifications": {
+      "label": "通知"
+    },
+    "profileUnavailable": {
+      "title": "プロフィールを利用できません"
+    },
+    "settings": {
+      "label": "設定"
+    },
+    "signOut": {
+      "label": "ログアウト"
+    }
+  },
+  "actions": {
+    "actionButtons": {
+      "authenticateButton": {
+        "ariaLabel": "認証して {serverName} に接続",
+        "label": "認証"
+      },
+      "deleteButton": {
+        "ariaLabel": "{serverName} サーバーを削除",
+        "tooltip": "サーバーを削除"
+      },
+      "disconnectButton": {
+        "ariaLabel": "{serverName} サーバーを切断",
+        "tooltip": "サーバーを切断"
+      },
+      "fetchingTools": {
+        "label": "ツールを取得中..."
+      },
+      "manageButton": {
+        "ariaLabel": "{serverName} サーバーを管理",
+        "tooltip": "サーバーを管理"
+      },
+      "reconnectButton": {
+        "ariaLabel": "{serverName} に再接続",
+        "label": "再接続"
+      },
+      "viewToolsButton": {
+        "ariaLabel": "{serverName} のツールを表示",
+        "label": "{count, plural, one {# 個のツールを表示} other {# 個のツールを表示}}"
+      }
+    },
+    "actionCard": {
+      "card": {
+        "ariaLabel": "{title} アクションカード"
+      }
+    },
+    "addMcpModal": {
+      "addHeader": {
+        "description": "MCP (Model Context Protocol) サーバーに接続して、カスタムアクションを追加します。",
+        "title": "MCP サーバーを追加"
+      },
+      "authStatus": {
+        "apiTokenDescription": "API token を設定済み",
+        "connectedDescription": "接続済み",
+        "oauthDescription": "{owner} に OAuth で接続済み",
+        "title": "認証済み・接続済み"
+      },
+      "cancelButton": {
+        "label": "キャンセル"
+      },
+      "description": {
+        "placeholder": "MCP サーバーの詳細",
+        "suffix": "任意",
+        "title": "説明"
+      },
+      "disconnectButton": {
+        "tooltip": "サーバーを切断"
+      },
+      "editConfigsButton": {
+        "label": "設定を編集"
+      },
+      "manageHeader": {
+        "description": "MCP サーバーの設定を更新し、認証を管理します。",
+        "title": "MCP サーバーを管理"
+      },
+      "name": {
+        "placeholder": "MCP サーバーの名前を入力",
+        "required": "サーバー名は必須です",
+        "title": "サーバー名"
+      },
+      "serverUrl": {
+        "invalid": "有効な URL を入力してください",
+        "required": "サーバー URL は必須です",
+        "subDescription": "信頼できるサーバーにのみ接続してください。この接続で実行される操作と、ツールを最新の状態に保つ責任はお客様にあります。",
+        "title": "MCP サーバー URL"
+      },
+      "submitButton": {
+        "addLabel": "サーバーを追加",
+        "addingLabel": "追加中...",
+        "saveLabel": "変更を保存",
+        "savingLabel": "保存中..."
+      },
+      "toasts": {
+        "createFailed": "MCP サーバーの作成に失敗しました",
+        "serverCreated": "MCP サーバーを作成しました",
+        "serverUpdated": "MCP サーバーを更新しました",
+        "updateFailed": "MCP サーバーの更新に失敗しました"
+      }
+    },
+    "addOpenApiModal": {
+      "addHeader": {
+        "description": "OpenAPI スキーマを追加して、カスタムアクションを追加します。",
+        "title": "OpenAPI アクションを追加"
+      },
+      "authStatus": {
+        "configuredTitle": "認証を設定済み",
+        "enabledTitle": "認証済み・有効",
+        "headersDescription": "カスタム認証ヘッダーを設定済み",
+        "oauthDescription": "OAuth 認証を設定済み",
+        "oauthNamedDescription": "{name} 経由で OAuth 接続済み",
+        "passthroughDescription": "パススルー認証が有効です"
+      },
+      "cancelButton": {
+        "label": "キャンセル"
+      },
+      "copyButton": {
+        "tooltip": "定義をコピー"
+      },
+      "definition": {
+        "invalidJson": "JSON の形式が無効です",
+        "placeholder": "ここに OpenAPI スキーマを入力してください",
+        "required": "OpenAPI スキーマ定義は必須です",
+        "subDescription": "このアクションで利用可能にする API を定義する OpenAPI スキーマを指定します。スキーマ内のどこでも (サーバー URL、パス、パラメーターの既定値など) プレースホルダー `CHAT_SESSION_ID`、`MESSAGE_ID`、`USER_ID`、`USER_EMAIL` を使用できます。呼び出し時に、現在のリクエストの値に置き換えられます。詳細は [OpenAPI アクション]({docsUrl}) を参照してください。",
+        "title": "OpenAPI スキーマ定義"
+      },
+      "disableButton": {
+        "tooltip": "アクションを無効化"
+      },
+      "editConfigsButton": {
+        "disabledTooltip": "認証を管理できるのは、アクションの作成者または管理者のみです",
+        "label": "設定を編集"
+      },
+      "editHeader": {
+        "description": "このアクションの OpenAPI スキーマを更新します。",
+        "title": "OpenAPI アクションを編集"
+      },
+      "empty": {
+        "description": "OpenAPI スキーマを入力すると、ここにアクションのプレビューが表示されます。",
+        "title": "アクションが見つかりません"
+      },
+      "formatButton": {
+        "tooltip": "定義を整形"
+      },
+      "method": {
+        "noSummary": "概要はありません"
+      },
+      "serverUrl": {
+        "description": "スキーマ内で見つかった URL です。信頼できるサーバーにのみ接続してください。"
+      },
+      "submitButton": {
+        "addLabel": "アクションを追加",
+        "addingLabel": "追加中...",
+        "saveLabel": "変更を保存",
+        "savingLabel": "保存中..."
+      },
+      "toasts": {
+        "actionCreated": "OpenAPI アクションを作成しました",
+        "actionUpdated": "OpenAPI アクションを更新しました",
+        "createFailed": "OpenAPI アクションの作成に失敗しました",
+        "invalidJson": "OpenAPI スキーマ定義の JSON 形式が無効です",
+        "updateFailed": "OpenAPI アクションの更新に失敗しました"
+      }
+    },
+    "cardHeader": {
+      "disconnected": {
+        "label": "(切断済み)"
+      },
+      "notAuthenticated": {
+        "label": "(未認証)"
+      },
+      "renameButton": {
+        "ariaLabel": "{title} の名前を変更",
+        "tooltip": "名前を変更"
+      }
+    },
+    "cardSkeleton": {
+      "card": {
+        "ariaLabel": "アクションカードを読み込み中"
+      }
+    },
+    "disconnectModal": {
+      "body": {
+        "confirmation": "続行してもよろしいですか？",
+        "description": "{name} に接続されているすべてのツールが動作しなくなります。必要に応じて、後でこのサーバーに再接続できます。"
+      },
+      "cancelButton": {
+        "label": "キャンセル"
+      },
+      "confirmButton": {
+        "label": "切断",
+        "pendingLabel": "切断中..."
+      },
+      "deleteButton": {
+        "label": "切断して削除"
+      },
+      "header": {
+        "title": "*{name}* を切断"
+      }
+    },
+    "mcpAuthModal": {
+      "additionalAuthParams": {
+        "label": "追加の認証パラメーター (JSON)"
+      },
+      "advanced": {
+        "description": "自動検出の代わりに、認可エンドポイントとトークンエンドポイントを明示的に指定して、既知の OAuth プロバイダーを設定します。",
+        "title": "詳細設定"
+      },
+      "apiKey": {
+        "required": "API token は必須です"
+      },
+      "apiKeyTabs": {
+        "admin": {
+          "label": "共有キー (管理者)"
+        },
+        "perUser": {
+          "label": "個別キー (ユーザーごと)"
+        }
+      },
+      "authPerformer": {
+        "required": "認証の実行者は必須です"
+      },
+      "authType": {
+        "apiToken": {
+          "description": "ユーザーごとの個別 API キー、または組織全体の共有 API キーを使用します。",
+          "label": "API キー"
+        },
+        "label": "認証方法",
+        "none": {
+          "description": "推奨しません",
+          "label": "なし"
+        },
+        "oauth": {
+          "description": "各ユーザーが自分の資格情報で OAuth 認証を行う必要があります。",
+          "label": "OAuth"
+        },
+        "placeholder": "方法を選択",
+        "ptOauth": {
+          "description": "Onyx の認証に使用したユーザーの OAuth アクセストークンを転送します。",
+          "label": "OAuth パススルー"
+        },
+        "required": "認証タイプは必須です"
+      },
+      "authorizationEndpoint": {
+        "label": "認可エンドポイント",
+        "required": "既知のプロバイダーモードでは、認可エンドポイントは必須です"
+      },
+      "cancelButton": {
+        "label": "キャンセル"
+      },
+      "clientId": {
+        "label": "クライアント ID"
+      },
+      "clientSecret": {
+        "label": "クライアントシークレット"
+      },
+      "errors": {
+        "additionalParamsInvalid": "追加の認証パラメーターの JSON が無効です",
+        "additionalParamsInvalidWithReason": "追加の認証パラメーターの JSON が無効です: {reason}",
+        "additionalParamsNotObject": "追加の認証パラメーターは JSON オブジェクトである必要があります",
+        "oauthInitFailed": "OAuth の開始に失敗しました: {detail}",
+        "saveAuthFailed": "認証設定の保存に失敗しました",
+        "saveConfigFailed": "サーバー設定の保存に失敗しました"
+      },
+      "header": {
+        "defaultTitle": "MCP サーバーを認証",
+        "description": "接続を認証すると、MCP サーバーを使用できます。",
+        "title": "*{name}* を認証"
+      },
+      "knownProvider": {
+        "hint": "既知のプロバイダーモードでは、エンドポイントの設定が必要です。Google の参考エンドポイント: 認可 {authorizationEndpoint}、トークン {tokenEndpoint}。"
+      },
+      "noAuthNotice": {
+        "description": "この接続では認証を使用しません。このサーバーが信頼できることを確認してください。この接続で実行される操作の責任はお客様にあります。",
+        "title": "この MCP サーバーでは認証を使用しません"
+      },
+      "oauthInfo": {
+        "discovery": "クライアント ID とシークレットは任意です。自動検出では、Onyx はサポートされている場合に Client ID Metadata Document (CIMD) を使用し、対応していない場合は Dynamic Client Registration (DCR) を使用します。",
+        "manualRegistration": "サーバーがどちらの方法にも対応していない場合は、先に Onyx インスタンスをサーバーの提供元に登録してください。アクションに必要なスコープを Onyx に付与してください。"
+      },
+      "passThroughNotice": {
+        "description": "Onyx はユーザーの OAuth アクセストークンを Authorization ヘッダーとしてサーバーに直接転送します。サーバーが同じプロバイダーでの認証に対応していることを確認してください。",
+        "title": "ID プロバイダーを共有するサービスにはパススルーを使用してください。"
+      },
+      "providerMode": {
+        "autoDiscovery": {
+          "description": "MCP SDK のチャレンジ/検出フローを使用します (既定)。",
+          "label": "自動検出"
+        },
+        "knownProvider": {
+          "description": "設定済みの認可/トークンエンドポイントを使用します。",
+          "label": "既知のプロバイダー"
+        },
+        "label": "プロバイダーモード",
+        "placeholder": "モードを選択"
+      },
+      "redirectUri": {
+        "copyTooltip": "リダイレクト URI をコピー",
+        "label": "**リダイレクト URI** を使用:"
+      },
+      "scopesOverride": {
+        "label": "スコープの上書き (カンマ区切り)"
+      },
+      "sharedApiKey": {
+        "description": "個人の API キーは使用しないでください。このキーを組織の全員と共有しても問題ないことを確認してください。",
+        "label": "API キー",
+        "placeholder": "組織の共有 API キー"
+      },
+      "submitButton": {
+        "label": "接続",
+        "pendingLabel": "接続中..."
+      },
+      "tokenEndpoint": {
+        "label": "トークンエンドポイント",
+        "required": "既知のプロバイダーモードでは、トークンエンドポイントは必須です"
+      },
+      "transport": {
+        "required": "トランスポートは必須です"
+      }
+    },
+    "mcpCard": {
+      "card": {
+        "ariaLabel": "{title} MCP サーバーカード"
+      },
+      "deleteModal": {
+        "body": {
+          "confirmation": "この MCP サーバーを削除してもよろしいですか？",
+          "description": "<emphasis>{title}</emphasis> に接続されているすべてのツールが削除されます。削除は取り消せません。"
+        },
+        "submitButton": {
+          "label": "削除"
+        },
+        "title": "MCP サーバーを削除"
+      },
+      "lastRefreshed": {
+        "label": "ツールの最終更新 {time}"
+      },
+      "refreshToolsButton": {
+        "ariaLabel": "ツールを更新",
+        "tooltip": "ツールを更新"
+      }
+    },
+    "mcpPage": {
+      "addButton": {
+        "label": "MCP サーバーを追加"
+      },
+      "empty": {
+        "description": "MCP サーバーに接続して、カスタムアクションを追加します。"
+      },
+      "errors": {
+        "unknown": "不明なエラー"
+      },
+      "toasts": {
+        "deleteFailed": "MCP サーバーの削除に失敗しました",
+        "disableAllFailed": "すべてのツールの無効化に失敗しました",
+        "disconnectFailed": "MCP サーバーの切断に失敗しました",
+        "enableAllFailed": "すべてのツールの有効化に失敗しました",
+        "fetchToolsFailed": "ツールの取得に失敗しました: {error}",
+        "noToolsToDisable": "無効化するツールがありません",
+        "reconnectFailed": "MCP サーバーの再接続に失敗しました",
+        "refreshToolsFailed": "ツールの更新に失敗しました",
+        "renameFailed": "MCP サーバーの名前の変更に失敗しました",
+        "serverDeleted": "MCP サーバーを削除しました",
+        "serverDisconnected": "MCP サーバーを切断しました",
+        "serverReconnected": "MCP サーバーに再接続しました",
+        "serverRenamed": "MCP サーバーの名前を変更しました",
+        "toolDisabled": "ツールを無効にしました",
+        "toolEnabled": "ツールを有効にしました",
+        "toolUpdateFailed": "ツールの更新に失敗しました",
+        "toolsDisabled": "{count, plural, one {# 個のツールを無効にしました} other {# 個のツールを無効にしました}}",
+        "toolsEnabled": "{count, plural, one {# 個のツールを有効にしました} other {# 個のツールを有効にしました}}",
+        "toolsFetched": "接続してツールを取得しました",
+        "toolsRefreshed": "ツールを更新しました"
+      }
+    },
+    "openApiAuthModal": {
+      "authMethod": {
+        "customHeader": {
+          "description": "すべてのリクエストにカスタムヘッダーを送信します。",
+          "label": "カスタム Authorization ヘッダー"
+        },
+        "label": "認証方法",
+        "oauth": {
+          "description": "各ユーザーが自分の資格情報で OAuth 認証を行います。",
+          "label": "OAuth"
+        },
+        "placeholder": "方法を選択",
+        "ptOauth": {
+          "description": "Onyx の認証に使用したユーザーの OAuth アクセストークンを転送します。",
+          "label": "OAuth パススルー"
+        },
+        "required": "認証方法は必須です"
+      },
+      "authorizationUrl": {
+        "label": "認可 URL",
+        "required": "認可 URL は必須です"
+      },
+      "cancelButton": {
+        "label": "キャンセル"
+      },
+      "clientId": {
+        "description": "現在のクライアント ID を維持するには、空欄のままにしてください。",
+        "label": "OAuth クライアント ID",
+        "required": "クライアント ID は必須です"
+      },
+      "clientSecret": {
+        "description": "現在のクライアントシークレットを維持するには、空欄のままにしてください。",
+        "label": "OAuth クライアントシークレット",
+        "required": "クライアントシークレットは必須です"
+      },
+      "errors": {
+        "invalidUrl": "有効な URL を入力してください",
+        "loadConfigFailed": "既存の OAuth 設定の読み込みに失敗しました。更新するには、内容を再入力してください。"
+      },
+      "header": {
+        "description": "接続を認証すると、OpenAPI アクションを使用できます。"
+      },
+      "headers": {
+        "addButton": {
+          "label": "ヘッダーを追加"
+        },
+        "description": "このアクションの API エンドポイントに送信するすべてのリクエストに、カスタムヘッダーを指定します。",
+        "keyRequired": "ヘッダーのキーは必須です",
+        "keyTitle": "ヘッダー",
+        "minRequired": "認証ヘッダーを 1 つ以上追加してください",
+        "title": "認証ヘッダー",
+        "valueRequired": "ヘッダーの値は必須です",
+        "valueTitle": "値"
+      },
+      "loading": {
+        "label": "既存の設定を読み込み中..."
+      },
+      "oauthLoginNotice": {
+        "description": "OAuth パススルーには、OAuth に対応したログイン方法 (Google または OIDC) が必要です。"
+      },
+      "passThroughNotice": {
+        "description": "Onyx はユーザーの OAuth アクセストークンを Authorization ヘッダーとしてサーバーに直接転送します。サーバーが同じプロバイダーでの認証に対応していることを確認してください。",
+        "title": "ID プロバイダーを共有するサービスにはパススルーを使用してください。"
+      },
+      "redirectUri": {
+        "copyTooltip": "リダイレクト URI をコピー",
+        "label": "<emphasis>リダイレクト URI</emphasis> を使用:"
+      },
+      "scopes": {
+        "description": "リクエストする OAuth スコープのカンマ区切りリストです。",
+        "label": "スコープ <optional>(任意)</optional>",
+        "placeholder": "例: repo, user"
+      },
+      "submitButton": {
+        "label": "接続",
+        "pendingLabel": "接続中..."
+      },
+      "tokenUrl": {
+        "label": "トークン URL",
+        "required": "トークン URL は必須です"
+      }
+    },
+    "openApiCard": {
+      "card": {
+        "ariaLabel": "{name} OpenAPI アクションカード"
+      },
+      "deleteModal": {
+        "body": {
+          "confirmation": "この OpenAPI アクションを削除してもよろしいですか？",
+          "description": "OpenAPI アクション <emphasis>{name}</emphasis> とその設定を完全に削除します。"
+        },
+        "submitButton": {
+          "label": "削除"
+        },
+        "title": "OpenAPI アクションを削除"
+      },
+      "method": {
+        "noSummary": "概要はありません"
+      },
+      "toolsList": {
+        "emptyMessage": "この OpenAPI スキーマにはアクションが定義されていません",
+        "emptySearchMessage": "検索条件に一致するアクションはありません"
+      }
+    },
+    "openApiPage": {
+      "addButton": {
+        "label": "OpenAPI アクションを追加"
+      },
+      "authModal": {
+        "authenticateTitle": "{name} を認証",
+        "defaultTitle": "OpenAPI アクションを認証",
+        "updateTitle": "{name} の認証を更新"
+      },
+      "empty": {
+        "description": "OpenAPI スキーマからカスタムアクションを追加します。"
+      },
+      "toasts": {
+        "actionRenamed": "OpenAPI アクションの名前を変更しました",
+        "authHeadersSaved": "{name} の認証ヘッダーを保存しました。",
+        "authPassthroughSaved": "{name} の認証パススルーを保存しました。",
+        "authSaveFailed": "認証設定の保存に失敗しました。",
+        "authSaved": "{name} の認証を保存しました。",
+        "authUpdated": "{name} の認証を更新しました。",
+        "deleteFailed": "ツールの削除に失敗しました。",
+        "deleteUnexpectedError": "ツールの削除中に予期しないエラーが発生しました。",
+        "disconnectFailed": "OpenAPI アクションの切断に失敗しました。",
+        "renameFailed": "OpenAPI アクションの名前の変更に失敗しました",
+        "toolDeleted": "{name} を削除しました。",
+        "toolDisconnected": "{name} を切断しました。"
+      }
+    },
+    "perUserAuth": {
+      "credentialField": {
+        "placeholder": "{field} を入力"
+      },
+      "credentials": {
+        "perUserDescription": "次の資格情報は組織内で共有されません。",
+        "perUserTitle": "自分のアカウント専用",
+        "sharedDescription": "これらの値は組織内のすべてのユーザーに使用されます。",
+        "sharedTitle": "組織で共有する値"
+      },
+      "headers": {
+        "addButton": {
+          "label": "ヘッダーを追加"
+        },
+        "error": {
+          "message": "少なくとも 1 つのヘッダーの値に {apiKey} プレースホルダーを含めてください。"
+        },
+        "keyTitle": "ヘッダー名",
+        "label": "認証ヘッダー",
+        "perUserDescription": "各ユーザーが個別の資格情報を入力できるように、ヘッダーの形式を設定します。<mono>{apiKey}</mono> や <mono>{userEmail}</mono> などのプレースホルダーを使用してください。ユーザーには、プレースホルダーの値の入力を求めます (user_email を除く)。",
+        "sharedDescription": "組織の共有資格情報とともに送信するヘッダーの形式を設定します。少なくとも 1 つのヘッダーの値に <mono>{apiKey}</mono> などのプレースホルダーを使用してください。組織の共有キーに置き換えられます。",
+        "valueTitle": "ヘッダーの値"
+      }
+    },
+    "policyToggle": {
+      "always": {
+        "label": "自動承認"
+      },
+      "ask": {
+        "label": "確認"
+      },
+      "deny": {
+        "label": "拒否"
+      }
+    },
+    "toolItem": {
+      "unavailable": {
+        "label": "ツールを利用できません"
+      }
+    },
+    "toolsList": {
+      "disableAllButton": {
+        "ariaLabel": "すべてのツールを無効化",
+        "tooltip": "すべてのツールを無効化"
+      },
+      "empty": {
+        "message": "利用できるツールがありません",
+        "searchMessage": "ツールが見つかりません"
+      },
+      "enableAllButton": {
+        "label": "すべて有効化"
+      },
+      "showAllButton": {
+        "ariaLabel": "すべてのツールを表示",
+        "tooltip": "すべてのツールを表示"
+      },
+      "showEnabledButton": {
+        "ariaLabel": "有効なツールのみ表示",
+        "tooltip": "有効なもののみ表示"
+      }
+    },
+    "toolsSection": {
+      "foldButton": {
+        "label": "折りたたむ"
+      },
+      "search": {
+        "ariaLabel": "ツールを検索",
+        "placeholder": "ツールを検索…"
+      }
+    }
+  },
+  "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "コードリポジトリ"
+        },
+        "messaging": {
+          "label": "メッセージング"
+        },
+        "other": {
+          "label": "その他"
+        },
+        "sales": {
+          "label": "営業"
+        },
+        "storage": {
+          "label": "クラウドストレージ"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "チケット管理・タスク管理"
+        },
+        "wiki": {
+          "label": "ナレッジベース・Wiki"
+        }
+      },
+      "popular": {
+        "title": "人気"
+      },
+      "search": {
+        "placeholder": "コネクターを検索"
+      },
+      "seeConnectorsButton": {
+        "label": "コネクターを表示"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>フェデレーテッドコネクターは設定済みです。</strong> クリックすると、既存のコネクターを編集できます。",
+          "slackCredentialsFound": "<strong>既存の Slack 資格情報が見つかりました。</strong> クリックすると、Slack コネクターを管理できます。"
+        }
+      }
+    },
+    "agents": {
+      "deleteModal": {
+        "confirmation": {
+          "description": "<emphasis>{name}</emphasis> を削除してもよろしいですか？この操作は取り消せません。"
+        },
+        "header": {
+          "title": "エージェントを削除"
+        },
+        "submitButton": {
+          "label": "削除"
+        }
+      },
+      "emptyState": {
+        "description": "現在の検索条件に一致するエージェントはありません。",
+        "title": "エージェントが見つかりません"
+      },
+      "featuredModal": {
+        "addBody": {
+          "description": "注目のエージェントは、エージェント一覧の上部に表示され、アクセス権を持つ新規ユーザーのサイドバーに自動的にピン留めされます。組織全体におすすめのエージェントを紹介する場合に使用します。"
+        },
+        "addHeader": {
+          "title": "{name} を注目に設定"
+        },
+        "featureButton": {
+          "label": "注目に設定"
+        },
+        "removeBody": {
+          "description": "{name} をエージェント一覧上部の注目セクションから削除します。新規ユーザーのサイドバーには自動的にピン留めされなくなりますが、既存のピン留めには影響しません。"
+        },
+        "removeHeader": {
+          "title": "{name} を注目から削除"
+        },
+        "unfeatureButton": {
+          "label": "注目を解除"
+        }
+      },
+      "header": {
+        "description": "エージェントで AI の動作と知識をカスタマイズします。組織内のエージェントを管理します。",
+        "title": "エージェント"
+      },
+      "modals": {
+        "accessNote": {
+          "description": "このエージェントにアクセスできるユーザーは変更されません。"
+        }
+      },
+      "newAgentButton": {
+        "label": "新規エージェント"
+      },
+      "reorderError": {
+        "message": "エージェントの並び順の更新に失敗しました"
+      },
+      "rowActions": {
+        "deleteItem": {
+          "title": "削除"
+        },
+        "editAgentButton": {
+          "label": "エージェントを編集"
+        },
+        "genericError": {
+          "message": "エラーが発生しました"
+        },
+        "listItem": {
+          "title": "エージェントを一覧に表示"
+        },
+        "menuButton": {
+          "ariaLabel": "エージェントの操作"
+        },
+        "relistAgentButton": {
+          "label": "エージェントを再表示"
+        },
+        "removeFeaturedButton": {
+          "label": "注目を解除"
+        },
+        "setFeaturedButton": {
+          "label": "注目に設定"
+        },
+        "shareItem": {
+          "title": "共有"
+        },
+        "statsItem": {
+          "title": "統計"
+        },
+        "unlistItem": {
+          "title": "エージェントを一覧から外す"
+        },
+        "updateSuccess": {
+          "message": "{name} を更新しました。"
+        }
+      },
+      "search": {
+        "placeholder": "エージェントを検索..."
+      },
+      "table": {
+        "access": {
+          "featured": {
+            "label": "注目"
+          },
+          "private": {
+            "label": "プライベート"
+          },
+          "public": {
+            "label": "公開"
+          },
+          "shared": {
+            "label": "共有"
+          },
+          "unlisted": {
+            "label": "一覧非表示"
+          }
+        },
+        "accessColumn": {
+          "header": "アクセス"
+        },
+        "createdBy": {
+          "system": {
+            "label": "システム"
+          }
+        },
+        "createdByColumn": {
+          "header": "作成者"
+        },
+        "descriptionColumn": {
+          "header": "説明"
+        },
+        "nameColumn": {
+          "header": "名前"
+        }
+      },
+      "unlistModal": {
+        "body": {
+          "description": "一覧から外したエージェントはエージェント一覧に表示されませんが、直接リンクからは引き続きアクセスできます。以前に使用したユーザーやピン留めしたユーザーも引き続き利用できます。"
+        },
+        "header": {
+          "title": "*{name}* を一覧から外す"
+        },
+        "submitButton": {
+          "label": "一覧から外す"
+        }
+      }
+    },
+    "analytics": {
+      "agentChart": {
+        "description": "選択したエージェントの 1 日あたりのメッセージ数とユニークユーザー数",
+        "empty": "この期間に、選択したエージェントのデータはありません。",
+        "error": "エージェントのデータの取得に失敗しました。",
+        "selectPrompt": "分析を表示するエージェントを選択してください。",
+        "series": {
+          "messages": {
+            "label": "メッセージ"
+          },
+          "uniqueUsers": {
+            "label": "ユニークユーザー"
+          }
+        },
+        "title": "エージェント分析"
+      },
+      "agentPicker": {
+        "empty": {
+          "label": "検索条件に一致するエージェントはありません"
+        },
+        "placeholder": "表示するエージェントを選択",
+        "search": {
+          "placeholder": "エージェントを検索..."
+        }
+      },
+      "feedbackChart": {
+        "description": "高評価・低評価の推移",
+        "empty": "選択した期間にフィードバックはありません。",
+        "error": "フィードバックのデータの取得に失敗しました。",
+        "series": {
+          "negative": {
+            "label": "低評価"
+          },
+          "positive": {
+            "label": "高評価"
+          }
+        },
+        "title": "フィードバック"
+      },
+      "page": {
+        "description": "クエリ、フィードバック、エージェントの観点から、ワークスペースでの Onyx の利用状況を把握します。"
+      },
+      "reports": {
+        "calendar": {
+          "pickEnd": {
+            "label": "期間の終了日を選択"
+          },
+          "pickStart": {
+            "label": "期間の開始日を選択"
+          }
+        },
+        "description": "ユーザーごとの利用状況を CSV ファイルの ZIP としてエクスポートします。レポートはバックグラウンドで作成され、ここに残ります。",
+        "empty": {
+          "description": "レポートはまだありません。期間を選択して、最初のレポートを作成してください。"
+        },
+        "generateButton": {
+          "label": "レポートを作成",
+          "pendingLabel": "作成中…"
+        },
+        "listError": {
+          "title": "利用状況レポートの読み込みに失敗しました。"
+        },
+        "pendingRow": {
+          "description": "{range} · 通常は 1 分以内に完了します",
+          "slowDescription": "処理中です。このページを離れても、レポートはここに表示されます。",
+          "title": "レポートを準備中…"
+        },
+        "period": {
+          "allTime": {
+            "label": "全期間"
+          },
+          "custom": {
+            "label": "カスタム期間…"
+          },
+          "last30Days": {
+            "label": "過去 30 日間"
+          },
+          "last3Months": {
+            "label": "過去 3 か月間"
+          },
+          "last7Days": {
+            "label": "過去 7 日間"
+          },
+          "today": {
+            "label": "今日"
+          }
+        },
+        "row": {
+          "description": "{requestor} が作成 · {time}",
+          "downloadButton": {
+            "ariaLabel": "{label} のレポートをダウンロード",
+            "tooltip": "ZIP をダウンロード"
+          },
+          "systemRequestor": {
+            "label": "システム"
+          }
+        },
+        "title": "利用状況レポート",
+        "toasts": {
+          "ready": "利用状況レポートが完成しました。",
+          "startFailed": "レポート作成の開始に失敗しました: {message}",
+          "timedOut": "レポートの作成に時間がかかっています。もう一度実行するか、後で確認してください。",
+          "unknownError": "不明なエラー"
+        }
+      },
+      "slackChannelChart": {
+        "description": "総クエリ数と自動解決数の比較",
+        "empty": "選択した期間に、このワークスペースでの OnyxBot の利用はありません。",
+        "error": "OnyxBot のデータの取得に失敗しました。",
+        "series": {
+          "autoResolved": {
+            "label": "自動解決"
+          },
+          "totalQueries": {
+            "label": "総クエリ数"
+          }
+        },
+        "title": "Slack チャンネル"
+      },
+      "usageChart": {
+        "description": "利用状況の推移",
+        "empty": "選択した期間にクエリはありません。",
+        "error": "利用状況のデータの取得に失敗しました。",
+        "series": {
+          "queries": {
+            "label": "クエリ"
+          },
+          "uniqueUsers": {
+            "label": "ユニークユーザー"
+          }
+        },
+        "title": "利用状況"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "ライセンスを処理中です。確認が完了すると、請求の詳細に自動的に移動します。",
+        "title": "ライセンスを有効化中です"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "オンラインでの請求管理は無効です。サブスクリプションを更新するには、サポートにお問い合わせください。",
+          "title": "エアギャップ環境のデプロイ"
+        },
+        "expired": {
+          "description": "有料機能へのアクセスを回復するには、サブスクリプションを更新してください。",
+          "title": "サブスクリプションの有効期限が切れました。",
+          "withDate": {
+            "description": "アクセスを回復するには、{date} までにサブスクリプションを更新してください。"
+          },
+          "withDeletion": {
+            "title": "サブスクリプションの有効期限が切れました。データは {days} 日後に削除されます。"
+          }
+        },
+        "expiring": {
+          "description": "中断を避けるには、{date} までにサブスクリプションを更新してください。",
+          "title": "サブスクリプションは {days} 日後に期限切れになります。"
+        },
+        "graceSync": {
+          "title": "更新されたライセンスを確認中…"
+        },
+        "stripeError": {
+          "description": "インターネット接続を確認するか、ライセンスを手動で入力してください。",
+          "title": "Stripe の決済ポータルに接続できません。"
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "プランを調整"
+        },
+        "annual": {
+          "label": "年額"
+        },
+        "annualBadge": {
+          "label": "20% お得"
+        },
+        "billingCycle": {
+          "description": "1 か月の無料トライアル終了後",
+          "title": "請求サイクル"
+        },
+        "continueToPayment": {
+          "label": "支払いに進む"
+        },
+        "createSessionFailed": {
+          "error": "チェックアウトセッションの作成に失敗しました"
+        },
+        "loading": {
+          "label": "読み込み中..."
+        },
+        "monthly": {
+          "label": "月額"
+        },
+        "perSeatMonth": {
+          "label": "シートあたり/月"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "${price}"
+        },
+        "seats": {
+          "description": "{count, plural, one {現在のユーザーと Slack アカウントには、最低 #シートが必要です。} other {現在のユーザーと Slack アカウントには、最低 #シートが必要です。}}",
+          "title": "シート数"
+        },
+        "trialBilling": {
+          "text": "1 か月の無料トライアルの終了後、<value>{date}</value> に請求されます。"
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "ライセンスキーを有効化"
+        },
+        "billingHelp": {
+          "label": "請求に関するヘルプ"
+        },
+        "licenseKeyPrompt": {
+          "label": "ライセンスキーをお持ちですか？"
+        },
+        "updateLicenseKey": {
+          "label": "ライセンスキーを更新"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "プランと請求"
+        },
+        "upgradePlan": {
+          "title": "プランをアップグレード"
+        },
+        "viewPlans": {
+          "title": "プランを表示"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "ライセンスの有効化に失敗しました"
+        },
+        "activateLicense": {
+          "label": "ライセンスを有効化"
+        },
+        "activateSuccess": {
+          "message": "ライセンスを有効化しました！"
+        },
+        "activateTitle": {
+          "title": "ライセンスキーの有効化"
+        },
+        "activating": {
+          "label": "有効化しています..."
+        },
+        "activeUntil": {
+          "label": "ライセンスキーは <value>{date}</value> まで有効です"
+        },
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "close": {
+          "label": "閉じる"
+        },
+        "description": "この Onyx インスタンスにライセンスを手動で追加して有効化します。",
+        "emptyKey": {
+          "error": "ライセンスキーを入力してください"
+        },
+        "error": {
+          "text": "{error}。<link>請求に関するヘルプ</link>"
+        },
+        "expired": {
+          "label": "ライセンスキーの有効期限が切れています"
+        },
+        "keyField": {
+          "description": "Onyx から受け取ったライセンスキーを貼り付けるか、ファイルを添付してください。",
+          "title": "ライセンスキー"
+        },
+        "updateKey": {
+          "label": "キーを更新"
+        },
+        "updateLicense": {
+          "label": "ライセンスを更新"
+        },
+        "updateSuccess": {
+          "message": "ライセンスを更新しました！"
+        },
+        "updateTitle": {
+          "title": "ライセンスキーの更新"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "お支払い方法",
+          "title": "下 4 桁が 1234 の Visa"
+        },
+        "lastPayment": {
+          "description": "前回のお支払い"
+        },
+        "section": {
+          "title": "お支払い"
+        },
+        "update": {
+          "label": "更新"
+        },
+        "viewInvoice": {
+          "label": "請求書を表示"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Business プランを購入"
+          },
+          "description": "年払いの場合のシートあたり月額\n月払いの場合はシートあたり $25",
+          "features": {
+            "apiKeys": "サービスアカウントの API キー",
+            "documentPermissions": "ドキュメント権限の継承",
+            "encryption": "シークレットの暗号化",
+            "queryHistory": "クエリ履歴と使用状況ダッシュボード",
+            "rbac": "ロールベースアクセス制御 (RBAC)",
+            "selfHosting": "セルフホスティング (オプション)",
+            "theming": "カスタムテーマ"
+          },
+          "featuresPrefix": "チームのための AI で、より多くの業務を進められます。",
+          "pricing": "$20",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "{plan} プランのカード"
+        },
+        "currentPlan": {
+          "label": "現在のプラン"
+        },
+        "enterprise": {
+          "button": {
+            "label": "営業担当に問い合わせ"
+          },
+          "description": "大規模組織向けの\n柔軟な価格設定とデプロイの選択肢",
+          "features": {
+            "customDeployments": "カスタムデプロイ",
+            "customRoles": "カスタムロールと権限",
+            "hookExtensions": "フック拡張",
+            "regionalProcessing": "リージョン別のデータ処理",
+            "scim": "SCIM / グループ同期",
+            "support": "エンタープライズ SLA と優先サポート",
+            "usageLimits": "設定可能な使用量の上限",
+            "whiteLabeling": "完全なホワイトラベル対応"
+          },
+          "featuresPrefix": "Business プランのすべての機能に加えて：",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "現在のプランに含まれています"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "使用中/保留中の現在の **{minimum}** シートを下回る値は設定できません。シート数を調整する前に、まず [ユーザーを削除](/admin/users) してください。"
+        },
+        "billing": {
+          "added": "{count, plural, one {追加する <value>{count}</value> シート分は、日割り計算で請求されます。} other {追加する <value>{count}</value> シート分は、日割り計算で請求されます。}}",
+          "removed": "{count, plural, one {<value>{count}</value> シートは <value>{date}</value>（現在の請求サイクルの終了後）に削除されます。} other {<value>{count}</value> シートは <value>{date}</value>（現在の請求サイクルの終了後）に削除されます。}}",
+          "unchanged": "請求内容に変更はありません。"
+        },
+        "breakdown": {
+          "label": "使用中 {used} • 保留中 {pending} • 残り {remaining}"
+        },
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "confirmChange": {
+          "label": "変更を確定"
+        },
+        "delta": {
+          "added": "{count, plural, one {#シートを追加} other {#シートを追加}}",
+          "removed": "{count, plural, one {#シートを削除} other {#シートを削除}}"
+        },
+        "saving": {
+          "label": "保存しています..."
+        },
+        "seatsField": {
+          "title": "シート数"
+        },
+        "total": {
+          "label": "{count}シート"
+        },
+        "updateFailed": {
+          "error": "シート数の更新に失敗しました"
+        },
+        "updateSeats": {
+          "description": "チームの人数に合わせてシートを追加または削除します。",
+          "label": "シート数を更新",
+          "title": "シート数の更新"
+        },
+        "viewUsers": {
+          "label": "ユーザーを表示"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Business プラン"
+        },
+        "connectToStripe": {
+          "label": "Stripe に接続"
+        },
+        "connecting": {
+          "label": "接続しています..."
+        },
+        "enterprisePlan": {
+          "name": "Enterprise プラン"
+        },
+        "expired": {
+          "subtitle": "{date} に期限切れ"
+        },
+        "managePlan": {
+          "label": "プランを管理"
+        },
+        "managedBySales": {
+          "text": "お客様のプランは営業担当が管理しています。<br></br>変更をご希望の場合は <link>請求担当にお問い合わせ</link> ください。"
+        },
+        "nextPayment": {
+          "subtitle": "次回のお支払いは {date}"
+        },
+        "syncLicense": {
+          "label": "ライセンスを同期"
+        },
+        "syncing": {
+          "label": "同期しています..."
+        },
+        "trialDays": {
+          "subtitle": "トライアルはあと {days} 日で終了します。{date} にお支払いが必要です"
+        },
+        "trialToday": {
+          "subtitle": "トライアルは本日終了します。{date} にお支払いが必要です"
+        },
+        "trialTomorrow": {
+          "subtitle": "トライアルは明日終了します。{date} にお支払いが必要です"
+        },
+        "upgradeNow": {
+          "label": "今すぐアップグレード"
+        },
+        "upgrading": {
+          "label": "アップグレードしています..."
+        },
+        "validUntil": {
+          "subtitle": "{date} まで有効"
+        },
+        "viewPlanDetails": {
+          "label": "プランの詳細を表示"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "トライアルの終了に失敗しました",
+        "licenseSyncFailed": "ライセンスの同期に失敗しました",
+        "paymentMethodRequired": "先にお支払い方法を追加してから、もう一度アップグレードしてください。",
+        "syncLicenseFailed": "ライセンスの同期に失敗しました"
+      }
+    },
+    "chatPreferences": {
+      "advanced": {
+        "title": "詳細オプション"
+      },
+      "anonymousUsers": {
+        "description": "ログインなしで誰でもチャットを開始できるようにします。他のチャットは表示されず、エージェントの作成や設定の変更もできません。",
+        "title": "匿名ユーザーを許可"
+      },
+      "autoDetectFilters": {
+        "description": "検索クエリから推定したソースフィルターと期間フィルターを自動的に適用します。",
+        "title": "検索フィルターの自動検出"
+      },
+      "autoScroll": {
+        "description": "チャットが応答を生成するときに、新しい内容へ自動的にスクロールします。ユーザーは個人設定でこれを変更できます。",
+        "title": "チャットの自動スクロール"
+      },
+      "betaTag": {
+        "label": "ベータ"
+      },
+      "chatNaming": {
+        "description": "チャットセッションに自動で名前を付けるモデルです。既定では各セッションのモデルを使用します。メインのモデルが同時リクエストを処理できない場合は、小さく高速なモデルをここで指定してください。",
+        "resetButton": {
+          "label": "リセット"
+        },
+        "title": "チャット命名モデル"
+      },
+      "connectors": {
+        "empty": {
+          "title": "コネクターが設定されていません"
+        },
+        "manageAllButton": {
+          "label": "すべて管理"
+        },
+        "title": "コネクター"
+      },
+      "deepResearch": {
+        "description": "ウェブと接続済みソースを横断して調査するエージェント型のリサーチ機能です。クエリあたりの token 消費が大幅に増えます。",
+        "title": "ディープリサーチ"
+      },
+      "disableDefaultChat": {
+        "description": "ユーザーは必ずエージェントからチャットを開始します。新しいチャットは、最初にピン留めされたエージェントで作成されます。新しいユーザーを支援するため、注目のエージェントを設定してください。",
+        "title": "既定のチャットを無効化"
+      },
+      "fileLimits": {
+        "default": {
+          "placeholder": "既定値：{value}"
+        },
+        "description": "チャットとプロジェクトに添付するファイルは、両方の上限を満たす必要があります。ファイルが大きいほど、レイテンシ、メモリ使用量、token のコストが増加します。",
+        "noLimit": {
+          "placeholder": "上限なし"
+        },
+        "restoreDefault": {
+          "tooltip": "既定値に戻す"
+        },
+        "size": {
+          "maxDescription": "最大：{max} MB",
+          "suffix": "(MB)",
+          "title": "ファイルサイズの上限"
+        },
+        "title": "添付ファイルのサイズ上限",
+        "tokens": {
+          "suffix": "(千 token)",
+          "title": "ファイルの token 上限"
+        }
+      },
+      "header": {
+        "description": "組織全体のチャット設定と既定値です。ユーザーは一部を個人設定で変更できます。"
+      },
+      "mcpServer": {
+        "authTooltip": "この MCP サーバーのツールを有効にする前に、認証してください。",
+        "expandButton": {
+          "label": "展開"
+        },
+        "foldButton": {
+          "label": "折りたたむ"
+        },
+        "search": {
+          "placeholder": "ツールを検索..."
+        }
+      },
+      "multiModel": {
+        "description": "チャットで複数のモデルが並行して応答を生成できるようにします。",
+        "title": "マルチモデル生成"
+      },
+      "queryHistory": {
+        "anonymized": {
+          "description": "クエリは管理者に表示されますが、ユーザーの識別情報は削除されます",
+          "label": "匿名化"
+        },
+        "description": "組織のチャット履歴全体を管理パネルにどのように表示するかを制御します。",
+        "disabled": {
+          "description": "クエリ履歴のレポートは無効です。",
+          "label": "非表示"
+        },
+        "normal": {
+          "description": "すべてのクエリが管理者に表示され、個々のユーザーに紐づけられます。",
+          "label": "ユーザー情報付きで表示"
+        },
+        "title": "クエリ履歴の表示設定"
+      },
+      "reasoning": {
+        "description": "チャットのモデル選択メニューから、回答前にモデルが行う推論の量をユーザーが調整できるようにします。",
+        "title": "推論の制御"
+      },
+      "retention": {
+        "custom": {
+          "invalidError": "1 から {max} までの整数の日数を入力してください。",
+          "label": "カスタム保持期間",
+          "moreTooltip": "その他",
+          "placeholder": "日数",
+          "restoreTooltip": "既定値に戻す"
+        },
+        "description": "組織のチャットを Onyx が保持する期間を指定します。",
+        "enterprisePlanTag": {
+          "label": "Enterprise プラン"
+        },
+        "forever": {
+          "label": "無期限"
+        },
+        "presets": {
+          "days30": "30 日",
+          "days60": "60 日",
+          "days7": "7 日",
+          "days90": "90 日",
+          "year1": "1 年"
+        },
+        "reduceModal": {
+          "confirmLabel": "保持期間を短縮",
+          "message": "{days, plural, one {# 日} other {# 日}} を超えて操作がないチャットは完全に削除されます。この操作は元に戻せません。",
+          "title": "チャットの保持期間を短縮しますか？"
+        },
+        "tierTooltip": "チャット履歴の保持は Enterprise プランの機能です。",
+        "title": "チャット履歴の保持"
+      },
+      "searchMode": {
+        "businessPlanTag": {
+          "label": "Business プラン"
+        },
+        "description": "組織全体のドキュメントをすばやく検索するための UI モードです。",
+        "noConnectorsTooltip": "検索モードを使用するにはコネクターを設定してください",
+        "tierTooltip": "検索モードには Business プランまたは Enterprise プランが必要です。",
+        "title": "検索モード"
+      },
+      "systemPrompt": {
+        "description": "すべてのチャット、エージェント、プロジェクトの基本プロンプトです。変更は慎重に行ってください。大きな変更は応答品質を低下させる可能性があります。",
+        "modal": {
+          "cancelButton": {
+            "label": "キャンセル"
+          },
+          "caution": {
+            "description": "システムプロンプトはすべてのチャット、エージェント、プロジェクトに影響します。大きな変更は応答品質を低下させる可能性があります。",
+            "title": "変更は慎重に行ってください。"
+          },
+          "description": "この基本プロンプトは、すべてのチャット、エージェント、プロジェクトの先頭に追加されます。",
+          "placeholder": "システムプロンプトを入力...",
+          "placeholders": {
+            "citationGuidance": "`{token}` - 検索ツールから事実を取得したときに、引用を示す方法の指示です。",
+            "citationNote": "検索ツールを使用する場合にのみ含まれます。",
+            "currentDatetime": "`{token}` - 人が読める形式の現在の日付と曜日です。",
+            "intro": "プロンプトでは次のプレースホルダーを使用できます：",
+            "reminderTag": "`{token}` - ユーザーメッセージ内のシステムリマインダーを解釈する方法の指示です。"
+          },
+          "restoreTooltip": "既定値に戻す",
+          "saveButton": {
+            "label": "保存"
+          }
+        },
+        "modifyButton": {
+          "label": "プロンプトを変更"
+        },
+        "title": "システムプロンプト"
+      },
+      "teamContext": {
+        "description": "ユーザーは個人設定で、個別のコンテキストを追加することもできます。",
+        "placeholder": "チームの説明と、Onyx に期待する動作を入力してください。",
+        "title": "チームのコンテキスト"
+      },
+      "teamName": {
+        "description": "より充実したカスタマイズ体験を提供するため、追加のコンテキストとしてすべてのチャットセッションに付与されます。",
+        "placeholder": "チーム名を入力",
+        "title": "チーム名"
+      },
+      "temperature": {
+        "description": "チャットのモデル選択メニューから、モデル応答の Temperature（創造性）をユーザーが調整できるようにします。",
+        "title": "Temperature の制御"
+      },
+      "toasts": {
+        "chatNamingReset": "チャット命名をセッションのモデルにリセットしました",
+        "chatNamingResetFailed": "チャット命名モデルのリセットに失敗しました",
+        "chatNamingUpdateFailed": "チャット命名モデルの更新に失敗しました",
+        "chatNamingUpdated": "チャット命名モデルを更新しました",
+        "providerResolveFailed": "プロバイダーを解決できませんでした",
+        "settingsUpdateFailed": "設定の更新に失敗しました",
+        "settingsUpdated": "設定を更新しました",
+        "systemPromptUpdateFailed": "システムプロンプトの更新に失敗しました",
+        "systemPromptUpdated": "システムプロンプトを更新しました",
+        "toolsUpdateFailed": "ツールの更新に失敗しました",
+        "toolsUpdated": "ツールを更新しました",
+        "unknownError": "不明なエラーが発生しました"
+      },
+      "tools": {
+        "codeInterpreter": {
+          "description": "コードを生成して実行します。",
+          "title": "コードインタープリター"
+        },
+        "codingAgent": {
+          "description": "GitHub リポジトリを調査し、そのコードに関する質問に回答します。",
+          "title": "コーディングエージェント"
+        },
+        "description": "チャットで使用できるツールと機能です。エージェントには適用されません。",
+        "imageGeneration": {
+          "description": "AI ツールを使用して画像を生成・加工します。",
+          "disabledTooltip": "画像生成にはモデルの設定が必要です。「構成 > 画像生成」で設定するか、管理者に依頼してください。",
+          "title": "画像生成"
+        },
+        "internalSearch": {
+          "description": "組織の接続済みナレッジベースとドキュメントを検索します。",
+          "title": "内部検索"
+        },
+        "openUrl": {
+          "description": "ウェブ URL からコンテンツを取得して読み取ります。",
+          "title": "URL を開く"
+        },
+        "title": "アクションとツール",
+        "webSearch": {
+          "description": "ウェブを検索して、リアルタイムの情報と最新の結果を取得します。",
+          "title": "ウェブ検索"
+        }
+      }
+    },
+    "codeInterpreter": {
+      "card": {
+        "description": "組み込みの Python ランタイム",
+        "disconnectButton": {
+          "tooltip": "接続を解除"
+        },
+        "disconnectedTitle": "コードインタープリター (接続解除済み)",
+        "reconnectButton": {
+          "label": "再接続"
+        },
+        "refreshButton": {
+          "tooltip": "更新"
+        },
+        "title": "コードインタープリター"
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "<emphasis>コードインタープリター</emphasis> に接続している実行中のセッションは、すべて停止します。ランタイムからデータが削除されることはありません。必要に応じて、後でこのランタイムに再接続できます。"
+        },
+        "header": {
+          "title": "コードインタープリターの接続解除"
+        },
+        "submitButton": {
+          "label": "接続を解除"
+        }
+      },
+      "errorCard": {
+        "connectionLost": {
+          "title": "接続切断エラー"
+        },
+        "generic": {
+          "title": "コードインタープリターのエラー"
+        }
+      },
+      "header": {
+        "description": "LLM が利用できる、安全でサンドボックス化された Python ランタイムです。詳細はドキュメントを参照してください。",
+        "title": "コードインタープリター"
+      },
+      "status": {
+        "checking": {
+          "label": "確認しています..."
+        },
+        "connectionLost": {
+          "label": "接続が切断されました"
+        },
+        "healthy": {
+          "label": "接続済み"
+        },
+        "unhealthy": {
+          "label": "異常"
+        }
+      },
+      "toggleError": {
+        "disconnect": {
+          "message": "コードインタープリターの接続解除に失敗しました"
+        },
+        "reconnect": {
+          "message": "コードインタープリターの再接続に失敗しました"
+        }
+      }
+    },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# 日} other {# 日}}",
+          "hours": "{count, plural, one {# 時間} other {# 時間}}",
+          "minutes": "{count, plural, one {# 分} other {# 分}}"
+        },
+        "indexingStart": {
+          "label": "インデックス作成の開始日"
+        },
+        "pruningFrequency": {
+          "label": "プルーニングの頻度"
+        },
+        "refreshFrequency": {
+          "label": "更新の頻度"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "いいえ",
+        "booleanTrue": "はい",
+        "edit": {
+          "tooltip": "編集"
+        },
+        "showAll": {
+          "label": "すべて表示（{count} 件）"
+        },
+        "showLess": {
+          "label": "表示を減らす"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "このコネクターを削除すると削除ジョブがスケジュールされ、インデックス済みのドキュメントが削除されます。また、すべてのユーザーからこのコネクターが削除されます。",
+        "entityType": "コネクター"
+      },
+      "deletionError": {
+        "description": "コネクターの削除中にこのエラーが発生しました。「削除」ボタンをクリックすると、削除をもう一度実行できます。",
+        "title": "削除エラー"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "同期済みドキュメント数",
+          "errorMessage": "エラーメッセージ",
+          "permissionErrors": "権限エラー",
+          "status": "ステータス",
+          "timeStarted": "開始時刻"
+        },
+        "empty": {
+          "description": "ドキュメント権限の同期は、バックグラウンドでスケジュールされます。表示されるまで少し時間がかかる場合があります。30 秒ほどで再読み込みしてください。",
+          "title": "ドキュメント権限の同期はまだ実行されていません"
+        },
+        "errorModal": {
+          "title": "ドキュメント権限の同期エラー"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "ドキュメント ID",
+          "errorMessage": "エラーメッセージ",
+          "status": "ステータス",
+          "time": "時刻"
+        },
+        "description": "以下は、インデックス作成中に発生したエラーです。各行は失敗したドキュメントまたはエンティティを表します。",
+        "empty": {
+          "description": "このページにエラーはありません"
+        },
+        "fullReindex": {
+          "description": "これらのエラーの解決を試みるには、下のボタンをクリックして完全な再インデックスを開始してください。完全な再インデックスは、通常の更新よりもはるかに時間がかかる場合があります。"
+        },
+        "resolveAllButton": {
+          "label": "すべて解決"
+        },
+        "status": {
+          "resolved": "解決済み",
+          "unresolved": "未解決"
+        },
+        "targetedReindex": {
+          "description": "下のボタンをクリックすると、失敗したドキュメントだけを再取得します。完全な再インデックスよりはるかに高速です。"
+        },
+        "title": "インデックス作成エラー",
+        "unknownDocument": "不明"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "ファイルを追加"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "columns": {
+          "fileName": "ファイル名",
+          "size": "サイズ",
+          "uploadDate": "アップロード日"
+        },
+        "confirmModal": {
+          "addDetails": "新しいファイルがアップロードされ、チャンク分割と embedding 生成が行われ、ドキュメントインデックスに登録されます",
+          "addSummary": "{count} 件のファイルが追加されます",
+          "confirmButton": {
+            "label": "確認して保存"
+          },
+          "description": "これらの変更を保存すると、次の処理が行われます：",
+          "removeDetails": "これらのファイルのドキュメントは、ドキュメントインデックスから削除されます",
+          "removeSummary": "🗑️ {count} 件のファイルが削除されます",
+          "title": "ファイルの変更を確認"
+        },
+        "editButton": {
+          "label": "編集"
+        },
+        "empty": {
+          "description": "このコネクターにファイルはありません"
+        },
+        "header": {
+          "title": "ファイル（{count, plural, one {# 件} other {# 件}}）"
+        },
+        "loadError": "ファイルの読み込みエラー：{message}",
+        "newBadge": {
+          "label": "新規"
+        },
+        "removeFileButton": {
+          "tooltip": "ファイルを削除"
+        },
+        "removingBadge": {
+          "label": "削除中"
+        },
+        "saveButton": {
+          "label": "変更を保存",
+          "saving": "保存しています..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "コネクターからすべてのファイルを削除することはできません。必要な場合はコネクター自体を削除してください。",
+          "filesUpdated": "ファイルを更新しました。ドキュメントインデックスはバックグラウンドで更新されています。新しいファイルはインデックス作成中で、削除したファイルは検索結果から除外されます。",
+          "updateFailed": "ファイルの更新に失敗しました"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "エラーメッセージ",
+          "groups": "グループ",
+          "memberships": "メンバーシップ",
+          "status": "ステータス",
+          "timeStarted": "開始時刻",
+          "users": "ユーザー"
+        },
+        "empty": {
+          "description": "グループメンバーシップの同期は、バックグラウンドでスケジュールされます。表示されるまで少し時間がかかる場合があります。30 秒ほどで再読み込みしてください。",
+          "title": "グループメンバーシップの同期はまだ実行されていません"
+        },
+        "errorModal": {
+          "title": "グループメンバーシップの同期エラー"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "エラーメッセージ",
+          "newDocs": "新規ドキュメント数",
+          "status": "ステータス",
+          "timeStarted": "開始時刻",
+          "totalDocs": "総ドキュメント数",
+          "totalDocsTooltip": "このインデックス作成の試行でインデックス内に置き換えられたドキュメントの総数"
+        },
+        "docsPerMinute": "{rate} ドキュメント / 分",
+        "docsRemoved": "（ソースで削除が検出された {count} 件のドキュメントも削除しました）",
+        "empty": {
+          "description": "インデックス作成の試行はバックグラウンドでスケジュールされるため、表示されるまで少し時間がかかる場合があります。30 秒ほどでページを再読み込みしてください。",
+          "title": "インデックス作成の試行はまだスケジュールされていません"
+        },
+        "noAdditionalDocs": "追加で処理されたドキュメントはありません",
+        "reindexTooltip": {
+          "completed": "このインデックス作成の試行は、完全な再インデックスでした。ソースのすべてのドキュメントがシステムに同期されました。",
+          "inProgress": "このインデックス作成の試行は、完全な再インデックスです。ソースのすべてのドキュメントがシステムに同期されています。"
+        },
+        "stageMetricsButton": {
+          "tooltip": "ステージメトリクスを表示"
+        },
+        "viewTrace": {
+          "ariaLabel": "完全なトレースを表示"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "一部のドキュメントの処理中に問題が発生しました。<details>詳細を表示</details>",
+        "resolvingStatus": "失敗を解決しています",
+        "title": "一部のドキュメントのインデックス作成に失敗しました"
+      },
+      "invalidState": {
+        "description": "このコネクターは無効な状態です。再インデックスの前に、認証情報を更新するか、新しいコネクターを作成してください。",
+        "title": "コネクターの状態が無効です"
+      },
+      "loadError": {
+        "title": "ID {ccPairId} のコネクター情報の取得に失敗しました",
+        "unknownMessage": "不明なエラー"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "削除",
+          "tooltip": {
+            "active": "削除する前にコネクターを一時停止してください"
+          }
+        },
+        "reIndex": {
+          "label": "再インデックス",
+          "tooltip": {
+            "indexing": "インデックス作成の実行中は再インデックスできません",
+            "invalid": "再インデックスの前にコネクターの設定を修正してください",
+            "paused": "再インデックスの前にコネクターを再開してください"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "一時停止"
+          },
+          "resume": {
+            "label": "再開"
+          },
+          "tooltip": {
+            "updating": "ステータスを更新しています"
+          }
+        },
+        "trigger": {
+          "label": "管理"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "キャンセル済み"
+        },
+        "completedWithErrors": {
+          "label": "エラーありで完了"
+        },
+        "failed": {
+          "label": "失敗"
+        },
+        "fallback": {
+          "label": "未開始"
+        },
+        "inProgress": {
+          "label": "実行中"
+        },
+        "notStarted": {
+          "label": "スケジュール済み"
+        },
+        "success": {
+          "label": "成功"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "コネクターをプルーニングする頻度（時間単位）",
+        "title": "プルーニングの頻度"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "再有効化"
+        },
+        "additionalDetails": "このコネクターは以前、無効としてマークされました。再有効化する前に、設定が正しいことを確認してください。続行してもよろしいですか？",
+        "entityType": "無効なコネクター"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "ソースのすべてのドキュメントが完全に再インデックスされます。",
+          "note": "<strong>注意：</strong> ソースに保存されているドキュメントの数によっては、長い時間がかかる場合があります。"
+        },
+        "fullReindexButton": {
+          "label": "完全な再インデックスを実行"
+        },
+        "title": "インデックス作成の実行",
+        "update": {
+          "description": "前回成功したインデックス作成以降に変更または追加されたすべてのドキュメントを取得し、インデックスに登録します。"
+        },
+        "updateButton": {
+          "label": "更新を実行"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "コネクターを更新する頻度（分単位）",
+        "title": "更新の頻度"
+      },
+      "sections": {
+        "advanced": {
+          "title": "詳細設定"
+        },
+        "advancedConfiguration": {
+          "title": "詳細な構成"
+        },
+        "connectorConfiguration": {
+          "title": "コネクターの構成"
+        },
+        "credential": {
+          "title": "認証情報"
+        },
+        "indexing": {
+          "title": "インデックス作成"
+        },
+        "indexingAttempts": {
+          "title": "インデックス作成の試行"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "試行のオーバーヘッドを非表示"
+          },
+          "showButton": {
+            "label": "試行のオーバーヘッドを表示"
+          }
+        },
+        "batchTotal": {
+          "empty": "完了したバッチはまだありません",
+          "summary": "平均バッチ：{avgLabel}、{count, plural, one {# バッチ} other {# バッチ}} — 分布は以下のとおりです。"
+        },
+        "empty": {
+          "description": "この試行のステージ計測データは、まだ記録されていません。ステージ計測の導入前に実行された古い試行には、メトリクスがありません。"
+        },
+        "loadError": {
+          "description": "この試行のステージ計測データを読み込めませんでした。メトリクスを記録できない場合でもパイプラインは実行されるため、インデックス作成そのものに問題があるとは限りません。",
+          "title": "ステージメトリクスの読み込みに失敗しました"
+        },
+        "loading": "ステージメトリクスを読み込んでいます…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "平均時間",
+            "calls": "呼び出し回数",
+            "max": "最大",
+            "min": "最小",
+            "stage": "ステージ",
+            "totalTime": "合計時間"
+          },
+          "empty": "バッチごとのステージデータは記録されていません。"
+        },
+        "sort": {
+          "label": "並び替え：",
+          "pipelineOrder": {
+            "label": "パイプライン順"
+          },
+          "timeTaken": {
+            "label": "所要時間"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "オブジェクトストレージからバッチを読み戻し、ワーカーのメモリに展開します。",
+            "label": "バッチ読み込み"
+          },
+          "batchTotal": {
+            "description": "1 つのバッチを最初から最後まで処理するのにかかった実時間の合計です。",
+            "label": "バッチ合計"
+          },
+          "batchUnaccounted": {
+            "description": "どの名前付きステージにも割り当てられていないバッチ時間です。値が大きい場合は、計測の欠落が考えられます。",
+            "label": "未計上"
+          },
+          "checkpointLoad": {
+            "description": "保存されたチェックポイントを読み込み、前回の実行が停止した位置から試行を再開します。",
+            "label": "チェックポイント読み込み"
+          },
+          "chunking": {
+            "description": "各ドキュメントを、embedding 生成とインデックス登録の対象となるチャンクに分割します。",
+            "label": "チャンク分割"
+          },
+          "connectorFetch": {
+            "description": "コネクターがソースの API を呼び出し、生のドキュメントを返すのにかかる時間です。",
+            "label": "コネクター取得"
+          },
+          "connectorValidation": {
+            "description": "取得を開始する前に、コネクターが正しく設定され、到達可能であることを検証します。",
+            "label": "コネクター検証"
+          },
+          "contextualRag": {
+            "description": "検索の精度を高めるため、LLM でチャンクごとのコンテキスト要約を生成します。",
+            "label": "Contextual RAG"
+          },
+          "coordLockAcquireWait": {
+            "description": "試行の共有進捗カウンターを保護する調整ロックの取得を待機します。",
+            "label": "調整ロック取得待ち"
+          },
+          "coordinationUpdate": {
+            "description": "完了したバッチが UI に反映されるよう、試行の進捗カウンターを更新します。",
+            "label": "調整更新"
+          },
+          "docBatchEnqueue": {
+            "description": "保存したバッチを Celery キューに送信し、docprocessing ワーカーが取得できるようにします。",
+            "label": "ドキュメントバッチのキュー投入"
+          },
+          "docBatchStore": {
+            "description": "取得したドキュメントのバッチを、docprocessing ワーカー向けにオブジェクトストレージへ保存します。",
+            "label": "ドキュメントバッチ保存"
+          },
+          "docDbPrepare": {
+            "description": "どのドキュメントが新規または更新されたかを判別し、データベースの行を準備します。",
+            "label": "ドキュメント DB の準備"
+          },
+          "docLockAcquireWait": {
+            "description": "ドキュメントごとのロックを待機し、同時に実行される試行が同じドキュメントに書き込まないようにします。",
+            "label": "ドキュメントロックの取得待ち"
+          },
+          "docprocessingSetup": {
+            "description": "ワーカーを準備します。検索設定、embedding モデル、インデックスクライアントを読み込みます。",
+            "label": "ドキュメント処理のセットアップ"
+          },
+          "embedding": {
+            "description": "embedding モデルを呼び出し、チャンクをベクトルに変換します。通常、最も時間のかかる段階です。",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "書き込みの前に、各チャンクへアクセス制御、ブースト、その他のメタデータを付与します。",
+            "label": "エンリッチメントの準備"
+          },
+          "finalization": {
+            "description": "処理の完了後に、ワーカーのリソースを整理し、バッチを解放します。",
+            "label": "最終処理"
+          },
+          "gcCollect": {
+            "description": "バッチ間の明示的なガベージコレクションに要した時間です。",
+            "label": "ガベージコレクション"
+          },
+          "hierarchyUpsert": {
+            "description": "ソースのフォルダーまたはスペースの階層を書き込み、場所でドキュメントを絞り込めるようにします。",
+            "label": "階層のアップサート"
+          },
+          "imageProcessing": {
+            "description": "画像を抽出して要約し、その内容を検索できるテキストにします。",
+            "label": "画像処理"
+          },
+          "permissionValidation": {
+            "description": "認証情報にソースのドキュメントを読み取る権限があるか確認します。",
+            "label": "権限の検証"
+          },
+          "postIndexDbUpdate": {
+            "description": "インデックスへの書き込みが成功した後、Postgres のドキュメント行を更新します。",
+            "label": "インデックス後の DB 更新"
+          },
+          "queueWait": {
+            "description": "ドキュメント処理ワーカーが開始するまでに、バッチがキューで待機した時間です。",
+            "label": "キューの待ち時間"
+          },
+          "vectorDbWrite": {
+            "description": "embedding 済みのチャンクをドキュメントインデックスに書き込みます。",
+            "label": "ベクトル DB への書き込み"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "このインデックス試行における、バッチ単位および試行単位の処理時間です。",
+        "title": "インデックス作成の段階メトリクス"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "インデックス済みドキュメント数"
+        },
+        "indexingSpeed": "（{speed} 件 / 分）",
+        "lastIndexed": {
+          "label": "最終インデックス作成"
+        },
+        "lastSynced": {
+          "label": "最終同期"
+        },
+        "permissionSyncing": {
+          "label": "権限の同期"
+        },
+        "status": {
+          "label": "ステータス"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "エラーメッセージの全文を表示"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "ドキュメント権限の同期",
+          "notApplicableDescription": "このコネクターは、ドキュメント権限の同期ジョブを個別に使用しません。"
+        },
+        "groupMembership": {
+          "label": "グループメンバーシップの同期",
+          "notApplicableDescription": "このコネクターは、グループメンバーシップの同期ジョブを個別に使用しません。"
+        },
+        "indexing": {
+          "label": "インデックス作成"
+        },
+        "loadError": {
+          "title": "同期試行の読み込みに失敗しました"
+        },
+        "notApplicable": {
+          "title": "対象外"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "完全な再インデックス作成を開始しました",
+        "completeReindexStarting": "完全な再インデックス作成を開始しています...",
+        "deletionScheduleFailed": "コネクターの削除をスケジュールできませんでした - {message}",
+        "indexingProcessStartFailed": "インデックス作成の処理を開始できませんでした",
+        "indexingStartFailed": "インデックス作成を開始できませんでした",
+        "indexingStartUnexpectedError": "インデックス作成の開始中に予期しないエラーが発生しました",
+        "indexingUpdateStarted": "インデックスの更新を開始しました",
+        "indexingUpdateStarting": "インデックスの更新を開始しています...",
+        "invalidPruningFrequency": "プルーニング頻度が無効です。有効な数値を入力してください",
+        "invalidRefreshFrequency": "更新頻度が無効です。整数を入力してください",
+        "nameUpdateFailed": "コネクター名を更新できませんでした",
+        "nameUpdated": "コネクター名を更新しました",
+        "noUnresolvedErrors": "再試行する未解決のエラーはありません。",
+        "pruningFrequencyUpdateFailed": "コネクターのプルーニング頻度を更新できませんでした",
+        "pruningFrequencyUpdated": "コネクターのプルーニング頻度を更新しました",
+        "refreshFrequencyUpdateFailed": "コネクターの更新頻度を変更できませんでした",
+        "refreshFrequencyUpdated": "コネクターの更新頻度を変更しました",
+        "targetedReindexFailed": "対象を指定した再インデックス作成に失敗しました: {message}",
+        "targetedReindexSubmitted": "{count, plural, one {# 件のドキュメント} other {# 件のドキュメント}}について、対象を指定した再インデックス作成を送信しました。再インデックス作成が完了したドキュメントから、エラーは一覧から消えます。"
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "{source} で認可",
+          "pendingLabel": "認可しています..."
+        },
+        "createCredentialButton": {
+          "label": "新規作成"
+        },
+        "credentialDeleted": {
+          "toast": "認証情報を削除しました！"
+        },
+        "credentialModal": {
+          "title": "{source} の認証情報を作成"
+        },
+        "credentialStep": {
+          "title": "認証情報を選択"
+        },
+        "credentialSwapped": {
+          "toast": "認証情報を切り替えました！"
+        },
+        "error": {
+          "toast": "エラー: {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "このコネクターではフェデレーテッド検索を利用できます。ただし、レイテンシーが大きくなり、検索品質は下がります。",
+            "link": {
+              "label": "代わりにフェデレーテッド版を使用 →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "ファイルのアップロード中にエラーが発生しました"
+        },
+        "oauthRedirectFailed": {
+          "message": "{source} でのサインイン画面にリダイレクトできませんでした。もう一度お試しください。"
+        },
+        "oauthStartFailed": {
+          "toast": "OAuth を開始できません"
+        },
+        "oauthUrlFailed": {
+          "toast": "OAuth URL を取得できませんでした"
+        },
+        "retryButton": {
+          "label": "再試行"
+        },
+        "timeout": {
+          "toast": "{seconds} 秒後に操作がタイムアウトしました。設定に誤りがないか確認してください。"
+        },
+        "unknownError": {
+          "toast": "不明なエラーが発生しました"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "インデックス作成の開始日",
+          "subtext": "この日付より前のドキュメントは取り込まれません"
+        },
+        "pruneFrequency": {
+          "description": "すべてのドキュメントをソースと照合し、すでに存在しないものを削除します。注意: この処理はすべてのドキュメントを確認するため、頻度を上げるときは注意してください。既定値は {hours} 時間（{days} 日）です。小数の時間も指定できます（例: 0.1 時間 = 6 分）。このコネクターのプルーニングを無効にするには 0 を入力してください。",
+          "label": "プルーニング頻度（時間）"
+        },
+        "refreshFrequency": {
+          "description": "ソースから新しいドキュメントを取得する間隔です（分単位）。0 を入力すると、このコネクターで新しいドキュメントを取得しません。",
+          "label": "更新頻度（分）"
+        },
+        "resetButton": {
+          "label": "リセット"
+        },
+        "title": "詳細設定"
+      },
+      "connectorName": {
+        "label": "コネクター名",
+        "subtext": "コネクターの内容がわかる名前です。"
+      },
+      "credentialsLoadError": {
+        "title": "認証情報の読み込みに失敗しました。"
+      },
+      "field": {
+        "optional": {
+          "label": "（任意）"
+        },
+        "optionalSuffix": {
+          "label": "任意"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Google Drive の認証情報を作成しました。認証情報の一覧から管理または取り消しができます。",
+          "title": "認証が完了しました"
+        },
+        "authFailed": {
+          "toast": "Google Drive での認証に失敗しました - {error}"
+        },
+        "authenticateButton": {
+          "label": "Google Drive で認証",
+          "pendingLabel": "認証しています..."
+        },
+        "createButton": {
+          "label": "認証情報を作成",
+          "pendingLabel": "作成しています..."
+        },
+        "credentialsLoadError": {
+          "title": "Google Drive の認証情報の読み込みに失敗しました。"
+        },
+        "invalidFile": {
+          "toast": "指定したファイルが無効です - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "指定したファイルが無効です - サービスアカウントの JSON キーが必要です"
+        },
+        "missingServiceAccountKey": {
+          "toast": "認証情報を作成する前に、サービスアカウントキーをアップロードしてください"
+        },
+        "oauthOption": {
+          "description": "Google Cloud Console から OAuth アプリの JSON をアップロードし（[セットアップ手順]({docsUrl})）、インデックスを作成する Drive を持つ Google アカウントで認証してください。",
+          "title": "オプション 1: OAuth アプリ"
+        },
+        "oauthUpload": {
+          "placeholder": "OAuth アプリの JSON をアップロードまたは貼り付け"
+        },
+        "primaryAdmin": {
+          "description": "インデックスを作成する Google Drive を所有する Google 組織の、管理者またはオーナーのメールアドレスを入力してください。",
+          "invalidEmail": "有効なメールアドレスを入力してください",
+          "label": "主管理者のメールアドレス",
+          "required": "必須です"
+        },
+        "section": {
+          "title": "Google Drive の認証"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "サービスアカウントの認証情報を作成できませんでした - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "サービスアカウントの認証情報を作成しました"
+        },
+        "serviceAccountOption": {
+          "title": "オプション 2: サービスアカウント"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "サービスアカウントの JSON キーをアップロードまたは貼り付け"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Gmail の認証情報を作成しました。認証情報の一覧から管理または取り消しができます。",
+          "title": "認証が完了しました"
+        },
+        "authFailed": {
+          "toast": "Gmail での認証に失敗しました - {error}"
+        },
+        "authenticateButton": {
+          "label": "Gmail で認証",
+          "pendingLabel": "認証しています..."
+        },
+        "createButton": {
+          "label": "認証情報を作成",
+          "pendingLabel": "作成しています..."
+        },
+        "credentialsLoadError": {
+          "title": "Gmail の認証情報の読み込みに失敗しました。"
+        },
+        "invalidFile": {
+          "toast": "指定したファイルが無効です - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "指定したファイルが無効です - サービスアカウントの JSON キーが必要です"
+        },
+        "missingServiceAccountKey": {
+          "toast": "認証情報を作成する前に、サービスアカウントキーをアップロードしてください"
+        },
+        "oauthOption": {
+          "description": "Google Cloud Console から OAuth アプリの JSON をアップロードし（[セットアップ手順]({docsUrl})）、インデックスを作成する Gmail を持つ Google アカウントで認証してください。",
+          "title": "オプション 1: OAuth アプリ"
+        },
+        "oauthUpload": {
+          "placeholder": "OAuth アプリの JSON をアップロードまたは貼り付け"
+        },
+        "primaryAdmin": {
+          "description": "インデックスを作成する Gmail アカウントを所有する Google 組織の、管理者またはオーナーのメールアドレスを入力してください。",
+          "invalidEmail": "有効なメールアドレスを入力してください",
+          "label": "主管理者のメールアドレス",
+          "required": "必須です"
+        },
+        "section": {
+          "title": "Gmail の認証"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "サービスアカウントの認証情報を作成できませんでした - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "サービスアカウントの認証情報を作成しました"
+        },
+        "serviceAccountOption": {
+          "title": "オプション 2: サービスアカウント"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "サービスアカウントの JSON キーをアップロードまたは貼り付け"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "ホームに戻る"
+        },
+        "title": "「{connector}」は有効なコネクタータイプではありません。"
+      },
+      "listInput": {
+        "placeholder": "{label} を入力"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "詳細設定"
+        },
+        "continueButton": {
+          "label": "次へ"
+        },
+        "createButton": {
+          "label": "コネクターを作成"
+        },
+        "previousButton": {
+          "label": "戻る"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "問題が発生しました"
+        },
+        "invalidSource": {
+          "description": "{source} は有効なソースタイプではありません。",
+          "title": "指定されたコネクターのソースタイプ {source} は存在しません。"
+        },
+        "processing": {
+          "description": "セットアップが完了するまでお待ちください。",
+          "title": "処理しています..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "{source} で認可"
+        },
+        "authorizing": {
+          "description": "認可が完了するまでお待ちください。"
+        },
+        "continue": {
+          "message": "続けるには<link>こちら</link>をクリックしてください。"
+        },
+        "error": {
+          "description": "OAuth の処理中にエラーが発生しました。もう一度お試しください。"
+        },
+        "malformed": {
+          "missingCode": "認可コードがありません。",
+          "missingState": "state パラメーターがありません。",
+          "title": "OAuth 認可リクエストの形式が正しくありません。"
+        },
+        "page": {
+          "title": "サードパーティサービスで認可"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "{source} での認可が完了しました。認証情報の設定を終えるには、追加の手順が必要です。"
+          },
+          "description": "{source} での認可が完了しました。",
+          "title": "完了しました！"
+        }
+      },
+      "oauthFailed": {
+        "toast": "OAuth 認証に失敗しました。もう一度お試しください。"
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "{source} との認可を完了"
+        },
+        "cloudId": {
+          "required": "Confluence サイトを選択してください（id が見つかりません）。"
+        },
+        "cloudName": {
+          "required": "Confluence サイトを選択してください（name が見つかりません）。"
+        },
+        "cloudUrl": {
+          "required": "Confluence サイトを選択してください（url が見つかりません）。"
+        },
+        "continue": {
+          "message": "認可が完了しました。続けるには<link>こちら</link>をクリックしてください。"
+        },
+        "credentialId": {
+          "required": "認証情報の ID は必須です。"
+        },
+        "error": {
+          "description": "OAuth の完了処理中にエラーが発生しました。もう一度お試しください。"
+        },
+        "finalized": {
+          "title": "Confluence の認可が完了しました。"
+        },
+        "loadingSites": {
+          "description": "アクセスできるサイトの一覧を取得するまでお待ちください。"
+        },
+        "malformed": {
+          "description": "認証情報の id が無効か、指定されていません。",
+          "title": "OAuth の完了リクエストの形式が正しくありません。"
+        },
+        "page": {
+          "title": "サードパーティサービスとの認可を完了"
+        },
+        "selectSite": {
+          "title": "Confluence サイトを選択"
+        },
+        "submitButton": {
+          "label": "送信",
+          "pendingLabel": "送信しています..."
+        },
+        "submitError": {
+          "description": "送信の処理中にエラーが発生しました。もう一度お試しください。",
+          "title": "送信中にエラーが発生しました。"
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "選択してください"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "新規追加"
+        },
+        "removeButton": {
+          "tooltip": "削除"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "表示するタブはありません。"
+        }
+      }
+    },
+    "costOverrides": {
+      "allProviders": {
+        "label": "すべてのプロバイダー"
+      },
+      "empty": {
+        "description": "モデルに交渉済みの単価（100 万 tokens あたりの USD）を適用するには、追加してください。",
+        "title": "コストオーバーライドは設定されていません。"
+      },
+      "form": {
+        "addButton": {
+          "label": "オーバーライドを追加"
+        },
+        "cacheRate": {
+          "label": "キャッシュ読み取り単価（100 万 tokens あたりの USD、任意）",
+          "placeholder": "既定では入力単価を使用"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "inputRate": {
+          "label": "入力単価（100 万 tokens あたりの USD）"
+        },
+        "model": {
+          "label": "モデル",
+          "placeholder": "モデルを選択"
+        },
+        "outputRate": {
+          "label": "出力単価（100 万 tokens あたりの USD）"
+        },
+        "saveButton": {
+          "label": "保存"
+        }
+      },
+      "panel": {
+        "addButton": {
+          "label": "オーバーライドを追加"
+        },
+        "description": "モデルごとの交渉済み単価を **100 万 tokens あたりの USD** で設定します。この単価は、使用コストの計算で組み込みの価格表より優先されます。",
+        "error": {
+          "title": "コストオーバーライドの読み込みに失敗しました。"
+        },
+        "title": "コストオーバーライド"
+      },
+      "row": {
+        "deleteButton": {
+          "ariaLabel": "{model} の {provider} オーバーライドを削除"
+        },
+        "editButton": {
+          "ariaLabel": "{model} の {provider} オーバーライドを編集"
+        },
+        "rates": "{provider} · 入力 {input} · 出力 {output} · 100 万 tokens あたりの USD",
+        "ratesWithCache": "{provider} · 入力 {input} · 出力 {output} · キャッシュ {cache} · 100 万 tokens あたりの USD",
+        "updated": "更新 {time}"
+      },
+      "toasts": {
+        "removeFailed": "オーバーライドを削除できませんでした: {message}",
+        "removed": "{model} のオーバーライドを削除しました。",
+        "saveFailed": "オーバーライドを保存できませんでした: {message}",
+        "saved": "{model} の単価を保存しました。",
+        "unknownError": "不明なエラー"
+      }
+    },
+    "craft": {
+      "accessCell": {
+        "disabledSuccess": {
+          "message": "このユーザーの Craft を無効にしました"
+        },
+        "enabledSuccess": {
+          "message": "このユーザーの Craft を有効にしました"
+        },
+        "error": {
+          "message": "Craft のアクセス権を更新できませんでした"
+        }
+      },
+      "accessSummary": {
+        "description": "現在、{total} 人中 {enabledCount} 人のユーザーがアクセスできます"
+      },
+      "confirmModal": {
+        "disableBody": {
+          "description": "全員のアクセス権が解除されます。進行中のセッションには影響しません。",
+          "withExceptions": {
+            "description": "下でオンにした {enabledCount} 人のユーザーを除き、全員のアクセス権が解除されます。進行中のセッションには影響しません。"
+          }
+        },
+        "disableButton": {
+          "label": "既定で無効にする"
+        },
+        "disableHeader": {
+          "title": "Craft を既定で無効にしますか？"
+        },
+        "enableBody": {
+          "description": "{total} 人すべてのユーザーがアクセスできるようになります。Craft のエージェントはサンドボックスで実行され、あなたの認可と承認のもとで代理として動作します。",
+          "withExclusions": {
+            "description": "下でオフにした {excludedCount} 人を除き、{total} 人すべてのユーザーがアクセスできるようになります。Craft のエージェントはサンドボックスで実行され、あなたの認可と承認のもとで代理として動作します。"
+          }
+        },
+        "enableButton": {
+          "label": "全員に対して有効にする"
+        },
+        "enableHeader": {
+          "title": "すべてのユーザーで Craft を有効にしますか？"
+        }
+      },
+      "defaultToggle": {
+        "betaTag": {
+          "label": "ベータ"
+        },
+        "disabled": {
+          "description": "Craft は全員に対してオフです。下で個別のユーザーを切り替えられます。"
+        },
+        "disabledSuccess": {
+          "message": "Craft は既定で無効になりました"
+        },
+        "enabled": {
+          "description": "Craft は全員に対してオンです。下で個別のユーザーを切り替えられます。"
+        },
+        "enabledSuccess": {
+          "message": "Craft は既定で有効になりました"
+        },
+        "title": "Craft を既定で有効にする"
+      },
+      "emptyState": {
+        "description": "検索条件に一致するユーザーはいません。",
+        "title": "ユーザーが見つかりません"
+      },
+      "header": {
+        "description": "Onyx のエージェント型アプリビルダーである Craft を使えるユーザーを管理します。",
+        "title": "アクセス"
+      },
+      "perUserAccess": {
+        "description": "ワークスペースの既定値から変更したユーザーは、既定値が変わっても個別の設定を保持します。",
+        "title": "ユーザーごとのアクセス"
+      },
+      "saveError": {
+        "message": "設定を更新できませんでした"
+      },
+      "search": {
+        "placeholder": "ユーザーを検索..."
+      },
+      "settingsLoadError": {
+        "description": "設定の読み込みに失敗しました。ページを再読み込みしてください。"
+      },
+      "table": {
+        "accessColumn": {
+          "header": "アクセス"
+        },
+        "footer": {
+          "units": "ユーザー"
+        },
+        "groupsColumn": {
+          "header": "グループ"
+        },
+        "userColumn": {
+          "header": "ユーザー"
+        }
+      },
+      "unavailable": {
+        "description": "Craft はデプロイごとに Onyx が有効にします。利用するには、Onyx の担当者にお問い合わせください。",
+        "title": "このデプロイでは Craft を利用できません"
+      },
+      "usersLoadError": {
+        "description": "ユーザーの読み込みに失敗しました。ページを再読み込みしてください。"
+      }
+    },
+    "craftInstructions": {
+      "baseInstructions": {
+        "description": "入力した指示が追加される、組み込みのプロンプトです。動的な部分はセッションごとに埋められます。",
+        "loadError": {
+          "description": "基本の指示を読み込めませんでした。"
+        },
+        "title": "基本の指示を表示"
+      },
+      "header": {
+        "description": "Craft の組み込みの動作に加えて、すべての Craft エージェントが従うワークスペース全体の指示です。",
+        "title": "指示"
+      },
+      "instructions": {
+        "charCount": {
+          "label": "{count} / {max}"
+        },
+        "help": {
+          "description": "変更はセッションの開始時または復元時に適用されます。実行中のセッションには反映されません。"
+        },
+        "label": "ワークスペースの指示",
+        "placeholder": "例: 常に当社のブランドガイドラインに従い、簡潔で丁寧な文章にする。"
+      },
+      "resetButton": {
+        "label": "既定値に戻す"
+      },
+      "resetModal": {
+        "body": {
+          "description": "新しい Craft セッションは、組み込みの指示だけで実行されます。ワークスペースの指示は全員から削除されます。"
+        },
+        "header": {
+          "title": "Craft の指示をリセットしますか？"
+        },
+        "resettingLabel": "リセットしています…",
+        "submitButton": {
+          "label": "リセット"
+        }
+      },
+      "saveButton": {
+        "label": "保存",
+        "savingLabel": "保存しています…"
+      },
+      "saveError": {
+        "message": "指示を保存できませんでした"
+      },
+      "saveSuccess": {
+        "message": "Craft の指示を保存しました"
+      },
+      "settingsLoadError": {
+        "description": "設定の読み込みに失敗しました。ページを再読み込みしてください。"
+      },
+      "tryInCraftButton": {
+        "label": "Craft で試す"
+      },
+      "unavailable": {
+        "description": "Craft はデプロイごとに Onyx が有効にします。利用するには、Onyx の担当者にお問い合わせください。",
+        "title": "このデプロイでは Craft を利用できません"
+      }
+    },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "トークンを変更するには、現在のトークンを削除してから新しいトークンを追加してください。"
+        },
+        "configured": {
+          "badge": "設定済み",
+          "text": "Discord のボットトークンは設定済みです。"
+        },
+        "configuredWithDate": {
+          "text": "Discord のボットトークンは設定済みです。追加日: {date}。"
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "先にサーバー設定を削除してください"
+          },
+          "label": "Discord トークンを削除"
+        },
+        "deleteError": {
+          "toast": "ボットトークンを削除できませんでした"
+        },
+        "deleteModal": {
+          "additionalDetails": "Discord のボットの接続が解除されます。再び使うには、トークンを入力し直す必要があります。",
+          "entityName": "Discord ボットトークン",
+          "entityType": "Discord のボットトークン"
+        },
+        "deleted": {
+          "toast": "ボットトークンを削除しました"
+        },
+        "enterInstructions": {
+          "text": "ボットを有効にするには、Discord のボットトークンを入力してください。トークンは Discord Developer Portal で取得できます。"
+        },
+        "input": {
+          "placeholder": "ボットトークンを入力..."
+        },
+        "missing": {
+          "toast": "ボットトークンを入力してください"
+        },
+        "notConfigured": {
+          "badge": "未設定"
+        },
+        "saveButton": {
+          "label": "トークンを保存",
+          "saving": {
+            "label": "保存しています..."
+          }
+        },
+        "saveError": {
+          "toast": "ボットトークンを保存できませんでした"
+        },
+        "saved": {
+          "toast": "ボットトークンを保存しました"
+        },
+        "section": {
+          "title": "ボットトークン"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "チャンネルの設定は、サーバーの登録後に利用できます。"
+        },
+        "disableAllButton": {
+          "label": "すべて無効にする"
+        },
+        "empty": {
+          "description": "チャンネルを追加するには、Discord で !sync-channels を実行してください。",
+          "title": "設定済みのチャンネルはありません"
+        },
+        "enableAllButton": {
+          "label": "すべて有効にする"
+        },
+        "partialUpdate": {
+          "toast": "{succeeded} 件のチャンネルを更新しましたが、{failed} 件は失敗しました"
+        },
+        "section": {
+          "description": "チャンネル一覧を更新するには、Discord で !sync-channels を実行してください。",
+          "title": "チャンネル設定"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "エージェントのオーバーライド"
+          },
+          "channel": {
+            "header": "チャンネル"
+          },
+          "enabled": {
+            "header": "有効"
+          },
+          "requireMention": {
+            "header": "@メンション必須"
+          },
+          "threadOnly": {
+            "header": "スレッド限定モード"
+          }
+        },
+        "updateError": {
+          "toast": "チャンネルを更新できませんでした"
+        },
+        "updated": {
+          "toast": "{count, plural, one {# 件のチャンネル} other {# 件のチャンネル}}を更新しました"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "既定のエージェントを解除しました"
+        },
+        "section": {
+          "description": "オーバーライドがない限り、ボットがすべてのチャンネルで使用するエージェントです。",
+          "title": "既定のエージェント"
+        },
+        "select": {
+          "default": {
+            "label": "既定のエージェント"
+          },
+          "placeholder": "エージェントを選択"
+        },
+        "updateError": {
+          "toast": "エージェントを更新できませんでした"
+        },
+        "updated": {
+          "toast": "既定のエージェントを更新しました"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "チャンネルを読み込めませんでした",
+          "title": "チャンネルの読み込みに失敗しました"
+        },
+        "loadServer": {
+          "title": "サーバーの読み込みに失敗しました"
+        },
+        "loadServers": {
+          "title": "Discord サーバーの読み込みに失敗しました"
+        },
+        "serverNotFound": {
+          "message": "サーバーが見つかりません"
+        },
+        "unknown": {
+          "message": "不明なエラーが発生しました"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "セットアップを完了するには、Discord サーバーで登録キーを付けて !register コマンドを実行してください。",
+          "title": "登録を待っています"
+        },
+        "pending": {
+          "text": "登録の保留中"
+        },
+        "registered": {
+          "text": "登録日: {date}"
+        },
+        "updateButton": {
+          "label": "設定を更新"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "サーバーを作成できませんでした"
+        },
+        "created": {
+          "toast": "サーバー設定を作成しました！"
+        },
+        "deleteError": {
+          "toast": "サーバー設定を削除できませんでした"
+        },
+        "deleteModal": {
+          "additionalDetails": "この Discord サーバーのすべての設定が削除されます。",
+          "entityType": "Discord のサーバー設定"
+        },
+        "deleted": {
+          "toast": "サーバー設定を削除しました"
+        },
+        "disabled": {
+          "toast": "サーバーを無効にしました"
+        },
+        "empty": {
+          "description": "まずはサーバー設定を作成してください。",
+          "title": "設定済みの Discord サーバーはまだありません"
+        },
+        "enabled": {
+          "toast": "サーバーを有効にしました"
+        },
+        "fallbackName": "サーバー #{id}",
+        "notRegistered": {
+          "toast": "サーバーを有効にする前に、登録を完了してください"
+        },
+        "pending": {
+          "badge": "保留中"
+        },
+        "registered": {
+          "badge": "登録済み"
+        },
+        "table": {
+          "actions": {
+            "header": "操作"
+          },
+          "enabled": {
+            "header": "有効"
+          },
+          "registered": {
+            "header": "登録済み"
+          },
+          "server": {
+            "header": "サーバー"
+          },
+          "status": {
+            "header": "ステータス"
+          }
+        },
+        "updateError": {
+          "toast": "サーバーを更新できませんでした"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Onyx を Discord サーバーに接続します。ユーザーは Discord のチャンネルで直接質問できます。"
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "このキーは一度しか表示されません。",
+          "title": "登録キー"
+        },
+        "instructions": {
+          "text": "コマンドをコピーして、サーバーの任意のテキストチャンネルから送信してください。"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "作成しています..."
+          },
+          "label": "サーバーを追加"
+        },
+        "section": {
+          "title": "サーバー設定"
+        }
+      },
+      "unsavedChanges": {
+        "description": "保存するには「更新」をクリックしてください。",
+        "title": "保存していない変更があります"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "API キーを入力"
+        },
+        "deleteButton": {
+          "label": "API キーを削除"
+        },
+        "deleteHint": "更新する前に、現在の API キーを削除してください。",
+        "description": "Unstructured は .pdf、.docx、.png、.pptx などの形式から複雑なデータを抽出し、Onyx が取り込める整ったテキストに変換します。Unstructured によるドキュメント処理を有効にするには、API キーを入力してください。",
+        "learnMore": "Unstructured の詳細は<link>こちら</link>をご覧ください。",
+        "note": "<label>注意:</label> ドキュメントは処理のため Unstructured のサーバーに送信されます。",
+        "saveButton": {
+          "label": "API キーを保存"
+        },
+        "title": "Unstructured API で処理"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "ブースト:"
+        },
+        "search": {
+          "placeholder": "タイトルや内容でドキュメントを検索..."
+        },
+        "updateFailed": {
+          "toast": "ドキュメントを更新できませんでした - {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "ドキュメントの読み込み中にエラーが発生しました - {detail}"
+        },
+        "loading": {
+          "label": "読み込み中"
+        },
+        "mostDisliked": {
+          "title": "低評価が最も多いドキュメント"
+        },
+        "mostLiked": {
+          "title": "高評価が最も多いドキュメント"
+        },
+        "table": {
+          "name": {
+            "header": "ドキュメント名"
+          },
+          "score": {
+            "header": "スコア"
+          },
+          "searchable": {
+            "header": "検索可能か"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "非表示状態の更新中にエラーが発生しました - {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "スコアは数値で入力してください"
+        },
+        "updated": {
+          "toast": "スコアを更新しました！"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "非公開"
+          },
+          "public": {
+            "label": "公開"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "名称未設定"
+          }
+        },
+        "deleteFailed": {
+          "toast": "ドキュメントセットの削除をスケジュールできませんでした - {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "ドキュメントセット「{name}」の削除をスケジュールしました"
+        },
+        "description": "**ドキュメントセット**を使うと、関連するドキュメントを 1 つのまとまりにグループ化できます。作成したセットは検索時のフィルターとして使い、Onyx が検索する情報の範囲を制御できます。",
+        "edit": {
+          "header": {
+            "title": "ドキュメントセットを編集"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "同期中は更新できません。同期の完了後に、もう一度お試しください。"
+          }
+        },
+        "federatedBadge": {
+          "label": "フェデレーテッド"
+        },
+        "fetchConnectorsFailed": {
+          "title": "コネクターを取得できませんでした"
+        },
+        "fetchSetsFailed": {
+          "title": "ドキュメントセットを取得できませんでした"
+        },
+        "form": {
+          "connectors": {
+            "label": "コネクターを選択",
+            "placeholder": "コネクターを検索...",
+            "required": "コネクターを 1 つ以上選択してください（通常またはフェデレーテッド）"
+          },
+          "createFailed": {
+            "toast": "ドキュメントセットの作成中にエラーが発生しました - {detail}"
+          },
+          "created": {
+            "toast": "ドキュメントセットを作成しました！"
+          },
+          "description": {
+            "label": "説明:",
+            "placeholder": "このドキュメントセットの内容を説明してください"
+          },
+          "federatedConnectors": {
+            "label": "フェデレーテッドコネクター",
+            "placeholder": "フェデレーテッドコネクターを検索..."
+          },
+          "name": {
+            "label": "名前:",
+            "placeholder": "ドキュメントセットの名前",
+            "required": "セットの名前を入力してください"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {選択したグループで利用できるコネクター} one {選択したグループで利用できるコネクター} other {選択したグループで利用できるコネクター}}"
+          },
+          "submitButton": {
+            "createLabel": "ドキュメントセットを作成",
+            "updateLabel": "ドキュメントセットを更新"
+          },
+          "unavailableConnectors": {
+            "description": "ドキュメントセットを追加するグループに直接割り当てられたコネクターだけを利用できます。",
+            "title": "{count, plural, =0 {選択したグループで利用できないコネクター} one {選択したグループで利用できないコネクター} other {選択したグループで利用できないコネクター}}"
+          },
+          "updateFailed": {
+            "toast": "ドキュメントセットの更新中にエラーが発生しました - {detail}"
+          },
+          "updated": {
+            "toast": "ドキュメントセットを更新しました！"
+          }
+        },
+        "loadError": {
+          "message": "エラー: {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "新しいドキュメントセット"
+          }
+        },
+        "newButton": {
+          "label": "新しいドキュメントセット"
+        },
+        "notFound": {
+          "message": "id が {id} のドキュメントセットは見つかりません",
+          "title": "ドキュメントセットが見つかりません"
+        },
+        "status": {
+          "deleting": {
+            "label": "削除中"
+          },
+          "syncing": {
+            "label": "同期中"
+          },
+          "upToDate": {
+            "label": "最新"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "コネクター"
+          },
+          "delete": {
+            "header": "削除"
+          },
+          "name": {
+            "header": "名前"
+          },
+          "public": {
+            "header": "公開"
+          },
+          "status": {
+            "header": "ステータス"
+          },
+          "title": "既存のドキュメントセット"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "非表示"
+        },
+        "hide": {
+          "ariaLabel": "ドキュメントを非表示にする",
+          "label": "非表示にする"
+        },
+        "unhide": {
+          "ariaLabel": "ドキュメントを再表示する",
+          "label": "再表示する"
+        },
+        "visible": {
+          "label": "表示"
+        }
+      }
+    },
+    "externalApps": {
+      "apps": {
+        "empty": {
+          "addButton": {
+            "label": "アプリを追加"
+          },
+          "description": "アプリを追加すると、組織の全員が使用できるようになります。",
+          "title": "アプリがまだありません"
+        },
+        "panel": {
+          "blurb": "組織全体に対して一度だけ設定します。アプリを編集して、共有の認証情報、アクションポリシー、関連するスキルを設定してください。"
+        },
+        "tab": {
+          "label": "アプリ",
+          "labelWithCount": "アプリ · {count, number}"
+        }
+      },
+      "card": {
+        "actionsButton": {
+          "ariaLabel": "{name} のアクション"
+        },
+        "availableInCraft": {
+          "label": "Craft で使用可能"
+        },
+        "customTag": {
+          "label": "カスタム"
+        },
+        "deleteAction": {
+          "label": "削除"
+        },
+        "deleteModal": {
+          "description": "組織全体からこのアプリを削除します。設定、すべてのメンバーの接続、プロバイダー管理のスキルがすべて削除されます。",
+          "retainedSkills": "{count, plural, =0 {削除される関連カスタムスキルはありません。} one {関連するカスタムスキル # 件は保持されますが、このアプリとのリンクが解除され、全員に対して無効になります。} other {関連するカスタムスキル # 件は保持されますが、このアプリとのリンクが解除され、全員に対して無効になります。}}",
+          "submit": {
+            "label": "アプリを削除"
+          },
+          "submitting": {
+            "label": "削除しています…"
+          },
+          "title": "「{name}」を削除しますか？"
+        },
+        "editAction": {
+          "label": "編集"
+        },
+        "toasts": {
+          "deleteFailed": "「{name}」を削除できませんでした",
+          "disableFailed": "「{name}」を無効にできませんでした",
+          "enableFailed": "「{name}」を有効にできませんでした"
+        },
+        "toggle": {
+          "disableAriaLabel": "{name} を無効にする",
+          "enableAriaLabel": "{name} を有効にする"
+        }
+      },
+      "facts": {
+        "actions": "{count, plural, one {アクション # 件} other {アクション # 件}}",
+        "customSkills": "{count, plural, one {カスタムスキル # 件} other {カスタムスキル # 件}}",
+        "noCredentials": "認証情報なし",
+        "noCustomSkills": "カスタムスキルなし",
+        "orgCredentialsSet": "組織の認証情報を設定済み",
+        "perUserCredentials": "ユーザーごとの認証情報",
+        "providedByOnyx": "Onyx が提供",
+        "tools": "{count, plural, one {ツール # 個} other {ツール # 個}}",
+        "upstreamPatterns": "{count, plural, one {アップストリームパターン # 件} other {アップストリームパターン # 件}}"
+      },
+      "loading": {
+        "label": "読み込んでいます…"
+      },
+      "mcpServers": {
+        "empty": {
+          "description": "アクションでサーバーを接続してから、ここで組織向けに有効にしてください。",
+          "openActionsButton": {
+            "label": "アクションを開く"
+          },
+          "title": "MCP サーバーがまだありません"
+        },
+        "manageInActionsButton": {
+          "label": "アクションで管理"
+        },
+        "panel": {
+          "blurb": "サーバーを有効にすると、アクセス権のあるメンバーが Craft でそのツールを使用できます。編集して各ツールの承認ポリシーを設定してください。サーバーの接続とアクセス権はアクションで管理します。"
+        },
+        "tab": {
+          "label": "MCP サーバー",
+          "labelWithCount": "MCP サーバー · {count, number}"
+        }
+      },
+      "page": {
+        "addAppButton": {
+          "label": "アプリを追加"
+        },
+        "backToCraftButton": {
+          "label": "Craft に戻る"
+        },
+        "description": "組織の Craft エージェントが使用できるアプリを設定します。各メンバーは Craft のアプリページで自分のアカウントを接続します。"
+      },
+      "warnings": {
+        "invalidSkill": "無効なスキル",
+        "providerUnavailable": "プロバイダーを利用できません"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "コネクターを読み込めませんでした: {details}",
+        "title": "エラー"
+      },
+      "loading": {
+        "description": "コネクターの詳細と認証情報スキーマを取得しています",
+        "title": "コネクター設定を読み込んでいます..."
+      }
+    },
+    "groups": {
+      "card": {
+        "defaultTag": {
+          "label": "デフォルト"
+        },
+        "toasts": {
+          "renameFailed": "グループの名前を変更できませんでした",
+          "renamed": "グループ名を「{name}」に変更しました"
+        },
+        "viewGroup": {
+          "label": "グループを表示"
+        }
+      },
+      "create": {
+        "header": {
+          "title": "グループを作成"
+        },
+        "submit": {
+          "label": "作成"
+        },
+        "toasts": {
+          "createFailed": "グループを作成できませんでした",
+          "created": "グループ「{name}」を作成しました"
+        }
+      },
+      "edit": {
+        "delete": {
+          "button": {
+            "label": "グループを削除"
+          },
+          "description": "メンバーはこのグループで共有されているすべてのリソースにアクセスできなくなります。",
+          "title": "このグループを削除"
+        },
+        "deleteModal": {
+          "deleting": {
+            "label": "削除しています..."
+          },
+          "description": "グループ <highlight>{name}</highlight> のメンバーは、直接アクセス権を付与されていない限り、このグループで共有されているすべてのリソースにアクセスできなくなります。削除は元に戻せません。",
+          "submit": {
+            "label": "削除"
+          },
+          "title": "グループを削除"
+        },
+        "header": {
+          "title": "グループを編集"
+        },
+        "incognito": {
+          "description": "このグループのメンバーはシークレットチャットを開始できます。",
+          "title": "シークレットチャット"
+        },
+        "loadError": {
+          "text": "グループデータを読み込めませんでした。"
+        },
+        "notFound": {
+          "description": "このグループは存在しないか、削除された可能性があります。",
+          "header": {
+            "title": "グループが見つかりません"
+          },
+          "title": "グループが見つかりません"
+        },
+        "saving": {
+          "label": "保存しています..."
+        },
+        "submit": {
+          "label": "変更を保存"
+        },
+        "syncing": {
+          "label": "同期しています...",
+          "tooltip": "このグループの最近の変更により、ドキュメントの embedding を更新しています。"
+        },
+        "systemGroup": {
+          "description": "このグループは Onyx が管理します。保持するのはメンバーのみで、変更できるのもメンバーだけです。",
+          "title": "システムグループ"
+        },
+        "toasts": {
+          "deleteFailed": "グループを削除できませんでした",
+          "deleted": "グループ「{name}」を削除しました",
+          "managerAssigned": "マネージャーを割り当てました",
+          "managerRevoked": "マネージャー権限を取り消しました",
+          "managerUpdateFailed": "マネージャーを更新できませんでした",
+          "membersStranded": "一部のメンバーがどのグループにも所属しなくなります。先に別のグループへ追加してください。",
+          "syncing": "このグループは現在同期中です。しばらく待ってからもう一度お試しください。",
+          "updateFailed": "グループを更新できませんでした",
+          "updated": "グループ「{name}」を更新しました"
+        }
+      },
+      "form": {
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "name": {
+          "label": "グループ名",
+          "placeholder": "グループ名を入力"
+        },
+        "toasts": {
+          "nameRequired": "グループ名は必須です"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "グループを作成して、ユーザーを整理しアクセス権を管理しましょう。"
+        },
+        "loadError": {
+          "description": "詳細はコンソールを確認してください。",
+          "title": "グループを読み込めませんでした。"
+        },
+        "newGroup": {
+          "label": "新しいグループ"
+        },
+        "noResults": {
+          "description": "「{query}」に一致するグループはありません",
+          "title": "グループが見つかりません"
+        },
+        "search": {
+          "placeholder": "グループを検索..."
+        }
+      },
+      "members": {
+        "add": {
+          "label": "追加"
+        },
+        "done": {
+          "label": "完了"
+        },
+        "lastGroup": {
+          "tooltip": "このユーザーが所属する唯一のグループです。先に別のグループへ追加してください。"
+        },
+        "loadError": {
+          "text": "ユーザーを読み込めませんでした。"
+        },
+        "makeManager": {
+          "label": "マネージャーにする"
+        },
+        "managerTag": {
+          "label": "マネージャー"
+        },
+        "noMembers": {
+          "description": "このグループにメンバーを追加してください。",
+          "title": "メンバーがいません"
+        },
+        "noUsers": {
+          "description": "検索に一致するユーザーはいません。",
+          "title": "ユーザーが見つかりません"
+        },
+        "ownManager": {
+          "tooltip": "自分のマネージャー権限は取り消せません"
+        },
+        "removeMember": {
+          "label": "メンバーを削除"
+        },
+        "removeSelf": {
+          "tooltip": "このグループを管理している間は自分を削除できません"
+        },
+        "revokeManager": {
+          "label": "マネージャー権限を取り消す"
+        },
+        "saveBeforeManager": {
+          "tooltip": "マネージャーを割り当てる前にグループを保存してください"
+        },
+        "searchMembers": {
+          "placeholder": "メンバーを検索..."
+        },
+        "searchUsers": {
+          "placeholder": "ユーザーとアカウントを検索..."
+        },
+        "table": {
+          "accountType": {
+            "header": "アカウントタイプ"
+          },
+          "name": {
+            "header": "名前"
+          }
+        }
+      },
+      "page": {
+        "title": "グループ"
+      },
+      "permissions": {
+        "section": {
+          "description": "このグループのメンバーのアクセス権と権限を設定します。",
+          "title": "グループの権限"
+        }
+      },
+      "permissionsChanged": {
+        "description": "Onyx はグループ単位の権限を使用するようになりました。アクセス権はグループごとに設定するため、ユーザーの権限は所属するすべてのグループの組み合わせになります。",
+        "learnMore": {
+          "label": "詳細を見る"
+        },
+        "title": "権限の仕組みが変わりました"
+      },
+      "sharedResources": {
+        "agent": {
+          "description": "エージェント"
+        },
+        "agents": {
+          "label": "エージェント",
+          "placeholder": "エージェントを追加"
+        },
+        "connector": {
+          "description": "コネクター"
+        },
+        "connectorFallback": {
+          "label": "コネクター #{id}"
+        },
+        "connectors": {
+          "label": "コネクターとドキュメントセット",
+          "placeholder": "コネクター、ドキュメントセットを追加"
+        },
+        "documentSet": {
+          "description": "ドキュメントセット"
+        },
+        "noAgents": {
+          "description": "このグループと共有するエージェントを追加してください。",
+          "title": "エージェントが追加されていません"
+        },
+        "noConnectors": {
+          "description": "このグループと共有するコネクターまたはドキュメントセットを追加してください。",
+          "title": "コネクターとドキュメントセットが追加されていません"
+        },
+        "popover": {
+          "connectors": {
+            "label": "コネクター"
+          },
+          "documentSets": {
+            "label": "ドキュメントセット"
+          },
+          "noResults": {
+            "title": "結果が見つかりません"
+          }
+        },
+        "section": {
+          "description": "コネクター、ドキュメントセット、エージェントをこのグループのメンバーと共有します。",
+          "title": "このグループと共有中"
+        },
+        "sharedBadge": {
+          "label": "共有中"
+        }
+      },
+      "tokenLimits": {
+        "addLimit": {
+          "label": "上限を追加"
+        },
+        "costLimit": {
+          "header": "コスト上限",
+          "placeholder": "コスト上限",
+          "unit": "(USD)"
+        },
+        "disabledTooltip": "token レート制限は [Onyx の Enterprise 版](/admin/billing) でのみ利用できます。",
+        "section": {
+          "description": "このグループが指定期間内に使用できる token 数を制限します。",
+          "title": "Token レート制限"
+        },
+        "timeWindow": {
+          "header": "期間",
+          "unit": "(UTC 日数)"
+        },
+        "tokenLimit": {
+          "header": "Token 上限",
+          "placeholder": "Token 上限 (千単位)",
+          "unit": "(千単位)"
+        }
+      }
+    },
+    "imageGeneration": {
+      "configureSuccess": {
+        "message": "プロバイダーを設定しました"
+      },
+      "deselectError": {
+        "message": "選択を解除できませんでした"
+      },
+      "deselectSuccess": {
+        "message": "{title} の選択を解除しました"
+      },
+      "disconnectError": {
+        "message": "接続を解除できませんでした"
+      },
+      "disconnectModal": {
+        "connectAnother": {
+          "description": "画像生成を続けて使用するには、別のプロバイダーを接続してください。"
+        },
+        "defaultNoReplacement": {
+          "description": "現在、**{title}** がデフォルトの画像生成モデルです。"
+        },
+        "defaultWithReplacement": {
+          "description": "現在、**{title}** がデフォルトの画像生成モデルです。セッション履歴は保持されます。"
+        },
+        "header": {
+          "description": "このプロバイダーに保存されている認証情報を削除します。",
+          "title": "*{title}* の接続を解除"
+        },
+        "noDefaultOption": {
+          "description": "(画像生成を無効にする)",
+          "label": "デフォルトなし"
+        },
+        "nonDefault": {
+          "description": "**{title}** のモデルは画像生成に使用されなくなります。"
+        },
+        "replacement": {
+          "label": "新しいデフォルトを設定",
+          "placeholder": "代わりのモデルを選択"
+        },
+        "sessionHistory": {
+          "description": "セッション履歴は保持されます。"
+        },
+        "submitButton": {
+          "label": "接続を解除"
+        }
+      },
+      "disconnectSuccess": {
+        "message": "{title} の接続を解除しました"
+      },
+      "emptyState": {
+        "title": "チャットで使用する画像生成モデルを接続してください。"
+      },
+      "form": {
+        "apiKey": {
+          "comboPlaceholder": "新しい API キーを入力するか、既存のプロバイダーを選択",
+          "idle": "新しい API キーを入力するか、既存のプロバイダーを選択してください。",
+          "label": "API キー",
+          "placeholder": "API キーを入力",
+          "required": "API キーは必須です"
+        },
+        "apiKeyTest": {
+          "error": "API キーが無効です",
+          "loading": "{title} で API キーをテストしています...",
+          "success": "API キーは有効です。設定を保存しました。"
+        },
+        "apiKeyValidationFailed": {
+          "message": "API キーの検証に失敗しました"
+        },
+        "authMethod": {
+          "idle": "Onyx が Google Vertex AI に認証する方法を選択してください。",
+          "label": "認証方法",
+          "required": "認証方法は必須です",
+          "serviceAccount": {
+            "description": "GCP サービスアカウントキーの JSON ファイルをアップロード",
+            "label": "サービスアカウント JSON"
+          },
+          "workloadIdentity": {
+            "description": "Pod に付与された GCP 認証情報を使用 (GKE Workload Identity)",
+            "label": "Workload Identity (GKE)"
+          }
+        },
+        "azureApiKey": {
+          "idle": "モデルにアクセスするには、Azure OpenAI の <link>API キー</link> を貼り付けてください。"
+        },
+        "connectHeader": {
+          "title": "{title} を接続"
+        },
+        "credentials": {
+          "idle": "Google Cloud の <link>サービスアカウント認証情報</link> をアップロードするか貼り付けてください。",
+          "label": "認証情報ファイル",
+          "placeholder": "認証情報をアップロードまたは貼り付け",
+          "required": "認証情報ファイルは必須です"
+        },
+        "credentialsTest": {
+          "error": "認証情報が無効です",
+          "loading": "{title} で認証情報をテストしています...",
+          "success": "認証情報は有効です。設定を保存しました。"
+        },
+        "editHeader": {
+          "title": "{title} を編集"
+        },
+        "invalidProviderSelection": {
+          "message": "プロバイダーの選択が無効です"
+        },
+        "loading": {
+          "placeholder": "読み込んでいます..."
+        },
+        "location": {
+          "idle": "Vertex AI モデルを使用する Google Cloud リージョンです。利用できるリージョンは <link>Google のドキュメント</link> を参照してください。",
+          "label": "リージョン",
+          "required": "リージョンは必須です"
+        },
+        "projectId": {
+          "idle": "Vertex AI を有効にした GCP プロジェクトです。Onyx は Pod にバインドされたサービスアカウント (GKE Workload Identity) で認証します。",
+          "label": "GCP プロジェクト ID",
+          "required": "プロジェクト ID は必須です"
+        },
+        "targetUri": {
+          "idle": "<link>Azure OpenAI</link> のエンドポイントターゲット URI を貼り付けてください (API エンドポイントのベース、デプロイ名、API バージョンを含む)。",
+          "invalid": "ターゲット URI は api-version とデプロイ名を含む有効な URL である必要があります",
+          "label": "ターゲット URI",
+          "required": "ターゲット URI は必須です"
+        },
+        "unknownError": {
+          "message": "不明なエラーが発生しました"
+        }
+      },
+      "header": {
+        "description": "チャット内の画像生成に関する設定です。",
+        "title": "画像生成"
+      },
+      "loadError": {
+        "message": "設定を読み込めませんでした。ページを再読み込みしてください。"
+      },
+      "model": {
+        "description": "チャットで画像を生成するモデルを選択してください。",
+        "title": "画像生成モデル"
+      },
+      "providers": {
+        "azureGptImage1": {
+          "description": "Microsoft Azure でホストされる GPT Image 1 画像生成モデルです。"
+        },
+        "azureGptImage15": {
+          "description": "Microsoft Azure でホストされる GPT Image 1.5 画像生成モデルです。"
+        },
+        "azureGptImage2": {
+          "description": "Microsoft Azure でホストされる GPT Image 2 画像生成モデルです。"
+        },
+        "gemini25FlashImage": {
+          "description": "Gemini 2.5 Flash Image (Nano Banana) は速度と効率を重視して設計されたモデルです。"
+        },
+        "gemini3ProImage": {
+          "description": "Gemini 3 Pro Image (Nano Banana Pro) はプロ向けのアセット制作を想定して設計されています。"
+        },
+        "gemini3ProImagePreview": {
+          "description": "Google Cloud により 2026 年 7 月 17 日に提供終了となります。Gemini 3 Pro Image に切り替えてください。"
+        },
+        "openaiGptImage1": {
+          "description": "プロンプトへの忠実度が高い、OpenAI の高性能な画像生成モデルです。"
+        },
+        "openaiGptImage15": {
+          "description": "OpenAI の従来のフラッグシップ画像生成モデルです。"
+        },
+        "openaiGptImage2": {
+          "description": "プロンプト忠実度が最も高い、OpenAI の最新の画像生成モデルです。"
+        }
+      },
+      "setDefaultError": {
+        "message": "デフォルトに設定できませんでした"
+      },
+      "setDefaultSuccess": {
+        "message": "{title} をデフォルトに設定しました"
+      }
+    },
+    "indexSettings": {
+      "actions": {
+        "applyForward": {
+          "label": "新規および更新されたドキュメントに適用"
+        },
+        "applyReindex": {
+          "label": "適用して再インデックス"
+        },
+        "rebuildAll": {
+          "label": "既存のすべてのドキュメントを再構築"
+        },
+        "revert": {
+          "label": "元に戻す"
+        }
+      },
+      "azure": {
+        "apiVersion": {
+          "description": "デプロイが対象とする Azure OpenAI の API バージョンです。",
+          "placeholder": "例: 2023-05-15",
+          "title": "API バージョン"
+        },
+        "deploymentName": {
+          "description": "この embedding モデル用に Azure で設定したデプロイ名です。",
+          "placeholder": "my-embedding-deployment",
+          "title": "デプロイ名"
+        },
+        "modelName": {
+          "description": "Onyx 内でこのモデルを示すラベルです。Azure はデプロイ名でリクエストを振り分けるため、一意の識別子であれば十分です。"
+        },
+        "targetUrl": {
+          "title": "ターゲット URL"
+        }
+      },
+      "cancelReindexModal": {
+        "description": "キャンセルすると以前の embedding モデルに戻り、再インデックスの進捗はすべて失われます。",
+        "submit": {
+          "label": "キャンセル"
+        },
+        "title": "再インデックスをキャンセル"
+      },
+      "captioningModel": {
+        "description": "このモデルはインデックス作成時に画像を解析するために使用します。選択できるのは画像認識に対応したモデルのみです。変更は以降にインデックスされるドキュメントに適用されます。既存のキャプションは以前の embedding に埋め込まれたままです。",
+        "title": "キャプション生成 LLM"
+      },
+      "changesBanner": {
+        "contextualModelMissing": {
+          "description": "コンテキスト検索は有効ですが、モデルが選択されていません。再インデックスの前に、下でコンテキスト検索 LLM を選択してください。選択しないと再インデックスは実行できません。",
+          "title": "コンテキスト検索 LLM を選択してください"
+        },
+        "contextualModelOnly": {
+          "description": "モデルを新規および更新されたドキュメントのみに適用するか、すべてのドキュメントを再構築してコンテキストを統一します。",
+          "title": "このコンテキスト検索 LLM の適用方法を選択してください"
+        },
+        "default": {
+          "description": "embedding または検索の設定を変更すると、反映するためにすべてのドキュメントの完全な再インデックスが必要です。コーパスの規模によっては **数時間から数日** かかることがあります。[詳細を見る](https://docs.onyx.app/security/architecture/data_flows)",
+          "title": "変更には完全な再インデックスが必要です。"
+        },
+        "orSeparator": {
+          "label": "または"
+        }
+      },
+      "cloudDisabled": {
+        "tooltip": "この設定は Onyx Cloud が管理します。"
+      },
+      "contextualModel": {
+        "description": "このモデルはチャンクのコンテキストを生成するために使用します。",
+        "disabledTooltip": "コンテキスト検索が無効の間は変更できません。",
+        "title": "コンテキスト検索 LLM"
+      },
+      "contextualRetrieval": {
+        "description": "インデックスする各チャンクにドキュメント全体のコンテキストを追加し、ハイブリッド検索の関連性を高めます。embedding のコストが大幅に増える場合があります。",
+        "noModelsTooltip": "モデルが設定されていないため、コンテキスト検索は無効です。先に [言語モデル]({link}) を設定してください。",
+        "title": "コンテキスト検索"
+      },
+      "embeddingModel": {
+        "cloudManaged": {
+          "title": "embedding モデルと関連設定は Onyx Cloud が管理します。"
+        },
+        "description": "Onyx はこのモデルを使用して、検索と取得のためにドキュメントをエンコードします。",
+        "title": "Embedding モデル"
+      },
+      "errorsModal": {
+        "columns": {
+          "error": "エラー",
+          "id": "ID",
+          "name": "名前",
+          "status": "ステータス",
+          "type": "タイプ"
+        },
+        "description": "直近の再インデックスが失敗した (自動で再試行中)、または一時停止された (「再開」で再試行) コネクターとユーザーファイルです。",
+        "empty": "対応が必要な項目はありません。",
+        "loadError": "再インデックスの状態を読み込めませんでした。もう一度お試しください。",
+        "loading": "読み込んでいます…",
+        "resumeButton": {
+          "label": "再開"
+        },
+        "resumeFailed": "再開できませんでした。",
+        "resumingButton": {
+          "label": "再開しています…"
+        },
+        "scope": {
+          "connector": "コネクター",
+          "userFiles": "ユーザーファイル"
+        },
+        "status": {
+          "failed": "失敗",
+          "paused": "一時停止"
+        },
+        "title": "再インデックスの要対応項目",
+        "unknownError": "不明なエラー"
+      },
+      "fields": {
+        "apiKey": {
+          "description": "モデルにアクセスするには、{provider} の [API キー]({link}) を貼り付けてください。",
+          "title": "API キー"
+        },
+        "googleCredentials": {
+          "title": "JSON 認証情報ファイルをアップロード"
+        },
+        "modelDim": {
+          "description": "このモデルが生成する embedding の次元数です。",
+          "placeholder": "例: 768",
+          "title": "モデルの次元数"
+        },
+        "modelName": {
+          "placeholder": "model-name",
+          "selfHostedDescription": "Onyx はセルフホストのエンドポイント上にあるこのモデルに接続します。",
+          "title": "モデル名"
+        },
+        "normalize": {
+          "description": "モデルが生成する embedding を正規化します。embedding モデルのドキュメントに別段の指定がない限り、ほとんどのモデルで推奨されます。",
+          "title": "Embedding の正規化"
+        },
+        "optional": {
+          "suffix": "任意"
+        },
+        "passagePrefix": {
+          "description": "embedding モデルが必要とする場合、インデックスするドキュメントチャンクをモデルに渡す前に、この文字列を先頭に追加します。プレフィックスが正しくない、または不足していると embedding の品質が低下します。",
+          "placeholder": "例: 'passage: '",
+          "title": "パッセージプレフィックス"
+        },
+        "queryPrefix": {
+          "description": "embedding モデルが必要とする場合、検索クエリをモデルに渡す前に、この文字列を先頭に追加します。プレフィックスが正しくない、または不足していると embedding の品質が低下します。",
+          "placeholder": "例: 'query: '",
+          "title": "クエリプレフィックス"
+        }
+      },
+      "forwardOnlyModal": {
+        "description": "既存のドキュメントは以前のモデルが生成したコンテキストを保持します。新しいモデルは、ドキュメントの追加時または更新時にのみ適用されます。コンテキストの内容がドキュメントによって異なる場合があります。",
+        "title": "コンテキスト検索 LLM を以降のドキュメントに適用"
+      },
+      "header": {
+        "description": "ドキュメントのインデックス作成、embedding の生成、検索と取得に向けた準備の方法を設定します。"
+      },
+      "imageExtraction": {
+        "description": "アップロードされたファイル (PDF、DOCX など) に含まれる画像を抽出し、画像認識に対応した LLM で要約します。これにより、画像だけのドキュメントも検索や回答に使用できます。画像認識に対応したデフォルト LLM が必要です。",
+        "title": "画像の抽出とキャプション生成"
+      },
+      "imageProcessing": {
+        "description": "インデックス作成時に LLM を使用して画像を解析し、説明を追加します。",
+        "enableFirstTooltip": "設定するには「画像の抽出とキャプション生成」を有効にしてください。",
+        "noVisionModelsTooltip": "画像認識に対応したモデルが設定されていないため、画像処理は無効です。先に画像認識に対応した [言語モデル]({link}) を設定してください。",
+        "title": "画像処理"
+      },
+      "litellm": {
+        "apiUrl": {
+          "description": "{provider} 互換のエンドポイント URL を貼り付けてください。",
+          "title": "API ベース URL"
+        },
+        "modelName": {
+          "description": "Onyx は {provider} プロキシ上にあるこのモデルに接続します。"
+        }
+      },
+      "maxImageSize": {
+        "description": "リソース使用量を抑えるため、このサイズを超える画像はスキップされます。",
+        "suffix": "(MB)",
+        "title": "解析する画像の最大サイズ"
+      },
+      "modal": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "connectButton": {
+          "label": "接続"
+        },
+        "manage": {
+          "description": "{provider} のプロバイダー設定とモデルの詳細を管理します。",
+          "title": "{provider} を管理"
+        },
+        "setUp": {
+          "description": "{provider} に接続して、{provider} の embedding モデルを設定します。",
+          "title": "{provider} を設定"
+        },
+        "updateButton": {
+          "label": "更新"
+        }
+      },
+      "modelCard": {
+        "connectButton": {
+          "label": "接続"
+        },
+        "currentButton": {
+          "label": "現在のモデル"
+        },
+        "deprecated": {
+          "connectTooltip": "この embedding モデルは非推奨のため接続できません。",
+          "selectTooltip": "この embedding モデルは非推奨のため選択できません。"
+        },
+        "selectButton": {
+          "label": "モデルを選択"
+        },
+        "selectedButton": {
+          "label": "選択済み"
+        }
+      },
+      "modelPicker": {
+        "addCustomModel": {
+          "label": "カスタムモデルを追加"
+        },
+        "cloudTab": {
+          "label": "クラウド型"
+        },
+        "customModel": {
+          "title": "カスタム embedding モデルを設定します。"
+        },
+        "customModels": {
+          "title": "カスタムモデル"
+        },
+        "foldModels": {
+          "label": "モデルを折りたたむ"
+        },
+        "noCloudResults": {
+          "title": "クラウド型のモデルが見つかりません"
+        },
+        "noResults": {
+          "description": "別の検索語をお試しください。"
+        },
+        "noSelfHostedResults": {
+          "title": "セルフホストのモデルが見つかりません"
+        },
+        "revertSelection": {
+          "tooltip": "embedding モデルの選択を元に戻す"
+        },
+        "search": {
+          "placeholder": "モデルを検索..."
+        },
+        "selfHostedTab": {
+          "label": "セルフホスト"
+        },
+        "viewAllModels": {
+          "label": "すべてのモデルを表示"
+        }
+      },
+      "multipass": {
+        "description": "ドキュメントをさまざまなサイズのチャンクとしてインデックスし、関連する情報源をより正確に特定します。",
+        "disabledTooltip": "マルチパスインデックスは一時的に無効です。今後利用できるようになります。",
+        "tag": {
+          "label": "一時的に利用不可"
+        },
+        "title": "マルチパスインデックス"
+      },
+      "progressBanner": {
+        "attentionButton": {
+          "label": "対応が必要な項目を表示"
+        },
+        "cancelButton": {
+          "label": "再インデックスをキャンセルして元に戻す"
+        },
+        "description": {
+          "withModel": "再インデックスの進行に合わせて、新しい embedding 設定 (**{model}**) を適用しています。コーパスの規模によっては **数時間から数日** かかることがあります。",
+          "withoutModel": "再インデックスの進行に合わせて、新しい embedding 設定を適用しています。コーパスの規模によっては **数時間から数日** かかることがあります。"
+        },
+        "progress": {
+          "ariaLabel": "再インデックスの進捗"
+        },
+        "status": {
+          "label": "再インデックスの状態:"
+        },
+        "title": "再インデックスを実行中です…"
+      },
+      "providerGroup": {
+        "addConfig": {
+          "button": {
+            "label": "設定を追加"
+          },
+          "title": "{provider} の embedding プロバイダーの設定を追加します。"
+        },
+        "deprecated": {
+          "suffix": "(非推奨)"
+        },
+        "disconnect": {
+          "errorToast": "{provider} の接続を解除できませんでした",
+          "successToast": "{provider} の接続を解除しました"
+        },
+        "disconnectButton": {
+          "disabledTooltip": "この embedding モデルは現在のデフォルトのため、接続を解除できません。先に別のモデルを選択してください。"
+        },
+        "disconnectModal": {
+          "description": "プロバイダー **{provider}** のすべての embedding モデルの接続を解除します。",
+          "submit": {
+            "label": "接続を解除"
+          },
+          "title": "{provider} の接続を解除"
+        },
+        "editCredentialsButton": {
+          "label": "認証情報を編集"
+        }
+      },
+      "providerInfo": {
+        "cloudProvider": {
+          "title": "クラウドプロバイダー"
+        },
+        "docsLink": {
+          "label": "ドキュメント"
+        },
+        "pricingLink": {
+          "label": "料金"
+        },
+        "selfHosted": {
+          "title": "セルフホスト"
+        }
+      },
+      "reindexBanner": {
+        "cancelReindex": {
+          "label": "再インデックスをキャンセル"
+        },
+        "description": "**{model}** に切り替えています。既存のドキュメントの embedding を作り直しています。コーパスの規模によっては数時間から数日かかることがあります。切り替えが完了するまで、クエリには以前のモデルが応答します。",
+        "seeConnectors": {
+          "label": "コネクターを表示"
+        },
+        "title": "再インデックスを実行中"
+      },
+      "reindexing": {
+        "disabledTooltip": "再インデックスの実行中です。変更するにはキャンセルしてください。"
+      },
+      "retrieval": {
+        "description": "ドキュメントのチャンク分割とコンテキスト付与を設定し、検索精度を高める追加のインデックス機能です。embedding のコストが増える場合があります。",
+        "title": "検索の最適化"
+      },
+      "switchover": {
+        "activeOnly": {
+          "description": "アクティブな (一時停止中でも削除中でもない) すべてのコネクターがインデックス作成に成功するまで、既存の設定の現在のドキュメントインデックスを使い続けます。",
+          "label": "アクティブなコネクターを再インデックスしてから切り替え"
+        },
+        "instant": {
+          "description": "現在のドキュメントインデックスをすぐに消去し、新しい設定に切り替えます。検索用のインデックスが再び揃うまで、すべてのコネクターの再インデックスが必要です。",
+          "label": "再インデックスの前に切り替え"
+        },
+        "placeholder": "切り替え方法を選択",
+        "reindexAll": {
+          "description": "最も安全な方法です。すべてのコネクターがインデックス作成に成功するまで、既存の設定の現在のドキュメントインデックスを使い続けます。",
+          "label": "すべてのコネクターを再インデックスしてから切り替え"
+        }
+      },
+      "toasts": {
+        "applyFailed": "設定を適用できませんでした",
+        "cancelReindexFailed": "再インデックスをキャンセルできませんでした",
+        "captioningUpdateFailed": "キャプション生成 LLM を更新できませんでした",
+        "captioningUpdated": "キャプション生成 LLM を更新しました",
+        "contextualModelRequired": "再インデックスの前にコンテキスト検索 LLM を選択してください。",
+        "contextualModelUpdateFailed": "コンテキスト検索 LLM を更新できませんでした",
+        "contextualModelUpdated": "コンテキスト検索 LLM を更新しました",
+        "modelNotFound": "選択したモデルが見つかりませんでした",
+        "providerResolveFailed": "プロバイダーを特定できませんでした",
+        "reindexCanceled": "再インデックスをキャンセルしました",
+        "reindexStarted": "再インデックスを開始しました",
+        "settingsUpdateFailed": "設定を更新できませんでした",
+        "settingsUpdated": "設定を更新しました",
+        "unknownError": "不明なエラーが発生しました"
+      },
+      "validation": {
+        "apiBaseUrlRequired": "API ベース URL は必須です",
+        "apiKeyRequired": "API キーは必須です",
+        "apiVersionRequired": "API バージョンは必須です",
+        "deploymentNameRequired": "デプロイ名は必須です",
+        "modelDimPositive": "正の整数を入力してください",
+        "modelDimRequired": "モデルの次元数は必須です",
+        "modelNameRequired": "モデル名は必須です",
+        "serviceAccountJsonInvalid": "有効な Google サービスアカウントの JSON ファイルを指定してください",
+        "serviceAccountJsonRequired": "サービスアカウント JSON は必須です",
+        "targetUrlRequired": "ターゲット URL は必須です",
+        "urlInvalid": "有効な URL を入力してください"
+      }
+    },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "{source} から継承"
+          },
+          "organizationPublic": {
+            "label": "組織全体に公開"
+          },
+          "private": {
+            "label": "非公開"
+          }
+        },
+        "addConnectorButton": {
+          "label": "コネクターを追加"
+        },
+        "connectorCreated": {
+          "toast": "コネクターを作成しました"
+        },
+        "empty": {
+          "message": "コネクターがまだ設定されていないようです。[コネクターを追加](/admin/add-connector) ページで開始してください。"
+        },
+        "federated": {
+          "access": {
+            "label": "フェデレーションアクセス"
+          },
+          "indexed": {
+            "label": "インデックス済み"
+          },
+          "notApplicable": {
+            "label": "該当なし"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "自動同期"
+            },
+            "private": {
+              "label": "非公開"
+            },
+            "public": {
+              "label": "公開"
+            },
+            "title": "アクセス種別"
+          },
+          "applyButton": {
+            "label": "適用"
+          },
+          "docCount": {
+            "placeholder": "件数",
+            "title": "ドキュメント数"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "エラーありで完了"
+            },
+            "failed": {
+              "label": "失敗"
+            },
+            "inProgress": {
+              "label": "実行中"
+            },
+            "interrupted": {
+              "label": "中断"
+            },
+            "notStarted": {
+              "label": "未開始"
+            },
+            "success": {
+              "label": "成功"
+            },
+            "title": "最終ステータス"
+          },
+          "title": "コネクターを絞り込む"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "アクセス：{values}"
+          },
+          "clearBadge": {
+            "label": "クリア"
+          },
+          "docsAnyBadge": {
+            "label": "ドキュメント数 {operator} 任意"
+          },
+          "docsBadge": {
+            "label": "ドキュメント数 {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "ステータス：{values}"
+          }
+        },
+        "loadError": {
+          "message": "インデックスステータスの読み込みでエラーが発生しました。"
+        },
+        "manageConnector": {
+          "tooltip": "コネクターを管理"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "フェデレーションコネクターを管理"
+        },
+        "search": {
+          "placeholder": "コネクターを検索"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "アクティブなコネクター"
+          },
+          "publicConnectors": {
+            "label": "公開コネクター"
+          },
+          "totalConnectors": {
+            "label": "コネクター合計"
+          },
+          "totalDocsIndexed": {
+            "label": "インデックス済みドキュメント合計"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "すべて確認済みです。表示するコネクターはこれ以上ありません"
+          },
+          "lastIndexed": {
+            "header": "最終インデックス日時"
+          },
+          "name": {
+            "header": "名前"
+          },
+          "permissions": {
+            "header": "権限 / アクセス"
+          },
+          "status": {
+            "header": "ステータス"
+          },
+          "totalDocs": {
+            "header": "ドキュメント合計"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "すべて折りたたむ"
+          },
+          "expand": {
+            "label": "すべて展開"
+          }
+        }
+      }
+    },
+    "languageModels": {
+      "availableProviders": {
+        "title": "利用可能なプロバイダー"
+      },
+      "configurationDisabled": {
+        "description": "既存の LLM プロバイダーは引き続き使用および更新できます。",
+        "title": "新しい LLM の設定は一時的に利用できません。"
+      },
+      "defaultModel": {
+        "description": "このモデルは Onyx のチャットでデフォルトとして使用されます。",
+        "title": "デフォルトモデル"
+      },
+      "deleteModal": {
+        "defaultProviderWarning": "デフォルトのプロバイダーは削除できません。削除する前に、別のプロバイダーをデフォルトに設定してください。",
+        "description": "プロバイダー **{provider}** のすべての LLM モデルが削除され、以降のチャットで使用できなくなります。チャット履歴は保持されます。",
+        "lastProviderNote": "チャットを引き続き使用するには、別のプロバイダーを接続してください。",
+        "submit": {
+          "label": "削除"
+        },
+        "title": "*{provider}* を削除"
+      },
+      "groups": {
+        "addProvider": {
+          "description": "Onyx は主要なプロバイダーとセルフホストモデルの両方に対応しています。",
+          "title": "プロバイダーを追加"
+        },
+        "gateways": {
+          "title": "ゲートウェイとルーター"
+        },
+        "selfHosted": {
+          "title": "セルフホストとカスタム"
+        }
+      },
+      "modals": {
+        "access": {
+          "admin": {
+            "sharedNote": "常に共有",
+            "title": "管理者"
+          },
+          "agent": {
+            "name": "エージェント {id}"
+          },
+          "agentOption": {
+            "description": "エージェント"
+          },
+          "comboBox": {
+            "placeholder": "グループとエージェントを追加"
+          },
+          "field": {
+            "description": "このプロバイダーにアクセスできる対象を指定します。",
+            "title": "モデルのアクセス権"
+          },
+          "group": {
+            "name": "グループ {id}"
+          },
+          "groupOption": {
+            "description": "グループ"
+          },
+          "memberCount": {
+            "label": "{count, plural, one {# 人のメンバー} other {# 人のメンバー}}"
+          },
+          "noAgents": {
+            "description": "このプロバイダーはどのエージェントでも使用されません。",
+            "title": "エージェントが追加されていません"
+          },
+          "private": {
+            "label": "指定したグループとエージェント"
+          },
+          "public": {
+            "label": "すべてのユーザーとエージェント"
+          },
+          "select": {
+            "placeholder": "アクセスレベルを選択"
+          }
+        },
+        "azure": {
+          "targetUriField": {
+            "description": "Azure OpenAI のエンドポイントターゲット URI を貼り付けてください（API エンドポイントのベース、デプロイ名、API バージョンを含む）。",
+            "title": "ターゲット URI"
+          },
+          "toasts": {
+            "targetUriParseFailed": "ターゲット URI を解析できませんでした。元の値を使用します。"
+          },
+          "validation": {
+            "targetUriInvalid": "ターゲット URI は、api-version クエリパラメータを含み、パスにデプロイ名または /openai/responses を含む有効な URL である必要があります",
+            "targetUriRequired": "ターゲット URI は必須です"
+          }
+        },
+        "bedrock": {
+          "accessKeyIdField": {
+            "title": "AWS アクセスキー ID"
+          },
+          "authMethodField": {
+            "accessKey": {
+              "description": "AWS 以外の環境向け",
+              "label": "アクセスキー"
+            },
+            "description": "Onyx が Bedrock で認証する方法を選択してください。",
+            "iam": {
+              "description": "AWS 環境で推奨",
+              "label": "環境の IAM ロール"
+            },
+            "longTermApiKey": {
+              "description": "AWS 以外の環境向け",
+              "label": "長期 API キー"
+            },
+            "title": "認証方法"
+          },
+          "iamNotice": {
+            "title": "Onyx は実行環境に割り当てられた IAM ロールを使用して認証します。"
+          },
+          "longTermApiKeyField": {
+            "placeholder": "長期 API キー",
+            "title": "長期 API キー"
+          },
+          "regionField": {
+            "description": "Amazon Bedrock のモデルがホストされているリージョンです。",
+            "placeholder": "リージョンを選択",
+            "title": "AWS リージョン"
+          },
+          "secretAccessKeyField": {
+            "title": "AWS シークレットアクセスキー"
+          },
+          "validation": {
+            "regionRequired": "AWS リージョンは必須です"
+          }
+        },
+        "bifrost": {
+          "apiBaseField": {
+            "description": "Bifrost ゲートウェイのエンドポイント URL を貼り付けてください（API バージョンを含む）。"
+          },
+          "apiKeyField": {
+            "description": "モデルにアクセスするには、[Bifrost](https://docs.getbifrost.ai/overview) の API キーを貼り付けてください。"
+          },
+          "apiMode": {
+            "chatCompletions": {
+              "label": "Chat Completions API"
+            },
+            "responses": {
+              "label": "Responses API"
+            }
+          }
+        },
+        "custom": {
+          "addModelButton": {
+            "label": "モデルを追加"
+          },
+          "apiKeyField": {
+            "description": "モデルプロバイダーが認証を必要とする場合は、API キーを貼り付けてください。"
+          },
+          "apiVersionField": {
+            "title": "API バージョン"
+          },
+          "description": "LiteLLM 互換の他のプロバイダーのモデルを接続します。",
+          "envVars": {
+            "addButton": {
+              "label": "行を追加"
+            },
+            "description": "モデルプロバイダーが必要とする追加のプロパティを指定します。これらは [環境変数](https://docs.litellm.ai/docs/set_keys#environment-variables) として LiteLLM の `completion()` 呼び出しに渡されます。詳しい手順は [ドキュメント](https://docs.onyx.app/admins/ai_models/custom_inference_provider) を参照してください。",
+            "title": "環境変数"
+          },
+          "modelRow": {
+            "displayNamePlaceholder": "表示名",
+            "inputTypePlaceholder": "入力タイプ",
+            "maxTokensPlaceholder": "デフォルト",
+            "namePlaceholder": "モデル名",
+            "textImage": {
+              "label": "テキストと画像"
+            },
+            "textOnly": {
+              "label": "テキストのみ"
+            }
+          },
+          "modelTable": {
+            "displayName": {
+              "header": "表示名"
+            },
+            "inputType": {
+              "header": "入力タイプ"
+            },
+            "maxTokens": {
+              "header": "最大 token 数"
+            },
+            "name": {
+              "header": "モデル名"
+            }
+          },
+          "models": {
+            "description": "このプロバイダーで使用する LLM モデルとその設定を一覧に追加してください。モデルの全一覧は LiteLLM で確認できます。",
+            "empty": {
+              "title": "モデルがまだ追加されていません。"
+            },
+            "title": "モデル"
+          },
+          "providerField": {
+            "createPrefix": "使用",
+            "description": "対応する LLM プロバイダーの全一覧は [LiteLLM](https://docs.litellm.ai/docs/providers) を参照してください。",
+            "placeholder": "LiteLLM に表示されるプロバイダー ID 文字列",
+            "title": "プロバイダー"
+          },
+          "toasts": {
+            "modelNameRequired": "モデル名を 1 つ以上入力してください"
+          },
+          "validation": {
+            "displayNameRequired": "表示名は必須です",
+            "providerNameRequired": "プロバイダー名は必須です"
+          }
+        },
+        "liteLlmProxy": {
+          "apiBaseField": {
+            "description": "LiteLLM Proxy サーバーのベース URL です。"
+          }
+        },
+        "lmStudio": {
+          "apiBaseField": {
+            "description": "LM Studio サーバーのベース URL です。",
+            "placeholder": "LM Studio の API ベース URL"
+          },
+          "apiKeyField": {
+            "description": "LM Studio サーバーが認証を必要とする場合に指定する任意の API キーです。"
+          }
+        },
+        "modelSettings": {
+          "capabilities": {
+            "chat": {
+              "label": "チャット"
+            },
+            "multiModal": {
+              "label": "マルチモーダル"
+            },
+            "reasoning": {
+              "label": "推論"
+            }
+          },
+          "reasoningLevel": {
+            "defaultSlider": {
+              "label": "デフォルト"
+            },
+            "maxSlider": {
+              "label": "最大レベル"
+            }
+          },
+          "temperature": {
+            "defaultSlider": {
+              "label": "デフォルト"
+            },
+            "pinned": {
+              "tooltip": "推論モデルは常に temperature 1 で実行されます。"
+            }
+          },
+          "trigger": {
+            "tooltip": "モデル設定"
+          }
+        },
+        "models": {
+          "addModelButton": {
+            "label": "モデルを追加"
+          },
+          "addModelInput": {
+            "placeholder": "モデル名を入力"
+          },
+          "autoUpdate": {
+            "description": "新しいモデルがリリースされたときに、利用可能なモデルを更新します。",
+            "title": "自動更新"
+          },
+          "deselectAllButton": {
+            "label": "すべて選択解除"
+          },
+          "empty": {
+            "title": "利用可能なモデルがありません。"
+          },
+          "field": {
+            "description": "このプロバイダーで利用可能にするモデルを選択してください。",
+            "title": "モデル"
+          },
+          "foldButton": {
+            "label": "モデルを折りたたむ"
+          },
+          "moreButton": {
+            "label": "モデルをもっと見る"
+          },
+          "refetch": {
+            "errorToast": "モデルを取得できませんでした"
+          },
+          "row": {
+            "defaultLabel": "デフォルトモデル",
+            "renameButton": {
+              "tooltip": "名前を変更"
+            },
+            "setDefaultButton": {
+              "label": "デフォルトに設定"
+            },
+            "visionMarker": {
+              "title": "画像対応"
+            }
+          },
+          "selectAllButton": {
+            "label": "すべて選択"
+          }
+        },
+        "nebius": {
+          "apiBaseField": {
+            "description": "Nebius TokenFactory のエンドポイント URL です（API バージョンを含む）。"
+          },
+          "apiKeyField": {
+            "description": "利用可能なモデルを読み込むには、[Nebius TokenFactory](https://tokenfactory.nebius.com/) の API キーを貼り付けてください。"
+          }
+        },
+        "ollama": {
+          "apiBaseField": {
+            "description": "Ollama インスタンスのベース URL です。",
+            "placeholder": "Ollama の API ベース URL"
+          },
+          "apiKeyField": {
+            "description": "Ollama Cloud の API キーです。",
+            "placeholder": "API キー"
+          },
+          "tabs": {
+            "cloud": {
+              "label": "Ollama Cloud"
+            },
+            "selfHosted": {
+              "label": "セルフホストの Ollama"
+            }
+          }
+        },
+        "openAiCompatible": {
+          "apiBaseField": {
+            "description": "OpenAI 互換のエンドポイント URL を貼り付けてください。",
+            "learnMore": "[詳細](https://docs.litellm.ai/docs/providers/openai_compatible)"
+          },
+          "apiKeyField": {
+            "description": "モデルプロバイダーが認証を必要とする場合は、API キーを貼り付けてください。"
+          },
+          "description": "OpenAI 互換のエンドポイント経由で、他のクラウドモデルやセルフホストモデルを接続します。"
+        },
+        "openRouter": {
+          "apiBaseField": {
+            "description": "OpenRouter 互換のエンドポイント URL を貼り付けるか、OpenRouter API を直接使用してください。",
+            "placeholder": "OpenRouter のベース URL"
+          }
+        },
+        "portkey": {
+          "apiBaseField": {
+            "description": "Portkey のベース URL を使用するか、セルフホストゲートウェイのベース URL を貼り付けてください。",
+            "placeholder": "Portkey ゲートウェイのベース URL"
+          },
+          "apiKeyField": {
+            "description": "モデルにアクセスするには、[Portkey](https://portkey.ai/) の API キーを貼り付けてください。"
+          },
+          "apiMode": {
+            "chatCompletions": {
+              "caption": "OpenAI 互換",
+              "label": "Chat Completions API"
+            },
+            "messages": {
+              "caption": "Anthropic 互換",
+              "label": "Messages API"
+            },
+            "responses": {
+              "caption": "OpenAI 互換",
+              "label": "Responses API"
+            }
+          },
+          "description": "Portkey ゲートウェイに接続し、互換モデルを設定します。",
+          "models": {
+            "empty": {
+              "title": "利用可能なモデルがありません。有効なベース URL とキーを入力してください。"
+            }
+          },
+          "restoreDefaultButton": {
+            "ariaLabel": "デフォルトの API ベース URL を復元",
+            "tooltip": "デフォルトに戻す"
+          }
+        },
+        "setup": {
+          "apiBaseField": {
+            "containerizedNote": "Onyx をコンテナで実行している場合、ホスト上のサービスに接続するには `localhost` の代わりに `host.docker.internal` を使用してください。",
+            "title": "API ベース URL"
+          },
+          "apiKeyField": {
+            "description": "モデルにアクセスするには、API キーを貼り付けてください。",
+            "providerDescription": "モデルにアクセスするには、{provider} の API キーを貼り付けてください。",
+            "title": "API キー"
+          },
+          "cancelButton": {
+            "label": "キャンセル"
+          },
+          "connectButton": {
+            "label": "接続"
+          },
+          "description": "{company} に接続して {product} のモデルを設定します。",
+          "displayNameField": {
+            "description": "アプリ内でこのプロバイダーを識別するために使用します。",
+            "placeholder": "表示名",
+            "title": "表示名"
+          },
+          "optionalSuffix": {
+            "label": "任意"
+          },
+          "submitButton": {
+            "invalidTooltip": "必須項目をすべて入力してください。",
+            "pristineTooltip": "保存する変更はありません。"
+          },
+          "title": {
+            "configure": "*{provider}* を設定",
+            "create": "{product} を設定"
+          },
+          "updateButton": {
+            "label": "更新"
+          }
+        },
+        "toasts": {
+          "providerEnableFailed": "プロバイダーを有効にできませんでした：{message}",
+          "providerEnabled": "プロバイダーを有効にしました。",
+          "providerUpdateFailed": "プロバイダーを更新できませんでした：{message}",
+          "providerUpdated": "プロバイダーを更新しました。",
+          "setDefaultFailed": "プロバイダーをデフォルトに設定できませんでした",
+          "setNewDefaultFailed": "新しいプロバイダーをデフォルトに設定できませんでした",
+          "testApiKeyFailed": "API キーのテスト中にエラーが発生しました。",
+          "testCustomProviderFailed": "カスタムプロバイダーのテスト中にエラーが発生しました。",
+          "testProviderFailed": "プロバイダーのテスト中にエラーが発生しました。"
+        },
+        "validation": {
+          "apiBaseRequired": "API ベース URL は必須です",
+          "apiKeyRequired": "API キーは必須です",
+          "modelNameRequired": "モデル名は必須です"
+        },
+        "vertexAi": {
+          "authMethodField": {
+            "description": "Onyx が Google Vertex AI で認証する方法を選択してください。",
+            "serviceAccount": {
+              "description": "GCP サービスアカウントキーの JSON ファイルをアップロード",
+              "label": "サービスアカウント JSON"
+            },
+            "title": "認証方法",
+            "workloadIdentity": {
+              "description": "Pod の環境に設定された GCP 認証情報を使用（GKE Workload Identity）",
+              "label": "Workload Identity（GKE）"
+            }
+          },
+          "credentialsField": {
+            "description": "モデルにアクセスするには、Google Cloud の API キー JSON を添付してください。",
+            "title": "API キー"
+          },
+          "locationField": {
+            "description": "Google Vertex AI のモデルがホストされているリージョンです。対応リージョンの全一覧は Google Cloud で確認できます。",
+            "title": "Google Cloud リージョン名"
+          },
+          "projectField": {
+            "description": "Vertex AI が有効になっている GCP プロジェクトです。サービスアカウントの権限借用では ADC が対象プロジェクトを確実に推定できないため、指定が必要です。",
+            "title": "GCP プロジェクト ID"
+          },
+          "validation": {
+            "authMethodRequired": "認証方法は必須です",
+            "credentialsRequired": "認証情報ファイルは必須です",
+            "projectRequired": "GCP プロジェクト ID は必須です"
+          },
+          "workloadIdentityNotice": {
+            "title": "Onyx は Pod の環境に設定された Google Cloud 認証情報を google.auth.default 経由で使用します。Kubernetes ServiceAccount が Vertex AI にアクセスできる GCP サービスアカウントにバインドされていることを確認してください。"
+          }
+        }
+      },
+      "newCustomProviderCard": {
+        "setUpButton": {
+          "label": "設定"
+        }
+      },
+      "newProviderCard": {
+        "ariaLabel": "{company} {product} を追加",
+        "connectButton": {
+          "label": "接続"
+        }
+      },
+      "noProviders": {
+        "title": "チャットを開始するには、LLM プロバイダーを設定してください。"
+      },
+      "providerCard": {
+        "defaultTag": {
+          "label": "デフォルト"
+        },
+        "deleteButton": {
+          "ariaLabel": "{provider} を削除"
+        },
+        "editButton": {
+          "ariaLabel": "{provider} を編集"
+        }
+      },
+      "toasts": {
+        "providerDeleteFailed": "プロバイダーを削除できませんでした：{message}",
+        "providerDeleted": "プロバイダーを削除しました。",
+        "unknownError": "不明なエラー"
+      }
+    },
+    "mcpActions": {
+      "header": {
+        "description": "MCP（Model Context Protocol）サーバーを接続して、エージェント用のカスタムアクションとツールを追加します。"
+      }
+    },
+    "modals": {
+      "newTeam": {
+        "body": "参加リクエストは {domain} のいずれかの管理者が承認できます。",
+        "continueButton": {
+          "label": "新しいチームで続行"
+        },
+        "header": {
+          "requestSentTitle": "参加リクエストを送信しました",
+          "title": "{domain} の既存のチームが見つかりました"
+        },
+        "inviteRequestedToast": {
+          "message": "招待リクエストをチーム管理者に送信しました。"
+        },
+        "loadError": {
+          "message": "チーム情報を取得できませんでした。しばらくしてからもう一度お試しください。"
+        },
+        "requestButton": {
+          "label": "チームへの参加をリクエスト",
+          "pendingLabel": "リクエストを送信しています..."
+        },
+        "requestError": {
+          "message": "招待をリクエストできませんでした",
+          "responseFallback": "招待のリクエストに失敗しました"
+        },
+        "requestSentBody": "参加リクエストを送信しました。{domain} の管理者が承認するまで、自分のチームで操作を試すことができます。",
+        "tryOnyxButton": {
+          "label": "待っている間に Onyx を試す"
+        }
+      },
+      "newTenant": {
+        "acceptError": {
+          "responseFallback": "招待を承諾できませんでした"
+        },
+        "acceptedToast": {
+          "message": "招待を承諾しました。"
+        },
+        "approvedTitle": "{domain} の他 {count} 人のユーザーが所属するチームへの参加リクエストが承認されました。",
+        "declineButton": {
+          "label": "辞退"
+        },
+        "declineError": {
+          "message": "招待を辞退できませんでした。もう一度お試しください。",
+          "responseFallback": "招待の辞退に失敗しました"
+        },
+        "declinedToast": {
+          "message": "招待を辞退しました。"
+        },
+        "inviteDescription": "この招待を承諾すると、既存の {domain} チームに参加し、現在のチームにはアクセスできなくなります。注意：現在のエージェント、プロンプト、チャット、接続済みソースにもアクセスできなくなります。",
+        "inviteTitle": "{domain} の他 {count, plural, one {# 人のメンバー} other {# 人のメンバー}}が所属するチームに招待されました。",
+        "joinError": {
+          "message": "チームに参加できませんでした。もう一度お試しください。"
+        },
+        "joinRequestToast": {
+          "message": "チームへの参加リクエストを処理しています..."
+        },
+        "reauthenticateDescription": "チームへの参加を完了するには、{email} で再認証してください。",
+        "submitButton": {
+          "acceptLabel": "招待を承諾",
+          "acceptingLabel": "承諾しています...",
+          "joiningLabel": "参加しています...",
+          "reauthenticateLabel": "再認証"
+        }
+      },
+      "provider": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "submitButton": {
+          "label": "接続"
+        }
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "受信したクレームはありません。"
+        },
+        "table": {
+          "claim": {
+            "header": "クレーム"
+          },
+          "value": {
+            "header": "値"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "プロバイダー API",
+        "subtitle": "プロバイダー API から取得したディレクトリのフィールドです。例えば Entra ID では Microsoft Graph の /me を使用します。ここには、ctry オプションクレームを設定しない限り id_token に含まれない country / usageLocation が含まれます。",
+        "title": "ディレクトリプロファイル（{source}）"
+      },
+      "idToken": {
+        "subtitle": "token エンドポイントが返した id_token の JWT をデコードした内容です。",
+        "title": "id_token のクレーム"
+      },
+      "intro": {
+        "description": "前回の OAuth/OIDC ログイン時に ID プロバイダーが送信した生のフィールド、つまり id_token のクレームと userinfo エンドポイントの応答を表示します。IdP がどの属性を公開する設定になっているかを確認できます。クレームはログインのたびに記録されます。"
+      },
+      "loadFailed": {
+        "title": "OAuth クレームを読み込めませんでした"
+      },
+      "noSnapshot": {
+        "description": "{email} の OAuth ログインスナップショットが見つかりません。ID プロバイダー経由でログインし（上のボタン）、このページを再読み込みしてください。",
+        "title": "記録されたクレームはまだありません"
+      },
+      "rerun": {
+        "label": "OAuth ログインを再実行"
+      },
+      "resolved": {
+        "subtitle": "クレームをマッピングしたディレクトリプロファイルです。組織プロファイルのプロンプトブロックと {placeholder} プレースホルダーに実際に使用されます。",
+        "title": "解決済みプロファイル（プロンプトで使用）"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "記録日時：{timestamp}"
+        },
+        "provider": {
+          "label": "プロバイダー：{provider}"
+        },
+        "tokenFields": {
+          "label": "token 応答のフィールド：{fields}"
+        },
+        "user": {
+          "label": "ユーザー：{email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "アクセス token に対する OIDC userinfo エンドポイントの応答です。",
+        "title": "userinfo のクレーム"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "OpenAPI サーバーを接続して、エージェント用のカスタムアクションとツールを追加します。"
+      }
+    },
+    "perUserUsage": {
+      "panel": {
+        "description": "{start} – {end} · コストは記録されたモデル使用量から算出されます。",
+        "emptyDescription": "選択した期間のユーザーごとの支出と token 使用量です。",
+        "error": {
+          "title": "この期間の使用状況を読み込めませんでした。"
+        },
+        "title": "使用状況の概要"
+      },
+      "summary": {
+        "activeUsers": {
+          "detail": "記録のあるユーザー {count, number} 人",
+          "label": "アクティブユーザー"
+        },
+        "topSpender": {
+          "label": "支出が最も多いユーザー",
+          "noSpend": "支出の記録はありません"
+        },
+        "totalTokens": {
+          "detail": "入力（キャッシュ読み取りを含む）と出力",
+          "label": "token 合計"
+        },
+        "workspaceSpend": {
+          "detail": "一覧のすべてのユーザーの合計",
+          "label": "ワークスペースの支出"
+        }
+      },
+      "users": {
+        "description": "支出の多い順に並んでいます。一覧を絞り込み、ユーザーを選択すると詳細な内訳を表示します。",
+        "empty": {
+          "description": "この期間の使用状況の記録はありません。"
+        },
+        "title": "ユーザー"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "接続済み"
+        },
+        "description": "ID プロバイダーを接続して、ユーザーとグループをインポートおよび同期します。",
+        "generate": {
+          "label": "SCIM token を生成"
+        },
+        "regenerate": {
+          "label": "token を再生成"
+        },
+        "title": "SCIM 同期",
+        "waiting": {
+          "description": "ユーザーとグループの同期を開始するには、SCIM キーを ID プロバイダーに設定してください。",
+          "label": "接続待ち"
+        }
+      },
+      "header": {
+        "description": "System for Cross-domain Identity Management（SCIM）プロトコルでユーザーとグループを同期します。",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "SCIM token のステータスを読み込めませんでした。"
+      },
+      "modal": {
+        "copied": {
+          "message": "token をクリップボードにコピーしました"
+        },
+        "copyFailed": {
+          "error": "token をコピーできませんでした"
+        },
+        "regenerate": {
+          "description": "現在の SCIM token は失効し、新しい token が生成されます。SCIM プロビジョニングを再開するには、ID プロバイダー側で token を更新する必要があります。",
+          "submit": {
+            "label": "token を再生成"
+          },
+          "title": "SCIM token を再生成"
+        },
+        "token": {
+          "copy": {
+            "label": "token をコピー"
+          },
+          "description": "続行する前にこのキーを保存してください。再表示されません。",
+          "download": {
+            "label": "ダウンロード"
+          },
+          "title": "SCIM token"
+        }
+      },
+      "toasts": {
+        "generateFailed": "token を生成できませんでした：{detail}",
+        "genericError": "問題が発生しました。もう一度お試しください。",
+        "regenerated": "token を再生成しました"
+      }
+    },
+    "security": {
+      "adminControls": {
+        "incognito": {
+          "description": "シークレットチャットは所有者の履歴に表示されません。グループごとのアクセス権は「グループ」で設定します。",
+          "everyone": {
+            "description": "サインインしているすべてのユーザーがシークレットチャットを開始できます。",
+            "label": "全員"
+          },
+          "groups": {
+            "description": "シークレットアクセスが有効なグループのメンバーのみです。",
+            "label": "指定グループ"
+          },
+          "off": {
+            "description": "シークレットチャットを開始できるユーザーはいません。",
+            "label": "オフ"
+          },
+          "title": "シークレットチャット"
+        },
+        "incognitoRecords": {
+          "description": "シークレットチャットからワークスペースが保持する内容です。新しいセッションは、開始時点で有効なモードを固定します。",
+          "fullHistory": {
+            "description": "他のチャットと同様に、クエリ履歴、使用状況、トレースを記録します。所有者自身の履歴からのみ非表示になります。",
+            "label": "完全な履歴"
+          },
+          "title": "シークレットチャットの記録",
+          "usageOnly": {
+            "description": "メッセージの内容は保存されません。token 使用量は引き続き記録され、これらのチャットはクエリ履歴に表示されません。",
+            "label": "使用状況のみ"
+          }
+        },
+        "maskCredentials": {
+          "description": "管理者に対する、保存済み API キーと認証情報の表示形式です。",
+          "masked": {
+            "description": "先頭と末尾の数文字のみ表示します（例：abcd...wxyz）。",
+            "label": "部分的にマスク"
+          },
+          "title": "保存済み認証情報のマスク",
+          "visible": {
+            "description": "認証情報の値を管理者に完全に表示します。",
+            "label": "完全に表示"
+          }
+        },
+        "section": {
+          "title": "管理者コントロール"
+        },
+        "userDirectory": {
+          "adminsOnly": {
+            "description": "管理者のみが全ユーザー一覧を表示できます。",
+            "label": "管理者のみに表示"
+          },
+          "allUsers": {
+            "description": "サインインしているすべてのユーザーが、リソースの共有時に全ユーザー一覧を表示できます。",
+            "label": "すべてのユーザーに表示"
+          },
+          "description": "名前とメールアドレスの完全一致検索は、この設定に関係なく動作します。",
+          "title": "全ユーザーディレクトリの公開範囲"
+        }
+      },
+      "authentication": {
+        "allowedEmailDomains": {
+          "placeholder": "ドメインを追加（例：onyx.app）",
+          "subDescription": "新規ユーザーは、このドメイン一覧に含まれるメールアドレスでのみアカウントを登録できます。",
+          "title": "許可するメールドメイン"
+        },
+        "emailDomains": {
+          "description": "新規ユーザーの登録を特定のメールドメインに制限します。",
+          "title": "メールドメインを制限"
+        },
+        "idpExpiry": {
+          "description": "上流の OAuth/OIDC プロバイダーのセッションが期限切れになったときに、ユーザーをログアウトします。",
+          "title": "セッションの有効期限を ID プロバイダーと同期"
+        },
+        "openSignUp": {
+          "description": "新規ユーザーは、招待された場合のみこのワークスペースに参加できます。",
+          "title": "自由なサインアップを制限"
+        },
+        "passwordLockdown": {
+          "description": "全員が SSO のみでサインインおよび登録します。有効な SSO プロバイダーが 1 つ以上必要です。",
+          "title": "パスワードでのログインと登録を無効化"
+        },
+        "section": {
+          "title": "認証"
+        }
+      },
+      "jwt": {
+        "expectedAudience": {
+          "description": "aud クレームが一致しない token を拒否します。空にするとチェックを無効にします。",
+          "title": "想定するオーディエンス"
+        },
+        "expectedIssuer": {
+          "description": "iss クレームが一致しない token を拒否します。空にするとチェックを無効にします。",
+          "title": "想定する発行者"
+        },
+        "pinnedField": {
+          "description": "環境変数で固定されています。"
+        },
+        "publicKeyUrl": {
+          "description": "token の署名の検証に使用する JWKS または PEM のエンドポイントです。空にすると JWT 認証を無効にします。",
+          "title": "公開鍵 URL"
+        },
+        "section": {
+          "description": "ID プロバイダーが署名した RS256 のベアラー token を受け入れます。環境変数で設定した値は固定され、ここでは編集できません。",
+          "title": "外部 JWT 認証"
+        }
+      },
+      "networkSafety": {
+        "envInjection": {
+          "description": "カスタム LLM プロバイダーの設定が、呼び出し中にプロセスの環境変数を一時的に設定できるようにします。無効にすると、すべてのプロバイダー設定に LiteLLM の同等のパラメータが必要になります。",
+          "multiTenantDescription": "マルチテナント環境では、カスタム LLM プロバイダーの設定でプロセスの環境変数を設定することはできません。",
+          "title": "LLM の環境変数インジェクション"
+        },
+        "section": {
+          "title": "ネットワークの安全性"
+        },
+        "ssrf": {
+          "allowPrivateNetwork": {
+            "description": "「LLM リクエストを検証」と同様ですが、管理者が設定した MCP/OAuth のエンドポイントはプライベート LAN のホストにも接続できます。ループバック（アプリのホスト自体）とクラウドメタデータは引き続きブロックされます。",
+            "label": "プライベートネットワークを許可"
+          },
+          "description": "Server-Side Request Forgery（SSRF）対策として、外向きリクエストがプライベート IP や内部 IP に向かっていないか検証します。",
+          "disabled": {
+            "description": "信頼できるネットワークでのみ使用してください。すべての外向きリクエストを許可します。ローカルの LLM バックエンドに接続する場合に必要です。",
+            "label": "無効"
+          },
+          "title": "SSRF 保護",
+          "validateAll": {
+            "description": "最も厳しい設定です。Web コネクターを含め、すべての外向きリクエストがプライベート IP や内部 IP に接続できません。",
+            "label": "すべてのリクエストを検証"
+          },
+          "validateLlm": {
+            "description": "LLM が開始するすべての URL 取得を検証します。管理者が設定したコネクターは、引き続きプライベート IP や内部 IP に接続できます。",
+            "label": "LLM リクエストを検証"
+          }
+        }
+      },
+      "page": {
+        "description": "実行時に変更できるセキュリティ設定です。未設定の値は、デプロイの環境設定が使用されます。"
+      },
+      "passwordPolicy": {
+        "charactersSuffix": {
+          "label": "（文字）"
+        },
+        "lengthInput": {
+          "placeholder": "デフォルト"
+        },
+        "maxLength": {
+          "title": "パスワードの最大文字数"
+        },
+        "minLength": {
+          "title": "パスワードの最小文字数"
+        },
+        "requireLowercase": {
+          "title": "小文字を必須にする"
+        },
+        "requireNumber": {
+          "title": "数字を必須にする"
+        },
+        "requireSpecialChar": {
+          "description": "使用できる文字：`{characters}`",
+          "title": "特殊文字を必須にする"
+        },
+        "requireUppercase": {
+          "title": "大文字を必須にする"
+        },
+        "section": {
+          "description": "すべての新しいパスワードに適用される要件です。ベーシック認証にのみ適用されます。",
+          "title": "パスワードポリシー"
+        }
+      },
+      "toasts": {
+        "securitySettingsUpdateFailed": "セキュリティ設定を更新できませんでした",
+        "securitySettingsUpdated": "セキュリティ設定を更新しました",
+        "settingsUpdateFailed": "設定を更新できませんでした",
+        "settingsUpdated": "設定を更新しました"
+      }
+    },
+    "serviceAccounts": {
+      "deleteModal": {
+        "description": "アカウント *{name}*（`{keyDisplay}`）の API キーを使用しているアプリケーションは、Onyx にアクセスできなくなります。",
+        "submit": {
+          "label": "削除"
+        },
+        "title": "アカウントを削除",
+        "warning": "削除は取り消せません。"
+      },
+      "editModal": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "groupList": {
+          "loading": {
+            "description": "グループを読み込んでいます...",
+            "title": "読み込み中..."
+          },
+          "memberCount": "{count, plural, one {# 人のユーザー} other {# 人のユーザー}}",
+          "noResults": {
+            "description": "別の検索語をお試しください。",
+            "title": "グループが見つかりません"
+          }
+        },
+        "joinedGroups": {
+          "empty": {
+            "description": "{name} はどのグループにも所属していません。",
+            "title": "グループが見つかりません"
+          }
+        },
+        "removeGroupButton": {
+          "tooltip": "グループから削除"
+        },
+        "saveButton": {
+          "label": "変更を保存"
+        },
+        "search": {
+          "placeholder": "参加するグループを検索..."
+        },
+        "title": "{name} のグループを編集",
+        "toasts": {
+          "error": "エラーが発生しました",
+          "updated": "サービスアカウントを更新しました"
+        }
+      },
+      "formModal": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "description": "サービスアカウントの API キーを使用すると、ユーザーレベルの権限で Onyx API にプログラムからアクセスできます。アカウントの詳細は後から変更できます。",
+        "groups": {
+          "empty": {
+            "description": "このサービスアカウントに割り当てられたグループはありません。",
+            "title": "グループなし"
+          },
+          "loading": {
+            "description": "グループを読み込み中...",
+            "title": "読み込み中..."
+          },
+          "memberCount": "{count, plural, one {# 人のユーザー} other {# 人のユーザー}}",
+          "noResults": {
+            "description": "別の検索語をお試しください。",
+            "title": "グループが見つかりません"
+          },
+          "search": {
+            "placeholder": "グループを検索..."
+          },
+          "title": "グループ"
+        },
+        "name": {
+          "placeholder": "名前を入力",
+          "title": "名前"
+        },
+        "submitButton": {
+          "create": "アカウントを作成",
+          "update": "更新"
+        },
+        "title": {
+          "create": "サービスアカウントを作成",
+          "update": "サービスアカウントを更新"
+        },
+        "toasts": {
+          "createFailed": "サービスアカウントの作成に失敗しました - {detail}",
+          "created": "サービスアカウントを作成しました。",
+          "unexpectedError": "予期しないエラーが発生しました。",
+          "updateFailed": "サービスアカウントの更新に失敗しました - {detail}",
+          "updated": "サービスアカウントを更新しました。"
+        }
+      },
+      "keyModal": {
+        "copyButton": {
+          "label": "API キーをコピー"
+        },
+        "description": "続行する前にこのキーを保存してください。再表示はできません。",
+        "downloadButton": {
+          "label": "ダウンロード"
+        },
+        "title": "サービスアカウント API キー"
+      },
+      "list": {
+        "createButton": {
+          "label": "新しいサービスアカウント"
+        },
+        "empty": {
+          "description": "ユーザーレベルのアクセス権を持つサービスアカウント API キーを作成します。"
+        },
+        "search": {
+          "placeholder": "サービスアカウントを検索..."
+        }
+      },
+      "page": {
+        "description": "サービスアカウントを使用して、Onyx API にプログラムからアクセスします。",
+        "error": {
+          "description": "詳細はコンソールを確認してください。",
+          "title": "サービスアカウントの読み込みに失敗しました。"
+        }
+      },
+      "regenerateModal": {
+        "description": "現在の API キー *{name}*(`{keyDisplay}`)は失効し、新しいキーが生成されます。このキーを使用しているアプリケーションは、新しいキーに更新する必要があります。",
+        "submit": {
+          "label": "キーを再生成"
+        },
+        "title": "API キーを再生成"
+      },
+      "table": {
+        "actions": {
+          "delete": {
+            "label": "アカウントを削除"
+          },
+          "edit": {
+            "label": "アカウントを編集"
+          },
+          "groups": {
+            "label": "グループ"
+          }
+        },
+        "columns": {
+          "apiKey": {
+            "header": "API キー"
+          },
+          "groups": {
+            "header": "グループ"
+          },
+          "name": {
+            "header": "名前"
+          }
+        },
+        "groups": {
+          "overflow": {
+            "label": "+{count}"
+          }
+        },
+        "moreButton": {
+          "tooltip": "その他"
+        },
+        "name": {
+          "unnamed": "名前なし"
+        },
+        "regenerateButton": {
+          "tooltip": "再生成"
+        }
+      },
+      "toasts": {
+        "deleteFailed": "API キーの削除に失敗しました。",
+        "deleteFailedWithDetail": "API キーの削除に失敗しました: {detail}",
+        "keyCopied": "API キーをクリップボードにコピーしました。",
+        "regenerateFailed": "API キーの再生成に失敗しました。",
+        "regenerateFailedWithDetail": "API キーの再生成に失敗しました: {detail}"
+      },
+      "trialNotice": {
+        "description": "トライアルアカウントには API キーへのアクセスが含まれません。この機能を利用するには有料プランをご購入ください。",
+        "title": "API キーを作成するには有料プランにアップグレードしてください。"
+      }
+    },
+    "shared": {
+      "listHeader": {
+        "search": {
+          "placeholder": "検索..."
+        }
+      },
+      "liteModeNotice": {
+        "description": "このデプロイでは Onyx Lite が動作しています。ベクトルデータベースがないため、コネクターとドキュメントのインデックス作成は無効で、何もインデックスされません。データソースを接続してドキュメントをインデックスするには、Onyx を **Standard モード** でデプロイしてください。開始するには [デプロイガイド]({docsUrl}) を参照してください。",
+        "title": "Lite モードではインデックス作成を利用できません"
+      },
+      "providerCard": {
+        "connectButton": {
+          "label": "接続"
+        },
+        "currentDefault": {
+          "label": "現在のデフォルト"
+        },
+        "disconnectButton": {
+          "ariaLabel": "{title} を切断",
+          "tooltip": "切断"
+        },
+        "editButton": {
+          "ariaLabel": "{title} を編集",
+          "tooltip": "編集"
+        },
+        "setDefaultButton": {
+          "label": "デフォルトに設定"
+        }
+      }
+    },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "OnyxBot 設定の作成に失敗しました - {error}"
+        },
+        "updateError": {
+          "toast": "OnyxBot 設定の更新に失敗しました - {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "Slack ボット設定の削除に失敗しました - {error}"
+        },
+        "deleted": {
+          "toast": "Slack ボット設定「{configId}」を削除しました"
+        },
+        "editDefaultButton": {
+          "label": "デフォルト設定を編集"
+        },
+        "newConfigButton": {
+          "label": "新しいチャンネル設定"
+        },
+        "section": {
+          "title": "チャンネル別の設定"
+        },
+        "table": {
+          "actions": {
+            "header": "操作"
+          },
+          "assistant": {
+            "header": "アシスタント"
+          },
+          "channel": {
+            "header": "チャンネル"
+          },
+          "documentSets": {
+            "header": "ドキュメントセット"
+          },
+          "empty": {
+            "message": "チャンネル別の設定はありません。特定のチャンネルの動作をカスタマイズするには、新しい設定を追加してください。"
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "削除"
+        },
+        "error": {
+          "toast": "Slack ボットの削除に失敗しました"
+        },
+        "message": "この Slack ボットを削除してもよろしいですか。この操作は元に戻せません。",
+        "success": {
+          "toast": "Slack ボットを削除しました"
+        },
+        "title": "Slack ボットを削除"
+      },
+      "edit": {
+        "header": {
+          "title": "Slack ボットを編集"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Slack チャンネル設定を編集"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "デフォルトの Slack 設定を編集"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "ID が {id} の Slack チャンネル設定が見つかりませんでした"
+        },
+        "fetchAgents": {
+          "message": "エージェントの取得に失敗しました - {error}"
+        },
+        "fetchBot": {
+          "message": "Slack ボット {botId} の取得に失敗しました: {error}"
+        },
+        "fetchChannels": {
+          "message": "Slack チャンネルの取得に失敗しました - {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "ドキュメントセットの取得に失敗しました - {error}"
+        },
+        "generic": {
+          "title": "問題が発生しました :("
+        },
+        "unknown": {
+          "message": "不明なエラー"
+        },
+        "unknownOccurred": {
+          "message": "不明なエラーが発生しました"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "エージェントを検索..."
+        },
+        "answerValidity": {
+          "label": "引用が見つかった場合のみ応答する",
+          "tooltip": "設定すると、モデルが引用の生成に成功した質問にのみ回答します"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "channelName": {
+          "label": "Slack チャンネル名",
+          "placeholder": "チャンネル名を入力(例: general、support)",
+          "subtext": "Slack チャンネルの名前を入力してください(# 記号は不要です)"
+        },
+        "createButton": {
+          "label": "作成"
+        },
+        "defaultConfig": {
+          "badge": "デフォルト設定",
+          "description": "このデフォルト設定は、Slack ワークスペース内のすべてのチャンネルとダイレクトメッセージ(DM)に適用されます。"
+        },
+        "disableDefault": {
+          "label": "デフォルト設定を無効にする",
+          "warning": "警告: デフォルト設定を無効にすると、OnyxBot は明示的に設定されたチャンネル以外では応答しません。また、OnyxBot は DM にも応答しません。"
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "このドキュメントセットには自動同期権限のコネクターが含まれるため、使用できません。このチャンネルでの OnyxBot の応答はすべての Slack ユーザーに表示されるため、質問者の権限をそのまま適用すると、非公開の情報が意図せず公開される可能性があります。"
+          },
+          "autoSyncedNote": {
+            "text": "次のドキュメントセットは自動同期されたドキュメントを含むため、添付できません:"
+          },
+          "description": "OnyxBot が Slack で質問に回答するときに使用するドキュメントセットを選択してください。",
+          "hideUnselectableButton": {
+            "label": "選択できないドキュメントセットを非表示"
+          },
+          "incompatibleHidden": {
+            "text": "互換性のないドキュメントセットの一部が非表示になっています。"
+          },
+          "incompatibleVisible": {
+            "text": "互換性のないドキュメントセットの一部が表示されています。"
+          },
+          "viewAllButton": {
+            "label": "すべてのドキュメントセットを表示"
+          }
+        },
+        "followUpTags": {
+          "label": "(任意)タグ付けするユーザー / グループ",
+          "subtext": "ユーザーが「Still need help?」ボタンをクリックしたときにタグ付けする Slack のユーザー / グループです。メールアドレスを指定しない場合は、誰にもタグ付けせず、元のメッセージに 🆘 の絵文字でリアクションします。"
+        },
+        "generalConfig": {
+          "section": {
+            "title": "一般設定"
+          }
+        },
+        "isEphemeral": {
+          "label": "プライベート(エフェメラル)メッセージでユーザーに応答する",
+          "tooltip": "設定すると、OnyxBot はプライベート(エフェメラル)メッセージでユーザーにのみ応答します。上で「検索エージェント」を選択している場合、このオプションを選ぶと、そのユーザーだけが閲覧できるドキュメントもクエリで利用できます。"
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "すべての公開ナレッジ",
+            "sublabel": "OnyxBot がすべての公開コネクターの情報に基づいて応答します"
+          },
+          "documentSets": {
+            "label": "特定のドキュメントセット",
+            "sublabel": "質問への回答に使用するドキュメントを制御します"
+          },
+          "label": "ナレッジソース",
+          "nonSearchAgent": {
+            "label": "検索なしエージェント",
+            "sublabel": "ドキュメントを使用しないエージェントとチャットします"
+          },
+          "searchAgent": {
+            "label": "検索エージェント",
+            "sublabel": "質問への回答に使用するドキュメントとプロンプトの両方を制御します"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "OnyxBot が Slack で質問に回答するときに使用する検索なしエージェントを選択してください。"
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "関連するコネクター:"
+          },
+          "description": "プライベート(エフェメラル)応答を*選択しない*場合、ユーザーのクエリで利用できるのは、選択したドキュメントセット内の公開ドキュメントのみです。プライベート(エフェメラル)応答を*選択した*場合は、ユーザーがすでにアクセス権を付与されているドキュメントもクエリで利用できます。ユーザーは応答をチャンネル内の他のメンバーと共有できるため、自社の共有ポリシーに沿っているか確認してください。",
+          "title": "プライバシーに関する注意"
+        },
+        "questionmarkPrefilter": {
+          "label": "質問にのみ応答する",
+          "tooltip": "設定すると、OnyxBot は疑問符を含むメッセージにのみ応答します"
+        },
+        "removedDocumentSets": {
+          "toast": "一部のドキュメントセットが無効になったため、選択から削除しました。設定を確認して更新してください。"
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "「プライベート(エフェメラル)メッセージでユーザーに応答する」が有効な間は使用できません。エフェメラル応答は 1 人のユーザーのみを対象とします。"
+          },
+          "label": "(任意)特定のユーザー / グループに応答",
+          "subtext": "指定すると、このチャンネルで OnyxBot を呼び出せるのはこれらのユーザー / グループのみになり、応答もそのユーザーにのみ表示されます。"
+        },
+        "respondTagOnly": {
+          "label": "@OnyxBot へのメンション時のみ応答",
+          "tooltip": "設定すると、OnyxBot は直接タグ付けされたときにのみ応答します"
+        },
+        "respondToBots": {
+          "label": "ボットのメッセージに応答する",
+          "tooltip": "設定しない場合、OnyxBot はボットからのメッセージを常に無視します"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "詳細"
+          },
+          "label": "回答タイプ",
+          "standard": {
+            "label": "標準"
+          },
+          "tooltip": "OnyxBot の応答の形式を制御します。"
+        },
+        "searchAgent": {
+          "description": "OnyxBot が Slack で質問に回答するときに使用する検索対応エージェントを選択してください。"
+        },
+        "searchConfig": {
+          "section": {
+            "title": "検索設定"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "「Web UI で続ける」ボタンを表示",
+          "tooltip": "設定すると、応答の下部にボタンを表示し、ユーザーが Onyx の Web UI で会話を続けられるようにします"
+        },
+        "stillNeedHelp": {
+          "label": "「Still need help?」ボタンを表示する",
+          "section": {
+            "prompt": "「Still need help?」ボタンを設定"
+          },
+          "tooltip": "OnyxBot の応答の下部に、まだサポートが必要かどうかをユーザーに尋ねるボタンが表示されます。"
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "選択できないエージェントを非表示"
+          },
+          "listLabel": "選択できないエージェント:",
+          "note": "注意: 一部のエージェントは、ドキュメントセットに自動同期コネクターを含んでいます。これらのエージェントは Slack で質問に回答できないため、選択できません。",
+          "viewAllButton": {
+            "label": "すべてのエージェントを表示"
+          }
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "userOrGroup": {
+          "placeholder": "ユーザーのメールアドレスまたはユーザーグループ名..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "特定のチャンネルで OnyxBot が自動的に質問に回答するように設定できます。"
+        },
+        "description": "Onyx に接続する Slack ボットを設定します。設定が完了すると、Slack から直接 Onyx に質問できます。さらに、次のことができます:",
+        "directMessage": {
+          "item": "OnyxBot にダイレクトメッセージを送ると、Web UI と同じように検索できます。"
+        },
+        "docsPrompt": {
+          "text": "Onyx のドキュメントにある<link>ガイド</link>に沿って始めてください。"
+        },
+        "documentSets": {
+          "item": "質問が投稿されるチャンネルに応じて、OnyxBot が回答に使用するドキュメントセットを選べます。"
+        }
+      },
+      "list": {
+        "error": {
+          "title": "アプリの読み込みエラー"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "新しい Slack ボット"
+        }
+      },
+      "newBotButton": {
+        "label": "新しい Slack ボット"
+      },
+      "newChannel": {
+        "header": {
+          "title": "Slack チャンネル向けに OnyxBot を設定"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "チャンネル数"
+        },
+        "defaultConfig": {
+          "header": "デフォルト設定"
+        },
+        "defaultSet": {
+          "badge": "デフォルト設定済み"
+        },
+        "disabled": {
+          "badge": "無効"
+        },
+        "empty": {
+          "message": "Onyx とのチャットを始めるには、新しい Slack ボットを追加してください。"
+        },
+        "enabled": {
+          "badge": "有効"
+        },
+        "name": {
+          "header": "名前"
+        },
+        "status": {
+          "header": "ステータス"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Slack App Token"
+        },
+        "botToken": {
+          "label": "Slack Bot Token"
+        },
+        "createButton": {
+          "label": "作成"
+        },
+        "createError": {
+          "toast": "Slack ボットの作成に失敗しました - {error}"
+        },
+        "created": {
+          "toast": "Slack ボットを作成しました。"
+        },
+        "docsPrompt": {
+          "text": "これらの token の取得方法が分からない場合は、<link>ガイド</link>を参照してください。"
+        },
+        "invalidAppToken": {
+          "message": "Slack App Token が無効です"
+        },
+        "invalidBotToken": {
+          "message": "Slack Bot Token が無効です"
+        },
+        "name": {
+          "label": "この Slack ボットの名前:"
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "updateError": {
+          "toast": "Slack ボットの更新に失敗しました - {error}"
+        },
+        "updated": {
+          "toast": "Slack ボットを更新しました。"
+        },
+        "userToken": {
+          "label": "Slack User Token(任意)",
+          "subtext": "任意: プライベートチャンネルへのアクセスを強化するためのユーザー OAuth token です"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "削除"
+        },
+        "enabledCheckbox": {
+          "label": "有効"
+        },
+        "fieldUpdateFailed": {
+          "toast": "コネクターの {field} の更新に失敗しました"
+        },
+        "fieldUpdated": {
+          "toast": "コネクターの {field} を更新しました"
+        },
+        "updateTokensButton": {
+          "label": "Token を更新"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "「エージェント」ナレッジソースを使用する場合は、エージェントが必要です"
+        },
+        "channelNameRequired": {
+          "message": "チャンネル名は必須です"
+        },
+        "documentSetRequired": {
+          "message": "「ドキュメントセット」ナレッジソースを使用する場合は、1 つ以上のドキュメントセットが必要です"
+        }
+      }
+    },
+    "ssoProviders": {
+      "addProvider": {
+        "button": {
+          "label": "プロバイダーを追加"
+        },
+        "gatedTooltip": "複数の SSO プロバイダーを有効にできるのは、Business プランまたは Enterprise プランです。"
+      },
+      "copyRedirectUri": {
+        "tooltip": "リダイレクト URI をコピー"
+      },
+      "editProvider": {
+        "tooltip": "編集"
+      },
+      "empty": {
+        "description": "プロバイダーを追加して、ユーザーが Google、OIDC、SAML でサインインできるようにします。",
+        "title": "SSO プロバイダーはまだありません"
+      },
+      "loadError": {
+        "description": "SSO プロバイダーを読み込めません。",
+        "title": "SSO プロバイダーの読み込みに失敗しました"
+      },
+      "modals": {
+        "domainVerification": {
+          "description": "ドメインの所有権を確認すると、そのドメインのユーザーはワークスペースに自動でサインインできます。下の DNS レコードを追加してから確認してください。",
+          "loadError": {
+            "message": "DNS レコードを読み込めませんでした。"
+          },
+          "loading": {
+            "message": "読み込み中…"
+          },
+          "pendingDescription": "DNS プロバイダーでこの TXT レコードを追加してから確認してください。",
+          "record": {
+            "labelPrefix": "{label}: ",
+            "nameLabel": "名前",
+            "typeLabel": "種類",
+            "valueLabel": "値"
+          },
+          "refreshError": {
+            "message": "これらのレコードを更新できなかったため、内容が最新でない可能性があります。"
+          },
+          "retryButton": {
+            "label": "再試行"
+          },
+          "status": {
+            "pending": "保留中",
+            "verified": "確認済み"
+          },
+          "title": "ドメインの確認",
+          "verifiedDescription": "このドメインのユーザーは自動でサインインします。",
+          "verifiedToast": {
+            "message": "{domain} を確認しました"
+          },
+          "verifyButton": {
+            "label": "ドメインを確認",
+            "unclaimedTooltip": "先に、このドメインを設定したプロバイダーを保存してください。"
+          }
+        },
+        "provider": {
+          "cancelButton": {
+            "label": "キャンセル"
+          },
+          "configField": {
+            "optionalTitle": "{label}(任意)"
+          },
+          "displayNameField": {
+            "description": "サインインボタンに表示されるラベルです。",
+            "placeholder": "Company A",
+            "title": "表示名"
+          },
+          "emailDomainsField": {
+            "description": "これらのドメインのメールアドレスのみ、このプロバイダーでサインインできます。",
+            "optionalDescription": "これらのドメインのメールアドレスのみ、このプロバイダーでサインインできます。設定を推奨しますが、空のままにするとすべてのドメインを許可します。",
+            "placeholder": "ドメインを追加(例: onyx.app)",
+            "recommendedTitle": "許可するメールドメイン(推奨)",
+            "title": "許可するメールドメイン"
+          },
+          "header": {
+            "createDescription": "サインイン用の SSO プロバイダーを追加します。",
+            "createTitle": "SSO プロバイダーを追加",
+            "editDescription": "このプロバイダーのサインイン方法を更新します。",
+            "editTitle": "{name} を編集"
+          },
+          "nameField": {
+            "description": "ログイン URL に使用する一意の小文字スラッグです。後から変更できません。",
+            "title": "名前"
+          },
+          "providerTypeField": {
+            "description": "このプロバイダーが認証に使用するプロトコルです。",
+            "placeholder": "プロバイダーの種類を選択",
+            "title": "プロバイダーの種類"
+          },
+          "redirectField": {
+            "acsLabel": "ACS(応答)URL",
+            "copyTooltip": "{label} をコピー",
+            "description": "この URL をコールバックとして IdP に登録してください。",
+            "redirectUriLabel": "リダイレクト URI"
+          },
+          "submitButton": {
+            "createLabel": "作成",
+            "updateLabel": "更新"
+          },
+          "toasts": {
+            "created": "SSO プロバイダーを作成しました",
+            "updated": "SSO プロバイダーを更新しました"
+          },
+          "validation": {
+            "displayNameRequired": "表示名は必須です",
+            "emailDomainsMin": "サインインを許可するメールドメインを 1 つ以上指定してください",
+            "fieldRequired": "{field} は必須です",
+            "namePattern": "小文字、数字、ハイフンのみを使用してください",
+            "nameRequired": "名前は必須です",
+            "providerTypeRequired": "プロバイダーの種類は必須です"
+          }
+        }
+      },
+      "page": {
+        "description": "ユーザーが自社の ID プロバイダー経由でサインインできるようにします。"
+      },
+      "toasts": {
+        "unexpectedError": "予期しないエラーが発生しました。"
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "バックエンドバージョン: "
+      },
+      "version": {
+        "title": "バージョン"
+      },
+      "webVersion": {
+        "label": "Web バージョン: "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "最大 {cost} または {tokens} tokens",
+          "cost": "最大 {cost}",
+          "none": "予算は未設定",
+          "tokens": "最大 {tokens} tokens"
+        },
+        "cadence": {
+          "label": "{days, plural, one {毎日 UTC 午前 0 時にリセット} other {# 日ごとに UTC 午前 0 時にリセット}}"
+        },
+        "deleteFailed": {
+          "error": "Token レート制限の削除に失敗しました"
+        },
+        "empty": {
+          "message": "上限はまだありません。使用量を抑えるには支出上限を作成してください。"
+        },
+        "loadFailed": {
+          "error": "Token レート制限の読み込みに失敗しました"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "{label} を削除",
+            "tooltip": "上限を削除"
+          },
+          "disable": {
+            "ariaLabel": "{label} を無効にする"
+          },
+          "enable": {
+            "ariaLabel": "{label} を有効にする"
+          },
+          "label": "{budget}、{cadence}"
+        },
+        "updateFailed": {
+          "error": "Token レート制限の更新に失敗しました"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "costBudget": {
+          "description": "リセット期間ごとの最大支出額です。コスト予算、token 予算、またはその両方を設定してください。",
+          "placeholder": "コスト上限なし",
+          "title": "コスト予算",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "コスト予算、token 予算、またはその両方を入力してください",
+          "costMax": "コスト予算の上限は ${amount, number} です",
+          "costMinCents": "コスト予算は $0.01 以上にしてください",
+          "costMoreThanZero": "コスト予算は 0 より大きい値にしてください",
+          "groupRequired": "ユーザーグループを選択してください",
+          "periodInteger": "日数は整数で入力してください",
+          "periodMin": "1 日以上を指定してください",
+          "periodRequired": "リセット期間を入力してください",
+          "scopeRequired": "適用範囲は必須項目です",
+          "tokenIncrement": "1,000 tokens 単位で指定してください",
+          "tokenInteger": "token 数は整数で入力してください",
+          "tokenMax": "Token 予算の上限は 1 兆です",
+          "tokenMin": "1,000 tokens 以上を指定してください"
+        },
+        "groupMenu": {
+          "empty": "ユーザーグループはまだありません。「ユーザーとグループ」から作成してください。"
+        },
+        "groupPicker": {
+          "placeholder": "グループを選択"
+        },
+        "header": {
+          "title": "支出上限を作成"
+        },
+        "period": {
+          "description": "予算は UTC 午前 0 時にリセットされます",
+          "title": "リセット期間",
+          "unit": "日"
+        },
+        "scope": {
+          "caption": {
+            "global": "ワークスペースの全員が 1 つの予算を共有します。",
+            "group": "{group} のメンバーが 1 つの予算を共有します。",
+            "groupUnchosen": "選択したグループのメンバーが 1 つの予算を共有します。",
+            "user": "各ユーザーが個別の予算を持ちます。"
+          },
+          "title": "適用範囲"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "ワークスペース"
+          },
+          "user": {
+            "title": "ユーザーごと"
+          },
+          "userGroup": {
+            "title": "ユーザーグループ"
+          }
+        },
+        "submit": {
+          "label": "上限を作成"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} または {tokens} tokens",
+            "tokens": "{tokens} tokens"
+          },
+          "global": "{days, plural, one {ワークスペースの全員が毎日 {budget} までを共有します。期間がリセットされるまで、使用はブロックされます。} other {ワークスペースの全員が # 日ごとに {budget} までを共有します。期間がリセットされるまで、使用はブロックされます。}}",
+          "group": "{days, plural, one {{group} のメンバーが毎日 {budget} までを共有します。期間がリセットされるまで、使用はブロックされます。} other {{group} のメンバーが # 日ごとに {budget} までを共有します。期間がリセットされるまで、使用はブロックされます。}}",
+          "groupUnchosen": "{days, plural, one {選択したグループのメンバーが毎日 {budget} までを共有します。期間がリセットされるまで、使用はブロックされます。} other {選択したグループのメンバーが # 日ごとに {budget} までを共有します。期間がリセットされるまで、使用はブロックされます。}}",
+          "user": "{days, plural, one {各ユーザーは毎日 {budget} まで使用できます。期間がリセットされるまで、使用はブロックされます。} other {各ユーザーは # 日ごとに {budget} まで使用できます。期間がリセットされるまで、使用はブロックされます。}}"
+        },
+        "tokenBudget": {
+          "description": "リセット期間ごとの最大 token 数",
+          "placeholder": "Token の上限なし",
+          "title": "Token 予算",
+          "unit": "tokens"
+        },
+        "userGroup": {
+          "description": "この予算を共有するグループを選択してください",
+          "title": "ユーザーグループ"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "支出上限を作成"
+        },
+        "createFailed": {
+          "error": "支出上限の作成に失敗しました"
+        },
+        "created": {
+          "message": "支出上限を作成しました。"
+        },
+        "embedded": {
+          "description": "ワークスペース、ユーザー、グループの使用量にガードレールを設定します。上限は設定を削除せずに、有効と無効を切り替えられます。",
+          "title": "支出上限を管理"
+        },
+        "global": {
+          "description": "グローバル上限は、すべてのユーザー、ユーザーグループ、API キーに適用されます。グローバル上限に達すると、これ以上 token を消費できません。"
+        },
+        "intro": {
+          "description": "支出上限を使うと、一定の期間に消費できる token 数を制御できます。",
+          "groupLimit": "ユーザーグループに上限を設定して、チームの支出を管理します。",
+          "toggleLimit": "必要に応じて上限を有効または無効にします。",
+          "userLimit": "ユーザーに上限を設定して、1 人のユーザーが使いすぎないようにします。",
+          "workspaceLimit": "ワークスペース全体に上限を設定して、チーム全体の支出を管理します。"
+        },
+        "tabs": {
+          "global": {
+            "name": "グローバル"
+          },
+          "groups": {
+            "name": "グループ"
+          },
+          "users": {
+            "name": "ユーザー"
+          }
+        },
+        "user": {
+          "description": "ユーザー上限は、各ユーザーに個別に適用されます。ユーザーが上限に達すると、token の消費が一時的にブロックされます。"
+        },
+        "userGroup": {
+          "description": "グループ上限は、グループ内のすべてのユーザーに適用されます。ユーザーが複数のグループに所属する場合は、最も緩やかな上限が適用されます。"
+        }
+      }
+    },
+    "tracing": {
+      "disconnectModal": {
+        "body": "LLM 呼び出しのトレースは **{label}** に送信されなくなります。すでに送信されたトレースには影響しません。",
+        "description": "このプロバイダーへの LLM 呼び出しトレースの送信を停止します。",
+        "submit": {
+          "label": "切断"
+        },
+        "title": "{label} を切断"
+      },
+      "field": {
+        "optional": {
+          "title": "{label}(任意)"
+        },
+        "required": {
+          "error": "{label} は必須です"
+        }
+      },
+      "loadError": {
+        "description": "トレース設定を読み込めません。",
+        "title": "トレース設定の読み込みに失敗しました"
+      },
+      "page": {
+        "description": "オブザーバビリティプラットフォームを接続して、LLM 呼び出しを監視・評価します。"
+      },
+      "provider": {
+        "connected": {
+          "label": "接続済み"
+        }
+      },
+      "setupModal": {
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "connect": {
+          "label": "接続"
+        },
+        "createTitle": "{label} をセットアップ",
+        "description": "{label} に接続して、LLM 呼び出しのトレースを送信します。",
+        "editTitle": "{label} を設定",
+        "update": {
+          "label": "更新"
+        }
+      },
+      "toasts": {
+        "connected": "{label} に接続しました",
+        "disconnected": "{label} を切断しました",
+        "unexpectedError": "予期しないエラーが発生しました。"
+      }
+    },
+    "usage": {
+      "detail": {
+        "breakdown": {
+          "byFlow": {
+            "title": "フロー別"
+          },
+          "byModel": {
+            "title": "モデル別"
+          },
+          "byProvider": {
+            "title": "プロバイダー別"
+          },
+          "slice": {
+            "ariaLabel": "{label} の支出割合",
+            "summary": " · {percent}% · {tokens} tokens"
+          }
+        },
+        "dailySpend": {
+          "chart": {
+            "ariaLabel": "選択した期間の日次支出: {days}"
+          },
+          "day": {
+            "ariaLabel": "{day}、{cost}",
+            "tooltip": "{day} · {cost}"
+          },
+          "title": "日次支出"
+        },
+        "done": {
+          "label": "完了"
+        },
+        "empty": {
+          "description": "この期間にはモデル別の記録がありません。"
+        },
+        "stats": {
+          "cacheReads": {
+            "label": "キャッシュ読み取り"
+          },
+          "cacheWrites": {
+            "label": "キャッシュ書き込み"
+          },
+          "inputTokens": {
+            "label": "入力 token 数"
+          },
+          "outputTokens": {
+            "label": "出力 token 数"
+          },
+          "spend": {
+            "label": "支出"
+          }
+        }
+      },
+      "spendByUser": {
+        "columns": {
+          "input": {
+            "header": "入力"
+          },
+          "output": {
+            "header": "出力"
+          },
+          "spend": {
+            "header": "支出"
+          },
+          "tokens": {
+            "header": "Token 数"
+          },
+          "user": {
+            "header": "ユーザー"
+          }
+        },
+        "empty": {
+          "description": "現在のフィルターに一致する使用状況はありません。"
+        },
+        "filters": {
+          "allFlows": {
+            "label": "すべてのフロー"
+          },
+          "allModels": {
+            "label": "すべてのモデル"
+          }
+        },
+        "row": {
+          "ariaLabel": "{email} の使用状況の詳細を表示"
+        },
+        "rowCount": {
+          "label": "{count, plural, one {# 人のユーザー} other {# 人のユーザー}}"
+        },
+        "search": {
+          "ariaLabel": "メールアドレスでユーザーを検索",
+          "placeholder": "メールアドレスでユーザーを検索…"
+        }
+      }
+    },
+    "users": {
+      "accountType": {
+        "anonymous": {
+          "label": "匿名"
+        },
+        "bot": {
+          "label": "Slack ボット"
+        },
+        "extPermUser": {
+          "label": "外部ユーザー"
+        },
+        "serviceAccount": {
+          "label": "サービスアカウント"
+        },
+        "standard": {
+          "label": "標準"
+        }
+      },
+      "activateModal": {
+        "description": "<strong>{email}</strong> は Onyx へのアクセスを回復します。",
+        "submit": {
+          "label": "有効化"
+        },
+        "title": "ユーザーを有効化",
+        "toasts": {
+          "success": "ユーザーを有効化しました"
+        }
+      },
+      "cancelInviteModal": {
+        "description": "<strong>{email}</strong> は、この招待で Onyx に参加できなくなります。",
+        "submit": {
+          "label": "招待を取り消す"
+        },
+        "title": "招待を取り消す",
+        "toasts": {
+          "success": "招待を取り消しました"
+        }
+      },
+      "deactivateModal": {
+        "description": "<strong>{email}</strong> は Onyx へのアクセスを直ちに失います。セッションとエージェントは保持されます。ライセンスのシートは解放されます。このアカウントは後から再度有効化できます。",
+        "submit": {
+          "label": "無効化"
+        },
+        "title": "ユーザーを無効化",
+        "toasts": {
+          "success": "ユーザーを無効化しました"
+        }
+      },
+      "deleteModal": {
+        "description": "<strong>{email}</strong> は Onyx から完全に削除されます。セッション履歴もすべて削除されます。削除は元に戻せません。",
+        "submit": {
+          "label": "削除"
+        },
+        "title": "ユーザーを削除",
+        "toasts": {
+          "success": "ユーザーを削除しました"
+        }
+      },
+      "editModal": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "groupList": {
+          "loading": {
+            "description": "グループを読み込んでいます...",
+            "title": "読み込み中..."
+          },
+          "memberCount": "{count, plural, one {# 人のユーザー} other {# 人のユーザー}}",
+          "noResults": {
+            "description": "別の検索語をお試しください。",
+            "title": "グループが見つかりません"
+          }
+        },
+        "joinedGroups": {
+          "empty": {
+            "description": "{name} はどのグループにも所属していません。",
+            "title": "グループが見つかりません"
+          }
+        },
+        "removeGroupButton": {
+          "tooltip": "グループから削除"
+        },
+        "saveButton": {
+          "label": "変更を保存"
+        },
+        "search": {
+          "placeholder": "参加するグループを検索..."
+        },
+        "title": "ユーザーのグループを編集",
+        "toasts": {
+          "error": "エラーが発生しました",
+          "updated": "ユーザーを更新しました"
+        }
+      },
+      "filters": {
+        "accountType": {
+          "allOption": {
+            "label": "すべてのアカウント種別"
+          },
+          "button": {
+            "ariaLabel": "アカウント種別で絞り込み"
+          }
+        },
+        "button": {
+          "moreLabel": "{names}、+{count}"
+        },
+        "group": {
+          "allOption": {
+            "label": "すべてのグループ"
+          },
+          "button": {
+            "ariaLabel": "グループで絞り込み"
+          },
+          "empty": {
+            "label": "グループが見つかりません"
+          },
+          "search": {
+            "placeholder": "グループを検索..."
+          }
+        },
+        "status": {
+          "allOption": {
+            "label": "すべてのステータス"
+          },
+          "button": {
+            "ariaLabel": "ステータスで絞り込み"
+          }
+        }
+      },
+      "groupsCell": {
+        "editButton": {
+          "tooltip": "編集"
+        },
+        "editCell": {
+          "ariaLabel": "グループを編集"
+        },
+        "overflow": {
+          "label": "+{count}"
+        }
+      },
+      "inviteModal": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "emails": {
+          "placeholder": "招待するメールアドレスを追加（スペースまたはカンマ区切り）"
+        },
+        "message": {
+          "needsValidEmail": "招待するには有効なメールアドレスを入力してください。",
+          "readyCount": "{count, plural, one {招待するメールアドレス # 件} other {招待するメールアドレス # 件}}",
+          "someInvalid": "一部のメールアドレスが無効なため、スキップされます。"
+        },
+        "submitButton": {
+          "label": "招待"
+        },
+        "title": "ユーザーを招待",
+        "toasts": {
+          "inviteFailed": "ユーザーの招待に失敗しました",
+          "invited": "{count, plural, one {# 人のユーザーを招待しました} other {# 人のユーザーを招待しました}}",
+          "noValidEmails": "有効なメールアドレスを 1 件以上追加してください"
+        }
+      },
+      "modals": {
+        "toasts": {
+          "error": "エラーが発生しました"
+        }
+      },
+      "page": {
+        "inviteButton": {
+          "label": "ユーザーを招待"
+        },
+        "title": "ユーザーとリクエスト"
+      },
+      "permissionsNotice": {
+        "description": "Onyx はグループベースの権限を使用するようになりました。Curator と Global Curator のロールは、設定可能なグループ権限に置き換えられました。グループごとの管理者が、範囲を限定した管理を行います。",
+        "learnMoreButton": {
+          "label": "詳細を見る"
+        },
+        "title": "権限が変更されました"
+      },
+      "resetPasswordModal": {
+        "description": "<strong>{email}</strong> の新しいランダムなパスワードを生成します。現在のパスワードは直ちに使用できなくなります。",
+        "doneButton": {
+          "label": "完了"
+        },
+        "submit": {
+          "label": "パスワードをリセット"
+        },
+        "successDescription": "<strong>{email}</strong> のパスワードをリセットしました。以下の新しいパスワードをコピーしてください。この後は再表示されません。",
+        "successTitle": "パスワードをリセットしました",
+        "title": "パスワードをリセット",
+        "toasts": {
+          "error": "パスワードのリセットに失敗しました"
+        }
+      },
+      "rowActions": {
+        "activate": {
+          "label": "ユーザーを有効化"
+        },
+        "approve": {
+          "label": "承認"
+        },
+        "cancelInvite": {
+          "label": "招待を取り消す"
+        },
+        "deactivate": {
+          "label": "ユーザーを無効化"
+        },
+        "delete": {
+          "label": "ユーザーを削除"
+        },
+        "editGroups": {
+          "label": "グループとロール"
+        },
+        "makeAdmin": {
+          "label": "管理者にする"
+        },
+        "removeAdmin": {
+          "label": "管理者権限を削除"
+        },
+        "resetPassword": {
+          "label": "パスワードをリセット"
+        },
+        "scimNotice": {
+          "description": "これは ID プロバイダーが管理する、同期された SCIM ユーザーです。"
+        },
+        "toasts": {
+          "adminAccessGranted": "ユーザーを管理者に設定しました",
+          "adminAccessRemoved": "管理者権限を削除しました",
+          "error": "エラーが発生しました",
+          "requestApproved": "リクエストを承認しました"
+        }
+      },
+      "status": {
+        "active": {
+          "label": "有効"
+        },
+        "inactive": {
+          "label": "無効"
+        },
+        "invited": {
+          "label": "招待保留中"
+        },
+        "requested": {
+          "label": "参加リクエスト"
+        }
+      },
+      "summary": {
+        "activeUsers": {
+          "label": "有効なユーザー"
+        },
+        "filterButton": {
+          "tooltip": "フィルターを追加"
+        },
+        "pendingInvites": {
+          "label": "保留中の招待"
+        },
+        "requests": {
+          "label": "参加リクエスト"
+        },
+        "scim": {
+          "description": "ユーザーは ID プロバイダーから同期されます。",
+          "manageButton": {
+            "label": "管理"
+          },
+          "title": "SCIM 同期"
+        },
+        "statCell": {
+          "ariaLabel": "{label} で絞り込み"
+        }
+      },
+      "table": {
+        "columns": {
+          "accountType": {
+            "header": "アカウント種別"
+          },
+          "groups": {
+            "header": "グループ"
+          },
+          "lastUpdated": {
+            "header": "最終更新"
+          },
+          "name": {
+            "header": "名前"
+          },
+          "status": {
+            "header": "ステータス"
+          }
+        },
+        "downloadCsvButton": {
+          "ariaLabel": "CSV をダウンロード",
+          "tooltip": "CSV をダウンロード"
+        },
+        "empty": {
+          "description": "現在のフィルターに一致するユーザーはいません。",
+          "title": "ユーザーが見つかりません"
+        },
+        "error": {
+          "description": "ユーザーの読み込みに失敗しました。ページを再読み込みしてください。"
+        },
+        "search": {
+          "placeholder": "ユーザーを検索..."
+        },
+        "status": {
+          "scimSynced": {
+            "label": "SCIM 同期済み"
+          }
+        },
+        "toasts": {
+          "downloadFailed": "CSV のダウンロードに失敗しました"
+        }
+      }
+    },
+    "voice": {
+      "disconnectModal": {
+        "body": {
+          "description": "**{label}** のモデルは音声テキスト変換やテキスト読み上げに使用されなくなり、デフォルトからも外れます。セッション履歴は保持されます。"
+        },
+        "connectAnother": {
+          "description": "音声機能を引き続き使用するには、別のプロバイダーを接続してください。"
+        },
+        "disconnectError": {
+          "message": "プロバイダーの接続解除に失敗しました。"
+        },
+        "disconnectSuccess": {
+          "message": "{label} の接続を解除しました"
+        },
+        "header": {
+          "description": "このプロバイダーに保存された認証情報を削除します。",
+          "title": "{label} の接続を解除"
+        },
+        "submitButton": {
+          "label": "接続を解除"
+        }
+      },
+      "header": {
+        "description": "音声入力と読み上げ応答のために、音声テキスト変換とテキスト読み上げのプロバイダーを設定します。",
+        "title": "音声"
+      },
+      "models": {
+        "azureSpeechStt": {
+          "subtitle": "Microsoft Foundry Tools の音声テキスト変換。"
+        },
+        "azureSpeechTts": {
+          "subtitle": "Microsoft Foundry Tools のテキスト読み上げ。"
+        },
+        "elevenlabsStt": {
+          "subtitle": "ElevenLabs の音声テキスト変換 API。"
+        },
+        "elevenlabsTts": {
+          "subtitle": "ElevenLabs のテキスト読み上げ API。"
+        },
+        "tts1": {
+          "subtitle": "速度に最適化された OpenAI のテキスト読み上げモデル。"
+        },
+        "tts1Hd": {
+          "subtitle": "品質に最適化された OpenAI のテキスト読み上げモデル。"
+        },
+        "whisper": {
+          "subtitle": "OpenAI の汎用音声認識モデル。"
+        }
+      },
+      "setupModal": {
+        "apiKey": {
+          "description": "モデルにアクセスするには、{provider} の [API キー]({url}) を貼り付けてください。",
+          "label": "API キー",
+          "placeholder": "API キー",
+          "required": "API キーは必須です"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "connectButton": {
+          "label": "接続"
+        },
+        "connectionTestFailed": {
+          "message": "接続テストに失敗しました"
+        },
+        "createHeader": {
+          "title": "{provider} をセットアップ"
+        },
+        "editHeader": {
+          "title": "{provider} を設定"
+        },
+        "header": {
+          "description": "{provider} に接続して、音声モデルをセットアップします。"
+        },
+        "saveError": {
+          "message": "プロバイダーの保存に失敗しました"
+        },
+        "sttLanguages": {
+          "azureCapExceeded": "Azure は音声言語を最大 {cap} 個までサポートします",
+          "description": "ユーザーが話す可能性のあるロケールをカンマ区切りで指定します（例：`en-US, fr-FR`）。複数指定すると、リアルタイム文字起こしが話されている言語を自動検出します（アップロードされた音声は最初のロケールを使用します）。[対応ロケール]({docsUrl}) を参照してください。",
+          "invalid": "en-US, fr-FR のようにロケールをカンマ区切りで入力してください（1 言語につき 1 つ）",
+          "label": "音声言語",
+          "selfHostedCapExceeded": "セルフホストのエンドポイントは音声言語を最大 {cap} 個までサポートします（開始時に検出）"
+        },
+        "sttModel": {
+          "label": "STT モデル"
+        },
+        "targetUri": {
+          "description": "[Azure Portal（キーとエンドポイント）]({portalUrl}) に表示されるエンドポイントを貼り付けてください。Onyx はこの URL から音声リージョンを抽出します。例：`https://westus.api.cognitive.microsoft.com/` または `https://westus.tts.speech.microsoft.com/`。",
+          "label": "ターゲット URI",
+          "required": "ターゲット URI は必須です"
+        },
+        "ttsModel": {
+          "description": "このモデルが、Onyx のテキスト読み上げでデフォルトとして使用されます。",
+          "label": "デフォルトモデル"
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "voice": {
+          "description": "このボイスが読み上げ応答に使用されます。対応する言語とボイスの一覧は [{docsLabel}]({docsUrl}) を参照してください。",
+          "label": "ボイス",
+          "loadingPlaceholder": "ボイスを読み込んでいます...",
+          "placeholder": "ボイスを選択するか、ボイス ID を入力"
+        }
+      },
+      "speechToText": {
+        "description": "チャットで音声をテキストに文字起こしするモデルを選択します。",
+        "emptyState": {
+          "title": "チャットで使用する音声テキスト変換プロバイダーを接続してください。"
+        },
+        "title": "音声テキスト変換"
+      },
+      "textToSpeech": {
+        "description": "チャットの応答を読み上げるモデルを選択します。",
+        "emptyState": {
+          "title": "チャットで使用するテキスト読み上げプロバイダーを接続してください。"
+        },
+        "title": "テキスト読み上げ"
+      },
+      "unexpectedError": {
+        "message": "予期しないエラーが発生しました。"
+      }
+    },
+    "webSearch": {
+      "apiKeyField": {
+        "noLink": {
+          "description": "接続するには、{provider} の API キーを貼り付けてください。"
+        },
+        "placeholder": "API キー",
+        "title": "API キー",
+        "withLink": {
+          "description": "接続するには、{provider} の [API キー]({url}) を貼り付けてください。"
+        }
+      },
+      "crawler": {
+        "currentCrawler": {
+          "label": "現在のクローラー"
+        },
+        "description": "検索結果ページの全文を読み取るために使用します。",
+        "title": "Web クローラー"
+      },
+      "customIntegration": {
+        "subtitle": "カスタム統合"
+      },
+      "disconnectModal": {
+        "connectAnother": {
+          "description": "Web 検索を引き続き使用するには、別の検索エンジンを接続してください。"
+        },
+        "content": {
+          "description": "**{label}** は検索結果の Web ページの読み取りに使用されなくなります。"
+        },
+        "disconnectSuccess": {
+          "message": "{label} の接続を解除しました"
+        },
+        "fallback": {
+          "description": "Onyx は組み込みの Web クローラーにフォールバックします。"
+        },
+        "header": {
+          "description": "このプロバイダーに保存された認証情報を削除します。",
+          "title": "{label} の接続を解除"
+        },
+        "search": {
+          "description": "Web 検索は **{label}** を経由しなくなります。検索履歴は保持されます。"
+        },
+        "submitButton": {
+          "label": "接続を解除"
+        }
+      },
+      "header": {
+        "description": "インターネット全体を対象とした外部検索の設定です。",
+        "title": "Web 検索"
+      },
+      "loadError": {
+        "description": "Web 検索の設定を読み込めません。",
+        "title": "Web 検索設定の読み込みに失敗しました"
+      },
+      "searchEngine": {
+        "connectPrompt": {
+          "title": "Web 検索を設定するには、検索エンジンを接続してください。"
+        },
+        "description": "Web 検索結果の URL、スニペット、メタデータに使用する外部検索エンジン API です。",
+        "selectPrompt": {
+          "title": "Web 検索を有効にするには、検索エンジンを選択してください。"
+        },
+        "title": "検索エンジン"
+      },
+      "setupModal": {
+        "apiKey": {
+          "required": "API キーは必須です"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "config": {
+          "required": "{title} は必須です"
+        },
+        "connectButton": {
+          "label": "接続"
+        },
+        "connectSuccess": {
+          "message": "プロバイダーを接続しました"
+        },
+        "createHeader": {
+          "title": "{provider} をセットアップ"
+        },
+        "editHeader": {
+          "title": "{provider} を設定"
+        },
+        "updateButton": {
+          "label": "更新"
+        }
+      },
+      "unexpectedError": {
+        "message": "予期しないエラーが発生しました。"
+      }
+    }
+  },
+  "agents": {
+    "card": {
+      "actionsCount": {
+        "label": "{count, plural, =0 {アクションなし} one {# 個のアクション} other {# 個のアクション}}"
+      },
+      "edit": {
+        "tooltip": "エージェントを編集"
+      },
+      "pin": {
+        "tooltip": "サイドバーにピン留め"
+      },
+      "share": {
+        "tooltip": "エージェントを共有"
+      },
+      "startChat": {
+        "label": "チャットを開始"
+      },
+      "unpin": {
+        "tooltip": "サイドバーのピン留めを解除"
+      },
+      "viewStats": {
+        "tooltip": "エージェントの統計を表示"
+      }
+    },
+    "filters": {
+      "actions": {
+        "all": {
+          "label": "すべてのアクション"
+        },
+        "multiple": {
+          "label": "{count} 件選択中"
+        },
+        "search": {
+          "placeholder": "アクションを絞り込み..."
+        }
+      },
+      "creator": {
+        "all": {
+          "label": "全員"
+        },
+        "me": {
+          "description": "自分"
+        },
+        "multiple": {
+          "label": "{count} 人"
+        },
+        "search": {
+          "placeholder": "作成者..."
+        },
+        "single": {
+          "label": "{email} が作成"
+        }
+      }
+    },
+    "modals": {
+      "agentButton": {
+        "unpin": {
+          "tooltip": "エージェントのピン留めを解除"
+        }
+      },
+      "moveCustomAgentChat": {
+        "body": {
+          "description": "このチャットは <b>カスタムエージェント</b> を使用しています。<b>プロジェクト</b> に移動しても、エージェントのプロンプトやナレッジの設定は上書きされません。整理を目的とする場合にのみ使用してください。"
+        },
+        "confirm": {
+          "label": "移動を確定"
+        },
+        "doNotShowAgain": {
+          "label": "今後表示しない"
+        },
+        "title": "カスタムエージェントのチャットを移動"
+      },
+      "noAgent": {
+        "admin": {
+          "description": "管理者は、管理パネルで新しいエージェントを作成するか、デフォルトチャットを再度有効にできます。"
+        },
+        "body": {
+          "description": "現在、設定済みのエージェントはありません。デフォルトチャットも明示的に無効化されています。"
+        },
+        "configureAgent": {
+          "label": "新しいエージェントを設定"
+        },
+        "nonAdmin": {
+          "description": "エージェントの設定、またはデフォルトチャットの再有効化について、管理者にお問い合わせください。"
+        },
+        "reenableDefaultChat": {
+          "label": "デフォルトチャットを再有効化"
+        },
+        "title": "利用可能なエージェントがありません"
+      },
+      "shareAgent": {
+        "admins": {
+          "description": "{count, plural, one {# 人のユーザー} other {# 人のユーザー}}",
+          "title": "管理者"
+        },
+        "agentFallback": {
+          "name": "エージェント"
+        },
+        "back": {
+          "label": "戻る"
+        },
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "copyLink": {
+          "label": "リンクをコピー"
+        },
+        "done": {
+          "label": "完了"
+        },
+        "loading": {
+          "description": "共有の詳細を読み込んでいます..."
+        },
+        "permission": {
+          "edit": {
+            "label": "編集"
+          },
+          "owner": {
+            "label": "オーナー"
+          }
+        },
+        "publicPermissionMenu": {
+          "ariaLabel": "公開権限を変更"
+        },
+        "row": {
+          "updateAccess": {
+            "ariaLabel": "{name} のアクセス権を更新"
+          },
+          "you": {
+            "title": "{email}（自分）"
+          }
+        },
+        "save": {
+          "label": "保存"
+        },
+        "scopeMenu": {
+          "ariaLabel": "共有範囲を変更"
+        },
+        "share": {
+          "title": "*{name}* を共有"
+        },
+        "toasts": {
+          "accessRemoved": "アクセス権を削除しました。",
+          "copyLinkFailed": "リンクのコピーに失敗しました。",
+          "linkCopied": "リンクをコピーしました。",
+          "ownershipTransferred": "オーナー権限を譲渡しました。",
+          "sharingUpdated": "共有設定を更新しました。"
+        },
+        "transfer": {
+          "label": "譲渡",
+          "title": "*{name}* を譲渡"
+        }
+      },
+      "viewer": {
+        "actions": {
+          "empty": {
+            "title": "アクションなし"
+          },
+          "title": "アクションとツール"
+        },
+        "conversationStarters": {
+          "title": "会話のきっかけ"
+        },
+        "defaultModel": {
+          "description": "このモデルが、Onyx のチャットでデフォルトとして使用されます。",
+          "title": "デフォルトモデル"
+        },
+        "featured": {
+          "label": "おすすめ"
+        },
+        "instructions": {
+          "title": "指示"
+        },
+        "knowledge": {
+          "empty": {
+            "title": "ナレッジなし"
+          },
+          "title": "ナレッジ"
+        },
+        "knowledgeCutoff": {
+          "description": "この日付より前に最終更新されたドキュメントは無視されます。",
+          "title": "ナレッジのカットオフ日"
+        },
+        "mcpCard": {
+          "expand": {
+            "label": "展開"
+          },
+          "fold": {
+            "label": "折りたたむ"
+          }
+        },
+        "moreInfo": {
+          "title": "詳細情報"
+        },
+        "overwritePrompts": {
+          "description": "有用な指示（例：「Markdown の表を使用できます」）を含む基本システムプロンプトを削除します。応答の品質に影響する場合があります。",
+          "title": "システムプロンプトを上書き"
+        },
+        "promptReminders": {
+          "title": "プロンプトリマインダー"
+        },
+        "public": {
+          "label": "組織全体に公開"
+        }
+      }
+    },
+    "userVariables": {
+      "insert": {
+        "tooltip": "ユーザー変数を挿入"
+      }
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "新しい組織を作成"
+      },
+      "createTeamOption": {
+        "text": "新しい Onyx チームを作成する"
+      },
+      "differentEmailPrompt": {
+        "text": "別のメールアドレスのアカウントをお持ちですか？"
+      },
+      "heading": {
+        "title": "アカウントが見つかりません"
+      },
+      "inviteOption": {
+        "text": "既存の Onyx チームに招待してもらう"
+      },
+      "notFound": {
+        "description": "お客様のアカウントが記録内に見つかりませんでした。Onyx を利用するには、次のいずれかが必要です："
+      },
+      "signInLink": {
+        "label": "サインイン"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "アカウントのアクセス制限または権限"
+      },
+      "cloudSupportPrompt": {
+        "text": "問題が解決しない場合は、Onyx チーム（<link>support@onyx.app</link>）までご連絡ください"
+      },
+      "code": {
+        "accessDenied": "ID プロバイダーによってアクセスが拒否されました。",
+        "consentRequired": "続行する前に、ID プロバイダーでの同意が必要です。",
+        "interactionRequired": "ID プロバイダーでの追加の操作が必要です。",
+        "invalidScope": "要求された権限は利用できません。",
+        "loginBadCredentials": "このアカウントはサインインできません。無効化されている可能性があります。ワークスペースの管理者にお問い合わせください。",
+        "loginRequired": "先に ID プロバイダーでログインする必要があります。",
+        "oauthUserAlreadyExists": "このメールアドレスのアカウントは、別のサインイン方法で既に存在します。最初に使用した方法でサインインするか、管理者にこのプロバイダーの連携を依頼してください。",
+        "serverError": "ID プロバイダーでエラーが発生しました。もう一度お試しください。",
+        "temporarilyUnavailable": "ID プロバイダーは一時的に利用できません。しばらくしてからもう一度お試しください。"
+      },
+      "credentialsIssue": {
+        "description": "ログイン認証情報の誤りまたは期限切れ"
+      },
+      "heading": {
+        "description": "ログインの試行中に問題が発生しました。",
+        "title": "認証エラー"
+      },
+      "possibleIssues": {
+        "title": "考えられる原因："
+      },
+      "returnToLoginButton": {
+        "label": "ログインページに戻る"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "問題が解決しない場合は、システム管理者にお問い合わせください。"
+      },
+      "systemDisruptionIssue": {
+        "description": "認証システムの一時的な障害"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[ログインに戻る](/auth/login)"
+      },
+      "emailField": {
+        "label": "メールアドレス"
+      },
+      "emailSent": {
+        "toast": "パスワードリセットのメールを送信しました。受信トレイをご確認ください。"
+      },
+      "genericError": {
+        "toast": "パスワードのリセット中にエラーが発生しました。"
+      },
+      "heading": {
+        "title": "パスワードをお忘れの場合"
+      },
+      "submitButton": {
+        "label": "パスワードをリセット"
+      },
+      "unexpectedError": {
+        "toast": "エラーが発生しました。もう一度お試しください。"
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "注：この機能は @onyx.app の管理者のみが利用できます"
+      },
+      "apiKeyField": {
+        "label": "API キー",
+        "placeholder": "API キーを入力"
+      },
+      "emailField": {
+        "label": "メールアドレス"
+      },
+      "genericError": {
+        "toast": "ユーザーへのなりすましに失敗しました"
+      },
+      "heading": {
+        "title": "ユーザーになりすます"
+      },
+      "invalidEmail": {
+        "error": "無効なメールアドレス"
+      },
+      "requiredField": {
+        "error": "必須"
+      },
+      "submitButton": {
+        "label": "ユーザーになりすます"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "チームに参加するには再認証が必要です"
+      },
+      "orDivider": {
+        "text": "または"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "アカウントを作成"
+      },
+      "noSsoProviders": {
+        "error": "そのメールアドレスには SSO サインインが設定されていません。下の Google またはパスワードをお試しください。"
+      },
+      "resetPasswordButton": {
+        "label": "パスワードをリセット"
+      },
+      "signupPrompt": {
+        "text": "アカウントをお持ちではありませんか？"
+      },
+      "ssoEmailInvalid": {
+        "error": "有効なメールアドレスを入力してください"
+      },
+      "ssoEmailRequired": {
+        "error": "メールアドレスは必須です"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "サインインの応答に認可 URL が含まれていませんでした"
+      },
+      "ssoSignInButton": {
+        "label": "SSO でサインイン"
+      },
+      "ssoStartFailed": {
+        "error": "サインインを開始できませんでした（ステータス {status}）"
+      },
+      "verifiedMessage": {
+        "title": "メールアドレスを確認しました。続行するにはサインインしてください。"
+      },
+      "workEmailField": {
+        "label": "職場のメールアドレス"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[ログインに戻る](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "新しいパスワードの確認",
+        "placeholder": "新しいパスワードを再入力"
+      },
+      "confirmPasswordRequired": {
+        "error": "パスワードの確認は必須です"
+      },
+      "genericError": {
+        "toast": "パスワードのリセット中にエラーが発生しました。"
+      },
+      "heading": {
+        "title": "パスワードをリセット"
+      },
+      "invalidPassword": {
+        "error": "無効なパスワード"
+      },
+      "missingToken": {
+        "toast": "リセットトークンが無効または見つかりません。"
+      },
+      "newPasswordField": {
+        "label": "新しいパスワード",
+        "placeholder": "新しいパスワードを入力"
+      },
+      "passwordRequired": {
+        "error": "パスワードは必須です"
+      },
+      "passwordsMatch": {
+        "error": "パスワードが一致しません"
+      },
+      "submitButton": {
+        "label": "パスワードをリセット"
+      },
+      "successRedirect": {
+        "toast": "パスワードをリセットしました。ログインページに移動しています..."
+      },
+      "unexpectedError": {
+        "toast": "予期しないエラーが発生しました。もう一度お試しください。"
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "サインアップを完了"
+      },
+      "createAccountHeading": {
+        "title": "アカウントを作成"
+      },
+      "orDivider": {
+        "text": "または"
+      },
+      "referralOptionAds": {
+        "label": "広告"
+      },
+      "referralOptionBlog": {
+        "label": "記事・ブログ"
+      },
+      "referralOptionFriend": {
+        "label": "友人・同僚"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "その他"
+      },
+      "referralOptionPodcast": {
+        "label": "ポッドキャスト"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "検索エンジン（Google/Bing）"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "選択してください"
+      },
+      "referralQuestion": {
+        "label": "Onyx をどこでお知りになりましたか？"
+      },
+      "subtitle": {
+        "text": "Onyx を始めましょう"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "確認メールを再送信"
+      },
+      "missingToken": {
+        "error": "確認トークンがありません。確認メールを再度リクエストしてください。"
+      },
+      "unknownError": {
+        "text": "不明なエラー"
+      },
+      "verificationFailed": {
+        "error": "メールアドレスの確認に失敗しました - {errorDetail}。確認メールを再度リクエストしてください。"
+      },
+      "verifying": {
+        "text": "メールアドレスを確認しています..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "新しい確認メールを送信しました。"
+      },
+      "greeting": {
+        "text": "*{email}* さん、メールアドレスがまだ確認されていないようです。\n受信トレイで当社からのメールを確認して、始めましょう。"
+      },
+      "helpPrompt": {
+        "text": "メールが見当たらない場合は、<link>こちら</link> をクリックして再送信をリクエストしてください。"
+      },
+      "sendFailed": {
+        "toast": "確認メールの再送信に失敗しました - {errorDetail}"
+      }
+    }
+  },
+  "cards": {
+    "file": {
+      "processing": {
+        "description": "処理中..."
+      },
+      "remove": {
+        "label": "削除"
+      },
+      "uploading": {
+        "description": "アップロード中..."
+      }
+    },
+    "skill": {
+      "dependency": {
+        "appDisabled": "アプリ「{app}」は無効です",
+        "connectToEnable": "有効にするにはアプリ「{app}」を接続してください",
+        "connectToUse": "使用するにはアプリ「{app}」を接続してください",
+        "nameConflict": "同じ名前の別のスキルが有効です",
+        "usesApp": "アプリ「{app}」を使用します"
+      },
+      "edit": {
+        "tooltip": "スキルを編集"
+      },
+      "invalid": {
+        "description": "この無効なスキルを削除して、新しいスキルを作成してください。"
+      },
+      "tags": {
+        "appSkill": {
+          "label": "アプリスキル"
+        },
+        "builtin": {
+          "label": "組み込み"
+        },
+        "custom": {
+          "label": "カスタム"
+        },
+        "invalid": {
+          "label": "無効"
+        },
+        "personal": {
+          "label": "個人用"
+        },
+        "unavailable": {
+          "label": "利用できません - クリックして詳細を表示"
+        }
+      },
+      "toggle": {
+        "disable": {
+          "ariaLabel": "{name} を無効にする"
+        },
+        "disableForApp": {
+          "ariaLabel": "{app} で {name} を無効にする"
+        },
+        "enable": {
+          "ariaLabel": "{name} を有効にする"
+        },
+        "enableForApp": {
+          "ariaLabel": "{app} で {name} を有効にする"
+        }
+      },
+      "tooltips": {
+        "appDisabled": "アプリ「{app}」は管理者によって無効化されています。",
+        "connectApp": "このスキルを使用するには、アプリページでアプリ「{app}」を接続してください。",
+        "invalid": "このスキルは無効です。削除して新しいスキルを作成してください。",
+        "unavailable": "このスキルは現在利用できません。クリックすると詳細を表示します。"
+      }
+    }
+  },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {ファイルの処理に失敗したため削除しました：{names}} other {ファイルの処理に失敗したため削除しました：{names}}}"
+      },
+      "newChatButton": {
+        "label": "新しいチャットを開始"
+      },
+      "noPreviousMessage": {
+        "toast": "以前に送信されたユーザーメッセージが見つかりません。"
+      },
+      "oauthConnected": {
+        "toast": "認証に成功しました"
+      },
+      "scrollToBottomButton": {
+        "label": "一番下までスクロール"
+      },
+      "sessionAccessDenied": {
+        "description": "このチャットセッションを表示する権限がありません。",
+        "title": "アクセスが拒否されました"
+      },
+      "sessionGenericError": {
+        "title": "問題が発生しました"
+      },
+      "sessionNotFound": {
+        "description": "このチャットセッションは存在しないか、削除されています。",
+        "title": "チャットが見つかりません"
+      },
+      "sourcesModal": {
+        "title": "ソース"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "他 +{count} 件"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "複数のコネクターの認証情報が無効です。コネクターページを開いて確認してください。",
+          "title": "{count, plural, one {# 個のコネクターが無効です} other {# 個のコネクターが無効です}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "複数のコネクターでインデックス作成の失敗が続いています。コネクターページを開いて確認してください。",
+          "title": "{count, plural, one {# 個のコネクターが失敗しています} other {# 個のコネクターが失敗しています}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "コネクターを表示"
+        },
+        "source": {
+          "label": "コネクター"
+        }
+      },
+      "defaultCta": {
+        "label": "表示"
+      },
+      "defaultSource": {
+        "label": "通知"
+      },
+      "dismissButton": {
+        "ariaLabel": "閉じる"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "初回セットアップ直後、または Onyx のデプロイを更新した直後の場合は、バックエンドがまだ起動中である可能性が高いです。1〜2 分ほど待ってから、ページを再読み込みしてください。それでも解決しない場合は、バックエンドが正しくセットアップされているか確認するか、管理者にお問い合わせください。",
+          "title": "バックエンドは現在利用できません"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "ライセンス"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "次のバナー"
+      },
+      "previousButton": {
+        "ariaLabel": "前のバナー"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "管理者のお知らせ"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "トライアル"
+        }
+      }
+    },
+    "documentSidebar": {
+      "citedSources": {
+        "title": "引用したソース"
+      },
+      "closeButton": {
+        "tooltip": "サイドバーを閉じる"
+      },
+      "foundSources": {
+        "title": "見つかったソース"
+      },
+      "moreSources": {
+        "title": "その他"
+      },
+      "userFiles": {
+        "title": "ユーザーファイル"
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "接続"
+      },
+      "header": {
+        "description": "{appName} が接続済みのすべてのデータを検索できるようにして、回答の品質を向上させます。",
+        "title": "アプリを接続"
+      },
+      "skipButton": {
+        "label": "今はスキップ"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "アップロードされた添付ファイル"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "ダウンロード"
+        },
+        "image": {
+          "alt": "チャットの添付ファイル"
+        },
+        "viewFullImage": {
+          "label": "画像全体を表示"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "プレビュー"
+        },
+        "viewFullImage": {
+          "label": "画像全体を表示"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "ファイルを添付"
+        },
+        "createPromptItem": {
+          "title": "新しいプロンプトを作成"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "マルチモデルモードでは Deep Research を使用できません",
+          "label": "Deep Research"
+        },
+        "incognitoNotice": {
+          "text": "このチャットは履歴に表示されず、メモリにも使用されません。"
+        },
+        "incognitoPolicyNotice": {
+          "text": "組織のポリシーによっては、管理者がこのチャットを閲覧できる場合があります。サードパーティのツールが操作を記録する場合もあります。"
+        },
+        "input": {
+          "ariaLabel": "メッセージ入力",
+          "listeningPlaceholder": "聞き取り中...",
+          "placeholder": "今日はどのようなご用件でしょうか？",
+          "queuedPlaceholder": "上キーを押すとキュー内のメッセージを編集できます",
+          "searchPlaceholder": "接続済みのソースを検索",
+          "speakingPlaceholder": "Onyx が話しています..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "添付ファイルの処理が完了するのを待っています"
+        },
+        "tabReadingButton": {
+          "readLabel": "このタブを読み取る",
+          "readingLabel": "タブを読み取り中..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "音声を設定",
+          "tooltip": "音声が未設定です。管理設定で設定してください。"
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "メッセージ入力",
+          "placeholder": "タスクを説明してください..."
+        },
+        "pasteExpandHint": {
+          "text": "もう一度貼り付けると展開します"
+        },
+        "queuedMessagesHint": {
+          "text": "でキュー内のメッセージを編集"
+        },
+        "sendButton": {
+          "initializingTooltip": "サンドボックスを初期化中...",
+          "queueLabel": "メッセージをキューに追加",
+          "sendLabel": "送信"
+        },
+        "stopButton": {
+          "ariaLabel": "生成を停止",
+          "tooltip": "停止 · esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "セッションの準備を待っています..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "スキル: {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "アプリ"
+        },
+        "connectAction": {
+          "label": "接続"
+        },
+        "connectedRow": {
+          "description": "接続済み"
+        },
+        "connectionRequiredRow": {
+          "description": "接続が必要"
+        },
+        "content": {
+          "ariaLabel": "スキル選択"
+        },
+        "empty": {
+          "text": "一致するスキルはありません"
+        },
+        "mcpServersGroup": {
+          "label": "MCP サーバー"
+        },
+        "skillsGroup": {
+          "label": "スキル"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "{label} を削除"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "マイクにアクセスできませんでした"
+        },
+        "autoStartError": {
+          "toast": "マイクを自動的に開始できませんでした"
+        },
+        "startRecording": {
+          "ariaLabel": "録音を開始"
+        },
+        "stopRecording": {
+          "ariaLabel": "録音を停止"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "貼り付けたテキストを編集"
+        },
+        "expandButton": {
+          "label": "入力バーに展開",
+          "tooltip": "このタイルを全文に置き換えて入力欄に表示します"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "追加メニューを開く",
+          "tooltip": "追加"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "キュー内のメッセージを削除"
+        },
+        "editHint": {
+          "label": "編集 ·"
+        },
+        "item": {
+          "ariaLabel": "キュー内のメッセージを切り替え"
+        },
+        "removeHint": {
+          "label": "削除"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "Onyx がお手伝いできることはありますか"
+        },
+        "startSessionButton": {
+          "label": "新しいセッションを開始"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "API キー",
+        "placeholder": "API キーを入力"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "API キーを非表示",
+        "showAriaLabel": "API キーを表示"
+      },
+      "cancelButton": {
+        "label": "キャンセル"
+      },
+      "credentialField": {
+        "placeholder": "{field} を入力"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "認証情報を非表示",
+        "showAriaLabel": "認証情報を表示"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "API キーの入力"
+        },
+        "enterCredentials": {
+          "title": "認証情報の入力"
+        },
+        "manageApiKey": {
+          "title": "API キーの管理"
+        },
+        "manageCredentials": {
+          "title": "認証情報の管理"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "認証を有効にするには、{server} の API キーを入力してください。"
+        },
+        "enterCredentials": {
+          "text": "認証を有効にするには、{server} の認証情報を入力してください。"
+        },
+        "updateApiKey": {
+          "text": "{server} の API キーを更新してください。"
+        },
+        "updateCredentials": {
+          "text": "{server} の認証情報を更新してください。"
+        }
+      },
+      "saveApiKeyError": {
+        "message": "API キーを保存できませんでした"
+      },
+      "saveCredentialsError": {
+        "message": "認証情報を保存できませんでした"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "API キーを保存"
+        },
+        "saveCredentials": {
+          "label": "認証情報を保存"
+        },
+        "saving": {
+          "label": "保存中..."
+        },
+        "updateApiKey": {
+          "label": "API キーを更新"
+        },
+        "updateCredentials": {
+          "label": "認証情報を更新"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "API キーはサーバーで検証され、安全に保管されます。"
+        },
+        "authenticated": {
+          "text": "変更は保存前にサーバーで検証されます。"
+        },
+        "credentials": {
+          "text": "認証情報はサーバーで検証され、安全に保管されます。"
+        }
+      }
+    },
+    "messages": {
+      "agentMessage": {
+        "stoppedGeneration": {
+          "text": "ユーザーが生成を停止しました"
+        }
+      },
+      "codeBlock": {
+        "copyButton": {
+          "copiedLabel": "コピーしました！",
+          "label": "コピー"
+        }
+      },
+      "customTool": {
+        "authFailedStatus": {
+          "text": "{toolName} の認証に失敗しました (HTTP {statusCode})"
+        },
+        "completedStatus": {
+          "text": "{toolName} が完了しました"
+        },
+        "downloadFileLink": {
+          "label": "ダウンロード"
+        },
+        "failedStatus": {
+          "text": "{toolName} が失敗しました (HTTP {statusCode})"
+        },
+        "fallbackName": {
+          "label": "ツール"
+        },
+        "fileItem": {
+          "label": "ファイル {index}"
+        },
+        "fileStatus": {
+          "text": "{toolName} がファイルを返しました"
+        },
+        "imagesStatus": {
+          "text": "{toolName} が画像を返しました"
+        },
+        "openFileLink": {
+          "label": "開く"
+        },
+        "requestBlock": {
+          "label": "リクエスト"
+        },
+        "responseBlock": {
+          "label": "レスポンス"
+        },
+        "runningStatus": {
+          "text": "{toolName} を実行中..."
+        },
+        "waitingIndicator": {
+          "text": "レスポンスを待っています..."
+        }
+      },
+      "customToolAuth": {
+        "card": {
+          "description": "このツールを使用するには {toolName} に接続してください",
+          "title": "{toolName} は未接続です"
+        },
+        "connectButton": {
+          "label": "接続"
+        }
+      },
+      "errorBanner": {
+        "apiError": {
+          "title": "API エラー"
+        },
+        "authError": {
+          "title": "認証エラー"
+        },
+        "badRequest": {
+          "title": "無効なリクエスト"
+        },
+        "budgetExceeded": {
+          "title": "予算を超過しました"
+        },
+        "connectionError": {
+          "title": "接続エラー"
+        },
+        "contentPolicy": {
+          "title": "コンテンツポリシー違反"
+        },
+        "genericError": {
+          "title": "エラー"
+        },
+        "initializationError": {
+          "title": "初期化エラー"
+        },
+        "messageTooLong": {
+          "title": "メッセージが長すぎます"
+        },
+        "model": {
+          "label": "モデル: {model}"
+        },
+        "modelRefusal": {
+          "title": "モデルが応答を拒否しました"
+        },
+        "modelWithProvider": {
+          "label": "モデル: {model} ({provider})"
+        },
+        "permissionDenied": {
+          "title": "権限がありません"
+        },
+        "rateLimitExceeded": {
+          "title": "レート制限を超過しました"
+        },
+        "resourceNotFound": {
+          "title": "リソースが見つかりません"
+        },
+        "serviceUnavailable": {
+          "title": "サービスを利用できません"
+        },
+        "stackTraceButton": {
+          "label": "スタックトレース"
+        },
+        "tool": {
+          "label": "ツール: {tool}"
+        },
+        "toolError": {
+          "title": "ツールエラー"
+        },
+        "usageLimitReached": {
+          "title": "使用量の上限に達しました"
+        },
+        "validationError": {
+          "title": "検証エラー"
+        }
+      },
+      "humanMessage": {
+        "editButton": {
+          "tooltip": "編集"
+        }
+      },
+      "imageTool": {
+        "defaultStatus": {
+          "text": "画像生成"
+        },
+        "emptyState": {
+          "text": "生成された画像はありません"
+        },
+        "failedStatus": {
+          "text": "画像の生成に失敗しました"
+        },
+        "generatedStatus": {
+          "text": "{count, plural, one {# 枚の画像を生成しました} other {# 枚の画像を生成しました}}"
+        },
+        "generatingImagesStatus": {
+          "text": "画像を生成中..."
+        },
+        "generatingStatus": {
+          "text": "画像を生成中..."
+        }
+      },
+      "memoizedLink": {
+        "questionFallback": {
+          "label": "質問"
+        }
+      },
+      "messageEditing": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "submitButton": {
+          "label": "送信"
+        }
+      },
+      "messageSwitcher": {
+        "disabledWhileStreaming": {
+          "tooltip": "エージェントのメッセージが完了するまでお待ちください"
+        },
+        "nextButton": {
+          "tooltip": "次へ"
+        },
+        "previousButton": {
+          "tooltip": "前へ"
+        }
+      },
+      "multiModelPanel": {
+        "deselectButton": {
+          "tooltip": "優先する応答の選択を解除"
+        },
+        "hideButton": {
+          "tooltip": "応答を非表示"
+        },
+        "preferredResponse": {
+          "label": "優先する応答"
+        },
+        "selectButton": {
+          "label": "この応答を選択"
+        },
+        "selectPanel": {
+          "ariaLabel": "{model} の応答を選択"
+        },
+        "showButton": {
+          "tooltip": "応答を表示"
+        },
+        "showPanel": {
+          "ariaLabel": "{model} の応答を表示"
+        }
+      },
+      "rateLimitBanner": {
+        "defaultError": {
+          "text": "使用量の上限に達しました。"
+        },
+        "resetsInDays": {
+          "text": "{count, plural, one {# 日} other {# 日}}後にリセットされます ({at})。"
+        },
+        "resetsInHours": {
+          "text": "{count, plural, one {# 時間} other {# 時間}}後にリセットされます ({at})。"
+        },
+        "resetsInMinutes": {
+          "text": "{count, plural, one {# 分} other {# 分}}後にリセットされます ({at})。"
+        },
+        "tryAgainNow": {
+          "text": "今すぐ再試行できます。"
+        }
+      },
+      "resubmit": {
+        "regenerateButton": {
+          "label": "再生成"
+        },
+        "responseError": {
+          "text": "応答でエラーが発生しました。"
+        }
+      },
+      "text": {
+        "thinkingPlaceholder": {
+          "text": "思考中"
+        }
+      },
+      "timeline": {
+        "codingAgent": {
+          "bashExit": {
+            "header": "Bash · 終了コード {exitCode}"
+          },
+          "bashRequest": {
+            "label": "リクエスト"
+          },
+          "bashResponse": {
+            "label": "レスポンス"
+          },
+          "bashRunning": {
+            "header": "Bash · 実行中…"
+          },
+          "bashTimedOut": {
+            "header": "Bash · タイムアウト"
+          },
+          "noOutput": {
+            "text": "出力なし"
+          },
+          "response": {
+            "header": "レスポンス"
+          },
+          "task": {
+            "header": "コーディングタスク"
+          },
+          "taskWithRepo": {
+            "text": "{query}\n\nリポジトリ: {repo}"
+          },
+          "thinking": {
+            "header": "思考中"
+          }
+        },
+        "collapseButton": {
+          "ariaLabel": "タイムラインを折りたたむ"
+        },
+        "deepResearchPlan": {
+          "expandable": {
+            "title": "リサーチプラン"
+          },
+          "generated": {
+            "status": "プランを生成しました"
+          },
+          "generating": {
+            "status": "プランを生成中"
+          }
+        },
+        "doneStep": {
+          "header": "完了"
+        },
+        "expandButton": {
+          "ariaLabel": "タイムラインを展開"
+        },
+        "fetch": {
+          "reading": {
+            "status": "読み取り中"
+          }
+        },
+        "fileReader": {
+          "charRange": {
+            "label": "{total, number} 文字中 {start, number}–{end, number} 文字目"
+          },
+          "read": {
+            "status": "{fileName} を読み取りました ({total, number} 文字中 {start, number}–{end, number} 文字目)"
+          },
+          "reading": {
+            "status": "ファイルを読み取り中"
+          }
+        },
+        "generatedImages": {
+          "label": "{count, plural, one {# 枚の画像を生成しました} other {# 枚の画像を生成しました}}"
+        },
+        "header": {
+          "executingCode": {
+            "label": "コードを実行中"
+          },
+          "executingNamedTool": {
+            "label": "{toolName} を実行中"
+          },
+          "executingTool": {
+            "label": "ツールを実行中"
+          },
+          "generatingImage": {
+            "label": "画像を生成中..."
+          },
+          "generatingImages": {
+            "label": "画像を生成中"
+          },
+          "generatingPlan": {
+            "label": "プランを生成中"
+          },
+          "reading": {
+            "label": "読み取り中"
+          },
+          "readingFile": {
+            "label": "ファイルを読み取り中"
+          },
+          "researching": {
+            "label": "リサーチ中"
+          },
+          "searchingWeb": {
+            "label": "ウェブを検索中"
+          },
+          "thinking": {
+            "label": "思考中"
+          },
+          "thinkingEllipsis": {
+            "label": "思考中..."
+          },
+          "updatingMemory": {
+            "label": "メモリを更新中..."
+          }
+        },
+        "internalSearch": {
+          "noResults": {
+            "text": "結果が見つかりません"
+          },
+          "reading": {
+            "status": "読み取り中"
+          }
+        },
+        "interruptedThinking": {
+          "label": "中断された思考"
+        },
+        "memory": {
+          "default": {
+            "status": "メモリ"
+          },
+          "disabled": {
+            "text": "メモリツールは無効です"
+          },
+          "updating": {
+            "status": "メモリを更新中"
+          },
+          "viewMemoriesButton": {
+            "tooltip": "メモリを表示"
+          }
+        },
+        "memoryTag": {
+          "added": {
+            "label": "メモリに追加しました"
+          },
+          "updated": {
+            "label": "メモリを更新しました"
+          }
+        },
+        "python": {
+          "completed": {
+            "status": "Python の実行が完了しました"
+          },
+          "default": {
+            "status": "Python の実行"
+          },
+          "error": {
+            "label": "エラー:"
+          },
+          "executing": {
+            "status": "Python コードを実行中..."
+          },
+          "failed": {
+            "status": "Python の実行に失敗しました"
+          },
+          "generatedFiles": {
+            "label": "{count, plural, one {# 件のファイルを生成しました} other {# 件のファイルを生成しました}}"
+          },
+          "noOutput": {
+            "text": "出力なし"
+          },
+          "output": {
+            "label": "出力:"
+          },
+          "runningCode": {
+            "label": "コードを実行中..."
+          },
+          "writingCode": {
+            "status": "コードを作成中..."
+          }
+        },
+        "reasoning": {
+          "fullText": {
+            "title": "全文"
+          },
+          "thinking": {
+            "status": "思考中"
+          }
+        },
+        "researchAgent": {
+          "report": {
+            "title": "リサーチレポート"
+          },
+          "task": {
+            "title": "リサーチタスク"
+          }
+        },
+        "searchChips": {
+          "showMore": {
+            "label": "他 {count} 件"
+          },
+          "viewFullQuery": {
+            "tooltip": "検索語の全文を表示"
+          }
+        },
+        "stepsButton": {
+          "label": "{count, plural, one {# ステップ} other {# ステップ}}"
+        },
+        "stoppedStep": {
+          "header": "停止しました"
+        },
+        "thoughtDuration": {
+          "label": "{duration} 思考しました"
+        },
+        "thoughtUnknownDuration": {
+          "label": "しばらく思考しました"
+        },
+        "toggleRow": {
+          "ariaLabel": "タイムラインを切り替え"
+        },
+        "toolNames": {
+          "codeInterpreter": "コードインタープリター",
+          "codingAgent": "コーディングエージェント",
+          "customTool": "カスタムツール",
+          "generateImage": "画像生成",
+          "generatePlan": "プラン生成",
+          "internalSearch": "社内検索",
+          "memory": "メモリ",
+          "openUrls": "URL を開く",
+          "researchAgent": "リサーチエージェント",
+          "thinking": "思考",
+          "tool": "ツール",
+          "webSearch": "ウェブ検索"
+        },
+        "webSearch": {
+          "searching": {
+            "status": "ウェブを検索中"
+          }
+        }
+      },
+      "toolbar": {
+        "dislikeButton": {
+          "removeTooltip": "低評価を取り消す",
+          "tooltip": "良くない応答"
+        },
+        "likeButton": {
+          "removeTooltip": "高評価を取り消す",
+          "tooltip": "良い応答"
+        },
+        "regenerateButton": {
+          "tooltip": "別のモデルで再試行"
+        },
+        "sourcesTag": {
+          "label": "ソース"
+        }
+      },
+      "tts": {
+        "loadingButton": {
+          "tooltip": "読み込み中..."
+        },
+        "playButton": {
+          "tooltip": "読み上げ"
+        },
+        "playbackError": {
+          "toast": "音声を再生できませんでした"
+        },
+        "stopButton": {
+          "tooltip": "再生を停止"
+        }
+      }
+    },
+    "modals": {
+      "confirmEntity": {
+        "confirmButton": {
+          "label": "確認"
+        },
+        "confirmation": {
+          "description": "<b>{entityName}</b> を{action}してもよろしいですか？"
+        },
+        "deleteAction": {
+          "label": "削除"
+        },
+        "deleteButton": {
+          "label": "削除"
+        },
+        "header": {
+          "title": "{entityType}を{action}"
+        },
+        "modifyAction": {
+          "label": "変更"
+        }
+      },
+      "editProperty": {
+        "header": {
+          "title": "{property} を編集"
+        },
+        "submitButton": {
+          "label": "プロパティを更新",
+          "loadingLabel": "更新中..."
+        },
+        "valueInput": {
+          "placeholder": "プロパティの値"
+        }
+      },
+      "feedback": {
+        "additionalDetails": {
+          "dislikePlaceholder": "この応答のどこが良くなかったですか？",
+          "label": "詳細を入力",
+          "likePlaceholder": "この応答のどこが良かったですか？"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "header": {
+          "title": "フィードバック"
+        },
+        "submitButton": {
+          "label": "送信",
+          "loadingLabel": "送信中..."
+        }
+      },
+      "genericConfirm": {
+        "confirmButton": {
+          "label": "確認"
+        }
+      },
+      "preview": {
+        "code": {
+          "headerDescription": "{language} - {lineCount, plural, one {# 行} other {# 行}} · {fileSize}"
+        },
+        "copyButton": {
+          "tooltip": "内容をコピー"
+        },
+        "csv": {
+          "footer": "{columnCount, plural, one {# 列} other {# 列}} • {rowCount, plural, one {# 行} other {# 行}}",
+          "headerDescription": "CSV - {rowCount, plural, one {# 行} other {# 行}} • {fileSize}",
+          "rowSeparator": "{count, plural, one {# 行} other {# 行}}"
+        },
+        "docx": {
+          "headerDescription": "{count, plural, one {Word 文書 • # 語} other {Word 文書 • # 語}}",
+          "headerDescriptionFallback": "Word 文書",
+          "legacyDocMessage": "従来の .doc 形式はプレビューできません。ファイルをダウンロードして表示してください。",
+          "loadError": {
+            "message": "この文書をプレビューできませんでした。ファイルをダウンロードして表示してください。"
+          }
+        },
+        "downloadButton": {
+          "label": "ファイルをダウンロード",
+          "tooltip": "ダウンロード"
+        },
+        "exceptionTrace": {
+          "defaultTitle": "例外トレースの全文"
+        },
+        "header": {
+          "fallbackTitle": "ドキュメント"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# 行} other {# 行}}"
+        },
+        "loadError": {
+          "message": "ドキュメントを読み込めませんでした。"
+        },
+        "pdf": {
+          "iframeTitle": "PDF ビューアー"
+        },
+        "text": {
+          "headerDescription": "{lineCount, plural, one {# 行} other {# 行}} · {fileSize}"
+        },
+        "unsupported": {
+          "message": "このファイル形式はプレビューに対応していません。"
+        },
+        "xlsx": {
+          "headerDescription": "スプレッドシート - {count, plural, one {#シート} other {#シート}}",
+          "parseError": {
+            "message": "このスプレッドシートはプレビューできません。"
+          },
+          "sheetCount": "{count, plural, one {#シート} other {#シート}}"
+        },
+        "zoomControls": {
+          "level": "{zoom}%",
+          "zoomInTooltip": "拡大",
+          "zoomOutTooltip": "縮小"
+        }
+      },
+      "share": {
+        "addPeople": {
+          "groupSuggestion": {
+            "description": "グループ"
+          },
+          "permissionMenu": {
+            "ariaLabel": "設定する権限を選択"
+          },
+          "searchInput": {
+            "placeholder": "ユーザー、グループ、アカウントを追加"
+          },
+          "sharedTag": {
+            "label": "共有済み"
+          }
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "copyLinkButton": {
+          "label": "リンクをコピー"
+        },
+        "createLinkButton": {
+          "label": "共有リンクを作成"
+        },
+        "generateLinkErrorToast": {
+          "message": "共有リンクを生成できませんでした"
+        },
+        "genericErrorToast": {
+          "message": "エラーが発生しました"
+        },
+        "header": {
+          "description": "このチャットの既存および今後のすべてのメッセージが共有されます。",
+          "sharedTitle": "チャットを共有しました",
+          "title": "このチャットを共有"
+        },
+        "linkCopiedToast": {
+          "message": "共有リンクをクリップボードにコピーしました！"
+        },
+        "linkInput": {
+          "copyTooltip": "リンクをコピー"
+        },
+        "makePrivateButton": {
+          "label": "非公開にする"
+        },
+        "makePrivateErrorToast": {
+          "message": "チャットを非公開にできませんでした"
+        },
+        "nowPrivateToast": {
+          "message": "チャットを非公開にしました"
+        },
+        "organizationOption": {
+          "description": "組織内の全員がこのチャットを閲覧できます。",
+          "title": "所属組織"
+        },
+        "permissionMenu": {
+          "edit": {
+            "label": "編集"
+          },
+          "removeAccess": {
+            "label": "アクセス権を削除"
+          },
+          "viewAndChat": {
+            "label": "閲覧とチャット"
+          }
+        },
+        "privateOption": {
+          "description": "このチャットにアクセスできるのはあなただけです。",
+          "title": "非公開"
+        },
+        "scope": {
+          "invitedOnly": {
+            "label": "招待した相手のみ"
+          },
+          "organization": {
+            "label": "組織内の全員"
+          }
+        },
+        "transferOwnership": {
+          "currentOwner": {
+            "label": "現在の所有者"
+          },
+          "groupTag": {
+            "label": "グループ"
+          },
+          "targetInput": {
+            "label": "所有権の譲渡先",
+            "placeholder": "ユーザーまたはグループを追加"
+          },
+          "trailingButton": {
+            "tooltip": "所有権を譲渡"
+          }
+        }
+      },
+      "unsavedChanges": {
+        "body": {
+          "description": "変更は保存されていません。このまま移動すると、変更は失われます。"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "discardButton": {
+          "label": "変更を破棄"
+        },
+        "header": {
+          "title": "保存していない変更を破棄しますか？"
+        }
+      },
+      "userFiles": {
+        "addFilesButton": {
+          "label": "ファイルを追加"
+        },
+        "doneButton": {
+          "label": "完了"
+        },
+        "emptyState": {
+          "description": "ファイルが見つかりません"
+        },
+        "fileCount": {
+          "label": "{count, plural, one {# 件のファイル} other {# 件のファイル}}"
+        },
+        "fileStatus": {
+          "deleting": {
+            "label": "削除中..."
+          },
+          "processing": {
+            "label": "処理中..."
+          },
+          "uploading": {
+            "label": "アップロード中..."
+          }
+        },
+        "searchInput": {
+          "placeholder": "ファイルを検索..."
+        },
+        "selectedCount": {
+          "label": "{count, plural, one {# 件のファイルを選択中} other {# 件のファイルを選択中}}"
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "管理者により、このモデルの推論レベルは低く制限されています。"
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "セッションごとの token 上限",
+          "title": "コンテキストウィンドウ"
+        },
+        "unknown": {
+          "tooltip": "このモデルのコンテキストサイズは不明です。チャットには自動的に token 上限が適用されます。"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "モデルが見つかりません"
+        },
+        "loading": {
+          "text": "モデルを読み込み中..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "{model} の設定",
+        "tooltip": "モデル設定"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "モデルを追加"
+        },
+        "noModels": {
+          "tooltip": "設定済みのモデルがありません"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "高"
+        },
+        "low": {
+          "label": "低"
+        },
+        "medium": {
+          "label": "中"
+        },
+        "off": {
+          "label": "オフ"
+        },
+        "row": {
+          "caption": "回答前にモデルが行う思考の量",
+          "title": "推論レベル"
+        },
+        "xhigh": {
+          "label": "最高"
+        }
+      },
+      "searchInput": {
+        "placeholder": "モデルを検索..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "バランス"
+        },
+        "creative": {
+          "label": "創造的"
+        },
+        "deterministic": {
+          "label": "決定的"
+        },
+        "row": {
+          "caption": "モデルの応答をどれだけ予測可能または創造的にするか",
+          "title": "温度"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "モデルを選択"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "このモデルでは、この設定の変更に対応していません。"
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "同意チェックボックス"
+      },
+      "consentRequired": {
+        "error": "アプリケーションを利用するには、規約に同意する必要があります。"
+      },
+      "header": {
+        "title": "Onyx へようこそ！"
+      },
+      "logoIcon": {
+        "alt": "ロゴ"
+      },
+      "startButton": {
+        "label": "開始"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "共有チャットにメッセージがありません。"
+      },
+      "header": {
+        "owner": {
+          "text": "{name} による"
+        },
+        "sharedOn": {
+          "text": "{date} に共有"
+        },
+        "untitledChat": {
+          "title": "新しいチャット"
+        }
+      },
+      "newChatButton": {
+        "label": "新しいチャットを開始"
+      },
+      "notFound": {
+        "description": "指定された ID の共有チャットが見つかりませんでした。",
+        "title": "共有チャットが見つかりません"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "何かお手伝いできることはありますか？",
+        "startText": "始めましょう。"
+      },
+      "incognito": {
+        "title": "シークレットモードです"
+      }
+    }
+  },
+  "knowledge": {
+    "addView": {
+      "connectedSources": {
+        "label": "接続済みソース"
+      },
+      "documentSets": {
+        "label": "ドキュメントセット"
+      },
+      "yourFiles": {
+        "description": "最近または新規のアップロード",
+        "label": "マイファイル"
+      }
+    },
+    "browser": {
+      "copyLink": {
+        "tooltip": "リンクをコピー"
+      },
+      "empty": {
+        "folder": {
+          "description": "このフォルダーに項目はありません。"
+        },
+        "root": {
+          "description": "フォルダーを選択してドキュメントを閲覧してください。"
+        }
+      },
+      "loadFoldersError": {
+        "description": "フォルダーを読み込めませんでした"
+      },
+      "loadingFolders": {
+        "description": "フォルダーを読み込み中..."
+      },
+      "loadingMore": {
+        "description": "さらに読み込み中..."
+      },
+      "selectedCount": {
+        "label": "{count, plural, one {# 件の項目を選択中} other {# 件の項目を選択中}}"
+      },
+      "selectedItems": {
+        "label": "選択した項目"
+      },
+      "sort": {
+        "ascending": {
+          "lastUpdated": {
+            "label": "古い順"
+          },
+          "name": {
+            "label": "A から Z"
+          }
+        },
+        "descending": {
+          "lastUpdated": {
+            "label": "新しい順"
+          },
+          "name": {
+            "label": "Z から A"
+          }
+        },
+        "folders": {
+          "title": "フォルダー"
+        },
+        "foldersMixed": {
+          "label": "ファイルと混在"
+        },
+        "foldersOnTop": {
+          "label": "先頭に表示"
+        },
+        "sortBy": {
+          "title": "並べ替え"
+        },
+        "sortingOrder": {
+          "title": "並び順"
+        }
+      }
+    },
+    "documentSets": {
+      "empty": {
+        "description": "利用できるドキュメントセットがありません。"
+      },
+      "filter": {
+        "placeholder": "ドキュメントセットを絞り込み..."
+      }
+    },
+    "mainContent": {
+      "empty": {
+        "description": "このエージェントが使用するドキュメントまたは接続済みソースを追加してください。"
+      },
+      "selectedCount": {
+        "label": "{count, plural, one {# 件のナレッジソースを選択中} other {# 件のナレッジソースを選択中}}"
+      },
+      "viewEdit": {
+        "label": "表示 / 編集"
+      }
+    },
+    "pane": {
+      "header": {
+        "description": "このエージェントが応答の参考に使用するコネクターやドキュメントを追加します。",
+        "title": "ナレッジ"
+      },
+      "useKnowledge": {
+        "description": "このエージェントが応答の参考としてこれらのドキュメントを参照できるようにします。",
+        "title": "ナレッジを使用"
+      }
+    },
+    "recentFiles": {
+      "addFile": {
+        "label": "ファイルを追加"
+      },
+      "empty": {
+        "description": "利用できるファイルがありません。ファイルをアップロードして始めてください。"
+      },
+      "filter": {
+        "placeholder": "ファイルを絞り込み..."
+      },
+      "processing": {
+        "description": "Onyx はアップロードされたファイルをまだ処理中です。今すぐエージェントを作成できますが、処理が完了するまで一部のファイルにはアクセスできません。"
+      }
+    },
+    "search": {
+      "error": {
+        "description": "検索に失敗しました。もう一度お試しください。"
+      },
+      "input": {
+        "placeholder": "ドキュメントを検索..."
+      },
+      "loading": {
+        "description": "検索中..."
+      },
+      "noResults": {
+        "description": "結果が見つかりません。"
+      },
+      "noResultsInSource": {
+        "description": "{source} に結果が見つかりません。"
+      },
+      "prompt": {
+        "description": "検索語を入力して Enter キーを押してください。"
+      },
+      "sidebar": {
+        "all": {
+          "label": "すべて"
+        }
+      },
+      "stale": {
+        "description": "Enter キーを押すと新しい結果を表示します。"
+      }
+    },
+    "sidebar": {
+      "documentSet": {
+        "label": "ドキュメントセット"
+      },
+      "yourFiles": {
+        "label": "マイファイル"
+      }
+    },
+    "table": {
+      "columns": {
+        "lastUpdated": {
+          "header": "最終更新"
+        },
+        "name": {
+          "header": "名前"
+        },
+        "sources": {
+          "header": "ソース"
+        }
+      },
+      "empty": {
+        "description": "利用できる項目がありません。"
+      },
+      "filter": {
+        "placeholder": "絞り込み..."
+      }
+    }
+  },
+  "onboarding": {
+    "finalStep": {
+      "imageGeneration": {
+        "button": {
+          "label": "画像生成"
+        },
+        "description": "チャットで画像を作成できるようにモデルを設定します。",
+        "title": "画像生成を有効にする"
+      },
+      "inviteTeam": {
+        "button": {
+          "label": "ユーザー管理"
+        },
+        "description": "チームのユーザーと権限を管理します",
+        "title": "チームを招待する"
+      },
+      "webSearch": {
+        "button": {
+          "label": "ウェブ検索"
+        },
+        "description": "Onyx がインターネットで情報を検索できるようにします。",
+        "title": "ウェブ検索プロバイダーを選択"
+      }
+    },
+    "header": {
+      "progress": {
+        "label": "ステップ {current}/{total}"
+      }
+    },
+    "llmStep": {
+      "adminPanel": {
+        "label": "管理パネルで表示"
+      },
+      "connectedCount": {
+        "label": "{count, plural, one {# 個のモデルを接続済み} other {# 個のモデルを接続済み}}"
+      },
+      "customProvider": {
+        "subtitle": "LiteLLM 互換 API",
+        "title": "カスタム LLM プロバイダー"
+      },
+      "description": "Onyx はセルフホストのモデルと主要なプロバイダーの両方に対応しています。",
+      "edit": {
+        "ariaLabel": "LLM プロバイダーを編集"
+      },
+      "providerCard": {
+        "connect": {
+          "label": "接続"
+        }
+      },
+      "title": "LLM モデルを接続"
+    },
+    "nameStep": {
+      "description": "この名前をアプリ内に表示します。",
+      "edit": {
+        "ariaLabel": "表示名を編集",
+        "tooltip": "編集"
+      },
+      "input": {
+        "placeholder": "お名前"
+      },
+      "title": "Onyx はあなたを何と呼べばよいですか？"
+    },
+    "nonAdminStep": {
+      "confirmation": {
+        "title": "準備が完了しました！"
+      },
+      "save": {
+        "label": "保存"
+      },
+      "toasts": {
+        "saveNameFailed": "名前を保存できませんでした。もう一度お試しください。"
+      }
+    },
+    "steps": {
+      "complete": {
+        "button": {
+          "label": "セットアップを完了"
+        },
+        "title": "準備が完了しました。任意の設定を確認するか、「セットアップを完了」をクリックしてください"
+      },
+      "llmSetup": {
+        "button": {
+          "label": "次へ"
+        },
+        "title": "あと少しです。モデルを接続してチャットを始めましょう。"
+      },
+      "name": {
+        "button": {
+          "label": "次へ"
+        },
+        "title": "少しだけお時間をいただき、セットアップを行いましょう。"
+      },
+      "welcome": {
+        "button": {
+          "label": "はじめる"
+        },
+        "title": "少しだけお時間をいただき、セットアップを行いましょう。"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "匿名",
+        "description": "アカウントのメールアドレスです。",
+        "title": "メールアドレス"
+      },
+      "password": {
+        "changeButton": "パスワードを変更",
+        "description": "アカウントのパスワードを更新します。",
+        "title": "パスワード"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "新しいパスワード（確認）"
+        },
+        "currentPassword": {
+          "title": "現在のパスワード"
+        },
+        "newPassword": {
+          "title": "新しいパスワード"
+        },
+        "submit": {
+          "update": "更新",
+          "updating": "更新中..."
+        },
+        "title": "パスワードを変更",
+        "toasts": {
+          "networkError": "パスワードの変更中にエラーが発生しました",
+          "updateFailed": "パスワードを変更できませんでした",
+          "updated": "パスワードを更新しました"
+        }
+      },
+      "title": "アカウント"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "このトークンを使用するすべての API リクエストは、あなたのアクセス権限を継承し、あなた個人の操作として記録されます。",
+        "expiration": {
+          "days30": "30 日",
+          "days365": "365 日",
+          "days7": "7 日",
+          "expiresAtNote": "このトークンの有効期限: {date}",
+          "noExpiration": "有効期限なし",
+          "placeholder": "有効期限を選択",
+          "title": "有効期限"
+        },
+        "name": {
+          "placeholder": "トークンの名前を入力",
+          "title": "トークン名"
+        },
+        "permissions": {
+          "fullAccessNote": "あなたのすべての権限を継承します。",
+          "fullAccessOption": "フルアクセス",
+          "limitedAccessNote": "このトークンを特定の機能に制限します。",
+          "limitedAccessOption": "制限付きアクセス",
+          "placeholder": "権限を選択",
+          "title": "権限"
+        },
+        "submit": {
+          "create": "トークンを作成",
+          "creating": "トークンを作成中..."
+        },
+        "title": "アクセストークンを作成"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {# 日前に作成} other {# 日前に作成}}",
+        "createdToday": "本日作成",
+        "deleteTokenAriaLabel": "トークン {name} を削除",
+        "empty": "作成されたアクセストークンはありません。",
+        "expiresIn": "{count, plural, one {あと # 日で期限切れ} other {あと # 日で期限切れ}}",
+        "loading": "トークンを読み込み中...",
+        "neverExpires": "有効期限なし",
+        "newTokenButton": "新しいアクセストークン",
+        "noPermissionTooltip": "アクセストークンを作成する権限がありません",
+        "searchPlaceholder": "検索..."
+      },
+      "revokeModal": {
+        "description": "トークン {name}（{tokenDisplay}）を使用しているアプリケーションは、Onyx にアクセスできなくなります。この操作は取り消せません。",
+        "question": "このトークンを無効化しますか？",
+        "submit": "無効化",
+        "title": "アクセストークンを無効化"
+      },
+      "scopeSelector": {
+        "includedWith": "{label}（{lockReason} に含まれます）",
+        "loadError": "権限を読み込めませんでした。",
+        "loading": "権限を読み込み中..."
+      },
+      "section": {
+        "title": "アクセストークン"
+      },
+      "toasts": {
+        "createFailed": "トークンを作成できませんでした",
+        "createNetworkError": "トークンの作成中にネットワークエラーが発生しました",
+        "created": "トークンを作成しました",
+        "deleteFailed": "トークンを削除できませんでした",
+        "deleteNetworkError": "トークンの削除中にネットワークエラーが発生しました",
+        "deleted": "トークンを削除しました",
+        "loadFailed": "トークンを読み込めませんでした",
+        "loadPermissionsFailed": "権限オプションを読み込めませんでした",
+        "nameRequired": "トークン名は必須です"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "トークンをコピー",
+        "description": "続行する前にこのトークンを保存してください。再度表示することはできません。",
+        "title": "アクセストークン"
+      },
+      "upsell": {
+        "description": "アクセストークンの利用には有効な有料プランが必要です。",
+        "upgradeButton": "プランをアップグレード"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "なし",
+        "optionAriaLabel": "{label} の背景{selected, select, true {（選択中）} other {}}",
+        "title": "チャットの背景"
+      },
+      "colorMode": {
+        "auto": "自動",
+        "dark": "ダーク",
+        "description": "UI で使用するカラーモードを選択してください。",
+        "light": "ライト",
+        "title": "カラーモード"
+      },
+      "title": "外観"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "チャットが応答を生成するときに、新しい内容へ自動でスクロールします。",
+        "title": "チャットの自動スクロール"
+      },
+      "collapseLargePastes": {
+        "description": "3 行または 200 文字を超えるテキストを貼り付けたときに、インラインで挿入せずコンパクトなタイルにまとめます。タイルをクリックすると全文を表示または編集できます。",
+        "title": "大きな貼り付けを折りたたむ"
+      },
+      "defaultAppMode": {
+        "chatOption": "チャット",
+        "description": "新しいセッションを検索モードとチャットモードのどちらで開始するかを選択します。",
+        "disabledTooltip": "検索 UI は無効です。管理者のみが有効にできます。",
+        "searchOption": "検索",
+        "title": "デフォルトのアプリモード"
+      },
+      "defaultModel": {
+        "description": "Onyx はチャットでこのモデルをデフォルトで使用します。",
+        "title": "デフォルトのモデル"
+      },
+      "defaultReasoningLevel": {
+        "description": "新しいチャットの初期推論レベルです。モデルに対する管理者の設定は常に適用され、個々のチャットではモデル設定でこの値を上書きできます。",
+        "title": "デフォルトの推論レベル"
+      },
+      "defaultTemperature": {
+        "description": "新しいチャットの初期 Temperature です。モデルに対する管理者の設定は常に適用され、個々のチャットではモデル設定でこの値を上書きできます。",
+        "title": "デフォルトの Temperature"
+      },
+      "smoothStreaming": {
+        "description": "ストリーミング応答を 1 文字ずつアニメーション表示します。無効にすると、受信したチャンクをそのまま表示します。",
+        "title": "スムーズストリーミング"
+      },
+      "title": "チャット",
+      "toasts": {
+        "saveFailed": "設定を保存できませんでした",
+        "saved": "設定を保存しました"
+      }
+    },
+    "connectors": {
+      "connectButton": "接続",
+      "disconnectModal": {
+        "continueNote": "{name} のコンテンツを参照している既存のセッションは、引き続き利用できます。",
+        "description": "Onyx はあなたの {name} アカウントのコンテンツにアクセスまたは検索できなくなります。",
+        "disconnecting": "切断中...",
+        "submit": "切断",
+        "title": "*{name}* を切断"
+      },
+      "emptyMessage": "組織に設定されたコネクターはありません。",
+      "status": {
+        "connected": "接続済み",
+        "notConnected": "未接続",
+        "paused": "一時停止中"
+      },
+      "title": "コネクター",
+      "toasts": {
+        "disconnectFailed": "切断できませんでした",
+        "disconnected": "切断しました"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "すべてのチャットを削除",
+        "confirm": {
+          "deleting": "削除中...",
+          "description": "すべてのチャットセッションと履歴が完全に削除されます。削除は取り消せません。",
+          "question": "すべてのチャットを削除しますか？",
+          "submit": "削除",
+          "title": "すべてのチャットを削除"
+        },
+        "description": "すべてのチャットセッションを完全に削除します。",
+        "title": "すべてのチャットを削除",
+        "toasts": {
+          "deleteFailed": "すべてのチャットセッションを削除できませんでした",
+          "deleted": "すべてのチャットセッションを削除しました。"
+        }
+      },
+      "title": "危険な操作"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "新しいトークン",
+        "description": "アプリケーションを接続する前に、スコープを設定したトークンを作成してください。",
+        "title": "アクセストークン"
+      },
+      "copyButton": {
+        "copied": "コピーしました",
+        "copy": "コピー",
+        "copyError": "値をコピーできませんでした。"
+      },
+      "description": "Onyx で利用できるモデルに外部ツールを接続します。",
+      "guideButton": "ガイド",
+      "models": {
+        "description": "{count, plural, one {お使いのアカウントで # 個のモデルを利用できます。プロバイダーを開いて ID をコピーしてください。} other {お使いのアカウントで # 個のモデルを利用できます。プロバイダーを開いて ID をコピーしてください。}}",
+        "title": "モデル"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# 個のモデルが利用可能} other {# 個のモデルが利用可能}}"
+      },
+      "title": "LLM ゲートウェイ",
+      "url": {
+        "description": "このベース URL を、互換性のある OpenAI および Anthropic のクライアントで使用してください。",
+        "title": "ゲートウェイ URL"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "UI で使用する言語を選択してください。",
+        "title": "表示言語"
+      },
+      "title": "言語",
+      "toasts": {
+        "updateFailed": "言語設定を更新できませんでした"
+      }
+    },
+    "memory": {
+      "empty": {
+        "description": "Onyx に覚えておいてほしい個人的なメモやメモリを追加します。"
+      },
+      "referenceStoredMemories": {
+        "description": "チャットで保存済みのメモリを Onyx が参照できるようにします。",
+        "title": "保存済みメモリを参照"
+      },
+      "title": "メモリ",
+      "updateMemories": {
+        "description": "Onyx が保存済みのメモリを生成・更新できるようにします。",
+        "title": "メモリを更新"
+      },
+      "viewAll": {
+        "description": "すべてのメモリ",
+        "title": "表示・追加"
+      }
+    },
+    "personalPreferences": {
+      "description": "カスタム設定を自然な文章で入力してください。",
+      "placeholder": "システムに期待する動作と、使ってほしい口調を記述してください。",
+      "title": "個人設定"
+    },
+    "profile": {
+      "fullName": {
+        "description": "この名前をアプリ内に表示します。",
+        "placeholder": "お名前",
+        "title": "氏名"
+      },
+      "title": "プロフィール",
+      "toasts": {
+        "updateFailed": "パーソナライズ設定を更新できませんでした",
+        "updated": "パーソナライズ設定を更新しました"
+      },
+      "workRole": {
+        "description": "役割を入力すると、応答をより適切に調整できます。",
+        "placeholder": "あなたの役割",
+        "title": "職務"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "以下の内容を 1〜2 文で簡潔に要約してください：",
+        "promptPlaceholder": "要約",
+        "publicTooltip": "公開のプロンプトショートカットは削除できません。",
+        "removeAriaLabel": "ショートカットを削除"
+      },
+      "title": "プロンプトショートカット",
+      "toasts": {
+        "bothRequired": "ショートカットと展開後のテキストの両方が必要です",
+        "created": "ショートカットを作成しました",
+        "deleteFailed": "ショートカットを削除できませんでした",
+        "deleted": "ショートカットを削除しました",
+        "loadFailed": "ショートカットを読み込めませんでした",
+        "saveFailed": "ショートカットを保存できませんでした",
+        "updated": "ショートカットを更新しました"
+      },
+      "toggle": {
+        "description": "ショートカットを有効にすると、よく使うプロンプトをすばやく挿入できます。",
+        "title": "プロンプトショートカットを使用"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "音声応答を自動で再生します。",
+        "title": "自動再生"
+      },
+      "autoSend": {
+        "description": "話し終わったときに音声入力を自動で送信します。",
+        "title": "停止時に自動送信"
+      },
+      "playbackSpeed": {
+        "description": "音声再生の速度を調整します。",
+        "title": "再生速度"
+      },
+      "title": "音声"
+    }
+  },
+  "sidebar": {
+    "adminNav": {
+      "items": {
+        "addConnector": {
+          "label": "コネクターを追加"
+        },
+        "agents": {
+          "label": "エージェント"
+        },
+        "analytics": {
+          "label": "分析"
+        },
+        "appearanceAndTheming": {
+          "label": "外観とテーマ"
+        },
+        "chatPreferences": {
+          "label": "チャット設定"
+        },
+        "codeInterpreter": {
+          "label": "コードインタープリター"
+        },
+        "craftAccess": {
+          "label": "アクセス"
+        },
+        "craftApps": {
+          "label": "アプリ"
+        },
+        "craftInstructions": {
+          "label": "指示"
+        },
+        "customAnalytics": {
+          "label": "カスタム分析"
+        },
+        "discordIntegration": {
+          "label": "Discord 連携"
+        },
+        "documentSets": {
+          "label": "ドキュメントセット"
+        },
+        "existingConnectors": {
+          "label": "既存のコネクター"
+        },
+        "exportLogs": {
+          "label": "ログのエクスポート"
+        },
+        "groups": {
+          "label": "グループ"
+        },
+        "hookExtensions": {
+          "label": "フック拡張"
+        },
+        "imageGeneration": {
+          "label": "画像生成"
+        },
+        "indexSettings": {
+          "label": "インデックス設定"
+        },
+        "languageModels": {
+          "label": "言語モデル"
+        },
+        "mcpActions": {
+          "label": "MCP アクション"
+        },
+        "openapiActions": {
+          "label": "OpenAPI アクション"
+        },
+        "plansAndBilling": {
+          "label": "プランと請求"
+        },
+        "queryHistory": {
+          "label": "クエリ履歴"
+        },
+        "scim": {
+          "label": "SCIM"
+        },
+        "securityAndHardening": {
+          "label": "セキュリティと堅牢化"
+        },
+        "serviceAccounts": {
+          "label": "サービスアカウント"
+        },
+        "slackIntegration": {
+          "label": "Slack 連携"
+        },
+        "ssoProviders": {
+          "label": "SSO プロバイダー"
+        },
+        "tracing": {
+          "label": "トレース"
+        },
+        "upgradePlan": {
+          "label": "プランをアップグレード"
+        },
+        "usage": {
+          "label": "使用状況"
+        },
+        "users": {
+          "label": "ユーザー"
+        },
+        "voice": {
+          "label": "音声"
+        },
+        "webSearch": {
+          "label": "Web 検索"
+        }
+      },
+      "sections": {
+        "agentsAndActions": {
+          "label": "エージェントとアクション"
+        },
+        "craft": {
+          "label": "Craft"
+        },
+        "documentsAndKnowledge": {
+          "label": "ドキュメントとナレッジ"
+        },
+        "integrations": {
+          "label": "連携"
+        },
+        "organization": {
+          "label": "組織"
+        },
+        "permissions": {
+          "label": "権限"
+        },
+        "usage": {
+          "label": "使用状況"
+        }
+      }
+    },
+    "adminSidebar": {
+      "businessOrEnterpriseOnly": {
+        "tooltip": "この機能は [Onyx の Business 版または Enterprise 版](/admin/billing) でのみ利用できます。"
+      },
+      "enterpriseOnly": {
+        "tooltip": "この機能は [Onyx の Enterprise 版](/admin/billing) でのみ利用できます。"
+      },
+      "exitAdminPanel": {
+        "label": "管理パネルを終了"
+      },
+      "search": {
+        "label": "検索"
+      },
+      "searchInput": {
+        "placeholder": "検索..."
+      }
+    },
+    "appSidebar": {
+      "adminPanel": {
+        "label": "管理パネル"
+      },
+      "agents": {
+        "title": "エージェント"
+      },
+      "craft": {
+        "label": "Craft"
+      },
+      "exploreAgents": {
+        "label": "エージェントを探す"
+      },
+      "moreAgents": {
+        "label": "その他のエージェント"
+      },
+      "moveChatError": {
+        "message": "チャットを移動できませんでした。もう一度お試しください。"
+      },
+      "newProject": {
+        "label": "新しいプロジェクト",
+        "tooltip": "新しいプロジェクト"
+      },
+      "newSession": {
+        "label": "新しいセッション"
+      },
+      "projects": {
+        "title": "プロジェクト"
+      },
+      "recents": {
+        "empty": {
+          "text": "メッセージを送信してみましょう。チャット履歴がここに表示されます。"
+        },
+        "title": "最近の項目"
+      },
+      "searchChats": {
+        "label": "チャットを検索"
+      }
+    },
+    "chatButton": {
+      "createProject": {
+        "label": "{projectName} を作成"
+      },
+      "createProjectError": {
+        "message": "プロジェクトを作成できませんでした。もう一度お試しください。"
+      },
+      "delete": {
+        "label": "削除"
+      },
+      "deleteConfirmation": {
+        "confirmButton": {
+          "label": "削除"
+        },
+        "description": "このチャットを削除しますか？この操作は取り消せません。",
+        "title": "チャットを削除"
+      },
+      "deleteError": {
+        "message": "チャットを削除できませんでした。もう一度お試しください。"
+      },
+      "moveToProject": {
+        "label": "プロジェクトに移動"
+      },
+      "projectSearchInput": {
+        "placeholder": "プロジェクトを検索"
+      },
+      "removeFromProject": {
+        "label": "{projectName} から削除"
+      },
+      "rename": {
+        "label": "名前を変更"
+      },
+      "share": {
+        "label": "共有"
+      }
+    },
+    "chatSearch": {
+      "createNamedProject": {
+        "label": "新しいプロジェクト「<name>{projectName}</name>」を作成"
+      },
+      "footer": {
+        "openAction": {
+          "label": "開く"
+        },
+        "selectAction": {
+          "label": "選択"
+        },
+        "showAllAction": {
+          "label": "すべて表示"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "チャットやプロジェクトはまだありません"
+        },
+        "noResults": {
+          "text": "結果が見つかりません"
+        }
+      },
+      "newProject": {
+        "label": "新しいプロジェクト"
+      },
+      "newSession": {
+        "label": "新しいセッション"
+      },
+      "noMoreResults": {
+        "text": "これ以上の結果はありません"
+      },
+      "projectsFilter": {
+        "label": "プロジェクト"
+      },
+      "recentFilter": {
+        "label": "最近"
+      },
+      "recentSessionsFilter": {
+        "label": "最近のセッション"
+      },
+      "searchInput": {
+        "placeholder": "チャットセッションやプロジェクトを検索..."
+      },
+      "sessionsFilter": {
+        "label": "セッション"
+      }
+    },
+    "createConnector": {
+      "advancedStep": {
+        "label": "詳細設定（任意）"
+      },
+      "connectorStep": {
+        "label": "コネクター"
+      },
+      "credentialStep": {
+        "label": "認証情報"
+      },
+      "exitSetup": {
+        "label": "コネクター設定を終了"
+      }
+    },
+    "notifications": {
+      "empty": {
+        "title": "通知はありません"
+      },
+      "header": {
+        "title": "通知"
+      },
+      "markAllAsReadButton": {
+        "tooltip": "すべて既読にする"
+      },
+      "markAsReadButton": {
+        "tooltip": "既読にする"
+      },
+      "newSection": {
+        "title": "新着"
+      },
+      "olderSection": {
+        "title": "以前"
+      },
+      "unreadCount": {
+        "label": "{count, plural, one {未読 # 件} other {未読 # 件}}"
+      }
+    }
+  },
+  "skills": {
+    "modals": {
+      "addInstruction": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "header": {
+          "description": "このプロジェクトのチャットセッションでの動作や口調を指定します。",
+          "title": "プロジェクトの指示を設定"
+        },
+        "instructionsField": {
+          "placeholder": "私の目的は…です。回答では必ず…してください。"
+        },
+        "saveButton": {
+          "label": "指示を保存"
+        }
+      },
+      "create": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "continueButton": {
+          "label": "スキルを確認",
+          "loadingLabel": "開いています…"
+        },
+        "header": {
+          "description": "SKILL.md ファイル、ZIP ファイル、またはスキルフォルダーをアップロードします。保存する前に詳細を確認して編集できます。",
+          "title": "スキルをアップロード"
+        },
+        "readError": {
+          "message": "スキルを読み込めませんでした"
+        },
+        "requirements": {
+          "frontmatter": "SKILL.md には、名前と説明を含む有効なフロントマターが必要です。",
+          "singleSkill": "スキルは一度に 1 つずつアップロードしてください。",
+          "title": "ファイルの要件",
+          "zip": "ZIP ファイルには SKILL.md ファイルを含める必要があります。"
+        }
+      },
+      "importGithub": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "doneButton": {
+          "label": "完了"
+        },
+        "header": {
+          "chooseDescription": "{repository} からスキルを選択してください。",
+          "completeDescription": "スキルに追加された内容を確認してください。",
+          "completeTitle": "GitHub からのインポートが完了しました",
+          "description": "GitHub リポジトリから 1 つ以上のスキルをインポートします。",
+          "title": "GitHub からインポート"
+        },
+        "importError": {
+          "message": "スキルをインポートできませんでした。",
+          "title": "スキルをインポートできませんでした"
+        },
+        "loadError": {
+          "message": "リポジトリを読み込めませんでした。",
+          "title": "リポジトリを読み込めませんでした"
+        },
+        "privateRepos": {
+          "askAdmin": "パブリックリポジトリはそのままインポートできます。プライベートリポジトリをインポートする前に、管理者に GitHub の設定を依頼してください。",
+          "connect": "パブリックリポジトリはそのままインポートできます。プライベートリポジトリをインポートするには GitHub を接続してください。",
+          "connectButton": {
+            "label": "GitHub を接続"
+          },
+          "connected": "パブリックリポジトリはそのままインポートできます。プライベートリポジトリでは、お使いの GitHub 接続を使用します。",
+          "needsConnection": "パブリックリポジトリはそのままインポートできます。プライベートリポジトリには GitHub 接続が必要です。",
+          "setUp": "パブリックリポジトリはそのままインポートできます。プライベートリポジトリをインポートする前に GitHub を設定してください。",
+          "setUpButton": {
+            "label": "GitHub を設定"
+          }
+        },
+        "repositoryInput": {
+          "label": "リポジトリ"
+        },
+        "result": {
+          "disabledCount": "同じ名前のスキルが有効になっているため、{count} 件は無効の状態でインポートしました。",
+          "enabledCount": "{count} 件を自動的に有効にしました。",
+          "failedCount": "{count} 件をインポートできませんでした。",
+          "importedSection": {
+            "title": "インポート済み"
+          },
+          "importedTitle": "{count, plural, one {# 件のスキルをインポートしました} other {# 件のスキルをインポートしました}}",
+          "noneTitle": "インポートされたスキルはありません",
+          "notImportedSection": {
+            "title": "インポートなし"
+          },
+          "notSelectedCount": "{count} 件は選択されていません。"
+        },
+        "selectAll": {
+          "ariaLabel": "インポート可能なすべてのスキルを選択"
+        },
+        "selection": {
+          "label": "インポート可能な{total, plural, one {# 件のスキル} other {# 件のスキル}}のうち {selected} 件を選択中"
+        },
+        "skillCheckbox": {
+          "ariaLabel": "{name} を選択"
+        },
+        "skillTag": {
+          "disabled": "無効",
+          "enabled": "有効"
+        },
+        "submitButton": {
+          "importLabel": "{count, plural, one {スキルをインポート} other {# 件のスキルをインポート}}",
+          "importingLabel": "インポート中…",
+          "searchLabel": "リポジトリを検索",
+          "searchingLabel": "検索中…"
+        },
+        "unavailableFallback": "このスキルはインポートできません。",
+        "unavailableTag": {
+          "label": "インポート不可"
+        }
+      },
+      "nameConflict": {
+        "body": "新しいスキルは無効な状態で作成されます。どちらを有効にするかは「スキル」ページで切り替えられます。",
+        "confirmButton": {
+          "label": "このまま作成",
+          "pendingLabel": "作成中..."
+        },
+        "description": "この名前の有効なスキルがすでに存在します。",
+        "title": "「{name}」という名前のスキルをもう 1 つ作成しますか？"
+      },
+      "preview": {
+        "closeButton": {
+          "label": "閉じる"
+        },
+        "fallbackTitle": "スキルのプレビュー",
+        "instructions": {
+          "title": "指示"
+        },
+        "loadError": {
+          "description": "プレビューを一度閉じてから、もう一度開いてください。",
+          "title": "スキルを読み込めませんでした"
+        },
+        "metadata": {
+          "createdBy": {
+            "label": "作成者"
+          },
+          "externalApp": {
+            "label": "外部アプリ"
+          }
+        },
+        "noInstructions": {
+          "message": "指示が見つかりません。"
+        },
+        "unavailable": {
+          "appDisabled": "アプリ「{appName}」は管理者によって無効にされています。",
+          "appNotConnected": "このスキルを使用するには、「アプリ」ページからアプリ「{appName}」を接続してください。",
+          "title": "スキルを利用できません"
+        }
+      },
+      "share": {
+        "backButton": {
+          "label": "戻る"
+        },
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "currentUserLabel": "{email}（自分）",
+        "doneButton": {
+          "label": "完了"
+        },
+        "externalAppNotice": "このスキルがアプリ「{appName}」に関連付けられている間は、組織全体への閲覧者アクセスが必要です。",
+        "header": {
+          "title": "*{name}* を共有",
+          "transferTitle": "*{name}* を譲渡"
+        },
+        "loading": {
+          "message": "共有設定を読み込み中..."
+        },
+        "noOwnerTitle": "有効な所有者がいません",
+        "organizationPermissionMenu": {
+          "ariaLabel": "組織の権限を変更"
+        },
+        "ownerLabel": "所有者",
+        "permissionMenu": {
+          "ariaLabel": "{name} のアクセス権を更新"
+        },
+        "saveButton": {
+          "label": "保存"
+        },
+        "saveErrorToast": {
+          "message": "共有設定を更新できませんでした"
+        },
+        "savedToast": {
+          "message": "共有設定を更新しました。"
+        },
+        "scopeMenu": {
+          "ariaLabel": "共有範囲を変更"
+        },
+        "transferButton": {
+          "label": "譲渡"
+        },
+        "transferErrorToast": {
+          "message": "所有権を譲渡できませんでした"
+        },
+        "transferredToast": {
+          "message": "所有権を譲渡しました。"
+        }
+      }
+    },
+    "sections": {
+      "bundlePicker": {
+        "chooseDifferent": {
+          "label": "別のファイルを選択"
+        },
+        "noFile": {
+          "description": "ファイルが選択されていません"
+        },
+        "preparing": {
+          "label": "アップロードを準備中..."
+        },
+        "upload": {
+          "label": "ドラッグ＆ドロップするか、クリックしてアップロード"
+        }
+      },
+      "fileTree": {
+        "empty": {
+          "description": "補助ファイルはまだありません。"
+        },
+        "remove": {
+          "label": "{name} を削除"
+        }
+      },
+      "filesPicker": {
+        "addFiles": {
+          "label": "ファイルを追加"
+        },
+        "input": {
+          "ariaLabel": "スキルファイルを追加"
+        },
+        "preparing": {
+          "label": "準備中..."
+        },
+        "prompt": {
+          "description": "ファイルまたは ZIP を選択するか、フォルダーをここにドロップしてください。"
+        }
+      },
+      "instructionsToggle": {
+        "group": {
+          "ariaLabel": "指示の表示モード"
+        },
+        "raw": {
+          "label": "生の Markdown"
+        },
+        "rendered": {
+          "label": "レンダリング済み Markdown"
+        }
+      },
+      "upload": {
+        "error": {
+          "readFailed": "アップロードされたファイルを読み込めませんでした。"
+        }
+      }
+    }
+  }
+}

--- a/web/src/i18n/messages/keyParity.ts
+++ b/web/src/i18n/messages/keyParity.ts
@@ -12,7 +12,10 @@ import type de from "@/i18n/messages/de.json";
 import type en from "@/i18n/messages/en.json";
 import type es from "@/i18n/messages/es.json";
 import type fr from "@/i18n/messages/fr.json";
+import type ja from "@/i18n/messages/ja.json";
+import type ko from "@/i18n/messages/ko.json";
 import type pt from "@/i18n/messages/pt.json";
+import type zh from "@/i18n/messages/zh.json";
 
 /** Compiles only when `Catalog` has every key of `Shape`, same nesting. */
 type Covers<Catalog extends Shape, Shape> = Catalog;
@@ -33,4 +36,16 @@ export type FrenchParity = [
 export type GermanParity = [
   Covers<typeof de, typeof en>,
   Covers<typeof en, typeof de>,
+];
+export type JapaneseParity = [
+  Covers<typeof ja, typeof en>,
+  Covers<typeof en, typeof ja>,
+];
+export type SimplifiedChineseParity = [
+  Covers<typeof zh, typeof en>,
+  Covers<typeof en, typeof zh>,
+];
+export type KoreanParity = [
+  Covers<typeof ko, typeof en>,
+  Covers<typeof en, typeof ko>,
 ];

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -1,0 +1,9561 @@
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "계정"
+    },
+    "helpFaq": {
+      "label": "도움말 및 FAQ"
+    },
+    "logIn": {
+      "label": "로그인"
+    },
+    "logoutFailed": {
+      "message": "로그아웃하지 못했습니다"
+    },
+    "notifications": {
+      "label": "알림"
+    },
+    "profileUnavailable": {
+      "title": "프로필을 사용할 수 없음"
+    },
+    "settings": {
+      "label": "설정"
+    },
+    "signOut": {
+      "label": "로그아웃"
+    }
+  },
+  "actions": {
+    "actionButtons": {
+      "authenticateButton": {
+        "ariaLabel": "{serverName}에 인증하고 연결",
+        "label": "인증"
+      },
+      "deleteButton": {
+        "ariaLabel": "{serverName} 서버 삭제",
+        "tooltip": "서버 삭제"
+      },
+      "disconnectButton": {
+        "ariaLabel": "{serverName} 서버 연결 해제",
+        "tooltip": "서버 연결 해제"
+      },
+      "fetchingTools": {
+        "label": "도구를 가져오는 중..."
+      },
+      "manageButton": {
+        "ariaLabel": "{serverName} 서버 관리",
+        "tooltip": "서버 관리"
+      },
+      "reconnectButton": {
+        "ariaLabel": "{serverName}에 다시 연결",
+        "label": "다시 연결"
+      },
+      "viewToolsButton": {
+        "ariaLabel": "{serverName}의 도구 보기",
+        "label": "{count, plural, one {도구 #개 보기} other {도구 #개 보기}}"
+      }
+    },
+    "actionCard": {
+      "card": {
+        "ariaLabel": "{title} 액션 카드"
+      }
+    },
+    "addMcpModal": {
+      "addHeader": {
+        "description": "MCP(Model Context Protocol) 서버를 연결하여 사용자 지정 액션을 추가하세요.",
+        "title": "MCP 서버 추가"
+      },
+      "authStatus": {
+        "apiTokenDescription": "API token 설정됨",
+        "connectedDescription": "연결됨",
+        "oauthDescription": "{owner}에 OAuth로 연결됨",
+        "title": "인증 및 연결됨"
+      },
+      "cancelButton": {
+        "label": "취소"
+      },
+      "description": {
+        "placeholder": "MCP 서버에 대한 자세한 설명",
+        "suffix": "선택 사항",
+        "title": "설명"
+      },
+      "disconnectButton": {
+        "tooltip": "서버 연결 해제"
+      },
+      "editConfigsButton": {
+        "label": "설정 편집"
+      },
+      "manageHeader": {
+        "description": "MCP 서버 구성을 업데이트하고 인증을 관리합니다.",
+        "title": "MCP 서버 관리"
+      },
+      "name": {
+        "placeholder": "MCP 서버 이름을 입력하세요",
+        "required": "서버 이름은 필수입니다",
+        "title": "서버 이름"
+      },
+      "serverUrl": {
+        "invalid": "유효한 URL이어야 합니다",
+        "required": "서버 URL은 필수입니다",
+        "subDescription": "신뢰할 수 있는 서버에만 연결하세요. 이 연결로 수행되는 작업과 도구를 최신 상태로 유지하는 책임은 사용자에게 있습니다.",
+        "title": "MCP 서버 URL"
+      },
+      "submitButton": {
+        "addLabel": "서버 추가",
+        "addingLabel": "추가하는 중...",
+        "saveLabel": "변경 사항 저장",
+        "savingLabel": "저장하는 중..."
+      },
+      "toasts": {
+        "createFailed": "MCP 서버를 만들지 못했습니다",
+        "serverCreated": "MCP 서버를 만들었습니다",
+        "serverUpdated": "MCP 서버를 업데이트했습니다",
+        "updateFailed": "MCP 서버를 업데이트하지 못했습니다"
+      }
+    },
+    "addOpenApiModal": {
+      "addHeader": {
+        "description": "OpenAPI 스키마를 추가하여 사용자 지정 액션을 추가하세요.",
+        "title": "OpenAPI 액션 추가"
+      },
+      "authStatus": {
+        "configuredTitle": "인증 구성됨",
+        "enabledTitle": "인증 및 활성화됨",
+        "headersDescription": "사용자 지정 인증 헤더 구성됨",
+        "oauthDescription": "OAuth 인증 구성됨",
+        "oauthNamedDescription": "{name}을(를) 통해 OAuth 연결됨",
+        "passthroughDescription": "패스스루 인증 활성화됨"
+      },
+      "cancelButton": {
+        "label": "취소"
+      },
+      "copyButton": {
+        "tooltip": "정의 복사"
+      },
+      "definition": {
+        "invalidJson": "잘못된 JSON 형식입니다",
+        "placeholder": "여기에 OpenAPI 스키마를 입력하세요",
+        "required": "OpenAPI 스키마 정의는 필수입니다",
+        "subDescription": "이 액션의 일부로 제공할 API를 정의하는 OpenAPI 스키마를 지정하세요. 스키마의 어느 위치(예: 서버 URL, 경로, 파라미터 기본값)에나 `CHAT_SESSION_ID`, `MESSAGE_ID`, `USER_ID`, `USER_EMAIL` 자리 표시자를 사용할 수 있으며, 호출 시점에 현재 요청의 값으로 대체됩니다. [OpenAPI 액션]({docsUrl})에 대해 자세히 알아보세요.",
+        "title": "OpenAPI 스키마 정의"
+      },
+      "disableButton": {
+        "tooltip": "액션 비활성화"
+      },
+      "editConfigsButton": {
+        "disabledTooltip": "액션을 만든 사용자 또는 관리자만 인증을 관리할 수 있습니다",
+        "label": "설정 편집"
+      },
+      "editHeader": {
+        "description": "이 액션의 OpenAPI 스키마를 업데이트합니다.",
+        "title": "OpenAPI 액션 편집"
+      },
+      "empty": {
+        "description": "OpenAPI 스키마를 입력하면 여기에서 액션을 미리 볼 수 있습니다.",
+        "title": "액션을 찾을 수 없음"
+      },
+      "formatButton": {
+        "tooltip": "정의 서식 지정"
+      },
+      "method": {
+        "noSummary": "요약이 제공되지 않음"
+      },
+      "serverUrl": {
+        "description": "스키마에서 찾은 URL입니다. 신뢰할 수 있는 서버에만 연결하세요."
+      },
+      "submitButton": {
+        "addLabel": "액션 추가",
+        "addingLabel": "추가하는 중...",
+        "saveLabel": "변경 사항 저장",
+        "savingLabel": "저장하는 중..."
+      },
+      "toasts": {
+        "actionCreated": "OpenAPI 액션을 만들었습니다",
+        "actionUpdated": "OpenAPI 액션을 업데이트했습니다",
+        "createFailed": "OpenAPI 액션을 만들지 못했습니다",
+        "invalidJson": "OpenAPI 스키마 정의의 JSON 형식이 잘못되었습니다",
+        "updateFailed": "OpenAPI 액션을 업데이트하지 못했습니다"
+      }
+    },
+    "cardHeader": {
+      "disconnected": {
+        "label": "(연결 해제됨)"
+      },
+      "notAuthenticated": {
+        "label": "(인증되지 않음)"
+      },
+      "renameButton": {
+        "ariaLabel": "{title} 이름 변경",
+        "tooltip": "이름 변경"
+      }
+    },
+    "cardSkeleton": {
+      "card": {
+        "ariaLabel": "액션 카드를 불러오는 중"
+      }
+    },
+    "disconnectModal": {
+      "body": {
+        "confirmation": "계속하시겠습니까?",
+        "description": "{name}에 연결된 모든 도구가 작동을 멈춥니다. 필요하면 나중에 이 서버에 다시 연결할 수 있습니다."
+      },
+      "cancelButton": {
+        "label": "취소"
+      },
+      "confirmButton": {
+        "label": "연결 해제",
+        "pendingLabel": "연결을 해제하는 중..."
+      },
+      "deleteButton": {
+        "label": "연결 해제 및 삭제"
+      },
+      "header": {
+        "title": "*{name}* 연결 해제"
+      }
+    },
+    "mcpAuthModal": {
+      "additionalAuthParams": {
+        "label": "추가 인증 파라미터(JSON)"
+      },
+      "advanced": {
+        "description": "자동 검색 대신 권한 부여 엔드포인트와 token 엔드포인트를 직접 지정하여 알려진 OAuth 공급자를 구성합니다.",
+        "title": "고급"
+      },
+      "apiKey": {
+        "required": "API token은 필수입니다"
+      },
+      "apiKeyTabs": {
+        "admin": {
+          "label": "공유 키(관리자)"
+        },
+        "perUser": {
+          "label": "개별 키(사용자별)"
+        }
+      },
+      "authPerformer": {
+        "required": "인증 수행자는 필수입니다"
+      },
+      "authType": {
+        "apiToken": {
+          "description": "사용자별 개별 API 키 또는 조직 전체 공유 API 키를 사용합니다.",
+          "label": "API 키"
+        },
+        "label": "인증 방법",
+        "none": {
+          "description": "권장하지 않음",
+          "label": "없음"
+        },
+        "oauth": {
+          "description": "각 사용자가 자신의 자격 증명으로 OAuth 인증을 해야 합니다.",
+          "label": "OAuth"
+        },
+        "placeholder": "방법 선택",
+        "ptOauth": {
+          "description": "Onyx 인증에 사용된 사용자의 OAuth 액세스 token을 전달합니다.",
+          "label": "OAuth 패스스루"
+        },
+        "required": "인증 유형은 필수입니다"
+      },
+      "authorizationEndpoint": {
+        "label": "권한 부여 엔드포인트",
+        "required": "알려진 공급자 모드에서는 권한 부여 엔드포인트가 필수입니다"
+      },
+      "cancelButton": {
+        "label": "취소"
+      },
+      "clientId": {
+        "label": "클라이언트 ID"
+      },
+      "clientSecret": {
+        "label": "클라이언트 시크릿"
+      },
+      "errors": {
+        "additionalParamsInvalid": "추가 인증 파라미터 JSON이 잘못되었습니다",
+        "additionalParamsInvalidWithReason": "추가 인증 파라미터 JSON이 잘못되었습니다: {reason}",
+        "additionalParamsNotObject": "추가 인증 파라미터는 JSON 객체여야 합니다",
+        "oauthInitFailed": "OAuth를 시작하지 못했습니다: {detail}",
+        "saveAuthFailed": "인증 구성을 저장하지 못했습니다",
+        "saveConfigFailed": "서버 구성을 저장하지 못했습니다"
+      },
+      "header": {
+        "defaultTitle": "MCP 서버 인증",
+        "description": "MCP 서버를 사용하려면 연결을 인증하세요.",
+        "title": "*{name}* 인증"
+      },
+      "knownProvider": {
+        "hint": "알려진 공급자 모드에서는 엔드포인트 구성이 필요합니다. Google 참조 엔드포인트: 권한 부여 {authorizationEndpoint}, token {tokenEndpoint}."
+      },
+      "noAuthNotice": {
+        "description": "이 연결에는 인증을 사용하지 않습니다. 이 서버를 신뢰할 수 있는지 확인하세요. 이 연결로 수행되는 작업에 대한 책임은 사용자에게 있습니다.",
+        "title": "이 MCP 서버에 인증 없음"
+      },
+      "oauthInfo": {
+        "discovery": "클라이언트 ID와 시크릿은 선택 사항입니다. 자동 검색 중에 Onyx는 지원되는 경우 Client ID Metadata Document(CIMD)를 사용하고, 지원되지 않으면 Dynamic Client Registration(DCR)으로 대체합니다.",
+        "manualRegistration": "서버가 두 방법을 모두 지원하지 않으면 먼저 서버 공급자에 Onyx 인스턴스를 등록하세요. 액션에 필요한 스코프를 Onyx에 부여하세요."
+      },
+      "passThroughNotice": {
+        "description": "Onyx는 사용자의 OAuth 액세스 token을 Authorization 헤더로 서버에 직접 전달합니다. 서버가 동일한 공급자로 인증을 지원하는지 확인하세요.",
+        "title": "ID 공급자를 공유하는 서비스에는 패스스루를 사용하세요."
+      },
+      "providerMode": {
+        "autoDiscovery": {
+          "description": "MCP SDK 챌린지/검색 플로우를 사용합니다(기본값).",
+          "label": "자동 검색"
+        },
+        "knownProvider": {
+          "description": "구성된 권한 부여/token 엔드포인트를 사용합니다.",
+          "label": "알려진 공급자"
+        },
+        "label": "공급자 모드",
+        "placeholder": "모드 선택"
+      },
+      "redirectUri": {
+        "copyTooltip": "리디렉션 URI 복사",
+        "label": "**리디렉션 URI** 사용:"
+      },
+      "scopesOverride": {
+        "label": "스코프 재정의(쉼표로 구분)"
+      },
+      "sharedApiKey": {
+        "description": "개인 API 키는 사용하지 마세요. 이 키를 조직의 모든 사용자와 공유해도 되는지 확인하세요.",
+        "label": "API 키",
+        "placeholder": "조직의 공유 API 키"
+      },
+      "submitButton": {
+        "label": "연결",
+        "pendingLabel": "연결하는 중..."
+      },
+      "tokenEndpoint": {
+        "label": "Token 엔드포인트",
+        "required": "알려진 공급자 모드에서는 token 엔드포인트가 필수입니다"
+      },
+      "transport": {
+        "required": "전송 방식은 필수입니다"
+      }
+    },
+    "mcpCard": {
+      "card": {
+        "ariaLabel": "{title} MCP 서버 카드"
+      },
+      "deleteModal": {
+        "body": {
+          "confirmation": "이 MCP 서버를 삭제하시겠습니까?",
+          "description": "<emphasis>{title}</emphasis>에 연결된 모든 도구가 제거됩니다. 삭제는 되돌릴 수 없습니다."
+        },
+        "submitButton": {
+          "label": "삭제"
+        },
+        "title": "MCP 서버 삭제"
+      },
+      "lastRefreshed": {
+        "label": "도구 마지막 새로 고침 {time}"
+      },
+      "refreshToolsButton": {
+        "ariaLabel": "도구 새로 고침",
+        "tooltip": "도구 새로 고침"
+      }
+    },
+    "mcpPage": {
+      "addButton": {
+        "label": "MCP 서버 추가"
+      },
+      "empty": {
+        "description": "MCP 서버를 연결하여 사용자 지정 액션을 추가하세요."
+      },
+      "errors": {
+        "unknown": "알 수 없는 오류"
+      },
+      "toasts": {
+        "deleteFailed": "MCP 서버를 삭제하지 못했습니다",
+        "disableAllFailed": "모든 도구를 비활성화하지 못했습니다",
+        "disconnectFailed": "MCP 서버 연결을 해제하지 못했습니다",
+        "enableAllFailed": "모든 도구를 활성화하지 못했습니다",
+        "fetchToolsFailed": "도구를 가져오지 못했습니다: {error}",
+        "noToolsToDisable": "비활성화할 도구가 없습니다",
+        "reconnectFailed": "MCP 서버에 다시 연결하지 못했습니다",
+        "refreshToolsFailed": "도구를 새로 고치지 못했습니다",
+        "renameFailed": "MCP 서버 이름을 변경하지 못했습니다",
+        "serverDeleted": "MCP 서버를 삭제했습니다",
+        "serverDisconnected": "MCP 서버 연결을 해제했습니다",
+        "serverReconnected": "MCP 서버에 다시 연결했습니다",
+        "serverRenamed": "MCP 서버 이름을 변경했습니다",
+        "toolDisabled": "도구를 비활성화했습니다",
+        "toolEnabled": "도구를 활성화했습니다",
+        "toolUpdateFailed": "도구를 업데이트하지 못했습니다",
+        "toolsDisabled": "{count, plural, one {도구 #개를 비활성화했습니다} other {도구 #개를 비활성화했습니다}}",
+        "toolsEnabled": "{count, plural, one {도구 #개를 활성화했습니다} other {도구 #개를 활성화했습니다}}",
+        "toolsFetched": "연결한 후 도구를 가져왔습니다",
+        "toolsRefreshed": "도구를 새로 고쳤습니다"
+      }
+    },
+    "openApiAuthModal": {
+      "authMethod": {
+        "customHeader": {
+          "description": "모든 요청에 사용자 지정 헤더를 보냅니다.",
+          "label": "사용자 지정 Authorization 헤더"
+        },
+        "label": "인증 방법",
+        "oauth": {
+          "description": "각 사용자가 자신의 자격 증명으로 OAuth 인증을 합니다.",
+          "label": "OAuth"
+        },
+        "placeholder": "방법 선택",
+        "ptOauth": {
+          "description": "Onyx 인증에 사용된 사용자의 OAuth 액세스 token을 전달합니다.",
+          "label": "OAuth 패스스루"
+        },
+        "required": "인증 방법은 필수입니다"
+      },
+      "authorizationUrl": {
+        "label": "권한 부여 URL",
+        "required": "권한 부여 URL은 필수입니다"
+      },
+      "cancelButton": {
+        "label": "취소"
+      },
+      "clientId": {
+        "description": "현재 클라이언트 ID를 유지하려면 비워 두세요.",
+        "label": "OAuth 클라이언트 ID",
+        "required": "클라이언트 ID는 필수입니다"
+      },
+      "clientSecret": {
+        "description": "현재 클라이언트 시크릿을 유지하려면 비워 두세요.",
+        "label": "OAuth 클라이언트 시크릿",
+        "required": "클라이언트 시크릿은 필수입니다"
+      },
+      "errors": {
+        "invalidUrl": "유효한 URL을 입력하세요",
+        "loadConfigFailed": "기존 OAuth 구성을 불러오지 못했습니다. 업데이트하려면 세부 정보를 다시 입력하세요."
+      },
+      "header": {
+        "description": "OpenAPI 액션을 사용하려면 연결을 인증하세요."
+      },
+      "headers": {
+        "addButton": {
+          "label": "헤더 추가"
+        },
+        "description": "이 액션의 API 엔드포인트로 보내는 모든 요청에 사용할 사용자 지정 헤더를 지정하세요.",
+        "keyRequired": "헤더 키는 필수입니다",
+        "keyTitle": "헤더",
+        "minRequired": "인증 헤더를 하나 이상 추가하세요",
+        "title": "인증 헤더",
+        "valueRequired": "헤더 값은 필수입니다",
+        "valueTitle": "값"
+      },
+      "loading": {
+        "label": "기존 구성을 불러오는 중..."
+      },
+      "oauthLoginNotice": {
+        "description": "OAuth 패스스루에는 OAuth를 지원하는 로그인 방법(Google 또는 OIDC)이 필요합니다."
+      },
+      "passThroughNotice": {
+        "description": "Onyx는 사용자의 OAuth 액세스 token을 Authorization 헤더로 서버에 직접 전달합니다. 서버가 동일한 공급자로 인증을 지원하는지 확인하세요.",
+        "title": "ID 공급자를 공유하는 서비스에는 패스스루를 사용하세요."
+      },
+      "redirectUri": {
+        "copyTooltip": "리디렉션 URI 복사",
+        "label": "<emphasis>리디렉션 URI</emphasis> 사용:"
+      },
+      "scopes": {
+        "description": "요청할 OAuth 스코프를 쉼표로 구분하여 입력하세요.",
+        "label": "스코프 <optional>(선택 사항)</optional>",
+        "placeholder": "예: repo, user"
+      },
+      "submitButton": {
+        "label": "연결",
+        "pendingLabel": "연결하는 중..."
+      },
+      "tokenUrl": {
+        "label": "Token URL",
+        "required": "Token URL은 필수입니다"
+      }
+    },
+    "openApiCard": {
+      "card": {
+        "ariaLabel": "{name} OpenAPI 액션 카드"
+      },
+      "deleteModal": {
+        "body": {
+          "confirmation": "이 OpenAPI 액션을 삭제하시겠습니까?",
+          "description": "OpenAPI 액션 <emphasis>{name}</emphasis>과(와) 해당 구성이 영구적으로 삭제됩니다."
+        },
+        "submitButton": {
+          "label": "삭제"
+        },
+        "title": "OpenAPI 액션 삭제"
+      },
+      "method": {
+        "noSummary": "요약이 제공되지 않음"
+      },
+      "toolsList": {
+        "emptyMessage": "이 OpenAPI 스키마에 정의된 액션이 없습니다",
+        "emptySearchMessage": "검색과 일치하는 액션이 없습니다"
+      }
+    },
+    "openApiPage": {
+      "addButton": {
+        "label": "OpenAPI 액션 추가"
+      },
+      "authModal": {
+        "authenticateTitle": "{name} 인증",
+        "defaultTitle": "OpenAPI 액션 인증",
+        "updateTitle": "{name}의 인증 업데이트"
+      },
+      "empty": {
+        "description": "OpenAPI 스키마로 사용자 지정 액션을 추가하세요."
+      },
+      "toasts": {
+        "actionRenamed": "OpenAPI 액션 이름을 변경했습니다",
+        "authHeadersSaved": "{name}의 인증 헤더를 저장했습니다.",
+        "authPassthroughSaved": "{name}의 인증 패스스루를 저장했습니다.",
+        "authSaveFailed": "인증 설정을 저장하지 못했습니다.",
+        "authSaved": "{name}의 인증을 저장했습니다.",
+        "authUpdated": "{name}의 인증을 업데이트했습니다.",
+        "deleteFailed": "도구를 삭제하지 못했습니다.",
+        "deleteUnexpectedError": "도구를 삭제하는 중에 예기치 않은 오류가 발생했습니다.",
+        "disconnectFailed": "OpenAPI 액션의 연결을 해제하지 못했습니다.",
+        "renameFailed": "OpenAPI 액션 이름을 변경하지 못했습니다",
+        "toolDeleted": "{name}을(를) 삭제했습니다.",
+        "toolDisconnected": "{name}의 연결이 해제되었습니다."
+      }
+    },
+    "perUserAuth": {
+      "credentialField": {
+        "placeholder": "{field} 입력"
+      },
+      "credentials": {
+        "perUserDescription": "다음 자격 증명은 조직과 공유되지 않습니다.",
+        "perUserTitle": "내 계정 전용",
+        "sharedDescription": "이 값은 조직의 모든 사용자에게 사용됩니다.",
+        "sharedTitle": "조직 공유 값"
+      },
+      "headers": {
+        "addButton": {
+          "label": "헤더 추가"
+        },
+        "error": {
+          "message": "헤더 값 중 하나 이상에 {apiKey} 자리 표시자가 있어야 합니다."
+        },
+        "keyTitle": "헤더 이름",
+        "label": "인증 헤더",
+        "perUserDescription": "각 사용자가 개별 자격 증명을 입력할 수 있도록 헤더 형식을 지정하세요. <mono>{apiKey}</mono> 또는 <mono>{userEmail}</mono> 같은 자리 표시자를 사용하세요. 사용자에게 자리 표시자의 값을 입력하라는 메시지가 표시됩니다(user_email 제외).",
+        "sharedDescription": "조직의 공유 자격 증명과 함께 보낼 헤더의 형식을 지정하세요. 헤더 값 중 하나 이상에 <mono>{apiKey}</mono> 같은 자리 표시자를 사용하세요. 이 자리 표시자는 조직의 공유 키로 대체됩니다.",
+        "valueTitle": "헤더 값"
+      }
+    },
+    "policyToggle": {
+      "always": {
+        "label": "자동 승인"
+      },
+      "ask": {
+        "label": "확인 요청"
+      },
+      "deny": {
+        "label": "거부"
+      }
+    },
+    "toolItem": {
+      "unavailable": {
+        "label": "도구를 사용할 수 없음"
+      }
+    },
+    "toolsList": {
+      "disableAllButton": {
+        "ariaLabel": "모든 도구 비활성화",
+        "tooltip": "모든 도구 비활성화"
+      },
+      "empty": {
+        "message": "사용할 수 있는 도구가 없습니다",
+        "searchMessage": "도구를 찾을 수 없습니다"
+      },
+      "enableAllButton": {
+        "label": "모두 활성화"
+      },
+      "showAllButton": {
+        "ariaLabel": "모든 도구 표시",
+        "tooltip": "모든 도구 표시"
+      },
+      "showEnabledButton": {
+        "ariaLabel": "활성화된 도구만 표시",
+        "tooltip": "활성화된 항목만 표시"
+      }
+    },
+    "toolsSection": {
+      "foldButton": {
+        "label": "접기"
+      },
+      "search": {
+        "ariaLabel": "도구 검색",
+        "placeholder": "도구 검색…"
+      }
+    }
+  },
+  "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "코드 저장소"
+        },
+        "messaging": {
+          "label": "메시징"
+        },
+        "other": {
+          "label": "기타"
+        },
+        "sales": {
+          "label": "영업"
+        },
+        "storage": {
+          "label": "클라우드 스토리지"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "티켓팅 및 작업 관리"
+        },
+        "wiki": {
+          "label": "지식 베이스 및 위키"
+        }
+      },
+      "popular": {
+        "title": "인기"
+      },
+      "search": {
+        "placeholder": "커넥터 검색"
+      },
+      "seeConnectorsButton": {
+        "label": "커넥터 보기"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>페더레이션 커넥터가 이미 구성되어 있습니다.</strong> 클릭하여 기존 커넥터를 편집하세요.",
+          "slackCredentialsFound": "<strong>기존 Slack 자격 증명을 찾았습니다.</strong> 클릭하여 Slack 커넥터를 관리하세요."
+        }
+      }
+    },
+    "agents": {
+      "deleteModal": {
+        "confirmation": {
+          "description": "<emphasis>{name}</emphasis>을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+        },
+        "header": {
+          "title": "에이전트 삭제"
+        },
+        "submitButton": {
+          "label": "삭제"
+        }
+      },
+      "emptyState": {
+        "description": "현재 검색과 일치하는 에이전트가 없습니다.",
+        "title": "에이전트를 찾을 수 없음"
+      },
+      "featuredModal": {
+        "addBody": {
+          "description": "추천 에이전트는 에이전트 탐색 목록의 맨 위에 표시되며, 접근 권한이 있는 신규 사용자의 사이드바에 자동으로 고정됩니다. 조직 전체에 권장 에이전트를 강조할 때 사용하세요."
+        },
+        "addHeader": {
+          "title": "{name} 추천 설정"
+        },
+        "featureButton": {
+          "label": "추천 설정"
+        },
+        "removeBody": {
+          "description": "{name}이(가) 에이전트 탐색 목록 맨 위의 추천 섹션에서 제거됩니다. 신규 사용자의 사이드바에는 더 이상 고정되지 않지만, 기존 고정은 영향을 받지 않습니다."
+        },
+        "removeHeader": {
+          "title": "추천에서 {name} 제거"
+        },
+        "unfeatureButton": {
+          "label": "추천 해제"
+        }
+      },
+      "header": {
+        "description": "에이전트로 AI 동작과 지식을 사용자 지정하세요. 조직의 에이전트를 관리합니다.",
+        "title": "에이전트"
+      },
+      "modals": {
+        "accessNote": {
+          "description": "이 설정은 이 에이전트에 접근할 수 있는 사용자를 변경하지 않습니다."
+        }
+      },
+      "newAgentButton": {
+        "label": "새 에이전트"
+      },
+      "reorderError": {
+        "message": "에이전트 순서를 업데이트하지 못했습니다"
+      },
+      "rowActions": {
+        "deleteItem": {
+          "title": "삭제"
+        },
+        "editAgentButton": {
+          "label": "에이전트 편집"
+        },
+        "genericError": {
+          "message": "오류가 발생했습니다"
+        },
+        "listItem": {
+          "title": "에이전트 목록에 표시"
+        },
+        "menuButton": {
+          "ariaLabel": "에이전트 작업"
+        },
+        "relistAgentButton": {
+          "label": "에이전트 다시 목록에 표시"
+        },
+        "removeFeaturedButton": {
+          "label": "추천 해제"
+        },
+        "setFeaturedButton": {
+          "label": "추천으로 설정"
+        },
+        "shareItem": {
+          "title": "공유"
+        },
+        "statsItem": {
+          "title": "통계"
+        },
+        "unlistItem": {
+          "title": "에이전트 목록에서 숨기기"
+        },
+        "updateSuccess": {
+          "message": "{name}을(를) 업데이트했습니다."
+        }
+      },
+      "search": {
+        "placeholder": "에이전트 검색..."
+      },
+      "table": {
+        "access": {
+          "featured": {
+            "label": "추천"
+          },
+          "private": {
+            "label": "비공개"
+          },
+          "public": {
+            "label": "공개"
+          },
+          "shared": {
+            "label": "공유됨"
+          },
+          "unlisted": {
+            "label": "목록에서 숨김"
+          }
+        },
+        "accessColumn": {
+          "header": "접근 권한"
+        },
+        "createdBy": {
+          "system": {
+            "label": "시스템"
+          }
+        },
+        "createdByColumn": {
+          "header": "만든 사람"
+        },
+        "descriptionColumn": {
+          "header": "설명"
+        },
+        "nameColumn": {
+          "header": "이름"
+        }
+      },
+      "unlistModal": {
+        "body": {
+          "description": "목록에서 숨긴 에이전트는 에이전트 탐색 목록에 표시되지 않습니다. 하지만 직접 링크로는 계속 접근할 수 있으며, 이전에 사용했거나 고정한 사용자도 계속 사용할 수 있습니다."
+        },
+        "header": {
+          "title": "*{name}* 목록에서 숨기기"
+        },
+        "submitButton": {
+          "label": "목록에서 숨기기"
+        }
+      }
+    },
+    "analytics": {
+      "agentChart": {
+        "description": "선택한 에이전트의 일별 메시지 수와 순 사용자 수",
+        "empty": "이 기간에 선택한 에이전트의 데이터가 없습니다.",
+        "error": "에이전트 데이터를 가져오지 못했습니다.",
+        "selectPrompt": "분석을 보려면 에이전트를 선택하세요.",
+        "series": {
+          "messages": {
+            "label": "메시지"
+          },
+          "uniqueUsers": {
+            "label": "순 사용자"
+          }
+        },
+        "title": "에이전트 분석"
+      },
+      "agentPicker": {
+        "empty": {
+          "label": "검색과 일치하는 에이전트가 없습니다"
+        },
+        "placeholder": "표시할 에이전트 선택",
+        "search": {
+          "placeholder": "에이전트 검색..."
+        }
+      },
+      "feedbackChart": {
+        "description": "기간별 좋아요 / 싫어요",
+        "empty": "선택한 기간에 피드백이 없습니다.",
+        "error": "피드백 데이터를 가져오지 못했습니다.",
+        "series": {
+          "negative": {
+            "label": "부정적 피드백"
+          },
+          "positive": {
+            "label": "긍정적 피드백"
+          }
+        },
+        "title": "피드백"
+      },
+      "page": {
+        "description": "쿼리, 피드백, 에이전트 전반에서 워크스페이스가 Onyx를 어떻게 사용하는지 확인하세요."
+      },
+      "reports": {
+        "calendar": {
+          "pickEnd": {
+            "label": "기간 종료일 선택"
+          },
+          "pickStart": {
+            "label": "기간 시작일 선택"
+          }
+        },
+        "description": "사용자별 사용량을 CSV 파일 ZIP으로 내보냅니다. 보고서는 백그라운드에서 생성되며 여기에 계속 남아 있습니다.",
+        "empty": {
+          "description": "아직 보고서가 없습니다. 기간을 선택하고 첫 보고서를 생성하세요."
+        },
+        "generateButton": {
+          "label": "보고서 생성",
+          "pendingLabel": "생성하는 중…"
+        },
+        "listError": {
+          "title": "사용량 보고서를 불러오지 못했습니다."
+        },
+        "pendingRow": {
+          "description": "{range} · 보통 1분 이내에 준비됩니다",
+          "slowDescription": "아직 작업 중입니다. 이 페이지를 벗어나도 되며, 보고서는 여기에 표시됩니다.",
+          "title": "보고서를 준비하는 중…"
+        },
+        "period": {
+          "allTime": {
+            "label": "전체 기간"
+          },
+          "custom": {
+            "label": "사용자 지정 기간…"
+          },
+          "last30Days": {
+            "label": "지난 30일"
+          },
+          "last3Months": {
+            "label": "지난 3개월"
+          },
+          "last7Days": {
+            "label": "지난 7일"
+          },
+          "today": {
+            "label": "오늘"
+          }
+        },
+        "row": {
+          "description": "{requestor} 생성 · {time}",
+          "downloadButton": {
+            "ariaLabel": "{label} 보고서 다운로드",
+            "tooltip": "ZIP 다운로드"
+          },
+          "systemRequestor": {
+            "label": "시스템"
+          }
+        },
+        "title": "사용량 보고서",
+        "toasts": {
+          "ready": "사용량 보고서가 준비되었습니다.",
+          "startFailed": "보고서 생성을 시작하지 못했습니다: {message}",
+          "timedOut": "보고서 생성에 시간이 너무 오래 걸립니다. 다시 시도하거나 나중에 확인하세요.",
+          "unknownError": "알 수 없는 오류"
+        }
+      },
+      "slackChannelChart": {
+        "description": "전체 쿼리 대비 자동 해결",
+        "empty": "선택한 기간에 이 워크스페이스의 OnyxBot 활동이 없습니다.",
+        "error": "OnyxBot 데이터를 가져오지 못했습니다.",
+        "series": {
+          "autoResolved": {
+            "label": "자동 해결됨"
+          },
+          "totalQueries": {
+            "label": "전체 쿼리"
+          }
+        },
+        "title": "Slack 채널"
+      },
+      "usageChart": {
+        "description": "기간별 사용량",
+        "empty": "선택한 기간에 쿼리가 없습니다.",
+        "error": "사용량 데이터를 가져오지 못했습니다.",
+        "series": {
+          "queries": {
+            "label": "쿼리"
+          },
+          "uniqueUsers": {
+            "label": "순 사용자"
+          }
+        },
+        "title": "사용량"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "라이선스를 처리하는 중입니다. 확인이 끝나면 결제 세부 정보로 자동 이동합니다.",
+        "title": "라이선스를 아직 활성화하는 중입니다"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "온라인 결제 관리가 비활성화되어 있습니다. 구독을 변경하려면 지원팀에 문의하세요.",
+          "title": "에어갭 배포"
+        },
+        "expired": {
+          "description": "유료 기능에 다시 접근하려면 구독을 갱신하세요.",
+          "title": "구독이 만료되었습니다.",
+          "withDate": {
+            "description": "{date}까지 구독을 갱신하면 접근 권한이 복구됩니다."
+          },
+          "withDeletion": {
+            "title": "구독이 만료되었습니다. {days}일 후에 데이터가 삭제됩니다."
+          }
+        },
+        "expiring": {
+          "description": "서비스 중단을 방지하려면 {date}까지 구독을 갱신하세요.",
+          "title": "구독이 {days}일 후에 만료됩니다."
+        },
+        "graceSync": {
+          "title": "갱신된 라이선스를 확인하는 중…"
+        },
+        "stripeError": {
+          "description": "인터넷 연결을 확인하거나 라이선스를 직접 입력하세요.",
+          "title": "Stripe 결제 포털에 연결할 수 없습니다."
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "요금제 조정"
+        },
+        "annual": {
+          "label": "연간"
+        },
+        "annualBadge": {
+          "label": "20% 절약"
+        },
+        "billingCycle": {
+          "description": "1개월 무료 체험 이후",
+          "title": "결제 주기"
+        },
+        "continueToPayment": {
+          "label": "결제로 계속"
+        },
+        "createSessionFailed": {
+          "error": "결제 세션을 만들지 못했습니다"
+        },
+        "loading": {
+          "label": "불러오는 중..."
+        },
+        "monthly": {
+          "label": "월간"
+        },
+        "perSeatMonth": {
+          "label": "시트당/월"
+        },
+        "plan": {
+          "title": "Business"
+        },
+        "price": {
+          "label": "${price}"
+        },
+        "seats": {
+          "description": "{count, plural, one {현재 사용자와 Slack 계정에는 최소 # 시트가 필요합니다.} other {현재 사용자와 Slack 계정에는 최소 # 시트가 필요합니다.}}",
+          "title": "시트 수"
+        },
+        "trialBilling": {
+          "text": "1개월 무료 체험이 끝나면 <value>{date}</value>에 결제됩니다."
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "라이선스 키 활성화"
+        },
+        "billingHelp": {
+          "label": "결제 도움말"
+        },
+        "licenseKeyPrompt": {
+          "label": "라이선스 키가 있으신가요?"
+        },
+        "updateLicenseKey": {
+          "label": "라이선스 키 업데이트"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "요금제 및 결제"
+        },
+        "upgradePlan": {
+          "title": "요금제 업그레이드"
+        },
+        "viewPlans": {
+          "title": "요금제 보기"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "라이선스를 활성화하지 못했습니다"
+        },
+        "activateLicense": {
+          "label": "라이선스 활성화"
+        },
+        "activateSuccess": {
+          "message": "라이선스를 활성화했습니다!"
+        },
+        "activateTitle": {
+          "title": "라이선스 키 활성화"
+        },
+        "activating": {
+          "label": "활성화 중..."
+        },
+        "activeUntil": {
+          "label": "라이선스 키는 <value>{date}</value>까지 유효합니다"
+        },
+        "cancel": {
+          "label": "취소"
+        },
+        "close": {
+          "label": "닫기"
+        },
+        "description": "이 Onyx 인스턴스에 라이선스를 직접 추가하고 활성화합니다.",
+        "emptyKey": {
+          "error": "라이선스 키를 입력하세요"
+        },
+        "error": {
+          "text": "{error}. <link>결제 도움말</link>"
+        },
+        "expired": {
+          "label": "라이선스 키가 만료되었습니다"
+        },
+        "keyField": {
+          "description": "Onyx에서 받은 라이선스 키를 붙여넣거나 키 파일을 첨부하세요.",
+          "title": "라이선스 키"
+        },
+        "updateKey": {
+          "label": "키 업데이트"
+        },
+        "updateLicense": {
+          "label": "라이선스 업데이트"
+        },
+        "updateSuccess": {
+          "message": "라이선스를 업데이트했습니다!"
+        },
+        "updateTitle": {
+          "title": "라이선스 키 업데이트"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "결제 수단",
+          "title": "Visa 끝자리 1234"
+        },
+        "lastPayment": {
+          "description": "최근 결제"
+        },
+        "section": {
+          "title": "결제"
+        },
+        "update": {
+          "label": "업데이트"
+        },
+        "viewInvoice": {
+          "label": "인보이스 보기"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "Business 플랜 시작하기"
+          },
+          "description": "연간 결제 시 시트당 월 요금\n월간 결제 시 시트당 $25",
+          "features": {
+            "apiKeys": "서비스 계정 API 키",
+            "documentPermissions": "문서 권한 상속",
+            "encryption": "보안 정보 암호화",
+            "queryHistory": "질의 기록 및 사용량 대시보드",
+            "rbac": "역할 기반 접근 제어(RBAC)",
+            "selfHosting": "자체 호스팅(선택)",
+            "theming": "맞춤 테마"
+          },
+          "featuresPrefix": "팀을 위한 AI로 더 많은 일을 처리하세요.",
+          "pricing": "$20",
+          "title": "Business"
+        },
+        "card": {
+          "ariaLabel": "{plan} 요금제 카드"
+        },
+        "currentPlan": {
+          "label": "현재 요금제"
+        },
+        "enterprise": {
+          "button": {
+            "label": "영업팀 문의"
+          },
+          "description": "대규모 조직을 위한 유연한 가격 및\n배포 옵션",
+          "features": {
+            "customDeployments": "맞춤 배포",
+            "customRoles": "맞춤 역할 및 권한",
+            "hookExtensions": "후크 확장",
+            "regionalProcessing": "지역별 데이터 처리",
+            "scim": "SCIM / 그룹 동기화",
+            "support": "Enterprise SLA 및 우선 지원",
+            "usageLimits": "설정 가능한 사용량 한도",
+            "whiteLabeling": "완전한 화이트 라벨링"
+          },
+          "featuresPrefix": "Business 플랜의 모든 기능에 더해:",
+          "title": "Enterprise"
+        },
+        "includedInPlan": {
+          "label": "요금제에 포함됨"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "현재 사용 중이거나 대기 중인 **{minimum}** 시트보다 적게 설정할 수 없습니다. 시트를 조정하기 전에 먼저 [사용자를 삭제](/admin/users)하세요."
+        },
+        "billing": {
+          "added": "{count, plural, one {추가한 시트 <value>{count}</value>개에 대해 일할 계산된 금액이 청구됩니다.} other {추가한 시트 <value>{count}</value>개에 대해 일할 계산된 금액이 청구됩니다.}}",
+          "removed": "{count, plural, one {시트 <value>{count}</value>개가 <value>{date}</value>에 제거됩니다(현재 결제 주기 종료 후).} other {시트 <value>{count}</value>개가 <value>{date}</value>에 제거됩니다(현재 결제 주기 종료 후).}}",
+          "unchanged": "결제 내용에 변경 사항이 없습니다."
+        },
+        "breakdown": {
+          "label": "사용 중 {used} • 대기 중 {pending} • 남음 {remaining}"
+        },
+        "cancel": {
+          "label": "취소"
+        },
+        "confirmChange": {
+          "label": "변경 확인"
+        },
+        "delta": {
+          "added": "{count, plural, one {시트 #개 추가 예정} other {시트 #개 추가 예정}}",
+          "removed": "{count, plural, one {시트 #개 제거 예정} other {시트 #개 제거 예정}}"
+        },
+        "saving": {
+          "label": "저장 중..."
+        },
+        "seatsField": {
+          "title": "시트 수"
+        },
+        "total": {
+          "label": "시트 {count}개"
+        },
+        "updateFailed": {
+          "error": "시트를 업데이트하지 못했습니다"
+        },
+        "updateSeats": {
+          "description": "팀 규모에 맞게 시트를 추가하거나 제거하세요.",
+          "label": "시트 업데이트",
+          "title": "시트 업데이트"
+        },
+        "viewUsers": {
+          "label": "사용자 보기"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "Business 플랜"
+        },
+        "connectToStripe": {
+          "label": "Stripe에 연결"
+        },
+        "connecting": {
+          "label": "연결 중..."
+        },
+        "enterprisePlan": {
+          "name": "Enterprise 플랜"
+        },
+        "expired": {
+          "subtitle": "{date}에 만료됨"
+        },
+        "managePlan": {
+          "label": "요금제 관리"
+        },
+        "managedBySales": {
+          "text": "요금제는 영업팀을 통해 관리됩니다.<br></br>변경하려면 <link>결제팀에 문의</link>하세요."
+        },
+        "nextPayment": {
+          "subtitle": "다음 결제일: {date}"
+        },
+        "syncLicense": {
+          "label": "라이선스 동기화"
+        },
+        "syncing": {
+          "label": "동기화 중..."
+        },
+        "trialDays": {
+          "subtitle": "체험이 {days}일 후에 끝납니다. {date}에 결제가 필요합니다"
+        },
+        "trialToday": {
+          "subtitle": "체험이 오늘 끝납니다. {date}에 결제가 필요합니다"
+        },
+        "trialTomorrow": {
+          "subtitle": "체험이 내일 끝납니다. {date}에 결제가 필요합니다"
+        },
+        "upgradeNow": {
+          "label": "지금 업그레이드"
+        },
+        "upgrading": {
+          "label": "업그레이드 중..."
+        },
+        "validUntil": {
+          "subtitle": "{date}까지 유효"
+        },
+        "viewPlanDetails": {
+          "label": "요금제 상세 보기"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "체험을 종료하지 못했습니다",
+        "licenseSyncFailed": "라이선스 동기화에 실패했습니다",
+        "paymentMethodRequired": "먼저 결제 수단을 추가한 다음 다시 업그레이드하세요.",
+        "syncLicenseFailed": "라이선스를 동기화하지 못했습니다"
+      }
+    },
+    "chatPreferences": {
+      "advanced": {
+        "title": "고급 옵션"
+      },
+      "anonymousUsers": {
+        "description": "로그인하지 않아도 누구나 채팅을 시작할 수 있습니다. 이러한 사용자는 다른 채팅을 볼 수 없고 에이전트를 만들거나 설정을 변경할 수 없습니다.",
+        "title": "익명 사용자 허용"
+      },
+      "autoDetectFilters": {
+        "description": "검색어에서 추론한 소스 및 기간 필터를 자동으로 적용합니다.",
+        "title": "검색 필터 자동 감지"
+      },
+      "autoScroll": {
+        "description": "채팅이 응답을 생성하는 동안 새 내용으로 자동 스크롤합니다. 사용자는 개인 설정에서 이 값을 변경할 수 있습니다.",
+        "title": "채팅 자동 스크롤"
+      },
+      "betaTag": {
+        "label": "베타"
+      },
+      "chatNaming": {
+        "description": "채팅 세션의 이름을 자동으로 지정하는 데 사용하는 모델입니다. 기본값은 각 세션의 모델입니다. 기본 모델이 동시 요청을 처리할 수 없으면 여기에 작고 빠른 모델을 지정하세요.",
+        "resetButton": {
+          "label": "초기화"
+        },
+        "title": "채팅 이름 지정 모델"
+      },
+      "connectors": {
+        "empty": {
+          "title": "설정된 커넥터 없음"
+        },
+        "manageAllButton": {
+          "label": "전체 관리"
+        },
+        "title": "커넥터"
+      },
+      "deepResearch": {
+        "description": "웹과 연결된 소스 전반을 조사하는 에이전트 기반 리서치 시스템입니다. 질의당 훨씬 많은 token을 사용합니다.",
+        "title": "심층 리서치"
+      },
+      "disableDefaultChat": {
+        "description": "사용자가 항상 에이전트에서 시작하도록 강제합니다. 새 채팅은 사용자가 처음 고정한 에이전트에서 생성됩니다. 새 사용자가 쉽게 시작하도록 추천 에이전트를 설정하세요.",
+        "title": "기본 채팅 비활성화"
+      },
+      "fileLimits": {
+        "default": {
+          "placeholder": "기본값: {value}"
+        },
+        "description": "채팅과 프로젝트에 첨부하는 파일은 두 한도를 모두 충족해야 허용됩니다. 파일이 클수록 지연 시간, 메모리 사용량, token 비용이 늘어납니다.",
+        "noLimit": {
+          "placeholder": "제한 없음"
+        },
+        "restoreDefault": {
+          "tooltip": "기본값 복원"
+        },
+        "size": {
+          "maxDescription": "최대: {max} MB",
+          "suffix": "(MB)",
+          "title": "파일 크기 한도"
+        },
+        "title": "파일 첨부 크기 한도",
+        "tokens": {
+          "suffix": "(천 token)",
+          "title": "파일 token 한도"
+        }
+      },
+      "header": {
+        "description": "조직 전체에 적용되는 채팅 설정과 기본값입니다. 사용자는 개인 설정에서 일부 항목을 변경할 수 있습니다."
+      },
+      "mcpServer": {
+        "authTooltip": "도구를 활성화하기 전에 이 MCP 서버를 인증하세요.",
+        "expandButton": {
+          "label": "펼치기"
+        },
+        "foldButton": {
+          "label": "접기"
+        },
+        "search": {
+          "placeholder": "도구 검색..."
+        }
+      },
+      "multiModel": {
+        "description": "채팅에서 여러 모델이 동시에 응답을 생성할 수 있게 합니다.",
+        "title": "다중 모델 생성"
+      },
+      "queryHistory": {
+        "anonymized": {
+          "description": "관리자가 질의를 볼 수 있지만 사용자 정보는 표시되지 않습니다",
+          "label": "익명 처리"
+        },
+        "description": "조직의 전체 채팅 기록이 관리자 패널에 표시되는 방식을 제어합니다.",
+        "disabled": {
+          "description": "질의 기록 보고가 비활성화되어 있습니다.",
+          "label": "숨김"
+        },
+        "normal": {
+          "description": "모든 질의를 관리자가 볼 수 있으며 개별 사용자와 연결됩니다.",
+          "label": "사용자 정보와 함께 표시"
+        },
+        "title": "질의 기록 공개 범위"
+      },
+      "reasoning": {
+        "description": "채팅의 모델 선택기에서 모델이 답변 전에 수행할 추론의 양을 사용자가 조절할 수 있게 합니다.",
+        "title": "추론 제어"
+      },
+      "retention": {
+        "custom": {
+          "invalidError": "1에서 {max} 사이의 정수 일수를 입력하세요.",
+          "label": "맞춤 보관 기간",
+          "moreTooltip": "더 보기",
+          "placeholder": "일 단위",
+          "restoreTooltip": "기본값 복원"
+        },
+        "description": "Onyx가 조직의 채팅을 보관할 기간을 지정하세요.",
+        "enterprisePlanTag": {
+          "label": "Enterprise 플랜"
+        },
+        "forever": {
+          "label": "무기한"
+        },
+        "presets": {
+          "days30": "30일",
+          "days60": "60일",
+          "days7": "7일",
+          "days90": "90일",
+          "year1": "1년"
+        },
+        "reduceModal": {
+          "confirmLabel": "보관 기간 단축",
+          "message": "{days, plural, one {#일} other {#일}} 넘게 활동이 없는 채팅은 영구 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+          "title": "채팅 보관 기간을 단축할까요?"
+        },
+        "tierTooltip": "채팅 기록 보관은 Enterprise 플랜 기능입니다.",
+        "title": "채팅 기록 보관"
+      },
+      "searchMode": {
+        "businessPlanTag": {
+          "label": "Business 플랜"
+        },
+        "description": "조직 전체 문서를 빠르게 검색하는 UI 모드입니다.",
+        "noConnectorsTooltip": "검색 모드를 사용하려면 커넥터를 설정하세요",
+        "tierTooltip": "검색 모드는 Business 또는 Enterprise 플랜이 필요합니다.",
+        "title": "검색 모드"
+      },
+      "systemPrompt": {
+        "description": "모든 채팅, 에이전트, 프로젝트에 적용되는 기본 프롬프트입니다. 신중하게 수정하세요. 큰 변경은 응답 품질을 떨어뜨릴 수 있습니다.",
+        "modal": {
+          "cancelButton": {
+            "label": "취소"
+          },
+          "caution": {
+            "description": "시스템 프롬프트는 모든 채팅, 에이전트, 프로젝트에 영향을 줍니다. 큰 변경은 응답 품질을 떨어뜨릴 수 있습니다.",
+            "title": "신중하게 수정하세요."
+          },
+          "description": "이 기본 프롬프트는 모든 채팅, 에이전트, 프로젝트의 앞부분에 추가됩니다.",
+          "placeholder": "시스템 프롬프트를 입력하세요...",
+          "placeholders": {
+            "citationGuidance": "`{token}` - 검색 도구에서 사실을 가져올 때 인용을 표시하는 방법에 대한 지침입니다.",
+            "citationNote": "검색 도구를 사용할 때만 포함됩니다.",
+            "currentDatetime": "`{token}` - 사람이 읽을 수 있는 형식의 현재 날짜와 요일입니다.",
+            "intro": "프롬프트에서 다음 자리 표시자를 사용할 수 있습니다:",
+            "reminderTag": "`{token}` - 사용자 메시지의 시스템 알림을 해석하는 방법에 대한 지침입니다."
+          },
+          "restoreTooltip": "기본값 복원",
+          "saveButton": {
+            "label": "저장"
+          }
+        },
+        "modifyButton": {
+          "label": "프롬프트 수정"
+        },
+        "title": "시스템 프롬프트"
+      },
+      "teamContext": {
+        "description": "사용자는 개인 설정에서 개별 컨텍스트를 추가로 제공할 수도 있습니다.",
+        "placeholder": "팀에 대한 설명과 Onyx가 어떻게 동작해야 하는지 입력하세요.",
+        "title": "팀 컨텍스트"
+      },
+      "teamName": {
+        "description": "더 풍부하고 맞춤화된 경험을 제공하기 위해 모든 채팅 세션에 추가 컨텍스트로 포함됩니다.",
+        "placeholder": "팀 이름 입력",
+        "title": "팀 이름"
+      },
+      "temperature": {
+        "description": "채팅의 모델 선택기에서 모델 응답의 temperature(창의성)를 사용자가 조절할 수 있게 합니다.",
+        "title": "Temperature 제어"
+      },
+      "toasts": {
+        "chatNamingReset": "채팅 이름 지정 모델을 세션 모델로 초기화했습니다",
+        "chatNamingResetFailed": "채팅 이름 지정 모델을 초기화하지 못했습니다",
+        "chatNamingUpdateFailed": "채팅 이름 지정 모델을 업데이트하지 못했습니다",
+        "chatNamingUpdated": "채팅 이름 지정 모델을 업데이트했습니다",
+        "providerResolveFailed": "제공자를 확인할 수 없습니다",
+        "settingsUpdateFailed": "설정을 업데이트하지 못했습니다",
+        "settingsUpdated": "설정을 업데이트했습니다",
+        "systemPromptUpdateFailed": "시스템 프롬프트를 업데이트하지 못했습니다",
+        "systemPromptUpdated": "시스템 프롬프트를 업데이트했습니다",
+        "toolsUpdateFailed": "도구를 업데이트하지 못했습니다",
+        "toolsUpdated": "도구를 업데이트했습니다",
+        "unknownError": "알 수 없는 오류가 발생했습니다"
+      },
+      "tools": {
+        "codeInterpreter": {
+          "description": "코드를 생성하고 실행합니다.",
+          "title": "코드 인터프리터"
+        },
+        "codingAgent": {
+          "description": "GitHub 저장소를 조사하고 코드에 대한 질문에 답변합니다.",
+          "title": "코딩 에이전트"
+        },
+        "description": "채팅에서 사용할 수 있는 도구와 기능입니다. 에이전트에는 적용되지 않습니다.",
+        "imageGeneration": {
+          "description": "AI 기반 도구로 이미지를 생성하고 편집합니다.",
+          "disabledTooltip": "이미지 생성에는 설정된 모델이 필요합니다. 구성 > 이미지 생성에서 모델을 설정하거나 관리자에게 문의하세요.",
+          "title": "이미지 생성"
+        },
+        "internalSearch": {
+          "description": "조직에 연결된 지식 베이스와 문서를 검색합니다.",
+          "title": "내부 검색"
+        },
+        "openUrl": {
+          "description": "웹 URL에서 콘텐츠를 가져와 읽습니다.",
+          "title": "URL 열기"
+        },
+        "title": "액션 및 도구",
+        "webSearch": {
+          "description": "웹에서 실시간 정보와 최신 결과를 검색합니다.",
+          "title": "웹 검색"
+        }
+      }
+    },
+    "codeInterpreter": {
+      "card": {
+        "description": "내장 Python 런타임",
+        "disconnectButton": {
+          "tooltip": "연결 해제"
+        },
+        "disconnectedTitle": "코드 인터프리터(연결 해제됨)",
+        "reconnectButton": {
+          "label": "다시 연결"
+        },
+        "refreshButton": {
+          "tooltip": "새로 고침"
+        },
+        "title": "코드 인터프리터"
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "<emphasis>코드 인터프리터</emphasis>에 연결된 실행 중인 모든 세션이 중지됩니다. 런타임의 데이터는 삭제되지 않습니다. 필요하면 나중에 이 런타임에 다시 연결할 수 있습니다."
+        },
+        "header": {
+          "title": "코드 인터프리터 연결 해제"
+        },
+        "submitButton": {
+          "label": "연결 해제"
+        }
+      },
+      "errorCard": {
+        "connectionLost": {
+          "title": "연결 끊김 오류"
+        },
+        "generic": {
+          "title": "코드 인터프리터 오류"
+        }
+      },
+      "header": {
+        "description": "LLM이 사용할 수 있는 안전한 샌드박스 Python 런타임입니다. 자세한 내용은 문서를 참조하세요.",
+        "title": "코드 인터프리터"
+      },
+      "status": {
+        "checking": {
+          "label": "확인 중..."
+        },
+        "connectionLost": {
+          "label": "연결 끊김"
+        },
+        "healthy": {
+          "label": "연결됨"
+        },
+        "unhealthy": {
+          "label": "비정상"
+        }
+      },
+      "toggleError": {
+        "disconnect": {
+          "message": "코드 인터프리터 연결을 해제하지 못했습니다"
+        },
+        "reconnect": {
+          "message": "코드 인터프리터에 다시 연결하지 못했습니다"
+        }
+      }
+    },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {#일} other {#일}}",
+          "hours": "{count, plural, one {#시간} other {#시간}}",
+          "minutes": "{count, plural, one {#분} other {#분}}"
+        },
+        "indexingStart": {
+          "label": "인덱싱 시작"
+        },
+        "pruningFrequency": {
+          "label": "정리 주기"
+        },
+        "refreshFrequency": {
+          "label": "새로 고침 주기"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "아니요",
+        "booleanTrue": "예",
+        "edit": {
+          "tooltip": "수정"
+        },
+        "showAll": {
+          "label": "전체 보기({count}개 항목)"
+        },
+        "showLess": {
+          "label": "간략히 보기"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "이 커넥터를 삭제하면 인덱싱된 문서를 제거하고 모든 사용자에게서 커넥터를 삭제하는 삭제 작업이 예약됩니다.",
+        "entityType": "커넥터"
+      },
+      "deletionError": {
+        "description": "커넥터를 삭제하는 중에 이 오류가 발생했습니다. \"삭제\" 버튼을 클릭하여 삭제를 다시 시도할 수 있습니다.",
+        "title": "삭제 오류"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "동기화된 문서",
+          "errorMessage": "오류 메시지",
+          "permissionErrors": "권한 오류",
+          "status": "상태",
+          "timeStarted": "시작 시간"
+        },
+        "empty": {
+          "description": "문서 권한 동기화 작업은 백그라운드에서 예약됩니다. 표시되기까지 시간이 걸릴 수 있습니다. 약 30초 후에 새로 고쳐 보세요.",
+          "title": "아직 문서 권한 동기화 시도가 없습니다"
+        },
+        "errorModal": {
+          "title": "문서 권한 동기화 오류"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "문서 ID",
+          "errorMessage": "오류 메시지",
+          "status": "상태",
+          "time": "시간"
+        },
+        "description": "인덱싱 중에 발생한 오류입니다. 각 행은 실패한 문서 또는 엔터티를 나타냅니다.",
+        "empty": {
+          "description": "이 페이지에 오류가 없습니다"
+        },
+        "fullReindex": {
+          "description": "아래 버튼을 클릭하면 전체 재인덱싱을 시작하여 이러한 오류를 해결할 수 있습니다. 전체 재인덱싱은 일반 업데이트보다 훨씬 오래 걸릴 수 있습니다."
+        },
+        "resolveAllButton": {
+          "label": "모두 해결"
+        },
+        "status": {
+          "resolved": "해결됨",
+          "unresolved": "미해결"
+        },
+        "targetedReindex": {
+          "description": "아래 버튼을 클릭하면 실패한 문서만 다시 가져옵니다. 전체 재인덱싱보다 훨씬 빠릅니다."
+        },
+        "title": "인덱싱 오류",
+        "unknownDocument": "알 수 없음"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "파일 추가"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "columns": {
+          "fileName": "파일 이름",
+          "size": "크기",
+          "uploadDate": "업로드 날짜"
+        },
+        "confirmModal": {
+          "addDetails": "새 파일이 업로드되고 청크로 나뉜 뒤 embedding되어 문서 인덱스에 인덱싱됩니다",
+          "addSummary": "파일 {count}개가 추가됩니다",
+          "confirmButton": {
+            "label": "확인 후 저장"
+          },
+          "description": "이 변경 사항을 저장하면 다음이 실행됩니다:",
+          "removeDetails": "이 파일에서 생성된 문서가 문서 인덱스에서 제거됩니다",
+          "removeSummary": "🗑️ 파일 {count}개가 제거됩니다",
+          "title": "파일 변경 확인"
+        },
+        "editButton": {
+          "label": "수정"
+        },
+        "empty": {
+          "description": "이 커넥터에 파일이 없습니다"
+        },
+        "header": {
+          "title": "파일({count, plural, one {#개} other {#개}})"
+        },
+        "loadError": "파일을 불러오지 못했습니다: {message}",
+        "newBadge": {
+          "label": "신규"
+        },
+        "removeFileButton": {
+          "tooltip": "파일 제거"
+        },
+        "removingBadge": {
+          "label": "제거 중"
+        },
+        "saveButton": {
+          "label": "변경 사항 저장",
+          "saving": "저장 중..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "커넥터에서 모든 파일을 제거할 수는 없습니다. 필요하면 커넥터를 삭제하세요.",
+          "filesUpdated": "파일을 업데이트했습니다! 문서 인덱스는 백그라운드에서 업데이트됩니다. 새 파일은 인덱싱되고 제거된 파일은 검색 결과에서 삭제됩니다.",
+          "updateFailed": "파일을 업데이트하지 못했습니다"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "오류 메시지",
+          "groups": "그룹",
+          "memberships": "멤버십",
+          "status": "상태",
+          "timeStarted": "시작 시간",
+          "users": "사용자"
+        },
+        "empty": {
+          "description": "그룹 멤버십 동기화 작업은 백그라운드에서 예약됩니다. 표시되기까지 시간이 걸릴 수 있습니다. 약 30초 후에 새로 고쳐 보세요.",
+          "title": "아직 그룹 멤버십 동기화 시도가 없습니다"
+        },
+        "errorModal": {
+          "title": "그룹 멤버십 동기화 오류"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "오류 메시지",
+          "newDocs": "새 문서",
+          "status": "상태",
+          "timeStarted": "시작 시간",
+          "totalDocs": "전체 문서",
+          "totalDocsTooltip": "이번 인덱싱 시도에서 인덱스에 교체된 전체 문서 수"
+        },
+        "docsPerMinute": "분당 {rate}개 문서",
+        "docsRemoved": "(소스에서 삭제된 것으로 확인된 문서 {count}개도 제거됨)",
+        "empty": {
+          "description": "인덱싱 시도는 백그라운드에서 예약되며 표시되기까지 시간이 걸릴 수 있습니다. 약 30초 후에 페이지를 새로 고쳐 보세요!",
+          "title": "아직 예약된 인덱싱 시도가 없습니다"
+        },
+        "noAdditionalDocs": "추가로 처리된 문서 없음",
+        "reindexTooltip": {
+          "completed": "이 인덱싱 시도는 전체 재인덱싱이었습니다. 소스의 모든 문서가 시스템에 동기화되었습니다.",
+          "inProgress": "이 인덱싱 시도는 전체 재인덱싱입니다. 소스의 모든 문서가 시스템에 동기화되고 있습니다."
+        },
+        "stageMetricsButton": {
+          "tooltip": "단계별 지표 보기"
+        },
+        "viewTrace": {
+          "ariaLabel": "전체 추적 보기"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "일부 문서를 처리하는 중에 문제가 발생했습니다. <details>상세 보기.</details>",
+        "resolvingStatus": "실패 해결 중",
+        "title": "일부 문서를 인덱싱하지 못했습니다"
+      },
+      "invalidState": {
+        "description": "이 커넥터는 유효하지 않은 상태입니다. 재인덱싱하기 전에 자격 증명을 업데이트하거나 새 커넥터를 만드세요.",
+        "title": "유효하지 않은 커넥터 상태"
+      },
+      "loadError": {
+        "title": "ID가 {ccPairId}인 커넥터 정보를 가져오지 못했습니다",
+        "unknownMessage": "알 수 없는 오류"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "삭제",
+          "tooltip": {
+            "active": "삭제하기 전에 커넥터를 일시 중지하세요"
+          }
+        },
+        "reIndex": {
+          "label": "재인덱싱",
+          "tooltip": {
+            "indexing": "인덱싱이 이미 진행 중이면 재인덱싱할 수 없습니다",
+            "invalid": "재인덱싱하기 전에 커넥터 구성을 수정하세요",
+            "paused": "재인덱싱하기 전에 커넥터를 다시 시작하세요"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "일시 중지"
+          },
+          "resume": {
+            "label": "다시 시작"
+          },
+          "tooltip": {
+            "updating": "상태 업데이트 진행 중"
+          }
+        },
+        "trigger": {
+          "label": "관리"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "취소됨"
+        },
+        "completedWithErrors": {
+          "label": "오류와 함께 완료됨"
+        },
+        "failed": {
+          "label": "실패"
+        },
+        "fallback": {
+          "label": "시작 안 됨"
+        },
+        "inProgress": {
+          "label": "진행 중"
+        },
+        "notStarted": {
+          "label": "예약됨"
+        },
+        "success": {
+          "label": "성공"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "커넥터를 정리할 주기(시간 단위)",
+        "title": "정리 주기"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "다시 활성화"
+        },
+        "additionalDetails": "이 커넥터는 이전에 유효하지 않음으로 표시되었습니다. 다시 활성화하기 전에 구성이 올바른지 확인하세요. 계속하시겠습니까?",
+        "entityType": "유효하지 않은 커넥터"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "소스의 모든 문서를 전체 재인덱싱합니다.",
+          "note": "<strong>참고:</strong> 소스에 저장된 문서 수에 따라 시간이 오래 걸릴 수 있습니다."
+        },
+        "fullReindexButton": {
+          "label": "전체 재인덱싱 실행"
+        },
+        "title": "인덱싱 실행",
+        "update": {
+          "description": "마지막으로 성공한 인덱싱 이후 변경되거나 추가된 모든 문서를 가져와 인덱싱합니다."
+        },
+        "updateButton": {
+          "label": "업데이트 실행"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "커넥터를 새로 고칠 주기(분 단위)",
+        "title": "새로 고침 주기"
+      },
+      "sections": {
+        "advanced": {
+          "title": "고급"
+        },
+        "advancedConfiguration": {
+          "title": "고급 구성"
+        },
+        "connectorConfiguration": {
+          "title": "커넥터 구성"
+        },
+        "credential": {
+          "title": "자격 증명"
+        },
+        "indexing": {
+          "title": "인덱싱"
+        },
+        "indexingAttempts": {
+          "title": "인덱싱 시도"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "시도 오버헤드 숨기기"
+          },
+          "showButton": {
+            "label": "시도 오버헤드 표시"
+          }
+        },
+        "batchTotal": {
+          "empty": "완료된 배치가 아직 없습니다",
+          "summary": "평균 배치: {avgLabel}, {count, plural, one {배치 #개} other {배치 #개}} — 분포는 아래에 표시됩니다."
+        },
+        "empty": {
+          "description": "이 시도의 단계별 시간 데이터가 아직 기록되지 않았습니다. 단계 계측이 배포되기 전에 실행된 이전 시도에는 지표가 없습니다."
+        },
+        "loadError": {
+          "description": "이 시도의 단계별 시간 데이터를 불러올 수 없습니다. 지표 기록을 사용할 수 없어도 파이프라인은 실행되므로, 인덱싱 실행 자체의 문제를 의미하지는 않습니다.",
+          "title": "단계별 지표를 불러오지 못했습니다"
+        },
+        "loading": "단계별 지표를 불러오는 중…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "평균 시간",
+            "calls": "호출 수",
+            "max": "최대",
+            "min": "최소",
+            "stage": "단계",
+            "totalTime": "총 시간"
+          },
+          "empty": "배치별 단계 데이터가 기록되지 않았습니다."
+        },
+        "sort": {
+          "label": "정렬:",
+          "pipelineOrder": {
+            "label": "파이프라인 순서"
+          },
+          "timeTaken": {
+            "label": "소요 시간"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "객체 스토리지에서 배치를 다시 읽어 워커 메모리에 올립니다.",
+            "label": "배치 로드"
+          },
+          "batchTotal": {
+            "description": "단일 배치를 처음부터 끝까지 처리하는 데 걸린 전체 실제 시간입니다.",
+            "label": "배치 전체"
+          },
+          "batchUnaccounted": {
+            "description": "지정된 단계에 할당되지 않은 배치 시간입니다. 값이 크면 계측이 누락되었을 수 있습니다.",
+            "label": "미분류"
+          },
+          "checkpointLoad": {
+            "description": "저장된 체크포인트를 불러와 이전 실행이 멈춘 지점부터 시도를 재개합니다.",
+            "label": "체크포인트 로드"
+          },
+          "chunking": {
+            "description": "각 문서를 embedding과 인덱싱 대상이 되는 청크로 나눕니다.",
+            "label": "청킹"
+          },
+          "connectorFetch": {
+            "description": "커넥터가 소스 API를 호출하고 원본 문서를 반환하는 데 걸리는 시간입니다.",
+            "label": "커넥터 가져오기"
+          },
+          "connectorValidation": {
+            "description": "가져오기를 시작하기 전에 커넥터 구성이 올바르고 접근할 수 있는지 확인합니다.",
+            "label": "커넥터 검증"
+          },
+          "contextualRag": {
+            "description": "검색 품질을 높이기 위해 LLM으로 청크별 컨텍스트 요약을 생성합니다.",
+            "label": "컨텍스트 기반 RAG"
+          },
+          "coordLockAcquireWait": {
+            "description": "시도의 공유 진행 카운터를 보호하는 조정 잠금을 기다립니다.",
+            "label": "조정 잠금 대기"
+          },
+          "coordinationUpdate": {
+            "description": "완료된 배치가 UI에 반영되도록 시도의 진행 카운터를 업데이트합니다.",
+            "label": "조정 업데이트"
+          },
+          "docBatchEnqueue": {
+            "description": "docprocessing 워커가 가져갈 수 있도록 저장된 배치를 Celery 큐에 게시합니다.",
+            "label": "문서 배치 큐 등록"
+          },
+          "docBatchStore": {
+            "description": "docprocessing 워커를 위해 가져온 문서 배치를 객체 스토리지에 저장합니다.",
+            "label": "문서 배치 저장"
+          },
+          "docDbPrepare": {
+            "description": "어떤 문서가 새로 추가되었거나 업데이트되었는지 확인하고 데이터베이스 행을 준비합니다.",
+            "label": "문서 DB 준비"
+          },
+          "docLockAcquireWait": {
+            "description": "문서별 잠금을 기다립니다. 동시에 실행되는 시도가 같은 문서를 쓰지 않도록 합니다.",
+            "label": "문서 잠금 획득 대기"
+          },
+          "docprocessingSetup": {
+            "description": "워커를 준비합니다. 검색 설정, embedding 모델, 인덱스 클라이언트를 로드합니다.",
+            "label": "문서 처리 설정"
+          },
+          "embedding": {
+            "description": "embedding 모델을 호출하여 청크를 벡터로 변환합니다. 보통 가장 느린 단계입니다.",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "쓰기 전에 각 청크에 접근 제어, 부스트, 기타 메타데이터를 추가합니다.",
+            "label": "보강 준비"
+          },
+          "finalization": {
+            "description": "처리가 끝나면 워커 리소스를 정리하고 배치를 해제합니다.",
+            "label": "마무리"
+          },
+          "gcCollect": {
+            "description": "배치 사이에 명시적 가비지 컬렉션에 사용한 시간입니다.",
+            "label": "가비지 컬렉션"
+          },
+          "hierarchyUpsert": {
+            "description": "소스의 폴더 또는 스페이스 계층을 기록하여 위치로 문서를 필터링할 수 있게 합니다.",
+            "label": "계층 업서트"
+          },
+          "imageProcessing": {
+            "description": "이미지를 추출하고 요약하여 내용을 검색 가능한 텍스트로 만듭니다.",
+            "label": "이미지 처리"
+          },
+          "permissionValidation": {
+            "description": "자격 증명이 소스의 문서를 읽는 데 필요한 권한을 가지고 있는지 확인합니다.",
+            "label": "권한 검증"
+          },
+          "postIndexDbUpdate": {
+            "description": "인덱스 쓰기가 성공한 후 Postgres의 문서 행을 업데이트합니다.",
+            "label": "인덱싱 후 DB 업데이트"
+          },
+          "queueWait": {
+            "description": "문서 처리 워커가 배치를 시작하기 전까지 큐에서 대기한 시간입니다.",
+            "label": "큐 대기"
+          },
+          "vectorDbWrite": {
+            "description": "embedding된 청크를 문서 인덱스에 기록합니다.",
+            "label": "벡터 DB 쓰기"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "이 인덱싱 시도의 배치별, 시도별 소요 시간입니다.",
+        "title": "인덱싱 단계 지표"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "인덱싱된 문서"
+        },
+        "indexingSpeed": "(분당 {speed}개 문서)",
+        "lastIndexed": {
+          "label": "마지막 인덱싱"
+        },
+        "lastSynced": {
+          "label": "마지막 동기화"
+        },
+        "permissionSyncing": {
+          "label": "권한 동기화"
+        },
+        "status": {
+          "label": "상태"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "전체 오류 메시지 보기"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "문서 권한 동기화",
+          "notApplicableDescription": "이 커넥터는 별도의 문서 권한 동기화 작업을 사용하지 않습니다."
+        },
+        "groupMembership": {
+          "label": "그룹 멤버십 동기화",
+          "notApplicableDescription": "이 커넥터는 별도의 그룹 멤버십 동기화 작업을 사용하지 않습니다."
+        },
+        "indexing": {
+          "label": "인덱싱"
+        },
+        "loadError": {
+          "title": "동기화 시도를 불러오지 못했습니다"
+        },
+        "notApplicable": {
+          "title": "해당 없음"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "전체 재인덱싱을 시작했습니다",
+        "completeReindexStarting": "전체 재인덱싱을 시작하는 중...",
+        "deletionScheduleFailed": "커넥터 삭제를 예약하지 못했습니다 - {message}",
+        "indexingProcessStartFailed": "인덱싱 프로세스를 시작하지 못했습니다",
+        "indexingStartFailed": "인덱싱을 시작하지 못했습니다",
+        "indexingStartUnexpectedError": "인덱싱을 시작하는 중 예기치 않은 오류가 발생했습니다",
+        "indexingUpdateStarted": "인덱싱 업데이트를 시작했습니다",
+        "indexingUpdateStarting": "인덱싱 업데이트를 시작하는 중...",
+        "invalidPruningFrequency": "정리 주기가 올바르지 않습니다: 유효한 숫자여야 합니다",
+        "invalidRefreshFrequency": "새로 고침 주기가 올바르지 않습니다: 정수여야 합니다",
+        "nameUpdateFailed": "커넥터 이름을 업데이트하지 못했습니다",
+        "nameUpdated": "커넥터 이름을 업데이트했습니다",
+        "noUnresolvedErrors": "다시 시도할 미해결 오류가 없습니다.",
+        "pruningFrequencyUpdateFailed": "커넥터 정리 주기를 업데이트하지 못했습니다",
+        "pruningFrequencyUpdated": "커넥터 정리 주기를 업데이트했습니다",
+        "refreshFrequencyUpdateFailed": "커넥터 새로 고침 주기를 업데이트하지 못했습니다",
+        "refreshFrequencyUpdated": "커넥터 새로 고침 주기를 업데이트했습니다",
+        "targetedReindexFailed": "대상 지정 재인덱싱에 실패했습니다: {message}",
+        "targetedReindexSubmitted": "{count, plural, one {문서 #개} other {문서 #개}}에 대해 대상 지정 재인덱싱을 요청했습니다. 문서의 재인덱싱이 끝나면 목록에서 오류가 사라집니다."
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "{source}(으)로 인증",
+          "pendingLabel": "인증하는 중..."
+        },
+        "createCredentialButton": {
+          "label": "새로 만들기"
+        },
+        "credentialDeleted": {
+          "toast": "자격 증명을 삭제했습니다!"
+        },
+        "credentialModal": {
+          "title": "{source} 자격 증명 만들기"
+        },
+        "credentialStep": {
+          "title": "자격 증명 선택"
+        },
+        "credentialSwapped": {
+          "toast": "자격 증명을 교체했습니다!"
+        },
+        "error": {
+          "toast": "오류: {detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "이 커넥터에는 페더레이션 검색 옵션이 있습니다. 지연 시간이 늘어나고 검색 품질이 낮아집니다.",
+            "link": {
+              "label": "대신 페더레이션 버전 사용 →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "파일 업로드 중 오류가 발생했습니다"
+        },
+        "oauthRedirectFailed": {
+          "message": "{source} 로그인 페이지로 이동하지 못했습니다. 다시 시도하세요."
+        },
+        "oauthStartFailed": {
+          "toast": "OAuth를 시작할 수 없습니다"
+        },
+        "oauthUrlFailed": {
+          "toast": "OAuth URL을 가져오지 못했습니다"
+        },
+        "retryButton": {
+          "label": "다시 시도"
+        },
+        "timeout": {
+          "toast": "{seconds}초 후 작업 시간이 초과되었습니다. 설정에 오류가 있는지 확인하세요."
+        },
+        "unknownError": {
+          "toast": "알 수 없는 오류가 발생했습니다"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "인덱싱 시작 날짜",
+          "subtext": "이 날짜 이전의 문서는 가져오지 않습니다"
+        },
+        "pruneFrequency": {
+          "description": "모든 문서를 소스와 대조하여 더 이상 존재하지 않는 문서를 삭제합니다. 참고: 이 과정은 모든 문서를 확인하므로 실행 빈도를 높일 때는 주의하세요. 기본값은 {hours}시간({days}일)입니다. 소수점 시간도 지원합니다(예: 0.1시간 = 6분). 이 커넥터의 정리를 사용하지 않으려면 0을 입력하세요.",
+          "label": "정리 주기(시간)"
+        },
+        "refreshFrequency": {
+          "description": "소스에서 새 문서를 가져오는 주기입니다(분 단위). 0을 입력하면 이 커넥터의 새 문서를 가져오지 않습니다.",
+          "label": "새로 고침 주기(분)"
+        },
+        "resetButton": {
+          "label": "초기화"
+        },
+        "title": "고급 설정"
+      },
+      "connectorName": {
+        "label": "커넥터 이름",
+        "subtext": "커넥터를 설명하는 이름입니다."
+      },
+      "credentialsLoadError": {
+        "title": "자격 증명을 불러오지 못했습니다."
+      },
+      "field": {
+        "optional": {
+          "label": "(선택 사항)"
+        },
+        "optionalSuffix": {
+          "label": "선택 사항"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "Google Drive 자격 증명을 만들었습니다. 자격 증명 목록에서 관리하거나 취소할 수 있습니다.",
+          "title": "인증 완료"
+        },
+        "authFailed": {
+          "toast": "Google Drive 인증에 실패했습니다 - {error}"
+        },
+        "authenticateButton": {
+          "label": "Google Drive로 인증",
+          "pendingLabel": "인증하는 중..."
+        },
+        "createButton": {
+          "label": "자격 증명 만들기",
+          "pendingLabel": "만드는 중..."
+        },
+        "credentialsLoadError": {
+          "title": "Google Drive 자격 증명을 불러오지 못했습니다."
+        },
+        "invalidFile": {
+          "toast": "잘못된 파일입니다 - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "잘못된 파일입니다 - 서비스 계정 JSON 키가 필요합니다"
+        },
+        "missingServiceAccountKey": {
+          "toast": "자격 증명을 만들기 전에 서비스 계정 키를 업로드하세요"
+        },
+        "oauthOption": {
+          "description": "Google Cloud Console에서 OAuth 앱 JSON을 업로드한 다음([설정 방법]({docsUrl})), 인덱싱할 Drive의 Google 계정으로 인증하세요.",
+          "title": "옵션 1: OAuth 앱"
+        },
+        "oauthUpload": {
+          "placeholder": "OAuth 앱 JSON을 업로드하거나 붙여 넣으세요"
+        },
+        "primaryAdmin": {
+          "description": "인덱싱할 Google Drive를 소유한 Google 조직의 관리자 또는 소유자 이메일을 입력하세요.",
+          "invalidEmail": "유효한 이메일이어야 합니다",
+          "label": "기본 관리자 이메일",
+          "required": "필수 항목입니다"
+        },
+        "section": {
+          "title": "Google Drive 인증"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "서비스 계정 자격 증명을 만들지 못했습니다 - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "서비스 계정 자격 증명을 만들었습니다"
+        },
+        "serviceAccountOption": {
+          "title": "옵션 2: 서비스 계정"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "서비스 계정 JSON 키를 업로드하거나 붙여 넣으세요"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "Gmail 자격 증명을 만들었습니다. 자격 증명 목록에서 관리하거나 취소할 수 있습니다.",
+          "title": "인증 완료"
+        },
+        "authFailed": {
+          "toast": "Gmail 인증에 실패했습니다 - {error}"
+        },
+        "authenticateButton": {
+          "label": "Gmail로 인증",
+          "pendingLabel": "인증하는 중..."
+        },
+        "createButton": {
+          "label": "자격 증명 만들기",
+          "pendingLabel": "만드는 중..."
+        },
+        "credentialsLoadError": {
+          "title": "Gmail 자격 증명을 불러오지 못했습니다."
+        },
+        "invalidFile": {
+          "toast": "잘못된 파일입니다 - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "잘못된 파일입니다 - 서비스 계정 JSON 키가 필요합니다"
+        },
+        "missingServiceAccountKey": {
+          "toast": "자격 증명을 만들기 전에 서비스 계정 키를 업로드하세요"
+        },
+        "oauthOption": {
+          "description": "Google Cloud Console에서 OAuth 앱 JSON을 업로드한 다음([설정 방법]({docsUrl})), 인덱싱할 Gmail의 Google 계정으로 인증하세요.",
+          "title": "옵션 1: OAuth 앱"
+        },
+        "oauthUpload": {
+          "placeholder": "OAuth 앱 JSON을 업로드하거나 붙여 넣으세요"
+        },
+        "primaryAdmin": {
+          "description": "인덱싱할 Gmail 계정을 소유한 Google 조직의 관리자 또는 소유자 이메일을 입력하세요.",
+          "invalidEmail": "유효한 이메일이어야 합니다",
+          "label": "기본 관리자 이메일",
+          "required": "필수 항목입니다"
+        },
+        "section": {
+          "title": "Gmail 인증"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "서비스 계정 자격 증명을 만들지 못했습니다 - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "서비스 계정 자격 증명을 만들었습니다"
+        },
+        "serviceAccountOption": {
+          "title": "옵션 2: 서비스 계정"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "서비스 계정 JSON 키를 업로드하거나 붙여 넣으세요"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "홈으로 이동"
+        },
+        "title": "‘{connector}’은(는) 유효한 커넥터 유형이 아닙니다!"
+      },
+      "listInput": {
+        "placeholder": "{label} 입력"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "고급"
+        },
+        "continueButton": {
+          "label": "계속"
+        },
+        "createButton": {
+          "label": "커넥터 만들기"
+        },
+        "previousButton": {
+          "label": "이전"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "문제가 발생했습니다!"
+        },
+        "invalidSource": {
+          "description": "{source}은(는) 유효한 소스 유형이 아닙니다.",
+          "title": "지정한 커넥터 소스 유형 {source}이(가) 없습니다."
+        },
+        "processing": {
+          "description": "설정을 완료하는 동안 기다려 주세요.",
+          "title": "처리 중..."
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "{source}(으)로 인증"
+        },
+        "authorizing": {
+          "description": "인증을 완료하는 동안 기다려 주세요."
+        },
+        "continue": {
+          "message": "계속하려면 <link>여기</link>를 클릭하세요."
+        },
+        "error": {
+          "description": "OAuth 과정에서 오류가 발생했습니다. 다시 시도하세요."
+        },
+        "malformed": {
+          "missingCode": "인증 코드가 없습니다.",
+          "missingState": "state 매개변수가 없습니다.",
+          "title": "형식이 잘못된 OAuth 인증 요청입니다."
+        },
+        "page": {
+          "title": "타사 서비스로 인증"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "{source} 인증이 완료되었습니다. 자격 증명 설정을 마치려면 추가 단계가 필요합니다."
+          },
+          "description": "{source} 인증이 완료되었습니다.",
+          "title": "완료!"
+        }
+      },
+      "oauthFailed": {
+        "toast": "OAuth 인증에 실패했습니다. 다시 시도하세요."
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "{source} 인증 마무리"
+        },
+        "cloudId": {
+          "required": "Confluence 사이트를 선택해야 합니다(id를 찾을 수 없습니다)."
+        },
+        "cloudName": {
+          "required": "Confluence 사이트를 선택해야 합니다(이름을 찾을 수 없습니다)."
+        },
+        "cloudUrl": {
+          "required": "Confluence 사이트를 선택해야 합니다(url을 찾을 수 없습니다)."
+        },
+        "continue": {
+          "message": "인증을 마쳤습니다. 계속하려면 <link>여기</link>를 클릭하세요."
+        },
+        "credentialId": {
+          "required": "자격 증명 ID는 필수입니다."
+        },
+        "error": {
+          "description": "OAuth 마무리 과정에서 오류가 발생했습니다. 다시 시도하세요."
+        },
+        "finalized": {
+          "title": "Confluence 인증을 마쳤습니다."
+        },
+        "loadingSites": {
+          "description": "접근 가능한 사이트 목록을 가져오는 동안 기다려 주세요."
+        },
+        "malformed": {
+          "description": "자격 증명 id가 없거나 올바르지 않습니다.",
+          "title": "형식이 잘못된 OAuth 마무리 요청입니다."
+        },
+        "page": {
+          "title": "타사 서비스 인증 마무리"
+        },
+        "selectSite": {
+          "title": "Confluence 사이트 선택"
+        },
+        "submitButton": {
+          "label": "제출",
+          "pendingLabel": "제출하는 중..."
+        },
+        "submitError": {
+          "description": "제출 과정에서 오류가 발생했습니다. 다시 시도하세요.",
+          "title": "제출 중 오류가 발생했습니다."
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "옵션 선택"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "새로 추가"
+        },
+        "removeButton": {
+          "tooltip": "제거"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "표시할 탭이 없습니다."
+        }
+      }
+    },
+    "costOverrides": {
+      "allProviders": {
+        "label": "모든 제공업체"
+      },
+      "empty": {
+        "description": "모델에 협상된 요금(100만 token당 USD)을 적용하려면 재정의를 추가하세요.",
+        "title": "설정된 비용 재정의가 없습니다."
+      },
+      "form": {
+        "addButton": {
+          "label": "재정의 추가"
+        },
+        "cacheRate": {
+          "label": "캐시 읽기 요금(100만 token당 USD, 선택 사항)",
+          "placeholder": "기본값은 입력 요금입니다"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "inputRate": {
+          "label": "입력 요금(100만 token당 USD)"
+        },
+        "model": {
+          "label": "모델",
+          "placeholder": "모델 선택"
+        },
+        "outputRate": {
+          "label": "출력 요금(100만 token당 USD)"
+        },
+        "saveButton": {
+          "label": "저장"
+        }
+      },
+      "panel": {
+        "addButton": {
+          "label": "재정의 추가"
+        },
+        "description": "모델별 협상 요금을 **100만 token당 USD** 단위로 설정합니다. 이 값은 사용 비용 계산에서 기본 가격표를 재정의합니다.",
+        "error": {
+          "title": "비용 재정의를 불러오지 못했습니다."
+        },
+        "title": "비용 재정의"
+      },
+      "row": {
+        "deleteButton": {
+          "ariaLabel": "{model}의 {provider} 재정의 삭제"
+        },
+        "editButton": {
+          "ariaLabel": "{model}의 {provider} 재정의 편집"
+        },
+        "rates": "{provider} · 입력 {input} · 출력 {output} · 100만 token당 USD",
+        "ratesWithCache": "{provider} · 입력 {input} · 출력 {output} · 캐시 {cache} · 100만 token당 USD",
+        "updated": "{time}에 업데이트됨"
+      },
+      "toasts": {
+        "removeFailed": "재정의를 제거하지 못했습니다: {message}",
+        "removed": "{model}의 재정의를 제거했습니다.",
+        "saveFailed": "재정의를 저장하지 못했습니다: {message}",
+        "saved": "{model}의 요금을 저장했습니다.",
+        "unknownError": "알 수 없는 오류"
+      }
+    },
+    "craft": {
+      "accessCell": {
+        "disabledSuccess": {
+          "message": "사용자의 Craft를 사용 중지했습니다"
+        },
+        "enabledSuccess": {
+          "message": "사용자의 Craft를 사용 설정했습니다"
+        },
+        "error": {
+          "message": "Craft 접근 권한을 업데이트하지 못했습니다"
+        }
+      },
+      "accessSummary": {
+        "description": "현재: 전체 사용자 {total}명 중 {enabledCount}명이 접근할 수 있습니다"
+      },
+      "confirmModal": {
+        "disableBody": {
+          "description": "모든 사용자의 접근 권한이 제거됩니다. 진행 중인 세션은 영향을 받지 않습니다.",
+          "withExceptions": {
+            "description": "아래에서 켠 {enabledCount}명을 제외한 모든 사용자의 접근 권한이 제거됩니다. 진행 중인 세션은 영향을 받지 않습니다."
+          }
+        },
+        "disableButton": {
+          "label": "기본값으로 사용 중지"
+        },
+        "disableHeader": {
+          "title": "Craft를 기본으로 사용 중지할까요?"
+        },
+        "enableBody": {
+          "description": "전체 사용자 {total}명이 접근할 수 있습니다. Craft 에이전트는 샌드박스에서 실행되며, 사용자의 권한 부여와 승인을 받아 사용자를 대신해 작업할 수 있습니다.",
+          "withExclusions": {
+            "description": "아래에서 끈 {excludedCount}명을 제외한 전체 사용자 {total}명이 접근할 수 있습니다. Craft 에이전트는 샌드박스에서 실행되며, 사용자의 권한 부여와 승인을 받아 사용자를 대신해 작업할 수 있습니다."
+          }
+        },
+        "enableButton": {
+          "label": "모든 사용자에게 사용 설정"
+        },
+        "enableHeader": {
+          "title": "모든 사용자에게 Craft를 사용 설정할까요?"
+        }
+      },
+      "defaultToggle": {
+        "betaTag": {
+          "label": "베타"
+        },
+        "disabled": {
+          "description": "Craft가 모든 사용자에게 꺼져 있습니다. 아래에서 사용자별로 전환하세요."
+        },
+        "disabledSuccess": {
+          "message": "이제 Craft가 기본으로 사용 중지됩니다"
+        },
+        "enabled": {
+          "description": "Craft가 모든 사용자에게 켜져 있습니다. 아래에서 사용자별로 전환하세요."
+        },
+        "enabledSuccess": {
+          "message": "이제 Craft가 기본으로 사용 설정됩니다"
+        },
+        "title": "Craft 기본 사용 설정"
+      },
+      "emptyState": {
+        "description": "검색과 일치하는 사용자가 없습니다.",
+        "title": "사용자를 찾을 수 없습니다"
+      },
+      "header": {
+        "description": "Onyx의 에이전트형 앱 빌더인 Craft를 사용할 수 있는 사람을 관리합니다.",
+        "title": "접근 권한"
+      },
+      "perUserAccess": {
+        "description": "워크스페이스 기본값과 다르게 전환한 사용자는 기본값이 바뀌어도 자신의 설정을 유지합니다.",
+        "title": "사용자별 접근 권한"
+      },
+      "saveError": {
+        "message": "설정을 업데이트하지 못했습니다"
+      },
+      "search": {
+        "placeholder": "사용자 검색..."
+      },
+      "settingsLoadError": {
+        "description": "설정을 불러오지 못했습니다. 페이지를 새로 고쳐 보세요."
+      },
+      "table": {
+        "accessColumn": {
+          "header": "접근 권한"
+        },
+        "footer": {
+          "units": "명"
+        },
+        "groupsColumn": {
+          "header": "그룹"
+        },
+        "userColumn": {
+          "header": "사용자"
+        }
+      },
+      "unavailable": {
+        "description": "Craft는 Onyx가 배포별로 사용 설정합니다. 접근하려면 Onyx 담당자에게 문의하세요.",
+        "title": "이 배포에서는 Craft를 사용할 수 없습니다"
+      },
+      "usersLoadError": {
+        "description": "사용자를 불러오지 못했습니다. 페이지를 새로 고쳐 보세요."
+      }
+    },
+    "craftInstructions": {
+      "baseInstructions": {
+        "description": "작성한 지침이 덧붙여지는 기본 프롬프트입니다. 동적 섹션은 세션마다 채워집니다.",
+        "loadError": {
+          "description": "기본 지침을 불러오지 못했습니다."
+        },
+        "title": "기본 지침 보기"
+      },
+      "header": {
+        "description": "Craft의 기본 동작에 더해 모든 Craft 에이전트가 따르는 워크스페이스 전체 지침입니다.",
+        "title": "지침"
+      },
+      "instructions": {
+        "charCount": {
+          "label": "{count} / {max}"
+        },
+        "help": {
+          "description": "변경 사항은 세션이 시작되거나 복원될 때 적용됩니다. 실행 중인 세션에는 적용되지 않습니다."
+        },
+        "label": "워크스페이스 지침",
+        "placeholder": "예: 항상 브랜드 가이드라인을 따르고 간결하고 격식 있는 문구를 사용하세요."
+      },
+      "resetButton": {
+        "label": "기본값으로 초기화"
+      },
+      "resetModal": {
+        "body": {
+          "description": "새 Craft 세션은 기본 지침만 사용하여 실행됩니다. 모든 사용자의 워크스페이스 지침이 제거됩니다."
+        },
+        "header": {
+          "title": "Craft 지침을 초기화할까요?"
+        },
+        "resettingLabel": "초기화하는 중…",
+        "submitButton": {
+          "label": "초기화"
+        }
+      },
+      "saveButton": {
+        "label": "저장",
+        "savingLabel": "저장하는 중…"
+      },
+      "saveError": {
+        "message": "지침을 저장하지 못했습니다"
+      },
+      "saveSuccess": {
+        "message": "Craft 지침을 저장했습니다"
+      },
+      "settingsLoadError": {
+        "description": "설정을 불러오지 못했습니다. 페이지를 새로 고쳐 보세요."
+      },
+      "tryInCraftButton": {
+        "label": "Craft에서 사용해 보기"
+      },
+      "unavailable": {
+        "description": "Craft는 Onyx가 배포별로 사용 설정합니다. 접근하려면 Onyx 담당자에게 문의하세요.",
+        "title": "이 배포에서는 Craft를 사용할 수 없습니다"
+      }
+    },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "token을 변경하려면 현재 token을 삭제하고 새 token을 추가하세요."
+        },
+        "configured": {
+          "badge": "설정됨",
+          "text": "Discord 봇 token이 설정되었습니다."
+        },
+        "configuredWithDate": {
+          "text": "Discord 봇 token이 설정되었습니다. {date}에 추가되었습니다."
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "서버 설정을 먼저 삭제하세요"
+          },
+          "label": "Discord token 삭제"
+        },
+        "deleteError": {
+          "toast": "봇 token을 삭제하지 못했습니다"
+        },
+        "deleteModal": {
+          "additionalDetails": "Discord 봇의 연결이 끊어집니다. 봇을 다시 사용하려면 token을 다시 입력해야 합니다.",
+          "entityName": "Discord 봇 token",
+          "entityType": "Discord 봇 token"
+        },
+        "deleted": {
+          "toast": "봇 token을 삭제했습니다"
+        },
+        "enterInstructions": {
+          "text": "봇을 사용하려면 Discord 봇 token을 입력하세요. token은 Discord Developer Portal에서 받을 수 있습니다."
+        },
+        "input": {
+          "placeholder": "봇 token 입력..."
+        },
+        "missing": {
+          "toast": "봇 token을 입력하세요"
+        },
+        "notConfigured": {
+          "badge": "설정되지 않음"
+        },
+        "saveButton": {
+          "label": "token 저장",
+          "saving": {
+            "label": "저장하는 중..."
+          }
+        },
+        "saveError": {
+          "toast": "봇 token을 저장하지 못했습니다"
+        },
+        "saved": {
+          "toast": "봇 token을 저장했습니다"
+        },
+        "section": {
+          "title": "봇 token"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "서버를 등록한 후에 채널 설정을 사용할 수 있습니다."
+        },
+        "disableAllButton": {
+          "label": "모두 사용 중지"
+        },
+        "empty": {
+          "description": "채널을 추가하려면 Discord에서 !sync-channels를 실행하세요.",
+          "title": "설정된 채널이 없습니다"
+        },
+        "enableAllButton": {
+          "label": "모두 사용 설정"
+        },
+        "partialUpdate": {
+          "toast": "채널 {succeeded}개를 업데이트했지만 {failed}개는 실패했습니다"
+        },
+        "section": {
+          "description": "채널 목록을 업데이트하려면 Discord에서 !sync-channels를 실행하세요.",
+          "title": "채널 설정"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "에이전트 재정의"
+          },
+          "channel": {
+            "header": "채널"
+          },
+          "enabled": {
+            "header": "사용"
+          },
+          "requireMention": {
+            "header": "@멘션 필요"
+          },
+          "threadOnly": {
+            "header": "스레드 전용 모드"
+          }
+        },
+        "updateError": {
+          "toast": "채널을 업데이트하지 못했습니다"
+        },
+        "updated": {
+          "toast": "{count, plural, one {채널 #개} other {채널 #개}}를 업데이트했습니다"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "기본 에이전트를 해제했습니다"
+        },
+        "section": {
+          "description": "재정의하지 않는 한 봇이 모든 채널에서 사용하는 에이전트입니다.",
+          "title": "기본 에이전트"
+        },
+        "select": {
+          "default": {
+            "label": "기본 에이전트"
+          },
+          "placeholder": "에이전트 선택"
+        },
+        "updateError": {
+          "toast": "에이전트를 업데이트하지 못했습니다"
+        },
+        "updated": {
+          "toast": "기본 에이전트를 업데이트했습니다"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "채널을 불러올 수 없습니다",
+          "title": "채널을 불러오지 못했습니다"
+        },
+        "loadServer": {
+          "title": "서버를 불러오지 못했습니다"
+        },
+        "loadServers": {
+          "title": "Discord 서버를 불러오지 못했습니다"
+        },
+        "serverNotFound": {
+          "message": "서버를 찾을 수 없습니다"
+        },
+        "unknown": {
+          "message": "알 수 없는 오류가 발생했습니다"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "설정을 마치려면 Discord 서버에서 등록 키와 함께 !register 명령을 사용하세요.",
+          "title": "등록 대기 중"
+        },
+        "pending": {
+          "text": "등록 대기 중"
+        },
+        "registered": {
+          "text": "등록: {date}"
+        },
+        "updateButton": {
+          "label": "설정 업데이트"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "서버를 만들지 못했습니다"
+        },
+        "created": {
+          "toast": "서버 설정을 만들었습니다!"
+        },
+        "deleteError": {
+          "toast": "서버 설정을 삭제하지 못했습니다"
+        },
+        "deleteModal": {
+          "additionalDetails": "이 Discord 서버의 모든 설정이 제거됩니다.",
+          "entityType": "Discord 서버 설정"
+        },
+        "deleted": {
+          "toast": "서버 설정을 삭제했습니다"
+        },
+        "disabled": {
+          "toast": "서버를 사용 중지했습니다"
+        },
+        "empty": {
+          "description": "시작하려면 서버 설정을 만드세요.",
+          "title": "아직 설정된 Discord 서버가 없습니다"
+        },
+        "enabled": {
+          "toast": "서버를 사용 설정했습니다"
+        },
+        "fallbackName": "서버 #{id}",
+        "notRegistered": {
+          "toast": "서버를 사용 설정하려면 먼저 등록해야 합니다"
+        },
+        "pending": {
+          "badge": "대기 중"
+        },
+        "registered": {
+          "badge": "등록됨"
+        },
+        "table": {
+          "actions": {
+            "header": "작업"
+          },
+          "enabled": {
+            "header": "사용"
+          },
+          "registered": {
+            "header": "등록됨"
+          },
+          "server": {
+            "header": "서버"
+          },
+          "status": {
+            "header": "상태"
+          }
+        },
+        "updateError": {
+          "toast": "서버를 업데이트하지 못했습니다"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "Onyx를 Discord 서버에 연결합니다. 사용자는 Discord 채널에서 바로 질문할 수 있습니다."
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "이 키는 한 번만 표시됩니다!",
+          "title": "등록 키"
+        },
+        "instructions": {
+          "text": "명령을 복사하여 서버의 아무 텍스트 채널에서 보내세요!"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "만드는 중..."
+          },
+          "label": "서버 추가"
+        },
+        "section": {
+          "title": "서버 설정"
+        }
+      },
+      "unsavedChanges": {
+        "description": "저장하려면 업데이트를 클릭하세요.",
+        "title": "저장하지 않은 변경 사항이 있습니다"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "API 키 입력"
+        },
+        "deleteButton": {
+          "label": "API 키 삭제"
+        },
+        "deleteHint": "업데이트하기 전에 현재 API 키를 삭제하세요.",
+        "description": "Unstructured는 .pdf, .docx, .png, .pptx 등의 형식에서 복잡한 데이터를 추출하고 변환하여 Onyx가 수집할 수 있는 깨끗한 텍스트로 만듭니다. Unstructured 문서 처리를 사용하려면 API 키를 입력하세요.",
+        "learnMore": "Unstructured에 대한 자세한 내용은 <link>여기</link>를 참고하세요.",
+        "note": "<label>참고:</label> 처리를 위해 문서가 Unstructured 서버로 전송됩니다.",
+        "saveButton": {
+          "label": "API 키 저장"
+        },
+        "title": "Unstructured API로 처리"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "부스트:"
+        },
+        "search": {
+          "placeholder": "제목 / 내용으로 문서 찾기..."
+        },
+        "updateFailed": {
+          "toast": "문서를 업데이트하지 못했습니다 - {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "문서를 불러오는 중 오류가 발생했습니다 - {detail}"
+        },
+        "loading": {
+          "label": "불러오는 중"
+        },
+        "mostDisliked": {
+          "title": "낮은 평가를 가장 많이 받은 문서"
+        },
+        "mostLiked": {
+          "title": "높은 평가를 가장 많이 받은 문서"
+        },
+        "table": {
+          "name": {
+            "header": "문서 이름"
+          },
+          "score": {
+            "header": "점수"
+          },
+          "searchable": {
+            "header": "검색 가능 여부"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "숨김 상태를 업데이트하는 중 오류가 발생했습니다 - {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "점수는 숫자여야 합니다"
+        },
+        "updated": {
+          "toast": "점수를 업데이트했습니다!"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "비공개"
+          },
+          "public": {
+            "label": "공개"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "이름 없음"
+          }
+        },
+        "deleteFailed": {
+          "toast": "문서 세트 삭제를 예약하지 못했습니다 - {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "문서 세트 \"{name}\"의 삭제를 예약했습니다"
+        },
+        "description": "**문서 세트**를 사용하면 논리적으로 연결된 문서를 하나의 묶음으로 그룹화할 수 있습니다. 검색할 때 필터로 사용하여 Onyx가 검색하는 정보 범위를 제어할 수 있습니다.",
+        "edit": {
+          "header": {
+            "title": "문서 세트 편집"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "동기화 중에는 업데이트할 수 없습니다! 동기화가 끝난 후 다시 시도하세요."
+          }
+        },
+        "federatedBadge": {
+          "label": "페더레이션"
+        },
+        "fetchConnectorsFailed": {
+          "title": "커넥터를 가져오지 못했습니다"
+        },
+        "fetchSetsFailed": {
+          "title": "문서 세트를 가져오지 못했습니다"
+        },
+        "form": {
+          "connectors": {
+            "label": "커넥터 선택",
+            "placeholder": "커넥터 검색...",
+            "required": "커넥터를 하나 이상 선택하세요(일반 또는 페더레이션)"
+          },
+          "createFailed": {
+            "toast": "문서 세트를 만드는 중 오류가 발생했습니다 - {detail}"
+          },
+          "created": {
+            "toast": "문서 세트를 만들었습니다!"
+          },
+          "description": {
+            "label": "설명:",
+            "placeholder": "문서 세트가 무엇을 나타내는지 설명하세요"
+          },
+          "federatedConnectors": {
+            "label": "페더레이션 커넥터",
+            "placeholder": "페더레이션 커넥터 검색..."
+          },
+          "name": {
+            "label": "이름:",
+            "placeholder": "문서 세트의 이름",
+            "required": "세트의 이름을 입력하세요"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {선택한 그룹에서 사용할 수 있는 커넥터} one {선택한 그룹에서 사용할 수 있는 커넥터} other {선택한 그룹에서 사용할 수 있는 커넥터}}"
+          },
+          "submitButton": {
+            "createLabel": "문서 세트 만들기",
+            "updateLabel": "문서 세트 업데이트"
+          },
+          "unavailableConnectors": {
+            "description": "문서 세트를 추가하려는 그룹에 직접 할당된 커넥터만 사용할 수 있습니다.",
+            "title": "{count, plural, =0 {선택한 그룹에서 사용할 수 없는 커넥터} one {선택한 그룹에서 사용할 수 없는 커넥터} other {선택한 그룹에서 사용할 수 없는 커넥터}}"
+          },
+          "updateFailed": {
+            "toast": "문서 세트를 업데이트하는 중 오류가 발생했습니다 - {detail}"
+          },
+          "updated": {
+            "toast": "문서 세트를 업데이트했습니다!"
+          }
+        },
+        "loadError": {
+          "message": "오류: {detail}"
+        },
+        "new": {
+          "header": {
+            "title": "새 문서 세트"
+          }
+        },
+        "newButton": {
+          "label": "새 문서 세트"
+        },
+        "notFound": {
+          "message": "id가 {id}인 문서 세트를 찾을 수 없습니다",
+          "title": "문서 세트를 찾을 수 없습니다"
+        },
+        "status": {
+          "deleting": {
+            "label": "삭제 중"
+          },
+          "syncing": {
+            "label": "동기화 중"
+          },
+          "upToDate": {
+            "label": "최신"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "커넥터"
+          },
+          "delete": {
+            "header": "삭제"
+          },
+          "name": {
+            "header": "이름"
+          },
+          "public": {
+            "header": "공개"
+          },
+          "status": {
+            "header": "상태"
+          },
+          "title": "기존 문서 세트"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "숨김"
+        },
+        "hide": {
+          "ariaLabel": "문서 숨기기",
+          "label": "숨기기"
+        },
+        "unhide": {
+          "ariaLabel": "문서 숨기기 해제",
+          "label": "숨기기 해제"
+        },
+        "visible": {
+          "label": "표시"
+        }
+      }
+    },
+    "externalApps": {
+      "apps": {
+        "empty": {
+          "addButton": {
+            "label": "앱 추가"
+          },
+          "description": "앱을 추가하여 조직의 모든 사용자가 사용할 수 있도록 하세요.",
+          "title": "아직 앱이 없습니다"
+        },
+        "panel": {
+          "blurb": "조직 전체에 한 번만 설정합니다. 앱을 편집하여 공유 자격 증명, 액션 정책, 연결된 스킬을 설정하세요."
+        },
+        "tab": {
+          "label": "앱",
+          "labelWithCount": "앱 · {count, number}"
+        }
+      },
+      "card": {
+        "actionsButton": {
+          "ariaLabel": "{name} 작업"
+        },
+        "availableInCraft": {
+          "label": "Craft에서 사용 가능"
+        },
+        "customTag": {
+          "label": "사용자 지정"
+        },
+        "deleteAction": {
+          "label": "삭제"
+        },
+        "deleteModal": {
+          "description": "조직 전체에서 이 앱을 삭제합니다. 앱 구성, 모든 멤버의 연결, 제공업체가 관리하는 스킬이 함께 삭제됩니다.",
+          "retainedSkills": "{count, plural, =0 {삭제되는 연결된 사용자 지정 스킬은 없습니다.} one {연결된 사용자 지정 스킬 #개는 유지되지만, 이 앱과의 연결이 끊기고 모든 사용자에게 비활성화됩니다.} other {연결된 사용자 지정 스킬 #개는 유지되지만, 이 앱과의 연결이 끊기고 모든 사용자에게 비활성화됩니다.}}",
+          "submit": {
+            "label": "앱 삭제"
+          },
+          "submitting": {
+            "label": "삭제하는 중…"
+          },
+          "title": "“{name}”을(를) 삭제할까요?"
+        },
+        "editAction": {
+          "label": "편집"
+        },
+        "toasts": {
+          "deleteFailed": "\"{name}\" 삭제에 실패했습니다",
+          "disableFailed": "\"{name}\" 비활성화에 실패했습니다",
+          "enableFailed": "\"{name}\" 활성화에 실패했습니다"
+        },
+        "toggle": {
+          "disableAriaLabel": "{name} 비활성화",
+          "enableAriaLabel": "{name} 활성화"
+        }
+      },
+      "facts": {
+        "actions": "{count, plural, one {액션 #개} other {액션 #개}}",
+        "customSkills": "{count, plural, one {사용자 지정 스킬 #개} other {사용자 지정 스킬 #개}}",
+        "noCredentials": "자격 증명 없음",
+        "noCustomSkills": "사용자 지정 스킬 없음",
+        "orgCredentialsSet": "조직 자격 증명 설정됨",
+        "perUserCredentials": "사용자별 자격 증명",
+        "providedByOnyx": "Onyx 제공",
+        "tools": "{count, plural, one {도구 #개} other {도구 #개}}",
+        "upstreamPatterns": "{count, plural, one {업스트림 패턴 #개} other {업스트림 패턴 #개}}"
+      },
+      "loading": {
+        "label": "불러오는 중…"
+      },
+      "mcpServers": {
+        "empty": {
+          "description": "액션에서 서버를 연결한 다음, 여기에서 조직용으로 활성화하세요.",
+          "openActionsButton": {
+            "label": "액션 열기"
+          },
+          "title": "아직 MCP 서버가 없습니다"
+        },
+        "manageInActionsButton": {
+          "label": "액션에서 관리"
+        },
+        "panel": {
+          "blurb": "서버를 활성화하면 접근 권한이 있는 멤버가 Craft에서 해당 서버의 도구를 사용할 수 있습니다. 서버를 편집하여 도구별 승인 정책을 설정하세요. 서버 연결과 접근 권한은 액션에서 관리합니다."
+        },
+        "tab": {
+          "label": "MCP 서버",
+          "labelWithCount": "MCP 서버 · {count, number}"
+        }
+      },
+      "page": {
+        "addAppButton": {
+          "label": "앱 추가"
+        },
+        "backToCraftButton": {
+          "label": "Craft로 돌아가기"
+        },
+        "description": "조직의 Craft 에이전트가 사용할 앱을 설정합니다. 각 멤버는 Craft의 앱 페이지에서 자신의 계정을 연결합니다."
+      },
+      "warnings": {
+        "invalidSkill": "잘못된 스킬",
+        "providerUnavailable": "제공업체 사용 불가"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "커넥터를 불러오지 못했습니다: {details}",
+        "title": "오류"
+      },
+      "loading": {
+        "description": "커넥터 세부 정보와 자격 증명 스키마를 가져오는 중입니다",
+        "title": "커넥터 구성을 불러오는 중..."
+      }
+    },
+    "groups": {
+      "card": {
+        "defaultTag": {
+          "label": "기본"
+        },
+        "toasts": {
+          "renameFailed": "그룹 이름 변경에 실패했습니다",
+          "renamed": "그룹 이름을 \"{name}\"(으)로 변경했습니다"
+        },
+        "viewGroup": {
+          "label": "그룹 보기"
+        }
+      },
+      "create": {
+        "header": {
+          "title": "그룹 생성"
+        },
+        "submit": {
+          "label": "생성"
+        },
+        "toasts": {
+          "createFailed": "그룹 생성에 실패했습니다",
+          "created": "그룹 \"{name}\"을(를) 생성했습니다"
+        }
+      },
+      "edit": {
+        "delete": {
+          "button": {
+            "label": "그룹 삭제"
+          },
+          "description": "멤버는 이 그룹과 공유된 모든 리소스에 접근할 수 없게 됩니다.",
+          "title": "이 그룹 삭제"
+        },
+        "deleteModal": {
+          "deleting": {
+            "label": "삭제하는 중..."
+          },
+          "description": "<highlight>{name}</highlight> 그룹의 멤버는 직접 접근 권한을 받은 경우가 아니면 이 그룹과 공유된 리소스에 접근할 수 없게 됩니다. 삭제는 되돌릴 수 없습니다.",
+          "submit": {
+            "label": "삭제"
+          },
+          "title": "그룹 삭제"
+        },
+        "header": {
+          "title": "그룹 편집"
+        },
+        "incognito": {
+          "description": "이 그룹의 멤버는 시크릿 채팅을 시작할 수 있습니다.",
+          "title": "시크릿 채팅"
+        },
+        "loadError": {
+          "text": "그룹 데이터를 불러오지 못했습니다."
+        },
+        "notFound": {
+          "description": "이 그룹은 존재하지 않거나 삭제되었을 수 있습니다.",
+          "header": {
+            "title": "그룹을 찾을 수 없음"
+          },
+          "title": "그룹을 찾을 수 없습니다"
+        },
+        "saving": {
+          "label": "저장하는 중..."
+        },
+        "submit": {
+          "label": "변경 사항 저장"
+        },
+        "syncing": {
+          "label": "동기화하는 중...",
+          "tooltip": "이 그룹의 최근 변경 사항으로 인해 문서 embedding을 업데이트하는 중입니다."
+        },
+        "systemGroup": {
+          "description": "Onyx가 이 그룹을 관리합니다. 이 그룹에는 멤버만 포함되며, 변경할 수 있는 항목도 멤버뿐입니다.",
+          "title": "시스템 그룹"
+        },
+        "toasts": {
+          "deleteFailed": "그룹 삭제에 실패했습니다",
+          "deleted": "그룹 \"{name}\"을(를) 삭제했습니다",
+          "managerAssigned": "관리자를 지정했습니다",
+          "managerRevoked": "관리자 권한을 해제했습니다",
+          "managerUpdateFailed": "관리자 변경에 실패했습니다",
+          "membersStranded": "일부 멤버가 어떤 그룹에도 속하지 않게 됩니다. 먼저 다른 그룹에 추가하세요.",
+          "syncing": "이 그룹은 현재 동기화 중입니다. 잠시 후 다시 시도하세요.",
+          "updateFailed": "그룹 업데이트에 실패했습니다",
+          "updated": "그룹 \"{name}\"을(를) 업데이트했습니다"
+        }
+      },
+      "form": {
+        "cancel": {
+          "label": "취소"
+        },
+        "name": {
+          "label": "그룹 이름",
+          "placeholder": "그룹 이름을 입력하세요"
+        },
+        "toasts": {
+          "nameRequired": "그룹 이름은 필수입니다"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "그룹을 만들어 사용자를 정리하고 접근 권한을 관리하세요."
+        },
+        "loadError": {
+          "description": "자세한 내용은 콘솔을 확인하세요.",
+          "title": "그룹을 불러오지 못했습니다."
+        },
+        "newGroup": {
+          "label": "새 그룹"
+        },
+        "noResults": {
+          "description": "\"{query}\"와(과) 일치하는 그룹이 없습니다",
+          "title": "그룹을 찾을 수 없습니다"
+        },
+        "search": {
+          "placeholder": "그룹 검색..."
+        }
+      },
+      "members": {
+        "add": {
+          "label": "추가"
+        },
+        "done": {
+          "label": "완료"
+        },
+        "lastGroup": {
+          "tooltip": "이 멤버가 속한 유일한 그룹입니다. 먼저 다른 그룹에 추가하세요."
+        },
+        "loadError": {
+          "text": "사용자를 불러오지 못했습니다."
+        },
+        "makeManager": {
+          "label": "관리자로 지정"
+        },
+        "managerTag": {
+          "label": "관리자"
+        },
+        "noMembers": {
+          "description": "이 그룹에 멤버를 추가하세요.",
+          "title": "멤버 없음"
+        },
+        "noUsers": {
+          "description": "검색과 일치하는 사용자가 없습니다.",
+          "title": "사용자를 찾을 수 없습니다"
+        },
+        "ownManager": {
+          "tooltip": "자신의 관리자 권한은 해제할 수 없습니다"
+        },
+        "removeMember": {
+          "label": "멤버 제거"
+        },
+        "removeSelf": {
+          "tooltip": "이 그룹을 관리하는 동안에는 자신을 제거할 수 없습니다"
+        },
+        "revokeManager": {
+          "label": "관리자 권한 해제"
+        },
+        "saveBeforeManager": {
+          "tooltip": "관리자를 지정하기 전에 그룹을 저장하세요"
+        },
+        "searchMembers": {
+          "placeholder": "멤버 검색..."
+        },
+        "searchUsers": {
+          "placeholder": "사용자 및 계정 검색..."
+        },
+        "table": {
+          "accountType": {
+            "header": "계정 유형"
+          },
+          "name": {
+            "header": "이름"
+          }
+        }
+      },
+      "page": {
+        "title": "그룹"
+      },
+      "permissions": {
+        "section": {
+          "description": "이 그룹 멤버의 접근 및 사용 권한을 설정합니다.",
+          "title": "그룹 권한"
+        }
+      },
+      "permissionsChanged": {
+        "description": "이제 Onyx는 그룹 기반 권한을 사용합니다. 접근 권한은 그룹별로 설정하므로, 사용자의 권한은 그 사용자가 속한 모든 그룹의 권한을 합친 것입니다.",
+        "learnMore": {
+          "label": "자세히 알아보기"
+        },
+        "title": "권한이 변경되었습니다"
+      },
+      "sharedResources": {
+        "agent": {
+          "description": "에이전트"
+        },
+        "agents": {
+          "label": "에이전트",
+          "placeholder": "에이전트 추가"
+        },
+        "connector": {
+          "description": "커넥터"
+        },
+        "connectorFallback": {
+          "label": "커넥터 #{id}"
+        },
+        "connectors": {
+          "label": "커넥터 및 문서 세트",
+          "placeholder": "커넥터, 문서 세트 추가"
+        },
+        "documentSet": {
+          "description": "문서 세트"
+        },
+        "noAgents": {
+          "description": "이 그룹과 공유할 에이전트를 추가하세요.",
+          "title": "추가된 에이전트 없음"
+        },
+        "noConnectors": {
+          "description": "이 그룹과 공유할 커넥터 또는 문서 세트를 추가하세요.",
+          "title": "추가된 커넥터 또는 문서 세트 없음"
+        },
+        "popover": {
+          "connectors": {
+            "label": "커넥터"
+          },
+          "documentSets": {
+            "label": "문서 세트"
+          },
+          "noResults": {
+            "title": "결과를 찾을 수 없습니다"
+          }
+        },
+        "section": {
+          "description": "이 그룹의 멤버와 커넥터, 문서 세트, 에이전트를 공유합니다.",
+          "title": "이 그룹과 공유됨"
+        },
+        "sharedBadge": {
+          "label": "공유됨"
+        }
+      },
+      "tokenLimits": {
+        "addLimit": {
+          "label": "한도 추가"
+        },
+        "costLimit": {
+          "header": "비용 한도",
+          "placeholder": "비용 한도",
+          "unit": "(USD)"
+        },
+        "disabledTooltip": "Token 사용량 제한은 [Onyx 엔터프라이즈 버전](/admin/billing)에서만 사용할 수 있습니다.",
+        "section": {
+          "description": "이 그룹이 지정된 기간 동안 사용할 수 있는 token 수를 제한합니다.",
+          "title": "Token 사용량 제한"
+        },
+        "timeWindow": {
+          "header": "시간 범위",
+          "unit": "(UTC 기준 일수)"
+        },
+        "tokenLimit": {
+          "header": "Token 한도",
+          "placeholder": "Token 한도(천 단위)",
+          "unit": "(천 단위)"
+        }
+      }
+    },
+    "imageGeneration": {
+      "configureSuccess": {
+        "message": "제공업체를 설정했습니다"
+      },
+      "deselectError": {
+        "message": "선택 해제에 실패했습니다"
+      },
+      "deselectSuccess": {
+        "message": "{title} 선택을 해제했습니다"
+      },
+      "disconnectError": {
+        "message": "연결 해제에 실패했습니다"
+      },
+      "disconnectModal": {
+        "connectAnother": {
+          "description": "이미지 생성을 계속 사용하려면 다른 제공업체를 연결하세요."
+        },
+        "defaultNoReplacement": {
+          "description": "현재 **{title}**이(가) 기본 이미지 생성 모델입니다."
+        },
+        "defaultWithReplacement": {
+          "description": "현재 **{title}**이(가) 기본 이미지 생성 모델입니다. 세션 기록은 유지됩니다."
+        },
+        "header": {
+          "description": "이 제공업체에 저장된 자격 증명을 삭제합니다.",
+          "title": "*{title}* 연결 해제"
+        },
+        "noDefaultOption": {
+          "description": "(이미지 생성 비활성화)",
+          "label": "기본값 없음"
+        },
+        "nonDefault": {
+          "description": "이제 **{title}** 모델은 이미지 생성에 사용되지 않습니다."
+        },
+        "replacement": {
+          "label": "새 기본값 설정",
+          "placeholder": "대체할 모델을 선택하세요"
+        },
+        "sessionHistory": {
+          "description": "세션 기록은 유지됩니다."
+        },
+        "submitButton": {
+          "label": "연결 해제"
+        }
+      },
+      "disconnectSuccess": {
+        "message": "{title} 연결을 해제했습니다"
+      },
+      "emptyState": {
+        "title": "채팅에서 사용할 이미지 생성 모델을 연결하세요."
+      },
+      "form": {
+        "apiKey": {
+          "comboPlaceholder": "새 API 키를 입력하거나 기존 제공업체를 선택하세요",
+          "idle": "새 API 키를 입력하거나 기존 제공업체를 선택하세요.",
+          "label": "API 키",
+          "placeholder": "API 키를 입력하세요",
+          "required": "API 키는 필수입니다"
+        },
+        "apiKeyTest": {
+          "error": "잘못된 API 키입니다",
+          "loading": "{title}에서 API 키를 테스트하는 중...",
+          "success": "API 키가 유효합니다. 구성을 저장했습니다."
+        },
+        "apiKeyValidationFailed": {
+          "message": "API 키 검증에 실패했습니다"
+        },
+        "authMethod": {
+          "idle": "Onyx가 Google Vertex AI에 인증하는 방식을 선택하세요.",
+          "label": "인증 방식",
+          "required": "인증 방식은 필수입니다",
+          "serviceAccount": {
+            "description": "GCP 서비스 계정 키 JSON 파일을 업로드하세요",
+            "label": "서비스 계정 JSON"
+          },
+          "workloadIdentity": {
+            "description": "Pod의 기본 GCP 자격 증명을 사용합니다 (GKE Workload Identity)",
+            "label": "Workload Identity (GKE)"
+          }
+        },
+        "azureApiKey": {
+          "idle": "모델에 접근하려면 Azure OpenAI의 <link>API 키</link>를 붙여넣으세요."
+        },
+        "connectHeader": {
+          "title": "{title} 연결"
+        },
+        "credentials": {
+          "idle": "Google Cloud의 <link>서비스 계정 자격 증명</link>을 업로드하거나 붙여넣으세요.",
+          "label": "자격 증명 파일",
+          "placeholder": "자격 증명을 업로드하거나 붙여넣으세요",
+          "required": "자격 증명 파일은 필수입니다"
+        },
+        "credentialsTest": {
+          "error": "잘못된 자격 증명입니다",
+          "loading": "{title}에서 자격 증명을 테스트하는 중...",
+          "success": "자격 증명이 유효합니다. 구성을 저장했습니다."
+        },
+        "editHeader": {
+          "title": "{title} 편집"
+        },
+        "invalidProviderSelection": {
+          "message": "잘못된 제공업체 선택입니다"
+        },
+        "loading": {
+          "placeholder": "불러오는 중..."
+        },
+        "location": {
+          "idle": "Vertex AI 모델을 사용할 Google Cloud 리전입니다. 사용 가능한 리전은 <link>Google 문서</link>를 참고하세요.",
+          "label": "위치",
+          "required": "위치는 필수입니다"
+        },
+        "projectId": {
+          "idle": "Vertex AI가 활성화된 GCP 프로젝트입니다. Onyx는 Pod에 연결된 서비스 계정으로 인증합니다 (GKE Workload Identity).",
+          "label": "GCP 프로젝트 ID",
+          "required": "프로젝트 ID는 필수입니다"
+        },
+        "targetUri": {
+          "idle": "<link>Azure OpenAI</link>의 엔드포인트 대상 URI를 붙여넣으세요. API 엔드포인트 기본 주소, 배포 이름, API 버전이 포함되어야 합니다.",
+          "invalid": "대상 URI는 api-version과 배포 이름을 포함한 유효한 URL이어야 합니다",
+          "label": "대상 URI",
+          "required": "대상 URI는 필수입니다"
+        },
+        "unknownError": {
+          "message": "알 수 없는 오류가 발생했습니다"
+        }
+      },
+      "header": {
+        "description": "채팅 내 이미지 생성 설정입니다.",
+        "title": "이미지 생성"
+      },
+      "loadError": {
+        "message": "구성을 불러오지 못했습니다. 페이지를 새로고침하세요."
+      },
+      "model": {
+        "description": "채팅에서 이미지를 생성할 모델을 선택하세요.",
+        "title": "이미지 생성 모델"
+      },
+      "providers": {
+        "azureGptImage1": {
+          "description": "Microsoft Azure에서 호스팅되는 GPT Image 1 이미지 생성 모델입니다."
+        },
+        "azureGptImage15": {
+          "description": "Microsoft Azure에서 호스팅되는 GPT Image 1.5 이미지 생성 모델입니다."
+        },
+        "azureGptImage2": {
+          "description": "Microsoft Azure에서 호스팅되는 GPT Image 2 이미지 생성 모델입니다."
+        },
+        "gemini25FlashImage": {
+          "description": "Gemini 2.5 Flash Image (Nano Banana) 모델은 속도와 효율성에 중점을 둡니다."
+        },
+        "gemini3ProImage": {
+          "description": "Gemini 3 Pro Image (Nano Banana Pro)는 전문적인 에셋 제작에 중점을 둡니다."
+        },
+        "gemini3ProImagePreview": {
+          "description": "Google Cloud에서 2026년 7월 17일에 지원을 종료합니다. Gemini 3 Pro Image로 전환하세요."
+        },
+        "openaiGptImage1": {
+          "description": "프롬프트 준수도가 높은 OpenAI의 강력한 이미지 생성 모델입니다."
+        },
+        "openaiGptImage15": {
+          "description": "OpenAI의 이전 대표 이미지 생성 모델입니다."
+        },
+        "openaiGptImage2": {
+          "description": "프롬프트 재현도가 가장 높은 OpenAI의 최신 이미지 생성 모델입니다."
+        }
+      },
+      "setDefaultError": {
+        "message": "기본값 설정에 실패했습니다"
+      },
+      "setDefaultSuccess": {
+        "message": "{title}을(를) 기본값으로 설정했습니다"
+      }
+    },
+    "indexSettings": {
+      "actions": {
+        "applyForward": {
+          "label": "새 문서와 업데이트된 문서에 적용"
+        },
+        "applyReindex": {
+          "label": "적용 및 재인덱싱"
+        },
+        "rebuildAll": {
+          "label": "기존 문서 전체 다시 구축"
+        },
+        "revert": {
+          "label": "되돌리기"
+        }
+      },
+      "azure": {
+        "apiVersion": {
+          "description": "배포가 사용하는 Azure OpenAI API 버전입니다.",
+          "placeholder": "예: 2023-05-15",
+          "title": "API 버전"
+        },
+        "deploymentName": {
+          "description": "Azure에서 이 embedding 모델에 설정한 배포 이름입니다.",
+          "placeholder": "my-embedding-deployment",
+          "title": "배포 이름"
+        },
+        "modelName": {
+          "description": "Onyx에서 이 모델에 사용할 라벨입니다. Azure는 배포 이름으로 요청을 라우팅하므로, 고유한 식별자이기만 하면 됩니다."
+        },
+        "targetUrl": {
+          "title": "대상 URL"
+        }
+      },
+      "cancelReindexModal": {
+        "description": "취소하면 이전 embedding 모델로 되돌아가며 재인덱싱 진행 상황은 모두 사라집니다.",
+        "submit": {
+          "label": "취소"
+        },
+        "title": "재인덱싱 취소"
+      },
+      "captioningModel": {
+        "description": "인덱싱 중에 이미지를 분석하는 데 이 모델을 사용합니다. 비전 기능이 있는 모델만 선택할 수 있습니다. 변경 사항은 이후에 인덱싱되는 문서에만 적용됩니다. 기존 캡션은 이전 embedding에 이미 포함되어 있습니다.",
+        "title": "캡션 생성 LLM"
+      },
+      "changesBanner": {
+        "contextualModelMissing": {
+          "description": "컨텍스트 검색이 활성화되어 있지만 선택된 모델이 없습니다. 재인덱싱 전에 아래에서 컨텍스트 검색 LLM을 선택하세요. 모델이 없으면 재인덱싱을 실행할 수 없습니다.",
+          "title": "컨텍스트 검색 LLM 선택"
+        },
+        "contextualModelOnly": {
+          "description": "새 문서와 업데이트된 문서에만 모델을 적용하거나, 모든 문서를 다시 구축하여 컨텍스트 보강을 일관되게 적용하세요.",
+          "title": "이 컨텍스트 검색 LLM을 적용할 방식을 선택하세요"
+        },
+        "default": {
+          "description": "embedding 또는 검색 설정을 변경하면 적용을 위해 모든 문서를 전체 재인덱싱해야 하며, 문서 규모에 따라 **몇 시간에서 며칠**이 걸릴 수 있습니다. [자세히 알아보기](https://docs.onyx.app/security/architecture/data_flows)",
+          "title": "변경 사항을 적용하려면 전체 재인덱싱이 필요합니다."
+        },
+        "orSeparator": {
+          "label": "또는"
+        }
+      },
+      "cloudDisabled": {
+        "tooltip": "이 설정은 Onyx Cloud에서 관리합니다."
+      },
+      "contextualModel": {
+        "description": "청크의 컨텍스트를 생성하는 데 이 모델을 사용합니다.",
+        "disabledTooltip": "컨텍스트 검색이 꺼져 있으면 변경할 수 없습니다.",
+        "title": "컨텍스트 검색 LLM"
+      },
+      "contextualRetrieval": {
+        "description": "인덱싱된 모든 청크에 문서 수준 컨텍스트를 추가하여 하이브리드 검색의 정확도를 높입니다. embedding 비용이 크게 늘어날 수 있습니다.",
+        "noModelsTooltip": "설정된 모델이 없어 컨텍스트 검색을 사용할 수 없습니다. 먼저 [언어 모델]({link})을 설정하세요.",
+        "title": "컨텍스트 검색"
+      },
+      "embeddingModel": {
+        "cloudManaged": {
+          "title": "Embedding 모델과 설정은 Onyx Cloud에서 관리합니다."
+        },
+        "description": "Onyx는 검색과 조회를 위해 이 모델로 문서를 인코딩합니다.",
+        "title": "Embedding 모델"
+      },
+      "errorsModal": {
+        "columns": {
+          "error": "오류",
+          "id": "ID",
+          "name": "이름",
+          "status": "상태",
+          "type": "유형"
+        },
+        "description": "최근 재인덱싱 시도가 실패했거나(자동 재시도 중) 일시 중지된(재개하여 재시도) 커넥터와 사용자 파일입니다.",
+        "empty": "확인이 필요한 항목이 없습니다.",
+        "loadError": "재인덱싱 상태를 불러오지 못했습니다. 다시 시도하세요.",
+        "loading": "불러오는 중…",
+        "resumeButton": {
+          "label": "재개"
+        },
+        "resumeFailed": "재개하지 못했습니다.",
+        "resumingButton": {
+          "label": "재개하는 중…"
+        },
+        "scope": {
+          "connector": "커넥터",
+          "userFiles": "사용자 파일"
+        },
+        "status": {
+          "failed": "실패",
+          "paused": "일시 중지됨"
+        },
+        "title": "재인덱싱 확인 필요",
+        "unknownError": "알 수 없는 오류"
+      },
+      "fields": {
+        "apiKey": {
+          "description": "모델에 접근하려면 {provider}의 [API 키]({link})를 붙여넣으세요.",
+          "title": "API 키"
+        },
+        "googleCredentials": {
+          "title": "JSON 자격 증명 파일 업로드"
+        },
+        "modelDim": {
+          "description": "이 모델이 생성하는 embedding의 차원 수입니다.",
+          "placeholder": "예: 768",
+          "title": "모델 차원"
+        },
+        "modelName": {
+          "placeholder": "model-name",
+          "selfHostedDescription": "Onyx가 자체 호스팅 엔드포인트에서 이 모델에 연결합니다.",
+          "title": "모델 이름"
+        },
+        "normalize": {
+          "description": "모델이 생성한 embedding을 정규화합니다. embedding 모델 문서에서 다르게 안내하지 않는 한 대부분의 모델에 권장합니다.",
+          "title": "Embedding 정규화"
+        },
+        "optional": {
+          "suffix": "선택 사항"
+        },
+        "passagePrefix": {
+          "description": "embedding 모델에서 필요로 하는 경우, 인덱싱된 문서 청크를 모델에 전달하기 전에 앞에 붙이는 문자열입니다. 접두사가 잘못되었거나 없으면 embedding 품질이 떨어집니다.",
+          "placeholder": "예: 'passage: '",
+          "title": "패시지 접두사"
+        },
+        "queryPrefix": {
+          "description": "embedding 모델에서 필요로 하는 경우, 검색 쿼리를 모델에 전달하기 전에 앞에 붙이는 문자열입니다. 접두사가 잘못되었거나 없으면 embedding 품질이 떨어집니다.",
+          "placeholder": "예: 'query: '",
+          "title": "쿼리 접두사"
+        }
+      },
+      "forwardOnlyModal": {
+        "description": "기존 문서는 이전 모델이 생성한 컨텍스트를 그대로 유지합니다. 새 모델은 문서가 추가되거나 업데이트될 때만 적용됩니다. 문서마다 컨텍스트 보강 결과가 다를 수 있습니다.",
+        "title": "컨텍스트 검색 LLM을 이후 문서에만 적용"
+      },
+      "header": {
+        "description": "문서를 인덱싱하고 embedding하여 검색과 조회에 사용할 방식을 설정합니다."
+      },
+      "imageExtraction": {
+        "description": "업로드된 파일(PDF, DOCX 등)에 포함된 이미지를 추출하고 비전 기능이 있는 LLM으로 요약하여, 이미지만 있는 문서도 검색하고 답변에 활용할 수 있게 합니다. 비전 기능이 있는 기본 LLM이 필요합니다.",
+        "title": "이미지 추출 및 캡션 생성"
+      },
+      "imageProcessing": {
+        "description": "인덱싱 중에 LLM으로 이미지를 분석하고 설명을 추가합니다.",
+        "enableFirstTooltip": "이 항목을 설정하려면 이미지 추출 및 캡션 생성을 활성화하세요.",
+        "noVisionModelsTooltip": "비전 기능이 있는 모델이 설정되어 있지 않아 이미지 처리를 사용할 수 없습니다. 먼저 비전 기능이 있는 [언어 모델]({link})을 설정하세요.",
+        "title": "이미지 처리"
+      },
+      "litellm": {
+        "apiUrl": {
+          "description": "{provider} 호환 엔드포인트 URL을 붙여넣으세요.",
+          "title": "API 기본 URL"
+        },
+        "modelName": {
+          "description": "Onyx가 {provider} 프록시에서 이 모델에 연결합니다."
+        }
+      },
+      "maxImageSize": {
+        "description": "리소스 사용을 제한하기 위해 이 크기를 넘는 이미지는 건너뜁니다.",
+        "suffix": "(MB)",
+        "title": "분석할 최대 이미지 크기"
+      },
+      "modal": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "connectButton": {
+          "label": "연결"
+        },
+        "manage": {
+          "description": "{provider} 제공업체와 모델 정보를 관리합니다.",
+          "title": "{provider} 관리"
+        },
+        "setUp": {
+          "description": "{provider}에 연결하고 {provider} embedding 모델을 설정하세요.",
+          "title": "{provider} 설정"
+        },
+        "updateButton": {
+          "label": "업데이트"
+        }
+      },
+      "modelCard": {
+        "connectButton": {
+          "label": "연결"
+        },
+        "currentButton": {
+          "label": "현재 모델"
+        },
+        "deprecated": {
+          "connectTooltip": "이 embedding 모델은 지원이 중단되어 연결할 수 없습니다.",
+          "selectTooltip": "이 embedding 모델은 지원이 중단되어 선택할 수 없습니다."
+        },
+        "selectButton": {
+          "label": "모델 선택"
+        },
+        "selectedButton": {
+          "label": "선택됨"
+        }
+      },
+      "modelPicker": {
+        "addCustomModel": {
+          "label": "사용자 지정 모델 추가"
+        },
+        "cloudTab": {
+          "label": "클라우드 기반"
+        },
+        "customModel": {
+          "title": "사용자 지정 embedding 모델을 설정하세요."
+        },
+        "customModels": {
+          "title": "사용자 지정 모델"
+        },
+        "foldModels": {
+          "label": "모델 접기"
+        },
+        "noCloudResults": {
+          "title": "클라우드 기반 모델을 찾을 수 없습니다"
+        },
+        "noResults": {
+          "description": "다른 검색어로 시도해 보세요."
+        },
+        "noSelfHostedResults": {
+          "title": "자체 호스팅 모델을 찾을 수 없습니다"
+        },
+        "revertSelection": {
+          "tooltip": "embedding 모델 선택 되돌리기"
+        },
+        "search": {
+          "placeholder": "모델 검색..."
+        },
+        "selfHostedTab": {
+          "label": "자체 호스팅"
+        },
+        "viewAllModels": {
+          "label": "모든 모델 보기"
+        }
+      },
+      "multipass": {
+        "description": "문서를 다양한 크기의 청크로 인덱싱하여 관련 소스를 더 정확하게 찾습니다.",
+        "disabledTooltip": "멀티패스 인덱싱은 일시적으로 사용할 수 없으며 추후 제공될 예정입니다.",
+        "tag": {
+          "label": "일시적으로 사용 불가"
+        },
+        "title": "멀티패스 인덱싱"
+      },
+      "progressBanner": {
+        "attentionButton": {
+          "label": "확인이 필요한 항목 보기"
+        },
+        "cancelButton": {
+          "label": "재인덱싱 취소 및 되돌리기"
+        },
+        "description": {
+          "withModel": "재인덱싱이 진행되면서 새 embedding 설정(**{model}**)이 적용됩니다. 문서 규모에 따라 **몇 시간에서 며칠**이 걸릴 수 있습니다.",
+          "withoutModel": "재인덱싱이 진행되면서 새 embedding 설정이 적용됩니다. 문서 규모에 따라 **몇 시간에서 며칠**이 걸릴 수 있습니다."
+        },
+        "progress": {
+          "ariaLabel": "재인덱싱 진행률"
+        },
+        "status": {
+          "label": "재인덱싱 상태:"
+        },
+        "title": "재인덱싱 진행 중…"
+      },
+      "providerGroup": {
+        "addConfig": {
+          "button": {
+            "label": "구성 추가"
+          },
+          "title": "{provider} embedding 제공업체의 구성을 추가하세요."
+        },
+        "deprecated": {
+          "suffix": "(지원 중단됨)"
+        },
+        "disconnect": {
+          "errorToast": "{provider} 연결 해제에 실패했습니다",
+          "successToast": "{provider} 연결을 해제했습니다"
+        },
+        "disconnectButton": {
+          "disabledTooltip": "이 embedding 모델은 현재 기본 모델이므로 연결을 해제할 수 없습니다. 먼저 다른 모델을 선택하세요."
+        },
+        "disconnectModal": {
+          "description": "**{provider}** 제공업체의 모든 embedding 모델 연결을 해제합니다.",
+          "submit": {
+            "label": "연결 해제"
+          },
+          "title": "{provider} 연결 해제"
+        },
+        "editCredentialsButton": {
+          "label": "자격 증명 편집"
+        }
+      },
+      "providerInfo": {
+        "cloudProvider": {
+          "title": "클라우드 제공업체"
+        },
+        "docsLink": {
+          "label": "문서"
+        },
+        "pricingLink": {
+          "label": "가격"
+        },
+        "selfHosted": {
+          "title": "자체 호스팅"
+        }
+      },
+      "reindexBanner": {
+        "cancelReindex": {
+          "label": "재인덱싱 취소"
+        },
+        "description": "**{model}**(으)로 전환하는 중입니다. 기존 문서를 다시 embedding하고 있으며, 문서 규모에 따라 몇 시간에서 며칠이 걸릴 수 있습니다. 전환이 끝날 때까지는 이전 모델이 쿼리를 계속 처리합니다.",
+        "seeConnectors": {
+          "label": "커넥터 보기"
+        },
+        "title": "재인덱싱 진행 중"
+      },
+      "reindexing": {
+        "disabledTooltip": "재인덱싱이 진행 중입니다. 변경하려면 재인덱싱을 취소하세요."
+      },
+      "retrieval": {
+        "description": "문서를 청크로 나누고 컨텍스트를 부여하는 방식을 설정하여 검색 정확도를 높이는 추가 인덱싱 기능입니다. embedding 비용이 늘어날 수 있습니다.",
+        "title": "검색 최적화"
+      },
+      "switchover": {
+        "activeOnly": {
+          "description": "일시 중지 또는 삭제 중이 아닌 모든 활성 커넥터가 인덱싱을 성공적으로 완료할 때까지 기존 설정의 현재 문서 인덱스를 계속 사용합니다.",
+          "label": "활성 커넥터 재인덱싱 후 전환"
+        },
+        "instant": {
+          "description": "현재 문서 인덱스를 즉시 비우고 새 설정으로 전환합니다. 검색용 인덱스를 다시 채우려면 모든 커넥터를 재인덱싱해야 합니다.",
+          "label": "재인덱싱 전에 전환"
+        },
+        "placeholder": "전환 방식을 선택하세요",
+        "reindexAll": {
+          "description": "가장 안전한 방식입니다. 모든 커넥터가 인덱싱을 성공적으로 완료할 때까지 기존 설정의 현재 문서 인덱스를 계속 사용합니다.",
+          "label": "모든 커넥터 재인덱싱 후 전환"
+        }
+      },
+      "toasts": {
+        "applyFailed": "설정 적용에 실패했습니다",
+        "cancelReindexFailed": "재인덱싱 취소에 실패했습니다",
+        "captioningUpdateFailed": "캡션 생성 LLM 업데이트에 실패했습니다",
+        "captioningUpdated": "캡션 생성 LLM을 업데이트했습니다",
+        "contextualModelRequired": "재인덱싱 전에 컨텍스트 검색 LLM을 선택하세요.",
+        "contextualModelUpdateFailed": "컨텍스트 검색 LLM 업데이트에 실패했습니다",
+        "contextualModelUpdated": "컨텍스트 검색 LLM을 업데이트했습니다",
+        "modelNotFound": "선택한 모델을 찾을 수 없습니다",
+        "providerResolveFailed": "제공업체를 확인할 수 없습니다",
+        "reindexCanceled": "재인덱싱을 취소했습니다",
+        "reindexStarted": "재인덱싱을 시작했습니다",
+        "settingsUpdateFailed": "설정 업데이트에 실패했습니다",
+        "settingsUpdated": "설정을 업데이트했습니다",
+        "unknownError": "알 수 없는 오류가 발생했습니다"
+      },
+      "validation": {
+        "apiBaseUrlRequired": "API 기본 URL은 필수입니다",
+        "apiKeyRequired": "API 키는 필수입니다",
+        "apiVersionRequired": "API 버전은 필수입니다",
+        "deploymentNameRequired": "배포 이름은 필수입니다",
+        "modelDimPositive": "양의 정수여야 합니다",
+        "modelDimRequired": "모델 차원은 필수입니다",
+        "modelNameRequired": "모델 이름은 필수입니다",
+        "serviceAccountJsonInvalid": "유효한 Google 서비스 계정 JSON 파일이어야 합니다",
+        "serviceAccountJsonRequired": "서비스 계정 JSON은 필수입니다",
+        "targetUrlRequired": "대상 URL은 필수입니다",
+        "urlInvalid": "유효한 URL이어야 합니다"
+      }
+    },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "{source}에서 상속됨"
+          },
+          "organizationPublic": {
+            "label": "조직 전체 공개"
+          },
+          "private": {
+            "label": "비공개"
+          }
+        },
+        "addConnectorButton": {
+          "label": "커넥터 추가"
+        },
+        "connectorCreated": {
+          "toast": "커넥터를 생성했습니다"
+        },
+        "empty": {
+          "message": "아직 설정된 커넥터가 없는 것 같습니다. [커넥터 추가](/admin/add-connector) 페이지에서 시작하세요!"
+        },
+        "federated": {
+          "access": {
+            "label": "페더레이션 액세스"
+          },
+          "indexed": {
+            "label": "인덱싱됨"
+          },
+          "notApplicable": {
+            "label": "해당 없음"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "자동 동기화"
+            },
+            "private": {
+              "label": "비공개"
+            },
+            "public": {
+              "label": "공개"
+            },
+            "title": "액세스 유형"
+          },
+          "applyButton": {
+            "label": "적용"
+          },
+          "docCount": {
+            "placeholder": "개수",
+            "title": "문서 수"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "오류와 함께 완료"
+            },
+            "failed": {
+              "label": "실패"
+            },
+            "inProgress": {
+              "label": "진행 중"
+            },
+            "interrupted": {
+              "label": "중단됨"
+            },
+            "notStarted": {
+              "label": "시작되지 않음"
+            },
+            "success": {
+              "label": "성공"
+            },
+            "title": "최근 상태"
+          },
+          "title": "커넥터 필터"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "액세스: {values}"
+          },
+          "clearBadge": {
+            "label": "지우기"
+          },
+          "docsAnyBadge": {
+            "label": "문서 {operator} 전체"
+          },
+          "docsBadge": {
+            "label": "문서 {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "상태: {values}"
+          }
+        },
+        "loadError": {
+          "message": "인덱싱 상태를 불러오지 못했습니다."
+        },
+        "manageConnector": {
+          "tooltip": "커넥터 관리"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "페더레이션 커넥터 관리"
+        },
+        "search": {
+          "placeholder": "커넥터 검색"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "활성 커넥터"
+          },
+          "publicConnectors": {
+            "label": "공개 커넥터"
+          },
+          "totalConnectors": {
+            "label": "전체 커넥터"
+          },
+          "totalDocsIndexed": {
+            "label": "인덱싱된 총 문서 수"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "모두 확인했습니다! 표시할 커넥터가 더 없습니다"
+          },
+          "lastIndexed": {
+            "header": "마지막 인덱싱"
+          },
+          "name": {
+            "header": "이름"
+          },
+          "permissions": {
+            "header": "권한 / 액세스"
+          },
+          "status": {
+            "header": "상태"
+          },
+          "totalDocs": {
+            "header": "총 문서 수"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "모두 접기"
+          },
+          "expand": {
+            "label": "모두 펼치기"
+          }
+        }
+      }
+    },
+    "languageModels": {
+      "availableProviders": {
+        "title": "사용 가능한 제공자"
+      },
+      "configurationDisabled": {
+        "description": "기존 LLM 제공자는 계속 사용하고 업데이트할 수 있습니다.",
+        "title": "새 LLM 구성을 일시적으로 사용할 수 없습니다."
+      },
+      "defaultModel": {
+        "description": "Onyx가 채팅에서 이 모델을 기본으로 사용합니다.",
+        "title": "기본 모델"
+      },
+      "deleteModal": {
+        "defaultProviderWarning": "기본 제공자는 삭제할 수 없습니다. 이 제공자를 삭제하기 전에 다른 제공자를 기본으로 선택하세요.",
+        "description": "**{provider}** 제공자의 모든 LLM 모델이 제거되어 이후 채팅에서 사용할 수 없습니다. 채팅 기록은 유지됩니다.",
+        "lastProviderNote": "채팅을 계속 사용하려면 다른 제공자를 연결하세요.",
+        "submit": {
+          "label": "삭제"
+        },
+        "title": "*{provider}* 삭제"
+      },
+      "groups": {
+        "addProvider": {
+          "description": "Onyx는 널리 쓰이는 제공자와 자체 호스팅 모델을 모두 지원합니다.",
+          "title": "제공자 추가"
+        },
+        "gateways": {
+          "title": "게이트웨이 및 라우터"
+        },
+        "selfHosted": {
+          "title": "자체 호스팅 및 사용자 지정"
+        }
+      },
+      "modals": {
+        "access": {
+          "admin": {
+            "sharedNote": "항상 공유됨",
+            "title": "관리자"
+          },
+          "agent": {
+            "name": "에이전트 {id}"
+          },
+          "agentOption": {
+            "description": "에이전트"
+          },
+          "comboBox": {
+            "placeholder": "그룹 및 에이전트 추가"
+          },
+          "field": {
+            "description": "이 제공자에 액세스할 수 있는 대상입니다.",
+            "title": "모델 액세스"
+          },
+          "group": {
+            "name": "그룹 {id}"
+          },
+          "groupOption": {
+            "description": "그룹"
+          },
+          "memberCount": {
+            "label": "{count, plural, one {멤버 #명} other {멤버 #명}}"
+          },
+          "noAgents": {
+            "description": "이 제공자는 어떤 에이전트에서도 사용되지 않습니다.",
+            "title": "추가된 에이전트 없음"
+          },
+          "private": {
+            "label": "지정된 그룹 및 에이전트"
+          },
+          "public": {
+            "label": "모든 사용자 및 에이전트"
+          },
+          "select": {
+            "placeholder": "액세스 수준 선택"
+          }
+        },
+        "azure": {
+          "targetUriField": {
+            "description": "Azure OpenAI의 엔드포인트 대상 URI를 붙여넣으세요(API 엔드포인트 기본 주소, 배포 이름, API 버전 포함).",
+            "title": "대상 URI"
+          },
+          "toasts": {
+            "targetUriParseFailed": "대상 URI를 분석하지 못했습니다 — 원래 값을 사용합니다."
+          },
+          "validation": {
+            "targetUriInvalid": "대상 URI는 api-version 쿼리 파라미터를 포함하고 경로에 배포 이름 또는 /openai/responses가 있는 유효한 URL이어야 합니다",
+            "targetUriRequired": "대상 URI는 필수입니다"
+          }
+        },
+        "bedrock": {
+          "accessKeyIdField": {
+            "title": "AWS 액세스 키 ID"
+          },
+          "authMethodField": {
+            "accessKey": {
+              "description": "AWS 이외의 환경용",
+              "label": "액세스 키"
+            },
+            "description": "Onyx가 Bedrock에 인증하는 방식을 선택하세요.",
+            "iam": {
+              "description": "AWS 환경에 권장",
+              "label": "환경 IAM 역할"
+            },
+            "longTermApiKey": {
+              "description": "AWS 이외의 환경용",
+              "label": "장기 API 키"
+            },
+            "title": "인증 방식"
+          },
+          "iamNotice": {
+            "title": "Onyx는 실행 중인 환경에 연결된 IAM 역할을 사용해 인증합니다."
+          },
+          "longTermApiKeyField": {
+            "placeholder": "장기 API 키",
+            "title": "장기 API 키"
+          },
+          "regionField": {
+            "description": "Amazon Bedrock 모델이 호스팅되는 리전입니다.",
+            "placeholder": "리전 선택",
+            "title": "AWS 리전"
+          },
+          "secretAccessKeyField": {
+            "title": "AWS 비밀 액세스 키"
+          },
+          "validation": {
+            "regionRequired": "AWS 리전은 필수입니다"
+          }
+        },
+        "bifrost": {
+          "apiBaseField": {
+            "description": "Bifrost 게이트웨이 엔드포인트 URL을 붙여넣으세요(API 버전 포함)."
+          },
+          "apiKeyField": {
+            "description": "모델에 액세스하려면 [Bifrost](https://docs.getbifrost.ai/overview)에서 발급한 API 키를 붙여넣으세요."
+          },
+          "apiMode": {
+            "chatCompletions": {
+              "label": "Chat Completions API"
+            },
+            "responses": {
+              "label": "Responses API"
+            }
+          }
+        },
+        "custom": {
+          "addModelButton": {
+            "label": "모델 추가"
+          },
+          "apiKeyField": {
+            "description": "모델 제공자가 인증을 요구하면 API 키를 붙여넣으세요."
+          },
+          "apiVersionField": {
+            "title": "API 버전"
+          },
+          "description": "LiteLLM과 호환되는 다른 제공자의 모델을 연결합니다.",
+          "envVars": {
+            "addButton": {
+              "label": "줄 추가"
+            },
+            "description": "모델 제공자가 요구하는 추가 속성을 입력하세요. 이 값은 [환경 변수](https://docs.litellm.ai/docs/set_keys#environment-variables)로서 LiteLLM의 `completion()` 호출에 전달됩니다. 자세한 안내는 [문서](https://docs.onyx.app/admins/ai_models/custom_inference_provider)를 참고하세요.",
+            "title": "환경 변수"
+          },
+          "modelRow": {
+            "displayNamePlaceholder": "표시 이름",
+            "inputTypePlaceholder": "입력 유형",
+            "maxTokensPlaceholder": "기본값",
+            "namePlaceholder": "모델 이름",
+            "textImage": {
+              "label": "텍스트 및 이미지"
+            },
+            "textOnly": {
+              "label": "텍스트 전용"
+            }
+          },
+          "modelTable": {
+            "displayName": {
+              "header": "표시 이름"
+            },
+            "inputType": {
+              "header": "입력 유형"
+            },
+            "maxTokens": {
+              "header": "최대 token 수"
+            },
+            "name": {
+              "header": "모델 이름"
+            }
+          },
+          "models": {
+            "description": "이 제공자에서 사용할 LLM 모델과 해당 설정을 입력하세요. 전체 모델 목록은 LiteLLM에서 확인하세요.",
+            "empty": {
+              "title": "아직 추가된 모델이 없습니다."
+            },
+            "title": "모델"
+          },
+          "providerField": {
+            "createPrefix": "사용",
+            "description": "지원되는 LLM 제공자 전체 목록은 [LiteLLM](https://docs.litellm.ai/docs/providers)에서 확인하세요.",
+            "placeholder": "LiteLLM에 표시된 제공자 ID 문자열",
+            "title": "제공자"
+          },
+          "toasts": {
+            "modelNameRequired": "모델 이름을 최소 하나 입력해야 합니다"
+          },
+          "validation": {
+            "displayNameRequired": "표시 이름은 필수입니다",
+            "providerNameRequired": "제공자 이름은 필수입니다"
+          }
+        },
+        "liteLlmProxy": {
+          "apiBaseField": {
+            "description": "LiteLLM Proxy 서버의 기본 URL입니다."
+          }
+        },
+        "lmStudio": {
+          "apiBaseField": {
+            "description": "LM Studio 서버의 기본 URL입니다.",
+            "placeholder": "LM Studio API 기본 URL"
+          },
+          "apiKeyField": {
+            "description": "LM Studio 서버가 인증을 요구할 때 사용하는 선택 API 키입니다."
+          }
+        },
+        "modelSettings": {
+          "capabilities": {
+            "chat": {
+              "label": "채팅"
+            },
+            "multiModal": {
+              "label": "멀티모달"
+            },
+            "reasoning": {
+              "label": "추론"
+            }
+          },
+          "reasoningLevel": {
+            "defaultSlider": {
+              "label": "기본값"
+            },
+            "maxSlider": {
+              "label": "최대 수준"
+            }
+          },
+          "temperature": {
+            "defaultSlider": {
+              "label": "기본값"
+            },
+            "pinned": {
+              "tooltip": "추론 모델은 항상 temperature 1로 실행됩니다."
+            }
+          },
+          "trigger": {
+            "tooltip": "모델 설정"
+          }
+        },
+        "models": {
+          "addModelButton": {
+            "label": "모델 추가"
+          },
+          "addModelInput": {
+            "placeholder": "모델 이름 입력"
+          },
+          "autoUpdate": {
+            "description": "새 모델이 출시되면 사용 가능한 모델을 업데이트합니다.",
+            "title": "자동 업데이트"
+          },
+          "deselectAllButton": {
+            "label": "전체 선택 해제"
+          },
+          "empty": {
+            "title": "사용 가능한 모델이 없습니다."
+          },
+          "field": {
+            "description": "이 제공자에서 사용할 모델을 선택하세요.",
+            "title": "모델"
+          },
+          "foldButton": {
+            "label": "모델 접기"
+          },
+          "moreButton": {
+            "label": "모델 더 보기"
+          },
+          "refetch": {
+            "errorToast": "모델을 가져오지 못했습니다"
+          },
+          "row": {
+            "defaultLabel": "기본 모델",
+            "renameButton": {
+              "tooltip": "이름 변경"
+            },
+            "setDefaultButton": {
+              "label": "기본으로 설정"
+            },
+            "visionMarker": {
+              "title": "비전"
+            }
+          },
+          "selectAllButton": {
+            "label": "전체 선택"
+          }
+        },
+        "nebius": {
+          "apiBaseField": {
+            "description": "Nebius TokenFactory 엔드포인트 URL입니다(API 버전 포함)."
+          },
+          "apiKeyField": {
+            "description": "사용 가능한 모델을 불러오려면 [Nebius TokenFactory](https://tokenfactory.nebius.com/)에서 발급한 API 키를 붙여넣으세요."
+          }
+        },
+        "ollama": {
+          "apiBaseField": {
+            "description": "Ollama 인스턴스의 기본 URL입니다.",
+            "placeholder": "Ollama API 기본 URL"
+          },
+          "apiKeyField": {
+            "description": "Ollama Cloud API 키입니다.",
+            "placeholder": "API 키"
+          },
+          "tabs": {
+            "cloud": {
+              "label": "Ollama Cloud"
+            },
+            "selfHosted": {
+              "label": "자체 호스팅 Ollama"
+            }
+          }
+        },
+        "openAiCompatible": {
+          "apiBaseField": {
+            "description": "OpenAI 호환 엔드포인트 URL을 붙여넣으세요.",
+            "learnMore": "[자세히 보기](https://docs.litellm.ai/docs/providers/openai_compatible)"
+          },
+          "apiKeyField": {
+            "description": "모델 제공자가 인증을 요구하면 API 키를 붙여넣으세요."
+          },
+          "description": "OpenAI 호환 엔드포인트를 통해 다른 클라우드 모델이나 자체 호스팅 모델을 연결합니다."
+        },
+        "openRouter": {
+          "apiBaseField": {
+            "description": "OpenRouter 호환 엔드포인트 URL을 붙여넣거나 OpenRouter API를 직접 사용하세요.",
+            "placeholder": "OpenRouter 기본 URL"
+          }
+        },
+        "portkey": {
+          "apiBaseField": {
+            "description": "Portkey의 기본 URL을 사용하거나 자체 호스팅 게이트웨이의 기본 URL을 붙여넣으세요.",
+            "placeholder": "Portkey 게이트웨이 기본 URL"
+          },
+          "apiKeyField": {
+            "description": "모델에 액세스하려면 [Portkey](https://portkey.ai/)에서 발급한 API 키를 붙여넣으세요."
+          },
+          "apiMode": {
+            "chatCompletions": {
+              "caption": "OpenAI 호환",
+              "label": "Chat Completions API"
+            },
+            "messages": {
+              "caption": "Anthropic 호환",
+              "label": "Messages API"
+            },
+            "responses": {
+              "caption": "OpenAI 호환",
+              "label": "Responses API"
+            }
+          },
+          "description": "Portkey 게이트웨이에 연결하고 호환 모델을 설정합니다.",
+          "models": {
+            "empty": {
+              "title": "사용 가능한 모델이 없습니다. 유효한 기본 URL과 키를 입력하세요."
+            }
+          },
+          "restoreDefaultButton": {
+            "ariaLabel": "API 기본 URL을 기본값으로 복원",
+            "tooltip": "기본값 복원"
+          }
+        },
+        "setup": {
+          "apiBaseField": {
+            "containerizedNote": "Onyx가 컨테이너에서 실행 중이면 호스트의 서비스에 연결할 때 `localhost` 대신 `host.docker.internal`을 사용하세요.",
+            "title": "API 기본 URL"
+          },
+          "apiKeyField": {
+            "description": "모델에 액세스하려면 API 키를 붙여넣으세요.",
+            "providerDescription": "모델에 액세스하려면 {provider}에서 발급한 API 키를 붙여넣으세요.",
+            "title": "API 키"
+          },
+          "cancelButton": {
+            "label": "취소"
+          },
+          "connectButton": {
+            "label": "연결"
+          },
+          "description": "{company}에 연결하고 {product} 모델을 설정하세요.",
+          "displayNameField": {
+            "description": "앱에서 이 제공자를 식별하는 데 사용됩니다.",
+            "placeholder": "표시 이름",
+            "title": "표시 이름"
+          },
+          "optionalSuffix": {
+            "label": "선택 사항"
+          },
+          "submitButton": {
+            "invalidTooltip": "필수 항목을 모두 입력하세요.",
+            "pristineTooltip": "저장할 변경 사항이 없습니다."
+          },
+          "title": {
+            "configure": "*{provider}* 구성",
+            "create": "{product} 설정"
+          },
+          "updateButton": {
+            "label": "업데이트"
+          }
+        },
+        "toasts": {
+          "providerEnableFailed": "제공자를 활성화하지 못했습니다: {message}",
+          "providerEnabled": "제공자를 활성화했습니다!",
+          "providerUpdateFailed": "제공자를 업데이트하지 못했습니다: {message}",
+          "providerUpdated": "제공자를 업데이트했습니다!",
+          "setDefaultFailed": "제공자를 기본으로 설정하지 못했습니다",
+          "setNewDefaultFailed": "새 제공자를 기본으로 설정하지 못했습니다",
+          "testApiKeyFailed": "API 키를 테스트하는 중 오류가 발생했습니다.",
+          "testCustomProviderFailed": "사용자 지정 제공자를 테스트하는 중 오류가 발생했습니다.",
+          "testProviderFailed": "제공자를 테스트하는 중 오류가 발생했습니다."
+        },
+        "validation": {
+          "apiBaseRequired": "API 기본 URL은 필수입니다",
+          "apiKeyRequired": "API 키는 필수입니다",
+          "modelNameRequired": "모델 이름은 필수입니다"
+        },
+        "vertexAi": {
+          "authMethodField": {
+            "description": "Onyx가 Google Vertex AI에 인증하는 방식을 선택하세요.",
+            "serviceAccount": {
+              "description": "GCP 서비스 계정 키 JSON 파일을 업로드하세요",
+              "label": "서비스 계정 JSON"
+            },
+            "title": "인증 방식",
+            "workloadIdentity": {
+              "description": "파드의 기본 GCP 자격 증명을 사용합니다(GKE Workload Identity)",
+              "label": "Workload Identity (GKE)"
+            }
+          },
+          "credentialsField": {
+            "description": "모델에 액세스하려면 Google Cloud에서 받은 API 키 JSON을 첨부하세요.",
+            "title": "API 키"
+          },
+          "locationField": {
+            "description": "Google Vertex AI 모델이 호스팅되는 리전입니다. 지원되는 리전 전체 목록은 Google Cloud에서 확인하세요.",
+            "title": "Google Cloud 리전 이름"
+          },
+          "projectField": {
+            "description": "Vertex AI가 활성화된 GCP 프로젝트입니다. 서비스 계정 가장 환경에서는 ADC가 대상 프로젝트를 정확히 추론할 수 없으므로 필수입니다.",
+            "title": "GCP 프로젝트 ID"
+          },
+          "validation": {
+            "authMethodRequired": "인증 방식은 필수입니다",
+            "credentialsRequired": "자격 증명 파일은 필수입니다",
+            "projectRequired": "GCP 프로젝트 ID는 필수입니다"
+          },
+          "workloadIdentityNotice": {
+            "title": "Onyx는 파드의 기본 Google Cloud 자격 증명을 google.auth.default로 사용합니다. Kubernetes ServiceAccount가 Vertex AI에 액세스할 수 있는 GCP 서비스 계정에 바인딩되어 있는지 확인하세요."
+          }
+        }
+      },
+      "newCustomProviderCard": {
+        "setUpButton": {
+          "label": "설정"
+        }
+      },
+      "newProviderCard": {
+        "ariaLabel": "{company} {product} 추가",
+        "connectButton": {
+          "label": "연결"
+        }
+      },
+      "noProviders": {
+        "title": "채팅을 시작하려면 LLM 제공자를 설정하세요."
+      },
+      "providerCard": {
+        "defaultTag": {
+          "label": "기본"
+        },
+        "deleteButton": {
+          "ariaLabel": "{provider} 삭제"
+        },
+        "editButton": {
+          "ariaLabel": "{provider} 편집"
+        }
+      },
+      "toasts": {
+        "providerDeleteFailed": "제공자를 삭제하지 못했습니다: {message}",
+        "providerDeleted": "제공자를 삭제했습니다!",
+        "unknownError": "알 수 없는 오류"
+      }
+    },
+    "mcpActions": {
+      "header": {
+        "description": "MCP(Model Context Protocol) 서버를 연결해 에이전트용 사용자 지정 작업과 도구를 추가하세요."
+      }
+    },
+    "modals": {
+      "newTeam": {
+        "body": "{domain}의 관리자라면 누구나 참가 요청을 승인할 수 있습니다.",
+        "continueButton": {
+          "label": "새 팀으로 계속"
+        },
+        "header": {
+          "requestSentTitle": "참가 요청 전송됨",
+          "title": "{domain}의 기존 팀을 찾았습니다"
+        },
+        "inviteRequestedToast": {
+          "message": "초대 요청을 팀 관리자에게 보냈습니다."
+        },
+        "loadError": {
+          "message": "팀 정보를 가져오지 못했습니다. 나중에 다시 시도하세요."
+        },
+        "requestButton": {
+          "label": "팀 참가 요청",
+          "pendingLabel": "요청을 보내는 중..."
+        },
+        "requestError": {
+          "message": "초대를 요청하지 못했습니다",
+          "responseFallback": "초대 요청에 실패했습니다"
+        },
+        "requestSentBody": "참가 요청을 보냈습니다. {domain}의 관리자가 요청을 승인할 때까지 자신의 팀으로 둘러볼 수 있습니다.",
+        "tryOnyxButton": {
+          "label": "기다리는 동안 Onyx 사용해 보기"
+        }
+      },
+      "newTenant": {
+        "acceptError": {
+          "responseFallback": "초대를 수락하지 못했습니다"
+        },
+        "acceptedToast": {
+          "message": "초대를 수락했습니다."
+        },
+        "approvedTitle": "{domain}의 다른 사용자 {count}명이 있는 팀에 참가하려는 요청이 승인되었습니다.",
+        "declineButton": {
+          "label": "거절"
+        },
+        "declineError": {
+          "message": "초대를 거절하지 못했습니다. 다시 시도하세요.",
+          "responseFallback": "초대 거절에 실패했습니다"
+        },
+        "declinedToast": {
+          "message": "초대를 거절했습니다."
+        },
+        "inviteDescription": "이 초대를 수락하면 기존 {domain} 팀에 참가하고 현재 팀에 대한 액세스를 잃습니다. 참고: 현재 사용 중인 에이전트, 프롬프트, 채팅, 연결된 소스에도 액세스할 수 없게 됩니다.",
+        "inviteTitle": "{domain}의 다른 팀원 {count, plural, one {#명} other {#명}}과 함께하도록 초대되었습니다.",
+        "joinError": {
+          "message": "팀에 참가하지 못했습니다. 다시 시도하세요."
+        },
+        "joinRequestToast": {
+          "message": "팀 참가 요청을 처리하는 중..."
+        },
+        "reauthenticateDescription": "팀 참가를 완료하려면 {email}(으)로 다시 인증하세요.",
+        "submitButton": {
+          "acceptLabel": "초대 수락",
+          "acceptingLabel": "수락하는 중...",
+          "joiningLabel": "참가하는 중...",
+          "reauthenticateLabel": "다시 인증"
+        }
+      },
+      "provider": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "submitButton": {
+          "label": "연결"
+        }
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "수신된 클레임이 없습니다."
+        },
+        "table": {
+          "claim": {
+            "header": "클레임"
+          },
+          "value": {
+            "header": "값"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "제공자 API",
+        "subtitle": "제공자 API에서 가져온 디렉터리 필드입니다 — 예를 들어 Entra ID의 Microsoft Graph /me는 country/usageLocation을 제공하며, 이 값은 ctry 선택 클레임을 구성하지 않으면 id_token에 포함되지 않습니다.",
+        "title": "디렉터리 프로필({source})"
+      },
+      "idToken": {
+        "subtitle": "token 엔드포인트가 반환한 id_token JWT를 디코딩한 값입니다.",
+        "title": "id_token 클레임"
+      },
+      "intro": {
+        "description": "마지막 OAuth/OIDC 로그인에서 ID 제공자가 보낸 원본 필드, 즉 id_token 클레임과 userinfo 엔드포인트 응답을 표시합니다. IdP가 어떤 속성을 전달하도록 구성되어 있는지 확인할 때 사용하세요. 클레임은 로그인할 때마다 수집됩니다."
+      },
+      "loadFailed": {
+        "title": "OAuth 클레임을 불러오지 못했습니다"
+      },
+      "noSnapshot": {
+        "description": "{email}에 대한 OAuth 로그인 스냅샷이 없습니다. 위 버튼으로 ID 제공자를 통해 로그인한 다음 이 페이지를 새로 고치세요.",
+        "title": "아직 수집된 클레임 없음"
+      },
+      "rerun": {
+        "label": "OAuth 로그인 다시 실행"
+      },
+      "resolved": {
+        "subtitle": "조직 프로필 프롬프트 블록과 {placeholder} 자리 표시자에 실제로 사용되는, 클레임이 매핑된 디렉터리 프로필입니다.",
+        "title": "확정된 프로필(프롬프트에 사용)"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "수집 시각: {timestamp}"
+        },
+        "provider": {
+          "label": "제공자: {provider}"
+        },
+        "tokenFields": {
+          "label": "Token 응답 필드: {fields}"
+        },
+        "user": {
+          "label": "사용자: {email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "액세스 token에 대한 OIDC userinfo 엔드포인트의 응답입니다.",
+        "title": "userinfo 클레임"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "OpenAPI 서버를 연결해 에이전트용 사용자 지정 작업과 도구를 추가하세요."
+      }
+    },
+    "perUserUsage": {
+      "panel": {
+        "description": "{start} – {end} · 비용은 기록된 모델 사용량을 기준으로 계산됩니다.",
+        "emptyDescription": "선택한 기간의 사용자별 지출과 token 사용량입니다.",
+        "error": {
+          "title": "이 기간의 사용량을 불러오지 못했습니다."
+        },
+        "title": "사용량 개요"
+      },
+      "summary": {
+        "activeUsers": {
+          "detail": "기록이 있는 사용자 {count, number}명",
+          "label": "활성 사용자"
+        },
+        "topSpender": {
+          "label": "최다 지출 사용자",
+          "noSpend": "기록된 지출 없음"
+        },
+        "totalTokens": {
+          "detail": "입력(캐시 읽기 포함) 및 출력",
+          "label": "총 token 수"
+        },
+        "workspaceSpend": {
+          "detail": "목록에 있는 모든 사용자 합계",
+          "label": "워크스페이스 지출"
+        }
+      },
+      "users": {
+        "description": "지출이 많은 순으로 정렬됩니다. 목록을 필터링한 다음 사용자를 선택하면 전체 내역을 볼 수 있습니다.",
+        "empty": {
+          "description": "이 기간에 기록된 사용량이 없습니다."
+        },
+        "title": "사용자"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "연결됨"
+        },
+        "description": "ID 제공자를 연결해 사용자와 그룹을 가져오고 동기화하세요.",
+        "generate": {
+          "label": "SCIM Token 생성"
+        },
+        "regenerate": {
+          "label": "Token 재생성"
+        },
+        "title": "SCIM 동기화",
+        "waiting": {
+          "description": "사용자와 그룹 동기화를 시작하려면 ID 제공자에 SCIM 키를 등록하세요.",
+          "label": "연결 대기 중"
+        }
+      },
+      "header": {
+        "description": "System for Cross-domain Identity Management(SCIM) 프로토콜로 사용자와 그룹을 동기화합니다.",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "SCIM token 상태를 불러오지 못했습니다."
+      },
+      "modal": {
+        "copied": {
+          "message": "Token을 클립보드에 복사했습니다"
+        },
+        "copyFailed": {
+          "error": "Token을 복사하지 못했습니다"
+        },
+        "regenerate": {
+          "description": "현재 SCIM token이 취소되고 새 token이 생성됩니다. SCIM 프로비저닝을 다시 시작하려면 ID 제공자에서 token을 업데이트해야 합니다.",
+          "submit": {
+            "label": "Token 재생성"
+          },
+          "title": "SCIM Token 재생성"
+        },
+        "token": {
+          "copy": {
+            "label": "Token 복사"
+          },
+          "description": "계속하기 전에 이 키를 저장하세요. 다시 표시되지 않습니다.",
+          "download": {
+            "label": "다운로드"
+          },
+          "title": "SCIM Token"
+        }
+      },
+      "toasts": {
+        "generateFailed": "Token을 생성하지 못했습니다: {detail}",
+        "genericError": "문제가 발생했습니다. 다시 시도하세요.",
+        "regenerated": "Token을 재생성했습니다"
+      }
+    },
+    "security": {
+      "adminControls": {
+        "incognito": {
+          "description": "시크릿 채팅은 소유자의 기록에 표시되지 않습니다. 그룹 액세스는 그룹 페이지에서 그룹별로 설정합니다.",
+          "everyone": {
+            "description": "로그인한 모든 사용자가 시크릿 채팅을 시작할 수 있습니다.",
+            "label": "모든 사용자"
+          },
+          "groups": {
+            "description": "시크릿 액세스가 활성화된 그룹의 멤버만 가능합니다.",
+            "label": "지정된 그룹"
+          },
+          "off": {
+            "description": "아무도 시크릿 채팅을 시작할 수 없습니다.",
+            "label": "사용 안 함"
+          },
+          "title": "시크릿 채팅"
+        },
+        "incognitoRecords": {
+          "description": "워크스페이스가 시크릿 채팅에서 보관하는 내용입니다. 새 세션은 시작 시점에 활성화된 모드로 고정됩니다.",
+          "fullHistory": {
+            "description": "다른 채팅과 동일하게 질의 기록, 사용량, 추적을 기록합니다. 소유자 본인의 기록에서만 숨겨집니다.",
+            "label": "전체 기록"
+          },
+          "title": "시크릿 채팅 기록",
+          "usageOnly": {
+            "description": "메시지 내용은 저장되지 않습니다. token 사용량은 계속 추적되며, 이 채팅은 질의 기록에 표시되지 않습니다.",
+            "label": "사용량만"
+          }
+        },
+        "maskCredentials": {
+          "description": "관리자에게 저장된 API 키와 자격 증명을 표시하는 형식입니다.",
+          "masked": {
+            "description": "앞뒤 몇 글자만 표시합니다(예: abcd...wxyz).",
+            "label": "부분 마스킹"
+          },
+          "title": "저장된 자격 증명 마스킹",
+          "visible": {
+            "description": "관리자에게 자격 증명 값을 전체로 표시합니다.",
+            "label": "전체 표시"
+          }
+        },
+        "section": {
+          "title": "관리자 제어"
+        },
+        "userDirectory": {
+          "adminsOnly": {
+            "description": "관리자만 전체 사용자 목록을 볼 수 있습니다.",
+            "label": "관리자에게만 표시"
+          },
+          "allUsers": {
+            "description": "로그인한 모든 사용자가 리소스를 공유할 때 전체 사용자 목록을 볼 수 있습니다.",
+            "label": "모든 사용자에게 표시"
+          },
+          "description": "이름과 이메일을 정확히 입력한 검색은 이 설정과 관계없이 동작합니다.",
+          "title": "전체 사용자 디렉터리 공개 범위"
+        }
+      },
+      "authentication": {
+        "allowedEmailDomains": {
+          "placeholder": "도메인 추가(예: onyx.app)",
+          "subDescription": "신규 사용자는 이 도메인 목록에 있는 이메일로만 계정을 등록할 수 있습니다.",
+          "title": "허용된 이메일 도메인"
+        },
+        "emailDomains": {
+          "description": "신규 사용자 등록을 특정 이메일 도메인으로 제한합니다.",
+          "title": "이메일 도메인 제한"
+        },
+        "idpExpiry": {
+          "description": "상위 OAuth/OIDC 제공자의 세션이 만료되면 사용자를 로그아웃합니다.",
+          "title": "ID 제공자와 세션 만료 동기화"
+        },
+        "openSignUp": {
+          "description": "신규 사용자는 초대를 받아야 이 워크스페이스에 참가할 수 있습니다.",
+          "title": "자유 가입 제한"
+        },
+        "passwordLockdown": {
+          "description": "모든 사용자가 SSO로만 로그인하고 가입합니다. 활성화된 SSO 제공자가 하나 이상 필요합니다.",
+          "title": "비밀번호 로그인 및 가입 비활성화"
+        },
+        "section": {
+          "title": "인증"
+        }
+      },
+      "jwt": {
+        "expectedAudience": {
+          "description": "aud 클레임이 일치하지 않는 token을 거부합니다. 비워 두면 검사하지 않습니다.",
+          "title": "예상 Audience"
+        },
+        "expectedIssuer": {
+          "description": "iss 클레임이 일치하지 않는 token을 거부합니다. 비워 두면 검사하지 않습니다.",
+          "title": "예상 Issuer"
+        },
+        "pinnedField": {
+          "description": "환경 변수로 고정되었습니다."
+        },
+        "publicKeyUrl": {
+          "description": "token 서명을 확인하는 데 사용하는 JWKS 또는 PEM 엔드포인트입니다. 비워 두면 JWT 인증을 사용하지 않습니다.",
+          "title": "공개 키 URL"
+        },
+        "section": {
+          "description": "ID 제공자가 서명한 RS256 bearer token을 허용합니다. 환경 변수로 설정한 값은 고정되며 여기서 편집할 수 없습니다.",
+          "title": "외부 JWT 인증"
+        }
+      },
+      "networkSafety": {
+        "envInjection": {
+          "description": "사용자 지정 LLM 제공자 구성이 호출 중에 프로세스 환경 변수를 임시로 설정하도록 허용합니다. 비활성화하면 모든 제공자 설정에 대응하는 LiteLLM 파라미터가 있어야 합니다.",
+          "multiTenantDescription": "멀티테넌트 배포에서는 사용자 지정 LLM 제공자 구성이 프로세스 환경 변수를 설정할 수 없습니다.",
+          "title": "LLM 환경 변수 주입"
+        },
+        "section": {
+          "title": "네트워크 보안"
+        },
+        "ssrf": {
+          "allowPrivateNetwork": {
+            "description": "LLM 요청 검증과 같지만, 관리자가 구성한 MCP/OAuth 엔드포인트는 사설 LAN 호스트에도 연결할 수 있습니다. 루프백(앱 호스트 자체)과 클라우드 메타데이터는 계속 차단됩니다.",
+            "label": "사설 네트워크 허용"
+          },
+          "description": "Server-Side Request Forgery(SSRF) 보호를 위해 사설 또는 내부 IP로 향하는 아웃바운드 요청을 검증합니다.",
+          "disabled": {
+            "description": "신뢰할 수 있는 네트워크에서만 사용하세요. 모든 아웃바운드 요청을 허용합니다 — 로컬 LLM 백엔드에 연결하려면 필요합니다.",
+            "label": "사용 안 함"
+          },
+          "title": "SSRF 보호",
+          "validateAll": {
+            "description": "가장 엄격합니다. 웹 커넥터를 포함한 모든 아웃바운드 요청이 사설 또는 내부 IP에 연결할 수 없습니다.",
+            "label": "모든 요청 검증"
+          },
+          "validateLlm": {
+            "description": "LLM이 시작한 모든 URL 요청을 검증합니다. 관리자가 구성한 커넥터는 사설 또는 내부 IP에 계속 연결할 수 있습니다.",
+            "label": "LLM 요청 검증"
+          }
+        }
+      },
+      "page": {
+        "description": "런타임에 구성할 수 있는 보안 설정입니다. 설정하지 않은 값은 배포 환경 구성을 따릅니다."
+      },
+      "passwordPolicy": {
+        "charactersSuffix": {
+          "label": "(자)"
+        },
+        "lengthInput": {
+          "placeholder": "기본값"
+        },
+        "maxLength": {
+          "title": "최대 비밀번호 길이"
+        },
+        "minLength": {
+          "title": "최소 비밀번호 길이"
+        },
+        "requireLowercase": {
+          "title": "소문자 필수"
+        },
+        "requireNumber": {
+          "title": "숫자 필수"
+        },
+        "requireSpecialChar": {
+          "description": "허용 문자: `{characters}`",
+          "title": "특수 문자 필수"
+        },
+        "requireUppercase": {
+          "title": "대문자 필수"
+        },
+        "section": {
+          "description": "모든 새 비밀번호에 적용되는 요건입니다. 기본 인증에만 적용됩니다.",
+          "title": "비밀번호 정책"
+        }
+      },
+      "toasts": {
+        "securitySettingsUpdateFailed": "보안 설정을 업데이트하지 못했습니다",
+        "securitySettingsUpdated": "보안 설정을 업데이트했습니다",
+        "settingsUpdateFailed": "설정을 업데이트하지 못했습니다",
+        "settingsUpdated": "설정을 업데이트했습니다"
+      }
+    },
+    "serviceAccounts": {
+      "deleteModal": {
+        "description": "*{name}* 계정의 API 키(`{keyDisplay}`)를 사용하는 모든 애플리케이션이 Onyx에 액세스할 수 없게 됩니다.",
+        "submit": {
+          "label": "삭제"
+        },
+        "title": "계정 삭제",
+        "warning": "삭제는 되돌릴 수 없습니다."
+      },
+      "editModal": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "groupList": {
+          "loading": {
+            "description": "그룹을 불러오는 중...",
+            "title": "불러오는 중..."
+          },
+          "memberCount": "{count, plural, one {사용자 #명} other {사용자 #명}}",
+          "noResults": {
+            "description": "다른 검색어로 시도하세요.",
+            "title": "그룹을 찾을 수 없습니다"
+          }
+        },
+        "joinedGroups": {
+          "empty": {
+            "description": "{name}은(는) 어떤 그룹에도 속해 있지 않습니다.",
+            "title": "그룹을 찾을 수 없습니다"
+          }
+        },
+        "removeGroupButton": {
+          "tooltip": "그룹에서 제거"
+        },
+        "saveButton": {
+          "label": "변경 사항 저장"
+        },
+        "search": {
+          "placeholder": "참여할 그룹 검색..."
+        },
+        "title": "{name}의 그룹 편집",
+        "toasts": {
+          "error": "오류가 발생했습니다",
+          "updated": "서비스 계정을 업데이트했습니다"
+        }
+      },
+      "formModal": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "description": "서비스 계정 API 키를 사용하면 사용자 수준 권한으로 Onyx API에 프로그래밍 방식으로 접근할 수 있습니다. 계정 세부 정보는 나중에 수정할 수 있습니다.",
+        "groups": {
+          "empty": {
+            "description": "이 서비스 계정에 할당된 그룹이 없습니다.",
+            "title": "그룹 없음"
+          },
+          "loading": {
+            "description": "그룹을 불러오는 중...",
+            "title": "불러오는 중..."
+          },
+          "memberCount": "{count, plural, one {사용자 #명} other {사용자 #명}}",
+          "noResults": {
+            "description": "다른 검색어를 사용해 보세요.",
+            "title": "그룹을 찾을 수 없습니다"
+          },
+          "search": {
+            "placeholder": "그룹 검색..."
+          },
+          "title": "그룹"
+        },
+        "name": {
+          "placeholder": "이름 입력",
+          "title": "이름"
+        },
+        "submitButton": {
+          "create": "계정 생성",
+          "update": "업데이트"
+        },
+        "title": {
+          "create": "서비스 계정 생성",
+          "update": "서비스 계정 업데이트"
+        },
+        "toasts": {
+          "createFailed": "서비스 계정 생성 오류 - {detail}",
+          "created": "서비스 계정을 생성했습니다!",
+          "unexpectedError": "예기치 않은 오류가 발생했습니다.",
+          "updateFailed": "서비스 계정 업데이트 오류 - {detail}",
+          "updated": "서비스 계정을 업데이트했습니다!"
+        }
+      },
+      "keyModal": {
+        "copyButton": {
+          "label": "API 키 복사"
+        },
+        "description": "계속하기 전에 이 키를 저장하세요. 다시 표시되지 않습니다.",
+        "downloadButton": {
+          "label": "다운로드"
+        },
+        "title": "서비스 계정 API 키"
+      },
+      "list": {
+        "createButton": {
+          "label": "새 서비스 계정"
+        },
+        "empty": {
+          "description": "사용자 수준 접근 권한을 가진 서비스 계정 API 키를 생성하세요."
+        },
+        "search": {
+          "placeholder": "서비스 계정 검색..."
+        }
+      },
+      "page": {
+        "description": "서비스 계정을 사용하여 Onyx API에 프로그래밍 방식으로 접근하세요.",
+        "error": {
+          "description": "자세한 내용은 콘솔을 확인하세요.",
+          "title": "서비스 계정을 불러오지 못했습니다."
+        }
+      },
+      "regenerateModal": {
+        "description": "현재 API 키 *{name}*(`{keyDisplay}`)이(가) 취소되고 새 키가 생성됩니다. 이 키를 사용하는 모든 애플리케이션을 새 키로 업데이트해야 합니다.",
+        "submit": {
+          "label": "키 재생성"
+        },
+        "title": "API 키 재생성"
+      },
+      "table": {
+        "actions": {
+          "delete": {
+            "label": "계정 삭제"
+          },
+          "edit": {
+            "label": "계정 편집"
+          },
+          "groups": {
+            "label": "그룹"
+          }
+        },
+        "columns": {
+          "apiKey": {
+            "header": "API 키"
+          },
+          "groups": {
+            "header": "그룹"
+          },
+          "name": {
+            "header": "이름"
+          }
+        },
+        "groups": {
+          "overflow": {
+            "label": "+{count}"
+          }
+        },
+        "moreButton": {
+          "tooltip": "더 보기"
+        },
+        "name": {
+          "unnamed": "이름 없음"
+        },
+        "regenerateButton": {
+          "tooltip": "재생성"
+        }
+      },
+      "toasts": {
+        "deleteFailed": "API 키를 삭제하지 못했습니다.",
+        "deleteFailedWithDetail": "API 키를 삭제하지 못했습니다: {detail}",
+        "keyCopied": "API 키를 클립보드에 복사했습니다.",
+        "regenerateFailed": "API 키를 재생성하지 못했습니다.",
+        "regenerateFailedWithDetail": "API 키를 재생성하지 못했습니다: {detail}"
+      },
+      "trialNotice": {
+        "description": "체험판 계정에는 API 키 접근 권한이 포함되지 않습니다. 이 기능을 사용하려면 유료 구독을 구매하세요.",
+        "title": "API 키를 생성하려면 유료 요금제로 업그레이드하세요."
+      }
+    },
+    "shared": {
+      "listHeader": {
+        "search": {
+          "placeholder": "검색..."
+        }
+      },
+      "liteModeNotice": {
+        "description": "이 배포는 벡터 데이터베이스가 없는 Onyx Lite로 실행됩니다. 커넥터와 문서 인덱싱이 비활성화되어 아무것도 인덱싱되지 않습니다. 데이터 소스를 연결하고 문서를 인덱싱하려면 Onyx를 **Standard 모드**로 배포하세요. 시작하려면 [배포 가이드]({docsUrl})를 참조하세요.",
+        "title": "Lite 모드에서는 인덱싱을 사용할 수 없습니다"
+      },
+      "providerCard": {
+        "connectButton": {
+          "label": "연결"
+        },
+        "currentDefault": {
+          "label": "현재 기본값"
+        },
+        "disconnectButton": {
+          "ariaLabel": "{title} 연결 해제",
+          "tooltip": "연결 해제"
+        },
+        "editButton": {
+          "ariaLabel": "{title} 편집",
+          "tooltip": "편집"
+        },
+        "setDefaultButton": {
+          "label": "기본값으로 설정"
+        }
+      }
+    },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "OnyxBot 구성 생성 오류 - {error}"
+        },
+        "updateError": {
+          "toast": "OnyxBot 구성 업데이트 오류 - {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "Slack 봇 구성을 삭제하지 못했습니다 - {error}"
+        },
+        "deleted": {
+          "toast": "Slack 봇 구성 \"{configId}\"을(를) 삭제했습니다"
+        },
+        "editDefaultButton": {
+          "label": "기본 구성 편집"
+        },
+        "newConfigButton": {
+          "label": "새 채널 구성"
+        },
+        "section": {
+          "title": "채널별 구성"
+        },
+        "table": {
+          "actions": {
+            "header": "작업"
+          },
+          "assistant": {
+            "header": "어시스턴트"
+          },
+          "channel": {
+            "header": "채널"
+          },
+          "documentSets": {
+            "header": "문서 세트"
+          },
+          "empty": {
+            "message": "채널별 구성이 없습니다. 새 구성을 추가하여 특정 채널의 동작을 사용자 지정하세요."
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "삭제"
+        },
+        "error": {
+          "toast": "Slack 봇을 삭제하지 못했습니다"
+        },
+        "message": "이 Slack 봇을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
+        "success": {
+          "toast": "Slack 봇을 삭제했습니다"
+        },
+        "title": "Slack 봇 삭제"
+      },
+      "edit": {
+        "header": {
+          "title": "Slack 봇 편집"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "Slack 채널 구성 편집"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "기본 Slack 구성 편집"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "ID가 {id}인 Slack 채널 구성을 찾을 수 없습니다"
+        },
+        "fetchAgents": {
+          "message": "에이전트를 가져오지 못했습니다 - {error}"
+        },
+        "fetchBot": {
+          "message": "Slack 봇 {botId}을(를) 가져오지 못했습니다: {error}"
+        },
+        "fetchChannels": {
+          "message": "Slack 채널을 가져오지 못했습니다 - {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "문서 세트를 가져오지 못했습니다 - {error}"
+        },
+        "generic": {
+          "title": "문제가 발생했습니다 :("
+        },
+        "unknown": {
+          "message": "알 수 없는 오류"
+        },
+        "unknownOccurred": {
+          "message": "알 수 없는 오류가 발생했습니다"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "에이전트 검색..."
+        },
+        "answerValidity": {
+          "label": "인용을 찾은 경우에만 응답",
+          "tooltip": "설정하면 모델이 인용을 생성한 질문에만 답변합니다"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "channelName": {
+          "label": "Slack 채널 이름",
+          "placeholder": "채널 이름 입력 (예: general, support)",
+          "subtext": "Slack 채널 이름을 입력하세요 (# 기호 제외)"
+        },
+        "createButton": {
+          "label": "생성"
+        },
+        "defaultConfig": {
+          "badge": "기본 구성",
+          "description": "이 기본 구성은 Slack 워크스페이스의 모든 채널과 다이렉트 메시지(DM)에 적용됩니다."
+        },
+        "disableDefault": {
+          "label": "기본 구성 비활성화",
+          "warning": "경고: 기본 구성을 비활성화하면 OnyxBot은 명시적으로 구성된 Slack 채널에서만 응답합니다. 또한 OnyxBot은 DM에 응답하지 않습니다."
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "이 문서 세트에는 자동 동기화 권한이 있는 커넥터가 포함되어 있어 사용할 수 없습니다. 이 채널의 OnyxBot 응답은 모든 Slack 사용자에게 표시되므로, 질문자의 권한을 그대로 적용하면 비공개 정보가 의도치 않게 노출될 수 있습니다."
+          },
+          "autoSyncedNote": {
+            "text": "다음 문서 세트에는 자동 동기화된 문서가 있어 첨부할 수 없습니다:"
+          },
+          "description": "OnyxBot이 Slack에서 질문에 답변할 때 사용할 문서 세트를 선택하세요.",
+          "hideUnselectableButton": {
+            "label": "선택할 수 없는 문서 세트 숨기기"
+          },
+          "incompatibleHidden": {
+            "text": "일부 호환되지 않는 문서 세트가 숨겨져 있습니다."
+          },
+          "incompatibleVisible": {
+            "text": "일부 호환되지 않는 문서 세트가 표시되어 있습니다."
+          },
+          "viewAllButton": {
+            "label": "모든 문서 세트 보기"
+          }
+        },
+        "followUpTags": {
+          "label": "(선택 사항) 태그할 사용자 / 그룹",
+          "subtext": "사용자가 \"도움이 더 필요하신가요?\" 버튼을 클릭했을 때 태그할 Slack 사용자 / 그룹입니다. 이메일을 입력하지 않으면 아무도 태그하지 않고 원본 메시지에 🆘 이모지로만 반응합니다."
+        },
+        "generalConfig": {
+          "section": {
+            "title": "일반 구성"
+          }
+        },
+        "isEphemeral": {
+          "label": "비공개(임시) 메시지로 사용자에게 응답",
+          "tooltip": "설정하면 OnyxBot이 비공개(임시) 메시지로 해당 사용자에게만 응답합니다. 위에서 'Search' 에이전트도 선택한 경우, 이 옵션을 선택하면 사용자에게 비공개인 문서도 질의에 사용할 수 있습니다."
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "모든 공개 지식",
+            "sublabel": "OnyxBot이 모든 공개 커넥터의 정보를 바탕으로 응답하도록 합니다"
+          },
+          "documentSets": {
+            "label": "특정 문서 세트",
+            "sublabel": "질문에 답변할 때 사용할 문서를 제어합니다"
+          },
+          "label": "지식 소스",
+          "nonSearchAgent": {
+            "label": "비검색 에이전트",
+            "sublabel": "문서를 사용하지 않는 에이전트와 대화합니다"
+          },
+          "searchAgent": {
+            "label": "검색 에이전트",
+            "sublabel": "질문에 답변할 때 사용할 문서와 프롬프트를 모두 제어합니다"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "OnyxBot이 Slack에서 질문에 답변할 때 사용할 비검색 에이전트를 선택하세요."
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "관련 커넥터:"
+          },
+          "description": "비공개(임시) 응답을 *선택하지 않으면*, 선택한 문서 세트 내의 공개 문서만 사용자 질의에 사용할 수 있습니다. 비공개(임시) 응답을 *선택하면*, 사용자 질의에서 해당 사용자가 이미 접근 권한을 받은 문서도 활용할 수 있습니다. 사용자가 응답을 채널의 다른 사람과 공유할 수 있으므로, 회사의 공유 정책에 부합하는지 확인하세요.",
+          "title": "개인정보 보호 알림"
+        },
+        "questionmarkPrefilter": {
+          "label": "질문에만 응답",
+          "tooltip": "설정하면 OnyxBot이 물음표가 포함된 메시지에만 응답합니다"
+        },
+        "removedDocumentSets": {
+          "toast": "일부 문서 세트가 더 이상 유효하지 않아 선택 항목에서 제거했습니다. 구성을 검토하고 업데이트하세요."
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "'비공개(임시) 메시지로 사용자에게 응답'이 켜져 있는 동안에는 비활성화됩니다. 임시 응답은 한 명의 사용자에게만 전달됩니다."
+          },
+          "label": "(선택 사항) 특정 사용자 / 그룹에만 응답",
+          "subtext": "지정하면 이 채널에서 해당 사용자 / 그룹만 OnyxBot을 호출할 수 있으며, 응답도 그들에게만 표시됩니다."
+        },
+        "respondTagOnly": {
+          "label": "@OnyxBot 태그 시에만 응답",
+          "tooltip": "설정하면 OnyxBot이 직접 태그된 경우에만 응답합니다"
+        },
+        "respondToBots": {
+          "label": "봇 메시지에 응답",
+          "tooltip": "설정하지 않으면 OnyxBot이 봇의 메시지를 항상 무시합니다"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "상세"
+          },
+          "label": "답변 유형",
+          "standard": {
+            "label": "표준"
+          },
+          "tooltip": "OnyxBot 응답의 형식을 제어합니다."
+        },
+        "searchAgent": {
+          "description": "OnyxBot이 Slack에서 질문에 답변할 때 사용할 검색 지원 에이전트를 선택하세요."
+        },
+        "searchConfig": {
+          "section": {
+            "title": "검색 구성"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "웹 UI에서 계속하기 버튼 표시",
+          "tooltip": "설정하면 응답 하단에 Onyx 웹 UI에서 대화를 계속할 수 있는 버튼을 표시합니다"
+        },
+        "stillNeedHelp": {
+          "label": "\"도움이 더 필요하신가요?\" 버튼 표시",
+          "section": {
+            "prompt": "도움이 더 필요하신가요 버튼 구성"
+          },
+          "tooltip": "OnyxBot 응답 하단에 도움이 더 필요한지 묻는 버튼이 포함됩니다."
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "선택할 수 없는 에이전트 숨기기"
+          },
+          "listLabel": "선택할 수 없는 에이전트:",
+          "note": "참고: 일부 에이전트의 문서 세트에 자동 동기화 커넥터가 있습니다. 이러한 에이전트는 Slack에서 질문에 답변할 수 없으므로 선택할 수 없습니다.",
+          "viewAllButton": {
+            "label": "모든 에이전트 보기"
+          }
+        },
+        "updateButton": {
+          "label": "업데이트"
+        },
+        "userOrGroup": {
+          "placeholder": "사용자 이메일 또는 사용자 그룹 이름..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "특정 채널에서 질문에 자동으로 답변하도록 OnyxBot을 설정하세요."
+        },
+        "description": "Onyx에 연결되는 Slack 봇을 설정하세요. 설정을 마치면 Slack에서 바로 Onyx에 질문할 수 있습니다. 또한 다음을 할 수 있습니다:",
+        "directMessage": {
+          "item": "웹 UI에서와 똑같이 OnyxBot에 다이렉트 메시지를 보내 검색하세요."
+        },
+        "docsPrompt": {
+          "text": "시작하려면 Onyx 문서의 <link>가이드</link>를 따라 하세요!"
+        },
+        "documentSets": {
+          "item": "질문을 받은 채널에 따라 OnyxBot이 어떤 문서 세트를 기반으로 답변할지 선택하세요."
+        }
+      },
+      "list": {
+        "error": {
+          "title": "앱을 불러오는 중 오류가 발생했습니다"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "새 Slack 봇"
+        }
+      },
+      "newBotButton": {
+        "label": "새 Slack 봇"
+      },
+      "newChannel": {
+        "header": {
+          "title": "Slack 채널용 OnyxBot 구성"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "채널 수"
+        },
+        "defaultConfig": {
+          "header": "기본 구성"
+        },
+        "defaultSet": {
+          "badge": "기본값 설정됨"
+        },
+        "disabled": {
+          "badge": "비활성화됨"
+        },
+        "empty": {
+          "message": "Onyx와 대화를 시작하려면 새 Slack 봇을 추가하세요!"
+        },
+        "enabled": {
+          "badge": "활성화됨"
+        },
+        "name": {
+          "header": "이름"
+        },
+        "status": {
+          "header": "상태"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Slack 앱 token"
+        },
+        "botToken": {
+          "label": "Slack 봇 token"
+        },
+        "createButton": {
+          "label": "생성"
+        },
+        "createError": {
+          "toast": "Slack 봇 생성 오류 - {error}"
+        },
+        "created": {
+          "toast": "Slack 봇을 생성했습니다!"
+        },
+        "docsPrompt": {
+          "text": "이 token을 얻는 방법을 잘 모르겠다면 <link>가이드</link>를 참조하세요!"
+        },
+        "invalidAppToken": {
+          "message": "Slack 앱 token이 유효하지 않습니다"
+        },
+        "invalidBotToken": {
+          "message": "Slack 봇 token이 유효하지 않습니다"
+        },
+        "name": {
+          "label": "이 Slack 봇의 이름:"
+        },
+        "updateButton": {
+          "label": "업데이트"
+        },
+        "updateError": {
+          "toast": "Slack 봇 업데이트 오류 - {error}"
+        },
+        "updated": {
+          "toast": "Slack 봇을 업데이트했습니다!"
+        },
+        "userToken": {
+          "label": "Slack 사용자 token (선택 사항)",
+          "subtext": "선택 사항: 비공개 채널 접근을 확장하기 위한 사용자 OAuth token"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "삭제"
+        },
+        "enabledCheckbox": {
+          "label": "활성화됨"
+        },
+        "fieldUpdateFailed": {
+          "toast": "커넥터 {field}을(를) 업데이트하지 못했습니다"
+        },
+        "fieldUpdated": {
+          "toast": "커넥터 {field}을(를) 업데이트했습니다"
+        },
+        "updateTokensButton": {
+          "label": "token 업데이트"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "'Agent' 지식 소스를 사용할 때는 에이전트가 필요합니다"
+        },
+        "channelNameRequired": {
+          "message": "채널 이름은 필수 항목입니다"
+        },
+        "documentSetRequired": {
+          "message": "'Document Sets' 지식 소스를 사용할 때는 문서 세트를 하나 이상 선택해야 합니다"
+        }
+      }
+    },
+    "ssoProviders": {
+      "addProvider": {
+        "button": {
+          "label": "공급자 추가"
+        },
+        "gatedTooltip": "여러 SSO 공급자를 동시에 사용하려면 Business 또는 Enterprise 요금제가 필요합니다."
+      },
+      "copyRedirectUri": {
+        "tooltip": "리디렉션 URI 복사"
+      },
+      "editProvider": {
+        "tooltip": "편집"
+      },
+      "empty": {
+        "description": "사용자가 Google, OIDC 또는 SAML로 로그인할 수 있도록 공급자를 추가하세요.",
+        "title": "아직 SSO 공급자가 없습니다"
+      },
+      "loadError": {
+        "description": "SSO 공급자를 불러올 수 없습니다.",
+        "title": "SSO 공급자를 불러오지 못했습니다"
+      },
+      "modals": {
+        "domainVerification": {
+          "description": "도메인 소유권을 확인한 후에만 해당 도메인의 사용자가 워크스페이스에 자동으로 로그인합니다. 아래 DNS 레코드를 추가한 다음 확인하세요.",
+          "loadError": {
+            "message": "DNS 레코드를 불러올 수 없습니다."
+          },
+          "loading": {
+            "message": "불러오는 중…"
+          },
+          "pendingDescription": "DNS 공급자에 이 TXT 레코드를 추가한 다음 확인하세요.",
+          "record": {
+            "labelPrefix": "{label}: ",
+            "nameLabel": "이름",
+            "typeLabel": "유형",
+            "valueLabel": "값"
+          },
+          "refreshError": {
+            "message": "이 레코드를 새로 고칠 수 없어 최신 정보가 아닐 수 있습니다."
+          },
+          "retryButton": {
+            "label": "다시 시도"
+          },
+          "status": {
+            "pending": "대기 중",
+            "verified": "확인됨"
+          },
+          "title": "도메인 확인",
+          "verifiedDescription": "이 도메인의 사용자는 자동으로 로그인합니다.",
+          "verifiedToast": {
+            "message": "{domain}을(를) 확인했습니다"
+          },
+          "verifyButton": {
+            "label": "도메인 확인",
+            "unclaimedTooltip": "먼저 이 도메인으로 공급자를 저장하세요."
+          }
+        },
+        "provider": {
+          "cancelButton": {
+            "label": "취소"
+          },
+          "configField": {
+            "optionalTitle": "{label} (선택 사항)"
+          },
+          "displayNameField": {
+            "description": "로그인 버튼에 표시되는 레이블입니다.",
+            "placeholder": "Company A",
+            "title": "표시 이름"
+          },
+          "emailDomainsField": {
+            "description": "이 도메인에 속한 이메일만 이 공급자를 통해 로그인할 수 있습니다.",
+            "optionalDescription": "이 도메인에 속한 이메일만 이 공급자를 통해 로그인할 수 있습니다. 지정하는 것을 권장하지만, 비워 두면 모든 도메인을 허용합니다.",
+            "placeholder": "도메인 추가 (예: onyx.app)",
+            "recommendedTitle": "허용 이메일 도메인 (권장)",
+            "title": "허용 이메일 도메인"
+          },
+          "header": {
+            "createDescription": "로그인에 사용할 SSO 공급자를 추가하세요.",
+            "createTitle": "SSO 공급자 추가",
+            "editDescription": "이 공급자의 사용자 로그인 방식을 업데이트합니다.",
+            "editTitle": "{name} 편집"
+          },
+          "nameField": {
+            "description": "로그인 URL에 사용되는 고유한 소문자 슬러그입니다. 나중에 변경할 수 없습니다.",
+            "title": "이름"
+          },
+          "providerTypeField": {
+            "description": "이 공급자가 인증에 사용하는 프로토콜입니다.",
+            "placeholder": "공급자 유형 선택",
+            "title": "공급자 유형"
+          },
+          "redirectField": {
+            "acsLabel": "ACS(응답) URL",
+            "copyTooltip": "{label} 복사",
+            "description": "이 URL을 IdP에 콜백으로 등록하세요.",
+            "redirectUriLabel": "리디렉션 URI"
+          },
+          "submitButton": {
+            "createLabel": "생성",
+            "updateLabel": "업데이트"
+          },
+          "toasts": {
+            "created": "SSO 공급자를 생성했습니다",
+            "updated": "SSO 공급자를 업데이트했습니다"
+          },
+          "validation": {
+            "displayNameRequired": "표시 이름은 필수 항목입니다",
+            "emailDomainsMin": "로그인을 허용할 이메일 도메인을 하나 이상 입력하세요",
+            "fieldRequired": "{field}은(는) 필수 항목입니다",
+            "namePattern": "소문자, 숫자, 하이픈만 사용하세요",
+            "nameRequired": "이름은 필수 항목입니다",
+            "providerTypeRequired": "공급자 유형은 필수 항목입니다"
+          }
+        }
+      },
+      "page": {
+        "description": "사용자가 조직의 ID 공급자를 통해 로그인하도록 합니다."
+      },
+      "toasts": {
+        "unexpectedError": "예기치 않은 오류가 발생했습니다."
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "백엔드 버전: "
+      },
+      "version": {
+        "title": "버전"
+      },
+      "webVersion": {
+        "label": "웹 버전: "
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "최대 {cost} 또는 {tokens} tokens",
+          "cost": "최대 {cost}",
+          "none": "설정된 예산 없음",
+          "tokens": "최대 {tokens} tokens"
+        },
+        "cadence": {
+          "label": "{days, plural, one {매일 UTC 자정에 초기화} other {#일마다 UTC 자정에 초기화}}"
+        },
+        "deleteFailed": {
+          "error": "token 사용 한도를 삭제하지 못했습니다"
+        },
+        "empty": {
+          "message": "아직 한도가 없습니다. 사용량을 제한하려면 지출 한도를 생성하세요."
+        },
+        "loadFailed": {
+          "error": "token 사용 한도를 불러오지 못했습니다"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "{label} 삭제",
+            "tooltip": "한도 삭제"
+          },
+          "disable": {
+            "ariaLabel": "{label} 비활성화"
+          },
+          "enable": {
+            "ariaLabel": "{label} 활성화"
+          },
+          "label": "{budget}, {cadence}"
+        },
+        "updateFailed": {
+          "error": "token 사용 한도를 업데이트하지 못했습니다"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "취소"
+        },
+        "costBudget": {
+          "description": "초기화 주기당 최대 지출액입니다. 비용 예산, token 예산 또는 둘 다 설정하세요.",
+          "placeholder": "비용 한도 없음",
+          "title": "비용 예산",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "비용 예산, token 예산 또는 둘 다 입력하세요",
+          "costMax": "최대 비용 예산은 ${amount, number}입니다",
+          "costMinCents": "비용 예산은 최소 $0.01이어야 합니다",
+          "costMoreThanZero": "비용 예산은 0보다 커야 합니다",
+          "groupRequired": "사용자 그룹을 선택하세요",
+          "periodInteger": "일수를 정수로 입력하세요",
+          "periodMin": "최소 1일 이상이어야 합니다",
+          "periodRequired": "초기화 주기를 입력하세요",
+          "scopeRequired": "대상 범위는 필수 항목입니다",
+          "tokenIncrement": "1,000 tokens 단위로 입력하세요",
+          "tokenInteger": "token 수를 정수로 입력하세요",
+          "tokenMax": "최대 token 예산은 1조입니다",
+          "tokenMin": "최소 1,000 tokens 이상이어야 합니다"
+        },
+        "groupMenu": {
+          "empty": "아직 사용자 그룹이 없습니다. 사용자 및 그룹에서 그룹을 생성하세요."
+        },
+        "groupPicker": {
+          "placeholder": "그룹 선택"
+        },
+        "header": {
+          "title": "지출 한도 생성"
+        },
+        "period": {
+          "description": "예산은 UTC 자정에 초기화됩니다",
+          "title": "초기화 주기",
+          "unit": "일"
+        },
+        "scope": {
+          "caption": {
+            "global": "워크스페이스의 모든 사용자가 하나의 예산을 공유합니다.",
+            "group": "{group} 그룹의 구성원이 하나의 예산을 공유합니다.",
+            "groupUnchosen": "선택한 그룹의 구성원이 하나의 예산을 공유합니다.",
+            "user": "각 사용자가 자신의 예산을 갖습니다."
+          },
+          "title": "적용 대상"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "워크스페이스"
+          },
+          "user": {
+            "title": "사용자별"
+          },
+          "userGroup": {
+            "title": "사용자 그룹"
+          }
+        },
+        "submit": {
+          "label": "한도 생성"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} 또는 {tokens} tokens",
+            "tokens": "{tokens} tokens"
+          },
+          "global": "{days, plural, one {워크스페이스의 모든 사용자가 매일 최대 {budget}까지 함께 사용합니다. 주기가 초기화될 때까지 사용이 차단됩니다.} other {워크스페이스의 모든 사용자가 #일마다 최대 {budget}까지 함께 사용합니다. 주기가 초기화될 때까지 사용이 차단됩니다.}}",
+          "group": "{days, plural, one {{group} 그룹의 구성원이 매일 최대 {budget}까지 함께 사용합니다. 주기가 초기화될 때까지 사용이 차단됩니다.} other {{group} 그룹의 구성원이 #일마다 최대 {budget}까지 함께 사용합니다. 주기가 초기화될 때까지 사용이 차단됩니다.}}",
+          "groupUnchosen": "{days, plural, one {선택한 그룹의 구성원이 매일 최대 {budget}까지 함께 사용합니다. 주기가 초기화될 때까지 사용이 차단됩니다.} other {선택한 그룹의 구성원이 #일마다 최대 {budget}까지 함께 사용합니다. 주기가 초기화될 때까지 사용이 차단됩니다.}}",
+          "user": "{days, plural, one {각 사용자가 매일 최대 {budget}까지 사용할 수 있습니다. 주기가 초기화될 때까지 사용이 차단됩니다.} other {각 사용자가 #일마다 최대 {budget}까지 사용할 수 있습니다. 주기가 초기화될 때까지 사용이 차단됩니다.}}"
+        },
+        "tokenBudget": {
+          "description": "초기화 주기당 최대 token 수",
+          "placeholder": "token 한도 없음",
+          "title": "Token 예산",
+          "unit": "tokens"
+        },
+        "userGroup": {
+          "description": "이 예산을 공유할 그룹을 선택하세요",
+          "title": "사용자 그룹"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "지출 한도 생성"
+        },
+        "createFailed": {
+          "error": "지출 한도를 생성하지 못했습니다"
+        },
+        "created": {
+          "message": "지출 한도를 생성했습니다!"
+        },
+        "embedded": {
+          "description": "워크스페이스, 사용자, 그룹의 사용량에 가드레일을 설정하세요. 한도는 구성을 삭제하지 않고 활성화하거나 비활성화할 수 있습니다.",
+          "title": "지출 한도 관리"
+        },
+        "global": {
+          "description": "전역 한도는 모든 사용자, 사용자 그룹, API 키에 적용됩니다. 전역 한도에 도달하면 더 이상 token을 사용할 수 없습니다."
+        },
+        "intro": {
+          "description": "지출 한도를 사용하면 지정한 기간에 사용할 수 있는 token 수를 제어할 수 있습니다.",
+          "groupLimit": "사용자 그룹에 한도를 설정하여 팀의 지출을 제어하세요.",
+          "toggleLimit": "필요에 따라 한도를 활성화하거나 비활성화하세요.",
+          "userLimit": "사용자에게 한도를 설정하여 한 사용자가 너무 많이 지출하지 않도록 하세요.",
+          "workspaceLimit": "팀 전체 지출에 대해 워크스페이스 전역 한도를 설정하세요."
+        },
+        "tabs": {
+          "global": {
+            "name": "전역"
+          },
+          "groups": {
+            "name": "그룹"
+          },
+          "users": {
+            "name": "사용자"
+          }
+        },
+        "user": {
+          "description": "사용자 한도는 각 사용자에게 개별적으로 적용됩니다. 사용자가 한도에 도달하면 일시적으로 token 사용이 차단됩니다."
+        },
+        "userGroup": {
+          "description": "그룹 한도는 그룹 내 모든 사용자에게 적용됩니다. 사용자가 여러 그룹에 속한 경우 가장 관대한 한도가 적용됩니다."
+        }
+      }
+    },
+    "tracing": {
+      "disconnectModal": {
+        "body": "LLM 호출 추적 정보가 더 이상 **{label}**(으)로 전송되지 않습니다. 이미 전송된 추적 정보는 영향을 받지 않습니다.",
+        "description": "이 공급자로 LLM 호출 추적 정보를 보내는 것을 중지합니다.",
+        "submit": {
+          "label": "연결 해제"
+        },
+        "title": "{label} 연결 해제"
+      },
+      "field": {
+        "optional": {
+          "title": "{label} (선택 사항)"
+        },
+        "required": {
+          "error": "{label}은(는) 필수 항목입니다"
+        }
+      },
+      "loadError": {
+        "description": "추적 구성을 불러올 수 없습니다.",
+        "title": "추적 설정을 불러오지 못했습니다"
+      },
+      "page": {
+        "description": "관측 플랫폼을 연결하여 LLM 호출을 모니터링하고 평가하세요."
+      },
+      "provider": {
+        "connected": {
+          "label": "연결됨"
+        }
+      },
+      "setupModal": {
+        "cancel": {
+          "label": "취소"
+        },
+        "connect": {
+          "label": "연결"
+        },
+        "createTitle": "{label} 설정",
+        "description": "{label}에 연결하여 LLM 호출 추적 정보를 전송하세요.",
+        "editTitle": "{label} 구성",
+        "update": {
+          "label": "업데이트"
+        }
+      },
+      "toasts": {
+        "connected": "{label}에 연결했습니다",
+        "disconnected": "{label} 연결을 해제했습니다",
+        "unexpectedError": "예기치 않은 오류가 발생했습니다."
+      }
+    },
+    "usage": {
+      "detail": {
+        "breakdown": {
+          "byFlow": {
+            "title": "플로우별"
+          },
+          "byModel": {
+            "title": "모델별"
+          },
+          "byProvider": {
+            "title": "공급자별"
+          },
+          "slice": {
+            "ariaLabel": "{label}의 지출 비중",
+            "summary": " · {percent}% · {tokens} tokens"
+          }
+        },
+        "dailySpend": {
+          "chart": {
+            "ariaLabel": "선택한 기간의 일별 지출: {days}"
+          },
+          "day": {
+            "ariaLabel": "{day}, {cost}",
+            "tooltip": "{day} · {cost}"
+          },
+          "title": "일별 지출"
+        },
+        "done": {
+          "label": "완료"
+        },
+        "empty": {
+          "description": "이 기간에는 모델별 기록이 없습니다."
+        },
+        "stats": {
+          "cacheReads": {
+            "label": "캐시 읽기"
+          },
+          "cacheWrites": {
+            "label": "캐시 쓰기"
+          },
+          "inputTokens": {
+            "label": "입력 tokens"
+          },
+          "outputTokens": {
+            "label": "출력 tokens"
+          },
+          "spend": {
+            "label": "지출"
+          }
+        }
+      },
+      "spendByUser": {
+        "columns": {
+          "input": {
+            "header": "입력"
+          },
+          "output": {
+            "header": "출력"
+          },
+          "spend": {
+            "header": "지출"
+          },
+          "tokens": {
+            "header": "Tokens"
+          },
+          "user": {
+            "header": "사용자"
+          }
+        },
+        "empty": {
+          "description": "현재 필터와 일치하는 사용 내역이 없습니다."
+        },
+        "filters": {
+          "allFlows": {
+            "label": "모든 플로우"
+          },
+          "allModels": {
+            "label": "모든 모델"
+          }
+        },
+        "row": {
+          "ariaLabel": "{email}의 사용 내역 보기"
+        },
+        "rowCount": {
+          "label": "{count, plural, one {사용자 #명} other {사용자 #명}}"
+        },
+        "search": {
+          "ariaLabel": "이메일로 사용자 검색",
+          "placeholder": "이메일로 사용자 검색…"
+        }
+      }
+    },
+    "users": {
+      "accountType": {
+        "anonymous": {
+          "label": "익명"
+        },
+        "bot": {
+          "label": "Slack 봇"
+        },
+        "extPermUser": {
+          "label": "외부 사용자"
+        },
+        "serviceAccount": {
+          "label": "서비스 계정"
+        },
+        "standard": {
+          "label": "표준"
+        }
+      },
+      "activateModal": {
+        "description": "<strong>{email}</strong>이(가) Onyx에 다시 접근할 수 있습니다.",
+        "submit": {
+          "label": "활성화"
+        },
+        "title": "사용자 활성화",
+        "toasts": {
+          "success": "사용자를 활성화했습니다"
+        }
+      },
+      "cancelInviteModal": {
+        "description": "<strong>{email}</strong>은(는) 더 이상 이 초대로 Onyx에 참여할 수 없습니다.",
+        "submit": {
+          "label": "초대 취소"
+        },
+        "title": "초대 취소",
+        "toasts": {
+          "success": "초대를 취소했습니다"
+        }
+      },
+      "deactivateModal": {
+        "description": "<strong>{email}</strong>은(는) 즉시 Onyx 접근 권한을 잃습니다. 세션과 에이전트는 유지됩니다. 라이선스 시트는 반환됩니다. 이 계정은 나중에 다시 활성화할 수 있습니다.",
+        "submit": {
+          "label": "비활성화"
+        },
+        "title": "사용자 비활성화",
+        "toasts": {
+          "success": "사용자를 비활성화했습니다"
+        }
+      },
+      "deleteModal": {
+        "description": "<strong>{email}</strong>은(는) Onyx에서 영구히 제거됩니다. 모든 세션 기록이 삭제됩니다. 삭제는 취소할 수 없습니다.",
+        "submit": {
+          "label": "삭제"
+        },
+        "title": "사용자 삭제",
+        "toasts": {
+          "success": "사용자를 삭제했습니다"
+        }
+      },
+      "editModal": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "groupList": {
+          "loading": {
+            "description": "그룹을 불러오는 중...",
+            "title": "불러오는 중..."
+          },
+          "memberCount": "{count, plural, one {사용자 #명} other {사용자 #명}}",
+          "noResults": {
+            "description": "다른 검색어를 사용해 보세요.",
+            "title": "그룹을 찾을 수 없음"
+          }
+        },
+        "joinedGroups": {
+          "empty": {
+            "description": "{name} 님은 어떤 그룹에도 속해 있지 않습니다.",
+            "title": "그룹을 찾을 수 없음"
+          }
+        },
+        "removeGroupButton": {
+          "tooltip": "그룹에서 제거"
+        },
+        "saveButton": {
+          "label": "변경 사항 저장"
+        },
+        "search": {
+          "placeholder": "가입할 그룹 검색..."
+        },
+        "title": "사용자 그룹 편집",
+        "toasts": {
+          "error": "오류가 발생했습니다",
+          "updated": "사용자가 업데이트되었습니다"
+        }
+      },
+      "filters": {
+        "accountType": {
+          "allOption": {
+            "label": "모든 계정 유형"
+          },
+          "button": {
+            "ariaLabel": "계정 유형으로 필터링"
+          }
+        },
+        "button": {
+          "moreLabel": "{names}, +{count}"
+        },
+        "group": {
+          "allOption": {
+            "label": "모든 그룹"
+          },
+          "button": {
+            "ariaLabel": "그룹으로 필터링"
+          },
+          "empty": {
+            "label": "그룹을 찾을 수 없음"
+          },
+          "search": {
+            "placeholder": "그룹 검색..."
+          }
+        },
+        "status": {
+          "allOption": {
+            "label": "모든 상태"
+          },
+          "button": {
+            "ariaLabel": "상태로 필터링"
+          }
+        }
+      },
+      "groupsCell": {
+        "editButton": {
+          "tooltip": "편집"
+        },
+        "editCell": {
+          "ariaLabel": "그룹 편집"
+        },
+        "overflow": {
+          "label": "+{count}"
+        }
+      },
+      "inviteModal": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "emails": {
+          "placeholder": "초대할 이메일을 공백 또는 쉼표로 구분하여 입력하세요"
+        },
+        "message": {
+          "needsValidEmail": "초대하려면 유효한 이메일 주소를 입력하세요.",
+          "readyCount": "{count, plural, one {초대할 이메일 #개} other {초대할 이메일 #개}}",
+          "someInvalid": "일부 이메일 주소가 유효하지 않아 제외됩니다."
+        },
+        "submitButton": {
+          "label": "초대"
+        },
+        "title": "사용자 초대",
+        "toasts": {
+          "inviteFailed": "사용자를 초대하지 못했습니다",
+          "invited": "{count, plural, one {사용자 #명을 초대했습니다} other {사용자 #명을 초대했습니다}}",
+          "noValidEmails": "유효한 이메일 주소를 하나 이상 추가하세요"
+        }
+      },
+      "modals": {
+        "toasts": {
+          "error": "오류가 발생했습니다"
+        }
+      },
+      "page": {
+        "inviteButton": {
+          "label": "사용자 초대"
+        },
+        "title": "사용자 및 요청"
+      },
+      "permissionsNotice": {
+        "description": "Onyx는 이제 그룹 기반 권한을 사용합니다. Curator와 Global Curator 역할은 구성 가능한 그룹 권한으로 대체되었으며, 그룹별 관리자가 제한된 범위에서 관리합니다.",
+        "learnMoreButton": {
+          "label": "자세히 알아보기"
+        },
+        "title": "권한이 변경되었습니다"
+      },
+      "resetPasswordModal": {
+        "description": "<strong>{email}</strong>의 새 임의 비밀번호를 생성합니다. 현재 비밀번호는 즉시 사용할 수 없게 됩니다.",
+        "doneButton": {
+          "label": "완료"
+        },
+        "submit": {
+          "label": "비밀번호 재설정"
+        },
+        "successDescription": "<strong>{email}</strong>의 비밀번호가 재설정되었습니다. 아래의 새 비밀번호를 복사하세요 — 다시 표시되지 않습니다.",
+        "successTitle": "비밀번호 재설정 완료",
+        "title": "비밀번호 재설정",
+        "toasts": {
+          "error": "비밀번호를 재설정하지 못했습니다"
+        }
+      },
+      "rowActions": {
+        "activate": {
+          "label": "사용자 활성화"
+        },
+        "approve": {
+          "label": "승인"
+        },
+        "cancelInvite": {
+          "label": "초대 취소"
+        },
+        "deactivate": {
+          "label": "사용자 비활성화"
+        },
+        "delete": {
+          "label": "사용자 삭제"
+        },
+        "editGroups": {
+          "label": "그룹 및 역할"
+        },
+        "makeAdmin": {
+          "label": "관리자로 지정"
+        },
+        "removeAdmin": {
+          "label": "관리자 권한 해제"
+        },
+        "resetPassword": {
+          "label": "비밀번호 재설정"
+        },
+        "scimNotice": {
+          "description": "이 사용자는 조직의 ID 공급자가 관리하는 SCIM 동기화 사용자입니다."
+        },
+        "toasts": {
+          "adminAccessGranted": "이제 이 사용자는 관리자입니다",
+          "adminAccessRemoved": "관리자 권한이 해제되었습니다",
+          "error": "오류가 발생했습니다",
+          "requestApproved": "요청이 승인되었습니다"
+        }
+      },
+      "status": {
+        "active": {
+          "label": "활성"
+        },
+        "inactive": {
+          "label": "비활성"
+        },
+        "invited": {
+          "label": "초대 대기 중"
+        },
+        "requested": {
+          "label": "가입 요청"
+        }
+      },
+      "summary": {
+        "activeUsers": {
+          "label": "활성 사용자"
+        },
+        "filterButton": {
+          "tooltip": "필터 추가"
+        },
+        "pendingInvites": {
+          "label": "대기 중인 초대"
+        },
+        "requests": {
+          "label": "가입 요청"
+        },
+        "scim": {
+          "description": "사용자는 조직의 ID 공급자에서 동기화됩니다.",
+          "manageButton": {
+            "label": "관리"
+          },
+          "title": "SCIM 동기화"
+        },
+        "statCell": {
+          "ariaLabel": "{label}(으)로 필터링"
+        }
+      },
+      "table": {
+        "columns": {
+          "accountType": {
+            "header": "계정 유형"
+          },
+          "groups": {
+            "header": "그룹"
+          },
+          "lastUpdated": {
+            "header": "마지막 업데이트"
+          },
+          "name": {
+            "header": "이름"
+          },
+          "status": {
+            "header": "상태"
+          }
+        },
+        "downloadCsvButton": {
+          "ariaLabel": "CSV 다운로드",
+          "tooltip": "CSV 다운로드"
+        },
+        "empty": {
+          "description": "현재 필터와 일치하는 사용자가 없습니다.",
+          "title": "사용자를 찾을 수 없음"
+        },
+        "error": {
+          "description": "사용자를 불러오지 못했습니다. 페이지를 새로 고쳐 보세요."
+        },
+        "search": {
+          "placeholder": "사용자 검색..."
+        },
+        "status": {
+          "scimSynced": {
+            "label": "SCIM 동기화됨"
+          }
+        },
+        "toasts": {
+          "downloadFailed": "CSV를 다운로드하지 못했습니다"
+        }
+      }
+    },
+    "voice": {
+      "disconnectModal": {
+        "body": {
+          "description": "**{label}** 모델은 더 이상 음성 텍스트 변환이나 텍스트 음성 변환에 사용되지 않으며, 기본 모델에서도 해제됩니다. 세션 기록은 유지됩니다."
+        },
+        "connectAnother": {
+          "description": "음성 기능을 계속 사용하려면 다른 제공자를 연결하세요."
+        },
+        "disconnectError": {
+          "message": "제공자 연결을 해제하지 못했습니다."
+        },
+        "disconnectSuccess": {
+          "message": "{label} 연결이 해제되었습니다"
+        },
+        "header": {
+          "description": "이 제공자에 저장된 자격 증명을 제거합니다.",
+          "title": "{label} 연결 해제"
+        },
+        "submitButton": {
+          "label": "연결 해제"
+        }
+      },
+      "header": {
+        "description": "음성 입력과 음성 응답에 사용할 음성 텍스트 변환 및 텍스트 음성 변환 제공자를 구성합니다.",
+        "title": "음성"
+      },
+      "models": {
+        "azureSpeechStt": {
+          "subtitle": "Microsoft Foundry Tools의 음성 텍스트 변환."
+        },
+        "azureSpeechTts": {
+          "subtitle": "Microsoft Foundry Tools의 텍스트 음성 변환."
+        },
+        "elevenlabsStt": {
+          "subtitle": "ElevenLabs 음성 텍스트 변환 API."
+        },
+        "elevenlabsTts": {
+          "subtitle": "ElevenLabs 텍스트 음성 변환 API."
+        },
+        "tts1": {
+          "subtitle": "속도에 최적화된 OpenAI의 텍스트 음성 변환 모델."
+        },
+        "tts1Hd": {
+          "subtitle": "품질에 최적화된 OpenAI의 텍스트 음성 변환 모델."
+        },
+        "whisper": {
+          "subtitle": "OpenAI의 범용 음성 인식 모델."
+        }
+      },
+      "setupModal": {
+        "apiKey": {
+          "description": "모델을 사용하려면 {provider}의 [API 키]({url})를 붙여넣으세요.",
+          "label": "API 키",
+          "placeholder": "API 키",
+          "required": "API 키가 필요합니다"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "connectButton": {
+          "label": "연결"
+        },
+        "connectionTestFailed": {
+          "message": "연결 테스트에 실패했습니다"
+        },
+        "createHeader": {
+          "title": "{provider} 설정"
+        },
+        "editHeader": {
+          "title": "{provider} 구성"
+        },
+        "header": {
+          "description": "{provider}에 연결하고 음성 모델을 설정하세요."
+        },
+        "saveError": {
+          "message": "제공자를 저장하지 못했습니다"
+        },
+        "sttLanguages": {
+          "azureCapExceeded": "Azure는 음성 언어를 최대 {cap}개까지 지원합니다",
+          "description": "사용자가 말할 수 있는 로캘을 쉼표로 구분하여 입력하세요. 예: `en-US, fr-FR`. 두 개 이상이면 실시간 전사가 발화 언어를 자동으로 감지합니다(업로드한 오디오는 첫 번째 로캘을 사용). [지원되는 로캘]({docsUrl})을 참조하세요.",
+          "invalid": "en-US, fr-FR처럼 쉼표로 구분한 로캘을 입력하세요(언어당 하나씩)",
+          "label": "음성 언어",
+          "selfHostedCapExceeded": "자체 호스팅 엔드포인트는 음성 언어를 최대 {cap}개까지 지원합니다(시작 시 감지)"
+        },
+        "sttModel": {
+          "label": "STT 모델"
+        },
+        "targetUri": {
+          "description": "[Azure Portal(키 및 엔드포인트)]({portalUrl})에 표시된 엔드포인트를 붙여넣으세요. Onyx는 이 URL에서 음성 지역을 추출합니다. 예: `https://westus.api.cognitive.microsoft.com/` 또는 `https://westus.tts.speech.microsoft.com/`.",
+          "label": "대상 URI",
+          "required": "대상 URI가 필요합니다"
+        },
+        "ttsModel": {
+          "description": "Onyx는 기본적으로 이 모델을 텍스트 음성 변환에 사용합니다.",
+          "label": "기본 모델"
+        },
+        "updateButton": {
+          "label": "업데이트"
+        },
+        "voice": {
+          "description": "이 음성이 음성 응답에 사용됩니다. 지원되는 언어와 음성의 전체 목록은 [{docsLabel}]({docsUrl})에서 확인하세요.",
+          "label": "음성",
+          "loadingPlaceholder": "음성을 불러오는 중...",
+          "placeholder": "음성을 선택하거나 음성 ID를 입력하세요"
+        }
+      },
+      "speechToText": {
+        "description": "채팅에서 음성을 텍스트로 전사할 모델을 선택하세요.",
+        "emptyState": {
+          "title": "채팅에서 사용할 음성 텍스트 변환 제공자를 연결하세요."
+        },
+        "title": "음성 텍스트 변환"
+      },
+      "textToSpeech": {
+        "description": "채팅 응답을 읽어 줄 모델을 선택하세요.",
+        "emptyState": {
+          "title": "채팅에서 사용할 텍스트 음성 변환 제공자를 연결하세요."
+        },
+        "title": "텍스트 음성 변환"
+      },
+      "unexpectedError": {
+        "message": "예기치 않은 오류가 발생했습니다."
+      }
+    },
+    "webSearch": {
+      "apiKeyField": {
+        "noLink": {
+          "description": "연결하려면 {provider}의 API 키를 붙여넣으세요."
+        },
+        "placeholder": "API 키",
+        "title": "API 키",
+        "withLink": {
+          "description": "연결하려면 {provider}의 [API 키]({url})를 붙여넣으세요."
+        }
+      },
+      "crawler": {
+        "currentCrawler": {
+          "label": "현재 크롤러"
+        },
+        "description": "검색 결과 페이지의 전체 내용을 읽는 데 사용됩니다.",
+        "title": "웹 크롤러"
+      },
+      "customIntegration": {
+        "subtitle": "사용자 지정 통합"
+      },
+      "disconnectModal": {
+        "connectAnother": {
+          "description": "웹 검색을 계속 사용하려면 다른 검색 엔진을 연결하세요."
+        },
+        "content": {
+          "description": "**{label}**은(는) 더 이상 검색 결과 웹 페이지를 읽는 데 사용되지 않습니다."
+        },
+        "disconnectSuccess": {
+          "message": "{label} 연결이 해제되었습니다"
+        },
+        "fallback": {
+          "description": "Onyx는 기본 제공 웹 크롤러를 대신 사용합니다."
+        },
+        "header": {
+          "description": "이 제공자에 저장된 자격 증명을 제거합니다.",
+          "title": "{label} 연결 해제"
+        },
+        "search": {
+          "description": "웹 검색은 더 이상 **{label}**을(를) 통해 수행되지 않습니다. 검색 기록은 유지됩니다."
+        },
+        "submitButton": {
+          "label": "연결 해제"
+        }
+      },
+      "header": {
+        "description": "인터넷 전반의 외부 검색에 대한 검색 설정입니다.",
+        "title": "웹 검색"
+      },
+      "loadError": {
+        "description": "웹 검색 구성을 불러올 수 없습니다.",
+        "title": "웹 검색 설정을 불러오지 못했습니다"
+      },
+      "searchEngine": {
+        "connectPrompt": {
+          "title": "웹 검색을 설정하려면 검색 엔진을 연결하세요."
+        },
+        "description": "웹 검색 결과의 URL, 스니펫, 메타데이터에 사용하는 외부 검색 엔진 API입니다.",
+        "selectPrompt": {
+          "title": "웹 검색을 사용하려면 검색 엔진을 선택하세요."
+        },
+        "title": "검색 엔진"
+      },
+      "setupModal": {
+        "apiKey": {
+          "required": "API 키가 필요합니다"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "config": {
+          "required": "{title}이(가) 필요합니다"
+        },
+        "connectButton": {
+          "label": "연결"
+        },
+        "connectSuccess": {
+          "message": "제공자가 연결되었습니다"
+        },
+        "createHeader": {
+          "title": "{provider} 설정"
+        },
+        "editHeader": {
+          "title": "{provider} 구성"
+        },
+        "updateButton": {
+          "label": "업데이트"
+        }
+      },
+      "unexpectedError": {
+        "message": "예기치 않은 오류가 발생했습니다."
+      }
+    }
+  },
+  "agents": {
+    "card": {
+      "actionsCount": {
+        "label": "{count, plural, =0 {액션 없음} one {액션 #개} other {액션 #개}}"
+      },
+      "edit": {
+        "tooltip": "에이전트 편집"
+      },
+      "pin": {
+        "tooltip": "사이드바에 고정"
+      },
+      "share": {
+        "tooltip": "에이전트 공유"
+      },
+      "startChat": {
+        "label": "채팅 시작"
+      },
+      "unpin": {
+        "tooltip": "사이드바에서 고정 해제"
+      },
+      "viewStats": {
+        "tooltip": "에이전트 통계 보기"
+      }
+    },
+    "filters": {
+      "actions": {
+        "all": {
+          "label": "모든 액션"
+        },
+        "multiple": {
+          "label": "{count}개 선택됨"
+        },
+        "search": {
+          "placeholder": "액션 필터링..."
+        }
+      },
+      "creator": {
+        "all": {
+          "label": "모든 사용자"
+        },
+        "me": {
+          "description": "나"
+        },
+        "multiple": {
+          "label": "{count}명"
+        },
+        "search": {
+          "placeholder": "만든 사람..."
+        },
+        "single": {
+          "label": "작성자: {email}"
+        }
+      }
+    },
+    "modals": {
+      "agentButton": {
+        "unpin": {
+          "tooltip": "에이전트 고정 해제"
+        }
+      },
+      "moveCustomAgentChat": {
+        "body": {
+          "description": "이 채팅은 <b>사용자 지정 에이전트</b>를 사용합니다. 채팅을 <b>프로젝트</b>로 이동해도 에이전트의 프롬프트나 지식 구성은 변경되지 않습니다. 정리 목적으로만 사용하세요."
+        },
+        "confirm": {
+          "label": "이동 확인"
+        },
+        "doNotShowAgain": {
+          "label": "다시 표시하지 않기"
+        },
+        "title": "사용자 지정 에이전트 채팅 이동"
+      },
+      "noAgent": {
+        "admin": {
+          "description": "관리자는 관리자 패널에서 새 에이전트를 만들거나 기본 채팅을 다시 활성화할 수 있습니다."
+        },
+        "body": {
+          "description": "현재 사용할 수 있도록 구성된 에이전트가 없습니다. 기본 채팅도 명시적으로 비활성화되어 있습니다."
+        },
+        "configureAgent": {
+          "label": "새 에이전트 구성"
+        },
+        "nonAdmin": {
+          "description": "에이전트를 구성하거나 기본 채팅을 다시 활성화하려면 관리자에게 문의하세요."
+        },
+        "reenableDefaultChat": {
+          "label": "기본 채팅 다시 활성화"
+        },
+        "title": "사용 가능한 에이전트 없음"
+      },
+      "shareAgent": {
+        "admins": {
+          "description": "{count, plural, one {사용자 #명} other {사용자 #명}}",
+          "title": "관리자"
+        },
+        "agentFallback": {
+          "name": "에이전트"
+        },
+        "back": {
+          "label": "뒤로"
+        },
+        "cancel": {
+          "label": "취소"
+        },
+        "copyLink": {
+          "label": "링크 복사"
+        },
+        "done": {
+          "label": "완료"
+        },
+        "loading": {
+          "description": "공유 정보를 불러오는 중..."
+        },
+        "permission": {
+          "edit": {
+            "label": "편집"
+          },
+          "owner": {
+            "label": "소유자"
+          }
+        },
+        "publicPermissionMenu": {
+          "ariaLabel": "공개 권한 변경"
+        },
+        "row": {
+          "updateAccess": {
+            "ariaLabel": "{name}의 액세스 권한 업데이트"
+          },
+          "you": {
+            "title": "{email} (나)"
+          }
+        },
+        "save": {
+          "label": "저장"
+        },
+        "scopeMenu": {
+          "ariaLabel": "공유 범위 변경"
+        },
+        "share": {
+          "title": "*{name}* 공유"
+        },
+        "toasts": {
+          "accessRemoved": "액세스 권한이 제거되었습니다.",
+          "copyLinkFailed": "링크를 복사하지 못했습니다.",
+          "linkCopied": "링크를 복사했습니다.",
+          "ownershipTransferred": "소유권이 이전되었습니다.",
+          "sharingUpdated": "공유 설정이 업데이트되었습니다."
+        },
+        "transfer": {
+          "label": "이전",
+          "title": "*{name}* 이전"
+        }
+      },
+      "viewer": {
+        "actions": {
+          "empty": {
+            "title": "액션 없음"
+          },
+          "title": "액션 및 도구"
+        },
+        "conversationStarters": {
+          "title": "대화 시작 문구"
+        },
+        "defaultModel": {
+          "description": "Onyx는 기본적으로 이 모델을 채팅에 사용합니다.",
+          "title": "기본 모델"
+        },
+        "featured": {
+          "label": "추천"
+        },
+        "instructions": {
+          "title": "지침"
+        },
+        "knowledge": {
+          "empty": {
+            "title": "지식 없음"
+          },
+          "title": "지식"
+        },
+        "knowledgeCutoff": {
+          "description": "이 날짜 이전에 마지막으로 업데이트된 문서는 무시됩니다.",
+          "title": "지식 기준 날짜"
+        },
+        "mcpCard": {
+          "expand": {
+            "label": "펼치기"
+          },
+          "fold": {
+            "label": "접기"
+          }
+        },
+        "moreInfo": {
+          "title": "추가 정보"
+        },
+        "overwritePrompts": {
+          "description": "유용한 지침(예: \"Markdown 표를 사용할 수 있습니다\")이 포함된 기본 시스템 프롬프트를 제거합니다. 응답 품질에 영향을 줄 수 있습니다.",
+          "title": "시스템 프롬프트 덮어쓰기"
+        },
+        "promptReminders": {
+          "title": "프롬프트 리마인더"
+        },
+        "public": {
+          "label": "조직에 공개"
+        }
+      }
+    },
+    "userVariables": {
+      "insert": {
+        "tooltip": "사용자 변수 삽입"
+      }
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "새 조직 만들기"
+      },
+      "createTeamOption": {
+        "text": "새 Onyx 팀 만들기"
+      },
+      "differentEmailPrompt": {
+        "text": "다른 이메일로 만든 계정이 있으신가요?"
+      },
+      "heading": {
+        "title": "계정을 찾을 수 없음"
+      },
+      "inviteOption": {
+        "text": "기존 Onyx 팀에 초대받기"
+      },
+      "notFound": {
+        "description": "기록에서 회원님의 계정을 찾을 수 없습니다. Onyx를 사용하려면 다음 중 하나가 필요합니다:"
+      },
+      "signInLink": {
+        "label": "로그인"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "계정 액세스 제한 또는 권한 문제"
+      },
+      "cloudSupportPrompt": {
+        "text": "문제가 계속되면 <link>support@onyx.app</link>으로 Onyx 팀에 문의하세요"
+      },
+      "code": {
+        "accessDenied": "ID 공급자가 액세스를 거부했습니다.",
+        "consentRequired": "계속하려면 ID 공급자의 동의가 필요합니다.",
+        "interactionRequired": "ID 공급자와의 추가 상호작용이 필요합니다.",
+        "invalidScope": "요청한 권한을 사용할 수 없습니다.",
+        "loginBadCredentials": "이 계정으로는 로그인할 수 없습니다. 비활성화되었을 수 있습니다. 워크스페이스 관리자에게 문의하세요.",
+        "loginRequired": "먼저 ID 공급자로 로그인해야 합니다.",
+        "oauthUserAlreadyExists": "이 이메일로 다른 로그인 방식의 계정이 이미 있습니다. 처음 사용한 방식으로 로그인하거나, 관리자에게 이 공급자의 연결을 요청하세요.",
+        "serverError": "ID 공급자에서 오류가 발생했습니다. 다시 시도하세요.",
+        "temporarilyUnavailable": "ID 공급자를 일시적으로 사용할 수 없습니다. 나중에 다시 시도하세요."
+      },
+      "credentialsIssue": {
+        "description": "잘못되었거나 만료된 로그인 자격 증명"
+      },
+      "heading": {
+        "description": "로그인 시도 중 문제가 발생했습니다.",
+        "title": "인증 오류"
+      },
+      "possibleIssues": {
+        "title": "가능한 원인:"
+      },
+      "returnToLoginButton": {
+        "label": "로그인 페이지로 돌아가기"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "문제가 계속되면 시스템 관리자에게 도움을 요청하세요."
+      },
+      "systemDisruptionIssue": {
+        "description": "일시적인 인증 시스템 장애"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[로그인으로 돌아가기](/auth/login)"
+      },
+      "emailField": {
+        "label": "이메일"
+      },
+      "emailSent": {
+        "toast": "비밀번호 재설정 메일을 보냈습니다. 받은 편지함을 확인하세요."
+      },
+      "genericError": {
+        "toast": "비밀번호 재설정 중 오류가 발생했습니다."
+      },
+      "heading": {
+        "title": "비밀번호 찾기"
+      },
+      "submitButton": {
+        "label": "비밀번호 재설정"
+      },
+      "unexpectedError": {
+        "toast": "오류가 발생했습니다. 다시 시도하세요."
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "참고: 이 기능은 @onyx.app 관리자만 사용할 수 있습니다"
+      },
+      "apiKeyField": {
+        "label": "API 키",
+        "placeholder": "API 키 입력"
+      },
+      "emailField": {
+        "label": "이메일"
+      },
+      "genericError": {
+        "toast": "사용자 가장에 실패했습니다"
+      },
+      "heading": {
+        "title": "사용자 가장"
+      },
+      "invalidEmail": {
+        "error": "유효하지 않은 이메일"
+      },
+      "requiredField": {
+        "error": "필수 항목"
+      },
+      "submitButton": {
+        "label": "사용자 가장"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "팀에 참여하려면 다시 인증하세요"
+      },
+      "orDivider": {
+        "text": "또는"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "계정 만들기"
+      },
+      "noSsoProviders": {
+        "error": "해당 주소로 설정된 SSO 로그인이 없습니다. 아래에서 Google 또는 비밀번호로 로그인해 보세요."
+      },
+      "resetPasswordButton": {
+        "label": "비밀번호 재설정"
+      },
+      "signupPrompt": {
+        "text": "계정이 없으신가요?"
+      },
+      "ssoEmailInvalid": {
+        "error": "유효한 이메일 주소를 입력하세요"
+      },
+      "ssoEmailRequired": {
+        "error": "이메일은 필수입니다"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "로그인 응답에 인증 URL이 없습니다"
+      },
+      "ssoSignInButton": {
+        "label": "SSO로 로그인"
+      },
+      "ssoStartFailed": {
+        "error": "로그인을 시작할 수 없습니다(상태 {status})"
+      },
+      "verifiedMessage": {
+        "title": "이메일이 인증되었습니다! 계속하려면 로그인하세요."
+      },
+      "workEmailField": {
+        "label": "회사 이메일"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[로그인으로 돌아가기](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "새 비밀번호 확인",
+        "placeholder": "새 비밀번호를 다시 입력하세요"
+      },
+      "confirmPasswordRequired": {
+        "error": "비밀번호 확인은 필수입니다"
+      },
+      "genericError": {
+        "toast": "비밀번호 재설정 중 오류가 발생했습니다."
+      },
+      "heading": {
+        "title": "비밀번호 재설정"
+      },
+      "invalidPassword": {
+        "error": "유효하지 않은 비밀번호"
+      },
+      "missingToken": {
+        "toast": "재설정 token이 잘못되었거나 없습니다."
+      },
+      "newPasswordField": {
+        "label": "새 비밀번호",
+        "placeholder": "새 비밀번호를 입력하세요"
+      },
+      "passwordRequired": {
+        "error": "비밀번호는 필수입니다"
+      },
+      "passwordsMatch": {
+        "error": "비밀번호가 일치해야 합니다"
+      },
+      "submitButton": {
+        "label": "비밀번호 재설정"
+      },
+      "successRedirect": {
+        "toast": "비밀번호를 재설정했습니다. 로그인 페이지로 이동합니다..."
+      },
+      "unexpectedError": {
+        "toast": "예기치 않은 오류가 발생했습니다. 다시 시도하세요."
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "가입 완료하기"
+      },
+      "createAccountHeading": {
+        "title": "계정 만들기"
+      },
+      "orDivider": {
+        "text": "또는"
+      },
+      "referralOptionAds": {
+        "label": "광고"
+      },
+      "referralOptionBlog": {
+        "label": "기사/블로그"
+      },
+      "referralOptionFriend": {
+        "label": "친구/동료"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "기타"
+      },
+      "referralOptionPodcast": {
+        "label": "팟캐스트"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "검색 엔진(Google/Bing)"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "옵션을 선택하세요"
+      },
+      "referralQuestion": {
+        "label": "저희를 어떻게 알게 되셨나요?"
+      },
+      "subtitle": {
+        "text": "Onyx 시작하기"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "새 인증 메일 받기"
+      },
+      "missingToken": {
+        "error": "인증 token이 없습니다. 새 인증 메일을 요청해 보세요."
+      },
+      "unknownError": {
+        "text": "알 수 없는 오류"
+      },
+      "verificationFailed": {
+        "error": "이메일을 인증하지 못했습니다 - {errorDetail}. 새 인증 메일을 요청해 보세요."
+      },
+      "verifying": {
+        "text": "이메일을 인증하는 중..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "새 인증 메일을 보냈습니다!"
+      },
+      "greeting": {
+        "text": "*{email}* 님, 아직 이메일을 인증하지 않으셨습니다.\n받은 편지함에서 저희가 보낸 메일을 확인하고 시작하세요!"
+      },
+      "helpPrompt": {
+        "text": "메일이 보이지 않으면 <link>여기</link>를 클릭하여 새 메일을 요청하세요."
+      },
+      "sendFailed": {
+        "toast": "새 인증 메일을 보내지 못했습니다 - {errorDetail}"
+      }
+    }
+  },
+  "cards": {
+    "file": {
+      "processing": {
+        "description": "처리 중..."
+      },
+      "remove": {
+        "label": "제거"
+      },
+      "uploading": {
+        "description": "업로드 중..."
+      }
+    },
+    "skill": {
+      "dependency": {
+        "appDisabled": "앱 “{app}”이(가) 비활성화되어 있습니다",
+        "connectToEnable": "활성화하려면 앱 “{app}”을(를) 연결하세요",
+        "connectToUse": "사용하려면 앱 “{app}”을(를) 연결하세요",
+        "nameConflict": "같은 이름의 다른 스킬이 활성화되어 있습니다",
+        "usesApp": "앱 “{app}”을(를) 사용합니다"
+      },
+      "edit": {
+        "tooltip": "스킬 편집"
+      },
+      "invalid": {
+        "description": "잘못된 이 스킬을 삭제하고 새 스킬을 만드세요."
+      },
+      "tags": {
+        "appSkill": {
+          "label": "앱 스킬"
+        },
+        "builtin": {
+          "label": "기본 제공"
+        },
+        "custom": {
+          "label": "사용자 지정"
+        },
+        "invalid": {
+          "label": "잘못됨"
+        },
+        "personal": {
+          "label": "개인"
+        },
+        "unavailable": {
+          "label": "사용 불가 - 클릭하여 자세히 보기"
+        }
+      },
+      "toggle": {
+        "disable": {
+          "ariaLabel": "{name} 비활성화"
+        },
+        "disableForApp": {
+          "ariaLabel": "{app}에서 {name} 비활성화"
+        },
+        "enable": {
+          "ariaLabel": "{name} 활성화"
+        },
+        "enableForApp": {
+          "ariaLabel": "{app}에서 {name} 활성화"
+        }
+      },
+      "tooltips": {
+        "appDisabled": "앱 “{app}”은(는) 관리자가 비활성화했습니다.",
+        "connectApp": "이 스킬을 사용하려면 앱 페이지에서 앱 “{app}”을(를) 연결하세요.",
+        "invalid": "이 스킬은 잘못되었습니다. 삭제하고 새 스킬을 만드세요.",
+        "unavailable": "현재 이 스킬을 사용할 수 없습니다. 클릭하여 자세히 보세요."
+      }
+    }
+  },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {파일 처리에 실패하여 제거되었습니다: {names}} other {파일 처리에 실패하여 제거되었습니다: {names}}}"
+      },
+      "newChatButton": {
+        "label": "새 채팅 시작"
+      },
+      "noPreviousMessage": {
+        "toast": "이전에 보낸 사용자 메시지를 찾을 수 없습니다."
+      },
+      "oauthConnected": {
+        "toast": "인증에 성공했습니다"
+      },
+      "scrollToBottomButton": {
+        "label": "맨 아래로 이동"
+      },
+      "sessionAccessDenied": {
+        "description": "이 채팅 세션을 볼 수 있는 권한이 없습니다.",
+        "title": "액세스 거부됨"
+      },
+      "sessionGenericError": {
+        "title": "문제가 발생했습니다"
+      },
+      "sessionNotFound": {
+        "description": "이 채팅 세션이 없거나 삭제되었습니다.",
+        "title": "채팅을 찾을 수 없음"
+      },
+      "sourcesModal": {
+        "title": "출처"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count}개 더"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "여러 커넥터의 자격 증명이 유효하지 않습니다. 커넥터 페이지에서 확인하세요.",
+          "title": "{count, plural, one {커넥터 #개가 유효하지 않습니다} other {커넥터 #개가 유효하지 않습니다}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "여러 커넥터에서 인덱싱 실패가 반복되고 있습니다. 커넥터 페이지에서 확인하세요.",
+          "title": "{count, plural, one {커넥터 #개가 실패하고 있습니다} other {커넥터 #개가 실패하고 있습니다}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "커넥터 보기"
+        },
+        "source": {
+          "label": "커넥터"
+        }
+      },
+      "defaultCta": {
+        "label": "보기"
+      },
+      "defaultSource": {
+        "label": "알림"
+      },
+      "dismissButton": {
+        "ariaLabel": "닫기"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "최초 설정 중이거나 Onyx 배포를 방금 업데이트했다면 백엔드가 아직 시작 중이기 때문일 수 있습니다. 1~2분 기다린 다음 페이지를 새로 고치세요. 그래도 해결되지 않으면 백엔드 설정을 확인하거나 관리자에게 문의하세요.",
+          "title": "현재 백엔드를 사용할 수 없습니다"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "라이선스"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "다음 배너"
+      },
+      "previousButton": {
+        "ariaLabel": "이전 배너"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "관리자 공지"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "체험판"
+        }
+      }
+    },
+    "documentSidebar": {
+      "citedSources": {
+        "title": "인용된 출처"
+      },
+      "closeButton": {
+        "tooltip": "사이드바 닫기"
+      },
+      "foundSources": {
+        "title": "찾은 출처"
+      },
+      "moreSources": {
+        "title": "더 보기"
+      },
+      "userFiles": {
+        "title": "사용자 파일"
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "연결"
+      },
+      "header": {
+        "description": "{appName}이(가) 연결된 모든 데이터를 검색하도록 하여 답변 품질을 높이세요.",
+        "title": "앱 연결"
+      },
+      "skipButton": {
+        "label": "나중에 하기"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "업로드된 첨부 파일"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "다운로드"
+        },
+        "image": {
+          "alt": "채팅 첨부 파일"
+        },
+        "viewFullImage": {
+          "label": "전체 이미지 보기"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "미리보기"
+        },
+        "viewFullImage": {
+          "label": "전체 이미지 보기"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "파일 첨부"
+        },
+        "createPromptItem": {
+          "title": "새 프롬프트 만들기"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "다중 모델 모드에서는 Deep Research를 사용할 수 없습니다",
+          "label": "Deep Research"
+        },
+        "incognitoNotice": {
+          "text": "이 채팅은 기록에 표시되지 않으며 메모리에도 사용되지 않습니다."
+        },
+        "incognitoPolicyNotice": {
+          "text": "조직의 정책에 따라 관리자가 이 채팅을 볼 수도 있습니다. 서드파티 도구가 회원님의 활동을 기록할 수도 있습니다."
+        },
+        "input": {
+          "ariaLabel": "메시지 입력",
+          "listeningPlaceholder": "듣는 중...",
+          "placeholder": "무엇을 도와드릴까요?",
+          "queuedPlaceholder": "위쪽 방향키를 눌러 대기 중인 메시지를 편집하세요",
+          "searchPlaceholder": "연결된 소스 검색",
+          "speakingPlaceholder": "Onyx가 말하는 중..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "첨부 파일 처리가 끝나기를 기다리는 중"
+        },
+        "tabReadingButton": {
+          "readLabel": "이 탭 읽기",
+          "readingLabel": "탭 읽는 중..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "음성 설정",
+          "tooltip": "음성이 구성되지 않았습니다. 관리자 설정에서 구성하세요."
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "메시지 입력",
+          "placeholder": "작업을 설명하세요..."
+        },
+        "pasteExpandHint": {
+          "text": "다시 붙여넣으면 펼쳐집니다"
+        },
+        "queuedMessagesHint": {
+          "text": "대기 중인 메시지 편집"
+        },
+        "sendButton": {
+          "initializingTooltip": "샌드박스 초기화 중...",
+          "queueLabel": "메시지 대기열에 추가",
+          "sendLabel": "보내기"
+        },
+        "stopButton": {
+          "ariaLabel": "생성 중지",
+          "tooltip": "중지 · esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "세션이 준비되기를 기다리는 중..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "스킬: {name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "앱"
+        },
+        "connectAction": {
+          "label": "연결"
+        },
+        "connectedRow": {
+          "description": "연결됨"
+        },
+        "connectionRequiredRow": {
+          "description": "연결 필요"
+        },
+        "content": {
+          "ariaLabel": "스킬 선택기"
+        },
+        "empty": {
+          "text": "일치하는 스킬 없음"
+        },
+        "mcpServersGroup": {
+          "label": "MCP 서버"
+        },
+        "skillsGroup": {
+          "label": "스킬"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "{label} 제거"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "마이크에 접근할 수 없습니다"
+        },
+        "autoStartError": {
+          "toast": "마이크를 자동으로 시작할 수 없습니다"
+        },
+        "startRecording": {
+          "ariaLabel": "녹음 시작"
+        },
+        "stopRecording": {
+          "ariaLabel": "녹음 중지"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "붙여넣은 텍스트 편집"
+        },
+        "expandButton": {
+          "label": "입력창에 펼치기",
+          "tooltip": "이 타일을 전체 텍스트로 바꿔 입력창에 넣습니다"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "추가 메뉴 열기",
+          "tooltip": "추가"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "대기 중인 메시지 제거"
+        },
+        "editHint": {
+          "label": "편집 ·"
+        },
+        "item": {
+          "ariaLabel": "대기 중인 메시지 전환"
+        },
+        "removeHint": {
+          "label": "제거"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "오늘 Onyx가 무엇을 도와드릴까요"
+        },
+        "startSessionButton": {
+          "label": "새 세션 시작"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "API 키",
+        "placeholder": "API 키를 입력하세요"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "API 키 숨기기",
+        "showAriaLabel": "API 키 표시"
+      },
+      "cancelButton": {
+        "label": "취소"
+      },
+      "credentialField": {
+        "placeholder": "{field}을(를) 입력하세요"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "자격 증명 숨기기",
+        "showAriaLabel": "자격 증명 표시"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "API 키 입력"
+        },
+        "enterCredentials": {
+          "title": "자격 증명 입력"
+        },
+        "manageApiKey": {
+          "title": "API 키 관리"
+        },
+        "manageCredentials": {
+          "title": "자격 증명 관리"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "인증을 사용하려면 {server}의 API 키를 입력하세요."
+        },
+        "enterCredentials": {
+          "text": "인증을 사용하려면 {server}의 자격 증명을 입력하세요."
+        },
+        "updateApiKey": {
+          "text": "{server}의 API 키를 업데이트하세요."
+        },
+        "updateCredentials": {
+          "text": "{server}의 자격 증명을 업데이트하세요."
+        }
+      },
+      "saveApiKeyError": {
+        "message": "API 키를 저장하지 못했습니다"
+      },
+      "saveCredentialsError": {
+        "message": "자격 증명을 저장하지 못했습니다"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "API 키 저장"
+        },
+        "saveCredentials": {
+          "label": "자격 증명 저장"
+        },
+        "saving": {
+          "label": "저장 중..."
+        },
+        "updateApiKey": {
+          "label": "API 키 업데이트"
+        },
+        "updateCredentials": {
+          "label": "자격 증명 업데이트"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "API 키는 서버에서 검증한 후 안전하게 저장됩니다."
+        },
+        "authenticated": {
+          "text": "변경 사항은 저장하기 전에 서버에서 검증됩니다."
+        },
+        "credentials": {
+          "text": "자격 증명은 서버에서 검증한 후 안전하게 저장됩니다."
+        }
+      }
+    },
+    "messages": {
+      "agentMessage": {
+        "stoppedGeneration": {
+          "text": "사용자가 생성을 중지했습니다"
+        }
+      },
+      "codeBlock": {
+        "copyButton": {
+          "copiedLabel": "복사됨!",
+          "label": "복사"
+        }
+      },
+      "customTool": {
+        "authFailedStatus": {
+          "text": "{toolName} 인증 실패 (HTTP {statusCode})"
+        },
+        "completedStatus": {
+          "text": "{toolName} 완료"
+        },
+        "downloadFileLink": {
+          "label": "다운로드"
+        },
+        "failedStatus": {
+          "text": "{toolName} 실패 (HTTP {statusCode})"
+        },
+        "fallbackName": {
+          "label": "도구"
+        },
+        "fileItem": {
+          "label": "파일 {index}"
+        },
+        "fileStatus": {
+          "text": "{toolName}에서 파일을 반환했습니다"
+        },
+        "imagesStatus": {
+          "text": "{toolName}에서 이미지를 반환했습니다"
+        },
+        "openFileLink": {
+          "label": "열기"
+        },
+        "requestBlock": {
+          "label": "요청"
+        },
+        "responseBlock": {
+          "label": "응답"
+        },
+        "runningStatus": {
+          "text": "{toolName} 실행 중..."
+        },
+        "waitingIndicator": {
+          "text": "응답 대기 중..."
+        }
+      },
+      "customToolAuth": {
+        "card": {
+          "description": "이 도구를 사용하려면 {toolName}에 연결하세요",
+          "title": "{toolName} 연결 안 됨"
+        },
+        "connectButton": {
+          "label": "연결"
+        }
+      },
+      "errorBanner": {
+        "apiError": {
+          "title": "API 오류"
+        },
+        "authError": {
+          "title": "인증 오류"
+        },
+        "badRequest": {
+          "title": "잘못된 요청"
+        },
+        "budgetExceeded": {
+          "title": "예산 초과"
+        },
+        "connectionError": {
+          "title": "연결 오류"
+        },
+        "contentPolicy": {
+          "title": "콘텐츠 정책 위반"
+        },
+        "genericError": {
+          "title": "오류"
+        },
+        "initializationError": {
+          "title": "초기화 오류"
+        },
+        "messageTooLong": {
+          "title": "메시지가 너무 깁니다"
+        },
+        "model": {
+          "label": "모델: {model}"
+        },
+        "modelRefusal": {
+          "title": "모델이 응답을 거부함"
+        },
+        "modelWithProvider": {
+          "label": "모델: {model} ({provider})"
+        },
+        "permissionDenied": {
+          "title": "권한 거부됨"
+        },
+        "rateLimitExceeded": {
+          "title": "요청 한도 초과"
+        },
+        "resourceNotFound": {
+          "title": "리소스를 찾을 수 없음"
+        },
+        "serviceUnavailable": {
+          "title": "서비스를 사용할 수 없음"
+        },
+        "stackTraceButton": {
+          "label": "스택 트레이스"
+        },
+        "tool": {
+          "label": "도구: {tool}"
+        },
+        "toolError": {
+          "title": "도구 오류"
+        },
+        "usageLimitReached": {
+          "title": "사용량 한도 도달"
+        },
+        "validationError": {
+          "title": "검증 오류"
+        }
+      },
+      "humanMessage": {
+        "editButton": {
+          "tooltip": "편집"
+        }
+      },
+      "imageTool": {
+        "defaultStatus": {
+          "text": "이미지 생성"
+        },
+        "emptyState": {
+          "text": "생성된 이미지 없음"
+        },
+        "failedStatus": {
+          "text": "이미지 생성 실패"
+        },
+        "generatedStatus": {
+          "text": "{count, plural, one {이미지 #개 생성됨} other {이미지 #개 생성됨}}"
+        },
+        "generatingImagesStatus": {
+          "text": "이미지 생성 중..."
+        },
+        "generatingStatus": {
+          "text": "이미지 생성 중..."
+        }
+      },
+      "memoizedLink": {
+        "questionFallback": {
+          "label": "질문"
+        }
+      },
+      "messageEditing": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "submitButton": {
+          "label": "제출"
+        }
+      },
+      "messageSwitcher": {
+        "disabledWhileStreaming": {
+          "tooltip": "에이전트 메시지가 완료될 때까지 기다리세요"
+        },
+        "nextButton": {
+          "tooltip": "다음"
+        },
+        "previousButton": {
+          "tooltip": "이전"
+        }
+      },
+      "multiModelPanel": {
+        "deselectButton": {
+          "tooltip": "선호 응답 선택 해제"
+        },
+        "hideButton": {
+          "tooltip": "응답 숨기기"
+        },
+        "preferredResponse": {
+          "label": "선호 응답"
+        },
+        "selectButton": {
+          "label": "이 응답 선택"
+        },
+        "selectPanel": {
+          "ariaLabel": "{model} 응답 선택"
+        },
+        "showButton": {
+          "tooltip": "응답 표시"
+        },
+        "showPanel": {
+          "ariaLabel": "{model} 응답 표시"
+        }
+      },
+      "rateLimitBanner": {
+        "defaultError": {
+          "text": "사용량 한도에 도달했습니다."
+        },
+        "resetsInDays": {
+          "text": "{count, plural, one {#일} other {#일}} 후에 초기화됩니다 ({at})."
+        },
+        "resetsInHours": {
+          "text": "{count, plural, one {#시간} other {#시간}} 후에 초기화됩니다 ({at})."
+        },
+        "resetsInMinutes": {
+          "text": "{count, plural, one {#분} other {#분}} 후에 초기화됩니다 ({at})."
+        },
+        "tryAgainNow": {
+          "text": "지금 다시 시도할 수 있습니다."
+        }
+      },
+      "resubmit": {
+        "regenerateButton": {
+          "label": "다시 생성"
+        },
+        "responseError": {
+          "text": "응답에 오류가 발생했습니다."
+        }
+      },
+      "text": {
+        "thinkingPlaceholder": {
+          "text": "생각 중"
+        }
+      },
+      "timeline": {
+        "codingAgent": {
+          "bashExit": {
+            "header": "Bash · 종료 코드 {exitCode}"
+          },
+          "bashRequest": {
+            "label": "요청"
+          },
+          "bashResponse": {
+            "label": "응답"
+          },
+          "bashRunning": {
+            "header": "Bash · 실행 중…"
+          },
+          "bashTimedOut": {
+            "header": "Bash · 시간 초과"
+          },
+          "noOutput": {
+            "text": "출력 없음"
+          },
+          "response": {
+            "header": "응답"
+          },
+          "task": {
+            "header": "코딩 작업"
+          },
+          "taskWithRepo": {
+            "text": "{query}\n\n리포지토리: {repo}"
+          },
+          "thinking": {
+            "header": "생각 중"
+          }
+        },
+        "collapseButton": {
+          "ariaLabel": "타임라인 접기"
+        },
+        "deepResearchPlan": {
+          "expandable": {
+            "title": "리서치 계획"
+          },
+          "generated": {
+            "status": "계획 생성됨"
+          },
+          "generating": {
+            "status": "계획 생성 중"
+          }
+        },
+        "doneStep": {
+          "header": "완료"
+        },
+        "expandButton": {
+          "ariaLabel": "타임라인 펼치기"
+        },
+        "fetch": {
+          "reading": {
+            "status": "읽는 중"
+          }
+        },
+        "fileReader": {
+          "charRange": {
+            "label": "총 {total, number}자 중 {start, number}–{end, number}자"
+          },
+          "read": {
+            "status": "{fileName} 읽음 (총 {total, number}자 중 {start, number}–{end, number}자)"
+          },
+          "reading": {
+            "status": "파일 읽는 중"
+          }
+        },
+        "generatedImages": {
+          "label": "{count, plural, one {이미지 #개 생성됨} other {이미지 #개 생성됨}}"
+        },
+        "header": {
+          "executingCode": {
+            "label": "코드 실행 중"
+          },
+          "executingNamedTool": {
+            "label": "{toolName} 실행 중"
+          },
+          "executingTool": {
+            "label": "도구 실행 중"
+          },
+          "generatingImage": {
+            "label": "이미지 생성 중..."
+          },
+          "generatingImages": {
+            "label": "이미지 생성 중"
+          },
+          "generatingPlan": {
+            "label": "계획 생성 중"
+          },
+          "reading": {
+            "label": "읽는 중"
+          },
+          "readingFile": {
+            "label": "파일 읽는 중"
+          },
+          "researching": {
+            "label": "리서치 중"
+          },
+          "searchingWeb": {
+            "label": "웹 검색 중"
+          },
+          "thinking": {
+            "label": "생각 중"
+          },
+          "thinkingEllipsis": {
+            "label": "생각 중..."
+          },
+          "updatingMemory": {
+            "label": "메모리 업데이트 중..."
+          }
+        },
+        "internalSearch": {
+          "noResults": {
+            "text": "결과를 찾을 수 없음"
+          },
+          "reading": {
+            "status": "읽는 중"
+          }
+        },
+        "interruptedThinking": {
+          "label": "중단된 사고"
+        },
+        "memory": {
+          "default": {
+            "status": "메모리"
+          },
+          "disabled": {
+            "text": "메모리 도구가 비활성화되었습니다"
+          },
+          "updating": {
+            "status": "메모리 업데이트 중"
+          },
+          "viewMemoriesButton": {
+            "tooltip": "메모리 보기"
+          }
+        },
+        "memoryTag": {
+          "added": {
+            "label": "메모리에 추가됨"
+          },
+          "updated": {
+            "label": "메모리 업데이트됨"
+          }
+        },
+        "python": {
+          "completed": {
+            "status": "Python 실행 완료"
+          },
+          "default": {
+            "status": "Python 실행"
+          },
+          "error": {
+            "label": "오류:"
+          },
+          "executing": {
+            "status": "Python 코드 실행 중..."
+          },
+          "failed": {
+            "status": "Python 실행 실패"
+          },
+          "generatedFiles": {
+            "label": "{count, plural, one {파일 #개 생성됨} other {파일 #개 생성됨}}"
+          },
+          "noOutput": {
+            "text": "출력 없음"
+          },
+          "output": {
+            "label": "출력:"
+          },
+          "runningCode": {
+            "label": "코드 실행 중..."
+          },
+          "writingCode": {
+            "status": "코드 작성 중..."
+          }
+        },
+        "reasoning": {
+          "fullText": {
+            "title": "전체 텍스트"
+          },
+          "thinking": {
+            "status": "생각 중"
+          }
+        },
+        "researchAgent": {
+          "report": {
+            "title": "리서치 보고서"
+          },
+          "task": {
+            "title": "리서치 작업"
+          }
+        },
+        "searchChips": {
+          "showMore": {
+            "label": "+{count}개 더"
+          },
+          "viewFullQuery": {
+            "tooltip": "전체 검색어 보기"
+          }
+        },
+        "stepsButton": {
+          "label": "{count, plural, one {#단계} other {#단계}}"
+        },
+        "stoppedStep": {
+          "header": "중지됨"
+        },
+        "thoughtDuration": {
+          "label": "{duration} 동안 생각함"
+        },
+        "thoughtUnknownDuration": {
+          "label": "잠시 생각함"
+        },
+        "toggleRow": {
+          "ariaLabel": "타임라인 전환"
+        },
+        "toolNames": {
+          "codeInterpreter": "코드 인터프리터",
+          "codingAgent": "코딩 에이전트",
+          "customTool": "사용자 지정 도구",
+          "generateImage": "이미지 생성",
+          "generatePlan": "계획 생성",
+          "internalSearch": "내부 검색",
+          "memory": "메모리",
+          "openUrls": "URL 열기",
+          "researchAgent": "리서치 에이전트",
+          "thinking": "생각 중",
+          "tool": "도구",
+          "webSearch": "웹 검색"
+        },
+        "webSearch": {
+          "searching": {
+            "status": "웹 검색 중"
+          }
+        }
+      },
+      "toolbar": {
+        "dislikeButton": {
+          "removeTooltip": "싫어요 취소",
+          "tooltip": "나쁜 응답"
+        },
+        "likeButton": {
+          "removeTooltip": "좋아요 취소",
+          "tooltip": "좋은 응답"
+        },
+        "regenerateButton": {
+          "tooltip": "다른 모델로 다시 시도"
+        },
+        "sourcesTag": {
+          "label": "출처"
+        }
+      },
+      "tts": {
+        "loadingButton": {
+          "tooltip": "불러오는 중..."
+        },
+        "playButton": {
+          "tooltip": "소리 내어 읽기"
+        },
+        "playbackError": {
+          "toast": "오디오를 재생할 수 없습니다"
+        },
+        "stopButton": {
+          "tooltip": "재생 중지"
+        }
+      }
+    },
+    "modals": {
+      "confirmEntity": {
+        "confirmButton": {
+          "label": "확인"
+        },
+        "confirmation": {
+          "description": "<b>{entityName}</b>을(를) {action}하시겠습니까?"
+        },
+        "deleteAction": {
+          "label": "삭제"
+        },
+        "deleteButton": {
+          "label": "삭제"
+        },
+        "header": {
+          "title": "{entityType} {action}"
+        },
+        "modifyAction": {
+          "label": "수정"
+        }
+      },
+      "editProperty": {
+        "header": {
+          "title": "{property} 편집"
+        },
+        "submitButton": {
+          "label": "속성 업데이트",
+          "loadingLabel": "업데이트 중..."
+        },
+        "valueInput": {
+          "placeholder": "속성 값"
+        }
+      },
+      "feedback": {
+        "additionalDetails": {
+          "dislikePlaceholder": "이 응답에서 마음에 들지 않은 점은 무엇인가요?",
+          "label": "추가 세부 정보 입력",
+          "likePlaceholder": "이 응답에서 마음에 든 점은 무엇인가요?"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "header": {
+          "title": "피드백"
+        },
+        "submitButton": {
+          "label": "제출",
+          "loadingLabel": "제출 중..."
+        }
+      },
+      "genericConfirm": {
+        "confirmButton": {
+          "label": "확인"
+        }
+      },
+      "preview": {
+        "code": {
+          "headerDescription": "{language} - {lineCount, plural, one {#줄} other {#줄}} · {fileSize}"
+        },
+        "copyButton": {
+          "tooltip": "내용 복사"
+        },
+        "csv": {
+          "footer": "{columnCount, plural, one {#개 열} other {#개 열}} • {rowCount, plural, one {#개 행} other {#개 행}}",
+          "headerDescription": "CSV - {rowCount, plural, one {#개 행} other {#개 행}} • {fileSize}",
+          "rowSeparator": "{count, plural, one {#개 행} other {#개 행}}"
+        },
+        "docx": {
+          "headerDescription": "{count, plural, one {Word 문서 • 단어 #개} other {Word 문서 • 단어 #개}}",
+          "headerDescriptionFallback": "Word 문서",
+          "legacyDocMessage": "이전 .doc 형식은 미리 볼 수 없습니다. 파일을 다운로드하여 확인하세요.",
+          "loadError": {
+            "message": "이 문서를 미리 볼 수 없습니다. 파일을 다운로드하여 확인하세요."
+          }
+        },
+        "downloadButton": {
+          "label": "파일 다운로드",
+          "tooltip": "다운로드"
+        },
+        "exceptionTrace": {
+          "defaultTitle": "전체 예외 트레이스"
+        },
+        "header": {
+          "fallbackTitle": "문서"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {#줄} other {#줄}}"
+        },
+        "loadError": {
+          "message": "문서를 불러오지 못했습니다."
+        },
+        "pdf": {
+          "iframeTitle": "PDF 뷰어"
+        },
+        "text": {
+          "headerDescription": "{lineCount, plural, one {#줄} other {#줄}} · {fileSize}"
+        },
+        "unsupported": {
+          "message": "이 파일 형식은 미리 보기를 지원하지 않습니다."
+        },
+        "xlsx": {
+          "headerDescription": "스프레드시트 - {count, plural, one {시트 #개} other {시트 #개}}",
+          "parseError": {
+            "message": "이 스프레드시트를 미리 볼 수 없습니다."
+          },
+          "sheetCount": "{count, plural, one {시트 #개} other {시트 #개}}"
+        },
+        "zoomControls": {
+          "level": "{zoom}%",
+          "zoomInTooltip": "확대",
+          "zoomOutTooltip": "축소"
+        }
+      },
+      "share": {
+        "addPeople": {
+          "groupSuggestion": {
+            "description": "그룹"
+          },
+          "permissionMenu": {
+            "ariaLabel": "지정할 권한 선택"
+          },
+          "searchInput": {
+            "placeholder": "사용자, 그룹, 계정 추가"
+          },
+          "sharedTag": {
+            "label": "공유됨"
+          }
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "copyLinkButton": {
+          "label": "링크 복사"
+        },
+        "createLinkButton": {
+          "label": "공유 링크 만들기"
+        },
+        "generateLinkErrorToast": {
+          "message": "공유 링크를 생성하지 못했습니다"
+        },
+        "genericErrorToast": {
+          "message": "오류가 발생했습니다"
+        },
+        "header": {
+          "description": "이 채팅의 기존 메시지와 이후 메시지가 모두 공유됩니다.",
+          "sharedTitle": "채팅이 공유됨",
+          "title": "이 채팅 공유"
+        },
+        "linkCopiedToast": {
+          "message": "공유 링크를 클립보드에 복사했습니다!"
+        },
+        "linkInput": {
+          "copyTooltip": "링크 복사"
+        },
+        "makePrivateButton": {
+          "label": "비공개로 전환"
+        },
+        "makePrivateErrorToast": {
+          "message": "채팅을 비공개로 전환하지 못했습니다"
+        },
+        "nowPrivateToast": {
+          "message": "채팅이 비공개로 전환되었습니다"
+        },
+        "organizationOption": {
+          "description": "조직의 모든 구성원이 이 채팅을 볼 수 있습니다.",
+          "title": "내 조직"
+        },
+        "permissionMenu": {
+          "edit": {
+            "label": "편집"
+          },
+          "removeAccess": {
+            "label": "액세스 제거"
+          },
+          "viewAndChat": {
+            "label": "보기 및 채팅"
+          }
+        },
+        "privateOption": {
+          "description": "나만 이 채팅에 액세스할 수 있습니다.",
+          "title": "비공개"
+        },
+        "scope": {
+          "invitedOnly": {
+            "label": "초대된 사람만"
+          },
+          "organization": {
+            "label": "조직의 모든 구성원"
+          }
+        },
+        "transferOwnership": {
+          "currentOwner": {
+            "label": "현재 소유자"
+          },
+          "groupTag": {
+            "label": "그룹"
+          },
+          "targetInput": {
+            "label": "소유권 이전 대상",
+            "placeholder": "사용자 또는 그룹 추가"
+          },
+          "trailingButton": {
+            "tooltip": "소유권 이전"
+          }
+        }
+      },
+      "unsavedChanges": {
+        "body": {
+          "description": "변경 사항이 저장되지 않았습니다. 지금 나가면 변경 사항이 사라집니다."
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "discardButton": {
+          "label": "변경 사항 취소"
+        },
+        "header": {
+          "title": "저장하지 않은 변경 사항을 취소할까요?"
+        }
+      },
+      "userFiles": {
+        "addFilesButton": {
+          "label": "파일 추가"
+        },
+        "doneButton": {
+          "label": "완료"
+        },
+        "emptyState": {
+          "description": "파일을 찾을 수 없음"
+        },
+        "fileCount": {
+          "label": "{count, plural, one {파일 #개} other {파일 #개}}"
+        },
+        "fileStatus": {
+          "deleting": {
+            "label": "삭제 중..."
+          },
+          "processing": {
+            "label": "처리 중..."
+          },
+          "uploading": {
+            "label": "업로드 중..."
+          }
+        },
+        "searchInput": {
+          "placeholder": "파일 검색..."
+        },
+        "selectedCount": {
+          "label": "{count, plural, one {파일 #개 선택됨} other {파일 #개 선택됨}}"
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "관리자가 이 모델의 추론 수준을 더 낮게 제한했습니다."
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "각 세션의 token 한도",
+          "title": "컨텍스트 윈도우"
+        },
+        "unknown": {
+          "tooltip": "이 모델은 컨텍스트 크기를 제공하지 않습니다. 채팅에는 token 한도가 자동으로 적용됩니다."
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "모델을 찾을 수 없음"
+        },
+        "loading": {
+          "text": "모델 불러오는 중..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "{model} 설정",
+        "tooltip": "모델 설정"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "모델 추가"
+        },
+        "noModels": {
+          "tooltip": "현재 구성된 모델이 없습니다"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "높음"
+        },
+        "low": {
+          "label": "낮음"
+        },
+        "medium": {
+          "label": "중간"
+        },
+        "off": {
+          "label": "끄기"
+        },
+        "row": {
+          "caption": "모델이 답변하기 전에 얼마나 많이 생각할지 정합니다",
+          "title": "추론 수준"
+        },
+        "xhigh": {
+          "label": "매우 높음"
+        }
+      },
+      "searchInput": {
+        "placeholder": "모델 검색..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "균형"
+        },
+        "creative": {
+          "label": "창의적"
+        },
+        "deterministic": {
+          "label": "일관적"
+        },
+        "row": {
+          "caption": "모델의 응답이 얼마나 예측 가능한지 또는 창의적인지 정합니다",
+          "title": "온도"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "모델 선택"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "이 모델은 이 설정의 변경을 지원하지 않습니다."
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "동의 체크박스"
+      },
+      "consentRequired": {
+        "error": "애플리케이션을 사용하려면 약관에 동의해야 합니다."
+      },
+      "header": {
+        "title": "Onyx에 오신 것을 환영합니다!"
+      },
+      "logoIcon": {
+        "alt": "로고"
+      },
+      "startButton": {
+        "label": "시작"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "공유된 채팅에 메시지가 없습니다."
+      },
+      "header": {
+        "owner": {
+          "text": "{name} 작성"
+        },
+        "sharedOn": {
+          "text": "{date}에 공유됨"
+        },
+        "untitledChat": {
+          "title": "새 채팅"
+        }
+      },
+      "newChatButton": {
+        "label": "새 채팅 시작"
+      },
+      "notFound": {
+        "description": "지정한 ID의 공유 채팅을 찾을 수 없습니다.",
+        "title": "공유 채팅을 찾을 수 없음"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "무엇을 도와드릴까요?",
+        "startText": "시작해 볼까요."
+      },
+      "incognito": {
+        "title": "시크릿 모드입니다"
+      }
+    }
+  },
+  "knowledge": {
+    "addView": {
+      "connectedSources": {
+        "label": "연결된 소스"
+      },
+      "documentSets": {
+        "label": "문서 세트"
+      },
+      "yourFiles": {
+        "description": "최근 또는 새로 업로드한 파일",
+        "label": "내 파일"
+      }
+    },
+    "browser": {
+      "copyLink": {
+        "tooltip": "링크 복사"
+      },
+      "empty": {
+        "folder": {
+          "description": "이 폴더에 항목이 없습니다."
+        },
+        "root": {
+          "description": "문서를 찾아보려면 폴더를 선택하세요."
+        }
+      },
+      "loadFoldersError": {
+        "description": "폴더를 불러오지 못했습니다"
+      },
+      "loadingFolders": {
+        "description": "폴더 불러오는 중..."
+      },
+      "loadingMore": {
+        "description": "더 불러오는 중..."
+      },
+      "selectedCount": {
+        "label": "{count, plural, one {항목 #개 선택됨} other {항목 #개 선택됨}}"
+      },
+      "selectedItems": {
+        "label": "선택한 항목"
+      },
+      "sort": {
+        "ascending": {
+          "lastUpdated": {
+            "label": "오래된 순"
+          },
+          "name": {
+            "label": "A에서 Z 순"
+          }
+        },
+        "descending": {
+          "lastUpdated": {
+            "label": "최신 순"
+          },
+          "name": {
+            "label": "Z에서 A 순"
+          }
+        },
+        "folders": {
+          "title": "폴더"
+        },
+        "foldersMixed": {
+          "label": "파일과 함께"
+        },
+        "foldersOnTop": {
+          "label": "맨 위에"
+        },
+        "sortBy": {
+          "title": "정렬 기준"
+        },
+        "sortingOrder": {
+          "title": "정렬 순서"
+        }
+      }
+    },
+    "documentSets": {
+      "empty": {
+        "description": "사용할 수 있는 문서 세트가 없습니다."
+      },
+      "filter": {
+        "placeholder": "문서 세트 필터..."
+      }
+    },
+    "mainContent": {
+      "empty": {
+        "description": "이 에이전트가 사용할 문서 또는 연결된 소스를 추가하세요."
+      },
+      "selectedCount": {
+        "label": "{count, plural, one {지식 소스 #개 선택됨} other {지식 소스 #개 선택됨}}"
+      },
+      "viewEdit": {
+        "label": "보기 / 편집"
+      }
+    },
+    "pane": {
+      "header": {
+        "description": "이 에이전트가 응답에 참고할 커넥터와 문서를 추가하세요.",
+        "title": "지식"
+      },
+      "useKnowledge": {
+        "description": "이 에이전트가 응답할 때 이 문서들을 참고하도록 합니다.",
+        "title": "지식 사용"
+      }
+    },
+    "recentFiles": {
+      "addFile": {
+        "label": "파일 추가"
+      },
+      "empty": {
+        "description": "사용할 수 있는 파일이 없습니다. 파일을 업로드하여 시작하세요."
+      },
+      "filter": {
+        "placeholder": "파일 필터..."
+      },
+      "processing": {
+        "description": "Onyx가 업로드한 파일을 아직 처리하고 있습니다. 지금 에이전트를 만들 수 있지만, 처리가 끝날 때까지 모든 파일을 사용할 수는 없습니다."
+      }
+    },
+    "search": {
+      "error": {
+        "description": "검색에 실패했습니다. 다시 시도하세요."
+      },
+      "input": {
+        "placeholder": "문서 검색..."
+      },
+      "loading": {
+        "description": "검색 중..."
+      },
+      "noResults": {
+        "description": "결과를 찾을 수 없습니다."
+      },
+      "noResultsInSource": {
+        "description": "{source}에서 결과를 찾을 수 없습니다."
+      },
+      "prompt": {
+        "description": "검색어를 입력하고 Enter 키를 누르세요."
+      },
+      "sidebar": {
+        "all": {
+          "label": "전체"
+        }
+      },
+      "stale": {
+        "description": "새 결과를 보려면 Enter 키를 누르세요."
+      }
+    },
+    "sidebar": {
+      "documentSet": {
+        "label": "문서 세트"
+      },
+      "yourFiles": {
+        "label": "내 파일"
+      }
+    },
+    "table": {
+      "columns": {
+        "lastUpdated": {
+          "header": "마지막 업데이트"
+        },
+        "name": {
+          "header": "이름"
+        },
+        "sources": {
+          "header": "소스"
+        }
+      },
+      "empty": {
+        "description": "사용할 수 있는 항목이 없습니다."
+      },
+      "filter": {
+        "placeholder": "필터..."
+      }
+    }
+  },
+  "onboarding": {
+    "finalStep": {
+      "imageGeneration": {
+        "button": {
+          "label": "이미지 생성"
+        },
+        "description": "채팅에서 이미지를 만들 수 있도록 모델을 설정하세요.",
+        "title": "이미지 생성 사용"
+      },
+      "inviteTeam": {
+        "button": {
+          "label": "사용자 관리"
+        },
+        "description": "팀의 사용자와 권한을 관리합니다",
+        "title": "팀 초대"
+      },
+      "webSearch": {
+        "button": {
+          "label": "웹 검색"
+        },
+        "description": "Onyx가 인터넷에서 정보를 검색할 수 있도록 합니다.",
+        "title": "웹 검색 제공자 선택"
+      }
+    },
+    "header": {
+      "progress": {
+        "label": "{total}단계 중 {current}단계"
+      }
+    },
+    "llmStep": {
+      "adminPanel": {
+        "label": "관리자 패널에서 보기"
+      },
+      "connectedCount": {
+        "label": "{count, plural, one {모델 #개 연결됨} other {모델 #개 연결됨}}"
+      },
+      "customProvider": {
+        "subtitle": "LiteLLM 호환 API",
+        "title": "사용자 지정 LLM 제공자"
+      },
+      "description": "Onyx는 자체 호스팅 모델과 널리 쓰이는 제공자를 모두 지원합니다.",
+      "edit": {
+        "ariaLabel": "LLM 제공자 편집"
+      },
+      "providerCard": {
+        "connect": {
+          "label": "연결"
+        }
+      },
+      "title": "LLM 모델 연결"
+    },
+    "nameStep": {
+      "description": "이 이름을 앱에 표시합니다.",
+      "edit": {
+        "ariaLabel": "표시 이름 편집",
+        "tooltip": "편집"
+      },
+      "input": {
+        "placeholder": "이름"
+      },
+      "title": "Onyx가 어떤 이름으로 부르면 될까요?"
+    },
+    "nonAdminStep": {
+      "confirmation": {
+        "title": "모든 준비가 끝났습니다!"
+      },
+      "save": {
+        "label": "저장"
+      },
+      "toasts": {
+        "saveNameFailed": "이름을 저장하지 못했습니다. 다시 시도하세요."
+      }
+    },
+    "steps": {
+      "complete": {
+        "button": {
+          "label": "설정 완료"
+        },
+        "title": "모든 준비가 끝났습니다. 선택 설정을 확인하거나 설정 완료를 클릭하세요"
+      },
+      "llmSetup": {
+        "button": {
+          "label": "다음"
+        },
+        "title": "거의 다 됐습니다! 모델을 연결하고 채팅을 시작하세요."
+      },
+      "name": {
+        "button": {
+          "label": "다음"
+        },
+        "title": "잠시 설정을 진행하겠습니다."
+      },
+      "welcome": {
+        "button": {
+          "label": "시작하기"
+        },
+        "title": "잠시 설정을 진행하겠습니다."
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "익명",
+        "description": "계정 이메일 주소입니다.",
+        "title": "이메일"
+      },
+      "password": {
+        "changeButton": "비밀번호 변경",
+        "description": "계정 비밀번호를 변경합니다.",
+        "title": "비밀번호"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "새 비밀번호 확인"
+        },
+        "currentPassword": {
+          "title": "현재 비밀번호"
+        },
+        "newPassword": {
+          "title": "새 비밀번호"
+        },
+        "submit": {
+          "update": "변경",
+          "updating": "변경 중..."
+        },
+        "title": "비밀번호 변경",
+        "toasts": {
+          "networkError": "비밀번호를 변경하는 중 오류가 발생했습니다",
+          "updateFailed": "비밀번호를 변경하지 못했습니다",
+          "updated": "비밀번호를 변경했습니다"
+        }
+      },
+      "title": "계정"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "이 token으로 보내는 모든 API 요청은 사용자의 접근 권한을 그대로 상속하며, 개인 사용자에게 귀속됩니다.",
+        "expiration": {
+          "days30": "30일",
+          "days365": "365일",
+          "days7": "7일",
+          "expiresAtNote": "이 token은 다음 시점에 만료됩니다: {date}",
+          "noExpiration": "만료 없음",
+          "placeholder": "만료 기간 선택",
+          "title": "만료 기간"
+        },
+        "name": {
+          "placeholder": "token 이름을 입력하세요",
+          "title": "token 이름"
+        },
+        "permissions": {
+          "fullAccessNote": "사용자의 모든 권한을 상속합니다.",
+          "fullAccessOption": "전체 접근",
+          "limitedAccessNote": "이 token을 특정 기능으로 제한합니다.",
+          "limitedAccessOption": "제한 접근",
+          "placeholder": "권한 선택",
+          "title": "권한"
+        },
+        "submit": {
+          "create": "token 생성",
+          "creating": "token 생성 중..."
+        },
+        "title": "액세스 token 생성"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {#일 전에 생성됨} other {#일 전에 생성됨}}",
+        "createdToday": "오늘 생성됨",
+        "deleteTokenAriaLabel": "token {name} 삭제",
+        "empty": "생성된 액세스 token이 없습니다.",
+        "expiresIn": "{count, plural, one {#일 후 만료} other {#일 후 만료}}",
+        "loading": "token을 불러오는 중...",
+        "neverExpires": "만료되지 않음",
+        "newTokenButton": "새 액세스 token",
+        "noPermissionTooltip": "액세스 token을 생성할 권한이 없습니다",
+        "searchPlaceholder": "검색..."
+      },
+      "revokeModal": {
+        "description": "{name}({tokenDisplay}) token을 사용하는 모든 애플리케이션은 Onyx에 접근할 수 없게 됩니다. 이 작업은 되돌릴 수 없습니다.",
+        "question": "이 token을 해지하시겠습니까?",
+        "submit": "해지",
+        "title": "액세스 token 해지"
+      },
+      "scopeSelector": {
+        "includedWith": "{label} ({lockReason}에 포함됨)",
+        "loadError": "권한을 불러오지 못했습니다.",
+        "loading": "권한을 불러오는 중..."
+      },
+      "section": {
+        "title": "액세스 token"
+      },
+      "toasts": {
+        "createFailed": "token을 생성하지 못했습니다",
+        "createNetworkError": "token 생성 중 네트워크 오류가 발생했습니다",
+        "created": "token을 생성했습니다",
+        "deleteFailed": "token을 삭제하지 못했습니다",
+        "deleteNetworkError": "token 삭제 중 네트워크 오류가 발생했습니다",
+        "deleted": "token을 삭제했습니다",
+        "loadFailed": "token을 불러오지 못했습니다",
+        "loadPermissionsFailed": "권한 옵션을 불러오지 못했습니다",
+        "nameRequired": "token 이름을 입력해야 합니다"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "token 복사",
+        "description": "계속하기 전에 이 token을 저장하세요. 다시 표시되지 않습니다.",
+        "title": "액세스 token"
+      },
+      "upsell": {
+        "description": "액세스 token을 사용하려면 유료 구독이 활성 상태여야 합니다.",
+        "upgradeButton": "요금제 업그레이드"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "없음",
+        "optionAriaLabel": "{label} 배경{selected, select, true { (선택됨)} other {}}",
+        "title": "채팅 배경"
+      },
+      "colorMode": {
+        "auto": "자동",
+        "dark": "다크",
+        "description": "UI에 사용할 색상 모드를 선택하세요.",
+        "light": "라이트",
+        "title": "색상 모드"
+      },
+      "title": "모양"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "채팅이 응답을 생성하는 동안 새 내용으로 자동으로 스크롤합니다.",
+        "title": "채팅 자동 스크롤"
+      },
+      "collapseLargePastes": {
+        "description": "3줄 또는 200자보다 긴 텍스트를 붙여넣으면 본문에 넣지 않고 작은 타일로 접습니다. 타일을 클릭하면 전체 텍스트를 보거나 편집할 수 있습니다.",
+        "title": "긴 붙여넣기 접기"
+      },
+      "defaultAppMode": {
+        "chatOption": "채팅",
+        "description": "새 세션을 검색 모드로 시작할지 채팅 모드로 시작할지 선택하세요.",
+        "disabledTooltip": "검색 UI가 비활성화되어 있으며 관리자만 활성화할 수 있습니다.",
+        "searchOption": "검색",
+        "title": "기본 앱 모드"
+      },
+      "defaultModel": {
+        "description": "Onyx가 채팅에서 기본으로 사용하는 모델입니다.",
+        "title": "기본 모델"
+      },
+      "defaultReasoningLevel": {
+        "description": "새 채팅의 시작 추론 수준입니다. 모델에 적용된 관리자 설정이 항상 우선하며, 각 채팅의 모델 설정에서 이 값을 변경할 수 있습니다.",
+        "title": "기본 추론 수준"
+      },
+      "defaultTemperature": {
+        "description": "새 채팅의 시작 온도입니다. 모델에 적용된 관리자 설정이 항상 우선하며, 각 채팅의 모델 설정에서 이 값을 변경할 수 있습니다.",
+        "title": "기본 온도"
+      },
+      "smoothStreaming": {
+        "description": "스트리밍 응답을 한 글자씩 애니메이션으로 표시합니다. 비활성화하면 도착한 청크를 그대로 표시합니다.",
+        "title": "부드러운 스트리밍"
+      },
+      "title": "채팅",
+      "toasts": {
+        "saveFailed": "환경설정을 저장하지 못했습니다",
+        "saved": "환경설정을 저장했습니다"
+      }
+    },
+    "connectors": {
+      "connectButton": "연결",
+      "disconnectModal": {
+        "continueNote": "{name} 콘텐츠를 참조하는 기존 세션은 계속 사용할 수 있습니다.",
+        "description": "Onyx는 더 이상 {name} 계정의 콘텐츠에 접근하거나 검색할 수 없습니다.",
+        "disconnecting": "연결 해제 중...",
+        "submit": "연결 해제",
+        "title": "*{name}* 연결 해제"
+      },
+      "emptyMessage": "조직에 설정된 커넥터가 없습니다.",
+      "status": {
+        "connected": "연결됨",
+        "notConnected": "연결 안 됨",
+        "paused": "일시 중지됨"
+      },
+      "title": "커넥터",
+      "toasts": {
+        "disconnectFailed": "연결을 해제하지 못했습니다",
+        "disconnected": "연결을 해제했습니다"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "모든 채팅 삭제",
+        "confirm": {
+          "deleting": "삭제 중...",
+          "description": "모든 채팅 세션과 기록이 영구히 삭제됩니다. 삭제는 되돌릴 수 없습니다.",
+          "question": "모든 채팅을 삭제하시겠습니까?",
+          "submit": "삭제",
+          "title": "모든 채팅 삭제"
+        },
+        "description": "모든 채팅 세션을 영구히 삭제합니다.",
+        "title": "모든 채팅 삭제",
+        "toasts": {
+          "deleteFailed": "모든 채팅 세션을 삭제하지 못했습니다",
+          "deleted": "모든 채팅 세션을 삭제했습니다."
+        }
+      },
+      "title": "위험 구역"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "새 token",
+        "description": "애플리케이션을 연결하기 전에 범위를 지정한 token을 생성하세요.",
+        "title": "액세스 token"
+      },
+      "copyButton": {
+        "copied": "복사됨",
+        "copy": "복사",
+        "copyError": "값을 복사하지 못했습니다."
+      },
+      "description": "Onyx에서 사용할 수 있는 모델에 외부 도구를 연결합니다.",
+      "guideButton": "가이드",
+      "models": {
+        "description": "{count, plural, one {계정에서 모델 #개를 사용할 수 있습니다. 제공자를 열어 ID를 복사하세요.} other {계정에서 모델 #개를 사용할 수 있습니다. 제공자를 열어 ID를 복사하세요.}}",
+        "title": "모델"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {모델 #개 사용 가능} other {모델 #개 사용 가능}}"
+      },
+      "title": "LLM 게이트웨이",
+      "url": {
+        "description": "호환되는 OpenAI 및 Anthropic 클라이언트에서 이 기본 URL을 사용하세요.",
+        "title": "게이트웨이 URL"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "UI에 사용할 언어를 선택하세요.",
+        "title": "표시 언어"
+      },
+      "title": "언어",
+      "toasts": {
+        "updateFailed": "언어 설정을 변경하지 못했습니다"
+      }
+    },
+    "memory": {
+      "empty": {
+        "description": "Onyx가 기억할 개인 메모나 메모리를 추가하세요."
+      },
+      "referenceStoredMemories": {
+        "description": "Onyx가 채팅에서 저장된 메모리를 참조하도록 합니다.",
+        "title": "저장된 메모리 참조"
+      },
+      "title": "메모리",
+      "updateMemories": {
+        "description": "Onyx가 저장된 메모리를 생성하고 갱신하도록 합니다.",
+        "title": "메모리 갱신"
+      },
+      "viewAll": {
+        "description": "모든 메모리",
+        "title": "보기/추가"
+      }
+    },
+    "personalPreferences": {
+      "description": "원하는 설정을 자연어로 입력하세요.",
+      "placeholder": "시스템이 어떻게 동작하고 어떤 어조를 사용할지 설명하세요.",
+      "title": "개인 환경설정"
+    },
+    "profile": {
+      "fullName": {
+        "description": "이 이름을 앱에 표시합니다.",
+        "placeholder": "이름",
+        "title": "전체 이름"
+      },
+      "title": "프로필",
+      "toasts": {
+        "updateFailed": "개인화 설정을 변경하지 못했습니다",
+        "updated": "개인화 설정을 변경했습니다"
+      },
+      "workRole": {
+        "description": "직무를 알려주면 응답을 더 잘 맞출 수 있습니다.",
+        "placeholder": "직무",
+        "title": "직무"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "다음 내용을 1~2문장으로 간결하게 요약하세요:",
+        "promptPlaceholder": "요약",
+        "publicTooltip": "공개 프롬프트 단축어는 삭제할 수 없습니다.",
+        "removeAriaLabel": "단축어 제거"
+      },
+      "title": "프롬프트 단축어",
+      "toasts": {
+        "bothRequired": "단축어와 확장 내용을 모두 입력해야 합니다",
+        "created": "단축어를 생성했습니다",
+        "deleteFailed": "단축어를 삭제하지 못했습니다",
+        "deleted": "단축어를 삭제했습니다",
+        "loadFailed": "단축어를 불러오지 못했습니다",
+        "saveFailed": "단축어를 저장하지 못했습니다",
+        "updated": "단축어를 수정했습니다"
+      },
+      "toggle": {
+        "description": "단축어를 활성화하면 자주 쓰는 프롬프트를 빠르게 넣을 수 있습니다.",
+        "title": "프롬프트 단축어 사용"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "음성 응답을 자동으로 재생합니다.",
+        "title": "자동 재생"
+      },
+      "autoSend": {
+        "description": "말을 멈추면 음성 입력을 자동으로 전송합니다.",
+        "title": "멈추면 자동 전송"
+      },
+      "playbackSpeed": {
+        "description": "음성 재생 속도를 조정합니다.",
+        "title": "재생 속도"
+      },
+      "title": "음성"
+    }
+  },
+  "sidebar": {
+    "adminNav": {
+      "items": {
+        "addConnector": {
+          "label": "커넥터 추가"
+        },
+        "agents": {
+          "label": "에이전트"
+        },
+        "analytics": {
+          "label": "분석"
+        },
+        "appearanceAndTheming": {
+          "label": "모양 및 테마"
+        },
+        "chatPreferences": {
+          "label": "채팅 환경설정"
+        },
+        "codeInterpreter": {
+          "label": "코드 인터프리터"
+        },
+        "craftAccess": {
+          "label": "접근 권한"
+        },
+        "craftApps": {
+          "label": "앱"
+        },
+        "craftInstructions": {
+          "label": "지침"
+        },
+        "customAnalytics": {
+          "label": "사용자 지정 분석"
+        },
+        "discordIntegration": {
+          "label": "Discord 연동"
+        },
+        "documentSets": {
+          "label": "문서 세트"
+        },
+        "existingConnectors": {
+          "label": "기존 커넥터"
+        },
+        "exportLogs": {
+          "label": "로그 내보내기"
+        },
+        "groups": {
+          "label": "그룹"
+        },
+        "hookExtensions": {
+          "label": "훅 확장"
+        },
+        "imageGeneration": {
+          "label": "이미지 생성"
+        },
+        "indexSettings": {
+          "label": "인덱스 설정"
+        },
+        "languageModels": {
+          "label": "언어 모델"
+        },
+        "mcpActions": {
+          "label": "MCP 액션"
+        },
+        "openapiActions": {
+          "label": "OpenAPI 액션"
+        },
+        "plansAndBilling": {
+          "label": "요금제 및 결제"
+        },
+        "queryHistory": {
+          "label": "쿼리 기록"
+        },
+        "scim": {
+          "label": "SCIM"
+        },
+        "securityAndHardening": {
+          "label": "보안 및 강화"
+        },
+        "serviceAccounts": {
+          "label": "서비스 계정"
+        },
+        "slackIntegration": {
+          "label": "Slack 연동"
+        },
+        "ssoProviders": {
+          "label": "SSO 제공자"
+        },
+        "tracing": {
+          "label": "추적"
+        },
+        "upgradePlan": {
+          "label": "요금제 업그레이드"
+        },
+        "usage": {
+          "label": "사용량"
+        },
+        "users": {
+          "label": "사용자"
+        },
+        "voice": {
+          "label": "음성"
+        },
+        "webSearch": {
+          "label": "웹 검색"
+        }
+      },
+      "sections": {
+        "agentsAndActions": {
+          "label": "에이전트 및 액션"
+        },
+        "craft": {
+          "label": "Craft"
+        },
+        "documentsAndKnowledge": {
+          "label": "문서 및 지식"
+        },
+        "integrations": {
+          "label": "연동"
+        },
+        "organization": {
+          "label": "조직"
+        },
+        "permissions": {
+          "label": "권한"
+        },
+        "usage": {
+          "label": "사용량"
+        }
+      }
+    },
+    "adminSidebar": {
+      "businessOrEnterpriseOnly": {
+        "tooltip": "이 기능은 [Onyx Business 또는 Enterprise 버전](/admin/billing)에서만 사용할 수 있습니다."
+      },
+      "enterpriseOnly": {
+        "tooltip": "이 기능은 [Onyx Enterprise 버전](/admin/billing)에서만 사용할 수 있습니다."
+      },
+      "exitAdminPanel": {
+        "label": "관리자 패널 나가기"
+      },
+      "search": {
+        "label": "검색"
+      },
+      "searchInput": {
+        "placeholder": "검색..."
+      }
+    },
+    "appSidebar": {
+      "adminPanel": {
+        "label": "관리자 패널"
+      },
+      "agents": {
+        "title": "에이전트"
+      },
+      "craft": {
+        "label": "Craft"
+      },
+      "exploreAgents": {
+        "label": "에이전트 둘러보기"
+      },
+      "moreAgents": {
+        "label": "에이전트 더 보기"
+      },
+      "moveChatError": {
+        "message": "채팅을 이동하지 못했습니다. 다시 시도하세요."
+      },
+      "newProject": {
+        "label": "새 프로젝트",
+        "tooltip": "새 프로젝트"
+      },
+      "newSession": {
+        "label": "새 세션"
+      },
+      "projects": {
+        "title": "프로젝트"
+      },
+      "recents": {
+        "empty": {
+          "text": "메시지를 보내 보세요! 채팅 기록이 여기에 표시됩니다."
+        },
+        "title": "최근 항목"
+      },
+      "searchChats": {
+        "label": "채팅 검색"
+      }
+    },
+    "chatButton": {
+      "createProject": {
+        "label": "{projectName} 생성"
+      },
+      "createProjectError": {
+        "message": "프로젝트를 생성하지 못했습니다. 다시 시도하세요."
+      },
+      "delete": {
+        "label": "삭제"
+      },
+      "deleteConfirmation": {
+        "confirmButton": {
+          "label": "삭제"
+        },
+        "description": "이 채팅을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+        "title": "채팅 삭제"
+      },
+      "deleteError": {
+        "message": "채팅을 삭제하지 못했습니다. 다시 시도하세요."
+      },
+      "moveToProject": {
+        "label": "프로젝트로 이동"
+      },
+      "projectSearchInput": {
+        "placeholder": "프로젝트 검색"
+      },
+      "removeFromProject": {
+        "label": "{projectName}에서 제거"
+      },
+      "rename": {
+        "label": "이름 변경"
+      },
+      "share": {
+        "label": "공유"
+      }
+    },
+    "chatSearch": {
+      "createNamedProject": {
+        "label": "새 프로젝트 \"<name>{projectName}</name>\" 생성"
+      },
+      "footer": {
+        "openAction": {
+          "label": "열기"
+        },
+        "selectAction": {
+          "label": "선택"
+        },
+        "showAllAction": {
+          "label": "모두 보기"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "아직 채팅이나 프로젝트가 없습니다"
+        },
+        "noResults": {
+          "text": "결과가 없습니다"
+        }
+      },
+      "newProject": {
+        "label": "새 프로젝트"
+      },
+      "newSession": {
+        "label": "새 세션"
+      },
+      "noMoreResults": {
+        "text": "더 이상 결과가 없습니다"
+      },
+      "projectsFilter": {
+        "label": "프로젝트"
+      },
+      "recentFilter": {
+        "label": "최근"
+      },
+      "recentSessionsFilter": {
+        "label": "최근 세션"
+      },
+      "searchInput": {
+        "placeholder": "채팅 세션, 프로젝트 검색..."
+      },
+      "sessionsFilter": {
+        "label": "세션"
+      }
+    },
+    "createConnector": {
+      "advancedStep": {
+        "label": "고급 (선택)"
+      },
+      "connectorStep": {
+        "label": "커넥터"
+      },
+      "credentialStep": {
+        "label": "자격 증명"
+      },
+      "exitSetup": {
+        "label": "커넥터 설정 나가기"
+      }
+    },
+    "notifications": {
+      "empty": {
+        "title": "알림 없음"
+      },
+      "header": {
+        "title": "알림"
+      },
+      "markAllAsReadButton": {
+        "tooltip": "모두 읽음으로 표시"
+      },
+      "markAsReadButton": {
+        "tooltip": "읽음으로 표시"
+      },
+      "newSection": {
+        "title": "새 알림"
+      },
+      "olderSection": {
+        "title": "이전 알림"
+      },
+      "unreadCount": {
+        "label": "{count, plural, one {읽지 않음 #개} other {읽지 않음 #개}}"
+      }
+    }
+  },
+  "skills": {
+    "modals": {
+      "addInstruction": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "header": {
+          "description": "이 프로젝트의 채팅 세션에 적용할 동작이나 어조를 지정하세요.",
+          "title": "프로젝트 지침 설정"
+        },
+        "instructionsField": {
+          "placeholder": "제 목표는... 응답할 때 반드시... 해 주세요."
+        },
+        "saveButton": {
+          "label": "지침 저장"
+        }
+      },
+      "create": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "continueButton": {
+          "label": "스킬 검토",
+          "loadingLabel": "여는 중…"
+        },
+        "header": {
+          "description": "SKILL.md 파일, ZIP 파일 또는 스킬 폴더를 업로드하세요. 저장하기 전에 세부 정보를 확인하고 편집할 수 있습니다.",
+          "title": "스킬 업로드"
+        },
+        "readError": {
+          "message": "스킬을 읽지 못했습니다"
+        },
+        "requirements": {
+          "frontmatter": "SKILL.md에는 이름과 설명이 있는 올바른 프론트매터가 있어야 합니다.",
+          "singleSkill": "한 번에 스킬 하나만 업로드하세요.",
+          "title": "파일 요구 사항",
+          "zip": "ZIP 파일에는 SKILL.md 파일이 있어야 합니다."
+        }
+      },
+      "importGithub": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "doneButton": {
+          "label": "완료"
+        },
+        "header": {
+          "chooseDescription": "{repository}에서 스킬을 선택하세요.",
+          "completeDescription": "스킬에 추가된 항목을 확인하세요.",
+          "completeTitle": "GitHub 가져오기 완료",
+          "description": "GitHub 리포지토리에서 스킬을 하나 이상 가져옵니다.",
+          "title": "GitHub에서 가져오기"
+        },
+        "importError": {
+          "message": "스킬을 가져오지 못했습니다.",
+          "title": "스킬을 가져오지 못했습니다"
+        },
+        "loadError": {
+          "message": "리포지토리를 불러오지 못했습니다.",
+          "title": "리포지토리를 불러오지 못했습니다"
+        },
+        "privateRepos": {
+          "askAdmin": "공개 리포지토리는 바로 가져옵니다. 비공개 리포지토리를 가져오려면 관리자에게 GitHub 설정을 요청하세요.",
+          "connect": "공개 리포지토리는 바로 가져옵니다. 비공개 리포지토리를 가져오려면 GitHub를 연결하세요.",
+          "connectButton": {
+            "label": "GitHub 연결"
+          },
+          "connected": "공개 리포지토리는 바로 가져옵니다. 비공개 리포지토리는 사용자의 GitHub 연결을 사용합니다.",
+          "needsConnection": "공개 리포지토리는 바로 가져옵니다. 비공개 리포지토리에는 GitHub 연결이 필요합니다.",
+          "setUp": "공개 리포지토리는 바로 가져옵니다. 비공개 리포지토리를 가져오기 전에 GitHub를 설정하세요.",
+          "setUpButton": {
+            "label": "GitHub 설정"
+          }
+        },
+        "repositoryInput": {
+          "label": "리포지토리"
+        },
+        "result": {
+          "disabledCount": "이름이 같은 다른 스킬이 활성화되어 있어 {count}개를 비활성 상태로 가져왔습니다.",
+          "enabledCount": "{count}개를 자동으로 활성화했습니다.",
+          "failedCount": "{count}개를 가져오지 못했습니다.",
+          "importedSection": {
+            "title": "가져옴"
+          },
+          "importedTitle": "{count, plural, one {스킬 #개를 가져왔습니다} other {스킬 #개를 가져왔습니다}}",
+          "noneTitle": "가져온 스킬이 없습니다",
+          "notImportedSection": {
+            "title": "가져오지 않음"
+          },
+          "notSelectedCount": "{count}개를 선택하지 않았습니다."
+        },
+        "selectAll": {
+          "ariaLabel": "가져올 수 있는 스킬 모두 선택"
+        },
+        "selection": {
+          "label": "가져올 수 있는 스킬 {total, plural, one {#개} other {#개}} 중 {selected}개 선택됨"
+        },
+        "skillCheckbox": {
+          "ariaLabel": "{name} 선택"
+        },
+        "skillTag": {
+          "disabled": "비활성화됨",
+          "enabled": "활성화됨"
+        },
+        "submitButton": {
+          "importLabel": "{count, plural, one {스킬 가져오기} other {스킬 #개 가져오기}}",
+          "importingLabel": "가져오는 중…",
+          "searchLabel": "리포지토리 검색",
+          "searchingLabel": "검색 중…"
+        },
+        "unavailableFallback": "이 스킬은 가져올 수 없습니다.",
+        "unavailableTag": {
+          "label": "가져올 수 없음"
+        }
+      },
+      "nameConflict": {
+        "body": "새 스킬은 비활성 상태로 시작합니다. 스킬 페이지에서 어느 스킬을 활성화할지 변경할 수 있습니다.",
+        "confirmButton": {
+          "label": "그래도 생성",
+          "pendingLabel": "생성 중..."
+        },
+        "description": "이 이름으로 활성화된 스킬이 이미 있습니다.",
+        "title": "“{name}” 스킬을 하나 더 생성하시겠습니까?"
+      },
+      "preview": {
+        "closeButton": {
+          "label": "닫기"
+        },
+        "fallbackTitle": "스킬 미리보기",
+        "instructions": {
+          "title": "지침"
+        },
+        "loadError": {
+          "description": "미리보기를 닫았다가 다시 열어 보세요.",
+          "title": "스킬을 불러오지 못했습니다"
+        },
+        "metadata": {
+          "createdBy": {
+            "label": "생성자"
+          },
+          "externalApp": {
+            "label": "외부 앱"
+          }
+        },
+        "noInstructions": {
+          "message": "지침이 없습니다."
+        },
+        "unavailable": {
+          "appDisabled": "관리자가 “{appName}” 앱을 비활성화했습니다.",
+          "appNotConnected": "이 스킬을 사용하려면 앱 페이지에서 “{appName}” 앱을 연결하세요.",
+          "title": "스킬 사용 불가"
+        }
+      },
+      "share": {
+        "backButton": {
+          "label": "뒤로"
+        },
+        "cancelButton": {
+          "label": "취소"
+        },
+        "currentUserLabel": "{email} (나)",
+        "doneButton": {
+          "label": "완료"
+        },
+        "externalAppNotice": "이 스킬이 “{appName}” 앱과 연결되어 있는 동안에는 조직 전체 뷰어 권한이 필요합니다.",
+        "header": {
+          "title": "*{name}* 공유",
+          "transferTitle": "*{name}* 이전"
+        },
+        "loading": {
+          "message": "공유 정보를 불러오는 중..."
+        },
+        "noOwnerTitle": "활성 소유자 없음",
+        "organizationPermissionMenu": {
+          "ariaLabel": "조직 권한 변경"
+        },
+        "ownerLabel": "소유자",
+        "permissionMenu": {
+          "ariaLabel": "{name}의 접근 권한 변경"
+        },
+        "saveButton": {
+          "label": "저장"
+        },
+        "saveErrorToast": {
+          "message": "공유 설정을 변경하지 못했습니다"
+        },
+        "savedToast": {
+          "message": "공유 설정을 변경했습니다."
+        },
+        "scopeMenu": {
+          "ariaLabel": "공유 범위 변경"
+        },
+        "transferButton": {
+          "label": "이전"
+        },
+        "transferErrorToast": {
+          "message": "소유권을 이전하지 못했습니다"
+        },
+        "transferredToast": {
+          "message": "소유권을 이전했습니다."
+        }
+      }
+    },
+    "sections": {
+      "bundlePicker": {
+        "chooseDifferent": {
+          "label": "다른 파일 선택"
+        },
+        "noFile": {
+          "description": "선택한 파일 없음"
+        },
+        "preparing": {
+          "label": "업로드 준비 중..."
+        },
+        "upload": {
+          "label": "끌어다 놓거나 클릭하여 업로드"
+        }
+      },
+      "fileTree": {
+        "empty": {
+          "description": "아직 보조 파일이 없습니다."
+        },
+        "remove": {
+          "label": "{name} 제거"
+        }
+      },
+      "filesPicker": {
+        "addFiles": {
+          "label": "파일 추가"
+        },
+        "input": {
+          "ariaLabel": "스킬 파일 추가"
+        },
+        "preparing": {
+          "label": "준비 중..."
+        },
+        "prompt": {
+          "description": "파일이나 ZIP을 선택하거나 폴더를 여기에 놓으세요."
+        }
+      },
+      "instructionsToggle": {
+        "group": {
+          "ariaLabel": "지침 표시 모드"
+        },
+        "raw": {
+          "label": "원본 마크다운"
+        },
+        "rendered": {
+          "label": "렌더링된 마크다운"
+        }
+      },
+      "upload": {
+        "error": {
+          "readFailed": "업로드한 파일을 읽지 못했습니다."
+        }
+      }
+    }
+  }
+}

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -1,0 +1,9561 @@
+{
+  "accountPopover": {
+    "accountFallback": {
+      "label": "账户"
+    },
+    "helpFaq": {
+      "label": "帮助与常见问题"
+    },
+    "logIn": {
+      "label": "登录"
+    },
+    "logoutFailed": {
+      "message": "退出登录失败"
+    },
+    "notifications": {
+      "label": "通知"
+    },
+    "profileUnavailable": {
+      "title": "无法获取个人资料"
+    },
+    "settings": {
+      "label": "设置"
+    },
+    "signOut": {
+      "label": "退出登录"
+    }
+  },
+  "actions": {
+    "actionButtons": {
+      "authenticateButton": {
+        "ariaLabel": "验证身份并连接到 {serverName}",
+        "label": "验证身份"
+      },
+      "deleteButton": {
+        "ariaLabel": "删除 {serverName} 服务器",
+        "tooltip": "删除服务器"
+      },
+      "disconnectButton": {
+        "ariaLabel": "断开 {serverName} 服务器的连接",
+        "tooltip": "断开服务器连接"
+      },
+      "fetchingTools": {
+        "label": "正在获取工具..."
+      },
+      "manageButton": {
+        "ariaLabel": "管理 {serverName} 服务器",
+        "tooltip": "管理服务器"
+      },
+      "reconnectButton": {
+        "ariaLabel": "重新连接到 {serverName}",
+        "label": "重新连接"
+      },
+      "viewToolsButton": {
+        "ariaLabel": "查看 {serverName} 的工具",
+        "label": "{count, plural, one {查看 # 个工具} other {查看 # 个工具}}"
+      }
+    },
+    "actionCard": {
+      "card": {
+        "ariaLabel": "{title} 操作卡片"
+      }
+    },
+    "addMcpModal": {
+      "addHeader": {
+        "description": "连接 MCP（Model Context Protocol）服务器以添加自定义操作。",
+        "title": "添加 MCP 服务器"
+      },
+      "authStatus": {
+        "apiTokenDescription": "已配置 API token",
+        "connectedDescription": "已连接",
+        "oauthDescription": "已通过 OAuth 连接到 {owner}",
+        "title": "已验证身份并连接"
+      },
+      "cancelButton": {
+        "label": "取消"
+      },
+      "description": {
+        "placeholder": "关于该 MCP 服务器的更多详情",
+        "suffix": "可选",
+        "title": "描述"
+      },
+      "disconnectButton": {
+        "tooltip": "断开服务器连接"
+      },
+      "editConfigsButton": {
+        "label": "编辑配置"
+      },
+      "manageHeader": {
+        "description": "更新 MCP 服务器配置并管理身份验证。",
+        "title": "管理 MCP 服务器"
+      },
+      "name": {
+        "placeholder": "为 MCP 服务器命名",
+        "required": "必须填写服务器名称",
+        "title": "服务器名称"
+      },
+      "serverUrl": {
+        "invalid": "必须是有效的 URL",
+        "required": "必须填写服务器 URL",
+        "subDescription": "只连接您信任的服务器。您需要对通过此连接执行的操作负责，并负责及时更新工具。",
+        "title": "MCP 服务器 URL"
+      },
+      "submitButton": {
+        "addLabel": "添加服务器",
+        "addingLabel": "正在添加...",
+        "saveLabel": "保存更改",
+        "savingLabel": "正在保存..."
+      },
+      "toasts": {
+        "createFailed": "创建 MCP 服务器失败",
+        "serverCreated": "MCP 服务器创建成功",
+        "serverUpdated": "MCP 服务器更新成功",
+        "updateFailed": "更新 MCP 服务器失败"
+      }
+    },
+    "addOpenApiModal": {
+      "addHeader": {
+        "description": "添加 OpenAPI 架构以添加自定义操作。",
+        "title": "添加 OpenAPI 操作"
+      },
+      "authStatus": {
+        "configuredTitle": "已配置身份验证",
+        "enabledTitle": "已验证身份并启用",
+        "headersDescription": "已配置自定义身份验证请求头",
+        "oauthDescription": "已配置 OAuth 身份验证",
+        "oauthNamedDescription": "已通过 {name} 连接 OAuth",
+        "passthroughDescription": "已启用透传身份验证"
+      },
+      "cancelButton": {
+        "label": "取消"
+      },
+      "copyButton": {
+        "tooltip": "复制定义"
+      },
+      "definition": {
+        "invalidJson": "JSON 格式无效",
+        "placeholder": "在此输入您的 OpenAPI 架构",
+        "required": "必须填写 OpenAPI 架构定义",
+        "subDescription": "指定一个 OpenAPI 架构，用于定义您想作为此操作一部分开放的 API。您可以在架构的任意位置使用占位符 `CHAT_SESSION_ID`、`MESSAGE_ID`、`USER_ID` 和 `USER_EMAIL`（例如服务器 URL、路径、参数默认值），调用时它们会被替换为当前请求的值。详细了解 [OpenAPI 操作]({docsUrl})。",
+        "title": "OpenAPI 架构定义"
+      },
+      "disableButton": {
+        "tooltip": "禁用操作"
+      },
+      "editConfigsButton": {
+        "disabledTooltip": "只有该操作的创建者或管理员才能管理身份验证",
+        "label": "编辑配置"
+      },
+      "editHeader": {
+        "description": "更新此操作的 OpenAPI 架构。",
+        "title": "编辑 OpenAPI 操作"
+      },
+      "empty": {
+        "description": "提供 OpenAPI 架构后即可在此预览操作。",
+        "title": "未找到操作"
+      },
+      "formatButton": {
+        "tooltip": "格式化定义"
+      },
+      "method": {
+        "noSummary": "未提供摘要"
+      },
+      "serverUrl": {
+        "description": "从架构中找到的 URL。只连接您信任的服务器。"
+      },
+      "submitButton": {
+        "addLabel": "添加操作",
+        "addingLabel": "正在添加...",
+        "saveLabel": "保存更改",
+        "savingLabel": "正在保存..."
+      },
+      "toasts": {
+        "actionCreated": "OpenAPI 操作创建成功",
+        "actionUpdated": "OpenAPI 操作更新成功",
+        "createFailed": "创建 OpenAPI 操作失败",
+        "invalidJson": "OpenAPI 架构定义中的 JSON 格式无效",
+        "updateFailed": "更新 OpenAPI 操作失败"
+      }
+    },
+    "cardHeader": {
+      "disconnected": {
+        "label": "（已断开连接）"
+      },
+      "notAuthenticated": {
+        "label": "（未验证身份）"
+      },
+      "renameButton": {
+        "ariaLabel": "重命名 {title}",
+        "tooltip": "重命名"
+      }
+    },
+    "cardSkeleton": {
+      "card": {
+        "ariaLabel": "正在加载操作卡片"
+      }
+    },
+    "disconnectModal": {
+      "body": {
+        "confirmation": "确定要继续吗？",
+        "description": "连接到 {name} 的所有工具将停止工作。如有需要，您可以稍后重新连接此服务器。"
+      },
+      "cancelButton": {
+        "label": "取消"
+      },
+      "confirmButton": {
+        "label": "断开连接",
+        "pendingLabel": "正在断开连接..."
+      },
+      "deleteButton": {
+        "label": "断开连接并删除"
+      },
+      "header": {
+        "title": "断开 *{name}* 的连接"
+      }
+    },
+    "mcpAuthModal": {
+      "additionalAuthParams": {
+        "label": "附加身份验证参数（JSON）"
+      },
+      "advanced": {
+        "description": "配置已知的 OAuth 提供方，明确指定授权端点和 token 端点，不使用自动发现。",
+        "title": "高级"
+      },
+      "apiKey": {
+        "required": "必须填写 API token"
+      },
+      "apiKeyTabs": {
+        "admin": {
+          "label": "共享密钥（管理员）"
+        },
+        "perUser": {
+          "label": "独立密钥（每位用户）"
+        }
+      },
+      "authPerformer": {
+        "required": "必须指定身份验证执行者"
+      },
+      "authType": {
+        "apiToken": {
+          "description": "使用每位用户的独立 API 密钥，或组织范围的共享 API 密钥。",
+          "label": "API 密钥"
+        },
+        "label": "身份验证方式",
+        "none": {
+          "description": "不推荐",
+          "label": "无"
+        },
+        "oauth": {
+          "description": "每位用户需要使用各自的凭据通过 OAuth 验证身份。",
+          "label": "OAuth"
+        },
+        "placeholder": "选择方式",
+        "ptOauth": {
+          "description": "转发用户用于验证 Onyx 身份的 OAuth 访问 token。",
+          "label": "OAuth 透传"
+        },
+        "required": "必须选择身份验证类型"
+      },
+      "authorizationEndpoint": {
+        "label": "授权端点",
+        "required": "在已知提供方模式下必须填写授权端点"
+      },
+      "cancelButton": {
+        "label": "取消"
+      },
+      "clientId": {
+        "label": "客户端 ID"
+      },
+      "clientSecret": {
+        "label": "客户端密钥"
+      },
+      "errors": {
+        "additionalParamsInvalid": "附加身份验证参数的 JSON 无效",
+        "additionalParamsInvalidWithReason": "附加身份验证参数的 JSON 无效：{reason}",
+        "additionalParamsNotObject": "附加身份验证参数必须是 JSON 对象",
+        "oauthInitFailed": "发起 OAuth 失败：{detail}",
+        "saveAuthFailed": "保存身份验证配置失败",
+        "saveConfigFailed": "保存服务器配置失败"
+      },
+      "header": {
+        "defaultTitle": "验证 MCP 服务器身份",
+        "description": "验证连接身份后即可开始使用 MCP 服务器。",
+        "title": "验证 *{name}* 的身份"
+      },
+      "knownProvider": {
+        "hint": "已知提供方模式需要配置端点。Google 参考端点：授权端点 {authorizationEndpoint}，token 端点 {tokenEndpoint}。"
+      },
+      "noAuthNotice": {
+        "description": "此连接不使用任何身份验证。请确保您信任该服务器。您需要对通过此连接执行的操作负责。",
+        "title": "此 MCP 服务器不使用身份验证"
+      },
+      "oauthInfo": {
+        "discovery": "客户端 ID 和密钥为可选项。在自动发现过程中，Onyx 会在服务器支持时使用客户端 ID 元数据文档（CIMD），否则回退到动态客户端注册（DCR）。",
+        "manualRegistration": "如果您的服务器两种方式都不支持，请先在服务器提供方处注册您的 Onyx 实例。为 Onyx 授予操作所需的权限范围。"
+      },
+      "passThroughNotice": {
+        "description": "Onyx 会将用户的 OAuth 访问 token 作为 Authorization 请求头直接转发给服务器。请确保该服务器支持使用同一提供方进行身份验证。",
+        "title": "对使用同一身份提供方的服务，请使用透传方式。"
+      },
+      "providerMode": {
+        "autoDiscovery": {
+          "description": "使用 MCP SDK 的质询/发现流程（默认）。",
+          "label": "自动发现"
+        },
+        "knownProvider": {
+          "description": "使用已配置的授权端点/token 端点。",
+          "label": "已知提供方"
+        },
+        "label": "提供方模式",
+        "placeholder": "选择模式"
+      },
+      "redirectUri": {
+        "copyTooltip": "复制重定向 URI",
+        "label": "使用**重定向 URI**："
+      },
+      "scopesOverride": {
+        "label": "权限范围覆盖（以逗号分隔）"
+      },
+      "sharedApiKey": {
+        "description": "请勿使用您的个人 API 密钥。请确保此密钥适合与组织中的所有人共享。",
+        "label": "API 密钥",
+        "placeholder": "组织共享的 API 密钥"
+      },
+      "submitButton": {
+        "label": "连接",
+        "pendingLabel": "正在连接..."
+      },
+      "tokenEndpoint": {
+        "label": "Token 端点",
+        "required": "在已知提供方模式下必须填写 token 端点"
+      },
+      "transport": {
+        "required": "必须选择传输方式"
+      }
+    },
+    "mcpCard": {
+      "card": {
+        "ariaLabel": "{title} MCP 服务器卡片"
+      },
+      "deleteModal": {
+        "body": {
+          "confirmation": "确定要删除此 MCP 服务器吗？",
+          "description": "连接到 <emphasis>{title}</emphasis> 的所有工具都将被移除。删除后无法恢复。"
+        },
+        "submitButton": {
+          "label": "删除"
+        },
+        "title": "删除 MCP 服务器"
+      },
+      "lastRefreshed": {
+        "label": "工具上次刷新时间：{time}"
+      },
+      "refreshToolsButton": {
+        "ariaLabel": "刷新工具",
+        "tooltip": "刷新工具"
+      }
+    },
+    "mcpPage": {
+      "addButton": {
+        "label": "添加 MCP 服务器"
+      },
+      "empty": {
+        "description": "连接 MCP 服务器以添加自定义操作。"
+      },
+      "errors": {
+        "unknown": "未知错误"
+      },
+      "toasts": {
+        "deleteFailed": "删除 MCP 服务器失败",
+        "disableAllFailed": "禁用所有工具失败",
+        "disconnectFailed": "断开 MCP 服务器连接失败",
+        "enableAllFailed": "启用所有工具失败",
+        "fetchToolsFailed": "获取工具失败：{error}",
+        "noToolsToDisable": "没有可禁用的工具",
+        "reconnectFailed": "重新连接 MCP 服务器失败",
+        "refreshToolsFailed": "刷新工具失败",
+        "renameFailed": "重命名 MCP 服务器失败",
+        "serverDeleted": "MCP 服务器删除成功",
+        "serverDisconnected": "MCP 服务器已成功断开连接",
+        "serverReconnected": "MCP 服务器重新连接成功",
+        "serverRenamed": "MCP 服务器重命名成功",
+        "toolDisabled": "工具已成功禁用",
+        "toolEnabled": "工具已成功启用",
+        "toolUpdateFailed": "更新工具失败",
+        "toolsDisabled": "{count, plural, one {已成功禁用 # 个工具} other {已成功禁用 # 个工具}}",
+        "toolsEnabled": "{count, plural, one {已成功启用 # 个工具} other {已成功启用 # 个工具}}",
+        "toolsFetched": "已成功连接并获取工具",
+        "toolsRefreshed": "工具刷新成功"
+      }
+    },
+    "openApiAuthModal": {
+      "authMethod": {
+        "customHeader": {
+          "description": "每次请求都发送自定义请求头。",
+          "label": "自定义 Authorization 请求头"
+        },
+        "label": "身份验证方式",
+        "oauth": {
+          "description": "每位用户使用各自的凭据通过 OAuth 验证身份。",
+          "label": "OAuth"
+        },
+        "placeholder": "选择方式",
+        "ptOauth": {
+          "description": "转发用户用于验证 Onyx 身份的 OAuth 访问 token。",
+          "label": "OAuth 透传"
+        },
+        "required": "必须选择身份验证方式"
+      },
+      "authorizationUrl": {
+        "label": "授权 URL",
+        "required": "必须填写授权 URL"
+      },
+      "cancelButton": {
+        "label": "取消"
+      },
+      "clientId": {
+        "description": "留空则保留当前的客户端 ID。",
+        "label": "OAuth 客户端 ID",
+        "required": "必须填写客户端 ID"
+      },
+      "clientSecret": {
+        "description": "留空则保留当前的客户端密钥。",
+        "label": "OAuth 客户端密钥",
+        "required": "必须填写客户端密钥"
+      },
+      "errors": {
+        "invalidUrl": "请输入有效的 URL",
+        "loadConfigFailed": "加载现有 OAuth 配置失败。请重新输入详细信息以更新配置。"
+      },
+      "header": {
+        "description": "验证连接身份后即可开始使用 OpenAPI 操作。"
+      },
+      "headers": {
+        "addButton": {
+          "label": "添加请求头"
+        },
+        "description": "为发送到此操作 API 端点的所有请求指定自定义请求头。",
+        "keyRequired": "必须填写请求头名称",
+        "keyTitle": "请求头",
+        "minRequired": "请至少添加一个身份验证请求头",
+        "title": "身份验证请求头",
+        "valueRequired": "必须填写请求头的值",
+        "valueTitle": "值"
+      },
+      "loading": {
+        "label": "正在加载现有配置..."
+      },
+      "oauthLoginNotice": {
+        "description": "OAuth 透传需要支持 OAuth 的登录方式（Google 或 OIDC）。"
+      },
+      "passThroughNotice": {
+        "description": "Onyx 会将用户的 OAuth 访问 token 作为 Authorization 请求头直接转发给服务器。请确保该服务器支持使用同一提供方进行身份验证。",
+        "title": "对使用同一身份提供方的服务，请使用透传方式。"
+      },
+      "redirectUri": {
+        "copyTooltip": "复制重定向 URI",
+        "label": "使用<emphasis>重定向 URI</emphasis>："
+      },
+      "scopes": {
+        "description": "要请求的 OAuth 权限范围列表，以逗号分隔。",
+        "label": "权限范围 <optional>（可选）</optional>",
+        "placeholder": "例如 repo、user"
+      },
+      "submitButton": {
+        "label": "连接",
+        "pendingLabel": "正在连接..."
+      },
+      "tokenUrl": {
+        "label": "Token URL",
+        "required": "必须填写 token URL"
+      }
+    },
+    "openApiCard": {
+      "card": {
+        "ariaLabel": "{name} OpenAPI 操作卡片"
+      },
+      "deleteModal": {
+        "body": {
+          "confirmation": "确定要删除此 OpenAPI 操作吗？",
+          "description": "此操作将永久删除 OpenAPI 操作 <emphasis>{name}</emphasis> 及其配置。"
+        },
+        "submitButton": {
+          "label": "删除"
+        },
+        "title": "删除 OpenAPI 操作"
+      },
+      "method": {
+        "noSummary": "未提供摘要"
+      },
+      "toolsList": {
+        "emptyMessage": "此 OpenAPI 架构未定义任何操作",
+        "emptySearchMessage": "没有与搜索匹配的操作"
+      }
+    },
+    "openApiPage": {
+      "addButton": {
+        "label": "添加 OpenAPI 操作"
+      },
+      "authModal": {
+        "authenticateTitle": "验证 {name} 的身份",
+        "defaultTitle": "验证 OpenAPI 操作的身份",
+        "updateTitle": "更新 {name} 的身份验证"
+      },
+      "empty": {
+        "description": "通过 OpenAPI 架构添加自定义操作。"
+      },
+      "toasts": {
+        "actionRenamed": "OpenAPI 操作重命名成功",
+        "authHeadersSaved": "{name} 的身份验证请求头保存成功。",
+        "authPassthroughSaved": "{name} 的身份验证透传保存成功。",
+        "authSaveFailed": "保存身份验证设置失败。",
+        "authSaved": "{name} 的身份验证保存成功。",
+        "authUpdated": "{name} 的身份验证更新成功。",
+        "deleteFailed": "删除工具失败。",
+        "deleteUnexpectedError": "删除工具时发生意外错误。",
+        "disconnectFailed": "断开 OpenAPI 操作连接失败。",
+        "renameFailed": "重命名 OpenAPI 操作失败",
+        "toolDeleted": "{name} 删除成功。",
+        "toolDisconnected": "{name} 已断开连接。"
+      }
+    },
+    "perUserAuth": {
+      "credentialField": {
+        "placeholder": "输入 {field}"
+      },
+      "credentials": {
+        "perUserDescription": "以下凭据不会与您的组织共享。",
+        "perUserTitle": "仅用于您自己的账户",
+        "sharedDescription": "这些值将用于您组织中的每位用户。",
+        "sharedTitle": "组织共享的值"
+      },
+      "headers": {
+        "addButton": {
+          "label": "添加请求头"
+        },
+        "error": {
+          "message": "至少要有一个请求头的值包含 {apiKey} 占位符。"
+        },
+        "keyTitle": "请求头名称",
+        "label": "身份验证请求头",
+        "perUserDescription": "设置请求头格式，供每位用户填写各自的凭据。使用 <mono>{apiKey}</mono> 或 <mono>{userEmail}</mono> 这类占位符。系统会提示用户为占位符提供值（user_email 除外）。",
+        "sharedDescription": "设置随组织共享凭据一起发送的请求头格式。至少在一个请求头的值中使用 <mono>{apiKey}</mono> 这类占位符；它会被替换为您组织的共享密钥。",
+        "valueTitle": "请求头的值"
+      }
+    },
+    "policyToggle": {
+      "always": {
+        "label": "自动批准"
+      },
+      "ask": {
+        "label": "询问"
+      },
+      "deny": {
+        "label": "拒绝"
+      }
+    },
+    "toolItem": {
+      "unavailable": {
+        "label": "工具不可用"
+      }
+    },
+    "toolsList": {
+      "disableAllButton": {
+        "ariaLabel": "禁用所有工具",
+        "tooltip": "禁用所有工具"
+      },
+      "empty": {
+        "message": "没有可用的工具",
+        "searchMessage": "未找到工具"
+      },
+      "enableAllButton": {
+        "label": "全部启用"
+      },
+      "showAllButton": {
+        "ariaLabel": "显示所有工具",
+        "tooltip": "显示所有工具"
+      },
+      "showEnabledButton": {
+        "ariaLabel": "仅显示已启用的工具",
+        "tooltip": "仅显示已启用"
+      }
+    },
+    "toolsSection": {
+      "foldButton": {
+        "label": "折叠"
+      },
+      "search": {
+        "ariaLabel": "搜索工具",
+        "placeholder": "搜索工具…"
+      }
+    }
+  },
+  "admin": {
+    "addConnector": {
+      "categories": {
+        "codeRepository": {
+          "label": "代码仓库"
+        },
+        "messaging": {
+          "label": "即时通讯"
+        },
+        "other": {
+          "label": "其他"
+        },
+        "sales": {
+          "label": "销售"
+        },
+        "storage": {
+          "label": "云存储"
+        },
+        "ticketingAndTaskManagement": {
+          "label": "工单与任务管理"
+        },
+        "wiki": {
+          "label": "知识库与 Wiki"
+        }
+      },
+      "popular": {
+        "title": "热门"
+      },
+      "search": {
+        "placeholder": "搜索连接器"
+      },
+      "seeConnectorsButton": {
+        "label": "查看连接器"
+      },
+      "sourceTile": {
+        "tooltip": {
+          "federatedConfigured": "<strong>联合连接器已配置。</strong>点击可编辑现有连接器。",
+          "slackCredentialsFound": "<strong>已找到现有的 Slack 凭据。</strong>点击可管理您的 Slack 连接器。"
+        }
+      }
+    },
+    "agents": {
+      "deleteModal": {
+        "confirmation": {
+          "description": "确定要删除 <emphasis>{name}</emphasis> 吗？此操作无法撤销。"
+        },
+        "header": {
+          "title": "删除智能体"
+        },
+        "submitButton": {
+          "label": "删除"
+        }
+      },
+      "emptyState": {
+        "description": "没有与当前搜索匹配的智能体。",
+        "title": "未找到智能体"
+      },
+      "featuredModal": {
+        "addBody": {
+          "description": "精选智能体会显示在探索智能体列表的顶部，并自动固定到有访问权限的新用户的侧边栏中。用它在整个组织中突出推荐的智能体。"
+        },
+        "addHeader": {
+          "title": "将 {name} 设为精选"
+        },
+        "featureButton": {
+          "label": "设为精选"
+        },
+        "removeBody": {
+          "description": "此操作会将 {name} 从探索智能体列表顶部的精选区移除。新用户的侧边栏中不再固定该智能体，但已有的固定不受影响。"
+        },
+        "removeHeader": {
+          "title": "将 {name} 移出精选"
+        },
+        "unfeatureButton": {
+          "label": "取消精选"
+        }
+      },
+      "header": {
+        "description": "用智能体自定义 AI 的行为和知识。管理您组织中的智能体。",
+        "title": "智能体"
+      },
+      "modals": {
+        "accessNote": {
+          "description": "此操作不会改变谁可以访问该智能体。"
+        }
+      },
+      "newAgentButton": {
+        "label": "新建智能体"
+      },
+      "reorderError": {
+        "message": "更新智能体排序失败"
+      },
+      "rowActions": {
+        "deleteItem": {
+          "title": "删除"
+        },
+        "editAgentButton": {
+          "label": "编辑智能体"
+        },
+        "genericError": {
+          "message": "发生错误"
+        },
+        "listItem": {
+          "title": "列出智能体"
+        },
+        "menuButton": {
+          "ariaLabel": "智能体操作"
+        },
+        "relistAgentButton": {
+          "label": "重新列出智能体"
+        },
+        "removeFeaturedButton": {
+          "label": "取消精选"
+        },
+        "setFeaturedButton": {
+          "label": "设为精选"
+        },
+        "shareItem": {
+          "title": "共享"
+        },
+        "statsItem": {
+          "title": "统计"
+        },
+        "unlistItem": {
+          "title": "取消列出智能体"
+        },
+        "updateSuccess": {
+          "message": "{name} 更新成功。"
+        }
+      },
+      "search": {
+        "placeholder": "搜索智能体..."
+      },
+      "table": {
+        "access": {
+          "featured": {
+            "label": "精选"
+          },
+          "private": {
+            "label": "私有"
+          },
+          "public": {
+            "label": "公开"
+          },
+          "shared": {
+            "label": "共享"
+          },
+          "unlisted": {
+            "label": "未列出"
+          }
+        },
+        "accessColumn": {
+          "header": "访问权限"
+        },
+        "createdBy": {
+          "system": {
+            "label": "系统"
+          }
+        },
+        "createdByColumn": {
+          "header": "创建者"
+        },
+        "descriptionColumn": {
+          "header": "描述"
+        },
+        "nameColumn": {
+          "header": "名称"
+        }
+      },
+      "unlistModal": {
+        "body": {
+          "description": "取消列出的智能体不会显示在探索智能体列表中，但仍可通过直接链接访问；之前使用过或固定过它的用户也仍可访问。"
+        },
+        "header": {
+          "title": "取消列出 *{name}*"
+        },
+        "submitButton": {
+          "label": "取消列出"
+        }
+      }
+    },
+    "analytics": {
+      "agentChart": {
+        "description": "所选智能体每天的消息数和独立用户数",
+        "empty": "此时间范围内没有所选智能体的数据。",
+        "error": "获取智能体数据失败。",
+        "selectPrompt": "选择一个智能体以查看分析数据。",
+        "series": {
+          "messages": {
+            "label": "消息数"
+          },
+          "uniqueUsers": {
+            "label": "独立用户数"
+          }
+        },
+        "title": "智能体分析"
+      },
+      "agentPicker": {
+        "empty": {
+          "label": "没有与搜索匹配的智能体"
+        },
+        "placeholder": "选择要显示的智能体",
+        "search": {
+          "placeholder": "搜索智能体..."
+        }
+      },
+      "feedbackChart": {
+        "description": "点赞/点踩随时间的变化",
+        "empty": "所选时间范围内没有反馈。",
+        "error": "获取反馈数据失败。",
+        "series": {
+          "negative": {
+            "label": "负面反馈"
+          },
+          "positive": {
+            "label": "正面反馈"
+          }
+        },
+        "title": "反馈"
+      },
+      "page": {
+        "description": "了解您的工作区在查询、反馈和智能体方面如何使用 Onyx。"
+      },
+      "reports": {
+        "calendar": {
+          "pickEnd": {
+            "label": "选择时间段的结束日期"
+          },
+          "pickStart": {
+            "label": "选择时间段的开始日期"
+          }
+        },
+        "description": "将每位用户的使用情况导出为包含 CSV 文件的 ZIP 压缩包。报告在后台生成，并保留在此处。",
+        "empty": {
+          "description": "暂无报告。选择一个时间段，生成第一份报告。"
+        },
+        "generateButton": {
+          "label": "生成报告",
+          "pendingLabel": "正在生成…"
+        },
+        "listError": {
+          "title": "加载使用报告失败。"
+        },
+        "pendingRow": {
+          "description": "{range} · 通常在一分钟内完成",
+          "slowDescription": "仍在处理。您可以离开此页面，报告完成后会显示在这里。",
+          "title": "正在准备报告…"
+        },
+        "period": {
+          "allTime": {
+            "label": "全部时间"
+          },
+          "custom": {
+            "label": "自定义时间段…"
+          },
+          "last30Days": {
+            "label": "最近 30 天"
+          },
+          "last3Months": {
+            "label": "最近 3 个月"
+          },
+          "last7Days": {
+            "label": "最近 7 天"
+          },
+          "today": {
+            "label": "今天"
+          }
+        },
+        "row": {
+          "description": "由 {requestor} 生成 · {time}",
+          "downloadButton": {
+            "ariaLabel": "下载 {label} 的报告",
+            "tooltip": "下载 ZIP"
+          },
+          "systemRequestor": {
+            "label": "系统"
+          }
+        },
+        "title": "使用报告",
+        "toasts": {
+          "ready": "使用报告已就绪。",
+          "startFailed": "启动报告生成失败：{message}",
+          "timedOut": "报告生成用时过长。请重试，或稍后再来查看。",
+          "unknownError": "未知错误"
+        }
+      },
+      "slackChannelChart": {
+        "description": "查询总数与自动解决数对比",
+        "empty": "所选时间范围内此工作区没有 OnyxBot 活动。",
+        "error": "获取 OnyxBot 数据失败。",
+        "series": {
+          "autoResolved": {
+            "label": "自动解决"
+          },
+          "totalQueries": {
+            "label": "查询总数"
+          }
+        },
+        "title": "Slack 频道"
+      },
+      "usageChart": {
+        "description": "使用量随时间的变化",
+        "empty": "所选时间范围内没有查询。",
+        "error": "获取使用数据失败。",
+        "series": {
+          "queries": {
+            "label": "查询数"
+          },
+          "uniqueUsers": {
+            "label": "独立用户数"
+          }
+        },
+        "title": "使用情况"
+      }
+    },
+    "billing": {
+      "activatingBanner": {
+        "description": "正在处理您的许可证。确认后会自动跳转到账单详情。",
+        "title": "您的许可证仍在激活中"
+      },
+      "banners": {
+        "airGapped": {
+          "description": "在线账单管理已禁用。请联系支持团队更新您的订阅。",
+          "title": "隔离网络部署"
+        },
+        "expired": {
+          "description": "续订后可恢复对付费功能的访问。",
+          "title": "您的订阅已过期。",
+          "withDate": {
+            "description": "请在 {date} 之前续订以恢复访问。"
+          },
+          "withDeletion": {
+            "title": "您的订阅已过期。数据将在 {days} 天后删除。"
+          }
+        },
+        "expiring": {
+          "description": "请在 {date} 之前续订，以免服务中断。",
+          "title": "您的订阅将在 {days} 天后到期。"
+        },
+        "graceSync": {
+          "title": "正在检查是否有已续订的许可证…"
+        },
+        "stripeError": {
+          "description": "请检查网络连接，或手动提供许可证。",
+          "title": "无法连接到 Stripe 付款门户。"
+        }
+      },
+      "checkout": {
+        "adjustPlan": {
+          "label": "调整方案"
+        },
+        "annual": {
+          "label": "按年"
+        },
+        "annualBadge": {
+          "label": "节省 20%"
+        },
+        "billingCycle": {
+          "description": "1 个月免费试用结束后",
+          "title": "计费周期"
+        },
+        "continueToPayment": {
+          "label": "继续付款"
+        },
+        "createSessionFailed": {
+          "error": "创建结账会话失败"
+        },
+        "loading": {
+          "label": "加载中..."
+        },
+        "monthly": {
+          "label": "按月"
+        },
+        "perSeatMonth": {
+          "label": "每席位/月"
+        },
+        "plan": {
+          "title": "商业版"
+        },
+        "price": {
+          "label": "${price}"
+        },
+        "seats": {
+          "description": "{count, plural, one {当前用户和 Slack 账号至少需要 # 个席位。} other {当前用户和 Slack 账号至少需要 # 个席位。}}",
+          "title": "席位数量"
+        },
+        "trialBilling": {
+          "text": "在您的 1 个月免费试用结束后，我们将于 <value>{date}</value> 向您收费。"
+        }
+      },
+      "footer": {
+        "activateLicenseKey": {
+          "label": "激活许可证密钥"
+        },
+        "billingHelp": {
+          "label": "账单帮助"
+        },
+        "licenseKeyPrompt": {
+          "label": "已有许可证密钥？"
+        },
+        "updateLicenseKey": {
+          "label": "更新许可证密钥"
+        }
+      },
+      "header": {
+        "plansBilling": {
+          "title": "套餐与账单"
+        },
+        "upgradePlan": {
+          "title": "升级套餐"
+        },
+        "viewPlans": {
+          "title": "查看套餐"
+        }
+      },
+      "license": {
+        "activateFailed": {
+          "error": "激活许可证失败"
+        },
+        "activateLicense": {
+          "label": "激活许可证"
+        },
+        "activateSuccess": {
+          "message": "许可证激活成功！"
+        },
+        "activateTitle": {
+          "title": "激活许可证密钥"
+        },
+        "activating": {
+          "label": "激活中..."
+        },
+        "activeUntil": {
+          "label": "许可证密钥有效期至 <value>{date}</value>"
+        },
+        "cancel": {
+          "label": "取消"
+        },
+        "close": {
+          "label": "关闭"
+        },
+        "description": "手动为此 Onyx 实例添加并激活许可证。",
+        "emptyKey": {
+          "error": "请输入许可证密钥"
+        },
+        "error": {
+          "text": "{error}。<link>账单帮助</link>"
+        },
+        "expired": {
+          "label": "许可证密钥已过期"
+        },
+        "keyField": {
+          "description": "粘贴或附加您从 Onyx 收到的许可证密钥文件。",
+          "title": "许可证密钥"
+        },
+        "updateKey": {
+          "label": "更新密钥"
+        },
+        "updateLicense": {
+          "label": "更新许可证"
+        },
+        "updateSuccess": {
+          "message": "许可证更新成功！"
+        },
+        "updateTitle": {
+          "title": "更新许可证密钥"
+        }
+      },
+      "payment": {
+        "card": {
+          "description": "付款方式",
+          "title": "尾号 1234 的 Visa 卡"
+        },
+        "lastPayment": {
+          "description": "上次付款"
+        },
+        "section": {
+          "title": "付款"
+        },
+        "update": {
+          "label": "更新"
+        },
+        "viewInvoice": {
+          "label": "查看发票"
+        }
+      },
+      "plans": {
+        "business": {
+          "button": {
+            "label": "购买商业版套餐"
+          },
+          "description": "每席位/月，按年计费\n按月计费则为每席位 $25",
+          "features": {
+            "apiKeys": "服务账号 API 密钥",
+            "documentPermissions": "继承文档权限",
+            "encryption": "机密信息加密",
+            "queryHistory": "查询历史与使用情况看板",
+            "rbac": "基于角色的访问控制（RBAC）",
+            "selfHosting": "自托管（可选）",
+            "theming": "自定义主题"
+          },
+          "featuresPrefix": "借助 AI 帮助您的团队完成更多工作。",
+          "pricing": "$20",
+          "title": "商业版"
+        },
+        "card": {
+          "ariaLabel": "{plan} 套餐卡片"
+        },
+        "currentPlan": {
+          "label": "您当前的套餐"
+        },
+        "enterprise": {
+          "button": {
+            "label": "联系销售"
+          },
+          "description": "面向大型组织的\n灵活定价与部署方案",
+          "features": {
+            "customDeployments": "自定义部署",
+            "customRoles": "自定义角色与权限",
+            "hookExtensions": "钩子扩展",
+            "regionalProcessing": "特定区域数据处理",
+            "scim": "SCIM / 用户组同步",
+            "support": "企业级 SLA 与优先支持",
+            "usageLimits": "可配置的用量限制",
+            "whiteLabeling": "完整白标定制"
+          },
+          "featuresPrefix": "包含商业版套餐的全部功能，另加：",
+          "title": "企业版"
+        },
+        "includedInPlan": {
+          "label": "已包含在您的套餐中"
+        }
+      },
+      "seats": {
+        "belowMinimum": {
+          "error": "您不能将席位数量设置为低于当前使用中/待处理的 **{minimum}** 个。请先[移除用户](/admin/users)，再调整席位数量。"
+        },
+        "billing": {
+          "added": "{count, plural, one {我们将按比例向您收取新增 <value>{count}</value> 个席位 的费用。} other {我们将按比例向您收取新增 <value>{count}</value> 个席位 的费用。}}",
+          "removed": "{count, plural, one {<value>{count}</value> 个席位将于 <value>{date}</value> 移除（在当前计费周期结束后）。} other {<value>{count}</value> 个席位将于 <value>{date}</value> 移除（在当前计费周期结束后）。}}",
+          "unchanged": "您的账单不会有变化。"
+        },
+        "breakdown": {
+          "label": "{used} 使用中 • {pending} 待处理 • {remaining} 剩余"
+        },
+        "cancel": {
+          "label": "取消"
+        },
+        "confirmChange": {
+          "label": "确认更改"
+        },
+        "delta": {
+          "added": "{count, plural, one {将新增 # 个席位} other {将新增 # 个席位}}",
+          "removed": "{count, plural, one {将移除 # 个席位} other {将移除 # 个席位}}"
+        },
+        "saving": {
+          "label": "保存中..."
+        },
+        "seatsField": {
+          "title": "席位数量"
+        },
+        "total": {
+          "label": "{count} 个席位"
+        },
+        "updateFailed": {
+          "error": "更新席位数量失败"
+        },
+        "updateSeats": {
+          "description": "增加或减少席位，以匹配您的团队规模。",
+          "label": "更新席位数量",
+          "title": "更新席位数量"
+        },
+        "viewUsers": {
+          "label": "查看用户"
+        }
+      },
+      "subscription": {
+        "businessPlan": {
+          "name": "商业版套餐"
+        },
+        "connectToStripe": {
+          "label": "连接到 Stripe"
+        },
+        "connecting": {
+          "label": "连接中..."
+        },
+        "enterprisePlan": {
+          "name": "企业版套餐"
+        },
+        "expired": {
+          "subtitle": "已于 {date} 过期"
+        },
+        "managePlan": {
+          "label": "管理套餐"
+        },
+        "managedBySales": {
+          "text": "您的套餐由销售团队管理。<br></br>如需变更，请<link>联系账单支持</link>。"
+        },
+        "nextPayment": {
+          "subtitle": "下次付款日期：{date}"
+        },
+        "syncLicense": {
+          "label": "同步许可证"
+        },
+        "syncing": {
+          "label": "同步中..."
+        },
+        "trialDays": {
+          "subtitle": "试用将在 {days} 天后结束。需在 {date} 付款"
+        },
+        "trialToday": {
+          "subtitle": "试用今天结束。需在 {date} 付款"
+        },
+        "trialTomorrow": {
+          "subtitle": "试用明天结束。需在 {date} 付款"
+        },
+        "upgradeNow": {
+          "label": "立即升级"
+        },
+        "upgrading": {
+          "label": "升级中..."
+        },
+        "validUntil": {
+          "subtitle": "有效期至 {date}"
+        },
+        "viewPlanDetails": {
+          "label": "查看套餐详情"
+        }
+      },
+      "toasts": {
+        "endTrialFailed": "结束试用失败",
+        "licenseSyncFailed": "许可证同步失败",
+        "paymentMethodRequired": "请先添加付款方式，然后重试升级。",
+        "syncLicenseFailed": "同步许可证失败"
+      }
+    },
+    "chatPreferences": {
+      "advanced": {
+        "title": "高级选项"
+      },
+      "anonymousUsers": {
+        "description": "允许任何人无需登录即可发起对话。他们看不到其他任何对话，也无法创建智能体或修改设置。",
+        "title": "允许匿名用户"
+      },
+      "autoDetectFilters": {
+        "description": "自动应用从搜索查询中推断出的来源和时间过滤条件。",
+        "title": "自动识别搜索过滤条件"
+      },
+      "autoScroll": {
+        "description": "在对话生成回复时自动滚动到新内容。用户可以在个人设置中覆盖此项。",
+        "title": "对话自动滚动"
+      },
+      "betaTag": {
+        "label": "测试版"
+      },
+      "chatNaming": {
+        "description": "用于自动命名对话会话的模型。默认使用每个会话自身的模型——如果主模型无法处理并发请求，请在此固定一个小而快的模型。",
+        "resetButton": {
+          "label": "重置"
+        },
+        "title": "对话命名模型"
+      },
+      "connectors": {
+        "empty": {
+          "title": "尚未设置连接器"
+        },
+        "manageAllButton": {
+          "label": "管理全部"
+        },
+        "title": "连接器"
+      },
+      "deepResearch": {
+        "description": "跨网络和已连接来源工作的智能体研究系统。每次查询消耗的 token 明显更多。",
+        "title": "深度研究"
+      },
+      "disableDefaultChat": {
+        "description": "这会强制用户始终在智能体中开始对话。新对话将在其第一个已固定的智能体中创建。设置精选智能体可帮助新用户快速上手。",
+        "title": "禁用默认对话"
+      },
+      "fileLimits": {
+        "default": {
+          "placeholder": "默认：{value}"
+        },
+        "description": "在对话和项目中附加的文件必须同时满足这两项限制才会被接受。文件越大，延迟、内存占用和 token 成本越高。",
+        "noLimit": {
+          "placeholder": "无限制"
+        },
+        "restoreDefault": {
+          "tooltip": "恢复默认"
+        },
+        "size": {
+          "maxDescription": "最大：{max} MB",
+          "suffix": "(MB)",
+          "title": "文件大小限制"
+        },
+        "title": "文件附件大小限制",
+        "tokens": {
+          "suffix": "（千 token）",
+          "title": "文件 token 限制"
+        }
+      },
+      "header": {
+        "description": "组织范围的对话设置和默认值。用户可以在个人设置中覆盖其中部分项。"
+      },
+      "mcpServer": {
+        "authTooltip": "启用此 MCP 服务器的工具前，请先完成身份验证。",
+        "expandButton": {
+          "label": "展开"
+        },
+        "foldButton": {
+          "label": "折叠"
+        },
+        "search": {
+          "placeholder": "搜索工具..."
+        }
+      },
+      "multiModel": {
+        "description": "允许多个模型在对话中并行生成回复。",
+        "title": "多模型生成"
+      },
+      "queryHistory": {
+        "anonymized": {
+          "description": "查询对管理员可见，但已移除用户身份信息",
+          "label": "匿名化"
+        },
+        "description": "控制组织的完整对话历史在管理面板中的显示方式。",
+        "disabled": {
+          "description": "查询历史报告已禁用。",
+          "label": "隐藏"
+        },
+        "normal": {
+          "description": "所有查询对管理员可见，并关联到具体用户。",
+          "label": "显示并附带用户信息"
+        },
+        "title": "查询历史可见性"
+      },
+      "reasoning": {
+        "description": "允许用户在对话的模型选择器中调整模型回答前的推理程度。",
+        "title": "推理控制"
+      },
+      "retention": {
+        "custom": {
+          "invalidError": "请输入 1 到 {max} 之间的整数天数。",
+          "label": "自定义保留期",
+          "moreTooltip": "更多",
+          "placeholder": "以天为单位",
+          "restoreTooltip": "恢复默认"
+        },
+        "description": "指定 Onyx 在您的组织中保留对话的时长。",
+        "enterprisePlanTag": {
+          "label": "企业版套餐"
+        },
+        "forever": {
+          "label": "永久"
+        },
+        "presets": {
+          "days30": "30 天",
+          "days60": "60 天",
+          "days7": "7 天",
+          "days90": "90 天",
+          "year1": "1 年"
+        },
+        "reduceModal": {
+          "confirmLabel": "缩短保留期",
+          "message": "超过 {days, plural, one {# 天} other {# 天}} 没有活动的对话将被永久删除。此操作无法撤销。",
+          "title": "缩短对话保留期？"
+        },
+        "tierTooltip": "对话历史保留是企业版套餐的功能。",
+        "title": "保留对话历史"
+      },
+      "searchMode": {
+        "businessPlanTag": {
+          "label": "商业版套餐"
+        },
+        "description": "用于在组织内快速搜索文档的界面模式。",
+        "noConnectorsTooltip": "设置连接器后才能使用搜索模式",
+        "tierTooltip": "搜索模式需要商业版或企业版套餐。",
+        "title": "搜索模式"
+      },
+      "systemPrompt": {
+        "description": "所有对话、智能体和项目的基础提示词。请谨慎修改：重大改动可能降低回复质量。",
+        "modal": {
+          "cancelButton": {
+            "label": "取消"
+          },
+          "caution": {
+            "description": "系统提示词会影响所有对话、智能体和项目。重大改动可能降低回复质量。",
+            "title": "请谨慎修改。"
+          },
+          "description": "此基础提示词会添加到所有对话、智能体和项目的开头。",
+          "placeholder": "输入您的系统提示词...",
+          "placeholders": {
+            "citationGuidance": "`{token}` - 从搜索工具检索到事实时如何提供引用的说明。",
+            "citationNote": "仅在使用搜索工具时包含。",
+            "currentDatetime": "`{token}` - 以易读格式显示的当前日期和星期。",
+            "intro": "您可以在提示词中使用以下占位符：",
+            "reminderTag": "`{token}` - 如何解读用户消息中系统提醒的说明。"
+          },
+          "restoreTooltip": "恢复默认",
+          "saveButton": {
+            "label": "保存"
+          }
+        },
+        "modifyButton": {
+          "label": "修改提示词"
+        },
+        "title": "系统提示词"
+      },
+      "teamContext": {
+        "description": "用户还可以在个人设置中提供额外的个人上下文。",
+        "placeholder": "描述您的团队以及 Onyx 应有的行为方式。",
+        "title": "团队上下文"
+      },
+      "teamName": {
+        "description": "这会作为额外上下文添加到所有对话会话中，以提供更丰富、更定制化的体验。",
+        "placeholder": "输入团队名称",
+        "title": "团队名称"
+      },
+      "temperature": {
+        "description": "允许用户在对话的模型选择器中调整模型回复的温度（创造性）。",
+        "title": "温度控制"
+      },
+      "toasts": {
+        "chatNamingReset": "对话命名已重置为会话自身的模型",
+        "chatNamingResetFailed": "重置对话命名模型失败",
+        "chatNamingUpdateFailed": "更新对话命名模型失败",
+        "chatNamingUpdated": "对话命名模型已更新",
+        "providerResolveFailed": "无法解析提供商",
+        "settingsUpdateFailed": "更新设置失败",
+        "settingsUpdated": "设置已更新",
+        "systemPromptUpdateFailed": "更新系统提示词失败",
+        "systemPromptUpdated": "系统提示词已更新",
+        "toolsUpdateFailed": "更新工具失败",
+        "toolsUpdated": "工具已更新",
+        "unknownError": "发生未知错误"
+      },
+      "tools": {
+        "codeInterpreter": {
+          "description": "生成并运行代码。",
+          "title": "代码解释器"
+        },
+        "codingAgent": {
+          "description": "调查 GitHub 仓库并回答有关其代码的问题。",
+          "title": "编程智能体"
+        },
+        "description": "对话可以使用的工具和能力。此项不适用于智能体。",
+        "imageGeneration": {
+          "description": "使用 AI 工具生成和处理图像。",
+          "disabledTooltip": "图像生成需要已配置的模型。请在“配置 > 图像生成”中设置一个，或联系管理员。",
+          "title": "图像生成"
+        },
+        "internalSearch": {
+          "description": "搜索组织已连接的知识库和文档。",
+          "title": "内部搜索"
+        },
+        "openUrl": {
+          "description": "获取并读取网页 URL 中的内容。",
+          "title": "打开 URL"
+        },
+        "title": "操作与工具",
+        "webSearch": {
+          "description": "搜索网络以获取实时信息和最新结果。",
+          "title": "网络搜索"
+        }
+      }
+    },
+    "codeInterpreter": {
+      "card": {
+        "description": "内置 Python 运行时",
+        "disconnectButton": {
+          "tooltip": "断开连接"
+        },
+        "disconnectedTitle": "代码解释器（已断开连接）",
+        "reconnectButton": {
+          "label": "重新连接"
+        },
+        "refreshButton": {
+          "tooltip": "刷新"
+        },
+        "title": "代码解释器"
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "所有连接到 <emphasis>代码解释器</emphasis> 的运行中会话都将停止工作。请注意，这不会删除运行时中的任何数据。如有需要，您稍后可以重新连接到此运行时。"
+        },
+        "header": {
+          "title": "断开代码解释器连接"
+        },
+        "submitButton": {
+          "label": "断开连接"
+        }
+      },
+      "errorCard": {
+        "connectionLost": {
+          "title": "连接丢失错误"
+        },
+        "generic": {
+          "title": "代码解释器错误"
+        }
+      },
+      "header": {
+        "description": "供您的 LLM 使用的安全沙箱化 Python 运行时。详情请参阅文档。",
+        "title": "代码解释器"
+      },
+      "status": {
+        "checking": {
+          "label": "检查中..."
+        },
+        "connectionLost": {
+          "label": "连接已丢失"
+        },
+        "healthy": {
+          "label": "已连接"
+        },
+        "unhealthy": {
+          "label": "状态异常"
+        }
+      },
+      "toggleError": {
+        "disconnect": {
+          "message": "断开代码解释器连接失败"
+        },
+        "reconnect": {
+          "message": "重新连接代码解释器失败"
+        }
+      }
+    },
+    "connector": {
+      "advancedConfig": {
+        "duration": {
+          "days": "{count, plural, one {# 天} other {# 天}}",
+          "hours": "{count, plural, one {# 小时} other {# 小时}}",
+          "minutes": "{count, plural, one {# 分钟} other {# 分钟}}"
+        },
+        "indexingStart": {
+          "label": "索引起始时间"
+        },
+        "pruningFrequency": {
+          "label": "清理频率"
+        },
+        "refreshFrequency": {
+          "label": "刷新频率"
+        }
+      },
+      "configItem": {
+        "booleanFalse": "否",
+        "booleanTrue": "是",
+        "edit": {
+          "tooltip": "编辑"
+        },
+        "showAll": {
+          "label": "显示全部（{count} 项）"
+        },
+        "showLess": {
+          "label": "收起"
+        }
+      },
+      "deleteModal": {
+        "additionalDetails": "删除此连接器会安排一个删除任务，移除其已索引的文档，并对所有用户删除该连接器。",
+        "entityType": "连接器"
+      },
+      "deletionError": {
+        "description": "尝试删除连接器时发生此错误。您可以点击“删除”按钮重新尝试删除。",
+        "title": "删除错误"
+      },
+      "docPermissionsTable": {
+        "columns": {
+          "docsSynced": "已同步文档数",
+          "errorMessage": "错误信息",
+          "permissionErrors": "权限错误",
+          "status": "状态",
+          "timeStarted": "开始时间"
+        },
+        "empty": {
+          "description": "文档权限同步任务在后台安排执行。可能需要一段时间才会显示——请在约 30 秒后刷新。",
+          "title": "暂无文档权限同步尝试"
+        },
+        "errorModal": {
+          "title": "文档权限同步错误"
+        }
+      },
+      "errorsModal": {
+        "columns": {
+          "documentId": "文档 ID",
+          "errorMessage": "错误信息",
+          "status": "状态",
+          "time": "时间"
+        },
+        "description": "以下是索引过程中遇到的错误。每一行代表一个失败的文档或实体。",
+        "empty": {
+          "description": "此页面未发现错误"
+        },
+        "fullReindex": {
+          "description": "点击下方按钮启动完整重新索引，尝试解决这些错误。完整重新索引可能比常规更新耗时长得多。"
+        },
+        "resolveAllButton": {
+          "label": "全部解决"
+        },
+        "status": {
+          "resolved": "已解决",
+          "unresolved": "未解决"
+        },
+        "targetedReindex": {
+          "description": "点击下方按钮，仅重新获取失败的文档。这比完整重新索引快得多。"
+        },
+        "title": "索引错误",
+        "unknownDocument": "未知"
+      },
+      "fileManagement": {
+        "addFilesButton": {
+          "label": "添加文件"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "columns": {
+          "fileName": "文件名",
+          "size": "大小",
+          "uploadDate": "上传日期"
+        },
+        "confirmModal": {
+          "addDetails": "新文件将被上传、分块、嵌入，并索引到文档索引中",
+          "addSummary": "将添加 {count} 个文件",
+          "confirmButton": {
+            "label": "确认并保存"
+          },
+          "description": "保存这些更改后，将执行以下操作：",
+          "removeDetails": "这些文件产生的文档将从文档索引中清理",
+          "removeSummary": "🗑️ 将移除 {count} 个文件",
+          "title": "确认文件更改"
+        },
+        "editButton": {
+          "label": "编辑"
+        },
+        "empty": {
+          "description": "此连接器中没有文件"
+        },
+        "header": {
+          "title": "文件（{count, plural, one {# 个文件} other {# 个文件}}）"
+        },
+        "loadError": "加载文件出错：{message}",
+        "newBadge": {
+          "label": "新增"
+        },
+        "removeFileButton": {
+          "tooltip": "移除文件"
+        },
+        "removingBadge": {
+          "label": "移除中"
+        },
+        "saveButton": {
+          "label": "保存更改",
+          "saving": "保存中..."
+        },
+        "toasts": {
+          "cannotRemoveAllFiles": "无法移除连接器中的所有文件。如需如此，请删除该连接器。",
+          "filesUpdated": "文件更新成功！文档索引正在后台更新。新文件正在建立索引，已移除的文件将从搜索结果中清理。",
+          "updateFailed": "更新文件失败"
+        }
+      },
+      "groupMembershipTable": {
+        "columns": {
+          "errorMessage": "错误信息",
+          "groups": "用户组",
+          "memberships": "成员关系",
+          "status": "状态",
+          "timeStarted": "开始时间",
+          "users": "用户"
+        },
+        "empty": {
+          "description": "用户组成员同步任务在后台安排执行。可能需要一段时间才会显示——请在约 30 秒后刷新。",
+          "title": "暂无用户组成员同步尝试"
+        },
+        "errorModal": {
+          "title": "用户组成员同步错误"
+        }
+      },
+      "indexAttemptsTable": {
+        "columns": {
+          "errorMessage": "错误信息",
+          "newDocs": "新增文档数",
+          "status": "状态",
+          "timeStarted": "开始时间",
+          "totalDocs": "文档总数",
+          "totalDocsTooltip": "本次索引尝试中在索引里被替换的文档总数"
+        },
+        "docsPerMinute": "{rate} 个文档 / 分钟",
+        "docsRemoved": "（同时移除了 {count} 个在来源中被检测为已删除的文档）",
+        "empty": {
+          "description": "索引尝试在后台安排执行，可能需要一段时间才会显示。请在约 30 秒后刷新页面！",
+          "title": "尚未安排索引尝试"
+        },
+        "noAdditionalDocs": "未处理额外的文档",
+        "reindexTooltip": {
+          "completed": "本次索引尝试是完整重新索引。来源中的所有文档均已同步到系统。",
+          "inProgress": "本次索引尝试是完整重新索引。来源中的所有文档正在同步到系统。"
+        },
+        "stageMetricsButton": {
+          "tooltip": "查看阶段指标"
+        },
+        "viewTrace": {
+          "ariaLabel": "查看完整追踪"
+        }
+      },
+      "indexErrorsAlert": {
+        "description": "处理部分文档时遇到问题。<details>查看详情。</details>",
+        "resolvingStatus": "正在解决失败项",
+        "title": "部分文档索引失败"
+      },
+      "invalidState": {
+        "description": "此连接器处于无效状态。请先更新凭据或创建新连接器，然后再重新索引。",
+        "title": "连接器状态无效"
+      },
+      "loadError": {
+        "title": "无法获取 ID 为 {ccPairId} 的连接器信息",
+        "unknownMessage": "未知错误"
+      },
+      "manageMenu": {
+        "delete": {
+          "label": "删除",
+          "tooltip": {
+            "active": "删除前请先暂停连接器"
+          }
+        },
+        "reIndex": {
+          "label": "重新索引",
+          "tooltip": {
+            "indexing": "索引正在进行中，无法重新索引",
+            "invalid": "重新索引前请先修复连接器配置",
+            "paused": "重新索引前请先恢复连接器"
+          }
+        },
+        "toggleStatus": {
+          "pause": {
+            "label": "暂停"
+          },
+          "resume": {
+            "label": "恢复"
+          },
+          "tooltip": {
+            "updating": "状态更新进行中"
+          }
+        },
+        "trigger": {
+          "label": "管理"
+        }
+      },
+      "permissionSyncStatus": {
+        "canceled": {
+          "label": "已取消"
+        },
+        "completedWithErrors": {
+          "label": "已完成，但有错误"
+        },
+        "failed": {
+          "label": "失败"
+        },
+        "fallback": {
+          "label": "未开始"
+        },
+        "inProgress": {
+          "label": "进行中"
+        },
+        "notStarted": {
+          "label": "已安排"
+        },
+        "success": {
+          "label": "成功"
+        }
+      },
+      "pruningFrequencyModal": {
+        "description": "连接器执行清理的频率（以小时为单位）",
+        "title": "清理频率"
+      },
+      "reEnableModal": {
+        "actionButton": {
+          "label": "重新启用"
+        },
+        "additionalDetails": "此连接器之前被标记为无效。重新启用前，请确认配置正确。确定要继续吗？",
+        "entityType": "无效连接器"
+      },
+      "reIndexModal": {
+        "fullReindex": {
+          "description": "这将对来源中的所有文档执行完整重新索引。",
+          "note": "<strong>注意：</strong>根据来源中存储的文档数量，这可能需要很长时间。"
+        },
+        "fullReindexButton": {
+          "label": "运行完整重新索引"
+        },
+        "title": "运行索引",
+        "update": {
+          "description": "这将拉取并索引自上次成功索引运行以来发生更改和/或新增的所有文档。"
+        },
+        "updateButton": {
+          "label": "运行更新"
+        }
+      },
+      "refreshFrequencyModal": {
+        "description": "连接器执行刷新的频率（以分钟为单位）",
+        "title": "刷新频率"
+      },
+      "sections": {
+        "advanced": {
+          "title": "高级"
+        },
+        "advancedConfiguration": {
+          "title": "高级配置"
+        },
+        "connectorConfiguration": {
+          "title": "连接器配置"
+        },
+        "credential": {
+          "title": "凭据"
+        },
+        "indexing": {
+          "title": "索引"
+        },
+        "indexingAttempts": {
+          "title": "索引尝试"
+        }
+      },
+      "stageMetrics": {
+        "attemptOverhead": {
+          "hideButton": {
+            "label": "隐藏尝试开销"
+          },
+          "showButton": {
+            "label": "显示尝试开销"
+          }
+        },
+        "batchTotal": {
+          "empty": "尚无已完成的批次",
+          "summary": "平均批次：{avgLabel}，共 {count, plural, one {# 个批次} other {# 个批次}}——分布如下所示。"
+        },
+        "empty": {
+          "description": "尚未记录本次尝试的阶段耗时数据。在部署阶段埋点之前运行的旧尝试没有指标数据。"
+        },
+        "loadError": {
+          "description": "无法加载本次尝试的阶段耗时数据。即使指标记录不可用，流水线仍会运行，因此这并不表示索引运行本身有问题。",
+          "title": "加载阶段指标失败"
+        },
+        "loading": "正在加载阶段指标…",
+        "perBatch": {
+          "columns": {
+            "avgTime": "平均耗时",
+            "calls": "调用次数",
+            "max": "最大值",
+            "min": "最小值",
+            "stage": "阶段",
+            "totalTime": "总耗时"
+          },
+          "empty": "未记录按批次的阶段数据。"
+        },
+        "sort": {
+          "label": "排序：",
+          "pipelineOrder": {
+            "label": "流水线顺序"
+          },
+          "timeTaken": {
+            "label": "耗时"
+          }
+        },
+        "stages": {
+          "batchLoad": {
+            "description": "将批次从对象存储读回工作进程内存。",
+            "label": "批次加载"
+          },
+          "batchTotal": {
+            "description": "端到端处理单个批次所用的总实际时间。",
+            "label": "批次总计"
+          },
+          "batchUnaccounted": {
+            "description": "未归入任何具名阶段的批次时间。数值偏大表示埋点缺失。",
+            "label": "未归类"
+          },
+          "checkpointLoad": {
+            "description": "加载已保存的检查点，使本次尝试从上次运行停止的位置继续。",
+            "label": "检查点加载"
+          },
+          "chunking": {
+            "description": "将每个文档拆分为用于生成 embedding 并建立索引的分块。",
+            "label": "分块"
+          },
+          "connectorFetch": {
+            "description": "连接器调用来源 API 并产出原始文档所花费的时间。",
+            "label": "连接器抓取"
+          },
+          "connectorValidation": {
+            "description": "在开始抓取前，验证连接器配置正确且可访问。",
+            "label": "连接器验证"
+          },
+          "contextualRag": {
+            "description": "使用 LLM 为每个分块生成上下文摘要，以提升检索质量。",
+            "label": "上下文 RAG"
+          },
+          "coordLockAcquireWait": {
+            "description": "等待保护本次尝试共享进度计数器的协调锁。",
+            "label": "协调锁获取等待"
+          },
+          "coordinationUpdate": {
+            "description": "更新本次尝试的进度计数器，使界面反映已完成的批次。",
+            "label": "协调更新"
+          },
+          "docBatchEnqueue": {
+            "description": "将已存储的批次发布到 Celery 队列，供 docprocessing 工作进程获取。",
+            "label": "文档批次入队"
+          },
+          "docBatchStore": {
+            "description": "将抓取到的一批文档持久化到对象存储，供 docprocessing 工作进程使用。",
+            "label": "文档批次存储"
+          },
+          "docDbPrepare": {
+            "description": "确定哪些文档是新增或已更新的，并准备相应的数据库行。",
+            "label": "文档数据库准备"
+          },
+          "docLockAcquireWait": {
+            "description": "等待单个文档的锁，避免并发任务写入同一文档。",
+            "label": "文档锁等待"
+          },
+          "docprocessingSetup": {
+            "description": "准备工作进程：加载搜索设置、embedding 模型和索引客户端。",
+            "label": "文档处理初始化"
+          },
+          "embedding": {
+            "description": "调用 embedding 模型，将文本块转换为向量。通常是最慢的阶段。",
+            "label": "Embedding"
+          },
+          "enrichmentPrep": {
+            "description": "在写入前，为每个文本块附加访问控制、权重提升和其他元数据。",
+            "label": "元数据填充准备"
+          },
+          "finalization": {
+            "description": "处理完成后清理工作进程资源并释放该批次。",
+            "label": "收尾"
+          },
+          "gcCollect": {
+            "description": "两个批次之间显式垃圾回收所用的时间。",
+            "label": "垃圾回收"
+          },
+          "hierarchyUpsert": {
+            "description": "写入数据源的文件夹或空间层级，以便按位置筛选文档。",
+            "label": "层级写入"
+          },
+          "imageProcessing": {
+            "description": "提取并总结图片，把图片内容转换为可搜索的文本。",
+            "label": "图片处理"
+          },
+          "permissionValidation": {
+            "description": "确认该凭据具有读取数据源文档所需的权限。",
+            "label": "权限校验"
+          },
+          "postIndexDbUpdate": {
+            "description": "索引写入成功后，更新 Postgres 中的文档记录。",
+            "label": "索引后数据库更新"
+          },
+          "queueWait": {
+            "description": "批次在队列中等待文档处理工作进程启动它的时间。",
+            "label": "队列等待"
+          },
+          "vectorDbWrite": {
+            "description": "将已生成 embedding 的文本块写入文档索引。",
+            "label": "向量数据库写入"
+          }
+        }
+      },
+      "stageMetricsModal": {
+        "description": "本次索引任务按批次和按尝试的耗时统计。",
+        "title": "索引阶段指标"
+      },
+      "statusCard": {
+        "documentsIndexed": {
+          "label": "已索引文档数"
+        },
+        "indexingSpeed": "（{speed} 文档 / 分钟）",
+        "lastIndexed": {
+          "label": "上次索引"
+        },
+        "lastSynced": {
+          "label": "上次同步"
+        },
+        "permissionSyncing": {
+          "label": "权限同步"
+        },
+        "status": {
+          "label": "状态"
+        }
+      },
+      "syncTables": {
+        "errorCell": {
+          "ariaLabel": "查看完整错误信息"
+        }
+      },
+      "syncTabs": {
+        "docPermissions": {
+          "label": "文档权限同步",
+          "notApplicableDescription": "此连接器不使用独立的文档权限同步任务。"
+        },
+        "groupMembership": {
+          "label": "群组成员同步",
+          "notApplicableDescription": "此连接器不使用独立的群组成员同步任务。"
+        },
+        "indexing": {
+          "label": "索引"
+        },
+        "loadError": {
+          "title": "加载同步任务失败"
+        },
+        "notApplicable": {
+          "title": "不适用"
+        }
+      },
+      "toasts": {
+        "completeReindexStarted": "已成功启动完全重新索引",
+        "completeReindexStarting": "正在启动完全重新索引…",
+        "deletionScheduleFailed": "安排删除连接器失败 - {message}",
+        "indexingProcessStartFailed": "启动索引进程失败",
+        "indexingStartFailed": "启动索引失败",
+        "indexingStartUnexpectedError": "尝试启动索引时发生意外错误",
+        "indexingUpdateStarted": "已成功启动索引更新",
+        "indexingUpdateStarting": "正在启动索引更新…",
+        "invalidPruningFrequency": "清理频率无效：必须是有效数字",
+        "invalidRefreshFrequency": "刷新频率无效：必须是整数",
+        "nameUpdateFailed": "更新连接器名称失败",
+        "nameUpdated": "已成功更新连接器名称",
+        "noUnresolvedErrors": "没有可重试的未解决错误。",
+        "pruningFrequencyUpdateFailed": "更新连接器清理频率失败",
+        "pruningFrequencyUpdated": "已成功更新连接器清理频率",
+        "refreshFrequencyUpdateFailed": "更新连接器刷新频率失败",
+        "refreshFrequencyUpdated": "已成功更新连接器刷新频率",
+        "targetedReindexFailed": "定向重新索引失败：{message}",
+        "targetedReindexSubmitted": "已为 {count, plural, one {# 个文档} other {# 个文档}} 提交定向重新索引。文档重新索引完成后，相关错误会从列表中消失。"
+      }
+    },
+    "connectorsList": {
+      "add": {
+        "authorizeButton": {
+          "label": "使用 {source} 授权",
+          "pendingLabel": "正在授权…"
+        },
+        "createCredentialButton": {
+          "label": "新建"
+        },
+        "credentialDeleted": {
+          "toast": "已成功删除凭据！"
+        },
+        "credentialModal": {
+          "title": "创建 {source} 凭据"
+        },
+        "credentialStep": {
+          "title": "选择凭据"
+        },
+        "credentialSwapped": {
+          "toast": "已成功更换凭据！"
+        },
+        "error": {
+          "toast": "错误：{detail}"
+        },
+        "federated": {
+          "tooltip": {
+            "description": "此连接器支持联合搜索选项。它会带来更高的延迟和更低的搜索质量。",
+            "link": {
+              "label": "改用联合搜索版本 →"
+            }
+          }
+        },
+        "fileUploadFailed": {
+          "toast": "上传文件出错"
+        },
+        "oauthRedirectFailed": {
+          "message": "无法将您重定向到 {source} 登录页面。请重试。"
+        },
+        "oauthStartFailed": {
+          "toast": "无法启动 OAuth"
+        },
+        "oauthUrlFailed": {
+          "toast": "获取 OAuth URL 失败"
+        },
+        "retryButton": {
+          "label": "重试"
+        },
+        "timeout": {
+          "toast": "操作在 {seconds} 秒后超时。请检查配置是否有误。"
+        },
+        "unknownError": {
+          "toast": "发生未知错误"
+        }
+      },
+      "advanced": {
+        "indexingStart": {
+          "label": "索引起始日期",
+          "subtext": "早于此日期的文档不会被拉取"
+        },
+        "pruneFrequency": {
+          "description": "对照数据源检查所有文档，删除已不存在的文档。注意：此过程会检查每一个文档，因此提高频率时请谨慎。默认为 {hours} 小时（{days} 天）。支持小数小时（例如 0.1 小时 = 6 分钟）。输入 0 可为此连接器禁用清理。",
+          "label": "清理频率（小时）"
+        },
+        "refreshFrequency": {
+          "description": "这是我们从数据源拉取新文档的频率（以分钟计）。如果输入 0，我们将不再为此连接器拉取新文档。",
+          "label": "刷新频率（分钟）"
+        },
+        "resetButton": {
+          "label": "重置"
+        },
+        "title": "高级配置"
+      },
+      "connectorName": {
+        "label": "连接器名称",
+        "subtext": "用于描述该连接器的名称。"
+      },
+      "credentialsLoadError": {
+        "title": "加载凭据失败。"
+      },
+      "field": {
+        "optional": {
+          "label": "（可选）"
+        },
+        "optionalSuffix": {
+          "label": "可选"
+        }
+      },
+      "gdrive": {
+        "authComplete": {
+          "description": "已创建您的 Google Drive 凭据。您可以在凭据列表中管理或撤销它。",
+          "title": "认证完成"
+        },
+        "authFailed": {
+          "toast": "使用 Google Drive 认证失败 - {error}"
+        },
+        "authenticateButton": {
+          "label": "使用 Google Drive 认证",
+          "pendingLabel": "正在认证…"
+        },
+        "createButton": {
+          "label": "创建凭据",
+          "pendingLabel": "正在创建…"
+        },
+        "credentialsLoadError": {
+          "title": "加载 Google Drive 凭据失败。"
+        },
+        "invalidFile": {
+          "toast": "提供的文件无效 - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "提供的文件无效 - 需要服务账号 JSON 密钥"
+        },
+        "missingServiceAccountKey": {
+          "toast": "请先上传服务账号密钥，然后再创建凭据"
+        },
+        "oauthOption": {
+          "description": "从 Google Cloud Console 上传 OAuth 应用 JSON（[设置说明]({docsUrl})），然后使用要索引其 Drive 的 Google 账号进行认证。",
+          "title": "选项 1：OAuth 应用"
+        },
+        "oauthUpload": {
+          "placeholder": "上传或粘贴您的 OAuth 应用 JSON"
+        },
+        "primaryAdmin": {
+          "description": "输入拥有目标 Google Drive 的 Google 组织的管理员或所有者邮箱。",
+          "invalidEmail": "必须是有效的邮箱地址",
+          "label": "主管理员邮箱",
+          "required": "必填"
+        },
+        "section": {
+          "title": "Google Drive 认证"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "创建服务账号凭据失败 - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "已成功创建服务账号凭据"
+        },
+        "serviceAccountOption": {
+          "title": "选项 2：服务账号"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "上传或粘贴您的服务账号 JSON 密钥"
+        }
+      },
+      "gmail": {
+        "authComplete": {
+          "description": "已创建您的 Gmail 凭据。您可以在凭据列表中管理或撤销它。",
+          "title": "认证完成"
+        },
+        "authFailed": {
+          "toast": "使用 Gmail 认证失败 - {error}"
+        },
+        "authenticateButton": {
+          "label": "使用 Gmail 认证",
+          "pendingLabel": "正在认证…"
+        },
+        "createButton": {
+          "label": "创建凭据",
+          "pendingLabel": "正在创建…"
+        },
+        "credentialsLoadError": {
+          "title": "加载 Gmail 凭据失败。"
+        },
+        "invalidFile": {
+          "toast": "提供的文件无效 - {error}"
+        },
+        "invalidServiceAccountFile": {
+          "toast": "提供的文件无效 - 需要服务账号 JSON 密钥"
+        },
+        "missingServiceAccountKey": {
+          "toast": "请先上传服务账号密钥，然后再创建凭据"
+        },
+        "oauthOption": {
+          "description": "从 Google Cloud Console 上传 OAuth 应用 JSON（[设置说明]({docsUrl})），然后使用要索引其 Gmail 的 Google 账号进行认证。",
+          "title": "选项 1：OAuth 应用"
+        },
+        "oauthUpload": {
+          "placeholder": "上传或粘贴您的 OAuth 应用 JSON"
+        },
+        "primaryAdmin": {
+          "description": "输入拥有目标 Gmail 账号的 Google 组织的管理员或所有者邮箱。",
+          "invalidEmail": "必须是有效的邮箱地址",
+          "label": "主管理员邮箱",
+          "required": "必填"
+        },
+        "section": {
+          "title": "Gmail 认证"
+        },
+        "serviceAccountCreateFailed": {
+          "toast": "创建服务账号凭据失败 - {error}"
+        },
+        "serviceAccountCreated": {
+          "toast": "已成功创建服务账号凭据"
+        },
+        "serviceAccountOption": {
+          "title": "选项 2：服务账号"
+        },
+        "serviceAccountUpload": {
+          "placeholder": "上传或粘贴您的服务账号 JSON 密钥"
+        }
+      },
+      "invalidConnector": {
+        "homeButton": {
+          "label": "返回首页"
+        },
+        "title": "‘{connector}’ 不是有效的连接器类型！"
+      },
+      "listInput": {
+        "placeholder": "输入{label}"
+      },
+      "navigation": {
+        "advancedButton": {
+          "label": "高级"
+        },
+        "continueButton": {
+          "label": "继续"
+        },
+        "createButton": {
+          "label": "创建连接器"
+        },
+        "previousButton": {
+          "label": "上一步"
+        }
+      },
+      "oauth": {
+        "error": {
+          "title": "糟糕，出错了！"
+        },
+        "invalidSource": {
+          "description": "{source} 不是有效的数据源类型。",
+          "title": "指定的连接器数据源类型 {source} 不存在。"
+        },
+        "processing": {
+          "description": "请稍候，我们正在完成设置。",
+          "title": "正在处理…"
+        }
+      },
+      "oauthCallback": {
+        "authorize": {
+          "title": "使用 {source} 授权"
+        },
+        "authorizing": {
+          "description": "请稍候，我们正在完成授权。"
+        },
+        "continue": {
+          "message": "点击<link>这里</link>继续。"
+        },
+        "error": {
+          "description": "OAuth 过程中发生错误。请重试。"
+        },
+        "malformed": {
+          "missingCode": "缺少授权码。",
+          "missingState": "缺少 state 参数。",
+          "title": "OAuth 授权请求格式不正确。"
+        },
+        "page": {
+          "title": "使用第三方服务授权"
+        },
+        "success": {
+          "additionalSteps": {
+            "description": "您与 {source} 的授权已成功完成。还需要执行其他步骤才能完成凭据设置。"
+          },
+          "description": "您与 {source} 的授权已成功完成。",
+          "title": "成功！"
+        }
+      },
+      "oauthFailed": {
+        "toast": "OAuth 认证失败。请重试。"
+      },
+      "oauthFinalize": {
+        "authorize": {
+          "title": "完成与 {source} 的授权"
+        },
+        "cloudId": {
+          "required": "您必须选择一个 Confluence 站点（未找到 id）。"
+        },
+        "cloudName": {
+          "required": "您必须选择一个 Confluence 站点（未找到名称）。"
+        },
+        "cloudUrl": {
+          "required": "您必须选择一个 Confluence 站点（未找到 url）。"
+        },
+        "continue": {
+          "message": "授权已完成。点击<link>这里</link>继续。"
+        },
+        "credentialId": {
+          "required": "凭据 ID 为必填项。"
+        },
+        "error": {
+          "description": "完成 OAuth 授权的过程中发生错误。请重试。"
+        },
+        "finalized": {
+          "title": "Confluence 授权已完成。"
+        },
+        "loadingSites": {
+          "description": "请稍候，我们正在获取您可访问的站点列表。"
+        },
+        "malformed": {
+          "description": "凭据 id 无效或缺失。",
+          "title": "OAuth 完成请求格式不正确。"
+        },
+        "page": {
+          "title": "完成与第三方服务的授权"
+        },
+        "selectSite": {
+          "title": "选择 Confluence 站点"
+        },
+        "submitButton": {
+          "label": "提交",
+          "pendingLabel": "正在提交…"
+        },
+        "submitError": {
+          "description": "提交过程中发生错误。请重试。",
+          "title": "提交时出错。"
+        }
+      },
+      "selectInput": {
+        "emptyOption": {
+          "label": "选择一个选项"
+        }
+      },
+      "stringPairList": {
+        "addButton": {
+          "label": "新增"
+        },
+        "removeButton": {
+          "tooltip": "移除"
+        }
+      },
+      "tabs": {
+        "empty": {
+          "label": "没有可显示的标签页。"
+        }
+      }
+    },
+    "costOverrides": {
+      "allProviders": {
+        "label": "所有提供方"
+      },
+      "empty": {
+        "description": "添加一项，为某个模型应用协商价格（每 100 万 tokens 的美元价格）。",
+        "title": "尚未设置费用覆盖。"
+      },
+      "form": {
+        "addButton": {
+          "label": "添加覆盖"
+        },
+        "cacheRate": {
+          "label": "缓存读取价格（每 100 万 tokens 美元，可选）",
+          "placeholder": "默认与输入价格相同"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "inputRate": {
+          "label": "输入价格（每 100 万 tokens 美元）"
+        },
+        "model": {
+          "label": "模型",
+          "placeholder": "选择模型"
+        },
+        "outputRate": {
+          "label": "输出价格（每 100 万 tokens 美元）"
+        },
+        "saveButton": {
+          "label": "保存"
+        }
+      },
+      "panel": {
+        "addButton": {
+          "label": "添加覆盖"
+        },
+        "description": "按模型设置协商价格，单位为**每 100 万 tokens 美元**。这些价格会在计算使用成本时覆盖内置价格表。",
+        "error": {
+          "title": "加载费用覆盖失败。"
+        },
+        "title": "费用覆盖"
+      },
+      "row": {
+        "deleteButton": {
+          "ariaLabel": "删除 {model} 的 {provider} 覆盖"
+        },
+        "editButton": {
+          "ariaLabel": "编辑 {model} 的 {provider} 覆盖"
+        },
+        "rates": "{provider} · 输入 {input} · 输出 {output} · 每 100 万 tokens 美元",
+        "ratesWithCache": "{provider} · 输入 {input} · 输出 {output} · 缓存 {cache} · 每 100 万 tokens 美元",
+        "updated": "更新于 {time}"
+      },
+      "toasts": {
+        "removeFailed": "移除覆盖失败：{message}",
+        "removed": "已移除 {model} 的覆盖。",
+        "saveFailed": "保存覆盖失败：{message}",
+        "saved": "已保存 {model} 的价格。",
+        "unknownError": "未知错误"
+      }
+    },
+    "craft": {
+      "accessCell": {
+        "disabledSuccess": {
+          "message": "已为该用户禁用 Craft"
+        },
+        "enabledSuccess": {
+          "message": "已为该用户启用 Craft"
+        },
+        "error": {
+          "message": "更新 Craft 访问权限失败"
+        }
+      },
+      "accessSummary": {
+        "description": "当前：{total} 位用户中有 {enabledCount} 位拥有访问权限"
+      },
+      "confirmModal": {
+        "disableBody": {
+          "description": "将移除所有人的访问权限。进行中的会话不受影响。",
+          "withExceptions": {
+            "description": "将移除所有人的访问权限，下方已开启的 {enabledCount} 位用户除外。进行中的会话不受影响。"
+          }
+        },
+        "disableButton": {
+          "label": "默认禁用"
+        },
+        "disableHeader": {
+          "title": "默认禁用 Craft？"
+        },
+        "enableBody": {
+          "description": "全部 {total} 位用户都将获得访问权限。Craft 智能体在沙箱中运行，可在您的授权和批准下代表您执行操作。",
+          "withExclusions": {
+            "description": "全部 {total} 位用户都将获得访问权限，下方已关闭的 {excludedCount} 位除外。Craft 智能体在沙箱中运行，可在您的授权和批准下代表您执行操作。"
+          }
+        },
+        "enableButton": {
+          "label": "为所有人启用"
+        },
+        "enableHeader": {
+          "title": "为所有用户启用 Craft？"
+        }
+      },
+      "defaultToggle": {
+        "betaTag": {
+          "label": "beta"
+        },
+        "disabled": {
+          "description": "Craft 对所有人关闭。可在下方逐个用户切换。"
+        },
+        "disabledSuccess": {
+          "message": "Craft 现已默认禁用"
+        },
+        "enabled": {
+          "description": "Craft 对所有人开启。可在下方逐个用户切换。"
+        },
+        "enabledSuccess": {
+          "message": "Craft 现已默认启用"
+        },
+        "title": "默认启用 Craft"
+      },
+      "emptyState": {
+        "description": "没有与搜索匹配的用户。",
+        "title": "未找到用户"
+      },
+      "header": {
+        "description": "控制谁可以使用 Craft，即 Onyx 的智能体式应用构建器。",
+        "title": "访问权限"
+      },
+      "perUserAccess": {
+        "description": "如果您把某位用户设为与工作区默认值不同，即使默认值变更，该用户也会保留自己的设置。",
+        "title": "按用户访问权限"
+      },
+      "saveError": {
+        "message": "更新设置失败"
+      },
+      "search": {
+        "placeholder": "搜索用户…"
+      },
+      "settingsLoadError": {
+        "description": "加载设置失败。请尝试刷新页面。"
+      },
+      "table": {
+        "accessColumn": {
+          "header": "访问权限"
+        },
+        "footer": {
+          "units": "位用户"
+        },
+        "groupsColumn": {
+          "header": "群组"
+        },
+        "userColumn": {
+          "header": "用户"
+        }
+      },
+      "unavailable": {
+        "description": "Craft 由 Onyx 按部署逐一启用。请联系您的 Onyx 客户代表以获取访问权限。",
+        "title": "此部署不提供 Craft"
+      },
+      "usersLoadError": {
+        "description": "加载用户失败。请尝试刷新页面。"
+      }
+    },
+    "craftInstructions": {
+      "baseInstructions": {
+        "description": "您的指令会追加到这段内置提示词之后。动态部分会在每个会话中分别填充。",
+        "loadError": {
+          "description": "加载基础指令失败。"
+        },
+        "title": "查看基础指令"
+      },
+      "header": {
+        "description": "在 Craft 内置行为之上，每个 Craft 智能体都会遵循的工作区级指令。",
+        "title": "指令"
+      },
+      "instructions": {
+        "charCount": {
+          "label": "{count} / {max}"
+        },
+        "help": {
+          "description": "更改在会话启动或恢复时生效 — 不会影响运行中的会话。"
+        },
+        "label": "工作区指令",
+        "placeholder": "例如：始终遵循我们的品牌规范，并优先使用简洁、正式的文案。"
+      },
+      "resetButton": {
+        "label": "重置为默认"
+      },
+      "resetModal": {
+        "body": {
+          "description": "新的 Craft 会话将仅使用内置指令运行。此操作会为所有人移除您的工作区指令。"
+        },
+        "header": {
+          "title": "重置 Craft 指令？"
+        },
+        "resettingLabel": "正在重置…",
+        "submitButton": {
+          "label": "重置"
+        }
+      },
+      "saveButton": {
+        "label": "保存",
+        "savingLabel": "正在保存…"
+      },
+      "saveError": {
+        "message": "保存指令失败"
+      },
+      "saveSuccess": {
+        "message": "已保存 Craft 指令"
+      },
+      "settingsLoadError": {
+        "description": "加载设置失败。请尝试刷新页面。"
+      },
+      "tryInCraftButton": {
+        "label": "在 Craft 中试用"
+      },
+      "unavailable": {
+        "description": "Craft 由 Onyx 按部署逐一启用。请联系您的 Onyx 客户代表以获取访问权限。",
+        "title": "此部署不提供 Craft"
+      }
+    },
+    "discordBot": {
+      "botToken": {
+        "changeInstructions": {
+          "text": "要更换 token，请先删除当前 token，再添加新的。"
+        },
+        "configured": {
+          "badge": "已配置",
+          "text": "您的 Discord 机器人 token 已配置。"
+        },
+        "configuredWithDate": {
+          "text": "您的 Discord 机器人 token 已配置。添加于 {date}。"
+        },
+        "deleteButton": {
+          "blocked": {
+            "tooltip": "请先删除服务器配置"
+          },
+          "label": "删除 Discord Token"
+        },
+        "deleteError": {
+          "toast": "删除机器人 token 失败"
+        },
+        "deleteModal": {
+          "additionalDetails": "此操作会断开您的 Discord 机器人。要再次使用该机器人，您需要重新输入 token。",
+          "entityName": "Discord 机器人 Token",
+          "entityType": "Discord 机器人 token"
+        },
+        "deleted": {
+          "toast": "已删除机器人 token"
+        },
+        "enterInstructions": {
+          "text": "输入您的 Discord 机器人 token 以启用机器人。您可以在 Discord 开发者门户中获取它。"
+        },
+        "input": {
+          "placeholder": "输入机器人 token…"
+        },
+        "missing": {
+          "toast": "请输入机器人 token"
+        },
+        "notConfigured": {
+          "badge": "未配置"
+        },
+        "saveButton": {
+          "label": "保存 Token",
+          "saving": {
+            "label": "正在保存…"
+          }
+        },
+        "saveError": {
+          "toast": "保存机器人 token 失败"
+        },
+        "saved": {
+          "toast": "已成功保存机器人 token"
+        },
+        "section": {
+          "title": "机器人 Token"
+        }
+      },
+      "channels": {
+        "awaitingRegistration": {
+          "text": "服务器注册完成后即可进行频道配置。"
+        },
+        "disableAllButton": {
+          "label": "全部禁用"
+        },
+        "empty": {
+          "description": "在 Discord 中运行 !sync-channels 来添加频道。",
+          "title": "尚未配置频道"
+        },
+        "enableAllButton": {
+          "label": "全部启用"
+        },
+        "partialUpdate": {
+          "toast": "已更新 {succeeded} 个频道，但 {failed} 个失败"
+        },
+        "section": {
+          "description": "在 Discord 中运行 !sync-channels 来更新频道列表。",
+          "title": "频道配置"
+        },
+        "table": {
+          "agentOverride": {
+            "header": "智能体覆盖"
+          },
+          "channel": {
+            "header": "频道"
+          },
+          "enabled": {
+            "header": "已启用"
+          },
+          "requireMention": {
+            "header": "需要 @提及"
+          },
+          "threadOnly": {
+            "header": "仅讨论串模式"
+          }
+        },
+        "updateError": {
+          "toast": "更新频道失败"
+        },
+        "updated": {
+          "toast": "已更新 {count, plural, one {# 个频道} other {# 个频道}}"
+        }
+      },
+      "defaultAgent": {
+        "cleared": {
+          "toast": "已清除默认智能体"
+        },
+        "section": {
+          "description": "机器人在所有频道中使用的智能体，除非被单独覆盖。",
+          "title": "默认智能体"
+        },
+        "select": {
+          "default": {
+            "label": "默认智能体"
+          },
+          "placeholder": "选择智能体"
+        },
+        "updateError": {
+          "toast": "更新智能体失败"
+        },
+        "updated": {
+          "toast": "已更新默认智能体"
+        }
+      },
+      "error": {
+        "loadChannels": {
+          "message": "无法加载频道",
+          "title": "加载频道失败"
+        },
+        "loadServer": {
+          "title": "加载服务器失败"
+        },
+        "loadServers": {
+          "title": "加载 Discord 服务器失败"
+        },
+        "serverNotFound": {
+          "message": "未找到服务器"
+        },
+        "unknown": {
+          "message": "发生未知错误"
+        }
+      },
+      "guildDetail": {
+        "awaiting": {
+          "text": "在您的 Discord 服务器中使用 !register 命令并附上注册密钥，以完成设置。",
+          "title": "等待注册"
+        },
+        "pending": {
+          "text": "待注册"
+        },
+        "registered": {
+          "text": "已注册：{date}"
+        },
+        "updateButton": {
+          "label": "更新配置"
+        }
+      },
+      "guilds": {
+        "createError": {
+          "toast": "创建服务器失败"
+        },
+        "created": {
+          "toast": "已创建服务器配置！"
+        },
+        "deleteError": {
+          "toast": "删除服务器配置失败"
+        },
+        "deleteModal": {
+          "additionalDetails": "此操作会移除该 Discord 服务器的所有设置。",
+          "entityType": "Discord 服务器配置"
+        },
+        "deleted": {
+          "toast": "已删除服务器配置"
+        },
+        "disabled": {
+          "toast": "已禁用服务器"
+        },
+        "empty": {
+          "description": "创建一个服务器配置即可开始。",
+          "title": "尚未配置 Discord 服务器"
+        },
+        "enabled": {
+          "toast": "已启用服务器"
+        },
+        "fallbackName": "服务器 #{id}",
+        "notRegistered": {
+          "toast": "服务器必须先注册才能启用"
+        },
+        "pending": {
+          "badge": "待注册"
+        },
+        "registered": {
+          "badge": "已注册"
+        },
+        "table": {
+          "actions": {
+            "header": "操作"
+          },
+          "enabled": {
+            "header": "已启用"
+          },
+          "registered": {
+            "header": "已注册"
+          },
+          "server": {
+            "header": "服务器"
+          },
+          "status": {
+            "header": "状态"
+          }
+        },
+        "updateError": {
+          "toast": "更新服务器失败"
+        }
+      },
+      "page": {
+        "header": {
+          "description": "将 Onyx 连接到您的 Discord 服务器。用户可以直接在 Discord 频道中提问。"
+        }
+      },
+      "registrationKey": {
+        "header": {
+          "description": "此密钥只会显示一次！",
+          "title": "注册密钥"
+        },
+        "instructions": {
+          "text": "复制该命令，并从您服务器的任意文字频道发送！"
+        }
+      },
+      "serverConfigs": {
+        "addButton": {
+          "creating": {
+            "label": "正在创建…"
+          },
+          "label": "添加服务器"
+        },
+        "section": {
+          "title": "服务器配置"
+        }
+      },
+      "unsavedChanges": {
+        "description": "点击“更新”以保存更改。",
+        "title": "您有未保存的更改"
+      }
+    },
+    "documentProcessing": {
+      "unstructured": {
+        "apiKey": {
+          "placeholder": "输入 API 密钥"
+        },
+        "deleteButton": {
+          "label": "删除 API 密钥"
+        },
+        "deleteHint": "更新前请先删除当前 API 密钥。",
+        "description": "Unstructured 可从 .pdf、.docx、.png、.pptx 等格式中提取并转换复杂数据，生成干净的文本供 Onyx 导入。提供 API 密钥即可启用 Unstructured 文档处理。",
+        "learnMore": "在<link>这里</link>了解有关 Unstructured 的更多信息。",
+        "note": "<label>注意：</label>此功能会将文档发送到 Unstructured 服务器进行处理。",
+        "saveButton": {
+          "label": "保存 API 密钥"
+        },
+        "title": "使用 Unstructured API 处理"
+      }
+    },
+    "documents": {
+      "explorer": {
+        "boost": {
+          "label": "权重提升："
+        },
+        "search": {
+          "placeholder": "按标题 / 内容查找文档…"
+        },
+        "updateFailed": {
+          "toast": "更新文档失败 - {detail}"
+        }
+      },
+      "feedback": {
+        "loadError": {
+          "message": "加载文档出错 - {detail}"
+        },
+        "loading": {
+          "label": "加载中"
+        },
+        "mostDisliked": {
+          "title": "点踩最多的文档"
+        },
+        "mostLiked": {
+          "title": "点赞最多的文档"
+        },
+        "table": {
+          "name": {
+            "header": "文档名称"
+          },
+          "score": {
+            "header": "评分"
+          },
+          "searchable": {
+            "header": "是否可搜索？"
+          }
+        },
+        "updateHiddenFailed": {
+          "toast": "更新隐藏状态出错 - {detail}"
+        }
+      },
+      "score": {
+        "notANumber": {
+          "toast": "评分必须是数字"
+        },
+        "updated": {
+          "toast": "已更新评分！"
+        }
+      },
+      "sets": {
+        "access": {
+          "private": {
+            "label": "私有"
+          },
+          "public": {
+            "label": "公开"
+          }
+        },
+        "connector": {
+          "unnamed": {
+            "label": "未命名"
+          }
+        },
+        "deleteFailed": {
+          "toast": "安排删除文档集失败 - {detail}"
+        },
+        "deleteScheduled": {
+          "toast": "已安排删除文档集“{name}”"
+        },
+        "description": "**文档集**可以把逻辑相关的文档归入同一个集合。搜索时可以将它们用作筛选条件，控制 Onyx 检索的信息范围。",
+        "edit": {
+          "header": {
+            "title": "编辑文档集"
+          }
+        },
+        "editRow": {
+          "syncing": {
+            "tooltip": "同步期间无法更新！请等待同步完成后重试。"
+          }
+        },
+        "federatedBadge": {
+          "label": "联合"
+        },
+        "fetchConnectorsFailed": {
+          "title": "获取连接器失败"
+        },
+        "fetchSetsFailed": {
+          "title": "获取文档集失败"
+        },
+        "form": {
+          "connectors": {
+            "label": "选择您的连接器",
+            "placeholder": "搜索连接器…",
+            "required": "请至少选择一个连接器（常规或联合）"
+          },
+          "createFailed": {
+            "toast": "创建文档集出错 - {detail}"
+          },
+          "created": {
+            "toast": "已成功创建文档集！"
+          },
+          "description": {
+            "label": "描述：",
+            "placeholder": "描述该文档集代表的内容"
+          },
+          "federatedConnectors": {
+            "label": "联合连接器",
+            "placeholder": "搜索联合连接器…"
+          },
+          "name": {
+            "label": "名称：",
+            "placeholder": "文档集的名称",
+            "required": "请为该文档集输入名称"
+          },
+          "scopedConnectors": {
+            "label": "{count, plural, =0 {所选群组可用的连接器} one {所选群组可用的连接器} other {所选群组可用的连接器}}"
+          },
+          "submitButton": {
+            "createLabel": "创建文档集",
+            "updateLabel": "更新文档集"
+          },
+          "unavailableConnectors": {
+            "description": "只有直接分配给目标群组的连接器才可用于该文档集。",
+            "title": "{count, plural, =0 {所选群组不可用的连接器} one {所选群组不可用的连接器} other {所选群组不可用的连接器}}"
+          },
+          "updateFailed": {
+            "toast": "更新文档集出错 - {detail}"
+          },
+          "updated": {
+            "toast": "已成功更新文档集！"
+          }
+        },
+        "loadError": {
+          "message": "错误：{detail}"
+        },
+        "new": {
+          "header": {
+            "title": "新建文档集"
+          }
+        },
+        "newButton": {
+          "label": "新建文档集"
+        },
+        "notFound": {
+          "message": "未找到 id 为 {id} 的文档集",
+          "title": "未找到文档集"
+        },
+        "status": {
+          "deleting": {
+            "label": "删除中"
+          },
+          "syncing": {
+            "label": "同步中"
+          },
+          "upToDate": {
+            "label": "已是最新"
+          }
+        },
+        "table": {
+          "connectors": {
+            "header": "连接器"
+          },
+          "delete": {
+            "header": "删除"
+          },
+          "name": {
+            "header": "名称"
+          },
+          "public": {
+            "header": "公开"
+          },
+          "status": {
+            "header": "状态"
+          },
+          "title": "现有文档集"
+        }
+      },
+      "visibility": {
+        "hidden": {
+          "label": "已隐藏"
+        },
+        "hide": {
+          "ariaLabel": "隐藏文档",
+          "label": "隐藏"
+        },
+        "unhide": {
+          "ariaLabel": "取消隐藏文档",
+          "label": "取消隐藏"
+        },
+        "visible": {
+          "label": "可见"
+        }
+      }
+    },
+    "externalApps": {
+      "apps": {
+        "empty": {
+          "addButton": {
+            "label": "添加应用"
+          },
+          "description": "添加应用，让组织中的所有人都可以使用。",
+          "title": "暂无应用"
+        },
+        "panel": {
+          "blurb": "为整个组织统一配置一次。编辑应用可设置共享凭证、操作策略和关联技能。"
+        },
+        "tab": {
+          "label": "应用",
+          "labelWithCount": "应用 · {count, number}"
+        }
+      },
+      "card": {
+        "actionsButton": {
+          "ariaLabel": "{name} 操作"
+        },
+        "availableInCraft": {
+          "label": "可在 Craft 中使用"
+        },
+        "customTag": {
+          "label": "自定义"
+        },
+        "deleteAction": {
+          "label": "删除"
+        },
+        "deleteModal": {
+          "description": "此操作会为整个组织删除该应用：包括它的配置、每位成员的连接，以及所有由提供商管理的技能。",
+          "retainedSkills": "{count, plural, =0 {不会删除任何关联的自定义技能。} one {将保留 # 个关联的自定义技能，解除与此应用的关联，并对所有人禁用。} other {将保留 # 个关联的自定义技能，解除与此应用的关联，并对所有人禁用。}}",
+          "submit": {
+            "label": "删除应用"
+          },
+          "submitting": {
+            "label": "正在删除…"
+          },
+          "title": "删除“{name}”？"
+        },
+        "editAction": {
+          "label": "编辑"
+        },
+        "toasts": {
+          "deleteFailed": "删除“{name}”失败",
+          "disableFailed": "禁用“{name}”失败",
+          "enableFailed": "启用“{name}”失败"
+        },
+        "toggle": {
+          "disableAriaLabel": "禁用 {name}",
+          "enableAriaLabel": "启用 {name}"
+        }
+      },
+      "facts": {
+        "actions": "{count, plural, one {# 个操作} other {# 个操作}}",
+        "customSkills": "{count, plural, one {# 个自定义技能} other {# 个自定义技能}}",
+        "noCredentials": "无凭证",
+        "noCustomSkills": "无自定义技能",
+        "orgCredentialsSet": "已设置组织凭证",
+        "perUserCredentials": "按用户凭证",
+        "providedByOnyx": "由 Onyx 提供",
+        "tools": "{count, plural, one {# 个工具} other {# 个工具}}",
+        "upstreamPatterns": "{count, plural, one {# 个上游模式} other {# 个上游模式}}"
+      },
+      "loading": {
+        "label": "正在加载…"
+      },
+      "mcpServers": {
+        "empty": {
+          "description": "先在“操作”中连接服务器，然后在此处为您的组织启用它。",
+          "openActionsButton": {
+            "label": "打开操作"
+          },
+          "title": "暂无 MCP 服务器"
+        },
+        "manageInActionsButton": {
+          "label": "在操作中管理"
+        },
+        "panel": {
+          "blurb": "启用服务器后，有权访问它的成员即可在 Craft 中使用它的工具。编辑服务器可设置每个工具的审批策略。服务器连接和访问权限在“操作”中管理。"
+        },
+        "tab": {
+          "label": "MCP 服务器",
+          "labelWithCount": "MCP 服务器 · {count, number}"
+        }
+      },
+      "page": {
+        "addAppButton": {
+          "label": "添加应用"
+        },
+        "backToCraftButton": {
+          "label": "返回 Craft"
+        },
+        "description": "设置组织的 Craft 智能体可以使用的应用。每位成员在 Craft 的“应用”页面连接自己的账户。"
+      },
+      "warnings": {
+        "invalidSkill": "无效技能",
+        "providerUnavailable": "提供商不可用"
+      }
+    },
+    "federated": {
+      "error": {
+        "loadFailed": "加载连接器失败：{details}",
+        "title": "错误"
+      },
+      "loading": {
+        "description": "正在获取连接器详情和凭证结构",
+        "title": "正在加载连接器配置..."
+      }
+    },
+    "groups": {
+      "card": {
+        "defaultTag": {
+          "label": "默认"
+        },
+        "toasts": {
+          "renameFailed": "重命名用户组失败",
+          "renamed": "用户组已重命名为“{name}”"
+        },
+        "viewGroup": {
+          "label": "查看用户组"
+        }
+      },
+      "create": {
+        "header": {
+          "title": "创建用户组"
+        },
+        "submit": {
+          "label": "创建"
+        },
+        "toasts": {
+          "createFailed": "创建用户组失败",
+          "created": "已创建用户组“{name}”"
+        }
+      },
+      "edit": {
+        "delete": {
+          "button": {
+            "label": "删除用户组"
+          },
+          "description": "成员将失去对共享给此用户组的所有资源的访问权限。",
+          "title": "删除此用户组"
+        },
+        "deleteModal": {
+          "deleting": {
+            "label": "正在删除..."
+          },
+          "description": "用户组 <highlight>{name}</highlight> 的成员将失去对共享给此用户组的所有资源的访问权限，除非他们已被直接授予访问权限。删除后无法撤销。",
+          "submit": {
+            "label": "删除"
+          },
+          "title": "删除用户组"
+        },
+        "header": {
+          "title": "编辑用户组"
+        },
+        "incognito": {
+          "description": "此用户组的成员可以发起无痕对话。",
+          "title": "无痕对话"
+        },
+        "loadError": {
+          "text": "加载用户组数据失败。"
+        },
+        "notFound": {
+          "description": "此用户组不存在，或者可能已被删除。",
+          "header": {
+            "title": "未找到用户组"
+          },
+          "title": "未找到用户组"
+        },
+        "saving": {
+          "label": "正在保存..."
+        },
+        "submit": {
+          "label": "保存更改"
+        },
+        "syncing": {
+          "label": "正在同步...",
+          "tooltip": "由于此用户组最近发生更改，正在更新文档 embedding。"
+        },
+        "systemGroup": {
+          "description": "此用户组由 Onyx 管理。它只包含成员，您也只能更改成员。",
+          "title": "系统用户组"
+        },
+        "toasts": {
+          "deleteFailed": "删除用户组失败",
+          "deleted": "已删除用户组“{name}”",
+          "managerAssigned": "已指定管理者",
+          "managerRevoked": "已撤销管理者",
+          "managerUpdateFailed": "更新管理者失败",
+          "membersStranded": "其中部分成员将不属于任何用户组。请先将他们添加到另一个用户组。",
+          "syncing": "此用户组正在同步。请稍候再试。",
+          "updateFailed": "更新用户组失败",
+          "updated": "已更新用户组“{name}”"
+        }
+      },
+      "form": {
+        "cancel": {
+          "label": "取消"
+        },
+        "name": {
+          "label": "用户组名称",
+          "placeholder": "为您的用户组命名"
+        },
+        "toasts": {
+          "nameRequired": "用户组名称为必填项"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "创建用户组以组织用户并管理访问权限。"
+        },
+        "loadError": {
+          "description": "请查看控制台以了解更多详情。",
+          "title": "加载用户组失败。"
+        },
+        "newGroup": {
+          "label": "新建用户组"
+        },
+        "noResults": {
+          "description": "没有与“{query}”匹配的用户组",
+          "title": "未找到用户组"
+        },
+        "search": {
+          "placeholder": "搜索用户组..."
+        }
+      },
+      "members": {
+        "add": {
+          "label": "添加"
+        },
+        "done": {
+          "label": "完成"
+        },
+        "lastGroup": {
+          "tooltip": "这是他们唯一的用户组。请先将他们添加到另一个用户组。"
+        },
+        "loadError": {
+          "text": "加载用户失败。"
+        },
+        "makeManager": {
+          "label": "设为管理者"
+        },
+        "managerTag": {
+          "label": "管理者"
+        },
+        "noMembers": {
+          "description": "向此用户组添加成员。",
+          "title": "暂无成员"
+        },
+        "noUsers": {
+          "description": "没有与您的搜索匹配的用户。",
+          "title": "未找到用户"
+        },
+        "ownManager": {
+          "tooltip": "您不能撤销自己的管理者权限"
+        },
+        "removeMember": {
+          "label": "移除成员"
+        },
+        "removeSelf": {
+          "tooltip": "在管理此用户组期间，您不能移除自己"
+        },
+        "revokeManager": {
+          "label": "撤销管理者"
+        },
+        "saveBeforeManager": {
+          "tooltip": "指定管理者前请先保存用户组"
+        },
+        "searchMembers": {
+          "placeholder": "搜索成员..."
+        },
+        "searchUsers": {
+          "placeholder": "搜索用户和账户..."
+        },
+        "table": {
+          "accountType": {
+            "header": "账户类型"
+          },
+          "name": {
+            "header": "名称"
+          }
+        }
+      },
+      "page": {
+        "title": "用户组"
+      },
+      "permissions": {
+        "section": {
+          "description": "为此用户组的成员设置访问权限。",
+          "title": "用户组权限"
+        }
+      },
+      "permissionsChanged": {
+        "description": "Onyx 现在使用基于用户组的权限。访问权限按用户组配置，因此用户的权限是其所属全部用户组权限的合集。",
+        "learnMore": {
+          "label": "了解更多"
+        },
+        "title": "权限已变更"
+      },
+      "sharedResources": {
+        "agent": {
+          "description": "智能体"
+        },
+        "agents": {
+          "label": "智能体",
+          "placeholder": "添加智能体"
+        },
+        "connector": {
+          "description": "连接器"
+        },
+        "connectorFallback": {
+          "label": "连接器 #{id}"
+        },
+        "connectors": {
+          "label": "连接器和文档集",
+          "placeholder": "添加连接器、文档集"
+        },
+        "documentSet": {
+          "description": "文档集"
+        },
+        "noAgents": {
+          "description": "添加要共享给此用户组的智能体。",
+          "title": "未添加智能体"
+        },
+        "noConnectors": {
+          "description": "添加要共享给此用户组的连接器或文档集。",
+          "title": "未添加连接器或文档集"
+        },
+        "popover": {
+          "connectors": {
+            "label": "连接器"
+          },
+          "documentSets": {
+            "label": "文档集"
+          },
+          "noResults": {
+            "title": "未找到结果"
+          }
+        },
+        "section": {
+          "description": "将连接器、文档集和智能体共享给此用户组的成员。",
+          "title": "共享给此用户组"
+        },
+        "sharedBadge": {
+          "label": "已共享"
+        }
+      },
+      "tokenLimits": {
+        "addLimit": {
+          "label": "添加限制"
+        },
+        "costLimit": {
+          "header": "费用上限",
+          "placeholder": "费用上限",
+          "unit": "(USD)"
+        },
+        "disabledTooltip": "Token 速率限制仅在 [Onyx 企业版](/admin/billing) 中提供。",
+        "section": {
+          "description": "限制此用户组在指定时间段内可以使用的 token 数量。",
+          "title": "Token 速率限制"
+        },
+        "timeWindow": {
+          "header": "时间窗口",
+          "unit": "(UTC 天)"
+        },
+        "tokenLimit": {
+          "header": "Token 上限",
+          "placeholder": "Token 上限（千）",
+          "unit": "(千)"
+        }
+      }
+    },
+    "imageGeneration": {
+      "configureSuccess": {
+        "message": "提供商配置成功"
+      },
+      "deselectError": {
+        "message": "取消选择失败"
+      },
+      "deselectSuccess": {
+        "message": "已取消选择 {title}"
+      },
+      "disconnectError": {
+        "message": "断开连接失败"
+      },
+      "disconnectModal": {
+        "connectAnother": {
+          "description": "连接另一个提供商以继续使用图像生成。"
+        },
+        "defaultNoReplacement": {
+          "description": "**{title}** 当前是默认的图像生成模型。"
+        },
+        "defaultWithReplacement": {
+          "description": "**{title}** 当前是默认的图像生成模型。会话历史将会保留。"
+        },
+        "header": {
+          "description": "此操作会移除为此提供商存储的凭证。",
+          "title": "断开 *{title}* 的连接"
+        },
+        "noDefaultOption": {
+          "description": "（禁用图像生成）",
+          "label": "无默认"
+        },
+        "nonDefault": {
+          "description": "将不再使用 **{title}** 模型生成图像。"
+        },
+        "replacement": {
+          "label": "设置新的默认模型",
+          "placeholder": "选择替代模型"
+        },
+        "sessionHistory": {
+          "description": "会话历史将会保留。"
+        },
+        "submitButton": {
+          "label": "断开连接"
+        }
+      },
+      "disconnectSuccess": {
+        "message": "已断开 {title} 的连接"
+      },
+      "emptyState": {
+        "title": "连接一个图像生成模型，以便在对话中使用。"
+      },
+      "form": {
+        "apiKey": {
+          "comboPlaceholder": "输入新的 API 密钥或选择现有提供商",
+          "idle": "输入新的 API 密钥或选择现有提供商。",
+          "label": "API 密钥",
+          "placeholder": "输入您的 API 密钥",
+          "required": "API 密钥为必填项"
+        },
+        "apiKeyTest": {
+          "error": "API 密钥无效",
+          "loading": "正在通过 {title} 测试 API 密钥...",
+          "success": "API 密钥有效。配置已保存。"
+        },
+        "apiKeyValidationFailed": {
+          "message": "API 密钥验证失败"
+        },
+        "authMethod": {
+          "idle": "选择 Onyx 与 Google Vertex AI 进行身份验证的方式。",
+          "label": "身份验证方式",
+          "required": "身份验证方式为必填项",
+          "serviceAccount": {
+            "description": "上传 GCP 服务账号密钥 JSON 文件",
+            "label": "服务账号 JSON"
+          },
+          "workloadIdentity": {
+            "description": "使用 pod 的环境 GCP 凭证（GKE Workload Identity）",
+            "label": "Workload Identity (GKE)"
+          }
+        },
+        "azureApiKey": {
+          "idle": "粘贴来自 Azure OpenAI 的 <link>API 密钥</link>，以访问您的模型。"
+        },
+        "connectHeader": {
+          "title": "连接 {title}"
+        },
+        "credentials": {
+          "idle": "上传或粘贴来自 Google Cloud 的 <link>服务账号凭证</link>。",
+          "label": "凭证文件",
+          "placeholder": "上传或粘贴您的凭证",
+          "required": "凭证文件为必填项"
+        },
+        "credentialsTest": {
+          "error": "凭证无效",
+          "loading": "正在通过 {title} 测试凭证...",
+          "success": "凭证有效。配置已保存。"
+        },
+        "editHeader": {
+          "title": "编辑 {title}"
+        },
+        "invalidProviderSelection": {
+          "message": "提供商选择无效"
+        },
+        "loading": {
+          "placeholder": "正在加载..."
+        },
+        "location": {
+          "idle": "用于 Vertex AI 模型的 Google Cloud 区域。可用区域请参见 <link>Google 文档</link>。",
+          "label": "位置",
+          "required": "位置为必填项"
+        },
+        "projectId": {
+          "idle": "已启用 Vertex AI 的 GCP 项目。Onyx 使用 pod 绑定的服务账号进行身份验证（GKE Workload Identity）。",
+          "label": "GCP 项目 ID",
+          "required": "项目 ID 为必填项"
+        },
+        "targetUri": {
+          "idle": "粘贴来自 <link>Azure OpenAI</link> 的端点目标 URI（包括 API 端点基址、部署名称和 API 版本）。",
+          "invalid": "目标 URI 必须是有效的 URL，并包含 api-version 和部署名称",
+          "label": "目标 URI",
+          "required": "目标 URI 为必填项"
+        },
+        "unknownError": {
+          "message": "发生未知错误"
+        }
+      },
+      "header": {
+        "description": "对话内图像生成的设置。",
+        "title": "图像生成"
+      },
+      "loadError": {
+        "message": "加载配置失败。请刷新页面。"
+      },
+      "model": {
+        "description": "选择用于在对话中生成图像的模型。",
+        "title": "图像生成模型"
+      },
+      "providers": {
+        "azureGptImage1": {
+          "description": "托管在 Microsoft Azure 上的 GPT Image 1 图像生成模型。"
+        },
+        "azureGptImage15": {
+          "description": "托管在 Microsoft Azure 上的 GPT Image 1.5 图像生成模型。"
+        },
+        "azureGptImage2": {
+          "description": "托管在 Microsoft Azure 上的 GPT Image 2 图像生成模型。"
+        },
+        "gemini25FlashImage": {
+          "description": "Gemini 2.5 Flash Image (Nano Banana) 模型专为速度和效率而设计。"
+        },
+        "gemini3ProImage": {
+          "description": "Gemini 3 Pro Image (Nano Banana Pro) 专为专业素材生产而设计。"
+        },
+        "gemini3ProImagePreview": {
+          "description": "Google Cloud 已于 2026 年 7 月 17 日停止提供。请切换到 Gemini 3 Pro Image。"
+        },
+        "openaiGptImage1": {
+          "description": "来自 OpenAI 的高性能图像生成模型，对提示词的遵循度很高。"
+        },
+        "openaiGptImage15": {
+          "description": "OpenAI 上一代旗舰图像生成模型。"
+        },
+        "openaiGptImage2": {
+          "description": "OpenAI 最新的图像生成模型，提示词还原度最高。"
+        }
+      },
+      "setDefaultError": {
+        "message": "设置默认项失败"
+      },
+      "setDefaultSuccess": {
+        "message": "已将 {title} 设为默认"
+      }
+    },
+    "indexSettings": {
+      "actions": {
+        "applyForward": {
+          "label": "应用于新增和更新的文档"
+        },
+        "applyReindex": {
+          "label": "应用并重新索引"
+        },
+        "rebuildAll": {
+          "label": "重建所有现有文档"
+        },
+        "revert": {
+          "label": "还原"
+        }
+      },
+      "azure": {
+        "apiVersion": {
+          "description": "您的部署所使用的 Azure OpenAI API 版本。",
+          "placeholder": "例如 2023-05-15",
+          "title": "API 版本"
+        },
+        "deploymentName": {
+          "description": "您在 Azure 中为此 embedding 模型配置的部署名称。",
+          "placeholder": "my-embedding-deployment",
+          "title": "部署名称"
+        },
+        "modelName": {
+          "description": "此模型在 Onyx 中的标签。Azure 按部署名称路由请求，因此这里只需是一个唯一标识符。"
+        },
+        "targetUrl": {
+          "title": "目标 URL"
+        }
+      },
+      "cancelReindexModal": {
+        "description": "取消后将还原为之前的 embedding 模型，并且所有重新索引的进度都会丢失。",
+        "submit": {
+          "label": "取消"
+        },
+        "title": "取消重新索引"
+      },
+      "captioningModel": {
+        "description": "此模型用于在索引期间分析图像。只能选择支持视觉的模型。更新仅对之后索引的文档生效——现有的图像描述已固化在先前的 embedding 中。",
+        "title": "图像描述 LLM"
+      },
+      "changesBanner": {
+        "contextualModelMissing": {
+          "description": "上下文检索已启用，但尚未选择模型。请先在下方选择上下文检索 LLM，再重新索引——没有模型，重新索引无法运行。",
+          "title": "选择上下文检索 LLM"
+        },
+        "contextualModelOnly": {
+          "description": "仅将该模型应用于新增和更新的文档，或者重建所有文档以获得一致的上下文增强。",
+          "title": "选择此上下文检索 LLM 的应用方式"
+        },
+        "default": {
+          "description": "修改 embedding 或检索设置后，需要对所有文档进行完整的重新索引才能生效，这可能需要**数小时或数天**，具体取决于语料库规模。[了解更多](https://docs.onyx.app/security/architecture/data_flows)",
+          "title": "更改需要完整的重新索引。"
+        },
+        "orSeparator": {
+          "label": "或"
+        }
+      },
+      "cloudDisabled": {
+        "tooltip": "此设置由 Onyx Cloud 管理。"
+      },
+      "contextualModel": {
+        "description": "此模型用于为分块生成上下文。",
+        "disabledTooltip": "上下文检索关闭时无法修改。",
+        "title": "上下文检索 LLM"
+      },
+      "contextualRetrieval": {
+        "description": "为每个已索引的分块添加文档级上下文，以提升混合搜索的相关性。这可能会显著增加 embedding 成本。",
+        "noModelsTooltip": "上下文检索已禁用，因为您尚未配置任何模型。请先设置[语言模型]({link})。",
+        "title": "上下文检索"
+      },
+      "embeddingModel": {
+        "cloudManaged": {
+          "title": "Embedding 模型和相关设置由 Onyx Cloud 管理。"
+        },
+        "description": "Onyx 使用此模型对文档进行编码，以供搜索和检索。",
+        "title": "Embedding 模型"
+      },
+      "errorsModal": {
+        "columns": {
+          "error": "错误",
+          "id": "ID",
+          "name": "名称",
+          "status": "状态",
+          "type": "类型"
+        },
+        "description": "最近一次重新索引尝试失败（正在自动重试）或已暂停（点击“恢复”重试）的连接器和用户文件。",
+        "empty": "没有需要处理的项目。",
+        "loadError": "无法加载重新索引状态。请重试。",
+        "loading": "正在加载…",
+        "resumeButton": {
+          "label": "恢复"
+        },
+        "resumeFailed": "恢复失败。",
+        "resumingButton": {
+          "label": "正在恢复…"
+        },
+        "scope": {
+          "connector": "连接器",
+          "userFiles": "用户文件"
+        },
+        "status": {
+          "failed": "失败",
+          "paused": "已暂停"
+        },
+        "title": "重新索引待处理项",
+        "unknownError": "未知错误"
+      },
+      "fields": {
+        "apiKey": {
+          "description": "粘贴来自 {provider} 的 [API 密钥]({link})，以访问您的模型。",
+          "title": "API 密钥"
+        },
+        "googleCredentials": {
+          "title": "上传 JSON 凭证文件"
+        },
+        "modelDim": {
+          "description": "此模型生成的 embedding 的维度数量。",
+          "placeholder": "例如 768",
+          "title": "模型维度"
+        },
+        "modelName": {
+          "placeholder": "model-name",
+          "selfHostedDescription": "Onyx 将在您的自托管端点上连接此模型。",
+          "title": "模型名称"
+        },
+        "normalize": {
+          "description": "对模型生成的 embedding 进行归一化。除非您的 embedding 模型文档另有说明，否则建议对大多数模型启用。",
+          "title": "归一化 Embedding"
+        },
+        "optional": {
+          "suffix": "可选"
+        },
+        "passagePrefix": {
+          "description": "如果您的 embedding 模型需要，此前缀会在传给模型之前添加到已索引的文档分块前面。前缀错误或缺失会降低 embedding 质量。",
+          "placeholder": "例如 'passage: '",
+          "title": "段落前缀"
+        },
+        "queryPrefix": {
+          "description": "如果您的 embedding 模型需要，此前缀会在传给模型之前添加到搜索查询前面。前缀错误或缺失会降低 embedding 质量。",
+          "placeholder": "例如 'query: '",
+          "title": "查询前缀"
+        }
+      },
+      "forwardOnlyModal": {
+        "description": "现有文档将保留由之前的模型生成的上下文。新模型仅在文档新增或更新时生效。不同文档之间的上下文增强可能存在差异。",
+        "title": "今后应用上下文检索 LLM"
+      },
+      "header": {
+        "description": "配置文档的索引方式、embedding 方式，以及为搜索和检索所做的准备。"
+      },
+      "imageExtraction": {
+        "description": "从上传的文件（PDF、DOCX 等）中提取内嵌图像，并用支持视觉的 LLM 进行总结，让纯图像文档也可被搜索和回答。需要支持视觉的默认 LLM。",
+        "title": "提取并描述图像"
+      },
+      "imageProcessing": {
+        "description": "在索引期间使用 LLM 分析图像并为其添加描述。",
+        "enableFirstTooltip": "启用“提取并描述图像”后才能配置此项。",
+        "noVisionModelsTooltip": "图像处理已禁用，因为您尚未配置支持视觉的模型。请先设置支持视觉的[语言模型]({link})。",
+        "title": "图像处理"
+      },
+      "litellm": {
+        "apiUrl": {
+          "description": "粘贴与 {provider} 兼容的端点 URL。",
+          "title": "API 基础 URL"
+        },
+        "modelName": {
+          "description": "Onyx 将在您的 {provider} 代理上连接此模型。"
+        }
+      },
+      "maxImageSize": {
+        "description": "超过此大小的图像将被跳过，以限制资源占用。",
+        "suffix": "(MB)",
+        "title": "分析的最大图像大小"
+      },
+      "modal": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "connectButton": {
+          "label": "连接"
+        },
+        "manage": {
+          "description": "管理 {provider} 提供商和模型详情。",
+          "title": "管理 {provider}"
+        },
+        "setUp": {
+          "description": "连接到 {provider} 并设置您的 {provider} embedding 模型。",
+          "title": "设置 {provider}"
+        },
+        "updateButton": {
+          "label": "更新"
+        }
+      },
+      "modelCard": {
+        "connectButton": {
+          "label": "连接"
+        },
+        "currentButton": {
+          "label": "当前模型"
+        },
+        "deprecated": {
+          "connectTooltip": "此 embedding 模型已弃用，无法连接。",
+          "selectTooltip": "此 embedding 模型已弃用，无法选择。"
+        },
+        "selectButton": {
+          "label": "选择模型"
+        },
+        "selectedButton": {
+          "label": "已选择"
+        }
+      },
+      "modelPicker": {
+        "addCustomModel": {
+          "label": "添加自定义模型"
+        },
+        "cloudTab": {
+          "label": "云端"
+        },
+        "customModel": {
+          "title": "设置自定义 embedding 模型。"
+        },
+        "customModels": {
+          "title": "自定义模型"
+        },
+        "foldModels": {
+          "label": "收起模型"
+        },
+        "noCloudResults": {
+          "title": "未找到云端模型"
+        },
+        "noResults": {
+          "description": "请尝试其他搜索词。"
+        },
+        "noSelfHostedResults": {
+          "title": "未找到自托管模型"
+        },
+        "revertSelection": {
+          "tooltip": "还原 embedding 模型选择"
+        },
+        "search": {
+          "placeholder": "搜索模型..."
+        },
+        "selfHostedTab": {
+          "label": "自托管"
+        },
+        "viewAllModels": {
+          "label": "查看所有模型"
+        }
+      },
+      "multipass": {
+        "description": "将文档索引为不同大小的分块，以更好地识别相关来源。",
+        "disabledTooltip": "多轮索引暂时禁用，将在未来提供。",
+        "tag": {
+          "label": "暂时不可用"
+        },
+        "title": "多轮索引"
+      },
+      "progressBanner": {
+        "attentionButton": {
+          "label": "查看需要处理的单元"
+        },
+        "cancelButton": {
+          "label": "取消重新索引并还原"
+        },
+        "description": {
+          "withModel": "随着重新索引的进行，新的 embedding 设置（**{model}**）正在生效。这可能需要**数小时或数天**，具体取决于语料库规模。",
+          "withoutModel": "随着重新索引的进行，新的 embedding 设置正在生效。这可能需要**数小时或数天**，具体取决于语料库规模。"
+        },
+        "progress": {
+          "ariaLabel": "重新索引进度"
+        },
+        "status": {
+          "label": "重新索引状态："
+        },
+        "title": "正在重新索引…"
+      },
+      "providerGroup": {
+        "addConfig": {
+          "button": {
+            "label": "添加配置"
+          },
+          "title": "为您的 {provider} embedding 提供商添加配置。"
+        },
+        "deprecated": {
+          "suffix": "（已弃用）"
+        },
+        "disconnect": {
+          "errorToast": "断开 {provider} 的连接失败",
+          "successToast": "已断开 {provider} 的连接"
+        },
+        "disconnectButton": {
+          "disabledTooltip": "无法断开此 embedding 模型的连接，因为它是当前的默认模型。请先选择新的模型再继续。"
+        },
+        "disconnectModal": {
+          "description": "此操作会断开提供商 **{provider}** 的所有 embedding 模型的连接。",
+          "submit": {
+            "label": "断开连接"
+          },
+          "title": "断开 {provider} 的连接"
+        },
+        "editCredentialsButton": {
+          "label": "编辑凭证"
+        }
+      },
+      "providerInfo": {
+        "cloudProvider": {
+          "title": "云提供商"
+        },
+        "docsLink": {
+          "label": "文档"
+        },
+        "pricingLink": {
+          "label": "价格"
+        },
+        "selfHosted": {
+          "title": "自托管"
+        }
+      },
+      "reindexBanner": {
+        "cancelReindex": {
+          "label": "取消重新索引"
+        },
+        "description": "正在切换到 **{model}**。现有文档正在重新生成 embedding——这可能需要数小时或数天，具体取决于语料库规模。在切换完成之前，之前的模型会继续处理查询。",
+        "seeConnectors": {
+          "label": "查看连接器"
+        },
+        "title": "正在重新索引"
+      },
+      "reindexing": {
+        "disabledTooltip": "重新索引正在进行中。取消后才能进行更改。"
+      },
+      "retrieval": {
+        "description": "通过配置文档的分块和上下文处理方式来提升搜索准确性的附加索引功能。这些功能可能会增加 embedding 成本。",
+        "title": "检索优化"
+      },
+      "switchover": {
+        "activeOnly": {
+          "description": "继续使用当前文档索引和现有设置，直到所有活动（未暂停/未删除）的连接器都成功完成一次索引尝试。",
+          "label": "重新索引活动连接器后再切换"
+        },
+        "instant": {
+          "description": "立即清空当前文档索引并切换到新设置。需要重新索引所有连接器，索引才能重新填充以供搜索。",
+          "label": "先切换再重新索引"
+        },
+        "placeholder": "选择切换策略",
+        "reindexAll": {
+          "description": "最安全的选项。继续使用当前文档索引和现有设置，直到所有连接器都成功完成一次索引尝试。",
+          "label": "重新索引所有连接器后再切换"
+        }
+      },
+      "toasts": {
+        "applyFailed": "应用设置失败",
+        "cancelReindexFailed": "取消重新索引失败",
+        "captioningUpdateFailed": "更新图像描述 LLM 失败",
+        "captioningUpdated": "已更新图像描述 LLM",
+        "contextualModelRequired": "请在重新索引前选择上下文检索 LLM。",
+        "contextualModelUpdateFailed": "更新上下文检索 LLM 失败",
+        "contextualModelUpdated": "已更新上下文检索 LLM",
+        "modelNotFound": "找不到所选模型",
+        "providerResolveFailed": "无法解析提供商",
+        "reindexCanceled": "已取消重新索引",
+        "reindexStarted": "已开始重新索引",
+        "settingsUpdateFailed": "更新设置失败",
+        "settingsUpdated": "已更新设置",
+        "unknownError": "发生未知错误"
+      },
+      "validation": {
+        "apiBaseUrlRequired": "API 基础 URL 为必填项",
+        "apiKeyRequired": "API 密钥为必填项",
+        "apiVersionRequired": "API 版本为必填项",
+        "deploymentNameRequired": "部署名称为必填项",
+        "modelDimPositive": "必须是正整数",
+        "modelDimRequired": "模型维度为必填项",
+        "modelNameRequired": "模型名称为必填项",
+        "serviceAccountJsonInvalid": "必须是有效的 Google 服务账号 JSON 文件",
+        "serviceAccountJsonRequired": "服务账号 JSON 为必填项",
+        "targetUrlRequired": "目标 URL 为必填项",
+        "urlInvalid": "必须是有效的 URL"
+      }
+    },
+    "indexing": {
+      "status": {
+        "access": {
+          "inherited": {
+            "label": "继承自 {source}"
+          },
+          "organizationPublic": {
+            "label": "组织内公开"
+          },
+          "private": {
+            "label": "私有"
+          }
+        },
+        "addConnectorButton": {
+          "label": "添加连接器"
+        },
+        "connectorCreated": {
+          "toast": "已成功创建连接器"
+        },
+        "empty": {
+          "message": "您似乎还没有设置任何连接器。请访问[添加连接器](/admin/add-connector)页面开始使用！"
+        },
+        "federated": {
+          "access": {
+            "label": "联合访问"
+          },
+          "indexed": {
+            "label": "已索引"
+          },
+          "notApplicable": {
+            "label": "不适用"
+          }
+        },
+        "filterMenu": {
+          "accessType": {
+            "autoSync": {
+              "label": "自动同步"
+            },
+            "private": {
+              "label": "私有"
+            },
+            "public": {
+              "label": "公开"
+            },
+            "title": "访问类型"
+          },
+          "applyButton": {
+            "label": "应用"
+          },
+          "docCount": {
+            "placeholder": "数量",
+            "title": "文档数量"
+          },
+          "lastStatus": {
+            "completedWithErrors": {
+              "label": "完成但有错误"
+            },
+            "failed": {
+              "label": "失败"
+            },
+            "inProgress": {
+              "label": "进行中"
+            },
+            "interrupted": {
+              "label": "已中断"
+            },
+            "notStarted": {
+              "label": "未开始"
+            },
+            "success": {
+              "label": "成功"
+            },
+            "title": "最近状态"
+          },
+          "title": "筛选连接器"
+        },
+        "filters": {
+          "accessBadge": {
+            "label": "访问：{values}"
+          },
+          "clearBadge": {
+            "label": "清除"
+          },
+          "docsAnyBadge": {
+            "label": "文档 {operator} 任意"
+          },
+          "docsBadge": {
+            "label": "文档 {operator} {value}"
+          },
+          "statusBadge": {
+            "label": "状态：{values}"
+          }
+        },
+        "loadError": {
+          "message": "加载索引状态时出错。"
+        },
+        "manageConnector": {
+          "tooltip": "管理连接器"
+        },
+        "manageFederatedConnector": {
+          "tooltip": "管理联合连接器"
+        },
+        "search": {
+          "placeholder": "搜索连接器"
+        },
+        "summary": {
+          "activeConnectors": {
+            "label": "活跃连接器"
+          },
+          "publicConnectors": {
+            "label": "公开连接器"
+          },
+          "totalConnectors": {
+            "label": "连接器总数"
+          },
+          "totalDocsIndexed": {
+            "label": "已索引文档总数"
+          }
+        },
+        "table": {
+          "allCaughtUp": {
+            "label": "已全部加载！没有更多连接器"
+          },
+          "lastIndexed": {
+            "header": "上次索引时间"
+          },
+          "name": {
+            "header": "名称"
+          },
+          "permissions": {
+            "header": "权限 / 访问"
+          },
+          "status": {
+            "header": "状态"
+          },
+          "totalDocs": {
+            "header": "文档总数"
+          }
+        },
+        "toggleAll": {
+          "collapse": {
+            "label": "全部折叠"
+          },
+          "expand": {
+            "label": "全部展开"
+          }
+        }
+      }
+    },
+    "languageModels": {
+      "availableProviders": {
+        "title": "可用提供商"
+      },
+      "configurationDisabled": {
+        "description": "现有的 LLM 提供商仍可继续使用和更新。",
+        "title": "暂时无法新增 LLM 配置。"
+      },
+      "defaultModel": {
+        "description": "Onyx 将在您的对话中默认使用此模型。",
+        "title": "默认模型"
+      },
+      "deleteModal": {
+        "defaultProviderWarning": "无法删除默认提供商。请先将其他提供商设为默认，再删除此提供商。",
+        "description": "提供商 **{provider}** 的所有 LLM 模型都将被移除，后续对话中无法使用。聊天记录会保留。",
+        "lastProviderNote": "请连接其他提供商以继续使用对话。",
+        "submit": {
+          "label": "删除"
+        },
+        "title": "删除 *{provider}*"
+      },
+      "groups": {
+        "addProvider": {
+          "description": "Onyx 同时支持主流提供商和自托管模型。",
+          "title": "添加提供商"
+        },
+        "gateways": {
+          "title": "网关和路由器"
+        },
+        "selfHosted": {
+          "title": "自托管和自定义"
+        }
+      },
+      "modals": {
+        "access": {
+          "admin": {
+            "sharedNote": "始终共享",
+            "title": "管理员"
+          },
+          "agent": {
+            "name": "智能体 {id}"
+          },
+          "agentOption": {
+            "description": "智能体"
+          },
+          "comboBox": {
+            "placeholder": "添加用户组和智能体"
+          },
+          "field": {
+            "description": "谁可以访问此提供商。",
+            "title": "模型访问权限"
+          },
+          "group": {
+            "name": "用户组 {id}"
+          },
+          "groupOption": {
+            "description": "用户组"
+          },
+          "memberCount": {
+            "label": "{count, plural, one {# 位成员} other {# 位成员}}"
+          },
+          "noAgents": {
+            "description": "任何智能体都不会使用此提供商。",
+            "title": "未添加智能体"
+          },
+          "private": {
+            "label": "指定用户组和智能体"
+          },
+          "public": {
+            "label": "所有用户和智能体"
+          },
+          "select": {
+            "placeholder": "选择访问级别"
+          }
+        },
+        "azure": {
+          "targetUriField": {
+            "description": "粘贴来自 Azure OpenAI 的端点目标 URI（包括 API 端点基址、部署名称和 API 版本）。",
+            "title": "目标 URI"
+          },
+          "toasts": {
+            "targetUriParseFailed": "无法解析目标 URI — 将使用原始值。"
+          },
+          "validation": {
+            "targetUriInvalid": "目标 URI 必须是有效的 URL，并带有 api-version 查询参数，且路径中包含部署名称或 /openai/responses",
+            "targetUriRequired": "目标 URI 为必填项"
+          }
+        },
+        "bedrock": {
+          "accessKeyIdField": {
+            "title": "AWS 访问密钥 ID"
+          },
+          "authMethodField": {
+            "accessKey": {
+              "description": "适用于非 AWS 环境",
+              "label": "访问密钥"
+            },
+            "description": "选择 Onyx 与 Bedrock 进行身份验证的方式。",
+            "iam": {
+              "description": "推荐用于 AWS 环境",
+              "label": "环境 IAM 角色"
+            },
+            "longTermApiKey": {
+              "description": "适用于非 AWS 环境",
+              "label": "长期 API 密钥"
+            },
+            "title": "身份验证方式"
+          },
+          "iamNotice": {
+            "title": "Onyx 将使用其运行环境所附加的 IAM 角色进行身份验证。"
+          },
+          "longTermApiKeyField": {
+            "placeholder": "您的长期 API 密钥",
+            "title": "长期 API 密钥"
+          },
+          "regionField": {
+            "description": "托管您的 Amazon Bedrock 模型的区域。",
+            "placeholder": "选择区域",
+            "title": "AWS 区域"
+          },
+          "secretAccessKeyField": {
+            "title": "AWS 私有访问密钥"
+          },
+          "validation": {
+            "regionRequired": "AWS 区域为必填项"
+          }
+        },
+        "bifrost": {
+          "apiBaseField": {
+            "description": "粘贴您的 Bifrost 网关端点 URL（包括 API 版本）。"
+          },
+          "apiKeyField": {
+            "description": "粘贴来自 [Bifrost](https://docs.getbifrost.ai/overview) 的 API 密钥以访问您的模型。"
+          },
+          "apiMode": {
+            "chatCompletions": {
+              "label": "Chat Completions API"
+            },
+            "responses": {
+              "label": "Responses API"
+            }
+          }
+        },
+        "custom": {
+          "addModelButton": {
+            "label": "添加模型"
+          },
+          "apiKeyField": {
+            "description": "如果您的模型提供商需要身份验证，请粘贴您的 API 密钥。"
+          },
+          "apiVersionField": {
+            "title": "API 版本"
+          },
+          "description": "连接来自其他 LiteLLM 兼容提供商的模型。",
+          "envVars": {
+            "addButton": {
+              "label": "添加行"
+            },
+            "description": "按模型提供商的要求添加额外属性。这些属性会作为[环境变量](https://docs.litellm.ai/docs/set_keys#environment-variables)传递给 LiteLLM 的 `completion()` 调用。更多说明请参见[文档](https://docs.onyx.app/admins/ai_models/custom_inference_provider)。",
+            "title": "环境变量"
+          },
+          "modelRow": {
+            "displayNamePlaceholder": "显示名称",
+            "inputTypePlaceholder": "输入类型",
+            "maxTokensPlaceholder": "默认",
+            "namePlaceholder": "模型名称",
+            "textImage": {
+              "label": "文本和图像"
+            },
+            "textOnly": {
+              "label": "仅文本"
+            }
+          },
+          "modelTable": {
+            "displayName": {
+              "header": "显示名称"
+            },
+            "inputType": {
+              "header": "输入类型"
+            },
+            "maxTokens": {
+              "header": "最大 token 数"
+            },
+            "name": {
+              "header": "模型名称"
+            }
+          },
+          "models": {
+            "description": "列出您要为此提供商使用的 LLM 模型及其配置。完整的模型列表请参见 LiteLLM。",
+            "empty": {
+              "title": "尚未添加模型。"
+            },
+            "title": "模型"
+          },
+          "providerField": {
+            "createPrefix": "使用",
+            "description": "支持的 LLM 提供商完整列表请参见 [LiteLLM](https://docs.litellm.ai/docs/providers)。",
+            "placeholder": "LiteLLM 上显示的提供商 ID 字符串",
+            "title": "提供商"
+          },
+          "toasts": {
+            "modelNameRequired": "至少需要填写一个模型名称"
+          },
+          "validation": {
+            "displayNameRequired": "显示名称为必填项",
+            "providerNameRequired": "提供商名称为必填项"
+          }
+        },
+        "liteLlmProxy": {
+          "apiBaseField": {
+            "description": "您的 LiteLLM Proxy 服务器的基础 URL。"
+          }
+        },
+        "lmStudio": {
+          "apiBaseField": {
+            "description": "您的 LM Studio 服务器的基础 URL。",
+            "placeholder": "您的 LM Studio API 基础 URL"
+          },
+          "apiKeyField": {
+            "description": "如果您的 LM Studio 服务器需要身份验证，可填写 API 密钥（可选）。"
+          }
+        },
+        "modelSettings": {
+          "capabilities": {
+            "chat": {
+              "label": "对话"
+            },
+            "multiModal": {
+              "label": "多模态"
+            },
+            "reasoning": {
+              "label": "推理"
+            }
+          },
+          "reasoningLevel": {
+            "defaultSlider": {
+              "label": "默认"
+            },
+            "maxSlider": {
+              "label": "最高级别"
+            }
+          },
+          "temperature": {
+            "defaultSlider": {
+              "label": "默认"
+            },
+            "pinned": {
+              "tooltip": "推理模型始终以 temperature 1 运行。"
+            }
+          },
+          "trigger": {
+            "tooltip": "模型设置"
+          }
+        },
+        "models": {
+          "addModelButton": {
+            "label": "添加模型"
+          },
+          "addModelInput": {
+            "placeholder": "输入模型名称"
+          },
+          "autoUpdate": {
+            "description": "有新模型发布时更新可用模型。",
+            "title": "自动更新"
+          },
+          "deselectAllButton": {
+            "label": "取消全选"
+          },
+          "empty": {
+            "title": "没有可用模型。"
+          },
+          "field": {
+            "description": "选择要为此提供商启用的模型。",
+            "title": "模型"
+          },
+          "foldButton": {
+            "label": "收起模型"
+          },
+          "moreButton": {
+            "label": "更多模型"
+          },
+          "refetch": {
+            "errorToast": "获取模型失败"
+          },
+          "row": {
+            "defaultLabel": "默认模型",
+            "renameButton": {
+              "tooltip": "重命名"
+            },
+            "setDefaultButton": {
+              "label": "设为默认"
+            },
+            "visionMarker": {
+              "title": "视觉"
+            }
+          },
+          "selectAllButton": {
+            "label": "全选"
+          }
+        },
+        "nebius": {
+          "apiBaseField": {
+            "description": "Nebius TokenFactory 端点 URL（包括 API 版本）。"
+          },
+          "apiKeyField": {
+            "description": "粘贴来自 [Nebius TokenFactory](https://tokenfactory.nebius.com/) 的 API 密钥以加载可用模型。"
+          }
+        },
+        "ollama": {
+          "apiBaseField": {
+            "description": "您的 Ollama 实例的基础 URL。",
+            "placeholder": "您的 Ollama API 基础 URL"
+          },
+          "apiKeyField": {
+            "description": "您的 Ollama Cloud API 密钥。",
+            "placeholder": "API 密钥"
+          },
+          "tabs": {
+            "cloud": {
+              "label": "Ollama Cloud"
+            },
+            "selfHosted": {
+              "label": "自托管 Ollama"
+            }
+          }
+        },
+        "openAiCompatible": {
+          "apiBaseField": {
+            "description": "粘贴您的 OpenAI 兼容端点 URL。",
+            "learnMore": "[了解更多](https://docs.litellm.ai/docs/providers/openai_compatible)"
+          },
+          "apiKeyField": {
+            "description": "如果您的模型提供商需要身份验证，请粘贴您的 API 密钥。"
+          },
+          "description": "通过 OpenAI 兼容端点连接其他云端或自托管模型。"
+        },
+        "openRouter": {
+          "apiBaseField": {
+            "description": "粘贴您的 OpenRouter 兼容端点 URL，或直接使用 OpenRouter API。",
+            "placeholder": "您的 OpenRouter 基础 URL"
+          }
+        },
+        "portkey": {
+          "apiBaseField": {
+            "description": "使用 Portkey 的基础 URL，或粘贴您自托管网关的基础 URL。",
+            "placeholder": "您的 Portkey 网关基础 URL"
+          },
+          "apiKeyField": {
+            "description": "粘贴来自 [Portkey](https://portkey.ai/) 的 API 密钥以访问您的模型。"
+          },
+          "apiMode": {
+            "chatCompletions": {
+              "caption": "OpenAI 兼容",
+              "label": "Chat Completions API"
+            },
+            "messages": {
+              "caption": "Anthropic 兼容",
+              "label": "Messages API"
+            },
+            "responses": {
+              "caption": "OpenAI 兼容",
+              "label": "Responses API"
+            }
+          },
+          "description": "连接到您的 Portkey 网关并设置兼容的模型。",
+          "models": {
+            "empty": {
+              "title": "没有可用模型。请提供有效的基础 URL 和密钥。"
+            }
+          },
+          "restoreDefaultButton": {
+            "ariaLabel": "恢复默认 API 基础 URL",
+            "tooltip": "恢复默认"
+          }
+        },
+        "setup": {
+          "apiBaseField": {
+            "containerizedNote": "当 Onyx 在容器中运行时，请使用 `host.docker.internal` 代替 `localhost` 来访问主机上的服务。",
+            "title": "API 基础 URL"
+          },
+          "apiKeyField": {
+            "description": "粘贴您的 API 密钥以访问您的模型。",
+            "providerDescription": "粘贴来自 {provider} 的 API 密钥以访问您的模型。",
+            "title": "API 密钥"
+          },
+          "cancelButton": {
+            "label": "取消"
+          },
+          "connectButton": {
+            "label": "连接"
+          },
+          "description": "连接到 {company} 并设置您的 {product} 模型。",
+          "displayNameField": {
+            "description": "用于在应用中标识此提供商。",
+            "placeholder": "显示名称",
+            "title": "显示名称"
+          },
+          "optionalSuffix": {
+            "label": "可选"
+          },
+          "submitButton": {
+            "invalidTooltip": "请填写所有必填字段。",
+            "pristineTooltip": "没有需要保存的更改。"
+          },
+          "title": {
+            "configure": "配置 *{provider}*",
+            "create": "设置 {product}"
+          },
+          "updateButton": {
+            "label": "更新"
+          }
+        },
+        "toasts": {
+          "providerEnableFailed": "启用提供商失败：{message}",
+          "providerEnabled": "提供商已成功启用！",
+          "providerUpdateFailed": "更新提供商失败：{message}",
+          "providerUpdated": "提供商已成功更新！",
+          "setDefaultFailed": "无法将提供商设为默认",
+          "setNewDefaultFailed": "无法将新提供商设为默认",
+          "testApiKeyFailed": "测试 API 密钥时出错。",
+          "testCustomProviderFailed": "测试自定义提供商时出错。",
+          "testProviderFailed": "测试提供商时出错。"
+        },
+        "validation": {
+          "apiBaseRequired": "API 基础 URL 为必填项",
+          "apiKeyRequired": "API 密钥为必填项",
+          "modelNameRequired": "模型名称为必填项"
+        },
+        "vertexAi": {
+          "authMethodField": {
+            "description": "选择 Onyx 与 Google Vertex AI 进行身份验证的方式。",
+            "serviceAccount": {
+              "description": "上传 GCP 服务账号密钥 JSON 文件",
+              "label": "服务账号 JSON"
+            },
+            "title": "身份验证方式",
+            "workloadIdentity": {
+              "description": "使用 Pod 的环境 GCP 凭据（GKE Workload Identity）",
+              "label": "Workload Identity (GKE)"
+            }
+          },
+          "credentialsField": {
+            "description": "附加来自 Google Cloud 的 API 密钥 JSON 文件以访问您的模型。",
+            "title": "API 密钥"
+          },
+          "locationField": {
+            "description": "托管您的 Google Vertex AI 模型的区域。支持的区域完整列表请参见 Google Cloud。",
+            "title": "Google Cloud 区域名称"
+          },
+          "projectField": {
+            "description": "已启用 Vertex AI 的 GCP 项目。此项必填，因为在服务账号模拟下，ADC 无法可靠地推断目标项目。",
+            "title": "GCP 项目 ID"
+          },
+          "validation": {
+            "authMethodRequired": "身份验证方式为必填项",
+            "credentialsRequired": "凭据文件为必填项",
+            "projectRequired": "GCP 项目 ID 为必填项"
+          },
+          "workloadIdentityNotice": {
+            "title": "Onyx 将使用 Pod 的环境 Google Cloud 凭据（通过 google.auth.default）。请确保 Kubernetes ServiceAccount 已绑定到有权访问 Vertex AI 的 GCP 服务账号。"
+          }
+        }
+      },
+      "newCustomProviderCard": {
+        "setUpButton": {
+          "label": "设置"
+        }
+      },
+      "newProviderCard": {
+        "ariaLabel": "添加 {company} {product}",
+        "connectButton": {
+          "label": "连接"
+        }
+      },
+      "noProviders": {
+        "title": "设置一个 LLM 提供商即可开始对话。"
+      },
+      "providerCard": {
+        "defaultTag": {
+          "label": "默认"
+        },
+        "deleteButton": {
+          "ariaLabel": "删除 {provider}"
+        },
+        "editButton": {
+          "ariaLabel": "编辑 {provider}"
+        }
+      },
+      "toasts": {
+        "providerDeleteFailed": "删除提供商失败：{message}",
+        "providerDeleted": "提供商已成功删除！",
+        "unknownError": "未知错误"
+      }
+    },
+    "mcpActions": {
+      "header": {
+        "description": "连接 MCP（Model Context Protocol）服务器，为您的智能体添加自定义操作和工具。"
+      }
+    },
+    "modals": {
+      "newTeam": {
+        "body": "{domain} 的任何管理员都可以批准您的加入请求。",
+        "continueButton": {
+          "label": "继续使用新团队"
+        },
+        "header": {
+          "requestSentTitle": "加入请求已发送",
+          "title": "我们找到了 {domain} 的现有团队"
+        },
+        "inviteRequestedToast": {
+          "message": "您的邀请请求已发送给团队管理员。"
+        },
+        "loadError": {
+          "message": "无法获取团队信息。请稍后重试。"
+        },
+        "requestButton": {
+          "label": "请求加入您的团队",
+          "pendingLabel": "正在发送请求..."
+        },
+        "requestError": {
+          "message": "请求邀请失败",
+          "responseFallback": "请求邀请失败"
+        },
+        "requestSentBody": "您的加入请求已发送。在等待 {domain} 管理员批准期间，您可以先以自己的团队身份浏览体验。",
+        "tryOnyxButton": {
+          "label": "等待期间先试用 Onyx"
+        }
+      },
+      "newTenant": {
+        "acceptError": {
+          "responseFallback": "接受邀请失败"
+        },
+        "acceptedToast": {
+          "message": "您已接受邀请。"
+        },
+        "approvedTitle": "您加入 {domain} 中其他 {count} 位用户的请求已获批准。",
+        "declineButton": {
+          "label": "拒绝"
+        },
+        "declineError": {
+          "message": "拒绝邀请失败。请重试。",
+          "responseFallback": "拒绝邀请失败"
+        },
+        "declinedToast": {
+          "message": "您已拒绝邀请。"
+        },
+        "inviteDescription": "接受此邀请后，您将加入现有的 {domain} 团队，并失去对当前团队的访问权限。注意：您将无法再访问当前的智能体、提示词、聊天记录和已连接的数据源。",
+        "inviteTitle": "您受邀加入 {domain} 团队，该团队已有 {count, plural, one {# 位其他成员} other {# 位其他成员}}。",
+        "joinError": {
+          "message": "加入团队失败。请重试。"
+        },
+        "joinRequestToast": {
+          "message": "正在处理您的团队加入请求..."
+        },
+        "reauthenticateDescription": "要完成加入团队，请使用 {email} 重新进行身份验证。",
+        "submitButton": {
+          "acceptLabel": "接受邀请",
+          "acceptingLabel": "正在接受...",
+          "joiningLabel": "正在加入...",
+          "reauthenticateLabel": "重新验证"
+        }
+      },
+      "provider": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "submitButton": {
+          "label": "连接"
+        }
+      }
+    },
+    "oauthTest": {
+      "claims": {
+        "empty": {
+          "message": "未收到任何声明。"
+        },
+        "table": {
+          "claim": {
+            "header": "声明"
+          },
+          "value": {
+            "header": "值"
+          }
+        }
+      },
+      "directory": {
+        "fallbackSource": "提供商 API",
+        "subtitle": "从提供商 API 获取的目录字段 — 例如 Entra ID 的 Microsoft Graph /me，其中带有 country/usageLocation；除非配置了 ctry 可选声明，否则 id_token 会省略这些字段。",
+        "title": "目录资料（{source}）"
+      },
+      "idToken": {
+        "subtitle": "从 token 端点返回的 id_token JWT 中解码得出。",
+        "title": "id_token 声明"
+      },
+      "intro": {
+        "description": "显示您的身份提供商在上次 OAuth/OIDC 登录时发送的关于您的原始字段：id_token 声明和 userinfo 端点响应。您可以用它来确认 IdP 配置了释放哪些属性。每次登录都会捕获声明。"
+      },
+      "loadFailed": {
+        "title": "加载 OAuth 声明失败"
+      },
+      "noSnapshot": {
+        "description": "未找到 {email} 的 OAuth 登录快照。请通过身份提供商登录（上方按钮），然后重新加载此页面。",
+        "title": "尚未捕获声明"
+      },
+      "rerun": {
+        "label": "重新执行 OAuth 登录"
+      },
+      "resolved": {
+        "subtitle": "经过声明映射的目录资料，实际用于填充“组织资料”提示块和 {placeholder} 占位符。",
+        "title": "解析后的资料（用于提示词）"
+      },
+      "snapshot": {
+        "capturedAt": {
+          "label": "捕获时间：{timestamp}"
+        },
+        "provider": {
+          "label": "提供商：{provider}"
+        },
+        "tokenFields": {
+          "label": "Token 响应字段：{fields}"
+        },
+        "user": {
+          "label": "用户：{email}"
+        }
+      },
+      "userinfo": {
+        "subtitle": "使用您的访问 token 调用 OIDC userinfo 端点得到的响应。",
+        "title": "userinfo 声明"
+      }
+    },
+    "openapiActions": {
+      "header": {
+        "description": "连接 OpenAPI 服务器，为您的智能体添加自定义操作和工具。"
+      }
+    },
+    "perUserUsage": {
+      "panel": {
+        "description": "{start} – {end} · 费用根据记录的模型用量计算。",
+        "emptyDescription": "所选期间内每位用户的支出和 token 用量。",
+        "error": {
+          "title": "加载此期间的用量失败。"
+        },
+        "title": "用量概览"
+      },
+      "summary": {
+        "activeUsers": {
+          "detail": "{count, number} 位用户有记录",
+          "label": "活跃用户"
+        },
+        "topSpender": {
+          "label": "支出最高的用户",
+          "noSpend": "未记录支出"
+        },
+        "totalTokens": {
+          "detail": "输入（含缓存读取）和输出",
+          "label": "token 总数"
+        },
+        "workspaceSpend": {
+          "detail": "所有列出用户的合计",
+          "label": "工作区支出"
+        }
+      },
+      "users": {
+        "description": "按支出从高到低排序。请先筛选列表，再选择用户查看完整明细。",
+        "empty": {
+          "description": "此期间没有用量记录。"
+        },
+        "title": "用户"
+      }
+    },
+    "scim": {
+      "card": {
+        "connected": {
+          "label": "已连接"
+        },
+        "description": "连接您的身份提供商，以导入和同步用户与用户组。",
+        "generate": {
+          "label": "生成 SCIM Token"
+        },
+        "regenerate": {
+          "label": "重新生成 Token"
+        },
+        "title": "SCIM 同步",
+        "waiting": {
+          "description": "将 SCIM 密钥提供给您的身份提供商，即可开始同步用户和用户组。",
+          "label": "等待连接"
+        }
+      },
+      "header": {
+        "description": "通过跨域身份管理系统（SCIM）协议同步用户和用户组。",
+        "title": "SCIM"
+      },
+      "loadFailed": {
+        "error": "加载 SCIM token 状态失败。"
+      },
+      "modal": {
+        "copied": {
+          "message": "Token 已复制到剪贴板"
+        },
+        "copyFailed": {
+          "error": "复制 token 失败"
+        },
+        "regenerate": {
+          "description": "您当前的 SCIM token 将被吊销，并生成一个新 token。您需要在身份提供商处更新此 token，SCIM 预配才会恢复。",
+          "submit": {
+            "label": "重新生成 Token"
+          },
+          "title": "重新生成 SCIM Token"
+        },
+        "token": {
+          "copy": {
+            "label": "复制 Token"
+          },
+          "description": "请在继续之前保存此密钥。它不会再次显示。",
+          "download": {
+            "label": "下载"
+          },
+          "title": "SCIM Token"
+        }
+      },
+      "toasts": {
+        "generateFailed": "生成 token 失败：{detail}",
+        "genericError": "出现问题。请重试。",
+        "regenerated": "Token 已重新生成"
+      }
+    },
+    "security": {
+      "adminControls": {
+        "incognito": {
+          "description": "无痕对话永远不会出现在其所有者的历史记录中。群组访问权限在“用户组”页面中按用户组配置。",
+          "everyone": {
+            "description": "任何已登录的用户都可以发起无痕对话。",
+            "label": "所有人"
+          },
+          "groups": {
+            "description": "仅限已启用无痕访问权限的用户组成员。",
+            "label": "指定用户组"
+          },
+          "off": {
+            "description": "任何人都不能发起无痕对话。",
+            "label": "关闭"
+          },
+          "title": "无痕对话"
+        },
+        "incognitoRecords": {
+          "description": "工作区从无痕对话中保留的内容。新会话在开始时会固定当时生效的模式。",
+          "fullHistory": {
+            "description": "与其他对话一样记录：查询历史、用量和追踪。仅在所有者自己的历史记录中隐藏。",
+            "label": "完整历史记录"
+          },
+          "title": "无痕对话记录",
+          "usageOnly": {
+            "description": "不存储任何消息内容。仍会跟踪 token 用量，且这些对话不会出现在查询历史中。",
+            "label": "仅用量"
+          }
+        },
+        "maskCredentials": {
+          "description": "向管理员显示已保存的 API 密钥和凭据时使用的格式。",
+          "masked": {
+            "description": "仅显示开头和结尾的几个字符（例如 abcd...wxyz）。",
+            "label": "部分掩码"
+          },
+          "title": "掩码存储的凭据",
+          "visible": {
+            "description": "向管理员显示完整的凭据值。",
+            "label": "完全可见"
+          }
+        },
+        "section": {
+          "title": "管理员控制"
+        },
+        "userDirectory": {
+          "adminsOnly": {
+            "description": "仅管理员可以查看完整用户列表。",
+            "label": "仅管理员可见"
+          },
+          "allUsers": {
+            "description": "任何已登录的用户在共享资源时都可以查看完整用户列表。",
+            "label": "所有用户可见"
+          },
+          "description": "无论此设置如何，按精确姓名和邮箱查找始终可用。",
+          "title": "完整用户目录可见性"
+        }
+      },
+      "authentication": {
+        "allowedEmailDomains": {
+          "placeholder": "添加域名（例如 onyx.app）",
+          "subDescription": "新用户只能使用此域名列表中的邮箱注册新账户。",
+          "title": "允许的邮箱域名"
+        },
+        "emailDomains": {
+          "description": "将新用户注册限制为特定的邮箱域名。",
+          "title": "限制邮箱域名"
+        },
+        "idpExpiry": {
+          "description": "当上游 OAuth/OIDC 提供商的会话过期时，让用户退出登录。",
+          "title": "会话过期时间与身份提供商同步"
+        },
+        "openSignUp": {
+          "description": "新用户必须受邀才能加入此工作区。",
+          "title": "限制开放注册"
+        },
+        "passwordLockdown": {
+          "description": "所有人只能通过 SSO 登录和注册。需要至少启用一个 SSO 提供商。",
+          "title": "禁用密码登录和注册"
+        },
+        "section": {
+          "title": "身份验证"
+        }
+      },
+      "jwt": {
+        "expectedAudience": {
+          "description": "拒绝 aud 声明不匹配的 token。留空则禁用此检查。",
+          "title": "预期受众"
+        },
+        "expectedIssuer": {
+          "description": "拒绝 iss 声明不匹配的 token。留空则禁用此检查。",
+          "title": "预期颁发者"
+        },
+        "pinnedField": {
+          "description": "由环境变量固定。"
+        },
+        "publicKeyUrl": {
+          "description": "用于验证 token 签名的 JWKS 或 PEM 端点。留空则禁用 JWT 身份验证。",
+          "title": "公钥 URL"
+        },
+        "section": {
+          "description": "接受由您的身份提供商签名的 RS256 bearer token。由环境变量设置的值已固定，无法在此编辑。",
+          "title": "外部 JWT 身份验证"
+        }
+      },
+      "networkSafety": {
+        "envInjection": {
+          "description": "允许自定义 LLM 提供商配置在调用期间临时设置进程环境变量。禁用后，所有提供商设置都必须有对应的 LiteLLM 参数。",
+          "multiTenantDescription": "在多租户部署中，自定义 LLM 提供商配置永远无法设置进程环境变量。",
+          "title": "LLM 环境变量注入"
+        },
+        "section": {
+          "title": "网络安全"
+        },
+        "ssrf": {
+          "allowPrivateNetwork": {
+            "description": "与“验证 LLM 请求”类似，但管理员配置的 MCP/OAuth 端点还可以访问局域网内的私有主机。回环地址（应用主机本身）和云元数据仍被阻止。",
+            "label": "允许私有网络"
+          },
+          "description": "校验出站请求是否指向私有或内部 IP，以防范服务端请求伪造（SSRF）。",
+          "disabled": {
+            "description": "仅在受信任的网络中使用。允许所有出站请求 — 连接本地 LLM 后端时需要此设置。",
+            "label": "已禁用"
+          },
+          "title": "SSRF 防护",
+          "validateAll": {
+            "description": "限制最严格。所有出站请求（包括网页连接器）都不能访问私有或内部 IP。",
+            "label": "验证所有请求"
+          },
+          "validateLlm": {
+            "description": "验证所有由 LLM 发起的 URL 抓取。管理员配置的连接器仍可访问私有或内部 IP。",
+            "label": "验证 LLM 请求"
+          }
+        }
+      },
+      "page": {
+        "description": "可在运行时配置的安全设置。未设置的值将回退到您部署的环境配置。"
+      },
+      "passwordPolicy": {
+        "charactersSuffix": {
+          "label": "（个字符）"
+        },
+        "lengthInput": {
+          "placeholder": "默认"
+        },
+        "maxLength": {
+          "title": "密码最大长度"
+        },
+        "minLength": {
+          "title": "密码最小长度"
+        },
+        "requireLowercase": {
+          "title": "要求包含小写字母"
+        },
+        "requireNumber": {
+          "title": "要求包含数字"
+        },
+        "requireSpecialChar": {
+          "description": "可接受的字符：`{characters}`",
+          "title": "要求包含特殊字符"
+        },
+        "requireUppercase": {
+          "title": "要求包含大写字母"
+        },
+        "section": {
+          "description": "所有新密码的要求。仅适用于基本身份验证。",
+          "title": "密码策略"
+        }
+      },
+      "toasts": {
+        "securitySettingsUpdateFailed": "更新安全设置失败",
+        "securitySettingsUpdated": "安全设置已更新",
+        "settingsUpdateFailed": "更新设置失败",
+        "settingsUpdated": "设置已更新"
+      }
+    },
+    "serviceAccounts": {
+      "deleteModal": {
+        "description": "任何使用账户 *{name}*（`{keyDisplay}`）的 API 密钥的应用都将失去对 Onyx 的访问权限。",
+        "submit": {
+          "label": "删除"
+        },
+        "title": "删除账户",
+        "warning": "删除后无法撤销。"
+      },
+      "editModal": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "groupList": {
+          "loading": {
+            "description": "正在加载用户组...",
+            "title": "正在加载..."
+          },
+          "memberCount": "{count, plural, one {# 位用户} other {# 位用户}}",
+          "noResults": {
+            "description": "请尝试其他搜索词。",
+            "title": "未找到用户组"
+          }
+        },
+        "joinedGroups": {
+          "empty": {
+            "description": "{name} 不属于任何用户组。",
+            "title": "未找到用户组"
+          }
+        },
+        "removeGroupButton": {
+          "tooltip": "移出用户组"
+        },
+        "saveButton": {
+          "label": "保存更改"
+        },
+        "search": {
+          "placeholder": "搜索要加入的用户组..."
+        },
+        "title": "编辑 {name} 的用户组",
+        "toasts": {
+          "error": "发生错误",
+          "updated": "服务账号已更新"
+        }
+      },
+      "formModal": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "description": "使用服务账号 API 密钥，以用户级权限通过程序访问 Onyx API。您可以稍后修改账号详情。",
+        "groups": {
+          "empty": {
+            "description": "尚未向此服务账号分配任何用户组。",
+            "title": "无用户组"
+          },
+          "loading": {
+            "description": "正在加载用户组...",
+            "title": "正在加载..."
+          },
+          "memberCount": "{count, plural, one {# 位用户} other {# 位用户}}",
+          "noResults": {
+            "description": "请尝试其他搜索词。",
+            "title": "未找到用户组"
+          },
+          "search": {
+            "placeholder": "搜索用户组..."
+          },
+          "title": "用户组"
+        },
+        "name": {
+          "placeholder": "输入名称",
+          "title": "名称"
+        },
+        "submitButton": {
+          "create": "创建账号",
+          "update": "更新"
+        },
+        "title": {
+          "create": "创建服务账号",
+          "update": "更新服务账号"
+        },
+        "toasts": {
+          "createFailed": "创建服务账号出错 - {detail}",
+          "created": "服务账号创建成功！",
+          "unexpectedError": "发生意外错误。",
+          "updateFailed": "更新服务账号出错 - {detail}",
+          "updated": "服务账号更新成功！"
+        }
+      },
+      "keyModal": {
+        "copyButton": {
+          "label": "复制 API 密钥"
+        },
+        "description": "请在继续之前保存此密钥。它不会再次显示。",
+        "downloadButton": {
+          "label": "下载"
+        },
+        "title": "服务账号 API 密钥"
+      },
+      "list": {
+        "createButton": {
+          "label": "新建服务账号"
+        },
+        "empty": {
+          "description": "创建具有用户级访问权限的服务账号 API 密钥。"
+        },
+        "search": {
+          "placeholder": "搜索服务账号..."
+        }
+      },
+      "page": {
+        "description": "使用服务账号通过程序访问 Onyx API。",
+        "error": {
+          "description": "请查看控制台了解更多详情。",
+          "title": "加载服务账号失败。"
+        }
+      },
+      "regenerateModal": {
+        "description": "您当前的 API 密钥 *{name}*（`{keyDisplay}`）将被吊销，同时会生成一个新密钥。您需要把使用此密钥的所有应用更新为新密钥。",
+        "submit": {
+          "label": "重新生成密钥"
+        },
+        "title": "重新生成 API 密钥"
+      },
+      "table": {
+        "actions": {
+          "delete": {
+            "label": "删除账号"
+          },
+          "edit": {
+            "label": "编辑账号"
+          },
+          "groups": {
+            "label": "用户组"
+          }
+        },
+        "columns": {
+          "apiKey": {
+            "header": "API 密钥"
+          },
+          "groups": {
+            "header": "用户组"
+          },
+          "name": {
+            "header": "名称"
+          }
+        },
+        "groups": {
+          "overflow": {
+            "label": "+{count}"
+          }
+        },
+        "moreButton": {
+          "tooltip": "更多"
+        },
+        "name": {
+          "unnamed": "未命名"
+        },
+        "regenerateButton": {
+          "tooltip": "重新生成"
+        }
+      },
+      "toasts": {
+        "deleteFailed": "删除 API 密钥失败。",
+        "deleteFailedWithDetail": "删除 API 密钥失败：{detail}",
+        "keyCopied": "API 密钥已复制到剪贴板。",
+        "regenerateFailed": "重新生成 API 密钥失败。",
+        "regenerateFailedWithDetail": "重新生成 API 密钥失败：{detail}"
+      },
+      "trialNotice": {
+        "description": "试用账号不包含 API 密钥访问权限，请购买付费订阅以解锁此功能。",
+        "title": "升级到付费方案即可创建 API 密钥。"
+      }
+    },
+    "shared": {
+      "listHeader": {
+        "search": {
+          "placeholder": "搜索..."
+        }
+      },
+      "liteModeNotice": {
+        "description": "此部署运行的是 Onyx Lite，它没有向量数据库，因此连接器和文档索引均已禁用，不会索引任何内容。要连接数据源并索引文档，请以**标准模式**部署 Onyx。请查看[部署指南]({docsUrl})开始使用。",
+        "title": "Lite 模式下无法使用索引功能"
+      },
+      "providerCard": {
+        "connectButton": {
+          "label": "连接"
+        },
+        "currentDefault": {
+          "label": "当前默认"
+        },
+        "disconnectButton": {
+          "ariaLabel": "断开 {title} 的连接",
+          "tooltip": "断开连接"
+        },
+        "editButton": {
+          "ariaLabel": "编辑 {title}",
+          "tooltip": "编辑"
+        },
+        "setDefaultButton": {
+          "label": "设为默认"
+        }
+      }
+    },
+    "slackBots": {
+      "channelConfig": {
+        "createError": {
+          "toast": "创建 OnyxBot 配置出错 - {error}"
+        },
+        "updateError": {
+          "toast": "更新 OnyxBot 配置出错 - {error}"
+        }
+      },
+      "channels": {
+        "deleteError": {
+          "toast": "删除 Slack 机器人配置失败 - {error}"
+        },
+        "deleted": {
+          "toast": "Slack 机器人配置“{configId}”已删除"
+        },
+        "editDefaultButton": {
+          "label": "编辑默认配置"
+        },
+        "newConfigButton": {
+          "label": "新建频道配置"
+        },
+        "section": {
+          "title": "频道专属配置"
+        },
+        "table": {
+          "actions": {
+            "header": "操作"
+          },
+          "assistant": {
+            "header": "助手"
+          },
+          "channel": {
+            "header": "频道"
+          },
+          "documentSets": {
+            "header": "文档集"
+          },
+          "empty": {
+            "message": "暂无频道专属配置。添加新配置可为特定频道自定义行为。"
+          }
+        }
+      },
+      "deleteModal": {
+        "confirmButton": {
+          "label": "删除"
+        },
+        "error": {
+          "toast": "删除 Slack 机器人失败"
+        },
+        "message": "确定要删除此 Slack 机器人吗？此操作无法撤销。",
+        "success": {
+          "toast": "Slack 机器人删除成功"
+        },
+        "title": "删除 Slack 机器人"
+      },
+      "edit": {
+        "header": {
+          "title": "编辑 Slack 机器人"
+        }
+      },
+      "editChannel": {
+        "channel": {
+          "header": {
+            "title": "编辑 Slack 频道配置"
+          }
+        },
+        "default": {
+          "header": {
+            "title": "编辑默认 Slack 配置"
+          }
+        }
+      },
+      "error": {
+        "channelConfigNotFound": {
+          "message": "未找到 ID 为 {id} 的 Slack 频道配置"
+        },
+        "fetchAgents": {
+          "message": "获取智能体失败 - {error}"
+        },
+        "fetchBot": {
+          "message": "获取 Slack 机器人 {botId} 失败：{error}"
+        },
+        "fetchChannels": {
+          "message": "获取 Slack 频道失败 - {error}"
+        },
+        "fetchDocumentSets": {
+          "message": "获取文档集失败 - {error}"
+        },
+        "generic": {
+          "title": "出了点问题 :("
+        },
+        "unknown": {
+          "message": "未知错误"
+        },
+        "unknownOccurred": {
+          "message": "发生未知错误"
+        }
+      },
+      "form": {
+        "agent": {
+          "placeholder": "搜索智能体..."
+        },
+        "answerValidity": {
+          "label": "仅在找到引用时回复",
+          "tooltip": "启用后，仅在模型成功生成引用时才回答问题"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "channelName": {
+          "label": "Slack 频道名称",
+          "placeholder": "输入频道名称（例如 general、support）",
+          "subtext": "输入 Slack 频道的名称（不含 # 符号）"
+        },
+        "createButton": {
+          "label": "创建"
+        },
+        "defaultConfig": {
+          "badge": "默认配置",
+          "description": "此默认配置将应用于您 Slack 工作区中的所有频道和私信（DM）。"
+        },
+        "disableDefault": {
+          "label": "禁用默认配置",
+          "warning": "警告：禁用默认配置后，OnyxBot 只会在明确配置过的 Slack 频道中回复。此外，OnyxBot 也不会回复私信。"
+        },
+        "documentSets": {
+          "autoSyncedDisabled": {
+            "tooltip": "无法使用此文档集，因为它包含启用了权限自动同步的连接器。OnyxBot 在此频道中的回复对所有 Slack 用户可见，因此沿用提问者的权限可能会意外泄露私密信息。"
+          },
+          "autoSyncedNote": {
+            "text": "以下文档集无法附加，因为它们包含自动同步的文档："
+          },
+          "description": "选择 OnyxBot 在 Slack 中回答问题时使用的文档集。",
+          "hideUnselectableButton": {
+            "label": "隐藏不可选的文档集"
+          },
+          "incompatibleHidden": {
+            "text": "部分不兼容的文档集已隐藏。"
+          },
+          "incompatibleVisible": {
+            "text": "部分不兼容的文档集处于显示状态。"
+          },
+          "viewAllButton": {
+            "label": "查看所有文档集"
+          }
+        },
+        "followUpTags": {
+          "label": "（可选）要提及的用户/用户组",
+          "subtext": "当用户点击“仍需帮助？”按钮时，我们应提及的 Slack 用户/用户组。如果未提供邮箱地址，我们不会提及任何人，只会用 🆘 表情回应原消息。"
+        },
+        "generalConfig": {
+          "section": {
+            "title": "常规配置"
+          }
+        },
+        "isEphemeral": {
+          "label": "以私密（临时）消息回复用户",
+          "tooltip": "启用后，OnyxBot 只会以私密（临时）消息回复该用户。如果您在上面还选择了“搜索”智能体，启用此选项后，该用户的私有文档也可用于其查询。"
+        },
+        "knowledgeSource": {
+          "allPublic": {
+            "label": "所有公开知识",
+            "sublabel": "让 OnyxBot 基于所有公开连接器中的信息进行回复"
+          },
+          "documentSets": {
+            "label": "指定文档集",
+            "sublabel": "控制用于回答问题的文档"
+          },
+          "label": "知识来源",
+          "nonSearchAgent": {
+            "label": "非搜索智能体",
+            "sublabel": "与不使用文档的智能体对话"
+          },
+          "searchAgent": {
+            "label": "搜索智能体",
+            "sublabel": "同时控制回答问题时使用的文档和提示词"
+          }
+        },
+        "nonSearchAgent": {
+          "description": "选择 OnyxBot 在 Slack 中回答问题时使用的非搜索智能体。"
+        },
+        "privacyAlert": {
+          "connectors": {
+            "title": "相关连接器："
+          },
+          "description": "请注意，如果*未选择*私密（临时）回复，用户查询只能访问所选文档集中的公开文档。如果*选择了*私密（临时）回复，用户查询还可以使用该用户已获授权访问的文档。请注意，用户可以把回复分享给频道中的其他人，因此请确保这符合贵公司的分享政策。",
+          "title": "隐私提醒"
+        },
+        "questionmarkPrefilter": {
+          "label": "仅回复提问",
+          "tooltip": "启用后，OnyxBot 只会回复包含问号的消息"
+        },
+        "removedDocumentSets": {
+          "toast": "我们已从您的选择中移除了一个或多个文档集，因为它们不再有效。请检查并更新您的配置。"
+        },
+        "respondMemberGroupList": {
+          "disabled": {
+            "tooltip": "启用“以私密（临时）消息回复用户”时不可用，因为临时回复只针对单个用户。"
+          },
+          "label": "（可选）仅回复特定用户/用户组",
+          "subtext": "如果指定，则只有这些用户/用户组可以在此频道中调用 OnyxBot，且回复仅对他们可见。"
+        },
+        "respondTagOnly": {
+          "label": "仅回复 @OnyxBot",
+          "tooltip": "启用后，OnyxBot 只会在被直接提及时回复"
+        },
+        "respondToBots": {
+          "label": "回复机器人消息",
+          "tooltip": "未启用时，OnyxBot 将始终忽略来自机器人的消息"
+        },
+        "responseType": {
+          "detailed": {
+            "label": "详细"
+          },
+          "label": "回答类型",
+          "standard": {
+            "label": "标准"
+          },
+          "tooltip": "控制 OnyxBot 回复的格式。"
+        },
+        "searchAgent": {
+          "description": "选择 OnyxBot 在 Slack 中回答问题时使用的搜索智能体。"
+        },
+        "searchConfig": {
+          "section": {
+            "title": "搜索配置"
+          }
+        },
+        "showContinueInWebUi": {
+          "label": "显示“在 Web 界面中继续”按钮",
+          "tooltip": "启用后，将在回复底部显示一个按钮，让用户可以在 Onyx Web 界面中继续对话"
+        },
+        "stillNeedHelp": {
+          "label": "提供“仍需帮助？”按钮",
+          "section": {
+            "prompt": "配置“仍需帮助”按钮"
+          },
+          "tooltip": "OnyxBot 的回复底部将包含一个按钮，询问用户是否仍需帮助。"
+        },
+        "syncEnabledAgents": {
+          "hideButton": {
+            "label": "隐藏不可选的智能体"
+          },
+          "listLabel": "不可选的智能体：",
+          "note": "注意：您的部分智能体在其文档集中包含自动同步的连接器。您无法选择这些智能体，因为它们无法在 Slack 中回答问题。",
+          "viewAllButton": {
+            "label": "查看所有智能体"
+          }
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "userOrGroup": {
+          "placeholder": "用户邮箱或用户组名称..."
+        }
+      },
+      "intro": {
+        "autoAnswer": {
+          "item": "设置 OnyxBot，让它在特定频道中自动回答问题。"
+        },
+        "description": "设置连接到 Onyx 的 Slack 机器人。设置完成后，您可以直接在 Slack 中向 Onyx 提问。此外，您还可以：",
+        "directMessage": {
+          "item": "像在 Web 界面中一样，直接给 OnyxBot 发消息进行搜索。"
+        },
+        "docsPrompt": {
+          "text": "请按照 Onyx 文档中的<link>指南</link>开始使用！"
+        },
+        "documentSets": {
+          "item": "根据提问所在的频道，选择 OnyxBot 应基于哪些文档集回答。"
+        }
+      },
+      "list": {
+        "error": {
+          "title": "加载应用出错"
+        }
+      },
+      "newBot": {
+        "header": {
+          "title": "新建 Slack 机器人"
+        }
+      },
+      "newBotButton": {
+        "label": "新建 Slack 机器人"
+      },
+      "newChannel": {
+        "header": {
+          "title": "为 Slack 频道配置 OnyxBot"
+        }
+      },
+      "table": {
+        "channelCount": {
+          "header": "频道数量"
+        },
+        "defaultConfig": {
+          "header": "默认配置"
+        },
+        "defaultSet": {
+          "badge": "已设默认"
+        },
+        "disabled": {
+          "badge": "已禁用"
+        },
+        "empty": {
+          "message": "请添加新的 Slack 机器人，开始与 Onyx 对话！"
+        },
+        "enabled": {
+          "badge": "已启用"
+        },
+        "name": {
+          "header": "名称"
+        },
+        "status": {
+          "header": "状态"
+        }
+      },
+      "tokensForm": {
+        "appToken": {
+          "label": "Slack 应用 Token"
+        },
+        "botToken": {
+          "label": "Slack 机器人 Token"
+        },
+        "createButton": {
+          "label": "创建"
+        },
+        "createError": {
+          "toast": "创建 Slack 机器人出错 - {error}"
+        },
+        "created": {
+          "toast": "Slack 机器人创建成功！"
+        },
+        "docsPrompt": {
+          "text": "如果您不确定如何获取这些 token，请参阅我们的<link>指南</link>！"
+        },
+        "invalidAppToken": {
+          "message": "Slack 应用 Token 无效"
+        },
+        "invalidBotToken": {
+          "message": "Slack 机器人 Token 无效"
+        },
+        "name": {
+          "label": "为此 Slack 机器人命名："
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "updateError": {
+          "toast": "更新 Slack 机器人出错 - {error}"
+        },
+        "updated": {
+          "toast": "Slack 机器人更新成功！"
+        },
+        "userToken": {
+          "label": "Slack 用户 Token（可选）",
+          "subtext": "可选：用于增强私有频道访问权限的用户 OAuth token"
+        }
+      },
+      "updateForm": {
+        "deleteButton": {
+          "label": "删除"
+        },
+        "enabledCheckbox": {
+          "label": "已启用"
+        },
+        "fieldUpdateFailed": {
+          "toast": "更新连接器 {field} 失败"
+        },
+        "fieldUpdated": {
+          "toast": "连接器 {field} 更新成功"
+        },
+        "updateTokensButton": {
+          "label": "更新 Token"
+        }
+      },
+      "validation": {
+        "agentRequired": {
+          "message": "使用“智能体”知识来源时必须选择一个智能体"
+        },
+        "channelNameRequired": {
+          "message": "频道名称为必填项"
+        },
+        "documentSetRequired": {
+          "message": "使用“文档集”知识来源时至少需要选择一个文档集"
+        }
+      }
+    },
+    "ssoProviders": {
+      "addProvider": {
+        "button": {
+          "label": "添加提供商"
+        },
+        "gatedTooltip": "同时启用多个 SSO 提供商需要 Business 或 Enterprise 方案。"
+      },
+      "copyRedirectUri": {
+        "tooltip": "复制重定向 URI"
+      },
+      "editProvider": {
+        "tooltip": "编辑"
+      },
+      "empty": {
+        "description": "添加提供商，让用户可以使用 Google、OIDC 或 SAML 登录。",
+        "title": "尚无 SSO 提供商"
+      },
+      "loadError": {
+        "description": "无法加载 SSO 提供商。",
+        "title": "加载 SSO 提供商失败"
+      },
+      "modals": {
+        "domainVerification": {
+          "description": "只有在您验证域名归属之后，该域名才会自动为您工作区的用户登录。请添加下面的 DNS 记录，然后进行验证。",
+          "loadError": {
+            "message": "我们无法加载 DNS 记录。"
+          },
+          "loading": {
+            "message": "正在加载…"
+          },
+          "pendingDescription": "请在您的 DNS 提供商处添加此 TXT 记录，然后进行验证。",
+          "record": {
+            "labelPrefix": "{label}：",
+            "nameLabel": "名称",
+            "typeLabel": "类型",
+            "valueLabel": "值"
+          },
+          "refreshError": {
+            "message": "我们无法刷新这些记录，因此它们可能已过期。"
+          },
+          "retryButton": {
+            "label": "重试"
+          },
+          "status": {
+            "pending": "待验证",
+            "verified": "已验证"
+          },
+          "title": "域名验证",
+          "verifiedDescription": "此域名会自动为其用户登录。",
+          "verifiedToast": {
+            "message": "{domain} 已验证"
+          },
+          "verifyButton": {
+            "label": "验证域名",
+            "unclaimedTooltip": "请先保存包含此域名的提供商。"
+          }
+        },
+        "provider": {
+          "cancelButton": {
+            "label": "取消"
+          },
+          "configField": {
+            "optionalTitle": "{label}（可选）"
+          },
+          "displayNameField": {
+            "description": "显示在登录按钮上的标签。",
+            "placeholder": "公司 A",
+            "title": "显示名称"
+          },
+          "emailDomainsField": {
+            "description": "只有这些域名下的邮箱才能通过此提供商登录。",
+            "optionalDescription": "只有这些域名下的邮箱才能通过此提供商登录。建议填写，也可以留空以允许任何域名。",
+            "placeholder": "添加域名（例如 onyx.app）",
+            "recommendedTitle": "允许的邮箱域名（推荐）",
+            "title": "允许的邮箱域名"
+          },
+          "header": {
+            "createDescription": "添加用于登录的 SSO 提供商。",
+            "createTitle": "添加 SSO 提供商",
+            "editDescription": "更新此提供商的用户登录方式。",
+            "editTitle": "编辑 {name}"
+          },
+          "nameField": {
+            "description": "用于登录 URL 的唯一小写标识符。创建后无法更改。",
+            "title": "名称"
+          },
+          "providerTypeField": {
+            "description": "此提供商使用的认证协议。",
+            "placeholder": "选择提供商类型",
+            "title": "提供商类型"
+          },
+          "redirectField": {
+            "acsLabel": "ACS（回复）URL",
+            "copyTooltip": "复制 {label}",
+            "description": "请在您的 IdP 中将此 URL 注册为回调地址。",
+            "redirectUriLabel": "重定向 URI"
+          },
+          "submitButton": {
+            "createLabel": "创建",
+            "updateLabel": "更新"
+          },
+          "toasts": {
+            "created": "SSO 提供商已创建",
+            "updated": "SSO 提供商已更新"
+          },
+          "validation": {
+            "displayNameRequired": "显示名称为必填项",
+            "emailDomainsMin": "请至少列出一个可以登录的邮箱域名",
+            "fieldRequired": "{field} 为必填项",
+            "namePattern": "只能使用小写字母、数字和连字符",
+            "nameRequired": "名称为必填项",
+            "providerTypeRequired": "提供商类型为必填项"
+          }
+        }
+      },
+      "page": {
+        "description": "让用户通过您的身份提供商登录。"
+      },
+      "toasts": {
+        "unexpectedError": "发生意外错误。"
+      }
+    },
+    "systemInfo": {
+      "backendVersion": {
+        "label": "后端版本："
+      },
+      "version": {
+        "title": "版本"
+      },
+      "webVersion": {
+        "label": "Web 版本："
+      }
+    },
+    "tokenRateLimits": {
+      "limits": {
+        "budget": {
+          "both": "最多 {cost} 或 {tokens} 个 token",
+          "cost": "最多 {cost}",
+          "none": "未设置预算",
+          "tokens": "最多 {tokens} 个 token"
+        },
+        "cadence": {
+          "label": "{days, plural, one {每天在 UTC 午夜重置} other {每 # 天在 UTC 午夜重置}}"
+        },
+        "deleteFailed": {
+          "error": "删除 token 速率限制失败"
+        },
+        "empty": {
+          "message": "尚无限额。创建支出限额以控制用量。"
+        },
+        "loadFailed": {
+          "error": "加载 token 速率限制失败"
+        },
+        "row": {
+          "delete": {
+            "ariaLabel": "删除 {label}",
+            "tooltip": "删除限额"
+          },
+          "disable": {
+            "ariaLabel": "禁用 {label}"
+          },
+          "enable": {
+            "ariaLabel": "启用 {label}"
+          },
+          "label": "{budget}，{cadence}"
+        },
+        "updateFailed": {
+          "error": "更新 token 速率限制失败"
+        }
+      },
+      "modal": {
+        "cancel": {
+          "label": "取消"
+        },
+        "costBudget": {
+          "description": "每个重置周期的最高支出。可设置费用预算、token 预算，或同时设置两者。",
+          "placeholder": "无费用限额",
+          "title": "费用预算",
+          "unit": "USD"
+        },
+        "errors": {
+          "budgetRequired": "请输入费用预算、token 预算，或同时输入两者",
+          "costMax": "最高费用预算为 ${amount, number}",
+          "costMinCents": "费用预算至少为 $0.01",
+          "costMoreThanZero": "费用预算必须大于 0",
+          "groupRequired": "请选择用户组",
+          "periodInteger": "请输入整数天数",
+          "periodMin": "至少为 1 天",
+          "periodRequired": "请输入重置周期",
+          "scopeRequired": "目标范围为必填项",
+          "tokenIncrement": "请以 1,000 个 token 为增量",
+          "tokenInteger": "请输入整数个 token",
+          "tokenMax": "最高 token 预算为 1 万亿",
+          "tokenMin": "至少为 1,000 个 token"
+        },
+        "groupMenu": {
+          "empty": "尚无用户组。请在“用户与用户组”中创建。"
+        },
+        "groupPicker": {
+          "placeholder": "选择用户组"
+        },
+        "header": {
+          "title": "创建支出限额"
+        },
+        "period": {
+          "description": "预算在 UTC 午夜重置",
+          "title": "重置周期",
+          "unit": "天"
+        },
+        "scope": {
+          "caption": {
+            "global": "工作区中的所有人共享一个预算。",
+            "group": "{group} 的成员共享一个预算。",
+            "groupUnchosen": "所选用户组的成员共享一个预算。",
+            "user": "每位用户拥有各自的预算。"
+          },
+          "title": "应用范围"
+        },
+        "scopeOptions": {
+          "global": {
+            "title": "工作区"
+          },
+          "user": {
+            "title": "每位用户"
+          },
+          "userGroup": {
+            "title": "用户组"
+          }
+        },
+        "submit": {
+          "label": "创建限额"
+        },
+        "summary": {
+          "budget": {
+            "both": "{cost} 或 {tokens} 个 token",
+            "tokens": "{tokens} 个 token"
+          },
+          "global": "{days, plural, one {工作区中的所有人每天共享最多 {budget} 的额度。在周期重置之前将无法继续使用。} other {工作区中的所有人每 # 天共享最多 {budget} 的额度。在周期重置之前将无法继续使用。}}",
+          "group": "{days, plural, one {每天，{group} 的成员共享最多 {budget} 的额度。在周期重置之前将无法继续使用。} other {每 # 天，{group} 的成员共享最多 {budget} 的额度。在周期重置之前将无法继续使用。}}",
+          "groupUnchosen": "{days, plural, one {所选用户组的成员每天共享最多 {budget} 的额度。在周期重置之前将无法继续使用。} other {所选用户组的成员每 # 天共享最多 {budget} 的额度。在周期重置之前将无法继续使用。}}",
+          "user": "{days, plural, one {每位用户每天最多可花费 {budget}。在周期重置之前将无法继续使用。} other {每位用户每 # 天最多可花费 {budget}。在周期重置之前将无法继续使用。}}"
+        },
+        "tokenBudget": {
+          "description": "每个重置周期的最大 token 数",
+          "placeholder": "无 token 限额",
+          "title": "Token 预算",
+          "unit": "token"
+        },
+        "userGroup": {
+          "description": "选择共享此预算的用户组",
+          "title": "用户组"
+        }
+      },
+      "panel": {
+        "create": {
+          "label": "创建支出限额"
+        },
+        "createFailed": {
+          "error": "创建支出限额失败"
+        },
+        "created": {
+          "message": "支出限额已创建！"
+        },
+        "embedded": {
+          "description": "为工作区、用户和用户组的用量设置护栏。可以启用或禁用限额，无需删除其配置。",
+          "title": "管理支出限额"
+        },
+        "global": {
+          "description": "全局限额适用于所有用户、用户组和 API 密钥。达到全局限额后，将无法再消耗 token。"
+        },
+        "intro": {
+          "description": "支出限额帮助您控制在给定时间段内可以消耗多少 token。",
+          "groupLimit": "为用户组设置限额，以控制团队的支出。",
+          "toggleLimit": "根据需要启用和禁用限额。",
+          "userLimit": "为用户设置限额，避免单个用户支出过多。",
+          "workspaceLimit": "设置工作区级限额，控制团队的总体支出。"
+        },
+        "tabs": {
+          "global": {
+            "name": "全局"
+          },
+          "groups": {
+            "name": "用户组"
+          },
+          "users": {
+            "name": "用户"
+          }
+        },
+        "user": {
+          "description": "用户限额分别应用于每位用户。当用户达到限额时，将暂时无法消耗 token。"
+        },
+        "userGroup": {
+          "description": "用户组限额适用于组内的所有用户。如果用户属于多个用户组，则以最宽松的限额为准。"
+        }
+      }
+    },
+    "tracing": {
+      "disconnectModal": {
+        "body": "LLM 调用追踪将不再发送到 **{label}**。已发送的追踪不受影响。",
+        "description": "停止向此提供商发送 LLM 调用追踪。",
+        "submit": {
+          "label": "断开连接"
+        },
+        "title": "断开 {label} 的连接"
+      },
+      "field": {
+        "optional": {
+          "title": "{label}（可选）"
+        },
+        "required": {
+          "error": "{label} 为必填项"
+        }
+      },
+      "loadError": {
+        "description": "无法加载追踪配置。",
+        "title": "加载追踪设置失败"
+      },
+      "page": {
+        "description": "连接可观测性平台，以监控和评估 LLM 调用。"
+      },
+      "provider": {
+        "connected": {
+          "label": "已连接"
+        }
+      },
+      "setupModal": {
+        "cancel": {
+          "label": "取消"
+        },
+        "connect": {
+          "label": "连接"
+        },
+        "createTitle": "设置 {label}",
+        "description": "连接到 {label} 以发送 LLM 调用追踪。",
+        "editTitle": "配置 {label}",
+        "update": {
+          "label": "更新"
+        }
+      },
+      "toasts": {
+        "connected": "{label} 已连接",
+        "disconnected": "{label} 已断开连接",
+        "unexpectedError": "发生意外错误。"
+      }
+    },
+    "usage": {
+      "detail": {
+        "breakdown": {
+          "byFlow": {
+            "title": "按流程"
+          },
+          "byModel": {
+            "title": "按模型"
+          },
+          "byProvider": {
+            "title": "按提供商"
+          },
+          "slice": {
+            "ariaLabel": "{label} 占支出的比例",
+            "summary": " · {percent}% · {tokens} 个 token"
+          }
+        },
+        "dailySpend": {
+          "chart": {
+            "ariaLabel": "所选周期的每日支出：{days}"
+          },
+          "day": {
+            "ariaLabel": "{day}，{cost}",
+            "tooltip": "{day} · {cost}"
+          },
+          "title": "每日支出"
+        },
+        "done": {
+          "label": "完成"
+        },
+        "empty": {
+          "description": "此周期内没有按模型统计的记录。"
+        },
+        "stats": {
+          "cacheReads": {
+            "label": "缓存读取"
+          },
+          "cacheWrites": {
+            "label": "缓存写入"
+          },
+          "inputTokens": {
+            "label": "输入 token"
+          },
+          "outputTokens": {
+            "label": "输出 token"
+          },
+          "spend": {
+            "label": "支出"
+          }
+        }
+      },
+      "spendByUser": {
+        "columns": {
+          "input": {
+            "header": "输入"
+          },
+          "output": {
+            "header": "输出"
+          },
+          "spend": {
+            "header": "支出"
+          },
+          "tokens": {
+            "header": "Token"
+          },
+          "user": {
+            "header": "用户"
+          }
+        },
+        "empty": {
+          "description": "没有符合当前筛选条件的用量。"
+        },
+        "filters": {
+          "allFlows": {
+            "label": "所有流程"
+          },
+          "allModels": {
+            "label": "所有模型"
+          }
+        },
+        "row": {
+          "ariaLabel": "查看 {email} 的用量详情"
+        },
+        "rowCount": {
+          "label": "{count, plural, one {# 位用户} other {# 位用户}}"
+        },
+        "search": {
+          "ariaLabel": "按邮箱搜索用户",
+          "placeholder": "按邮箱搜索用户…"
+        }
+      }
+    },
+    "users": {
+      "accountType": {
+        "anonymous": {
+          "label": "匿名"
+        },
+        "bot": {
+          "label": "Slack 机器人"
+        },
+        "extPermUser": {
+          "label": "外部用户"
+        },
+        "serviceAccount": {
+          "label": "服务账号"
+        },
+        "standard": {
+          "label": "标准"
+        }
+      },
+      "activateModal": {
+        "description": "<strong>{email}</strong> 将重新获得 Onyx 的访问权限。",
+        "submit": {
+          "label": "激活"
+        },
+        "title": "激活用户",
+        "toasts": {
+          "success": "用户已激活"
+        }
+      },
+      "cancelInviteModal": {
+        "description": "<strong>{email}</strong> 将无法再使用此邀请加入 Onyx。",
+        "submit": {
+          "label": "取消邀请"
+        },
+        "title": "取消邀请",
+        "toasts": {
+          "success": "邀请已取消"
+        }
+      },
+      "deactivateModal": {
+        "description": "<strong>{email}</strong> 将立即失去 Onyx 的访问权限。其会话和智能体将被保留，占用的许可席位将被释放。您可以稍后重新激活此账号。",
+        "submit": {
+          "label": "停用"
+        },
+        "title": "停用用户",
+        "toasts": {
+          "success": "用户已停用"
+        }
+      },
+      "deleteModal": {
+        "description": "<strong>{email}</strong> 将从 Onyx 中永久移除。其所有会话历史都将被删除。删除操作无法撤销。",
+        "submit": {
+          "label": "删除"
+        },
+        "title": "删除用户",
+        "toasts": {
+          "success": "用户已删除"
+        }
+      },
+      "editModal": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "groupList": {
+          "loading": {
+            "description": "正在加载用户组...",
+            "title": "加载中..."
+          },
+          "memberCount": "{count, plural, one {# 位用户} other {# 位用户}}",
+          "noResults": {
+            "description": "请尝试其他搜索词。",
+            "title": "未找到用户组"
+          }
+        },
+        "joinedGroups": {
+          "empty": {
+            "description": "{name} 不属于任何用户组。",
+            "title": "未找到用户组"
+          }
+        },
+        "removeGroupButton": {
+          "tooltip": "移出用户组"
+        },
+        "saveButton": {
+          "label": "保存更改"
+        },
+        "search": {
+          "placeholder": "搜索要加入的用户组..."
+        },
+        "title": "编辑用户所属的用户组",
+        "toasts": {
+          "error": "发生错误",
+          "updated": "用户已更新"
+        }
+      },
+      "filters": {
+        "accountType": {
+          "allOption": {
+            "label": "所有账户类型"
+          },
+          "button": {
+            "ariaLabel": "按账户类型筛选"
+          }
+        },
+        "button": {
+          "moreLabel": "{names}，+{count}"
+        },
+        "group": {
+          "allOption": {
+            "label": "所有用户组"
+          },
+          "button": {
+            "ariaLabel": "按用户组筛选"
+          },
+          "empty": {
+            "label": "未找到用户组"
+          },
+          "search": {
+            "placeholder": "搜索用户组..."
+          }
+        },
+        "status": {
+          "allOption": {
+            "label": "所有状态"
+          },
+          "button": {
+            "ariaLabel": "按状态筛选"
+          }
+        }
+      },
+      "groupsCell": {
+        "editButton": {
+          "tooltip": "编辑"
+        },
+        "editCell": {
+          "ariaLabel": "编辑用户组"
+        },
+        "overflow": {
+          "label": "+{count}"
+        }
+      },
+      "inviteModal": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "emails": {
+          "placeholder": "添加要邀请的邮箱，用空格或逗号分隔"
+        },
+        "message": {
+          "needsValidEmail": "请输入有效的邮箱地址以发送邀请。",
+          "readyCount": "{count, plural, one {# 个待邀请邮箱} other {# 个待邀请邮箱}}",
+          "someInvalid": "部分邮箱地址无效，将被跳过。"
+        },
+        "submitButton": {
+          "label": "邀请"
+        },
+        "title": "邀请用户",
+        "toasts": {
+          "inviteFailed": "邀请用户失败",
+          "invited": "{count, plural, one {已邀请 # 位用户} other {已邀请 # 位用户}}",
+          "noValidEmails": "请至少添加一个有效的邮箱地址"
+        }
+      },
+      "modals": {
+        "toasts": {
+          "error": "发生错误"
+        }
+      },
+      "page": {
+        "inviteButton": {
+          "label": "邀请用户"
+        },
+        "title": "用户与申请"
+      },
+      "permissionsNotice": {
+        "description": "Onyx 现在使用基于用户组的权限。策展人和全局策展人角色已由可配置的用户组权限取代，并可为每个用户组指定管理者，实现范围化管理。",
+        "learnMoreButton": {
+          "label": "了解更多"
+        },
+        "title": "权限已变更"
+      },
+      "resetPasswordModal": {
+        "description": "这将为 <strong>{email}</strong> 生成一个新的随机密码。该用户当前的密码将立即失效。",
+        "doneButton": {
+          "label": "完成"
+        },
+        "submit": {
+          "label": "重置密码"
+        },
+        "successDescription": "<strong>{email}</strong> 的密码已重置。请复制下方的新密码 — 它不会再次显示。",
+        "successTitle": "密码已重置",
+        "title": "重置密码",
+        "toasts": {
+          "error": "重置密码失败"
+        }
+      },
+      "rowActions": {
+        "activate": {
+          "label": "启用用户"
+        },
+        "approve": {
+          "label": "批准"
+        },
+        "cancelInvite": {
+          "label": "取消邀请"
+        },
+        "deactivate": {
+          "label": "停用用户"
+        },
+        "delete": {
+          "label": "删除用户"
+        },
+        "editGroups": {
+          "label": "用户组与角色"
+        },
+        "makeAdmin": {
+          "label": "设为管理员"
+        },
+        "removeAdmin": {
+          "label": "移除管理员权限"
+        },
+        "resetPassword": {
+          "label": "重置密码"
+        },
+        "scimNotice": {
+          "description": "这是由您的身份提供方管理的 SCIM 同步用户。"
+        },
+        "toasts": {
+          "adminAccessGranted": "该用户现在是管理员",
+          "adminAccessRemoved": "已移除管理员权限",
+          "error": "发生错误",
+          "requestApproved": "申请已批准"
+        }
+      },
+      "status": {
+        "active": {
+          "label": "已启用"
+        },
+        "inactive": {
+          "label": "已停用"
+        },
+        "invited": {
+          "label": "邀请待接受"
+        },
+        "requested": {
+          "label": "申请加入"
+        }
+      },
+      "summary": {
+        "activeUsers": {
+          "label": "活跃用户"
+        },
+        "filterButton": {
+          "tooltip": "添加筛选条件"
+        },
+        "pendingInvites": {
+          "label": "待接受邀请"
+        },
+        "requests": {
+          "label": "加入申请"
+        },
+        "scim": {
+          "description": "用户从您的身份提供方同步。",
+          "manageButton": {
+            "label": "管理"
+          },
+          "title": "SCIM 同步"
+        },
+        "statCell": {
+          "ariaLabel": "按 {label} 筛选"
+        }
+      },
+      "table": {
+        "columns": {
+          "accountType": {
+            "header": "账户类型"
+          },
+          "groups": {
+            "header": "用户组"
+          },
+          "lastUpdated": {
+            "header": "最后更新"
+          },
+          "name": {
+            "header": "名称"
+          },
+          "status": {
+            "header": "状态"
+          }
+        },
+        "downloadCsvButton": {
+          "ariaLabel": "下载 CSV",
+          "tooltip": "下载 CSV"
+        },
+        "empty": {
+          "description": "没有用户符合当前的筛选条件。",
+          "title": "未找到用户"
+        },
+        "error": {
+          "description": "加载用户失败。请尝试刷新页面。"
+        },
+        "search": {
+          "placeholder": "搜索用户..."
+        },
+        "status": {
+          "scimSynced": {
+            "label": "SCIM 已同步"
+          }
+        },
+        "toasts": {
+          "downloadFailed": "下载 CSV 失败"
+        }
+      }
+    },
+    "voice": {
+      "disconnectModal": {
+        "body": {
+          "description": "**{label}** 模型将不再用于语音转文字或文字转语音，也不再是您的默认模型。会话历史将会保留。"
+        },
+        "connectAnother": {
+          "description": "连接其他提供方以继续使用语音功能。"
+        },
+        "disconnectError": {
+          "message": "断开提供方连接失败。"
+        },
+        "disconnectSuccess": {
+          "message": "{label} 已断开连接"
+        },
+        "header": {
+          "description": "这将删除为此提供方存储的凭据。",
+          "title": "断开 {label} 连接"
+        },
+        "submitButton": {
+          "label": "断开连接"
+        }
+      },
+      "header": {
+        "description": "配置语音转文字和文字转语音提供方，用于语音输入和语音回复。",
+        "title": "语音"
+      },
+      "models": {
+        "azureSpeechStt": {
+          "subtitle": "Microsoft Foundry Tools 中的语音转文字。"
+        },
+        "azureSpeechTts": {
+          "subtitle": "Microsoft Foundry Tools 中的文字转语音。"
+        },
+        "elevenlabsStt": {
+          "subtitle": "ElevenLabs 语音转文字 API。"
+        },
+        "elevenlabsTts": {
+          "subtitle": "ElevenLabs 文字转语音 API。"
+        },
+        "tts1": {
+          "subtitle": "OpenAI 针对速度优化的文字转语音模型。"
+        },
+        "tts1Hd": {
+          "subtitle": "OpenAI 针对质量优化的文字转语音模型。"
+        },
+        "whisper": {
+          "subtitle": "OpenAI 的通用语音识别模型。"
+        }
+      },
+      "setupModal": {
+        "apiKey": {
+          "description": "粘贴来自 {provider} 的 [API 密钥]({url})，以访问您的模型。",
+          "label": "API 密钥",
+          "placeholder": "API 密钥",
+          "required": "API 密钥为必填项"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "connectButton": {
+          "label": "连接"
+        },
+        "connectionTestFailed": {
+          "message": "连接测试失败"
+        },
+        "createHeader": {
+          "title": "设置 {provider}"
+        },
+        "editHeader": {
+          "title": "配置 {provider}"
+        },
+        "header": {
+          "description": "连接到 {provider} 并设置您的语音模型。"
+        },
+        "saveError": {
+          "message": "保存提供方失败"
+        },
+        "sttLanguages": {
+          "azureCapExceeded": "Azure 最多支持 {cap} 种语音语言",
+          "description": "用户可能使用的区域设置，以逗号分隔，例如 `en-US, fr-FR`。设置多个时，实时转录会自动检测所说的语言（上传的音频使用第一个）。请参阅[支持的区域设置]({docsUrl})。",
+          "invalid": "请输入以逗号分隔的区域设置，例如 en-US, fr-FR（每种语言一个）",
+          "label": "语音语言",
+          "selfHostedCapExceeded": "自托管端点最多支持 {cap} 种语音语言（在开始时检测）"
+        },
+        "sttModel": {
+          "label": "STT 模型"
+        },
+        "targetUri": {
+          "description": "粘贴 [Azure Portal（密钥和终结点）]({portalUrl}) 中显示的终结点。Onyx 会从该 URL 中提取语音区域。示例：`https://westus.api.cognitive.microsoft.com/` 或 `https://westus.tts.speech.microsoft.com/`。",
+          "label": "目标 URI",
+          "required": "目标 URI 为必填项"
+        },
+        "ttsModel": {
+          "description": "Onyx 将默认使用此模型进行文字转语音。",
+          "label": "默认模型"
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "voice": {
+          "description": "此音色将用于语音回复。请在 [{docsLabel}]({docsUrl}) 查看支持的语言和音色的完整列表。",
+          "label": "音色",
+          "loadingPlaceholder": "正在加载音色...",
+          "placeholder": "选择音色或输入音色 ID"
+        }
+      },
+      "speechToText": {
+        "description": "选择用于在聊天中将语音转录为文字的模型。",
+        "emptyState": {
+          "title": "连接语音转文字提供方，以在聊天中使用。"
+        },
+        "title": "语音转文字"
+      },
+      "textToSpeech": {
+        "description": "选择用于朗读聊天回复的模型。",
+        "emptyState": {
+          "title": "连接文字转语音提供方，以在聊天中使用。"
+        },
+        "title": "文字转语音"
+      },
+      "unexpectedError": {
+        "message": "发生意外错误。"
+      }
+    },
+    "webSearch": {
+      "apiKeyField": {
+        "noLink": {
+          "description": "粘贴来自 {provider} 的 API 密钥以进行连接。"
+        },
+        "placeholder": "API 密钥",
+        "title": "API 密钥",
+        "withLink": {
+          "description": "粘贴来自 {provider} 的 [API 密钥]({url}) 以进行连接。"
+        }
+      },
+      "crawler": {
+        "currentCrawler": {
+          "label": "当前爬虫"
+        },
+        "description": "用于读取搜索结果页面的完整内容。",
+        "title": "网页爬虫"
+      },
+      "customIntegration": {
+        "subtitle": "自定义集成"
+      },
+      "disconnectModal": {
+        "connectAnother": {
+          "description": "连接其他搜索引擎以继续使用网页搜索。"
+        },
+        "content": {
+          "description": "**{label}** 将不再用于读取搜索结果网页。"
+        },
+        "disconnectSuccess": {
+          "message": "{label} 已断开连接"
+        },
+        "fallback": {
+          "description": "Onyx 将回退到内置的网页爬虫。"
+        },
+        "header": {
+          "description": "这将删除为此提供方存储的凭据。",
+          "title": "断开 {label} 连接"
+        },
+        "search": {
+          "description": "网页搜索将不再通过 **{label}** 进行。搜索历史将会保留。"
+        },
+        "submitButton": {
+          "label": "断开连接"
+        }
+      },
+      "header": {
+        "description": "面向互联网的外部搜索设置。",
+        "title": "网页搜索"
+      },
+      "loadError": {
+        "description": "无法加载网页搜索配置。",
+        "title": "加载网页搜索设置失败"
+      },
+      "searchEngine": {
+        "connectPrompt": {
+          "title": "连接搜索引擎以设置网页搜索。"
+        },
+        "description": "用于获取网页搜索结果 URL、摘要和元数据的外部搜索引擎 API。",
+        "selectPrompt": {
+          "title": "选择搜索引擎以启用网页搜索。"
+        },
+        "title": "搜索引擎"
+      },
+      "setupModal": {
+        "apiKey": {
+          "required": "API 密钥为必填项"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "config": {
+          "required": "{title} 为必填项"
+        },
+        "connectButton": {
+          "label": "连接"
+        },
+        "connectSuccess": {
+          "message": "提供方已连接"
+        },
+        "createHeader": {
+          "title": "设置 {provider}"
+        },
+        "editHeader": {
+          "title": "配置 {provider}"
+        },
+        "updateButton": {
+          "label": "更新"
+        }
+      },
+      "unexpectedError": {
+        "message": "发生意外错误。"
+      }
+    }
+  },
+  "agents": {
+    "card": {
+      "actionsCount": {
+        "label": "{count, plural, =0 {无操作} one {# 个操作} other {# 个操作}}"
+      },
+      "edit": {
+        "tooltip": "编辑智能体"
+      },
+      "pin": {
+        "tooltip": "固定到侧边栏"
+      },
+      "share": {
+        "tooltip": "分享智能体"
+      },
+      "startChat": {
+        "label": "开始聊天"
+      },
+      "unpin": {
+        "tooltip": "从侧边栏取消固定"
+      },
+      "viewStats": {
+        "tooltip": "查看智能体统计"
+      }
+    },
+    "filters": {
+      "actions": {
+        "all": {
+          "label": "所有操作"
+        },
+        "multiple": {
+          "label": "已选择 {count} 项"
+        },
+        "search": {
+          "placeholder": "筛选操作..."
+        }
+      },
+      "creator": {
+        "all": {
+          "label": "所有人"
+        },
+        "me": {
+          "description": "我"
+        },
+        "multiple": {
+          "label": "{count} 人"
+        },
+        "search": {
+          "placeholder": "创建者..."
+        },
+        "single": {
+          "label": "由 {email} 创建"
+        }
+      }
+    },
+    "modals": {
+      "agentButton": {
+        "unpin": {
+          "tooltip": "取消固定智能体"
+        }
+      },
+      "moveCustomAgentChat": {
+        "body": {
+          "description": "此聊天使用<b>自定义智能体</b>，将它移动到<b>项目</b>不会覆盖该智能体的提示词或知识配置。此操作仅用于整理归类。"
+        },
+        "confirm": {
+          "label": "确认移动"
+        },
+        "doNotShowAgain": {
+          "label": "不再显示"
+        },
+        "title": "移动自定义智能体聊天"
+      },
+      "noAgent": {
+        "admin": {
+          "description": "作为管理员，您可以前往管理面板创建新的智能体，也可以重新启用默认聊天。"
+        },
+        "body": {
+          "description": "当前没有可用的已配置智能体。默认聊天也已被明确禁用。"
+        },
+        "configureAgent": {
+          "label": "配置新的智能体"
+        },
+        "nonAdmin": {
+          "description": "请联系您的管理员为您配置智能体，或重新启用默认聊天。"
+        },
+        "reenableDefaultChat": {
+          "label": "重新启用默认聊天"
+        },
+        "title": "没有可用的智能体"
+      },
+      "shareAgent": {
+        "admins": {
+          "description": "{count, plural, one {# 位用户} other {# 位用户}}",
+          "title": "管理员"
+        },
+        "agentFallback": {
+          "name": "智能体"
+        },
+        "back": {
+          "label": "返回"
+        },
+        "cancel": {
+          "label": "取消"
+        },
+        "copyLink": {
+          "label": "复制链接"
+        },
+        "done": {
+          "label": "完成"
+        },
+        "loading": {
+          "description": "正在加载分享详情..."
+        },
+        "permission": {
+          "edit": {
+            "label": "编辑"
+          },
+          "owner": {
+            "label": "所有者"
+          }
+        },
+        "publicPermissionMenu": {
+          "ariaLabel": "更改公开权限"
+        },
+        "row": {
+          "updateAccess": {
+            "ariaLabel": "更新 {name} 的访问权限"
+          },
+          "you": {
+            "title": "{email}（您）"
+          }
+        },
+        "save": {
+          "label": "保存"
+        },
+        "scopeMenu": {
+          "ariaLabel": "更改分享范围"
+        },
+        "share": {
+          "title": "分享 *{name}*"
+        },
+        "toasts": {
+          "accessRemoved": "已移除访问权限。",
+          "copyLinkFailed": "复制链接失败。",
+          "linkCopied": "已复制链接。",
+          "ownershipTransferred": "所有权已转移。",
+          "sharingUpdated": "分享设置已更新。"
+        },
+        "transfer": {
+          "label": "转移",
+          "title": "转移 *{name}*"
+        }
+      },
+      "viewer": {
+        "actions": {
+          "empty": {
+            "title": "无操作"
+          },
+          "title": "操作与工具"
+        },
+        "conversationStarters": {
+          "title": "对话开场白"
+        },
+        "defaultModel": {
+          "description": "Onyx 将在您的聊天中默认使用此模型。",
+          "title": "默认模型"
+        },
+        "featured": {
+          "label": "精选"
+        },
+        "instructions": {
+          "title": "指令"
+        },
+        "knowledge": {
+          "empty": {
+            "title": "无知识"
+          },
+          "title": "知识"
+        },
+        "knowledgeCutoff": {
+          "description": "最后更新日期早于此日期的文档将被忽略。",
+          "title": "知识截止日期"
+        },
+        "mcpCard": {
+          "expand": {
+            "label": "展开"
+          },
+          "fold": {
+            "label": "折叠"
+          }
+        },
+        "moreInfo": {
+          "title": "更多信息"
+        },
+        "overwritePrompts": {
+          "description": "移除包含实用指令的基础系统提示词（例如“您可以使用 Markdown 表格”）。这可能影响回复质量。",
+          "title": "覆盖系统提示词"
+        },
+        "promptReminders": {
+          "title": "提示词提醒"
+        },
+        "public": {
+          "label": "对您的组织公开"
+        }
+      }
+    },
+    "userVariables": {
+      "insert": {
+        "tooltip": "插入用户变量"
+      }
+    }
+  },
+  "auth": {
+    "createAccount": {
+      "createOrgButton": {
+        "label": "创建新组织"
+      },
+      "createTeamOption": {
+        "text": "创建新的 Onyx 团队"
+      },
+      "differentEmailPrompt": {
+        "text": "拥有使用其他邮箱的账户？"
+      },
+      "heading": {
+        "title": "未找到账户"
+      },
+      "inviteOption": {
+        "text": "受邀加入现有的 Onyx 团队"
+      },
+      "notFound": {
+        "description": "我们在记录中找不到您的账户。要访问 Onyx，您需要执行以下操作之一："
+      },
+      "signInLink": {
+        "label": "登录"
+      }
+    },
+    "error": {
+      "accessRestrictionIssue": {
+        "description": "账户访问限制或权限问题"
+      },
+      "cloudSupportPrompt": {
+        "text": "如果问题持续存在，请通过 <link>support@onyx.app</link> 联系 Onyx 团队"
+      },
+      "code": {
+        "accessDenied": "您的身份提供方拒绝了访问。",
+        "consentRequired": "您的身份提供方要求先同意授权才能继续。",
+        "interactionRequired": "需要与您的身份提供方进行额外的交互。",
+        "invalidScope": "请求的权限不可用。",
+        "loginBadCredentials": "此账户无法登录，可能已被停用。请联系您的工作区管理员。",
+        "loginRequired": "您需要先通过身份提供方登录。",
+        "oauthUserAlreadyExists": "使用此邮箱的账户已通过其他登录方式存在。请使用您首次使用的方式登录，或请管理员关联此提供方。",
+        "serverError": "您的身份提供方遇到错误。请重试。",
+        "temporarilyUnavailable": "您的身份提供方暂时不可用。请稍后重试。"
+      },
+      "credentialsIssue": {
+        "description": "登录凭据不正确或已过期"
+      },
+      "heading": {
+        "description": "您的登录尝试出现问题。",
+        "title": "身份验证错误"
+      },
+      "possibleIssues": {
+        "title": "可能的原因："
+      },
+      "returnToLoginButton": {
+        "label": "返回登录页面"
+      },
+      "selfHostedSupportPrompt": {
+        "text": "如果问题持续存在，请联系您的系统管理员寻求帮助。"
+      },
+      "systemDisruptionIssue": {
+        "description": "身份验证系统临时中断"
+      }
+    },
+    "forgotPassword": {
+      "backToLoginLink": {
+        "label": "[返回登录](/auth/login)"
+      },
+      "emailField": {
+        "label": "邮箱"
+      },
+      "emailSent": {
+        "toast": "密码重置邮件已发送。请查收您的收件箱。"
+      },
+      "genericError": {
+        "toast": "重置密码时发生错误。"
+      },
+      "heading": {
+        "title": "忘记密码"
+      },
+      "submitButton": {
+        "label": "重置密码"
+      },
+      "unexpectedError": {
+        "toast": "发生错误。请重试。"
+      }
+    },
+    "impersonate": {
+      "adminNote": {
+        "text": "注意：此功能仅面向 @onyx.app 管理员开放"
+      },
+      "apiKeyField": {
+        "label": "API 密钥",
+        "placeholder": "输入 API 密钥"
+      },
+      "emailField": {
+        "label": "邮箱"
+      },
+      "genericError": {
+        "toast": "模拟用户失败"
+      },
+      "heading": {
+        "title": "模拟用户"
+      },
+      "invalidEmail": {
+        "error": "邮箱无效"
+      },
+      "requiredField": {
+        "error": "必填"
+      },
+      "submitButton": {
+        "label": "模拟用户"
+      }
+    },
+    "join": {
+      "heading": {
+        "title": "重新验证身份以加入团队"
+      },
+      "orDivider": {
+        "text": "或"
+      }
+    },
+    "login": {
+      "createAccountButton": {
+        "label": "创建账户"
+      },
+      "noSsoProviders": {
+        "error": "该地址未设置 SSO 登录。请尝试使用 Google 或下方的密码登录。"
+      },
+      "resetPasswordButton": {
+        "label": "重置密码"
+      },
+      "signupPrompt": {
+        "text": "还没有账户？"
+      },
+      "ssoEmailInvalid": {
+        "error": "请输入有效的邮箱地址"
+      },
+      "ssoEmailRequired": {
+        "error": "邮箱为必填项"
+      },
+      "ssoMissingAuthUrl": {
+        "error": "登录响应中缺少授权 URL"
+      },
+      "ssoSignInButton": {
+        "label": "使用 SSO 登录"
+      },
+      "ssoStartFailed": {
+        "error": "无法开始登录（状态 {status}）"
+      },
+      "verifiedMessage": {
+        "title": "您的邮箱已验证！请登录以继续。"
+      },
+      "workEmailField": {
+        "label": "工作邮箱"
+      }
+    },
+    "resetPassword": {
+      "backToLoginLink": {
+        "label": "[返回登录](/auth/login)"
+      },
+      "confirmPasswordField": {
+        "label": "确认新密码",
+        "placeholder": "确认您的新密码"
+      },
+      "confirmPasswordRequired": {
+        "error": "确认密码为必填项"
+      },
+      "genericError": {
+        "toast": "重置密码时发生错误。"
+      },
+      "heading": {
+        "title": "重置密码"
+      },
+      "invalidPassword": {
+        "error": "密码无效"
+      },
+      "missingToken": {
+        "toast": "重置令牌无效或缺失。"
+      },
+      "newPasswordField": {
+        "label": "新密码",
+        "placeholder": "输入您的新密码"
+      },
+      "passwordRequired": {
+        "error": "密码为必填项"
+      },
+      "passwordsMatch": {
+        "error": "两次输入的密码必须一致"
+      },
+      "submitButton": {
+        "label": "重置密码"
+      },
+      "successRedirect": {
+        "toast": "密码重置成功。正在跳转到登录页面..."
+      },
+      "unexpectedError": {
+        "toast": "发生意外错误。请重试。"
+      }
+    },
+    "signup": {
+      "cloudSignupHeading": {
+        "title": "完成注册"
+      },
+      "createAccountHeading": {
+        "title": "创建账户"
+      },
+      "orDivider": {
+        "text": "或"
+      },
+      "referralOptionAds": {
+        "label": "广告"
+      },
+      "referralOptionBlog": {
+        "label": "文章/博客"
+      },
+      "referralOptionFriend": {
+        "label": "朋友/同事"
+      },
+      "referralOptionHackernews": {
+        "label": "HackerNews"
+      },
+      "referralOptionLinkedin": {
+        "label": "LinkedIn"
+      },
+      "referralOptionOther": {
+        "label": "其他"
+      },
+      "referralOptionPodcast": {
+        "label": "播客"
+      },
+      "referralOptionReddit": {
+        "label": "Reddit"
+      },
+      "referralOptionSearch": {
+        "label": "搜索引擎（Google/Bing）"
+      },
+      "referralOptionTwitter": {
+        "label": "Twitter"
+      },
+      "referralOptionYoutube": {
+        "label": "YouTube"
+      },
+      "referralPlaceholder": {
+        "placeholder": "请选择一个选项"
+      },
+      "referralQuestion": {
+        "label": "您是如何了解到我们的？"
+      },
+      "subtitle": {
+        "text": "开始使用 Onyx"
+      }
+    },
+    "verifyEmail": {
+      "getNewEmailLink": {
+        "label": "获取新的验证邮件"
+      },
+      "missingToken": {
+        "error": "缺少验证令牌。请尝试重新请求验证邮件。"
+      },
+      "unknownError": {
+        "text": "未知错误"
+      },
+      "verificationFailed": {
+        "error": "验证您的邮箱失败 - {errorDetail}。请尝试重新请求验证邮件。"
+      },
+      "verifying": {
+        "text": "正在验证您的邮箱..."
+      }
+    },
+    "waitingOnVerification": {
+      "emailSent": {
+        "toast": "新的验证邮件已发送！"
+      },
+      "greeting": {
+        "text": "您好，*{email}*，看起来您还没有验证邮箱。\n请查收我们发送的邮件，然后开始使用！"
+      },
+      "helpPrompt": {
+        "text": "如果没有收到，请点击<link>这里</link>重新请求邮件。"
+      },
+      "sendFailed": {
+        "toast": "发送新的验证邮件失败 - {errorDetail}"
+      }
+    }
+  },
+  "cards": {
+    "file": {
+      "processing": {
+        "description": "正在处理..."
+      },
+      "remove": {
+        "label": "移除"
+      },
+      "uploading": {
+        "description": "正在上传..."
+      }
+    },
+    "skill": {
+      "dependency": {
+        "appDisabled": "应用“{app}”已禁用",
+        "connectToEnable": "连接应用“{app}”以启用",
+        "connectToUse": "连接应用“{app}”以使用",
+        "nameConflict": "已启用另一个同名技能",
+        "usesApp": "使用应用“{app}”"
+      },
+      "edit": {
+        "tooltip": "编辑技能"
+      },
+      "invalid": {
+        "description": "删除此无效技能，然后创建一个新技能。"
+      },
+      "tags": {
+        "appSkill": {
+          "label": "应用技能"
+        },
+        "builtin": {
+          "label": "内置"
+        },
+        "custom": {
+          "label": "自定义"
+        },
+        "invalid": {
+          "label": "无效"
+        },
+        "personal": {
+          "label": "个人"
+        },
+        "unavailable": {
+          "label": "不可用 - 点击了解更多"
+        }
+      },
+      "toggle": {
+        "disable": {
+          "ariaLabel": "禁用 {name}"
+        },
+        "disableForApp": {
+          "ariaLabel": "为 {app} 禁用 {name}"
+        },
+        "enable": {
+          "ariaLabel": "启用 {name}"
+        },
+        "enableForApp": {
+          "ariaLabel": "为 {app} 启用 {name}"
+        }
+      },
+      "tooltips": {
+        "appDisabled": "应用“{app}”已被管理员禁用。",
+        "connectApp": "请在“应用”页面连接应用“{app}”，以使用此技能。",
+        "invalid": "此技能无效。请删除它并创建新技能。",
+        "unavailable": "技能当前不可用。点击查看详情。"
+      }
+    }
+  },
+  "chat": {
+    "app": {
+      "failedFiles": {
+        "toast": "{count, plural, one {文件处理失败并已移除：{names}} other {文件处理失败并已移除：{names}}}"
+      },
+      "newChatButton": {
+        "label": "开始新聊天"
+      },
+      "noPreviousMessage": {
+        "toast": "未找到先前提交的用户消息。"
+      },
+      "oauthConnected": {
+        "toast": "身份验证成功"
+      },
+      "scrollToBottomButton": {
+        "label": "滚动到底部"
+      },
+      "sessionAccessDenied": {
+        "description": "您没有查看此聊天会话的权限。",
+        "title": "访问被拒绝"
+      },
+      "sessionGenericError": {
+        "title": "出了点问题"
+      },
+      "sessionNotFound": {
+        "description": "此聊天会话不存在或已被删除。",
+        "title": "未找到聊天"
+      },
+      "sourcesModal": {
+        "title": "来源"
+      }
+    },
+    "banners": {
+      "collapsedSiblings": {
+        "label": "+{count} 条"
+      },
+      "connectorInvalid": {
+        "aggregate": {
+          "description": "多个连接器的凭据无效。打开连接器页面进行查看。",
+          "title": "{count, plural, one {# 个连接器无效} other {# 个连接器无效}}"
+        }
+      },
+      "connectorRepeatedErrors": {
+        "aggregate": {
+          "description": "多个连接器多次索引失败。打开连接器页面进行查看。",
+          "title": "{count, plural, one {# 个连接器出现故障} other {# 个连接器出现故障}}"
+        }
+      },
+      "connectors": {
+        "cta": {
+          "label": "查看连接器"
+        },
+        "source": {
+          "label": "连接器"
+        }
+      },
+      "defaultCta": {
+        "label": "查看"
+      },
+      "defaultSource": {
+        "label": "通知"
+      },
+      "dismissButton": {
+        "ariaLabel": "关闭"
+      },
+      "healthBanner": {
+        "backendUnavailable": {
+          "description": "如果这是您的首次设置，或者您刚更新了 Onyx 部署，这可能是因为后端仍在启动。请等待一两分钟，然后刷新页面。如果仍然无效，请确认后端已正确设置，或联系管理员。",
+          "title": "后端当前不可用"
+        }
+      },
+      "licenseExpiry": {
+        "source": {
+          "label": "许可证"
+        }
+      },
+      "nextButton": {
+        "ariaLabel": "下一条横幅"
+      },
+      "previousButton": {
+        "ariaLabel": "上一条横幅"
+      },
+      "systemAnnouncement": {
+        "source": {
+          "label": "管理员公告"
+        }
+      },
+      "trialEnds": {
+        "source": {
+          "label": "试用"
+        }
+      }
+    },
+    "documentSidebar": {
+      "citedSources": {
+        "title": "引用的来源"
+      },
+      "closeButton": {
+        "tooltip": "关闭侧边栏"
+      },
+      "foundSources": {
+        "title": "找到的来源"
+      },
+      "moreSources": {
+        "title": "更多"
+      },
+      "userFiles": {
+        "title": "用户文件"
+      }
+    },
+    "federatedOAuth": {
+      "connectButton": {
+        "label": "连接"
+      },
+      "header": {
+        "description": "让 {appName} 搜索您所有已连接的数据，提升回答质量。",
+        "title": "连接您的应用"
+      },
+      "skipButton": {
+        "label": "暂时跳过"
+      }
+    },
+    "files": {
+      "fullImageModal": {
+        "image": {
+          "alt": "已上传的附件"
+        }
+      },
+      "inMessageImage": {
+        "downloadButton": {
+          "tooltip": "下载"
+        },
+        "image": {
+          "alt": "聊天附件"
+        },
+        "viewFullImage": {
+          "label": "查看完整图片"
+        }
+      },
+      "inputBarPreviewImage": {
+        "image": {
+          "alt": "预览"
+        },
+        "viewFullImage": {
+          "label": "查看完整图片"
+        }
+      }
+    },
+    "input": {
+      "appInputBar": {
+        "attachFilesButton": {
+          "tooltip": "附加文件"
+        },
+        "createPromptItem": {
+          "title": "创建新提示词"
+        },
+        "deepResearchButton": {
+          "disabledTooltip": "多模型模式下无法使用深度研究",
+          "label": "深度研究"
+        },
+        "incognitoNotice": {
+          "text": "此聊天不会出现在您的历史记录中，也不会用于记忆。"
+        },
+        "incognitoPolicyNotice": {
+          "text": "根据您组织的政策，您的管理员仍可能查看此聊天。第三方工具仍可能记录您的活动。"
+        },
+        "input": {
+          "ariaLabel": "消息输入框",
+          "listeningPlaceholder": "正在聆听...",
+          "placeholder": "今天我能帮您做些什么？",
+          "queuedPlaceholder": "按上箭头键编辑排队的消息",
+          "searchPlaceholder": "搜索已连接的来源",
+          "speakingPlaceholder": "Onyx 正在朗读..."
+        },
+        "sendButton": {
+          "processingFilesTooltip": "正在等待附件处理完成"
+        },
+        "tabReadingButton": {
+          "readLabel": "读取此标签页",
+          "readingLabel": "正在读取标签页..."
+        },
+        "voiceSetupButton": {
+          "ariaLabel": "设置语音",
+          "tooltip": "未配置语音。请在管理员设置中配置。"
+        }
+      },
+      "baseInputBar": {
+        "input": {
+          "ariaLabel": "消息输入框",
+          "placeholder": "描述您的任务..."
+        },
+        "pasteExpandHint": {
+          "text": "再次粘贴以展开"
+        },
+        "queuedMessagesHint": {
+          "text": "编辑排队的消息"
+        },
+        "sendButton": {
+          "initializingTooltip": "正在初始化沙盒...",
+          "queueLabel": "加入消息队列",
+          "sendLabel": "发送"
+        },
+        "stopButton": {
+          "ariaLabel": "停止生成",
+          "tooltip": "停止 · esc"
+        }
+      },
+      "buildFileCard": {
+        "pending": {
+          "tooltip": "正在等待会话就绪..."
+        }
+      },
+      "entryInfoPopover": {
+        "dialog": {
+          "ariaLabel": "技能：{name}"
+        }
+      },
+      "entryPickerPopover": {
+        "appsGroup": {
+          "label": "应用"
+        },
+        "connectAction": {
+          "label": "连接"
+        },
+        "connectedRow": {
+          "description": "已连接"
+        },
+        "connectionRequiredRow": {
+          "description": "需要连接"
+        },
+        "content": {
+          "ariaLabel": "技能选择器"
+        },
+        "empty": {
+          "text": "没有匹配的技能"
+        },
+        "mcpServersGroup": {
+          "label": "MCP 服务器"
+        },
+        "skillsGroup": {
+          "label": "技能"
+        }
+      },
+      "inputChip": {
+        "removeButton": {
+          "ariaLabel": "移除 {label}"
+        }
+      },
+      "microphoneButton": {
+        "accessError": {
+          "toast": "无法访问麦克风"
+        },
+        "autoStartError": {
+          "toast": "无法自动启动麦克风"
+        },
+        "startRecording": {
+          "ariaLabel": "开始录音"
+        },
+        "stopRecording": {
+          "ariaLabel": "停止录音"
+        }
+      },
+      "pasteTilePopover": {
+        "dialog": {
+          "ariaLabel": "编辑粘贴的文本"
+        },
+        "expandButton": {
+          "label": "展开到输入框",
+          "tooltip": "在输入框中用完整文本替换此卡片"
+        }
+      },
+      "plusMenuButton": {
+        "trigger": {
+          "ariaLabel": "打开添加菜单",
+          "tooltip": "添加"
+        }
+      },
+      "queuedMessageBar": {
+        "discardButton": {
+          "tooltip": "移除排队的消息"
+        },
+        "editHint": {
+          "label": "编辑 ·"
+        },
+        "item": {
+          "ariaLabel": "切换排队的消息"
+        },
+        "removeHint": {
+          "label": "移除"
+        }
+      },
+      "sharedAppInputBar": {
+        "input": {
+          "placeholder": "今天 Onyx 能为您做些什么"
+        },
+        "startSessionButton": {
+          "label": "开始新会话"
+        }
+      }
+    },
+    "mcpApiKey": {
+      "apiKeyField": {
+        "label": "API 密钥",
+        "placeholder": "输入您的 API 密钥"
+      },
+      "apiKeyVisibilityButton": {
+        "hideAriaLabel": "隐藏 API 密钥",
+        "showAriaLabel": "显示 API 密钥"
+      },
+      "cancelButton": {
+        "label": "取消"
+      },
+      "credentialField": {
+        "placeholder": "输入您的 {field}"
+      },
+      "credentialVisibilityButton": {
+        "hideAriaLabel": "隐藏凭据",
+        "showAriaLabel": "显示凭据"
+      },
+      "header": {
+        "enterApiKey": {
+          "title": "输入 API 密钥"
+        },
+        "enterCredentials": {
+          "title": "输入凭据"
+        },
+        "manageApiKey": {
+          "title": "管理 API 密钥"
+        },
+        "manageCredentials": {
+          "title": "管理凭据"
+        }
+      },
+      "intro": {
+        "enterApiKey": {
+          "text": "输入 {server} 的 API 密钥以启用身份验证。"
+        },
+        "enterCredentials": {
+          "text": "输入 {server} 的凭据以启用身份验证。"
+        },
+        "updateApiKey": {
+          "text": "更新 {server} 的 API 密钥。"
+        },
+        "updateCredentials": {
+          "text": "更新 {server} 的凭据。"
+        }
+      },
+      "saveApiKeyError": {
+        "message": "保存 API 密钥失败"
+      },
+      "saveCredentialsError": {
+        "message": "保存凭据失败"
+      },
+      "submitButton": {
+        "saveApiKey": {
+          "label": "保存 API 密钥"
+        },
+        "saveCredentials": {
+          "label": "保存凭据"
+        },
+        "saving": {
+          "label": "正在保存..."
+        },
+        "updateApiKey": {
+          "label": "更新 API 密钥"
+        },
+        "updateCredentials": {
+          "label": "更新凭据"
+        }
+      },
+      "validationNote": {
+        "apiKey": {
+          "text": "您的 API 密钥将由服务器验证，并安全存储。"
+        },
+        "authenticated": {
+          "text": "更改在保存前将由服务器验证。"
+        },
+        "credentials": {
+          "text": "您的凭据将由服务器验证，并安全存储。"
+        }
+      }
+    },
+    "messages": {
+      "agentMessage": {
+        "stoppedGeneration": {
+          "text": "用户已停止生成"
+        }
+      },
+      "codeBlock": {
+        "copyButton": {
+          "copiedLabel": "已复制！",
+          "label": "复制"
+        }
+      },
+      "customTool": {
+        "authFailedStatus": {
+          "text": "{toolName} 身份验证失败（HTTP {statusCode}）"
+        },
+        "completedStatus": {
+          "text": "{toolName} 已完成"
+        },
+        "downloadFileLink": {
+          "label": "下载"
+        },
+        "failedStatus": {
+          "text": "{toolName} 失败（HTTP {statusCode}）"
+        },
+        "fallbackName": {
+          "label": "工具"
+        },
+        "fileItem": {
+          "label": "文件 {index}"
+        },
+        "fileStatus": {
+          "text": "{toolName} 返回了一个文件"
+        },
+        "imagesStatus": {
+          "text": "{toolName} 返回了图片"
+        },
+        "openFileLink": {
+          "label": "打开"
+        },
+        "requestBlock": {
+          "label": "请求"
+        },
+        "responseBlock": {
+          "label": "响应"
+        },
+        "runningStatus": {
+          "text": "{toolName} 正在运行..."
+        },
+        "waitingIndicator": {
+          "text": "正在等待响应..."
+        }
+      },
+      "customToolAuth": {
+        "card": {
+          "description": "连接到 {toolName} 以启用此工具",
+          "title": "{toolName} 未连接"
+        },
+        "connectButton": {
+          "label": "连接"
+        }
+      },
+      "errorBanner": {
+        "apiError": {
+          "title": "API 错误"
+        },
+        "authError": {
+          "title": "身份验证错误"
+        },
+        "badRequest": {
+          "title": "请求无效"
+        },
+        "budgetExceeded": {
+          "title": "已超出预算"
+        },
+        "connectionError": {
+          "title": "连接错误"
+        },
+        "contentPolicy": {
+          "title": "违反内容政策"
+        },
+        "genericError": {
+          "title": "错误"
+        },
+        "initializationError": {
+          "title": "初始化错误"
+        },
+        "messageTooLong": {
+          "title": "消息过长"
+        },
+        "model": {
+          "label": "模型：{model}"
+        },
+        "modelRefusal": {
+          "title": "模型拒绝回答"
+        },
+        "modelWithProvider": {
+          "label": "模型：{model}（{provider}）"
+        },
+        "permissionDenied": {
+          "title": "权限被拒绝"
+        },
+        "rateLimitExceeded": {
+          "title": "已超出速率限制"
+        },
+        "resourceNotFound": {
+          "title": "未找到资源"
+        },
+        "serviceUnavailable": {
+          "title": "服务不可用"
+        },
+        "stackTraceButton": {
+          "label": "堆栈跟踪"
+        },
+        "tool": {
+          "label": "工具：{tool}"
+        },
+        "toolError": {
+          "title": "工具错误"
+        },
+        "usageLimitReached": {
+          "title": "已达到用量上限"
+        },
+        "validationError": {
+          "title": "验证错误"
+        }
+      },
+      "humanMessage": {
+        "editButton": {
+          "tooltip": "编辑"
+        }
+      },
+      "imageTool": {
+        "defaultStatus": {
+          "text": "图片生成"
+        },
+        "emptyState": {
+          "text": "未生成图片"
+        },
+        "failedStatus": {
+          "text": "图片生成失败"
+        },
+        "generatedStatus": {
+          "text": "{count, plural, one {已生成 # 张图片} other {已生成 # 张图片}}"
+        },
+        "generatingImagesStatus": {
+          "text": "正在生成图片..."
+        },
+        "generatingStatus": {
+          "text": "正在生成图片..."
+        }
+      },
+      "memoizedLink": {
+        "questionFallback": {
+          "label": "问题"
+        }
+      },
+      "messageEditing": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "submitButton": {
+          "label": "提交"
+        }
+      },
+      "messageSwitcher": {
+        "disabledWhileStreaming": {
+          "tooltip": "请等待智能体消息完成"
+        },
+        "nextButton": {
+          "tooltip": "下一条"
+        },
+        "previousButton": {
+          "tooltip": "上一条"
+        }
+      },
+      "multiModelPanel": {
+        "deselectButton": {
+          "tooltip": "取消选择首选回复"
+        },
+        "hideButton": {
+          "tooltip": "隐藏回复"
+        },
+        "preferredResponse": {
+          "label": "首选回复"
+        },
+        "selectButton": {
+          "label": "选择此回复"
+        },
+        "selectPanel": {
+          "ariaLabel": "选择 {model} 的回复"
+        },
+        "showButton": {
+          "tooltip": "显示回复"
+        },
+        "showPanel": {
+          "ariaLabel": "显示 {model} 的回复"
+        }
+      },
+      "rateLimitBanner": {
+        "defaultError": {
+          "text": "您已达到用量上限。"
+        },
+        "resetsInDays": {
+          "text": "将在 {count, plural, one {# 天} other {# 天}}后重置（{at}）。"
+        },
+        "resetsInHours": {
+          "text": "将在 {count, plural, one {# 小时} other {# 小时}}后重置（{at}）。"
+        },
+        "resetsInMinutes": {
+          "text": "将在 {count, plural, one {# 分钟} other {# 分钟}}后重置（{at}）。"
+        },
+        "tryAgainNow": {
+          "text": "您现在可以重试。"
+        }
+      },
+      "resubmit": {
+        "regenerateButton": {
+          "label": "重新生成"
+        },
+        "responseError": {
+          "text": "回复出现错误。"
+        }
+      },
+      "text": {
+        "thinkingPlaceholder": {
+          "text": "思考中"
+        }
+      },
+      "timeline": {
+        "codingAgent": {
+          "bashExit": {
+            "header": "Bash · 退出码 {exitCode}"
+          },
+          "bashRequest": {
+            "label": "请求"
+          },
+          "bashResponse": {
+            "label": "响应"
+          },
+          "bashRunning": {
+            "header": "Bash · 运行中…"
+          },
+          "bashTimedOut": {
+            "header": "Bash · 已超时"
+          },
+          "noOutput": {
+            "text": "无输出"
+          },
+          "response": {
+            "header": "响应"
+          },
+          "task": {
+            "header": "编码任务"
+          },
+          "taskWithRepo": {
+            "text": "{query}\n\n仓库：{repo}"
+          },
+          "thinking": {
+            "header": "思考"
+          }
+        },
+        "collapseButton": {
+          "ariaLabel": "收起时间线"
+        },
+        "deepResearchPlan": {
+          "expandable": {
+            "title": "研究计划"
+          },
+          "generated": {
+            "status": "已生成计划"
+          },
+          "generating": {
+            "status": "正在生成计划"
+          }
+        },
+        "doneStep": {
+          "header": "完成"
+        },
+        "expandButton": {
+          "ariaLabel": "展开时间线"
+        },
+        "fetch": {
+          "reading": {
+            "status": "正在读取"
+          }
+        },
+        "fileReader": {
+          "charRange": {
+            "label": "第 {start, number}–{end, number} 个字符，共 {total, number} 个"
+          },
+          "read": {
+            "status": "已读取 {fileName}（第 {start, number}–{end, number} 个字符，共 {total, number} 个）"
+          },
+          "reading": {
+            "status": "正在读取文件"
+          }
+        },
+        "generatedImages": {
+          "label": "{count, plural, one {已生成 # 张图片} other {已生成 # 张图片}}"
+        },
+        "header": {
+          "executingCode": {
+            "label": "正在执行代码"
+          },
+          "executingNamedTool": {
+            "label": "正在执行 {toolName}"
+          },
+          "executingTool": {
+            "label": "正在执行工具"
+          },
+          "generatingImage": {
+            "label": "正在生成图片..."
+          },
+          "generatingImages": {
+            "label": "正在生成图片"
+          },
+          "generatingPlan": {
+            "label": "正在生成计划"
+          },
+          "reading": {
+            "label": "正在读取"
+          },
+          "readingFile": {
+            "label": "正在读取文件"
+          },
+          "researching": {
+            "label": "正在研究"
+          },
+          "searchingWeb": {
+            "label": "正在搜索网页"
+          },
+          "thinking": {
+            "label": "思考中"
+          },
+          "thinkingEllipsis": {
+            "label": "思考中..."
+          },
+          "updatingMemory": {
+            "label": "正在更新记忆..."
+          }
+        },
+        "internalSearch": {
+          "noResults": {
+            "text": "未找到结果"
+          },
+          "reading": {
+            "status": "正在读取"
+          }
+        },
+        "interruptedThinking": {
+          "label": "思考已中断"
+        },
+        "memory": {
+          "default": {
+            "status": "记忆"
+          },
+          "disabled": {
+            "text": "记忆工具已禁用"
+          },
+          "updating": {
+            "status": "正在更新记忆"
+          },
+          "viewMemoriesButton": {
+            "tooltip": "查看记忆"
+          }
+        },
+        "memoryTag": {
+          "added": {
+            "label": "已添加到记忆"
+          },
+          "updated": {
+            "label": "已更新记忆"
+          }
+        },
+        "python": {
+          "completed": {
+            "status": "Python 执行完成"
+          },
+          "default": {
+            "status": "Python 执行"
+          },
+          "error": {
+            "label": "错误："
+          },
+          "executing": {
+            "status": "正在执行 Python 代码..."
+          },
+          "failed": {
+            "status": "Python 执行失败"
+          },
+          "generatedFiles": {
+            "label": "{count, plural, one {已生成 # 个文件} other {已生成 # 个文件}}"
+          },
+          "noOutput": {
+            "text": "无输出"
+          },
+          "output": {
+            "label": "输出："
+          },
+          "runningCode": {
+            "label": "正在运行代码..."
+          },
+          "writingCode": {
+            "status": "正在编写代码..."
+          }
+        },
+        "reasoning": {
+          "fullText": {
+            "title": "完整文本"
+          },
+          "thinking": {
+            "status": "思考中"
+          }
+        },
+        "researchAgent": {
+          "report": {
+            "title": "研究报告"
+          },
+          "task": {
+            "title": "研究任务"
+          }
+        },
+        "searchChips": {
+          "showMore": {
+            "label": "还有 {count} 个"
+          },
+          "viewFullQuery": {
+            "tooltip": "查看完整搜索词"
+          }
+        },
+        "stepsButton": {
+          "label": "{count, plural, one {# 个步骤} other {# 个步骤}}"
+        },
+        "stoppedStep": {
+          "header": "已停止"
+        },
+        "thoughtDuration": {
+          "label": "思考了 {duration}"
+        },
+        "thoughtUnknownDuration": {
+          "label": "思考了一段时间"
+        },
+        "toggleRow": {
+          "ariaLabel": "切换时间线"
+        },
+        "toolNames": {
+          "codeInterpreter": "代码解释器",
+          "codingAgent": "编码智能体",
+          "customTool": "自定义工具",
+          "generateImage": "生成图片",
+          "generatePlan": "生成计划",
+          "internalSearch": "内部搜索",
+          "memory": "记忆",
+          "openUrls": "打开 URL",
+          "researchAgent": "研究智能体",
+          "thinking": "思考",
+          "tool": "工具",
+          "webSearch": "网页搜索"
+        },
+        "webSearch": {
+          "searching": {
+            "status": "正在搜索网页"
+          }
+        }
+      },
+      "toolbar": {
+        "dislikeButton": {
+          "removeTooltip": "取消踩",
+          "tooltip": "回复不佳"
+        },
+        "likeButton": {
+          "removeTooltip": "取消赞",
+          "tooltip": "回复很好"
+        },
+        "regenerateButton": {
+          "tooltip": "换用模型重试"
+        },
+        "sourcesTag": {
+          "label": "来源"
+        }
+      },
+      "tts": {
+        "loadingButton": {
+          "tooltip": "正在加载..."
+        },
+        "playButton": {
+          "tooltip": "朗读"
+        },
+        "playbackError": {
+          "toast": "无法播放音频"
+        },
+        "stopButton": {
+          "tooltip": "停止播放"
+        }
+      }
+    },
+    "modals": {
+      "confirmEntity": {
+        "confirmButton": {
+          "label": "确认"
+        },
+        "confirmation": {
+          "description": "确定要{action} <b>{entityName}</b> 吗？"
+        },
+        "deleteAction": {
+          "label": "删除"
+        },
+        "deleteButton": {
+          "label": "删除"
+        },
+        "header": {
+          "title": "{action}{entityType}"
+        },
+        "modifyAction": {
+          "label": "修改"
+        }
+      },
+      "editProperty": {
+        "header": {
+          "title": "编辑{property}"
+        },
+        "submitButton": {
+          "label": "更新属性",
+          "loadingLabel": "正在更新..."
+        },
+        "valueInput": {
+          "placeholder": "属性值"
+        }
+      },
+      "feedback": {
+        "additionalDetails": {
+          "dislikePlaceholder": "您不喜欢这条回复的哪些方面？",
+          "label": "提供更多详情",
+          "likePlaceholder": "您喜欢这条回复的哪些方面？"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "header": {
+          "title": "反馈"
+        },
+        "submitButton": {
+          "label": "提交",
+          "loadingLabel": "正在提交..."
+        }
+      },
+      "genericConfirm": {
+        "confirmButton": {
+          "label": "确认"
+        }
+      },
+      "preview": {
+        "code": {
+          "headerDescription": "{language} - {lineCount, plural, one {# 行} other {# 行}} · {fileSize}"
+        },
+        "copyButton": {
+          "tooltip": "复制内容"
+        },
+        "csv": {
+          "footer": "{columnCount, plural, one {# 列} other {# 列}} • {rowCount, plural, one {# 行} other {# 行}}",
+          "headerDescription": "CSV - {rowCount, plural, one {# 行} other {# 行}} • {fileSize}",
+          "rowSeparator": "{count, plural, one {# 行} other {# 行}}"
+        },
+        "docx": {
+          "headerDescription": "{count, plural, one {Word 文档 • # 个字} other {Word 文档 • # 个字}}",
+          "headerDescriptionFallback": "Word 文档",
+          "legacyDocMessage": "无法预览旧版 .doc 格式。请下载文件后查看。",
+          "loadError": {
+            "message": "无法预览此文档。请下载文件后查看。"
+          }
+        },
+        "downloadButton": {
+          "label": "下载文件",
+          "tooltip": "下载"
+        },
+        "exceptionTrace": {
+          "defaultTitle": "完整异常跟踪"
+        },
+        "header": {
+          "fallbackTitle": "文档"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# 行} other {# 行}}"
+        },
+        "loadError": {
+          "message": "加载文档失败。"
+        },
+        "pdf": {
+          "iframeTitle": "PDF 查看器"
+        },
+        "text": {
+          "headerDescription": "{lineCount, plural, one {# 行} other {# 行}} · {fileSize}"
+        },
+        "unsupported": {
+          "message": "不支持预览此文件格式。"
+        },
+        "xlsx": {
+          "headerDescription": "电子表格 - {count, plural, one {# 个工作表} other {# 个工作表}}",
+          "parseError": {
+            "message": "无法预览此电子表格。"
+          },
+          "sheetCount": "{count, plural, one {# 个工作表} other {# 个工作表}}"
+        },
+        "zoomControls": {
+          "level": "{zoom}%",
+          "zoomInTooltip": "放大",
+          "zoomOutTooltip": "缩小"
+        }
+      },
+      "share": {
+        "addPeople": {
+          "groupSuggestion": {
+            "description": "群组"
+          },
+          "permissionMenu": {
+            "ariaLabel": "选择待设置的权限"
+          },
+          "searchInput": {
+            "placeholder": "添加用户、群组和账户"
+          },
+          "sharedTag": {
+            "label": "已共享"
+          }
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "copyLinkButton": {
+          "label": "复制链接"
+        },
+        "createLinkButton": {
+          "label": "创建共享链接"
+        },
+        "generateLinkErrorToast": {
+          "message": "生成共享链接失败"
+        },
+        "genericErrorToast": {
+          "message": "发生错误"
+        },
+        "header": {
+          "description": "此对话中现有和之后的所有消息都将被共享。",
+          "sharedTitle": "对话已共享",
+          "title": "共享此对话"
+        },
+        "linkCopiedToast": {
+          "message": "共享链接已复制到剪贴板！"
+        },
+        "linkInput": {
+          "copyTooltip": "复制链接"
+        },
+        "makePrivateButton": {
+          "label": "设为私有"
+        },
+        "makePrivateErrorToast": {
+          "message": "将对话设为私有失败"
+        },
+        "nowPrivateToast": {
+          "message": "对话现在为私有"
+        },
+        "organizationOption": {
+          "description": "您所在组织的任何人都可以查看此对话。",
+          "title": "您的组织"
+        },
+        "permissionMenu": {
+          "edit": {
+            "label": "编辑"
+          },
+          "removeAccess": {
+            "label": "移除访问权限"
+          },
+          "viewAndChat": {
+            "label": "查看和对话"
+          }
+        },
+        "privateOption": {
+          "description": "只有您可以访问此对话。",
+          "title": "私有"
+        },
+        "scope": {
+          "invitedOnly": {
+            "label": "仅受邀者"
+          },
+          "organization": {
+            "label": "您所在组织的任何人"
+          }
+        },
+        "transferOwnership": {
+          "currentOwner": {
+            "label": "当前所有者"
+          },
+          "groupTag": {
+            "label": "群组"
+          },
+          "targetInput": {
+            "label": "将所有权转移给",
+            "placeholder": "添加用户或群组"
+          },
+          "trailingButton": {
+            "tooltip": "转移所有权"
+          }
+        }
+      },
+      "unsavedChanges": {
+        "body": {
+          "description": "您的更改尚未保存。如果现在离开，更改将丢失。"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "discardButton": {
+          "label": "放弃更改"
+        },
+        "header": {
+          "title": "放弃未保存的更改？"
+        }
+      },
+      "userFiles": {
+        "addFilesButton": {
+          "label": "添加文件"
+        },
+        "doneButton": {
+          "label": "完成"
+        },
+        "emptyState": {
+          "description": "未找到文件"
+        },
+        "fileCount": {
+          "label": "{count, plural, one {# 个文件} other {# 个文件}}"
+        },
+        "fileStatus": {
+          "deleting": {
+            "label": "正在删除..."
+          },
+          "processing": {
+            "label": "正在处理..."
+          },
+          "uploading": {
+            "label": "正在上传..."
+          }
+        },
+        "searchInput": {
+          "placeholder": "搜索文件..."
+        },
+        "selectedCount": {
+          "label": "{count, plural, one {已选择 # 个文件} other {已选择 # 个文件}}"
+        }
+      }
+    },
+    "modelSelector": {
+      "adminLimitedSetting": {
+        "tooltip": "管理员将此模型限制为较低的推理级别。"
+      },
+      "contextWindow": {
+        "row": {
+          "caption": "每个会话的 token 上限",
+          "title": "上下文窗口"
+        },
+        "unknown": {
+          "tooltip": "此模型没有可用的上下文大小信息。对话仍会自动应用 token 上限。"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "未找到模型"
+        },
+        "loading": {
+          "text": "正在加载模型..."
+        }
+      },
+      "modelSettingsButton": {
+        "ariaLabel": "{model} 设置",
+        "tooltip": "模型设置"
+      },
+      "multiModel": {
+        "addModelButton": {
+          "label": "添加模型"
+        },
+        "noModels": {
+          "tooltip": "当前未配置任何模型"
+        }
+      },
+      "reasoningLevel": {
+        "high": {
+          "label": "高"
+        },
+        "low": {
+          "label": "低"
+        },
+        "medium": {
+          "label": "中"
+        },
+        "off": {
+          "label": "关闭"
+        },
+        "row": {
+          "caption": "模型在回答前应进行多少思考",
+          "title": "推理级别"
+        },
+        "xhigh": {
+          "label": "极高"
+        }
+      },
+      "searchInput": {
+        "placeholder": "搜索模型..."
+      },
+      "temperature": {
+        "balanced": {
+          "label": "平衡"
+        },
+        "creative": {
+          "label": "创意"
+        },
+        "deterministic": {
+          "label": "确定性"
+        },
+        "row": {
+          "caption": "模型回复的可预测程度或创造性程度",
+          "title": "温度"
+        }
+      },
+      "trigger": {
+        "noSelection": {
+          "label": "选择模型"
+        }
+      },
+      "unsupportedSetting": {
+        "tooltip": "此模型不支持修改该设置。"
+      }
+    },
+    "popup": {
+      "consentCheckbox": {
+        "label": "同意复选框"
+      },
+      "consentRequired": {
+        "error": "您需要同意条款才能使用本应用。"
+      },
+      "header": {
+        "title": "欢迎使用 Onyx！"
+      },
+      "logoIcon": {
+        "alt": "徽标"
+      },
+      "startButton": {
+        "label": "开始"
+      }
+    },
+    "sharedChat": {
+      "emptyChat": {
+        "description": "共享对话中未找到消息。"
+      },
+      "header": {
+        "owner": {
+          "text": "来自 {name}"
+        },
+        "sharedOn": {
+          "text": "共享于 {date}"
+        },
+        "untitledChat": {
+          "title": "新对话"
+        }
+      },
+      "newChatButton": {
+        "label": "开始新对话"
+      },
+      "notFound": {
+        "description": "未找到指定 ID 的共享对话。",
+        "title": "未找到共享对话"
+      }
+    },
+    "welcome": {
+      "greeting": {
+        "helpText": "有什么可以帮您？",
+        "startText": "开始吧。"
+      },
+      "incognito": {
+        "title": "您处于无痕模式"
+      }
+    }
+  },
+  "knowledge": {
+    "addView": {
+      "connectedSources": {
+        "label": "已连接的来源"
+      },
+      "documentSets": {
+        "label": "文档集"
+      },
+      "yourFiles": {
+        "description": "最近或新上传的文件",
+        "label": "您的文件"
+      }
+    },
+    "browser": {
+      "copyLink": {
+        "tooltip": "复制链接"
+      },
+      "empty": {
+        "folder": {
+          "description": "此文件夹中没有项目。"
+        },
+        "root": {
+          "description": "选择文件夹以浏览文档。"
+        }
+      },
+      "loadFoldersError": {
+        "description": "加载文件夹失败"
+      },
+      "loadingFolders": {
+        "description": "正在加载文件夹..."
+      },
+      "loadingMore": {
+        "description": "正在加载更多..."
+      },
+      "selectedCount": {
+        "label": "{count, plural, one {已选择 # 个项目} other {已选择 # 个项目}}"
+      },
+      "selectedItems": {
+        "label": "已选项目"
+      },
+      "sort": {
+        "ascending": {
+          "lastUpdated": {
+            "label": "从旧到新"
+          },
+          "name": {
+            "label": "从 A 到 Z"
+          }
+        },
+        "descending": {
+          "lastUpdated": {
+            "label": "从新到旧"
+          },
+          "name": {
+            "label": "从 Z 到 A"
+          }
+        },
+        "folders": {
+          "title": "文件夹"
+        },
+        "foldersMixed": {
+          "label": "与文件混排"
+        },
+        "foldersOnTop": {
+          "label": "置顶"
+        },
+        "sortBy": {
+          "title": "排序依据"
+        },
+        "sortingOrder": {
+          "title": "排序顺序"
+        }
+      }
+    },
+    "documentSets": {
+      "empty": {
+        "description": "没有可用的文档集。"
+      },
+      "filter": {
+        "placeholder": "筛选文档集..."
+      }
+    },
+    "mainContent": {
+      "empty": {
+        "description": "添加此智能体要使用的文档或已连接的来源。"
+      },
+      "selectedCount": {
+        "label": "{count, plural, one {已选择 # 个知识来源} other {已选择 # 个知识来源}}"
+      },
+      "viewEdit": {
+        "label": "查看 / 编辑"
+      }
+    },
+    "pane": {
+      "header": {
+        "description": "添加特定的连接器和文档，供此智能体在生成回复时参考。",
+        "title": "知识"
+      },
+      "useKnowledge": {
+        "description": "让此智能体参考这些文档来生成回复。",
+        "title": "使用知识"
+      }
+    },
+    "recentFiles": {
+      "addFile": {
+        "label": "添加文件"
+      },
+      "empty": {
+        "description": "没有可用的文件。上传文件即可开始。"
+      },
+      "filter": {
+        "placeholder": "筛选文件..."
+      },
+      "processing": {
+        "description": "Onyx 仍在处理您上传的文件。您现在可以创建智能体，但在处理完成前，它无法访问所有文件。"
+      }
+    },
+    "search": {
+      "error": {
+        "description": "搜索失败，请重试。"
+      },
+      "input": {
+        "placeholder": "搜索文档..."
+      },
+      "loading": {
+        "description": "正在搜索..."
+      },
+      "noResults": {
+        "description": "未找到结果。"
+      },
+      "noResultsInSource": {
+        "description": "在 {source} 中未找到结果。"
+      },
+      "prompt": {
+        "description": "输入搜索词并按回车键。"
+      },
+      "sidebar": {
+        "all": {
+          "label": "全部"
+        }
+      },
+      "stale": {
+        "description": "按回车键获取新结果。"
+      }
+    },
+    "sidebar": {
+      "documentSet": {
+        "label": "文档集"
+      },
+      "yourFiles": {
+        "label": "您的文件"
+      }
+    },
+    "table": {
+      "columns": {
+        "lastUpdated": {
+          "header": "最后更新"
+        },
+        "name": {
+          "header": "名称"
+        },
+        "sources": {
+          "header": "来源"
+        }
+      },
+      "empty": {
+        "description": "没有可用的项目。"
+      },
+      "filter": {
+        "placeholder": "筛选..."
+      }
+    }
+  },
+  "onboarding": {
+    "finalStep": {
+      "imageGeneration": {
+        "button": {
+          "label": "图片生成"
+        },
+        "description": "设置模型，以在对话中生成图片。",
+        "title": "启用图片生成"
+      },
+      "inviteTeam": {
+        "button": {
+          "label": "管理用户"
+        },
+        "description": "管理团队的用户和权限",
+        "title": "邀请您的团队"
+      },
+      "webSearch": {
+        "button": {
+          "label": "网页搜索"
+        },
+        "description": "让 Onyx 能够在互联网上搜索信息。",
+        "title": "选择网页搜索提供商"
+      }
+    },
+    "header": {
+      "progress": {
+        "label": "第 {current} 步，共 {total} 步"
+      }
+    },
+    "llmStep": {
+      "adminPanel": {
+        "label": "在管理面板中查看"
+      },
+      "connectedCount": {
+        "label": "{count, plural, one {已连接 # 个模型} other {已连接 # 个模型}}"
+      },
+      "customProvider": {
+        "subtitle": "兼容 LiteLLM 的 API",
+        "title": "自定义 LLM 提供商"
+      },
+      "description": "Onyx 同时支持自托管模型和主流提供商。",
+      "edit": {
+        "ariaLabel": "编辑 LLM 提供商"
+      },
+      "providerCard": {
+        "connect": {
+          "label": "连接"
+        }
+      },
+      "title": "连接您的 LLM 模型"
+    },
+    "nameStep": {
+      "description": "我们会在应用中显示此名称。",
+      "edit": {
+        "ariaLabel": "编辑显示名称",
+        "tooltip": "编辑"
+      },
+      "input": {
+        "placeholder": "您的姓名"
+      },
+      "title": "Onyx 该怎么称呼您？"
+    },
+    "nonAdminStep": {
+      "confirmation": {
+        "title": "全部设置完成！"
+      },
+      "save": {
+        "label": "保存"
+      },
+      "toasts": {
+        "saveNameFailed": "保存姓名失败。请重试。"
+      }
+    },
+    "steps": {
+      "complete": {
+        "button": {
+          "label": "完成设置"
+        },
+        "title": "全部设置完成，请查看可选设置或点击“完成设置”"
+      },
+      "llmSetup": {
+        "button": {
+          "label": "下一步"
+        },
+        "title": "就快好了！连接您的模型即可开始对话。"
+      },
+      "name": {
+        "button": {
+          "label": "下一步"
+        },
+        "title": "花点时间来完成设置吧。"
+      },
+      "welcome": {
+        "button": {
+          "label": "开始吧"
+        },
+        "title": "花点时间来完成设置吧。"
+      }
+    }
+  },
+  "settings": {
+    "accounts": {
+      "email": {
+        "anonymousFallback": "匿名",
+        "description": "您的账户电子邮件地址。",
+        "title": "电子邮件"
+      },
+      "password": {
+        "changeButton": "修改密码",
+        "description": "更新您的账户密码。",
+        "title": "密码"
+      },
+      "passwordModal": {
+        "confirmPassword": {
+          "title": "确认新密码"
+        },
+        "currentPassword": {
+          "title": "当前密码"
+        },
+        "newPassword": {
+          "title": "新密码"
+        },
+        "submit": {
+          "update": "更新",
+          "updating": "正在更新…"
+        },
+        "title": "修改密码",
+        "toasts": {
+          "networkError": "修改密码时发生错误",
+          "updateFailed": "修改密码失败",
+          "updated": "密码更新成功"
+        }
+      },
+      "title": "账户"
+    },
+    "apiKeys": {
+      "createModal": {
+        "description": "使用此 token 的所有 API 请求都会继承您的访问权限，并归属到您个人名下。",
+        "expiration": {
+          "days30": "30 天",
+          "days365": "365 天",
+          "days7": "7 天",
+          "expiresAtNote": "此 token 将于以下时间过期：{date}",
+          "noExpiration": "永不过期",
+          "placeholder": "选择有效期",
+          "title": "有效期"
+        },
+        "name": {
+          "placeholder": "为 token 命名",
+          "title": "Token 名称"
+        },
+        "permissions": {
+          "fullAccessNote": "继承您的全部权限。",
+          "fullAccessOption": "完全访问",
+          "limitedAccessNote": "将此 token 限制为特定能力。",
+          "limitedAccessOption": "受限访问",
+          "placeholder": "选择权限",
+          "title": "权限"
+        },
+        "submit": {
+          "create": "创建 token",
+          "creating": "正在创建 token…"
+        },
+        "title": "创建访问 token"
+      },
+      "list": {
+        "createdDaysAgo": "{count, plural, one {创建于 # 天前} other {创建于 # 天前}}",
+        "createdToday": "今天创建",
+        "deleteTokenAriaLabel": "删除 token {name}",
+        "empty": "尚未创建访问 token。",
+        "expiresIn": "{count, plural, one {# 天后过期} other {# 天后过期}}",
+        "loading": "正在加载 token…",
+        "neverExpires": "永不过期",
+        "newTokenButton": "新建访问 token",
+        "noPermissionTooltip": "您没有创建访问 token 的权限",
+        "searchPlaceholder": "搜索…"
+      },
+      "revokeModal": {
+        "description": "任何使用 token {name}（{tokenDisplay}）的应用都将失去对 Onyx 的访问权限。此操作无法撤销。",
+        "question": "确定要吊销此 token 吗？",
+        "submit": "吊销",
+        "title": "吊销访问 token"
+      },
+      "scopeSelector": {
+        "includedWith": "{label}（包含于 {lockReason}）",
+        "loadError": "无法加载权限。",
+        "loading": "正在加载权限…"
+      },
+      "section": {
+        "title": "访问 token"
+      },
+      "toasts": {
+        "createFailed": "创建 token 失败",
+        "createNetworkError": "创建 token 时发生网络错误",
+        "created": "Token 创建成功",
+        "deleteFailed": "删除 token 失败",
+        "deleteNetworkError": "删除 token 时发生网络错误",
+        "deleted": "Token 删除成功",
+        "loadFailed": "加载 token 失败",
+        "loadPermissionsFailed": "加载权限选项失败",
+        "nameRequired": "必须填写 token 名称"
+      },
+      "tokenCreatedModal": {
+        "copyButton": "复制 token",
+        "description": "请在继续之前保存此 token。它不会再次显示。",
+        "title": "访问 token"
+      },
+      "upsell": {
+        "description": "访问 token 需要有效的付费订阅。",
+        "upgradeButton": "升级套餐"
+      }
+    },
+    "appearance": {
+      "chatBackground": {
+        "none": "无",
+        "optionAriaLabel": "{label} 背景{selected, select, true {（已选中）} other {}}",
+        "title": "对话背景"
+      },
+      "colorMode": {
+        "auto": "自动",
+        "dark": "深色",
+        "description": "选择您偏好的界面配色模式。",
+        "light": "浅色",
+        "title": "配色模式"
+      },
+      "title": "外观"
+    },
+    "chats": {
+      "autoScroll": {
+        "description": "在对话生成回复时自动滚动到新内容。",
+        "title": "对话自动滚动"
+      },
+      "collapseLargePastes": {
+        "description": "粘贴超过 3 行或 200 个字符的文本时，将其折叠为紧凑卡片，而不是直接插入正文。点击卡片可查看或编辑完整文本。",
+        "title": "折叠大段粘贴内容"
+      },
+      "defaultAppMode": {
+        "chatOption": "对话",
+        "description": "选择新会话以搜索模式还是对话模式启动。",
+        "disabledTooltip": "搜索界面已禁用，只有管理员才能启用。",
+        "searchOption": "搜索",
+        "title": "默认应用模式"
+      },
+      "defaultModel": {
+        "description": "Onyx 会在您的对话中默认使用此模型。",
+        "title": "默认模型"
+      },
+      "defaultReasoningLevel": {
+        "description": "新对话的起始推理级别。模型上的管理员设置始终生效，任何单个对话都可以在其模型设置中覆盖此项。",
+        "title": "默认推理级别"
+      },
+      "defaultTemperature": {
+        "description": "新对话的起始温度。模型上的管理员设置始终生效，任何单个对话都可以在其模型设置中覆盖此项。",
+        "title": "默认温度"
+      },
+      "smoothStreaming": {
+        "description": "以逐字动画的方式显示流式回复。禁用后，内容块到达时会直接渲染。",
+        "title": "平滑流式输出"
+      },
+      "title": "对话",
+      "toasts": {
+        "saveFailed": "保存偏好设置失败",
+        "saved": "偏好设置已保存"
+      }
+    },
+    "connectors": {
+      "connectButton": "连接",
+      "disconnectModal": {
+        "continueNote": "您仍然可以继续引用 {name} 内容的现有会话。",
+        "description": "Onyx 将无法再访问或搜索您 {name} 账户中的内容。",
+        "disconnecting": "正在断开连接…",
+        "submit": "断开连接",
+        "title": "断开 *{name}* 连接"
+      },
+      "emptyMessage": "您的组织尚未设置任何连接器。",
+      "status": {
+        "connected": "已连接",
+        "notConnected": "未连接",
+        "paused": "已暂停"
+      },
+      "title": "连接器",
+      "toasts": {
+        "disconnectFailed": "断开连接失败",
+        "disconnected": "已成功断开连接"
+      }
+    },
+    "dangerZone": {
+      "deleteAllChats": {
+        "button": "删除全部对话",
+        "confirm": {
+          "deleting": "正在删除…",
+          "description": "您的所有对话会话和历史记录都将被永久删除。删除后无法恢复。",
+          "question": "确定要删除全部对话吗？",
+          "submit": "删除",
+          "title": "删除全部对话"
+        },
+        "description": "永久删除您的所有对话会话。",
+        "title": "删除全部对话",
+        "toasts": {
+          "deleteFailed": "删除全部对话会话失败",
+          "deleted": "您的所有对话会话已删除。"
+        }
+      },
+      "title": "危险区域"
+    },
+    "gateway": {
+      "accessToken": {
+        "button": "新建 token",
+        "description": "在连接应用之前，请先创建一个限定范围的 token。",
+        "title": "访问 token"
+      },
+      "copyButton": {
+        "copied": "已复制",
+        "copy": "复制",
+        "copyError": "无法复制该值。"
+      },
+      "description": "将外部工具连接到您在 Onyx 中可用的模型。",
+      "guideButton": "指南",
+      "models": {
+        "description": "{count, plural, one {您的账户可使用 # 个模型。打开某个提供商即可复制 ID。} other {您的账户可使用 # 个模型。打开某个提供商即可复制 ID。}}",
+        "title": "模型"
+      },
+      "provider": {
+        "modelsAvailable": "{count, plural, one {# 个模型可用} other {# 个模型可用}}"
+      },
+      "title": "LLM 网关",
+      "url": {
+        "description": "在兼容的 OpenAI 和 Anthropic 客户端中使用此基础 URL。",
+        "title": "网关 URL"
+      }
+    },
+    "language": {
+      "displayLanguage": {
+        "description": "选择界面语言。",
+        "title": "显示语言"
+      },
+      "title": "语言",
+      "toasts": {
+        "updateFailed": "更新语言偏好设置失败"
+      }
+    },
+    "memory": {
+      "empty": {
+        "description": "添加希望 Onyx 记住的个人笔记或记忆。"
+      },
+      "referenceStoredMemories": {
+        "description": "允许 Onyx 在对话中引用已存储的记忆。",
+        "title": "引用已存储的记忆"
+      },
+      "title": "记忆",
+      "updateMemories": {
+        "description": "允许 Onyx 生成并更新已存储的记忆。",
+        "title": "更新记忆"
+      },
+      "viewAll": {
+        "description": "全部记忆",
+        "title": "查看/添加"
+      }
+    },
+    "personalPreferences": {
+      "description": "用自然语言填写您的自定义偏好。",
+      "placeholder": "描述您希望系统如何表现，以及应使用的语气。",
+      "title": "个人偏好"
+    },
+    "profile": {
+      "fullName": {
+        "description": "我们会在应用中显示此名称。",
+        "placeholder": "您的姓名",
+        "title": "全名"
+      },
+      "title": "个人资料",
+      "toasts": {
+        "updateFailed": "更新个性化设置失败",
+        "updated": "个性化设置更新成功"
+      },
+      "workRole": {
+        "description": "填写您的职位，以便更好地定制回复。",
+        "placeholder": "您的职位",
+        "title": "职位"
+      }
+    },
+    "promptShortcuts": {
+      "row": {
+        "contentPlaceholder": "请用 1–2 句话对以下内容做简明总结：",
+        "promptPlaceholder": "总结",
+        "publicTooltip": "无法删除公开的提示词快捷方式。",
+        "removeAriaLabel": "移除快捷方式"
+      },
+      "title": "提示词快捷方式",
+      "toasts": {
+        "bothRequired": "快捷方式和展开内容都必须填写",
+        "created": "快捷方式已创建",
+        "deleteFailed": "删除快捷方式失败",
+        "deleted": "快捷方式已删除",
+        "loadFailed": "加载快捷方式失败",
+        "saveFailed": "保存快捷方式失败",
+        "updated": "快捷方式已更新"
+      },
+      "toggle": {
+        "description": "启用快捷方式以快速插入常用提示词。",
+        "title": "使用提示词快捷方式"
+      }
+    },
+    "voice": {
+      "autoPlayback": {
+        "description": "自动播放语音回复。",
+        "title": "自动播放"
+      },
+      "autoSend": {
+        "description": "在您停止说话时自动发送语音输入。",
+        "title": "停顿时自动发送"
+      },
+      "playbackSpeed": {
+        "description": "调整语音播放速度。",
+        "title": "播放速度"
+      },
+      "title": "语音"
+    }
+  },
+  "sidebar": {
+    "adminNav": {
+      "items": {
+        "addConnector": {
+          "label": "添加连接器"
+        },
+        "agents": {
+          "label": "智能体"
+        },
+        "analytics": {
+          "label": "分析"
+        },
+        "appearanceAndTheming": {
+          "label": "外观与主题"
+        },
+        "chatPreferences": {
+          "label": "对话偏好设置"
+        },
+        "codeInterpreter": {
+          "label": "代码解释器"
+        },
+        "craftAccess": {
+          "label": "访问权限"
+        },
+        "craftApps": {
+          "label": "应用"
+        },
+        "craftInstructions": {
+          "label": "指令"
+        },
+        "customAnalytics": {
+          "label": "自定义分析"
+        },
+        "discordIntegration": {
+          "label": "Discord 集成"
+        },
+        "documentSets": {
+          "label": "文档集"
+        },
+        "existingConnectors": {
+          "label": "现有连接器"
+        },
+        "exportLogs": {
+          "label": "导出日志"
+        },
+        "groups": {
+          "label": "用户组"
+        },
+        "hookExtensions": {
+          "label": "Hook 扩展"
+        },
+        "imageGeneration": {
+          "label": "图像生成"
+        },
+        "indexSettings": {
+          "label": "索引设置"
+        },
+        "languageModels": {
+          "label": "语言模型"
+        },
+        "mcpActions": {
+          "label": "MCP 操作"
+        },
+        "openapiActions": {
+          "label": "OpenAPI 操作"
+        },
+        "plansAndBilling": {
+          "label": "套餐与账单"
+        },
+        "queryHistory": {
+          "label": "查询历史"
+        },
+        "scim": {
+          "label": "SCIM"
+        },
+        "securityAndHardening": {
+          "label": "安全与加固"
+        },
+        "serviceAccounts": {
+          "label": "服务账号"
+        },
+        "slackIntegration": {
+          "label": "Slack 集成"
+        },
+        "ssoProviders": {
+          "label": "SSO 提供商"
+        },
+        "tracing": {
+          "label": "追踪"
+        },
+        "upgradePlan": {
+          "label": "升级套餐"
+        },
+        "usage": {
+          "label": "用量"
+        },
+        "users": {
+          "label": "用户"
+        },
+        "voice": {
+          "label": "语音"
+        },
+        "webSearch": {
+          "label": "网页搜索"
+        }
+      },
+      "sections": {
+        "agentsAndActions": {
+          "label": "智能体与操作"
+        },
+        "craft": {
+          "label": "Craft"
+        },
+        "documentsAndKnowledge": {
+          "label": "文档与知识"
+        },
+        "integrations": {
+          "label": "集成"
+        },
+        "organization": {
+          "label": "组织"
+        },
+        "permissions": {
+          "label": "权限"
+        },
+        "usage": {
+          "label": "用量"
+        }
+      }
+    },
+    "adminSidebar": {
+      "businessOrEnterpriseOnly": {
+        "tooltip": "此功能仅在 [Onyx 商业版或企业版](/admin/billing) 中提供。"
+      },
+      "enterpriseOnly": {
+        "tooltip": "此功能仅在 [Onyx 企业版](/admin/billing) 中提供。"
+      },
+      "exitAdminPanel": {
+        "label": "退出管理面板"
+      },
+      "search": {
+        "label": "搜索"
+      },
+      "searchInput": {
+        "placeholder": "搜索…"
+      }
+    },
+    "appSidebar": {
+      "adminPanel": {
+        "label": "管理面板"
+      },
+      "agents": {
+        "title": "智能体"
+      },
+      "craft": {
+        "label": "Craft"
+      },
+      "exploreAgents": {
+        "label": "探索智能体"
+      },
+      "moreAgents": {
+        "label": "更多智能体"
+      },
+      "moveChatError": {
+        "message": "移动对话失败。请重试。"
+      },
+      "newProject": {
+        "label": "新建项目",
+        "tooltip": "新建项目"
+      },
+      "newSession": {
+        "label": "新建会话"
+      },
+      "projects": {
+        "title": "项目"
+      },
+      "recents": {
+        "empty": {
+          "text": "试着发送一条消息吧！您的对话历史将显示在这里。"
+        },
+        "title": "最近"
+      },
+      "searchChats": {
+        "label": "搜索对话"
+      }
+    },
+    "chatButton": {
+      "createProject": {
+        "label": "创建 {projectName}"
+      },
+      "createProjectError": {
+        "message": "创建项目失败。请重试。"
+      },
+      "delete": {
+        "label": "删除"
+      },
+      "deleteConfirmation": {
+        "confirmButton": {
+          "label": "删除"
+        },
+        "description": "确定要删除此对话吗？此操作无法撤销。",
+        "title": "删除对话"
+      },
+      "deleteError": {
+        "message": "删除对话失败。请重试。"
+      },
+      "moveToProject": {
+        "label": "移动到项目"
+      },
+      "projectSearchInput": {
+        "placeholder": "搜索项目"
+      },
+      "removeFromProject": {
+        "label": "从 {projectName} 中移除"
+      },
+      "rename": {
+        "label": "重命名"
+      },
+      "share": {
+        "label": "共享"
+      }
+    },
+    "chatSearch": {
+      "createNamedProject": {
+        "label": "创建新项目“<name>{projectName}</name>”"
+      },
+      "footer": {
+        "openAction": {
+          "label": "打开"
+        },
+        "selectAction": {
+          "label": "选择"
+        },
+        "showAllAction": {
+          "label": "显示全部"
+        }
+      },
+      "list": {
+        "empty": {
+          "text": "暂无对话或项目"
+        },
+        "noResults": {
+          "text": "未找到结果"
+        }
+      },
+      "newProject": {
+        "label": "新建项目"
+      },
+      "newSession": {
+        "label": "新建会话"
+      },
+      "noMoreResults": {
+        "text": "没有更多结果"
+      },
+      "projectsFilter": {
+        "label": "项目"
+      },
+      "recentFilter": {
+        "label": "最近"
+      },
+      "recentSessionsFilter": {
+        "label": "最近会话"
+      },
+      "searchInput": {
+        "placeholder": "搜索对话会话、项目…"
+      },
+      "sessionsFilter": {
+        "label": "会话"
+      }
+    },
+    "createConnector": {
+      "advancedStep": {
+        "label": "高级（可选）"
+      },
+      "connectorStep": {
+        "label": "连接器"
+      },
+      "credentialStep": {
+        "label": "凭据"
+      },
+      "exitSetup": {
+        "label": "退出连接器设置"
+      }
+    },
+    "notifications": {
+      "empty": {
+        "title": "暂无通知"
+      },
+      "header": {
+        "title": "通知"
+      },
+      "markAllAsReadButton": {
+        "tooltip": "全部标为已读"
+      },
+      "markAsReadButton": {
+        "tooltip": "标为已读"
+      },
+      "newSection": {
+        "title": "新增"
+      },
+      "olderSection": {
+        "title": "更早"
+      },
+      "unreadCount": {
+        "label": "{count, plural, one {# 条未读} other {# 条未读}}"
+      }
+    }
+  },
+  "skills": {
+    "modals": {
+      "addInstruction": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "header": {
+          "description": "指定此项目中对话会话的行为方式或语气。",
+          "title": "设置项目指令"
+        },
+        "instructionsField": {
+          "placeholder": "我的目标是……请在回复中务必……"
+        },
+        "saveButton": {
+          "label": "保存指令"
+        }
+      },
+      "create": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "continueButton": {
+          "label": "查看技能",
+          "loadingLabel": "正在打开…"
+        },
+        "header": {
+          "description": "上传 SKILL.md 文件、ZIP 文件或技能文件夹。保存前可以查看并编辑其详细信息。",
+          "title": "上传技能"
+        },
+        "readError": {
+          "message": "读取技能失败"
+        },
+        "requirements": {
+          "frontmatter": "SKILL.md 必须包含有效的 frontmatter，并带有名称和描述。",
+          "singleSkill": "每次只能上传一个技能。",
+          "title": "文件要求",
+          "zip": "ZIP 文件必须包含一个 SKILL.md 文件。"
+        }
+      },
+      "importGithub": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "doneButton": {
+          "label": "完成"
+        },
+        "header": {
+          "chooseDescription": "从 {repository} 中选择技能。",
+          "completeDescription": "查看已添加到您技能中的内容。",
+          "completeTitle": "GitHub 导入完成",
+          "description": "从 GitHub 仓库导入一个或多个技能。",
+          "title": "从 GitHub 导入"
+        },
+        "importError": {
+          "message": "无法导入技能。",
+          "title": "无法导入技能"
+        },
+        "loadError": {
+          "message": "无法加载仓库。",
+          "title": "无法加载仓库"
+        },
+        "privateRepos": {
+          "askAdmin": "公开仓库可直接导入。导入私有仓库前，请联系管理员设置 GitHub。",
+          "connect": "公开仓库可直接导入。连接 GitHub 即可导入私有仓库。",
+          "connectButton": {
+            "label": "连接 GitHub"
+          },
+          "connected": "公开仓库可直接导入。私有仓库将使用您的 GitHub 连接。",
+          "needsConnection": "公开仓库可直接导入。私有仓库需要 GitHub 连接。",
+          "setUp": "公开仓库可直接导入。导入私有仓库前，请先设置 GitHub。",
+          "setUpButton": {
+            "label": "设置 GitHub"
+          }
+        },
+        "repositoryInput": {
+          "label": "仓库"
+        },
+        "result": {
+          "disabledCount": "{count} 个导入后处于禁用状态，因为已有同名技能处于启用状态。",
+          "enabledCount": "{count} 个已自动启用。",
+          "failedCount": "{count} 个无法导入。",
+          "importedSection": {
+            "title": "已导入"
+          },
+          "importedTitle": "{count, plural, one {已导入 # 个技能} other {已导入 # 个技能}}",
+          "noneTitle": "未导入任何技能",
+          "notImportedSection": {
+            "title": "未导入"
+          },
+          "notSelectedCount": "{count} 个未选择。"
+        },
+        "selectAll": {
+          "ariaLabel": "选择全部可导入技能"
+        },
+        "selection": {
+          "label": "已选择 {selected} / {total, plural, one {# 个可导入技能} other {# 个可导入技能}}"
+        },
+        "skillCheckbox": {
+          "ariaLabel": "选择 {name}"
+        },
+        "skillTag": {
+          "disabled": "已禁用",
+          "enabled": "已启用"
+        },
+        "submitButton": {
+          "importLabel": "{count, plural, one {导入技能} other {导入 # 个技能}}",
+          "importingLabel": "正在导入…",
+          "searchLabel": "搜索仓库",
+          "searchingLabel": "正在搜索…"
+        },
+        "unavailableFallback": "无法导入此技能。",
+        "unavailableTag": {
+          "label": "无法导入"
+        }
+      },
+      "nameConflict": {
+        "body": "新技能创建后将处于禁用状态。您可以在“技能”页面切换当前生效的技能。",
+        "confirmButton": {
+          "label": "仍然创建",
+          "pendingLabel": "正在创建…"
+        },
+        "description": "您已有一个同名且已启用的技能。",
+        "title": "再创建一个“{name}”技能？"
+      },
+      "preview": {
+        "closeButton": {
+          "label": "关闭"
+        },
+        "fallbackTitle": "技能预览",
+        "instructions": {
+          "title": "指令"
+        },
+        "loadError": {
+          "description": "请尝试关闭预览后重新打开。",
+          "title": "加载技能失败"
+        },
+        "metadata": {
+          "createdBy": {
+            "label": "创建者"
+          },
+          "externalApp": {
+            "label": "外部应用"
+          }
+        },
+        "noInstructions": {
+          "message": "未找到指令。"
+        },
+        "unavailable": {
+          "appDisabled": "应用“{appName}”已被管理员禁用。",
+          "appNotConnected": "请在“应用”页面连接应用“{appName}”，才能使用此技能。",
+          "title": "技能不可用"
+        }
+      },
+      "share": {
+        "backButton": {
+          "label": "返回"
+        },
+        "cancelButton": {
+          "label": "取消"
+        },
+        "currentUserLabel": "{email}（您）",
+        "doneButton": {
+          "label": "完成"
+        },
+        "externalAppNotice": "只要此技能与应用“{appName}”关联，就必须开放全组织的查看权限。",
+        "header": {
+          "title": "共享 *{name}*",
+          "transferTitle": "转移 *{name}*"
+        },
+        "loading": {
+          "message": "正在加载共享详情…"
+        },
+        "noOwnerTitle": "没有有效的所有者",
+        "organizationPermissionMenu": {
+          "ariaLabel": "更改组织权限"
+        },
+        "ownerLabel": "所有者",
+        "permissionMenu": {
+          "ariaLabel": "更新 {name} 的访问权限"
+        },
+        "saveButton": {
+          "label": "保存"
+        },
+        "saveErrorToast": {
+          "message": "更新共享设置失败"
+        },
+        "savedToast": {
+          "message": "共享设置已更新。"
+        },
+        "scopeMenu": {
+          "ariaLabel": "更改共享范围"
+        },
+        "transferButton": {
+          "label": "转移"
+        },
+        "transferErrorToast": {
+          "message": "转移所有权失败"
+        },
+        "transferredToast": {
+          "message": "所有权已转移。"
+        }
+      }
+    },
+    "sections": {
+      "bundlePicker": {
+        "chooseDifferent": {
+          "label": "选择其他文件"
+        },
+        "noFile": {
+          "description": "未选择文件"
+        },
+        "preparing": {
+          "label": "正在准备上传…"
+        },
+        "upload": {
+          "label": "拖放文件或点击上传"
+        }
+      },
+      "fileTree": {
+        "empty": {
+          "description": "暂无支持文件。"
+        },
+        "remove": {
+          "label": "移除 {name}"
+        }
+      },
+      "filesPicker": {
+        "addFiles": {
+          "label": "添加文件"
+        },
+        "input": {
+          "ariaLabel": "添加技能文件"
+        },
+        "preparing": {
+          "label": "正在准备…"
+        },
+        "prompt": {
+          "description": "选择文件或 ZIP，也可以将文件夹拖放到这里。"
+        }
+      },
+      "instructionsToggle": {
+        "group": {
+          "ariaLabel": "指令显示模式"
+        },
+        "raw": {
+          "label": "原始 markdown"
+        },
+        "rendered": {
+          "label": "渲染后的 markdown"
+        }
+      },
+      "upload": {
+        "error": {
+          "readFailed": "无法读取上传的内容。"
+        }
+      }
+    }
+  }
+}

--- a/web/tests/e2e/settings/language_switch.spec.ts
+++ b/web/tests/e2e/settings/language_switch.spec.ts
@@ -2,25 +2,36 @@ import { test } from "@playwright/test";
 import { loginAsRandomUser } from "@tests/e2e/utils/auth";
 import { SettingsGeneralPage } from "@tests/e2e/pages/SettingsGeneralPage";
 
-// Uses a fresh random user: changing the language mutates the user row, and
-// doing that to the shared admin fixture would leak a non-English UI into
-// concurrently running specs.
-test("language picker switches the UI locale and persists", async ({
-  page,
-}) => {
-  await loginAsRandomUser(page);
+// One Latin-script locale and one CJK locale cover the two rendering paths
+// (the CJK case also exercises the ja catalog and the <html lang> switch the
+// :lang() line-breaking CSS keys off). marker is the locale's translation of
+// settings.appearance.title, visible on the settings page.
+const LOCALES = [
+  { endonym: "Español", lang: "es", marker: "Apariencia" },
+  { endonym: "日本語", lang: "ja", marker: "外観" },
+] as const;
 
-  const settingsPage = new SettingsGeneralPage(page);
-  await settingsPage.goto();
+for (const { endonym, lang, marker } of LOCALES) {
+  // Uses a fresh random user: changing the language mutates the user row, and
+  // doing that to the shared admin fixture would leak a non-English UI into
+  // concurrently running specs.
+  test(`language picker switches the UI locale to ${lang} and persists`, async ({
+    page,
+  }) => {
+    await loginAsRandomUser(page);
 
-  await settingsPage.switchLanguage("English", "Español");
-  // router.refresh() re-renders the server layout with the new locale.
-  await settingsPage.expectLocale("es", "Apariencia");
+    const settingsPage = new SettingsGeneralPage(page);
+    await settingsPage.goto();
 
-  // The cookie and DB row both carry the preference across a full reload.
-  await settingsPage.reload();
-  await settingsPage.expectLocale("es", "Apariencia");
+    await settingsPage.switchLanguage("English", endonym);
+    // router.refresh() re-renders the server layout with the new locale.
+    await settingsPage.expectLocale(lang, marker);
 
-  await settingsPage.switchLanguage("Español", "English");
-  await settingsPage.expectLocale("en", "Appearance");
-});
+    // The cookie and DB row both carry the preference across a full reload.
+    await settingsPage.reload();
+    await settingsPage.expectLocale(lang, marker);
+
+    await settingsPage.switchLanguage(endonym, "English");
+    await settingsPage.expectLocale("en", "Appearance");
+  });
+}


### PR DESCRIPTION
## Summary

Stacked on #14322 (fonts + line breaking). Adds the three CJK locales end to end:

- **Catalogs**: `ja.json`, `zh.json`, `ko.json` with all **3,673 keys** each, translated via the wave-3 pipeline (flat English export → per-chunk translation agents → ICU-shape validation → merge). The validator enforces per key: identical argument names, identical plural branch keywords (CJK is other-only grammatically, but branch sets mirror English exactly), and identical rich-text tag names. Every chunk was validated twice — once by its agent, once independently before merge.
- **Registries**: backend `SupportedLanguage` enum (+`ja`/`zh`/`ko`), `SUPPORTED_LOCALES`, endonyms (日本語 / 简体中文 / 한국어) in the picker, the enum drift-guard test, three new `Covers` pairs in `keyParity.ts`, and the three locales in the catalog ICU test's `TARGET_LOCALES`. The `user.language` column is a plain string — no migration.
- **e2e**: the `language_switch` spec is parameterized over `es` and `ja` instead of duplicated; the ja case covers the CJK rendering path and the `<html lang>` switch.

Glossary and consistency, per the rollout plan: brand names and token/embedding stay in Latin script. Post-merge passes normalized terminology (エージェント / 智能体 / 에이전트 etc. are uniform across all 3,673 keys), naturalized "seat" (シート / 席位 / 시트, with Korean particle corrections), and unified zh on 您.

## Out of scope (flag for admins)

CJK **search** quality depends on the deployment-wide `OPENSEARCH_TEXT_ANALYZER` (default `english`) — a separate search workstream, independent of UI language.

## Test plan

- `bun run test src/i18n` — 9/9: ICU/placeholder parity across all seven locales plus the config drift guard.
- `bun run types:check` — compile-time key parity for the three new catalogs (branch has pre-existing unrelated `ButtonProps` errors; count is byte-identical with this change stashed).
- `language_switch` e2e: **2/2 passing** against live dev servers — switch to 日本語, `<html lang="ja">`, translated marker, persistence across reload, switch back.
- Visual spot-check of ja/zh/ko chat + settings pages: natural phrasing, no overflow (text shrinks vs English).
- `pre-commit run` on all touched files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2880" height="1920" alt="20260826_17h50m41s_grim" src="https://github.com/user-attachments/assets/de63967d-b4c4-499f-88da-68ab392c3959" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Japanese, Simplified Chinese, and Korean as selectable UI languages with full translation catalogs (3,673 keys each).

- Catalogs pass ICU parity validation against English — identical argument names, plural branch keywords, and rich-text tags. Brand names and token/embedding stay Latin across all locales.
- Registers the locales in the backend `SupportedLanguage` enum and frontend `SUPPORTED_LOCALES`, with endonyms (日本語 / 简体中文 / 한국어) in the picker.
- Extends the catalog, key-parity, and enum drift-guard tests to the new locales.
- Parameterizes the `language_switch` e2e spec over `es` and `ja`; the `ja` case also exercises CJK rendering and the `<html lang>` switch.
- No DB migration is needed — `user.language` is a plain string.
- CJK search quality is out of scope; it depends on a separate OpenSearch analyzer workstream.

<sup>Written for commit b5d43132ab142b9c4afb756c19e04f6a0768f9be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



