### PR TITLE
fix(document360): handle timestamps without fractional seconds

### DIFF
--- a/backend/onyx/connectors/document360/connector.py
+++ b/backend/onyx/connectors/document360/connector.py
@@ -6,7 +6,10 @@ import requests
 from onyx.configs.app_configs import INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import rate_limit_builder
-from onyx.connectors.document360.utils import flatten_child_categories
+from onyx.connectors.document360.utils import (
+    flatten_child_categories,
+    parse_document360_datetime,
+)
 from onyx.connectors.interfaces import (
     GenerateDocumentsOutput,
     LoadConnector,
@@ -129,12 +132,12 @@ class Document360Connector(LoadConnector, PollConnector):
                 f"Articles/{article['id']}", {"langCode": "en"}
             )
 
-            updated_at = datetime.strptime(
-                article_details["modified_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
-            ).replace(tzinfo=timezone.utc)
-            created_at = datetime.strptime(
-                article_details["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
-            ).replace(tzinfo=timezone.utc)
+            updated_at = parse_document360_datetime(
+                article_details["modified_at"]
+            )
+            created_at = parse_document360_datetime(
+                article_details["created_at"]
+            )
             if start is not None and updated_at < start:
                 continue
             if end is not None and updated_at > end:

--- a/backend/onyx/connectors/document360/utils.py
+++ b/backend/onyx/connectors/document360/utils.py
@@ -1,3 +1,17 @@
+from datetime import datetime
+
+
+def parse_document360_datetime(value: str) -> datetime:
+    """Parse a Document360 ISO-8601 timestamp.
+
+    Document360 returns timestamps with a trailing ``Z`` but the fractional
+    seconds part is optional (e.g. ``2025-02-03T14:06:14Z`` vs
+    ``2025-04-24T09:23:54.494Z``).  ``datetime.fromisoformat`` on Python
+    3.11+ handles both forms and returns a timezone-aware datetime.
+    """
+    return datetime.fromisoformat(value)
+
+
 def flatten_child_categories(category: dict) -> list[dict]:
     if not category["child_categories"]:
         return [category]

--- a/backend/tests/unit/onyx/connectors/document360/test_document360_utils.py
+++ b/backend/tests/unit/onyx/connectors/document360/test_document360_utils.py
@@ -1,0 +1,44 @@
+"""Regression tests for Document360 datetime parsing (issue #14117).
+
+Document360 returns timestamps in ISO-8601 format with a trailing 'Z',
+but the fractional-seconds portion is optional.  The old strptime format
+string required ``.%f`` and failed when no fractional seconds were present.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+# We test the helper directly so we don't need the full connector import graph.
+from onyx.connectors.document360.utils import parse_document360_datetime
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # No fractional seconds
+        (
+            "2025-02-03T14:06:14Z",
+            datetime(2025, 2, 3, 14, 6, 14, tzinfo=timezone.utc),
+        ),
+        # Three-digit fractional seconds
+        (
+            "2025-04-24T09:23:54.494Z",
+            datetime(2025, 4, 24, 9, 23, 54, 494_000, tzinfo=timezone.utc),
+        ),
+        # Two-digit fractional seconds
+        (
+            "2026-01-05T14:48:29.93Z",
+            datetime(2026, 1, 5, 14, 48, 29, 930_000, tzinfo=timezone.utc),
+        ),
+    ],
+    ids=[
+        "no_fractional",
+        "three_digit_fractional",
+        "two_digit_fractional",
+    ],
+)
+def test_parse_document360_datetime(raw: str, expected: datetime) -> None:
+    result = parse_document360_datetime(raw)
+    assert result == expected
+    assert result.tzinfo is timezone.utc


### PR DESCRIPTION
## Description

Fixes #14117.

Document360 may return ISO-8601 article timestamps both with and without fractional seconds, for example:

* `2025-02-03T14:06:14Z`
* `2025-04-24T09:23:54.494Z`
* `2026-01-05T14:48:29.93Z`

The existing parser used:

`%Y-%m-%dT%H:%M:%S.%fZ`

which requires fractional seconds and raises `ValueError` for timestamps without them.

This change adds a small `parse_document360_datetime()` helper using `datetime.fromisoformat()` and uses it for both `created_at` and `modified_at`.

## How Has This Been Tested?

Added focused regression tests covering:

* timestamp without fractional seconds
* timestamp with 3-digit fractional seconds
* timestamp with 2-digit fractional seconds
* timezone-aware UTC output

Targeted test command:

`python -m pytest backend/tests/unit/onyx/connectors/document360/test_document360_utils.py --confcutdir=backend/tests/unit/onyx/connectors/document360 -q`

Result:

`3 passed`

### Verification Screenshot

<img width="1280" height="966" alt="01-tests-passing" src="https://github.com/user-attachments/assets/f29b46e8-7bce-4865-9ca3-73a4d5529d1c" />

## Additional Options

* [ ] Please cherry-pick this PR to the latest release version.
* [ ] Override Linear Check
