### PR TITLE
feat(craft): outputs reconciler wired into every terminal branch

### DIFF
--- a/backend/onyx/server/features/build/db/artifact.py
+++ b/backend/onyx/server/features/build/db/artifact.py
@@ -9,7 +9,7 @@ event.
 
 from uuid import UUID
 
-from sqlalchemy import case, desc, func, select
+from sqlalchemy import case, desc, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -92,6 +92,35 @@ def mark_artifact_deleted(
     artifact.deleted = True
     db_session.flush()
     return artifact
+
+
+def mark_artifacts_deleted(
+    db_session: Session,
+    *,
+    session_id: UUID,
+    paths: list[str],
+) -> list[Artifact]:
+    """Flag every live row whose path vanished from the manifest, in one
+    statement. Returns the rows that actually flipped."""
+    if not paths:
+        return []
+    stmt = (
+        update(Artifact)
+        .where(
+            Artifact.session_id == session_id,
+            Artifact.path.in_(paths),
+            Artifact.deleted.is_(False),
+        )
+        .values(deleted=True, updated_at=func.now())
+        .returning(Artifact)
+    )
+    return list(
+        db_session.execute(
+            select(Artifact)
+            .from_statement(stmt)
+            .execution_options(populate_existing=True)
+        ).scalars()
+    )
 
 
 def get_session_artifacts(

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -33,6 +33,10 @@ from onyx.server.features.build.interactive_turns.state import (
     get_active_turn,
     touch_turn,
 )
+from onyx.server.features.build.outputs_reconciler import (
+    announce_artifacts,
+    reconcile_session_outputs,
+)
 from onyx.server.features.build.sandbox.event_schema import (
     ActivityTimeoutError,
     PromptResponse,
@@ -292,6 +296,24 @@ def _drive_interactive_turn(
                     "Failed to persist turn error message for turn %s", turn_id
                 )
 
+        def reconcile_outputs() -> None:
+            """Best-effort outputs index update on every owned terminal branch,
+            while the prompt slot is still held. Failures never block
+            finish_turn."""
+            try:
+                packets = reconcile_session_outputs(
+                    db_session,
+                    get_sandbox_manager(),
+                    sandbox_id=sandbox.id,
+                    session_id=session_id,
+                    turn_index=turn_index,
+                )
+                db_session.commit()
+                announce_artifacts(session_id, packets, cache)
+            except Exception:
+                logger.exception("Outputs reconcile failed for turn %s", turn_id)
+                db_session.rollback()
+
         prompt_slot_cm = session_manager.prompt_slot(
             sandbox.id,
             session_id,
@@ -359,6 +381,7 @@ def _drive_interactive_turn(
             if interrupt_requested():
                 session_manager.finalize_persist(session_id, state)
                 db_session.commit()
+                reconcile_outputs()
                 finish_turn(
                     cache=cache,
                     turn_id=turn_id,
@@ -414,6 +437,8 @@ def _drive_interactive_turn(
                         persist_turn_error(
                             "This turn was interrupted and could not finish."
                         )
+                        # No reconcile here: the lease is lost, so the slot
+                        # holder owns the index now.
                         finish_turn(
                             cache=cache,
                             turn_id=turn_id,
@@ -441,6 +466,7 @@ def _drive_interactive_turn(
                         session_manager.finalize_persist(session_id, state)
                         db_session.commit()
                         persist_turn_error(sandbox_event.message)
+                        reconcile_outputs()
                         finish_turn(
                             cache=cache,
                             turn_id=turn_id,
@@ -491,6 +517,7 @@ def _drive_interactive_turn(
 
             session_manager.finalize_persist(session_id, state)
             db_session.commit()
+            reconcile_outputs()
 
             if deadline_exceeded:
                 persist_turn_error(
@@ -543,6 +570,8 @@ def _drive_interactive_turn(
             except Exception:
                 logger.exception("Failed to finalize persistence for turn %s", turn_id)
             persist_turn_error("This turn failed unexpectedly.")
+            if not slot.lost:
+                reconcile_outputs()
             finish_turn(
                 cache=cache,
                 turn_id=turn_id,

--- a/backend/onyx/server/features/build/outputs_reconciler.py
+++ b/backend/onyx/server/features/build/outputs_reconciler.py
@@ -1,0 +1,186 @@
+"""Reconciles a session's outputs tree into artifact rows at turn end.
+
+One call per owned terminal branch, while the turn still holds its prompt
+slot, so the next turn never starts against a half-written index. Idempotent
+because the rows are the baseline: a run skipped by a hard crash self-heals
+at the next turn end. An incomplete manifest is skipped outright, missing
+entries would flap rows deleted and directory hashes stale.
+"""
+
+from uuid import UUID
+
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from onyx.cache.interface import CacheBackend
+from onyx.db.models import Artifact
+from onyx.server.features.build.artifact_classifier import (
+    OutputEntry,
+    derive_artifacts,
+)
+from onyx.server.features.build.db.artifact import (
+    get_session_artifacts,
+    mark_artifacts_deleted,
+    upsert_artifact,
+)
+from onyx.server.features.build.packets import ArtifactPacket
+from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_ANNOUNCE_TTL_S = 60
+# The announce exists so an attached stream can render cards promptly. The
+# index refetch at turn end is the completeness guarantee, so a huge first
+# reconcile does not need every row on the wire.
+_MAX_ANNOUNCED = 50
+
+
+def _announce_key(session_id: UUID) -> str:
+    return f"craft:artifact:announce:{session_id}"
+
+
+def announce_artifacts(
+    session_id: UUID, packets: list[ArtifactPacket], cache: CacheBackend
+) -> None:
+    """Hand changed rows to the SSE stream attached to this session.
+
+    Called after commit, so a card never announces a row a reader cannot
+    fetch.
+    """
+    if not packets:
+        return
+    key = _announce_key(session_id)
+    for packet in packets[:_MAX_ANNOUNCED]:
+        cache.rpush(key, packet.model_dump_json())
+    cache.expire(key, _ANNOUNCE_TTL_S)
+
+
+def pop_artifact_announcement(
+    session_id: UUID, timeout_s: int, cache: CacheBackend
+) -> ArtifactPacket | None:
+    """BLPOP one announced artifact. None on timeout or unparseable payload."""
+    result = cache.blpop([_announce_key(session_id)], timeout_s)
+    if result is None:
+        return None
+    _key, value = result
+    if isinstance(value, bytes):
+        value = value.decode()
+    try:
+        return ArtifactPacket.model_validate_json(value)
+    except ValidationError:
+        logger.warning("artifact: unparseable announce %r for %s", value, session_id)
+        return None
+
+
+def reconcile_session_outputs(
+    db_session: Session,
+    sandbox_manager: SandboxManager,
+    *,
+    sandbox_id: UUID,
+    session_id: UUID,
+    turn_index: int | None,
+) -> list[ArtifactPacket]:
+    """Diff the sandbox outputs manifest against the artifact rows.
+
+    Upserts rows whose content or type moved or whose path came back, flags
+    rows whose path vanished, and leaves untouched rows alone so
+    ``turn_index`` keeps naming the turn that last changed each artifact.
+    Flushes only, the caller owns the commit and announces the returned
+    packets after it.
+
+    Returns an empty list without touching rows when the manifest is
+    unavailable or incomplete: the rows stay the baseline and the next turn
+    end self-heals. Unreadable entries count as incomplete because the
+    delete pass would otherwise flag rows the walk merely failed to see.
+    """
+    try:
+        manifest = sandbox_manager.get_outputs_manifest(
+            sandbox_id=sandbox_id, session_id=session_id
+        )
+    except (RuntimeError, ValidationError):
+        logger.warning(
+            "Outputs manifest unavailable for session %s; skipping reconcile",
+            session_id,
+            exc_info=True,
+        )
+        return []
+    if manifest.truncated or manifest.skipped_unreadable:
+        logger.warning(
+            "Outputs manifest incomplete for session %s "
+            "(truncated=%s skipped_unreadable=%d); skipping reconcile",
+            session_id,
+            manifest.truncated,
+            manifest.skipped_unreadable,
+        )
+        return []
+
+    derived = derive_artifacts(
+        [
+            OutputEntry(
+                path=entry.path,
+                is_directory=entry.is_directory,
+                size=entry.size,
+                mtime_ns=entry.mtime_ns,
+                sha256=entry.sha256,
+            )
+            for entry in manifest.entries
+        ]
+    )
+    rows_by_path = {
+        row.path: row
+        for row in get_session_artifacts(
+            db_session, session_id=session_id, include_deleted=True
+        )
+    }
+
+    packets: list[ArtifactPacket] = []
+    for artifact in derived:
+        row = rows_by_path.get(artifact.path)
+        unchanged = (
+            row is not None
+            and not row.deleted
+            and row.content_hash == artifact.content_hash
+            and row.type == artifact.type
+        )
+        if unchanged:
+            continue
+        updated = upsert_artifact(
+            db_session,
+            session_id=session_id,
+            artifact_type=artifact.type,
+            path=artifact.path,
+            name=artifact.name,
+            turn_index=turn_index,
+            size_bytes=artifact.size_bytes,
+            content_hash=artifact.content_hash,
+        )
+        packets.append(_packet_for(updated))
+
+    derived_paths = {artifact.path for artifact in derived}
+    vanished = [
+        path
+        for path, row in rows_by_path.items()
+        if path not in derived_paths and not row.deleted
+    ]
+    packets.extend(
+        _packet_for(row)
+        for row in mark_artifacts_deleted(
+            db_session, session_id=session_id, paths=vanished
+        )
+    )
+    return packets
+
+
+def _packet_for(row: Artifact) -> ArtifactPacket:
+    return ArtifactPacket(
+        artifact_id=row.id,
+        session_id=row.session_id,
+        path=row.path,
+        name=row.name,
+        artifact_type=row.type,
+        version=row.version,
+        turn_index=row.turn_index,
+        size_bytes=row.size_bytes,
+        deleted=row.deleted,
+    )

--- a/backend/onyx/server/features/build/packets.py
+++ b/backend/onyx/server/features/build/packets.py
@@ -18,9 +18,8 @@ Sandbox events (re-emitted from :mod:`sandbox.event_schema`):
 - prompt_response: Agent finished processing
 - error: An error occurred
 
-Custom Onyx packets (defined here):
-- error: Onyx-specific errors (e.g., session not found)
-- subagent_started: A child opencode session was created under a parent turn
+The custom Onyx packet classes below are the authoritative list; the
+``BuildPacket`` union at the bottom names them all.
 """
 
 from datetime import datetime, timezone
@@ -28,6 +27,8 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+from onyx.db.enums import ArtifactType
 
 # =============================================================================
 # Base Packet Type
@@ -89,6 +90,26 @@ class ConnectAppRequestPacket(BasePacket):
     reason: str | None = None
 
 
+class ArtifactPacket(BasePacket):
+    """An artifact row was produced, changed, or deleted at turn end.
+
+    Carries the full row, unlike the ids-only approval packet, so a consumer
+    can render a card with no round trip. The version is pinned at announce
+    time and the index refetch at turn end is the completeness guarantee.
+    """
+
+    type: Literal["artifact"] = "artifact"
+    artifact_id: UUID
+    session_id: UUID
+    path: str
+    name: str
+    artifact_type: ArtifactType
+    version: int
+    turn_index: int | None
+    size_bytes: int | None
+    deleted: bool
+
+
 class ContextUsagePacket(BasePacket):
     type: Literal["context_usage"] = "context_usage"
     used_tokens: int
@@ -109,6 +130,7 @@ BuildPacket = (
     | ApprovalRequestedPacket
     | SubagentStartedPacket
     | ConnectAppRequestPacket
+    | ArtifactPacket
     | ContextUsagePacket
     | CompactionPacket
 )

--- a/backend/onyx/server/features/build/packets.py
+++ b/backend/onyx/server/features/build/packets.py
@@ -96,6 +96,8 @@ class ArtifactPacket(BasePacket):
     Carries the full row, unlike the ids-only approval packet, so a consumer
     can render a card with no round trip. The version is pinned at announce
     time and the index refetch at turn end is the completeness guarantee.
+    No shipped client parses this type yet: clients ignore unknown packet
+    types by design, and the consumer lands with the output panel frontend.
     """
 
     type: Literal["artifact"] = "artifact"

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1637,6 +1637,11 @@ fi
             result = _run_in_container_as_sandbox_user(
                 container,
                 [
+                    # exec_run has no timeout, so a pathological walk must
+                    # not hang the turn's terminal handling. 30s matches the
+                    # kubernetes RPC bound.
+                    "/usr/bin/timeout",
+                    "30",
                     "/usr/local/bin/python3",
                     "-E",
                     "-s",

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
@@ -1,3 +1,11 @@
+"""Sandbox daemon HTTP server.
+
+Runs standalone inside the sandbox container with only stdlib, fastapi, and
+pydantic available. ``onyx.*`` is unimportable here, so routes raise
+``HTTPException`` directly instead of the api-server's ``OnyxError`` contract,
+and the api-server's SidecarClient translates failures for its callers.
+"""
+
 import asyncio
 import base64
 import binascii

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -41,6 +41,7 @@ import time
 from typing import Any
 from uuid import UUID
 
+from onyx.cache.factory import get_cache_backend
 from onyx.configs.constants import MessageType, NotificationType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import ScheduledTaskErrorClass, ScheduledTaskRunStatus, SessionOrigin
@@ -51,12 +52,17 @@ from onyx.server.features.build.db.build_session import (
     get_session_messages,
 )
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
+from onyx.server.features.build.outputs_reconciler import (
+    announce_artifacts,
+    reconcile_session_outputs,
+)
 from onyx.server.features.build.sandbox.event_schema import (
     TURN_ERROR_CODE_TIMEOUT,
     Error,
     PromptResponse,
     RequestPermissionRequest,
 )
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.session.locks import session_creation_lock
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.streaming import BuildStreamingState
@@ -381,6 +387,26 @@ def _drive_agent(
         state = BuildStreamingState(turn_index=0)
         deadline = time.monotonic() + budget_seconds
 
+        cache = get_cache_backend()
+
+        def reconcile_outputs() -> None:
+            """Best-effort outputs index update on every owned terminal branch,
+            while the prompt slot is still held. Failures never block the run
+            status."""
+            try:
+                packets = reconcile_session_outputs(
+                    db_session,
+                    get_sandbox_manager(),
+                    sandbox_id=sandbox_id,
+                    session_id=session_id,
+                    turn_index=0,
+                )
+                db_session.commit()
+                announce_artifacts(session_id, packets, cache)
+            except Exception:
+                logger.exception("Outputs reconcile failed for run %s", run_id)
+                db_session.rollback()
+
         # Mirror the interactive path's serialization invariant. Each
         # scheduled run has a fresh BuildSession so the lock never
         # contends today, but acquire it anyway so any future change
@@ -477,6 +503,8 @@ def _drive_agent(
                 # agent can't keep growing the transcript.
                 if time.monotonic() > deadline:
                     session_manager.finalize_persist(session_id, state)
+                    db_session.commit()
+                    reconcile_outputs()
                     mark_run_status(
                         db_session=db_session,
                         run_id=run_id,
@@ -511,6 +539,7 @@ def _drive_agent(
                 summary = summary_from_chunks or _summary_from_session_messages(
                     session_id, db_session
                 )
+                reconcile_outputs()
                 mark_run_status(
                     db_session=db_session,
                     run_id=run_id,
@@ -531,6 +560,7 @@ def _drive_agent(
             if terminal_error is not None or cancelled or not got_prompt_response:
                 session_manager.finalize_persist(session_id, state)
                 db_session.commit()
+                reconcile_outputs()
                 if terminal_error is not None:
                     error_class = (
                         ScheduledTaskErrorClass.TIMEOUT
@@ -575,6 +605,7 @@ def _drive_agent(
             summary_from_chunks = _summary_from_state(state)
             session_manager.finalize_persist(session_id, state)
             db_session.commit()
+            reconcile_outputs()
             summary = summary_from_chunks or _summary_from_session_messages(
                 session_id, db_session
             )
@@ -597,6 +628,8 @@ def _drive_agent(
             # to FAILED. Do NOT re-raise — Celery would retry, which is
             # explicitly out of scope for V1.
             db_session.rollback()
+            if not slot.lost:
+                reconcile_outputs()
             exc_name = type(exc).__name__
             exc_message = str(exc)
             # Keep the specific exception class name visible by prepending

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -44,8 +44,10 @@ from onyx.server.features.build.db.sandbox import (
     get_sandbox_by_user_id,
     update_sandbox_heartbeat,
 )
+from onyx.server.features.build.outputs_reconciler import pop_artifact_announcement
 from onyx.server.features.build.packets import (
     ApprovalRequestedPacket,
+    ArtifactPacket,
     BuildPacket,
     CompactionPacket,
     ConnectAppRequestPacket,
@@ -278,6 +280,7 @@ def event_to_sse(event: Any) -> str:
         event,
         (
             ApprovalRequestedPacket,
+            ArtifactPacket,
             ErrorPacket,
             SubagentStartedPacket,
             ConnectAppRequestPacket,
@@ -301,10 +304,10 @@ def merge_events_with_announces(
 ) -> Generator[Any, None, None]:
     """Merge sandbox events and announces into one stream.
 
-    Three producer threads feed a shared queue: the sandbox-event iterator, and
-    two BLPOP pollers that inject an `ApprovalRequestedPacket` / a
-    `ConnectAppRequestPacket` when a request is announced from another worker.
-    Announce latency is bounded by the 1s BLPOP.
+    Four producer threads feed a shared queue: the sandbox-event iterator, and
+    three BLPOP pollers that inject an `ApprovalRequestedPacket`, a
+    `ConnectAppRequestPacket`, or an `ArtifactPacket` when one is announced
+    from another worker. Announce latency is bounded by the 1s BLPOP.
     """
     output: queue_lib.Queue[Any] = queue_lib.Queue()
     stop = threading.Event()
@@ -367,6 +370,21 @@ def merge_events_with_announces(
                 )
             )
 
+    def drive_artifact_announces() -> None:
+        cache = get_cache_backend(tenant_id=tenant_id)
+        while not stop.is_set():
+            try:
+                packet = pop_artifact_announcement(session_id, timeout_s=1, cache=cache)
+            except Exception:
+                logger.exception(
+                    "artifact.announce_poll_failed session_id=%s", session_id
+                )
+                time.sleep(1)
+                continue
+            if packet is None:
+                continue
+            output.put(packet)
+
     # Spawn via the context-preserving helper so the event iterator's lazy
     # tenant-scoped DB access (e.g. event-bus creation) sees the caller's
     # contextvars instead of raising "Tenant ID is not set".
@@ -385,6 +403,11 @@ def merge_events_with_announces(
     start_thread_with_context(
         drive_connect_app_announces,
         name=f"connect-app-pump-{session_id}",
+        daemon=True,
+    )
+    start_thread_with_context(
+        drive_artifact_announces,
+        name=f"artifact-pump-{session_id}",
         daemon=True,
     )
     try:

--- a/backend/tests/external_dependency_unit/craft/test_outputs_reconciler.py
+++ b/backend/tests/external_dependency_unit/craft/test_outputs_reconciler.py
@@ -1,0 +1,385 @@
+"""External-dependency-unit tests for the outputs reconciler.
+
+Runs the real DAL against Postgres so the diff semantics the panel depends on
+(create, version bump, delete, resurrect, untouched turn_index) fail on
+regression, with the sandbox manifest stubbed at the manager seam.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.cache.factory import get_cache_backend
+from onyx.db.enums import ArtifactType
+from onyx.db.models import BuildSession
+from onyx.server.features.build.db.artifact import (
+    get_session_artifacts,
+    upsert_artifact,
+)
+from onyx.server.features.build.outputs_reconciler import (
+    announce_artifacts,
+    pop_artifact_announcement,
+    reconcile_session_outputs,
+)
+from onyx.server.features.build.packets import ArtifactPacket
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    OutputsManifestEntry,
+    OutputsManifestResponse,
+)
+from tests.common.craft.stubs import StubSandboxManager
+
+
+def _manifest(
+    *entries: OutputsManifestEntry,
+    truncated: bool = False,
+    skipped_unreadable: int = 0,
+) -> OutputsManifestResponse:
+    return OutputsManifestResponse(
+        entries=list(entries),
+        truncated=truncated,
+        skipped_unreadable=skipped_unreadable,
+    )
+
+
+def _file(path: str, sha: str, size: int = 10) -> OutputsManifestEntry:
+    return OutputsManifestEntry(
+        path=path, is_directory=False, size=size, mtime_ns=1, sha256=sha
+    )
+
+
+def _dir(path: str) -> OutputsManifestEntry:
+    return OutputsManifestEntry(path=path, is_directory=True, mtime_ns=1)
+
+
+def _reconcile(
+    db_session: Session,
+    session: BuildSession,
+    manifest: OutputsManifestResponse | None,
+    *,
+    turn_index: int | None = 1,
+) -> list[ArtifactPacket]:
+    stub = StubSandboxManager()
+    stub.outputs_manifest_returns = manifest
+    packets = reconcile_session_outputs(
+        db_session,
+        stub,
+        sandbox_id=uuid4(),
+        session_id=session.id,
+        turn_index=turn_index,
+    )
+    db_session.commit()
+    return packets
+
+
+def test_first_reconcile_creates_rows_and_packets(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    packets = _reconcile(
+        db_session,
+        session,
+        _manifest(
+            _file("deck.pptx", "a" * 64),
+            _dir("web"),
+            _file("web/package.json", "b" * 64),
+        ),
+    )
+
+    by_path = {p.path: p for p in packets}
+    assert set(by_path) == {"deck.pptx", "web"}
+    assert by_path["deck.pptx"].artifact_type == ArtifactType.PPTX
+    assert by_path["web"].artifact_type == ArtifactType.WEB_APP
+    assert all(p.version == 1 and not p.deleted for p in packets)
+    rows = get_session_artifacts(db_session, session_id=session.id)
+    assert {row.path for row in rows} == {"deck.pptx", "web"}
+
+
+def test_unchanged_rows_stay_untouched(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    manifest = _manifest(_file("deck.pptx", "a" * 64))
+    _reconcile(db_session, session, manifest, turn_index=1)
+    packets = _reconcile(db_session, session, manifest, turn_index=2)
+
+    assert packets == []
+    (row,) = get_session_artifacts(db_session, session_id=session.id)
+    assert row.version == 1
+    assert row.turn_index == 1
+
+
+def test_content_change_bumps_version(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _reconcile(db_session, session, _manifest(_file("deck.pptx", "a" * 64)))
+    packets = _reconcile(
+        db_session, session, _manifest(_file("deck.pptx", "c" * 64)), turn_index=2
+    )
+
+    (packet,) = packets
+    assert packet.version == 2
+    assert packet.turn_index == 2
+
+
+def test_vanished_path_deletes_and_resurrect_undeletes(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    manifest = _manifest(_file("deck.pptx", "a" * 64))
+    _reconcile(db_session, session, manifest)
+
+    (deleted_packet,) = _reconcile(db_session, session, _manifest(), turn_index=2)
+    assert deleted_packet.deleted
+    (row,) = get_session_artifacts(
+        db_session, session_id=session.id, include_deleted=True
+    )
+    assert row.deleted
+
+    (resurrected,) = _reconcile(db_session, session, manifest, turn_index=3)
+    assert not resurrected.deleted
+    # Same content, so resurrection announces without a version bump.
+    assert resurrected.version == 1
+
+
+def test_truncated_manifest_leaves_rows_alone(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _reconcile(db_session, session, _manifest(_file("deck.pptx", "a" * 64)))
+
+    packets = _reconcile(db_session, session, _manifest(truncated=True), turn_index=2)
+
+    assert packets == []
+    (row,) = get_session_artifacts(db_session, session_id=session.id)
+    assert not row.deleted
+
+
+def test_manifest_failure_leaves_rows_alone(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _reconcile(db_session, session, _manifest(_file("deck.pptx", "a" * 64)))
+
+    # An unconfigured stub raises the RuntimeError family the backends raise.
+    packets = _reconcile(db_session, session, None, turn_index=2)
+
+    assert packets == []
+    (row,) = get_session_artifacts(db_session, session_id=session.id)
+    assert not row.deleted
+
+
+def test_partial_manifest_never_deletes(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _reconcile(db_session, session, _manifest(_file("deck.pptx", "a" * 64)))
+
+    # An unreadable-tree walk returns empty entries WITHOUT truncated, which
+    # must never read as "everything was deleted".
+    packets = _reconcile(
+        db_session, session, _manifest(skipped_unreadable=1), turn_index=2
+    )
+
+    assert packets == []
+    (row,) = get_session_artifacts(db_session, session_id=session.id)
+    assert not row.deleted
+
+
+def test_validation_error_is_a_skip_not_a_crash(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+
+    class _MalformedStub(StubSandboxManager):
+        def get_outputs_manifest(
+            self,
+            sandbox_id: object,  # noqa: ARG002
+            session_id: object,  # noqa: ARG002
+        ) -> OutputsManifestResponse:
+            return OutputsManifestResponse.model_validate_json("{")
+
+    packets = reconcile_session_outputs(
+        db_session,
+        _MalformedStub(),
+        sandbox_id=uuid4(),
+        session_id=session.id,
+        turn_index=1,
+    )
+    assert packets == []
+
+
+def test_seeded_type_drift_is_corrected(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    upsert_artifact(
+        db_session,
+        session_id=session.id,
+        artifact_type=ArtifactType.FILE,
+        path="deck.pptx",
+        name="deck.pptx",
+        turn_index=1,
+        size_bytes=10,
+        content_hash="a" * 64,
+    )
+    db_session.commit()
+
+    (packet,) = _reconcile(
+        db_session, session, _manifest(_file("deck.pptx", "a" * 64)), turn_index=2
+    )
+    assert packet.artifact_type == ArtifactType.PPTX
+
+
+def test_webapp_scaffold_removal_becomes_directory(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _reconcile(
+        db_session,
+        session,
+        _manifest(_dir("web"), _file("web/package.json", "a" * 64)),
+    )
+
+    (packet,) = _reconcile(
+        db_session,
+        session,
+        _manifest(_dir("web"), _file("web/index.html", "b" * 64)),
+        turn_index=2,
+    )
+    assert packet.artifact_type == ArtifactType.DIRECTORY
+    assert packet.version == 2
+
+
+def test_file_replaced_by_directory_keeps_one_row(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    _reconcile(db_session, session, _manifest(_file("notes", "a" * 64)))
+
+    (packet,) = _reconcile(
+        db_session,
+        session,
+        _manifest(_dir("notes"), _file("notes/entry.md", "b" * 64)),
+        turn_index=2,
+    )
+    assert packet.artifact_type == ArtifactType.DIRECTORY
+    rows = get_session_artifacts(db_session, session_id=session.id)
+    assert [row.path for row in rows] == ["notes"]
+
+
+def test_hidden_churn_yields_no_packets(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    base = _manifest(_dir("web"), _file("web/package.json", "a" * 64))
+    _reconcile(db_session, session, base)
+
+    packets = _reconcile(
+        db_session,
+        session,
+        _manifest(
+            _dir("web"),
+            _file("web/package.json", "a" * 64),
+            _dir("web/node_modules"),
+            _file("web/node_modules/x.js", "b" * 64),
+        ),
+        turn_index=2,
+    )
+    assert packets == []
+
+
+def test_sessions_are_isolated(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session_a = build_session_with_user()
+    session_b = build_session_with_user()
+    _reconcile(db_session, session_b, _manifest(_file("other.txt", "b" * 64)))
+
+    _reconcile(db_session, session_a, _manifest(_file("deck.pptx", "a" * 64)))
+    _reconcile(db_session, session_a, _manifest(), turn_index=2)
+
+    (row_b,) = get_session_artifacts(db_session, session_id=session_b.id)
+    assert not row_b.deleted
+    cache = get_cache_backend()
+    assert pop_artifact_announcement(session_b.id, timeout_s=1, cache=cache) is None
+
+
+def test_none_turn_index_is_accepted(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    (packet,) = _reconcile(
+        db_session, session, _manifest(_file("deck.pptx", "a" * 64)), turn_index=None
+    )
+    assert packet.turn_index is None
+
+
+def test_announce_roundtrip(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    packets = _reconcile(db_session, session, _manifest(_file("deck.pptx", "a" * 64)))
+
+    cache = get_cache_backend()
+    announce_artifacts(session.id, packets, cache)
+    popped = pop_artifact_announcement(session.id, timeout_s=1, cache=cache)
+    assert popped == packets[0]
+    assert pop_artifact_announcement(session.id, timeout_s=1, cache=cache) is None
+
+
+def test_announce_preserves_order(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    packets = _reconcile(
+        db_session,
+        session,
+        _manifest(
+            _file("a.txt", "a" * 64),
+            _file("b.txt", "b" * 64),
+            _file("c.txt", "c" * 64),
+        ),
+    )
+
+    cache = get_cache_backend()
+    announce_artifacts(session.id, packets, cache)
+    popped = [
+        pop_artifact_announcement(session.id, timeout_s=1, cache=cache) for _ in packets
+    ]
+    assert [p.path for p in popped if p is not None] == ["a.txt", "b.txt", "c.txt"]


### PR DESCRIPTION
## Description

**Why.** Schema (#14319), manifest (#14325), and classifier (#14326) are inert until something runs them at the right moment. The design's requirement is specific: reconcile at turn end, while the turn still holds its prompt slot, so the next turn never starts against a half-written index, and idempotently, so a run skipped by a hard crash self-heals at the next turn end. This PR is that wiring. Stacked on #14326; the diff also carries #14325's commits (the manifest it consumes) until that merges — review this PR's own commits: `outputs_reconciler.py`, `db/artifact.py`, `packets.py`, `session/streaming.py`, and both executors.

**What.**
- `outputs_reconciler.py`: fetch the manifest, adapt entries into the classifier, diff derived artifacts against the rows. Upserts only rows whose content or type moved or whose path came back, so `turn_index` keeps naming the turn that last changed each artifact; vanished paths flag deleted in one bulk statement. Incomplete manifests — truncated or partially unreadable — are never reduced, because the delete pass would otherwise flag rows the walk merely failed to see; the rows stay the baseline and the next turn end self-heals.
- Wired into every owned terminal branch: the interactive executor (interrupt, sandbox error, deadline, no-final-response, cancel, success, owned exception) and the scheduled-task executor (awaiting-approval, budget timeout, failure, success, owned exception). Best-effort: a reconcile failure never blocks the turn's terminal handling.
- Changed rows announce over Redis (capped at 50, the turn-end index refetch is the completeness guarantee) into the live SSE merge as a new `artifact` packet. No shipped client parses the type yet; clients ignore unknown packet types by design and the consumer lands with the output panel frontend.
- The docker manifest exec is bounded by `timeout(1)` at 30s, matching the kubernetes RPC bound, so a pathological walk cannot hang terminal handling (`exec_run` has no timeout of its own).

## How Has This Been Tested?

- 16 external-dependency-unit tests (`test_outputs_reconciler.py`, real Postgres + Redis, sandbox stubbed at the manager seam): first reconcile creates rows and packets, unchanged rows stay untouched (turn_index preserved), content change bumps version, vanish/resurrect round-trip without a spurious bump, truncated and partially-unreadable manifests leave rows alone, manifest failures (RuntimeError family and ValidationError) skip cleanly, seeded type drift is corrected, webapp→directory transition bumps, file→directory at one path keeps one row, hidden churn produces zero packets, sessions are isolated, and the announce round-trips in FIFO order.
- Crash recovery is the same mechanism as the idempotence tests: rows are the baseline, a re-run converges.
- The `timeout`-wrapped exec verified live in the real sandbox image (exit 0, correct JSON, `/usr/bin/timeout` present and root-owned).
- Full craft external-dependency suite and unit suite green alongside.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check