### PR TITLE
fix(llm): isolate Bedrock sync calls from litellm's shared HTTP pool

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1071,14 +1071,15 @@ class LitellmLLM(LLM):
     def _uses_isolated_client(self) -> bool:
         """Providers whose sync calls need a fresh per-call HTTPHandler instead of
         litellm's shared module_level_client (see threading notes in invoke())."""
-        return (
-            any(
-                is_true_openai_model(self.config.model_provider, name)
-                for name in resolve_model_identity_names(
-                    self.config.model_name, self.config.deployment_name
-                )
+        return any(
+            is_true_openai_model(self.config.model_provider, name)
+            for name in resolve_model_identity_names(
+                self.config.model_name, self.config.deployment_name
             )
-            or self.config.model_provider == LlmProviderNames.ANTHROPIC
+        ) or self.config.model_provider in (
+            LlmProviderNames.ANTHROPIC,
+            LlmProviderNames.BEDROCK,
+            LlmProviderNames.BEDROCK_CONVERSE,
         )
 
     def invoke(
@@ -1117,12 +1118,13 @@ class LitellmLLM(LLM):
         #      corrupt the pool state for other threads
         #    - Each request gets its own fresh httpx.Client via HTTPHandler
         #
-        # 3. WHY ANTHROPIC ALSO GETS AN ISOLATED CLIENT:
+        # 3. WHY ANTHROPIC AND BEDROCK ALSO GET AN ISOLATED CLIENT:
         #    - An abandoned sync stream is finalized by GC, which can fire on a thread
         #      already inside the shared pool's non-reentrant lock and deadlock it,
         #      wedging all later LLM calls (encode/httpcore#996; seen in prod).
-        #    - A per-call client keeps abandoned streams off the shared pool. litellm's
-        #      anthropic handler uses module_level_client only when client is None.
+        #    - A per-call client keeps abandoned streams off the shared pool. The
+        #      litellm anthropic and bedrock handlers both use module_level_client
+        #      only when client is None.
         #
         # 4. PITFALL - is_true_openai_model() CHECK:
         #    - Must use is_true_openai_model() NOT just check model_provider == "openai"

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1315,12 +1315,19 @@ def test_anthropic_model_passes_isolated_client() -> None:
         assert isinstance(kwargs["client"], HTTPHandler)
 
 
-def test_bedrock_model_passes_no_client() -> None:
-    """Test that Bedrock models don't get a client passed."""
+@pytest.mark.parametrize(
+    "model_provider",
+    [LlmProviderNames.BEDROCK, LlmProviderNames.BEDROCK_CONVERSE],
+)
+def test_bedrock_model_passes_isolated_client(model_provider: str) -> None:
+    """Bedrock gets a per-call HTTPHandler so abandoned streams can't deadlock
+    litellm's shared module_level_client pool (see _uses_isolated_client)."""
+    from litellm import HTTPHandler
+
     llm = LitellmLLM(
         api_key=None,
         timeout=30,
-        model_provider=LlmProviderNames.BEDROCK,
+        model_provider=model_provider,
         model_name="anthropic.claude-3-sonnet-20240229-v1:0",
         max_input_tokens=200000,
     )
@@ -1346,7 +1353,7 @@ def test_bedrock_model_passes_no_client() -> None:
 
         mock_completion.assert_called_once()
         kwargs = mock_completion.call_args.kwargs
-        assert kwargs["client"] is None
+        assert isinstance(kwargs["client"], HTTPHandler)
 
 
 def test_azure_openai_model_uses_httphandler_client() -> None:


### PR DESCRIPTION
## Description

Bedrock chat streams ran on litellm's shared `module_level_client`.

The GC finalizes an abandoned sync stream on whichever thread triggers collection. That
thread can already hold httpcore's non-reentrant connection-pool lock. The finalizer
re-enters that lock and deadlocks the shared pool permanently.

Every later LLM call in the process then blocks on that lock. Each blocked call pins an
anyio threadpool thread. The pool holds 40 threads by default. When it empties, every sync
endpoint stops answering. Nothing appears in the logs, because nothing raises.

#13295 fixed this exact failure for Anthropic and left Bedrock on the shared pool. This
change gives Bedrock the same per-call `HTTPHandler`. The litellm bedrock handler takes an
explicit client and falls back to `module_level_client` only when that client is `None`, so
abandoned streams stay off the shared pool.

Covers `bedrock_converse` as well as `bedrock`.

Note for reviewers: `test_bedrock_model_passes_no_client` pinned the previous behaviour. This
PR inverts it to `test_bedrock_model_passes_isolated_client` and runs it over both provider
names.

## How Has This Been Tested?

- `pytest backend/tests/unit/onyx/llm/` - 554 pass.
- `pre-commit run --files backend/onyx/llm/multi_llm.py backend/tests/unit/onyx/llm/test_multi_llm.py`
  - ty, ruff and ruff format pass.
- Confirmed the commit cherry-picks onto `release/v4.6` with no conflicts, and that 146 tests
  pass on that branch with it applied.
- Not yet exercised against live Bedrock. The litellm signatures accept a passed client
  (`make_sync_call(client: Optional[HTTPHandler])`, `completion(client=...)`). One real call
  should confirm this before merge.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bedrock sync calls deadlocking litellm's shared HTTP pool by giving each Bedrock request its own per-call `HTTPHandler`, matching the existing Anthropic fix.

Applies to both `bedrock` and `bedrock_converse` providers. Deadlocked calls previously blocked every subsequent sync LLM call in the process, exhausting the default 40-thread pool while logging nothing.

- Updates the unit test to assert an isolated `HTTPHandler` is passed for both Bedrock provider names, replacing the test that pinned the old no-client behavior.
- Cherry-picks cleanly onto `release/v4.6`; 146 tests pass there.

**Migration**
- Not yet validated against live Bedrock; one real call should confirm the litellm signatures accept the passed client before merge.

<sup>Written for commit 27babd46b69a180cec1c77f28e68fbf1f18c989f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

