### PR TITLE
perf(auth): refresh disposable email domains in the background

### DIFF
--- a/backend/onyx/auth/disposable_email_validator.py
+++ b/backend/onyx/auth/disposable_email_validator.py
@@ -168,14 +168,20 @@ class DisposableEmailValidator:
         """
         with self._spawn_lock:
             thread = self._refresh_thread
-            if thread is None or not thread.is_alive():
-                thread = threading.Thread(
-                    target=self._refresh,
-                    name="disposable-email-domains-refresh",
-                    daemon=True,
-                )
-                self._refresh_thread = thread
-                thread.start()
+            if thread is not None:
+                if thread.is_alive():
+                    return thread
+                # Re-check staleness under the lock: a refresh may have
+                # completed after the caller decided one was needed
+                if not self._should_refresh():
+                    return thread
+            thread = threading.Thread(
+                target=self._refresh,
+                name="disposable-email-domains-refresh",
+                daemon=True,
+            )
+            self._refresh_thread = thread
+            thread.start()
             return thread
 
     def get_domains(self) -> Set[str]:

--- a/backend/onyx/auth/disposable_email_validator.py
+++ b/backend/onyx/auth/disposable_email_validator.py
@@ -22,7 +22,11 @@ class DisposableEmailValidator:
     """
     Thread-safe singleton validator for disposable email domains.
 
-    Fetches and caches the list of disposable domains, with periodic refresh.
+    Fetches and caches the list of disposable domains. Refreshes are
+    stale-while-revalidate: callers always get the cached set (or the
+    hardcoded fallback before the first fetch completes) immediately,
+    and a background thread updates the cache. Callers never wait on
+    the network.
     """
 
     _instance: "DisposableEmailValidator | None" = None
@@ -49,7 +53,10 @@ class DisposableEmailValidator:
         # conditional requests so unchanged lists are not re-downloaded.
         self._etag: str | None = None
         self._last_modified: str | None = None
-        self._fetch_lock = threading.Lock()
+        # Guards check-and-set of the refresh thread so only one refresh
+        # runs at a time. Never held during network calls.
+        self._spawn_lock = threading.Lock()
+        self._refresh_thread: threading.Thread | None = None
         # Cache for 1 hour
         self._cache_duration = 3600
         # Hardcoded fallback list of common disposable domains
@@ -146,27 +153,48 @@ class DisposableEmailValidator:
         # On error, keep the last good set (or the fallback if none exists)
         return self._previous_or_fallback_domains()
 
+    def _refresh(self) -> None:
+        """Fetch the list and swap the cache. Runs on the refresh thread."""
+        domains = self._fetch_domains()
+        self._domains = domains
+        self._last_fetch_time = time.time()
+
+    def _start_refresh(self) -> threading.Thread:
+        """
+        Start a background refresh unless one is already running.
+
+        Returns:
+            The running (or just-started) refresh thread
+        """
+        with self._spawn_lock:
+            thread = self._refresh_thread
+            if thread is None or not thread.is_alive():
+                thread = threading.Thread(
+                    target=self._refresh,
+                    name="disposable-email-domains-refresh",
+                    daemon=True,
+                )
+                self._refresh_thread = thread
+                thread.start()
+            return thread
+
     def get_domains(self) -> Set[str]:
         """
         Get the cached set of disposable email domains.
-        Refreshes the cache if needed.
+
+        Stale-while-revalidate: a stale cache triggers a background
+        refresh, and the current set is returned immediately. Before
+        the first fetch completes, this is the hardcoded fallback set.
 
         Returns:
             Set of disposable domain strings (lowercased)
         """
-        # Fast path: return cached domains if still fresh
-        if self._domains and not self._should_refresh():
-            return self._domains.copy()
+        if self._should_refresh():
+            self._start_refresh()
 
-        # Slow path: need to refresh
-        with self._fetch_lock:
-            # Double-check after acquiring lock
-            if self._domains and not self._should_refresh():
-                return self._domains.copy()
-
-            self._domains = self._fetch_domains()
-            self._last_fetch_time = time.time()
+        if self._domains:
             return self._domains.copy()
+        return self._fallback_domains.copy()
 
     def is_disposable(self, email: str) -> bool:
         """
@@ -217,7 +245,8 @@ def refresh_disposable_domains() -> None:
     Force a refresh of the disposable domains list.
 
     This can be called manually if you want to update the list
-    without waiting for the cache to expire.
+    without waiting for the cache to expire. Unlike normal cache
+    expiry, this blocks until the refresh completes.
     """
     _validator._last_fetch_time = 0
-    _validator.get_domains()
+    _validator._start_refresh().join()

--- a/backend/tests/unit/onyx/auth/test_disposable_email_validator.py
+++ b/backend/tests/unit/onyx/auth/test_disposable_email_validator.py
@@ -44,7 +44,8 @@ def _response(
 
 
 def _refresh_and_get(validator: DisposableEmailValidator) -> set[str]:
-    """Run a refresh to completion and return the resulting domains."""
+    """Force a refresh, run it to completion, and return the domains."""
+    validator._last_fetch_time = 0
     thread = validator._start_refresh()
     thread.join(timeout=5)
     assert not thread.is_alive()
@@ -208,6 +209,25 @@ class TestStaleWhileRevalidate:
 
             assert client.get.call_count == 1
             assert "fetched-domain.example" in fresh_validator.get_domains()
+
+    def test_no_redundant_refresh_when_cache_became_fresh(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+            client.get.return_value = _response(
+                200, json_body=["fetched-domain.example"], headers={"ETag": _ETAG}
+            )
+            _refresh_and_get(fresh_validator)
+            assert client.get.call_count == 1
+
+            # A caller that saw a stale cache before this refresh finished
+            # must not trigger a second fetch now that the cache is fresh
+            thread = fresh_validator._start_refresh()
+            thread.join(timeout=5)
+            assert client.get.call_count == 1
 
 
 class TestDisposableEmailValidator:

--- a/backend/tests/unit/onyx/auth/test_disposable_email_validator.py
+++ b/backend/tests/unit/onyx/auth/test_disposable_email_validator.py
@@ -2,6 +2,7 @@
 Tests for disposable email validation.
 """
 
+import threading
 from collections.abc import Generator
 from unittest import mock
 
@@ -42,6 +43,14 @@ def _response(
     )
 
 
+def _refresh_and_get(validator: DisposableEmailValidator) -> set[str]:
+    """Run a refresh to completion and return the resulting domains."""
+    thread = validator._start_refresh()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    return validator.get_domains()
+
+
 class TestConditionalFetch:
     """Test ETag / Last-Modified handling when fetching the domain list."""
 
@@ -58,7 +67,7 @@ class TestConditionalFetch:
                 headers={"ETag": _ETAG, "Last-Modified": _LAST_MODIFIED},
             )
 
-            domains = fresh_validator.get_domains()
+            domains = _refresh_and_get(fresh_validator)
 
         sent_headers = client.get.call_args.kwargs["headers"]
         assert "If-None-Match" not in sent_headers
@@ -80,12 +89,11 @@ class TestConditionalFetch:
                 json_body=["fetched-domain.example"],
                 headers={"ETag": _ETAG, "Last-Modified": _LAST_MODIFIED},
             )
-            fresh_validator.get_domains()
+            _refresh_and_get(fresh_validator)
 
-            # Expire the cache and answer the refresh with a 304
-            fresh_validator._last_fetch_time = 0
+            # Answer the next refresh with a 304
             client.get.return_value = _response(304)
-            domains = fresh_validator.get_domains()
+            domains = _refresh_and_get(fresh_validator)
 
         sent_headers = client.get.call_args.kwargs["headers"]
         assert sent_headers["If-None-Match"] == _ETAG
@@ -106,11 +114,10 @@ class TestConditionalFetch:
                 json_body=["fetched-domain.example"],
                 headers={"ETag": _ETAG},
             )
-            fresh_validator.get_domains()
+            _refresh_and_get(fresh_validator)
 
-            fresh_validator._last_fetch_time = 0
             client.get.side_effect = httpx.ConnectError("network down")
-            domains = fresh_validator.get_domains()
+            domains = _refresh_and_get(fresh_validator)
 
         assert "fetched-domain.example" in domains
         # Fallback domains stay included as well
@@ -124,9 +131,83 @@ class TestConditionalFetch:
         ) as mock_client:
             client = mock_client.return_value.__enter__.return_value
             client.get.side_effect = httpx.ConnectError("network down")
-            domains = fresh_validator.get_domains()
+            domains = _refresh_and_get(fresh_validator)
 
         assert domains == fresh_validator._fallback_domains
+
+
+class TestStaleWhileRevalidate:
+    """Test that callers never wait on the network for a refresh."""
+
+    def test_stale_cache_is_served_while_refresh_runs(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+            client.get.return_value = _response(
+                200, json_body=["old-domain.example"], headers={"ETag": _ETAG}
+            )
+            _refresh_and_get(fresh_validator)
+
+            release = threading.Event()
+
+            def slow_get(*_args: object, **_kwargs: object) -> httpx.Response:
+                assert release.wait(timeout=5)
+                return _response(200, json_body=["new-domain.example"])
+
+            client.get.side_effect = slow_get
+
+            # Expire the cache: the next call must return the stale set
+            # immediately while the refresh runs in the background
+            fresh_validator._last_fetch_time = 0
+            stale = fresh_validator.get_domains()
+            assert "old-domain.example" in stale
+            assert "new-domain.example" not in stale
+
+            thread = fresh_validator._refresh_thread
+            assert thread is not None
+            assert thread.is_alive()
+
+            release.set()
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+            assert "new-domain.example" in fresh_validator.get_domains()
+
+    def test_cold_start_returns_fallback_and_shares_one_refresh(
+        self, fresh_validator: DisposableEmailValidator
+    ) -> None:
+        with mock.patch(
+            "onyx.auth.disposable_email_validator.httpx.Client"
+        ) as mock_client:
+            client = mock_client.return_value.__enter__.return_value
+
+            release = threading.Event()
+
+            def slow_get(*_args: object, **_kwargs: object) -> httpx.Response:
+                assert release.wait(timeout=5)
+                return _response(200, json_body=["fetched-domain.example"])
+
+            client.get.side_effect = slow_get
+
+            # Both calls return the fallback immediately; the second call
+            # must not start a second refresh
+            first = fresh_validator.get_domains()
+            second = fresh_validator.get_domains()
+            assert first == fresh_validator._fallback_domains
+            assert second == fresh_validator._fallback_domains
+
+            thread = fresh_validator._refresh_thread
+            assert thread is not None
+
+            release.set()
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+            assert client.get.call_count == 1
+            assert "fetched-domain.example" in fresh_validator.get_domains()
 
 
 class TestDisposableEmailValidator:


### PR DESCRIPTION
## Description

Stacked on #14356.

`is_disposable_email` is called from the async registration path (`UserManager.create` → `verify_email_domain`). When the hourly cache expired, the next registration ran the domain-list fetch inline on the event loop thread — up to the 10s HTTP timeout during which every concurrent request on that process stalled.

This PR switches the cache to stale-while-revalidate:

- `get_domains()` never blocks on the network. A stale cache triggers a refresh on a daemon thread, and the current set is returned immediately.
- Before the first fetch completes (process cold start), callers get the hardcoded fallback set.
- Only one refresh thread runs at a time; concurrent callers share it.
- `refresh_disposable_domains()` keeps its blocking "force refresh" semantics by joining the refresh thread.

## How Has This Been Tested?

- New unit tests: a stale cache is served immediately while a (deliberately blocked) refresh runs, and the new list is visible after it completes; cold start returns the fallback set, and concurrent calls share a single refresh (one HTTP request).
- Reworked the conditional-fetch (ETag/304) tests from #14356 to drive the refresh thread explicitly.
- `uv run pytest backend/tests/unit/onyx/auth/test_disposable_email_validator.py` — 15 passed.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops registration requests from stalling when the disposable email domain cache expires: the domain-list fetch ran inline on the event loop and could block every request for the 10s HTTP timeout. The cache now refreshes stale-while-revalidate — callers get the cached set immediately while a background thread fetches a new one.

- Before the first fetch completes, callers get the hardcoded fallback set.
- Concurrent callers share a single refresh thread, so only one HTTP request fires.
- `refresh_disposable_domains()` keeps its blocking force-refresh behavior by joining the refresh thread.
- ETag/304 conditional fetch behavior is preserved.
- A staleness re-check under the spawn lock prevents a redundant fetch if a refresh completes between the staleness check and thread spawn.

<sup>Written for commit 1dad6ede8ea9a730daabbb0927e98db30501228c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

