### PR TITLE
perf(auth): use conditional requests for the disposable email domain fetch

### DIFF
--- a/backend/onyx/auth/disposable_email_validator.py
+++ b/backend/onyx/auth/disposable_email_validator.py
@@ -45,6 +45,10 @@ class DisposableEmailValidator:
 
         self._domains: Set[str] = set()
         self._last_fetch_time: float = 0
+        # HTTP cache validators from the last successful fetch. Used for
+        # conditional requests so unchanged lists are not re-downloaded.
+        self._etag: str | None = None
+        self._last_modified: str | None = None
         self._fetch_lock = threading.Lock()
         # Cache for 1 hour
         self._cache_duration = 3600
@@ -70,9 +74,19 @@ class DisposableEmailValidator:
         """Check if the cached domains should be refreshed."""
         return (time.time() - self._last_fetch_time) > self._cache_duration
 
+    def _previous_or_fallback_domains(self) -> Set[str]:
+        """Return the last good set if one exists, else the hardcoded fallback."""
+        if self._domains:
+            return self._domains
+        return self._fallback_domains.copy()
+
     def _fetch_domains(self) -> Set[str]:
         """
         Fetch disposable email domains from the configured URL.
+
+        Sends a conditional request (If-None-Match / If-Modified-Since) when
+        validators from a previous fetch are available. A 304 response keeps
+        the cached set without downloading the full list again.
 
         Returns:
             Set of domain strings (lowercased)
@@ -81,13 +95,24 @@ class DisposableEmailValidator:
             logger.debug("DISPOSABLE_EMAIL_DOMAINS_URL not configured")
             return self._fallback_domains.copy()
 
+        headers: dict[str, str] = {}
+        if self._etag:
+            headers["If-None-Match"] = self._etag
+        if self._last_modified:
+            headers["If-Modified-Since"] = self._last_modified
+
         try:
             logger.info(
                 "Fetching disposable email domains from %s",
                 DISPOSABLE_EMAIL_DOMAINS_URL,
             )
             with httpx.Client(timeout=10.0) as client:
-                response = client.get(DISPOSABLE_EMAIL_DOMAINS_URL)
+                response = client.get(DISPOSABLE_EMAIL_DOMAINS_URL, headers=headers)
+
+                if response.status_code == 304 and self._domains:
+                    logger.info("Disposable email domains unchanged (304)")
+                    return self._domains
+
                 response.raise_for_status()
 
                 domains_list = response.json()
@@ -97,13 +122,16 @@ class DisposableEmailValidator:
                         "Expected list from disposable domains URL, got %s",
                         type(domains_list),
                     )
-                    return self._fallback_domains.copy()
+                    return self._previous_or_fallback_domains()
 
                 # Convert all to lowercase and create set
                 domains = {domain.lower().strip() for domain in domains_list if domain}
 
                 # Always include fallback domains
                 domains.update(self._fallback_domains)
+
+                self._etag = response.headers.get("ETag")
+                self._last_modified = response.headers.get("Last-Modified")
 
                 logger.info(
                     "Successfully fetched %s disposable email domains", len(domains)
@@ -115,8 +143,8 @@ class DisposableEmailValidator:
         except Exception as e:
             logger.warning("Failed to fetch disposable domains: %s", e)
 
-        # On error, return fallback domains
-        return self._fallback_domains.copy()
+        # On error, keep the last good set (or the fallback if none exists)
+        return self._previous_or_fallback_domains()
 
     def get_domains(self) -> Set[str]:
         """

--- a/backend/tests/unit/onyx/auth/test_disposable_email_validator.py
+++ b/backend/tests/unit/onyx/auth/test_disposable_email_validator.py
@@ -2,10 +2,131 @@
 Tests for disposable email validation.
 """
 
+from collections.abc import Generator
+from unittest import mock
+
+import httpx
+import pytest
+
 from onyx.auth.disposable_email_validator import (
     DisposableEmailValidator,
     is_disposable_email,
 )
+
+_TEST_URL = "https://example.com/domains.json"
+_ETAG = '"6a919fa3-14d4e7"'
+_LAST_MODIFIED = "Fri, 28 Aug 2026 14:48:03 GMT"
+
+
+@pytest.fixture
+def fresh_validator() -> Generator[DisposableEmailValidator, None, None]:
+    """Provide a non-singleton validator instance and restore the singleton."""
+    original = DisposableEmailValidator._instance
+    DisposableEmailValidator._instance = None
+    try:
+        yield DisposableEmailValidator()
+    finally:
+        DisposableEmailValidator._instance = original
+
+
+def _response(
+    status_code: int,
+    json_body: list[str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=json_body,
+        headers=headers,
+        request=httpx.Request("GET", _TEST_URL),
+    )
+
+
+class TestConditionalFetch:
+    """Test ETag / Last-Modified handling when fetching the domain list."""
+
+    def test_first_fetch_sends_no_conditional_headers_and_stores_validators(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+            client.get.return_value = _response(
+                200,
+                json_body=["fetched-domain.example"],
+                headers={"ETag": _ETAG, "Last-Modified": _LAST_MODIFIED},
+            )
+
+            domains = fresh_validator.get_domains()
+
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert "If-None-Match" not in sent_headers
+        assert "If-Modified-Since" not in sent_headers
+
+        assert "fetched-domain.example" in domains
+        assert fresh_validator._etag == _ETAG
+        assert fresh_validator._last_modified == _LAST_MODIFIED
+
+    def test_304_keeps_cached_domains(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+            client.get.return_value = _response(
+                200,
+                json_body=["fetched-domain.example"],
+                headers={"ETag": _ETAG, "Last-Modified": _LAST_MODIFIED},
+            )
+            fresh_validator.get_domains()
+
+            # Expire the cache and answer the refresh with a 304
+            fresh_validator._last_fetch_time = 0
+            client.get.return_value = _response(304)
+            domains = fresh_validator.get_domains()
+
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert sent_headers["If-None-Match"] == _ETAG
+        assert sent_headers["If-Modified-Since"] == _LAST_MODIFIED
+
+        assert "fetched-domain.example" in domains
+        assert fresh_validator._etag == _ETAG
+
+    def test_fetch_error_keeps_previously_fetched_domains(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+            client.get.return_value = _response(
+                200,
+                json_body=["fetched-domain.example"],
+                headers={"ETag": _ETAG},
+            )
+            fresh_validator.get_domains()
+
+            fresh_validator._last_fetch_time = 0
+            client.get.side_effect = httpx.ConnectError("network down")
+            domains = fresh_validator.get_domains()
+
+        assert "fetched-domain.example" in domains
+        # Fallback domains stay included as well
+        assert "trashlify.com" in domains
+
+    def test_fetch_error_without_prior_fetch_returns_fallback(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+            client.get.side_effect = httpx.ConnectError("network down")
+            domains = fresh_validator.get_domains()
+
+        assert domains == fresh_validator._fallback_domains
 
 
 class TestDisposableEmailValidator:


### PR DESCRIPTION
## Description

`DisposableEmailValidator` re-downloads the full disposable email domain list (~1.3 MB) on every hourly cache refresh. The GitHub Pages host behind the default `DISPOSABLE_EMAIL_DOMAINS_URL` returns `ETag` and `Last-Modified` headers and honors conditional requests.

This PR:

- Stores the `ETag` / `Last-Modified` values from the last successful fetch.
- Sends them as `If-None-Match` / `If-Modified-Since` on refresh. A `304 Not Modified` response keeps the cached set and skips the download.
- Keeps the last good set (instead of shrinking to the hardcoded fallback list) when a refresh fails after a successful fetch.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/auth/test_disposable_email_validator.py` cover: no conditional headers on the first fetch, validator storage, the 304 path, and the error paths with and without a prior successful fetch.
- `uv run pytest backend/tests/unit/onyx/auth/test_disposable_email_validator.py` — 13 passed.
- Verified live that the default URL answers `If-None-Match` and `If-Modified-Since` with `304` and an empty body.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the hourly disposable email domain refresh from a full ~1.3 MB download to a conditional request, keeping the cached set when the server responds `304 Not Modified`. Also keeps the last successfully fetched domain set instead of shrinking to the hardcoded fallback list when a refresh fails.

- Stores `ETag` and `Last-Modified` from the last successful fetch and sends them as `If-None-Match` / `If-Modified-Since` on refresh.
- A `304` response returns the current cached domains without re-downloading.
- On fetch errors, returns the last good set if one exists; falls back to the hardcoded list only if no fetch has ever succeeded.
- Adds unit tests covering the initial fetch, the `304` path, and both error scenarios.

<sup>Written for commit 4fb04c1a1e1a686b7437e8f0ca355135723b499e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

