### PR TITLE
fix(opal): make tooltip content readable in light mode

### DIFF
--- a/web/lib/opal/src/components/tooltip/README.md
+++ b/web/lib/opal/src/components/tooltip/README.md
@@ -46,6 +46,9 @@ import { Tooltip } from "@opal/components";
 - `string` and `RichStr` content is rendered via `Text font="secondary-body" color="inherit"`.
 - `ReactNode` content is rendered as-is for custom tooltip layouts.
 - The `opal-tooltip` CSS class provides z-indexing, animations, and a `max-width: 20rem` cap.
+- The surface is dark in both themes, so content renders inside a `dark` theme scope. Adaptive
+  tokens (`text-03` and friends) resolve to their dark values; `text-inverted-*` resolves
+  backwards and is wrong here.
 - There is no controlled `open`. Radix drops any open change that already matches the value it
   was given, so a caller that gates `open` on something other than the hover state stops hearing
   about closes and holds a hover that ended.

--- a/web/lib/opal/src/components/tooltip/components.tsx
+++ b/web/lib/opal/src/components/tooltip/components.tsx
@@ -119,7 +119,8 @@ function Tooltip({
       {!suppressed && (
         <TooltipPrimitive.Portal>
           <TooltipPrimitive.Content
-            className="opal-tooltip"
+            /* Dark surface in both themes, so the content resolves dark tokens. */
+            className="dark opal-tooltip"
             side={side}
             align={align}
             sideOffset={sideOffset}

--- a/web/lib/opal/src/components/tooltip/styles.css
+++ b/web/lib/opal/src/components/tooltip/styles.css
@@ -1,5 +1,6 @@
 @reference "#reference.css";
 
+/* Fixed dark surface in both themes. components.tsx scopes the content to match. */
 .opal-tooltip {
   z-index: var(--z-tooltip);
   max-width: 20rem;


### PR DESCRIPTION
## Description

**Why:** In light mode the "Added to memories" tooltip was unreadable. The memory text, the "Added to memories" label and the expand icon all sat as near-black text on the tooltip's dark surface.

The tooltip surface uses theme-invariant tokens (`background-neutral-dark-03` / `text-light-05`), so it is dark in both themes. Custom `ReactNode` tooltip content styles itself with the adaptive tokens instead. In light mode `--text-03` resolves to 55% black, which lands on a `#333` surface at roughly 1.2:1 contrast. Only the built-in `string` path was safe, because it renders through `Text color="inherit"`.

**What:** The tooltip content now runs as a `dark` theme scope, so anything rendered inside it resolves the dark token values. This is the theme scope class, not the `dark:` modifier that `web/AGENTS.md` forbids. One line, and it fixes every custom tooltip rather than just this one. Dark mode is unchanged.

## How Has This Been Tested?

Light mode, hovering the "Added to memories" tag:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/pr-14339/before.png) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/pr-14339/after.png) |

Live in the running app on dev1, on a chat turn that writes a memory:

- **Light mode, before:** tooltip surface `rgb(51, 51, 51)`, every piece of content computed to `rgba(0, 0, 0, 0.55)`, with `html.class = "light"`.
- **Light mode, after:** same surface, content computes to `rgba(255, 255, 255, 0.6)`. Readable.
- **Dark mode, after:** re-checked, visually identical to before the change.
- Confirmed the trigger pill itself is untouched (still `rgba(0, 0, 0, 0.55)` on `rgb(230, 230, 233)`).
- Checked the other four custom-`ReactNode` tooltip call sites. Two already use `textLight05`, which is theme-invariant and unaffected. None use `text-inverted-*`, the one family that would flip the wrong way.

Also ran `bun run types:check` and `oxlint`, both clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
