### PR TITLE
feat(craft): outputs artifact classifier

### DIFF
--- a/backend/onyx/server/features/build/artifact_classifier.py
+++ b/backend/onyx/server/features/build/artifact_classifier.py
@@ -1,0 +1,190 @@
+"""Classifies a session's outputs listing into artifacts.
+
+Pure functions: each visible top-level entry is one artifact, files typed by
+extension with a generic fallback, directories aggregated over their visible
+descendants, and the scaffolded webapp directory recognized. Hidden names (the
+shared workspace visibility rule) never influence the result, so churn in
+node_modules or .next cannot dirty an artifact. Callers adapt the sandbox
+daemon's outputs manifest into ``OutputEntry`` values, and the listing must be
+complete: a truncated manifest reduces to hashes that flap, so skip
+reconciliation instead of reducing one.
+"""
+
+import mimetypes
+from collections import defaultdict
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import PurePosixPath
+
+from onyx.db.enums import ArtifactType
+from onyx.server.features.build.configs import is_hidden_workspace_name
+from onyx.server.features.build.sandbox.nextjs_dev import (
+    WEBAPP_OUTPUTS_RELATIVE_PACKAGE_JSON,
+    WEBAPP_ROOT_NAME,
+)
+
+# Formats a product surface handles (preview, export). .doc and .xls have no
+# such surface and stay generic.
+_EXTENSION_TYPES = {
+    ".pptx": ArtifactType.PPTX,
+    ".ppt": ArtifactType.PPTX,
+    ".docx": ArtifactType.DOCX,
+    ".xlsx": ArtifactType.EXCEL,
+    ".xlsm": ArtifactType.EXCEL,
+    ".pdf": ArtifactType.PDF,
+    ".csv": ArtifactType.CSV,
+    ".md": ArtifactType.MARKDOWN,
+    ".markdown": ArtifactType.MARKDOWN,
+}
+
+_ARCHIVE_SUFFIXES = {".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar"}
+
+# Checked before the mimetypes families: .ts is registered as video/mp2t.
+_CODE_SUFFIXES = {
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".html",
+    ".css",
+    ".scss",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".sql",
+    ".sh",
+    ".ipynb",
+    ".go",
+    ".rs",
+    ".java",
+    ".c",
+    ".cpp",
+    ".rb",
+    ".php",
+}
+
+_MEDIA_FAMILY_TYPES = {
+    "image": ArtifactType.IMAGE,
+    "audio": ArtifactType.AUDIO,
+    "video": ArtifactType.VIDEO,
+}
+
+
+@dataclass(frozen=True)
+class OutputEntry:
+    """One entry of an outputs listing, path outputs-relative with ``/``
+    separators. ``sha256`` is None for directories and unhashed files."""
+
+    path: str
+    is_directory: bool
+    size: int | None = None
+    mtime_ns: int | None = None
+    sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class DerivedArtifact:
+    """One artifact a reconciler should upsert, keyed by ``path``."""
+
+    path: str
+    name: str
+    type: ArtifactType
+    size_bytes: int | None
+    content_hash: str | None
+
+
+def classify_file(filename: str) -> ArtifactType:
+    suffix = PurePosixPath(filename).suffix.lower()
+    if suffix in _EXTENSION_TYPES:
+        return _EXTENSION_TYPES[suffix]
+    if suffix in _ARCHIVE_SUFFIXES:
+        return ArtifactType.ARCHIVE
+    if suffix in _CODE_SUFFIXES:
+        return ArtifactType.CODE
+    mime, _ = mimetypes.guess_type(filename)
+    if mime is not None:
+        family = mime.split("/", 1)[0]
+        if family in _MEDIA_FAMILY_TYPES:
+            return _MEDIA_FAMILY_TYPES[family]
+    return ArtifactType.FILE
+
+
+def _is_visible(path: str) -> bool:
+    return not any(is_hidden_workspace_name(part) for part in path.split("/"))
+
+
+def _file_signal(entry: OutputEntry) -> str | None:
+    """Change signal for a file: its hash, or a size-and-mtime surrogate for
+    files past the hash ceiling, shaped so it can never read as a real sha."""
+    if entry.sha256 is not None:
+        return entry.sha256
+    if entry.size is None and entry.mtime_ns is None:
+        return None
+    size = "" if entry.size is None else entry.size
+    mtime = "" if entry.mtime_ns is None else entry.mtime_ns
+    return f"meta:{size}:{mtime}"
+
+
+def _directory_hash(root: str, contents: list[OutputEntry]) -> str:
+    """Deterministic hash of a directory's visible content, over paths
+    relative to the directory, so identical trees hash identically. A child
+    rename, addition, removal, or change signal all move it."""
+    prefix = len(root) + 1
+    digest = sha256()
+    for entry in sorted(contents, key=lambda e: e.path):
+        relative = entry.path[prefix:]
+        if entry.is_directory:
+            digest.update(f"{relative}\x00dir\n".encode())
+        else:
+            digest.update(f"{relative}\x00{_file_signal(entry) or ''}\n".encode())
+    return digest.hexdigest()
+
+
+def derive_artifacts(entries: list[OutputEntry]) -> list[DerivedArtifact]:
+    """Reduce a complete outputs listing to its artifacts, sorted by path.
+
+    Each visible top-level entry is one artifact, nested files belong to
+    their top-level directory and never surface on their own.
+    """
+    top_level: list[OutputEntry] = []
+    children: dict[str, list[OutputEntry]] = defaultdict(list)
+    for entry in entries:
+        if not _is_visible(entry.path):
+            continue
+        root, _, nested = entry.path.partition("/")
+        if nested:
+            children[root].append(entry)
+        else:
+            top_level.append(entry)
+
+    artifacts: list[DerivedArtifact] = []
+    for entry in top_level:
+        name = PurePosixPath(entry.path).name
+        if not entry.is_directory:
+            artifacts.append(
+                DerivedArtifact(
+                    path=entry.path,
+                    name=name,
+                    type=classify_file(entry.path),
+                    size_bytes=entry.size,
+                    content_hash=_file_signal(entry),
+                )
+            )
+            continue
+        contents = children[entry.path]
+        is_webapp = entry.path == WEBAPP_ROOT_NAME and any(
+            c.path == WEBAPP_OUTPUTS_RELATIVE_PACKAGE_JSON and not c.is_directory
+            for c in contents
+        )
+        artifacts.append(
+            DerivedArtifact(
+                path=entry.path,
+                name=name,
+                type=ArtifactType.WEB_APP if is_webapp else ArtifactType.DIRECTORY,
+                size_bytes=sum(c.size or 0 for c in contents if not c.is_directory),
+                content_hash=_directory_hash(entry.path, contents),
+            )
+        )
+    return sorted(artifacts, key=lambda a: a.path)

--- a/backend/onyx/server/features/build/artifact_classifier.py
+++ b/backend/onyx/server/features/build/artifact_classifier.py
@@ -117,7 +117,10 @@ def _is_visible(path: str) -> bool:
 
 def _file_signal(entry: OutputEntry) -> str | None:
     """Change signal for a file: its hash, or a size-and-mtime surrogate for
-    files past the hash ceiling, shaped so it can never read as a real sha."""
+    files past the hash ceiling, shaped so it can never read as a real sha.
+    The manifest carries fstat size and mtime for every file it lists. An
+    adapter omitting one degrades detection to the other field alone, which
+    still beats no signal, so partial metadata is accepted."""
     if entry.sha256 is not None:
         return entry.sha256
     if entry.size is None and entry.mtime_ns is None:

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -53,6 +53,27 @@ MAX_TOTAL_UPLOAD_SIZE_MB = int(os.environ.get("BUILD_MAX_TOTAL_UPLOAD_SIZE_MB", 
 MAX_TOTAL_UPLOAD_SIZE_BYTES = MAX_TOTAL_UPLOAD_SIZE_MB * 1024 * 1024
 ATTACHMENTS_DIRECTORY = "attachments"
 
+# Workspace names hidden from every user-facing surface: listings, zips, and
+# artifact derivation all share this one visibility rule.
+_HIDDEN_WORKSPACE_NAMES = {
+    ".venv",
+    ".git",
+    ".next",
+    "__pycache__",
+    "node_modules",
+    ".DS_Store",
+    "opencode.json",
+    ".env",
+    ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
+}
+
+
+def is_hidden_workspace_name(name: str) -> bool:
+    return name in _HIDDEN_WORKSPACE_NAMES or name.startswith(".")
+
+
 # ==============================================================================
 # Kubernetes sandbox (SANDBOX_BACKEND=kubernetes)
 # ==============================================================================

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -15,8 +15,12 @@ _TEMPLATE_NEXT_CONFIG = (
     Path(__file__).parent / "image" / "templates" / "outputs" / "web" / "next.config.ts"
 )
 
-# Canonical scaffold marker shared by bootstrap, restore, and API detection.
-WEBAPP_PACKAGE_JSON_PATH = "outputs/web/package.json"
+# Canonical scaffold marker shared by bootstrap, restore, API detection, and
+# artifact classification, built from one set of parts so the variants cannot
+# drift.
+WEBAPP_ROOT_NAME = "web"
+WEBAPP_OUTPUTS_RELATIVE_PACKAGE_JSON = f"{WEBAPP_ROOT_NAME}/package.json"
+WEBAPP_PACKAGE_JSON_PATH = f"outputs/{WEBAPP_OUTPUTS_RELATIVE_PACKAGE_JSON}"
 
 
 def webapp_base_path(session_id: UUID | str) -> str:

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -36,6 +36,7 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.configs import (
     MAX_TOTAL_UPLOAD_SIZE_BYTES,
     MAX_UPLOAD_FILES_PER_SESSION,
+    is_hidden_workspace_name,
 )
 from onyx.server.features.build.db.build_session import (
     create_build_session__no_commit,
@@ -132,21 +133,6 @@ def mark_opencode_dispose_pending(session_id: UUID) -> None:
 _WEBAPP_PROBE_TIMEOUT_SECONDS = 2.0
 
 
-# Hidden directories/files to filter from listings
-HIDDEN_PATTERNS = {
-    ".venv",
-    ".git",
-    ".next",
-    "__pycache__",
-    "node_modules",
-    ".DS_Store",
-    "opencode.json",
-    ".env",
-    ".gitignore",
-    "nextjs.log",
-    "nextjs.pid",
-}
-
 _WEBAPP_DIRECTORY = str(Path(WEBAPP_PACKAGE_JSON_PATH).parent)
 _WEBAPP_PACKAGE_FILENAME = Path(WEBAPP_PACKAGE_JSON_PATH).name
 
@@ -159,7 +145,7 @@ def _sanitize_zip_basename(name: str, *, allow_dots: bool) -> str:
 
 
 def _is_hidden_workspace_entry(entry: FilesystemEntry) -> bool:
-    return entry.name in HIDDEN_PATTERNS or entry.name.startswith(".")
+    return is_hidden_workspace_name(entry.name)
 
 
 class SessionManager:

--- a/backend/tests/unit/onyx/server/features/craft/test_artifact_classifier.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_artifact_classifier.py
@@ -158,6 +158,14 @@ def test_unhashed_file_signals_size_and_mtime_changes() -> None:
     assert top(base) != top(OutputEntry("big.bin", False, size=10, mtime_ns=2))
     assert top(OutputEntry("big.bin", False)) is None
 
+    # Partial metadata degrades to what is present, never to no signal.
+    assert top(OutputEntry("big.bin", False, size=10)) != top(
+        OutputEntry("big.bin", False, size=20)
+    )
+    assert top(OutputEntry("big.bin", False, mtime_ns=1)) != top(
+        OutputEntry("big.bin", False, mtime_ns=2)
+    )
+
     # The same surrogate drives the directory hash for nested unhashed files.
     def nested(entry: OutputEntry) -> str | None:
         return derive_artifacts([OutputEntry("d", True), entry])[0].content_hash

--- a/backend/tests/unit/onyx/server/features/craft/test_artifact_classifier.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_artifact_classifier.py
@@ -1,0 +1,234 @@
+"""Unit tests for the outputs artifact classifier.
+
+The classifier decides what the panel presents as deliverables, so its
+top-level-only reduction, the webapp convention, and the hidden-name rule are
+all load-bearing, and directory hashes must move exactly when visible content
+moves.
+"""
+
+import pytest
+
+from onyx.db.enums import ArtifactType
+from onyx.server.features.build.artifact_classifier import (
+    DerivedArtifact,
+    OutputEntry,
+    classify_file,
+    derive_artifacts,
+)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("deck.pptx", ArtifactType.PPTX),
+        ("legacy.ppt", ArtifactType.PPTX),
+        ("report.DOCX", ArtifactType.DOCX),
+        ("sheet.xlsx", ArtifactType.EXCEL),
+        ("macro.xlsm", ArtifactType.EXCEL),
+        ("paper.pdf", ArtifactType.PDF),
+        ("rows.csv", ArtifactType.CSV),
+        ("notes.md", ArtifactType.MARKDOWN),
+        ("logo.png", ArtifactType.IMAGE),
+        ("LOGO.PNG", ArtifactType.IMAGE),
+        ("icon.svg", ArtifactType.IMAGE),
+        ("song.mp3", ArtifactType.AUDIO),
+        ("clip.mp4", ArtifactType.VIDEO),
+        ("bundle.zip", ArtifactType.ARCHIVE),
+        ("bundle.tar", ArtifactType.ARCHIVE),
+        ("bundle.tar.gz", ArtifactType.ARCHIVE),
+        ("script.py", ArtifactType.CODE),
+        ("page.html", ArtifactType.CODE),
+        ("data.json", ArtifactType.CODE),
+        ("view.tsx", ArtifactType.CODE),
+        # .ts is registered as video/mp2t, the code set must win.
+        ("main.ts", ArtifactType.CODE),
+        # Legacy binary formats with no product surface stay generic.
+        ("old.doc", ArtifactType.FILE),
+        ("mystery.xyz", ArtifactType.FILE),
+        ("no_extension", ArtifactType.FILE),
+    ],
+)
+def test_classify_file(name: str, expected: ArtifactType) -> None:
+    assert classify_file(name) == expected
+
+
+def test_top_level_entries_become_artifacts_nested_do_not() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("deck.pptx", False, size=10, sha256="a" * 64),
+            OutputEntry("report", True),
+            OutputEntry("report/final.pdf", False, size=5, sha256="b" * 64),
+        ]
+    )
+    assert [a.path for a in artifacts] == ["deck.pptx", "report"]
+    deck, report = artifacts
+    assert deck == DerivedArtifact(
+        path="deck.pptx",
+        name="deck.pptx",
+        type=ArtifactType.PPTX,
+        size_bytes=10,
+        content_hash="a" * 64,
+    )
+    assert report.type == ArtifactType.DIRECTORY
+    assert report.size_bytes == 5
+    assert report.content_hash is not None
+
+
+def test_deep_nesting_collapses_into_the_top_level_directory() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("a", True),
+            OutputEntry("a/b", True),
+            OutputEntry("a/b/c", True),
+            OutputEntry("a/b/c/d.txt", False, size=7, sha256="a" * 64),
+            OutputEntry("a/top.txt", False, size=3, sha256="b" * 64),
+        ]
+    )
+    assert [a.path for a in artifacts] == ["a"]
+    assert artifacts[0].size_bytes == 10
+
+
+def test_directory_hash_tracks_visible_content() -> None:
+    base = [
+        OutputEntry("report", True),
+        OutputEntry("report/final.pdf", False, size=5, sha256="b" * 64),
+    ]
+    changed_hash = [
+        OutputEntry("report", True),
+        OutputEntry("report/final.pdf", False, size=5, sha256="c" * 64),
+    ]
+    renamed_child = [
+        OutputEntry("report", True),
+        OutputEntry("report/renamed.pdf", False, size=5, sha256="b" * 64),
+    ]
+    added_file = base + [
+        OutputEntry("report/extra.txt", False, size=1, sha256="d" * 64)
+    ]
+    hidden_churn = base + [
+        OutputEntry("report/node_modules", True),
+        OutputEntry("report/node_modules/x.js", False, size=9, sha256="e" * 64),
+    ]
+
+    def one(entries: list[OutputEntry]) -> DerivedArtifact:
+        (artifact,) = derive_artifacts(entries)
+        return artifact
+
+    assert one(base).content_hash != one(changed_hash).content_hash
+    assert one(base).content_hash != one(renamed_child).content_hash
+    assert one(base).content_hash != one(added_file).content_hash
+    assert one(base).content_hash == one(hidden_churn).content_hash
+    assert one(base).size_bytes == one(hidden_churn).size_bytes
+
+
+def test_identical_trees_hash_identically() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("first", True),
+            OutputEntry("first/x.txt", False, size=2, sha256="a" * 64),
+            OutputEntry("second", True),
+            OutputEntry("second/x.txt", False, size=2, sha256="a" * 64),
+        ]
+    )
+    assert artifacts[0].content_hash == artifacts[1].content_hash
+
+
+def test_hidden_only_directory_hashes_like_an_empty_one() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("empty", True),
+            OutputEntry("shell", True),
+            OutputEntry("shell/node_modules", True),
+            OutputEntry("shell/node_modules/x.js", False, size=9, sha256="a" * 64),
+        ]
+    )
+    empty, shell = artifacts
+    assert empty.content_hash == shell.content_hash
+    assert shell.size_bytes == 0
+
+
+def test_unhashed_file_signals_size_and_mtime_changes() -> None:
+    def top(entry: OutputEntry) -> str | None:
+        (artifact,) = derive_artifacts([entry])
+        return artifact.content_hash
+
+    base = OutputEntry("big.bin", False, size=10, mtime_ns=1, sha256=None)
+    assert top(base) is not None
+    assert top(base) == top(OutputEntry("big.bin", False, size=10, mtime_ns=1))
+    assert top(base) != top(OutputEntry("big.bin", False, size=20, mtime_ns=1))
+    assert top(base) != top(OutputEntry("big.bin", False, size=10, mtime_ns=2))
+    assert top(OutputEntry("big.bin", False)) is None
+
+    # The same surrogate drives the directory hash for nested unhashed files.
+    def nested(entry: OutputEntry) -> str | None:
+        return derive_artifacts([OutputEntry("d", True), entry])[0].content_hash
+
+    assert nested(OutputEntry("d/big.bin", False, size=10, mtime_ns=1)) != nested(
+        OutputEntry("d/big.bin", False, size=10, mtime_ns=2)
+    )
+
+
+def test_webapp_detected_by_scaffold_convention() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("web", True),
+            OutputEntry("web/package.json", False, size=100, sha256="a" * 64),
+            OutputEntry("web/app", True),
+        ]
+    )
+    assert [a.type for a in artifacts] == [ArtifactType.WEB_APP]
+
+
+def test_web_directory_without_package_json_is_a_directory() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("web", True),
+            OutputEntry("web/index.html", False, size=10, sha256="a" * 64),
+        ]
+    )
+    assert [a.type for a in artifacts] == [ArtifactType.DIRECTORY]
+
+
+def test_webapp_convention_is_exact() -> None:
+    artifacts = derive_artifacts(
+        [
+            # A nested web directory is not the scaffold.
+            OutputEntry("sub", True),
+            OutputEntry("sub/web", True),
+            OutputEntry("sub/web/package.json", False, size=1, sha256="a" * 64),
+            # Nor is a package.json that is itself a directory.
+            OutputEntry("web", True),
+            OutputEntry("web/package.json", True),
+        ]
+    )
+    assert [(a.path, a.type) for a in artifacts] == [
+        ("sub", ArtifactType.DIRECTORY),
+        ("web", ArtifactType.DIRECTORY),
+    ]
+
+
+def test_hidden_names_never_surface() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry(".DS_Store", False, size=1, sha256="a" * 64),
+            OutputEntry(".secrets", True),
+            OutputEntry(".secrets/key.pem", False, size=1, sha256="b" * 64),
+            OutputEntry("node_modules", True),
+            OutputEntry("real.txt", False, size=1, sha256="c" * 64),
+        ]
+    )
+    assert [a.path for a in artifacts] == ["real.txt"]
+
+
+def test_output_is_sorted_regardless_of_input_order() -> None:
+    artifacts = derive_artifacts(
+        [
+            OutputEntry("zeta.txt", False, size=1, sha256="a" * 64),
+            OutputEntry("mid", True),
+            OutputEntry("alpha.txt", False, size=1, sha256="b" * 64),
+        ]
+    )
+    assert [a.path for a in artifacts] == ["alpha.txt", "mid", "zeta.txt"]
+
+
+def test_empty_listing_yields_no_artifacts() -> None:
+    assert derive_artifacts([]) == []


### PR DESCRIPTION
## Description

**Why.** Between the manifest (#14325, what exists in outputs/) and the artifact rows (#14319, what the panel renders) sits a decision: which entries are deliverables, what type each one is, and what hash a directory gets so version bumps fire exactly when content changes. The only classification in the codebase today is the fabricated webapp check (`web/` directory exists, no package.json required). This PR makes that decision a set of pure, unit-testable functions so the reconciler (#14327) stays a thin diff loop. Stacked on #14319 because the classifier emits the widened `ArtifactType` values.

**What.**
- `artifact_classifier.py`: `derive_artifacts` reduces an outputs listing to its artifacts — each visible top-level entry is one artifact, nested files belong to their top-level directory and never surface on their own. Files are typed by extension with a generic fallback (`.ts` is pinned to CODE before the mimetypes families, which register it as video/mp2t). The scaffolded webapp is recognized by the same `web/package.json` convention the runtime uses.
- Directory hashes are deterministic over root-relative paths, so identical trees hash identically and a child rename, addition, removal, or content change all move the hash. Hidden names (`node_modules`, `.next`, dotfiles) never influence the result, so build churn cannot dirty an artifact.
- Files past the manifest hash ceiling get a `meta:<size>:<mtime>` surrogate signal. Passing NULL instead would mean the version never bumps for large files, because #14319's upsert compares with `IS DISTINCT FROM` and NULL never differs from NULL.
- The shared hidden-name rule moves to `configs.py` so the classifier and the session manager filter identically without the classifier importing the manager, and the webapp path constants unify in `nextjs_dev.py` so the convention cannot drift across its three consumers.

Nothing consumes `derive_artifacts` yet; the reconciler in #14327 does.

## How Has This Been Tested?

- 36 unit tests (`test_artifact_classifier.py`): the full extension table including the `.ts`/mimetypes pitfall and legacy binary formats staying generic, top-level-only reduction, deep-nesting aggregation, directory hashes moving on content change/rename/add and not on hidden churn, identical trees hashing identically, hidden-only directories hashing like empty ones, the exact webapp convention (nested `web/` and package.json-as-directory both rejected), surrogate behavior for unhashed files including partial-metadata degradation, and sort determinism.
- Craft unit suite green alongside (session manager still filters identically after the constant move).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check