### PR TITLE
chore(devops): blame-ignore the getattr annotation commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,4 @@ ed3f72bc75f3e3a9ae9e4d8cd38278f9c97e78b4  # refactor(whitespace): rm react fragm
 7b927e79c25f4ddfd18a067f489e122acd2c89de  # chore(format): format files where `ruff` and `black` agree (#9339)
 9881c0382283cf959e77cfd02e9275a5a6d98615  # chore(fmt): remove `order-by-type` (#13183)
 46af76e98a7252e29cf63e1e995bf1fa4b358389  # chore(fmt): remove `force-single-line` (#12996)
+8ddc6df49c2339ae74ff5146cffb95992b9b5012  # chore(devops): enforce `ods check-getattr` via pre-commit (#14263)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ods check-getattr` pre-commit commit (#14263) to `.git-blame-ignore-revs` so git blame skips that large formatting change and stays focused on meaningful edits.

<sup>Written for commit 5c4736cb76031fdd8e883b0f92fc0b8df031eddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

