### PR TITLE
feat(embedding): support OpenAI-compatible embedding providers

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -633,10 +633,10 @@ class CloudEmbedding:
             else:
                 raise ValueError(f"Unsupported provider: {self.provider}")
         except openai.AuthenticationError:
-            raise AuthenticationError(provider=str(self.provider))
+            raise AuthenticationError(provider=self.provider.value)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
-                raise AuthenticationError(provider=str(self.provider))
+                raise AuthenticationError(provider=self.provider.value)
 
             error_string = format_embedding_error(
                 e,
@@ -657,7 +657,7 @@ class CloudEmbedding:
             raise RuntimeError(error_string)
         except Exception as e:
             if is_authentication_error(e):
-                raise AuthenticationError(provider=str(self.provider))
+                raise AuthenticationError(provider=self.provider.value)
 
             error_string = format_embedding_error(
                 e,

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -287,7 +287,7 @@ def format_embedding_error(
     return (
         f"{'HTTP error' if status_code else 'Exception'} embedding text with {service_name} - {detail}: "
         f"Model: {model} "
-        f"Provider: {provider} "
+        f"Provider: {provider.value} "
         f"API Key: {sanitized_api_key} "
         f"Exception: {error}"
     )
@@ -640,7 +640,7 @@ class CloudEmbedding:
 
             error_string = format_embedding_error(
                 e,
-                str(self.provider),
+                self.provider.value,
                 model_name or deployment_name,
                 self.provider,
                 sanitized_api_key=self.sanitized_api_key,
@@ -661,7 +661,7 @@ class CloudEmbedding:
 
             error_string = format_embedding_error(
                 e,
-                str(self.provider),
+                self.provider.value,
                 model_name or deployment_name,
                 self.provider,
                 sanitized_api_key=self.sanitized_api_key,

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -343,8 +343,15 @@ class CloudEmbedding:
         self.sanitized_api_key = api_key[:4] + "********" + api_key[-4:]
 
     async def _embed_openai(
-        self, texts: list[str], model: str | None, reduced_dimension: int | None
+        self,
+        texts: list[str],
+        model: str | None,
+        reduced_dimension: int | None,
+        base_url: str | None = None,
     ) -> list[Embedding]:
+        """Embeds via the OpenAI SDK. `base_url` targets an OpenAI-compatible
+        endpoint instead of OpenAI itself; the SDK appends the `/embeddings`
+        path, so it expects a base URL such as `https://host/v1`."""
         if not model:
             model = DEFAULT_OPENAI_MODEL
 
@@ -352,7 +359,9 @@ class CloudEmbedding:
 
         # Use the OpenAI specific timeout for this one
         client = openai.AsyncOpenAI(
-            api_key=self.api_key, timeout=OPENAI_EMBEDDING_TIMEOUT
+            api_key=self.api_key,
+            timeout=OPENAI_EMBEDDING_TIMEOUT,
+            base_url=base_url,
         )
 
         final_embeddings: list[Embedding] = []
@@ -595,6 +604,18 @@ class CloudEmbedding:
         try:
             if self.provider == EmbeddingProvider.OPENAI:
                 return await self._embed_openai(texts, model_name, reduced_dimension)
+            elif self.provider == EmbeddingProvider.OPENAI_COMPATIBLE:
+                if not model_name:
+                    raise ValueError(
+                        "Model name is required for OpenAI-compatible embedding."
+                    )
+                if not self.api_url:
+                    raise ValueError(
+                        "API base URL is required for OpenAI-compatible embedding."
+                    )
+                return await self._embed_openai(
+                    texts, model_name, reduced_dimension, base_url=self.api_url
+                )
             elif self.provider == EmbeddingProvider.AZURE:
                 return await self._embed_azure(texts, f"azure/{deployment_name}")
             elif self.provider == EmbeddingProvider.LITELLM:
@@ -612,7 +633,7 @@ class CloudEmbedding:
             else:
                 raise ValueError(f"Unsupported provider: {self.provider}")
         except openai.AuthenticationError:
-            raise AuthenticationError(provider="OpenAI")
+            raise AuthenticationError(provider=str(self.provider))
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 401:
                 raise AuthenticationError(provider=str(self.provider))

--- a/backend/shared_configs/enums.py
+++ b/backend/shared_configs/enums.py
@@ -8,6 +8,7 @@ class EmbeddingProvider(str, Enum):
     GOOGLE = "google"
     LITELLM = "litellm"
     AZURE = "azure"
+    OPENAI_COMPATIBLE = "openai_compatible"
 
 
 class RerankerProvider(str, Enum):

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -15,6 +15,7 @@ from onyx.natural_language_processing.search_nlp_models import (
     CloudEmbedding,
     EmbeddingModel,
     clean_model_name,
+    format_embedding_error,
 )
 from shared_configs.enums import EmbeddingProvider, EmbedTextType
 from shared_configs.model_server_models import EmbedRequest, EmbedResponse
@@ -189,6 +190,20 @@ async def test_authentication_error_names_the_provider_by_value(
         assert "EmbeddingProvider." not in str(caught.value)
 
     await embedding.aclose()
+
+
+def test_format_embedding_error_names_the_provider_by_value() -> None:
+    """This string reaches the admin as an index-attempt failure message, so it
+    must not leak the enum repr."""
+    message = format_embedding_error(
+        ValueError("boom"),
+        EmbeddingProvider.OPENAI_COMPATIBLE.value,
+        "Qwen3-Embedding-8B",
+        EmbeddingProvider.OPENAI_COMPATIBLE,
+    )
+
+    assert "EmbeddingProvider." not in message
+    assert "Provider: openai_compatible" in message
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -3,6 +3,7 @@ from threading import Lock
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from httpx import AsyncClient
 from litellm.exceptions import RateLimitError
@@ -10,6 +11,7 @@ from tenacity import wait_none
 
 from onyx.llm.constants import LlmProviderNames
 from onyx.natural_language_processing.search_nlp_models import (
+    AuthenticationError,
     CloudEmbedding,
     EmbeddingModel,
     clean_model_name,
@@ -146,6 +148,47 @@ async def test_openai_compatible_embedding_omits_dimensions_when_not_reduced(
 
         create_kwargs = mock_client.embeddings.create.call_args.kwargs
         assert create_kwargs["dimensions"] is openai.omit
+
+
+@pytest.mark.asyncio
+async def test_authentication_error_names_the_provider_by_value(
+    mock_http_client: AsyncMock,  # noqa: ARG001
+) -> None:
+    """`str()` on a `str, Enum` member yields `EmbeddingProvider.OPENAI_COMPATIBLE`,
+    so the message must use `.value` to stay readable."""
+    import openai
+
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_client = AsyncMock()
+        mock_openai.return_value = mock_client
+        mock_client.embeddings.create = AsyncMock(
+            side_effect=openai.AuthenticationError(
+                message="bad key",
+                response=httpx.Response(
+                    status_code=401, request=httpx.Request("POST", "https://host/v1")
+                ),
+                body=None,
+            )
+        )
+
+        embedding = CloudEmbedding(
+            "fake-key",
+            EmbeddingProvider.OPENAI_COMPATIBLE,
+            api_url="https://host/v1",
+        )
+
+        with patch.object(cast(Any, CloudEmbedding.embed).retry, "wait", wait_none()):
+            with pytest.raises(AuthenticationError) as caught:
+                await embedding.embed(
+                    texts=["test1"],
+                    text_type=EmbedTextType.PASSAGE,
+                    model_name="Qwen3-Embedding-8B",
+                )
+
+        assert caught.value.provider == "openai_compatible"
+        assert "EmbeddingProvider." not in str(caught.value)
+
+    await embedding.aclose()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -79,6 +79,92 @@ async def test_openai_embedding(
         mock_client.embeddings.create.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_openai_compatible_embedding_sends_base_url_and_dimensions(
+    mock_http_client: AsyncMock,  # noqa: ARG001
+    sample_embeddings: list[list[float]],
+) -> None:
+    """A reduced dimension must reach the server as `dimensions`, which is what
+    lets Matryoshka-capable models return a shorter vector."""
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_client = AsyncMock()
+        mock_openai.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=emb) for emb in sample_embeddings]
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        async with CloudEmbedding(
+            "fake-key",
+            EmbeddingProvider.OPENAI_COMPATIBLE,
+            api_url="https://embeddings.internal/v1",
+        ) as embedding:
+            result = await embedding.embed(
+                texts=["test1", "test2"],
+                text_type=EmbedTextType.PASSAGE,
+                model_name="Qwen3-Embedding-8B",
+                reduced_dimension=1024,
+            )
+
+        assert result == sample_embeddings
+        assert mock_openai.call_args.kwargs["base_url"] == (
+            "https://embeddings.internal/v1"
+        )
+        create_kwargs = mock_client.embeddings.create.call_args.kwargs
+        assert create_kwargs["model"] == "Qwen3-Embedding-8B"
+        assert create_kwargs["dimensions"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_embedding_omits_dimensions_when_not_reduced(
+    mock_http_client: AsyncMock,  # noqa: ARG001
+    sample_embeddings: list[list[float]],
+) -> None:
+    """Without a reduced dimension we must not send `dimensions` at all, because
+    some OpenAI-compatible servers reject the parameter."""
+    import openai
+
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_client = AsyncMock()
+        mock_openai.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=emb) for emb in sample_embeddings]
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        async with CloudEmbedding(
+            "fake-key",
+            EmbeddingProvider.OPENAI_COMPATIBLE,
+            api_url="https://embeddings.internal/v1",
+        ) as embedding:
+            await embedding.embed(
+                texts=["test1", "test2"],
+                text_type=EmbedTextType.PASSAGE,
+                model_name="Qwen3-Embedding-8B",
+                reduced_dimension=None,
+            )
+
+        create_kwargs = mock_client.embeddings.create.call_args.kwargs
+        assert create_kwargs["dimensions"] is openai.omit
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_embedding_requires_api_url() -> None:
+    """A missing base URL is a likely misconfiguration, so it must fail with a
+    message that names the cause."""
+    embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI_COMPATIBLE)
+
+    with patch.object(cast(Any, CloudEmbedding.embed).retry, "wait", wait_none()):
+        with pytest.raises(RuntimeError, match="API base URL is required"):
+            await embedding.embed(
+                texts=["test1"],
+                text_type=EmbedTextType.PASSAGE,
+                model_name="Qwen3-Embedding-8B",
+            )
+
+    await embedding.aclose()
+
+
 def _build_google_embed_response(
     embeddings: list[list[float]],
 ) -> MagicMock:

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "الصق [مفتاح API]({link}) من {provider} للوصول إلى نماذجك.",
+          "descriptionNoLink": "الصق مفتاح API لنقطة نهاية {provider} للوصول إلى نماذجك.",
           "title": "مفتاح API"
         },
         "googleCredentials": {
@@ -4796,6 +4797,20 @@
         },
         "title": "الفهرسة متعددة التمريرات"
       },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "عنوان URL الأساسي لنقطة النهاية المتوافقة مع OpenAI، على سبيل المثال http://localhost:8000/v1. يضيف Onyx المسار /embeddings.",
+          "title": "عنوان URL الأساسي لواجهة API"
+        },
+        "modelName": {
+          "description": "سيتصل Onyx بهذا النموذج على نقطة النهاية المتوافقة مع OpenAI."
+        },
+        "reducedDimension": {
+          "description": "اطلب متجهات أقصر من النموذج. يعمل هذا فقط مع النماذج التي تدعم تعلّم تمثيل ماتريوشكا. تحتاج المتجهات الأقصر إلى مساحة تخزين أقل وتبحث بسرعة أكبر. اتركه فارغًا لاستخدام الحجم الكامل للنموذج.",
+          "placeholder": "مثل 1024",
+          "title": "أبعاد التضمين"
+        }
+      },
       "progressBanner": {
         "attentionButton": {
           "label": "عرض الوحدات التي تحتاج اهتمامًا"
@@ -4913,6 +4928,7 @@
         "modelDimPositive": "يجب أن يكون عددًا صحيحًا موجبًا",
         "modelDimRequired": "أبعاد النموذج مطلوبة",
         "modelNameRequired": "اسم النموذج مطلوب",
+        "reducedDimensionAboveModelDim": "يجب ألا يكون أكبر من أبعاد النموذج",
         "serviceAccountJsonInvalid": "يجب أن يكون ملف JSON صالحًا لحساب خدمة Google",
         "serviceAccountJsonRequired": "JSON حساب الخدمة مطلوب",
         "targetUrlRequired": "عنوان URL الهدف مطلوب",

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "Muss eine positive ganze Zahl sein",
         "modelDimRequired": "Modelldimension ist erforderlich",
         "modelNameRequired": "Modellname ist erforderlich",
+        "reducedDimensionAboveModelDim": "Darf nicht größer als die Modelldimension sein",
         "serviceAccountJsonInvalid": "Muss eine gültige JSON-Datei für ein Google-Dienstkonto sein",
         "serviceAccountJsonRequired": "Dienstkonto-JSON ist erforderlich",
         "targetUrlRequired": "Ziel-URL ist erforderlich",

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "Fügen Sie Ihren [API-Schlüssel]({link}) von {provider} ein, um auf Ihre Modelle zuzugreifen.",
+          "descriptionNoLink": "Fügen Sie den API-Schlüssel für Ihren {provider}-Endpunkt ein, um auf Ihre Modelle zuzugreifen.",
           "title": "API-Schlüssel"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "vorübergehend nicht verfügbar"
         },
         "title": "Multipass-Indizierung"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "Basis-URL Ihres OpenAI-kompatiblen Endpunkts, zum Beispiel http://localhost:8000/v1. Onyx hängt den Pfad /embeddings an.",
+          "title": "API-Basis-URL"
+        },
+        "modelName": {
+          "description": "Onyx verbindet sich mit diesem Modell an Ihrem OpenAI-kompatiblen Endpunkt."
+        },
+        "reducedDimension": {
+          "description": "Fordern Sie kürzere Vektoren vom Modell an. Dies funktioniert nur bei Modellen, die Matryoshka Representation Learning unterstützen. Kürzere Vektoren benötigen weniger Speicher und werden schneller durchsucht. Leer lassen, um die volle Größe des Modells zu verwenden.",
+          "placeholder": "z. B. 1024",
+          "title": "Embedding-Dimensionen"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "Must be a positive integer",
         "modelDimRequired": "Model dimension is required",
         "modelNameRequired": "Model name is required",
+        "reducedDimensionAboveModelDim": "Must not be larger than the model dimension",
         "serviceAccountJsonInvalid": "Must be a valid Google service account JSON file",
         "serviceAccountJsonRequired": "Service account JSON is required",
         "targetUrlRequired": "Target URL is required",

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "Paste your [API key]({link}) from {provider} to access your models.",
+          "descriptionNoLink": "Paste the API key for your {provider} endpoint to access your models.",
           "title": "API Key"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "temporarily unavailable"
         },
         "title": "Multipass Indexing"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "Base URL of your OpenAI-compatible endpoint, for example http://localhost:8000/v1. Onyx adds the /embeddings path.",
+          "title": "API Base URL"
+        },
+        "modelName": {
+          "description": "Onyx will connect to this model on your OpenAI-compatible endpoint."
+        },
+        "reducedDimension": {
+          "description": "Request shorter vectors from the model. This works only with models that support Matryoshka Representation Learning. Shorter vectors need less storage and search faster. Leave empty to use the full size of the model.",
+          "placeholder": "e.g., 1024",
+          "title": "Embedding Dimensions"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "Debe ser un número entero positivo",
         "modelDimRequired": "La dimensión del modelo es obligatoria",
         "modelNameRequired": "El nombre del modelo es obligatorio",
+        "reducedDimensionAboveModelDim": "No debe ser mayor que la dimensión del modelo",
         "serviceAccountJsonInvalid": "Debe ser un archivo JSON válido de cuenta de servicio de Google",
         "serviceAccountJsonRequired": "El JSON de la cuenta de servicio es obligatorio",
         "targetUrlRequired": "La URL de destino es obligatoria",

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "Pega tu [clave de API]({link}) de {provider} para acceder a tus modelos.",
+          "descriptionNoLink": "Pega la clave de API de tu endpoint de {provider} para acceder a tus modelos.",
           "title": "Clave de API"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "no disponible temporalmente"
         },
         "title": "Indexación multipaso"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "URL base de tu endpoint compatible con OpenAI, por ejemplo http://localhost:8000/v1. Onyx añade la ruta /embeddings.",
+          "title": "URL base de la API"
+        },
+        "modelName": {
+          "description": "Onyx se conectará a este modelo en tu endpoint compatible con OpenAI."
+        },
+        "reducedDimension": {
+          "description": "Solicita vectores más cortos al modelo. Esto solo funciona con modelos que admiten Matryoshka Representation Learning. Los vectores más cortos ocupan menos espacio y se buscan más rápido. Déjalo vacío para usar el tamaño completo del modelo.",
+          "placeholder": "p. ej., 1024",
+          "title": "Dimensiones del embedding"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "Doit être un entier positif",
         "modelDimRequired": "La dimension du modèle est obligatoire",
         "modelNameRequired": "Le nom du modèle est obligatoire",
+        "reducedDimensionAboveModelDim": "Ne doit pas être supérieur à la dimension du modèle",
         "serviceAccountJsonInvalid": "Doit être un fichier JSON de compte de service Google valide",
         "serviceAccountJsonRequired": "Le JSON du compte de service est obligatoire",
         "targetUrlRequired": "L'URL cible est obligatoire",

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "Collez votre [clé d'API]({link}) de {provider} pour accéder à vos modèles.",
+          "descriptionNoLink": "Collez la clé API de votre point de terminaison {provider} pour accéder à vos modèles.",
           "title": "Clé d'API"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "temporairement indisponible"
         },
         "title": "Indexation multi-passes"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "URL de base de votre point de terminaison compatible OpenAI, par exemple http://localhost:8000/v1. Onyx ajoute le chemin /embeddings.",
+          "title": "URL de base de l'API"
+        },
+        "modelName": {
+          "description": "Onyx se connectera à ce modèle sur votre point de terminaison compatible OpenAI."
+        },
+        "reducedDimension": {
+          "description": "Demandez des vecteurs plus courts au modèle. Cela fonctionne uniquement avec les modèles qui prennent en charge le Matryoshka Representation Learning. Les vecteurs plus courts occupent moins d'espace et se recherchent plus vite. Laissez vide pour utiliser la taille complète du modèle.",
+          "placeholder": "ex. : 1024",
+          "title": "Dimensions de l'embedding"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "モデルにアクセスするには、{provider} の [API キー]({link}) を貼り付けてください。",
+          "descriptionNoLink": "モデルにアクセスするには、{provider} エンドポイントの API キーを貼り付けてください。",
           "title": "API キー"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "一時的に利用不可"
         },
         "title": "マルチパスインデックス"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "OpenAI 互換エンドポイントのベース URL（例: http://localhost:8000/v1）。Onyx が /embeddings パスを追加します。",
+          "title": "API ベース URL"
+        },
+        "modelName": {
+          "description": "Onyx は OpenAI 互換エンドポイント上のこのモデルに接続します。"
+        },
+        "reducedDimension": {
+          "description": "モデルに短いベクトルを要求します。これは Matryoshka Representation Learning に対応したモデルでのみ動作します。短いベクトルは保存容量が少なく、検索も高速です。空欄にすると、モデル本来のサイズを使用します。",
+          "placeholder": "例: 1024",
+          "title": "埋め込みの次元数"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "正の整数を入力してください",
         "modelDimRequired": "モデルの次元数は必須です",
         "modelNameRequired": "モデル名は必須です",
+        "reducedDimensionAboveModelDim": "モデルの次元数より大きくすることはできません",
         "serviceAccountJsonInvalid": "有効な Google サービスアカウントの JSON ファイルを指定してください",
         "serviceAccountJsonRequired": "サービスアカウント JSON は必須です",
         "targetUrlRequired": "ターゲット URL は必須です",

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "양의 정수여야 합니다",
         "modelDimRequired": "모델 차원은 필수입니다",
         "modelNameRequired": "모델 이름은 필수입니다",
+        "reducedDimensionAboveModelDim": "모델 차원보다 클 수 없습니다",
         "serviceAccountJsonInvalid": "유효한 Google 서비스 계정 JSON 파일이어야 합니다",
         "serviceAccountJsonRequired": "서비스 계정 JSON은 필수입니다",
         "targetUrlRequired": "대상 URL은 필수입니다",

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "모델에 접근하려면 {provider}의 [API 키]({link})를 붙여넣으세요.",
+          "descriptionNoLink": "모델에 액세스하려면 {provider} 엔드포인트의 API 키를 붙여넣으세요.",
           "title": "API 키"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "일시적으로 사용 불가"
         },
         "title": "멀티패스 인덱싱"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "OpenAI 호환 엔드포인트의 기본 URL입니다. 예: http://localhost:8000/v1. Onyx가 /embeddings 경로를 추가합니다.",
+          "title": "API 기본 URL"
+        },
+        "modelName": {
+          "description": "Onyx가 OpenAI 호환 엔드포인트에서 이 모델에 연결합니다."
+        },
+        "reducedDimension": {
+          "description": "모델에 더 짧은 벡터를 요청합니다. Matryoshka Representation Learning을 지원하는 모델에서만 작동합니다. 짧은 벡터는 저장 공간을 덜 사용하고 검색이 더 빠릅니다. 비워 두면 모델의 전체 크기를 사용합니다.",
+          "placeholder": "예: 1024",
+          "title": "임베딩 차원"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "Deve ser um número inteiro positivo",
         "modelDimRequired": "A dimensão do modelo é obrigatória",
         "modelNameRequired": "O nome do modelo é obrigatório",
+        "reducedDimensionAboveModelDim": "Não deve ser maior que a dimensão do modelo",
         "serviceAccountJsonInvalid": "Deve ser um arquivo JSON de conta de serviço do Google válido",
         "serviceAccountJsonRequired": "O JSON da conta de serviço é obrigatório",
         "targetUrlRequired": "A URL de destino é obrigatória",

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "Cole sua [chave de API]({link}) do {provider} para acessar seus modelos.",
+          "descriptionNoLink": "Cole a chave de API do seu endpoint {provider} para acessar seus modelos.",
           "title": "Chave de API"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "temporariamente indisponível"
         },
         "title": "Indexação multipass"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "URL base do seu endpoint compatível com OpenAI, por exemplo http://localhost:8000/v1. O Onyx adiciona o caminho /embeddings.",
+          "title": "URL base da API"
+        },
+        "modelName": {
+          "description": "O Onyx se conectará a este modelo no seu endpoint compatível com OpenAI."
+        },
+        "reducedDimension": {
+          "description": "Solicite vetores mais curtos ao modelo. Isso funciona apenas com modelos que suportam Matryoshka Representation Learning. Vetores mais curtos ocupam menos espaço e são pesquisados mais rápido. Deixe vazio para usar o tamanho completo do modelo.",
+          "placeholder": "ex.: 1024",
+          "title": "Dimensões do embedding"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -4649,6 +4649,7 @@
       "fields": {
         "apiKey": {
           "description": "粘贴来自 {provider} 的 [API 密钥]({link})，以访问您的模型。",
+          "descriptionNoLink": "粘贴您的 {provider} 端点的 API 密钥以访问您的模型。",
           "title": "API 密钥"
         },
         "googleCredentials": {
@@ -4795,6 +4796,20 @@
           "label": "暂时不可用"
         },
         "title": "多轮索引"
+      },
+      "openaiCompatible": {
+        "apiUrl": {
+          "description": "您的 OpenAI 兼容端点的基础 URL，例如 http://localhost:8000/v1。Onyx 会附加 /embeddings 路径。",
+          "title": "API 基础 URL"
+        },
+        "modelName": {
+          "description": "Onyx 将连接到您的 OpenAI 兼容端点上的此模型。"
+        },
+        "reducedDimension": {
+          "description": "向模型请求更短的向量。这仅适用于支持 Matryoshka Representation Learning 的模型。更短的向量占用更少存储空间，搜索速度更快。留空则使用模型的完整维度。",
+          "placeholder": "例如 1024",
+          "title": "嵌入维度"
+        }
       },
       "progressBanner": {
         "attentionButton": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -4928,6 +4928,7 @@
         "modelDimPositive": "必须是正整数",
         "modelDimRequired": "模型维度为必填项",
         "modelNameRequired": "模型名称为必填项",
+        "reducedDimensionAboveModelDim": "不能大于模型维度",
         "serviceAccountJsonInvalid": "必须是有效的 Google 服务账号 JSON 文件",
         "serviceAccountJsonRequired": "服务账号 JSON 为必填项",
         "targetUrlRequired": "目标 URL 为必填项",

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -1,4 +1,4 @@
-import { SvgHardDrive } from "@opal/icons";
+import { SvgHardDrive, SvgPlug } from "@opal/icons";
 import {
   SvgAzure,
   SvgCohere,
@@ -164,6 +164,14 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
     displayName: "LiteLLM",
     icon: SvgLitellm,
     apiLink: "https://docs.litellm.ai/docs/proxy/quick_start",
+    embeddingModels: [],
+  },
+  {
+    providerName: EmbeddingProviderName.OPENAI_COMPATIBLE,
+    displayName: "OpenAI-Compatible",
+    icon: SvgPlug,
+    docsLink:
+      "https://platform.openai.com/docs/api-reference/embeddings/create",
     embeddingModels: [],
   },
   {

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -208,6 +208,10 @@ export async function setNewSearchSettings({
     body: JSON.stringify({
       model_name: model.modelName,
       model_dim: model.modelDim,
+      // Trims the stored vector for Matryoshka-capable models. The backend
+      // indexes at `reduced_dimension or model_dim`, and forwards this as the
+      // OpenAI `dimensions` parameter.
+      reduced_dimension: model.reducedDimension ?? null,
       normalize: model.normalize,
       query_prefix: model.queryPrefix,
       passage_prefix: model.passagePrefix,

--- a/web/src/lib/indexing/types.ts
+++ b/web/src/lib/indexing/types.ts
@@ -12,6 +12,7 @@ export enum EmbeddingProviderName {
   GOOGLE = "google",
   LITELLM = "litellm",
   AZURE = "azure",
+  OPENAI_COMPATIBLE = "openai_compatible",
 
   // Self-hosted
   NOMIC = "nomic",
@@ -68,6 +69,9 @@ export interface EmbeddingModel {
   queryPrefix?: string | null;
   passagePrefix?: string | null;
   description: string;
+  /** See `EmbeddingModelRequest.reducedDimension`. Registry presets leave this
+   *  unset; it is only staged by providers whose modal collects it. */
+  reducedDimension?: number | null;
 }
 
 export type EmbeddingModelSpec = Omit<EmbeddingModel, "description">;
@@ -134,6 +138,15 @@ export interface EmbeddingModelRequest {
   normalize: boolean;
   queryPrefix?: string | null;
   passagePrefix?: string | null;
+  /**
+   * Requests a shorter vector from providers whose models support Matryoshka
+   * Representation Learning. When set, it becomes the OpenAI `dimensions`
+   * parameter AND the width of the vector index (`reduced_dimension or
+   * model_dim` on the backend), so `modelDim` stays the model's native size.
+   * Only settable while creating search settings, because changing the vector
+   * width needs a re-index.
+   */
+  reducedDimension?: number | null;
 }
 
 /** Shape returned by `GET /api/admin/embedding/embedding-provider`. */

--- a/web/src/views/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/views/admin/IndexSettingsPage/modals.tsx
@@ -472,6 +472,126 @@ function LiteLLMProviderModal({
 }
 
 // ---------------------------------------------------------------------------
+// OpenAI-Compatible
+// ---------------------------------------------------------------------------
+
+interface OpenAICompatibleFormValues {
+  apiUrl: string;
+  apiKey: string;
+  modelName: string;
+  modelDim: number;
+  /** Kept as a string so an empty box stays empty instead of becoming NaN. */
+  reducedDimension: string;
+  queryPrefix: string;
+  passagePrefix: string;
+  normalize: boolean;
+}
+
+function OpenAICompatibleProviderModal({
+  provider,
+  existingCredentials,
+  existingModel,
+  onSubmit,
+}: ProviderModalProps) {
+  const t = useTranslations("admin.indexSettings");
+  const isEditing = !!existingCredentials;
+  const maskedApiKey = existingCredentials?.api_key ?? "";
+
+  const schema = Yup.object({
+    apiUrl: Yup.string()
+      .trim()
+      .required(t("validation.apiBaseUrlRequired"))
+      .url(t("validation.urlInvalid")),
+    apiKey: isEditing
+      ? Yup.string().trim()
+      : Yup.string().trim().required(t("validation.apiKeyRequired")),
+    reducedDimension: Yup.string()
+      .defined()
+      .default("")
+      .test(
+        "optional-positive-int",
+        t("validation.modelDimPositive"),
+        (value) => {
+          if (!value?.trim()) return true;
+          const parsed = Number(value);
+          return Number.isInteger(parsed) && parsed > 0 && parsed <= 10000;
+        }
+      ),
+    ...modelSpecSchemaShape(t),
+  });
+
+  const initialValues: OpenAICompatibleFormValues = {
+    apiUrl: existingCredentials?.api_url ?? "",
+    apiKey: maskedApiKey,
+    modelName: existingModel?.modelName ?? "",
+    modelDim: existingModel?.modelDim ?? 0,
+    reducedDimension: "",
+    queryPrefix: existingModel?.queryPrefix ?? "",
+    passagePrefix: existingModel?.passagePrefix ?? "",
+    normalize: existingModel?.normalize ?? false,
+  };
+
+  return (
+    <Formik<OpenAICompatibleFormValues>
+      initialValues={initialValues}
+      validationSchema={schema}
+      validateOnMount
+      onSubmit={async (values) => {
+        const apiKey =
+          values.apiKey === maskedApiKey ? null : values.apiKey || null;
+        if (
+          await testAndSaveProviderCredentials({
+            provider,
+            apiKey,
+            apiUrl: values.apiUrl,
+            modelName: values.modelName.trim(),
+            unknownErrorMessage: t("toasts.unknownError"),
+          })
+        ) {
+          onSubmit({
+            modelName: values.modelName.trim(),
+            modelDim: values.modelDim,
+            normalize: values.normalize,
+            queryPrefix: values.queryPrefix || null,
+            passagePrefix: values.passagePrefix || null,
+            reducedDimension: values.reducedDimension.trim()
+              ? Number(values.reducedDimension)
+              : null,
+          });
+        }
+      }}
+    >
+      <ModalShell provider={provider} isEditing={isEditing}>
+        <ApiUrlField
+          title={t("openaiCompatible.apiUrl.title")}
+          placeholder="http://localhost:8000/v1"
+          subDescription={t("openaiCompatible.apiUrl.description")}
+        />
+
+        <ApiKeyField provider={provider} />
+
+        <ModelSpecFields
+          modelNameSubDescription={t("openaiCompatible.modelName.description")}
+        />
+
+        {/* Only offered while creating: the vector width is fixed at index
+            build time, and the edit flow discards the staged model spec. */}
+        {!isEditing && (
+          <TextField
+            name="reducedDimension"
+            title={t("openaiCompatible.reducedDimension.title")}
+            suffix={t("fields.optional.suffix")}
+            placeholder={t("openaiCompatible.reducedDimension.placeholder")}
+            inputMode="numeric"
+            subDescription={t("openaiCompatible.reducedDimension.description")}
+          />
+        )}
+      </ModalShell>
+    </Formik>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Custom Self-Hosted
 // ---------------------------------------------------------------------------
 
@@ -526,6 +646,8 @@ export function ProviderCredentialsModal(props: ProviderModalProps) {
       return <AzureProviderModal {...props} />;
     case EmbeddingProviderName.LITELLM:
       return <LiteLLMProviderModal {...props} />;
+    case EmbeddingProviderName.OPENAI_COMPATIBLE:
+      return <OpenAICompatibleProviderModal {...props} />;
     case EmbeddingProviderName.CUSTOM:
       return <CustomSelfHostedModal {...props} />;
     default:

--- a/web/src/views/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/views/admin/IndexSettingsPage/modals.tsx
@@ -516,6 +516,18 @@ function OpenAICompatibleProviderModal({
           const parsed = Number(value);
           return Number.isInteger(parsed) && parsed > 0 && parsed <= 10000;
         }
+      )
+      // Truncation can only shorten a vector. A larger value would size the
+      // index above what the model returns, which breaks indexing.
+      .test(
+        "not-above-model-dim",
+        t("validation.reducedDimensionAboveModelDim"),
+        function (value) {
+          if (!value?.trim()) return true;
+          const modelDim = Number(this.parent.modelDim);
+          if (!Number.isInteger(modelDim) || modelDim <= 0) return true;
+          return Number(value) <= modelDim;
+        }
       ),
     ...modelSpecSchemaShape(t),
   });

--- a/web/src/views/admin/IndexSettingsPage/shared.tsx
+++ b/web/src/views/admin/IndexSettingsPage/shared.tsx
@@ -35,16 +35,22 @@ interface ApiKeyFieldProps {
 export function ApiKeyField({ provider }: ApiKeyFieldProps) {
   const t = useTranslations("admin.indexSettings");
 
+  // Self-supplied endpoints have no vendor page to link to, so avoid rendering
+  // an empty `[API key]()` link.
+  const subDescription = provider.apiLink
+    ? markdown(
+        t("fields.apiKey.description", {
+          link: provider.apiLink,
+          provider: provider.displayName,
+        })
+      )
+    : t("fields.apiKey.descriptionNoLink", { provider: provider.displayName });
+
   return (
     <InputVertical
       title={t("fields.apiKey.title")}
       withLabel="apiKey"
-      subDescription={markdown(
-        t("fields.apiKey.description", {
-          link: provider.apiLink ?? "",
-          provider: provider.displayName,
-        })
-      )}
+      subDescription={subDescription}
     >
       <PasswordInputTypeInField name="apiKey" />
     </InputVertical>

--- a/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
+++ b/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
@@ -151,6 +151,13 @@ export class IndexSettingsPage {
       .fill(String(spec.modelDim));
   }
 
+  /** Asserts the open setup modal rejects its current values. */
+  async expectProviderSetupBlocked(): Promise<void> {
+    await expect(
+      this.activeSetupModal.getByRole("button", { name: /connect/i })
+    ).toBeDisabled({ timeout: 5000 });
+  }
+
   /** Submit the open setup modal ("Connect") and wait for it to close. */
   async submitProviderSetup(): Promise<void> {
     const connectButton = this.activeSetupModal.getByRole("button", {

--- a/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
+++ b/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
@@ -126,6 +126,21 @@ export class IndexSettingsPage {
       .fill(creds.deploymentName);
   }
 
+  async fillOpenAICompatibleCredentials(creds: {
+    apiBaseUrl: string;
+    apiKey: string;
+  }): Promise<void> {
+    await this.activeSetupModal.locator("#apiUrl").fill(creds.apiBaseUrl);
+    await this.activeSetupModal.locator("#apiKey").fill(creds.apiKey);
+  }
+
+  /** Optional Matryoshka trim field, offered only while creating a provider. */
+  async fillReducedDimension(reducedDimension: number): Promise<void> {
+    await this.activeSetupModal
+      .locator("#reducedDimension")
+      .fill(String(reducedDimension));
+  }
+
   async fillModelSpec(spec: {
     modelName: string;
     modelDim: number;

--- a/web/tests/e2e/admin/index-settings/index_settings.spec.ts
+++ b/web/tests/e2e/admin/index-settings/index_settings.spec.ts
@@ -627,6 +627,10 @@ test.describe("Index Settings — empty-registry providers @exclusive", () => {
         modelDim: 1024,
       });
       if (reducedDimension !== undefined) {
+        // Truncation can only shorten a vector, so a trim wider than the
+        // model's native width must block submission.
+        await indexSettings.fillReducedDimension(2048);
+        await indexSettings.expectProviderSetupBlocked();
         await indexSettings.fillReducedDimension(reducedDimension);
       }
       await indexSettings.submitProviderSetup();

--- a/web/tests/e2e/admin/index-settings/index_settings.spec.ts
+++ b/web/tests/e2e/admin/index-settings/index_settings.spec.ts
@@ -528,6 +528,9 @@ interface EmptyRegistryProviderCase {
   // Fills the credential fields unique to this provider via the page object
   // (the shared model-spec fields are filled by the test body).
   fillCredentials: (indexSettings: IndexSettingsPage) => Promise<void>;
+  // Set only for providers whose modal offers the optional Matryoshka trim
+  // field. Providers that leave it unset must send reduced_dimension: null.
+  reducedDimension?: number;
 }
 
 const EMPTY_REGISTRY_PROVIDERS: EmptyRegistryProviderCase[] = [
@@ -551,6 +554,17 @@ const EMPTY_REGISTRY_PROVIDERS: EmptyRegistryProviderCase[] = [
         deploymentName: "my-deployment",
       }),
   },
+  {
+    providerType: "openai_compatible",
+    displayName: "OpenAI-Compatible",
+    fillCredentials: (indexSettings) =>
+      indexSettings.fillOpenAICompatibleCredentials({
+        apiBaseUrl: "http://localhost:8000/v1",
+        apiKey: "sk-test-key",
+      }),
+    // Trims the stored vector below the model's native size.
+    reducedDimension: 512,
+  },
 ];
 
 test.describe("Index Settings — empty-registry providers @exclusive", () => {
@@ -563,6 +577,7 @@ test.describe("Index Settings — empty-registry providers @exclusive", () => {
     providerType,
     displayName,
     fillCredentials,
+    reducedDimension,
   } of EMPTY_REGISTRY_PROVIDERS) {
     test(`connecting ${displayName} stages its model and applies with provider_type="${providerType}"`, async ({
       page,
@@ -611,6 +626,9 @@ test.describe("Index Settings — empty-registry providers @exclusive", () => {
         modelName: "my-embed-model",
         modelDim: 1024,
       });
+      if (reducedDimension !== undefined) {
+        await indexSettings.fillReducedDimension(reducedDimension);
+      }
       await indexSettings.submitProviderSetup();
 
       // The just-defined model must be staged — Apply & Re-index appears.
@@ -624,6 +642,9 @@ test.describe("Index Settings — empty-registry providers @exclusive", () => {
       // sent as provider_type=null (which the backend treats as self-hosted
       // and would ignore the credentials we just saved).
       expect(body.provider_type).toBe(providerType);
+      // Providers without the trim field must send null, so we never ask a
+      // server for a `dimensions` value the admin did not choose.
+      expect(body.reduced_dimension).toBe(reducedDimension ?? null);
     });
   }
 });


### PR DESCRIPTION
## Description

Closes #14335.

Adds a first-class `OPENAI_COMPATIBLE` embedding provider, so an admin can point Onyx at any endpoint that implements `POST /v1/embeddings` — vLLM, TEI, Ollama, LM Studio, or a hosted service — and optionally ask for a shorter vector.

Today the only route to such an endpoint is the LiteLLM provider, whose client posts a hand-rolled body and never sends `dimensions`. The LiteLLM SDK cannot supply it either: `get_optional_params_embeddings` gates the parameter on `"text-embedding-3" not in model`, so a custom model name is always rejected or silently dropped. Issue #14335 has the detail.

**Backend.** The new provider reuses `_embed_openai`, which already uses the OpenAI SDK and already forwards `dimensions=reduced_dimension or openai.omit`. It only needed a caller-supplied `base_url`. Batching and error handling come with it.

**Frontend.** A setup modal modelled on the LiteLLM one, plus an optional "Embedding Dimensions" field. That field writes `reduced_dimension`, a column that already exists and that `set-new-search-settings` already accepts, but that no UI exposed. It is offered only while creating a provider, because the vector width is fixed when the index is built.

Notes for review:

- **No migration.** `embedding_provider.provider_type` is a `VARCHAR(50)`; no `CREATE TYPE embeddingprovider` has ever run, so a new enum member needs no schema change.
- The base-URL field takes a base (`http://localhost:8000/v1`) because the SDK appends `/embeddings`. The LiteLLM field takes a full endpoint URL. The field description states this.
- `dimensions` is sent only when the admin fills the field, so servers that reject the parameter are unaffected.
- Three small drive-by fixes in touched code: an OpenAI auth error reported the provider as "OpenAI" for every provider; embedding error messages interpolated the `EmbeddingProvider` member directly, so an admin saw `EmbeddingProvider.OPENAI_COMPATIBLE` in an index-attempt failure (seen while testing this on a real deployment); and `ApiKeyField` rendered an empty markdown link when a provider had no `apiLink`.

## How Has This Been Tested?

- New unit tests in `test_search_nlp_models.py`: `base_url` reaches the SDK, `dimensions` is forwarded when a reduced dimension is set, `openai.omit` is sent when it is not, a missing base URL fails with a message that names the cause, and error messages name the provider by value. Full file passes (27), as does the rest of the `natural_language_processing` suite (28).
- New Playwright case added to the table-driven `EMPTY_REGISTRY_PROVIDERS` block in `index_settings.spec.ts`. It asserts the captured `set-new-search-settings` body carries `provider_type: "openai_compatible"` and the requested `reduced_dimension`. The existing LiteLLM and Azure cases now also assert `reduced_dimension: null`, so no provider sends a value the admin did not choose.
- New i18n keys added to all nine catalogs. `types:check` (key parity) and the ICU catalog tests pass.
- `pre-commit` is green on every touched file: `ty`, `ruff`, `ruff format`, `oxfmt`, `oxlint`, `types:check`, `ripsecrets`, `check-getattr`.
- **Deployed and verified against a live provider.** I applied the backend part of this PR to a self-hosted v4.6.2 instance and pointed it at a Scaleway endpoint serving `qwen3-embedding-8b` (4096 dims native), with `reduced_dimension: 1024`:
  - `POST /admin/embedding/test-embedding` returns 200 for `provider_type: "openai_compatible"`.
  - The OpenAI SDK calls `/embeddings` on the supplied base URL.
  - The new vector index is built at **1024** dimensions, against 4096 for the previous index on the same model.
  - Re-indexed chunks store vectors of exactly **1024** floats, L2 norm 1.0.
  - Re-indexing succeeds, and cancelling the switchover leaves the previous index serving untouched.

  That instance predates the i18n system the frontend here builds on, so I configured the provider through the API rather than the new modal. The modal itself is covered by the Playwright case above.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
