### PR TITLE
fix(web): never enable auto mode for custom LLM providers

### DIFF
--- a/web/src/sections/modals/languageModels/CustomModal.test.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.test.tsx
@@ -158,6 +158,13 @@ describe("Custom LLM Provider Configuration Workflow", () => {
       );
     });
 
+    // Custom providers must never be created in auto mode — auto mode would
+    // merge the recommended models for matching providers (e.g. "openai").
+    const createCall = fetchSpy.mock.calls.find(
+      ([url]) => url === "/api/admin/llm/provider?is_creation=true"
+    );
+    expect(JSON.parse(createCall![1].body as string).is_auto_mode).toBe(false);
+
     // Verify success toast
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(
@@ -253,7 +260,9 @@ describe("Custom LLM Provider Configuration Workflow", () => {
       ],
       custom_config: {},
       is_public: true,
-      is_auto_mode: false,
+      // Simulates a provider saved before custom providers were excluded from
+      // auto mode; the next update must flip it back to false.
+      is_auto_mode: true,
       groups: [],
       personas: [],
       deployment_name: null,
@@ -289,6 +298,12 @@ describe("Custom LLM Provider Configuration Workflow", () => {
         })
       );
     });
+
+    // The update must force auto mode off, repairing the stored provider.
+    const updateCall = fetchSpy.mock.calls.find(
+      ([url]) => url === "/api/admin/llm/provider"
+    );
+    expect(JSON.parse(updateCall![1].body as string).is_auto_mode).toBe(false);
 
     // Credential test should NOT have been called when only model name changed
     expect(fetchSpy).not.toHaveBeenCalledWith(

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -287,6 +287,10 @@ export default function CustomModal({
       existingLlmProvider
     ),
     provider: existingLlmProvider?.provider ?? "",
+    // Custom providers must never be in auto mode: the backend's auto-mode
+    // sync keys off the provider string, so a custom provider named e.g.
+    // "openai" would get the recommended OpenAI models merged into it.
+    is_auto_mode: false,
     api_version: existingLlmProvider?.api_version ?? "",
     model_configurations: existingLlmProvider?.model_configurations.map((mc) =>
       // Stored policy can exceed a capability that shrank since the save,


### PR DESCRIPTION
## Description

CustomModal merged the recommended models into a custom provider when the typed provider string matched a provider with recommended models (e.g. `openai`).

Root cause: `useInitialValues` defaults `is_auto_mode` to `true`. That default is meant for the well-known modals that render the auto-update toggle. CustomModal spreads those values, never shows the toggle, and never overrides the field. So every new custom provider was saved in auto mode. On save, `put_llm_provider` sees the transition to auto mode and calls `sync_auto_mode_models`, which keys off the provider string. If that string is in the recommended-models config (`openai`, `anthropic`, `vertex_ai`, `openrouter`), the recommended models get merged into the provider. The periodic `llm_model_update` Celery task then re-merges them on each sync. Only CustomModal is exposed: its provider combo box accepts free text, while every other modal uses a fixed provider name that is not in that config.

Fix: pin `is_auto_mode: false` in CustomModal's form values. New custom providers never enter auto mode. A provider already saved in auto mode is repaired on its next save, which stops the background sync.

Note: this does not retroactively delete model rows that a prior sync already inserted; admins can remove them in the modal.

## How Has This Been Tested?

- Extended `CustomModal.test.tsx`:
  - The create test asserts the PUT body carries `is_auto_mode: false`.
  - The update test simulates a provider stored with `is_auto_mode: true` and asserts the update request sends `false`.
- All 7 tests in the file pass. `oxfmt`/`oxlint` pass on the touched files. The `types:check` failures in this environment are pre-existing (identical 572 errors on the clean tree, all unrelated Opal `ButtonProps` resolution errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops custom LLM providers from inheriting recommended models when their provider string matches a known provider like `openai`. CustomModal now pins `is_auto_mode: false`, so new custom providers never enter auto mode, and providers already in auto mode flip back to manual on their next save.

- CustomModal previously inherited `is_auto_mode: true` from `useInitialValues`, a default meant for modals that show the auto-update toggle.
- The backend's auto-mode sync keys off the provider string, so matching names (`openai`, `anthropic`, `vertex_ai`, `openrouter`) got recommended models merged on every save and periodic sync.
- Existing model rows inserted by a prior sync are not deleted retroactively; admins can remove them in the modal.

<sup>Written for commit 985606ab732b617733166c7d4189d82803c9ae02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

