### PR TITLE
feat(web): share one search selection across the input bar

### DIFF
--- a/web/src/app/app/page.tsx
+++ b/web/src/app/app/page.tsx
@@ -1,4 +1,5 @@
 import AppPage from "@/views/AppPage";
+import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
 import { defaultAgentRedirectTarget } from "@/lib/app/utils";
 import { redirect } from "next/navigation";
 
@@ -16,5 +17,14 @@ export default async function Page(props: PageProps) {
 
   // Other pages in `web/src/app/chat` are wrapped with `<AppPageLayout>`.
   // `chat/page.tsx` is not because it also needs to handle rendering of the document-sidebar (`web/src/sections/document-sidebar/DocumentsSidebar.tsx`).
-  return <AppPage firstMessage={firstMessage} />;
+  //
+  // The filters are mounted here rather than inside AppPage because AppPage is
+  // itself a consumer — it reads the selection to send, and the tools popover
+  // below it edits the same one. A provider cannot sit under something that
+  // reads from it.
+  return (
+    <SearchFiltersProvider>
+      <AppPage firstMessage={firstMessage} />
+    </SearchFiltersProvider>
+  );
 }

--- a/web/src/app/nrf/(main)/page.tsx
+++ b/web/src/app/nrf/(main)/page.tsx
@@ -1,6 +1,7 @@
 import { unstable_noStore as noStore } from "next/cache";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import NRFPage from "@/app/nrf/NRFPage";
+import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
 import { NRFPreferencesProvider } from "@/components/context/NRFPreferencesContext";
 import NRFChrome from "../NRFChrome";
 
@@ -23,7 +24,9 @@ export default async function Page() {
     <div className="relative w-full h-full">
       <InstantSSRAutoRefresh />
       <NRFPreferencesProvider>
-        <NRFPage />
+        <SearchFiltersProvider>
+          <NRFPage />
+        </SearchFiltersProvider>
       </NRFPreferencesProvider>
       <NRFChrome />
     </div>

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -9,7 +9,6 @@ import AppInputBar, { AppInputBarHandle } from "@/sections/input/AppInputBar";
 import { Button } from "@opal/components";
 import { Modal } from "@opal/components";
 import { useLlmManager } from "@/lib/hooks";
-import { useSearchFilters } from "@/lib/searchFilters/hooks";
 import Dropzone from "react-dropzone";
 import { getPanelOrigin } from "@/lib/extension/utils";
 import { sendSetDefaultNewTabMessage } from "@/lib/extension/svc";
@@ -63,7 +62,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   const { setUseOnyxAsNewTab } = useNRFPreferences();
 
   const searchParams = useSearchParams();
-  const filterManager = useSearchFilters();
+  // Shared with the tools popover in AppInputBar below. Mounted by the route.
   const { user, authTypeMetadata } = useUser();
 
   // Chat sessions
@@ -265,7 +264,6 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   // Chat controller for submitting messages
   const { onSubmit, stopGenerating, handleMessageSpecificFileUpload } =
     useChatController({
-      filterManager,
       llmManager,
       availableAgents: availableAgents || [],
       activeAgent,
@@ -279,7 +277,6 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   const { currentSessionFileTokenCount } = useChatSessionController({
     existingChatSessionId,
     searchParams: searchParams!,
-    filterManager,
     firstMessage: undefined,
     setSelectedDocuments: () => {}, // No-op: NRF doesn't support document selection
     setCurrentMessageFiles,
@@ -543,7 +540,6 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
                 deepResearchEnabled={deepResearchEnabled}
                 toggleDeepResearch={toggleDeepResearch}
                 isMultiModelActive={multiModel.isMultiModelActive}
-                filterManager={filterManager}
                 llmManager={llmManager}
                 initialMessage={message}
                 stopGenerating={stopGenerating}

--- a/web/src/app/nrf/side-panel/page.tsx
+++ b/web/src/app/nrf/side-panel/page.tsx
@@ -1,6 +1,7 @@
 import { unstable_noStore as noStore } from "next/cache";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import NRFPage from "@/app/nrf/NRFPage";
+import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
 import { NRFPreferencesProvider } from "@/components/context/NRFPreferencesContext";
 
 /**
@@ -17,7 +18,9 @@ export default async function Page() {
     <>
       <InstantSSRAutoRefresh />
       <NRFPreferencesProvider>
-        <NRFPage isSidePanel />
+        <SearchFiltersProvider>
+          <NRFPage isSidePanel />
+        </SearchFiltersProvider>
       </NRFPreferencesProvider>
     </>
   );

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -85,7 +85,7 @@ import { ProjectFile, useProjectsContext } from "@/lib/projects/providers";
 import { useIncognito } from "@/providers/IncognitoProvider";
 import { useAppParams } from "@/hooks/appNavigation";
 import { projectFilesToFileDescriptors } from "@/lib/projects/utils";
-import type { SearchFilters } from "@/lib/searchFilters/types";
+import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
 
 const SYSTEM_MESSAGE_ID = -3;
 
@@ -117,7 +117,6 @@ interface RegenerationRequest {
 }
 
 interface UseChatControllerProps {
-  filterManager: SearchFilters;
   llmManager: LlmManager;
   activeAgent: MinimalAgent | undefined;
   availableAgents: MinimalAgent[];
@@ -141,7 +140,6 @@ async function stopChatSession(chatSessionId: string): Promise<void> {
 }
 
 export default function useChatController({
-  filterManager,
   llmManager,
   availableAgents,
   activeAgent,
@@ -149,6 +147,7 @@ export default function useChatController({
   selectedDocuments,
   resetInputBar,
 }: UseChatControllerProps) {
+  const searchFilters = useSharedSearchFilters();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -1058,10 +1057,10 @@ export default function useChatController({
           })(),
           chatSessionId: currChatSessionId,
           filters: buildFilters(
-            filterManager.selectedSources,
-            filterManager.selectedDocumentSets,
-            filterManager.timeRange,
-            filterManager.selectedTags
+            searchFilters.selectedSources,
+            searchFilters.selectedDocumentSets,
+            searchFilters.timeRange,
+            searchFilters.selectedTags
           ),
           modelProvider: isMultiModel
             ? undefined
@@ -1469,10 +1468,10 @@ export default function useChatController({
     },
     [
       // Narrow to stable fields from managers to avoid re-creation
-      filterManager.selectedSources,
-      filterManager.selectedDocumentSets,
-      filterManager.selectedTags,
-      filterManager.timeRange,
+      searchFilters.selectedSources,
+      searchFilters.selectedDocumentSets,
+      searchFilters.selectedTags,
+      searchFilters.timeRange,
       llmManager.currentLlm,
       llmManager.temperature,
       llmManager.hasTemperatureOverride,

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -36,7 +36,7 @@ import {
   getProjectFilesForSession,
 } from "@/lib/projects/svc";
 import { AppInputBarHandle } from "@/sections/input/AppInputBar";
-import type { SearchFilters } from "@/lib/searchFilters/types";
+import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
 
 // Runs currently being re-attached; module-level so effect re-runs (incl.
 // strict mode) can't start a second tail for the same run.
@@ -45,7 +45,6 @@ const resumingRuns = new Set<number>();
 interface UseChatSessionControllerProps {
   existingChatSessionId: string | null;
   searchParams: ReadonlyURLSearchParams;
-  filterManager: SearchFilters;
   firstMessage?: string;
 
   // UI state setters
@@ -79,7 +78,6 @@ export type SessionFetchError = {
 export default function useChatSessionController({
   existingChatSessionId,
   searchParams,
-  filterManager,
   firstMessage,
   setSelectedDocuments,
   setCurrentMessageFiles,
@@ -91,6 +89,7 @@ export default function useChatSessionController({
   refreshChatSessions,
   onSubmit,
 }: UseChatSessionControllerProps) {
+  const searchFilters = useSharedSearchFilters();
   const [currentSessionFileTokenCount, setCurrentSessionFileTokenCount] =
     useState<number>(0);
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([]);
@@ -150,9 +149,9 @@ export default function useChatSessionController({
     // Only reset filters/selections when switching between existing sessions
     if (isSwitchingBetweenSessions) {
       setSelectedDocuments([]);
-      filterManager.setSelectedDocumentSets([]);
-      filterManager.setSelectedTags([]);
-      filterManager.setTimeRange(null);
+      searchFilters.setSelectedDocumentSets([]);
+      searchFilters.setSelectedTags([]);
+      searchFilters.setTimeRange(null);
 
       // Remove uploaded files
       setCurrentMessageFiles([]);

--- a/web/src/lib/agents/components/AgentViewerModal.tsx
+++ b/web/src/lib/agents/components/AgentViewerModal.tsx
@@ -31,7 +31,7 @@ import { Button } from "@opal/components";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import AppInputBar from "@/sections/input/AppInputBar";
 import { useLlmManager } from "@/lib/hooks";
-import { useSearchFilters } from "@/lib/searchFilters/hooks";
+import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
 import { formatMmDdYyyy } from "@/lib/dateUtils";
 import { useProjectsContext } from "@/lib/projects/providers";
 import { FileCard } from "@/sections/cards/FileCard";
@@ -129,23 +129,25 @@ interface AgentChatInputProps {
 }
 function AgentChatInput({ agent, onSubmit }: AgentChatInputProps) {
   const llmManager = useLlmManager(undefined, agent);
-  const filterManager = useSearchFilters();
 
   return (
-    <AppInputBar
-      onSubmit={onSubmit}
-      llmManager={llmManager}
-      chatState="input"
-      filterManager={filterManager}
-      activeAgent={agent}
-      stopGenerating={() => {}}
-      handleFileUpload={() => {}}
-      currentSessionFileTokenCount={0}
-      availableContextTokens={Infinity}
-      deepResearchEnabled={false}
-      toggleDeepResearch={() => {}}
-      disabled={false}
-    />
+    // Its own instance, so source toggles made while previewing an agent do not
+    // reach the chat this modal opened over.
+    <SearchFiltersProvider>
+      <AppInputBar
+        onSubmit={onSubmit}
+        llmManager={llmManager}
+        chatState="input"
+        activeAgent={agent}
+        stopGenerating={() => {}}
+        handleFileUpload={() => {}}
+        currentSessionFileTokenCount={0}
+        availableContextTokens={Infinity}
+        deepResearchEnabled={false}
+        toggleDeepResearch={() => {}}
+        disabled={false}
+      />
+    </SearchFiltersProvider>
   );
 }
 

--- a/web/src/lib/chat/hooks.ts
+++ b/web/src/lib/chat/hooks.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { OnSubmitProps } from "@/hooks/useChatController";
+import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
+import { SUBMIT_MESSAGE_TYPES } from "@/lib/extension/constants";
+import { useAvailableSources } from "@/lib/connectors/hooks";
+import { useDocumentSets } from "@/lib/hooks/useDocumentSets";
+import { useProjectsContext } from "@/lib/projects/providers";
+import type { SourceMetadata } from "@/lib/search/interfaces";
+import { useTags } from "@/lib/searchFilters/hooks";
+import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
+import { getSourceMetadata } from "@/lib/sources";
+
+interface UseSendChatMessageFromURLProps {
+  /** From `useChatController`, which needs more than this hook can see. */
+  onSubmit: (props: OnSubmitProps) => void;
+  /** Resolved against the active project, so the page decides it, not this. */
+  deepResearch: boolean;
+}
+
+/**
+ * Sends the message a URL asks for, scoped by the filters that URL names.
+ *
+ * A link into the app can carry both a prompt and a search scope —
+ * `?sources=slack&user-prompt=…&send-on-load=true` — which is how the Chrome
+ * extension, an agent preview, and a shared link all open a chat that is
+ * already narrowed and already asking.
+ *
+ * Two arrivals are handled: the page loading with `send-on-load` set, and a
+ * `PAGE_CHANGE` message posted by the extension while the page stays put.
+ *
+ * `send-on-load` is stripped from the URL afterwards, so a refresh does not
+ * send the message a second time.
+ *
+ * Everything reachable from context is read here — the filters, the project's
+ * files, and the sources, sets and tags a name resolves against. Only the
+ * submit itself and the deep-research flag come from the caller, because
+ * neither is context.
+ */
+export function useSendChatMessageFromURL({
+  onSubmit,
+  deepResearch,
+}: UseSendChatMessageFromURLProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const searchFilters = useSharedSearchFilters();
+  const { currentMessageFiles } = useProjectsContext();
+  const { availableSources } = useAvailableSources();
+  const { documentSets } = useDocumentSets();
+  const { tags } = useTags();
+
+  const sources: SourceMetadata[] = useMemo(() => {
+    const seen = new Set<string>();
+    return availableSources.reduce<SourceMetadata[]>((acc, source) => {
+      const metadata = getSourceMetadata(source);
+      if (seen.has(metadata.internalName)) return acc;
+      seen.add(metadata.internalName);
+      acc.push(metadata);
+      return acc;
+    }, []);
+  }, [availableSources]);
+
+  const send = useCallback(
+    (searchParamsString: string) => {
+      const params = new URLSearchParams(searchParamsString);
+      const message = params.get(SEARCH_PARAM_NAMES.USER_PROMPT);
+
+      // Names that match nothing available are dropped, so a stale or
+      // hand-typed link narrows the search rather than failing it.
+      const namesIn = (param: string): string[] =>
+        params.get(param)?.split(",").map(decodeURIComponent) ?? [];
+
+      const from = new Date(params.get("from") ?? "");
+      const to = new Date(params.get("to") ?? "");
+      const hasRange = !isNaN(from.getTime()) && !isNaN(to.getTime());
+      searchFilters.setTimeRange(
+        hasRange ? { from, to, selectValue: "" } : null
+      );
+
+      const sourceNames = namesIn("sources");
+      searchFilters.setSelectedSources(
+        sources.filter((source) => sourceNames.includes(source.internalName))
+      );
+
+      const docSetNames = namesIn("documentSets");
+      searchFilters.setSelectedDocumentSets(
+        documentSets
+          .map((ds) => ds.name)
+          .filter((name) => docSetNames.includes(name))
+      );
+
+      const tagValues = namesIn("tags");
+      searchFilters.setSelectedTags(
+        tags.filter((tag) => tagValues.includes(tag.tag_value))
+      );
+
+      // Dropped before the replace so a refresh does not resend.
+      params.delete(SEARCH_PARAM_NAMES.SEND_ON_LOAD);
+      router.replace(`?${params.toString()}`, { scroll: false });
+
+      if (!message) return;
+
+      onSubmit({ message, currentMessageFiles, deepResearch });
+    },
+    [
+      router,
+      searchFilters,
+      sources,
+      documentSets,
+      tags,
+      currentMessageFiles,
+      deepResearch,
+      onSubmit,
+    ]
+  );
+
+  // Arriving with the parameters already on the URL.
+  useEffect(() => {
+    if (searchParams?.get(SEARCH_PARAM_NAMES.SEND_ON_LOAD)) {
+      send(searchParams.toString());
+    }
+  }, [searchParams, send]);
+
+  // The extension navigating the embedded page without a reload.
+  useEffect(() => {
+    function onPageChange(event: MessageEvent) {
+      if (event.data.type !== SUBMIT_MESSAGE_TYPES.PAGE_CHANGE) return;
+      try {
+        send(new URL(event.data.href).searchParams.toString());
+      } catch (error) {
+        console.error("Error parsing URL:", error);
+      }
+    }
+
+    window.addEventListener("message", onPageChange);
+    return () => window.removeEventListener("message", onPageChange);
+  }, [send]);
+}

--- a/web/src/lib/chat/hooks.ts
+++ b/web/src/lib/chat/hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { OnSubmitProps } from "@/hooks/useChatController";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
@@ -118,10 +118,18 @@ export function useSendChatMessageFromURL({
   );
 
   // Arriving with the parameters already on the URL.
+  //
+  // Guarded because `send` changes identity as the filters, sets, tags and
+  // project files resolve, and `router.replace` only drops `send-on-load` a
+  // tick later — so without this the effect re-runs inside that window and
+  // sends the same prompt twice.
+  const sentForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (searchParams?.get(SEARCH_PARAM_NAMES.SEND_ON_LOAD)) {
-      send(searchParams.toString());
-    }
+    if (!searchParams?.get(SEARCH_PARAM_NAMES.SEND_ON_LOAD)) return;
+    const query = searchParams.toString();
+    if (sentForRef.current === query) return;
+    sentForRef.current = query;
+    send(query);
   }, [searchParams, send]);
 
   // The extension navigating the embedded page without a reload.

--- a/web/src/lib/searchFilters/hooks.ts
+++ b/web/src/lib/searchFilters/hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -18,52 +18,56 @@ export function useSearchFilters(): SearchFilters {
   );
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
 
-  function getFilterString() {
-    const params = new URLSearchParams();
+  const getFilterString = useCallback(
+    function () {
+      const params = new URLSearchParams();
 
-    if (timeRange) {
-      params.set("from", timeRange.from.toISOString());
-      params.set("to", timeRange.to.toISOString());
-    }
+      if (timeRange) {
+        params.set("from", timeRange.from.toISOString());
+        params.set("to", timeRange.to.toISOString());
+      }
 
-    if (selectedSources.length > 0) {
-      const sourcesParam = selectedSources
-        .map((source) => encodeURIComponent(source.internalName))
-        .join(",");
-      params.set("sources", sourcesParam);
-    }
+      if (selectedSources.length > 0) {
+        const sourcesParam = selectedSources
+          .map((source) => encodeURIComponent(source.internalName))
+          .join(",");
+        params.set("sources", sourcesParam);
+      }
 
-    if (selectedDocumentSets.length > 0) {
-      const docSetsParam = selectedDocumentSets
-        .map((ds) => encodeURIComponent(ds))
-        .join(",");
-      params.set("documentSets", docSetsParam);
-    }
+      if (selectedDocumentSets.length > 0) {
+        const docSetsParam = selectedDocumentSets
+          .map((ds) => encodeURIComponent(ds))
+          .join(",");
+        params.set("documentSets", docSetsParam);
+      }
 
-    if (selectedTags.length > 0) {
-      const tagsParam = selectedTags
-        .map((tag) => encodeURIComponent(tag.tag_value))
-        .join(",");
-      params.set("tags", tagsParam);
-    }
+      if (selectedTags.length > 0) {
+        const tagsParam = selectedTags
+          .map((tag) => encodeURIComponent(tag.tag_value))
+          .join(",");
+        params.set("tags", tagsParam);
+      }
 
-    const queryString = params.toString();
-    return queryString ? `&${queryString}` : "";
-  }
+      const queryString = params.toString();
+      return queryString ? `&${queryString}` : "";
+      // Setters are stable by React's contract, so only the values are deps.
+    },
+    [timeRange, selectedSources, selectedDocumentSets, selectedTags]
+  );
 
-  function clearFilters() {
+  const clearFilters = useCallback(function () {
     setTimeRange(null);
     setSelectedSources([]);
     setSelectedDocumentSets([]);
     setSelectedTags([]);
-  }
+  }, []);
 
-  function buildFiltersFromQueryString(
+  const buildFiltersFromQueryString = useCallback(function (
     filterString: string,
     availableSources: SourceMetadata[],
     availableDocumentSets: string[],
     availableTags: Tag[]
-  ): void {
+  ) {
     const params = new URLSearchParams(filterString);
 
     // Parse the "from" parameter as a DateRangePickerValue
@@ -108,26 +112,40 @@ export function useSearchFilters(): SearchFilters {
       );
     }
 
-    // Update filter manager's values instead of returning
+    // Update the selection instead of returning it
     setTimeRange(newTimeRange);
     setSelectedSources(newSelectedSources);
     setSelectedDocumentSets(newSelectedDocSets);
     setSelectedTags(newSelectedTags);
-  }
+  }, []);
 
-  return {
-    clearFilters,
-    timeRange,
-    setTimeRange,
-    selectedSources,
-    setSelectedSources,
-    selectedDocumentSets,
-    setSelectedDocumentSets,
-    selectedTags,
-    setSelectedTags,
-    getFilterString,
-    buildFiltersFromQueryString,
-  };
+  // Memoized so the identity changes only when a filter does. Consumers read
+  // this through a context, where a fresh object every render would re-render
+  // all of them for nothing.
+  return useMemo(
+    () => ({
+      clearFilters,
+      timeRange,
+      setTimeRange,
+      selectedSources,
+      setSelectedSources,
+      selectedDocumentSets,
+      setSelectedDocumentSets,
+      selectedTags,
+      setSelectedTags,
+      getFilterString,
+      buildFiltersFromQueryString,
+    }),
+    [
+      clearFilters,
+      timeRange,
+      selectedSources,
+      selectedDocumentSets,
+      selectedTags,
+      getFilterString,
+      buildFiltersFromQueryString,
+    ]
+  );
 }
 
 interface UseSourcePreferencesProps {

--- a/web/src/lib/searchFilters/hooks.ts
+++ b/web/src/lib/searchFilters/hooks.ts
@@ -18,105 +18,11 @@ export function useSearchFilters(): SearchFilters {
   );
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
 
-  const getFilterString = useCallback(
-    function () {
-      const params = new URLSearchParams();
-
-      if (timeRange) {
-        params.set("from", timeRange.from.toISOString());
-        params.set("to", timeRange.to.toISOString());
-      }
-
-      if (selectedSources.length > 0) {
-        const sourcesParam = selectedSources
-          .map((source) => encodeURIComponent(source.internalName))
-          .join(",");
-        params.set("sources", sourcesParam);
-      }
-
-      if (selectedDocumentSets.length > 0) {
-        const docSetsParam = selectedDocumentSets
-          .map((ds) => encodeURIComponent(ds))
-          .join(",");
-        params.set("documentSets", docSetsParam);
-      }
-
-      if (selectedTags.length > 0) {
-        const tagsParam = selectedTags
-          .map((tag) => encodeURIComponent(tag.tag_value))
-          .join(",");
-        params.set("tags", tagsParam);
-      }
-
-      const queryString = params.toString();
-      return queryString ? `&${queryString}` : "";
-      // Setters are stable by React's contract, so only the values are deps.
-    },
-    [timeRange, selectedSources, selectedDocumentSets, selectedTags]
-  );
-
   const clearFilters = useCallback(function () {
     setTimeRange(null);
     setSelectedSources([]);
     setSelectedDocumentSets([]);
     setSelectedTags([]);
-  }, []);
-
-  const buildFiltersFromQueryString = useCallback(function (
-    filterString: string,
-    availableSources: SourceMetadata[],
-    availableDocumentSets: string[],
-    availableTags: Tag[]
-  ) {
-    const params = new URLSearchParams(filterString);
-
-    // Parse the "from" parameter as a DateRangePickerValue
-    let newTimeRange: DateRangePickerValue | null = null;
-    const fromParam = params.get("from");
-    const toParam = params.get("to");
-    if (fromParam && toParam) {
-      const fromDate = new Date(fromParam);
-      const toDate = new Date(toParam);
-      if (!isNaN(fromDate.getTime()) && !isNaN(toDate.getTime())) {
-        newTimeRange = { from: fromDate, to: toDate, selectValue: "" };
-      }
-    }
-
-    // Parse sources
-    let newSelectedSources: SourceMetadata[] = [];
-    const sourcesParam = params.get("sources");
-    if (sourcesParam) {
-      const sourceNames = sourcesParam.split(",").map(decodeURIComponent);
-      newSelectedSources = availableSources.filter((source) =>
-        sourceNames.includes(source.internalName)
-      );
-    }
-
-    // Parse document sets
-    let newSelectedDocSets: string[] = [];
-    const docSetsParam = params.get("documentSets");
-    if (docSetsParam) {
-      const docSetNames = docSetsParam.split(",").map(decodeURIComponent);
-      newSelectedDocSets = availableDocumentSets.filter((ds) =>
-        docSetNames.includes(ds)
-      );
-    }
-
-    // Parse tags
-    let newSelectedTags: Tag[] = [];
-    const tagsParam = params.get("tags");
-    if (tagsParam) {
-      const tagValues = tagsParam.split(",").map(decodeURIComponent);
-      newSelectedTags = availableTags.filter((tag) =>
-        tagValues.includes(tag.tag_value)
-      );
-    }
-
-    // Update the selection instead of returning it
-    setTimeRange(newTimeRange);
-    setSelectedSources(newSelectedSources);
-    setSelectedDocumentSets(newSelectedDocSets);
-    setSelectedTags(newSelectedTags);
   }, []);
 
   // Memoized so the identity changes only when a filter does. Consumers read
@@ -133,8 +39,6 @@ export function useSearchFilters(): SearchFilters {
       setSelectedDocumentSets,
       selectedTags,
       setSelectedTags,
-      getFilterString,
-      buildFiltersFromQueryString,
     }),
     [
       clearFilters,
@@ -142,8 +46,6 @@ export function useSearchFilters(): SearchFilters {
       selectedSources,
       selectedDocumentSets,
       selectedTags,
-      getFilterString,
-      buildFiltersFromQueryString,
     ]
   );
 }

--- a/web/src/lib/searchFilters/providers.tsx
+++ b/web/src/lib/searchFilters/providers.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { createSharedHook } from "@opal/hooks";
+import { useSearchFilters } from "@/lib/searchFilters/hooks";
+
+/**
+ * One search selection, shared across a tree.
+ *
+ * The chat input bar and the tools popover edit the same filters, and the send
+ * path reads them. Without this the state has to live above all three and reach
+ * the popover as a prop through `AppInputBar`, which never looks at it.
+ *
+ * The provider is the unit of sharing, so a modal that mounts its own gets its
+ * own selection and cannot disturb the chat behind it. Anything wanting its own
+ * state and no provider — the admin document explorer, for one — keeps calling
+ * {@link useSearchFilters} directly.
+ */
+export const [SearchFiltersProvider, useSharedSearchFilters] = createSharedHook(
+  useSearchFilters,
+  "SearchFilters"
+);

--- a/web/src/lib/searchFilters/types.ts
+++ b/web/src/lib/searchFilters/types.ts
@@ -2,25 +2,22 @@ import type { Tag } from "@/lib/types";
 import type { SourceMetadata } from "@/lib/search/interfaces";
 import type { DateRangePickerValue } from "@/refresh-components/DateRangePicker";
 
-/** The live selection a user edits: which sources, sets, tags and dates to search. */
-export interface SearchFilters {
+/** What is selected, without the means to change it. */
+export interface SearchFiltersSelection {
   timeRange: DateRangePickerValue | null;
+  selectedSources: SourceMetadata[];
+  selectedDocumentSets: string[];
+  selectedTags: Tag[];
+}
+
+/** The live selection a user edits: which sources, sets, tags and dates to search. */
+export interface SearchFilters extends SearchFiltersSelection {
   setTimeRange: React.Dispatch<
     React.SetStateAction<DateRangePickerValue | null>
   >;
-  selectedSources: SourceMetadata[];
   setSelectedSources: React.Dispatch<React.SetStateAction<SourceMetadata[]>>;
-  selectedDocumentSets: string[];
   setSelectedDocumentSets: React.Dispatch<React.SetStateAction<string[]>>;
-  selectedTags: Tag[];
   setSelectedTags: React.Dispatch<React.SetStateAction<Tag[]>>;
-  getFilterString: () => string;
-  buildFiltersFromQueryString: (
-    filterString: string,
-    availableSources: SourceMetadata[],
-    availableDocumentSets: string[],
-    availableTags: Tag[]
-  ) => void;
   clearFilters: () => void;
 }
 

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -41,7 +41,7 @@ import {
   saveMCPUserCredentials,
   startMCPUserOAuth,
 } from "@/lib/tools/svc";
-import type { SearchFilters } from "@/lib/searchFilters/types";
+import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
 
 /**
  * The actions popover.
@@ -56,13 +56,11 @@ import type { SearchFilters } from "@/lib/searchFilters/types";
  */
 export interface ToolsPopoverProps {
   agent: MinimalAgent;
-  filterManager: SearchFilters;
   disabled?: boolean;
 }
 
 export default function ToolsPopover({
   agent,
-  filterManager,
   disabled = false,
 }: ToolsPopoverProps) {
   const { availableSources } = useAvailableSources();
@@ -74,7 +72,7 @@ export default function ToolsPopover({
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
   // const [showFadeMask, setShowFadeMask] = useState(false);
   // const [showTopShadow, setShowTopShadow] = useState(false);
-  const { selectedSources, setSelectedSources } = filterManager;
+  const { selectedSources, setSelectedSources } = useSharedSearchFilters();
   const [mcpServers, setMcpServers] = useState<MCPServer[]>([]);
   const { llmProviders, isLoading: isLLMLoading } = useLLMProviders(agent.id);
   const hasAnyProvider = !isLLMLoading && (llmProviders?.length ?? 0) > 0;

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -71,7 +71,6 @@ import {
 } from "@/app/app/stores/useChatSessionStore";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
 import { handleInputNavKeys } from "@/sections/input/inputBarKeys";
-import type { SearchFilters } from "@/lib/searchFilters/types";
 
 export interface AppInputBarHandle {
   reset: () => void;
@@ -91,7 +90,6 @@ export interface AppInputBarProps {
   activeAgent: MinimalAgent | undefined;
 
   handleFileUpload: (files: File[]) => void;
-  filterManager: SearchFilters;
   deepResearchEnabled: boolean;
   setPresentingDocument?: (document: MinimalOnyxDocument) => void;
   toggleDeepResearch: () => void;
@@ -106,7 +104,6 @@ export interface AppInputBarProps {
 
 const AppInputBar = React.memo(
   ({
-    filterManager,
     initialMessage = "",
     stopGenerating,
     onSubmit,
@@ -654,7 +651,6 @@ const AppInputBar = React.memo(
               <ToolsPopover
                 key={activeAgent.id}
                 agent={activeAgent}
-                filterManager={filterManager}
                 disabled={disabled}
               />
             )}

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -6,7 +6,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { Section } from "@/layouts/general-layouts";
 import { useFederatedConnectors, useLlmManager } from "@/lib/hooks";
-import { useSearchFilters, useTags } from "@/lib/searchFilters/hooks";
+import { useTags } from "@/lib/searchFilters/hooks";
+import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
 import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
@@ -320,7 +321,9 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   const chatInputBarRef = useRef<AppInputBarHandle>(null);
 
-  const filterManager = useSearchFilters();
+  // Shared with AppInputBar's tools popover below, which edits the same
+  // selection this page sends. Mounted by the route.
+  const filterManager = useSharedSearchFilters();
 
   // An unresolved agent reads as plain chat, so a named-agent layout never
   // flashes for an agent that is not there yet.
@@ -511,7 +514,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     handleMessageSpecificFileUpload,
     availableContextTokens,
   } = useChatController({
-    filterManager,
     llmManager,
     availableAgents: agents,
     activeAgent,
@@ -528,7 +530,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   } = useChatSessionController({
     existingChatSessionId: currentChatSessionId,
     searchParams,
-    filterManager,
     firstMessage,
     setSelectedDocuments,
     setCurrentMessageFiles,
@@ -1089,7 +1090,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                         }
                         toggleDeepResearch={toggleDeepResearch}
                         isMultiModelActive={multiModel.isMultiModelActive}
-                        filterManager={filterManager}
                         llmManager={llmManager}
                         initialMessage={
                           searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) ||

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -6,8 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { Section } from "@/layouts/general-layouts";
 import { useFederatedConnectors, useLlmManager } from "@/lib/hooks";
-import { useTags } from "@/lib/searchFilters/hooks";
-import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
+import { useSendChatMessageFromURL } from "@/lib/chat/hooks";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
 import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
@@ -25,8 +24,6 @@ import { NoAgentModal } from "@/lib/agents/components";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import { Modal } from "@opal/components";
 import { useSendMessageToParent } from "@/lib/extension/hooks";
-import { SUBMIT_MESSAGE_TYPES } from "@/lib/extension/constants";
-import { getSourceMetadata } from "@/lib/sources";
 import { SourceMetadata } from "@/lib/search/interfaces";
 import { FederatedConnectorDetail, ValidSources } from "@/lib/types";
 import DocumentsSidebar from "@/sections/document-sidebar/DocumentsSidebar";
@@ -158,9 +155,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   } = useChatSessions();
   const { vectorDbEnabled, disable_default_assistant } = useSettings();
 
-  const { ccPairs } = useCCPairs(vectorDbEnabled);
-  const { tags } = useTags();
-  const { documentSets } = useDocumentSets();
   const {
     currentMessageFiles,
     setCurrentMessageFiles,
@@ -180,40 +174,12 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   const { agents, isLoading: isLoadingAgents } = useAgents();
 
-  // Also fetch federated connectors for the sources list
-  const { data: federatedConnectorsData } = useFederatedConnectors();
-
   const { user } = useUser();
   // `useUser()` reports null while loading, so gating on it would redirect during
   // the /me load window. Read the raw result instead (undefined = loading, null =
   // resolved signed-out). This matters for anonymous users specifically: they're
   // kept on the login page, so unlike logged-in users they wouldn't bounce back.
   const { user: resolvedUser } = useCurrentUser();
-
-  function processSearchParamsAndSubmitMessage(searchParamsString: string) {
-    const newSearchParams = new URLSearchParams(searchParamsString);
-    const message = newSearchParams?.get("user-prompt");
-
-    filterManager.buildFiltersFromQueryString(
-      newSearchParams.toString(),
-      sources,
-      documentSets.map((ds) => ds.name),
-      tags
-    );
-
-    newSearchParams.delete(SEARCH_PARAM_NAMES.SEND_ON_LOAD);
-
-    router.replace(`?${newSearchParams.toString()}`, { scroll: false });
-
-    // If there's a message, submit it
-    if (message) {
-      onSubmit({
-        message,
-        currentMessageFiles,
-        deepResearch: deepResearchEnabledForCurrentWorkflow,
-      });
-    }
-  }
 
   const activeAgent = useActiveAgent();
 
@@ -279,35 +245,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     userId: user?.id,
   });
 
-  const availableSources: ValidSources[] = useMemo(() => {
-    return ccPairs.map((ccPair) => ccPair.source);
-  }, [ccPairs]);
-
-  const sources: SourceMetadata[] = useMemo(() => {
-    const uniqueSources = Array.from(new Set(availableSources));
-    const regularSources = uniqueSources.map((source) =>
-      getSourceMetadata(source)
-    );
-
-    // Add federated connectors as sources
-    const federatedSources =
-      federatedConnectorsData?.map((connector: FederatedConnectorDetail) => {
-        return getSourceMetadata(connector.source);
-      }) || [];
-
-    // Combine sources and deduplicate based on internalName
-    const allSources = [...regularSources, ...federatedSources];
-    const deduplicatedSources = allSources.reduce((acc, source) => {
-      const existing = acc.find((s) => s.internalName === source.internalName);
-      if (!existing) {
-        acc.push(source);
-      }
-      return acc;
-    }, [] as SourceMetadata[]);
-
-    return deduplicatedSources;
-  }, [availableSources, federatedConnectorsData]);
-
   // Show toast if any files failed in ProjectsContext reconciliation
   useEffect(() => {
     if (lastFailedFiles && lastFailedFiles.length > 0) {
@@ -320,10 +257,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   }, [lastFailedFiles, clearLastFailedFiles, t]);
 
   const chatInputBarRef = useRef<AppInputBarHandle>(null);
-
-  // Shared with AppInputBar's tools popover below, which edits the same
-  // selection this page sends. Mounted by the route.
-  const filterManager = useSharedSearchFilters();
 
   // An unresolved agent reads as plain chat, so a named-agent layout never
   // flashes for an agent that is not there yet.
@@ -350,32 +283,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const chatSessionIdRef = useRef<string | null>(currentChatSessionId);
   const loadedIdSessionRef = useRef<string | null>(currentChatSessionId);
   const submitOnLoadPerformed = useRef<boolean>(false);
-
-  function loadNewPageLogic(event: MessageEvent) {
-    if (event.data.type === SUBMIT_MESSAGE_TYPES.PAGE_CHANGE) {
-      try {
-        const url = new URL(event.data.href);
-        processSearchParamsAndSubmitMessage(url.searchParams.toString());
-      } catch (error) {
-        console.error("Error parsing URL:", error);
-      }
-    }
-  }
-
-  // Equivalent to `loadNewPageLogic`
-  useEffect(() => {
-    if (searchParams?.get(SEARCH_PARAM_NAMES.SEND_ON_LOAD)) {
-      processSearchParamsAndSubmitMessage(searchParams.toString());
-    }
-  }, [searchParams, router]);
-
-  useEffect(() => {
-    window.addEventListener("message", loadNewPageLogic);
-
-    return () => {
-      window.removeEventListener("message", loadNewPageLogic);
-    };
-  }, []);
 
   const [selectedDocuments, setSelectedDocuments] = useState<OnyxDocument[]>(
     []
@@ -540,6 +447,13 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     submitOnLoadPerformed,
     refreshChatSessions,
     onSubmit,
+  });
+
+  // A link can arrive carrying both a prompt and a search scope. Declared here
+  // because it submits, so it needs `onSubmit` above it.
+  useSendChatMessageFromURL({
+    onSubmit,
+    deepResearch: deepResearchEnabledForCurrentWorkflow,
   });
 
   useSendMessageToParent();


### PR DESCRIPTION
## Description

Two commits, both about the same thing: the search selection was reachable only by
threading it, and it carried behaviour that was not its own.

### 1. One selection, shared across the tree

The tools popover edits the sources a search reads, and the page sends them. Both needed
the same selection, so it lived above them and reached the popover as a prop through
`AppInputBar` — which declared it, forwarded it, and never once looked at it.

`SearchFiltersProvider` holds it instead, built on `createSharedHook` (#14312).
`ToolsPopoverProps` is down to `{ agent, disabled }`, and `AppInputBar` no longer mentions
filters at all.

The provider mounts at the routes rather than inside `AppPage`, because `AppPage` reads the
selection too and a provider cannot sit under something that reads from it.
`AgentViewerModal` mounts its own, so toggling sources while previewing an agent cannot
reach the chat it opened over. The admin document explorer keeps calling
`useSearchFilters` directly and has no provider at all — it never drilled the value
anywhere.

`useSearchFilters` now returns a memoized object. It was rebuilding its helpers every
render, so the value was a fresh reference each time — which defeated `AppInputBar`'s
`React.memo` even before any of this, and under a context would have re-rendered every
consumer for nothing.

### 2. The URL is not the selection's business

`SearchFilters` carried two codecs: `buildFiltersFromQueryString` read a query string into
itself, and `getFilterString` wrote itself back out. Both meant a selection of four values
knew what a URL is.

Both are gone. `getFilterString` had no callers at all. The parse moved into a new
`useSendChatMessageFromURL` in `lib/chat/hooks.ts`, which owns the whole behaviour it was
one step of: a link arriving with both a prompt and a scope —
`?sources=slack&user-prompt=…&send-on-load=true` — from the Chrome extension, an agent
preview, or a shared link.

The hook reads everything reachable from context (the filters, the project's files, and
the sources, sets and tags a name resolves against) and takes only what is not: `onSubmit`,
which comes from `useChatController`, and whether deep research applies, which is resolved
against the active project.

`SearchFilters` is now four values, four setters, and `clearFilters`.

### What this costs

`useChatController` and `useChatSessionController` resolve the filters themselves now, so
both require a provider above them. A future caller outside one gets a runtime throw rather
than a type error. All four call sites are covered today.

### Known, pre-existing, not fixed here

`useSendChatMessageFromURL` applies the parsed filters through setters and then submits in
the same tick, so the submit reads pre-parse state. This is exactly the behaviour that was
in `AppPage` before, moved verbatim — fixing it means letting the submit take filters as an
argument, and four different things submit messages, so it is its own change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares the search selection through a new `SearchFiltersProvider` so the tools popover and the input bar edit the same state without threading it through `AppInputBar`. Also moves the query-string message flow out of `SearchFilters` into a new `useSendChatMessageFromURL` hook, which still strips `send-on-load` after sending.

**Refactors**
- `useSearchFilters` now returns a memoized object instead of a fresh reference each render.
- Removed `getFilterString` and `buildFiltersFromQueryString` from `SearchFilters`; the parse now lives entirely in `lib/chat/hooks.ts`.
- The send path reads filters from context, so `useChatController` and `useChatSessionController` no longer take a `filterManager` argument.
- Submitting from a URL still applies filters and sends in the same tick, so the message reads pre-parse state — pre-existing, moved verbatim.

**Migration**
- `AppInputBar` no longer accepts a `filterManager` prop, and `ToolsPopoverProps` is down to `{ agent, disabled }`.
- `useChatController` and `useChatSessionController` now require a `SearchFiltersProvider` above them; a caller outside one gets a runtime throw instead of a type error.
- `AgentViewerModal` mounts its own provider, so source toggles while previewing an agent do not reach the chat behind it.

<sup>Written for commit 1c787d319ca905dcc04b8fcfa7d066339c92ff44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->