### PR TITLE
feat(craft): sandbox outputs manifest

### DIFF
--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -32,6 +32,9 @@ from onyx.server.features.build.sandbox.event_schema import (
     ToolCallProgress,
     ToolCallStart,
 )
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    OutputsManifestResponse,
+)
 from onyx.server.features.build.sandbox.models import (
     CraftLLMProviderConfig,
     CraftMCPServerConfig,
@@ -468,6 +471,19 @@ class SandboxManager(_ServeMixin, ABC):
 
         Raises:
             ValueError: If path traversal attempted or path is not a directory
+        """
+        ...
+
+    @abstractmethod
+    def get_outputs_manifest(
+        self, sandbox_id: UUID, session_id: UUID
+    ) -> OutputsManifestResponse:
+        """Describe the session's outputs tree in one call.
+
+        Symlinks and non-regular files are counted, never followed. Regular
+        files carry size, mtime, and a content hash when under the hash
+        ceilings. A missing outputs tree is an empty manifest, not an error.
+        Raises RuntimeError-family errors when the backend cannot answer.
         """
         ...
 

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -112,6 +112,9 @@ from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
     stream_stdin_to_container,
     stream_stdout_from_container,
 )
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    OutputsManifestResponse,
+)
 from onyx.server.features.build.sandbox.labels import (
     LABEL_K8S_MANAGED_BY,
     LABEL_K8S_MANAGED_BY_ONYX,
@@ -1620,6 +1623,32 @@ fi
 
         entries = self._parse_ls_output(output, clean_path)
         return sorted(entries, key=lambda e: (not e.is_directory, e.name.lower()))
+
+    def get_outputs_manifest(
+        self, sandbox_id: UUID, session_id: UUID
+    ) -> OutputsManifestResponse:
+        container = self._require_container(sandbox_id)
+        try:
+            # Root-owned interpreter and module: the sandbox user owns
+            # /workspace, so anything under it could be swapped to lie.
+            # workdir=/opt is load-bearing, python -m imports the root-owned
+            # /opt/sandbox_daemon only because cwd leads sys.path. -E -s
+            # ignore PYTHON* env vars and the user site directory.
+            result = _run_in_container_as_sandbox_user(
+                container,
+                [
+                    "/usr/local/bin/python3",
+                    "-E",
+                    "-s",
+                    "-m",
+                    "sandbox_daemon.manifest",
+                    str(session_id),
+                ],
+                workdir="/opt",
+            )
+        except ExecError as e:
+            raise RuntimeError(f"Failed to build outputs manifest: {e}") from e
+        return OutputsManifestResponse.model_validate_json(result.stdout_text)
 
     def _parse_ls_output(self, ls_output: str, base_path: str) -> list[FilesystemEntry]:
         entries: list[FilesystemEntry] = []

--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1-labs
 # Sandbox Container Image
 #
 # User-shared sandbox: one pod per user, sessions created via kubectl exec.
@@ -186,6 +187,15 @@ ENV PATH="/home/sandbox/.opencode/bin:${PATH}"
 ENV OPENCODE_DISABLE_MODELS_FETCH=1
 
 COPY --exclude=__pycache__ sandbox_daemon/ /workspace/sandbox_daemon/
+# Root-owned copy for exec-based backends: the manifest must run code the
+# sandbox user cannot replace. /workspace stays sandbox-owned below. The
+# contract model needs pydantic, so the root-owned system interpreter gets its
+# own copy (version pinned to match initial-requirements.txt): the exec path
+# must share nothing with the sandbox-owned venv.
+COPY --exclude=__pycache__ sandbox_daemon/ /opt/sandbox_daemon/
+RUN /usr/local/bin/python3 -m pip install --no-cache-dir --only-binary=:all: \
+    pydantic==2.13.4 && \
+    rm -rf /root/.cache/pip
 COPY entrypoint.sh /workspace/entrypoint.sh
 COPY sidecar-entrypoint.sh /workspace/sidecar-entrypoint.sh
 

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/contract.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/contract.py
@@ -15,6 +15,7 @@ SIDECAR_READY_PATH = "/ready"
 SIDECAR_PUSH_PATH = "/push"
 PUSH_DAEMON_PORT = 8731
 SIDECAR_FILESYSTEM_LIST_PATH = "/filesystem/list"
+SIDECAR_OUTPUTS_MANIFEST_PATH = "/filesystem/outputs-manifest"
 SIDECAR_SNAPSHOT_CREATE_PATH = "/snapshot/create"
 SIDECAR_SNAPSHOT_RESTORE_PREFIX = "/snapshot/restore"
 SIDECAR_SNAPSHOT_RESTORE_ROUTE = f"{SIDECAR_SNAPSHOT_RESTORE_PREFIX}/{{session_id}}"
@@ -32,6 +33,9 @@ class SnapshotCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     session_id: UUID
+
+
+# Restore has no response body. Failures raise, success is the 204.
 
 
 class FilesystemListRequest(BaseModel):
@@ -57,4 +61,28 @@ class FilesystemListResponse(BaseModel):
     entries: list[SidecarFilesystemEntry]
 
 
-# Restore has no response body — failures raise, success is the 204.
+class OutputsManifestRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: UUID
+
+
+class OutputsManifestEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    is_directory: bool
+    size: int | None = None
+    mtime_ns: int | None = None
+    # None for directories and for files past the hash ceilings.
+    sha256: str | None = None
+
+
+class OutputsManifestResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    entries: list[OutputsManifestEntry]
+    skipped_symlinks: int = 0
+    skipped_special: int = 0
+    skipped_unreadable: int = 0
+    truncated: bool = False

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/manifest.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/manifest.py
@@ -115,6 +115,9 @@ def _walk_directory(walk: _Walk, dir_fd: int, prefix: str, depth: int) -> None:
                 resp.truncated = True
                 children = children[:MANIFEST_MAX_DIR_CHILDREN]
         except OSError:
+            # The listing failed after the open, so the directory's contents
+            # are unknown: admit the gap instead of looking complete.
+            resp.skipped_unreadable += 1
             return
         for child in children:
             if len(resp.entries) >= MANIFEST_MAX_ENTRIES:
@@ -126,6 +129,8 @@ def _walk_directory(walk: _Walk, dir_fd: int, prefix: str, depth: int) -> None:
             try:
                 st = child.stat(follow_symlinks=False)
             except OSError:
+                # Vanished or unreadable between scandir and stat.
+                resp.skipped_unreadable += 1
                 continue
             relative = f"{prefix}{child.name}"
             if stat.S_ISLNK(st.st_mode):

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/manifest.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/manifest.py
@@ -1,0 +1,250 @@
+"""Outputs manifest for the sandbox daemon.
+
+One call describes the outputs tree of a session: regular files with size,
+mtime, and content hash, directories, nothing else, capped by the ceilings
+below.
+
+The sandbox agent mutates this filesystem concurrently, so pathname reopens
+are a symlink-swap race. Every descent below the anchor and every file open
+is fd-relative with O_NOFOLLOW, and file metadata comes from fstat on the
+very descriptor being hashed, so a swapped path can only fail the open,
+never route the walk or the hash outside outputs.
+
+Runs in-process for the sidecar HTTP route and as ``python -m
+sandbox_daemon.manifest <session_id>`` for exec-based backends, both
+producing the same contract model.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import stat
+import sys
+from dataclasses import dataclass, field
+from itertools import islice
+from pathlib import Path
+from uuid import UUID
+
+from sandbox_daemon.contract import OutputsManifestEntry, OutputsManifestResponse
+from sandbox_daemon.snapshot import SESSIONS_ROOT
+
+# Ceilings so a pathological outputs tree cannot stall the daemon or exhaust
+# its memory: the response flags truncation instead of growing without bound.
+MANIFEST_MAX_ENTRIES = 10_000
+MANIFEST_MAX_DEPTH = 64
+MANIFEST_MAX_DIR_CHILDREN = 10_000
+# Files past the per-file ceiling, or hit once the walk-wide budget is
+# spent, are listed with sha256=None rather than read forever (sparse or
+# growing files could otherwise stall the walk).
+MANIFEST_MAX_HASH_BYTES = 256 * 1024 * 1024
+MANIFEST_MAX_TOTAL_HASH_BYTES = 2 * 1024 * 1024 * 1024
+
+_HASH_CHUNK_SIZE = 1024 * 1024
+
+# Vanished, never there, or swapped for a symlink: an empty manifest.
+# Anything else (EACCES, EMFILE, EIO) is a real failure the caller must see.
+_MISSING_ERRNOS = frozenset({errno.ENOENT, errno.ENOTDIR, errno.ELOOP})
+
+
+@dataclass
+class _Walk:
+    response: OutputsManifestResponse = field(
+        default_factory=lambda: OutputsManifestResponse(entries=[])
+    )
+    hash_budget: int = MANIFEST_MAX_TOTAL_HASH_BYTES
+
+
+def _hash_regular_file(
+    dir_fd: int, name: str, allowed_bytes: int
+) -> tuple[os.stat_result, str | None, int] | None:
+    """Open ``name`` relative to ``dir_fd`` and hash it.
+
+    None when the entry is not an openable regular file. Otherwise
+    ``(stat, sha256 or None, bytes read)``, where a None hash means the file
+    was past ``allowed_bytes``. O_NONBLOCK keeps a raced FIFO swap from
+    blocking the open.
+    """
+    try:
+        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dir_fd)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            return None
+        if st.st_size > allowed_bytes:
+            return st, None, 0
+        digest = hashlib.sha256()
+        read_total = 0
+        while chunk := os.read(fd, _HASH_CHUNK_SIZE):
+            digest.update(chunk)
+            read_total += len(chunk)
+            if read_total > allowed_bytes:
+                return st, None, read_total
+        return st, digest.hexdigest(), read_total
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
+def _utf8_safe(name: str) -> bool:
+    try:
+        name.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+def _walk_directory(walk: _Walk, dir_fd: int, prefix: str, depth: int) -> None:
+    """Describe one directory's children, recursing into subdirectories.
+
+    Owns ``dir_fd`` and closes it before returning.
+    """
+    resp = walk.response
+    try:
+        try:
+            with os.scandir(dir_fd) as it:
+                children = sorted(
+                    islice(it, MANIFEST_MAX_DIR_CHILDREN + 1),
+                    key=lambda e: e.name,
+                )
+            if len(children) > MANIFEST_MAX_DIR_CHILDREN:
+                resp.truncated = True
+                children = children[:MANIFEST_MAX_DIR_CHILDREN]
+        except OSError:
+            return
+        for child in children:
+            if len(resp.entries) >= MANIFEST_MAX_ENTRIES:
+                resp.truncated = True
+                return
+            if not _utf8_safe(child.name):
+                resp.skipped_unreadable += 1
+                continue
+            try:
+                st = child.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            relative = f"{prefix}{child.name}"
+            if stat.S_ISLNK(st.st_mode):
+                resp.skipped_symlinks += 1
+                continue
+            if stat.S_ISDIR(st.st_mode):
+                if depth >= MANIFEST_MAX_DEPTH:
+                    resp.truncated = True
+                    continue
+                try:
+                    child_fd = os.open(
+                        child.name,
+                        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                        dir_fd=dir_fd,
+                    )
+                except OSError as e:
+                    # ELOOP means it became a symlink between lstat and
+                    # open, anything else is simply unreadable.
+                    if e.errno == errno.ELOOP:
+                        resp.skipped_symlinks += 1
+                    else:
+                        resp.skipped_unreadable += 1
+                    continue
+                resp.entries.append(
+                    OutputsManifestEntry(
+                        path=relative,
+                        is_directory=True,
+                        mtime_ns=os.fstat(child_fd).st_mtime_ns,
+                    )
+                )
+                _walk_directory(walk, child_fd, f"{relative}/", depth + 1)
+                continue
+            if not stat.S_ISREG(st.st_mode):
+                resp.skipped_special += 1
+                continue
+            allowed = min(MANIFEST_MAX_HASH_BYTES, walk.hash_budget)
+            hashed = _hash_regular_file(dir_fd, child.name, allowed)
+            if hashed is None:
+                resp.skipped_unreadable += 1
+                continue
+            file_st, sha256, bytes_read = hashed
+            walk.hash_budget -= bytes_read
+            resp.entries.append(
+                OutputsManifestEntry(
+                    path=relative,
+                    is_directory=False,
+                    size=file_st.st_size,
+                    mtime_ns=file_st.st_mtime_ns,
+                    sha256=sha256,
+                )
+            )
+    finally:
+        os.close(dir_fd)
+
+
+def _open_dir_no_follow(name: str | Path, dir_fd: int | None = None) -> int | None:
+    """Open a directory refusing symlinks. None means gone or swapped, raises
+    on real failures (permissions, fd exhaustion) so they surface instead of
+    masquerading as an empty tree. Opens inside the walk instead swallow
+    OSError, a partial answer beats none once the walk has begun."""
+    try:
+        return os.open(
+            str(name), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd
+        )
+    except OSError as e:
+        if e.errno in _MISSING_ERRNOS:
+            return None
+        raise
+
+
+def _open_dir_chain(root: Path, *names: str) -> int | None:
+    """Open ``root``, then descend each name fd-relative, refusing symlinks
+    at every hop. None when any component is gone."""
+    fd = _open_dir_no_follow(root)
+    for name in names:
+        if fd is None:
+            return None
+        parent_fd = fd
+        try:
+            fd = _open_dir_no_follow(name, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+    return fd
+
+
+def _walk_from_fd(dir_fd: int | None) -> OutputsManifestResponse:
+    if dir_fd is None:
+        return OutputsManifestResponse(entries=[])
+    walk = _Walk()
+    _walk_directory(walk, dir_fd, "", depth=0)
+    return walk.response
+
+
+def build_manifest_for_root(root: Path) -> OutputsManifestResponse:
+    """Walk ``root`` fd-relative and describe it.
+
+    A missing root is an empty manifest, not an error: a tree that never
+    existed has nothing to describe.
+    """
+    return _walk_from_fd(_open_dir_chain(root))
+
+
+def build_outputs_manifest(session_id: UUID) -> OutputsManifestResponse:
+    """Describe sessions/{sid}/outputs.
+
+    Docker leaves the workspace directory sandbox-owned, so everything under
+    it can be swapped. Each hop below the anchor is therefore opened
+    fd-relative refusing symlinks, and the anchor's own O_NOFOLLOW is
+    defense in depth.
+    """
+    return _walk_from_fd(
+        _open_dir_chain(
+            SESSIONS_ROOT.parent,
+            SESSIONS_ROOT.name,
+            str(session_id),
+            "outputs",
+        )
+    )
+
+
+if __name__ == "__main__":
+    print(build_outputs_manifest(UUID(sys.argv[1])).model_dump_json())

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/manifest.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/manifest.py
@@ -25,6 +25,7 @@ import sys
 from dataclasses import dataclass, field
 from itertools import islice
 from pathlib import Path
+from typing import NamedTuple
 from uuid import UUID
 
 from sandbox_daemon.contract import OutputsManifestEntry, OutputsManifestResponse
@@ -56,15 +57,20 @@ class _Walk:
     hash_budget: int = MANIFEST_MAX_TOTAL_HASH_BYTES
 
 
+class _HashedFile(NamedTuple):
+    stat: os.stat_result
+    # None means the file was past the hash allowance.
+    sha256: str | None
+    bytes_read: int
+
+
 def _hash_regular_file(
     dir_fd: int, name: str, allowed_bytes: int
-) -> tuple[os.stat_result, str | None, int] | None:
+) -> _HashedFile | None:
     """Open ``name`` relative to ``dir_fd`` and hash it.
 
-    None when the entry is not an openable regular file. Otherwise
-    ``(stat, sha256 or None, bytes read)``, where a None hash means the file
-    was past ``allowed_bytes``. O_NONBLOCK keeps a raced FIFO swap from
-    blocking the open.
+    None when the entry is not an openable regular file. O_NONBLOCK keeps a
+    raced FIFO swap from blocking the open.
     """
     try:
         fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dir_fd)
@@ -75,15 +81,15 @@ def _hash_regular_file(
         if not stat.S_ISREG(st.st_mode):
             return None
         if st.st_size > allowed_bytes:
-            return st, None, 0
+            return _HashedFile(st, None, 0)
         digest = hashlib.sha256()
         read_total = 0
         while chunk := os.read(fd, _HASH_CHUNK_SIZE):
             digest.update(chunk)
             read_total += len(chunk)
             if read_total > allowed_bytes:
-                return st, None, read_total
-        return st, digest.hexdigest(), read_total
+                return _HashedFile(st, None, read_total)
+        return _HashedFile(st, digest.hexdigest(), read_total)
     except OSError:
         return None
     finally:
@@ -171,15 +177,14 @@ def _walk_directory(walk: _Walk, dir_fd: int, prefix: str, depth: int) -> None:
             if hashed is None:
                 resp.skipped_unreadable += 1
                 continue
-            file_st, sha256, bytes_read = hashed
-            walk.hash_budget -= bytes_read
+            walk.hash_budget -= hashed.bytes_read
             resp.entries.append(
                 OutputsManifestEntry(
                     path=relative,
                     is_directory=False,
-                    size=file_st.st_size,
-                    mtime_ns=file_st.st_mtime_ns,
-                    sha256=sha256,
+                    size=hashed.stat.st_size,
+                    mtime_ns=hashed.stat.st_mtime_ns,
+                    sha256=hashed.sha256,
                 )
             )
     finally:

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
@@ -22,17 +22,20 @@ from sandbox_daemon.contract import (
     SIDECAR_OPENCODE_HISTORY_CREATE_PATH,
     SIDECAR_OPENCODE_HISTORY_MARK_RESTORED_PATH,
     SIDECAR_OPENCODE_HISTORY_RESTORE_PATH,
+    SIDECAR_OUTPUTS_MANIFEST_PATH,
     SIDECAR_PUSH_PATH,
     SIDECAR_PUSH_PUBLIC_KEY_ENV_VAR,
     SIDECAR_READY_PATH,
     SIDECAR_SNAPSHOT_CREATE_PATH,
     SIDECAR_SNAPSHOT_RESTORE_ROUTE,
     FilesystemListRequest,
+    OutputsManifestRequest,
     SnapshotCreateRequest,
     sidecar_snapshot_restore_path,
 )
 from sandbox_daemon.extract import MAX_BUNDLE_BYTES, safe_extract_then_atomic_swap
 from sandbox_daemon.filesystem import FilesystemPathError, list_session_directory
+from sandbox_daemon.manifest import build_outputs_manifest
 from sandbox_daemon.opencode_history import (
     create_opencode_history_archive_file,
     mark_opencode_history_restored,
@@ -181,6 +184,33 @@ async def filesystem_list(
         raise HTTPException(status_code=500, detail=f"filesystem list OS error: {e}")
 
     return listing.model_dump()
+
+
+@app.post(SIDECAR_OUTPUTS_MANIFEST_PATH)
+async def outputs_manifest(
+    request: Request,
+    x_push_signature: str = Header(..., alias="X-Push-Signature"),
+    x_push_timestamp: str = Header(..., alias="X-Push-Timestamp"),
+) -> dict[str, object]:
+    body = await request.body()
+    _verify_signature(
+        SIDECAR_OUTPUTS_MANIFEST_PATH,
+        hashlib.sha256(body).hexdigest(),
+        x_push_signature,
+        x_push_timestamp,
+    )
+
+    try:
+        payload = OutputsManifestRequest.model_validate_json(body)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid request body: {e}")
+
+    try:
+        manifest = await asyncio.to_thread(build_outputs_manifest, payload.session_id)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"outputs manifest OS error: {e}")
+
+    return manifest.model_dump()
 
 
 @app.post(SIDECAR_PUSH_PATH)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -85,6 +85,7 @@ from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     SIDECAR_OPENCODE_HISTORY_RESTORE_PATH,
     SIDECAR_PUSH_PUBLIC_KEY_ENV_VAR,
     SIDECAR_SNAPSHOT_CREATE_PATH,
+    OutputsManifestResponse,
     SnapshotCreateRequest,
     sidecar_snapshot_restore_path,
 )
@@ -2031,6 +2032,16 @@ fi
             raise RuntimeError(f"Failed to list directory: {e}") from e
         except SidecarRequestError as e:
             raise RuntimeError(f"Failed to list directory: {e}") from e
+
+    def get_outputs_manifest(
+        self, sandbox_id: UUID, session_id: UUID
+    ) -> OutputsManifestResponse:
+        try:
+            return self._sidecar_client.outputs_manifest(
+                sandbox_id=sandbox_id, session_id=session_id
+            )
+        except SidecarRequestError as e:
+            raise RuntimeError(f"Failed to build outputs manifest: {e}") from e
 
     def read_file(self, sandbox_id: UUID, session_id: UUID, path: str) -> bytes:
         """Read a file from the session's workspace.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/sidecar_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/sidecar_client.py
@@ -20,9 +20,12 @@ from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     PUSH_DAEMON_PORT,
     SIDECAR_FILESYSTEM_LIST_PATH,
     SIDECAR_HEALTH_PATH,
+    SIDECAR_OUTPUTS_MANIFEST_PATH,
     SIDECAR_PUSH_PATH,
     FilesystemListRequest,
     FilesystemListResponse,
+    OutputsManifestRequest,
+    OutputsManifestResponse,
 )
 from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.timeouts import (
@@ -169,6 +172,36 @@ class SidecarClient:
             )
             for entry in listing.entries
         ]
+
+    def outputs_manifest(
+        self,
+        *,
+        sandbox_id: UUID,
+        session_id: UUID,
+        timeout_seconds: float = RPC_TIMEOUT_SECONDS,
+    ) -> OutputsManifestResponse:
+        payload = OutputsManifestRequest(session_id=session_id)
+        body = payload.model_dump_json().encode()
+        sha256_hex = hashlib.sha256(body).hexdigest()
+
+        try:
+            with httpx.Client(timeout=timeout_seconds) as http_client:
+                resp = http_client.post(
+                    self._url(self._host(sandbox_id), SIDECAR_OUTPUTS_MANIFEST_PATH),
+                    content=body,
+                    headers=self._signed_headers(
+                        signing_path=SIDECAR_OUTPUTS_MANIFEST_PATH,
+                        sha256_hex=sha256_hex,
+                        content_type="application/json",
+                    ),
+                )
+        except httpx.TransportError as e:
+            raise SidecarRequestError(f"outputs manifest request failed: {e}") from e
+
+        if resp.status_code != 200:
+            raise SidecarStatusError("outputs manifest", resp.status_code, resp.text)
+
+        return OutputsManifestResponse.model_validate_json(resp.content)
 
     @contextmanager
     def request_and_stream_new_snapshot(

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -57,6 +57,9 @@ from typing import Any, cast
 from uuid import UUID
 
 from onyx.server.features.build.sandbox.base import SandboxEvent, SandboxManager
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    OutputsManifestResponse,
+)
 from onyx.server.features.build.sandbox.models import (
     CraftLLMProviderConfig,
     CraftMCPServerConfig,
@@ -156,6 +159,7 @@ class StubSandboxManager(SandboxManager):
         ] = {}
         self.create_opencode_history_snapshot_returns: bool | object = _UNSET
         self.list_directory_returns: list[FilesystemEntry] | None = None
+        self.outputs_manifest_returns: OutputsManifestResponse | None = None
         self.list_directory_returns_by_path: dict[str, list[FilesystemEntry]] | None = (
             None
         )
@@ -213,6 +217,7 @@ class StubSandboxManager(SandboxManager):
         self.send_message_count: int = 0
         self.subscribe_to_opencode_session_count: int = 0
         self.list_directory_count: int = 0
+        self.get_outputs_manifest_count: int = 0
         self.read_file_count: int = 0
         self.upload_file_count: int = 0
         self.delete_file_count: int = 0
@@ -239,6 +244,7 @@ class StubSandboxManager(SandboxManager):
         self.last_send_message_payload: dict[str, Any] | None = None
         self.last_subscribe_to_opencode_session_payload: dict[str, Any] | None = None
         self.last_list_directory_payload: dict[str, Any] | None = None
+        self.last_outputs_manifest_payload: dict[str, Any] | None = None
         self.list_directory_payloads: list[dict[str, Any]] = []
         self.last_read_file_payload: dict[str, Any] | None = None
         self.last_upload_file_payload: dict[str, Any] | None = None
@@ -602,6 +608,18 @@ class StubSandboxManager(SandboxManager):
         if self.list_directory_returns is None:
             raise _not_configured("list_directory")
         return self.list_directory_returns
+
+    def get_outputs_manifest(
+        self, sandbox_id: UUID, session_id: UUID
+    ) -> OutputsManifestResponse:
+        self.get_outputs_manifest_count += 1
+        self.last_outputs_manifest_payload = {
+            "sandbox_id": sandbox_id,
+            "session_id": session_id,
+        }
+        if self.outputs_manifest_returns is None:
+            raise _not_configured("get_outputs_manifest")
+        return self.outputs_manifest_returns
 
     def read_file(self, sandbox_id: UUID, session_id: UUID, path: str) -> bytes:
         self.read_file_count += 1

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/sandbox_daemon/test_sandbox_daemon.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/sandbox_daemon/test_sandbox_daemon.py
@@ -77,6 +77,7 @@ def _load_sandbox_daemon_modules() -> tuple[ModuleType, ModuleType]:
         "snapshot",
         "opencode_history",
         "filesystem",
+        "manifest",
         "server",
     ):
         spec = importlib.util.spec_from_file_location(

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_outputs_manifest.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_outputs_manifest.py
@@ -131,6 +131,23 @@ def test_special_files_skipped(manifest_module: ModuleType, tmp_path: Path) -> N
     assert result.skipped_special == 1
 
 
+def test_unreadable_directory_counted_not_listed(
+    manifest_module: ModuleType, tmp_path: Path
+) -> None:
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses directory permissions")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    (locked / "hidden.txt").write_bytes(b"x")
+    locked.chmod(0o000)
+    try:
+        result = manifest_module.build_manifest_for_root(tmp_path)
+    finally:
+        locked.chmod(0o755)
+    assert [e.path for e in result.entries] == []
+    assert result.skipped_unreadable == 1
+
+
 def test_truncation_flags_instead_of_growing(
     manifest_module: ModuleType,
     tmp_path: Path,

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_outputs_manifest.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_outputs_manifest.py
@@ -1,0 +1,185 @@
+"""Unit tests for the sandbox daemon's outputs manifest walk.
+
+The manifest is the server's only view of the outputs tree, so the walk's
+lstat discipline (symlinks never followed, non-regular files never described)
+and its hash/size accuracy are load-bearing. The daemon modules are loaded
+dynamically under the ``sandbox_daemon`` package name because their
+in-container layout is not on the backend Python path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+from uuid import uuid4
+
+import pytest
+
+from tests.common.paths import find_ancestor_containing
+
+_DAEMON_DIR = (
+    find_ancestor_containing("backend/onyx")
+    / "backend"
+    / "onyx"
+    / "server"
+    / "features"
+    / "build"
+    / "sandbox"
+    / "image"
+    / "sandbox_daemon"
+)
+
+# Same full module list as test_sandbox_daemon's loader, so whichever file
+# runs first the other's cache guard sees every module and reuses it, and no
+# model class gets two identities in one session.
+_DAEMON_MODULES = (
+    "contract",
+    "extract",
+    "snapshot",
+    "opencode_history",
+    "filesystem",
+    "manifest",
+    "server",
+)
+
+
+def _load_manifest_module() -> ModuleType:
+    if "sandbox_daemon.manifest" in sys.modules:
+        return sys.modules["sandbox_daemon.manifest"]
+
+    sys.modules.setdefault("sandbox_daemon", types.ModuleType("sandbox_daemon"))
+    for name in _DAEMON_MODULES:
+        spec = importlib.util.spec_from_file_location(
+            f"sandbox_daemon.{name}", str(_DAEMON_DIR / f"{name}.py")
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[f"sandbox_daemon.{name}"] = mod
+        spec.loader.exec_module(mod)
+
+    return sys.modules["sandbox_daemon.manifest"]
+
+
+@pytest.fixture()
+def manifest_module() -> ModuleType:
+    return _load_manifest_module()
+
+
+def test_missing_root_is_empty(manifest_module: ModuleType, tmp_path: Path) -> None:
+    result = manifest_module.build_manifest_for_root(tmp_path / "outputs")
+    assert result.entries == []
+    assert not result.truncated
+
+
+def test_files_and_directories_described(
+    manifest_module: ModuleType, tmp_path: Path
+) -> None:
+    (tmp_path / "report.md").write_bytes(b"hello")
+    (tmp_path / "web").mkdir()
+    (tmp_path / "web" / "index.html").write_bytes(b"<html>")
+
+    result = manifest_module.build_manifest_for_root(tmp_path)
+    by_path = {e.path: e for e in result.entries}
+
+    assert set(by_path) == {"report.md", "web", "web/index.html"}
+    assert by_path["web"].is_directory and by_path["web"].sha256 is None
+    report = by_path["report.md"]
+    assert report.size == 5
+    assert report.sha256 is not None and report.mtime_ns is not None
+
+
+def test_hash_tracks_content(manifest_module: ModuleType, tmp_path: Path) -> None:
+    target = tmp_path / "deck.pptx"
+    target.write_bytes(b"v1")
+    first = {
+        e.path: e for e in manifest_module.build_manifest_for_root(tmp_path).entries
+    }["deck.pptx"].sha256
+    target.write_bytes(b"v2")
+    second = {
+        e.path: e for e in manifest_module.build_manifest_for_root(tmp_path).entries
+    }["deck.pptx"].sha256
+    assert first != second
+
+
+def test_symlinks_skipped_never_followed(
+    manifest_module: ModuleType, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_bytes(b"secret")
+    root = tmp_path / "outputs"
+    root.mkdir()
+    (root / "escape").symlink_to(outside)
+    (root / "file_link").symlink_to(outside / "secret.txt")
+    (root / "real.txt").write_bytes(b"ok")
+
+    result = manifest_module.build_manifest_for_root(root)
+    assert [e.path for e in result.entries] == ["real.txt"]
+    assert result.skipped_symlinks == 2
+
+
+def test_special_files_skipped(manifest_module: ModuleType, tmp_path: Path) -> None:
+    os.mkfifo(tmp_path / "pipe")
+    (tmp_path / "real.txt").write_bytes(b"ok")
+
+    result = manifest_module.build_manifest_for_root(tmp_path)
+    assert [e.path for e in result.entries] == ["real.txt"]
+    assert result.skipped_special == 1
+
+
+def test_truncation_flags_instead_of_growing(
+    manifest_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manifest_module, "MANIFEST_MAX_ENTRIES", 3)
+    for i in range(5):
+        (tmp_path / f"f{i}.txt").write_bytes(b"x")
+
+    result = manifest_module.build_manifest_for_root(tmp_path)
+    assert len(result.entries) == 3
+    assert result.truncated
+
+
+def test_oversize_file_listed_without_hash(
+    manifest_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manifest_module, "MANIFEST_MAX_HASH_BYTES", 4)
+    (tmp_path / "big.bin").write_bytes(b"x" * 10)
+    (tmp_path / "small.bin").write_bytes(b"x")
+
+    result = manifest_module.build_manifest_for_root(tmp_path)
+    by_path = {e.path: e for e in result.entries}
+    assert by_path["big.bin"].sha256 is None
+    assert by_path["big.bin"].size == 10
+    assert by_path["small.bin"].sha256 is not None
+
+
+def test_session_descent_reaches_outputs(
+    manifest_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = uuid4()
+    sessions_root = tmp_path / "workspace" / "sessions"
+    outputs = sessions_root / str(session_id) / "outputs"
+    outputs.mkdir(parents=True)
+    (outputs / "deck.pptx").write_bytes(b"deck")
+    monkeypatch.setattr(manifest_module, "SESSIONS_ROOT", sessions_root)
+
+    result = manifest_module.build_outputs_manifest(session_id)
+    assert [e.path for e in result.entries] == ["deck.pptx"]
+
+    # A session directory swapped for a symlink yields nothing.
+    other = uuid4()
+    elsewhere = tmp_path / "elsewhere" / "outputs"
+    elsewhere.mkdir(parents=True)
+    (elsewhere / "leak.txt").write_bytes(b"leak")
+    (sessions_root / str(other)).symlink_to(tmp_path / "elsewhere")
+    assert manifest_module.build_outputs_manifest(other).entries == []


### PR DESCRIPTION
## Description

**Why.** The artifact index (PR1, #14319) is only useful if something can fill it, and the reconciler that will (PR4) needs a trustworthy answer to "what is in this session's outputs tree right now". Nothing provides that today: `list_directory` walks one level with no hashes, and the sandbox agent mutates the filesystem concurrently, so a naive pathname walk can be routed anywhere by a symlink swapped in mid-walk. This PR gives the daemon one call that describes the whole outputs tree, hardened against the agent it shares a filesystem with.

**What.**
- `sandbox_daemon/manifest.py`: a bounded, fd-relative walk of `sessions/{sid}/outputs`. Every descent below the anchor is `O_NOFOLLOW`, file metadata comes from fstat on the very descriptor being hashed, so a swapped path can only fail an open, never route the walk or the hash outside outputs. Symlinks and special files are counted, never followed. Ceilings on entries, depth, per-directory children, per-file hash bytes, and a walk-wide hash budget; the response carries skip counters and a `truncated` flag so a partial listing is always distinguishable from a complete one.
- Served two ways, both returning the same contract model: a signed sidecar HTTP route on kubernetes, and `python -m sandbox_daemon.manifest` over exec on docker. The docker exec runs the root-owned system interpreter (`-E -s`, with its own pinned pydantic) against a root-owned `/opt` copy of the daemon, because the sandbox user owns `/workspace` and could otherwise swap the code that describes its outputs.
- Manager plumbing: `SandboxManager.get_outputs_manifest` on both backends and the test stub.
- Pins the labs BuildKit syntax the Dockerfile's pre-existing `COPY --exclude` requires, so local builds work without flag overrides.

The manifest, concretely — every regular file and directory under outputs/, recursively, paths outputs-relative and sorted. Files carry size, mtime (fstat on the hashed descriptor), and sha256, null past the hash ceilings; directories carry mtime only. The four trailers are the honesty signals, and the reconciler refuses to act unless `truncated` is false and `skipped_unreadable` is zero:

```json
{
  "entries": [
    {"path": "deck.pptx", "is_directory": false, "size": 48211,
     "mtime_ns": 1787795635366373007, "sha256": "5891b5b5..."},
    {"path": "web", "is_directory": true, "size": null,
     "mtime_ns": 1787795635366373007, "sha256": null},
    {"path": "web/package.json", "is_directory": false, "size": 412,
     "mtime_ns": 1787795635366373007, "sha256": "b53a5538..."}
  ],
  "skipped_symlinks": 1,
  "skipped_special": 0,
  "skipped_unreadable": 0,
  "truncated": false
}
```

Nothing calls `get_outputs_manifest` yet; the consumer is the reconciler in #14327.

## How Has This Been Tested?

- Unit tests (`test_outputs_manifest.py`): files/directories described with sizes and hashes, hash tracks content, symlinks skipped and never followed (including a session directory swapped for a symlink yielding an empty manifest), special files skipped, entry-cap truncation flagged, oversize files listed without a hash, an unreadable directory counted rather than silently omitted, and the full `sessions/{sid}/outputs` descent.
- Live verification in the real image: built the sandbox image from this branch and ran the exact manager exec (`docker exec -u 1000:1000 -w /opt ... /usr/local/bin/python3 -E -s -m sandbox_daemon.manifest <sid>`) — correct manifest JSON, planted symlink skipped, exit 0. This caught and fixed a real bug: `/usr/bin/python3` does not exist in the image and the system interpreter had no pydantic, so the exec path now installs a root-owned pydantic and uses the real interpreter path.
- Full CI matrix green (160 checks).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check