### PR TITLE
fix(perm-sync): release the DB session before the connector crawl

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -496,6 +496,8 @@ def connector_permission_sync_generator_task(
 
     sync_start = time.monotonic()
     connector_type: str = "unknown"
+    tasks_generated = 0
+    docs_with_errors = 0
     try:
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair_from_id(
@@ -568,82 +570,85 @@ def connector_permission_sync_generator_task(
                 redis_connector, lock, r, timeout_seconds=JOB_TIMEOUT
             )
 
-            # pass in the capability to fetch all existing docs for the cc_pair
-            # this is can be used to determine documents that are "missing" and thus
-            # should no longer be accessible. The decision as to whether we should find
-            # every document during the doc sync process is connector-specific.
-            def fetch_all_existing_docs_fn(
-                sort_order: SortOrder | None = None,
-            ) -> list[DocumentRow]:
+        # The crawl runs for hours issuing no queries. A session held across it pins
+        # one pooled connection until PgBouncer drops it at client_idle_timeout.
+
+        # cc_pair is detached here: read only eager-loaded connector/credential columns.
+
+        # lets each connector decide which existing docs are now missing and should
+        # lose access
+        def fetch_all_existing_docs_fn(
+            sort_order: SortOrder | None = None,
+        ) -> list[DocumentRow]:
+            with get_session_with_current_tenant() as fetch_session:
                 result = get_documents_for_connector_credential_pair_limited_columns(
-                    db_session=db_session,
+                    db_session=fetch_session,
                     connector_id=cc_pair.connector.id,
                     credential_id=cc_pair.credential.id,
                     sort_order=sort_order,
                 )
                 return list(result)
 
-            def fetch_all_existing_docs_ids_fn() -> list[str]:
-                result = get_document_ids_for_connector_credential_pair(
-                    db_session=db_session,
+        def fetch_all_existing_docs_ids_fn() -> list[str]:
+            with get_session_with_current_tenant() as fetch_session:
+                return get_document_ids_for_connector_credential_pair(
+                    db_session=fetch_session,
                     connector_id=cc_pair.connector.id,
                     credential_id=cc_pair.credential.id,
                 )
-                return result
 
-            doc_sync_func = sync_config.doc_sync_config.doc_sync_func
-            document_external_accesses = doc_sync_func(
-                cc_pair,
-                fetch_all_existing_docs_fn,
-                fetch_all_existing_docs_ids_fn,
-                callback,
-            )
+        doc_sync_func = sync_config.doc_sync_config.doc_sync_func
+        document_external_accesses = doc_sync_func(
+            cc_pair,
+            fetch_all_existing_docs_fn,
+            fetch_all_existing_docs_ids_fn,
+            callback,
+        )
 
-            task_logger.info(
-                f"RedisConnector.permissions.generate_tasks starting. cc_pair={cc_pair_id}"
-            )
+        task_logger.info(
+            f"RedisConnector.permissions.generate_tasks starting. cc_pair={cc_pair_id}"
+        )
 
-            tasks_generated = 0
-            docs_with_errors = 0
-            for doc_external_access in document_external_accesses:
-                if callback.should_stop():
-                    raise RuntimeError(
-                        f"Permission sync task timed out or stop signal detected: "
-                        f"cc_pair={cc_pair_id} "
-                        f"tasks_generated={tasks_generated}"
-                    )
-
-                result = redis_connector.permissions.update_db(
-                    lock=lock,
-                    new_permissions=[doc_external_access],
-                    source_string=connector_type,
-                    connector_id=cc_pair.connector.id,
-                    credential_id=cc_pair.credential.id,
-                    task_logger=task_logger,
+        for doc_external_access in document_external_accesses:
+            if callback.should_stop():
+                raise RuntimeError(
+                    f"Permission sync task timed out or stop signal detected: "
+                    f"cc_pair={cc_pair_id} "
+                    f"tasks_generated={tasks_generated}"
                 )
-                tasks_generated += result.num_updated
-                docs_with_errors += result.num_errors
 
-            task_logger.info(
-                f"RedisConnector.permissions.generate_tasks finished. "
-                f"cc_pair={cc_pair_id} tasks_generated={tasks_generated} docs_with_errors={docs_with_errors}"
+            result = redis_connector.permissions.update_db(
+                lock=lock,
+                new_permissions=[doc_external_access],
+                source_string=connector_type,
+                connector_id=cc_pair.connector.id,
+                credential_id=cc_pair.credential.id,
+                task_logger=task_logger,
             )
+            tasks_generated += result.num_updated
+            docs_with_errors += result.num_errors
 
-            inc_doc_perm_sync_docs_processed(connector_type, tasks_generated)
-            if docs_with_errors > 0:
-                inc_doc_perm_sync_errors(connector_type, docs_with_errors)
+        task_logger.info(
+            f"RedisConnector.permissions.generate_tasks finished. "
+            f"cc_pair={cc_pair_id} tasks_generated={tasks_generated} docs_with_errors={docs_with_errors}"
+        )
 
+        inc_doc_perm_sync_docs_processed(connector_type, tasks_generated)
+        if docs_with_errors > 0:
+            inc_doc_perm_sync_errors(connector_type, docs_with_errors)
+
+        with get_session_with_current_tenant() as db_session:
             complete_doc_permission_sync_attempt(
                 db_session=db_session,
                 attempt_id=attempt_id,
                 total_docs_synced=tasks_generated,
                 docs_with_permission_errors=docs_with_errors,
             )
-            task_logger.info(
-                f"Completed doc permission sync attempt {attempt_id}: {tasks_generated} docs, {docs_with_errors} errors"
-            )
+        task_logger.info(
+            f"Completed doc permission sync attempt {attempt_id}: {tasks_generated} docs, {docs_with_errors} errors"
+        )
 
-            redis_connector.permissions.generator_complete = tasks_generated
+        redis_connector.permissions.generator_complete = tasks_generated
 
     except Exception as e:
         error_msg = format_error_for_logging(e)
@@ -662,6 +667,8 @@ def connector_permission_sync_generator_task(
                 db_session,
                 error_message=error_msg,
                 full_exception_trace=full_exception_trace,
+                total_docs_synced=tasks_generated,
+                docs_with_permission_errors=docs_with_errors,
             )
 
         redis_connector.permissions.generator_clear()

--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -141,11 +141,22 @@ def _get_fence_validation_block_expiration() -> int:
 """Jobs / utils for kicking off doc permissions sync tasks."""
 
 
-def _fail_doc_permission_sync_attempt(attempt_id: int, error_msg: str) -> None:
+def _fail_doc_permission_sync_attempt(
+    attempt_id: int,
+    error_msg: str,
+    full_exception_trace: str | None = None,
+    total_docs_synced: int = 0,
+    docs_with_permission_errors: int = 0,
+) -> None:
     """Helper to mark a doc permission sync attempt as failed with an error message."""
     with get_session_with_current_tenant() as db_session:
         mark_doc_permission_sync_attempt_failed(
-            attempt_id, db_session, error_message=error_msg
+            attempt_id,
+            db_session,
+            error_message=error_msg,
+            full_exception_trace=full_exception_trace,
+            total_docs_synced=total_docs_synced,
+            docs_with_permission_errors=docs_with_permission_errors,
         )
 
 
@@ -499,6 +510,9 @@ def connector_permission_sync_generator_task(
     tasks_generated = 0
     docs_with_errors = 0
     try:
+        # Scoped to setup, never across the crawl below: on multi-tenant this session
+        # is bound to one checked-out Connection, which PgBouncer closes once the gaps
+        # between its queries pass client_idle_timeout.
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair_from_id(
                 db_session=db_session,
@@ -570,10 +584,8 @@ def connector_permission_sync_generator_task(
                 redis_connector, lock, r, timeout_seconds=JOB_TIMEOUT
             )
 
-        # The crawl runs for hours issuing no queries. A session held across it pins
-        # one pooled connection until PgBouncer drops it at client_idle_timeout.
-
-        # cc_pair is detached here: read only eager-loaded connector/credential columns.
+            connector_id = cc_pair.connector.id
+            credential_id = cc_pair.credential.id
 
         # lets each connector decide which existing docs are now missing and should
         # lose access
@@ -581,22 +593,25 @@ def connector_permission_sync_generator_task(
             sort_order: SortOrder | None = None,
         ) -> list[DocumentRow]:
             with get_session_with_current_tenant() as fetch_session:
-                result = get_documents_for_connector_credential_pair_limited_columns(
-                    db_session=fetch_session,
-                    connector_id=cc_pair.connector.id,
-                    credential_id=cc_pair.credential.id,
-                    sort_order=sort_order,
+                return list(
+                    get_documents_for_connector_credential_pair_limited_columns(
+                        db_session=fetch_session,
+                        connector_id=connector_id,
+                        credential_id=credential_id,
+                        sort_order=sort_order,
+                    )
                 )
-                return list(result)
 
         def fetch_all_existing_docs_ids_fn() -> list[str]:
             with get_session_with_current_tenant() as fetch_session:
                 return get_document_ids_for_connector_credential_pair(
                     db_session=fetch_session,
-                    connector_id=cc_pair.connector.id,
-                    credential_id=cc_pair.credential.id,
+                    connector_id=connector_id,
+                    credential_id=credential_id,
                 )
 
+        # cc_pair is detached: connectors may read eager-loaded connector/credential
+        # columns off it, never a lazy relationship.
         doc_sync_func = sync_config.doc_sync_config.doc_sync_func
         document_external_accesses = doc_sync_func(
             cc_pair,
@@ -621,8 +636,8 @@ def connector_permission_sync_generator_task(
                 lock=lock,
                 new_permissions=[doc_external_access],
                 source_string=connector_type,
-                connector_id=cc_pair.connector.id,
-                credential_id=cc_pair.credential.id,
+                connector_id=connector_id,
+                credential_id=credential_id,
                 task_logger=task_logger,
             )
             tasks_generated += result.num_updated
@@ -661,15 +676,13 @@ def connector_permission_sync_generator_task(
             f"Permission sync exceptioned: cc_pair={cc_pair_id} payload_id={payload_id}"
         )
 
-        with get_session_with_current_tenant() as db_session:
-            mark_doc_permission_sync_attempt_failed(
-                attempt_id,
-                db_session,
-                error_message=error_msg,
-                full_exception_trace=full_exception_trace,
-                total_docs_synced=tasks_generated,
-                docs_with_permission_errors=docs_with_errors,
-            )
+        _fail_doc_permission_sync_attempt(
+            attempt_id,
+            error_msg,
+            full_exception_trace=full_exception_trace,
+            total_docs_synced=tasks_generated,
+            docs_with_permission_errors=docs_with_errors,
+        )
 
         redis_connector.permissions.generator_clear()
         redis_connector.permissions.taskset_clear()

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -160,9 +160,10 @@ def mark_doc_permission_sync_attempt_failed(
     ``traceback.format_exc()`` so the full stack is persisted alongside
     the short ``error_message``.
 
-    The progress counters default to 0 for call sites that fail before any
-    document is processed. A sync that fails partway through keeps the work
-    it already committed, so those callers pass the counts they reached.
+    A sync that fails partway through keeps the work it already committed, so
+    callers pass the counts they reached. These assign rather than accumulate:
+    a failure raised after ``complete_doc_permission_sync_attempt`` has already
+    committed would otherwise count the same documents twice.
     """
     try:
         attempt = db_session.execute(
@@ -177,10 +178,8 @@ def mark_doc_permission_sync_attempt_failed(
         attempt.time_finished = func.now()
         attempt.error_message = error_message
         attempt.full_exception_trace = full_exception_trace
-        attempt.total_docs_synced = (attempt.total_docs_synced or 0) + total_docs_synced
-        attempt.docs_with_permission_errors = (
-            attempt.docs_with_permission_errors or 0
-        ) + docs_with_permission_errors
+        attempt.total_docs_synced = total_docs_synced
+        attempt.docs_with_permission_errors = docs_with_permission_errors
         db_session.commit()
 
         # Add telemetry for permission sync attempt status change

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -148,6 +148,8 @@ def mark_doc_permission_sync_attempt_failed(
     db_session: Session,
     error_message: str,
     full_exception_trace: str | None = None,
+    total_docs_synced: int = 0,
+    docs_with_permission_errors: int = 0,
 ) -> None:
     """Mark a doc permission sync attempt as failed.
 
@@ -157,6 +159,10 @@ def mark_doc_permission_sync_attempt_failed(
     originates from an ``except`` block, callers should pass
     ``traceback.format_exc()`` so the full stack is persisted alongside
     the short ``error_message``.
+
+    The progress counters default to 0 for call sites that fail before any
+    document is processed. A sync that fails partway through keeps the work
+    it already committed, so those callers pass the counts they reached.
     """
     try:
         attempt = db_session.execute(
@@ -171,6 +177,10 @@ def mark_doc_permission_sync_attempt_failed(
         attempt.time_finished = func.now()
         attempt.error_message = error_message
         attempt.full_exception_trace = full_exception_trace
+        attempt.total_docs_synced = (attempt.total_docs_synced or 0) + total_docs_synced
+        attempt.docs_with_permission_errors = (
+            attempt.docs_with_permission_errors or 0
+        ) + docs_with_permission_errors
         db_session.commit()
 
         # Add telemetry for permission sync attempt status change

--- a/backend/tests/external_dependency_unit/permission_sync/conftest.py
+++ b/backend/tests/external_dependency_unit/permission_sync/conftest.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType, ConnectorCredentialPairStatus
+from onyx.db.models import Connector, ConnectorCredentialPair, Credential
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def create_test_connector_credential_pair(
+    db_session: Session,
+    source: DocumentSource = DocumentSource.GOOGLE_DRIVE,
+    access_type: AccessType = AccessType.PUBLIC,
+) -> ConnectorCredentialPair:
+    """Create a test connector credential pair for testing.
+
+    Names carry a random suffix so repeated runs against the same scratch
+    database do not collide.
+    """
+    suffix = uuid4().hex[:8]
+    user = create_test_user(db_session, f"perm_sync_{suffix}")
+
+    connector = Connector(
+        name=f"Test {source.value} Connector {suffix}",
+        source=source,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=datetime.now(timezone.utc),
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        credential_json={},
+        user_id=user.id,
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.flush()
+    # Expire the credential so it reloads from DB with SensitiveValue wrapper
+    db_session.expire(credential)
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"Test CC Pair {suffix}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=access_type,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+
+    return cc_pair

--- a/backend/tests/external_dependency_unit/permission_sync/test_doc_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_doc_permission_sync_attempt.py
@@ -5,19 +5,13 @@ Tests the basic CRUD operations for document permission sync attempts,
 including creation, status updates, progress tracking, and querying.
 """
 
-from datetime import datetime, timezone
-
 import pytest
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.models import InputType
 from onyx.db.enums import (
-    AccessType,
-    ConnectorCredentialPairStatus,
     PermissionSyncStatus,
 )
-from onyx.db.models import Connector, ConnectorCredentialPair, Credential
 from onyx.db.permission_sync_attempt import (
     complete_doc_permission_sync_attempt,
     create_doc_permission_sync_attempt,
@@ -26,54 +20,15 @@ from onyx.db.permission_sync_attempt import (
     mark_doc_permission_sync_attempt_failed,
     mark_doc_permission_sync_attempt_in_progress,
 )
-from tests.external_dependency_unit.conftest import create_test_user
-
-
-def _create_test_connector_credential_pair(
-    db_session: Session, source: DocumentSource = DocumentSource.GOOGLE_DRIVE
-) -> ConnectorCredentialPair:
-    """Create a test connector credential pair for testing."""
-    user = create_test_user(db_session, "test_user")
-
-    connector = Connector(
-        name=f"Test {source.value} Connector",
-        source=source,
-        input_type=InputType.LOAD_STATE,
-        connector_specific_config={},
-        refresh_freq=None,
-        prune_freq=None,
-        indexing_start=datetime.now(timezone.utc),
-    )
-    db_session.add(connector)
-    db_session.flush()
-
-    credential = Credential(
-        credential_json={},
-        user_id=user.id,
-        admin_public=True,
-    )
-    db_session.add(credential)
-    db_session.flush()
-    # Expire the credential so it reloads from DB with SensitiveValue wrapper
-    db_session.expire(credential)
-
-    cc_pair = ConnectorCredentialPair(
-        connector_id=connector.id,
-        credential_id=credential.id,
-        name="Test CC Pair",
-        status=ConnectorCredentialPairStatus.ACTIVE,
-        access_type=AccessType.PUBLIC,
-    )
-    db_session.add(cc_pair)
-    db_session.commit()
-
-    return cc_pair
+from tests.external_dependency_unit.permission_sync.conftest import (
+    create_test_connector_credential_pair,
+)
 
 
 class TestDocPermissionSyncAttempt:
     def test_create_doc_permission_sync_attempt(self, db_session: Session) -> None:
         """Test creating a new doc permission sync attempt."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
 
         attempt_id = create_doc_permission_sync_attempt(
             connector_credential_pair_id=cc_pair.id,
@@ -96,7 +51,7 @@ class TestDocPermissionSyncAttempt:
 
     def test_get_doc_permission_sync_attempt(self, db_session: Session) -> None:
         """Test retrieving a doc permission sync attempt by ID."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Test basic retrieval
@@ -120,7 +75,7 @@ class TestDocPermissionSyncAttempt:
         self, db_session: Session
     ) -> None:
         """Test marking a doc permission sync attempt as in progress."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Mark as in progress
@@ -138,7 +93,7 @@ class TestDocPermissionSyncAttempt:
 
     def test_mark_doc_permission_sync_attempt_failed(self, db_session: Session) -> None:
         """Test marking a doc permission sync attempt as failed."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Mark as failed with error message (should work even without starting)
@@ -166,7 +121,7 @@ class TestDocPermissionSyncAttempt:
         through the failure helper so the connector-detail UI can
         surface the full Python stack instead of just a single-line
         summary."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         error_msg = "Sync process crashed unexpectedly"
@@ -189,11 +144,41 @@ class TestDocPermissionSyncAttempt:
         assert attempt.error_message == error_msg
         assert attempt.full_exception_trace == full_trace
 
+    def test_mark_doc_permission_sync_attempt_failed_assigns_progress(
+        self, db_session: Session
+    ) -> None:
+        """Progress counters assign rather than accumulate, so a failure raised
+        after ``complete_doc_permission_sync_attempt`` already committed (e.g. the
+        Redis write that follows it) cannot count the same documents twice."""
+        cc_pair = create_test_connector_credential_pair(db_session)
+        attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
+        mark_doc_permission_sync_attempt_in_progress(attempt_id, db_session)
+        complete_doc_permission_sync_attempt(
+            db_session=db_session,
+            attempt_id=attempt_id,
+            total_docs_synced=5,
+            docs_with_permission_errors=1,
+        )
+
+        mark_doc_permission_sync_attempt_failed(
+            attempt_id,
+            db_session,
+            error_message="fence write failed after completion",
+            total_docs_synced=5,
+            docs_with_permission_errors=1,
+        )
+
+        attempt = get_doc_permission_sync_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == PermissionSyncStatus.FAILED
+        assert attempt.total_docs_synced == 5
+        assert attempt.docs_with_permission_errors == 1
+
     def test_get_recent_doc_permission_sync_attempts_for_cc_pair(
         self, db_session: Session
     ) -> None:
         """Test retrieving recent doc permission sync attempts for a connector credential pair."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
 
         # Create multiple attempts
         attempt_ids = []
@@ -221,7 +206,7 @@ class TestDocPermissionSyncAttempt:
             assert attempt.connector_credential_pair_id == cc_pair.id
 
         # Test with different cc_pair (should return empty)
-        other_cc_pair = _create_test_connector_credential_pair(
+        other_cc_pair = create_test_connector_credential_pair(
             db_session, source=DocumentSource.SLACK
         )
         other_attempts = get_recent_doc_permission_sync_attempts_for_cc_pair(
@@ -233,7 +218,7 @@ class TestDocPermissionSyncAttempt:
 
     def test_status_enum_methods(self, db_session: Session) -> None:
         """Test the status enum helper methods."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Test NOT_STARTED status
@@ -291,7 +276,7 @@ class TestDocPermissionSyncAttempt:
         self, db_session: Session
     ) -> None:
         """Test completing a doc permission sync attempt without errors."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Mark as in progress first
@@ -314,7 +299,7 @@ class TestDocPermissionSyncAttempt:
         self, db_session: Session
     ) -> None:
         """Test completing a doc permission sync attempt with errors."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Mark as in progress first
@@ -337,7 +322,7 @@ class TestDocPermissionSyncAttempt:
         self, db_session: Session
     ) -> None:
         """Test that complete can be called multiple times if needed (accumulates correctly)."""
-        cc_pair = _create_test_connector_credential_pair(db_session)
+        cc_pair = create_test_connector_credential_pair(db_session)
         attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
 
         # Mark as in progress

--- a/backend/tests/external_dependency_unit/permission_sync/test_perm_sync_no_pg_conn_during_crawl.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_perm_sync_no_pg_conn_during_crawl.py
@@ -1,0 +1,227 @@
+"""
+Regression coverage for connector_permission_sync_generator_task pinning a
+Postgres connection across the connector crawl.
+
+The task used to open one session before the crawl and hold it until the crawl
+finished. On multi-tenant deployments get_session_with_tenant binds a session to
+an explicitly checked-out Connection (for schema translation), so that one
+connection sat idle, issuing no queries, for the whole crawl. PgBouncer drops
+idle clients at client_idle_timeout, so the first query after a long crawl hit a
+dead connection and failed with "server closed the connection unexpectedly".
+pool_pre_ping and pool_recycle cannot help because there is only ever one
+checkout. The task now closes the setup session before the crawl and opens a
+fresh session for each DB access after it.
+
+MULTI_TENANT is patched on because the single-tenant branch binds to the engine
+instead, which returns the connection to the pool at commit and so never
+reproduces the pin.
+"""
+
+from collections.abc import Generator
+from datetime import datetime, timezone
+from typing import cast
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import QueuePool
+
+from ee.onyx.background.celery.tasks.doc_permission_syncing import tasks as perm_tasks
+from ee.onyx.external_permissions.perm_sync_types import (
+    DocSyncFuncType,
+    FetchAllDocumentsFunction,
+    FetchAllDocumentsIdsFunction,
+)
+from ee.onyx.external_permissions.sync_params import DocSyncConfig, SyncConfig
+from onyx.access.models import (
+    DocExternalAccess,
+    ElementExternalAccess,
+    ExternalAccess,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import (
+    AccessType,
+    ConnectorCredentialPairStatus,
+    PermissionSyncStatus,
+)
+from onyx.db.models import Connector, ConnectorCredentialPair, Credential
+from onyx.db.permission_sync_attempt import (
+    delete_doc_permission_sync_attempts__no_commit,
+    get_latest_doc_permission_sync_attempt_for_cc_pair,
+)
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.redis.redis_connector import RedisConnector
+from onyx.redis.redis_connector_doc_perm_sync import (
+    PermissionSyncResult,
+    RedisConnectorPermissionSync,
+    RedisConnectorPermissionSyncPayload,
+)
+from shared_configs.configs import (
+    POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE as TEST_TENANT_ID,
+)
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@pytest.fixture
+def synced_cc_pair(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> Generator[ConnectorCredentialPair, None, None]:
+    """A permission-synced cc_pair with a fence ready for the generator task."""
+    suffix = uuid4().hex[:8]
+    user = create_test_user(db_session, f"perm_sync_crawl_{suffix}")
+
+    connector = Connector(
+        name=f"Perm Sync Crawl Connector {suffix}",
+        source=DocumentSource.JIRA,
+        input_type=InputType.POLL,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=datetime.now(timezone.utc),
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(credential_json={}, user_id=user.id, admin_public=True)
+    db_session.add(credential)
+    db_session.flush()
+
+    cc_pair = ConnectorCredentialPair(
+        name=f"Perm Sync Crawl CC Pair {suffix}",
+        connector_id=connector.id,
+        credential_id=credential.id,
+        access_type=AccessType.SYNC,
+        status=ConnectorCredentialPairStatus.ACTIVE,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+
+    redis_connector = RedisConnector(TEST_TENANT_ID, cc_pair.id)
+    redis_connector.permissions.set_fence(
+        RedisConnectorPermissionSyncPayload(
+            id=f"payload-{suffix}",
+            submitted=datetime.now(timezone.utc),
+            started=None,
+            celery_task_id=f"task-{suffix}",
+        )
+    )
+
+    try:
+        yield cc_pair
+    finally:
+        redis_connector.permissions.set_fence(None)
+        db_session.rollback()
+        delete_doc_permission_sync_attempts__no_commit(db_session, cc_pair.id)
+        db_session.delete(cc_pair)
+        db_session.commit()
+
+
+def _run_perm_sync(cc_pair_id: int) -> None:
+    perm_tasks.connector_permission_sync_generator_task.apply(
+        args=(cc_pair_id,), kwargs={"tenant_id": TEST_TENANT_ID}
+    ).get()
+
+
+def _sync_config(doc_sync_func: DocSyncFuncType) -> SyncConfig:
+    return SyncConfig(
+        doc_sync_config=DocSyncConfig(
+            doc_sync_frequency=1,
+            doc_sync_func=doc_sync_func,
+            initial_index_should_sync=False,
+        )
+    )
+
+
+def test_no_db_connection_held_during_crawl(
+    synced_cc_pair: ConnectorCredentialPair, db_session: Session
+) -> None:
+    """The connector crawl must run with no connection checked out by the task,
+    and the post-crawl doc-id query must still succeed on a fresh session."""
+    pool = cast(QueuePool, SqlEngine.get_engine().pool)
+    checked_out_during_crawl: list[int] = []
+    fetched_existing_ids: list[list[str]] = []
+    baseline = pool.checkedout()
+
+    def _fake_doc_sync(
+        cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+        fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
+        fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
+        callback: IndexingHeartbeatInterface | None,  # noqa: ARG001
+    ) -> Generator[ElementExternalAccess, None, None]:
+        # stands in for the source crawl: the long stretch where the task makes
+        # no DB queries at all
+        checked_out_during_crawl.append(pool.checkedout() - baseline)
+        # the query that used to land on a connection PgBouncer had already killed
+        fetched_existing_ids.append(fetch_all_existing_docs_ids_fn())
+        return
+        yield  # noqa: unreachable - makes this a generator
+
+    with (
+        patch("onyx.db.engine.sql_engine.MULTI_TENANT", True),
+        patch.object(perm_tasks, "validate_ccpair_for_user", return_value=True),
+        patch.object(
+            perm_tasks,
+            "get_source_perm_sync_config",
+            return_value=_sync_config(_fake_doc_sync),
+        ),
+    ):
+        _run_perm_sync(synced_cc_pair.id)
+
+    assert checked_out_during_crawl == [0]
+    assert fetched_existing_ids == [[]]
+
+    db_session.expire_all()
+    attempt = get_latest_doc_permission_sync_attempt_for_cc_pair(
+        db_session, synced_cc_pair.id
+    )
+    assert attempt is not None
+    assert attempt.status == PermissionSyncStatus.SUCCESS
+
+
+def test_failed_crawl_records_docs_synced_before_the_error(
+    synced_cc_pair: ConnectorCredentialPair, db_session: Session
+) -> None:
+    """A sync that dies partway through keeps the documents it already committed,
+    so the failed attempt must report them rather than a default of zero."""
+
+    def _fake_doc_sync(
+        cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+        fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
+        fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,  # noqa: ARG001
+        callback: IndexingHeartbeatInterface | None,  # noqa: ARG001
+    ) -> Generator[ElementExternalAccess, None, None]:
+        for i in range(2):
+            yield DocExternalAccess(
+                doc_id=f"doc-{i}", external_access=ExternalAccess.empty()
+            )
+        raise RuntimeError("connector died mid-crawl")
+
+    with (
+        patch("onyx.db.engine.sql_engine.MULTI_TENANT", True),
+        patch.object(perm_tasks, "validate_ccpair_for_user", return_value=True),
+        patch.object(
+            RedisConnectorPermissionSync,
+            "update_db",
+            return_value=PermissionSyncResult(num_updated=1, num_errors=0),
+        ),
+        patch.object(
+            perm_tasks,
+            "get_source_perm_sync_config",
+            return_value=_sync_config(_fake_doc_sync),
+        ),
+        pytest.raises(RuntimeError, match="connector died mid-crawl"),
+    ):
+        _run_perm_sync(synced_cc_pair.id)
+
+    db_session.expire_all()
+    attempt = get_latest_doc_permission_sync_attempt_for_cc_pair(
+        db_session, synced_cc_pair.id
+    )
+    assert attempt is not None
+    assert attempt.status == PermissionSyncStatus.FAILED
+    assert attempt.total_docs_synced == 2
+    assert attempt.docs_with_permission_errors == 0

--- a/backend/tests/external_dependency_unit/permission_sync/test_perm_sync_no_pg_conn_during_crawl.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_perm_sync_no_pg_conn_during_crawl.py
@@ -1,20 +1,13 @@
 """
-Regression coverage for connector_permission_sync_generator_task pinning a
-Postgres connection across the connector crawl.
+Regression coverage for connector_permission_sync_generator_task: no DB
+connection may stay checked out across the connector crawl.
 
-The task used to open one session before the crawl and hold it until the crawl
-finished. On multi-tenant deployments get_session_with_tenant binds a session to
-an explicitly checked-out Connection (for schema translation), so that one
-connection sat idle, issuing no queries, for the whole crawl. PgBouncer drops
-idle clients at client_idle_timeout, so the first query after a long crawl hit a
-dead connection and failed with "server closed the connection unexpectedly".
-pool_pre_ping and pool_recycle cannot help because there is only ever one
-checkout. The task now closes the setup session before the crawl and opens a
-fresh session for each DB access after it.
-
-MULTI_TENANT is patched on because the single-tenant branch binds to the engine
-instead, which returns the connection to the pool at commit and so never
-reproduces the pin.
+On multi-tenant, get_session_with_tenant binds a session to an explicitly
+checked-out Connection for schema translation. A session held across a crawl
+therefore pins one client connection through gaps long enough to exceed
+PgBouncer's client_idle_timeout, and the next query on it fails with "server
+closed the connection unexpectedly". pool_pre_ping and pool_recycle act only at
+checkout, of which there is exactly one.
 """
 
 from collections.abc import Generator
@@ -40,16 +33,13 @@ from onyx.access.models import (
     ExternalAccess,
 )
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.models import InputType
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.enums import (
     AccessType,
-    ConnectorCredentialPairStatus,
     PermissionSyncStatus,
 )
-from onyx.db.models import Connector, ConnectorCredentialPair, Credential
+from onyx.db.models import ConnectorCredentialPair
 from onyx.db.permission_sync_attempt import (
-    delete_doc_permission_sync_attempts__no_commit,
     get_latest_doc_permission_sync_attempt_for_cc_pair,
 )
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
@@ -62,7 +52,9 @@ from onyx.redis.redis_connector_doc_perm_sync import (
 from shared_configs.configs import (
     POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE as TEST_TENANT_ID,
 )
-from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.permission_sync.conftest import (
+    create_test_connector_credential_pair,
+)
 
 
 @pytest.fixture
@@ -71,35 +63,11 @@ def synced_cc_pair(
     db_session: Session,
 ) -> Generator[ConnectorCredentialPair, None, None]:
     """A permission-synced cc_pair with a fence ready for the generator task."""
+    cc_pair = create_test_connector_credential_pair(
+        db_session, source=DocumentSource.JIRA, access_type=AccessType.SYNC
+    )
+
     suffix = uuid4().hex[:8]
-    user = create_test_user(db_session, f"perm_sync_crawl_{suffix}")
-
-    connector = Connector(
-        name=f"Perm Sync Crawl Connector {suffix}",
-        source=DocumentSource.JIRA,
-        input_type=InputType.POLL,
-        connector_specific_config={},
-        refresh_freq=None,
-        prune_freq=None,
-        indexing_start=datetime.now(timezone.utc),
-    )
-    db_session.add(connector)
-    db_session.flush()
-
-    credential = Credential(credential_json={}, user_id=user.id, admin_public=True)
-    db_session.add(credential)
-    db_session.flush()
-
-    cc_pair = ConnectorCredentialPair(
-        name=f"Perm Sync Crawl CC Pair {suffix}",
-        connector_id=connector.id,
-        credential_id=credential.id,
-        access_type=AccessType.SYNC,
-        status=ConnectorCredentialPairStatus.ACTIVE,
-    )
-    db_session.add(cc_pair)
-    db_session.commit()
-
     redis_connector = RedisConnector(TEST_TENANT_ID, cc_pair.id)
     redis_connector.permissions.set_fence(
         RedisConnectorPermissionSyncPayload(
@@ -114,33 +82,38 @@ def synced_cc_pair(
         yield cc_pair
     finally:
         redis_connector.permissions.set_fence(None)
-        db_session.rollback()
-        delete_doc_permission_sync_attempts__no_commit(db_session, cc_pair.id)
-        db_session.delete(cc_pair)
-        db_session.commit()
 
 
-def _run_perm_sync(cc_pair_id: int) -> None:
-    perm_tasks.connector_permission_sync_generator_task.apply(
-        args=(cc_pair_id,), kwargs={"tenant_id": TEST_TENANT_ID}
-    ).get()
+def _run_perm_sync(cc_pair_id: int, doc_sync_func: DocSyncFuncType) -> None:
+    """Drive the generator task with a stand-in connector crawl.
 
-
-def _sync_config(doc_sync_func: DocSyncFuncType) -> SyncConfig:
-    return SyncConfig(
+    MULTI_TENANT is patched on so the session factory takes its
+    checked-out-Connection branch, the one a held session would pin.
+    """
+    sync_config = SyncConfig(
         doc_sync_config=DocSyncConfig(
             doc_sync_frequency=1,
             doc_sync_func=doc_sync_func,
             initial_index_should_sync=False,
         )
     )
+    with (
+        patch("onyx.db.engine.sql_engine.MULTI_TENANT", True),
+        patch.object(perm_tasks, "validate_ccpair_for_user", return_value=True),
+        patch.object(
+            perm_tasks, "get_source_perm_sync_config", return_value=sync_config
+        ),
+    ):
+        perm_tasks.connector_permission_sync_generator_task.apply(
+            args=(cc_pair_id,), kwargs={"tenant_id": TEST_TENANT_ID}
+        ).get()
 
 
 def test_no_db_connection_held_during_crawl(
     synced_cc_pair: ConnectorCredentialPair, db_session: Session
 ) -> None:
     """The connector crawl must run with no connection checked out by the task,
-    and the post-crawl doc-id query must still succeed on a fresh session."""
+    and the doc-id query connectors make mid-crawl must still succeed."""
     pool = cast(QueuePool, SqlEngine.get_engine().pool)
     checked_out_during_crawl: list[int] = []
     fetched_existing_ids: list[list[str]] = []
@@ -152,26 +125,19 @@ def test_no_db_connection_held_during_crawl(
         fetch_all_existing_docs_ids_fn: FetchAllDocumentsIdsFunction,
         callback: IndexingHeartbeatInterface | None,  # noqa: ARG001
     ) -> Generator[ElementExternalAccess, None, None]:
-        # stands in for the source crawl: the long stretch where the task makes
-        # no DB queries at all
+        # stands in for the source crawl: the long stretch between the task's
+        # own DB queries
         checked_out_during_crawl.append(pool.checkedout() - baseline)
-        # the query that used to land on a connection PgBouncer had already killed
+        # connectors query the DB mid-crawl, so this must work on a fresh session
         fetched_existing_ids.append(fetch_all_existing_docs_ids_fn())
-        return
-        yield  # noqa: unreachable - makes this a generator
+        yield from ()
 
-    with (
-        patch("onyx.db.engine.sql_engine.MULTI_TENANT", True),
-        patch.object(perm_tasks, "validate_ccpair_for_user", return_value=True),
-        patch.object(
-            perm_tasks,
-            "get_source_perm_sync_config",
-            return_value=_sync_config(_fake_doc_sync),
-        ),
-    ):
-        _run_perm_sync(synced_cc_pair.id)
+    _run_perm_sync(synced_cc_pair.id, _fake_doc_sync)
 
-    assert checked_out_during_crawl == [0]
+    # the crawl ran...
+    assert len(checked_out_during_crawl) == 1
+    # ...with no connection checked out by the task at that moment
+    assert checked_out_during_crawl[0] == 0
     assert fetched_existing_ids == [[]]
 
     db_session.expire_all()
@@ -201,21 +167,14 @@ def test_failed_crawl_records_docs_synced_before_the_error(
         raise RuntimeError("connector died mid-crawl")
 
     with (
-        patch("onyx.db.engine.sql_engine.MULTI_TENANT", True),
-        patch.object(perm_tasks, "validate_ccpair_for_user", return_value=True),
         patch.object(
             RedisConnectorPermissionSync,
             "update_db",
             return_value=PermissionSyncResult(num_updated=1, num_errors=0),
         ),
-        patch.object(
-            perm_tasks,
-            "get_source_perm_sync_config",
-            return_value=_sync_config(_fake_doc_sync),
-        ),
         pytest.raises(RuntimeError, match="connector died mid-crawl"),
     ):
-        _run_perm_sync(synced_cc_pair.id)
+        _run_perm_sync(synced_cc_pair.id, _fake_doc_sync)
 
     db_session.expire_all()
     attempt = get_latest_doc_permission_sync_attempt_for_cc_pair(


### PR DESCRIPTION
## Description

**Bug:** Document permission sync fails on any connector whose crawl runs longer than 30 minutes. Fleet-wide over 21 days: 43,004 successful syncs under 30 minutes of crawl, **zero** above it, across 10 tenants. The run does all the work, then dies at the very end with `psycopg2.OperationalError: server closed the connection unexpectedly`.

**Why:** The task opened one session before the crawl and held it until the crawl finished. On multi-tenant, `get_session_with_tenant` binds the session to an explicitly checked-out `Connection` for schema translation, so one pooled connection sat there issuing no queries (per-document writes use their own short-lived sessions). PgBouncer drops idle clients at `client_idle_timeout = 1800`. `pool_pre_ping` and `pool_recycle` only act at checkout, of which there is exactly one, and TCP keepalives can't help because the timeout is application-level. Single-tenant binds to the engine and returns the connection at commit, so it was never affected.

**Fix:** Close the setup session before the crawl; each later DB access opens its own. Same phase split `document_index_metadata_sync_task` already uses.

Also records `total_docs_synced` / `docs_with_permission_errors` on failed attempts, which previously always reported 0 regardless of real progress.

## How Has This Been Tested?

## Additional Options

- [x] Override Linear Check
- [ ] Explicit override of the [cherry-pick](https://docs.onyx.app/contributing/cherry-picking) consideration
