### PR TITLE
Add Gandr as a voice provider (TTS)

### DIFF
--- a/backend/onyx/server/manage/voice/models.py
+++ b/backend/onyx/server/manage/voice/models.py
@@ -8,7 +8,7 @@ class VoiceProviderView(BaseModel):
 
     id: int
     name: str
-    provider_type: str  # "openai", "azure", "elevenlabs"
+    provider_type: str  # "openai", "azure", "elevenlabs", "gandr"
     is_default_stt: bool
     is_default_tts: bool
     stt_model: str | None
@@ -46,7 +46,7 @@ class VoiceProviderUpsertRequest(BaseModel):
 
     id: int | None = Field(default=None, description="Existing provider ID to update.")
     name: str
-    provider_type: str  # "openai", "azure", "elevenlabs"
+    provider_type: str  # "openai", "azure", "elevenlabs", "gandr"
     api_key: str | None = Field(
         default=None,
         description="API key for the provider.",

--- a/backend/onyx/voice/factory.py
+++ b/backend/onyx/voice/factory.py
@@ -66,5 +66,16 @@ def get_voice_provider(provider: VoiceProvider) -> VoiceProviderInterface:
             default_voice=default_voice,
         )
 
+    elif provider_type == "gandr":
+        from onyx.voice.providers.gandr import GandrVoiceProvider
+
+        return GandrVoiceProvider(
+            api_key=api_key,
+            api_base=api_base,
+            stt_model=stt_model,
+            tts_model=tts_model,
+            default_voice=default_voice,
+        )
+
     else:
         raise ValueError(f"Unsupported voice provider type: {provider_type}")

--- a/backend/onyx/voice/providers/gandr.py
+++ b/backend/onyx/voice/providers/gandr.py
@@ -1,0 +1,383 @@
+"""Gandr voice provider for TTS.
+
+Gandr exposes an OpenAI compatible speech endpoint:
+- **TTS**: `POST /v1/audio/speech` with a JSON body of `model`, `input`,
+  `voice`, and `response_format`. The response body streams audio.
+  Output formats are mp3 (default), wav, and pcm; pcm is headerless
+  s16le mono at 24000 Hz. Input is capped at 2000 characters per request.
+- **STT**: not offered. The transcription methods raise.
+
+Voices: gandr-mia, gandr-ava, gandr-jenny, gandr-dane, gandr-leo,
+gandr-lewis. The service covers 23 languages, and every render is
+watermarked.
+
+API keys are issued at https://gandr.ai.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import aiohttp
+
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
+from onyx.voice.interface import (
+    StreamingSynthesizerProtocol,
+    VoiceProviderInterface,
+)
+
+# Default Gandr API base URL
+DEFAULT_GANDR_API_BASE = "https://tts.gandr.ai"
+
+# Gandr caps speech input at 2000 characters per request.
+GANDR_MAX_INPUT_CHARACTERS = 2000
+
+# Gandr available voices for TTS
+GANDR_VOICES = [
+    {"id": "gandr-mia", "name": "Mia"},
+    {"id": "gandr-ava", "name": "Ava"},
+    {"id": "gandr-jenny", "name": "Jenny"},
+    {"id": "gandr-dane", "name": "Dane"},
+    {"id": "gandr-leo", "name": "Leo"},
+    {"id": "gandr-lewis", "name": "Lewis"},
+]
+
+# Valid Gandr TTS model IDs
+GANDR_TTS_MODELS = {"tts-1"}
+
+
+def _validate_input_length(text: str) -> None:
+    """Reject input over the Gandr per-request character cap.
+
+    The cap is validated client side so callers get a clear error instead
+    of a rejected HTTP request.
+    """
+    if len(text) > GANDR_MAX_INPUT_CHARACTERS:
+        raise ValueError(
+            f"Gandr TTS accepts at most {GANDR_MAX_INPUT_CHARACTERS} characters "
+            f"per request, got {len(text)}. Split the text and synthesize it "
+            "in parts."
+        )
+
+
+class GandrStreamingSynthesizer(StreamingSynthesizerProtocol):
+    """Streaming TTS using the Gandr HTTP speech API with streaming responses."""
+
+    def __init__(
+        self,
+        api_key: str,
+        voice: str = "gandr-mia",
+        model: str = "tts-1",
+        api_base: str | None = None,
+    ):
+        from onyx.utils.logger import setup_logger
+
+        self._logger = setup_logger()
+        self.api_key = api_key
+        self.voice = voice
+        self.model = model
+        self.api_base = api_base or DEFAULT_GANDR_API_BASE
+        self._session: aiohttp.ClientSession | None = None
+        self._audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self._text_queue: asyncio.Queue[str | None] = asyncio.Queue()
+        self._synthesis_task: asyncio.Task | None = None
+        self._closed = False
+        self._flushed = False
+
+    async def connect(self) -> None:
+        """Initialize HTTP session for TTS requests."""
+        self._logger.info("GandrStreamingSynthesizer: connecting")
+        self._session = aiohttp.ClientSession()
+        # Start background task to process text queue
+        self._synthesis_task = asyncio.create_task(self._process_text_queue())
+        self._logger.info("GandrStreamingSynthesizer: connected")
+
+    async def _process_text_queue(self) -> None:
+        """Background task to process queued text for synthesis."""
+        while not self._closed:
+            try:
+                text = await asyncio.wait_for(self._text_queue.get(), timeout=0.1)
+                if text is None:
+                    break
+                await self._synthesize_text(text)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self._logger.error("Error processing text queue: %s", e)
+
+    async def _synthesize_text(self, text: str) -> None:
+        """Make an HTTP TTS request and stream audio to the queue."""
+        if not self._session or self._closed:
+            return
+
+        url = f"{self.api_base.rstrip('/')}/v1/audio/speech"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        # The Gandr speech endpoint takes exactly these fields.
+        payload = {
+            "model": self.model,
+            "input": text,
+            "voice": self.voice,
+            "response_format": "mp3",
+        }
+
+        try:
+            async with self._session.post(
+                url, headers=headers, json=payload
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    self._logger.error("Gandr TTS error: %s", error_text)
+                    return
+
+                # Use 8192 byte chunks so MP3 frames arrive mostly complete
+                # for playback.
+                async for chunk in response.content.iter_chunked(8192):
+                    if self._closed:
+                        break
+                    if chunk:
+                        await self._audio_queue.put(chunk)
+        except Exception as e:
+            self._logger.error("GandrStreamingSynthesizer synthesis error: %s", e)
+
+    async def send_text(self, text: str) -> None:
+        """Queue text to be synthesized via HTTP streaming.
+
+        Each queued piece of text becomes one request, so each piece must
+        stay within the Gandr per-request character cap.
+        """
+        if not text.strip() or self._closed:
+            return
+        _validate_input_length(text)
+        await self._text_queue.put(text)
+
+    async def receive_audio(self) -> bytes | None:
+        """Receive next audio chunk (MP3 format)."""
+        try:
+            return await asyncio.wait_for(self._audio_queue.get(), timeout=0.1)
+        except asyncio.TimeoutError:
+            return b""  # No audio yet, but not done
+
+    async def flush(self) -> None:
+        """Signal end of text input, then wait for synthesis to complete."""
+        if self._flushed:
+            return
+        self._flushed = True
+
+        # Signal end of text input
+        await self._text_queue.put(None)
+
+        # Wait for synthesis task to complete processing all text
+        if self._synthesis_task and not self._synthesis_task.done():
+            try:
+                await asyncio.wait_for(self._synthesis_task, timeout=60.0)
+            except asyncio.TimeoutError:
+                self._logger.warning("GandrStreamingSynthesizer: flush timeout")
+                self._synthesis_task.cancel()
+                try:
+                    await self._synthesis_task
+                except asyncio.CancelledError:
+                    pass
+            except asyncio.CancelledError:
+                pass
+
+        # Signal end of audio stream
+        await self._audio_queue.put(None)
+
+    async def close(self) -> None:
+        """Close the session."""
+        if self._closed:
+            return
+        self._closed = True
+
+        # Signal end of queues only if flush wasn't already called
+        if not self._flushed:
+            await self._text_queue.put(None)
+            await self._audio_queue.put(None)
+
+        if self._synthesis_task and not self._synthesis_task.done():
+            self._synthesis_task.cancel()
+            try:
+                await self._synthesis_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._session:
+            await self._session.close()
+
+
+class GandrVoiceProvider(VoiceProviderInterface):
+    """Gandr voice provider. TTS only, no STT."""
+
+    def __init__(
+        self,
+        api_key: str | None,
+        api_base: str | None = None,
+        stt_model: str | None = None,
+        tts_model: str | None = None,
+        default_voice: str | None = None,
+    ):
+        self.api_key = api_key
+        self.api_base = api_base or DEFAULT_GANDR_API_BASE
+        # Gandr has no STT models; the field is kept for interface parity.
+        self.stt_model = stt_model
+        # Validate and default the model, matching the other providers.
+        self.tts_model = tts_model if tts_model in GANDR_TTS_MODELS else "tts-1"
+        self.default_voice = default_voice or "gandr-mia"
+
+    async def transcribe(self, audio_data: bytes, audio_format: str) -> str:
+        """Gandr is a text to speech provider and does not offer STT."""
+        raise NotImplementedError(
+            "Gandr does not support transcription. Configure a different "
+            "provider for STT."
+        )
+
+    async def synthesize_stream(
+        self, text: str, voice: str | None = None, speed: float = 1.0
+    ) -> AsyncIterator[bytes]:
+        """
+        Convert text to audio using Gandr TTS with streaming.
+
+        Args:
+            text: Text to convert to speech, at most 2000 characters
+            voice: Voice ID (defaults to provider's default voice or gandr-mia)
+            speed: Accepted for interface compatibility. The Gandr request
+                body carries only model, input, voice, and response_format,
+                so this value is not forwarded.
+
+        Yields:
+            Audio data chunks (mp3 format)
+        """
+        from onyx.utils.logger import setup_logger
+
+        logger = setup_logger()
+
+        if not self.api_key:
+            raise ValueError("Gandr API key required for TTS")
+
+        _validate_input_length(text)
+
+        voice_id = voice or self.default_voice or "gandr-mia"
+
+        url = f"{self.api_base.rstrip('/')}/v1/audio/speech"
+
+        logger.info(
+            "Gandr TTS: starting synthesis, text='%s...', voice=%s, model=%s",
+            text[:50],
+            voice_id,
+            self.tts_model,
+        )
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "model": self.tts_model,
+            "input": text,
+            "voice": voice_id,
+            "response_format": "mp3",
+        }
+
+        with traced_llm_call(
+            flow=LLMFlow.TTS,
+            model=self.tts_model,
+            provider="gandr",
+            input_messages=[{"role": "user", "content": text}],
+        ):
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json=payload) as response:
+                    logger.info(
+                        "Gandr TTS: got response status=%s, content-type=%s",
+                        response.status,
+                        response.headers.get("content-type"),
+                    )
+                    if response.status != 200:
+                        error_text = await response.text()
+                        logger.error("Gandr TTS failed: %s", error_text)
+                        raise RuntimeError(f"Gandr TTS failed: {error_text}")
+
+                    # Use 8192 byte chunks so MP3 frames arrive mostly complete
+                    chunk_count = 0
+                    total_bytes = 0
+                    async for chunk in response.content.iter_chunked(8192):
+                        if chunk:
+                            chunk_count += 1
+                            total_bytes += len(chunk)
+                            yield chunk
+                    logger.info(
+                        "Gandr TTS: streaming complete, %s chunks, %s total bytes",
+                        chunk_count,
+                        total_bytes,
+                    )
+
+    async def validate_credentials(self) -> None:
+        """Validate the Gandr API key.
+
+        Gandr's public API surface is the speech endpoint itself, so this
+        issues a minimal synthesis request and checks the response status.
+        Note that this performs a real synthesis request.
+        """
+        if not self.api_key:
+            raise ValueError("Gandr API key required")
+
+        url = f"{self.api_base.rstrip('/')}/v1/audio/speech"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.tts_model,
+            "input": "Hello.",
+            "voice": self.default_voice or "gandr-mia",
+            "response_format": "mp3",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status == 200:
+                    return
+                if response.status in (401, 403):
+                    raise RuntimeError("Invalid Gandr API key.")
+                raise RuntimeError("Gandr credential validation failed.")
+
+    def get_available_voices(self) -> list[dict[str, str]]:
+        """Return the Gandr voices."""
+        return GANDR_VOICES.copy()
+
+    def get_available_stt_models(self) -> list[dict[str, str]]:
+        """Gandr has no STT models."""
+        return []
+
+    def get_available_tts_models(self) -> list[dict[str, str]]:
+        return [
+            {"id": "tts-1", "name": "Gandr TTS"},
+        ]
+
+    def supports_streaming_tts(self) -> bool:
+        """Gandr supports streaming TTS via HTTP streaming responses."""
+        return True
+
+    async def create_streaming_synthesizer(
+        self, voice: str | None = None, speed: float = 1.0
+    ) -> GandrStreamingSynthesizer:
+        """Create a streaming TTS session using the HTTP streaming API.
+
+        The speed argument is accepted for interface compatibility and is
+        not forwarded; the Gandr request body carries only model, input,
+        voice, and response_format.
+        """
+        if not self.api_key:
+            raise ValueError("API key required for streaming TTS")
+        synthesizer = GandrStreamingSynthesizer(
+            api_key=self.api_key,
+            voice=voice or self.default_voice or "gandr-mia",
+            model=self.tts_model or "tts-1",
+            api_base=self.api_base,
+        )
+        await synthesizer.connect()
+        return synthesizer

--- a/backend/tests/unit/onyx/voice/providers/test_gandr_provider.py
+++ b/backend/tests/unit/onyx/voice/providers/test_gandr_provider.py
@@ -1,0 +1,87 @@
+import asyncio
+
+import pytest
+
+from onyx.voice.providers.gandr import (
+    DEFAULT_GANDR_API_BASE,
+    GANDR_MAX_INPUT_CHARACTERS,
+    GandrVoiceProvider,
+    _validate_input_length,
+)
+
+# --- Input length validation ---
+
+
+def test_validate_input_length_allows_input_at_cap() -> None:
+    _validate_input_length("a" * GANDR_MAX_INPUT_CHARACTERS)
+
+
+def test_validate_input_length_rejects_input_over_cap() -> None:
+    with pytest.raises(ValueError, match="2000"):
+        _validate_input_length("a" * (GANDR_MAX_INPUT_CHARACTERS + 1))
+
+
+def test_synthesize_stream_rejects_input_over_cap() -> None:
+    """Over-cap input fails client side before any request is made."""
+    provider = GandrVoiceProvider(api_key="test")
+
+    async def _consume() -> None:
+        text = "a" * (GANDR_MAX_INPUT_CHARACTERS + 1)
+        async for _ in provider.synthesize_stream(text):
+            pass
+
+    with pytest.raises(ValueError, match="2000"):
+        asyncio.run(_consume())
+
+
+# --- Provider Model Defaulting ---
+
+
+def test_provider_defaults_invalid_tts_model() -> None:
+    provider = GandrVoiceProvider(api_key="test", tts_model="invalid_model")
+    assert provider.tts_model == "tts-1"
+
+
+def test_provider_accepts_valid_model() -> None:
+    provider = GandrVoiceProvider(api_key="test", tts_model="tts-1")
+    assert provider.tts_model == "tts-1"
+
+
+def test_provider_defaults_api_base() -> None:
+    provider = GandrVoiceProvider(api_key="test")
+    assert provider.api_base == DEFAULT_GANDR_API_BASE
+
+
+def test_provider_defaults_voice() -> None:
+    provider = GandrVoiceProvider(api_key="test")
+    assert provider.default_voice == "gandr-mia"
+
+
+def test_provider_get_available_voices_returns_copy() -> None:
+    provider = GandrVoiceProvider(api_key="test")
+    voices = provider.get_available_voices()
+    voices.clear()
+    assert len(provider.get_available_voices()) > 0
+
+
+# --- STT surface ---
+
+
+def test_provider_has_no_stt_models() -> None:
+    provider = GandrVoiceProvider(api_key="test")
+    assert provider.get_available_stt_models() == []
+
+
+def test_transcribe_raises_not_implemented() -> None:
+    provider = GandrVoiceProvider(api_key="test")
+    with pytest.raises(NotImplementedError):
+        asyncio.run(provider.transcribe(b"", "wav"))
+
+
+# --- Streaming support flags ---
+
+
+def test_supports_streaming_tts_but_not_stt() -> None:
+    provider = GandrVoiceProvider(api_key="test")
+    assert provider.supports_streaming_tts() is True
+    assert provider.supports_streaming_stt() is False


### PR DESCRIPTION
This adds Gandr as a text to speech provider, following the existing voice provider pattern. Gandr exposes an OpenAI compatible speech endpoint, so the implementation mirrors the tts-1 style HTTP flow that the OpenAI provider already uses, with the aiohttp based request and error handling style of the ElevenLabs provider.

What changed:

- backend/onyx/voice/providers/gandr.py (new): GandrVoiceProvider and GandrStreamingSynthesizer. TTS calls POST https://tts.gandr.ai/v1/audio/speech with Bearer auth and a JSON body of model, input, voice, and response_format, then streams the mp3 response body in 8192 byte chunks, wrapped in traced_llm_call like the other providers. Input is validated client side against Gandr's 2000 character per request cap with a clear error. The streaming synthesizer mirrors OpenAIStreamingSynthesizer: a text queue drained by a background task, one HTTP request per queued fragment, and the same flush and close semantics. Gandr has no STT, so transcribe raises NotImplementedError and get_available_stt_models returns an empty list; the base class defaults already report streaming STT as unsupported.
- backend/onyx/voice/factory.py: register the "gandr" provider_type, mirroring the elevenlabs branch.
- backend/onyx/server/manage/voice/models.py: extend the provider_type comment lists with "gandr".
- backend/tests/unit/onyx/voice/providers/test_gandr_provider.py (new): unit tests mirroring the conventions of test_elevenlabs_provider.py: model defaulting, api_base defaulting, voice list copy semantics, the input cap, and the STT surface.

Notes on the provider:

- Voices: gandr-mia, gandr-ava, gandr-jenny, gandr-dane, gandr-leo, gandr-lewis. Default is gandr-mia.
- Output formats on the API are mp3 (default), wav, and pcm (headerless s16le mono at 24000 Hz). This integration requests mp3, matching the format both existing TTS paths stream.
- The speed argument is accepted for interface compatibility and not forwarded, since the Gandr request body carries only model, input, voice, and response_format.
- validate_credentials issues a minimal synthesis request, because the speech endpoint is Gandr's public API surface; it treats 401 and 403 as an invalid key, matching the ElevenLabs error style.
- API keys are issued at https://gandr.ai and are entered through the existing admin voice provider form, like the other providers. The free tier is 50,000 tokens.

How to verify:

1. Run the new unit tests: `pytest backend/tests/unit/onyx/voice/providers/test_gandr_provider.py -v`. They are network free.
2. Run the existing voice unit tests to confirm no regressions: `pytest backend/tests/unit/onyx/voice/ -v`.
3. With a real key, add a voice provider of type "gandr" in the admin UI (or via the voice provider test endpoint) and confirm credential validation and TTS playback.

Disclosure: I work on Gandr.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gandr as a text-to-speech voice provider alongside the existing OpenAI, Azure, and ElevenLabs options. Gandr is TTS-only, so selecting it leaves speech-to-text unavailable.

- Registers the `gandr` provider type in the voice factory and updates the admin API provider type comments.
- New `GandrVoiceProvider` streams mp3 audio in 8192-byte chunks over Gandr's OpenAI-compatible speech endpoint, with a 2000-character per-request cap enforced client side.
- Credential validation performs a real synthesis request and treats 401/403 responses as an invalid key.
- Voice support is limited to Gandr's six voices with `gandr-mia` as the default; the `speed` argument is accepted but not forwarded.
- Adds network-free unit tests covering the input cap, model and API base defaults, voice list copy semantics, and the STT surface.

<sup>Written for commit d390655b344461eff324d7f38a68f40817b89dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

