### PR TITLE
fix(web): give docx previews a paper page so dark mode is readable

### DIFF
--- a/web/src/sections/modals/PreviewModal/variants/docx-preview.css
+++ b/web/src/sections/modals/PreviewModal/variants/docx-preview.css
@@ -1,0 +1,13 @@
+/* We render without docx-preview's wrapper, which is what supplies the white
+   page, the centering and the gap between pages. Its text stays hardcoded
+   black, so the pages need the paper surface back. */
+
+.docx-host section.docx {
+  background-color: var(--background-neutral-light-00);
+  border-radius: var(--radius-08);
+  margin-inline: auto;
+}
+
+.docx-host section.docx + section.docx {
+  margin-top: 1rem;
+}

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -12,6 +12,7 @@ import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { CopyButton } from "@opal/components";
 import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
 import { sanitizeDocxHtml } from "@/sections/modals/PreviewModal/variants/sanitizeDocxHtml";
+import "@/sections/modals/PreviewModal/variants/docx-preview.css";
 
 const DOCX_MIMES = [
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -128,7 +129,7 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
       {/* Style container for docx-preview generated styles */}
       <div ref={styleRef} />
       {/* Body container where docx-preview renders the document */}
-      <div ref={bodyRef} className="docx-host px-32 pb-16" />
+      <div ref={bodyRef} className="docx-host px-32 py-16" />
     </ScrollIndicatorDiv>
   );
 }


### PR DESCRIPTION
## Description

**Why:** In dark mode a .docx preview was unreadable. Anything the document did not explicitly color, which is most of the body text, rendered black on the app's dark surface and disappeared entirely.

`docx-preview` keeps the document's own colors, and a Word file authors those against a white page. The library paints that page only inside its own wrapper, and we render with `inWrapper: false` to keep our own layout, so the pages came out transparent. Its generated `.docx { color: black }` and the document's inline colors then landed on `background-tint-00`, which is black in dark mode.

**What:** The rendered pages now get the paper surface they were authored for, using the theme-invariant `background-neutral-light-00` token. They are centered, consecutive pages are separated, and the host's top padding now matches its bottom padding so the first page is not flush against the header. Light mode is unchanged, since the container there is already white.

## How Has This Been Tested?

Dark mode, previewing a Word document:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/pr-14343/before.png) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/pr-14343/after.png) |

Live in the running app on dev1, previewing a .docx with a colored heading, a shaded table and plain black body paragraphs:

- **Dark mode, before:** `section.docx` background `rgba(0, 0, 0, 0)` on a `rgb(0, 0, 0)` container, text `rgb(0, 0, 0)`. The two body paragraphs were invisible.
- **Dark mode, after:** `section.docx` background `rgb(255, 255, 255)`, radius `8px`, auto side margins. Everything readable.
- **Light mode, after:** page `rgb(255, 255, 255)` on a `rgb(255, 255, 255)` container with black text, identical to before the change.

Also ran `oxfmt`, `oxlint` and `bun run types:check`, all clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
