### PR TITLE
fix(web): keep the saved embedding provider when re-indexing

### DIFF
--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -11,6 +11,7 @@ import {
 } from "@opal/logos";
 import {
   EmbeddingModel,
+  EmbeddingModelSpec,
   EmbeddingProvider,
   EmbeddingProviderName,
 } from "@/lib/indexing/types";
@@ -416,6 +417,73 @@ export function resolveProviderName(
     }
   }
   return EmbeddingProviderName.CUSTOM;
+}
+
+/**
+ * Always write all three fields together. A name without its spec and provider forces
+ * the submit path to guess them back, which misroutes LiteLLM and Azure models.
+ */
+export interface EmbeddingModelSelection {
+  model_name: string;
+  model_spec: EmbeddingModelSpec | null;
+  model_provider: EmbeddingProviderName | null;
+}
+
+export interface ResolvedEmbeddingModelForApply {
+  model: EmbeddingModelSpec;
+  providerName: EmbeddingProviderName;
+}
+
+export function savedModelSelection(
+  currentModel: EmbeddingModelSpec | null,
+  currentProviderType: EmbeddingProviderName | null
+): EmbeddingModelSelection {
+  return {
+    model_name: currentModel?.modelName ?? "",
+    model_spec: currentModel,
+    model_provider: currentProviderType,
+  };
+}
+
+/**
+ * Compared field by field rather than by reference: `initialValues` is rebuilt from a
+ * memo whenever the settings query revalidates, so two deep-equal specs routinely
+ * arrive as different objects.
+ */
+export function isSameModelSelection(
+  a: EmbeddingModelSelection,
+  b: EmbeddingModelSelection
+): boolean {
+  if (a.model_name !== b.model_name || a.model_provider !== b.model_provider) {
+    return false;
+  }
+  if (a.model_spec === b.model_spec) return true;
+  if (!a.model_spec || !b.model_spec) return false;
+
+  return (
+    a.model_spec.modelName === b.model_spec.modelName &&
+    a.model_spec.modelDim === b.model_spec.modelDim &&
+    a.model_spec.normalize === b.model_spec.normalize &&
+    (a.model_spec.queryPrefix ?? null) === (b.model_spec.queryPrefix ?? null) &&
+    (a.model_spec.passagePrefix ?? null) ===
+      (b.model_spec.passagePrefix ?? null)
+  );
+}
+
+/**
+ * The fallbacks here only work for registry models. LiteLLM and Azure models aren't in
+ * the registry, so they have to arrive already carrying their own spec and provider.
+ */
+export function resolveModelForApply(
+  selection: EmbeddingModelSelection
+): ResolvedEmbeddingModelForApply | null {
+  const model = selection.model_spec ?? findRegistryModel(selection.model_name);
+  if (!model) return null;
+
+  const providerName =
+    selection.model_provider ?? resolveProviderName(selection.model_name, null);
+
+  return { model, providerName };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -11,7 +11,6 @@ import {
 } from "@opal/logos";
 import {
   EmbeddingModel,
-  EmbeddingModelSpec,
   EmbeddingProvider,
   EmbeddingProviderName,
 } from "@/lib/indexing/types";
@@ -417,73 +416,6 @@ export function resolveProviderName(
     }
   }
   return EmbeddingProviderName.CUSTOM;
-}
-
-/**
- * Always write all three fields together. A name without its spec and provider forces
- * the submit path to guess them back, which misroutes LiteLLM and Azure models.
- */
-export interface EmbeddingModelSelection {
-  model_name: string;
-  model_spec: EmbeddingModelSpec | null;
-  model_provider: EmbeddingProviderName | null;
-}
-
-export interface ResolvedEmbeddingModelForApply {
-  model: EmbeddingModelSpec;
-  providerName: EmbeddingProviderName;
-}
-
-export function savedModelSelection(
-  currentModel: EmbeddingModelSpec | null,
-  currentProviderType: EmbeddingProviderName | null
-): EmbeddingModelSelection {
-  return {
-    model_name: currentModel?.modelName ?? "",
-    model_spec: currentModel,
-    model_provider: currentProviderType,
-  };
-}
-
-/**
- * Compared field by field rather than by reference: `initialValues` is rebuilt from a
- * memo whenever the settings query revalidates, so two deep-equal specs routinely
- * arrive as different objects.
- */
-export function isSameModelSelection(
-  a: EmbeddingModelSelection,
-  b: EmbeddingModelSelection
-): boolean {
-  if (a.model_name !== b.model_name || a.model_provider !== b.model_provider) {
-    return false;
-  }
-  if (a.model_spec === b.model_spec) return true;
-  if (!a.model_spec || !b.model_spec) return false;
-
-  return (
-    a.model_spec.modelName === b.model_spec.modelName &&
-    a.model_spec.modelDim === b.model_spec.modelDim &&
-    a.model_spec.normalize === b.model_spec.normalize &&
-    (a.model_spec.queryPrefix ?? null) === (b.model_spec.queryPrefix ?? null) &&
-    (a.model_spec.passagePrefix ?? null) ===
-      (b.model_spec.passagePrefix ?? null)
-  );
-}
-
-/**
- * The fallbacks here only work for registry models. LiteLLM and Azure models aren't in
- * the registry, so they have to arrive already carrying their own spec and provider.
- */
-export function resolveModelForApply(
-  selection: EmbeddingModelSelection
-): ResolvedEmbeddingModelForApply | null {
-  const model = selection.model_spec ?? findRegistryModel(selection.model_name);
-  if (!model) return null;
-
-  const providerName =
-    selection.model_provider ?? resolveProviderName(selection.model_name, null);
-
-  return { model, providerName };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/web/src/lib/indexing/modelSelection.test.ts
+++ b/web/src/lib/indexing/modelSelection.test.ts
@@ -2,7 +2,7 @@ import {
   isSameModelSelection,
   resolveModelForApply,
   savedModelSelection,
-} from "@/lib/indexing";
+} from "@/lib/indexing/utils";
 import {
   EmbeddingModelSpec,
   EmbeddingProviderName,

--- a/web/src/lib/indexing/modelSelection.test.ts
+++ b/web/src/lib/indexing/modelSelection.test.ts
@@ -1,0 +1,165 @@
+import {
+  isSameModelSelection,
+  resolveModelForApply,
+  savedModelSelection,
+} from "@/lib/indexing";
+import {
+  EmbeddingModelSpec,
+  EmbeddingProviderName,
+} from "@/lib/indexing/types";
+
+/** A deployment the static registry has never heard of, which is the whole point. */
+function deployment(modelName: string): EmbeddingModelSpec {
+  return {
+    modelName,
+    modelDim: 1536,
+    normalize: false,
+    queryPrefix: "",
+    passagePrefix: "",
+  };
+}
+
+describe("the model the form loads with", () => {
+  it("keeps an Azure deployment on its own provider and dimension when the label collides with the OpenAI registry", () => {
+    const seeded = savedModelSelection(
+      deployment("text-embedding-3-large"),
+      EmbeddingProviderName.AZURE
+    );
+
+    const resolved = resolveModelForApply(seeded);
+
+    expect(resolved?.providerName).toBe(EmbeddingProviderName.AZURE);
+    // The OpenAI registry entry of the same name is 3072 — sending it would
+    // build the new index at the wrong width.
+    expect(resolved?.model.modelDim).toBe(1536);
+  });
+
+  it("resolves a LiteLLM deployment whose label is in no registry", () => {
+    const seeded = savedModelSelection(
+      deployment("text-embedding-ada-002"),
+      EmbeddingProviderName.LITELLM
+    );
+
+    expect(resolveModelForApply(seeded)).toEqual({
+      model: deployment("text-embedding-ada-002"),
+      providerName: EmbeddingProviderName.LITELLM,
+    });
+  });
+
+  it("resolves a self-hosted model to its display bucket, which is only a name away", () => {
+    const seeded = savedModelSelection(
+      {
+        modelName: "nomic-ai/nomic-embed-text-v1",
+        modelDim: 768,
+        normalize: true,
+      },
+      null
+    );
+
+    const resolved = resolveModelForApply(seeded);
+
+    // Self-hosted rows carry no provider, so the name picks the bucket. That is safe
+    // here because the bucket only chooses an icon and a heading.
+    expect(resolved?.providerName).toBe(EmbeddingProviderName.NOMIC);
+    expect(resolved?.model.modelDim).toBe(768);
+  });
+});
+
+describe("the model the user stages", () => {
+  it("takes a registry model's provider and spec from the registry", () => {
+    const resolved = resolveModelForApply({
+      model_name: "text-embedding-3-large",
+      model_spec: null,
+      model_provider: null,
+    });
+
+    expect(resolved?.providerName).toBe(EmbeddingProviderName.OPENAI);
+    expect(resolved?.model.modelDim).toBe(3072);
+  });
+
+  it("takes a LiteLLM model's provider and spec from the selection", () => {
+    const staged = deployment("my-proxy-model");
+
+    expect(
+      resolveModelForApply({
+        model_name: staged.modelName,
+        model_spec: staged,
+        model_provider: EmbeddingProviderName.LITELLM,
+      })
+    ).toEqual({ model: staged, providerName: EmbeddingProviderName.LITELLM });
+  });
+
+  it("returns null for an unknown model with no spec", () => {
+    expect(
+      resolveModelForApply({
+        model_name: "some/unregistered-model",
+        model_spec: null,
+        model_provider: null,
+      })
+    ).toBeNull();
+  });
+});
+
+describe("comparing one selection to another", () => {
+  const saved = savedModelSelection(
+    deployment("my-deployment"),
+    EmbeddingProviderName.AZURE
+  );
+
+  it("treats a rebuilt but identical selection as unchanged", () => {
+    // The settings query revalidates and the memo hands back a fresh object.
+    const rebuilt = savedModelSelection(
+      deployment("my-deployment"),
+      EmbeddingProviderName.AZURE
+    );
+
+    expect(rebuilt.model_spec).not.toBe(saved.model_spec);
+    expect(isSameModelSelection(saved, rebuilt)).toBe(true);
+  });
+
+  it("spots a respec that keeps the same name", () => {
+    const respecced = {
+      ...saved,
+      model_spec: { ...deployment("my-deployment"), modelDim: 3072 },
+    };
+
+    expect(isSameModelSelection(saved, respecced)).toBe(false);
+  });
+
+  it("spots a prefix change that keeps the same name and dimension", () => {
+    const respecced = {
+      ...saved,
+      model_spec: { ...deployment("my-deployment"), queryPrefix: "query: " },
+    };
+
+    expect(isSameModelSelection(saved, respecced)).toBe(false);
+  });
+
+  it("spots a staged registry model replacing the saved spec", () => {
+    expect(isSameModelSelection(saved, { ...saved, model_spec: null })).toBe(
+      false
+    );
+  });
+
+  it("spots a different name and a different provider", () => {
+    expect(isSameModelSelection(saved, { ...saved, model_name: "other" })).toBe(
+      false
+    );
+    expect(
+      isSameModelSelection(saved, {
+        ...saved,
+        model_provider: EmbeddingProviderName.LITELLM,
+      })
+    ).toBe(false);
+  });
+
+  it("treats two spec-less selections as unchanged", () => {
+    const registry = {
+      model_name: "text-embedding-3-large",
+      model_spec: null,
+      model_provider: null,
+    };
+
+    expect(isSameModelSelection(registry, { ...registry })).toBe(true);
+  });
+});

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -1,7 +1,7 @@
 import type { Settings } from "@/lib/settings/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
-  EmbeddingModel,
+  EmbeddingModelSpec,
   EmbeddingProviderName,
   ReindexErrorRow,
   SavedSearchSettings,
@@ -175,7 +175,7 @@ export async function resumePausedPort(
 }
 
 interface SetNewSearchSettingsArgs {
-  model: EmbeddingModel;
+  model: EmbeddingModelSpec;
   providerName: EmbeddingProviderName;
   switchoverType: SwitchoverType;
   enableContextualRag: boolean;

--- a/web/src/lib/indexing/types.ts
+++ b/web/src/lib/indexing/types.ts
@@ -72,6 +72,21 @@ export interface EmbeddingModel {
 
 export type EmbeddingModelSpec = Omit<EmbeddingModel, "description">;
 
+/**
+ * Always write all three fields together. A name without its spec and provider forces
+ * the submit path to guess them back, which misroutes LiteLLM and Azure models.
+ */
+export interface EmbeddingModelSelection {
+  model_name: string;
+  model_spec: EmbeddingModelSpec | null;
+  model_provider: EmbeddingProviderName | null;
+}
+
+export interface ResolvedEmbeddingModelForApply {
+  model: EmbeddingModelSpec;
+  providerName: EmbeddingProviderName;
+}
+
 export interface RerankingModel {
   rerank_provider_type: RerankerProvider | null;
   modelName?: string;

--- a/web/src/lib/indexing/types.ts
+++ b/web/src/lib/indexing/types.ts
@@ -70,6 +70,8 @@ export interface EmbeddingModel {
   description: string;
 }
 
+export type EmbeddingModelSpec = Omit<EmbeddingModel, "description">;
+
 export interface RerankingModel {
   rerank_provider_type: RerankerProvider | null;
   modelName?: string;

--- a/web/src/lib/indexing/utils.ts
+++ b/web/src/lib/indexing/utils.ts
@@ -1,0 +1,59 @@
+import { findRegistryModel, resolveProviderName } from "@/lib/indexing";
+import type {
+  EmbeddingModelSelection,
+  EmbeddingModelSpec,
+  EmbeddingProviderName,
+  ResolvedEmbeddingModelForApply,
+} from "@/lib/indexing/types";
+
+export function savedModelSelection(
+  currentModel: EmbeddingModelSpec | null,
+  currentProviderType: EmbeddingProviderName | null
+): EmbeddingModelSelection {
+  return {
+    model_name: currentModel?.modelName ?? "",
+    model_spec: currentModel,
+    model_provider: currentProviderType,
+  };
+}
+
+/**
+ * Compared field by field rather than by reference: `initialValues` is rebuilt from a
+ * memo whenever the settings query revalidates, so two deep-equal specs routinely
+ * arrive as different objects.
+ */
+export function isSameModelSelection(
+  a: EmbeddingModelSelection,
+  b: EmbeddingModelSelection
+): boolean {
+  if (a.model_name !== b.model_name || a.model_provider !== b.model_provider) {
+    return false;
+  }
+  if (a.model_spec === b.model_spec) return true;
+  if (!a.model_spec || !b.model_spec) return false;
+
+  return (
+    a.model_spec.modelName === b.model_spec.modelName &&
+    a.model_spec.modelDim === b.model_spec.modelDim &&
+    a.model_spec.normalize === b.model_spec.normalize &&
+    (a.model_spec.queryPrefix ?? null) === (b.model_spec.queryPrefix ?? null) &&
+    (a.model_spec.passagePrefix ?? null) ===
+      (b.model_spec.passagePrefix ?? null)
+  );
+}
+
+/**
+ * The fallbacks here only work for registry models. LiteLLM and Azure models aren't in
+ * the registry, so they have to arrive already carrying their own spec and provider.
+ */
+export function resolveModelForApply(
+  selection: EmbeddingModelSelection
+): ResolvedEmbeddingModelForApply | null {
+  const model = selection.model_spec ?? findRegistryModel(selection.model_name);
+  if (!model) return null;
+
+  const providerName =
+    selection.model_provider ?? resolveProviderName(selection.model_name, null);
+
+  return { model, providerName };
+}

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -63,8 +63,12 @@ import {
   findProvider,
   findRegistryModel,
   isCloudBased,
+  isSameModelSelection,
   MAX_IMAGE_SIZE_OPTIONS,
+  resolveModelForApply,
   resolveProviderName,
+  savedModelSelection,
+  type EmbeddingModelSelection,
 } from "@/lib/indexing";
 import {
   saveAdminSettings,
@@ -191,11 +195,8 @@ interface ProviderGroupProps {
    */
   existingModel?: EmbeddingModel;
   /**
-   * Stage a model into the parent form. `customModel` is populated only when
-   * the provider has no pre-registered models and the user defined the spec in
-   * the connect modal (LiteLLM / Azure) — the parent uses it to set both
-   * `model_name` and `custom_model`, and to remember this cloud provider as the
-   * staged model's owner so submit doesn't misresolve it as self-hosted.
+   * `customModel` is set only for providers with no pre-registered models
+   * (LiteLLM / Azure), where the user defines the spec in the connect modal.
    */
   onSelectModel: (
     modelName: string,
@@ -573,26 +574,7 @@ function EmbeddingModelCard({
   );
 }
 
-interface IndexSettingsFormValues {
-  model_name: string;
-  /**
-   * Populated when the staged model came from the "Add Custom Model" modal
-   * — i.e. it's not in `CLOUD_BASED_PROVIDERS` / `SELF_HOSTED_PROVIDERS`.
-   * The submit path uses this directly instead of looking the name up in
-   * the static registry. Cleared whenever the user selects a registered
-   * model.
-   */
-  custom_model: EmbeddingModel | null;
-  /**
-   * The cloud provider that owns a staged `custom_model` (LiteLLM / Azure).
-   * Those providers have no pre-registered models, so `resolveProviderName`
-   * can't recover their identity from the model name alone and would fall
-   * through to `CUSTOM` (self-hosted) — sending `provider_type=null` to the
-   * backend and bypassing the cloud credentials. Carrying it explicitly keeps
-   * the staged model bound to its provider. `null` for registered or
-   * self-hosted models, where name-based resolution is sufficient.
-   */
-  custom_model_provider: EmbeddingProviderName | null;
+interface IndexSettingsFormValues extends EmbeddingModelSelection {
   enable_contextual_rag: boolean;
   contextual_rag_model_configuration_id: number | null;
 }
@@ -607,9 +589,7 @@ function isContextualModelOnlyChange(
     values.contextual_rag_model_configuration_id !== null &&
     values.contextual_rag_model_configuration_id !==
       initialValues.contextual_rag_model_configuration_id &&
-    values.model_name === initialValues.model_name &&
-    values.custom_model === null &&
-    values.custom_model_provider === null
+    isSameModelSelection(values, initialValues)
   );
 }
 
@@ -808,16 +788,23 @@ export default function IndexSettingsPage() {
     return null;
   }, [llmProviders, defaultVision]);
 
+  const savedSelection = useMemo(
+    () =>
+      savedModelSelection(
+        currentEmbeddingModelSpec,
+        currentEmbeddingModel?.provider_type ?? null
+      ),
+    [currentEmbeddingModelSpec, currentEmbeddingModel]
+  );
+
   const initialFormValues: IndexSettingsFormValues = useMemo(
     () => ({
-      model_name: currentEmbeddingModel?.model_name ?? "",
-      custom_model: null,
-      custom_model_provider: null,
+      ...savedSelection,
       enable_contextual_rag: searchSettings?.enable_contextual_rag ?? false,
       contextual_rag_model_configuration_id:
         searchSettings?.contextual_rag_model_configuration_id ?? null,
     }),
-    [currentEmbeddingModel, searchSettings]
+    [savedSelection, searchSettings]
   );
 
   const applyContextualModelForward = useCallback(
@@ -940,29 +927,15 @@ export default function IndexSettingsPage() {
                 toast.error(t("toasts.contextualModelRequired"));
                 return;
               }
-              // Custom self-hosted models live outside the static registry,
-              // so the form carries their spec (`modelDim`, `normalize`, etc.)
-              // in `custom_model` for submission. The provider, however, is
-              // ALWAYS resolved through `resolveProviderName` — see its NOTE
-              // for why this is the single source of truth for provider
-              // discrimination.
-              const stagedModel =
-                values.custom_model ?? findRegistryModel(values.model_name);
-              if (!stagedModel) {
+              const resolved = resolveModelForApply(values);
+              if (!resolved) {
                 toast.error(t("toasts.modelNotFound"));
                 return;
               }
-              // A staged custom model from a no-registry cloud provider
-              // (LiteLLM / Azure) carries its owning provider explicitly;
-              // otherwise fall back to resolving the provider from the model
-              // name against the static registry.
-              const providerName =
-                values.custom_model_provider ??
-                resolveProviderName(values.model_name, null);
 
               const response = await setNewSearchSettings({
-                model: stagedModel,
-                providerName,
+                model: resolved.model,
+                providerName: resolved.providerName,
                 switchoverType,
                 enableContextualRag: values.enable_contextual_rag,
                 contextualRagModelConfigurationId: values.enable_contextual_rag
@@ -984,6 +957,11 @@ export default function IndexSettingsPage() {
             }}
           >
             {({ values, dirty, setFieldValue, resetForm, submitForm }) => {
+              const applySelection = (selection: EmbeddingModelSelection) => {
+                void setFieldValue("model_name", selection.model_name);
+                void setFieldValue("model_spec", selection.model_spec);
+                void setFieldValue("model_provider", selection.model_provider);
+              };
               const isModelStaged =
                 values.model_name !== initialFormValues.model_name &&
                 !!values.model_name;
@@ -1096,15 +1074,15 @@ export default function IndexSettingsPage() {
                           : undefined
                       }
                       onSubmit={(customModel) => {
-                        if (customModel) {
-                          void setFieldValue(
-                            "model_name",
-                            customModel.modelName
-                          );
-                          void setFieldValue("custom_model", customModel);
-                          // Self-hosted custom models resolve to CUSTOM by
-                          // name — no cloud provider to bind.
-                          void setFieldValue("custom_model_provider", null);
+                        if (customModel?.modelName) {
+                          applySelection({
+                            model_name: customModel.modelName,
+                            model_spec: {
+                              ...customModel,
+                              modelName: customModel.modelName,
+                            },
+                            model_provider: null,
+                          });
                         }
                         customModelModal.toggle(false);
                       }}
@@ -1331,39 +1309,23 @@ export default function IndexSettingsPage() {
                                                 onSelectModel={(
                                                   name,
                                                   customModel
-                                                ) => {
-                                                  void setFieldValue(
-                                                    "model_name",
-                                                    name
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model",
-                                                    customModel ?? null
-                                                  );
-                                                  // Bind a just-defined LiteLLM /
-                                                  // Azure model to its provider so
-                                                  // submit doesn't misresolve it.
-                                                  void setFieldValue(
-                                                    "custom_model_provider",
-                                                    customModel
+                                                ) =>
+                                                  applySelection({
+                                                    model_name: name,
+                                                    model_spec: customModel
+                                                      ? {
+                                                          ...customModel,
+                                                          modelName: name,
+                                                        }
+                                                      : null,
+                                                    model_provider: customModel
                                                       ? provider.providerName
-                                                      : null
-                                                  );
-                                                }}
-                                                onDeselectModel={() => {
-                                                  void setFieldValue(
-                                                    "model_name",
-                                                    initialFormValues.model_name
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model",
-                                                    null
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model_provider",
-                                                    null
-                                                  );
-                                                }}
+                                                      : null,
+                                                  })
+                                                }
+                                                onDeselectModel={() =>
+                                                  applySelection(savedSelection)
+                                                }
                                               />
                                             )
                                           )}
@@ -1399,34 +1361,16 @@ export default function IndexSettingsPage() {
                                                 selectedModelName={
                                                   stagedModelName ?? undefined
                                                 }
-                                                onSelectModel={(name) => {
-                                                  void setFieldValue(
-                                                    "model_name",
-                                                    name
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model",
-                                                    null
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model_provider",
-                                                    null
-                                                  );
-                                                }}
-                                                onDeselectModel={() => {
-                                                  void setFieldValue(
-                                                    "model_name",
-                                                    initialFormValues.model_name
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model",
-                                                    null
-                                                  );
-                                                  void setFieldValue(
-                                                    "custom_model_provider",
-                                                    null
-                                                  );
-                                                }}
+                                                onSelectModel={(name) =>
+                                                  applySelection({
+                                                    model_name: name,
+                                                    model_spec: null,
+                                                    model_provider: null,
+                                                  })
+                                                }
+                                                onDeselectModel={() =>
+                                                  applySelection(savedSelection)
+                                                }
                                               />
                                             )
                                           )}
@@ -1526,20 +1470,9 @@ export default function IndexSettingsPage() {
                                             tooltip={t(
                                               "modelPicker.revertSelection.tooltip"
                                             )}
-                                            onClick={() => {
-                                              void setFieldValue(
-                                                "model_name",
-                                                initialFormValues.model_name
-                                              );
-                                              void setFieldValue(
-                                                "custom_model",
-                                                null
-                                              );
-                                              void setFieldValue(
-                                                "custom_model_provider",
-                                                null
-                                              );
-                                            }}
+                                            onClick={() =>
+                                              applySelection(savedSelection)
+                                            }
                                           />
                                         )}
                                         <Button

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -53,6 +53,7 @@ import {
   type ConfiguredEmbeddingProvider,
   type EmbeddingModel,
   type EmbeddingModelRequest,
+  type EmbeddingModelSelection,
   type EmbeddingModelState,
   type EmbeddingProvider,
 } from "@/lib/indexing/types";
@@ -63,13 +64,14 @@ import {
   findProvider,
   findRegistryModel,
   isCloudBased,
-  isSameModelSelection,
   MAX_IMAGE_SIZE_OPTIONS,
-  resolveModelForApply,
   resolveProviderName,
-  savedModelSelection,
-  type EmbeddingModelSelection,
 } from "@/lib/indexing";
+import {
+  isSameModelSelection,
+  resolveModelForApply,
+  savedModelSelection,
+} from "@/lib/indexing/utils";
 import {
   saveAdminSettings,
   cancelNewEmbedding,


### PR DESCRIPTION
## Description

- Fix admins being unable to re-index a LiteLLM or Azure embedding model after reopening Index Settings — they hit either "No embedding provider exists for cloud embedding type openai" or "Could not find the selected model", depending on how the deployment was labelled.
- Stop the re-index from being submitted with another provider's embedding dimension, which built the new index at the wrong width and failed during embedding.
- Keep the "Apply to new and updated documents" option working when only the Contextual Retrieval LLM changes.

## How Has This Been Tested?

Unit tests added for the model/provider resolution, plus manual verification in the admin UI against a live instance: re-index with a LiteLLM model, connecting a real OpenAI provider and switching to `text-embedding-3-large`, toggling Contextual Retrieval both on and off, and a contextual-model-only change. All re-indexes completed with 492 chunks / 8 documents intact and no port failures.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes re-indexing for LiteLLM and Azure embedding models in Index Settings. Reopening the page and saving a re-index previously failed with either `No embedding provider exists for cloud embedding type openai` or `Could not find the selected model`, because the submit path re-resolved the model from the static registry — which has no entry for LiteLLM or Azure deployments.

- Re-index no longer submits another provider's embedding dimension, which previously built the new index at the wrong width and failed during embedding.
- Contextual Retrieval-only changes still trigger `Apply to new and updated documents` correctly, since the saved model selection is now carried through the form and compared by value.

<sup>Written for commit c838c01ef65a790c25eac7ca3c9721bcd11e0b71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




