### PR TITLE
feat(craft): receipt deep links, provider verdicts, and upload coalescing

### DIFF
--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -11,6 +11,7 @@ import ipaddress
 import operator
 import socket
 import threading
+import zlib
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
@@ -217,6 +218,43 @@ RECEIPT_FLOW_KEY = "craft_recorded_receipts"
 RECEIPT_REFINE_MAX_BODY_BYTES = 1024 * 1024
 
 
+class _CappedBodyCapture:
+    """Streams a recorded flow's response through untouched while keeping a
+    copy for the extractors, up to the refine cap. Oversize drops the copy."""
+
+    def __init__(self) -> None:
+        self.body = bytearray()
+        self.overflowed = False
+
+    def __call__(self, chunk: bytes) -> bytes:
+        if chunk and not self.overflowed:
+            self.body.extend(chunk)
+            if len(self.body) > RECEIPT_REFINE_MAX_BODY_BYTES:
+                self.overflowed = True
+                self.body = bytearray()
+        return chunk
+
+
+def _bounded_decode(data: bytes, content_encoding: str) -> bytes | None:
+    """Undo Content-Encoding without trusting it: output is capped so a small
+    compressed body cannot balloon in memory. Unsupported or broken codings
+    refine nothing rather than risk an unbounded decode."""
+    coding = content_encoding.strip().lower()
+    if coding in ("", "identity"):
+        return data if len(data) <= RECEIPT_REFINE_MAX_BODY_BYTES else None
+    if coding not in ("gzip", "deflate"):
+        return None
+    wbits = 16 + zlib.MAX_WBITS if coding == "gzip" else zlib.MAX_WBITS
+    try:
+        decompressor = zlib.decompressobj(wbits=wbits)
+        decoded = decompressor.decompress(data, RECEIPT_REFINE_MAX_BODY_BYTES + 1)
+    except zlib.error:
+        return None
+    if len(decoded) > RECEIPT_REFINE_MAX_BODY_BYTES or decompressor.unconsumed_tail:
+        return None
+    return decoded
+
+
 class ParkedApprovals:
     """Approvals the proxy is currently parked on, grouped by tenant.
 
@@ -376,15 +414,18 @@ class GateAddon:
         if flow.response is None:
             return
         # A recorded flow's response feeds the receipt extractors: buffer it
-        # unless declared oversize (chunked declares nothing and must buffer).
-        # The decoded-length cap in `response` bounds the read either way.
+        # when its declared size fits, otherwise stream through a capped
+        # observer so chunked or lying origins can never grow proxy memory.
         if RECEIPT_FLOW_KEY in flow.metadata:
             declared = flow.response.headers.get("content-length")
             try:
                 length = int(declared) if declared is not None else None
             except ValueError:
                 length = None
-            if length is None or length <= RECEIPT_REFINE_MAX_BODY_BYTES:
+            if length is not None and length <= RECEIPT_REFINE_MAX_BODY_BYTES:
+                return
+            if length is None:
+                flow.response.stream = _CappedBodyCapture()
                 return
         flow.response.stream = True
 
@@ -627,12 +668,21 @@ class GateAddon:
             return
         confirmed = flow.response is not None and flow.response.status_code < 400
         response_body: bytes | None = None
-        if flow.response is not None and not flow.response.stream:
-            # get_content undoes Content-Encoding. raw_content is still
-            # compressed on the wire and would parse as garbage.
-            decoded = flow.response.get_content(strict=False)
-            if decoded is not None and len(decoded) <= RECEIPT_REFINE_MAX_BODY_BYTES:
-                response_body = decoded
+        if flow.response is not None:
+            stream = flow.response.stream
+            wire: bytes | None = None
+            if isinstance(stream, _CappedBodyCapture):
+                wire = bytes(stream.body) if not stream.overflowed else None
+            elif not stream:
+                raw = flow.response.raw_content
+                if raw is not None and len(raw) <= RECEIPT_REFINE_MAX_BODY_BYTES:
+                    wire = raw
+            if wire is not None:
+                # The wire body is still Content-Encoding compressed and
+                # would parse as garbage undecoded.
+                response_body = _bounded_decode(
+                    wire, flow.response.headers.get("content-encoding", "")
+                )
         await self._finalize_recorded(
             recorded,
             ReceiptStatus.CONFIRMED if confirmed else ReceiptStatus.FAILED,

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -64,7 +64,7 @@ from onyx.sandbox_proxy.logging_utils import (
     short_log_id,
 )
 from onyx.sandbox_proxy.receipt_recorder import (
-    finalize_receipts,
+    finalize_recorded_flow,
     record_pending_receipts,
 )
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
@@ -211,6 +211,10 @@ _GRANT_CACHE_MAX_ENTRIES = 4096
 # flow.metadata value for recorded receipts: primitives only, because
 # mitmproxy deep-copies and tnetstring-serializes flow metadata.
 RECEIPT_FLOW_KEY = "craft_recorded_receipts"
+
+# Bodies past this cap refine nothing: request facts and response links are
+# small JSON, and handing the extractors a huge body buys nothing.
+RECEIPT_REFINE_MAX_BODY_BYTES = 1024 * 1024
 
 
 class ParkedApprovals:
@@ -369,8 +373,20 @@ class GateAddon:
         """
         if not self._stream_responses:
             return
-        if flow.response is not None:
-            flow.response.stream = True
+        if flow.response is None:
+            return
+        # A recorded flow's response feeds the receipt extractors: buffer it
+        # unless declared oversize (chunked declares nothing and must buffer).
+        # The decoded-length cap in `response` bounds the read either way.
+        if RECEIPT_FLOW_KEY in flow.metadata:
+            declared = flow.response.headers.get("content-length")
+            try:
+                length = int(declared) if declared is not None else None
+            except ValueError:
+                length = None
+            if length is None or length <= RECEIPT_REFINE_MAX_BODY_BYTES:
+                return
+        flow.response.stream = True
 
     async def request(self, flow: http.HTTPFlow) -> None:
         task = asyncio.current_task()
@@ -564,14 +580,22 @@ class GateAddon:
         """Write PENDING receipts and remember them on the flow for the
         response and error hooks. Best-effort: the action proceeds either way,
         and an unrecorded action is invisible, not blocked."""
+        request_body = flow.request.raw_content
+        if (
+            request_body is not None
+            and len(request_body) > RECEIPT_REFINE_MAX_BODY_BYTES
+        ):
+            request_body = None
         try:
-            receipt_ids = await asyncio.to_thread(
+            entries = await asyncio.to_thread(
                 record_pending_receipts,
                 tenant_id=ctx.tenant_id,
                 session_id=ctx.session_id,
                 matched_actions=matched_actions,
                 approval_id=approval_id,
                 cache_factory=self._cache_factory,
+                request_path=flow.request.path,
+                request_body=request_body,
             )
         except Exception:
             logger.exception(
@@ -581,26 +605,38 @@ class GateAddon:
                 matched_actions.governing_action.action_type,
             )
             return
-        if receipt_ids:
+        if entries:
             flow.metadata[RECEIPT_FLOW_KEY] = {
                 "tenant_id": ctx.tenant_id,
                 "session_id": str(ctx.session_id),
-                "receipt_ids": [str(receipt_id) for receipt_id in receipt_ids],
+                "receipts": [
+                    [str(receipt_id), action_type]
+                    for receipt_id, action_type in entries
+                ],
             }
 
     async def response(self, flow: http.HTTPFlow) -> None:
         """Finalize recorded receipts from the origin's verdict.
 
-        Transport-level truth only: a non-error status whose body carries a
-        provider error still records CONFIRMED.
+        The buffered body rides along so the extractors can refine it; a
+        provider error hiding inside a non-error status is downgraded to
+        FAILED downstream.
         """
         recorded = flow.metadata.pop(RECEIPT_FLOW_KEY, None)
         if recorded is None:
             return
         confirmed = flow.response is not None and flow.response.status_code < 400
+        response_body: bytes | None = None
+        if flow.response is not None and not flow.response.stream:
+            # get_content undoes Content-Encoding. raw_content is still
+            # compressed on the wire and would parse as garbage.
+            decoded = flow.response.get_content(strict=False)
+            if decoded is not None and len(decoded) <= RECEIPT_REFINE_MAX_BODY_BYTES:
+                response_body = decoded
         await self._finalize_recorded(
             recorded,
             ReceiptStatus.CONFIRMED if confirmed else ReceiptStatus.FAILED,
+            response_body=response_body,
         )
 
     async def error(self, flow: http.HTTPFlow) -> None:
@@ -613,22 +649,32 @@ class GateAddon:
         await self._finalize_recorded(
             recorded,
             ReceiptStatus.UNKNOWN if seen_ok else ReceiptStatus.FAILED,
+            response_body=None,
         )
 
     async def _finalize_recorded(
-        self, recorded: dict[str, object], status: ReceiptStatus
+        self,
+        recorded: dict[str, object],
+        status: ReceiptStatus,
+        *,
+        response_body: bytes | None,
     ) -> None:
         tenant_id = str(recorded["tenant_id"])
         session_id = UUID(str(recorded["session_id"]))
-        receipt_ids_raw = recorded["receipt_ids"]
-        assert isinstance(receipt_ids_raw, list)
+        entries_raw = recorded["receipts"]
+        assert isinstance(entries_raw, list)
         try:
             await asyncio.to_thread(
-                finalize_receipts,
+                finalize_recorded_flow,
                 tenant_id=tenant_id,
                 session_id=session_id,
-                receipt_ids=[UUID(str(rid)) for rid in receipt_ids_raw],
-                status=status,
+                entries=[
+                    (UUID(str(entry[0])), str(entry[1]))
+                    for entry in entries_raw
+                    if isinstance(entry, list) and len(entry) == 2
+                ],
+                transport_status=status,
+                response_body=response_body,
                 cache_factory=self._cache_factory,
             )
         except Exception:

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -422,7 +422,7 @@ class GateAddon:
                 length = int(declared) if declared is not None else None
             except ValueError:
                 length = None
-            if length is not None and length <= RECEIPT_REFINE_MAX_BODY_BYTES:
+            if length is not None and 0 <= length <= RECEIPT_REFINE_MAX_BODY_BYTES:
                 return
             if length is None:
                 flow.response.stream = _CappedBodyCapture()

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -413,20 +413,12 @@ class GateAddon:
             return
         if flow.response is None:
             return
-        # A recorded flow's response feeds the receipt extractors: buffer it
-        # when its declared size fits, otherwise stream through a capped
-        # observer so chunked or lying origins can never grow proxy memory.
+        # A recorded flow's response feeds the receipt extractors: stream it
+        # through a capped observer, trusting no declared length, so no origin
+        # can grow proxy memory past the refine cap.
         if RECEIPT_FLOW_KEY in flow.metadata:
-            declared = flow.response.headers.get("content-length")
-            try:
-                length = int(declared) if declared is not None else None
-            except ValueError:
-                length = None
-            if length is not None and 0 <= length <= RECEIPT_REFINE_MAX_BODY_BYTES:
-                return
-            if length is None:
-                flow.response.stream = _CappedBodyCapture()
-                return
+            flow.response.stream = _CappedBodyCapture()
+            return
         flow.response.stream = True
 
     async def request(self, flow: http.HTTPFlow) -> None:

--- a/backend/onyx/sandbox_proxy/receipt_extractors.py
+++ b/backend/onyx/sandbox_proxy/receipt_extractors.py
@@ -214,8 +214,10 @@ def _gmail_facts(action_type: str, body: dict[str, Any]) -> ResponseFacts:
     message_id = _safe_id(message.get("id"))
     if message_id is None:
         return ResponseFacts()
-    # A draft is not in #all until sent, so link the drafts view instead.
-    view = "drafts" if action_type.startswith("gmail.drafts.") else "all"
+    # An unsent draft is not in #all, so its link opens the drafts view.
+    # drafts.send returns the sent Message, which lives in #all like any send.
+    is_draft = action_type in ("gmail.drafts.create", "gmail.drafts.update")
+    view = "drafts" if is_draft else "all"
     return ResponseFacts(link=f"https://mail.google.com/mail/u/0/#{view}/{message_id}")
 
 

--- a/backend/onyx/sandbox_proxy/receipt_extractors.py
+++ b/backend/onyx/sandbox_proxy/receipt_extractors.py
@@ -1,0 +1,238 @@
+"""Per-provider receipt refinement.
+
+Pure functions from a gated request and its response to the details a receipt
+card deserves: a human destination, a deep link, a provider-level verdict,
+and the operation key that coalesces multi-request flows into one receipt.
+Best-effort: a body that cannot be parsed refines nothing, and the
+response-side caller additionally guards against extractor bugs.
+
+Deep links are constructed from shape-checked provider ids, not payload URLs,
+except Linear, which only returns a canonical URL and is accepted after a
+scheme, host, and full-path shape check.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs
+
+from onyx.db.enums import ReceiptStatus
+
+# Coalescing keys are session-scoped by the DAL's unique index, so no tenant
+# or session qualifier. The action-type prefix keeps provider ids from
+# colliding across providers.
+SLACK_UPLOAD_KEY_PREFIX = "slack.files.write:"
+
+_LINEAR_URL_SHAPE = re.compile(
+    r"^https://linear\.app/[A-Za-z0-9\-_]+/(issue|project)(/[A-Za-z0-9\-_]+)+/?$"
+)
+_MAX_LINK_LEN = 512
+
+# Provider ids interpolated into links. Anything else refines nothing.
+_SAFE_ID_SHAPE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+# Slack conversation ids (C../G../D..), which are not channel names.
+_SLACK_CONVERSATION_ID_SHAPE = re.compile(r"^[CGD][A-Z0-9]{7,}$")
+
+_GDRIVE_LINKS_BY_MIME = {
+    "application/vnd.google-apps.document": "https://docs.google.com/document/d/{id}",
+    "application/vnd.google-apps.spreadsheet": "https://docs.google.com/spreadsheets/d/{id}",
+    "application/vnd.google-apps.presentation": "https://docs.google.com/presentation/d/{id}",
+}
+_GDRIVE_GENERIC_LINK = "https://drive.google.com/file/d/{id}"
+
+
+@dataclass(frozen=True)
+class RequestFacts:
+    """Refinements known before the request executes."""
+
+    destination: str | None = None
+    operation_key: str | None = None
+
+
+@dataclass(frozen=True)
+class ResponseFacts:
+    """Refinements the origin's response reveals."""
+
+    link: str | None = None
+    # Provider-level failure inside a transport-level success, e.g. Slack's
+    # 200 with ok=false. None keeps the transport verdict.
+    status_override: ReceiptStatus | None = None
+    # Learned late: the Slack upload's file id only exists after step one.
+    operation_key: str | None = None
+
+
+def parse_json_object(raw: bytes | str | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _parse_request_body(raw: bytes | None) -> dict[str, Any] | None:
+    """Request payloads arrive as JSON or form-encoded (slack_sdk's default);
+    a form field holding serialized JSON is decoded in place."""
+    parsed = parse_json_object(raw)
+    if parsed is not None or raw is None:
+        return parsed
+    try:
+        fields = parse_qs(raw.decode(), strict_parsing=True)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    body: dict[str, Any] = {}
+    for key, values in fields.items():
+        value = values[0]
+        if value[:1] in ("{", "["):
+            try:
+                body[key] = json.loads(value)
+                continue
+            except ValueError:
+                pass
+        body[key] = value
+    return body
+
+
+def _safe_id(value: Any) -> str | None:
+    if isinstance(value, str) and _SAFE_ID_SHAPE.match(value):
+        return value
+    return None
+
+
+def _slack_destination(channel: str) -> str:
+    if channel.startswith("#") or _SLACK_CONVERSATION_ID_SHAPE.match(channel):
+        return channel
+    return f"#{channel}"
+
+
+def request_facts(action_type: str, request_body: bytes | None) -> RequestFacts:
+    """What the request alone reveals: a destination and, for flows whose
+    later steps carry the correlating id, the coalescing key."""
+    body = _parse_request_body(request_body)
+    if action_type == "slack.messages.write":
+        channel = (body or {}).get("channel")
+        if isinstance(channel, str) and channel:
+            return RequestFacts(destination=_slack_destination(channel))
+    if action_type == "slack.files.write":
+        # completeUploadExternal names the files being shared. The earlier
+        # steps of the flow key in through the response or the token map.
+        files = (body or {}).get("files")
+        if isinstance(files, list) and files:
+            first = files[0]
+            file_id = first.get("id") if isinstance(first, dict) else None
+            if _safe_id(file_id) is not None:
+                return RequestFacts(operation_key=f"{SLACK_UPLOAD_KEY_PREFIX}{file_id}")
+    return RequestFacts()
+
+
+def response_facts(action_type: str, response_body: bytes | None) -> ResponseFacts:
+    """What the origin's response reveals, keyed by the recorded action."""
+    body = parse_json_object(response_body)
+    if body is None:
+        return ResponseFacts()
+    if action_type.startswith("slack."):
+        return _slack_facts(action_type, body)
+    if action_type.startswith("gdrive."):
+        return _gdrive_facts(body)
+    if action_type.startswith("gmail."):
+        return _gmail_facts(body)
+    if action_type.startswith("linear."):
+        return _linear_facts(body)
+    return ResponseFacts()
+
+
+def slack_upload_key(body: dict[str, Any]) -> str | None:
+    """The coalescing key step one of the upload flow reveals."""
+    file_id = _safe_id(body.get("file_id"))
+    if file_id is not None:
+        return f"{SLACK_UPLOAD_KEY_PREFIX}{file_id}"
+    return None
+
+
+def upload_url_token(url_or_path: str) -> str | None:
+    """The trailing path segment of a pre-signed upload URL, shared by the
+    writer (step one's upload_url) and the reader (step two's request path)
+    so the two derivations can never disagree."""
+    path = url_or_path.split("?", 1)[0].rstrip("/")
+    if "/" not in path:
+        return None
+    return path.rsplit("/", 1)[-1] or None
+
+
+def slack_upload_url_token(body: dict[str, Any]) -> str | None:
+    """The upload URL token correlating step two of the upload flow back to
+    the file id step one returned."""
+    upload_url = body.get("upload_url")
+    if isinstance(upload_url, str):
+        return upload_url_token(upload_url)
+    return None
+
+
+def _slack_facts(action_type: str, body: dict[str, Any]) -> ResponseFacts:
+    # The Slack Web API reports failures as 200 with ok=false.
+    if body.get("ok") is False:
+        return ResponseFacts(status_override=ReceiptStatus.FAILED)
+    link = None
+    operation_key = None
+    if action_type == "slack.messages.write":
+        channel, ts = _safe_id(body.get("channel")), _safe_id(body.get("ts"))
+        if channel is not None and ts is not None:
+            link = f"https://slack.com/archives/{channel}/p{ts.replace('.', '')}"
+    if action_type == "slack.files.write":
+        operation_key = slack_upload_key(body)
+    return ResponseFacts(link=link, operation_key=operation_key)
+
+
+def _gdrive_facts(body: dict[str, Any]) -> ResponseFacts:
+    file_id = _safe_id(
+        body.get("id") or body.get("documentId") or body.get("spreadsheetId")
+    )
+    if file_id is None:
+        return ResponseFacts()
+    mime = body.get("mimeType")
+    template = _GDRIVE_LINKS_BY_MIME.get(str(mime), _GDRIVE_GENERIC_LINK)
+    return ResponseFacts(link=template.format(id=file_id))
+
+
+def _gmail_facts(body: dict[str, Any]) -> ResponseFacts:
+    # Drafts nest the message, sends carry it at the top level.
+    nested = body.get("message")
+    message = nested if isinstance(nested, dict) else body
+    message_id = _safe_id(message.get("id"))
+    if message_id is not None:
+        return ResponseFacts(link=f"https://mail.google.com/mail/u/0/#all/{message_id}")
+    return ResponseFacts()
+
+
+def _linear_facts(body: dict[str, Any]) -> ResponseFacts:
+    # GraphQL failures are 200s with an errors array.
+    if body.get("errors"):
+        return ResponseFacts(status_override=ReceiptStatus.FAILED)
+    url = _first_string_named(body.get("data"), "url")
+    if url is not None and len(url) <= _MAX_LINK_LEN and _LINEAR_URL_SHAPE.match(url):
+        return ResponseFacts(link=url)
+    return ResponseFacts()
+
+
+def _first_string_named(node: Any, key: str, depth: int = 0) -> str | None:
+    """First string value under ``key`` in a small nested payload. Bounded so
+    a pathological response cannot recurse away."""
+    if depth > 4:
+        return None
+    if isinstance(node, list):
+        children: list[Any] = node[:20]
+    elif isinstance(node, dict):
+        value = node.get(key)
+        if isinstance(value, str):
+            return value
+        children = list(node.values())
+    else:
+        return None
+    for child in children:
+        if isinstance(child, (dict, list)):
+            found = _first_string_named(child, key, depth + 1)
+            if found is not None:
+                return found
+    return None

--- a/backend/onyx/sandbox_proxy/receipt_extractors.py
+++ b/backend/onyx/sandbox_proxy/receipt_extractors.py
@@ -137,7 +137,7 @@ def response_facts(action_type: str, response_body: bytes | None) -> ResponseFac
     if action_type.startswith("gdrive."):
         return _gdrive_facts(body)
     if action_type.startswith("gmail."):
-        return _gmail_facts(body)
+        return _gmail_facts(action_type, body)
     if action_type.startswith("linear."):
         return _linear_facts(body)
     return ResponseFacts()
@@ -185,10 +185,21 @@ def _slack_facts(action_type: str, body: dict[str, Any]) -> ResponseFacts:
     return ResponseFacts(link=link, operation_key=operation_key)
 
 
+# The dedicated editor APIs name their id after the product and return no
+# mimeType, so the key alone picks the link.
+_GDRIVE_LINKS_BY_ID_KEY = {
+    "documentId": "https://docs.google.com/document/d/{id}",
+    "spreadsheetId": "https://docs.google.com/spreadsheets/d/{id}",
+    "presentationId": "https://docs.google.com/presentation/d/{id}",
+}
+
+
 def _gdrive_facts(body: dict[str, Any]) -> ResponseFacts:
-    file_id = _safe_id(
-        body.get("id") or body.get("documentId") or body.get("spreadsheetId")
-    )
+    for key, template in _GDRIVE_LINKS_BY_ID_KEY.items():
+        editor_id = _safe_id(body.get(key))
+        if editor_id is not None:
+            return ResponseFacts(link=template.format(id=editor_id))
+    file_id = _safe_id(body.get("id"))
     if file_id is None:
         return ResponseFacts()
     mime = body.get("mimeType")
@@ -196,14 +207,16 @@ def _gdrive_facts(body: dict[str, Any]) -> ResponseFacts:
     return ResponseFacts(link=template.format(id=file_id))
 
 
-def _gmail_facts(body: dict[str, Any]) -> ResponseFacts:
+def _gmail_facts(action_type: str, body: dict[str, Any]) -> ResponseFacts:
     # Drafts nest the message, sends carry it at the top level.
     nested = body.get("message")
     message = nested if isinstance(nested, dict) else body
     message_id = _safe_id(message.get("id"))
-    if message_id is not None:
-        return ResponseFacts(link=f"https://mail.google.com/mail/u/0/#all/{message_id}")
-    return ResponseFacts()
+    if message_id is None:
+        return ResponseFacts()
+    # A draft is not in #all until sent, so link the drafts view instead.
+    view = "drafts" if action_type.startswith("gmail.drafts.") else "all"
+    return ResponseFacts(link=f"https://mail.google.com/mail/u/0/#{view}/{message_id}")
 
 
 def _linear_facts(body: dict[str, Any]) -> ResponseFacts:

--- a/backend/onyx/sandbox_proxy/receipt_recorder.py
+++ b/backend/onyx/sandbox_proxy/receipt_recorder.py
@@ -6,8 +6,10 @@ hooks, swept to UNKNOWN when orphaned (a finalize landing after the sweep is
 dropped, so a response outliving the ten-minute TTL records UNKNOWN).
 Write-effect catalog actions always leave one, and so does anything that went
 through an approval. Reads that auto-pass leave nothing. Multi-request
-provider flows each leave their own receipt until the extractor PR derives
-operation keys, so ``insert_pending_receipt`` coalesces nothing yet.
+provider flows coalesce into one receipt through operation keys the
+extractors derive: request-side where the step carries the id, response-side
+where step one's response reveals it, and via a token map for the raw-bytes
+step that carries neither.
 
 Recording and finalizing announce the row to the session's live SSE stream,
 best-effort: the receipt listing is the durable record, so a lost announce
@@ -18,6 +20,7 @@ from collections.abc import Callable
 from uuid import UUID
 
 from pydantic import ValidationError
+from sqlalchemy.orm import Session
 
 from onyx.cache.interface import CacheBackend
 from onyx.db.engine.sql_engine import get_session_with_tenant
@@ -25,9 +28,20 @@ from onyx.db.enums import ActionEffect, ReceiptStatus
 from onyx.db.gated_app import get_or_create_gated_app_id
 from onyx.db.models import ActionReceipt
 from onyx.external_apps.matching.engine import AllMatchedActions, MatchedAction
+from onyx.sandbox_proxy.receipt_extractors import (
+    SLACK_UPLOAD_KEY_PREFIX,
+    ResponseFacts,
+    parse_json_object,
+    request_facts,
+    response_facts,
+    slack_upload_key,
+    slack_upload_url_token,
+    upload_url_token,
+)
 from onyx.server.features.build.db.receipt import (
     finalize_receipt,
     insert_pending_receipt,
+    set_receipt_operation_key,
 )
 from onyx.server.features.build.packets import ReceiptPacket
 from onyx.utils.logger import setup_logger
@@ -35,6 +49,7 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 _ANNOUNCE_TTL_S = 60
+_MAX_DESTINATION_LEN = 256
 
 
 def _announce_key(session_id: UUID) -> str:
@@ -98,60 +113,198 @@ def record_pending_receipts(
     matched_actions: AllMatchedActions,
     approval_id: UUID | None,
     cache_factory: Callable[[str], CacheBackend],
-) -> list[UUID]:
-    """Insert PENDING rows for this request, announce them, return their ids.
+    request_path: str = "",
+    request_body: bytes | None = None,
+) -> list[tuple[UUID, str]]:
+    """Insert PENDING rows for this request and announce the new ones.
 
     Called after the gate's verdict and credential injection, immediately
     before the request leaves for the origin, so the record exists even when
-    the proxy dies mid-flight (the sweep then marks it UNKNOWN).
+    the proxy dies mid-flight (the sweep then marks it UNKNOWN). Returns
+    ``(receipt_id, action_type)`` pairs for the flow's finalize hooks.
     """
     actions = receipt_worthy_actions(matched_actions, approval_id)
     if not actions:
         return []
+    facts_by_action = [
+        (action, request_facts(action.action_type, request_body)) for action in actions
+    ]
+    # Cache lookups stay outside the DB transaction.
+    token_keys = [
+        facts.operation_key
+        or _upload_token_key(
+            action.action_type, request_path, tenant_id, session_id, cache_factory
+        )
+        for action, facts in facts_by_action
+    ]
     target = matched_actions.target
+    entries: list[tuple[UUID, str]] = []
+    packets: list[ReceiptPacket] = []
     with get_session_with_tenant(tenant_id=tenant_id) as db:
         gated_app_id = get_or_create_gated_app_id(db, target.kind, target.id)
-        rows = [
-            insert_pending_receipt(
+        for (action, facts), operation_key in zip(
+            facts_by_action, token_keys, strict=True
+        ):
+            destination = (facts.destination or matched_actions.app_name)[
+                :_MAX_DESTINATION_LEN
+            ]
+            row, created = insert_pending_receipt(
                 db,
                 session_id=session_id,
                 action_type=action.action_type,
                 effect=action.effect.value,
-                destination=matched_actions.app_name,
+                destination=destination,
                 gated_app_id=gated_app_id,
                 approval_id=approval_id,
-                operation_key=None,
+                operation_key=operation_key,
             )
-            for action in actions
-        ]
-        db.commit()
-        receipt_ids = [row.id for row in rows]
-        packets = [_packet_for(row) for row in rows]
-    _announce_best_effort(tenant_id, session_id, packets, cache_factory)
-    return receipt_ids
-
-
-def finalize_receipts(
-    *,
-    tenant_id: str,
-    session_id: UUID,
-    receipt_ids: list[UUID],
-    status: ReceiptStatus,
-    cache_factory: Callable[[str], CacheBackend],
-) -> None:
-    """Move recorded rows to their terminal state and announce the outcome.
-
-    Only rows that carry the requested verdict announce: a row that lost the
-    race to an earlier verdict already announced that one.
-    """
-    packets: list[ReceiptPacket] = []
-    with get_session_with_tenant(tenant_id=tenant_id) as db:
-        for receipt_id in receipt_ids:
-            row = finalize_receipt(db, receipt_id=receipt_id, status=status)
-            if row is not None and row.status is status:
+            entries.append((row.id, action.action_type))
+            if created:
                 packets.append(_packet_for(row))
         db.commit()
     _announce_best_effort(tenant_id, session_id, packets, cache_factory)
+    return entries
+
+
+def finalize_recorded_flow(
+    *,
+    tenant_id: str,
+    session_id: UUID,
+    entries: list[tuple[UUID, str]],
+    transport_status: ReceiptStatus,
+    response_body: bytes | None,
+    cache_factory: Callable[[str], CacheBackend],
+) -> None:
+    """Finalize a flow's receipts with whatever the response reveals.
+
+    Each entry is ``(receipt_id, action_type)``. The extractor may refine the
+    verdict (a provider error inside a 200), attach a deep link, and claim a
+    late-learned coalescing key. Best-effort per receipt: a failure costs
+    only that receipt's finalize, and the sweep covers whatever is left
+    PENDING.
+    """
+    packets: list[ReceiptPacket] = []
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        for receipt_id, action_type in entries:
+            try:
+                packet = _finalize_one(
+                    db, receipt_id, action_type, transport_status, response_body
+                )
+            except Exception:
+                logger.exception(
+                    "receipt_finalize_error receipt=%s action_type=%s",
+                    receipt_id,
+                    action_type,
+                )
+                continue
+            if packet is not None:
+                packets.append(packet)
+        db.commit()
+    _announce_best_effort(tenant_id, session_id, packets, cache_factory)
+    if response_body is not None:
+        _remember_upload_tokens(
+            tenant_id, session_id, entries, response_body, cache_factory
+        )
+
+
+def _finalize_one(
+    db: Session,
+    receipt_id: UUID,
+    action_type: str,
+    transport_status: ReceiptStatus,
+    response_body: bytes | None,
+) -> ReceiptPacket | None:
+    facts = ResponseFacts()
+    if response_body is not None:
+        try:
+            facts = response_facts(action_type, response_body)
+        except Exception:
+            logger.warning(
+                "receipt_extract_error action_type=%s", action_type, exc_info=True
+            )
+    if facts.operation_key is not None:
+        claimed = set_receipt_operation_key(
+            db, receipt_id=receipt_id, operation_key=facts.operation_key
+        )
+        if not claimed:
+            # The flow already coalesced onto another row. This one stays a
+            # visible duplicate rather than being silently merged.
+            logger.info(
+                "receipt_operation_key_lost receipt=%s key=%s",
+                receipt_id,
+                facts.operation_key,
+            )
+    status = facts.status_override or transport_status
+    row, changed = finalize_receipt(
+        db,
+        receipt_id=receipt_id,
+        status=status,
+        link=facts.link,
+        allow_failed_downgrade=status is ReceiptStatus.FAILED,
+    )
+    if row is not None and changed:
+        return _packet_for(row)
+    return None
+
+
+_UPLOAD_TOKEN_TTL_S = 30 * 60
+
+
+def _upload_token_map_key(session_id: UUID, token: str) -> str:
+    return f"craft:receipt:upload-token:{session_id}:{token}"
+
+
+def _remember_upload_tokens(
+    tenant_id: str,
+    session_id: UUID,
+    entries: list[tuple[UUID, str]],
+    response_body: bytes,
+    cache_factory: Callable[[str], CacheBackend],
+) -> None:
+    """Map a Slack upload URL token to its coalescing key, so the raw-bytes
+    step of the flow (which carries only the token) lands on the same
+    receipt. Best-effort."""
+    if not any(a == "slack.files.write" for _r, a in entries):
+        return
+    body = parse_json_object(response_body)
+    if body is None:
+        return
+    key = slack_upload_key(body)
+    token = slack_upload_url_token(body)
+    if key is None or token is None:
+        return
+    try:
+        cache_factory(tenant_id).set(
+            _upload_token_map_key(session_id, token), key, ex=_UPLOAD_TOKEN_TTL_S
+        )
+    except Exception:
+        logger.warning("receipt_upload_token_map_error", exc_info=True)
+
+
+def _upload_token_key(
+    action_type: str,
+    request_path: str,
+    tenant_id: str,
+    session_id: UUID,
+    cache_factory: Callable[[str], CacheBackend],
+) -> str | None:
+    """The coalescing key for the upload flow's raw-bytes step, resolved from
+    the token map step one populated. Best-effort."""
+    if action_type != "slack.files.write" or "/upload/" not in request_path:
+        return None
+    token = upload_url_token(request_path)
+    if token is None:
+        return None
+    try:
+        value = cache_factory(tenant_id).get(_upload_token_map_key(session_id, token))
+    except Exception:
+        logger.warning("receipt_upload_token_lookup_error", exc_info=True)
+        return None
+    if isinstance(value, bytes):
+        value = value.decode()
+    if isinstance(value, str) and value.startswith(SLACK_UPLOAD_KEY_PREFIX):
+        return value
+    return None
 
 
 def _announce_best_effort(

--- a/backend/onyx/server/features/build/db/receipt.py
+++ b/backend/onyx/server/features/build/db/receipt.py
@@ -6,11 +6,12 @@ flush and never commit, the caller owns the transaction.
 """
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import desc, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ReceiptStatus
@@ -19,6 +20,13 @@ from onyx.db.models import ActionReceipt
 # A PENDING row older than this lost its recorder mid-flight. The sweeper
 # moves it to UNKNOWN so it can never linger as an implied in-progress send.
 PENDING_RECEIPT_TTL = timedelta(minutes=10)
+
+
+class InsertReceiptResult(NamedTuple):
+    receipt: ActionReceipt
+    # False when the operation key coalesced onto an existing row: the caller
+    # must not announce it as new.
+    created: bool
 
 
 def insert_pending_receipt(
@@ -31,7 +39,7 @@ def insert_pending_receipt(
     gated_app_id: int | None,
     approval_id: UUID | None,
     operation_key: str | None,
-) -> ActionReceipt:
+) -> InsertReceiptResult:
     """Record the attempt before the action executes.
 
     A repeated operation_key returns the existing row instead of a duplicate,
@@ -62,8 +70,8 @@ def insert_pending_receipt(
         .execution_options(populate_existing=True)
     ).scalar_one_or_none()
     if receipt is not None:
-        return receipt
-    return db_session.execute(
+        return InsertReceiptResult(receipt, created=True)
+    existing = db_session.execute(
         select(ActionReceipt)
         .where(
             ActionReceipt.session_id == session_id,
@@ -71,6 +79,15 @@ def insert_pending_receipt(
         )
         .execution_options(populate_existing=True)
     ).scalar_one()
+    return InsertReceiptResult(existing, created=False)
+
+
+class FinalizeReceiptResult(NamedTuple):
+    # None when the row does not exist.
+    receipt: ActionReceipt | None
+    # True when this call performed the transition. A row that already
+    # carried a terminal verdict comes back changed=False.
+    changed: bool
 
 
 def finalize_receipt(
@@ -79,25 +96,30 @@ def finalize_receipt(
     receipt_id: UUID,
     status: ReceiptStatus,
     link: str | None = None,
-) -> ActionReceipt | None:
+    allow_failed_downgrade: bool = False,
+) -> FinalizeReceiptResult:
     """Move a PENDING row to its terminal state.
 
     CONFIRMED and FAILED come from the origin's verdict, UNKNOWN when the
     outcome is genuinely unknowable (headers arrived but the body did not).
     The conditional UPDATE is the race arbiter: concurrent finalizes cannot
-    flip an already-recorded verdict. Returns the row (already-terminal
-    included) or None when it does not exist.
+    flip an already-recorded verdict. allow_failed_downgrade lets a FAILED
+    verdict overturn CONFIRMED: a coalesced multi-step flow confirms on its
+    early steps, and a later step's failure is the truer outcome.
     """
     if status is ReceiptStatus.PENDING:
         raise ValueError("finalize_receipt records terminal states only")
     values: dict[str, Any] = {"status": status}
     if link is not None:
         values["link"] = link
+    replaceable = [ReceiptStatus.PENDING]
+    if allow_failed_downgrade and status is ReceiptStatus.FAILED:
+        replaceable.append(ReceiptStatus.CONFIRMED)
     row = db_session.execute(
         update(ActionReceipt)
         .where(
             ActionReceipt.id == receipt_id,
-            ActionReceipt.status == ReceiptStatus.PENDING,
+            ActionReceipt.status.in_(replaceable),
         )
         .values(**values)
         .returning(ActionReceipt)
@@ -107,13 +129,44 @@ def finalize_receipt(
     if row is None:
         # Lost the race or already terminal. Read fresh, an identity-map hit
         # here could still say PENDING.
-        return db_session.execute(
+        current = db_session.execute(
             select(ActionReceipt)
             .where(ActionReceipt.id == receipt_id)
             .execution_options(populate_existing=True)
         ).scalar_one_or_none()
+        return FinalizeReceiptResult(current, changed=False)
     db_session.refresh(row)
-    return row
+    return FinalizeReceiptResult(row, changed=True)
+
+
+def set_receipt_operation_key(
+    db_session: Session,
+    *,
+    receipt_id: UUID,
+    operation_key: str,
+) -> bool:
+    """Attach a late-learned coalescing key to a keyless row.
+
+    False when the key is already claimed by another row (the flow already
+    coalesced there), the row already has one, or the row is gone. The
+    partial unique index arbitrates the race.
+    """
+    try:
+        with db_session.begin_nested():
+            claimed = db_session.execute(
+                update(ActionReceipt)
+                .where(
+                    ActionReceipt.id == receipt_id,
+                    ActionReceipt.operation_key.is_(None),
+                )
+                .values(operation_key=operation_key)
+                .returning(ActionReceipt.id)
+                .execution_options(synchronize_session=False)
+            ).scalar_one_or_none()
+    except IntegrityError:
+        return False
+    db_session.flush()
+    return claimed is not None
 
 
 def sweep_stale_pending_receipts(

--- a/backend/tests/external_dependency_unit/craft/test_artifact_receipt_dal.py
+++ b/backend/tests/external_dependency_unit/craft/test_artifact_receipt_dal.py
@@ -14,13 +14,14 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ArtifactType, ReceiptStatus
-from onyx.db.models import ActionReceipt, Artifact, BuildSession
+from onyx.db.models import Artifact, BuildSession
 from onyx.server.features.build.db.artifact import (
     get_session_artifacts,
     mark_artifact_deleted,
     upsert_artifact,
 )
 from onyx.server.features.build.db.receipt import (
+    InsertReceiptResult,
     finalize_receipt,
     get_session_receipts,
     insert_pending_receipt,
@@ -135,7 +136,7 @@ def _pending(
     *,
     operation_key: str | None = None,
     action_type: str = "slack.messages.write",
-) -> ActionReceipt:
+) -> InsertReceiptResult:
     return insert_pending_receipt(
         db_session,
         session_id=session.id,
@@ -159,8 +160,9 @@ def test_pending_receipt_coalesces_on_operation_key(
     third = _pending(db_session, session, operation_key="upload-2")
     db_session.commit()
 
-    assert second.id == first.id
-    assert third.id != first.id
+    assert first.created and third.created and not second.created
+    assert second.receipt.id == first.receipt.id
+    assert third.receipt.id != first.receipt.id
     assert len(get_session_receipts(db_session, session_id=session.id)) == 2
 
 
@@ -170,26 +172,41 @@ def test_finalize_is_terminal_and_rejects_pending(
     build_session_with_user: Callable[..., BuildSession],
 ) -> None:
     session = build_session_with_user()
-    receipt = _pending(db_session, session)
+    receipt = _pending(db_session, session).receipt
     db_session.commit()
 
-    confirmed = finalize_receipt(
+    confirmed, changed = finalize_receipt(
         db_session,
         receipt_id=receipt.id,
         status=ReceiptStatus.CONFIRMED,
         link="https://slack.com/archives/C1/p1",
     )
     db_session.commit()
+    assert changed
     assert confirmed is not None
     assert confirmed.status == ReceiptStatus.CONFIRMED
     assert confirmed.link is not None
 
-    flipped = finalize_receipt(
+    flipped, changed = finalize_receipt(
         db_session, receipt_id=receipt.id, status=ReceiptStatus.FAILED
     )
     db_session.commit()
+    assert not changed
     assert flipped is not None
     assert flipped.status == ReceiptStatus.CONFIRMED
+
+    # A coalesced flow's later failure is allowed to overturn the early
+    # CONFIRMED, and only then.
+    downgraded, changed = finalize_receipt(
+        db_session,
+        receipt_id=receipt.id,
+        status=ReceiptStatus.FAILED,
+        allow_failed_downgrade=True,
+    )
+    db_session.commit()
+    assert changed
+    assert downgraded is not None
+    assert downgraded.status == ReceiptStatus.FAILED
 
     with pytest.raises(ValueError):
         finalize_receipt(
@@ -203,8 +220,8 @@ def test_sweep_marks_only_stale_pending_unknown(
     build_session_with_user: Callable[..., BuildSession],
 ) -> None:
     session = build_session_with_user()
-    stale = _pending(db_session, session, action_type="drive.files.upload")
-    fresh = _pending(db_session, session)
+    stale = _pending(db_session, session, action_type="drive.files.upload").receipt
+    fresh = _pending(db_session, session).receipt
     db_session.commit()
 
     force_receipt_created_at(

--- a/backend/tests/external_dependency_unit/craft/test_receipt_recording.py
+++ b/backend/tests/external_dependency_unit/craft/test_receipt_recording.py
@@ -2,12 +2,13 @@
 
 Runs the recorder against Postgres and Redis: which actions leave receipts,
 the PENDING to terminal transitions the hooks drive through
-``finalize_receipts``, the sweep, the owner-only listing, and the announce
-stream the live SSE merge consumes.
+``finalize_recorded_flow``, the sweep, the owner-only listing, and the
+announce stream the live SSE merge consumes.
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
@@ -30,7 +31,7 @@ from onyx.external_apps.matching.engine import (
     MatchedAction,
 )
 from onyx.sandbox_proxy.receipt_recorder import (
-    finalize_receipts,
+    finalize_recorded_flow,
     pop_receipt_announcement,
     receipt_worthy_actions,
     record_pending_receipts,
@@ -77,7 +78,7 @@ def _record(
     session: BuildSession,
     *actions: MatchedAction,
     approval_id: UUID | None = None,
-) -> list[UUID]:
+) -> list[tuple[UUID, str]]:
     return record_pending_receipts(
         tenant_id=get_current_tenant_id(),
         session_id=session.id,
@@ -159,10 +160,10 @@ def test_listing_is_owner_only_and_sweeps(
     build_session_with_user: Callable[..., BuildSession],
 ) -> None:
     session = build_session_with_user()
-    receipt_ids = _record(db_session, session, _WRITE)
+    entries = _record(db_session, session, _WRITE)
     force_receipt_created_at(
         db_session,
-        receipt_ids[0],
+        entries[0][0],
         datetime.now(timezone.utc) - timedelta(hours=1),
     )
 
@@ -183,14 +184,15 @@ def test_finalize_confirms(
 ) -> None:
     session = build_session_with_user()
     cache = get_cache_backend()
-    receipt_ids = _record(db_session, session, _WRITE)
+    entries = _record(db_session, session, _WRITE)
     pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
 
-    finalize_receipts(
+    finalize_recorded_flow(
         tenant_id=get_current_tenant_id(),
         session_id=session.id,
-        receipt_ids=receipt_ids,
-        status=ReceiptStatus.CONFIRMED,
+        entries=entries,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=None,
         cache_factory=lambda _tenant: cache,
     )
 
@@ -209,22 +211,24 @@ def test_finalize_failed_verdicts_do_not_flip(
 ) -> None:
     session = build_session_with_user()
     cache = get_cache_backend()
-    receipt_ids = _record(db_session, session, _WRITE)
+    entries = _record(db_session, session, _WRITE)
     pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
 
-    finalize_receipts(
+    finalize_recorded_flow(
         tenant_id=get_current_tenant_id(),
         session_id=session.id,
-        receipt_ids=receipt_ids,
-        status=ReceiptStatus.FAILED,
+        entries=entries,
+        transport_status=ReceiptStatus.FAILED,
+        response_body=None,
         cache_factory=lambda _tenant: cache,
     )
     # A late second verdict must not flip the recorded one.
-    finalize_receipts(
+    finalize_recorded_flow(
         tenant_id=get_current_tenant_id(),
         session_id=session.id,
-        receipt_ids=receipt_ids,
-        status=ReceiptStatus.CONFIRMED,
+        entries=entries,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=None,
         cache_factory=lambda _tenant: cache,
     )
 
@@ -259,3 +263,193 @@ def test_multiple_writes_each_get_a_receipt(
         "slack.messages.write",
         "slack.files.write",
     }
+
+
+def test_upload_flow_coalesces_into_one_receipt(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    cache = get_cache_backend()
+    upload_action = MatchedAction(
+        action_type="slack.files.write",
+        display_name="Upload files",
+        description="Upload a file.",
+        policy=EndpointPolicy.ASK,
+        effect=ActionEffect.WRITE,
+    )
+    matched = _matched(db_session, upload_action)
+
+    # Step one: keyless record, then its response reveals file id and token.
+    step_one_ids = record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=matched,
+        approval_id=None,
+        cache_factory=lambda _tenant: cache,
+    )
+    step_one_body = json.dumps(
+        {
+            "ok": True,
+            "file_id": "F42",
+            "upload_url": "https://files.slack.com/upload/v1/tok42",
+        }
+    ).encode()
+    finalize_recorded_flow(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        entries=step_one_ids,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=step_one_body,
+        cache_factory=lambda _tenant: cache,
+    )
+
+    # Step two: the raw-bytes POST carries only the token, resolved via the map.
+    step_two_ids = record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=matched,
+        approval_id=None,
+        cache_factory=lambda _tenant: cache,
+        request_path="/upload/v1/tok42",
+    )
+
+    # Step three: completeUploadExternal names the file id in its request.
+    step_three_ids = record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=matched,
+        approval_id=None,
+        cache_factory=lambda _tenant: cache,
+        request_body=json.dumps({"files": [{"id": "F42"}]}).encode(),
+    )
+
+    assert step_one_ids == step_two_ids == step_three_ids
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.operation_key == "slack.files.write:F42"
+    assert row.status is ReceiptStatus.CONFIRMED
+
+    # One receipt, two announcements: created and confirmed. The coalesced
+    # later steps must not announce it again.
+    first = pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
+    second = pop_receipt_announcement(session.id, timeout_s=1, cache=cache)
+    assert first is not None and first.status is ReceiptStatus.PENDING
+    assert second is not None and second.status is ReceiptStatus.CONFIRMED
+    assert pop_receipt_announcement(session.id, timeout_s=1, cache=cache) is None
+
+
+def test_upload_flow_failure_downgrades_the_coalesced_confirm(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    cache = get_cache_backend()
+    upload_action = MatchedAction(
+        action_type="slack.files.write",
+        display_name="Upload files",
+        description="Upload a file.",
+        policy=EndpointPolicy.ASK,
+        effect=ActionEffect.WRITE,
+    )
+    matched = _matched(db_session, upload_action)
+
+    step_one = record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=matched,
+        approval_id=None,
+        cache_factory=lambda _tenant: cache,
+    )
+    finalize_recorded_flow(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        entries=step_one,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=json.dumps({"ok": True, "file_id": "F77"}).encode(),
+        cache_factory=lambda _tenant: cache,
+    )
+
+    step_three = record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=matched,
+        approval_id=None,
+        cache_factory=lambda _tenant: cache,
+        request_body=json.dumps({"files": [{"id": "F77"}]}).encode(),
+    )
+    assert step_three == step_one
+    # completeUploadExternal fails: the truer verdict overturns step one's
+    # early CONFIRMED on the coalesced receipt.
+    finalize_recorded_flow(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        entries=step_three,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=json.dumps({"ok": False, "error": "not_in_channel"}).encode(),
+        cache_factory=lambda _tenant: cache,
+    )
+
+    db_session.expire_all()
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.status is ReceiptStatus.FAILED
+
+
+def test_refinement_persists_link_and_provider_verdict(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    cache = get_cache_backend()
+    receipt_ids = _record(db_session, session, _WRITE)
+
+    # Slack's 200 with ok=false must override the transport CONFIRMED.
+    finalize_recorded_flow(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        entries=receipt_ids,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=json.dumps({"ok": False, "error": "channel_not_found"}).encode(),
+        cache_factory=lambda _tenant: cache,
+    )
+    db_session.expire_all()
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.status is ReceiptStatus.FAILED
+
+    other_ids = _record(db_session, session, _WRITE)
+    finalize_recorded_flow(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        entries=other_ids,
+        transport_status=ReceiptStatus.CONFIRMED,
+        response_body=json.dumps({"ok": True, "channel": "C7", "ts": "1.2"}).encode(),
+        cache_factory=lambda _tenant: cache,
+    )
+    db_session.expire_all()
+    rows = {r.id: r for r in get_session_receipts(db_session, session_id=session.id)}
+    assert rows[other_ids[0][0]].link == "https://slack.com/archives/C7/p12"
+    assert rows[other_ids[0][0]].status is ReceiptStatus.CONFIRMED
+
+
+def test_destination_refined_from_the_request(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    session = build_session_with_user()
+    record_pending_receipts(
+        tenant_id=get_current_tenant_id(),
+        session_id=session.id,
+        matched_actions=_matched(db_session, _WRITE),
+        approval_id=None,
+        cache_factory=lambda _tenant: get_cache_backend(),
+        request_body=json.dumps({"channel": "exec-team", "text": "hi"}).encode(),
+    )
+    (row,) = get_session_receipts(db_session, session_id=session.id)
+    assert row.destination == "#exec-team"

--- a/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
@@ -258,6 +258,12 @@ def test_responseheaders_caps_undeclared_recorded_flows(
     addon.responseheaders(declared_oversize)
     assert declared_oversize.response.stream is True
 
+    # A negative declaration is a broken origin, not a small body.
+    declared_negative = _recorded_flow(200)
+    declared_negative.response.headers["content-length"] = "-1"
+    addon.responseheaders(declared_negative)
+    assert declared_negative.response.stream is True
+
     unrecorded = tflow.tflow(resp=True)
     addon.responseheaders(unrecorded)
     assert unrecorded.response is not None and unrecorded.response.stream is True

--- a/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
@@ -28,6 +28,7 @@ from onyx.sandbox_proxy.addons import gate as gate_module
 from onyx.sandbox_proxy.addons.gate import (
     RECEIPT_FLOW_KEY,
     GateAddon,
+    _CappedBodyCapture,
     _IdentityResolver,
 )
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
@@ -226,24 +227,31 @@ def test_oversized_decoded_body_refines_nothing(
     asyncio.run(addon.response(flow))
     assert calls[0]["response_body"] is None
 
-    # An undecodable body falls back to its raw bytes rather than raising;
-    # the extractors then simply fail to parse it.
+    # An undecodable body refines nothing rather than raising.
     flow = _recorded_flow(200)
     flow.response.headers["content-encoding"] = "gzip"
     flow.response.raw_content = b"not gzip"
     asyncio.run(addon.response(flow))
-    assert calls[1]["response_body"] == b"not gzip"
+    assert calls[1]["response_body"] is None
 
 
-def test_responseheaders_buffers_recorded_flows_without_declared_length() -> None:
+def test_responseheaders_caps_undeclared_recorded_flows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     addon = _addon()
 
-    # Chunked responses declare no length, but a recorded flow still buffers
-    # so the extractors can read it. Anything else streams as usual.
-    recorded = _recorded_flow(200)
-    del recorded.response.headers["content-length"]
-    addon.responseheaders(recorded)
-    assert recorded.response.stream is False
+    # Chunked responses declare no length, so a recorded flow streams through
+    # a capped observer the response hook reads. Small declared bodies buffer,
+    # oversize ones and unrecorded flows stream unobserved.
+    chunked = _recorded_flow(200)
+    del chunked.response.headers["content-length"]
+    addon.responseheaders(chunked)
+    capture = chunked.response.stream
+    assert isinstance(capture, _CappedBodyCapture)
+
+    small = _recorded_flow(200)
+    addon.responseheaders(small)
+    assert small.response.stream is False
 
     declared_oversize = _recorded_flow(200)
     declared_oversize.response.headers["content-length"] = str(2 * 1024 * 1024)
@@ -253,6 +261,35 @@ def test_responseheaders_buffers_recorded_flows_without_declared_length() -> Non
     unrecorded = tflow.tflow(resp=True)
     addon.responseheaders(unrecorded)
     assert unrecorded.response is not None and unrecorded.response.stream is True
+
+    # The observer passes chunks through untouched and the response hook
+    # reads the copy, so chunked provider responses still refine.
+    calls = _finalize_capture(monkeypatch)
+    payload = b'{"ok": true}'
+    assert capture(payload) == payload
+    assert capture(b"") == b""
+    asyncio.run(addon.response(chunked))
+    assert calls[0]["response_body"] == payload
+
+
+def test_capped_capture_drops_oversized_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    addon = _addon()
+    calls = _finalize_capture(monkeypatch)
+    flow = _recorded_flow(200)
+    del flow.response.headers["content-length"]
+    addon.responseheaders(flow)
+    capture = flow.response.stream
+    assert isinstance(capture, _CappedBodyCapture)
+
+    chunk = b"x" * (512 * 1024)
+    for _ in range(5):
+        assert capture(chunk) == chunk
+    assert capture.overflowed and not capture.body
+
+    asyncio.run(addon.response(flow))
+    assert calls[0]["response_body"] is None
 
 
 def test_always_policy_writes_still_record(

--- a/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import gzip
 from typing import Any, cast
 from uuid import UUID, uuid4
 
@@ -79,9 +80,9 @@ def test_record_stashes_a_serializable_carrier(
     receipt_id = uuid4()
     calls: list[dict[str, Any]] = []
 
-    def _fake_record(**kwargs: Any) -> list[UUID]:
+    def _fake_record(**kwargs: Any) -> list[tuple[UUID, str]]:
         calls.append(kwargs)
-        return [receipt_id]
+        return [(receipt_id, "slack.messages.write")]
 
     monkeypatch.setattr(gate_module, "record_pending_receipts", _fake_record)
     addon = _addon()
@@ -94,7 +95,7 @@ def test_record_stashes_a_serializable_carrier(
     assert carrier == {
         "tenant_id": "public",
         "session_id": str(ctx.session_id),
-        "receipt_ids": [str(receipt_id)],
+        "receipts": [[str(receipt_id), "slack.messages.write"]],
     }
     # mitmproxy deep-copies and serializes metadata, so primitives only.
     assert copy.deepcopy(carrier) == carrier
@@ -104,7 +105,7 @@ def test_record_stashes_a_serializable_carrier(
 def test_record_failure_never_blocks_the_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _boom(**_kwargs: Any) -> list[UUID]:
+    def _boom(**_kwargs: Any) -> list[tuple[UUID, str]]:
         raise RuntimeError("db down")
 
     monkeypatch.setattr(gate_module, "record_pending_receipts", _boom)
@@ -125,7 +126,7 @@ def _finalize_capture(
     def _fake_finalize(**kwargs: Any) -> None:
         calls.append(kwargs)
 
-    monkeypatch.setattr(gate_module, "finalize_receipts", _fake_finalize)
+    monkeypatch.setattr(gate_module, "finalize_recorded_flow", _fake_finalize)
     return calls
 
 
@@ -137,7 +138,7 @@ def _recorded_flow(status_code: int | None) -> Any:
     flow.metadata[RECEIPT_FLOW_KEY] = {
         "tenant_id": "public",
         "session_id": str(uuid4()),
-        "receipt_ids": [str(uuid4())],
+        "receipts": [[str(uuid4()), "slack.messages.write"]],
     }
     return flow
 
@@ -162,7 +163,7 @@ def test_response_hook_maps_status_to_verdict(
 
     asyncio.run(addon.response(flow))
 
-    assert calls[0]["status"] is expected
+    assert calls[0]["transport_status"] is expected
     # The carrier is consumed, a later hook cannot double-finalize.
     assert RECEIPT_FLOW_KEY not in flow.metadata
     asyncio.run(addon.response(flow))
@@ -178,11 +179,11 @@ def test_error_after_ok_headers_is_unknown(
     # Headers said 200, the body never finished: the origin may have
     # committed, so the verdict is UNKNOWN.
     asyncio.run(addon.error(_recorded_flow(200)))
-    assert calls[0]["status"] is ReceiptStatus.UNKNOWN
+    assert calls[0]["transport_status"] is ReceiptStatus.UNKNOWN
 
     # No response at all: the request never got a verdict, FAILED.
     asyncio.run(addon.error(_recorded_flow(None)))
-    assert calls[1]["status"] is ReceiptStatus.FAILED
+    assert calls[1]["transport_status"] is ReceiptStatus.FAILED
 
 
 def test_hooks_ignore_unrecorded_flows(
@@ -195,6 +196,63 @@ def test_hooks_ignore_unrecorded_flows(
     asyncio.run(addon.error(tflow.tflow()))
 
     assert calls == []
+
+
+def test_response_hook_hands_extractors_the_decoded_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _finalize_capture(monkeypatch)
+    addon = _addon()
+    flow = _recorded_flow(200)
+    payload = b'{"ok": true, "channel": "C1", "ts": "1.2"}'
+    flow.response.headers["content-encoding"] = "gzip"
+    flow.response.raw_content = gzip.compress(payload)
+
+    asyncio.run(addon.response(flow))
+
+    assert calls[0]["response_body"] == payload
+
+
+def test_oversized_decoded_body_refines_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _finalize_capture(monkeypatch)
+    addon = _addon()
+
+    # A small compressed body must not smuggle a huge decoded one past the cap.
+    flow = _recorded_flow(200)
+    flow.response.headers["content-encoding"] = "gzip"
+    flow.response.raw_content = gzip.compress(b" " * (2 * 1024 * 1024))
+    asyncio.run(addon.response(flow))
+    assert calls[0]["response_body"] is None
+
+    # An undecodable body falls back to its raw bytes rather than raising;
+    # the extractors then simply fail to parse it.
+    flow = _recorded_flow(200)
+    flow.response.headers["content-encoding"] = "gzip"
+    flow.response.raw_content = b"not gzip"
+    asyncio.run(addon.response(flow))
+    assert calls[1]["response_body"] == b"not gzip"
+
+
+def test_responseheaders_buffers_recorded_flows_without_declared_length() -> None:
+    addon = _addon()
+
+    # Chunked responses declare no length, but a recorded flow still buffers
+    # so the extractors can read it. Anything else streams as usual.
+    recorded = _recorded_flow(200)
+    del recorded.response.headers["content-length"]
+    addon.responseheaders(recorded)
+    assert recorded.response.stream is False
+
+    declared_oversize = _recorded_flow(200)
+    declared_oversize.response.headers["content-length"] = str(2 * 1024 * 1024)
+    addon.responseheaders(declared_oversize)
+    assert declared_oversize.response.stream is True
+
+    unrecorded = tflow.tflow(resp=True)
+    addon.responseheaders(unrecorded)
+    assert unrecorded.response is not None and unrecorded.response.stream is True
 
 
 def test_always_policy_writes_still_record(

--- a/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate_receipts.py
@@ -235,46 +235,35 @@ def test_oversized_decoded_body_refines_nothing(
     assert calls[1]["response_body"] is None
 
 
-def test_responseheaders_caps_undeclared_recorded_flows(
+def test_responseheaders_caps_every_recorded_flow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     addon = _addon()
 
-    # Chunked responses declare no length, so a recorded flow streams through
-    # a capped observer the response hook reads. Small declared bodies buffer,
-    # oversize ones and unrecorded flows stream unobserved.
+    # Every recorded flow streams through a capped observer the response hook
+    # reads, regardless of what length the origin declares. Unrecorded flows
+    # stream unobserved.
+    recorded = _recorded_flow(200)
+    addon.responseheaders(recorded)
+    capture = recorded.response.stream
+    assert isinstance(capture, _CappedBodyCapture)
+
     chunked = _recorded_flow(200)
     del chunked.response.headers["content-length"]
     addon.responseheaders(chunked)
-    capture = chunked.response.stream
-    assert isinstance(capture, _CappedBodyCapture)
-
-    small = _recorded_flow(200)
-    addon.responseheaders(small)
-    assert small.response.stream is False
-
-    declared_oversize = _recorded_flow(200)
-    declared_oversize.response.headers["content-length"] = str(2 * 1024 * 1024)
-    addon.responseheaders(declared_oversize)
-    assert declared_oversize.response.stream is True
-
-    # A negative declaration is a broken origin, not a small body.
-    declared_negative = _recorded_flow(200)
-    declared_negative.response.headers["content-length"] = "-1"
-    addon.responseheaders(declared_negative)
-    assert declared_negative.response.stream is True
+    assert isinstance(chunked.response.stream, _CappedBodyCapture)
 
     unrecorded = tflow.tflow(resp=True)
     addon.responseheaders(unrecorded)
     assert unrecorded.response is not None and unrecorded.response.stream is True
 
     # The observer passes chunks through untouched and the response hook
-    # reads the copy, so chunked provider responses still refine.
+    # reads the copy, so streamed provider responses still refine.
     calls = _finalize_capture(monkeypatch)
     payload = b'{"ok": true}'
     assert capture(payload) == payload
     assert capture(b"") == b""
-    asyncio.run(addon.response(chunked))
+    asyncio.run(addon.response(recorded))
     assert calls[0]["response_body"] == payload
 
 

--- a/backend/tests/unit/sandbox_proxy/test_receipt_extractors.py
+++ b/backend/tests/unit/sandbox_proxy/test_receipt_extractors.py
@@ -7,6 +7,7 @@ nothing rather than raise.
 """
 
 import json
+from typing import Any
 from urllib.parse import urlencode
 
 import pytest
@@ -21,7 +22,7 @@ from onyx.sandbox_proxy.receipt_extractors import (
 )
 
 
-def _body(payload: dict) -> bytes:
+def _body(payload: dict[str, Any]) -> bytes:
     return json.dumps(payload).encode()
 
 
@@ -129,10 +130,24 @@ def test_gdrive_links_follow_the_mime_type(mime: str, prefix: str) -> None:
 def test_gmail_send_and_draft_shapes_both_link() -> None:
     sent = response_facts("gmail.messages.send", _body({"id": "m1", "threadId": "t1"}))
     assert sent.link == "https://mail.google.com/mail/u/0/#all/m1"
+    # A draft is not in #all until sent, so its link opens the drafts view.
     draft = response_facts(
         "gmail.drafts.create", _body({"id": "d1", "message": {"id": "m2"}})
     )
-    assert draft.link == "https://mail.google.com/mail/u/0/#all/m2"
+    assert draft.link == "https://mail.google.com/mail/u/0/#drafts/m2"
+
+
+@pytest.mark.parametrize(
+    "key,prefix",
+    [
+        ("documentId", "https://docs.google.com/document/d/"),
+        ("spreadsheetId", "https://docs.google.com/spreadsheets/d/"),
+        ("presentationId", "https://docs.google.com/presentation/d/"),
+    ],
+)
+def test_gdrive_editor_api_ids_link_without_a_mime_type(key: str, prefix: str) -> None:
+    facts = response_facts("gdrive.slides.create", _body({key: "p123"}))
+    assert facts.link == f"{prefix}p123"
 
 
 def test_linear_errors_fail_and_only_shaped_urls_pass() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_receipt_extractors.py
+++ b/backend/tests/unit/sandbox_proxy/test_receipt_extractors.py
@@ -1,0 +1,202 @@
+"""Unit tests for the receipt extractors.
+
+Pure request/response parsing: destinations, deep links built from provider
+ids, provider-level verdicts hiding inside transport successes, and the
+coalescing keys for the Slack upload flow. Malformed bodies must refine
+nothing rather than raise.
+"""
+
+import json
+from urllib.parse import urlencode
+
+import pytest
+
+from onyx.db.enums import ReceiptStatus
+from onyx.sandbox_proxy.receipt_extractors import (
+    request_facts,
+    response_facts,
+    slack_upload_key,
+    slack_upload_url_token,
+    upload_url_token,
+)
+
+
+def _body(payload: dict) -> bytes:
+    return json.dumps(payload).encode()
+
+
+def test_slack_message_request_names_the_channel() -> None:
+    facts = request_facts("slack.messages.write", _body({"channel": "exec-team"}))
+    assert facts.destination == "#exec-team"
+    assert (
+        request_facts("slack.messages.write", _body({"channel": "#ops"})).destination
+        == "#ops"
+    )
+
+
+def test_slack_conversation_id_is_not_hash_prefixed() -> None:
+    facts = request_facts("slack.messages.write", _body({"channel": "C08ABCDEF"}))
+    assert facts.destination == "C08ABCDEF"
+
+
+def test_form_encoded_request_bodies_parse() -> None:
+    # slack_sdk sends form-encoded bodies, with nested values JSON-serialized.
+    message = urlencode({"channel": "exec-team", "text": "hi"}).encode()
+    assert request_facts("slack.messages.write", message).destination == "#exec-team"
+    complete = urlencode(
+        {"files": json.dumps([{"id": "F42", "title": "deck"}])}
+    ).encode()
+    facts = request_facts("slack.files.write", complete)
+    assert facts.operation_key == "slack.files.write:F42"
+
+
+def test_slack_ok_false_overrides_the_transport_verdict() -> None:
+    facts = response_facts(
+        "slack.messages.write", _body({"ok": False, "error": "channel_not_found"})
+    )
+    assert facts.status_override is ReceiptStatus.FAILED
+    assert facts.link is None
+
+
+def test_slack_message_link_built_from_channel_and_ts() -> None:
+    facts = response_facts(
+        "slack.messages.write",
+        _body({"ok": True, "channel": "C0123", "ts": "1712.3456"}),
+    )
+    assert facts.link == "https://slack.com/archives/C0123/p17123456"
+
+
+def test_unsafe_provider_ids_refine_nothing() -> None:
+    evil = response_facts(
+        "slack.messages.write",
+        _body({"ok": True, "channel": "C0123/../evil", "ts": "1712.3456"}),
+    )
+    assert evil.link is None
+    assert response_facts("gdrive.files.create", _body({"id": "a?b#c"})).link is None
+
+
+def test_slack_upload_flow_keys_coalesce() -> None:
+    step_one = {
+        "ok": True,
+        "file_id": "F999",
+        "upload_url": "https://files.slack.com/upload/v1/tok123",
+    }
+    assert slack_upload_key(step_one) == "slack.files.write:F999"
+    assert slack_upload_url_token(step_one) == "tok123"
+    # Step three carries the same file id in its request.
+    facts = request_facts(
+        "slack.files.write", _body({"files": [{"id": "F999", "title": "deck"}]})
+    )
+    assert facts.operation_key == "slack.files.write:F999"
+    # Step one's response reveals the same key for the keyless first receipt.
+    assert (
+        response_facts("slack.files.write", _body(step_one)).operation_key
+        == "slack.files.write:F999"
+    )
+
+
+def test_upload_url_token_shared_derivation_strips_queries() -> None:
+    # Writer side (step one's upload_url) and reader side (step two's request
+    # path) must agree even when a query string rides along.
+    assert upload_url_token("https://files.slack.com/upload/v1/tok?x=1") == "tok"
+    assert upload_url_token("/upload/v1/tok?x=1") == "tok"
+    assert upload_url_token("/upload/v1/tok/") == "tok"
+    assert upload_url_token("token-only") is None
+
+
+@pytest.mark.parametrize(
+    "mime,prefix",
+    [
+        ("application/vnd.google-apps.document", "https://docs.google.com/document/d/"),
+        (
+            "application/vnd.google-apps.spreadsheet",
+            "https://docs.google.com/spreadsheets/d/",
+        ),
+        (
+            "application/vnd.google-apps.presentation",
+            "https://docs.google.com/presentation/d/",
+        ),
+        ("application/pdf", "https://drive.google.com/file/d/"),
+    ],
+)
+def test_gdrive_links_follow_the_mime_type(mime: str, prefix: str) -> None:
+    facts = response_facts(
+        "gdrive.files.create", _body({"id": "abc123", "mimeType": mime})
+    )
+    assert facts.link == f"{prefix}abc123"
+
+
+def test_gmail_send_and_draft_shapes_both_link() -> None:
+    sent = response_facts("gmail.messages.send", _body({"id": "m1", "threadId": "t1"}))
+    assert sent.link == "https://mail.google.com/mail/u/0/#all/m1"
+    draft = response_facts(
+        "gmail.drafts.create", _body({"id": "d1", "message": {"id": "m2"}})
+    )
+    assert draft.link == "https://mail.google.com/mail/u/0/#all/m2"
+
+
+def test_linear_errors_fail_and_only_shaped_urls_pass() -> None:
+    failed = response_facts(
+        "linear.issues.create", _body({"errors": [{"message": "boom"}]})
+    )
+    assert failed.status_override is ReceiptStatus.FAILED
+
+    good = response_facts(
+        "linear.issues.create",
+        _body(
+            {
+                "data": {
+                    "issueCreate": {
+                        "issue": {"url": "https://linear.app/acme/issue/ENG-42/title"}
+                    }
+                }
+            }
+        ),
+    )
+    assert good.link == "https://linear.app/acme/issue/ENG-42/title"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example/x",
+        "https://linear.app/acme/issue/ENG-42?redirect=https://evil.example",
+        "https://linear.app/acme/issue/ENG-42/title#fragment",
+        "https://linear.app/acme/issue/ENG-42/../../x",
+        "https://linear.app/acme/issue/" + "a" * 600,
+    ],
+)
+def test_linear_rejects_unshaped_urls(url: str) -> None:
+    facts = response_facts(
+        "linear.issues.create",
+        _body({"data": {"issueCreate": {"issue": {"url": url}}}}),
+    )
+    assert facts.link is None
+
+
+def test_linear_url_found_inside_a_list_payload() -> None:
+    facts = response_facts(
+        "linear.issues.create",
+        _body(
+            {
+                "data": {
+                    "issueBatchCreate": {
+                        "issues": [{"url": "https://linear.app/acme/issue/ENG-1/first"}]
+                    }
+                }
+            }
+        ),
+    )
+    assert facts.link == "https://linear.app/acme/issue/ENG-1/first"
+
+
+def test_malformed_bodies_refine_nothing() -> None:
+    for raw in (None, b"", b"{", b"[1,2]", b"\xff\xfe"):
+        assert request_facts("slack.messages.write", raw).destination is None
+        facts = response_facts("slack.messages.write", raw)
+        assert facts.link is None and facts.status_override is None
+
+
+def test_unknown_actions_refine_nothing() -> None:
+    assert response_facts("hubspot.deals.write", _body({"id": "x"})).link is None
+    assert request_facts("mcp.some_tool", _body({"channel": "x"})).destination is None

--- a/backend/tests/unit/sandbox_proxy/test_receipt_extractors.py
+++ b/backend/tests/unit/sandbox_proxy/test_receipt_extractors.py
@@ -135,6 +135,9 @@ def test_gmail_send_and_draft_shapes_both_link() -> None:
         "gmail.drafts.create", _body({"id": "d1", "message": {"id": "m2"}})
     )
     assert draft.link == "https://mail.google.com/mail/u/0/#drafts/m2"
+    # drafts.send consumes the draft and returns the sent Message.
+    sent_draft = response_facts("gmail.drafts.send", _body({"id": "m3"}))
+    assert sent_draft.link == "https://mail.google.com/mail/u/0/#all/m3"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**Why.** After #14341, a receipt proves an action left the sandbox, but says nothing a user can act on: no link to the thing that was created, a Slack failure inside a 200 still shows CONFIRMED, and one file upload shows as three receipts. This PR makes receipts user-grade proof.

**What.**
- New `receipt_extractors.py`: pure per-provider refinement. Request side names the destination (`#exec-team`, JSON or form-encoded bodies) and keys the upload flow's final step. Response side builds deep links from shape-checked provider ids (Slack permalink, Drive by mime type, Gmail message), and overrides the verdict when the provider hides failure inside a 200 (Slack `ok:false`, Linear GraphQL `errors`). Linear is the one provider whose canonical URL is accepted, behind an anchored shape check. Everything else is constructed from validated ids, never trusted from payloads.
- Slack's three-request upload flow coalesces into one receipt: step three keys in from its request, step one from its response, and the raw-bytes step through a short-lived session-scoped Redis token map. A later step's failure downgrades the coalesced receipt's early CONFIRMED, and coalesced repeats never re-announce (`insert`/`finalize` now report created/changed).
- The gate buffers a recorded flow's response unless declared oversize and reads it Content-Encoding decoded, with the 1 MiB cap applied to the decoded length.

Example receipt after this PR: `slack.messages.write → #exec-team, CONFIRMED, https://slack.com/archives/C0123/p17123456`.

## How Has This Been Tested?

- 22 extractor unit tests (links, verdict overrides, coalescing keys, form-encoded bodies, malformed/unsafe input refusal, anchored Linear shapes).
- 14 gate wiring unit tests, including the gzip decode path, the small-compressed/huge-decoded cap, and chunked-response buffering.
- Ext-dep tests against real Postgres+Redis: the full three-step upload coalescing to one receipt with exactly two announcements, failure downgrade of a coalesced CONFIRMED, link and verdict persistence, destination-from-request.
- Full sweeps: `tests/unit/sandbox_proxy` + `external_apps` + `server` 791 passed, craft ext-dep suite 377 passed + 1 xfailed, `ty check` and `ruff` clean.

## Additional Options

- [ ] This PR should be considered for cherry-picking to the release branch
- [x] Override Linear Check