### PR TITLE
docs(terraform-provider): give the provider its own LICENSE

### DIFF
--- a/terraform-provider-onyx/LICENSE
+++ b/terraform-provider-onyx/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2023-present DanswerAI, Inc.
+
+This provider is distributed under the "MIT Expat" license, the same terms the
+Onyx monorepo applies to content outside its "ee" directories. It contains no
+Enterprise-licensed code.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

The release mirror, `onyx-dot-app/terraform-provider-onyx`, is a standalone public repository and carries no license at all.

Copying the monorepo's `LICENSE` would not do the job: its text divides the tree into `ee` directories and everything else, and the mirror has no `ee` directories to divide. So this states MIT plainly, keeping the monorepo's copyright line and its licence text word for word.

That is accurate rather than a simplification. The provider is a standalone Go binary that talks to the Onyx HTTP API — `module github.com/onyx-dot-app/onyx/terraform-provider-onyx` with no `require` on any Onyx package. The only "Enterprise" references in it are schema documentation strings, such as "Enterprise Edition only — Community Edition rejects a set with users or groups." `onyx_user_group` manages an Enterprise *feature* over HTTP, which is not the same as containing Enterprise-licensed code.

**It has to live here, not in the mirror.** A release replaces the mirror's whole tree with this directory's tree, so a `LICENSE` added only to the mirror would be dropped by the next release.

## How Has This Been Tested?

Built a snapshot release and confirmed goreleaser now puts `LICENSE` into every platform archive alongside `README.md` and the provider binary. It needs no configuration — goreleaser includes `LICENSE*` by default.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
<!-- Tracked under the umbrella issue ENG-4322 (Terraform provider for Onyx — rollout plan) rather than as its own Linear issue. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MIT license to the Terraform provider, so the public release mirror's archives are no longer unlicensed.

- Reuses the monorepo's MIT text since the monorepo `LICENSE` splits `ee` vs non-`ee` content, which doesn't apply to the mirror.
- The provider contains no Enterprise-licensed code; it's a standalone Go binary that talks to the HTTP API.
- The file lives in `terraform-provider-onyx/` rather than the mirror because releases replace the mirror's entire tree.

<sup>Written for commit 97b41b35d59a253441b58c0c7a36d96b20397e17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

