### PR TITLE
feat(mobile): add model selector and fix composer and actions bugs

### DIFF
--- a/mobile/GETTING_STARTED.md
+++ b/mobile/GETTING_STARTED.md
@@ -13,7 +13,7 @@ once the tools below are installed, see [`README.md`](./README.md) to install de
    installing its components. An older Xcode fails to build the native project: `expo-modules-jsi`
    (an `expo-router` dependency) hits a Swift/C++ interop compiler bug under Xcode 26.3 and
    earlier — `'RuntimeScheduler' cannot be annotated with either SWIFT_RETURNS_RETAINED or
-   SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type` — confirmed
+SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type` — confirmed
    fixed by updating to Xcode 26.6 (upstream: [expo/expo#46242](https://github.com/expo/expo/issues/46242)
    describes the same class of Swift 6.2 strictness issue in this package).
 2. **Add a simulator:** Xcode → **Settings → Platforms → iOS Simulator → ＋ Add Additional

--- a/mobile/GETTING_STARTED.md
+++ b/mobile/GETTING_STARTED.md
@@ -9,8 +9,13 @@ once the tools below are installed, see [`README.md`](./README.md) to install de
 
 ## iOS
 
-1. Install **Xcode** from the **Mac App Store**, then open it once so it finishes installing its
-   components.
+1. Install **Xcode 26.4 or later** from the **Mac App Store**, then open it once so it finishes
+   installing its components. An older Xcode fails to build the native project: `expo-modules-jsi`
+   (an `expo-router` dependency) hits a Swift/C++ interop compiler bug under Xcode 26.3 and
+   earlier — `'RuntimeScheduler' cannot be annotated with either SWIFT_RETURNS_RETAINED or
+   SWIFT_RETURNS_UNRETAINED because it is not returning a SWIFT_SHARED_REFERENCE type` — confirmed
+   fixed by updating to Xcode 26.6 (upstream: [expo/expo#46242](https://github.com/expo/expo/issues/46242)
+   describes the same class of Swift 6.2 strictness issue in this package).
 2. **Add a simulator:** Xcode → **Settings → Platforms → iOS Simulator → ＋ Add Additional
    Simulators** to download a runtime, then **Window → Devices and Simulators → Simulators → ＋**
    to create one (the default iPhone is usually fine).

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -16,7 +16,8 @@ dependencies, lockfile, and tooling). Scaffolded with `create-expo-app` (Expo Ro
 > First-time machine setup (Xcode, Android Studio, JDK 17, NDK, simulator/emulator) is in
 > [`GETTING_STARTED.md`](./GETTING_STARTED.md). The list below is the short version.
 
-- Node LTS on PATH, **Bun**, Xcode + an iOS simulator, CocoaPods.
+- Node LTS on PATH, **Bun**, **Xcode 26.4+** (older versions fail to build — see
+  [`GETTING_STARTED.md`](./GETTING_STARTED.md#ios)) + an iOS simulator, CocoaPods.
 - Recommended: `brew install watchman` (faster, more reliable Metro file watching).
 - The project path must contain **no spaces** (RN/Xcode build scripts break otherwise).
 - Runs as a **development build** (not Expo Go) — `react-native-mmkv` v4 and FlashList are native

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -9,10 +9,12 @@ module.exports = function (api) {
       "nativewind/babel",
     ],
     plugins: [
-      // must stay last; workletizableModules pre-bundles remend for the worklet runtime
+      // must stay last; importForwarding.moduleNames compiles remend's import into the worklet
+      // bundle itself — without it, remend stays an external reference and calling it from inside
+      // the worklet throws "Tried to synchronously call a Remote Function" at runtime.
       [
         "react-native-worklets/plugin",
-        { bundleMode: true, workletizableModules: ["remend"] },
+        { bundleMode: true, importForwarding: { moduleNames: ["remend"] } },
       ],
     ],
   };

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -9,6 +9,7 @@
         "@expo-google-fonts/hanken-grotesk": "^0.4.3",
         "@onyx-ai/shared": "file:../web/lib/shared",
         "@react-native-community/netinfo": "12.0.1",
+        "@rn-primitives/popover": "1.5.2",
         "@rn-primitives/portal": "^1.5.3",
         "@rn-primitives/separator": "^1.5.2",
         "@rn-primitives/slot": "^1.5.2",
@@ -357,6 +358,14 @@
 
     "@expo/xcpretty": ["@expo/xcpretty@4.4.4", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "chalk": "^4.1.0", "js-yaml": "^4.1.0" }, "bin": { "excpretty": "build/cli.js" } }, "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -461,6 +470,8 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
 
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.15", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA=="],
+
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.15", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
@@ -478,6 +489,10 @@
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.16", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.23", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-controllable-state": "1.2.6", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.3.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-rect": "1.1.4", "@radix-ui/react-use-size": "1.1.4", "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg=="],
 
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.17", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ=="],
 
@@ -502,6 +517,12 @@
     "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.4", "", { "dependencies": { "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.3", "", {}, "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="],
 
     "@react-native-community/netinfo": ["@react-native-community/netinfo@12.0.1", "", { "peerDependencies": { "react": "*", "react-native": ">=0.59" } }, "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ=="],
 
@@ -536,6 +557,10 @@
     "@react-native/normalize-colors": ["@react-native/normalize-colors@0.86.2", "", {}, "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg=="],
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.86.2", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.2.0", "react": "*", "react-native": "0.86.2" }, "optionalPeers": ["@types/react"] }, "sha512-uO0J72gh3EvE+1/GHRk18QRyBDTRHRB0AraAfojsRjbT7VMuJwKrZYaKGshavoaEud6aw00ZB9/8mTMIKjjcAw=="],
+
+    "@rn-primitives/hooks": ["@rn-primitives/hooks@1.5.2", "", { "dependencies": { "@rn-primitives/types": "1.5.2" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native", "react-native-web"] }, "sha512-7XUVqR/nS309Fpltd19GflRTUPE/bYwZnOh/ofEDw7UMMelfI5CIgc70BXfZPHAkrjG9/tU3JAZl0KWSrWLJCQ=="],
+
+    "@rn-primitives/popover": ["@rn-primitives/popover@1.5.2", "", { "dependencies": { "@radix-ui/react-popover": "^1.1.15", "@rn-primitives/hooks": "1.5.2", "@rn-primitives/slot": "1.5.2", "@rn-primitives/types": "1.5.2" }, "peerDependencies": { "@rn-primitives/portal": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native", "react-native-web"] }, "sha512-eA4oYy96fV67/wiT+5h6BAFAQglV8i+z1LY0vKW7psoXiwca7TrDTAMrEiu2uUagJNwb9drscIQUoPq9Qz94Aw=="],
 
     "@rn-primitives/portal": ["@rn-primitives/portal@1.5.3", "", { "dependencies": { "zustand": "^5.0.4" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native", "react-native-web"] }, "sha512-P5k+StpUYVFmW6RwmIdKtvMPqpEwHh6q1GTroDFQsvykx3Z88iBskR2z1Uarnc0MO/lnoCWRJmDz3Cccd2u77w=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -7,6 +7,7 @@
     "@expo-google-fonts/hanken-grotesk": "^0.4.3",
     "@onyx-ai/shared": "file:../web/lib/shared",
     "@react-native-community/netinfo": "12.0.1",
+    "@rn-primitives/popover": "1.5.2",
     "@rn-primitives/portal": "^1.5.3",
     "@rn-primitives/separator": "^1.5.2",
     "@rn-primitives/slot": "^1.5.2",

--- a/mobile/src/api/chat/agents.ts
+++ b/mobile/src/api/chat/agents.ts
@@ -18,6 +18,9 @@ export function useAgents() {
     // No serverUrl → `getBaseUrl()` throws, so stay idle until connected.
     enabled: serverUrl !== null,
     queryFn: ({ signal }) => apiFetch<MinimalAgent[]>("/persona", { signal }),
+    // An agent created or reconfigured elsewhere (web, another device) should show up without
+    // needing to background and refocus the app. Only polls while this hook is actually mounted.
+    refetchInterval: 60_000,
   });
   return { ...query, agents: query.data ?? [] };
 }

--- a/mobile/src/api/chat/agents.ts
+++ b/mobile/src/api/chat/agents.ts
@@ -18,8 +18,6 @@ export function useAgents() {
     // No serverUrl → `getBaseUrl()` throws, so stay idle until connected.
     enabled: serverUrl !== null,
     queryFn: ({ signal }) => apiFetch<MinimalAgent[]>("/persona", { signal }),
-    // An agent created or reconfigured elsewhere (web, another device) should show up without
-    // needing to background and refocus the app. Only polls while this hook is actually mounted.
     refetchInterval: 60_000,
   });
   return { ...query, agents: query.data ?? [] };

--- a/mobile/src/api/chat/llm.ts
+++ b/mobile/src/api/chat/llm.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+import { QUERY_KEYS } from "@/api/query-keys";
+import {
+  buildModelOptions,
+  resolveDefaultOption,
+  type LlmProvidersResponse,
+  type ModelOption,
+} from "@/chat/models";
+import { useSession } from "@/state/session";
+
+const NO_OPTIONS: ModelOption[] = [];
+
+/*
+ * Scoped to one agent because each exposes its own subset of models. Asking per agent is cheap:
+ * the backend caches this listing.
+ */
+export function useLlmProviders(
+  agentId: number | null,
+  currentModelName?: string,
+) {
+  const serverUrl = useSession((state) => state.serverUrl);
+  const query = useQuery({
+    queryKey: QUERY_KEYS.llmProviders(serverUrl, agentId),
+    // Stays idle until a server is connected, because `getBaseUrl()` throws without one.
+    enabled: serverUrl !== null && agentId !== null,
+    queryFn: ({ signal }) =>
+      apiFetch<LlmProvidersResponse>(`/llm/persona/${agentId}/providers`, {
+        signal,
+      }),
+  });
+
+  const providers = query.data?.providers;
+
+  const options = useMemo(
+    () =>
+      providers ? buildModelOptions(providers, currentModelName) : NO_OPTIONS,
+    [providers, currentModelName],
+  );
+
+  const defaultOption = useMemo(
+    () =>
+      providers
+        ? resolveDefaultOption(
+            providers,
+            query.data?.default_text ?? null,
+            options,
+          )
+        : null,
+    [providers, query.data?.default_text, options],
+  );
+
+  return { ...query, options, defaultOption };
+}

--- a/mobile/src/api/chat/sessions.ts
+++ b/mobile/src/api/chat/sessions.ts
@@ -95,9 +95,6 @@ export function useChatSessions() {
       // Matches web; the compound-cursor fix stays out of scope to keep the port backend-free.
       return lastPage.sessions[lastPage.sessions.length - 1]!.time_updated;
     },
-    // A session created or renamed elsewhere (web, another device) should show up in the sidebar
-    // without needing to background and refocus the app. Only polls while this hook is mounted,
-    // and re-fetches every page already loaded, not just the first.
     refetchInterval: 60_000,
   });
 

--- a/mobile/src/api/chat/sessions.ts
+++ b/mobile/src/api/chat/sessions.ts
@@ -95,6 +95,10 @@ export function useChatSessions() {
       // Matches web; the compound-cursor fix stays out of scope to keep the port backend-free.
       return lastPage.sessions[lastPage.sessions.length - 1]!.time_updated;
     },
+    // A session created or renamed elsewhere (web, another device) should show up in the sidebar
+    // without needing to background and refocus the app. Only polls while this hook is mounted,
+    // and re-fetches every page already loaded, not just the first.
+    refetchInterval: 60_000,
   });
 
   const sessions = useMemo(

--- a/mobile/src/api/chat/stream.ts
+++ b/mobile/src/api/chat/stream.ts
@@ -5,6 +5,7 @@ import { getBaseUrl } from "@/api/config";
 import { getValidToken } from "@/api/auth/refreshState";
 import { createNdjsonBuffer } from "@/chat/ndjson";
 import { FileDescriptor } from "@/chat/interfaces";
+import { LlmOverride } from "@/chat/models";
 import { InternalSearchFilters } from "@/chat/sources";
 import {
   MessageResponseIDInfo,
@@ -26,6 +27,9 @@ export interface SendMessageBody {
   allowed_tool_ids?: number[] | null;
   forced_tool_id?: number | null;
   internal_search_filters?: InternalSearchFilters | null;
+  // Omitted or null runs the agent's own default model. Note the singular name: `llm_overrides`
+  // is a separate field for multi-model comparison, which mobile does not use.
+  llm_override?: LlmOverride | null;
 }
 
 export interface ChatToolOptions {
@@ -33,6 +37,7 @@ export interface ChatToolOptions {
   allowedToolIds: number[] | null;
   forcedToolId: number | null;
   internalSearchFilters: InternalSearchFilters | null;
+  llmOverride: LlmOverride | null;
 }
 
 // status lets the resume caller stay silent on the expected "nothing to resume" (404).

--- a/mobile/src/api/query-keys.ts
+++ b/mobile/src/api/query-keys.ts
@@ -25,4 +25,6 @@ export const QUERY_KEYS = {
     ["federated-sources", serverUrl] as const,
   availableTools: (serverUrl: string | null) =>
     ["available-tools", serverUrl] as const,
+  llmProviders: (serverUrl: string | null, agentId: number | null) =>
+    ["llm-providers", serverUrl, agentId] as const,
 };

--- a/mobile/src/api/query-keys.ts
+++ b/mobile/src/api/query-keys.ts
@@ -23,4 +23,6 @@ export const QUERY_KEYS = {
     ["connector-sources", serverUrl] as const,
   federatedSources: (serverUrl: string | null) =>
     ["federated-sources", serverUrl] as const,
+  availableTools: (serverUrl: string | null) =>
+    ["available-tools", serverUrl] as const,
 };

--- a/mobile/src/api/tools.ts
+++ b/mobile/src/api/tools.ts
@@ -22,6 +22,9 @@ export function useAvailableTools() {
     queryKey: QUERY_KEYS.availableTools(serverUrl),
     enabled: serverUrl !== null,
     queryFn: ({ signal }) => apiFetch<AvailableTool[]>("/tool", { signal }),
+    // An admin configuring a tool's provider while this is mounted (e.g. the actions sheet is
+    // open) should un-gray it without needing to background and refocus the app.
+    refetchInterval: 60_000,
   });
 
   // A malformed response is treated as not-yet-loaded rather than "confirmed zero tools

--- a/mobile/src/api/tools.ts
+++ b/mobile/src/api/tools.ts
@@ -22,8 +22,6 @@ export function useAvailableTools() {
     queryKey: QUERY_KEYS.availableTools(serverUrl),
     enabled: serverUrl !== null,
     queryFn: ({ signal }) => apiFetch<AvailableTool[]>("/tool", { signal }),
-    // An admin configuring a tool's provider while this is mounted (e.g. the actions sheet is
-    // open) should un-gray it without needing to background and refocus the app.
     refetchInterval: 60_000,
   });
 

--- a/mobile/src/api/tools.ts
+++ b/mobile/src/api/tools.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+import { QUERY_KEYS } from "@/api/query-keys";
+import { useSession } from "@/state/session";
+
+// The endpoint actually returns full ToolSnapshot objects; this only types the field callers
+// need — the id, to test membership.
+interface AvailableTool {
+  id: number;
+}
+
+const EMPTY_TOOLS: AvailableTool[] = [];
+
+// `GET /tool` returns only tools that currently pass their backend `is_available()` check — e.g.
+// image generation is omitted if no provider is configured. That's a different, narrower list
+// than an agent's assigned `tools`, which is what it's configured to use whether or not that's
+// actually live right now.
+export function useAvailableTools() {
+  const serverUrl = useSession((state) => state.serverUrl);
+  const query = useQuery({
+    queryKey: QUERY_KEYS.availableTools(serverUrl),
+    enabled: serverUrl !== null,
+    queryFn: ({ signal }) => apiFetch<AvailableTool[]>("/tool", { signal }),
+  });
+
+  // A malformed response is treated as not-yet-loaded rather than "confirmed zero tools
+  // available", which would otherwise mark every tool the agent has assigned as unavailable.
+  const tools = Array.isArray(query.data) ? query.data : EMPTY_TOOLS;
+  return {
+    ...query,
+    isSuccess: query.isSuccess && Array.isArray(query.data),
+    tools,
+  };
+}

--- a/mobile/src/chat/__tests__/models.test.ts
+++ b/mobile/src/chat/__tests__/models.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  buildModelOptions,
+  groupModelOptions,
+  isSameModelOption,
+  resolveDefaultOption,
+  toLlmOverride,
+  type LlmProvider,
+  type ModelConfiguration,
+} from "@/chat/models";
+
+function model(
+  overrides: Partial<ModelConfiguration> = {},
+): ModelConfiguration {
+  return {
+    id: 1,
+    name: "gpt-5",
+    is_visible: true,
+    display_name: null,
+    custom_display_name: null,
+    ...overrides,
+  };
+}
+
+function provider(overrides: Partial<LlmProvider> = {}): LlmProvider {
+  return {
+    id: 10,
+    name: "OpenAI Prod",
+    provider: "openai",
+    provider_display_name: "OpenAI",
+    model_configurations: [model()],
+    ...overrides,
+  };
+}
+
+describe("buildModelOptions", () => {
+  it("drops models the admin has hidden", () => {
+    const options = buildModelOptions([
+      provider({
+        model_configurations: [
+          model({ id: 1, name: "shown" }),
+          model({ id: 2, name: "hidden", is_visible: false }),
+        ],
+      }),
+    ]);
+    expect(options.map((o) => o.modelVersion)).toEqual(["shown"]);
+  });
+
+  it("keeps a hidden model when it is the one currently selected", () => {
+    const options = buildModelOptions(
+      [
+        provider({
+          model_configurations: [
+            model({ id: 2, name: "hidden", is_visible: false }),
+          ],
+        }),
+      ],
+      "hidden",
+    );
+    expect(options.map((o) => o.modelVersion)).toEqual(["hidden"]);
+  });
+
+  it("sends the provider's instance name, not its vendor slug", () => {
+    const [option] = buildModelOptions([provider()]);
+    expect(option?.modelProvider).toBe("OpenAI Prod");
+  });
+
+  it("prefers a custom display name, then the display name, then the raw name", () => {
+    const options = buildModelOptions([
+      provider({
+        model_configurations: [
+          model({ id: 1, name: "raw" }),
+          model({ id: 2, name: "b", display_name: "Display" }),
+          model({
+            id: 3,
+            name: "c",
+            display_name: "Display",
+            custom_display_name: "Custom",
+          }),
+        ],
+      }),
+    ]);
+    expect(options.map((o) => o.displayName)).toEqual([
+      "raw",
+      "Display",
+      "Custom",
+    ]);
+  });
+
+  it("keeps a model that has no configuration row, so it can still be sent by name", () => {
+    const options = buildModelOptions([
+      provider({
+        model_configurations: [model({ id: null, name: "unsaved" })],
+      }),
+    ]);
+    expect(options).toHaveLength(1);
+    expect(options[0]?.modelConfigurationId).toBeNull();
+  });
+
+  it("de-duplicates models that repeat across providers", () => {
+    const options = buildModelOptions([
+      provider({ id: 10, model_configurations: [model({ id: 1 })] }),
+      provider({ id: 11, model_configurations: [model({ id: 1 })] }),
+    ]);
+    expect(options).toHaveLength(1);
+  });
+});
+
+describe("resolveDefaultOption", () => {
+  it("resolves the default from its provider id and model name", () => {
+    const providers = [
+      provider({
+        id: 10,
+        name: "OpenAI Prod",
+        model_configurations: [model({ id: 1, name: "gpt-5" })],
+      }),
+    ];
+    const options = buildModelOptions(providers);
+    const resolved = resolveDefaultOption(
+      providers,
+      { provider_id: 10, model_name: "gpt-5" },
+      options,
+    );
+    expect(resolved?.modelConfigurationId).toBe(1);
+  });
+
+  it("returns null when the named default is not in the list", () => {
+    const providers = [provider()];
+    const options = buildModelOptions(providers);
+    expect(
+      resolveDefaultOption(
+        providers,
+        { provider_id: 10, model_name: "missing" },
+        options,
+      ),
+    ).toBeNull();
+    expect(resolveDefaultOption(providers, null, options)).toBeNull();
+  });
+
+  it("does not match a same-named model belonging to another provider", () => {
+    const providers = [
+      provider({
+        id: 10,
+        name: "First",
+        model_configurations: [model({ id: 1, name: "gpt-5" })],
+      }),
+      provider({
+        id: 11,
+        name: "Second",
+        model_configurations: [model({ id: 2, name: "gpt-5" })],
+      }),
+    ];
+    const options = buildModelOptions(providers);
+    const resolved = resolveDefaultOption(
+      providers,
+      { provider_id: 11, model_name: "gpt-5" },
+      options,
+    );
+    expect(resolved?.modelProvider).toBe("Second");
+  });
+});
+
+describe("groupModelOptions", () => {
+  it("groups by provider while preserving the original order", () => {
+    const options = buildModelOptions([
+      provider({ id: 10, name: "A", model_configurations: [model({ id: 1 })] }),
+      provider({ id: 11, name: "B", model_configurations: [model({ id: 2 })] }),
+      provider({ id: 12, name: "A", model_configurations: [model({ id: 3 })] }),
+    ]);
+    expect(
+      groupModelOptions(options).map((g) => g.providerDisplayName),
+    ).toEqual(["A", "B"]);
+    expect(groupModelOptions(options)[0]?.options).toHaveLength(2);
+  });
+});
+
+describe("isSameModelOption", () => {
+  const base = buildModelOptions([provider()])[0]!;
+
+  it("compares by configuration id when both have one", () => {
+    expect(isSameModelOption(base, { ...base, displayName: "renamed" })).toBe(
+      true,
+    );
+    expect(isSameModelOption(base, { ...base, modelConfigurationId: 99 })).toBe(
+      false,
+    );
+  });
+
+  it("falls back to the provider and model name when there is no id", () => {
+    const noId = { ...base, modelConfigurationId: null };
+    expect(isSameModelOption(noId, { ...noId })).toBe(true);
+    expect(isSameModelOption(noId, { ...noId, modelVersion: "other" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("toLlmOverride", () => {
+  it("sends the id alongside the provider and model names", () => {
+    expect(toLlmOverride(buildModelOptions([provider()])[0]!)).toEqual({
+      model_configuration_id: 1,
+      model_provider: "OpenAI Prod",
+      model_version: "gpt-5",
+    });
+  });
+});

--- a/mobile/src/chat/contracts/projects.ts
+++ b/mobile/src/chat/contracts/projects.ts
@@ -1,9 +1,9 @@
-// Mobile-native project types (read model, PR 6) — not shared with web.
+// These project types are mobile-only; they are not shared with the web codebase.
 import type { ChatFileType } from "@/chat/interfaces";
 import type { ChatSessionSummary } from "@/api/chat/sessions";
 
-// UPLOADING is client-only (PR 7); the rest come from the backend. Matched
-// case-insensitively — payload casing isn't guaranteed.
+// UPLOADING is set locally before the file has a server record; every other value comes from the
+// backend. Payload casing isn't guaranteed, so status checks below compare against an uppercased value.
 export enum UserFileStatus {
   UPLOADING = "UPLOADING",
   PROCESSING = "PROCESSING",
@@ -23,24 +23,23 @@ export interface ProjectFile {
   chat_file_type: ChatFileType;
   token_count: number | null;
   created_at: string;
-  // Client marker for an optimistic upload; the upload endpoint echoes it back, and reconcile()
-  // uses that echo as the primary key to match the returned server file to its local record.
+  // This is a client-generated marker set before the file has a server id. The upload endpoint
+  // echoes it back, and reconcile() uses that echo to match the returned file to its local record.
   temp_id?: string | null;
 }
 
-// reason is a human string shown to the user
 export interface RejectedFile {
   file_name: string;
   reason: string;
 }
 
-// Partial success is normal: rejected files land in rejected_files, not user_files.
+// An upload can partially succeed: some files land in rejected_files while others land in
+// user_files, in the same response.
 export interface CategorizedFiles {
   user_files: ProjectFile[];
   rejected_files: RejectedFile[];
 }
 
-// Case-insensitive: payload casing isn't guaranteed.
 export function isProcessingStatus(status: UserFileStatus | string): boolean {
   const upper = String(status).toUpperCase();
   return (
@@ -50,7 +49,13 @@ export function isProcessingStatus(status: UserFileStatus | string): boolean {
   );
 }
 
-// Server-side processing (has a real id, so it is pollable) — excludes the client-only UPLOADING.
+// Narrower than isProcessingStatus: true only while the file is still transferring, not once the
+// server has started processing or indexing it.
+export function isUploadingStatus(status: UserFileStatus | string): boolean {
+  return String(status).toUpperCase() === UserFileStatus.UPLOADING;
+}
+
+// Excludes UPLOADING because it's set locally, before the file has a real id to poll for.
 export function isServerProcessingStatus(
   status: UserFileStatus | string,
 ): boolean {
@@ -60,8 +65,8 @@ export function isServerProcessingStatus(
   );
 }
 
-// `chat_sessions` is embedded by the list/detail endpoints — a project's chats
-// need no separate fetch.
+// The list/detail endpoints embed `chat_sessions` inline, so a project's chats never need a
+// separate fetch.
 export interface Project {
   id: number;
   name: string;
@@ -71,8 +76,8 @@ export interface Project {
   chat_sessions: ChatSessionSummary[];
 }
 
-// `GET /user/projects/{id}/details` — project + files inline; featured map drives
-// a chat row's avatar-vs-bubble choice.
+// Returned by `GET /user/projects/{id}/details`. `persona_id_to_is_featured` decides whether a
+// chat row renders that agent's avatar or a plain bubble.
 export interface ProjectDetails {
   project: Project;
   files: ProjectFile[] | null;

--- a/mobile/src/chat/models.ts
+++ b/mobile/src/chat/models.ts
@@ -1,0 +1,150 @@
+/*
+ * The `GET /llm/persona/{id}/providers` contract and the logic for turning it into picker rows,
+ * mirroring the part of web/src/lib/languageModels/options.ts that mobile needs.
+ *
+ * These types cover only the fields the picker and the send path read. The endpoint returns more
+ * per model — reasoning efforts, token limits, temperature defaults — that mobile has no UI for.
+ */
+export interface ModelConfiguration {
+  // Null for a model the admin never saved a configuration row for. Such a model can still be
+  // sent, just by name rather than by the preferred id.
+  id: number | null;
+  name: string;
+  is_visible: boolean;
+  display_name: string | null;
+  custom_display_name: string | null;
+}
+
+export interface LlmProvider {
+  id: number;
+  // `name` is the admin's label for this provider instance, `provider` is the vendor slug like
+  // "openai". The send body's `model_provider` carries the label, not the slug.
+  name: string | null;
+  provider: string;
+  provider_display_name: string;
+  model_configurations: ModelConfiguration[];
+}
+
+// The backend names the default by provider + model name, never by model_configuration_id, so
+// resolving it back to an option means matching both.
+export interface DefaultModel {
+  provider_id: number;
+  model_name: string;
+}
+
+export interface LlmProvidersResponse {
+  providers: LlmProvider[];
+  default_text: DefaultModel | null;
+}
+
+export interface ModelOption {
+  // Preferred key for the send body; the backend treats it as authoritative because provider
+  // display names aren't unique.
+  modelConfigurationId: number | null;
+  modelProvider: string;
+  modelVersion: string;
+  providerDisplayName: string;
+  displayName: string;
+}
+
+export interface LlmOverride {
+  model_configuration_id: number | null;
+  model_provider: string;
+  model_version: string;
+}
+
+export interface ModelOptionGroup {
+  providerDisplayName: string;
+  options: ModelOption[];
+}
+
+function effectiveDisplayName(model: ModelConfiguration): string {
+  return model.custom_display_name || model.display_name || model.name;
+}
+
+/*
+ * The endpoint does not pre-filter on `is_visible`, so the client has to. `currentModelName` is
+ * kept whatever its visibility, or a model the admin has since hidden would vanish from the
+ * picker while still being the one in use, leaving nothing selected.
+ */
+export function buildModelOptions(
+  providers: LlmProvider[],
+  currentModelName?: string,
+): ModelOption[] {
+  const seen = new Set<string>();
+  const options: ModelOption[] = [];
+
+  for (const provider of providers) {
+    for (const model of provider.model_configurations) {
+      if (!model.is_visible && model.name !== currentModelName) continue;
+      const key =
+        model.id != null
+          ? `id:${model.id}`
+          : `${provider.provider}:${model.name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      options.push({
+        modelConfigurationId: model.id,
+        modelProvider: provider.name ?? "",
+        modelVersion: model.name,
+        providerDisplayName: provider.name || provider.provider_display_name,
+        displayName: effectiveDisplayName(model),
+      });
+    }
+  }
+
+  return options;
+}
+
+export function groupModelOptions(options: ModelOption[]): ModelOptionGroup[] {
+  const groups: ModelOptionGroup[] = [];
+  for (const option of options) {
+    const existing = groups.find(
+      (group) => group.providerDisplayName === option.providerDisplayName,
+    );
+    if (existing) existing.options.push(option);
+    else
+      groups.push({
+        providerDisplayName: option.providerDisplayName,
+        options: [option],
+      });
+  }
+  return groups;
+}
+
+export function resolveDefaultOption(
+  providers: LlmProvider[],
+  defaultText: DefaultModel | null,
+  options: ModelOption[],
+): ModelOption | null {
+  if (!defaultText) return null;
+  const provider = providers.find(
+    (candidate) => candidate.id === defaultText.provider_id,
+  );
+  if (!provider) return null;
+  return (
+    options.find(
+      (option) =>
+        option.modelVersion === defaultText.model_name &&
+        option.modelProvider === (provider.name ?? ""),
+    ) ?? null
+  );
+}
+
+export function isSameModelOption(a: ModelOption, b: ModelOption): boolean {
+  if (a.modelConfigurationId != null || b.modelConfigurationId != null) {
+    return a.modelConfigurationId === b.modelConfigurationId;
+  }
+  return (
+    a.modelProvider === b.modelProvider && a.modelVersion === b.modelVersion
+  );
+}
+
+export function toLlmOverride(option: ModelOption): LlmOverride {
+  return {
+    model_configuration_id: option.modelConfigurationId,
+    model_provider: option.modelProvider,
+    model_version: option.modelVersion,
+  };
+}

--- a/mobile/src/components/chat/ActionLineItem.tsx
+++ b/mobile/src/components/chat/ActionLineItem.tsx
@@ -12,6 +12,9 @@ interface ActionLineItemProps {
   isForced: boolean;
   // Switched off in this user's agent preferences, not unavailable: the row stays tappable.
   isDisabled: boolean;
+  // Assigned to the agent, but its backend integration isn't configured right now — the row is
+  // inert (no toggle) unless it's already forced, which stays tappable so it can be un-forced.
+  isUnavailable: boolean;
   // Non-null on the row that owns the source sub-view (internal search).
   sourceCounts: { enabled: number; total: number } | null;
   onForceToggle: () => void;
@@ -24,6 +27,7 @@ export function ActionLineItem({
   tool,
   isForced,
   isDisabled,
+  isUnavailable,
   sourceCounts,
   onForceToggle,
   onToggleEnabled,
@@ -31,8 +35,14 @@ export function ActionLineItem({
   onClose,
 }: ActionLineItemProps) {
   const hasSources = sourceCounts !== null;
+  const blocked = isUnavailable && !isForced;
 
   function handlePress() {
+    if (isUnavailable) {
+      onForceToggle();
+      onClose();
+      return;
+    }
     if (isDisabled) onToggleEnabled();
     onForceToggle();
     // Forcing search is when its sources matter, so drill in instead of dismissing.
@@ -51,15 +61,19 @@ export function ActionLineItem({
       icon={getIconForToolId(tool.in_code_tool_id)}
       title={tool.display_name || tool.name}
       titleMaxLines={1}
+      description={
+        isUnavailable ? "Ask an admin to configure this." : undefined
+      }
       sizePreset="main-ui"
       variant="section"
+      disabled={blocked}
       /*
        * Not LineItemButton's `selected`: its tint is the sheet surface's own token, so a forced
        * row would look identical to an unforced one.
        */
       className={isForced ? "bg-background-tint-02" : undefined}
-      // Mobile Text has no strikethrough (web's off-state), so an off tool reads as muted.
-      color={isDisabled ? "muted" : "default"}
+      // Mobile Text has no strikethrough (web's off-state), so an off/unavailable tool reads muted.
+      color={isDisabled || (isUnavailable && !isForced) ? "muted" : "default"}
       onPress={handlePress}
       rightChildren={
         <View className="flex-row items-center gap-2">
@@ -69,14 +83,18 @@ export function ActionLineItem({
             </Text>
           ) : null}
 
-          {/* Always visible: touch has no hover to reveal it on, as web does. */}
-          <Button
-            icon={SvgSlash}
-            prominence="tertiary"
-            size="sm"
-            accessibilityLabel={isDisabled ? "Enable" : "Disable"}
-            onPress={onToggleEnabled}
-          />
+          {/* Shown whenever the tool is usable — touch has no hover to reveal it on like web
+              does, so it can't be hidden until tapped. Hidden when unavailable: there's nothing
+              to enable until it's configured. */}
+          {!isUnavailable ? (
+            <Button
+              icon={SvgSlash}
+              prominence="tertiary"
+              size="sm"
+              accessibilityLabel={isDisabled ? "Enable" : "Disable"}
+              onPress={onToggleEnabled}
+            />
+          ) : null}
 
           {hasSources ? (
             <Button

--- a/mobile/src/components/chat/ActionsMenu.tsx
+++ b/mobile/src/components/chat/ActionsMenu.tsx
@@ -8,14 +8,20 @@ import { Keyboard, ScrollView } from "react-native";
 import { ActionLineItem } from "@/components/chat/ActionLineItem";
 import { SourceSwitchList } from "@/components/chat/SourceSwitchList";
 import { Button } from "@/components/ui/button";
+import { LineItemButton } from "@/components/ui/line-item-button";
 import { Sheet } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
 import { useComposerTools } from "@/state/ComposerToolsProvider";
+import SvgHourglass from "@/icons/hourglass";
 import SvgSliders from "@/icons/sliders";
 
 const MAX_LIST_HEIGHT = 420;
 
 export function ActionsMenu() {
   const {
+    showDeepResearch,
+    deepResearchEnabled,
+    toggleDeepResearch,
     actionTools,
     unavailableToolIds,
     forcedToolId,
@@ -29,7 +35,9 @@ export function ActionsMenu() {
   const [open, setOpen] = useState(false);
   const [showSources, setShowSources] = useState(false);
 
-  if (actionTools.length === 0) return null;
+  // Deep research lives in this sheet, so an agent with no action tools still needs the trigger.
+  // Gating on `actionTools` alone would leave that toggle with no way to reach it.
+  if (actionTools.length === 0 && !showDeepResearch) return null;
 
   function close() {
     setOpen(false);
@@ -64,27 +72,50 @@ export function ActionsMenu() {
           {showSources ? (
             <SourceSwitchList />
           ) : (
-            actionTools.map((tool) => (
-              <ActionLineItem
-                key={tool.id}
-                tool={tool}
-                isForced={forcedToolId === tool.id}
-                isDisabled={disabledToolIds.includes(tool.id)}
-                isUnavailable={unavailableToolIds.includes(tool.id)}
-                sourceCounts={
-                  tool.id === sourceToolId && sourceOptions.length > 0
-                    ? {
-                        enabled: enabledSourceCount,
-                        total: sourceOptions.length,
-                      }
-                    : null
-                }
-                onForceToggle={() => toggleForcedTool(tool.id)}
-                onToggleEnabled={() => toggleToolEnabled(tool.id)}
-                onOpenSources={() => setShowSources(true)}
-                onClose={close}
-              />
-            ))
+            <>
+              {/* Deep research is a mode, not a tool: nothing to force or disable, so it renders
+                  as a plain switch rather than an ActionLineItem. Web keeps it as a composer
+                  pill instead. */}
+              {showDeepResearch ? (
+                <LineItemButton
+                  icon={SvgHourglass}
+                  title="Deep Research"
+                  titleMaxLines={1}
+                  sizePreset="main-ui"
+                  variant="section"
+                  onPress={toggleDeepResearch}
+                  rightChildren={
+                    <Switch
+                      checked={deepResearchEnabled}
+                      onCheckedChange={toggleDeepResearch}
+                      accessibilityLabel="Toggle Deep Research"
+                    />
+                  }
+                />
+              ) : null}
+
+              {actionTools.map((tool) => (
+                <ActionLineItem
+                  key={tool.id}
+                  tool={tool}
+                  isForced={forcedToolId === tool.id}
+                  isDisabled={disabledToolIds.includes(tool.id)}
+                  isUnavailable={unavailableToolIds.includes(tool.id)}
+                  sourceCounts={
+                    tool.id === sourceToolId && sourceOptions.length > 0
+                      ? {
+                          enabled: enabledSourceCount,
+                          total: sourceOptions.length,
+                        }
+                      : null
+                  }
+                  onForceToggle={() => toggleForcedTool(tool.id)}
+                  onToggleEnabled={() => toggleToolEnabled(tool.id)}
+                  onOpenSources={() => setShowSources(true)}
+                  onClose={close}
+                />
+              ))}
+            </>
           )}
         </ScrollView>
       </Sheet>

--- a/mobile/src/components/chat/ActionsMenu.tsx
+++ b/mobile/src/components/chat/ActionsMenu.tsx
@@ -17,6 +17,7 @@ const MAX_LIST_HEIGHT = 420;
 export function ActionsMenu() {
   const {
     actionTools,
+    unavailableToolIds,
     forcedToolId,
     toggleForcedTool,
     disabledToolIds,
@@ -69,6 +70,7 @@ export function ActionsMenu() {
                 tool={tool}
                 isForced={forcedToolId === tool.id}
                 isDisabled={disabledToolIds.includes(tool.id)}
+                isUnavailable={unavailableToolIds.includes(tool.id)}
                 sourceCounts={
                   tool.id === sourceToolId && sourceOptions.length > 0
                     ? {

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -17,12 +17,12 @@ import SvgArrowUp from "@/icons/arrow-up";
 import SvgPaperclip from "@/icons/paperclip";
 import SvgStop from "@/icons/stop";
 
-// Fixed height via native min===max sizing, never a JS-computed height: a content-driven height
-// let a fast double-Enter paint the caret behind the toolbar.
+// The input height is fixed by setting min and max to the same value, never computed from
+// content: a content-driven height let a fast double-Enter paint the caret behind the toolbar.
 const INPUT_HEIGHT = 44;
 
-// Mirrors web `shadow-box-01` (tokens/shadow.json); RN renders one layer so we keep the primary
-// blur, Android uses `elevation`.
+// Mirrors web's `shadow-box-01` token (tokens/shadow.json). RN can only render one shadow layer,
+// so this keeps the primary blur; Android uses `elevation` instead.
 const SHADOW_BOX_01 = {
   shadowColor: "#000000",
   shadowOffset: { width: 0, height: 2 },
@@ -52,8 +52,12 @@ export function InputBar({
   const [pickerOpen, setPickerOpen] = useState(false);
 
   const isBusy = chatState === "loading" || chatState === "streaming";
+  const hasFiles = attachments.files.length > 0;
+  // Typed text isn't required once a file is attached and has finished uploading.
   const canSend =
-    value.trim().length > 0 && !isBusy && !attachments.hasBlockingFiles;
+    (value.trim().length > 0 || hasFiles) &&
+    !isBusy &&
+    !attachments.hasBlockingFiles;
 
   const { data: recentFiles = [], isLoading: isLoadingRecent } =
     useRecentFiles(pickerOpen);
@@ -62,7 +66,6 @@ export function InputBar({
     return recentFiles.filter((file) => !attachedIds.has(file.id));
   }, [attachments.files, recentFiles]);
 
-  const hasFiles = attachments.files.length > 0;
   const hasFailed = attachments.files.some(isFailedFile);
 
   return (
@@ -70,14 +73,15 @@ export function InputBar({
       className="bg-background-neutral-00 px-12 pt-8"
       style={{ paddingBottom: insets.bottom }}
     >
-      {/* Hairline border (web is borderless): in dark mode card and page are both near-black and the
-          shadow is invisible, so the border guarantees the card reads. */}
+      {/* Web leaves this borderless, but in dark mode the card and the page behind it are both
+          near-black and the shadow disappears, so mobile adds a hairline border to keep the
+          card visible. */}
       <View
         className="rounded-16 border border-border-01 bg-background-neutral-00"
         style={SHADOW_BOX_01}
       >
         {hasFiles ? (
-          // gap-8 (wider than web's 4px): mobile file chips are larger touch targets.
+          // Wider than web's 4px gap — mobile file chips are sized as larger touch targets.
           <View className="flex-row flex-wrap gap-8 px-12 pt-12">
             {attachments.files.map((file) => (
               <FileCard
@@ -106,7 +110,8 @@ export function InputBar({
           ]}
         />
 
-        {/* Only the actionable failed hint; in-progress uploads show a spinner on the chip. */}
+        {/* Only a failed attachment needs this hint — an in-progress one already shows a spinner
+            on its own chip. */}
         {hasFailed ? (
           <Text
             font="secondary-body"
@@ -118,8 +123,8 @@ export function InputBar({
         ) : null}
 
         <View className="min-h-40 flex-row items-center justify-between p-4">
-          {/* `min-w-0 shrink` so a long forced-tool pill compresses instead of pushing the send
-              cluster past the card's right edge — RN defaults flexShrink to 0. */}
+          {/* RN elements don't shrink by default, so a long forced-tool pill would push the send
+              button past the card's right edge without this. */}
           <View className="min-w-0 shrink flex-row items-center gap-8">
             <Button
               prominence="tertiary"
@@ -155,7 +160,8 @@ export function InputBar({
       <FilePickerSheet
         visible={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        // Sheet closes itself (choose→onClose) and defers the action past dismiss — no setPickerOpen here.
+        // FilePickerSheet already closes itself and waits for its own dismiss animation before
+        // running the chosen action, so this doesn't need to call setPickerOpen too.
         onUploadDocuments={() => void attachments.addDocuments()}
         onUploadPhotos={() => void attachments.addImages()}
         recentFiles={linkableRecent}

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -6,6 +6,7 @@ import { textPresets } from "@onyx-ai/shared/native";
 import { useRecentFiles } from "@/hooks/useRecentFiles";
 import { FileCard } from "@/components/chat/FileCard";
 import { FilePickerSheet } from "@/components/chat/FilePickerSheet";
+import { ModelSelector } from "@/components/chat/ModelSelector";
 import { ToolbarControls } from "@/components/chat/ToolbarControls";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
@@ -135,7 +136,8 @@ export function InputBar({
             <ToolbarControls />
           </View>
 
-          <View className="flex-row items-center gap-4">
+          <View className="min-w-0 flex-row items-center gap-4">
+            <ModelSelector />
             {isBusy ? (
               <Button
                 prominence="tertiary"

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -54,11 +54,9 @@ export function InputBar({
 
   const isBusy = chatState === "loading" || chatState === "streaming";
   const hasFiles = attachments.files.length > 0;
-  // Typed text isn't required once a file is attached and has finished uploading.
+
   const canSend =
-    (value.trim().length > 0 || hasFiles) &&
-    !isBusy &&
-    !attachments.hasBlockingFiles;
+    value.trim().length > 0 && !isBusy && !attachments.hasBlockingFiles;
 
   const { data: recentFiles = [], isLoading: isLoadingRecent } =
     useRecentFiles(pickerOpen);

--- a/mobile/src/components/chat/ModelSelector.tsx
+++ b/mobile/src/components/chat/ModelSelector.tsx
@@ -1,0 +1,132 @@
+/*
+ * The composer's model picker. Web puts its MultiModelSelector above the input bar; this sits
+ * beside the send button instead, because the mobile composer sticks to the keyboard and the
+ * space above it belongs to the conversation.
+ *
+ * Single-select only — web's parallel multi-model comparison has no mobile counterpart yet.
+ */
+import { ScrollView, View } from "react-native";
+
+import { Icon } from "@/components/ui/icon";
+import { LineItemButton } from "@/components/ui/line-item-button";
+import { Popover } from "@/components/ui/popover";
+import { Text } from "@/components/ui/text";
+import {
+  groupModelOptions,
+  isSameModelOption,
+  type ModelOption,
+} from "@/chat/models";
+import { useComposerTools } from "@/state/ComposerToolsProvider";
+import SvgCpu from "@/icons/cpu";
+
+// Yoga never shrinks the pill on its own, so without a cap a long model name pushes the send
+// button off the edge of the composer card.
+const TRIGGER_MAX_WIDTH = 140;
+
+const LIST_MAX_HEIGHT = 320;
+
+interface ModelListProps {
+  options: ModelOption[];
+  selected: ModelOption | null;
+  onSelect: (option: ModelOption) => void;
+}
+
+/*
+ * Kept separate from the popover so it can be rendered, and tested, on its own. The panel itself
+ * only mounts after the primitive has measured the trigger, which needs real native layout.
+ */
+export function ModelList({ options, selected, onSelect }: ModelListProps) {
+  const groups = groupModelOptions(options);
+  const showGroupHeadings = groups.length > 1;
+
+  return (
+    <ScrollView
+      style={{ maxHeight: LIST_MAX_HEIGHT }}
+      keyboardShouldPersistTaps="handled"
+    >
+      {groups.map((group) => (
+        <View key={group.providerDisplayName}>
+          {/* The px-8 matches LineItemButton's own inset, so the heading lines up with the row
+              labels below it. */}
+          {showGroupHeadings ? (
+            <Text
+              font="secondary-body"
+              color="text-02"
+              className="px-8 pb-4 pt-8"
+            >
+              {group.providerDisplayName}
+            </Text>
+          ) : null}
+
+          {group.options.map((option) => {
+            const isSelected =
+              selected != null && isSameModelOption(option, selected);
+            return (
+              <Popover.Close
+                key={`${option.modelProvider}:${option.modelVersion}`}
+              >
+                <LineItemButton
+                  title={option.displayName}
+                  titleMaxLines={1}
+                  sizePreset="main-ui"
+                  variant="section"
+                  className={isSelected ? "bg-action-selection-02" : undefined}
+                  onPress={() => onSelect(option)}
+                />
+              </Popover.Close>
+            );
+          })}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+export function ModelSelector() {
+  const { modelOptions, effectiveModel, selectModel } = useComposerTools();
+
+  // A lone model is not a choice, so the control would only take up composer width.
+  if (modelOptions.length < 2) return null;
+
+  return (
+    <Popover>
+      {/* These classes reproduce SelectButton's resting look, which this cannot simply be. */}
+      <Popover.Trigger
+        className="h-28 flex-row items-center justify-center rounded-08 px-8"
+        accessibilityLabel={
+          effectiveModel
+            ? `Model: ${effectiveModel.displayName}`
+            : "Select model"
+        }
+      >
+        <View className="p-2">
+          <Icon as={SvgCpu} size={16} className="text-text-03" />
+        </View>
+        <Text
+          font="main-ui-body"
+          color="text-04"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          className="mx-4 shrink"
+          style={{ maxWidth: TRIGGER_MAX_WIDTH }}
+        >
+          {effectiveModel?.displayName ?? "Model"}
+        </Text>
+      </Popover.Trigger>
+
+      {/* Bounded rather than fixed: model names run from "GPT-5" to "Claude Sonnet 4.5 (Bedrock)",
+          so any single width is either half empty or clipping. */}
+      <Popover.Content
+        side="top"
+        align="end"
+        className="min-w-[180px] max-w-[300px]"
+      >
+        <ModelList
+          options={modelOptions}
+          selected={effectiveModel}
+          onSelect={selectModel}
+        />
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/mobile/src/components/chat/ToolbarControls.tsx
+++ b/mobile/src/components/chat/ToolbarControls.tsx
@@ -6,22 +6,14 @@ import { ActionsMenu } from "@/components/chat/ActionsMenu";
 import { SelectButton } from "@/components/ui/select-button";
 import { getIconForToolId } from "@/chat/tools";
 import { useComposerTools } from "@/state/ComposerToolsProvider";
-import SvgHourglass from "@/icons/hourglass";
 
-// Leaves room for the actions trigger, the deep-research pill and the send cluster on the
-// narrowest supported phone.
+// Sized so the actions trigger on this side, and the model pill and send button on the other,
+// still fit on the narrowest supported phone.
 const FORCED_PILL_MAX_WIDTH = 132;
 
 export function ToolbarControls() {
-  const {
-    showDeepResearch,
-    deepResearchEnabled,
-    toggleDeepResearch,
-    actionTools,
-    forcedToolId,
-    toggleForcedTool,
-    disabledToolIds,
-  } = useComposerTools();
+  const { actionTools, forcedToolId, toggleForcedTool, disabledToolIds } =
+    useComposerTools();
 
   // A forced tool that is switched off is never sent, so its pill would advertise a control the
   // request ignores.
@@ -29,23 +21,9 @@ export function ToolbarControls() {
     (tool) => tool.id === forcedToolId && !disabledToolIds.includes(tool.id),
   );
 
-  // `SelectButton`'s `self-start` would top-align the 28px pill against the 36px paperclip;
-  // hugging it here keeps the row centered.
   return (
     <View className="min-w-0 shrink flex-row items-center gap-8">
       <ActionsMenu />
-
-      {showDeepResearch ? (
-        <SelectButton
-          icon={SvgHourglass}
-          state={deepResearchEnabled ? "selected" : "empty"}
-          foldable={!deepResearchEnabled}
-          onPress={toggleDeepResearch}
-          accessibilityLabel="Deep Research"
-        >
-          Deep Research
-        </SelectButton>
-      ) : null}
 
       {/* Kept outside the menu, as web does, so the force can be released in one tap. Capped
           because Yoga defaults flexShrink to 0: a long tool name would otherwise push the send

--- a/mobile/src/components/chat/__tests__/ActionLineItem.test.tsx
+++ b/mobile/src/components/chat/__tests__/ActionLineItem.test.tsx
@@ -21,6 +21,7 @@ function renderRow(
     tool,
     isForced: false,
     isDisabled: false,
+    isUnavailable: false,
     sourceCounts: null,
     onForceToggle: jest.fn(),
     onToggleEnabled: jest.fn(),

--- a/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
+++ b/mobile/src/components/chat/__tests__/ActionsMenu.test.tsx
@@ -53,9 +53,35 @@ function renderMenu(overrides: Partial<ComposerTools> = {}) {
 }
 
 describe("ActionsMenu", () => {
-  it("renders nothing when the agent exposes no selectable tools", () => {
-    renderMenu({ actionTools: [] });
+  it("renders nothing when there is neither a selectable tool nor deep research", () => {
+    renderMenu({ actionTools: [], showDeepResearch: false });
     expect(screen.queryByLabelText("Manage Actions")).toBeNull();
+  });
+
+  it("still opens for a toolless agent that offers deep research", () => {
+    renderMenu({ actionTools: [], showDeepResearch: true });
+    fireEvent.press(screen.getByLabelText("Manage Actions"));
+    expect(screen.getByText("Deep Research")).toBeTruthy();
+  });
+
+  it("leaves deep research out when it is gated off", () => {
+    renderMenu({ showDeepResearch: false });
+    fireEvent.press(screen.getByLabelText("Manage Actions"));
+    expect(screen.queryByText("Deep Research")).toBeNull();
+  });
+
+  it("reflects the deep research state and toggles it", () => {
+    const value = renderMenu({
+      showDeepResearch: true,
+      deepResearchEnabled: true,
+    });
+    fireEvent.press(screen.getByLabelText("Manage Actions"));
+
+    const toggle = screen.getByLabelText("Toggle Deep Research");
+    expect(toggle.props.accessibilityState.checked).toBe(true);
+
+    fireEvent.press(toggle);
+    expect(value.toggleDeepResearch).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the tool list closed until the trigger is pressed", () => {

--- a/mobile/src/components/chat/__tests__/ModelSelector.test.tsx
+++ b/mobile/src/components/chat/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { PortalHost } from "@rn-primitives/portal";
+
+import { ModelList, ModelSelector } from "@/components/chat/ModelSelector";
+import { Popover } from "@/components/ui/popover";
+import type { ModelOption } from "@/chat/models";
+import {
+  ComposerToolsProvider,
+  type ComposerTools,
+} from "@/state/ComposerToolsProvider";
+import { makeComposerTools } from "@/state/__tests__/fixtures";
+
+// These reach MMKV, which jest can't load; the suite only needs the context the provider supplies.
+jest.mock("@/state/storage");
+jest.mock("@/api/settings", () => ({ useWorkspaceSettings: jest.fn() }));
+jest.mock("@/hooks/useAgentPreferences", () => ({
+  useAgentPreferences: jest.fn(),
+}));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+function option(overrides: Partial<ModelOption> = {}): ModelOption {
+  return {
+    modelConfigurationId: 1,
+    modelProvider: "OpenAI Prod",
+    modelVersion: "gpt-5",
+    providerDisplayName: "OpenAI Prod",
+    displayName: "GPT-5",
+    ...overrides,
+  };
+}
+
+const gpt5 = option();
+const claude = option({
+  modelConfigurationId: 2,
+  modelProvider: "Anthropic Prod",
+  modelVersion: "claude-sonnet-5",
+  providerDisplayName: "Anthropic Prod",
+  displayName: "Claude Sonnet 5",
+});
+
+function renderSelector(overrides: Partial<ComposerTools> = {}) {
+  const value: ComposerTools = makeComposerTools({
+    modelOptions: [gpt5, claude],
+    effectiveModel: gpt5,
+    ...overrides,
+  });
+  render(
+    // The popover renders through the portal host that app/_layout.tsx mounts at the root.
+    <ComposerToolsProvider value={value}>
+      <ModelSelector />
+      <PortalHost />
+    </ComposerToolsProvider>,
+  );
+  return value;
+}
+
+describe("ModelSelector", () => {
+  it("labels the trigger with the active model", () => {
+    renderSelector();
+    expect(screen.getByText("GPT-5")).toBeTruthy();
+  });
+
+  it("renders nothing when there is nothing to choose between", () => {
+    renderSelector({ modelOptions: [gpt5] });
+    expect(screen.queryByText("GPT-5")).toBeNull();
+  });
+
+  it("keeps the list closed until the trigger is pressed", () => {
+    renderSelector();
+    expect(screen.queryByText("Claude Sonnet 5")).toBeNull();
+  });
+
+  it("falls back to a neutral label when no model has resolved yet", () => {
+    renderSelector({ effectiveModel: null });
+    expect(screen.getByText("Model")).toBeTruthy();
+  });
+});
+
+/*
+ * Exercised directly instead of through the trigger. The panel only mounts once the primitive
+ * has measured the trigger, and the test renderer reports no layout for it to measure.
+ */
+describe("ModelList", () => {
+  // The Popover root is here because each row dismisses the panel on press. It renders its
+  // children whether or not the panel is open, so the list is still reachable.
+  function renderList(options: ModelOption[] = [gpt5, claude]) {
+    const onSelect = jest.fn();
+    render(
+      <Popover>
+        <ModelList options={options} selected={gpt5} onSelect={onSelect} />
+      </Popover>,
+    );
+    return onSelect;
+  }
+
+  it("lists every model", () => {
+    renderList();
+    expect(screen.getByText("GPT-5")).toBeTruthy();
+    expect(screen.getByText("Claude Sonnet 5")).toBeTruthy();
+  });
+
+  it("reports the picked model", () => {
+    const onSelect = renderList();
+    fireEvent.press(screen.getByText("Claude Sonnet 5"));
+    expect(onSelect).toHaveBeenCalledWith(claude);
+  });
+
+  it("groups by provider when more than one is offered", () => {
+    renderList();
+    expect(screen.getByText("OpenAI Prod")).toBeTruthy();
+    expect(screen.getByText("Anthropic Prod")).toBeTruthy();
+  });
+
+  it("drops the headings when a single provider offers everything", () => {
+    renderList([
+      gpt5,
+      { ...claude, providerDisplayName: gpt5.providerDisplayName },
+    ]);
+    expect(screen.queryByText("OpenAI Prod")).toBeNull();
+  });
+});

--- a/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
+++ b/mobile/src/components/chat/__tests__/ToolbarControls.test.tsx
@@ -44,35 +44,20 @@ function renderControls(overrides: Partial<ComposerTools> = {}) {
 }
 
 describe("ToolbarControls", () => {
-  it("renders nothing when deep research is gated off", () => {
-    renderControls({ showDeepResearch: false });
+  // Deep research now lives in the actions sheet, so ActionsMenu covers how it behaves.
+  it("keeps deep research out of the toolbar", () => {
+    renderControls();
     expect(screen.queryByLabelText("Deep Research")).toBeNull();
   });
 
-  it("renders the pill icon-only and unselected while off", () => {
-    renderControls();
-    const pill = screen.getByLabelText("Deep Research");
-    expect(pill.props.accessibilityState.selected).toBe(false);
-    expect(screen.queryByText("Deep Research")).toBeNull();
-  });
-
-  it("shows the label and the selected state once enabled", () => {
-    renderControls({ deepResearchEnabled: true });
-    expect(screen.getByText("Deep Research")).toBeTruthy();
-    expect(
-      screen.getByLabelText("Deep Research").props.accessibilityState.selected,
-    ).toBe(true);
-  });
-
-  it("toggles on press", () => {
-    const value = renderControls();
-    fireEvent.press(screen.getByLabelText("Deep Research"));
-    expect(value.toggleDeepResearch).toHaveBeenCalledTimes(1);
-  });
-
-  it("hides the actions trigger when the agent has no selectable tools", () => {
-    renderControls({ actionTools: [] });
+  it("hides the actions trigger when there is neither a tool nor deep research", () => {
+    renderControls({ actionTools: [], showDeepResearch: false });
     expect(screen.queryByLabelText("Manage Actions")).toBeNull();
+  });
+
+  it("keeps the actions trigger for a toolless agent that still offers deep research", () => {
+    renderControls({ actionTools: [], showDeepResearch: true });
+    expect(screen.getByLabelText("Manage Actions")).toBeTruthy();
   });
 
   it("shows the actions trigger once the agent has selectable tools", () => {

--- a/mobile/src/components/ui/popover.tsx
+++ b/mobile/src/components/ui/popover.tsx
@@ -1,0 +1,126 @@
+/*
+ * Anchored floating panel, the RN counterpart of Opal's Popover
+ * (web/lib/opal/src/components/popover/). Use this instead of `Sheet` when the options belong
+ * visually to the control that opened them rather than to the screen.
+ *
+ * It draws through the app-wide PortalHost in app/_layout.tsx, which must stay mounted. Open
+ * state is internal: the native primitive has no controlled `open` prop the way Opal does, so
+ * wrap a row in `Popover.Close` to dismiss the panel when that row is pressed.
+ */
+import type { ReactNode } from "react";
+import { StyleSheet } from "react-native";
+import * as PopoverPrimitive from "@rn-primitives/popover";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { cn } from "@/lib/utils";
+
+// Mirrors web's `shadow-box-02` token, flattened to the single shadow layer RN can draw.
+const SHADOW_BOX_02 = {
+  shadowColor: "#000000",
+  shadowOffset: { width: 0, height: 2 },
+  shadowOpacity: 0.12,
+  shadowRadius: 24,
+  elevation: 8,
+} as const;
+
+const EDGE_PADDING = 8;
+
+interface PopoverProps {
+  onOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+}
+
+function Popover({ onOpenChange, children }: PopoverProps) {
+  return (
+    <PopoverPrimitive.Root onOpenChange={onOpenChange}>
+      {children}
+    </PopoverPrimitive.Root>
+  );
+}
+
+interface PopoverTriggerProps {
+  children: ReactNode;
+  className?: string;
+  accessibilityLabel?: string;
+}
+
+/*
+ * Pass presentational children only. The trigger is itself the pressable, so handing it another
+ * one (a Button, a SelectButton) means the inner control swallows the press and the panel never
+ * opens. It also has to stay a real pressable for the primitive to measure it and anchor to it.
+ */
+function PopoverTrigger({
+  children,
+  className,
+  accessibilityLabel,
+}: PopoverTriggerProps) {
+  return (
+    <PopoverPrimitive.Trigger
+      accessibilityLabel={accessibilityLabel}
+      className={className}
+    >
+      {children}
+    </PopoverPrimitive.Trigger>
+  );
+}
+
+interface PopoverCloseProps {
+  children: ReactNode;
+}
+
+// `asChild` keeps the caller's own row as the pressable; wrapping would nest two of them.
+function PopoverClose({ children }: PopoverCloseProps) {
+  return <PopoverPrimitive.Close asChild>{children}</PopoverPrimitive.Close>;
+}
+
+interface PopoverContentProps {
+  children: ReactNode;
+  side?: "top" | "bottom";
+  align?: "start" | "center" | "end";
+  sideOffset?: number;
+  className?: string;
+}
+
+function PopoverContent({
+  children,
+  side = "bottom",
+  align = "center",
+  sideOffset = 4,
+  className,
+}: PopoverContentProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <PopoverPrimitive.Portal>
+      {/* The overlay has to be absolutely positioned: the portal host sits in the root layout, so
+          a flex-sized one would take real space there and squeeze the screen underneath it. */}
+      <PopoverPrimitive.Overlay style={StyleSheet.absoluteFill}>
+        <PopoverPrimitive.Content
+          side={side}
+          align={align}
+          sideOffset={sideOffset}
+          insets={{
+            top: insets.top + EDGE_PADDING,
+            bottom: insets.bottom + EDGE_PADDING,
+            left: insets.left + EDGE_PADDING,
+            right: insets.right + EDGE_PADDING,
+          }}
+          style={SHADOW_BOX_02}
+          // Roomier than Opal's 4px inset, because these rows are touch targets, not hover targets.
+          className={cn(
+            "rounded-12 border border-border-01 bg-background-neutral-00 p-8",
+            className,
+          )}
+        >
+          {children}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Overlay>
+    </PopoverPrimitive.Portal>
+  );
+}
+
+Popover.Trigger = PopoverTrigger;
+Popover.Content = PopoverContent;
+Popover.Close = PopoverClose;
+
+export { Popover, type PopoverProps, type PopoverContentProps };

--- a/mobile/src/components/ui/select-button.styles.ts
+++ b/mobile/src/components/ui/select-button.styles.ts
@@ -42,18 +42,18 @@ export const SELECT_COLORS: SelectColorMatrix = {
     selected: {
       rest: {
         bg: "bg-transparent",
-        fg: "text-action-link-05",
-        icon: "text-action-link-05",
+        fg: "text-action-selection-05",
+        icon: "text-action-selection-05",
       },
       active: {
         bg: "bg-background-tint-00",
-        fg: "text-action-link-05",
-        icon: "text-action-link-05",
+        fg: "text-action-selection-05",
+        icon: "text-action-selection-05",
       },
       disabled: {
         bg: "bg-transparent",
-        fg: "text-action-link-03",
-        icon: "text-action-link-03",
+        fg: "text-action-selection-03",
+        icon: "text-action-selection-03",
       },
     },
   },

--- a/mobile/src/components/ui/select-button.tsx
+++ b/mobile/src/components/ui/select-button.tsx
@@ -48,7 +48,7 @@ function SelectButton({
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel ?? children}
       accessibilityState={{ disabled, selected: state === "selected" }}
-      className="self-start"
+      className="self-center"
     >
       {({ pressed }) => {
         const colors =

--- a/mobile/src/components/ui/switch.tsx
+++ b/mobile/src/components/ui/switch.tsx
@@ -44,10 +44,10 @@ function Switch({
 
   const trackColor = disabled
     ? checked
-      ? "bg-action-link-03"
+      ? "bg-action-selection-03"
       : "bg-background-neutral-04"
     : checked
-      ? "bg-action-link-05"
+      ? "bg-action-selection-05"
       : "bg-background-tint-03";
   const thumbColor = disabled
     ? "bg-background-neutral-03"

--- a/mobile/src/hooks/__tests__/useChatController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatController.test.tsx
@@ -313,6 +313,11 @@ describe("useChatController", () => {
         allowedToolIds: [1, 3],
         forcedToolId: 3,
         internalSearchFilters: { source_type: ["web"] },
+        llmOverride: {
+          model_configuration_id: 7,
+          model_provider: "OpenAI Prod",
+          model_version: "gpt-5",
+        },
       });
     });
 
@@ -323,11 +328,17 @@ describe("useChatController", () => {
       allowed_tool_ids: number[] | null;
       forced_tool_id: number | null;
       internal_search_filters: { source_type: string[] | null } | null;
+      llm_override: { model_configuration_id: number } | null;
     };
     expect(body.deep_research).toBe(true);
     expect(body.allowed_tool_ids).toEqual([1, 3]);
     expect(body.forced_tool_id).toBe(3);
     expect(body.internal_search_filters).toEqual({ source_type: ["web"] });
+    expect(body.llm_override).toEqual({
+      model_configuration_id: 7,
+      model_provider: "OpenAI Prod",
+      model_version: "gpt-5",
+    });
   });
 
   it("defaults the tool fields when no toolOptions are passed (backwards compatible)", async () => {
@@ -348,11 +359,14 @@ describe("useChatController", () => {
       allowed_tool_ids: number[] | null;
       forced_tool_id: number | null;
       internal_search_filters: unknown;
+      llm_override: unknown;
     };
     expect(body.deep_research).toBe(false);
     expect(body.allowed_tool_ids).toBeNull();
     expect(body.forced_tool_id).toBeNull();
     expect(body.internal_search_filters).toBeNull();
+    // Null, not omitted: the backend then runs the agent's own default model.
+    expect(body.llm_override).toBeNull();
   });
 
   it("creates a session on the first message of a new chat", async () => {

--- a/mobile/src/hooks/__tests__/useComposerDraft.test.tsx
+++ b/mobile/src/hooks/__tests__/useComposerDraft.test.tsx
@@ -137,13 +137,41 @@ describe("useComposerDraft", () => {
     ]);
   });
 
-  it("blocks send while an attachment is still indexing, and removing it unblocks", () => {
+  it("does not block send while an attachment is still processing/indexing on the server", () => {
     const { result } = renderHook(() => useComposerDraft("chat-1:"), {
       wrapper,
     });
     act(() =>
       result.current.addRecent(
         recent({ id: "r1", status: UserFileStatus.INDEXING }),
+      ),
+    );
+    expect(result.current.hasBlockingFiles).toBe(false);
+  });
+
+  it("blocks send while an attachment is still uploading, and removing it unblocks", () => {
+    const { result } = renderHook(() => useComposerDraft("chat-1:"), {
+      wrapper,
+    });
+    act(() =>
+      result.current.addRecent(
+        recent({ id: "r1", status: UserFileStatus.UPLOADING }),
+      ),
+    );
+    expect(result.current.hasBlockingFiles).toBe(true);
+
+    act(() => result.current.removeFile("r1"));
+    expect(result.current.files).toEqual([]);
+    expect(result.current.hasBlockingFiles).toBe(false);
+  });
+
+  it("blocks send while an attachment failed, and removing it unblocks", () => {
+    const { result } = renderHook(() => useComposerDraft("chat-1:"), {
+      wrapper,
+    });
+    act(() =>
+      result.current.addRecent(
+        recent({ id: "r1", status: UserFileStatus.FAILED }),
       ),
     );
     expect(result.current.hasBlockingFiles).toBe(true);

--- a/mobile/src/hooks/__tests__/useSelectedModel.test.ts
+++ b/mobile/src/hooks/__tests__/useSelectedModel.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+
+import type { ModelOption } from "@/chat/models";
+import { useSelectedModel } from "@/hooks/useSelectedModel";
+
+interface SelectedModelProps {
+  chatSessionId: string | null;
+  agentId: number | undefined;
+  projectId: number | null;
+}
+
+const model: ModelOption = {
+  modelConfigurationId: 1,
+  modelProvider: "OpenAI Prod",
+  modelVersion: "gpt-5",
+  providerDisplayName: "OpenAI Prod",
+  displayName: "GPT-5",
+};
+
+function renderSelected(
+  chatSessionId: string | null,
+  agentId: number | undefined,
+  projectId: number | null = null,
+) {
+  return renderHook((props: SelectedModelProps) => useSelectedModel(props), {
+    initialProps: { chatSessionId, agentId, projectId },
+  });
+}
+
+describe("useSelectedModel", () => {
+  it("starts with no pick and records one on select", () => {
+    const { result } = renderSelected(null, 0);
+    expect(result.current.selectedModel).toBeNull();
+
+    act(() => result.current.selectModel(model));
+    expect(result.current.selectedModel).toEqual(model);
+  });
+
+  it("clears the pick when moving to a different conversation", () => {
+    const { result, rerender } = renderSelected("session-1", 0);
+    act(() => result.current.selectModel(model));
+
+    rerender({ chatSessionId: "session-2", agentId: 0, projectId: null });
+    expect(result.current.selectedModel).toBeNull();
+  });
+
+  // That transition is the send that created the conversation, not a move to another one.
+  it("keeps the pick when a new session id arrives for the send that made it", () => {
+    const { result, rerender } = renderSelected(null, 0);
+    act(() => result.current.selectModel(model));
+
+    rerender({ chatSessionId: "session-1", agentId: 0, projectId: null });
+    expect(result.current.selectedModel).toEqual(model);
+  });
+
+  it("clears the pick when the agent changes", () => {
+    const { result, rerender } = renderSelected(null, 0);
+    act(() => result.current.selectModel(model));
+
+    rerender({ chatSessionId: null, agentId: 7, projectId: null });
+    expect(result.current.selectedModel).toBeNull();
+  });
+
+  it("keeps the pick while the agent is momentarily unresolved", () => {
+    const { result, rerender } = renderSelected(null, 0);
+    act(() => result.current.selectModel(model));
+
+    rerender({ chatSessionId: null, agentId: undefined, projectId: null });
+    expect(result.current.selectedModel).toEqual(model);
+  });
+
+  // Both project landing composers sit on a null session and the default agent, so only the
+  // project id separates them.
+  it("clears the pick when moving between projects", () => {
+    const { result, rerender } = renderSelected(null, 0, 1);
+    act(() => result.current.selectModel(model));
+
+    rerender({ chatSessionId: null, agentId: 0, projectId: 2 });
+    expect(result.current.selectedModel).toBeNull();
+  });
+
+  it("clears the pick when leaving a project for a plain chat", () => {
+    const { result, rerender } = renderSelected(null, 0, 1);
+    act(() => result.current.selectModel(model));
+
+    rerender({ chatSessionId: null, agentId: 0, projectId: null });
+    expect(result.current.selectedModel).toBeNull();
+  });
+});

--- a/mobile/src/hooks/useChatController.ts
+++ b/mobile/src/hooks/useChatController.ts
@@ -330,6 +330,7 @@ export function useChatController(
           allowed_tool_ids: toolOptions?.allowedToolIds ?? null,
           forced_tool_id: toolOptions?.forcedToolId ?? null,
           internal_search_filters: toolOptions?.internalSearchFilters ?? null,
+          llm_override: toolOptions?.llmOverride ?? null,
         };
 
         if (sessionId == null) {

--- a/mobile/src/hooks/useComposerDraft.ts
+++ b/mobile/src/hooks/useComposerDraft.ts
@@ -2,10 +2,7 @@ import { useCallback, useContext, useMemo } from "react";
 
 import { pickDocuments, pickImages } from "@/api/files/pickers";
 import { type NormalizedAsset } from "@/api/files/upload";
-import {
-  isProcessingStatus,
-  type ProjectFile,
-} from "@/chat/contracts/projects";
+import { isUploadingStatus, type ProjectFile } from "@/chat/contracts/projects";
 import { projectFilesToFileDescriptors } from "@/chat/fileDescriptors";
 import { type FileDescriptor } from "@/chat/interfaces";
 import { ComposerDraftContext } from "@/components/chat/ComposerDraftProvider";
@@ -23,18 +20,20 @@ export interface UseComposerDraft {
   setText: (text: string) => void;
   files: ProjectFile[];
   descriptors: FileDescriptor[];
-  // any file still uploading/indexing OR failed → block send (removal unblocks)
+  // True while any file is still uploading or has failed; send stays blocked until it's removed.
   hasBlockingFiles: boolean;
   addDocuments: () => Promise<void>;
   addImages: () => Promise<void>;
   addRecent: (file: ProjectFile) => void;
   removeFile: (id: string) => void;
-  consume: () => void; // accepted composer send: clear text + attachments
-  consumeAttachments: () => void; // accepted starter send: clear attachments, keep text
+  // Call once a normal composer send is accepted: clears both the text and the attachments.
+  consume: () => void;
+  // Call once a starter/prompt send is accepted: clears the attachments but keeps the text.
+  consumeAttachments: () => void;
 }
 
-// Sole ComposerDraftContext consumer: text/refs from context, file records from the store,
-// uploads via useUpload.
+// This is the only place that reads ComposerDraftContext — everything else goes through this
+// hook, combining the context's text with file records read live from the userFileStore.
 export function useComposerDraft(draftKey: string): UseComposerDraft {
   const ctx = useContext(ComposerDraftContext);
   if (!ctx) {
@@ -57,16 +56,18 @@ export function useComposerDraft(draftKey: string): UseComposerDraft {
     () => projectFilesToFileDescriptors(files),
     [files],
   );
+  // A file that's finished transferring can be sent even while the backend is still processing
+  // or indexing it — only an active transfer or a failure blocks send.
   const hasBlockingFiles = useMemo(
     () =>
       files.some(
-        (file) => isProcessingStatus(file.status) || isFailedFile(file),
+        (file) => isUploadingStatus(file.status) || isFailedFile(file),
       ),
     [files],
   );
 
-  // Depend on the provider's stable methods, not the whole `ctx` (its identity changes every
-  // keystroke), so these callbacks stay stable and the FileCard memo holds while typing.
+  // Destructured so these callbacks depend on the provider's stable methods, not the whole `ctx`
+  // object, which gets a new identity on every keystroke and would otherwise break FileCard's memo.
   const {
     setText: ctxSetText,
     addFiles,
@@ -97,14 +98,15 @@ export function useComposerDraft(draftKey: string): UseComposerDraft {
 
   const removeFile = useCallback(
     (id: string) => {
-      // A chip renders with file.id — a tempId before reconcile, its SERVER id after. The draft is
-      // keyed by clientId (tempId), so resolve back through the store's server→client index (a
-      // no-op for an already-client id), else a completed upload can't be removed.
+      // A chip's `file.id` is a temp id before its upload reconciles and the file's real server id
+      // after, but the draft still stores it under the original temp id. Resolving through the
+      // store's server-to-client index handles both cases (it's a no-op for an already-temp id) —
+      // skipping this would leave a completed upload's chip stuck, unable to be removed.
       const store = useUserFileStore.getState();
       const clientId = store.serverIdToClientId[id] ?? id;
       ctxRemoveFile(draftKey, clientId);
-      // Only hard-delete an upload this draft owns (the store gates on task target); a shared or
-      // recent-attached record is just de-referenced above.
+      // The store only lets the draft that started an upload cancel/delete it, so this is a no-op
+      // for a shared or recent-attached file — it's only de-referenced from the draft above.
       if (store.tasksById[clientId]?.status === "uploading") {
         upload.remove(clientId, target);
       }

--- a/mobile/src/hooks/useSelectedModel.ts
+++ b/mobile/src/hooks/useSelectedModel.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ModelOption } from "@/chat/models";
+
+interface UseSelectedModelArgs {
+  chatSessionId: string | null;
+  // undefined = unresolved (agents loading, or a new session missing from the sessions list).
+  agentId: number | undefined;
+}
+
+export interface SelectedModel {
+  // null = no explicit pick, so the agent's own default model applies.
+  selectedModel: ModelOption | null;
+  selectModel: (model: ModelOption | null) => void;
+}
+
+/*
+ * The model the next send runs on, held per conversation and reset on the same rules as
+ * useDeepResearchToggle. Switching to a null session id and back is the send that created the
+ * conversation, not a move to a different one, so clearing on it would drop the model that send
+ * just used.
+ */
+export function useSelectedModel({
+  chatSessionId,
+  agentId,
+}: UseSelectedModelArgs): SelectedModel {
+  const [selectedModel, setSelectedModel] = useState<ModelOption | null>(null);
+  const previousChatSessionId = useRef<string | null>(chatSessionId);
+  const previousAgentId = useRef<number | undefined>(agentId);
+
+  useEffect(() => {
+    const previousId = previousChatSessionId.current;
+    previousChatSessionId.current = chatSessionId;
+    if (previousId !== null && previousId !== chatSessionId) {
+      setSelectedModel(null);
+    }
+  }, [chatSessionId]);
+
+  // Only a move between two known agents counts as a switch. The unresolved gap after a send is
+  // not an agent change, and treating it as one would clear the pick mid-send.
+  useEffect(() => {
+    if (agentId === undefined) return;
+    const previousId = previousAgentId.current;
+    previousAgentId.current = agentId;
+    if (previousId !== undefined && previousId !== agentId) {
+      setSelectedModel(null);
+    }
+  }, [agentId]);
+
+  const selectModel = useCallback(
+    (model: ModelOption | null) => setSelectedModel(model),
+    [],
+  );
+
+  return { selectedModel, selectModel };
+}

--- a/mobile/src/hooks/useSelectedModel.ts
+++ b/mobile/src/hooks/useSelectedModel.ts
@@ -6,6 +6,8 @@ interface UseSelectedModelArgs {
   chatSessionId: string | null;
   // undefined = unresolved (agents loading, or a new session missing from the sessions list).
   agentId: number | undefined;
+  // Crossing this boundary releases the pick.
+  projectId: number | null;
 }
 
 export interface SelectedModel {
@@ -23,10 +25,12 @@ export interface SelectedModel {
 export function useSelectedModel({
   chatSessionId,
   agentId,
+  projectId,
 }: UseSelectedModelArgs): SelectedModel {
   const [selectedModel, setSelectedModel] = useState<ModelOption | null>(null);
   const previousChatSessionId = useRef<string | null>(chatSessionId);
   const previousAgentId = useRef<number | undefined>(agentId);
+  const previousProjectId = useRef<number | null>(projectId);
 
   useEffect(() => {
     const previousId = previousChatSessionId.current;
@@ -46,6 +50,18 @@ export function useSelectedModel({
       setSelectedModel(null);
     }
   }, [agentId]);
+
+  /*
+   * Two project landing composers both sit on a null session id and the default agent, so neither
+   * reset above fires between them and the pick would follow the user into the next project. No
+   * unresolved-value guard is needed here: the send reads its options before the route flips, so
+   * every project change is a real one.
+   */
+  useEffect(() => {
+    const previousId = previousProjectId.current;
+    previousProjectId.current = projectId;
+    if (previousId !== projectId) setSelectedModel(null);
+  }, [projectId]);
 
   const selectModel = useCallback(
     (model: ModelOption | null) => setSelectedModel(model),

--- a/mobile/src/hooks/useUpload.ts
+++ b/mobile/src/hooks/useUpload.ts
@@ -18,15 +18,17 @@ import {
 } from "@/state/userFileStore";
 
 export interface UseUpload {
-  // Returns optimistic clientIds synchronously; the transfer runs in the background, errors toast.
+  // Returns the optimistic clientIds right away; the transfer itself runs in the background and
+  // reports errors through a toast, not through the return value or a thrown error.
   upload: (assets: NormalizedAsset[], target: UploadTarget) => string[];
-  // Pick then upload; the one place picker-error-to-toast routing lives.
+  // Picks files and uploads them. This is the only place a picker error gets turned into a toast.
   pickAndUpload: (
     pick: () => Promise<NormalizedAsset[]>,
     target: UploadTarget,
   ) => Promise<string[]>;
   registerExisting: (file: ProjectFile) => string;
-  // `target` is the removing surface; the store only cancels/deletes an upload its target owns.
+  // `target` must be the surface that started the upload — the store refuses to cancel or delete
+  // an upload for any other target.
   remove: (clientId: string, target: UploadTarget) => void;
 }
 
@@ -65,9 +67,10 @@ export function useUpload(): UseUpload {
               setUploadCancel(tempId, handle.cancel);
               const result = await handle.result;
               if (result.user_files.length > 0) {
-                // Backend echoes temp_id only when its `size|name` file-key matches ours, but
-                // mobile picks routinely differ so it comes back null. Upload is 1:1, so the
-                // returned file is this record's — stamp our tempId when the server didn't echo one.
+                // The backend only echoes back our temp_id when its `size|name` file key matches
+                // ours, and mobile picks routinely don't match, so it often comes back null. Each
+                // upload call sends exactly one file, so the returned file is always this record's
+                // — stamp our own tempId onto it whenever the server didn't echo one.
                 store.reconcile(
                   result.user_files.map((file) => ({
                     ...file,
@@ -83,8 +86,9 @@ export function useUpload(): UseUpload {
                 );
               }
             } catch {
-              // Absent task = user already removed this attachment, aborting the transfer (rejects
-              // here). Intentional cancel, not a failure — don't toast.
+              // If the task is already gone, the user removed this attachment themselves, which
+              // aborts the transfer and rejects here. That's an intentional cancel, not a failure,
+              // so it shouldn't show an error toast.
               if (useUserFileStore.getState().tasksById[tempId] == null) return;
               store.removeFile(tempId, target);
               uploadRejections.push(`${asset.name} could not be uploaded`);
@@ -92,18 +96,26 @@ export function useUpload(): UseUpload {
           }),
         );
 
-        // Committed list renders from the store, hydrated by this refetch; the optimistic record
-        // stays (deduped against the committed list) — no hand-off.
-        if (target.kind === "project") {
-          try {
-            await queryClient.invalidateQueries({
-              queryKey: QUERY_KEYS.userProject(serverUrl, target.projectId),
-            });
-          } catch {
-            uploadRejections.push(
-              "Uploaded, but the file list didn't refresh.",
+        // The committed file list renders from the store once this refetch hydrates it; the
+        // optimistic record isn't cleared, it just gets deduped against the committed list. Every
+        // upload — draft or project — also lands in the user's library, so the recent-files picker
+        // needs the same refresh.
+        try {
+          const invalidations = [
+            queryClient.invalidateQueries({
+              queryKey: QUERY_KEYS.userRecentFiles(serverUrl),
+            }),
+          ];
+          if (target.kind === "project") {
+            invalidations.push(
+              queryClient.invalidateQueries({
+                queryKey: QUERY_KEYS.userProject(serverUrl, target.projectId),
+              }),
             );
           }
+          await Promise.all(invalidations);
+        } catch {
+          uploadRejections.push("Uploaded, but the file list didn't refresh.");
         }
 
         if (uploadRejections.length > 0)

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -175,6 +175,7 @@ export function useComposerToolsState({
   const { selectedModel, selectModel } = useSelectedModel({
     chatSessionId,
     agentId,
+    projectId,
   });
   const { options: modelOptions, defaultOption: defaultModel } =
     useLlmProviders(effectiveAgentId ?? null, selectedModel?.modelVersion);

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -15,8 +15,10 @@ import {
 
 import { useWorkspaceSettings } from "@/api/settings";
 import { useAvailableTools } from "@/api/tools";
+import { useLlmProviders } from "@/api/chat/llm";
 import type { ChatToolOptions } from "@/api/chat/stream";
 import { DEFAULT_AGENT_ID, type MinimalAgent } from "@/chat/agents";
+import { toLlmOverride, type ModelOption } from "@/chat/models";
 import {
   buildInternalSearchFilters,
   configuredSources,
@@ -33,6 +35,7 @@ import { useAgentPreferences } from "@/hooks/useAgentPreferences";
 import { useConnectorSources } from "@/hooks/useConnectorSources";
 import { useDeepResearchToggle } from "@/hooks/useDeepResearchToggle";
 import { useForcedTools } from "@/hooks/useForcedTools";
+import { useSelectedModel } from "@/hooks/useSelectedModel";
 import { useSourceSelection } from "@/hooks/useSourceSelection";
 
 const NO_TOOLS: ToolSnapshot[] = [];
@@ -51,6 +54,11 @@ export interface ComposerTools {
   toggleForcedTool: (toolId: number) => void;
   disabledToolIds: number[];
   toggleToolEnabled: (toolId: number) => void;
+  modelOptions: ModelOption[];
+  // The user's pick if there is one, else the agent's default. For display only — the send path
+  // reads the pick alone.
+  effectiveModel: ModelOption | null;
+  selectModel: (model: ModelOption) => void;
   sourceToolId: number | null;
   sourceOptions: DocumentSource[];
   enabledSourceCount: number;
@@ -163,6 +171,14 @@ export function useComposerToolsState({
       effectiveAgentId == null ? NO_IDS : disabledToolIdsFor(effectiveAgentId),
     [effectiveAgentId, disabledToolIdsFor],
   );
+
+  const { selectedModel, selectModel } = useSelectedModel({
+    chatSessionId,
+    agentId,
+  });
+  const { options: modelOptions, defaultOption: defaultModel } =
+    useLlmProviders(effectiveAgentId ?? null, selectedModel?.modelVersion);
+  const effectiveModel = selectedModel ?? defaultModel;
 
   // Inert in a project: a connector-type filter would exclude the project's own files.
   const sourcesManaged = !isProjectWorkflow;
@@ -378,6 +394,9 @@ export function useComposerToolsState({
       toggleForcedTool,
       disabledToolIds,
       toggleToolEnabled,
+      modelOptions,
+      effectiveModel,
+      selectModel,
       sourceToolId,
       sourceOptions,
       enabledSourceCount,
@@ -413,6 +432,10 @@ export function useComposerToolsState({
           internalSearchFilters: buildInternalSearchFilters(
             sourceOptions.filter(isSourceEnabled),
           ),
+          // Only an explicit pick is sent. Sending the resolved default instead would pin the
+          // conversation to whatever this client happened to read, rather than letting the
+          // backend apply its own.
+          llmOverride: selectedModel ? toLlmOverride(selectedModel) : null,
         };
       },
     }),
@@ -427,6 +450,10 @@ export function useComposerToolsState({
       toggleForcedTool,
       disabledToolIds,
       toggleToolEnabled,
+      modelOptions,
+      effectiveModel,
+      selectedModel,
+      selectModel,
       sourceToolId,
       sourceOptions,
       enabledSourceCount,

--- a/mobile/src/state/ComposerToolsProvider.tsx
+++ b/mobile/src/state/ComposerToolsProvider.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 
 import { useWorkspaceSettings } from "@/api/settings";
+import { useAvailableTools } from "@/api/tools";
 import type { ChatToolOptions } from "@/api/chat/stream";
 import { DEFAULT_AGENT_ID, type MinimalAgent } from "@/chat/agents";
 import {
@@ -43,6 +44,9 @@ export interface ComposerTools {
   deepResearchEnabled: boolean;
   toggleDeepResearch: () => void;
   actionTools: ToolSnapshot[];
+  // A row in actionTools whose backend integration isn't configured right now (e.g. no image
+  // provider set up) — still assigned to the agent, but not usable until an admin configures it.
+  unavailableToolIds: number[];
   forcedToolId: number | null;
   toggleForcedTool: (toolId: number) => void;
   disabledToolIds: number[];
@@ -79,6 +83,8 @@ export function useComposerToolsState({
   projectId,
 }: ComposerToolsInputs): ComposerTools {
   const { settings } = useWorkspaceSettings();
+  const { tools: globallyAvailableTools, isSuccess: availableToolsLoaded } =
+    useAvailableTools();
   const agentId = agent?.id;
 
   const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({
@@ -140,6 +146,17 @@ export function useComposerToolsState({
     () => (effectiveAgent ? displayableTools(effectiveAgent.tools) : NO_TOOLS),
     [effectiveAgent],
   );
+
+  // The search tool's own availability is governed by connector state, not this generic check —
+  // matching web, which never marks it unavailable here. Before the fetch resolves, treat every
+  // tool as available rather than flashing them all as unavailable.
+  const unavailableToolIds = useMemo(() => {
+    if (!availableToolsLoaded) return NO_IDS;
+    const availableIds = new Set(globallyAvailableTools.map((t) => t.id));
+    return actionTools
+      .filter((tool) => !availableIds.has(tool.id) && !isSearchTool(tool))
+      .map((tool) => tool.id);
+  }, [actionTools, availableToolsLoaded, globallyAvailableTools]);
 
   const disabledToolIds = useMemo(
     () =>
@@ -352,6 +369,7 @@ export function useComposerToolsState({
       deepResearchEnabled,
       toggleDeepResearch,
       actionTools,
+      unavailableToolIds,
       forcedToolId,
       /*
        * Unwrapped: the effect already keeps "search on" and "some source on" equivalent. Web
@@ -404,6 +422,7 @@ export function useComposerToolsState({
       deepResearchEnabled,
       toggleDeepResearch,
       actionTools,
+      unavailableToolIds,
       forcedToolId,
       toggleForcedTool,
       disabledToolIds,

--- a/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
+++ b/mobile/src/state/__tests__/ComposerToolsProvider.test.tsx
@@ -285,6 +285,7 @@ describe("useComposerToolsState", () => {
       allowedToolIds: null,
       forcedToolId: null,
       internalSearchFilters: null,
+      llmOverride: null,
     });
 
     act(() => result.current.toggleDeepResearch());
@@ -504,6 +505,7 @@ describe("useComposerToolsState", () => {
       allowedToolIds: null,
       forcedToolId: null,
       internalSearchFilters: null,
+      llmOverride: null,
     });
   });
 

--- a/mobile/src/state/__tests__/fixtures.ts
+++ b/mobile/src/state/__tests__/fixtures.ts
@@ -10,6 +10,7 @@ export function makeComposerTools(
     deepResearchEnabled: false,
     toggleDeepResearch: jest.fn(),
     actionTools: [],
+    unavailableToolIds: [],
     forcedToolId: null,
     toggleForcedTool: jest.fn(),
     disabledToolIds: [],

--- a/mobile/src/state/__tests__/fixtures.ts
+++ b/mobile/src/state/__tests__/fixtures.ts
@@ -15,6 +15,9 @@ export function makeComposerTools(
     toggleForcedTool: jest.fn(),
     disabledToolIds: [],
     toggleToolEnabled: jest.fn(),
+    modelOptions: [],
+    effectiveModel: null,
+    selectModel: jest.fn(),
     sourceToolId: null,
     sourceOptions: [],
     enabledSourceCount: 0,
@@ -28,6 +31,7 @@ export function makeComposerTools(
       allowedToolIds: null,
       forcedToolId: null,
       internalSearchFilters: null,
+      llmOverride: null,
     }),
     ...overrides,
   };


### PR DESCRIPTION
## Description

- Adds a model picker to the composer, beside the send button, built on a new anchored `Popover` primitive (RN counterpart of Opal's).
- Moves Deep Research out of the composer toolbar and into the actions sheet, freeing width for the model pill.
- Greys out actions whose backend integration isn't configured, matching how web treats them, instead of showing them as usable.
- Enables Send as soon as a file finishes uploading, rather than waiting for backend indexing to complete.
- Refreshes the recent-files list after a chat attachment upload — it previously only refreshed for project uploads.
- Fixes the selected state of `SelectButton` and `Switch`, which used a colour token that doesn't exist and so rendered with no tint at all.
- Centres the composer's pill controls, which sat higher than the buttons beside them.
- Polls agents, chat sessions, and available tools every 60s so changes made on web or another device appear without backgrounding the app.
- Fixes a crash when opening a chat inside a project, caused by an incorrect Worklets babel option that left `remend` outside the worklet bundle.
- Documents the Xcode 26.4+ requirement, below which `expo-modules-jsi` fails to compile.

## How Has This Been Tested?

Unit tests added for the model-selection logic, the picker, and the changed composer behaviour; the full mobile suite passes (92 suites, 851 tests), along with typecheck and lint. The model selector, file upload, actions sheet, and Deep Research changes were all verified on the iOS simulator.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
