### PR TITLE
test(web): mask the usage period in admin screenshots

### DIFF
--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -97,7 +97,12 @@ export default function PerUserUsagePanel({
       height="fit"
     >
       <Text font="heading-h3">{t("panel.title")}</Text>
-      <Text font="secondary-body" color="text-03">
+      {/* Holds the selected period, so visual tests mask it. */}
+      <Text
+        font="secondary-body"
+        color="text-03"
+        data-testid="usage-overview-period"
+      >
         {usage
           ? t("panel.description", {
               start: formatDate(usage.start),

--- a/web/tests/e2e/admin/admin_pages.spec.ts
+++ b/web/tests/e2e/admin/admin_pages.spec.ts
@@ -82,6 +82,8 @@ for (const theme of THEMES) {
             mask: [
               '[data-testid="admin-date-range-selector-button"]',
               '[data-column-id="updated_at"]',
+              // Shows the selected date range, which moves every day.
+              '[data-testid="usage-overview-period"]',
             ],
           });
         },


### PR DESCRIPTION
## Description

The admin visual-regression sweep reports `admin-light-performance--usage.png` and
`admin-dark-performance--usage.png` as changed on most runs. Example: the
[report for #14368](https://onyx-playwright-artifacts.s3.us-east-2.amazonaws.com/reports/pr-14368/33225410106/admin/index.html),
where both are 0.01% changed and nothing on that page was touched.

The cause is the `Usage overview` description in `PerUserUsagePanel`. It prints the
selected period — `Jul 30, 2026 – Aug 29, 2026 · Costs are calculated from recorded
model usage.` The diff overlay marks only the day digits. The range moves every day,
so the baseline drifts daily. The date-range picker next to it was already masked;
this line was not.

This change tags the description with `data-testid="usage-overview-period"` and adds
that selector to the mask list in `admin_pages.spec.ts`, next to the existing
date-range mask. It follows the `command-menu-timestamp` convention in
`chat-search-command-menu.spec.ts`.

The mask covers the full description line, not only the dates. A mask box covers the
bounding box of the element. A span around only `{start} – {end}` shrinks to fit its
text, so its width would change with the date length and still diff. The description
`Text` is a flex item under `alignItems="stretch"`, so it always spans the full width.
The cost is that the static half of the sentence leaves the baseline.

Baselines live in S3 and refresh from a green run on `main`, so there is nothing to
regenerate. Expect these two screenshots to report as changed one more time on this PR.

## How Has This Been Tested?

- Ran the app and measured the element live: width 960px, equal to its parent. The
  mask box is stable.
- Took a masked screenshot through Playwright: a full-width box over the line, with
  the heading and the metric cards untouched.
- `bun run types:check` passes.
- `oxfmt`, `oxlint`, and `ripsecrets` pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks the usage period line in the admin usage panel so the light and dark screenshots for `/admin/performance/usage` no longer drift daily as the selected date range changes. The full description line is masked, not just the dates, so the static half of the sentence also leaves the baseline; expect these two screenshots to report as changed one more time on this PR.

<sup>Written for commit fedf39ad2411727a99a7f563e415983299dbd29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

