### PR TITLE
feat(opal): give LineItemButton the states a menu row needs

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -39,6 +39,7 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 | `target`        | `string`                           | —                | Anchor target (e.g. `"_blank"`)                   |
 | `group`         | `string`                           | —                | Interactive group key                             |
 | `ref`           | `React.Ref<HTMLElement>`           | —                | Forwarded ref                                     |
+| `disabled`      | `boolean`                          | `false`          | Disabled colors; suppresses the row's own click only — nested `rightChildren` stay clickable |
 
 ### Sizing
 
@@ -49,6 +50,7 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 | `padding`     | `0 \| 0.5 \| 1 \| 2` | `0.5`    | Padding around the inner `ContentAction`, as a spacing step (`N / 4` rem) |
 | `tooltip`     | `string`             | —        | Tooltip text shown on hover                                               |
 | `tooltipSide` | `TooltipSide`        | `"top"`  | Tooltip side                                                              |
+| `data-testid` | `string`             | —        | Test hook placed on the row element, not on the inner `ContentAction`     |
 
 ### Content (pass-through to ContentAction)
 

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -19,7 +19,14 @@ type ContentPassthroughProps = DistributiveOmit<
 
 type LineItemButtonOwnProps = Pick<
   InteractiveStatefulProps,
-  "state" | "interaction" | "onClick" | "href" | "target" | "group" | "ref"
+  | "state"
+  | "interaction"
+  | "onClick"
+  | "href"
+  | "target"
+  | "group"
+  | "ref"
+  | "disabled"
 > & {
   /** Interactive select variant. @default "select-light" */
   selectVariant?: "select-light" | "select-heavy";
@@ -35,6 +42,12 @@ type LineItemButtonOwnProps = Pick<
 
   /** Which side the tooltip appears on. @default "top" */
   tooltipSide?: TooltipSide;
+
+  /**
+   * Test hook placed on the row element. Declared explicitly because the rest
+   * of the props go to `ContentAction`, which does not reach the DOM.
+   */
+  "data-testid"?: string;
 };
 
 type LineItemButtonProps = ContentPassthroughProps & LineItemButtonOwnProps;
@@ -89,6 +102,7 @@ function LineItemButton({
   target,
   group,
   ref,
+  disabled,
 
   // Sizing
   rounding = 3,
@@ -96,6 +110,7 @@ function LineItemButton({
   padding = 0.5,
   tooltip,
   tooltipSide = "top",
+  "data-testid": testId,
 
   // ContentAction pass-through
   ...contentActionProps
@@ -122,11 +137,13 @@ function LineItemButton({
       target={target}
       group={group}
       ref={ref}
+      disabled={disabled}
     >
       <Interactive.Container
         width={width}
         size="fit"
         rounding={rounding}
+        data-testid={testId}
         {...rowButtonProps}
       >
         <div className="w-full p-1.5">

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -29,6 +29,13 @@ interface TextProps extends WithoutStyles<
   maxLines?: number;
 
   /**
+   * Strike the text through. This is a presentational state (e.g. an option
+   * that is switched off), so it stays a prop rather than `~~` in the content:
+   * the caller keeps passing the plain string, and no escaping is needed.
+   */
+  strikethrough?: boolean;
+
+  /**
    * Plain string, `markdown()` for inline markdown, or `richNodes()` for
    * sentences that embed inline components (e.g. next-intl `t.rich` output).
    */
@@ -95,6 +102,7 @@ function Text({
   as: Tag = "span",
   nowrap,
   maxLines,
+  strikethrough,
   children,
   ...rest
 }: TextProps) {
@@ -104,7 +112,8 @@ function Text({
     COLOR_CONFIG[color],
     nowrap && "whitespace-nowrap",
     maxLines === 1 && "truncate",
-    maxLines && maxLines > 1 && "overflow-hidden"
+    maxLines && maxLines > 1 && "overflow-hidden",
+    strikethrough && "line-through"
   );
 
   const style =

--- a/web/lib/opal/src/core/interactive/container/components.tsx
+++ b/web/lib/opal/src/core/interactive/container/components.tsx
@@ -22,7 +22,7 @@ import {
  * Extends standard `<div>` attributes (minus `className` and `style`).
  */
 interface InteractiveContainerProps extends WithoutStyles<
-  React.HTMLAttributes<HTMLDivElement>
+  React.HTMLAttributes<HTMLDivElement> & { "data-testid"?: string }
 > {
   /**
    * Ref forwarded to the underlying element.

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -42,6 +42,9 @@ interface ContentLgProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -90,6 +93,7 @@ function ContentLg({
   description,
   titleMaxLines,
   descriptionMaxLines,
+  strikethrough,
   editable,
   onTitleChange,
   ref,
@@ -164,6 +168,7 @@ function ContentLg({
               font={config.titleFont}
               color="inherit"
               maxLines={titleMaxLines}
+              strikethrough={strikethrough}
               title={toPlainString(title)}
               onClick={editable ? startEditing : undefined}
             >

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -88,6 +88,9 @@ interface ContentMdProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** Size preset. Default: `"main-ui"`. */
   sizePreset?: ContentMdSizePreset;
 
@@ -158,6 +161,7 @@ function ContentMd({
   auxIcon,
   tag,
   titleMaxLines,
+  strikethrough,
   sizePreset = "main-ui",
   ref,
   editHandle,
@@ -259,6 +263,7 @@ function ContentMd({
               font={config.titleFont}
               color="inherit"
               maxLines={titleMaxLines}
+              strikethrough={strikethrough}
               title={toPlainString(title)}
               onClick={editable ? handleTitleClick : undefined}
             >

--- a/web/lib/opal/src/layouts/content/ContentSm.tsx
+++ b/web/lib/opal/src/layouts/content/ContentSm.tsx
@@ -38,6 +38,9 @@ interface ContentSmProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** ARIA role forwarded to the title text element. */
   role?: string;
 
@@ -78,6 +81,7 @@ function ContentSm({
   orientation = "inline",
   titleMaxLines,
   role,
+  strikethrough,
   ref,
 }: ContentSmProps) {
   const config = CONTENT_SM_PRESETS[sizePreset];
@@ -105,6 +109,7 @@ function ContentSm({
         font={config.titleFont}
         color="inherit"
         maxLines={titleMaxLines}
+        strikethrough={strikethrough}
         title={toPlainString(title)}
         role={role}
       >

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -48,6 +48,9 @@ interface ContentXlProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -108,6 +111,7 @@ function ContentXl({
   description,
   titleMaxLines,
   descriptionMaxLines,
+  strikethrough,
   editable,
   onTitleChange,
   moreIcon1: MoreIcon1,
@@ -214,6 +218,7 @@ function ContentXl({
             font={config.titleFont}
             color="inherit"
             maxLines={titleMaxLines}
+            strikethrough={strikethrough}
             title={toPlainString(title)}
             onClick={editable ? startEditing : undefined}
           >

--- a/web/lib/opal/src/layouts/content/README.md
+++ b/web/lib/opal/src/layouts/content/README.md
@@ -65,7 +65,7 @@ Invalid combinations (e.g. `sizePreset="headline" + variant="body"`) are exclude
 | `moreIcon1` | `IconFunctionComponent` | — | Secondary icon in icon row (ContentXl only) |
 | `moreIcon2` | `IconFunctionComponent` | — | Tertiary icon in icon row (ContentXl only) |
 | `color` | `ColorTypes` | `"default"` | Icon and title color pair. `"muted-success"` / `"muted-warning"` color only the icon and leave the text at `text-03` |
-| `strikethrough` | `boolean` | `false` | Strike the title through, for a row whose option is switched off (ContentMd only) |
+| `strikethrough` | `boolean` | `false` | Strike the title through, for a title whose option is switched off |
 
 ## Internal Layouts
 

--- a/web/lib/opal/src/layouts/content/README.md
+++ b/web/lib/opal/src/layouts/content/README.md
@@ -65,6 +65,7 @@ Invalid combinations (e.g. `sizePreset="headline" + variant="body"`) are exclude
 | `moreIcon1` | `IconFunctionComponent` | — | Secondary icon in icon row (ContentXl only) |
 | `moreIcon2` | `IconFunctionComponent` | — | Tertiary icon in icon row (ContentXl only) |
 | `color` | `ColorTypes` | `"default"` | Icon and title color pair. `"muted-success"` / `"muted-warning"` color only the icon and leave the text at `text-03` |
+| `strikethrough` | `boolean` | `false` | Strike the title through, for a row whose option is switched off (ContentMd only) |
 
 ## Internal Layouts
 

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -121,6 +121,8 @@ type MdContentProps = ContentBaseProps & {
   auxIcon?: "info-gray" | "info-blue" | "warning" | "error";
   /** Tag rendered beside the title. */
   tag?: TagProps;
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
   /** Slot for a control rendered to the right (desktop) / between title and description (mobile). See ContentMd. */
   rightChildren?: React.ReactNode;
 };

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -49,6 +49,12 @@ interface ContentBaseProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /**
+   * Strike the title through — a presentational state (e.g. an option that is
+   * switched off), not content, so callers keep passing a plain string.
+   */
+  strikethrough?: boolean;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -121,8 +127,6 @@ type MdContentProps = ContentBaseProps & {
   auxIcon?: "info-gray" | "info-blue" | "warning" | "error";
   /** Tag rendered beside the title. */
   tag?: TagProps;
-  /** Strike the title through, for a row whose option is switched off. */
-  strikethrough?: boolean;
   /** Slot for a control rendered to the right (desktop) / between title and description (mobile). See ContentMd. */
   rightChildren?: React.ReactNode;
 };


### PR DESCRIPTION
## Description

Adds the three states a menu row needs from Opal, so rows can move off the
legacy `refresh-components/buttons/LineItem`, which carried them as variants
of its own. Nothing calls the new props yet — the follow-up PR that migrates
the tools popover does.

**`strikethrough` on `Text` / `ContentMd` / `Content`.** The legacy row struck
a switched-off option through, and Opal had no equivalent. This is a
presentational state, not content, so it is a prop rather than `~~` wrapped
around the title: callers keep passing a plain string, and titles holding
markdown characters (`*`, backticks, `[...](...)`) need no escaping. Exposed
only on the `main-*` arm of the `Content` union, since `ContentMd` is the
layout that implements it.

**`disabled` on `LineItemButton`.** `Interactive.Stateful` already had it;
`LineItemButton` just did not pass it through. It greys the row and drops the
row's own click, and deliberately does not set `pointer-events`, so action
buttons in `rightChildren` stay reachable — matching what the legacy row did.

**`data-testid` on `LineItemButton`.** Declared explicitly because every other
prop goes to `ContentAction`, and `ContentMd` never spreads unknown props to
the DOM, so a test hook passed today is silently dropped. It lands on the row
element.

## How Has This Been Tested?

`bun run types:check` and pre-commit (oxfmt, oxlint, tsc) pass.

Not yet exercised at runtime: no caller sets any of the three props until the
follow-up PR. Worth a look at the `Content` and `LineItemButton` stories to
confirm nothing regressed for existing callers, since `Content`'s prop union
and `Interactive.Container`'s prop type both changed shape.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `strikethrough`, `disabled`, and `data-testid` to Opal's `LineItemButton` so menu rows can move off the legacy `refresh-components/buttons/LineItem`, which carried them as variants of its own. Nothing calls the new props yet — a follow-up PR migrates the tools popover.

- `strikethrough` is a presentational prop on `Text` and every `Content` layout (via `ContentBaseProps`) rather than `~~` wrapped around the title, so callers keep passing plain strings and markdown characters (`*`, backticks, `[...](...)`) need no escaping. The inline-edit input keeps its plain styling.
- `disabled` passes through from `Interactive.Stateful`; it greys the row and suppresses the row's own click but deliberately leaves nested `rightChildren` clickable, matching the legacy row's behavior.
- `data-testid` is declared explicitly because every other prop goes to `ContentAction`, which never reaches the DOM; it lands on the row element, which required widening `Interactive.Container`'s prop type.

Type checks and pre-commit pass. Not yet exercised at runtime — worth confirming the `Content` and `LineItemButton` stories don't regress, since `Content`'s prop union and `Interactive.Container`'s prop type both changed shape.

<sup>Written for commit d574c27e77af65389f0157e38578a5d91ccff7a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

