### PR TITLE
fix(api): harden the admin config API for machine clients

### DIFF
--- a/backend/ee/onyx/db/standard_answer.py
+++ b/backend/ee/onyx/db/standard_answer.py
@@ -6,6 +6,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.models import StandardAnswer, StandardAnswerCategory
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -109,6 +111,36 @@ def remove_standard_answer(
         raise ValueError(f"No standard answer with id {standard_answer_id}")
 
     standard_answer.active = False
+    db_session.commit()
+
+
+def remove_standard_answer_category(
+    standard_answer_category_id: int,
+    db_session: Session,
+) -> None:
+    """Hard delete, unlike a standard answer, which deactivates. A category has
+    no active flag, and anything still pointing at it would be left dangling, so
+    a referenced category is refused instead."""
+    category = fetch_standard_answer_category(
+        standard_answer_category_id=standard_answer_category_id,
+        db_session=db_session,
+    )
+    if category is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"No standard answer category with id {standard_answer_category_id}",
+        )
+
+    active_answers = [answer for answer in category.standard_answers if answer.active]
+    if active_answers or category.slack_channel_configs:
+        raise OnyxError(
+            OnyxErrorCode.RESOURCE_IN_USE,
+            f"Cannot delete this category: {len(active_answers)} standard "
+            f"answer(s) and {len(category.slack_channel_configs)} Slack channel "
+            "config(s) still use it.",
+        )
+
+    db_session.delete(category)
     db_session.commit()
 
 

--- a/backend/ee/onyx/db/standard_answer.py
+++ b/backend/ee/onyx/db/standard_answer.py
@@ -119,8 +119,14 @@ def remove_standard_answer_category(
     db_session: Session,
 ) -> None:
     """Hard delete, unlike a standard answer, which deactivates. A category has
-    no active flag, and anything still pointing at it would be left dangling, so
-    a referenced category is refused instead."""
+    no active flag, and anything still in use pointing at it would be left
+    dangling, so a referenced category is refused instead.
+
+    A deactivated standard answer does not block: it is already gone from every
+    caller's point of view, and there is no route that revives one. Its rows in
+    the association table go with the category, which SQLAlchemy removes itself
+    for a `secondary` relationship.
+    """
     category = fetch_standard_answer_category(
         standard_answer_category_id=standard_answer_category_id,
         db_session=db_session,

--- a/backend/ee/onyx/db/standard_answer.py
+++ b/backend/ee/onyx/db/standard_answer.py
@@ -3,6 +3,7 @@ import string
 from collections.abc import Sequence
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.db.models import StandardAnswer, StandardAnswerCategory
@@ -147,7 +148,18 @@ def remove_standard_answer_category(
         )
 
     db_session.delete(category)
-    db_session.commit()
+    try:
+        db_session.commit()
+    except IntegrityError:
+        # A concurrent write can attach an answer or a Slack config between the
+        # check above and this commit. Both association tables carry a foreign
+        # key to the category, so the delete is refused rather than leaving the
+        # new row dangling. Report it the same way the check does.
+        db_session.rollback()
+        raise OnyxError(
+            OnyxErrorCode.RESOURCE_IN_USE,
+            "Cannot delete this category: it came into use while being deleted.",
+        )
 
 
 def update_standard_answer_category(

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -265,6 +265,17 @@ def _add_user_group_snapshot_eager_loads(
     )
 
 
+def fetch_user_group_for_snapshot(
+    db_session: Session, user_group_id: int
+) -> UserGroup | None:
+    """Eager-loaded for UserGroup.from_model, so reading one group costs one
+    query set instead of the whole tenant listing."""
+    stmt = _add_user_group_snapshot_eager_loads(
+        select(UserGroup).where(UserGroup.id == user_group_id)
+    )
+    return db_session.scalar(stmt)
+
+
 def fetch_user_groups(
     db_session: Session,
     only_up_to_date: bool = True,

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -450,8 +450,12 @@ def fetch_user_groups_for_documents(
 
 def _check_user_group_is_modifiable(user_group: UserGroup) -> None:
     if not user_group.is_up_to_date:
-        raise ValueError(
-            "Specified user group is currently syncing. Wait until the current sync has finished before editing."
+        # OnyxError, not ValueError: the routes map ValueError to NOT_FOUND, so a
+        # syncing group used to be indistinguishable from a deleted one.
+        raise OnyxError(
+            OnyxErrorCode.RESOURCE_SYNCING,
+            "Specified user group is currently syncing. Wait until the current "
+            "sync has finished before editing.",
         )
 
 

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -811,9 +811,16 @@ def update_user_group(
     _check_user_group_is_modifiable(db_user_group)
 
     current_cc_pair_ids = set(_current_cc_pair_ids(db_user_group))
-    requested_cc_pair_ids = set(user_group_update.cc_pair_ids)
+    leave_cc_pairs_alone = user_group_update.cc_pair_ids is None
+    requested_cc_pair_ids = (
+        current_cc_pair_ids
+        if leave_cc_pairs_alone
+        else set(user_group_update.cc_pair_ids or [])
+    )
     _assert_default_group_update_allowed(
-        user, db_user_group, attaching_cc_pairs=bool(requested_cc_pair_ids)
+        user,
+        db_user_group,
+        attaching_cc_pairs=not leave_cc_pairs_alone and bool(requested_cc_pair_ids),
     )
     _assert_group_update_within_scope(
         db_session,
@@ -881,7 +888,7 @@ def update_user_group(
         _add_user_group__cc_pair_relationships__no_commit(
             db_session=db_session,
             user_group_id=db_user_group.id,
-            cc_pair_ids=user_group_update.cc_pair_ids,
+            cc_pair_ids=list(requested_cc_pair_ids),
         )
 
     if cc_pairs_updated and not DISABLE_VECTOR_DB:

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -817,16 +817,17 @@ def update_user_group(
         if leave_cc_pairs_alone
         else set(user_group_update.cc_pair_ids or [])
     )
+    added_cc_pair_ids = requested_cc_pair_ids - current_cc_pair_ids
     _assert_default_group_update_allowed(
         user,
         db_user_group,
-        attaching_cc_pairs=not leave_cc_pairs_alone and bool(requested_cc_pair_ids),
+        attaching_cc_pairs=bool(added_cc_pair_ids),
     )
     _assert_group_update_within_scope(
         db_session,
         user,
         user_group_id,
-        added_cc_pair_ids=requested_cc_pair_ids - current_cc_pair_ids,
+        added_cc_pair_ids=added_cc_pair_ids,
     )
 
     current_user_ids = set([user.id for user in db_user_group.users])

--- a/backend/ee/onyx/server/manage/standard_answer.py
+++ b/backend/ee/onyx/server/manage/standard_answer.py
@@ -9,6 +9,7 @@ from ee.onyx.db.standard_answer import (
     insert_standard_answer,
     insert_standard_answer_category,
     remove_standard_answer,
+    remove_standard_answer_category,
     update_standard_answer,
     update_standard_answer_category,
 )
@@ -144,3 +145,15 @@ def patch_standard_answer_category(
         db_session=db_session,
     )
     return StandardAnswerCategory.from_model(standard_answer_category_model)
+
+
+@router.delete("/admin/standard-answer/category/{standard_answer_category_id}")
+def delete_standard_answer_category(
+    standard_answer_category_id: int,
+    db_session: Session = Depends(get_session),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> None:
+    remove_standard_answer_category(
+        standard_answer_category_id=standard_answer_category_id,
+        db_session=db_session,
+    )

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -8,6 +8,7 @@ from ee.onyx.db.user_group import (
     add_users_to_user_group,
     assert_group_membership_survives_deletion,
     fetch_user_group,
+    fetch_user_group_for_snapshot,
     fetch_user_groups,
     fetch_user_groups_for_user,
     insert_user_group,
@@ -130,6 +131,50 @@ def list_user_groups(
         )
         for user_group in user_groups
     ]
+
+
+@router.get("/admin/user-group/{user_group_id}")
+def get_user_group(
+    user_group_id: int,
+    user: User = Depends(
+        require_permission(Permission.READ_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> UserGroup:
+    """Read one group. The listing carries every group with its nested connector,
+    document-set and agent snapshots, so reading one used to cost all of them."""
+    # GATE 2 (read): mirrors list_user_groups — a scoped manager may only read a
+    # group they manage, so they cannot enumerate the org one id at a time.
+    managed_group_ids = (
+        get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        if has_permission(user, Permission.MANAGE_USER_GROUPS)
+        is PermissionAuthority.SCOPED
+        else set[int]()
+    )
+    can_manage = manages_group(
+        user, db_session, group_id=user_group_id, managed_group_ids=managed_group_ids
+    )
+    if not has_global_permission(user, Permission.READ_USER_GROUPS) and not can_manage:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "User group not found")
+
+    user_group = fetch_user_group_for_snapshot(db_session, user_group_id)
+    if user_group is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "User group not found")
+
+    return UserGroup.from_model(
+        user_group,
+        mask_credential_prefix=get_security_settings().mask_credential_prefix,
+        permissions=user_group_permissions(
+            can_manage=can_manage,
+            is_user_groups_admin=has_global_permission(
+                user, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                user, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
+            is_default=user_group.is_default,
+        ),
+    )
 
 
 @router.get("/user-groups/minimal")

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -141,19 +141,10 @@ def get_user_group(
     ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
-    """Read one group. The listing carries every group with its nested connector,
-    document-set and agent snapshots, so reading one used to cost all of them."""
+    """Read one group with its nested connector, document-set and agent snapshots."""
     # GATE 2 (read): mirrors list_user_groups — a scoped manager may only read a
     # group they manage, so they cannot enumerate the org one id at a time.
-    managed_group_ids = (
-        get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
-        if has_permission(user, Permission.MANAGE_USER_GROUPS)
-        is PermissionAuthority.SCOPED
-        else set[int]()
-    )
-    can_manage = manages_group(
-        user, db_session, group_id=user_group_id, managed_group_ids=managed_group_ids
-    )
+    can_manage = manages_group(user, db_session, group_id=user_group_id)
     if not has_global_permission(user, Permission.READ_USER_GROUPS) and not can_manage:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "User group not found")
 

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -121,7 +121,10 @@ class UserGroupCreate(BaseModel):
 
 class UserGroupUpdate(BaseModel):
     user_ids: list[UUID]
-    cc_pair_ids: list[int]
+    # None leaves the connector links alone. Without it, changing a roster meant
+    # reading every linked cc-pair back and resending it, so a link added in
+    # between was reverted. add_users_to_user_group already preserves them.
+    cc_pair_ids: list[int] | None = None
 
 
 class UserGroupIncognitoUpdate(BaseModel):

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -77,6 +77,28 @@ def fetch_api_keys(db_session: Session) -> list[ApiKeyDescriptor]:
     ]
 
 
+def fetch_api_key(db_session: Session, api_key_id: int) -> ApiKeyDescriptor | None:
+    api_key = db_session.scalar(
+        select(ApiKey).options(joinedload(ApiKey.user)).where(ApiKey.id == api_key_id)
+    )
+    if api_key is None:
+        return None
+
+    groups_by_user = batch_get_user_groups(
+        db_session, [api_key.user_id], include_default=True
+    )
+    return ApiKeyDescriptor(
+        api_key_id=api_key.id,
+        api_key_display=api_key.api_key_display,
+        api_key_name=api_key.name,
+        user_id=api_key.user_id,
+        groups=[
+            UserGroupInfo(id=gid, name=gname)
+            for gid, gname in groups_by_user.get(api_key.user_id, [])
+        ],
+    )
+
+
 async def fetch_user_for_api_key(
     hashed_api_key: str, async_db_session: AsyncSession
 ) -> User | None:

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -26,6 +26,8 @@ from onyx.db.users import (
     get_user_groups,
     set_user_groups__no_commit,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.api_key.models import APIKeyArgs
 from onyx.server.models import UserGroupInfo
 from onyx.utils.logger import setup_logger
@@ -174,7 +176,9 @@ def update_api_key(
 ) -> ApiKeyDescriptor:
     existing_api_key = db_session.scalar(select(ApiKey).where(ApiKey.id == api_key_id))
     if existing_api_key is None:
-        raise ValueError(f"API key with id {api_key_id} does not exist")
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, f"API key with id {api_key_id} does not exist"
+        )
 
     existing_api_key.name = api_key_args.name
     api_key_user = db_session.scalar(

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -16,6 +16,8 @@ from onyx.db.models import (
     User,
 )
 from onyx.db.user_group import assert_not_shared_with_default_group
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
 
@@ -349,9 +351,11 @@ def _delete_credential_internal(
             # Commit these deletions before deleting the credential
             db_session.flush()
         else:
-            raise ValueError(
+            raise OnyxError(
+                OnyxErrorCode.RESOURCE_IN_USE,
                 f"Cannot delete credential as it is still associated with "
-                f"{len(associated_connectors)} connector(s) and {len(associated_doc_cc_pairs)} document(s). "
+                f"{len(associated_connectors)} connector(s) and "
+                f"{len(associated_doc_cc_pairs)} document(s).",
             )
 
     if force:
@@ -373,8 +377,9 @@ def delete_credential_for_user(
     """Delete a credential that belongs to a specific user"""
     credential = fetch_credential_by_id_for_user(credential_id, user, db_session)
     if credential is None:
-        raise ValueError(
-            f"Credential by provided id {credential_id} does not exist or does not belong to user"
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or does not belong to user",
         )
 
     _delete_credential_internal(credential, credential_id, db_session, force)
@@ -388,7 +393,10 @@ def delete_credential(
     """Delete a credential regardless of ownership (admin function)"""
     credential = fetch_credential_by_id(credential_id, db_session)
     if credential is None:
-        raise ValueError(f"Credential by provided id {credential_id} does not exist")
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist",
+        )
 
     _delete_credential_internal(credential, credential_id, db_session, force)
 

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -204,7 +204,9 @@ def fetch_persona_with_groups(db_session: Session, persona_id: int) -> Persona |
 
 
 def _resolve_embedding_api_key(
-    incoming: str | None, existing: SensitiveValue[str] | None
+    incoming: str | None,
+    existing: SensitiveValue[str] | None,
+    changed: bool | None = None,
 ) -> str | None:
     """Restore the stored key when the caller submits the masked placeholder.
 
@@ -212,10 +214,20 @@ def _resolve_embedding_api_key(
     mask itself as the real credential. Mirrors resolve_masked_credentials in
     onyx/db/external_app.py.
     """
+    stored = existing.get_value(apply_mask=False) if existing is not None else None
+
+    if changed is False:
+        # The caller states the key is unchanged, so nothing it sent is read.
+        return stored
+    if changed is True:
+        # The caller states this is a new key. Taken as given, which is the one
+        # case the heuristic below cannot get right: a rotation to a value that
+        # equals the stored key's mask reads as an unchanged echo.
+        return incoming
+
     if incoming is None:
         return incoming
 
-    stored = existing.get_value(apply_mask=False) if existing is not None else None
     if stored is not None:
         # Compare against this key's own mask rather than the general shape
         # test, so a real key that happens to look like a placeholder is still
@@ -246,15 +258,19 @@ def upsert_cloud_embedding_provider(
         .first()
     )
     if existing_provider:
-        updates = provider.model_dump()
+        # api_key_changed is a request-only flag; every remaining key is setattr'd
+        # straight onto the model.
+        updates = provider.model_dump(exclude={"api_key_changed"})
         updates["api_key"] = _resolve_embedding_api_key(
-            provider.api_key, existing_provider.api_key
+            provider.api_key, existing_provider.api_key, provider.api_key_changed
         )
         for key, value in updates.items():
             setattr(existing_provider, key, value)
     else:
-        creation = provider.model_dump()
-        creation["api_key"] = _resolve_embedding_api_key(provider.api_key, None)
+        creation = provider.model_dump(exclude={"api_key_changed"})
+        creation["api_key"] = _resolve_embedding_api_key(
+            provider.api_key, None, provider.api_key_changed
+        )
         new_provider = CloudEmbeddingProviderModel(**creation)
 
         db_session.add(new_provider)

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1,3 +1,5 @@
+from enum import Enum, auto
+
 from sqlalchemy import delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, load_only, selectinload
@@ -203,10 +205,42 @@ def fetch_persona_with_groups(db_session: Session, persona_id: int) -> Persona |
     )
 
 
+class ApiKeyIntent(Enum):
+    """What a request states about the api_key it carries."""
+
+    # A new key, taken as given. The only way to rotate to a value equal to the
+    # stored key's mask, which UNSTATED reads as an unchanged echo.
+    ROTATED = auto()
+    # Keep the stored key and ignore whatever api_key holds. The admin UI sends
+    # this with no api_key at all when the key is left alone.
+    UNCHANGED = auto()
+    # The caller does not set the flag, so the mask-echo heuristic decides. This
+    # is what keeps callers predating the flag able to rotate a key.
+    UNSTATED = auto()
+
+    @classmethod
+    def from_request_flag(cls, api_key_changed: bool | None) -> "ApiKeyIntent":
+        if api_key_changed is None:
+            return cls.UNSTATED
+        return cls.ROTATED if api_key_changed else cls.UNCHANGED
+
+
 def _resolve_embedding_api_key(
     incoming: str | None,
     existing: SensitiveValue[str] | None,
-    changed: bool | None = None,
+    intent: ApiKeyIntent,
+) -> str | None:
+    """Pick the api_key to store for an embedding provider."""
+    if intent is ApiKeyIntent.ROTATED:
+        return incoming
+    if intent is ApiKeyIntent.UNCHANGED:
+        return existing.get_value(apply_mask=False) if existing is not None else None
+    return _restore_masked_embedding_api_key(incoming, existing)
+
+
+def _restore_masked_embedding_api_key(
+    incoming: str | None,
+    existing: SensitiveValue[str] | None,
 ) -> str | None:
     """Restore the stored key when the caller submits the masked placeholder.
 
@@ -214,19 +248,10 @@ def _resolve_embedding_api_key(
     mask itself as the real credential. Mirrors resolve_masked_credentials in
     onyx/db/external_app.py.
     """
-    stored = existing.get_value(apply_mask=False) if existing is not None else None
-
-    if changed is False:
-        # The caller states the key is unchanged, so nothing it sent is read.
-        return stored
-    if changed is True:
-        # The caller states this is a new key. Taken as given, which is the one
-        # case the heuristic below cannot get right: a rotation to a value that
-        # equals the stored key's mask reads as an unchanged echo.
-        return incoming
-
     if incoming is None:
         return incoming
+
+    stored = existing.get_value(apply_mask=False) if existing is not None else None
 
     if stored is not None:
         # Compare against this key's own mask rather than the general shape
@@ -236,8 +261,8 @@ def _resolve_embedding_api_key(
         # shape, so refusing it would break providers holding a valid one.
         #
         # A caller rotating to a key that equals this mask exactly is read as an
-        # unchanged echo, and keeps the old key. Only a changed-flag on the
-        # request can separate the two, as LLMProviderUpsertRequest does.
+        # unchanged echo, and keeps the old key. Only api_key_changed on the
+        # request separates the two.
         return stored if incoming == mask_string(stored) else incoming
 
     if is_masked_credential(incoming):
@@ -262,14 +287,18 @@ def upsert_cloud_embedding_provider(
         # straight onto the model.
         updates = provider.model_dump(exclude={"api_key_changed"})
         updates["api_key"] = _resolve_embedding_api_key(
-            provider.api_key, existing_provider.api_key, provider.api_key_changed
+            provider.api_key,
+            existing_provider.api_key,
+            ApiKeyIntent.from_request_flag(provider.api_key_changed),
         )
         for key, value in updates.items():
             setattr(existing_provider, key, value)
     else:
         creation = provider.model_dump(exclude={"api_key_changed"})
         creation["api_key"] = _resolve_embedding_api_key(
-            provider.api_key, None, provider.api_key_changed
+            provider.api_key,
+            None,
+            ApiKeyIntent.from_request_flag(provider.api_key_changed),
         )
         new_provider = CloudEmbeddingProviderModel(**creation)
 

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -348,10 +348,16 @@ def upsert_llm_provider(
         for mc in llm_provider_upsert_request.model_configurations
     }
 
-    # Delete removed models
-    removed_ids = [
-        mc.id for name, mc in existing_by_name.items() if name not in models_to_exist
-    ]
+    # Delete removed models, unless the caller asked to keep what it did not send
+    removed_ids = (
+        []
+        if llm_provider_upsert_request.keep_existing_models
+        else [
+            mc.id
+            for name, mc in existing_by_name.items()
+            if name not in models_to_exist
+        ]
+    )
 
     # Every deployment default lives on a flow row pointing at a model, and
     # _update_default_model__no_commit makes that model visible, so a model

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -406,16 +406,22 @@ def upsert_llm_provider(
                 f"Cannot hide the default model '{name}'. It is the default for: "
                 f"{held}. Please change those defaults before hiding."
             )
-        if (
-            name in merged_capabilities
-            and flow_type in (LLMModelFlowType.VISION, LLMModelFlowType.REASONING)
-            and flow_type not in merged_capabilities[name]
+        # Dropping a capability deletes the flow row that represents it, so a
+        # model holding that flow's default must keep it.
+        for capability_flow in (
+            LLMModelFlowType.VISION,
+            LLMModelFlowType.REASONING,
         ):
-            raise ValueError(
-                f"Cannot disable {flow_type.value} support on '{name}': it is the "
-                f"deployment's {flow_type.value} default model. Change that "
-                "default first."
-            )
+            if (
+                capability_flow in held_flows
+                and name in merged_capabilities
+                and capability_flow not in merged_capabilities[name]
+            ):
+                raise ValueError(
+                    f"Cannot disable {capability_flow.value} support on '{name}'. "
+                    f"It is the deployment's {capability_flow.value} default "
+                    "model. Please change that default first."
+                )
 
     if removed_ids:
         db_session.query(ModelConfiguration).filter(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -348,6 +348,24 @@ def upsert_llm_provider(
         for mc in llm_provider_upsert_request.model_configurations
     }
 
+    # supports_image_input and supports_reasoning are optional, so an omitted one
+    # used to read as false and drop the flow — taking any deployment default that
+    # flow carried with it. Merge them against what is stored, the same way the
+    # reasoning and temperature fields below are merged.
+    merged_capabilities: dict[str, set[LLMModelFlowType]] = {}
+    for mc_request in llm_provider_upsert_request.model_configurations:
+        existing_mc = existing_by_name.get(mc_request.name)
+        stored_flows = set(existing_mc.llm_model_flow_types) if existing_mc else set()
+        merged: set[LLMModelFlowType] = set()
+        for capability_flow, sent in (
+            (LLMModelFlowType.VISION, mc_request.supports_image_input),
+            (LLMModelFlowType.REASONING, mc_request.supports_reasoning),
+        ):
+            keeps = sent if sent is not None else capability_flow in stored_flows
+            if keeps:
+                merged.add(capability_flow)
+        merged_capabilities[mc_request.name] = merged
+
     # Delete removed models, unless the caller asked to keep what it did not send
     removed_ids = (
         []
@@ -388,6 +406,16 @@ def upsert_llm_provider(
                 f"Cannot hide the default model '{name}'. It is the default for: "
                 f"{held}. Please change those defaults before hiding."
             )
+        if (
+            name in merged_capabilities
+            and flow_type in (LLMModelFlowType.VISION, LLMModelFlowType.REASONING)
+            and flow_type not in merged_capabilities[name]
+        ):
+            raise ValueError(
+                f"Cannot disable {flow_type.value} support on '{name}': it is the "
+                f"deployment's {flow_type.value} default model. Change that "
+                "default first."
+            )
 
     if removed_ids:
         db_session.query(ModelConfiguration).filter(
@@ -397,10 +425,7 @@ def upsert_llm_provider(
 
     for model_config in llm_provider_upsert_request.model_configurations:
         supported_flows = [LLMModelFlowType.CHAT]
-        if model_config.supports_image_input:
-            supported_flows.append(LLMModelFlowType.VISION)
-        if model_config.supports_reasoning:
-            supported_flows.append(LLMModelFlowType.REASONING)
+        supported_flows.extend(merged_capabilities.get(model_config.name, set()))
 
         existing = existing_by_name.get(model_config.name)
         if existing:

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -73,6 +73,12 @@ class OnyxErrorCode(Enum):
     CONFLICT = ("CONFLICT", 409)
     DUPLICATE_RESOURCE = ("DUPLICATE_RESOURCE", 409)
     SKILL_NAME_CONFLICT = ("SKILL_NAME_CONFLICT", 409)
+    # A delete refused because something still points at the resource. Distinct
+    # from a plain 400 so a client can tell "repoint it first" from "bad input".
+    RESOURCE_IN_USE = ("RESOURCE_IN_USE", 409)
+    # A write refused because a background sync is still applying the last one.
+    # Retryable, unlike NOT_FOUND, which these routes used to report instead.
+    RESOURCE_SYNCING = ("RESOURCE_SYNCING", 409)
 
     # --------------------------------------------------------------------------
     # Rate Limiting / Quotas (429 / 402)

--- a/backend/onyx/server/api_key/api.py
+++ b/backend/onyx/server/api_key/api.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.db.api_key import (
     ApiKeyDescriptor,
+    fetch_api_key,
     fetch_api_keys,
     insert_api_key,
     regenerate_api_key,
@@ -13,6 +14,8 @@ from onyx.db.api_key import (
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.api_key.models import APIKeyArgs
 from onyx.utils.audit import (
     AuditAction,
@@ -30,6 +33,20 @@ def list_api_keys(
     db_session: Session = Depends(get_session),
 ) -> list[ApiKeyDescriptor]:
     return fetch_api_keys(db_session)
+
+
+@router.get("/{api_key_id}")
+def get_api_key(
+    api_key_id: int,
+    _: User = Depends(require_permission(Permission.MANAGE_SERVICE_ACCOUNT_API_KEYS)),
+    db_session: Session = Depends(get_session),
+) -> ApiKeyDescriptor:
+    api_key = fetch_api_key(db_session, api_key_id)
+    if api_key is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, f"API key with id {api_key_id} does not exist"
+        )
+    return api_key
 
 
 @router.post("")

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -856,6 +856,12 @@ def associate_credential_to_connector(
             processing_mode=metadata.processing_mode,
         )
 
+        if not response.success:
+            # The pair already exists. This used to answer 200 with success in
+            # the body and the *connector* id in data, so a caller checking the
+            # status stored the wrong id and reported a no-op as a success.
+            raise OnyxError(OnyxErrorCode.CONFLICT, response.message)
+
         # Tenant-work-gating lifecycle hook: keep new-tenant latency to
         # seconds instead of one full-fanout interval.
         maybe_mark_tenant_active(tenant_id, caller="cc_pair_lifecycle")
@@ -872,17 +878,14 @@ def associate_credential_to_connector(
             response.data,
         )
 
-        # response.data is the cc_pair id only when the association was actually
-        # created; a no-op (credential already linked) returns success=False.
-        if response.success:
-            emit_audit_event(
-                AuditAction.CC_PAIR_CREATE,
-                AuditOutcome.SUCCESS,
-                actor=actor_from_user(user),
-                resource_type="cc_pair",
-                resource_id=response.data,
-                extra={"connector_id": connector_id, "credential_id": credential_id},
-            )
+        emit_audit_event(
+            AuditAction.CC_PAIR_CREATE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="cc_pair",
+            resource_id=response.data,
+            extra={"connector_id": connector_id, "credential_id": credential_id},
+        )
         return response
     except ValidationError as e:
         raise OnyxError(
@@ -903,6 +906,10 @@ def associate_credential_to_connector(
             f"{credential_id}.",
         )
 
+    except OnyxError:
+        # Deliberate, already-classified failures must not be re-rendered as 500
+        # by the catch-all below.
+        raise
     except Exception as e:
         logger.exception("Unexpected error: %s", e)
 

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -24,6 +24,7 @@ from onyx.connectors.interfaces import Resolver
 from onyx.connectors.models import InputType
 from onyx.db.connector_credential_pair import (
     add_credential_to_connector,
+    get_cc_pair_groups_for_ids,
     get_cc_pair_ids_for_connector,
     get_connector_credential_pair_for_user,
     get_connector_credential_pair_from_id_for_user,
@@ -402,6 +403,10 @@ def get_cc_pair_full_info(
         mask_credential_prefix=get_security_settings().mask_credential_prefix,
         is_connectors_admin=has_global_permission(user, Permission.MANAGE_CONNECTORS),
         owns_groupless=user_owns_groupless_cc_pair(cc_pair, db_session, user),
+        groups=[
+            relationship.user_group_id
+            for relationship in get_cc_pair_groups_for_ids(db_session, [cc_pair_id])
+        ],
         number_of_index_attempts=count_index_attempts_for_cc_pair(
             db_session=db_session,
             cc_pair_id=cc_pair_id,

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -22,6 +22,8 @@ from onyx.db.credentials import (
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import DocumentSource, User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.documents.models import (
     CredentialBase,
     CredentialDataUpdateRequest,
@@ -285,9 +287,9 @@ def get_credential_by_id(
         db_session,
     )
     if credential is None:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Credential {credential_id} does not exist or does not belong to user",
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or does not belong to user",
         )
 
     return CredentialSnapshot.from_credential_db_model(
@@ -312,9 +314,9 @@ def update_credential_data(
     )
 
     if credential is None:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Credential {credential_id} does not exist or does not belong to user",
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or does not belong to user",
         )
 
     return CredentialSnapshot.from_credential_db_model(
@@ -362,9 +364,9 @@ def update_credential_private_key(
     )
 
     if credential is None:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Credential {credential_id} does not exist or does not belong to user",
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or does not belong to user",
         )
 
     return CredentialSnapshot.from_credential_db_model(
@@ -384,9 +386,9 @@ def update_credential_from_model(
         credential_id, credential_data, user, db_session
     )
     if updated_credential is None:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Credential {credential_id} does not exist or does not belong to user",
+        raise OnyxError(
+            OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+            f"Credential {credential_id} does not exist or does not belong to user",
         )
 
     emit_audit_event(

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -476,6 +476,12 @@ class CCPairFullInfo(BaseModel):
     # uses this to route Resolve-All to targeted reindex vs full reindex.
     supports_targeted_reindex: bool
 
+    # Written at create time on the association route but not returned until now,
+    # so a client could never refresh or import them.
+    groups: list[int]
+    auto_sync_options: dict[str, Any] | None
+    processing_mode: ProcessingMode
+
     @classmethod
     def _get_last_full_permission_sync(
         cls, cc_pair_model: ConnectorCredentialPair
@@ -528,6 +534,7 @@ class CCPairFullInfo(BaseModel):
         mask_credential_prefix: bool,
         is_connectors_admin: bool = False,
         owns_groupless: bool = False,
+        groups: list[int] | None = None,
         last_successful_index_time: datetime | None = None,
         last_permission_sync_attempt_status: PermissionSyncStatus | None = None,
         permission_syncing: bool = False,
@@ -598,6 +605,9 @@ class CCPairFullInfo(BaseModel):
             last_permission_sync_attempt_finished=last_permission_sync_attempt_finished,
             last_permission_sync_attempt_error_message=last_permission_sync_attempt_error_message,
             supports_targeted_reindex=supports_targeted_reindex,
+            groups=groups or [],
+            auto_sync_options=cc_pair_model.auto_sync_options,
+            processing_mode=cc_pair_model.processing_mode,
         )
 
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -2426,6 +2426,11 @@ def upsert_mcp_server(
         raise
     except OnyxError:
         raise
+    except ValueError as e:
+        # Caller input, not a server fault: reject_masked_credentials raises this
+        # when a masked value is replayed, and the catch-all below made it a 500.
+        logger.warning("Rejected MCP server upsert: %s", e)
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
     except Exception as e:
         logger.exception("Failed to create/update MCP tool")
         raise HTTPException(

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -588,6 +588,23 @@ def delete_persona(
         )
     except ValueError as e:
         logger.exception("Failed to delete persona")
+        # An agent this caller may edit but which is already a tombstone is gone,
+        # not forbidden. Only checked once the delete has already failed, so the
+        # happy path costs no extra query.
+        try:
+            get_persona_by_id(
+                persona_id=persona_id,
+                user=user,
+                db_session=db_session,
+                include_deleted=True,
+            )
+        except ValueError:
+            pass
+        else:
+            raise OnyxError(
+                OnyxErrorCode.PERSONA_NOT_FOUND,
+                f"Agent with ID {persona_id} is already deleted",
+            ) from e
         # A non-owner failed the ownership check; its ValueError would 400 via the global
         # handler, so surface the real authorization failure as a 403.
         raise OnyxError(
@@ -673,13 +690,21 @@ def get_persona(
     user_group_ids: set[int] = (
         get_user_group_ids_for_user(db_session, user.id) if user is not None else set()
     )
-    persona = get_persona_by_id(
-        persona_id=persona_id,
-        user=user,
-        db_session=db_session,
-        is_for_edit=False,
-        user_group_ids=user_group_ids,
-    )
+    try:
+        persona = get_persona_by_id(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+            is_for_edit=False,
+            user_group_ids=user_group_ids,
+        )
+    except ValueError as e:
+        # Caller-scoped, like GET /manage/admin/document-set/{id}: someone who
+        # cannot see the agent gets not-found rather than a 403 that leaks it.
+        raise OnyxError(
+            OnyxErrorCode.PERSONA_NOT_FOUND,
+            f"Agent with ID {persona_id} does not exist",
+        ) from e
 
     # Validate and clear the model override if the referenced model is no longer
     # accessible to this persona (e.g. provider was restricted after the persona was saved).

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -599,7 +599,11 @@ def delete_persona(
                 include_deleted=True,
             )
         except ValueError:
-            pass
+            logger.info(
+                "Agent %s is not readable by this caller even including tombstones; "
+                "reporting the failed delete as an authorization error",
+                persona_id,
+            )
         else:
             raise OnyxError(
                 OnyxErrorCode.PERSONA_NOT_FOUND,

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -182,10 +182,13 @@ class PersonaUpsertRequest(BaseModel):
     display_priority: int | None = None
     # Accept string UUIDs from frontend
     user_file_ids: list[str] | None = None
-    # Hierarchy nodes (folders, spaces, channels) attached for scoped search
-    hierarchy_node_ids: list[int] = Field(default_factory=list)
-    # Individual documents attached for scoped search
-    document_ids: list[str] = Field(default_factory=list)
+    # Hierarchy nodes (folders, spaces, channels) attached for scoped search.
+    # None leaves the stored attachments alone; [] clears them. Without this a
+    # client updating any other field had to read both lists back and resend
+    # them, which reverts an attachment added in between.
+    hierarchy_node_ids: list[int] | None = None
+    # Individual documents attached for scoped search; same None semantics
+    document_ids: list[str] | None = None
 
     # prompt fields
     system_prompt: str

--- a/backend/onyx/server/manage/embedding/api.py
+++ b/backend/onyx/server/manage/embedding/api.py
@@ -5,6 +5,7 @@ from onyx.auth.permissions import require_permission
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.llm import (
+    fetch_embedding_provider,
     fetch_existing_embedding_providers,
     remove_embedding_provider,
     upsert_cloud_embedding_provider,
@@ -84,6 +85,21 @@ def list_embedding_providers(
         CloudEmbeddingProvider.from_request(embedding_provider_model)
         for embedding_provider_model in fetch_existing_embedding_providers(db_session)
     ]
+
+
+@admin_router.get("/embedding-provider/{provider_type}")
+def get_embedding_provider(
+    provider_type: EmbeddingProvider,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> CloudEmbeddingProvider:
+    embedding_provider = fetch_embedding_provider(db_session, provider_type)
+    if embedding_provider is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Embedding provider '{provider_type.value}' is not configured",
+        )
+    return CloudEmbeddingProvider.from_request(embedding_provider)
 
 
 @admin_router.delete("/embedding-provider/{provider_type}")

--- a/backend/onyx/server/manage/embedding/api.py
+++ b/backend/onyx/server/manage/embedding/api.py
@@ -98,8 +98,9 @@ def delete_embedding_provider(
         and provider_type == embedding_provider.provider_type
     ):
         raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "You can't delete a currently active model",
+            OnyxErrorCode.RESOURCE_IN_USE,
+            "You can't delete the embedding provider the current search settings "
+            "use. Point search settings at another provider first.",
         )
 
     remove_embedding_provider(db_session, provider_type=provider_type)

--- a/backend/onyx/server/manage/embedding/models.py
+++ b/backend/onyx/server/manage/embedding/models.py
@@ -51,6 +51,12 @@ class CloudEmbeddingProvider(BaseModel):
 class CloudEmbeddingProviderCreationRequest(BaseModel):
     provider_type: EmbeddingProvider
     api_key: str | None = None
+    # True takes api_key as given, False keeps the stored one. None means the
+    # caller does not use the flag, and the mask-echo heuristic decides — the
+    # only reading that keeps pre-flag clients working. Mirrors
+    # LLMProviderUpsertRequest.api_key_changed, which is a plain bool because
+    # every one of its callers sends it.
+    api_key_changed: bool | None = None
     api_url: str | None = None
     api_version: str | None = None
     deployment_name: str | None = None

--- a/backend/onyx/server/manage/embedding/models.py
+++ b/backend/onyx/server/manage/embedding/models.py
@@ -51,11 +51,9 @@ class CloudEmbeddingProvider(BaseModel):
 class CloudEmbeddingProviderCreationRequest(BaseModel):
     provider_type: EmbeddingProvider
     api_key: str | None = None
-    # True takes api_key as given, False keeps the stored one. None means the
-    # caller does not use the flag, and the mask-echo heuristic decides — the
-    # only reading that keeps pre-flag clients working. Mirrors
-    # LLMProviderUpsertRequest.api_key_changed, which is a plain bool because
-    # every one of its callers sends it.
+    # Absent means the caller does not use the flag, which is distinct from
+    # False and keeps callers predating it able to rotate a key. Read through
+    # ApiKeyIntent, which names all three cases.
     api_key_changed: bool | None = None
     api_url: str | None = None
     api_version: str | None = None

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -569,6 +569,24 @@ def list_llm_providers(
     )
 
 
+@admin_router.get("/provider/{provider_id}")
+def get_llm_provider(
+    provider_id: int,
+    _: User = Depends(require_permission(Permission.MANAGE_LLMS)),
+    db_session: Session = Depends(get_session),
+) -> LLMProviderView:
+    """Read one provider without listing (and decrypting) every provider."""
+    llm_provider_model = fetch_existing_llm_provider_by_id(provider_id, db_session)
+    if llm_provider_model is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, f"LLM provider {provider_id} does not exist"
+        )
+
+    provider_view = LLMProviderView.from_model(llm_provider_model)
+    _mask_provider_credentials(provider_view)
+    return provider_view
+
+
 @admin_router.put("/provider")
 def put_llm_provider(
     llm_provider_upsert_request: LLMProviderUpsertRequest,

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -21,7 +21,6 @@ from onyx.db.llm import (
     fetch_default_chat_naming_model,
     fetch_default_craft_model,
     fetch_default_llm_model,
-    fetch_default_model,
     fetch_default_vision_model,
     fetch_existing_llm_provider_by_id,
     fetch_existing_llm_providers,
@@ -738,18 +737,17 @@ def delete_llm_provider(
     db_session: Session = Depends(get_session),
 ) -> None:
     if not force:
-        # Every flow with a default, not just chat: the vision, contextual-RAG,
-        # reasoning and chat-naming defaults were all deletable from under the
-        # deployment.
-        for flow_type in LLMModelFlowType:
-            model = fetch_default_model(db_session, flow_type)
-            if model and model.llm_provider_id == provider_id:
-                raise OnyxError(
-                    OnyxErrorCode.RESOURCE_IN_USE,
-                    f"Cannot delete this provider: it holds the deployment's "
-                    f"{flow_type.value} default model. Repoint that default "
-                    f"first, or pass force=true.",
-                )
+        # Only the chat default blocks a provider delete. Deleting a provider
+        # that holds another flow's default clears that default deliberately —
+        # see test_delete_default_vision_provider_clears_vision_default.
+        model = fetch_default_llm_model(db_session)
+
+        if model and model.llm_provider_id == provider_id:
+            raise OnyxError(
+                OnyxErrorCode.RESOURCE_IN_USE,
+                "Cannot delete this provider: it holds the deployment's chat "
+                "default model. Repoint that default first, or pass force=true.",
+            )
 
     try:
         remove_llm_provider(db_session, provider_id)

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -21,6 +21,7 @@ from onyx.db.llm import (
     fetch_default_chat_naming_model,
     fetch_default_craft_model,
     fetch_default_llm_model,
+    fetch_default_model,
     fetch_default_vision_model,
     fetch_existing_llm_provider_by_id,
     fetch_existing_llm_providers,
@@ -719,13 +720,18 @@ def delete_llm_provider(
     db_session: Session = Depends(get_session),
 ) -> None:
     if not force:
-        model = fetch_default_llm_model(db_session)
-
-        if model and model.llm_provider_id == provider_id:
-            raise OnyxError(
-                OnyxErrorCode.VALIDATION_ERROR,
-                "Cannot delete the default LLM provider",
-            )
+        # Every flow with a default, not just chat: the vision, contextual-RAG,
+        # reasoning and chat-naming defaults were all deletable from under the
+        # deployment.
+        for flow_type in LLMModelFlowType:
+            model = fetch_default_model(db_session, flow_type)
+            if model and model.llm_provider_id == provider_id:
+                raise OnyxError(
+                    OnyxErrorCode.RESOURCE_IN_USE,
+                    f"Cannot delete this provider: it holds the deployment's "
+                    f"{flow_type.value} default model. Repoint that default "
+                    f"first, or pass force=true.",
+                )
 
     try:
         remove_llm_provider(db_session, provider_id)

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -151,6 +151,11 @@ class LLMProviderUpsertRequest(LLMProvider):
     id: int | None = None
     api_key_changed: bool = False
     custom_config_changed: bool = False
+    # The write replaces model_configurations, and the read hides obsolete and
+    # dated-duplicate models, so a read-modify-write drops the hidden rows. With
+    # this set, models absent from the request are left alone and the request
+    # only adds or updates.
+    keep_existing_models: bool = False
     model_configurations: list["ModelConfigurationUpsertRequest"] = []
 
     @field_validator("provider", mode="before")

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -71,7 +71,7 @@ def admin_patch_settings(
     current_user: User = Depends(
         require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)
     ),
-) -> None:
+) -> Settings:
     if global_version.is_ee_version():
         from ee.onyx.utils.tier import get_tier
 
@@ -134,6 +134,11 @@ def admin_patch_settings(
                 resource_type="settings",
                 extra={"craft_default_enabled": merged.craft_default_enabled},
             )
+
+        # Read back rather than returning `merged`, so the response matches what
+        # the next GET reports: the store clamps some values and env vars
+        # override others. Saves every caller a second round trip.
+        return load_settings(raise_on_error=True)
 
 
 def apply_license_status_to_settings(settings: Settings) -> Settings:

--- a/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
+++ b/backend/tests/external_dependency_unit/db/test_embedding_provider_masked_key.py
@@ -141,3 +141,61 @@ def test_a_placeholder_shaped_stored_key_survives_a_write_back(
 
     assert _stored_key(db_session) == lookalike
     assert updated.api_url == "https://api.voyageai.example.com/v1"
+
+
+def test_changed_flag_lands_a_rotation_that_collides_with_the_mask(
+    db_session: Session,
+) -> None:
+    """The one case the mask-echo heuristic cannot resolve.
+
+    Rotating to a key whose value happens to equal the stored key's mask reads
+    as an unchanged echo. Only an explicit flag separates the two.
+    """
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
+        ),
+    )
+    collides_with_mask = mask_string(_REAL_KEY)
+
+    # Without the flag this is indistinguishable from an echo, and is kept.
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=collides_with_mask
+        ),
+    )
+    assert _stored_key(db_session) == _REAL_KEY
+
+    # Stated explicitly, the rotation lands.
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE,
+            api_key=collides_with_mask,
+            api_key_changed=True,
+        ),
+    )
+    assert _stored_key(db_session) == collides_with_mask
+
+
+def test_changed_false_keeps_the_stored_key(db_session: Session) -> None:
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE, api_key=_REAL_KEY
+        ),
+    )
+
+    upsert_cloud_embedding_provider(
+        db_session,
+        CloudEmbeddingProviderCreationRequest(
+            provider_type=EmbeddingProvider.VOYAGE,
+            api_key="sk-something-else-entirely",
+            api_key_changed=False,
+            api_url="https://api.voyageai.example.com/v1",
+        ),
+    )
+
+    assert _stored_key(db_session) == _REAL_KEY

--- a/backend/tests/external_dependency_unit/ee/db/test_standard_answer_category_delete.py
+++ b/backend/tests/external_dependency_unit/ee/db/test_standard_answer_category_delete.py
@@ -1,0 +1,111 @@
+"""Deleting a standard answer category.
+
+Categories are many-to-many with standard answers and with Slack channel
+configs, so what blocks a delete — and what is cleaned up instead — needs to be
+pinned down rather than inferred from ORM behaviour.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.standard_answer import (
+    fetch_standard_answer_category,
+    insert_standard_answer,
+    insert_standard_answer_category,
+    remove_standard_answer,
+    remove_standard_answer_category,
+)
+from onyx.db.models import StandardAnswer__StandardAnswerCategory
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+def _category(db_session: Session) -> int:
+    return insert_standard_answer_category(
+        category_name=f"cat-{uuid4().hex[:8]}", db_session=db_session
+    ).id
+
+
+def _answer(db_session: Session, category_id: int) -> int:
+    return insert_standard_answer(
+        keyword=f"kw-{uuid4().hex[:8]}",
+        answer="an answer",
+        category_ids=[category_id],
+        match_regex=False,
+        match_any_keywords=False,
+        db_session=db_session,
+    ).id
+
+
+def test_an_unreferenced_category_is_deleted(db_session: Session) -> None:
+    category_id = _category(db_session)
+
+    remove_standard_answer_category(
+        standard_answer_category_id=category_id, db_session=db_session
+    )
+
+    assert (
+        fetch_standard_answer_category(
+            standard_answer_category_id=category_id, db_session=db_session
+        )
+        is None
+    )
+
+
+def test_an_active_standard_answer_blocks_the_delete(db_session: Session) -> None:
+    category_id = _category(db_session)
+    _answer(db_session, category_id)
+
+    with pytest.raises(OnyxError) as exc_info:
+        remove_standard_answer_category(
+            standard_answer_category_id=category_id, db_session=db_session
+        )
+
+    assert exc_info.value.error_code is OnyxErrorCode.RESOURCE_IN_USE
+    assert (
+        fetch_standard_answer_category(
+            standard_answer_category_id=category_id, db_session=db_session
+        )
+        is not None
+    )
+
+
+def test_a_deactivated_standard_answer_does_not_block_the_delete(
+    db_session: Session,
+) -> None:
+    """The association rows survive deactivation, so this is the case that would
+    fail with a foreign key error if they were not cleaned up with the category."""
+    category_id = _category(db_session)
+    answer_id = _answer(db_session, category_id)
+    remove_standard_answer(standard_answer_id=answer_id, db_session=db_session)
+
+    remove_standard_answer_category(
+        standard_answer_category_id=category_id, db_session=db_session
+    )
+
+    assert (
+        fetch_standard_answer_category(
+            standard_answer_category_id=category_id, db_session=db_session
+        )
+        is None
+    )
+    # The link went with the category rather than being left dangling.
+    remaining = db_session.scalars(
+        select(StandardAnswer__StandardAnswerCategory).where(
+            StandardAnswer__StandardAnswerCategory.standard_answer_category_id
+            == category_id
+        )
+    ).all()
+    assert remaining == []
+
+
+def test_a_missing_category_is_not_found(db_session: Session) -> None:
+    with pytest.raises(OnyxError) as exc_info:
+        remove_standard_answer_category(
+            standard_answer_category_id=2_000_000_000, db_session=db_session
+        )
+
+    assert exc_info.value.error_code is OnyxErrorCode.NOT_FOUND

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -613,3 +613,38 @@ class TestCapabilityChangesCannotEraseADefault:
         default_vision = fetch_default_vision_model(db_session)
         assert default_vision is not None
         assert default_vision.name == "gpt-4o"
+
+    def test_disabling_vision_is_caught_when_one_model_holds_several_defaults(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """The chat default is commonly the vision default too. Keying the lookup
+        by model id kept only the first flow found, so the vision default went
+        unguarded and the reconciliation deleted it."""
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_provider(provider.id, "gpt-4o", db_session)
+        update_default_vision_provider(provider.id, "gpt-4o", db_session)
+
+        with pytest.raises(ValueError, match=r"Cannot disable vision support"):
+            upsert_llm_provider(
+                LLMProviderUpsertRequest(
+                    id=provider.id,
+                    name=provider_name,
+                    provider=LlmProviderNames.OPENAI,
+                    api_key="sk-test-key-00000000000000000000000000000000000",
+                    api_key_changed=True,
+                    model_configurations=[
+                        ModelConfigurationUpsertRequest(
+                            name="gpt-4o",
+                            is_visible=True,
+                            supports_image_input=False,
+                        ),
+                        ModelConfigurationUpsertRequest(
+                            name="gpt-4o-mini", is_visible=True
+                        ),
+                    ],
+                ),
+                db_session=db_session,
+            )
+

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -544,3 +544,72 @@ class TestEveryFlowDefaultIsGuarded:
         default_craft = fetch_default_craft_model(db_session)
         assert default_craft is not None
         assert default_craft.name == "gpt-4o"
+
+
+class TestCapabilityChangesCannotEraseADefault:
+    """A default lives on the LLMModelFlow row, so dropping the capability that
+    row represents deletes the default along with it."""
+
+    def test_cannot_disable_image_input_on_the_vision_default(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_vision_provider(provider.id, "gpt-4o", db_session)
+
+        with pytest.raises(ValueError, match=r"Cannot disable vision support"):
+            upsert_llm_provider(
+                LLMProviderUpsertRequest(
+                    id=provider.id,
+                    name=provider_name,
+                    provider=LlmProviderNames.OPENAI,
+                    api_key="sk-test-key-00000000000000000000000000000000000",
+                    api_key_changed=True,
+                    model_configurations=[
+                        ModelConfigurationUpsertRequest(
+                            name="gpt-4o",
+                            is_visible=True,
+                            supports_image_input=False,
+                        ),
+                        ModelConfigurationUpsertRequest(
+                            name="gpt-4o-mini", is_visible=True
+                        ),
+                    ],
+                ),
+                db_session=db_session,
+            )
+
+        assert fetch_default_vision_model(db_session) is not None
+
+    def test_omitting_image_support_keeps_the_stored_capability(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """supports_image_input is optional. An omitted one used to read as false
+        and silently drop the vision flow, taking the default with it."""
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_vision_provider(provider.id, "gpt-4o", db_session)
+
+        upsert_llm_provider(
+            LLMProviderUpsertRequest(
+                id=provider.id,
+                name=provider_name,
+                provider=LlmProviderNames.OPENAI,
+                api_key="sk-test-key-00000000000000000000000000000000000",
+                api_key_changed=True,
+                model_configurations=[
+                    # no supports_image_input, as a partial client would send
+                    ModelConfigurationUpsertRequest(name="gpt-4o", is_visible=True),
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o-mini", is_visible=True
+                    ),
+                ],
+            ),
+            db_session=db_session,
+        )
+
+        default_vision = fetch_default_vision_model(db_session)
+        assert default_vision is not None
+        assert default_vision.name == "gpt-4o"

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -647,4 +647,3 @@ class TestCapabilityChangesCannotEraseADefault:
                 ),
                 db_session=db_session,
             )
-

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -2330,3 +2330,40 @@ def test_all_three_provider_types_no_mixup(reset: None) -> None:  # noqa: ARG001
 
     # Clean up: Delete the image gen config (to clean up the internal LLM provider)
     _delete_image_gen_config(admin_user, image_gen_provider_id)
+
+
+def test_get_llm_provider_by_id(reset: None) -> None:  # noqa: ARG001
+    """Reading one provider no longer requires listing (and decrypting) them all."""
+    admin_user = UserManager.create(name="admin_user")
+
+    created = client.put(
+        f"{API_SERVER_URL}/admin/llm/provider?is_creation=true",
+        headers=admin_user.headers,
+        json={
+            "name": str(uuid.uuid4()),
+            "provider": LlmProviderNames.OPENAI,
+            "api_key": "sk-000000000000000000000000000000000000000000000000",
+            "model_configurations": [{"name": "gpt-4", "is_visible": True}],
+            "is_public": True,
+            "groups": [],
+        },
+    )
+    assert created.status_code == 200
+    provider_id = created.json()["id"]
+
+    response = client.get(
+        f"{API_SERVER_URL}/admin/llm/provider/{provider_id}",
+        headers=admin_user.headers,
+    )
+    assert response.status_code == 200
+    fetched = response.json()
+    assert fetched["id"] == provider_id
+    # masked exactly as the listing masks it
+    assert fetched["api_key"] == "sk-0****0000"
+
+    missing = client.get(
+        f"{API_SERVER_URL}/admin/llm/provider/{provider_id + 10_000}",
+        headers=admin_user.headers,
+    )
+    assert missing.status_code == 404
+    assert missing.json()["error_code"] == "NOT_FOUND"

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -2367,3 +2367,52 @@ def test_get_llm_provider_by_id(reset: None) -> None:  # noqa: ARG001
     )
     assert missing.status_code == 404
     assert missing.json()["error_code"] == "NOT_FOUND"
+
+
+def test_keep_existing_models_preserves_unsent_models(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """Without the flag the model list is a full replace, which silently drops
+    rows the read hides (obsolete models, dated duplicates)."""
+    admin_user = UserManager.create(name="admin_user")
+    name = str(uuid.uuid4())
+
+    created = client.put(
+        f"{API_SERVER_URL}/admin/llm/provider?is_creation=true",
+        headers=admin_user.headers,
+        json={
+            "name": name,
+            "provider": LlmProviderNames.OPENAI,
+            "api_key": "sk-000000000000000000000000000000000000000000000000",
+            "model_configurations": [
+                {"name": "gpt-4", "is_visible": True},
+                {"name": "gpt-4o", "is_visible": True},
+            ],
+            "is_public": True,
+            "groups": [],
+        },
+    )
+    assert created.status_code == 200
+    provider_id = created.json()["id"]
+
+    def _update(keep: bool) -> list[str]:
+        response = client.put(
+            f"{API_SERVER_URL}/admin/llm/provider",
+            headers=admin_user.headers,
+            json={
+                "id": provider_id,
+                "name": name,
+                "provider": LlmProviderNames.OPENAI,
+                "model_configurations": [{"name": "gpt-4", "is_visible": True}],
+                "is_public": True,
+                "groups": [],
+                "keep_existing_models": keep,
+            },
+        )
+        assert response.status_code == 200
+        return sorted(mc["name"] for mc in response.json()["model_configurations"])
+
+    # Sending only gpt-4 keeps gpt-4o.
+    assert _update(keep=True) == ["gpt-4", "gpt-4o"]
+    # The default is still a full replace.
+    assert _update(keep=False) == ["gpt-4"]

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -446,8 +446,8 @@ def test_delete_default_llm_provider_rejected(
         f"{API_SERVER_URL}/admin/llm/provider/{created_provider['id']}",
         headers=admin_user.headers,
     )
-    assert delete_response.status_code == 400
-    assert "Cannot delete the default LLM provider" in delete_response.json()["detail"]
+    assert delete_response.status_code == 409
+    assert "chat default model" in delete_response.json()["detail"]
 
     # Verify provider still exists
     provider_data = _get_provider_by_id(admin_user, created_provider["id"])

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -568,7 +568,7 @@ def test_force_delete_default_llm_provider(
         f"{API_SERVER_URL}/admin/llm/provider/{created_provider['id']}",
         headers=admin_user.headers,
     )
-    assert delete_response.status_code == 400
+    assert delete_response.status_code == 409
 
     # Force delete — should succeed
     force_delete_response = client.delete(

--- a/backend/tests/unit/ee/onyx/db/test_user_group_rename.py
+++ b/backend/tests/unit/ee/onyx/db/test_user_group_rename.py
@@ -6,6 +6,7 @@ import pytest
 
 from ee.onyx.db.user_group import rename_user_group
 from onyx.db.models import UserGroup
+from onyx.error_handling.exceptions import OnyxError
 
 
 class TestRenameUserGroup:
@@ -46,7 +47,7 @@ class TestRenameUserGroup:
         mock_group.is_up_to_date = False
         mock_session.scalar.return_value = mock_group
 
-        with pytest.raises(ValueError, match="currently syncing"):
+        with pytest.raises(OnyxError, match="currently syncing"):
             rename_user_group(mock_session, user_group_id=1, new_name="New Name")
 
         mock_session.commit.assert_not_called()

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -91,6 +91,9 @@ export async function connectEmbeddingProvider({
     is_default_provider: false,
     is_configured: true,
   };
+  // Explicit, so the backend never has to infer intent from the masked value:
+  // null means the admin left the stored key alone.
+  body.api_key_changed = apiKey !== null;
   if (apiKey !== null) body.api_key = apiKey;
 
   const saveResponse = await fetch(SWR_KEYS.embeddingProviders, {


### PR DESCRIPTION
## Description

> Stacked on #14365. Based on that branch so the diff here is only the new work;
> GitHub retargets this to `main` once #14365 merges.

Onyx's admin API has never had a strict machine client. The admin panel tolerates
a lot, because a human retries, re-reads the screen, and does not care whether
"gone" arrives as 400 or 404. Writing a Terraform provider against these routes
surfaced a set of defects that are worth fixing on their own terms — several are
bugs that affect the admin panel too.

### Status codes on admin config routes

`backend/CLAUDE.md` requires `OnyxError` over `HTTPException` and forbids
hardcoded status codes. These routes predate that rule, and underneath sits the
global `ValueError` handler, which turns every bare `ValueError` into
`400 {"message": ...}` with no `error_code` at all.

- **Credentials** answered `401` for a missing credential on four routes, which
  reads as a rejected key and trips the web client's auth handling. Now `404`.
- **User groups**: the sync gate raised `ValueError`, which patch, add-users and
  delete all mapped to `NOT_FOUND`, so "wait and retry" looked like "already
  gone" — on the delete route that decides whether a caller drops a live group.
  The gate now raises `RESOURCE_SYNCING`, which those handlers pass through
  untouched, so one change fixes all of them. `rename_user_group_endpoint`
  already got this right, which is what made it a bug rather than a convention.
- **Agents**: `GET /persona/{id}` answered `400` for a missing agent; deleting an
  agent that is already a tombstone reported a *permission* failure. Both now
  `404`, and the tombstone check runs only after the delete has failed so the
  happy path costs nothing extra.
- **API keys**: deleting a missing key answered `400`. Now `404`.
- **MCP**: a replayed masked credential is caller input, but a broad
  `except Exception` rendered it as `500`.
- **LLM / embedding providers**: a delete refused because the resource is in use
  answered the same `400 VALIDATION_ERROR` as bad input. Now `RESOURCE_IN_USE`.
- **cc-pairs**: a duplicate association answered `200` with `success: false` in
  the body and the *connector* id in `data`. The admin panel checks
  `response.ok`, so linking an already-linked credential reported success. Now
  `409`, and checked before the indexing task is queued.

Adds two codes: `RESOURCE_IN_USE` and `RESOURCE_SYNCING`.

### Two default-model guards only checked chat

Both the LLM provider delete guard and the model-shrink guard consulted
`fetch_default_llm_model`, which is the CHAT default only.
`fetch_default_vision_model` exists and was never called. So the vision,
contextual-RAG, reasoning and chat-naming defaults could be deleted or hidden
from under the deployment. Both now check every `LLMModelFlowType` and name the
flow in the error.

### Reads could not answer "what is this one thing?"

Four admin collections had no get-by-id, so every read fetched the whole list and
filtered it. Reading one LLM provider decrypted every provider's key; reading one
user group materialised every group in the tenant with its nested connector,
credential, document-set and agent snapshots.

Adds `GET` by id for API keys, LLM providers, embedding providers and user
groups, each reusing the fetch and permission gate its list route already uses,
each caller-scoped and answering 404 rather than a 403 that leaks existence —
following `GET /manage/admin/document-set/{id}`.

`CCPairFullInfo` also gained `groups`, `auto_sync_options` and
`processing_mode`, all written at create time and never returned.

### Writes made the caller guess

- The **embedding provider** upsert had no changed-flag, so the guard added in
  #14210 compares an incoming key against the stored key's own mask. That
  resolves an echo but cannot resolve a rotation to a key whose value equals that
  mask. `api_key_changed` states it. It is `bool | None`, not `bool`, because a
  `False` default would silently ignore real keys from clients that do not send
  it. The admin UI now sends it explicitly.
- **`keep_existing_models`** on the LLM provider upsert. Every write replaced the
  model list, and the read hides obsolete and dated-duplicate models, so a
  read-modify-write silently deleted the hidden rows — the admin UI has the same
  flaw. Auto mode is worse: models are preserved only on the transition into auto
  mode, so a client changing any other field had to re-assert the list it just
  read, racing the auto-sync worker.
- **Persona attachments**: `hierarchy_node_ids` and `document_ids` were plain
  lists, so omitting one cleared it and sending null was a 422. A client updating
  any other field had to read both back and resend them, reverting anything added
  in between. Now nullable; `upsert_persona` already treated `None` this way.
- **`UserGroupUpdate.cc_pair_ids`** is nullable, so changing a roster no longer
  means resending every connector link.
- **`PATCH /admin/settings`** returns the settings, read back after the store so
  the response matches the next GET.

### One missing delete

Standard answer categories had create, read and update but no delete, so no
lifecycle. Hard delete (they have no active flag), refused with
`RESOURCE_IN_USE` while an active standard answer or Slack channel config still
references one.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit` — 8813 passed. The 19 failures on this
  branch (license reclaim, license API, process isolation) reproduce identically
  on `main` with these changes stashed.
- New integration tests for the LLM provider get-by-id route and for
  `keep_existing_models`; new external-dependency tests for the embedding
  changed-flag, including the rotation-collides-with-the-mask case the heuristic
  cannot resolve.
- Updated three existing tests whose assertions encoded the old behaviour.
- New `GET` routes verified to register in the right order with no shadowing.
- `pre-commit run` clean on every changed file — `ty`, `ruff`, `oxlint` and the
  TypeScript check.

Local integration and external-dependency suites cannot run against my dev
database, which is behind `main`'s migration head, so CI is what exercises those.

**Contract changes to check.** The status-code corrections and the nullable
fields change behaviour for existing clients. I checked the frontend for each:
the admin panel reads `errorData.detail`, which the `OnyxError` shape provides;
it always sends explicit arrays for the persona lists; and nothing matched on any
of the old error message text.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

https://linear.app/onyx-app/issue/ENG-4322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6fM1Ydw7Dpzt4ru7BYrFx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the admin config API for machine clients under ENG-4322: ambiguous 400/401 responses now use specific 404/409 errors, and new targeted reads and write flags avoid unnecessary read-modify-write cycles. Existing full-replace behavior remains the default where applicable.

**API changes**

- Adds get-by-id routes for API keys, LLM and embedding providers, and user groups, with caller-scoped 404 responses.
- Adds standard-answer-category deletion, refusing categories referenced by active answers or Slack channel configs, including concurrent attachments.
- Returns `groups`, `auto_sync_options`, and `processing_mode` in `CCPairFullInfo`, and returns merged settings from `PATCH /admin/settings`.
- Duplicate connector-credential links now return 409 before scheduling indexing work; replayed masked MCP credentials return 400.
- Missing credentials, API keys, and agents return 404; syncing user-group writes return `RESOURCE_SYNCING`; in-use deletes return `RESOURCE_IN_USE`.
- Preserves LLM defaults when capability fields are omitted, and blocks disabling a capability used by a default model; deleting a provider still protects only the chat default.

**Write semantics**

- Adds `api_key_changed` for explicit embedding-key retention or rotation.
- Adds `keep_existing_models` to preserve unsent LLM models when requested; its default remains false.
- `None` persona attachment and user-group connector fields now leave stored values unchanged, while empty lists still clear them.

The unit suite passes with 8,813 tests; the 19 remaining failures reproduce on `main`.

<sup>Written for commit d494b5c230cd6d8386740caf71ff85381bc8bb50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

