### PR TITLE
fix(mcp): store each MCP tool once when a connect fires two refreshes (#14348) to release v4.6

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -18,6 +18,7 @@ from mcp.client.auth import OAuthClientProvider
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl, BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import (
@@ -1563,9 +1564,7 @@ def _upsert_db_tools(
     processed_names: set[str],
     mcp_server_id: int,
     db: Session,
-) -> bool:
-    db_dirty = False
-
+) -> None:
     for tool in discovered_tools:
         tool_name = tool.name
         if not tool_name:
@@ -1578,15 +1577,9 @@ def _upsert_db_tools(
         input_schema = tool.inputSchema
 
         if existing_tool := existing_by_name.get(tool_name):
-            if existing_tool.description != description:
-                existing_tool.description = description
-                db_dirty = True
-            if existing_tool.display_name != display_name:
-                existing_tool.display_name = display_name
-                db_dirty = True
-            if existing_tool.mcp_input_schema != input_schema:
-                existing_tool.mcp_input_schema = input_schema
-                db_dirty = True
+            existing_tool.description = description
+            existing_tool.display_name = display_name
+            existing_tool.mcp_input_schema = input_schema
             continue
 
         new_tool = create_tool__no_commit(
@@ -1602,8 +1595,43 @@ def _upsert_db_tools(
         )
         new_tool.display_name = display_name
         new_tool.mcp_input_schema = input_schema
-        db_dirty = True
-    return db_dirty
+        # Register it so a repeated name in this response is not inserted again.
+        existing_by_name[tool_name] = new_tool
+
+
+def _sync_mcp_server_tools(
+    mcp_server_id: int,
+    discovered_tools: list[MCPLibTool],
+    db: Session,
+) -> None:
+    """Make the stored tools for the server match the discovered tools.
+
+    Locks the server row so concurrent refreshes run one at a time. The second
+    caller then sees the rows the first one committed instead of inserting them
+    again. The commit at the end releases the lock.
+    """
+    db.execute(
+        select(DbMCPServer.id).where(DbMCPServer.id == mcp_server_id).with_for_update()
+    )
+
+    existing_by_name: dict[str, Tool] = {}
+    for db_tool in get_tools_by_mcp_server_id(mcp_server_id, db, order_by_id=True):
+        if db_tool.name in existing_by_name:
+            # Duplicate left by an earlier unguarded sync; keep the oldest row.
+            delete_tool__no_commit(db_tool.id, db)
+            continue
+        existing_by_name[db_tool.name] = db_tool
+
+    processed_names: set[str] = set()
+    _upsert_db_tools(
+        discovered_tools, existing_by_name, processed_names, mcp_server_id, db
+    )
+
+    for name, db_tool in existing_by_name.items():
+        if name not in processed_names:
+            delete_tool__no_commit(db_tool.id, db)
+
+    db.commit()
 
 
 def _list_mcp_tools_by_id(
@@ -1683,21 +1711,7 @@ def _list_mcp_tools_by_id(
     db.commit()
 
     if is_admin:
-        existing_tools = get_tools_by_mcp_server_id(mcp_server.id, db)
-        existing_by_name = {db_tool.name: db_tool for db_tool in existing_tools}
-        processed_names: set[str] = set()
-
-        db_dirty = _upsert_db_tools(
-            discovered_tools, existing_by_name, processed_names, mcp_server.id, db
-        )
-
-        for name, db_tool in existing_by_name.items():
-            if name not in processed_names:
-                delete_tool__no_commit(db_tool.id, db)
-                db_dirty = True
-
-        if db_dirty:
-            db.commit()
+        _sync_mcp_server_tools(mcp_server.id, discovered_tools, db)
 
     # Truncate tool descriptions to prevent overly long responses
     for tool in discovered_tools:

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_tool_sync.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_tool_sync.py
@@ -1,0 +1,132 @@
+"""Tool sync for an MCP server (`_sync_mcp_server_tools`) against a real DB.
+
+Regression coverage for onyx-dot-app/onyx#14346: one OAuth connect fired two
+concurrent tool refreshes and every tool was stored twice."""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+import pytest
+from mcp.types import Tool as MCPLibTool
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.db.mcp import create_mcp_server__no_commit
+from onyx.db.models import MCPServer, Tool
+from onyx.db.tools import get_tools_by_mcp_server_id
+from onyx.server.features.mcp import api as mcp_api
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+def _make_server(db_session: Session) -> MCPServer:
+    server = create_mcp_server__no_commit(
+        owner_email="admin@example.com",
+        name=f"sync-{uuid4().hex[:8]}",
+        description=None,
+        server_url=f"https://sync-{uuid4().hex[:8]}.example.com/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        db_session=db_session,
+    )
+    db_session.commit()
+    return server
+
+
+def _discovered(names: list[str]) -> list[MCPLibTool]:
+    return [
+        MCPLibTool(name=name, description=f"{name} desc", inputSchema={})
+        for name in names
+    ]
+
+
+def _names(db_session: Session, server_id: int) -> list[str]:
+    db_session.expire_all()
+    return sorted(t.name for t in get_tools_by_mcp_server_id(server_id, db_session))
+
+
+def test_concurrent_syncs_store_each_tool_once(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _make_server(db_session)
+    names = [f"tool_{i}" for i in range(54)]
+
+    # Mirror the production race: both callers read the tool table before
+    # either writes. A short pause after the read widens that window.
+    real_get_tools = mcp_api.get_tools_by_mcp_server_id
+
+    def slow_get_tools(
+        mcp_server_id: int,
+        db_session: Session,
+        *,
+        only_enabled: bool = False,
+        order_by_id: bool = False,
+    ) -> list[Tool]:
+        rows = real_get_tools(
+            mcp_server_id,
+            db_session,
+            only_enabled=only_enabled,
+            order_by_id=order_by_id,
+        )
+        time.sleep(0.5)
+        return rows
+
+    monkeypatch.setattr(mcp_api, "get_tools_by_mcp_server_id", slow_get_tools)
+
+    start = threading.Barrier(2)
+
+    def run_sync() -> None:
+        CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+        with get_session_with_current_tenant() as session:
+            start.wait(timeout=10)
+            mcp_api._sync_mcp_server_tools(server.id, _discovered(names), session)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(run_sync) for _ in range(2)]
+        for future in futures:
+            future.result(timeout=30)
+
+    assert _names(db_session, server.id) == sorted(names)
+
+
+def test_repeated_name_in_one_discovery_is_stored_once(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    server = _make_server(db_session)
+
+    mcp_api._sync_mcp_server_tools(
+        server.id, _discovered(["dup", "dup", "other"]), db_session
+    )
+
+    assert _names(db_session, server.id) == ["dup", "other"]
+
+
+def test_sync_collapses_existing_duplicates_and_drops_stale_tools(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    server = _make_server(db_session)
+    for name in ("keep", "keep", "stale"):
+        db_session.add(Tool(name=name, description="", mcp_server_id=server.id))
+    db_session.commit()
+    keeper_id = min(
+        t.id
+        for t in get_tools_by_mcp_server_id(server.id, db_session)
+        if t.name == "keep"
+    )
+
+    mcp_api._sync_mcp_server_tools(server.id, _discovered(["keep"]), db_session)
+
+    remaining = get_tools_by_mcp_server_id(server.id, db_session)
+    assert [(t.id, t.name) for t in remaining] == [(keeper_id, "keep")]

--- a/web/src/sections/actions/MCPPageContent.test.tsx
+++ b/web/src/sections/actions/MCPPageContent.test.tsx
@@ -1,0 +1,96 @@
+import { render, waitFor } from "@tests/setup/test-utils";
+import MCPPageContent from "@/sections/actions/MCPPageContent";
+import { MCPServerStatus } from "@/lib/tools/interfaces";
+
+const mockUpdateMCPServerStatus = jest.fn();
+const mockRefreshMCPServerTools = jest.fn();
+const mockMutateMcpServers = jest.fn();
+const mockRouterReplace = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+// Regression for onyx-dot-app/onyx#14346: the OAuth return URL
+// (?server_id=N&trigger_fetch=true) must start exactly one tool fetch.
+const mockSearchParams = new URLSearchParams({
+  server_id: "7",
+  trigger_fetch: "true",
+});
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockRouterReplace, push: jest.fn() }),
+  usePathname: () => "/admin/actions",
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Stable identity, like SWR's cached data. A fresh object per render would
+// spin the component's own effects instead of testing the trigger effect.
+const mockMcpData = { mcp_servers: [] };
+
+jest.mock("@/hooks/useMcpServers", () => ({
+  __esModule: true,
+  default: () => ({
+    mcpData: mockMcpData,
+    isLoading: false,
+    mutateMcpServers: mockMutateMcpServers,
+  }),
+}));
+
+jest.mock("@/lib/tools/mcpService", () => ({
+  ...jest.requireActual("@/lib/tools/mcpService"),
+  updateMCPServerStatus: (...args: unknown[]) =>
+    mockUpdateMCPServerStatus(...args),
+  refreshMCPServerTools: (...args: unknown[]) =>
+    mockRefreshMCPServerTools(...args),
+}));
+
+jest.mock("@opal/layouts", () => ({
+  ...jest.requireActual("@opal/layouts"),
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+    info: jest.fn(),
+  },
+}));
+
+jest.mock("@/sections/actions/MCPActionCard", () => ({
+  __esModule: true,
+  default: () => <div data-testid="mcp-action-card" />,
+}));
+jest.mock("@/sections/actions/modals/MCPAuthenticationModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/sections/actions/modals/AddMCPServerModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("@/sections/actions/modals/DisconnectEntityModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateMCPServerStatus.mockResolvedValue(undefined);
+  mockRefreshMCPServerTools.mockResolvedValue([]);
+  mockMutateMcpServers.mockResolvedValue(undefined);
+});
+
+test("trigger_fetch query param fetches tools exactly once", async () => {
+  render(<MCPPageContent />);
+
+  await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledTimes(1));
+  // Give any stray second run time to land before asserting the counts.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  expect(mockUpdateMCPServerStatus).toHaveBeenCalledTimes(1);
+  expect(mockUpdateMCPServerStatus).toHaveBeenCalledWith(
+    7,
+    MCPServerStatus.FETCHING_TOOLS
+  );
+  expect(mockRefreshMCPServerTools).toHaveBeenCalledTimes(1);
+  expect(mockRefreshMCPServerTools).toHaveBeenCalledWith(7);
+  expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  expect(mockToastError).not.toHaveBeenCalled();
+  expect(mockRouterReplace).toHaveBeenCalledTimes(1);
+});

--- a/web/src/sections/actions/MCPPageContent.tsx
+++ b/web/src/sections/actions/MCPPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { KeyedMutator } from "swr";
 import MCPActionCard from "@/sections/actions/MCPActionCard";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
@@ -61,6 +61,11 @@ export default function MCPPageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
+  // Server whose `?trigger_fetch=true` was already handled. The effect below
+  // re-runs whenever a dependency changes identity, and the URL param is only
+  // cleared after async work, so this keeps the fetch one-shot.
+  const handledTriggerFetchServerIdRef = useRef<number | null>(null);
+
   useEffect(() => {
     const serverId = searchParams.get("server_id");
     const triggerFetch = searchParams.get("trigger_fetch");
@@ -69,9 +74,11 @@ export default function MCPPageContent() {
     if (
       serverId &&
       triggerFetch === "true" &&
+      handledTriggerFetchServerIdRef.current !== parseInt(serverId) &&
       !fetchingToolsServerIds.includes(parseInt(serverId))
     ) {
       const serverIdInt = parseInt(serverId);
+      handledTriggerFetchServerIdRef.current = serverIdInt;
 
       const handleFetchingTools = async () => {
         try {
@@ -115,12 +122,17 @@ export default function MCPPageContent() {
 
   // Track fetching tools server IDs
   useEffect(() => {
-    if (mcpServers) {
-      const fetchingIds = mcpServers
-        .filter((server) => server.status === MCPServerStatus.FETCHING_TOOLS)
-        .map((server) => server.id);
-      setFetchingToolsServerIds(fetchingIds);
-    }
+    const fetchingIds = mcpServers
+      .filter((server) => server.status === MCPServerStatus.FETCHING_TOOLS)
+      .map((server) => server.id);
+    // Keep the previous array when the ids are unchanged so effects that
+    // depend on it do not re-run for a new identity with the same contents.
+    setFetchingToolsServerIds((prev) =>
+      prev.length === fetchingIds.length &&
+      prev.every((id, index) => id === fetchingIds[index])
+        ? prev
+        : fetchingIds
+    );
   }, [mcpServers]);
 
   // Track if any modal is open to manage the shared overlay


### PR DESCRIPTION
Cherry-pick of commit 4ad5e21b2bc283446da8eb8ed92348805415d183 to release/v4.6 branch.

Original PR: #14348

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where an MCP OAuth connect fired two concurrent tool refreshes and stored every MCP tool twice; each tool is now stored exactly once without affecting tool discovery.

- Locks the MCP server row so concurrent refreshes run one at a time and see each other's committed rows.
- Dedupes duplicate tools left by earlier unguarded syncs and removes tools that are no longer discovered.
- Makes the web client's `?trigger_fetch=true` URL param start exactly one fetch per server instead of re-firing on re-renders.

<sup>Written for commit 3df1fe11fb562ba5374fe3447c1924476b8562a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

