### PR TITLE
feat(ods): add `ods test` for the repo's Go modules

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -246,26 +246,26 @@ ods web test --watch
 
 ### `test` - Run Tests
 
-Run the repo's Go test suites without changing directories or remembering
-which module owns a file.
+Run the repo's test suites without changing directories or remembering which
+suite owns a file.
 
 ```shell
 ods test <suite|path> [args...]
 ```
 
-The first argument is a suite name or a path inside a module. A path selects
-the suite that covers it, so you can pass a file straight from your editor. All
-later arguments go to `go test`.
+The first argument is a suite name or a path inside a suite. A path selects the
+suite that covers it, so you can pass a file straight from your editor. All
+later arguments go to the suite's test runner.
 
-| Suite | Aliases | Module |
-| --- | --- | --- |
-| `ods` | | `tools/ods` |
-| `cli` | | `cli` |
-| `terraform` | `tf` | `terraform-provider-onyx` |
+| Suite | Aliases | Directory | Runner |
+| --- | --- | --- | --- |
+| `ods` | | `tools/ods` | `go test` |
+| `cli` | | `cli` | `go test` |
+| `terraform` | `tf` | `terraform-provider-onyx` | `go test` |
 
-The suites run with `-race`, the same as `pr-golang-tests.yml`. `go test` takes
-packages rather than files, so a file argument runs the package that holds it,
-and `<file>::<TestName>` becomes a `-run` filter.
+The Go suites run with `-race`, the same as `pr-golang-tests.yml`. A runner that
+takes packages rather than files, such as `go test`, runs the package that holds
+a file argument. `<file>::<TestName>` runs one test.
 
 **Examples:**
 

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -244,6 +244,44 @@ ods web lint
 ods web test --watch
 ```
 
+### `test` - Run Tests
+
+Run the repo's Go test suites without changing directories or remembering
+which module owns a file.
+
+```shell
+ods test <suite|path> [args...]
+```
+
+The first argument is a suite name or a path inside a module. A path selects
+the suite that covers it, so you can pass a file straight from your editor. All
+later arguments go to `go test`.
+
+| Suite | Aliases | Module |
+| --- | --- | --- |
+| `ods` | | `tools/ods` |
+| `cli` | | `cli` |
+| `terraform` | `tf` | `terraform-provider-onyx` |
+
+The suites run with `-race`, the same as `pr-golang-tests.yml`. `go test` takes
+packages rather than files, so a file argument runs the package that holds it,
+and `<file>::<TestName>` becomes a `-run` filter.
+
+**Examples:**
+
+```shell
+# Run a whole module
+ods test ods
+
+# Run one package, one file's package, or one test
+ods test tools/ods/internal/testsuite
+ods test tools/ods/internal/testsuite/testsuite_test.go
+ods test tools/ods/internal/testsuite/testsuite_test.go::TestResolveGoTargets
+
+# Forward arguments to go test
+ods test cli -run TestChat -v
+```
+
 ### `dev` - Devcontainer Management
 
 Manage the Onyx devcontainer. Also available as `ods dc`.

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -63,6 +63,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewPullCommand())
 	cmd.AddCommand(NewRunCICommand())
 	cmd.AddCommand(NewScreenshotDiffCommand())
+	cmd.AddCommand(NewTestCommand())
 	cmd.AddCommand(NewDesktopCommand())
 	cmd.AddCommand(NewDevCommand())
 	cmd.AddCommand(NewWebCommand())

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/childproc"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
+)
+
+// NewTestCommand creates a command that runs the repo's Go test suites.
+func NewTestCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test [suite|path] [args...]",
+		Short: "Run tests for the repo's Go modules",
+		Long:  testHelpDescription(),
+		Args:  cobra.ArbitraryArgs,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			return testsuite.Names(), cobra.ShellCompDirectiveNoFileComp
+		},
+		Run: runTest,
+	}
+	// Stop parsing at the first positional so flags meant for go test reach
+	// it instead of cobra.
+	cmd.Flags().SetInterspersed(false)
+
+	return cmd
+}
+
+func runTest(cmd *cobra.Command, args []string) {
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to determine the working directory: %v", err)
+	}
+
+	suite, suiteArgs, err := testsuite.Resolve(root, cwd, args)
+	if errors.Is(err, testsuite.ErrNoArgs) {
+		_ = cmd.Help()
+		os.Exit(1)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	runGoSuite(root, suite, dropSeparator(suiteArgs))
+}
+
+// dropSeparator removes the first "--" from the arguments. Writing it is habit
+// for anyone used to `bun run` or `npm test`, and it can land either before or
+// after a path. go test would read a literal "--" as a package pattern rather
+// than a separator.
+func dropSeparator(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return append(args[:i:i], args[i+1:]...)
+		}
+	}
+	return args
+}
+
+// runGoSuite runs a Go module's tests from the module directory, which is where
+// go test resolves its "./..." package patterns.
+func runGoSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
+	goArgs := []string{"test"}
+	goArgs = append(goArgs, suite.DefaultArgs...)
+	// go test with no packages tests only the module root, so a bare run gets
+	// "./..." to cover the whole module.
+	if !testsuite.HasTarget(suiteArgs) {
+		goArgs = append(goArgs, "./...")
+	}
+	goArgs = append(goArgs, suiteArgs...)
+
+	suiteDir := filepath.Join(root, suite.Dir)
+	log.Infof("Running %s tests...", suite.Name)
+	log.Debugf("Running in %s: go %v", suiteDir, goArgs)
+
+	goCmd := exec.Command("go", goArgs...)
+	goCmd.Dir = suiteDir
+	childproc.Run(goCmd, "go test")
+}
+
+func testHelpDescription() string {
+	description := `Run tests for the repo's Go modules.
+
+The first argument is a suite name or a path inside a module. A path picks the
+suite that covers it, so you can pass a file straight from an editor. Every
+later argument goes to go test.
+
+go test takes packages rather than files, so a file argument runs the package
+that holds it, and "<file>::<TestName>" becomes a -run filter.
+
+Examples:
+  ods test ods
+  ods test tools/ods/internal/testsuite
+  ods test tools/ods/internal/testsuite/testsuite_test.go::TestResolveGoTargets
+  ods test cli -run TestChat -v
+
+Suites:`
+
+	var b strings.Builder
+	b.WriteString(description)
+	for _, suite := range testsuite.All() {
+		names := suite.Name
+		if len(suite.Aliases) > 0 {
+			names += ", " + strings.Join(suite.Aliases, ", ")
+		}
+		fmt.Fprintf(&b, "\n  %-28s %s", names, suite.Short)
+	}
+	return b.String()
+}

--- a/tools/ods/cmd/test.go
+++ b/tools/ods/cmd/test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
 )
 
-// NewTestCommand creates a command that runs the repo's Go test suites.
+// NewTestCommand creates a command that runs the repo's test suites.
 func NewTestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test [suite|path] [args...]",
-		Short: "Run tests for the repo's Go modules",
+		Short: "Run the repo's test suites",
 		Long:  testHelpDescription(),
 		Args:  cobra.ArbitraryArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -31,8 +31,8 @@ func NewTestCommand() *cobra.Command {
 		},
 		Run: runTest,
 	}
-	// Stop parsing at the first positional so flags meant for go test reach
-	// it instead of cobra.
+	// Stop parsing at the first positional so flags meant for the test runner
+	// reach it instead of cobra.
 	cmd.Flags().SetInterspersed(false)
 
 	return cmd
@@ -95,14 +95,14 @@ func runGoSuite(root string, suite *testsuite.Suite, suiteArgs []string) {
 }
 
 func testHelpDescription() string {
-	description := `Run tests for the repo's Go modules.
+	description := `Run the repo's test suites.
 
-The first argument is a suite name or a path inside a module. A path picks the
+The first argument is a suite name or a path inside a suite. A path picks the
 suite that covers it, so you can pass a file straight from an editor. Every
-later argument goes to go test.
+later argument goes to the suite's test runner.
 
-go test takes packages rather than files, so a file argument runs the package
-that holds it, and "<file>::<TestName>" becomes a -run filter.
+A runner that takes packages rather than files, such as go test, runs the
+package that holds a file argument. "<file>::<TestName>" runs one test.
 
 Examples:
   ods test ods

--- a/tools/ods/internal/childproc/childproc.go
+++ b/tools/ods/internal/childproc/childproc.go
@@ -1,0 +1,34 @@
+// Package childproc runs a wrapped tool as a child process and gives the tool's
+// result back to whoever ran ods. Every ods command that fronts another tool —
+// uv, bun, go — needs the same behavior, so it lives here rather than in each
+// command.
+package childproc
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Run runs a wrapped tool with our stdio attached and does not return on
+// failure. The child's exit code becomes ours, so shell chains and CI see the
+// underlying tool's result, and stderr the child already printed is not
+// repeated. label names the tool in the message used when the process could
+// not be started at all.
+func Run(c *exec.Cmd, label string) {
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+
+	if err := c.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if code := exitErr.ExitCode(); code != -1 {
+				os.Exit(code)
+			}
+		}
+		log.Fatalf("Failed to run %s: %v", label, err)
+	}
+}

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -1,0 +1,312 @@
+// Package testsuite maps a suite name or a file path onto the Go module that
+// owns it. The repo has three Go modules with different working directories;
+// this package holds the routing table and the pure logic that picks an entry
+// from it.
+package testsuite
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ErrNoArgs is returned when no suite or path was given.
+var ErrNoArgs = errors.New("no suite or path given")
+
+// Suite describes one test suite and how to run it.
+type Suite struct {
+	// Name is the canonical name accepted on the command line.
+	Name string
+	// Aliases are alternate names accepted on the command line.
+	Aliases []string
+	// Dir is the module directory, relative to the git root. It is the
+	// working directory for go test and the prefix used to infer the suite
+	// from a path.
+	Dir string
+	// DefaultArgs are passed to go test before any user arguments, so a
+	// user argument for the same option still wins.
+	DefaultArgs []string
+	// Short is the one-line description shown in help output.
+	Short string
+}
+
+// suites is the routing table. Order here is the order shown in help.
+var suites = []Suite{
+	{
+		Name: "ods",
+		Dir:  "tools/ods",
+		// -race matches pr-golang-tests.yml, which runs every Go module.
+		DefaultArgs: []string{"-race"},
+		Short:       "Tests for this tool (go)",
+	},
+	{
+		Name:        "cli",
+		Dir:         "cli",
+		DefaultArgs: []string{"-race"},
+		Short:       "Onyx CLI tests (go)",
+	},
+	{
+		Name:        "terraform",
+		Aliases:     []string{"tf"},
+		Dir:         "terraform-provider-onyx",
+		DefaultArgs: []string{"-race"},
+		Short:       "Terraform provider tests (go)",
+	},
+}
+
+// All returns every suite, in help order.
+func All() []Suite {
+	out := make([]Suite, len(suites))
+	copy(out, suites)
+	return out
+}
+
+// Names returns every accepted suite name, without aliases, in help order.
+func Names() []string {
+	names := make([]string, 0, len(suites))
+	for i := range suites {
+		names = append(names, suites[i].Name)
+	}
+	return names
+}
+
+// byName looks up a suite by its canonical name or one of its aliases.
+func byName(name string) *Suite {
+	for i := range suites {
+		if suites[i].Name == name {
+			return &suites[i]
+		}
+		for _, alias := range suites[i].Aliases {
+			if alias == name {
+				return &suites[i]
+			}
+		}
+	}
+	return nil
+}
+
+// Resolve picks the suite for args. The first argument is either a suite name,
+// an alias, or a path inside a suite. Paths are rewritten relative to the
+// suite's working directory, which is where the runner is started, and the
+// remaining arguments pass through untouched.
+//
+// root is the git root. cwd is the caller's working directory, so that a path
+// typed relative to it (for example inside tools/ods/) resolves correctly.
+func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
+	if len(args) == 0 {
+		return nil, nil, ErrNoArgs
+	}
+
+	first := args[0]
+
+	if suite := byName(first); suite != nil {
+		return suite, relocate(root, cwd, suite, args[1:]), nil
+	}
+
+	repoPath, ok := repoRelative(root, cwd, first)
+	if !ok {
+		return nil, nil, fmt.Errorf("%q is neither a suite name nor an existing path (suites: %s)",
+			first, strings.Join(Names(), ", "))
+	}
+
+	suite := suiteForPath(repoPath)
+	if suite == nil {
+		return nil, nil, fmt.Errorf("no test suite covers %q (suites: %s)",
+			first, strings.Join(Names(), ", "))
+	}
+
+	target, err := filepath.Rel(suite.Dir, repoPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to place %q inside %s: %w", first, suite.Dir, err)
+	}
+
+	// The first argument is always rewritten: it is known to be a target, so
+	// the bare-word caution that applies to later arguments is not needed.
+	rest := relocate(root, cwd, suite, args[1:])
+	return suite, append(runnerTarget(root, suite, path(target)), rest...), nil
+}
+
+// runnerTarget shapes a suite-relative path into what go test accepts. go test
+// takes packages rather than files, so a file becomes the directory that holds
+// it, and a "<file>::<TestName>" node id becomes a -run filter.
+func runnerTarget(root string, suite *Suite, rel string) []string {
+	file := stripNodeID(rel)
+	pkg := goPackage(root, suite, file)
+	if name := strings.TrimPrefix(rel[len(file):], "::"); name != "" {
+		return []string{pkg, "-run", "^" + name + "$"}
+	}
+	return []string{pkg}
+}
+
+// goPackage turns a suite-relative path into the "./..." pattern go test
+// accepts. Go tests one package at a time, so a file argument runs the package
+// that holds it.
+func goPackage(root string, suite *Suite, rel string) string {
+	if info, err := os.Stat(filepath.Join(root, suite.Dir, rel)); err == nil && !info.IsDir() {
+		rel = filepath.Dir(rel)
+	}
+	if rel == "." || rel == "" {
+		return "./..."
+	}
+	return "./" + path(rel)
+}
+
+// HasTarget reports whether args already name a test target. It takes the
+// suite-relative arguments returned by Resolve, where a target always carries a
+// path separator or a node id.
+//
+// Callers need this because go test with no packages tests only the module
+// root, so a bare run needs "./..." to cover the whole module — but only when
+// the caller has not already picked a target.
+func HasTarget(args []string) bool {
+	for _, arg := range args {
+		if looksLikePath(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// relocate rewrites arguments that name an existing path into paths relative
+// to the suite's working directory, which is where the runner starts.
+// Everything else — flags and their values — passes through untouched.
+func relocate(root, cwd string, suite *Suite, args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		out = append(out, relocateArg(root, cwd, suite, arg)...)
+	}
+	return out
+}
+
+func relocateArg(root, cwd string, suite *Suite, arg string) []string {
+	if !looksLikePath(arg) {
+		return []string{arg}
+	}
+	repoPath, ok := repoRelative(root, cwd, arg)
+	if !ok {
+		// The path may still be relative to the suite directory, which is
+		// where the runner starts. go test needs a "./" prefix, so shape it
+		// here.
+		if rel, ok := suiteRelative(root, suite, arg); ok {
+			return runnerTarget(root, suite, rel)
+		}
+		return []string{arg}
+	}
+	// A path outside this suite is left alone, so the runner reports it
+	// rather than us silently pointing somewhere else.
+	if !underPrefix(stripNodeID(repoPath), suite.Dir) {
+		return []string{arg}
+	}
+	rel, err := filepath.Rel(suite.Dir, repoPath)
+	if err != nil {
+		return []string{arg}
+	}
+	return runnerTarget(root, suite, path(rel))
+}
+
+// suiteRelative reports whether arg names a path inside the suite's working
+// directory, and returns it relative to that directory. Any node id is kept.
+func suiteRelative(root string, suite *Suite, arg string) (string, bool) {
+	filePart := stripNodeID(arg)
+	if filePart == "" || filepath.IsAbs(filePart) {
+		return "", false
+	}
+	if _, err := os.Stat(filepath.Join(root, suite.Dir, filePart)); err != nil {
+		return "", false
+	}
+	return path(filePart) + arg[len(filePart):], true
+}
+
+// suiteForPath returns the suite whose directory is the longest match for a
+// repo-relative path. Longest wins so that a suite nested inside another
+// resolves to the inner one, whatever the table holds.
+func suiteForPath(repoPath string) *Suite {
+	matches := make([]*Suite, 0, 2)
+	for i := range suites {
+		if underPrefix(repoPath, suites[i].Dir) {
+			matches = append(matches, &suites[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.SliceStable(matches, func(a, b int) bool {
+		return len(matches[a].Dir) > len(matches[b].Dir)
+	})
+	return matches[0]
+}
+
+// underPrefix reports whether repoPath is prefix itself or sits below it.
+func underPrefix(repoPath, prefix string) bool {
+	return repoPath == prefix || strings.HasPrefix(repoPath, prefix+"/")
+}
+
+// repoRelative turns a user-supplied path into a slash-separated path relative
+// to the git root, reporting false when it does not point at anything real.
+// The path is tried against the working directory first, then against the git
+// root, so both "internal/testsuite" from inside tools/ods/ and
+// "tools/ods/internal/testsuite" from anywhere work.
+func repoRelative(root, cwd, arg string) (string, bool) {
+	filePart := stripNodeID(arg)
+	if filePart == "" {
+		return "", false
+	}
+
+	candidates := []string{}
+	if filepath.IsAbs(filePart) {
+		candidates = append(candidates, filePart)
+	} else {
+		candidates = append(candidates,
+			filepath.Join(cwd, filePart),
+			filepath.Join(root, filePart),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(root, candidate)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		// Re-attach the node id, if any, now that the file part is anchored.
+		rel = path(rel) + arg[len(filePart):]
+		return rel, true
+	}
+	return "", false
+}
+
+// looksLikePath reports whether an argument is shaped like a path worth
+// rewriting: it has more than one segment, or carries a node id.
+//
+// A single bare word is deliberately excluded even when a file by that name
+// exists. Such a word is far more often a flag value (`-run TestFoo`) than a
+// target, and when it really is a target it is already relative to the
+// caller's directory, so rewriting it would only change a path that already
+// works.
+func looksLikePath(arg string) bool {
+	if strings.HasPrefix(arg, "-") {
+		return false
+	}
+	return strings.ContainsAny(arg, `/\`) || strings.Contains(arg, "::")
+}
+
+// stripNodeID drops the trailing "::TestName" of a node id, leaving the part
+// that exists on disk.
+func stripNodeID(arg string) string {
+	if idx := strings.Index(arg, "::"); idx >= 0 {
+		return arg[:idx]
+	}
+	return arg
+}
+
+// path joins segments and normalizes to forward slashes, which is what both
+// go test and the prefix table expect.
+func path(segments ...string) string {
+	joined := filepath.Join(segments...)
+	return filepath.ToSlash(joined)
+}

--- a/tools/ods/internal/testsuite/testsuite.go
+++ b/tools/ods/internal/testsuite/testsuite.go
@@ -1,7 +1,7 @@
-// Package testsuite maps a suite name or a file path onto the Go module that
-// owns it. The repo has three Go modules with different working directories;
-// this package holds the routing table and the pure logic that picks an entry
-// from it.
+// Package testsuite maps a suite name or a file path onto the test suite that
+// owns it. The repo holds several suites, each with its own working directory
+// and test runner; this package holds the routing table and the pure logic
+// that picks an entry from it.
 package testsuite
 
 import (
@@ -22,11 +22,11 @@ type Suite struct {
 	Name string
 	// Aliases are alternate names accepted on the command line.
 	Aliases []string
-	// Dir is the module directory, relative to the git root. It is the
-	// working directory for go test and the prefix used to infer the suite
-	// from a path.
+	// Dir is the suite's directory, relative to the git root. It is the
+	// working directory for the test runner and the prefix used to infer the
+	// suite from a path.
 	Dir string
-	// DefaultArgs are passed to go test before any user arguments, so a
+	// DefaultArgs are passed to the runner before any user arguments, so a
 	// user argument for the same option still wins.
 	DefaultArgs []string
 	// Short is the one-line description shown in help output.
@@ -40,20 +40,20 @@ var suites = []Suite{
 		Dir:  "tools/ods",
 		// -race matches pr-golang-tests.yml, which runs every Go module.
 		DefaultArgs: []string{"-race"},
-		Short:       "Tests for this tool (go)",
+		Short:       "Tests for this tool",
 	},
 	{
 		Name:        "cli",
 		Dir:         "cli",
 		DefaultArgs: []string{"-race"},
-		Short:       "Onyx CLI tests (go)",
+		Short:       "Onyx CLI tests",
 	},
 	{
 		Name:        "terraform",
 		Aliases:     []string{"tf"},
 		Dir:         "terraform-provider-onyx",
 		DefaultArgs: []string{"-race"},
-		Short:       "Terraform provider tests (go)",
+		Short:       "Terraform provider tests",
 	},
 }
 
@@ -129,9 +129,10 @@ func Resolve(root, cwd string, args []string) (*Suite, []string, error) {
 	return suite, append(runnerTarget(root, suite, path(target)), rest...), nil
 }
 
-// runnerTarget shapes a suite-relative path into what go test accepts. go test
-// takes packages rather than files, so a file becomes the directory that holds
-// it, and a "<file>::<TestName>" node id becomes a -run filter.
+// runnerTarget shapes a suite-relative path into what the suite's runner
+// accepts. go test takes packages rather than files, so a file becomes the
+// directory that holds it, and a "<file>::<TestName>" node id becomes a -run
+// filter.
 func runnerTarget(root string, suite *Suite, rel string) []string {
 	file := stripNodeID(rel)
 	pkg := goPackage(root, suite, file)
@@ -158,9 +159,9 @@ func goPackage(root string, suite *Suite, rel string) string {
 // suite-relative arguments returned by Resolve, where a target always carries a
 // path separator or a node id.
 //
-// Callers need this because go test with no packages tests only the module
-// root, so a bare run needs "./..." to cover the whole module — but only when
-// the caller has not already picked a target.
+// Callers need this because a runner given no target may cover less than the
+// whole suite, so a bare run needs the suite's catch-all target — but only
+// when the caller has not already picked one.
 func HasTarget(args []string) bool {
 	for _, arg := range args {
 		if looksLikePath(arg) {

--- a/tools/ods/internal/testsuite/testsuite_test.go
+++ b/tools/ods/internal/testsuite/testsuite_test.go
@@ -1,0 +1,249 @@
+package testsuite
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// newRepo builds a temp directory holding the paths a caller might name, so
+// Resolve's existence checks have something real to stat.
+func newRepo(t *testing.T, paths ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, p := range paths {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestResolveByName(t *testing.T) {
+	cases := []struct {
+		arg  string
+		want string
+	}{
+		{"ods", "ods"},
+		{"cli", "cli"},
+		{"terraform", "terraform"},
+		{"tf", "terraform"},
+	}
+
+	root := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			suite, rest, err := Resolve(root, root, []string{tc.arg})
+			if err != nil {
+				t.Fatalf("Resolve(%q) failed: %v", tc.arg, err)
+			}
+			if suite.Name != tc.want {
+				t.Fatalf("Resolve(%q) = %q, want %q", tc.arg, suite.Name, tc.want)
+			}
+			if len(rest) != 0 {
+				t.Fatalf("expected no remaining args, got %v", rest)
+			}
+		})
+	}
+}
+
+// go test takes packages, not files, so targets are shaped into "./..."
+// patterns and node ids into -run filters.
+func TestResolveGoTargets(t *testing.T) {
+	root := newRepo(t,
+		"tools/ods/main.go",
+		"tools/ods/cmd/env_test.go",
+		"tools/ods/internal/testsuite/testsuite_test.go",
+		"cli/internal/tui/tui_test.go",
+		"terraform-provider-onyx/internal/provider/provider_test.go",
+	)
+
+	cases := []struct {
+		name      string
+		args      []string
+		wantSuite string
+		want      []string
+	}{
+		{
+			name:      "package directory",
+			args:      []string{"tools/ods/internal/testsuite"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "file runs its package",
+			args:      []string{"tools/ods/internal/testsuite/testsuite_test.go"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "module root",
+			args:      []string{"tools/ods"},
+			wantSuite: "ods",
+			want:      []string{"./..."},
+		},
+		{
+			name:      "node id becomes a run filter",
+			args:      []string{"tools/ods/cmd/env_test.go::TestGenerateEnv"},
+			wantSuite: "ods",
+			want:      []string{"./cmd", "-run", "^TestGenerateEnv$"},
+		},
+		{
+			name:      "path after a suite name",
+			args:      []string{"ods", "tools/ods/cmd"},
+			wantSuite: "ods",
+			want:      []string{"./cmd"},
+		},
+		{
+			name:      "a second module",
+			args:      []string{"cli/internal/tui"},
+			wantSuite: "cli",
+			want:      []string{"./internal/tui"},
+		},
+		{
+			name:      "a third module",
+			args:      []string{"terraform-provider-onyx/internal/provider"},
+			wantSuite: "terraform",
+			want:      []string{"./internal/provider"},
+		},
+		{
+			name:      "path relative to the module",
+			args:      []string{"ods", "internal/testsuite"},
+			wantSuite: "ods",
+			want:      []string{"./internal/testsuite"},
+		},
+		{
+			name:      "node id relative to the module",
+			args:      []string{"cli", "internal/tui/tui_test.go::TestChat"},
+			wantSuite: "cli",
+			want:      []string{"./internal/tui", "-run", "^TestChat$"},
+		},
+		{
+			name:      "flags pass through",
+			args:      []string{"ods", "-run", "TestResolve", "-v"},
+			wantSuite: "ods",
+			want:      []string{"-run", "TestResolve", "-v"},
+		},
+		{
+			// A path outside the named suite is left alone, so go test
+			// reports it rather than us silently pointing somewhere else.
+			name:      "path outside the suite is left for the runner to report",
+			args:      []string{"ods", "cli/internal/tui"},
+			wantSuite: "ods",
+			want:      []string{"cli/internal/tui"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			suite, args, err := Resolve(root, root, tc.args)
+			if err != nil {
+				t.Fatalf("Resolve(%v) failed: %v", tc.args, err)
+			}
+			if suite.Name != tc.wantSuite {
+				t.Fatalf("suite = %q, want %q", suite.Name, tc.wantSuite)
+			}
+			if !reflect.DeepEqual(args, tc.want) {
+				t.Errorf("args = %v, want %v", args, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolvePathRelativeToWorkingDirectory(t *testing.T) {
+	root := newRepo(t, "tools/ods/internal/testsuite/testsuite_test.go")
+	cwd := filepath.Join(root, "tools", "ods")
+
+	suite, rest, err := Resolve(root, cwd, []string{"internal/testsuite"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "ods" {
+		t.Fatalf("suite = %q, want ods", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"./internal/testsuite"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+// A bare filename is still a target when it is the suite selector, so it has
+// to be anchored even though the same word would be left alone later in the
+// argument list.
+func TestResolveBareFilenameAsSelector(t *testing.T) {
+	root := newRepo(t, "tools/ods/internal/testsuite/testsuite_test.go")
+	cwd := filepath.Join(root, "tools", "ods", "internal", "testsuite")
+
+	suite, rest, err := Resolve(root, cwd, []string{"testsuite_test.go"})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if suite.Name != "ods" {
+		t.Fatalf("suite = %q, want ods", suite.Name)
+	}
+	if !reflect.DeepEqual(rest, []string{"./internal/testsuite"}) {
+		t.Fatalf("args = %v", rest)
+	}
+}
+
+func TestResolveErrors(t *testing.T) {
+	t.Run("no args", func(t *testing.T) {
+		root := t.TempDir()
+		if _, _, err := Resolve(root, root, nil); !errors.Is(err, ErrNoArgs) {
+			t.Fatalf("err = %v, want ErrNoArgs", err)
+		}
+	})
+
+	t.Run("unknown suite", func(t *testing.T) {
+		root := t.TempDir()
+		_, _, err := Resolve(root, root, []string{"bogus"})
+		if err == nil {
+			t.Fatal("expected an error for an unknown suite")
+		}
+		// The message has to name the alternatives, since that is the only
+		// discovery path a mistyped suite gets.
+		for _, name := range Names() {
+			if !strings.Contains(err.Error(), name) {
+				t.Fatalf("error %q does not mention suite %q", err, name)
+			}
+		}
+	})
+
+	t.Run("path outside every suite", func(t *testing.T) {
+		root := newRepo(t, "backend/tests/unit/test_foo.py")
+		_, _, err := Resolve(root, root, []string{"backend/tests/unit/test_foo.py"})
+		if err == nil {
+			t.Fatal("expected an error for a path no suite covers")
+		}
+	})
+}
+
+func TestHasTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no args", args: nil, want: false},
+		{name: "flags only", args: []string{"-run", "TestFoo"}, want: false},
+		{name: "long flag only", args: []string{"-v"}, want: false},
+		{name: "package pattern", args: []string{"./..."}, want: true},
+		{name: "package directory", args: []string{"./cmd"}, want: true},
+		{name: "run filter after a package", args: []string{"./cmd", "-run", "^TestFoo$"}, want: true},
+		{name: "target after a flag", args: []string{"-v", "./internal/testsuite"}, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasTarget(tc.args); got != tc.want {
+				t.Errorf("HasTarget(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds an \`ods test\` command that runs the tests of the repo's three Go modules: \`tools/ods\` (\`ods\`), \`cli\` (\`cli\`), and \`terraform-provider-onyx\` (\`terraform\`/\`tf\`).

The first argument is a suite name or a path inside a module. A path picks the suite that covers it, so you can pass a file straight from an editor. Every later argument goes to \`go test\`. Because \`go test\` takes packages rather than files, a file argument runs the package that holds it, and \`<file>::<TestName>\` becomes a \`-run\` filter. Suites run with \`-race\` to match \`pr-golang-tests.yml\`.

Examples:

```
ods test ods
ods test tools/ods/internal/testsuite
ods test tools/ods/internal/testsuite/testsuite_test.go::TestResolveGoTargets
ods test cli -run TestChat -v
```

This is the first slice of a larger \`ods test\` that will also cover the pytest, jest, and playwright suites (see \`kanban/jamison/ods-test-and-ods-coverage\`). The suite table and the new \`internal/childproc\` package are shaped so the follow-up PRs are additive.

## How Has This Been Tested?

- Unit tests for the suite/path resolution logic (\`tools/ods/internal/testsuite\`), run with \`-race\`.
- Ran the built binary against all three modules: bare suite names, package paths from the repo root and from inside a module, a \`::TestName\` filter, and pass-through flags.
- \`go vet\` and \`golangci-lint\` (pre-commit) are clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods test` to run the repo's Go test suites from any directory, so you no longer need to cd into a module or remember which suite owns a file.

- The first argument is a suite name (`ods`, `cli`, `terraform`/`tf`) or a path inside a suite; later args go to `go test`, with `--` accepted as a separator.
- A file path runs the file's package, and `<file>::<TestName>` becomes a `-run` filter.
- Suites run with `-race` to match `pr-golang-tests.yml`.
- A failing `go test` now exits with Go's exit code instead of a generic `ods` error.
- The suite table and `internal/childproc` are shaped so pytest, jest, and playwright suites can be added later.

<sup>Written for commit dad4fcc3034aa47f307df00282d7d9dae269aaf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

