### PR TITLE
chore(devops): drop sandbox from the image audit matrix

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1963,14 +1963,12 @@ jobs:
       - build-web-cloud-amd64
       - build-backend-amd64
       - build-model-server-amd64
-      - build-sandbox-amd64
     if: >-
       always() && !cancelled() &&
       (needs.build-web-amd64.result == 'success' ||
        needs.build-web-cloud-amd64.result == 'success' ||
        needs.build-backend-amd64.result == 'success' ||
-       needs.build-model-server-amd64.result == 'success' ||
-       needs.build-sandbox-amd64.result == 'success')
+       needs.build-model-server-amd64.result == 'success')
     runs-on:
       - runs-on
       # amd64 to match the images scanned: `ods audit image` uses the docker CLI,
@@ -1998,8 +1996,6 @@ jobs:
             registry-image: onyxdotapp/onyx-backend
           - component: model-server
             registry-image: onyxdotapp/onyx-model-server
-          - component: sandbox
-            registry-image: onyxdotapp/sandbox
     steps:
       - name: Check if this scan should run
         id: should-run
@@ -2009,7 +2005,6 @@ jobs:
             web-cloud) RESULT="$BUILD_WEB_CLOUD" ;;
             backend) RESULT="$BUILD_BACKEND" ;;
             model-server) RESULT="$BUILD_MODEL_SERVER" ;;
-            sandbox) RESULT="$BUILD_SANDBOX" ;;
           esac
           if [ "$RESULT" == "success" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
@@ -2022,7 +2017,6 @@ jobs:
           BUILD_WEB_CLOUD: ${{ needs.build-web-cloud-amd64.result }}
           BUILD_BACKEND: ${{ needs.build-backend-amd64.result }}
           BUILD_MODEL_SERVER: ${{ needs.build-model-server-amd64.result }}
-          BUILD_SANDBOX: ${{ needs.build-sandbox-amd64.result }}
 
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
         if: steps.should-run.outputs.run == 'true'
@@ -2066,7 +2060,6 @@ jobs:
             web-cloud) DIGEST="$DIGEST_WEB_CLOUD" ;;
             backend) DIGEST="$DIGEST_BACKEND" ;;
             model-server) DIGEST="$DIGEST_MODEL_SERVER" ;;
-            sandbox) DIGEST="$DIGEST_SANDBOX" ;;
           esac
           if [ "$IS_TEST_RUN" == "true" ]; then
             echo "image=${RUNS_ON_ECR_CACHE}@${DIGEST}" >> "$GITHUB_OUTPUT"
@@ -2081,7 +2074,6 @@ jobs:
           DIGEST_WEB_CLOUD: ${{ needs.build-web-cloud-amd64.outputs.digest }}
           DIGEST_BACKEND: ${{ needs.build-backend-amd64.outputs.digest }}
           DIGEST_MODEL_SERVER: ${{ needs.build-model-server-amd64.outputs.digest }}
-          DIGEST_SANDBOX: ${{ needs.build-sandbox-amd64.outputs.digest }}
 
       - name: Run image vulnerability audit
         if: steps.should-run.outputs.run == 'true'


### PR DESCRIPTION
This image in particular, primarily because it distributes chromium, is too noisy to have gating releases.

## Description

Remove the sandbox image from the `image-audit` job in `.github/workflows/deployment.yml`.

The change is scoped to that job:

- Drop `build-sandbox-amd64` from `needs` and from the job `if`.
- Drop the `sandbox` matrix entry.
- Drop the `sandbox)` branches from the "Check if this scan should run" and "Determine scan image" case statements, plus the `BUILD_SANDBOX` / `DIGEST_SANDBOX` env vars.

## Notes

- `merge-sandbox` keeps `needs.image-audit.result == 'success'`. The backend and model-server images always build, so `image-audit` always runs and the gate cannot deadlock the sandbox tags.
- The `image-audit-sandbox` SARIF category stops receiving uploads. Existing alerts under that category stay in the Security tab until they are dismissed.

## How Has This Been Tested?

`pre-commit run --files .github/workflows/deployment.yml` (zizmor, actionlint, Check YAML all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the sandbox image from the `image-audit` job so the workflow no longer builds or scans it. The `merge-sandbox` gate still works because the backend and model-server images always build, and the `image-audit-sandbox` SARIF category stops receiving uploads; existing alerts remain until dismissed.

<sup>Written for commit f445aa2c16ff86fb989c71636e492fdabe7ca0f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

