### PR TITLE
fix(llm): preserve reasoning from OpenAI-compatible providers

### DIFF
--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -220,7 +220,8 @@ def from_litellm_model_response_stream(
     delta_data: dict[str, Any] = choice_data.get("delta") or {}
     parsed_delta = Delta(
         content=delta_data.get("content"),
-        reasoning_content=delta_data.get("reasoning_content"),
+        reasoning_content=delta_data.get("reasoning_content")
+        or delta_data.get("reasoning"),
         thinking_blocks=_parse_thinking_blocks(delta_data.get("thinking_blocks")),
         tool_calls=_parse_delta_tool_calls(delta_data.get("tool_calls")),
     )
@@ -257,7 +258,8 @@ def from_litellm_model_response(
         content=message_data.get("content"),
         role=message_data.get("role", "assistant"),
         tool_calls=parsed_tool_calls if parsed_tool_calls else None,
-        reasoning_content=message_data.get("reasoning_content"),
+        reasoning_content=message_data.get("reasoning_content")
+        or message_data.get("reasoning"),
         thinking_blocks=_parse_thinking_blocks(message_data.get("thinking_blocks")),
     )
 

--- a/backend/tests/unit/onyx/llm/test_model_response.py
+++ b/backend/tests/unit/onyx/llm/test_model_response.py
@@ -363,3 +363,70 @@ def test_from_litellm_model_response_parses_tool_calls() -> None:
     assert tool_call.type == "function"
     assert tool_call.function.name == "search_documents"
     assert tool_call.function.arguments == '{"query": "test"}'
+
+
+# ---------------------------------------------------------------------------
+# Issue #14039 — OpenAI-compatible ``reasoning`` fallback.
+# ---------------------------------------------------------------------------
+
+
+def _stream_payload(delta: dict) -> dict:
+    return {
+        "id": "chatcmpl-14039",
+        "created": 1762544538,
+        "model": "m",
+        "object": "chat.completion.chunk",
+        "choices": [{"finish_reason": None, "index": 0, "delta": delta}],
+    }
+
+
+def _non_stream_payload(message: dict) -> dict:
+    return {
+        "id": "chatcmpl-14039",
+        "created": 1762544538,
+        "model": "m",
+        "object": "chat.completion",
+        "choices": [
+            {"finish_reason": "stop", "index": 0, "message": message}
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "delta, expected",
+    [
+        ({"reasoning": "fallback"}, "fallback"),
+        ({"reasoning_content": "primary", "reasoning": "other"}, "primary"),
+        ({"content": "only"}, None),
+    ],
+    ids=["reasoning-fallback", "reasoning_content-wins", "no-reasoning"],
+)
+def test_stream_reasoning_fallback(delta: dict, expected: str | None) -> None:
+    response = from_litellm_model_response_stream(
+        _make_stream_double(_stream_payload(delta))
+    )
+    assert response.choice.delta.reasoning_content == expected
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ({"content": "ok", "role": "assistant", "reasoning": "fallback"}, "fallback"),
+        (
+            {
+                "content": "ok",
+                "role": "assistant",
+                "reasoning_content": "primary",
+                "reasoning": "other",
+            },
+            "primary",
+        ),
+        ({"content": "ok", "role": "assistant"}, None),
+    ],
+    ids=["reasoning-fallback", "reasoning_content-wins", "no-reasoning"],
+)
+def test_non_streaming_reasoning_fallback(message: dict, expected: str | None) -> None:
+    response = from_litellm_model_response(
+        _make_response_double(_non_stream_payload(message))
+    )
+    assert response.choice.message.reasoning_content == expected


### PR DESCRIPTION
## Description

Fixes #14039.

Some OpenAI-compatible providers return model reasoning in a `reasoning` field instead of `reasoning_content`.

Onyx currently reads only `reasoning_content` in both streaming and non-streaming response parsing, so reasoning returned under `reasoning` is silently discarded.

This change normalizes the alternate field into Onyx's existing internal `reasoning_content` representation.

The precedence is:

* use `reasoning_content` when present
* otherwise fall back to `reasoning`
* otherwise keep reasoning as `None`

## How Has This Been Tested?

Added focused regression coverage for both streaming and non-streaming responses:

* `reasoning` fallback is preserved
* `reasoning_content` keeps precedence when both fields exist
* responses with no reasoning remain unchanged
* existing response parsing behavior remains intact

Before the fix:

`2 failed, 12 passed`

After the fix:

`14 passed, 0 failed`

Targeted test command:

`python -m pytest backend/tests/unit/onyx/llm/test_model_response.py -v --noconftest`

## Verification Screenshot

<img width="1280" height="1187" alt="image" src="https://github.com/user-attachments/assets/ffd8f330-a996-4292-aac7-b1274cbc1341" />


## Additional Options

* [ ] Please cherry-pick this PR to the latest release version.
* [ ] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #14039. Some OpenAI-compatible providers return reasoning in a `reasoning` field instead of `reasoning_content`, which Onyx was silently discarding. Both streaming and non-streaming response parsing now fall back to `reasoning` when `reasoning_content` is absent.

**Bug Fixes**
- Preserves reasoning from providers that use the `reasoning` field.
- Keeps `reasoning_content` as the preferred field when both are present.
- Adds regression tests covering the fallback, precedence, and no-reasoning cases.

<sup>Written for commit d93bce1b33aa2e38d169fa1059142536111dd343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

