### PR TITLE
refactor(web): give a chat one tool configuration

### DIFF
--- a/web/src/app/app/page.tsx
+++ b/web/src/app/app/page.tsx
@@ -1,6 +1,5 @@
 import AppPage from "@/views/AppPage";
 import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
-import { ForcedToolsProvider } from "@/lib/tools/hooks";
 import { defaultAgentRedirectTarget } from "@/lib/app/utils";
 import { redirect } from "next/navigation";
 
@@ -25,9 +24,7 @@ export default async function Page(props: PageProps) {
   // reads from it.
   return (
     <SearchFiltersProvider>
-      <ForcedToolsProvider>
-        <AppPage firstMessage={firstMessage} />
-      </ForcedToolsProvider>
+      <AppPage firstMessage={firstMessage} />
     </SearchFiltersProvider>
   );
 }

--- a/web/src/app/nrf/(main)/page.tsx
+++ b/web/src/app/nrf/(main)/page.tsx
@@ -2,7 +2,6 @@ import { unstable_noStore as noStore } from "next/cache";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import NRFPage from "@/app/nrf/NRFPage";
 import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
-import { ForcedToolsProvider } from "@/lib/tools/hooks";
 import { NRFPreferencesProvider } from "@/components/context/NRFPreferencesContext";
 import NRFChrome from "../NRFChrome";
 
@@ -26,9 +25,7 @@ export default async function Page() {
       <InstantSSRAutoRefresh />
       <NRFPreferencesProvider>
         <SearchFiltersProvider>
-          <ForcedToolsProvider>
-            <NRFPage />
-          </ForcedToolsProvider>
+          <NRFPage />
         </SearchFiltersProvider>
       </NRFPreferencesProvider>
       <NRFChrome />

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -21,6 +21,7 @@ import LoginPage from "@/app/auth/login/LoginPage";
 import { useAgents } from "@/lib/agents/hooks";
 import { useProjectsContext } from "@/lib/projects/providers";
 import useDeepResearchToggle from "@/hooks/useDeepResearchToggle";
+import { useToolConfiguration } from "@/lib/tools/hooks";
 import useChatController from "@/hooks/useChatController";
 import useChatSessionController from "@/hooks/useChatSessionController";
 import { useActiveAgent } from "@/lib/agents/hooks";
@@ -131,6 +132,8 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [multiModel.selectedModels]);
+
+  const toolConfiguration = useToolConfiguration();
 
   // Deep research toggle
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
@@ -265,6 +268,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
   const { onSubmit, stopGenerating, handleMessageSpecificFileUpload } =
     useChatController({
       llmManager,
+      toolConfiguration,
       availableAgents: availableAgents || [],
       activeAgent,
       existingChatSessionId,

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -540,6 +540,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
                 </div>
               )}
               <AppInputBar
+                toolConfiguration={toolConfiguration}
                 ref={chatInputBarRef}
                 deepResearchEnabled={deepResearchEnabled}
                 toggleDeepResearch={toggleDeepResearch}

--- a/web/src/app/nrf/side-panel/page.tsx
+++ b/web/src/app/nrf/side-panel/page.tsx
@@ -2,7 +2,6 @@ import { unstable_noStore as noStore } from "next/cache";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import NRFPage from "@/app/nrf/NRFPage";
 import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
-import { ForcedToolsProvider } from "@/lib/tools/hooks";
 import { NRFPreferencesProvider } from "@/components/context/NRFPreferencesContext";
 
 /**
@@ -20,9 +19,7 @@ export default async function Page() {
       <InstantSSRAutoRefresh />
       <NRFPreferencesProvider>
         <SearchFiltersProvider>
-          <ForcedToolsProvider>
-            <NRFPage isSidePanel />
-          </ForcedToolsProvider>
+          <NRFPage isSidePanel />
         </SearchFiltersProvider>
       </NRFPreferencesProvider>
     </>

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -79,8 +79,7 @@ import {
 } from "@/app/app/stores/useChatSessionStore";
 import { Packet, MessageStart } from "@/app/app/services/streamingModels";
 import { SelectedModel } from "@/sections/model-selector/MultiModelSelector";
-import { useAgentPreferences } from "@/lib/agents/hooks";
-import { useForcedTools } from "@/lib/tools/hooks";
+import type { ToolConfigurationHandle } from "@/lib/tools/hooks";
 import { ProjectFile, useProjectsContext } from "@/lib/projects/providers";
 import { useIncognito } from "@/providers/IncognitoProvider";
 import { projectFilesToFileDescriptors } from "@/lib/projects/utils";
@@ -117,6 +116,8 @@ interface RegenerationRequest {
 
 interface UseChatControllerProps {
   llmManager: LlmManager;
+  /** Owned by the surface, so the input bar and this read the same one. */
+  toolConfiguration: ToolConfigurationHandle;
   activeAgent: MinimalAgent | undefined;
   availableAgents: MinimalAgent[];
   existingChatSessionId: string | null;
@@ -140,6 +141,7 @@ async function stopChatSession(chatSessionId: string): Promise<void> {
 
 export default function useChatController({
   llmManager,
+  toolConfiguration,
   availableAgents,
   activeAgent,
   existingChatSessionId,
@@ -152,8 +154,6 @@ export default function useChatController({
   const searchParams = useSearchParams();
   const { refreshChatSessions, addPendingChatSession } = useChatSessions();
   const { pinnedAgents, togglePinnedAgent } = usePinnedAgents();
-  const { agentPreferences } = useAgentPreferences();
-  const { forcedToolId, keepThroughNextSessionChange } = useForcedTools();
   const { fetchProjects, setCurrentMessageFiles, beginUpload } =
     useProjectsContext();
   const { incognitoEnabledRef, incognitoSessionId } = useIncognito();
@@ -527,11 +527,6 @@ export default function useChatController({
         (m) => m.type === "user"
       );
       if (isNewSession) {
-        // This send is what creates the chat, so the session change it causes
-        // is not the user leaving one — the forced tool belongs to the message
-        // already on its way.
-        keepThroughNextSessionChange();
-
         // There is no incognito agent chat, so incognito pins the default
         // assistant regardless of any selected agent.
         currChatSessionId = await createChatSession(
@@ -541,6 +536,10 @@ export default function useChatController({
           incognito,
           incognito ? incognitoSessionId : null
         );
+
+        // This send is what created the chat, so the configuration chosen for
+        // it moves onto the session before the id reaches the composer.
+        toolConfiguration.handOffTo(currChatSessionId);
 
         // Optimistically add the new chat session to the sidebar cache so
         // "New Chat" appears immediately. Incognito sessions are excluded: they
@@ -1021,21 +1020,28 @@ export default function useChatController({
         const lastSuccessfulMessageId = getLastSuccessfulMessageId(
           currentMessageTreeLocal
         );
-        const disabledToolIds = activeAgent
-          ? agentPreferences?.[activeAgent?.id]?.disabled_tool_ids
-          : undefined;
 
         // Find the search tool's numeric ID for forceSearch
         const searchToolNumericId = activeAgent?.tools.find(
           (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
         )?.id;
 
-        // Determine the forced tool ID:
-        // 1. If forceSearch is true, use the search tool's numeric ID
-        // 2. Otherwise, whatever the user forced, if anything
-        const effectiveForcedToolId = forceSearch
+        // The tool this message is made to use: the search tool when the
+        // caller asked for a search, otherwise whatever the chat has forced.
+        //
+        // Only if the agent still has it. A configuration outlives the agent
+        // being edited, and a chat can be handed one that named a tool this
+        // agent does not have; the backend raises on a forced tool it cannot
+        // find, so an id nobody can act on would fail the whole message rather
+        // than the model simply choosing for itself.
+        const requestedForcedToolId = forceSearch
           ? (searchToolNumericId ?? null)
-          : forcedToolId;
+          : toolConfiguration.forcedToolId;
+        const effectiveForcedToolId =
+          requestedForcedToolId !== null &&
+          activeAgent?.tools.some((tool) => tool.id === requestedForcedToolId)
+            ? requestedForcedToolId
+            : null;
 
         // Determine origin for telemetry tracking (also used for frontend PostHog tracking below)
         const { isExtension, context: extensionContext } =
@@ -1083,10 +1089,18 @@ export default function useChatController({
             ? llmManager.temperature
             : undefined,
           deepResearch,
+          // Only sent when something is actually disabled. To the backend an
+          // explicit list is a whitelist, and this one is built from the tools
+          // the frontend can see — which excludes those marked
+          // `expose_to_frontend=False`. Sending it always would quietly
+          // withhold tools nobody chose to disable.
           enabledToolIds:
-            disabledToolIds && activeAgent
+            activeAgent && toolConfiguration.disabledToolIds.length > 0
               ? activeAgent.tools
-                  .filter((tool) => !disabledToolIds?.includes(tool.id))
+                  .filter(
+                    (tool) =>
+                      !toolConfiguration.disabledToolIds.includes(tool.id)
+                  )
                   .map((tool) => tool.id)
               : undefined,
           forcedToolId: effectiveForcedToolId,
@@ -1486,11 +1500,9 @@ export default function useChatController({
       updateSelectedNodeForDocDisplay,
       currentMessageTree,
       currentChatState,
-      // Ensure latest forced tools are used when submitting
-      forcedToolId,
-      keepThroughNextSessionChange,
+      // Ensure the configuration the chat was given is what gets sent
+      toolConfiguration,
       // Keep tool preference-derived values fresh
-      agentPreferences,
       fetchProjects,
       // For auto-pinning agents
       pinnedAgents,
@@ -1528,7 +1540,7 @@ export default function useChatController({
       setCurrentMessageFiles((prev) => [...prev, ...uploadedMessageFiles]);
       updateChatStateAction(getCurrentSessionId(), "input");
     },
-    [activeAgent, llmManager, forcedToolId]
+    [activeAgent, llmManager, toolConfiguration]
   );
 
   useEffect(() => {

--- a/web/src/lib/agents/components/AgentViewerModal.tsx
+++ b/web/src/lib/agents/components/AgentViewerModal.tsx
@@ -31,7 +31,7 @@ import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import AppInputBar from "@/sections/input/AppInputBar";
 import { useLlmManager } from "@/lib/hooks";
 import { SearchFiltersProvider } from "@/lib/searchFilters/providers";
-import { ForcedToolsProvider } from "@/lib/tools/hooks";
+import { useToolConfiguration } from "@/lib/tools/hooks";
 import { formatMmDdYyyy } from "@/lib/dateUtils";
 import { useProjectsContext } from "@/lib/projects/providers";
 import { FileCard } from "@/sections/cards/FileCard";
@@ -129,26 +129,39 @@ interface AgentChatInputProps {
 }
 function AgentChatInput({ agent, onSubmit }: AgentChatInputProps) {
   const llmManager = useLlmManager(undefined, agent);
+  // Over the listing, so the URL says nothing about the chat this would
+  // start; the agent is named here instead.
+  const toolConfiguration = useToolConfiguration(agent.id);
+
+  // This send navigates in order to send, so the configuration is left where
+  // that page will find it rather than travelling with the call. Closing the
+  // viewer without sending leaves nothing behind.
+  const submit = useCallback(
+    (message: string) => {
+      toolConfiguration.handOffToNewChatWith(agent.id);
+      onSubmit(message);
+    },
+    [toolConfiguration, agent.id, onSubmit]
+  );
 
   return (
-    // Its own instances, so neither the source toggles nor a forced tool chosen
-    // while previewing an agent reach the chat this modal opened over.
+    // Its own instance, so source toggles made while previewing an agent do not
+    // reach the chat this modal opened over.
     <SearchFiltersProvider>
-      <ForcedToolsProvider>
-        <AppInputBar
-          onSubmit={onSubmit}
-          llmManager={llmManager}
-          chatState="input"
-          activeAgent={agent}
-          stopGenerating={() => {}}
-          handleFileUpload={() => {}}
-          currentSessionFileTokenCount={0}
-          availableContextTokens={Infinity}
-          deepResearchEnabled={false}
-          toggleDeepResearch={() => {}}
-          disabled={false}
-        />
-      </ForcedToolsProvider>
+      <AppInputBar
+        toolConfiguration={toolConfiguration}
+        onSubmit={submit}
+        llmManager={llmManager}
+        chatState="input"
+        activeAgent={agent}
+        stopGenerating={() => {}}
+        handleFileUpload={() => {}}
+        currentSessionFileTokenCount={0}
+        availableContextTokens={Infinity}
+        deepResearchEnabled={false}
+        toggleDeepResearch={() => {}}
+        disabled={false}
+      />
     </SearchFiltersProvider>
   );
 }

--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -10,10 +10,6 @@ import {
   Agent,
   PaginatedAgentsResponse,
 } from "@/lib/agents/types";
-import {
-  UserSpecificAgentPreference,
-  UserSpecificAgentPreferences,
-} from "@/lib/types";
 import { toast } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { buildApiPath } from "@/lib/urlBuilder";
@@ -25,7 +21,6 @@ import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { DEFAULT_AGENT_ID } from "@/lib/constants";
 import { useSettings } from "@/lib/settings/hooks";
 import useChatSessions from "@/hooks/useChatSessions";
-import { buildUpdateAgentPreferenceUrl } from "./utils";
 
 // ── Data fetching ─────────────────────────────────────────────────────────────
 
@@ -307,55 +302,6 @@ export function useActiveAgent(): MinimalAgent | undefined {
     );
     return pinned ?? eligible[0];
   }, [agents, assistantDisabled, pinnedAgents, sessionAgentId, urlAgentIdRaw]);
-}
-
-// ── Agent preferences ─────────────────────────────────────────────────────────
-
-/**
- * Fetches and updates per-user preferences for each agent (e.g. temperature
- * overrides, custom instructions). Applies an optimistic local update before
- * the server confirms to keep the UI responsive.
- */
-export function useAgentPreferences() {
-  const { data, mutate } = useSWR<UserSpecificAgentPreferences>(
-    SWR_KEYS.agentPreferences,
-    errorHandlingFetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      dedupingInterval: 60000,
-    }
-  );
-
-  const setSpecificAgentPreferences = useCallback(
-    async (
-      agentId: number,
-      newAgentPreference: UserSpecificAgentPreference
-    ) => {
-      mutate({ ...data, [agentId]: newAgentPreference }, false);
-      try {
-        const response = await fetch(buildUpdateAgentPreferenceUrl(agentId), {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(newAgentPreference),
-        });
-        if (!response.ok) {
-          console.error(
-            `Failed to update agent preferences: ${response.status}`
-          );
-        }
-      } catch (error) {
-        console.error("Error updating agent preferences:", error);
-      }
-      mutate();
-    },
-    [data, mutate]
-  );
-
-  return {
-    agentPreferences: data ?? null,
-    setSpecificAgentPreferences,
-  };
 }
 
 // ── Agent Labels ──────────────────────────────────────────────────────────────

--- a/web/src/lib/agents/utils.ts
+++ b/web/src/lib/agents/utils.ts
@@ -46,12 +46,6 @@ export function buildAgentAvatarUrl(agentId: number) {
   return `/api/persona/${agentId}/avatar`;
 }
 
-// TODO(ENG-3766): rename to agent
-/** Returns the URL for patching a user's per-agent preferences. */
-export function buildUpdateAgentPreferenceUrl(agentId: number) {
-  return `/api/user/assistant/${agentId}/preferences`;
-}
-
 /**
  * Whether this is the built-in Assistant (id 0) rather than a chosen agent —
  * the "plain chat" case, which the UI shows without an agent description or a

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -34,7 +34,6 @@ export const SWR_KEYS = {
   // ── Agents ────────────────────────────────────────────────────────────────
   agents: "/api/persona",
   agent: (agentId: number) => `/api/persona/${agentId}`,
-  agentPreferences: "/api/user/assistant/preferences",
   defaultAssistantConfig: "/api/admin/default-assistant/configuration",
   agentLabels: "/api/persona/labels",
   adminAgentLabel: (labelId: number) => `/api/admin/persona/label/${labelId}`,

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  FILE_READER_TOOL_ID,
-  NO_DISABLED_TOOLS,
-  SEARCH_TOOL_ID,
-} from "@/lib/tools/constants";
+import { FILE_READER_TOOL_ID, SEARCH_TOOL_ID } from "@/lib/tools/constants";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useFocusOnMount } from "@opal/hooks";
 import { InputTypeIn, Button, Popover, PopoverMenu } from "@opal/components";
@@ -15,8 +11,6 @@ import {
   MCPAuthenticationPerformer,
   SecondaryViewState,
 } from "@/lib/tools/types";
-import { useForcedTools } from "@/lib/tools/hooks";
-import { useAgentPreferences } from "@/lib/agents/hooks";
 import { MinimalAgent } from "@/lib/agents/types";
 import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
@@ -29,6 +23,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SourceMetadata } from "@/lib/search/interfaces";
 import { SourceIcon } from "@/components/SourceIcon";
 import { useAvailableTools } from "@/lib/tools/hooks";
+import type { ToolConfigurationHandle } from "@/lib/tools/hooks";
 import { useAvailableSources } from "@/lib/connectors/hooks";
 import useCCPairs from "@/hooks/useCCPairs";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
@@ -59,11 +54,17 @@ import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
  */
 export interface ToolsPopoverProps {
   agent: MinimalAgent;
+  /**
+   * Owned by the surface, because the send path reads the same one. The
+   * popover decides nothing about where it lives or how long it lasts.
+   */
+  toolConfiguration: ToolConfigurationHandle;
   disabled?: boolean;
 }
 
 export default function ToolsPopover({
   agent,
+  toolConfiguration,
   disabled = false,
 }: ToolsPopoverProps) {
   const { availableSources } = useAvailableSources();
@@ -155,12 +156,6 @@ export default function ToolsPopover({
     isAuthenticated: false,
   });
 
-  // Get the agent preference for this assistant
-  const { agentPreferences, setSpecificAgentPreferences } =
-    useAgentPreferences();
-
-  const { forcedToolId, toggleForcedTool, clearForcedTool } = useForcedTools();
-
   const { permissions } = useUser();
   const { vectorDbEnabled } = useSettings();
 
@@ -171,32 +166,6 @@ export default function ToolsPopover({
 
   // Check if there are any connectors available
   const hasNoConnectors = ccPairs.length === 0;
-
-  const agentPreference = agentPreferences?.[agent.id];
-  const disabledToolIds =
-    agentPreference?.disabled_tool_ids || NO_DISABLED_TOOLS;
-  const toggleToolForCurrentAgent = useCallback(
-    (toolId: number) => {
-      const disabled = disabledToolIds.includes(toolId);
-      setSpecificAgentPreferences(agent.id, {
-        disabled_tool_ids: disabled
-          ? disabledToolIds.filter((id) => id !== toolId)
-          : [...disabledToolIds, toolId],
-      });
-
-      // If we're disabling a tool that is currently forced, remove it from forced tools
-      if (!disabled && forcedToolId === toolId) {
-        clearForcedTool();
-      }
-    },
-    [
-      disabledToolIds,
-      agent.id,
-      setSpecificAgentPreferences,
-      forcedToolId,
-      clearForcedTool,
-    ]
-  );
 
   // Get internal search tool reference for auto-pin logic
   const internalSearchTool = useMemo(
@@ -217,10 +186,10 @@ export default function ToolsPopover({
       ) {
         setSelectedSources(getConfiguredSources(effectiveAvailableSources));
       }
-      toggleForcedTool(toolId);
+      toolConfiguration.toggleToolState(toolId, "forced");
     },
     [
-      toggleForcedTool,
+      toolConfiguration,
       internalSearchTool,
       effectiveAvailableSources,
       setSelectedSources,
@@ -232,30 +201,28 @@ export default function ToolsPopover({
 
     // Toggling an already-forced tool would unforce it, so only fire when it
     // is not the forced one.
-    if (internalSearchTool && forcedToolId !== internalSearchTool.id) {
-      toggleForcedTool(internalSearchTool.id);
+    if (
+      internalSearchTool &&
+      toolConfiguration.forcedToolId !== internalSearchTool.id
+    ) {
+      toolConfiguration.toggleToolState(internalSearchTool.id, "forced");
     }
   }, [
     effectiveAvailableSources,
     setSelectedSources,
     internalSearchTool,
-    forcedToolId,
-    toggleForcedTool,
+    toolConfiguration,
   ]);
 
   const disableAllSources = useCallback(() => {
     baseDisableAllSources();
     const willUnpin =
-      internalSearchTool && forcedToolId === internalSearchTool.id;
+      internalSearchTool &&
+      toolConfiguration.forcedToolId === internalSearchTool.id;
     if (willUnpin) {
-      clearForcedTool();
+      toolConfiguration.clearForcedTool();
     }
-  }, [
-    baseDisableAllSources,
-    internalSearchTool,
-    forcedToolId,
-    clearForcedTool,
-  ]);
+  }, [baseDisableAllSources, internalSearchTool, toolConfiguration]);
 
   const toggleSource = useCallback(
     (sourceUniqueKey: string) => {
@@ -264,8 +231,8 @@ export default function ToolsPopover({
 
       if (internalSearchTool) {
         if (!wasEnabled) {
-          if (forcedToolId !== internalSearchTool.id) {
-            toggleForcedTool(internalSearchTool.id);
+          if (toolConfiguration.forcedToolId !== internalSearchTool.id) {
+            toolConfiguration.toggleToolState(internalSearchTool.id, "forced");
           }
         } else {
           const allSources = getConfiguredSources(effectiveAvailableSources);
@@ -275,9 +242,9 @@ export default function ToolsPopover({
           );
           if (
             remainingEnabled.length === 0 &&
-            forcedToolId === internalSearchTool.id
+            toolConfiguration.forcedToolId === internalSearchTool.id
           ) {
-            clearForcedTool();
+            toolConfiguration.clearForcedTool();
           }
         }
       }
@@ -287,9 +254,7 @@ export default function ToolsPopover({
       internalSearchTool,
       isSourceEnabled,
       effectiveAvailableSources,
-      forcedToolId,
-      toggleForcedTool,
-      clearForcedTool,
+      toolConfiguration,
     ]
   );
 
@@ -535,34 +500,24 @@ export default function ToolsPopover({
     id: tool.id.toString(),
     label: tool.display_name || tool.name,
     description: tool.description,
-    isEnabled: !disabledToolIds.includes(tool.id),
-    onToggle: () => toggleToolForCurrentAgent(tool.id),
+    isEnabled: !toolConfiguration.disabledToolIds.includes(tool.id),
+    onToggle: () => toolConfiguration.toggleToolState(tool.id, "disabled"),
   }));
 
   const mcpAllDisabled = selectedMcpTools.every((tool) =>
-    disabledToolIds.includes(tool.id)
+    toolConfiguration.disabledToolIds.includes(tool.id)
   );
 
-  const disableAllToolsForSelectedServer = () => {
+  // One call per tool rather than a second setter taking many. React batches
+  // them, and each sees what the one before it left, so the rules hold across
+  // the run instead of the last write landing on a stale map.
+  const setSelectedServerToolsDisabled = (disabled: boolean) => {
     if (!selectedMcpServer) return;
-    const serverToolIds = selectedMcpTools.map((tool) => tool.id);
-    const merged = Array.from(new Set([...disabledToolIds, ...serverToolIds]));
-    setSpecificAgentPreferences(agent.id, {
-      disabled_tool_ids: merged,
-    });
-    if (forcedToolId !== null && serverToolIds.includes(forcedToolId)) {
-      clearForcedTool();
+    for (const tool of selectedMcpTools) {
+      toolConfiguration.setToolState(tool.id, () =>
+        disabled ? "disabled" : null
+      );
     }
-  };
-
-  const enableAllToolsForSelectedServer = () => {
-    if (!selectedMcpServer) return;
-    const serverToolIdSet = new Set(selectedMcpTools.map((tool) => tool.id));
-    setSpecificAgentPreferences(agent.id, {
-      disabled_tool_ids: disabledToolIds.filter(
-        (id) => !serverToolIdSet.has(id)
-      ),
-    });
   };
 
   const handleFooterReauthClick = () => {
@@ -595,38 +550,30 @@ export default function ToolsPopover({
     isSourceEnabled(source.uniqueKey)
   ).length;
   const searchToolDisabled =
-    searchToolId !== null && disabledToolIds.includes(searchToolId);
+    searchToolId !== null &&
+    toolConfiguration.disabledToolIds.includes(searchToolId);
 
-  // Sync search tool state with sources on mount/when states change
+  // Searching nothing returns nothing, so the search tool follows whether any
+  // source is selected.
+  const setSearchToolEnabled = useCallback(
+    (enabled: boolean) => {
+      if (searchToolId === null) return;
+      toolConfiguration.setToolState(searchToolId, () =>
+        enabled ? null : "disabled"
+      );
+    },
+    [searchToolId, toolConfiguration]
+  );
+
   useEffect(() => {
     if (searchToolId === null || !sourcesInitialized) return;
-
-    const hasEnabledSources = numSourcesEnabled > 0;
-    if (hasEnabledSources && searchToolDisabled) {
-      // Sources are enabled but search tool is disabled - enable it
-      toggleToolForCurrentAgent(searchToolId);
-    } else if (!hasEnabledSources && !searchToolDisabled) {
-      // No sources enabled but search tool is enabled - disable it
-      toggleToolForCurrentAgent(searchToolId);
-    }
+    setSearchToolEnabled(numSourcesEnabled > 0);
   }, [
     searchToolId,
     numSourcesEnabled,
-    searchToolDisabled,
     sourcesInitialized,
-    toggleToolForCurrentAgent,
+    setSearchToolEnabled,
   ]);
-
-  // Set search tool to a specific enabled/disabled state (only toggles if needed)
-  const setSearchToolEnabled = (enabled: boolean) => {
-    if (searchToolId === null) return;
-
-    if (enabled && searchToolDisabled) {
-      toggleToolForCurrentAgent(searchToolId);
-    } else if (!enabled && !searchToolDisabled) {
-      toggleToolForCurrentAgent(searchToolId);
-    }
-  };
 
   const handleSourceToggle = (sourceUniqueKey: string) => {
     const willEnable = !isSourceEnabled(sourceUniqueKey);
@@ -647,8 +594,8 @@ export default function ToolsPopover({
   };
 
   const handleToggleTool = (toolId: number) => {
-    const wasDisabled = disabledToolIds.includes(toolId);
-    toggleToolForCurrentAgent(toolId);
+    const wasDisabled = toolConfiguration.disabledToolIds.includes(toolId);
+    toolConfiguration.toggleToolState(toolId, "disabled");
 
     if (toolId === searchToolId) {
       if (wasDisabled) {
@@ -718,8 +665,8 @@ export default function ToolsPopover({
               <ActionLineItem
                 key={tool.id}
                 tool={tool}
-                disabled={disabledToolIds.includes(tool.id)}
-                isForced={forcedToolId === tool.id}
+                disabled={toolConfiguration.disabledToolIds.includes(tool.id)}
+                isForced={toolConfiguration.forcedToolId === tool.id}
                 isUnavailable={isUnavailable}
                 tooltip={getToolTooltip(
                   tool,
@@ -733,7 +680,7 @@ export default function ToolsPopover({
                 onForceToggle={() =>
                   handleForceToggleWithTracking(
                     tool.id,
-                    forcedToolId === tool.id
+                    toolConfiguration.forcedToolId === tool.id
                   )
                 }
                 onSourceManagementOpen={() =>
@@ -764,7 +711,7 @@ export default function ToolsPopover({
             (t) => t.mcp_server_id === Number(server.id)
           );
           const enabledTools = serverTools.filter(
-            (t) => !disabledToolIds.includes(t.id)
+            (t) => !toolConfiguration.disabledToolIds.includes(t.id)
           );
 
           return (
@@ -820,8 +767,8 @@ export default function ToolsPopover({
       items={mcpToggleItems}
       searchPlaceholder={`Search ${selectedMcpServer?.name ?? "server"} tools`}
       allDisabled={mcpAllDisabled}
-      onDisableAll={disableAllToolsForSelectedServer}
-      onEnableAll={enableAllToolsForSelectedServer}
+      onDisableAll={() => setSelectedServerToolsDisabled(true)}
+      onEnableAll={() => setSelectedServerToolsDisabled(false)}
       disableAllLabel="Disable All Tools"
       enableAllLabel="Enable All Tools"
       onBack={() => setSecondaryView(null)}

--- a/web/src/lib/tools/constants.ts
+++ b/web/src/lib/tools/constants.ts
@@ -84,11 +84,3 @@ export const OPENAPI_ADMIN_CONFIG = {
   href: ADMIN_ROUTES.OPENAPI_ACTIONS.path,
   tooltip: "Manage OpenAPI Actions",
 };
-
-/**
- * Stands in for absent preferences.
- *
- * One frozen array rather than a fresh `[]` each render, so the callbacks that
- * depend on it keep their identity.
- */
-export const NO_DISABLED_TOOLS: number[] = [];

--- a/web/src/lib/tools/hooks.ts
+++ b/web/src/lib/tools/hooks.ts
@@ -8,8 +8,10 @@ import type {
   AgentEditorMCPServer,
   MCPServersResponse,
   ToolSnapshot,
+  ToolState,
 } from "@/lib/tools/types";
 import { createSharedHook } from "@opal/hooks";
+import { useAppPosition } from "@/lib/position/hooks";
 import { useActiveAgent } from "@/lib/agents/hooks";
 import { useActiveProject } from "@/lib/projects/hooks";
 import useChatSessions from "@/hooks/useChatSessions";
@@ -254,4 +256,334 @@ export function useAvailableTools() {
     error,
     refresh: mutate,
   };
+}
+
+// # NOTE (@raunakab):
+// ## The tool configuration
+//
+// What a message is sent with — the tool it must use, the tools it may not —
+// belongs to the chat it was chosen in, and returning any of it to neutral is
+// always something the user does. Nothing below is exported: a configuration
+// is only reachable through `useToolConfiguration`, so the two rules that hold
+// it together cannot be worked around by building one somewhere else.
+
+type ToolConfiguration = Readonly<Record<number, ToolState>>;
+
+const NEUTRAL: ToolConfiguration = {};
+
+const STORAGE_PREFIX = "onyx:tools";
+
+function chatKey(chatSessionId: string): string {
+  return `${STORAGE_PREFIX}:chat:${chatSessionId}`;
+}
+
+/** Whether this key names a chat that exists, which is the only kind kept. */
+function isChatKey(key: string): boolean {
+  return key.startsWith(`${STORAGE_PREFIX}:chat:`);
+}
+
+/**
+ * Applies the one rule a map cannot state: a single tool is forced at a time,
+ * because a message carries a single `forced_tool_id`. That a tool is forced,
+ * disabled or neutral and never two of those comes free, since a key holds one
+ * value.
+ *
+ * The next state arrives as a function of the current one, so a caller never
+ * reads before writing. Reading first is what let the server-side version of
+ * this rebuild a list from a value that had not loaded, and delete entries it
+ * had never seen.
+ */
+function withToolState(
+  configuration: ToolConfiguration,
+  toolId: number,
+  change: (current: ToolState | null) => ToolState | null
+): ToolConfiguration {
+  const next = change(configuration[toolId] ?? null);
+
+  const updated: Record<number, ToolState> = {};
+  for (const key of Object.keys(configuration)) {
+    const id = Number(key);
+    if (id === toolId) continue;
+    // Forcing this tool releases whatever was forced before it.
+    if (next === "forced" && configuration[id] === "forced") continue;
+    updated[id] = configuration[id]!;
+  }
+  if (next !== null) updated[toolId] = next;
+
+  return updated;
+}
+
+/**
+ * Reads a configuration back from untrusted text.
+ *
+ * The rules are applied again rather than assumed: storage can be edited by
+ * hand, and an older build may have written a shape this one does not know. So
+ * text claiming two forced tools keeps one, and anything unrecognised is
+ * dropped instead of carried through.
+ */
+function parseConfiguration(raw: string): ToolConfiguration {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return NEUTRAL;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return NEUTRAL;
+  }
+  // SAFETY: narrowed to a non-array object above, and every entry below is
+  // checked before it is kept.
+  const entries = value as Record<string, unknown>;
+
+  const configuration: Record<number, ToolState> = {};
+  let hasForced = false;
+  for (const key of Object.keys(entries)) {
+    const toolId = Number(key);
+    if (!Number.isInteger(toolId)) continue;
+
+    const state = entries[key];
+    if (state === "disabled") {
+      configuration[toolId] = "disabled";
+    } else if (state === "forced" && !hasForced) {
+      hasForced = true;
+      configuration[toolId] = "forced";
+    }
+  }
+  return configuration;
+}
+
+/** Session storage throws outright rather than degrading when it is blocked. */
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readConfiguration(key: string): ToolConfiguration {
+  const store = storage();
+  if (!store) return NEUTRAL;
+  try {
+    const raw = store.getItem(key);
+    return raw === null ? NEUTRAL : parseConfiguration(raw);
+  } catch {
+    return NEUTRAL;
+  }
+}
+
+/**
+ * A configuration saying nothing is not stored, so "no entry" and "everything
+ * neutral" are one state. That is what lets an entry renamed away leave a fresh
+ * composer at its defaults without anything having to clear it.
+ */
+function clearConfiguration(key: string) {
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(key);
+  } catch {
+    // Nothing to do; it will be overwritten or ignored.
+  }
+}
+
+function writeConfiguration(key: string, configuration: ToolConfiguration) {
+  const store = storage();
+  if (!store) return;
+  try {
+    if (Object.keys(configuration).length === 0) store.removeItem(key);
+    else store.setItem(key, JSON.stringify(configuration));
+  } catch {
+    // Blocked or full. The configuration still holds for this composer; only
+    // surviving a reload is lost.
+  }
+}
+
+export interface ToolConfigurationHandle {
+  /** What this chat has been told about one tool, or null for neutral. */
+  stateOf: (toolId: number) => ToolState | null;
+  /**
+   * The only way to change a configuration. Forcing a tool releases whatever
+   * was forced; a tool returned to neutral is forgotten rather than recorded.
+   */
+  setToolState: (
+    toolId: number,
+    change: (current: ToolState | null) => ToolState | null
+  ) => void;
+
+  /**
+   * What a control that means one state does when clicked: asks for that
+   * state, or takes it away when the tool already has it.
+   *
+   * Here rather than at each caller because every control in the popover wants
+   * it, and spelling it out per call site is how the popover ended up with two
+   * copies of the same three lines.
+   */
+  toggleToolState: (toolId: number, state: ToolState) => void;
+
+  /**
+   * Releases whatever is forced, for the callers that want no forced tool
+   * without caring which one is. Still goes through `setToolState`, so the
+   * rules hold.
+   */
+  clearForcedTool: () => void;
+
+  /** The tool every message in this chat is made to use, if any. */
+  forcedToolId: number | null;
+  /** The tools the model may not use in this chat. */
+  disabledToolIds: number[];
+
+  /**
+   * Called by the send path once the message it is sending has created the
+   * chat. Puts this configuration on that chat, which is where it starts
+   * being kept.
+   */
+  handOffTo: (chatSessionId: string) => void;
+
+  /**
+   * Called by a send that navigates somewhere else to do the sending — the
+   * agent viewer, which hands off to `/app` rather than sending in place.
+   * Leaves the configuration where that page will find it, once.
+   */
+  handOffToNewChatWith: (agentId: number) => void;
+}
+
+/**
+ * The tools this chat will send its next message with.
+ *
+ * Only a chat that exists keeps its configuration. What is chosen for a chat
+ * that does not exist yet — a new session, a new agent chat, a new project
+ * chat — lives as long as the composer does and no longer: leaving and coming
+ * back starts neutral, because there was never anything to come back to.
+ *
+ * The exception is a send that navigates in order to send. The agent viewer
+ * hands off to `/app` rather than sending in place, so its configuration is
+ * left where that page will find it, and picked up once. That is a message in
+ * flight rather than state being kept.
+ *
+ * Keyed by where the user is, so switching agent, chat or project reads a
+ * different configuration and there is no reset rule to run. A composer the
+ * URL does not describe — the agent viewer's, which sits over the listing —
+ * says which agent it is for instead. There is no key at all until the agent
+ * resolves: reading in that window is what made the server-side version
+ * destructive, since an unresolved value reads as "nothing chosen" and then
+ * overwrites something real.
+ */
+export function useToolConfiguration(
+  newChatWithAgentId?: number
+): ToolConfigurationHandle {
+  const appPosition = useAppPosition();
+  const activeAgent = useActiveAgent();
+
+  const key = useMemo(() => {
+    // A composer for a chat that the URL does not describe says which agent it
+    // is for. The agent viewer is one: it sits over the listing, so where the
+    // user is says nothing about the chat its input bar would start.
+    if (newChatWithAgentId !== undefined) {
+      return `${STORAGE_PREFIX}:new:${newChatWithAgentId}`;
+    }
+
+    const chatSessionId = appPosition.chat();
+    if (chatSessionId !== null) return chatKey(chatSessionId);
+
+    const agentId = appPosition.agent();
+    if (agentId !== null) return `${STORAGE_PREFIX}:new:${agentId}`;
+
+    if (activeAgent === undefined) return null;
+    const projectId = appPosition.project();
+    return projectId === null
+      ? `${STORAGE_PREFIX}:new:${activeAgent.id}`
+      : `${STORAGE_PREFIX}:new:${activeAgent.id}:${projectId}`;
+  }, [newChatWithAgentId, appPosition, activeAgent]);
+
+  // Tagged with the key it was read for, so a write cannot land on the entry
+  // the composer has since moved to.
+  const [entry, setEntry] = useState<{
+    key: string | null;
+    configuration: ToolConfiguration;
+  }>({ key: null, configuration: NEUTRAL });
+
+  // Storage is only reachable on the client, so the first paint shows neutral
+  // and this corrects it. Every later key change comes from the user moving
+  // between chats, which is many frames after anything can be sent.
+  useEffect(() => {
+    if (key === null) {
+      setEntry({ key, configuration: NEUTRAL });
+      return;
+    }
+    const stored = readConfiguration(key);
+    // A chat that does not exist yet keeps nothing, so anything found under
+    // its key was handed over by a send on its way here. Taken once, then
+    // removed, so returning later starts neutral.
+    if (!isChatKey(key) && Object.keys(stored).length > 0) {
+      clearConfiguration(key);
+    }
+    setEntry({ key, configuration: stored });
+  }, [key]);
+
+  const configuration = entry.key === key ? entry.configuration : NEUTRAL;
+
+  // Written from an effect rather than inside the setter, so two changes made
+  // in one tick compose instead of the later one landing on what the earlier
+  // one replaced. Only a chat that exists is written: everything else is held
+  // for as long as the composer lives and then let go.
+  useEffect(() => {
+    if (entry.key !== null && isChatKey(entry.key)) {
+      writeConfiguration(entry.key, entry.configuration);
+    }
+  }, [entry]);
+
+  const setToolState = useCallback(
+    (
+      toolId: number,
+      change: (current: ToolState | null) => ToolState | null
+    ) => {
+      if (key === null) return;
+      setEntry((previous) => ({
+        key,
+        configuration: withToolState(
+          previous.key === key ? previous.configuration : NEUTRAL,
+          toolId,
+          change
+        ),
+      }));
+    },
+    [key]
+  );
+
+  // Both land before the position that follows reaches this hook, so the key
+  // change reads the configuration back where it was left.
+  const handOffTo = useCallback(
+    (chatSessionId: string) =>
+      writeConfiguration(chatKey(chatSessionId), configuration),
+    [configuration]
+  );
+
+  const handOffToNewChatWith = useCallback(
+    (agentId: number) =>
+      writeConfiguration(`${STORAGE_PREFIX}:new:${agentId}`, configuration),
+    [configuration]
+  );
+
+  return useMemo(() => {
+    const ids = Object.keys(configuration).map(Number);
+    const forcedToolId =
+      ids.find((toolId) => configuration[toolId] === "forced") ?? null;
+    return {
+      stateOf: (toolId: number) => configuration[toolId] ?? null,
+      setToolState,
+      toggleToolState: (toolId: number, state: ToolState) =>
+        setToolState(toolId, (current) => (current === state ? null : state)),
+      clearForcedTool: () => {
+        if (forcedToolId !== null) setToolState(forcedToolId, () => null);
+      },
+      forcedToolId,
+      disabledToolIds: ids.filter(
+        (toolId) => configuration[toolId] === "disabled"
+      ),
+      handOffTo,
+      handOffToNewChatWith,
+    };
+  }, [configuration, setToolState, handOffTo, handOffToNewChatWith]);
 }

--- a/web/src/lib/tools/hooks.ts
+++ b/web/src/lib/tools/hooks.ts
@@ -310,7 +310,14 @@ function withToolState(
   }
   if (next !== null) updated[toolId] = next;
 
-  return updated;
+  // A change that changes nothing hands back what it was given. Callers read
+  // the result by identity to decide whether anything happened.
+  const ids = Object.keys(updated);
+  const same =
+    ids.length === Object.keys(configuration).length &&
+    ids.every((id) => updated[Number(id)] === configuration[Number(id)]);
+
+  return same ? configuration : updated;
 }
 
 /**
@@ -540,14 +547,15 @@ export function useToolConfiguration(
       change: (current: ToolState | null) => ToolState | null
     ) => {
       if (key === null) return;
-      setEntry((previous) => ({
-        key,
-        configuration: withToolState(
-          previous.key === key ? previous.configuration : NEUTRAL,
-          toolId,
-          change
-        ),
-      }));
+      setEntry((previous) => {
+        const current = previous.key === key ? previous.configuration : NEUTRAL;
+        const configuration = withToolState(current, toolId, change);
+        // Asking for the state it already holds has to leave the same entry
+        // behind. A new one every time is a change to everything reading it,
+        // and a caller that writes what it reads would never settle.
+        if (previous.key === key && configuration === current) return previous;
+        return { key, configuration };
+      });
     },
     [key]
   );

--- a/web/src/lib/tools/hooks.ts
+++ b/web/src/lib/tools/hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import useSWR, { mutate } from "swr";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type {
@@ -10,11 +10,8 @@ import type {
   ToolSnapshot,
   ToolState,
 } from "@/lib/tools/types";
-import { createSharedHook } from "@opal/hooks";
 import { useAppPosition } from "@/lib/position/hooks";
 import { useActiveAgent } from "@/lib/agents/hooks";
-import { useActiveProject } from "@/lib/projects/hooks";
-import useChatSessions from "@/hooks/useChatSessions";
 
 /**
  * Every MCP server the current user can reach.
@@ -117,109 +114,6 @@ export function useCraftMcpServers(enabled: boolean = true) {
 
   return { data, error, isLoading, refresh };
 }
-
-interface ForcedToolState {
-  forcedToolId: number | null;
-  toggleForcedTool: (id: number) => void;
-  clearForcedTool: () => void;
-  /**
-   * Called by the send path when a message is about to create the chat it is
-   * being sent to. Excuses exactly the next session change from the reset, so
-   * the tool survives to the request it was chosen for.
-   */
-  keepThroughNextSessionChange: () => void;
-}
-
-/**
- * The tool the next message will be made to use, if any.
- *
- * A forced tool runs whether or not the model would have chosen it. Only one
- * can be forced at a time — the request carries a single `forced_tool_id` — so
- * the state is that one id rather than a list callers must keep to one entry
- * by convention.
- */
-function useForcedToolsState(): ForcedToolState {
-  const [forcedToolId, setForcedToolId] = useState<number | null>(null);
-
-  // Clicking the tool that is already forced unforces it; clicking any other
-  // replaces it, since forcing two is not a state that can be sent.
-  const toggleForcedTool = useCallback(
-    (id: number) => setForcedToolId((current) => (current === id ? null : id)),
-    []
-  );
-  const clearForcedTool = useCallback(() => setForcedToolId(null), []);
-
-  // Only the send path can tell "the chat I just created" from "a chat I
-  // navigated to" — both read as null -> id from here, and the URL marker the
-  // navigation carries is stripped with `history.replaceState`, so it is not
-  // reliably visible. So the send path says so instead of this guessing.
-  const keepThroughNextSessionChangeRef = useRef(false);
-  const keepThroughNextSessionChange = useCallback(() => {
-    keepThroughNextSessionChangeRef.current = true;
-  }, []);
-
-  // Switching agent, project or chat leaves the choice meaningless, so it does
-  // not survive them. The exception is the common path: sending the first
-  // message is what creates the chat, so the session id goes null -> id on the
-  // way out, and clearing there would discard the tool the user forced by the
-  // act of using it. That is a chat appearing, not one being left. The provider
-  // is per surface rather than per agent, so an agent switch does not unmount
-  // it and this is what handles that case.
-  const agent = useActiveAgent();
-  const { currentChatSessionId } = useChatSessions();
-  const activeProject = useActiveProject();
-  const priorSessionIdRef = useRef(currentChatSessionId);
-  useEffect(() => {
-    const priorSessionId = priorSessionIdRef.current;
-    priorSessionIdRef.current = currentChatSessionId;
-
-    const wasOwnSend = keepThroughNextSessionChangeRef.current;
-    keepThroughNextSessionChangeRef.current = false;
-    // Both parts are required: the flag alone would also excuse an agent or
-    // project change that happened to land first.
-    if (
-      wasOwnSend &&
-      priorSessionId === null &&
-      currentChatSessionId !== null
-    ) {
-      return;
-    }
-
-    clearForcedTool();
-  }, [agent?.id, currentChatSessionId, activeProject?.id, clearForcedTool]);
-
-  // Memoized so consumers re-render when the forced tool changes and not
-  // merely because the provider did.
-  return useMemo(
-    () => ({
-      forcedToolId,
-      toggleForcedTool,
-      clearForcedTool,
-      keepThroughNextSessionChange,
-    }),
-    [
-      forcedToolId,
-      toggleForcedTool,
-      clearForcedTool,
-      keepThroughNextSessionChange,
-    ]
-  );
-}
-
-/**
- * Scoped to whatever tree mounts the provider, so one chat surface cannot
- * disturb another's choice. A preview modal over a conversation gets its own,
- * and opening it leaves the conversation's forced tool alone — which a
- * module-level store could not promise without every new surface remembering
- * to be careful.
- *
- * Mount above whatever reads it: the tools popover, the chip in the input bar,
- * and the send path all do, and the send path runs from the page itself.
- */
-export const [ForcedToolsProvider, useForcedTools] = createSharedHook(
-  useForcedToolsState,
-  "ForcedTools"
-);
 
 /**
  * Hook to fetch all available tools from the backend.

--- a/web/src/lib/tools/types.ts
+++ b/web/src/lib/tools/types.ts
@@ -224,3 +224,13 @@ export interface OAuthTokenStatus {
 export type SecondaryViewState =
   | { type: "sources" }
   | { type: "mcp"; serverId: number };
+
+/**
+ * What a chat has been told to do about one tool.
+ *
+ * Neutral is the absence of a state rather than a third name for one, so a
+ * tool nobody has said anything about is not recorded. A tool that appears
+ * after the choice was made is therefore already neutral, with nothing having
+ * to go and enrol it.
+ */
+export type ToolState = "forced" | "disabled";

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -6,15 +6,6 @@ import { Connector } from "./connectors/connectors";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
 import type { PermissionsOf } from "@/lib/permissions/resource-actions";
 
-export interface UserSpecificAgentPreference {
-  disabled_tool_ids?: number[];
-}
-
-export type UserSpecificAgentPreferences = Record<
-  number,
-  UserSpecificAgentPreference
->;
-
 export enum ThemePreference {
   LIGHT = "light",
   DARK = "dark",

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -18,7 +18,7 @@ import { useAvailableSources } from "@/lib/connectors/hooks";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { ChatState, MAX_QUEUED_MESSAGES } from "@/app/app/interfaces";
 import { useQueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
-import { useForcedTools } from "@/lib/tools/hooks";
+import type { ToolConfigurationHandle } from "@/lib/tools/hooks";
 import { useAppPosition } from "@/lib/position/hooks";
 import { useDraft, draftKey } from "@/hooks/useDraft";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
@@ -95,6 +95,11 @@ export interface AppInputBarProps {
   toggleDeepResearch: () => void;
   isMultiModelActive?: boolean;
   disabled: boolean;
+  /**
+   * Owned by the surface rather than read here, because the send path reads
+   * the same one and two instances would drift.
+   */
+  toolConfiguration: ToolConfigurationHandle;
   ref?: React.Ref<AppInputBarHandle>;
   // Side panel tab reading
   tabReadingEnabled?: boolean;
@@ -118,6 +123,7 @@ const AppInputBar = React.memo(
     isMultiModelActive,
     setPresentingDocument,
     disabled,
+    toolConfiguration,
     ref,
     tabReadingEnabled,
     currentTabUrl,
@@ -321,7 +327,7 @@ const AppInputBar = React.memo(
       }
     }, [isNewSession, initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const { forcedToolId, clearForcedTool } = useForcedTools();
+    const { forcedToolId, clearForcedTool } = toolConfiguration;
     const { currentMessageFiles, setCurrentMessageFiles } =
       useProjectsContext();
     const { isLoading: isLoadingProjects } = useProjects();
@@ -651,6 +657,7 @@ const AppInputBar = React.memo(
               <ToolsPopover
                 key={activeAgent.id}
                 agent={activeAgent}
+                toolConfiguration={toolConfiguration}
                 disabled={disabled}
               />
             )}

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -996,6 +996,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                         </div>
                       )}
                       <AppInputBar
+                        toolConfiguration={toolConfiguration}
                         ref={chatInputBarRef}
                         deepResearchEnabled={
                           deepResearchEnabledForCurrentWorkflow

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -9,6 +9,7 @@ import { useFederatedConnectors, useLlmManager } from "@/lib/hooks";
 import { useSendChatMessageFromURL } from "@/lib/chat/hooks";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
 import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
+import { useToolConfiguration } from "@/lib/tools/hooks";
 import { useSettings } from "@/lib/settings/hooks";
 import Dropzone from "react-dropzone";
 import AppInputBar, { AppInputBarHandle } from "@/sections/input/AppInputBar";
@@ -189,6 +190,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
       router.replace(`?${params.toString()}`, { scroll: false });
     }
   }, [searchParams, router]);
+
+  const toolConfiguration = useToolConfiguration();
 
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
     chatSessionId: currentChatSessionId,
@@ -416,6 +419,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     availableContextTokens,
   } = useChatController({
     llmManager,
+    toolConfiguration,
     availableAgents: agents,
     activeAgent,
     existingChatSessionId: currentChatSessionId,

--- a/web/tests/e2e/chat/tools_popover.spec.ts
+++ b/web/tests/e2e/chat/tools_popover.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { loginAs } from "@tests/e2e/utils/auth";
 import {
   TOOL_IDS,
@@ -8,6 +8,7 @@ import {
   getSourceToggle,
 } from "@tests/e2e/utils/tools";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import { sendMessage } from "@tests/e2e/utils/chatActions";
 
 const LOCAL_STORAGE_KEY = "selectedInternalSearchSources";
 
@@ -122,6 +123,9 @@ test.describe("ToolsPopover Tool Toggles", () => {
       (key) => localStorage.removeItem(key),
       LOCAL_STORAGE_KEY
     );
+    // Tool configurations belong to a chat and live in session storage, so a
+    // chat left behind by an earlier test would otherwise be read by this one.
+    await page.evaluate(() => sessionStorage.clear());
   });
 
   test("should show internal search and other tools in popover", async ({
@@ -247,57 +251,43 @@ test.describe("ToolsPopover Tool Toggles", () => {
     expect(enabledAfter).toBe(enabledBefore);
   });
 
-  test("tool enabled and disabled states both persist across reload", async ({
-    page,
-  }) => {
+  /** The slash button reads "Disable" while the tool is on, "Enable" once off. */
+  async function expectToolDisabled(
+    page: Page,
+    disabled: boolean
+  ): Promise<void> {
     await openActionManagement(page);
-    const searchOption = page.locator(TOOL_IDS.searchOption);
-    await expect(searchOption).toBeVisible({ timeout: 10000 });
+    const option = page.locator(TOOL_IDS.searchOption);
+    await expect(option).toBeVisible({ timeout: 10000 });
+    await option.hover();
+    await expect(
+      option
+        .locator('button[aria-label="Disable"], button[aria-label="Enable"]')
+        .first()
+    ).toHaveAttribute("aria-label", disabled ? "Enable" : "Disable");
+  }
 
-    // The slash button says "Disable" when the tool is enabled
-    await searchOption.hover();
-    const slashButton = searchOption.locator(
-      'button[aria-label="Disable"], button[aria-label="Enable"]'
-    );
-    await expect(slashButton.first()).toHaveAttribute("aria-label", "Disable");
+  test("a new session forgets a disabled tool", async ({ page }) => {
+    await expectToolDisabled(page, false);
+    await toggleToolDisabled(page, TOOL_IDS.searchOption);
+    await expectToolDisabled(page, true);
 
-    // Reload — enabled state should persist
+    // Nothing was chosen for a chat, because there is no chat yet.
     await page.reload();
     await page.waitForLoadState("networkidle");
-    await openActionManagement(page);
-    await page.locator(TOOL_IDS.searchOption).hover();
-    await expect(
-      page
-        .locator(TOOL_IDS.searchOption)
-        .locator('button[aria-label="Disable"], button[aria-label="Enable"]')
-        .first()
-    ).toHaveAttribute("aria-label", "Disable");
+    await expectToolDisabled(page, false);
+  });
 
-    // Disable the search tool
+  test("a chat keeps a disabled tool across a reload", async ({ page }) => {
+    await sendMessage(page, "hello");
+    await page.waitForURL(/chatId=/, { timeout: 30000 });
+
+    await expectToolDisabled(page, false);
     await toggleToolDisabled(page, TOOL_IDS.searchOption);
+    await expectToolDisabled(page, true);
 
-    // Verify it's now disabled (slash button says "Enable")
-    await page.locator(TOOL_IDS.searchOption).hover();
-    await expect(
-      page
-        .locator(TOOL_IDS.searchOption)
-        .locator('button[aria-label="Disable"], button[aria-label="Enable"]')
-        .first()
-    ).toHaveAttribute("aria-label", "Enable");
-
-    // Reload — disabled state should also persist (saved to DB)
     await page.reload();
     await page.waitForLoadState("networkidle");
-    await openActionManagement(page);
-    await page.locator(TOOL_IDS.searchOption).hover();
-    await expect(
-      page
-        .locator(TOOL_IDS.searchOption)
-        .locator('button[aria-label="Disable"], button[aria-label="Enable"]')
-        .first()
-    ).toHaveAttribute("aria-label", "Enable");
-
-    // Re-enable the tool for cleanup (serial tests follow)
-    await toggleToolDisabled(page, TOOL_IDS.searchOption);
+    await expectToolDisabled(page, true);
   });
 });

--- a/web/tests/e2e/chat/tools_popover.spec.ts
+++ b/web/tests/e2e/chat/tools_popover.spec.ts
@@ -251,13 +251,18 @@ test.describe("ToolsPopover Tool Toggles", () => {
     expect(enabledAfter).toBe(enabledBefore);
   });
 
+  // Image generation rather than internal search: the search tool's state is
+  // re-derived on mount from the selected sources, which are still global in
+  // `localStorage`, so it would answer for those rather than for the chat.
+  const CONFIGURED_TOOL = TOOL_IDS.imageGenerationOption;
+
   /** The slash button reads "Disable" while the tool is on, "Enable" once off. */
   async function expectToolDisabled(
     page: Page,
     disabled: boolean
   ): Promise<void> {
     await openActionManagement(page);
-    const option = page.locator(TOOL_IDS.searchOption);
+    const option = page.locator(CONFIGURED_TOOL);
     await expect(option).toBeVisible({ timeout: 10000 });
     await option.hover();
     await expect(
@@ -269,7 +274,7 @@ test.describe("ToolsPopover Tool Toggles", () => {
 
   test("a new session forgets a disabled tool", async ({ page }) => {
     await expectToolDisabled(page, false);
-    await toggleToolDisabled(page, TOOL_IDS.searchOption);
+    await toggleToolDisabled(page, CONFIGURED_TOOL);
     await expectToolDisabled(page, true);
 
     // Nothing was chosen for a chat, because there is no chat yet.
@@ -283,7 +288,7 @@ test.describe("ToolsPopover Tool Toggles", () => {
     await page.waitForURL(/chatId=/, { timeout: 30000 });
 
     await expectToolDisabled(page, false);
-    await toggleToolDisabled(page, TOOL_IDS.searchOption);
+    await toggleToolDisabled(page, CONFIGURED_TOOL);
     await expectToolDisabled(page, true);
 
     await page.reload();

--- a/web/tests/e2e/utils/tools.ts
+++ b/web/tests/e2e/utils/tools.ts
@@ -26,6 +26,10 @@ export async function waitForUnifiedGreeting(page: Page): Promise<string> {
 
 // Ensure the Action Management popover is open
 export async function openActionManagement(page: Page): Promise<void> {
+  // The toggle closes an open popover, so a caller that already has one would
+  // shut it by asking for it again.
+  if (await page.locator(TOOL_IDS.options).isVisible()) return;
+
   const actionToggle = page.locator(TOOL_IDS.actionToggle);
   await actionToggle.waitFor();
   await actionToggle.click();


### PR DESCRIPTION
## Description

What a message is sent with — the tool it must use, the tools it may not — was
two settings with nothing holding them together, and no agreement about how long
either lasts.

- **Disabled tools** were stored per user *and per agent*, in
  `assistant__user_specific_config`. Striking out Web Search in one chat turned it
  off for that agent in every chat, on every device. Almost certainly not what the
  strikethrough looks like it does.
- **The forced tool** was not stored at all. It died on navigation, and until
  #14347 it did not survive the send that created the chat.

They become one configuration, belonging to the chat it was chosen in.

### One state per tool

```ts
ToolState = "forced" | "disabled"          // absent = neutral
ToolConfiguration = Record<ToolId, ToolState>
```

A tool is forced, disabled, or neutral — never two of those, because a key holds
one value. The guard that used to say so by hand is gone with the state that made
it necessary:

```ts
// before: two booleans that could contradict, reconciled at each call site
if (!disabled && forcedToolId === toolId) clearForcedTool();
```

The other rule — only one tool forced at a time, since a request carries a single
`forced_tool_id` — a map cannot express, so `setToolState` enforces it: forcing a
tool releases whatever was forced.

### Callers never read before writing

```ts
setToolState(toolId, (current) => (current === "forced" ? null : "forced"));
```

The next state arrives as a function of the current one. Reading first is what let
the version this replaces rebuild a list from a value that had not loaded yet and
delete entries it had never seen — rows were being destroyed on page load, which is
what started this work.

Nothing but the hook is exported. A configuration cannot be built anywhere else, so
neither rule can be worked around by building one.

### Only a chat that exists keeps its configuration

A new session, a new agent chat and a new project chat are chats that do not exist
yet, and what is chosen for one lives as long as the composer does. Leave and come
back and it is neutral, because there was never anything to come back to.

The exception is a send that navigates *in order to* send. The agent viewer hands
off to `/app` rather than sending in place, so at submit it leaves the configuration
where that page will find it, and that page takes it once and removes it. Closing
the viewer without sending leaves nothing behind — a message in flight, not state
being kept.

### Web detaches from the endpoint

`useAgentPreferences`, its SWR key, its URL builder and its two types are deleted;
nothing called them once the popover and the send path moved over. The endpoint and
its table stay, because mobile still reads and writes them.

### Worth a reviewer's eye

**A tool whitelist is now sent only when something is disabled.** `allowed_tool_ids`
is a whitelist to the backend: null uses every tool the agent has, a list uses only
what is in it. The list is built from tools the frontend can see, and two —
`OktaProfileTool` and `MemoryTool` — are marked `expose_to_frontend=False`, so they
can never appear in it. Sending it unconditionally withheld tools nobody had
disabled. `MemoryTool` is exempted from the filter in the backend; Okta Profile is
not. When a tool *is* disabled the same gap remains; that predates this and belongs
with whatever closes it.

**Two intended behaviour changes.** Existing users' stored `disabled_tool_ids` stop
applying on web — a tool they disabled months ago is enabled again. And a forced
tool now persists across sends, for every message in that chat, until unforced.

**MCP bulk enable/disable calls the one setter per tool** rather than writing a
list. React batches, and each updater sees what the previous one left, so the rules
hold across the run instead of the last write landing on a stale map.

**A write that changes nothing hands back what it was given.** `withToolState` and
the entry holding it both built a fresh object every call, so asking for the state
a tool already had still counted as a change. The popover keeps the search tool
following whether any source is selected — a caller that writes what it reads —
and it re-ran on its own write until React gave up. Both sites now return the
object they were handed.

## How Has This Been Tested?

Manually, in the app. `bun run types:check` and the pre-commit hooks pass on every
commit. No automated test yet: the internals are private by design, so the
invariants want a `renderHook` test against the handle rather than the pure
functions — worth adding before this merges.

Source selection is untouched and still global in `localStorage`, so the search
tool and its sources still disagree about how long a choice lasts. That is the next
change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges forced-tool and disabled-tools settings into a single per-chat configuration, so tool choices stick to the chat they were made in instead of applying to every chat or dying on navigation.

**Behavior changes**
- Existing users' stored `disabled_tool_ids` stop applying on web, so previously disabled tools come back enabled.
- A forced tool now persists for every message in that chat until it is unforced.
- `allowed_tool_ids` is sent only when something is disabled, so tools hidden from the frontend like `OktaProfileTool` are no longer withheld on every message.
- A tool is forced, disabled, or neutral — one state at a time — and forcing a tool releases whatever was forced.
- Configurations are stored per chat and only for chats that exist; new-chat choices reset when the composer is left.
- State changes take an updater function, fixing a read-before-write bug that deleted tool rows on page load.
- A forced tool the agent no longer has is dropped instead of failing the message.
- Web stops using the per-agent preferences endpoint, which stays for mobile.

**Tests**
- E2E coverage asserts a disabled tool is forgotten by a session with no chat and kept by a chat that exists, using image generation rather than search — the search tool's state is re-derived from the selected sources, which remain global in `localStorage`.

<sup>Written for commit 7f1c2796b39333d99005afd2ce3bd292cab34d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

