### PR TITLE
feat(ods): add "ods release beta" to cut beta release tags

### DIFF
--- a/tools/ods/cmd/deploy_cloud.go
+++ b/tools/ods/cmd/deploy_cloud.go
@@ -84,7 +84,7 @@ Example usage:
 				return err
 			}
 			if opts.NoWatch {
-				announceCloudRun(tag)
+				announceDeploymentRun(tag)
 				return nil
 			}
 			log.Infof("Watching the release; Ctrl-C is safe, re-attach with: ods deploy cloud --attach %s", tag)
@@ -159,19 +159,4 @@ func deployCloud(opts *DeployCloudOptions) (string, error) {
 	}
 	log.Infof("Pushed %s; deployment.yml will build the cloud images.", tag)
 	return tag, nil
-}
-
-// announceCloudRun looks up the deployment.yml run triggered by pushing tag and
-// prints its URL. The lookup is best-effort: the tag is already pushed and the
-// build runs regardless, so failures only warn.
-func announceCloudRun(tag string) {
-	log.Info("Looking up the deployment run...")
-	run, err := waitForNewRun(onyxRepo, deploymentWorkflowFile, "push", tag, 0)
-	if err != nil {
-		log.Warnf("Could not find the deployment run for %s: %v", tag, err)
-		log.Warnf("Find it at https://github.com/%s/actions/workflows/%s", onyxRepo, deploymentWorkflowFile)
-		return
-	}
-	log.Infof("Deployment run: %s", run.URL)
-	fmt.Println(run.URL)
 }

--- a/tools/ods/cmd/deploy_cloud_test.go
+++ b/tools/ods/cmd/deploy_cloud_test.go
@@ -17,8 +17,6 @@ package cmd
 
 import (
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -140,10 +138,7 @@ func TestDeployCloud_pushFailureRollsBackLocalTag(t *testing.T) {
 	// Precondition.
 	// Origin rejects every push.
 	repo := gittest.SetupReleaseBranchRepo(t)
-	hook := filepath.Join(repo.Origin, "hooks", "pre-receive")
-	if err := os.WriteFile(hook, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	gittest.RejectPushes(t, repo.Origin)
 
 	// Under test.
 	tag, err := deployCloud(&DeployCloudOptions{Ref: "origin/main", Yes: true})

--- a/tools/ods/cmd/deploy_common.go
+++ b/tools/ods/cmd/deploy_common.go
@@ -79,6 +79,21 @@ func resolveDeployTarget(flagRepo, flagWorkflow string, workflowSelector func(*c
 	return repo, workflow
 }
 
+// announceDeploymentRun looks up the deployment.yml run triggered by pushing
+// tag and prints its URL. The lookup is best-effort: the tag is already pushed
+// and the build runs regardless, so failures only warn.
+func announceDeploymentRun(tag string) {
+	log.Info("Looking up the deployment run...")
+	run, err := waitForNewRun(onyxRepo, deploymentWorkflowFile, "push", tag, 0)
+	if err != nil {
+		log.Warnf("Could not find the deployment run for %s: %v", tag, err)
+		log.Warnf("Find it at https://github.com/%s/actions/workflows/%s", onyxRepo, deploymentWorkflowFile)
+		return
+	}
+	log.Infof("Deployment run: %s", run.URL)
+	fmt.Println(run.URL)
+}
+
 // workflowRun is a partial representation of a `gh run list` JSON entry.
 type workflowRun struct {
 	DatabaseID int64  `json:"databaseId"`

--- a/tools/ods/cmd/release.go
+++ b/tools/ods/cmd/release.go
@@ -62,6 +62,7 @@ Example usage:
 	cmd.Flags().BoolVar(&check, "check", false, "Validate an existing release tag (named by --ref, or pointing at it) instead of cutting one")
 	cmd.Flags().StringVar(&ref, "ref", "HEAD", "Tag to check, or a commit-ish that a single release tag points at")
 
+	cmd.AddCommand(NewReleaseBetaCommand())
 	cmd.AddCommand(NewReleaseOpalCommand())
 	cmd.AddCommand(NewReleaseTFProviderCommand())
 

--- a/tools/ods/cmd/release_beta.go
+++ b/tools/ods/cmd/release_beta.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
+)
+
+// ReleaseBetaOptions holds options for the release beta command.
+type ReleaseBetaOptions struct {
+	Ref     string
+	Version string
+	DryRun  bool
+	Yes     bool
+	Verify  bool
+}
+
+// NewReleaseBetaCommand creates the `ods release beta` command.
+func NewReleaseBetaCommand() *cobra.Command {
+	opts := &ReleaseBetaOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "beta",
+		Short: "Cut the next beta release tag (vX.Y.Z-beta.N) on a release branch",
+		Long: `Cut the next beta release tag (vX.Y.Z-beta.N) and push it to origin.
+
+The target branch is the newest release/vX.Y branch on origin. The base
+version is one patch past the highest stable vX.Y.* tag, so the first beta
+of a fresh branch is vX.Y.0-beta.0 and a beta cut after a stable release
+previews the next patch. N is one past the highest existing counter for the
+same base, starting at 0.
+
+By default the branch tip is tagged; --ref tags an older commit on the
+branch. --version pins the base outright and targets its release branch.
+
+Pushing the tag triggers deployment.yml, which builds the beta images and
+moves the "beta" Docker tags.
+
+To validate an existing tag instead of cutting one, see "ods release --check".
+
+Example usage:
+
+    $ ods release beta
+    $ ods release beta --dry-run
+    $ ods release beta --ref 1a2b3c4d
+    $ ods release beta --version 4.7.0`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tag, err := releaseBeta(opts)
+			if err != nil || tag == "" {
+				return err
+			}
+			announceDeploymentRun(tag)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Ref, "ref", "", "Commit-ish to tag; must be on the target release branch (default: its tip)")
+	cmd.Flags().StringVar(&opts.Version, "version", "", "Base version override (X.Y.Z, no leading v); skips branch and patch detection")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute and print the tag but don't tag or push")
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
+
+	return cmd
+}
+
+// releaseBeta computes and pushes the next beta tag. It returns the pushed
+// tag name, or an empty string when nothing was pushed (dry run, declined
+// prompt, or any failure).
+func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
+	if opts.Version != "" && !release.IsBareVersion(opts.Version) {
+		return "", fmt.Errorf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
+	}
+
+	log.Info("Fetching the release branch and its tags from origin...")
+	tag, sha, err := release.ComputeBetaTag(opts.Ref, opts.Version)
+	if err != nil {
+		return "", err
+	}
+
+	if opts.DryRun {
+		log.Warnf("[DRY RUN] Would tag %.10s as %s and push", sha, tag)
+		fmt.Println(tag)
+		return "", nil
+	}
+
+	if !opts.Yes {
+		if !prompt.Confirm(fmt.Sprintf("Tag %.10s as %s and push to trigger the beta build? (Y/n): ", sha, tag)) {
+			log.Info("Exiting...")
+			return "", nil
+		}
+	}
+
+	if err := git.RunCommand("tag", tag, sha); err != nil {
+		return "", fmt.Errorf("failed to create tag %s: %w", tag, err)
+	}
+	if err := git.PushTag(tag, false, opts.Verify); err != nil {
+		// Roll back the local tag so the command stays retryable after a failed
+		// push.
+		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
+			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
+		}
+		return "", fmt.Errorf("failed to push tag %s: %w", tag, err)
+	}
+	log.Infof("Pushed %s; deployment.yml will build the beta images.", tag)
+	return tag, nil
+}

--- a/tools/ods/cmd/release_beta.go
+++ b/tools/ods/cmd/release_beta.go
@@ -95,6 +95,14 @@ func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
 			log.Info("Exiting...")
 			return "", nil
 		}
+		// The prompt can wait a long time, and origin does not reject a beta
+		// tag whose base shipped meanwhile (the tag name is new). CI's tag
+		// check rejects it, but deployment.yml's image jobs run regardless and
+		// would move the "beta" Docker tags backwards. Recompute so the push
+		// reflects origin's current state, not the pre-prompt snapshot.
+		if err := verifyBetaStateUnchanged(tag, sha, opts); err != nil {
+			return "", err
+		}
 	}
 
 	if err := git.RunCommand("tag", tag, sha); err != nil {
@@ -110,4 +118,18 @@ func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
 	}
 	log.Infof("Pushed %s; deployment.yml will build the beta images.", tag)
 	return tag, nil
+}
+
+// verifyBetaStateUnchanged recomputes the beta tag and errors when the answer
+// no longer matches the one the user confirmed, which means origin moved
+// while the prompt was waiting.
+func verifyBetaStateUnchanged(tag, sha string, opts *ReleaseBetaOptions) error {
+	freshTag, freshSHA, err := release.ComputeBetaTag(opts.Ref, opts.Version)
+	if err != nil {
+		return err
+	}
+	if freshTag != tag || freshSHA != sha {
+		return fmt.Errorf("origin changed while waiting for confirmation: the computed tag was %s at %.10s but is now %s at %.10s; re-run to continue", tag, sha, freshTag, freshSHA)
+	}
+	return nil
 }

--- a/tools/ods/cmd/release_beta_test.go
+++ b/tools/ods/cmd/release_beta_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+// Command states for releaseBeta. Tag computation and validation are tested
+// in internal/release; these tests pin the command-level flow. The fixture's
+// newest release branch is release/v4.5 with tip CutSHA, so the computed tag
+// is v4.5.0-beta.0.
+//
+//	E1 dry run                               -> prints tag, creates nothing,
+//	                                            returns no pushed tag           TestReleaseBeta_dryRunCreatesNothing
+//	E2 real run                              -> tag on origin at the release
+//	                                            branch tip, tag name returned   TestReleaseBeta_tagsReleaseBranchTip
+//	E3 push rejected by origin               -> local tag rolled back,
+//	                                            returns no pushed tag           TestReleaseBeta_pushFailureRollsBackLocalTag
+//	E4 counter tag only on origin            -> fetched, counter continues,
+//	                                            tag name returned               TestReleaseBeta_fetchesRemoteOnlyCounterTags
+//	E5 --version with leading zeroes         -> rejected before any git work    TestReleaseBeta_rejectsLeadingZeroVersion
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/gittest"
+)
+
+func TestReleaseBeta_dryRunCreatesNothing(t *testing.T) {
+	// Precondition.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{DryRun: true, Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "" {
+		t.Errorf("dry run must return no pushed tag, got %q", tag)
+	}
+	if gittest.TagExists(repo.Work, "v4.5.0-beta.0") || gittest.TagExists(repo.Origin, "v4.5.0-beta.0") {
+		t.Error("dry run must not create the tag")
+	}
+}
+
+func TestReleaseBeta_tagsReleaseBranchTip(t *testing.T) {
+	// Precondition.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.0-beta.0" {
+		t.Errorf("expected pushed tag v4.5.0-beta.0, got %q", tag)
+	}
+	taggedSHA := gittest.Git(t, repo.Origin, "rev-parse", "refs/tags/v4.5.0-beta.0^{commit}")
+	if taggedSHA != repo.CutSHA {
+		t.Errorf("expected origin tag at %s, got %s", repo.CutSHA, taggedSHA)
+	}
+}
+
+func TestReleaseBeta_fetchesRemoteOnlyCounterTags(t *testing.T) {
+	// Precondition.
+	// A counter tag another developer pushed but this clone never fetched.
+	// Computing from local tags alone would mint a colliding v4.5.0-beta.3.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "tag", "v4.5.0-beta.3", repo.CutSHA)
+	gittest.Git(t, repo.Work, "push", "--quiet", "origin", "v4.5.0-beta.3")
+	gittest.Git(t, repo.Work, "tag", "-d", "v4.5.0-beta.3")
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.0-beta.4" {
+		t.Errorf("expected pushed tag v4.5.0-beta.4, got %q", tag)
+	}
+	if !gittest.TagExists(repo.Origin, "v4.5.0-beta.4") {
+		t.Error("expected v4.5.0-beta.4 on origin")
+	}
+}
+
+func TestReleaseBeta_rejectsLeadingZeroVersion(t *testing.T) {
+	// Precondition.
+	// SemVer 2.0.0 item 2 forbids leading zeroes in numeric identifiers; such
+	// an override must never become a tag.
+	gittest.SetupReleaseBranchRepo(t)
+
+	// Under test and postcondition.
+	for _, version := range []string{"04.5.0", "4.05.0", "4.5.00"} {
+		_, err := releaseBeta(&ReleaseBetaOptions{Version: version, DryRun: true, Yes: true})
+		if err == nil || !strings.Contains(err.Error(), "--version must be X.Y.Z") {
+			t.Errorf("expected validation error for %q, got %v", version, err)
+		}
+	}
+}
+
+func TestReleaseBeta_pushFailureRollsBackLocalTag(t *testing.T) {
+	// Precondition.
+	// Origin rejects every push.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.RejectPushes(t, repo.Origin)
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{Yes: true})
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "failed to push") {
+		t.Errorf("expected push failure, got %v", err)
+	}
+	if tag != "" {
+		t.Errorf("failed push must return no pushed tag, got %q", tag)
+	}
+	if gittest.TagExists(repo.Work, "v4.5.0-beta.0") {
+		t.Error("local tag must be rolled back after a failed push")
+	}
+}

--- a/tools/ods/cmd/release_beta_test.go
+++ b/tools/ods/cmd/release_beta_test.go
@@ -14,12 +14,16 @@ package cmd
 //	E4 counter tag only on origin            -> fetched, counter continues,
 //	                                            tag name returned               TestReleaseBeta_fetchesRemoteOnlyCounterTags
 //	E5 --version with leading zeroes         -> rejected before any git work    TestReleaseBeta_rejectsLeadingZeroVersion
+//	E6 origin moves during the prompt        -> recompute mismatch aborts       TestReleaseBeta_staleStateAbortsBeforePush
+//	                                            before any tag or push          (tests the guard directly; the
+//	                                                                            prompt itself is interactive)
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/gittest"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/release"
 )
 
 func TestReleaseBeta_dryRunCreatesNothing(t *testing.T) {
@@ -97,6 +101,36 @@ func TestReleaseBeta_rejectsLeadingZeroVersion(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "--version must be X.Y.Z") {
 			t.Errorf("expected validation error for %q, got %v", version, err)
 		}
+	}
+}
+
+func TestReleaseBeta_staleStateAbortsBeforePush(t *testing.T) {
+	// Precondition: the tag computed before the confirmation prompt.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	tag, sha, err := release.ComputeBetaTag("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// An unchanged origin passes.
+	if err := verifyBetaStateUnchanged(tag, sha, &ReleaseBetaOptions{}); err != nil {
+		t.Errorf("expected the unchanged state to pass, got %v", err)
+	}
+
+	// Another release process ships the stable base while the prompt waits.
+	// Origin would accept the beta push (the tag name is new), and
+	// deployment.yml's image jobs would move the "beta" Docker tags backwards
+	// even though its tag check fails; the guard must abort instead.
+	gittest.Git(t, repo.Work, "tag", "v4.5.0", repo.CutSHA)
+	gittest.Git(t, repo.Work, "push", "--quiet", "origin", "v4.5.0")
+	gittest.Git(t, repo.Work, "tag", "-d", "v4.5.0")
+
+	// Under test.
+	err = verifyBetaStateUnchanged(tag, sha, &ReleaseBetaOptions{})
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "origin changed while waiting") {
+		t.Errorf("expected an origin-changed error, got %v", err)
 	}
 }
 

--- a/tools/ods/internal/gittest/gittest.go
+++ b/tools/ods/internal/gittest/gittest.go
@@ -40,6 +40,18 @@ func TagExists(dir, tag string) bool {
 	return cmd.Run() == nil
 }
 
+// RejectPushes configures the repository at dir to reject every push via a
+// pre-receive hook. The hook directory is pinned in local config so a global
+// core.hooksPath (as some dev setups carry) cannot bypass it.
+func RejectPushes(t *testing.T, dir string) {
+	t.Helper()
+	hookDir := filepath.Join(dir, "hooks")
+	if err := os.WriteFile(filepath.Join(hookDir, "pre-receive"), []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	Git(t, dir, "config", "core.hooksPath", hookDir)
+}
+
 // InitOriginAndWork creates a bare origin and a work clone wired to it, and
 // returns both paths. The work clone is configured like a single-branch
 // checkout of main so tests also pin that detection fetches release branches

--- a/tools/ods/internal/release/beta.go
+++ b/tools/ods/internal/release/beta.go
@@ -1,0 +1,129 @@
+package release
+
+import (
+	"fmt"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+)
+
+// ComputeBetaTag returns the next beta tag (vX.Y.Z-beta.N) and the commit it
+// should point at. With overrideVersion ("X.Y.Z") the base is fixed and its
+// release branch is the target; otherwise the target is the newest
+// release/vX.Y branch on origin and the base is one patch past the highest
+// stable vX.Y.* tag. ref is the commit-ish to tag; when empty, the branch tip
+// is used. The commit must be on the branch, the base must not have shipped
+// as a stable tag, and the predecessor beta (if any) must be an ancestor of
+// the commit — the same policy "ods release --check" enforces.
+func ComputeBetaTag(ref, overrideVersion string) (tag, sha string, err error) {
+	// The ancestry checks below cannot be answered truthfully in a shallow
+	// clone; fail loudly instead.
+	shallow, err := git.IsShallowRepository()
+	if err != nil {
+		return "", "", err
+	}
+	if shallow {
+		return "", "", fmt.Errorf("this is a shallow clone, so beta tag computation cannot check branch ancestry")
+	}
+
+	var minor string // "X.Y"
+	if overrideVersion != "" {
+		matches := bareSemverRe.FindStringSubmatch(overrideVersion)
+		if matches == nil {
+			return "", "", fmt.Errorf("override version must be X.Y.Z with no leading v, got %q", overrideVersion)
+		}
+		minor = matches[1] + "." + matches[2]
+	} else {
+		version, err := newestReleaseVersion()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to detect the target release branch (pass --version to override): %w", err)
+		}
+		minor = fmt.Sprintf("%d.%d", version.Major, version.Minor)
+		log.Infof("Newest release branch on origin: release/v%s", minor)
+	}
+
+	branch := fmt.Sprintf("release/v%s", minor)
+	// Fetch so the tip default and the ancestry check run against the branch's
+	// current state; a missing branch fails here.
+	if err := git.RunCommand("fetch", "--quiet", "origin", BranchRefspec(branch)); err != nil {
+		return "", "", fmt.Errorf("failed to fetch %s (beta tags are cut on their release branch): %w", branch, err)
+	}
+
+	if ref == "" {
+		ref = "origin/" + branch
+	}
+	sha, err = ResolveCommit(ref)
+	if err != nil {
+		return "", "", err
+	}
+
+	onBranch, err := git.IsAncestor(sha, "origin/"+branch)
+	if err != nil {
+		return "", "", err
+	}
+	if !onBranch {
+		return "", "", fmt.Errorf("commit %.10s is not on origin/%s; beta tags are cut on their release branch", sha, branch)
+	}
+
+	// The base derives from the minor's stable tags, and a beta of an
+	// already-released base is itself a new tag: origin would accept the push
+	// and only CI's check would reject it. Unlike a counter collision there is
+	// no push backstop, so a failed fetch is an error, not a stale-tags
+	// fallback.
+	if err := FetchTags(fmt.Sprintf("v%s.*", minor)); err != nil {
+		return "", "", fmt.Errorf("failed to fetch v%s.* tags: %w", minor, err)
+	}
+
+	var base string
+	if overrideVersion != "" {
+		base = "v" + overrideVersion
+		// A beta precedes its stable release; a beta cut after the stable tag
+		// shipped would also move the "beta" Docker tag backwards.
+		if tagExists(base) {
+			return "", "", fmt.Errorf("%s has already been released; a beta must precede its stable tag", base)
+		}
+	} else {
+		base, err = nextSequencedTag(fmt.Sprintf("v%s.", minor), "")
+		if err != nil {
+			return "", "", err
+		}
+		log.Infof("Next unreleased patch on release/v%s -> beta base %s", minor, base)
+	}
+
+	tag, err = nextSequencedTag(base+"-beta.", "")
+	if err != nil {
+		return "", "", err
+	}
+
+	// The check also requires the predecessor beta to be an ancestor; catching
+	// that here keeps a doomed tag from being pushed (e.g. --ref pointing
+	// below the previous beta).
+	counter, err := strconv.Atoi(betaTagRe.FindStringSubmatch(tag)[3])
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse the counter of %s: %w", tag, err)
+	}
+	if counter > 0 {
+		predecessor := fmt.Sprintf("%s-beta.%d", base, counter-1)
+		if err := requireAncestorTag(predecessor, tag, sha); err != nil {
+			return "", "", err
+		}
+	}
+
+	return tag, sha, nil
+}
+
+// newestReleaseVersion returns the version of the newest release/vX.Y branch
+// on origin.
+func newestReleaseVersion() (Version, error) {
+	branchNames, err := listRemoteBranches()
+	if err != nil {
+		return Version{}, err
+	}
+	versions := parseVersions(branchNames)
+	if len(versions) == 0 {
+		return Version{}, fmt.Errorf("no release/vX.Y branches found on origin")
+	}
+	return versions[0], nil
+}

--- a/tools/ods/internal/release/beta_test.go
+++ b/tools/ods/internal/release/beta_test.go
@@ -1,0 +1,214 @@
+package release
+
+// Beta tag state matrix (ComputeBetaTag). Beta tags are cut on a release
+// branch: the target is the newest release/vX.Y branch on origin (or the
+// override's branch), the base is one patch past the highest stable vX.Y.*
+// tag, and the counter continues per base. The fixture
+// (gittest.SetupReleaseBranchRepo) cuts release/v4.4 at PreCutSHA (which
+// carries the v4.4.2 tag) and release/v4.5 at CutSHA, so the newest branch is
+// release/v4.5 with tip CutSHA.
+//
+//	B1 fresh branch, no vX.Y.* tags        -> vX.Y.0-beta.0 at the branch tip   TestComputeBetaTag_freshBranchFirstBeta
+//	B2 existing betas for the base         -> counter continues                 TestComputeBetaTag_counterContinues
+//	B3 stable patch already shipped        -> base bumps to the next patch      TestComputeBetaTag_baseBumpsPastStablePatch
+//	B4 stable tag only on origin           -> fetched, base still bumps         TestComputeBetaTag_fetchesRemoteOnlyStableTags
+//	B5 --version override                  -> override base, counter fresh      TestComputeBetaTag_versionOverride
+//	B6 override base already released      -> error                             TestComputeBetaTag_releasedBaseErrors
+//	B7 ref not on the release branch       -> error                             TestComputeBetaTag_refNotOnBranchErrors
+//	B8 no release branches on origin       -> error, hint --version             TestComputeBetaTag_noReleaseBranchesErrors
+//	B9 shallow clone (even with --version) -> error                             TestComputeBetaTag_shallowCloneErrors
+//	B10 predecessor beta not an ancestor   -> error                             TestComputeBetaTag_predecessorNotAncestorErrors
+//	B11 origin unreachable                 -> error, no stale-state fallback    TestComputeBetaTag_fetchFailureErrors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/gittest"
+)
+
+func TestComputeBetaTag_freshBranchFirstBeta(t *testing.T) {
+	// Precondition: no v4.5.* tags exist; the fixture's v4.4.* tags pin that
+	// other minors do not bleed into the base or counter.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test: empty ref defaults to the branch tip.
+	tag, sha, err := ComputeBetaTag("", "")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.0-beta.0" {
+		t.Errorf("expected v4.5.0-beta.0, got %s", tag)
+	}
+	if sha != repo.CutSHA {
+		t.Errorf("expected the release/v4.5 tip %s, got %s", repo.CutSHA, sha)
+	}
+}
+
+func TestComputeBetaTag_counterContinues(t *testing.T) {
+	// Precondition: beta.0 already exists at the branch tip.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "tag", "v4.5.0-beta.0", repo.CutSHA)
+
+	// Under test.
+	tag, _, err := ComputeBetaTag("", "")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.0-beta.1" {
+		t.Errorf("expected v4.5.0-beta.1, got %s", tag)
+	}
+}
+
+func TestComputeBetaTag_baseBumpsPastStablePatch(t *testing.T) {
+	// Precondition: v4.5.0 has shipped, so the next beta previews v4.5.1.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "tag", "v4.5.0", repo.CutSHA)
+
+	// Under test.
+	tag, _, err := ComputeBetaTag("", "")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.1-beta.0" {
+		t.Errorf("expected v4.5.1-beta.0, got %s", tag)
+	}
+}
+
+func TestComputeBetaTag_fetchesRemoteOnlyStableTags(t *testing.T) {
+	// Precondition: a stable tag another developer pushed but this clone never
+	// fetched. Computing from local tags alone would mint a beta of the
+	// already-released v4.5.0, which origin would accept (the tag itself is
+	// new) and only CI's check would reject.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "tag", "v4.5.0", repo.CutSHA)
+	gittest.Git(t, repo.Work, "push", "--quiet", "origin", "v4.5.0")
+	gittest.Git(t, repo.Work, "tag", "-d", "v4.5.0")
+
+	// Under test.
+	tag, _, err := ComputeBetaTag("", "")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.1-beta.0" {
+		t.Errorf("expected v4.5.1-beta.0, got %s", tag)
+	}
+}
+
+func TestComputeBetaTag_versionOverride(t *testing.T) {
+	// Precondition.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test: the override skips patch detection but still anchors to the
+	// override's release branch.
+	tag, sha, err := ComputeBetaTag("", "4.5.9")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.5.9-beta.0" {
+		t.Errorf("expected v4.5.9-beta.0, got %s", tag)
+	}
+	if sha != repo.CutSHA {
+		t.Errorf("expected the release/v4.5 tip %s, got %s", repo.CutSHA, sha)
+	}
+}
+
+func TestComputeBetaTag_releasedBaseErrors(t *testing.T) {
+	// Precondition: the fixture's v4.4.2 stable tag has already shipped.
+	gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	_, _, err := ComputeBetaTag("", "4.4.2")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "already been released") {
+		t.Errorf("expected an already-released error, got %v", err)
+	}
+}
+
+func TestComputeBetaTag_refNotOnBranchErrors(t *testing.T) {
+	// Precondition: the post-cut commit is on main only, not release/v4.5.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	_, _, err := ComputeBetaTag(repo.PostCutSHA, "")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "not on origin/release/v4.5") {
+		t.Errorf("expected a not-on-branch error, got %v", err)
+	}
+}
+
+func TestComputeBetaTag_noReleaseBranchesErrors(t *testing.T) {
+	// Precondition: an origin with main only.
+	_, work := gittest.InitOriginAndWork(t)
+	gittest.Commit(t, work, "a.txt")
+	gittest.PublishMain(t, work)
+	t.Chdir(work)
+
+	// Under test.
+	_, _, err := ComputeBetaTag("", "")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "no release/vX.Y branches") {
+		t.Errorf("expected no-release-branches error, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "--version") {
+		t.Errorf("expected a --version hint, got %v", err)
+	}
+}
+
+func TestComputeBetaTag_shallowCloneErrors(t *testing.T) {
+	// Precondition.
+	gittest.SetupShallowClone(t)
+
+	// Under test: the override skips branch detection, so this pins
+	// ComputeBetaTag's own shallow guard.
+	_, _, err := ComputeBetaTag("", "4.5.0")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "shallow clone") {
+		t.Errorf("expected shallow-clone error, got %v", err)
+	}
+}
+
+func TestComputeBetaTag_predecessorNotAncestorErrors(t *testing.T) {
+	// Precondition: beta.0 sits at the branch tip, but --ref points at an
+	// older on-branch commit; beta.1 there would fail CI's ancestry check.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "tag", "v4.5.0-beta.0", repo.CutSHA)
+
+	// Under test.
+	_, _, err := ComputeBetaTag(repo.PreCutSHA, "")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "not an ancestor") {
+		t.Errorf("expected a predecessor-not-ancestor error, got %v", err)
+	}
+}
+
+func TestComputeBetaTag_fetchFailureErrors(t *testing.T) {
+	// Precondition: an unreachable origin. Unlike a cloud cut (where origin
+	// rejects a colliding counter push), a beta cut must not fall back to
+	// local state: a stale view could mint a beta of a released base.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "remote", "set-url", "origin", t.TempDir())
+
+	// Under test: the override skips branch detection, pinning the fetches.
+	_, _, err := ComputeBetaTag("", "4.5.0")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "failed to fetch") {
+		t.Errorf("expected a fetch failure error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Adds `ods release beta`, which cuts the next `vX.Y.Z-beta.N` tag and pushes it to origin. The push triggers the `deployment.yml` beta build.

Tag computation (`internal/release.ComputeBetaTag`):

- The target is the newest `release/vX.Y` branch on origin; `--version` pins the base and targets its branch instead.
- The base is one patch past the highest stable `vX.Y.*` tag, so a fresh branch gets `vX.Y.0-beta.0` and a beta after a stable release previews the next patch.
- The counter is one past the highest existing `-beta.N` for the base.
- Guards: no shallow clones, the commit must be on the release branch, the base must not have shipped as a stable tag, and the predecessor beta must be an ancestor of the commit.

This is the same policy `ods release --check` enforces, so the pushed tag passes CI validation by construction. Tag fetches are hard errors here (unlike the cloud cut): a beta of an already-released base is a new tag name, so origin would accept the push and only CI would reject it — there is no push-rejection backstop against stale stable tags.

Because `deployment.yml`'s image jobs do not depend on the `check-version-tag` job, a stale computation could still move the `beta` Docker tags backwards (flagged by Greptile). The command therefore recomputes the tag after the confirmation prompt — the widest part of the fetch-to-push window — and aborts on any mismatch. The structural follow-up is making the image jobs depend on `check-version-tag`.

The command mirrors the `ods deploy cloud` cut flow: `--ref`, `--version`, `--dry-run`, `--yes`, `--verify`, confirmation prompt, and local-tag rollback on a failed push. After the push it prints the deployment run URL via `announceDeploymentRun` (moved from `deploy_cloud.go` to `deploy_common.go` and shared by both commands).

Also fixes a latent test-environment issue: the push-rejection fixture now pins `core.hooksPath` in the origin's local config (`gittest.RejectPushes`), so a global `core.hooksPath` (as the devcontainer sets) can no longer bypass the `pre-receive` hook and silently break `TestDeployCloud_pushFailureRollsBackLocalTag`.

## How Has This Been Tested?

- `internal/release/beta_test.go`: 11-state matrix for `ComputeBetaTag` (fresh branch, counter continuation, base bump past stable, remote-only stable tags, `--version` override, released base, off-branch ref, no release branches, shallow clone, predecessor not an ancestor, unreachable origin).
- `cmd/release_beta_test.go`: command-level states mirroring `deploy_cloud_test.go` (dry run, real run tags the branch tip on origin, push failure rolls back, remote-only counter tags, leading-zero `--version` rejected).
- `go test ./...` in `tools/ods` passes except the pre-existing `internal/git` failures caused by the devcontainer's global SSH commit-signing config.
- `pre-commit` (incl. golangci-lint) passes on all touched files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods release beta`, which cuts the next `vX.Y.Z-beta.N` tag on the newest release branch and pushes it to origin to trigger the `deployment.yml` beta build. Tag computation follows the same policy `ods release --check` enforces, so the pushed tag passes CI validation by construction.

**New Features**
- `--version` pins the base and targets its release branch; the default base is one patch past the newest stable `vX.Y.*` tag.
- The command mirrors `ods deploy cloud`: `--ref`, `--dry-run`, `--yes`, `--verify`, a confirmation prompt, and local-tag rollback on a failed push.
- Guards fail loudly instead of pushing a doomed tag: shallow clones, off-branch refs, released bases, and non-ancestor predecessor betas all error.
- The tag is recomputed after the confirmation prompt; if origin moved meanwhile, the command aborts so the `beta` Docker tags can't roll backwards.

**Bug Fixes**
- The push-rejection fixture now pins `core.hooksPath` in origin's local config so a global setting can no longer bypass the `pre-receive` hook in tests.

<sup>Written for commit 6333d12bf0b6d6829ddb93c0689eecf214084f53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


