### PR TITLE
feat: add llmman as a well-known LLM provider

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -22,6 +22,7 @@ class LlmProviderNames(str, Enum):
     OPENROUTER = "openrouter"
     AZURE = "azure"
     OLLAMA_CHAT = "ollama_chat"
+    LLMMAN = "llmman"
     LM_STUDIO = "lm_studio"
     MISTRAL = "mistral"
     LITELLM_PROXY = "litellm_proxy"
@@ -46,6 +47,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.OPENROUTER,
     LlmProviderNames.AZURE,
     LlmProviderNames.OLLAMA_CHAT,
+    LlmProviderNames.LLMMAN,
     LlmProviderNames.LM_STUDIO,
     LlmProviderNames.LITELLM_PROXY,
     LlmProviderNames.BIFROST,
@@ -67,6 +69,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.AZURE: "Azure",
     "ollama": "Ollama",
     LlmProviderNames.OLLAMA_CHAT: "Ollama",
+    LlmProviderNames.LLMMAN: "llmman",
     LlmProviderNames.LM_STUDIO: "LM Studio",
     LlmProviderNames.LITELLM_PROXY: "LiteLLM Proxy",
     LlmProviderNames.BIFROST: "Bifrost",
@@ -158,6 +161,7 @@ AGGREGATOR_PROVIDERS: set[str] = {
     LlmProviderNames.BEDROCK_CONVERSE,
     LlmProviderNames.OPENROUTER,
     LlmProviderNames.OLLAMA_CHAT,
+    LlmProviderNames.LLMMAN,
     LlmProviderNames.LM_STUDIO,
     LlmProviderNames.VERTEX_AI,
     LlmProviderNames.AZURE,

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -365,7 +365,7 @@ def extract_vendor_from_model_name(model_name: str, provider: str) -> str | None
                 vendor_key = parts[0].lower()
             return PROVIDER_DISPLAY_NAMES.get(vendor_key, vendor_key.title())
 
-    elif provider == LlmProviderNames.OLLAMA_CHAT:
+    elif provider in (LlmProviderNames.OLLAMA_CHAT, LlmProviderNames.LLMMAN):
         # Format: "model-name:tag" e.g., "llama3:70b", "qwen2.5:7b"
         # Extract base name (before colon)
         base_name = model_name.split(":")[0].lower()

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -105,6 +105,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   "bedrock_converse",
   "openrouter",
   "ollama_chat",
+  "llmman",
   "lm_studio",
   "litellm_proxy",
   "bifrost",

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -57,6 +57,7 @@ export enum LLMProviderName {
   OPENAI = "openai",
   ANTHROPIC = "anthropic",
   OLLAMA_CHAT = "ollama_chat",
+  LLMMAN = "llmman",
   LM_STUDIO = "lm_studio",
   AZURE = "azure",
   OPENROUTER = "openrouter",


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves OpenAI-, Ollama- and Anthropic-compatible APIs.

Model routing goes through LiteLLM, so this only registers the provider name, its display name, and the places that key off it — enum, `WELL_KNOWN_PROVIDER_NAMES`, `PROVIDER_DISPLAY_NAMES`, `AGGREGATOR_PROVIDERS`, and the two matching frontend lists.

Model ids share the `name:tag` shape of the neighbouring local provider, so vendor inference **reuses that branch** rather than adding a second copy of the same logic. It's registered as an aggregator because the models it serves come from several labs.

**One dependency worth flagging:** LiteLLM needs an `llmman` provider for routing to resolve. That's [BerriAI/litellm#38925](https://github.com/BerriAI/litellm/pull/38925), currently open. This PR is inert until that lands — happy for you to hold it until then, or close it if you'd rather I resubmit afterwards.

**Testing:** `tsc --noEmit -p web/tsconfig.json` clean for the frontend changes; `py_compile` clean on both backend files. Not verified end-to-end against a live server, since that needs the LiteLLM side first.

> AI-assisted, reviewed before submitting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `llmman` as a well-known LLM provider, making it selectable as an aggregator for local models served via LiteLLM. Vendor inference reuses the `ollama_chat` branch for `name:tag` model ids. Verified with `tsc` and `py_compile`; end-to-end testing awaits the LiteLLM change.

**Dependencies**
- Model routing requires a LiteLLM `llmman` provider from [BerriAI/litellm#38925](https://github.com/BerriAI/litellm/pull/38925); this PR is inert until that lands.

<sup>Written for commit 7a2159bac4912ecfcc1413e066952fd74c2d4334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

