### PR TITLE
fix(llm): isolate Bedrock sync calls from litellm's shared HTTP pool (#14362) to release v4.6

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1037,14 +1037,15 @@ class LitellmLLM(LLM):
     def _uses_isolated_client(self) -> bool:
         """Providers whose sync calls need a fresh per-call HTTPHandler instead of
         litellm's shared module_level_client (see threading notes in invoke())."""
-        return (
-            any(
-                is_true_openai_model(self.config.model_provider, name)
-                for name in resolve_model_identity_names(
-                    self.config.model_name, self.config.deployment_name
-                )
+        return any(
+            is_true_openai_model(self.config.model_provider, name)
+            for name in resolve_model_identity_names(
+                self.config.model_name, self.config.deployment_name
             )
-            or self.config.model_provider == LlmProviderNames.ANTHROPIC
+        ) or self.config.model_provider in (
+            LlmProviderNames.ANTHROPIC,
+            LlmProviderNames.BEDROCK,
+            LlmProviderNames.BEDROCK_CONVERSE,
         )
 
     def invoke(
@@ -1083,12 +1084,13 @@ class LitellmLLM(LLM):
         #      corrupt the pool state for other threads
         #    - Each request gets its own fresh httpx.Client via HTTPHandler
         #
-        # 3. WHY ANTHROPIC ALSO GETS AN ISOLATED CLIENT:
+        # 3. WHY ANTHROPIC AND BEDROCK ALSO GET AN ISOLATED CLIENT:
         #    - An abandoned sync stream is finalized by GC, which can fire on a thread
         #      already inside the shared pool's non-reentrant lock and deadlock it,
         #      wedging all later LLM calls (encode/httpcore#996; seen in prod).
-        #    - A per-call client keeps abandoned streams off the shared pool. litellm's
-        #      anthropic handler uses module_level_client only when client is None.
+        #    - A per-call client keeps abandoned streams off the shared pool. The
+        #      litellm anthropic and bedrock handlers both use module_level_client
+        #      only when client is None.
         #
         # 4. PITFALL - is_true_openai_model() CHECK:
         #    - Must use is_true_openai_model() NOT just check model_provider == "openai"

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1313,12 +1313,19 @@ def test_anthropic_model_passes_isolated_client() -> None:
         assert isinstance(kwargs["client"], HTTPHandler)
 
 
-def test_bedrock_model_passes_no_client() -> None:
-    """Test that Bedrock models don't get a client passed."""
+@pytest.mark.parametrize(
+    "model_provider",
+    [LlmProviderNames.BEDROCK, LlmProviderNames.BEDROCK_CONVERSE],
+)
+def test_bedrock_model_passes_isolated_client(model_provider: str) -> None:
+    """Bedrock gets a per-call HTTPHandler so abandoned streams can't deadlock
+    litellm's shared module_level_client pool (see _uses_isolated_client)."""
+    from litellm import HTTPHandler
+
     llm = LitellmLLM(
         api_key=None,
         timeout=30,
-        model_provider=LlmProviderNames.BEDROCK,
+        model_provider=model_provider,
         model_name="anthropic.claude-3-sonnet-20240229-v1:0",
         max_input_tokens=200000,
     )
@@ -1344,7 +1351,7 @@ def test_bedrock_model_passes_no_client() -> None:
 
         mock_completion.assert_called_once()
         kwargs = mock_completion.call_args.kwargs
-        assert kwargs["client"] is None
+        assert isinstance(kwargs["client"], HTTPHandler)
 
 
 def test_azure_openai_model_uses_httphandler_client() -> None:


### PR DESCRIPTION
Cherry-pick of commit b3093e11f80953eb13821570d141302daf8c6fe0 to release/v4.6 branch.

Original PR: #14362

Opened by hand because the cherry-pick automation only targets the latest release
version (v4.7, #14363). The reported deployments run 4.6.3 and 4.6.4, so v4.6 needs
the fix too.

Applies cleanly with no conflicts. `pytest backend/tests/unit/onyx/llm/` passes on
this branch (495 tests).

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bedrock sync calls in the v4.6 line so an abandoned stream can't deadlock litellm's shared HTTP pool and wedge later LLM calls. Cherry-picks the fix from #14362 because deployments seeing the issue run 4.6.3 and 4.6.4, and the cherry-pick automation only targets the latest release branch.

- `BEDROCK` and `BEDROCK_CONVERSE` now get a per-call `HTTPHandler` instead of litellm's shared module-level client.
- Unit tests updated to assert an isolated client is passed; the full `backend/tests/unit/onyx/llm/` suite passes on this branch.

<sup>Written for commit 5448c900aeeb3eb0d75203e9ec3cca041c16a90e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

