### PR TITLE
feat(craft): record action receipts at the proxy

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -508,6 +508,15 @@ class EndpointPolicy(str, PyEnum):
     DENY = "DENY"  # block the call outright
 
 
+class ActionEffect(str, PyEnum):
+    """Whether a catalog action mutates its destination. Write-effect actions
+    always leave a receipt when they execute, reads only when an approval
+    covered them."""
+
+    READ = "read"
+    WRITE = "write"
+
+
 # Strictness ordering: higher = stricter. When one request matches several
 # actions, the strictest policy governs (sort/`max` with this key); readers
 # of a persisted `actions` list rely on `actions[0]` being the strictest.

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -7,7 +7,13 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import POLICY_SEVERITY, EndpointPolicy, ExternalAppType, GatedAppKind
+from onyx.db.enums import (
+    POLICY_SEVERITY,
+    ActionEffect,
+    EndpointPolicy,
+    ExternalAppType,
+    GatedAppKind,
+)
 from onyx.db.gated_app import get_action_policies
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.request import MatchContext, ProxiedRequest
@@ -32,6 +38,9 @@ class MatchedAction(BaseModel):
     display_name: str
     description: str
     policy: EndpointPolicy
+    # Defaulted so persisted matched-action lists that lack the field still
+    # parse. The whole-domain fallback and MCP tools count as writes.
+    effect: ActionEffect = ActionEffect.READ
 
 
 class GatedTarget(BaseModel):
@@ -159,6 +168,7 @@ def recognize_actions(
             display_name=endpoint.normalised_name,
             description=endpoint.description,
             policy=effective_policy(endpoint, stored),
+            effect=endpoint.effect,
         )
         for endpoint in catalog
         if any(rule_matches(rule, context) for rule in endpoint.matches)
@@ -205,6 +215,7 @@ def apply_credential_gate(
                 display_name="Perform action",
                 description=f"{request.method} {request.path}",
                 policy=EndpointPolicy.ASK,
+                effect=ActionEffect.WRITE,
             ),
         ),
         target=GatedTarget(

--- a/backend/onyx/external_apps/providers/actions.py
+++ b/backend/onyx/external_apps/providers/actions.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, InstanceOf, field_validator
 
-from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ActionEffect, EndpointPolicy
 
 
 class ExternalAppAction(str, Enum):
@@ -120,6 +120,9 @@ class EndpointSpec(BaseModel):
     # The policy a freshly-created built-in app starts this action at, unless the
     # admin overrides it.
     default_policy: EndpointPolicy = EndpointPolicy.ASK
+    # Write-effect actions leave a receipt when they execute. Declared per
+    # action, defaulting to the harmless case.
+    effect: ActionEffect = ActionEffect.READ
     # Set when the action needs a scope only a self-hosted deployment requests,
     # which drops it from the cloud catalog (``registry.get_endpoint_catalog``).
     requires_self_hosted_scope: bool = False

--- a/backend/onyx/external_apps/providers/github.py
+++ b/backend/onyx/external_apps/providers/github.py
@@ -6,7 +6,7 @@ from onyx.configs.app_configs import (
     EXT_APP_GITHUB_CLIENT_ID,
     EXT_APP_GITHUB_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import (
@@ -175,6 +175,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GitHubAction.ISSUES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create an issue",
         description="Open a new issue in a repository.",
         matches=(
@@ -184,6 +185,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GitHubAction.COMMENTS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Comment on an issue",
         description="Add a comment to an issue or pull request.",
         matches=(
@@ -195,6 +197,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GitHubAction.CONTENTS_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create, update, or delete files",
         description="Write or delete a file in a repository (a single-file commit).",
         matches=(
@@ -204,6 +207,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GitHubAction.REFS_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create, update, or delete branches",
         description="Create a branch/ref, move it, or delete it.",
         matches=(
@@ -214,6 +218,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GitHubAction.PULLS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Open a pull request",
         description="Open a new pull request.",
         matches=(

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -4,7 +4,7 @@ from onyx.configs.app_configs import (
     EXT_APP_GMAIL_CLIENT_ID,
     EXT_APP_GMAIL_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.external_apps.presentation.payload_decoders import (
     GmailRawMimeDecoder,
     PayloadDecoder,
@@ -79,12 +79,14 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GmailAction.MESSAGES_SEND,
+        effect=ActionEffect.WRITE,
         normalised_name="Send a message",
         description="Send an email from the connected account.",
         matches=(RestRoute(method="POST", path=f"{_MESSAGES}/send"),),
     ),
     EndpointSpec(
         id=GmailAction.MESSAGES_MODIFY,
+        effect=ActionEffect.WRITE,
         normalised_name="Modify message labels",
         description="Add or remove labels on a message (mark read, archive, …).",
         matches=(RestRoute(method="POST", path=f"{_MESSAGE_ITEM}/modify"),),
@@ -92,6 +94,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GmailAction.MESSAGES_TRASH,
+        effect=ActionEffect.WRITE,
         normalised_name="Trash a message",
         description="Move a message to the trash.",
         matches=(RestRoute(method="POST", path=f"{_MESSAGE_ITEM}/trash"),),
@@ -133,6 +136,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GmailAction.DRAFTS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a draft",
         # Drafts aren't sent, so creating one is a safe place for the agent to
         # prepare an email for the user to review and send from Gmail.
@@ -142,6 +146,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GmailAction.DRAFTS_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Update a draft",
         description="Replace the contents of an existing draft (not sent).",
         matches=(RestRoute(method="PUT", path=_DRAFT_ITEM),),
@@ -150,6 +155,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GmailAction.DRAFTS_DELETE,
+        effect=ActionEffect.WRITE,
         normalised_name="Delete a draft",
         description="Permanently delete a draft.",
         matches=(RestRoute(method="DELETE", path=_DRAFT_ITEM),),
@@ -157,6 +163,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GmailAction.DRAFTS_SEND,
+        effect=ActionEffect.WRITE,
         normalised_name="Send a draft",
         description="Send an existing draft as an email.",
         matches=(RestRoute(method="POST", path=f"{_DRAFTS}/send"),),

--- a/backend/onyx/external_apps/providers/google_calendar.py
+++ b/backend/onyx/external_apps/providers/google_calendar.py
@@ -2,7 +2,7 @@ from onyx.configs.app_configs import (
     EXT_APP_GOOGLE_CALENDAR_CLIENT_ID,
     EXT_APP_GOOGLE_CALENDAR_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.external_apps.providers.actions import (
     EndpointSpec,
     ExternalAppAction,
@@ -58,12 +58,14 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleCalendarAction.EVENTS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create an event",
         description="Create a new event on a calendar.",
         matches=(RestRoute(method="POST", path=_EVENTS_COLLECTION),),
     ),
     EndpointSpec(
         id=GoogleCalendarAction.EVENTS_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Update an event",
         description="Modify an existing event.",
         matches=(
@@ -73,6 +75,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleCalendarAction.EVENTS_DELETE,
+        effect=ActionEffect.WRITE,
         normalised_name="Delete an event",
         description="Permanently delete an event.",
         matches=(RestRoute(method="DELETE", path=_EVENT_ITEM),),

--- a/backend/onyx/external_apps/providers/google_drive.py
+++ b/backend/onyx/external_apps/providers/google_drive.py
@@ -2,7 +2,7 @@ from onyx.configs.app_configs import (
     EXT_APP_GOOGLE_DRIVE_CLIENT_ID,
     EXT_APP_GOOGLE_DRIVE_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.external_apps.providers.actions import (
     EndpointSpec,
     ExternalAppAction,
@@ -91,6 +91,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleDriveAction.FILES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create or upload a file",
         description=(
             "Create a folder/file or upload new content (optionally converting "
@@ -103,6 +104,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleDriveAction.FILES_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Edit a file",
         description="Update a file's metadata or replace its contents.",
         matches=(
@@ -112,6 +114,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleDriveAction.FILES_DELETE,
+        effect=ActionEffect.WRITE,
         normalised_name="Delete a file",
         description="Trash or permanently delete a file.",
         matches=(RestRoute(method="DELETE", path=_FILE_ITEM),),
@@ -128,12 +131,14 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleDriveAction.DOCS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a document",
         description="Create a new, empty Google Doc via the Docs API.",
         matches=(RestRoute(method="POST", path=_DOCS),),
     ),
     EndpointSpec(
         id=GoogleDriveAction.DOCS_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Edit a document",
         description="Apply edits to a Google Doc's contents via the Docs API.",
         matches=(RestRoute(method="POST", path=_DOC_ITEM),),
@@ -152,12 +157,14 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleDriveAction.SHEETS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a spreadsheet",
         description="Create a new Google Sheet via the Sheets API.",
         matches=(RestRoute(method="POST", path=_SHEETS),),
     ),
     EndpointSpec(
         id=GoogleDriveAction.SHEETS_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Edit a spreadsheet",
         description=(
             "Write, append, or clear cell values and apply structural edits "
@@ -183,12 +190,14 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=GoogleDriveAction.SLIDES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a presentation",
         description="Create a new Google Slides presentation via the Slides API.",
         matches=(RestRoute(method="POST", path=_SLIDES),),
     ),
     EndpointSpec(
         id=GoogleDriveAction.SLIDES_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Edit a presentation",
         description=(
             "Apply edits (add slides, insert or replace text, restyle) to a "

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -7,7 +7,7 @@ from onyx.configs.app_configs import (
     EXT_APP_HUBSPOT_CLIENT_ID,
     EXT_APP_HUBSPOT_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import (
@@ -111,6 +111,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=HubspotAction.CONTACTS_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create or update contacts",
         description="Create a new contact or update an existing one.",
         matches=(
@@ -120,6 +121,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=HubspotAction.COMPANIES_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create or update companies",
         description="Create a new company or update an existing one.",
         matches=(
@@ -129,6 +131,7 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=HubspotAction.DEALS_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create or update deals",
         description="Create a new deal or update an existing one.",
         matches=(

--- a/backend/onyx/external_apps/providers/linear.py
+++ b/backend/onyx/external_apps/providers/linear.py
@@ -4,7 +4,7 @@ from onyx.configs.app_configs import (
     EXT_APP_LINEAR_CLIENT_ID,
     EXT_APP_LINEAR_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import (
@@ -72,24 +72,28 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=LinearAction.ISSUES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create an issue",
         description="Create a new issue.",
         matches=(GraphQLOp(operation_type="mutation", field="issueCreate"),),
     ),
     EndpointSpec(
         id=LinearAction.COMMENTS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Comment on an issue",
         description="Add a comment to an issue.",
         matches=(GraphQLOp(operation_type="mutation", field="commentCreate"),),
     ),
     EndpointSpec(
         id=LinearAction.PROJECTS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a project",
         description="Create a new project.",
         matches=(GraphQLOp(operation_type="mutation", field="projectCreate"),),
     ),
     EndpointSpec(
         id=LinearAction.PROJECTS_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Edit a project",
         description="Update an existing project.",
         matches=(GraphQLOp(operation_type="mutation", field="projectUpdate"),),

--- a/backend/onyx/external_apps/providers/notion.py
+++ b/backend/onyx/external_apps/providers/notion.py
@@ -5,7 +5,7 @@ from onyx.configs.app_configs import (
     EXT_APP_NOTION_CLIENT_ID,
     EXT_APP_NOTION_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import (
@@ -133,60 +133,70 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=NotionAction.PAGES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a page",
         description="Create a new page under a page or data source parent.",
         matches=(RestRoute(method="POST", path="/v1/pages"),),
     ),
     EndpointSpec(
         id=NotionAction.PAGES_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Update a page",
         description="Update a page's properties, icon, cover, or archive it.",
         matches=(RestRoute(method="PATCH", path="/v1/pages/{page_id}"),),
     ),
     EndpointSpec(
         id=NotionAction.BLOCKS_APPEND,
+        effect=ActionEffect.WRITE,
         normalised_name="Append blocks",
         description="Append child blocks (content) to a page or block.",
         matches=(RestRoute(method="PATCH", path="/v1/blocks/{block_id}/children"),),
     ),
     EndpointSpec(
         id=NotionAction.BLOCKS_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Update a block",
         description="Update or archive an individual block's content.",
         matches=(RestRoute(method="PATCH", path="/v1/blocks/{block_id}"),),
     ),
     EndpointSpec(
         id=NotionAction.BLOCKS_DELETE,
+        effect=ActionEffect.WRITE,
         normalised_name="Delete a block",
         description="Delete (move to trash) an individual block.",
         matches=(RestRoute(method="DELETE", path="/v1/blocks/{block_id}"),),
     ),
     EndpointSpec(
         id=NotionAction.DATABASES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a database",
         description="Create a new database (with an initial data source) under a page parent.",
         matches=(RestRoute(method="POST", path="/v1/databases"),),
     ),
     EndpointSpec(
         id=NotionAction.DATABASES_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Update a database",
         description="Update a database container's title or move its data sources.",
         matches=(RestRoute(method="PATCH", path="/v1/databases/{database_id}"),),
     ),
     EndpointSpec(
         id=NotionAction.DATA_SOURCES_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Create a data source",
         description="Add a new data source to an existing database.",
         matches=(RestRoute(method="POST", path="/v1/data_sources"),),
     ),
     EndpointSpec(
         id=NotionAction.DATA_SOURCES_UPDATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Update a data source",
         description="Update a data source's schema, title, or description.",
         matches=(RestRoute(method="PATCH", path="/v1/data_sources/{data_source_id}"),),
     ),
     EndpointSpec(
         id=NotionAction.COMMENTS_CREATE,
+        effect=ActionEffect.WRITE,
         normalised_name="Add a comment",
         description="Add a comment to a page or an existing discussion.",
         matches=(RestRoute(method="POST", path="/v1/comments"),),

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -4,7 +4,7 @@ from onyx.configs.app_configs import (
     EXT_APP_SLACK_CLIENT_ID,
     EXT_APP_SLACK_CLIENT_SECRET,
 )
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import (
@@ -82,18 +82,21 @@ _ENDPOINTS: list[EndpointSpec] = [
     ),
     EndpointSpec(
         id=SlackAction.MESSAGES_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Post a message",
         description="Post a message to a channel or conversation.",
         matches=(RestRoute(method="POST", path="/api/chat.postMessage"),),
     ),
     EndpointSpec(
         id=SlackAction.DM_OPEN,
+        effect=ActionEffect.WRITE,
         normalised_name="Open a direct message",
         description="Open (or resume) a direct message conversation with a user.",
         matches=(RestRoute(method="POST", path="/api/conversations.open"),),
     ),
     EndpointSpec(
         id=SlackAction.FILES_WRITE,
+        effect=ActionEffect.WRITE,
         normalised_name="Upload files",
         description=(
             "Upload a file and share it to a channel, direct message, or "

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -26,6 +26,7 @@ from onyx.cache.interface import CACHE_TRANSIENT_ERRORS, CacheBackend
 from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import (
+    ActionEffect,
     ApprovalDecidedVia,
     ApprovalDecision,
     EndpointPolicy,
@@ -520,6 +521,39 @@ class GateAddon:
             )
             await self._record_receipts(flow, ctx, matched_actions, approval_id)
 
+    async def _record_always_write_receipts(
+        self,
+        flow: http.HTTPFlow,
+        sandbox: ResolvedSandbox,
+        matched_actions: AllMatchedActions,
+    ) -> None:
+        """An admin-set ALWAYS policy must not exempt a write from the
+        activity record. Best-effort: the ALWAYS path deliberately skips
+        session resolution, so a write resolves it here and an unattributable
+        one goes unrecorded rather than blocked."""
+        if not any(
+            action.effect is ActionEffect.WRITE for action in matched_actions.actions
+        ):
+            return
+        try:
+            session_id = self._resolve_gated_session(flow, sandbox)
+        except Exception:
+            logger.exception(
+                "receipt_session_lookup_error tenant=%s sandbox=%s host=%s",
+                sandbox.tenant_id,
+                sandbox_log_label(sandbox),
+                flow.request.host,
+            )
+            return
+        if session_id is None:
+            return
+        await self._record_receipts(
+            flow,
+            sandbox.with_session(session_id),
+            matched_actions,
+            approval_id=None,
+        )
+
     async def _record_receipts(
         self,
         flow: http.HTTPFlow,
@@ -766,6 +800,7 @@ class GateAddon:
                     ),
                     credential_outcome_label(injection),
                 )
+                await self._record_always_write_receipts(flow, sandbox, matched_actions)
             return None
 
         # ASK: resolve the originating session before prompting. An

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -25,7 +25,12 @@ from sqlalchemy.orm import Session
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS, CacheBackend
 from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session_with_tenant
-from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, EndpointPolicy
+from onyx.db.enums import (
+    ApprovalDecidedVia,
+    ApprovalDecision,
+    EndpointPolicy,
+    ReceiptStatus,
+)
 from onyx.db.gated_app import get_gated_app_id
 from onyx.db.notification import create_notification
 from onyx.db.scheduled_task import ScheduledRunGrants, get_live_scheduled_run_grants
@@ -56,6 +61,10 @@ from onyx.sandbox_proxy.logging_utils import (
     full_log_id,
     sandbox_log_label,
     short_log_id,
+)
+from onyx.sandbox_proxy.receipt_recorder import (
+    finalize_receipts,
+    record_pending_receipts,
 )
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.server.features.build.configs import (
@@ -196,6 +205,11 @@ class _ApprovalGrant:
 # TTL bounds staleness past a run's RUNNING -> terminal transition.
 _GRANT_CACHE_TTL_S = 60.0
 _GRANT_CACHE_MAX_ENTRIES = 4096
+
+
+# flow.metadata value for recorded receipts: primitives only, because
+# mitmproxy deep-copies and tnetstring-serializes flow metadata.
+RECEIPT_FLOW_KEY = "craft_recorded_receipts"
 
 
 class ParkedApprovals:
@@ -503,6 +517,92 @@ class GateAddon:
                 "egress_allow " + fields + " credential_outcome=%s",
                 *args,
                 credential_outcome_label(injection),
+            )
+            await self._record_receipts(flow, ctx, matched_actions, approval_id)
+
+    async def _record_receipts(
+        self,
+        flow: http.HTTPFlow,
+        ctx: SessionContext,
+        matched_actions: AllMatchedActions,
+        approval_id: UUID | None,
+    ) -> None:
+        """Write PENDING receipts and remember them on the flow for the
+        response and error hooks. Best-effort: the action proceeds either way,
+        and an unrecorded action is invisible, not blocked."""
+        try:
+            receipt_ids = await asyncio.to_thread(
+                record_pending_receipts,
+                tenant_id=ctx.tenant_id,
+                session_id=ctx.session_id,
+                matched_actions=matched_actions,
+                approval_id=approval_id,
+                cache_factory=self._cache_factory,
+            )
+        except Exception:
+            logger.exception(
+                "receipt_record_error tenant=%s session=%s action_type=%s",
+                ctx.tenant_id,
+                short_log_id(ctx.session_id),
+                matched_actions.governing_action.action_type,
+            )
+            return
+        if receipt_ids:
+            flow.metadata[RECEIPT_FLOW_KEY] = {
+                "tenant_id": ctx.tenant_id,
+                "session_id": str(ctx.session_id),
+                "receipt_ids": [str(receipt_id) for receipt_id in receipt_ids],
+            }
+
+    async def response(self, flow: http.HTTPFlow) -> None:
+        """Finalize recorded receipts from the origin's verdict.
+
+        Transport-level truth only: a non-error status whose body carries a
+        provider error still records CONFIRMED.
+        """
+        recorded = flow.metadata.pop(RECEIPT_FLOW_KEY, None)
+        if recorded is None:
+            return
+        confirmed = flow.response is not None and flow.response.status_code < 400
+        await self._finalize_recorded(
+            recorded,
+            ReceiptStatus.CONFIRMED if confirmed else ReceiptStatus.FAILED,
+        )
+
+    async def error(self, flow: http.HTTPFlow) -> None:
+        recorded = flow.metadata.pop(RECEIPT_FLOW_KEY, None)
+        if recorded is None:
+            return
+        # Non-error headers already came back, so the origin may well have
+        # committed the write: the outcome is unknown, not failed.
+        seen_ok = flow.response is not None and flow.response.status_code < 400
+        await self._finalize_recorded(
+            recorded,
+            ReceiptStatus.UNKNOWN if seen_ok else ReceiptStatus.FAILED,
+        )
+
+    async def _finalize_recorded(
+        self, recorded: dict[str, object], status: ReceiptStatus
+    ) -> None:
+        tenant_id = str(recorded["tenant_id"])
+        session_id = UUID(str(recorded["session_id"]))
+        receipt_ids_raw = recorded["receipt_ids"]
+        assert isinstance(receipt_ids_raw, list)
+        try:
+            await asyncio.to_thread(
+                finalize_receipts,
+                tenant_id=tenant_id,
+                session_id=session_id,
+                receipt_ids=[UUID(str(rid)) for rid in receipt_ids_raw],
+                status=status,
+                cache_factory=self._cache_factory,
+            )
+        except Exception:
+            logger.exception(
+                "receipt_finalize_error tenant=%s session=%s status=%s",
+                tenant_id,
+                short_log_id(session_id),
+                status.value,
             )
 
     # --------------------------------------------------------------------------
@@ -1113,6 +1213,9 @@ class GateAddon:
            winner) and wake its parked BLPOP.
         2. `asyncio.wait` on tracked `request()` tasks so they return to
            mitmproxy before the caller tears down connections.
+
+        Recorded receipts still PENDING at shutdown ride the stale sweep
+        to UNKNOWN.
         """
         for tenant_id, approval_ids in self._parked.snapshot():
             cache = self._cache_factory(tenant_id)

--- a/backend/onyx/sandbox_proxy/receipt_recorder.py
+++ b/backend/onyx/sandbox_proxy/receipt_recorder.py
@@ -1,0 +1,188 @@
+"""Records receipts for egress actions at the proxy.
+
+A receipt is the user-facing proof of an external side effect: written PENDING
+before the action executes, finalized from the proxy's response and error
+hooks, swept to UNKNOWN when orphaned (a finalize landing after the sweep is
+dropped, so a response outliving the ten-minute TTL records UNKNOWN).
+Write-effect catalog actions always leave one, and so does anything that went
+through an approval. Reads that auto-pass leave nothing. Multi-request
+provider flows each leave their own receipt until the extractor PR derives
+operation keys, so ``insert_pending_receipt`` coalesces nothing yet.
+
+Recording and finalizing announce the row to the session's live SSE stream,
+best-effort: the receipt listing is the durable record, so a lost announce
+loses nothing.
+"""
+
+from collections.abc import Callable
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from onyx.cache.interface import CacheBackend
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import ActionEffect, ReceiptStatus
+from onyx.db.gated_app import get_or_create_gated_app_id
+from onyx.db.models import ActionReceipt
+from onyx.external_apps.matching.engine import AllMatchedActions, MatchedAction
+from onyx.server.features.build.db.receipt import (
+    finalize_receipt,
+    insert_pending_receipt,
+)
+from onyx.server.features.build.packets import ReceiptPacket
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_ANNOUNCE_TTL_S = 60
+
+
+def _announce_key(session_id: UUID) -> str:
+    return f"craft:receipt:announce:{session_id}"
+
+
+def announce_receipts(
+    session_id: UUID, packets: list[ReceiptPacket], cache: CacheBackend
+) -> None:
+    """Hand receipt transitions to the SSE stream attached to this session."""
+    if not packets:
+        return
+    key = _announce_key(session_id)
+    for packet in packets:
+        cache.rpush(key, packet.model_dump_json())
+    cache.expire(key, _ANNOUNCE_TTL_S)
+
+
+def pop_receipt_announcement(
+    session_id: UUID, timeout_s: int, cache: CacheBackend
+) -> ReceiptPacket | None:
+    """BLPOP one announced receipt. None on timeout or unparseable payload."""
+    result = cache.blpop([_announce_key(session_id)], timeout_s)
+    if result is None:
+        return None
+    _key, value = result
+    if isinstance(value, bytes):
+        value = value.decode()
+    try:
+        return ReceiptPacket.model_validate_json(value)
+    except ValidationError:
+        logger.warning("receipt: unparseable announce %r for %s", value, session_id)
+        return None
+
+
+def receipt_worthy_actions(
+    matched_actions: AllMatchedActions, approval_id: UUID | None
+) -> list[MatchedAction]:
+    """The actions this request must leave receipts for.
+
+    Every write-effect action gets its own receipt. A request with no write
+    actions still gets one for its governing action when the user approved
+    it, so approved reads stay visible in the activity record.
+    """
+    writes = [
+        action
+        for action in matched_actions.actions
+        if action.effect is ActionEffect.WRITE
+    ]
+    if writes:
+        return writes
+    if approval_id is not None:
+        return [matched_actions.governing_action]
+    return []
+
+
+def record_pending_receipts(
+    *,
+    tenant_id: str,
+    session_id: UUID,
+    matched_actions: AllMatchedActions,
+    approval_id: UUID | None,
+    cache_factory: Callable[[str], CacheBackend],
+) -> list[UUID]:
+    """Insert PENDING rows for this request, announce them, return their ids.
+
+    Called after the gate's verdict and credential injection, immediately
+    before the request leaves for the origin, so the record exists even when
+    the proxy dies mid-flight (the sweep then marks it UNKNOWN).
+    """
+    actions = receipt_worthy_actions(matched_actions, approval_id)
+    if not actions:
+        return []
+    target = matched_actions.target
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        gated_app_id = get_or_create_gated_app_id(db, target.kind, target.id)
+        rows = [
+            insert_pending_receipt(
+                db,
+                session_id=session_id,
+                action_type=action.action_type,
+                effect=action.effect.value,
+                destination=matched_actions.app_name,
+                gated_app_id=gated_app_id,
+                approval_id=approval_id,
+                operation_key=None,
+            )
+            for action in actions
+        ]
+        db.commit()
+        receipt_ids = [row.id for row in rows]
+        packets = [_packet_for(row) for row in rows]
+    _announce_best_effort(tenant_id, session_id, packets, cache_factory)
+    return receipt_ids
+
+
+def finalize_receipts(
+    *,
+    tenant_id: str,
+    session_id: UUID,
+    receipt_ids: list[UUID],
+    status: ReceiptStatus,
+    cache_factory: Callable[[str], CacheBackend],
+) -> None:
+    """Move recorded rows to their terminal state and announce the outcome.
+
+    Only rows that carry the requested verdict announce: a row that lost the
+    race to an earlier verdict already announced that one.
+    """
+    packets: list[ReceiptPacket] = []
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        for receipt_id in receipt_ids:
+            row = finalize_receipt(db, receipt_id=receipt_id, status=status)
+            if row is not None and row.status is status:
+                packets.append(_packet_for(row))
+        db.commit()
+    _announce_best_effort(tenant_id, session_id, packets, cache_factory)
+
+
+def _announce_best_effort(
+    tenant_id: str,
+    session_id: UUID,
+    packets: list[ReceiptPacket],
+    cache_factory: Callable[[str], CacheBackend],
+) -> None:
+    """The cache backend is built in here so cache trouble of any kind costs
+    an announce, never the recorded row."""
+    if not packets:
+        return
+    try:
+        announce_receipts(session_id, packets, cache_factory(tenant_id))
+    except Exception:
+        logger.warning(
+            "receipt_announce_error session=%s count=%d",
+            session_id,
+            len(packets),
+            exc_info=True,
+        )
+
+
+def _packet_for(row: ActionReceipt) -> ReceiptPacket:
+    return ReceiptPacket(
+        receipt_id=row.id,
+        session_id=row.session_id,
+        action_type=row.action_type,
+        effect=row.effect,
+        destination=row.destination,
+        link=row.link,
+        status=row.status,
+        created_at=row.created_at,
+    )

--- a/backend/onyx/sandbox_proxy/request_evaluator.py
+++ b/backend/onyx/sandbox_proxy/request_evaluator.py
@@ -17,7 +17,7 @@ from mitmproxy import http
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
-from onyx.db.enums import EndpointPolicy, GatedAppKind
+from onyx.db.enums import ActionEffect, EndpointPolicy, GatedAppKind
 from onyx.db.external_app import get_external_apps
 from onyx.db.gated_app import get_action_policies
 from onyx.db.mcp import get_craft_enabled_mcp_servers
@@ -220,6 +220,7 @@ class McpRequestEvaluator(RequestEvaluator):
                         display_name="Unrecognized MCP request",
                         description="MCP gating failed; blocked.",
                         policy=EndpointPolicy.DENY,
+                        effect=ActionEffect.WRITE,
                     ),
                 )
 
@@ -246,6 +247,7 @@ def _mcp_tool_actions(
                     "as an MCP tool call or protocol message; blocked."
                 ),
                 policy=EndpointPolicy.DENY,
+                effect=ActionEffect.WRITE,
             ),
         )
     stored = get_action_policies(db, GatedAppKind.MCP_SERVER, server.id)
@@ -262,6 +264,9 @@ def _mcp_tool_actions(
                 + (f" This request invokes it {count} times." if count > 1 else "")
             ),
             policy=stored.get(tool_name, MCP_TOOL_DEFAULT_POLICY),
+            # MCP tools always count as writes, a server's own hints never
+            # downgrade one to a read.
+            effect=ActionEffect.WRITE,
         )
         for tool_name, count in counts.items()
     )

--- a/backend/onyx/server/features/build/db/receipt.py
+++ b/backend/onyx/server/features/build/db/receipt.py
@@ -82,12 +82,14 @@ def finalize_receipt(
 ) -> ActionReceipt | None:
     """Move a PENDING row to its terminal state.
 
+    CONFIRMED and FAILED come from the origin's verdict, UNKNOWN when the
+    outcome is genuinely unknowable (headers arrived but the body did not).
     The conditional UPDATE is the race arbiter: concurrent finalizes cannot
     flip an already-recorded verdict. Returns the row (already-terminal
     included) or None when it does not exist.
     """
-    if status not in (ReceiptStatus.CONFIRMED, ReceiptStatus.FAILED):
-        raise ValueError("finalize_receipt only records CONFIRMED or FAILED")
+    if status is ReceiptStatus.PENDING:
+        raise ValueError("finalize_receipt records terminal states only")
     values: dict[str, Any] = {"status": status}
     if link is not None:
         values["link"] = link
@@ -114,17 +116,26 @@ def finalize_receipt(
     return row
 
 
-def sweep_stale_pending_receipts(db_session: Session) -> int:
-    """Mark orphaned PENDING rows UNKNOWN. Returns the number swept."""
+def sweep_stale_pending_receipts(
+    db_session: Session, *, session_id: UUID | None = None
+) -> int:
+    """Mark orphaned PENDING rows UNKNOWN. Returns the number swept.
+
+    Scope to one session on user-facing reads: the tenant-wide form has no
+    supporting index and belongs to maintenance paths.
+    """
     # DB clock on both sides, created_at is server-generated.
     cutoff = func.now() - PENDING_RECEIPT_TTL
+    conditions = [
+        ActionReceipt.status == ReceiptStatus.PENDING,
+        ActionReceipt.created_at < cutoff,
+    ]
+    if session_id is not None:
+        conditions.append(ActionReceipt.session_id == session_id)
     swept_ids = (
         db_session.execute(
             update(ActionReceipt)
-            .where(
-                ActionReceipt.status == ReceiptStatus.PENDING,
-                ActionReceipt.created_at < cutoff,
-            )
+            .where(*conditions)
             .values(status=ReceiptStatus.UNKNOWN)
             .returning(ActionReceipt.id)
             .execution_options(synchronize_session=False)

--- a/backend/onyx/server/features/build/packets.py
+++ b/backend/onyx/server/features/build/packets.py
@@ -29,6 +29,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from onyx.db.enums import ActionEffect, ReceiptStatus
+
 # =============================================================================
 # Base Packet Type
 # =============================================================================
@@ -89,6 +91,25 @@ class ConnectAppRequestPacket(BasePacket):
     reason: str | None = None
 
 
+class ReceiptPacket(BasePacket):
+    """An action receipt was recorded or reached its terminal state.
+
+    Carries the API-visible row so a consumer can render the receipt card
+    with no round trip. The receipt listing refetch is the completeness
+    guarantee, and clients ignore unknown packet types by design.
+    """
+
+    type: Literal["receipt"] = "receipt"
+    receipt_id: UUID
+    session_id: UUID
+    action_type: str
+    effect: ActionEffect
+    destination: str
+    link: str | None
+    status: ReceiptStatus
+    created_at: datetime
+
+
 class ContextUsagePacket(BasePacket):
     type: Literal["context_usage"] = "context_usage"
     used_tokens: int
@@ -109,6 +130,7 @@ BuildPacket = (
     | ApprovalRequestedPacket
     | SubagentStartedPacket
     | ConnectAppRequestPacket
+    | ReceiptPacket
     | ContextUsagePacket
     | CompactionPacket
 )

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -29,6 +29,10 @@ from onyx.server.features.build.db.build_session import (
     get_build_session,
     set_build_session_sharing_scope,
 )
+from onyx.server.features.build.db.receipt import (
+    get_session_receipts,
+    sweep_stale_pending_receipts,
+)
 from onyx.server.features.build.db.sandbox import (
     get_sandbox_by_user_id,
     update_sandbox_heartbeat,
@@ -52,6 +56,7 @@ from onyx.server.features.build.session.models import (
     OpencodeHistorySnapshotResponse,
     PptxPreviewResponse,
     PreProvisionedCheckResponse,
+    ReceiptResponse,
     SandboxStatusResponse,
     SessionCreateRequest,
     SessionListResponse,
@@ -515,6 +520,27 @@ def list_artifacts(
         raise HTTPException(status_code=404, detail="Session not found")
 
     return artifacts
+
+
+@router.get("/{session_id}/receipts")
+def list_receipts(
+    session_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[ReceiptResponse]:
+    """List the session's external-action receipts.
+
+    Owner-only on purpose, destinations can leak even when the session is
+    shared. Orphaned PENDING rows sweep to UNKNOWN on read, so a stuck row
+    stops presenting as in progress once stale.
+    """
+    session = get_build_session(session_id, user.id, db_session)
+    if session is None:
+        raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Session not found")
+    if sweep_stale_pending_receipts(db_session, session_id=session_id):
+        db_session.commit()
+    rows = get_session_receipts(db_session, session_id=session_id)
+    return [ReceiptResponse.from_model(row) for row in rows]
 
 
 @router.get("/{session_id}/files", response_model=DirectoryListing)

--- a/backend/onyx/server/features/build/session/models.py
+++ b/backend/onyx/server/features/build/session/models.py
@@ -6,8 +6,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from onyx.configs.constants import MessageType
 from onyx.db.enums import (
+    ActionEffect,
     ArtifactType,
     BuildSessionStatus,
+    ReceiptStatus,
     SandboxStatus,
     SessionOrigin,
     SharingScope,
@@ -15,7 +17,7 @@ from onyx.db.enums import (
 from onyx.server.features.build.db.build_session import session_runtime_stale
 
 if TYPE_CHECKING:
-    from onyx.db.models import BuildSession, Sandbox
+    from onyx.db.models import ActionReceipt, BuildSession, Sandbox
 
 
 # ===== Session Models =====
@@ -94,6 +96,32 @@ class ArtifactResponse(BaseModel):
             preview_url=getattr(artifact, "preview_url", None),
             created_at=artifact.created_at,
             updated_at=artifact.updated_at,
+        )
+
+
+class ReceiptResponse(BaseModel):
+    """One external-action receipt. Owner-only: destinations can leak."""
+
+    id: str
+    session_id: str
+    action_type: str
+    effect: ActionEffect
+    destination: str
+    link: str | None
+    status: ReceiptStatus
+    created_at: datetime
+
+    @classmethod
+    def from_model(cls, receipt: "ActionReceipt") -> "ReceiptResponse":
+        return cls(
+            id=str(receipt.id),
+            session_id=str(receipt.session_id),
+            action_type=receipt.action_type,
+            effect=receipt.effect,
+            destination=receipt.destination,
+            link=receipt.link,
+            status=receipt.status,
+            created_at=receipt.created_at,
         )
 
 

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -30,6 +30,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import BuildSession
 from onyx.sandbox_proxy import approval_cache
+from onyx.sandbox_proxy.receipt_recorder import pop_receipt_announcement
 from onyx.server.features.build import connect_app
 from onyx.server.features.build.configs import (
     SANDBOX_HEARTBEAT_REFRESH_INTERVAL_SECONDS,
@@ -51,6 +52,7 @@ from onyx.server.features.build.packets import (
     ConnectAppRequestPacket,
     ContextUsagePacket,
     ErrorPacket,
+    ReceiptPacket,
     SubagentStartedPacket,
 )
 from onyx.server.features.build.sandbox.base import SandboxManager
@@ -281,6 +283,7 @@ def event_to_sse(event: Any) -> str:
             ErrorPacket,
             SubagentStartedPacket,
             ConnectAppRequestPacket,
+            ReceiptPacket,
             ContextUsagePacket,
             CompactionPacket,
         ),
@@ -301,9 +304,10 @@ def merge_events_with_announces(
 ) -> Generator[Any, None, None]:
     """Merge sandbox events and announces into one stream.
 
-    Three producer threads feed a shared queue: the sandbox-event iterator, and
-    two BLPOP pollers that inject an `ApprovalRequestedPacket` / a
-    `ConnectAppRequestPacket` when a request is announced from another worker.
+    Four producer threads feed a shared queue: the sandbox-event iterator, and
+    three BLPOP pollers that inject an `ApprovalRequestedPacket`, a
+    `ConnectAppRequestPacket`, or a `ReceiptPacket` when one is announced from
+    another worker.
     Announce latency is bounded by the 1s BLPOP.
     """
     output: queue_lib.Queue[Any] = queue_lib.Queue()
@@ -367,6 +371,21 @@ def merge_events_with_announces(
                 )
             )
 
+    def drive_receipt_announces() -> None:
+        cache = get_cache_backend(tenant_id=tenant_id)
+        while not stop.is_set():
+            try:
+                packet = pop_receipt_announcement(session_id, timeout_s=1, cache=cache)
+            except Exception:
+                logger.exception(
+                    "receipt.announce_poll_failed session_id=%s", session_id
+                )
+                time.sleep(1)
+                continue
+            if packet is None:
+                continue
+            output.put(packet)
+
     # Spawn via the context-preserving helper so the event iterator's lazy
     # tenant-scoped DB access (e.g. event-bus creation) sees the caller's
     # contextvars instead of raising "Tenant ID is not set".
@@ -385,6 +404,11 @@ def merge_events_with_announces(
     start_thread_with_context(
         drive_connect_app_announces,
         name=f"connect-app-pump-{session_id}",
+        daemon=True,
+    )
+    start_thread_with_context(
+        drive_receipt_announces,
+        name=f"receipt-pump-{session_id}",
         daemon=True,
     )
     try:

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -26,7 +26,7 @@ import pytest
 from mitmproxy import http
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
+from onyx.db.enums import ActionEffect, EndpointPolicy, ExternalAppType, GatedAppKind
 from onyx.db.gated_app import get_or_create_gated_app_id
 from onyx.db.models import ExternalApp, GatedActionPolicy, User
 from onyx.external_apps.credentials import app_is_available
@@ -106,6 +106,7 @@ def test_match_stored_override_wins(
                 display_name="Post a message",
                 description="Post a message to a channel or conversation.",
                 policy=EndpointPolicy.ALWAYS,
+                effect=ActionEffect.WRITE,
             ),
         ),
         target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=app.id, app_name="Slack"),

--- a/backend/tests/external_dependency_unit/craft/test_artifact_receipt_dal.py
+++ b/backend/tests/external_dependency_unit/craft/test_artifact_receipt_dal.py
@@ -191,9 +191,10 @@ def test_finalize_is_terminal_and_rejects_pending(
     assert flipped is not None
     assert flipped.status == ReceiptStatus.CONFIRMED
 
-    for non_terminal in (ReceiptStatus.PENDING, ReceiptStatus.UNKNOWN):
-        with pytest.raises(ValueError):
-            finalize_receipt(db_session, receipt_id=receipt.id, status=non_terminal)
+    with pytest.raises(ValueError):
+        finalize_receipt(
+            db_session, receipt_id=receipt.id, status=ReceiptStatus.PENDING
+        )
 
 
 def test_sweep_marks_only_stale_pending_unknown(

--- a/backend/tests/external_dependency_unit/craft/test_receipt_recording.py
+++ b/backend/tests/external_dependency_unit/craft/test_receipt_recording.py
@@ -1,0 +1,261 @@
+"""External-dependency-unit tests for proxy receipt recording.
+
+Runs the recorder against Postgres and Redis: which actions leave receipts,
+the PENDING to terminal transitions the hooks drive through
+``finalize_receipts``, the sweep, the owner-only listing, and the announce
+stream the live SSE merge consumes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.cache.factory import get_cache_backend
+from onyx.db.enums import (
+    ActionEffect,
+    EndpointPolicy,
+    GatedAppKind,
+    ReceiptStatus,
+)
+from onyx.db.models import BuildSession, User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.matching.engine import (
+    AllMatchedActions,
+    GatedTarget,
+    MatchedAction,
+)
+from onyx.sandbox_proxy.receipt_recorder import (
+    finalize_receipts,
+    pop_receipt_announcement,
+    receipt_worthy_actions,
+    record_pending_receipts,
+)
+from onyx.server.features.build.db.action_approval import insert_action_approval
+from onyx.server.features.build.db.receipt import get_session_receipts
+from onyx.server.features.build.session.api import list_receipts
+from shared_configs.contextvars import get_current_tenant_id
+from tests.external_dependency_unit.craft.db_helpers import (
+    force_receipt_created_at,
+    make_external_app,
+    make_skill,
+    make_user,
+)
+
+_WRITE = MatchedAction(
+    action_type="slack.messages.write",
+    display_name="Post a message",
+    description="Post a message.",
+    policy=EndpointPolicy.ASK,
+    effect=ActionEffect.WRITE,
+)
+_READ = MatchedAction(
+    action_type="slack.messages.read",
+    display_name="Read messages",
+    description="Read messages.",
+    policy=EndpointPolicy.ALWAYS,
+    effect=ActionEffect.READ,
+)
+
+
+def _matched(db_session: Session, *actions: MatchedAction) -> AllMatchedActions:
+    skill = make_skill(db_session)
+    app = make_external_app(db_session, skill=skill, auth_template={"kind": "none"})
+    db_session.commit()
+    return AllMatchedActions(
+        actions=tuple(actions),
+        target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=app.id, app_name="Slack"),
+    )
+
+
+def _record(
+    db_session: Session,
+    session: BuildSession,
+    *actions: MatchedAction,
+    approval_id: UUID | None = None,
+) -> list[UUID]:
+    return record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=_matched(db_session, *actions),
+        approval_id=approval_id,
+        cache_factory=lambda _tenant: get_cache_backend(),
+    )
+
+
+def test_write_actions_leave_pending_receipts(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+
+    receipt_ids = _record(db_session, session, _WRITE, _READ)
+
+    assert len(receipt_ids) == 1
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.action_type == "slack.messages.write"
+    assert row.effect == "write"
+    assert row.destination == "Slack"
+    assert row.status is ReceiptStatus.PENDING
+    assert row.gated_app_id is not None
+
+    packet = pop_receipt_announcement(
+        session.id, timeout_s=1, cache=get_cache_backend()
+    )
+    assert packet is not None
+    assert packet.status is ReceiptStatus.PENDING
+    assert (
+        pop_receipt_announcement(session.id, timeout_s=1, cache=get_cache_backend())
+        is None
+    )
+
+
+def test_auto_passing_reads_leave_nothing(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+
+    assert _record(db_session, session, _READ) == []
+    assert get_session_receipts(db_session, session_id=session.id) == []
+
+
+def test_approved_read_stays_visible(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    approval = insert_action_approval(
+        db_session,
+        session_id=session.id,
+        actions=[_READ.model_dump(mode="json")],
+        app_name="Slack",
+        payload={},
+    )
+
+    receipt_ids = _record(db_session, session, _READ, approval_id=approval.approval_id)
+
+    assert len(receipt_ids) == 1
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.effect == "read"
+    assert row.approval_id == approval.approval_id
+    assert receipt_worthy_actions(_matched(db_session, _READ), approval_id=None) == []
+
+
+def test_listing_is_owner_only_and_sweeps(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    receipt_ids = _record(db_session, session, _WRITE)
+    force_receipt_created_at(
+        db_session,
+        receipt_ids[0],
+        datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+
+    listed = list_receipts(session.id, user=test_user, db_session=db_session)
+    assert [r.status for r in listed] == [ReceiptStatus.UNKNOWN]
+
+    other = make_user(db_session, standard_account=True)
+    db_session.commit()
+    with pytest.raises(OnyxError):
+        list_receipts(session.id, user=other, db_session=db_session)
+
+
+def test_finalize_confirms(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    cache = get_cache_backend()
+    receipt_ids = _record(db_session, session, _WRITE)
+    pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
+
+    finalize_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        receipt_ids=receipt_ids,
+        status=ReceiptStatus.CONFIRMED,
+        cache_factory=lambda _tenant: cache,
+    )
+
+    db_session.expire_all()
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.status is ReceiptStatus.CONFIRMED
+    packet = pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
+    assert packet is not None and packet.status is ReceiptStatus.CONFIRMED
+
+
+def test_finalize_failed_verdicts_do_not_flip(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    cache = get_cache_backend()
+    receipt_ids = _record(db_session, session, _WRITE)
+    pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
+
+    finalize_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        receipt_ids=receipt_ids,
+        status=ReceiptStatus.FAILED,
+        cache_factory=lambda _tenant: cache,
+    )
+    # A late second verdict must not flip the recorded one.
+    finalize_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        receipt_ids=receipt_ids,
+        status=ReceiptStatus.CONFIRMED,
+        cache_factory=lambda _tenant: cache,
+    )
+
+    db_session.expire_all()
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.status is ReceiptStatus.FAILED
+    packet = pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
+    assert packet is not None and packet.status is ReceiptStatus.FAILED
+    assert pop_receipt_announcement(session.id, timeout_s=1, cache=cache) is None
+
+
+def test_multiple_writes_each_get_a_receipt(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    other_write = MatchedAction(
+        action_type="slack.files.write",
+        display_name="Upload files",
+        description="Upload a file.",
+        policy=EndpointPolicy.ASK,
+        effect=ActionEffect.WRITE,
+    )
+
+    receipt_ids = _record(db_session, session, _WRITE, other_write, _READ)
+
+    assert len(receipt_ids) == 2
+    rows = get_session_receipts(db_session, session_id=session.id)
+    assert {row.action_type for row in rows} == {
+        "slack.messages.write",
+        "slack.files.write",
+    }

--- a/backend/tests/unit/onyx/external_apps/test_action_effects.py
+++ b/backend/tests/unit/onyx/external_apps/test_action_effects.py
@@ -1,0 +1,68 @@
+"""Unit tests for catalog action effects.
+
+The effect kind decides which actions leave receipts, so the catalog
+declarations and the persisted-JSONB compatibility default are load-bearing.
+"""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+from onyx.db.enums import ActionEffect, ExternalAppType
+from onyx.external_apps.matching.engine import apply_credential_gate
+
+if TYPE_CHECKING:
+    from onyx.db.models import ExternalApp
+    from onyx.external_apps.matching.request import ProxiedRequest
+from onyx.external_apps.matching.engine import MatchedAction
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+
+
+def _effects(app_type: ExternalAppType) -> dict[str, ActionEffect]:
+    return {spec.id.value: spec.effect for spec in get_endpoint_catalog(app_type)}
+
+
+def test_slack_effects_follow_the_action_semantics() -> None:
+    effects = _effects(ExternalAppType.SLACK)
+    assert effects["slack.messages.write"] is ActionEffect.WRITE
+    assert effects["slack.files.write"] is ActionEffect.WRITE
+    assert effects["slack.dm.open"] is ActionEffect.WRITE
+    assert effects["slack.messages.read"] is ActionEffect.READ
+    assert effects["slack.search.read"] is ActionEffect.READ
+
+
+def test_every_catalog_declares_write_actions() -> None:
+    """Every resolvable catalog mixes reads and writes: an all-read or
+    all-write catalog is a sign a declaration sweep went wrong."""
+    for app_type in ExternalAppType:
+        if app_type is ExternalAppType.CUSTOM:
+            continue  # the one type without a code-owned catalog
+        effects = {spec.effect for spec in get_endpoint_catalog(app_type)}
+        assert effects == {ActionEffect.READ, ActionEffect.WRITE}, app_type
+
+
+def test_whole_domain_fallback_counts_as_write() -> None:
+    """An unmatched request under a connected app's domain has an unknown
+    effect, so it must record as a write, never slip through as a read."""
+    request = SimpleNamespace(method="POST", path="/anything")
+    app = SimpleNamespace(app_type=ExternalAppType.CUSTOM, name="Custom", id=1)
+    matched = apply_credential_gate(
+        cast("ExternalApp", app),
+        cast("ProxiedRequest", request),
+        None,
+        is_available=True,
+    )
+    assert matched is not None
+    assert matched.governing_action.effect is ActionEffect.WRITE
+
+
+def test_matched_action_defaults_read_for_persisted_rows() -> None:
+    """Approval rows persisted before effects existed parse without the field."""
+    parsed = MatchedAction.model_validate(
+        {
+            "action_type": "slack.messages.write",
+            "display_name": "Post a message",
+            "description": "Post a message.",
+            "policy": "ASK",
+        }
+    )
+    assert parsed.effect is ActionEffect.READ

--- a/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
@@ -195,3 +195,74 @@ def test_hooks_ignore_unrecorded_flows(
     asyncio.run(addon.error(tflow.tflow()))
 
     assert calls == []
+
+
+def test_always_policy_writes_still_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    addon = _addon()
+    recorded: list[Any] = []
+
+    async def _fake_record(*args: Any, **kwargs: Any) -> None:
+        recorded.append((args, kwargs))
+
+    session_id = uuid4()
+    monkeypatch.setattr(addon, "_record_receipts", _fake_record)
+    monkeypatch.setattr(
+        addon, "_resolve_gated_session", lambda _flow, _sandbox: session_id
+    )
+    flow = tflow.tflow()
+    sandbox = _ctx().without_session()
+
+    asyncio.run(addon._record_always_write_receipts(flow, sandbox, _MATCHED))
+
+    assert len(recorded) == 1
+    ctx = recorded[0][0][1]
+    assert ctx.session_id == session_id
+
+
+def test_always_policy_reads_skip_session_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    addon = _addon()
+
+    def _must_not_resolve(_flow: Any, _sandbox: Any) -> None:
+        raise AssertionError("reads must not pay session resolution")
+
+    monkeypatch.setattr(addon, "_resolve_gated_session", _must_not_resolve)
+    read_only = AllMatchedActions(
+        actions=(
+            MatchedAction(
+                action_type="slack.messages.read",
+                display_name="Read messages",
+                description="Read messages.",
+                policy=EndpointPolicy.ALWAYS,
+                effect=ActionEffect.READ,
+            ),
+        ),
+        target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=1, app_name="Slack"),
+    )
+
+    asyncio.run(
+        addon._record_always_write_receipts(
+            tflow.tflow(), _ctx().without_session(), read_only
+        )
+    )
+
+
+def test_always_policy_unattributable_write_goes_unrecorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    addon = _addon()
+
+    async def _must_not_record(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("unattributable writes record nothing")
+
+    monkeypatch.setattr(addon, "_record_receipts", _must_not_record)
+    monkeypatch.setattr(addon, "_resolve_gated_session", lambda _flow, _sandbox: None)
+
+    asyncio.run(
+        addon._record_always_write_receipts(
+            tflow.tflow(), _ctx().without_session(), _MATCHED
+        )
+    )

--- a/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
@@ -1,0 +1,197 @@
+"""Unit tests for the gate's receipt wiring.
+
+The recorder itself is covered against Postgres elsewhere; here the risk is
+the mitmproxy plumbing: the metadata carrier surviving flow copies, the
+response and error hooks mapping transport outcomes to verdicts, and record
+failures never blocking the request. The recorder functions are patched with
+capturing fakes so no service is touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import pytest
+from mitmproxy.test import tflow
+
+from onyx.db.enums import ActionEffect, EndpointPolicy, GatedAppKind, ReceiptStatus
+from onyx.external_apps.matching.engine import (
+    AllMatchedActions,
+    GatedTarget,
+    MatchedAction,
+)
+from onyx.sandbox_proxy.addons import gate as gate_module
+from onyx.sandbox_proxy.addons.gate import (
+    RECEIPT_FLOW_KEY,
+    GateAddon,
+    _IdentityResolver,
+)
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
+from onyx.sandbox_proxy.identity import SessionContext
+from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
+
+_MATCHED = AllMatchedActions(
+    actions=(
+        MatchedAction(
+            action_type="slack.messages.write",
+            display_name="Post a message",
+            description="Post a message.",
+            policy=EndpointPolicy.ASK,
+            effect=ActionEffect.WRITE,
+        ),
+    ),
+    target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=1, app_name="Slack"),
+)
+
+
+def _unused_factory(_tenant_id: str) -> Any:
+    raise AssertionError("cache factory must not be consulted, recorder is patched")
+
+
+def _addon() -> GateAddon:
+    return GateAddon(
+        # The hooks under test never resolve identities or evaluate requests.
+        identity=cast("_IdentityResolver", None),
+        request_evaluator=cast("RequestEvaluator", None),
+        cache_factory=_unused_factory,
+        proxy_instance_id="proxy-test",
+        credential_dispatcher=CredentialInjectionDispatcher([]),
+    )
+
+
+def _ctx() -> SessionContext:
+    return SessionContext(
+        session_id=uuid4(),
+        user_id=uuid4(),
+        sandbox_id=uuid4(),
+        tenant_id="public",
+        sandbox_name="sandbox-test",
+        sandbox_ip="10.0.0.1",
+    )
+
+
+def test_record_stashes_a_serializable_carrier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_id = uuid4()
+    calls: list[dict[str, Any]] = []
+
+    def _fake_record(**kwargs: Any) -> list[UUID]:
+        calls.append(kwargs)
+        return [receipt_id]
+
+    monkeypatch.setattr(gate_module, "record_pending_receipts", _fake_record)
+    addon = _addon()
+    flow = tflow.tflow()
+    ctx = _ctx()
+
+    asyncio.run(addon._record_receipts(flow, ctx, _MATCHED, approval_id=None))
+
+    carrier = flow.metadata[RECEIPT_FLOW_KEY]
+    assert carrier == {
+        "tenant_id": "public",
+        "session_id": str(ctx.session_id),
+        "receipt_ids": [str(receipt_id)],
+    }
+    # mitmproxy deep-copies and serializes metadata, so primitives only.
+    assert copy.deepcopy(carrier) == carrier
+    assert calls[0]["approval_id"] is None
+
+
+def test_record_failure_never_blocks_the_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(**_kwargs: Any) -> list[UUID]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(gate_module, "record_pending_receipts", _boom)
+    addon = _addon()
+    flow = tflow.tflow()
+
+    asyncio.run(addon._record_receipts(flow, _ctx(), _MATCHED, approval_id=None))
+
+    assert RECEIPT_FLOW_KEY not in flow.metadata
+    assert flow.response is None
+
+
+def _finalize_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_finalize(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(gate_module, "finalize_receipts", _fake_finalize)
+    return calls
+
+
+def _recorded_flow(status_code: int | None) -> Any:
+    flow = tflow.tflow(resp=status_code is not None)
+    if status_code is not None:
+        assert flow.response is not None
+        flow.response.status_code = status_code
+    flow.metadata[RECEIPT_FLOW_KEY] = {
+        "tenant_id": "public",
+        "session_id": str(uuid4()),
+        "receipt_ids": [str(uuid4())],
+    }
+    return flow
+
+
+@pytest.mark.parametrize(
+    "status_code,expected",
+    [
+        (200, ReceiptStatus.CONFIRMED),
+        (302, ReceiptStatus.CONFIRMED),
+        (403, ReceiptStatus.FAILED),
+        (500, ReceiptStatus.FAILED),
+    ],
+)
+def test_response_hook_maps_status_to_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+    expected: ReceiptStatus,
+) -> None:
+    calls = _finalize_capture(monkeypatch)
+    addon = _addon()
+    flow = _recorded_flow(status_code)
+
+    asyncio.run(addon.response(flow))
+
+    assert calls[0]["status"] is expected
+    # The carrier is consumed, a later hook cannot double-finalize.
+    assert RECEIPT_FLOW_KEY not in flow.metadata
+    asyncio.run(addon.response(flow))
+    assert len(calls) == 1
+
+
+def test_error_after_ok_headers_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _finalize_capture(monkeypatch)
+    addon = _addon()
+
+    # Headers said 200, the body never finished: the origin may have
+    # committed, so the verdict is UNKNOWN.
+    asyncio.run(addon.error(_recorded_flow(200)))
+    assert calls[0]["status"] is ReceiptStatus.UNKNOWN
+
+    # No response at all: the request never got a verdict, FAILED.
+    asyncio.run(addon.error(_recorded_flow(None)))
+    assert calls[1]["status"] is ReceiptStatus.FAILED
+
+
+def test_hooks_ignore_unrecorded_flows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _finalize_capture(monkeypatch)
+    addon = _addon()
+
+    asyncio.run(addon.response(tflow.tflow(resp=True)))
+    asyncio.run(addon.error(tflow.tflow()))
+
+    assert calls == []


### PR DESCRIPTION
## Description

**Why.** When Craft posts a deck to Slack or sends a Gmail draft, the run ends with no evidence in the UI — the side effects class is the least served output type. The receipt schema landed in #14319; this PR makes the proxy write it, since the proxy is the one place every external action already flows through.

**What.**
- Effect kinds are declared per action in the provider catalogs (44 writes across 8 providers, reads stay the default). The whole-domain fallback and MCP tools count as writes, since their effect is unknowable or admin-set.
- The gate records PENDING receipts immediately before an approved request leaves for the origin — write-effect actions always, approved reads too — and finalizes from the response and error hooks: non-error status CONFIRMED, error FAILED, error after non-error headers UNKNOWN (the origin may have committed, and a false FAILED is the dangerous direction for a proof-of-side-effect feature).
- Recording is best-effort and can never block the request, and announce trouble can only cost the announce, never the row. Orphaned PENDING rows sweep to UNKNOWN on read, session-scoped.
- Transitions announce over Redis into the live SSE merge as a `receipt` packet (clients ignore unknown types). Owner-only listing endpoint — receipts stay off shared views since destinations can leak.
- Known deferral: multi-request provider flows (the Slack three-request upload) each leave a receipt until the extractor PR (#7 in the series) derives operation keys — the coalescing DAL from #14319 is ready for it. Same PR refines provider-level verdicts (Slack's 200-with-ok:false) and deep links.

## How Has This Been Tested?

- Proxy wiring unit tests (`test_gate_receipts.py`, patched recorder, real mitmproxy flows): the metadata carrier survives deep-copy/serialization, record failures never block the request, status→verdict mapping including 302, the consumed carrier prevents double-finalize, error-after-2xx-headers records UNKNOWN, unrecorded flows are ignored.
- Recorder external-dependency tests (`test_receipt_recording.py`, real Postgres + Redis): write actions leave PENDING rows with gated-app attribution, auto-passing reads leave nothing, an approved read records through a real ActionApproval row, finalize confirms/fails with no verdict flips and no losing-verdict announce, per-write receipts for multi-action requests, announce FIFO round-trip, and the listing route (owner-only 404, stale PENDING swept to UNKNOWN on read).
- Catalog unit tests (`test_action_effects.py`): Slack spot checks, every resolvable catalog mixes reads and writes, persisted-JSONB rows without the field still parse, the whole-domain fallback pins WRITE.
- Full craft external-dependency suite (373) and the craft/proxy/external-apps unit suites (979+) green; `ty check` passes project-wide.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check