### PR TITLE
feat(opal): let a Content title be struck through

### DIFF
--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -29,6 +29,13 @@ interface TextProps extends WithoutStyles<
   maxLines?: number;
 
   /**
+   * Strike the text through. This is a presentational state (e.g. an option
+   * that is switched off), so it stays a prop rather than `~~` in the content:
+   * the caller keeps passing the plain string, and no escaping is needed.
+   */
+  strikethrough?: boolean;
+
+  /**
    * Plain string, `markdown()` for inline markdown, or `richNodes()` for
    * sentences that embed inline components (e.g. next-intl `t.rich` output).
    */
@@ -95,6 +102,7 @@ function Text({
   as: Tag = "span",
   nowrap,
   maxLines,
+  strikethrough,
   children,
   ...rest
 }: TextProps) {
@@ -104,7 +112,8 @@ function Text({
     COLOR_CONFIG[color],
     nowrap && "whitespace-nowrap",
     maxLines === 1 && "truncate",
-    maxLines && maxLines > 1 && "overflow-hidden"
+    maxLines && maxLines > 1 && "overflow-hidden",
+    strikethrough && "line-through"
   );
 
   const style =

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -42,6 +42,9 @@ interface ContentLgProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -90,6 +93,7 @@ function ContentLg({
   description,
   titleMaxLines,
   descriptionMaxLines,
+  strikethrough,
   editable,
   onTitleChange,
   ref,
@@ -164,6 +168,7 @@ function ContentLg({
               font={config.titleFont}
               color="inherit"
               maxLines={titleMaxLines}
+              strikethrough={strikethrough}
               title={toPlainString(title)}
               onClick={editable ? startEditing : undefined}
             >

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -88,6 +88,9 @@ interface ContentMdProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** Size preset. Default: `"main-ui"`. */
   sizePreset?: ContentMdSizePreset;
 
@@ -158,6 +161,7 @@ function ContentMd({
   auxIcon,
   tag,
   titleMaxLines,
+  strikethrough,
   sizePreset = "main-ui",
   ref,
   editHandle,
@@ -259,6 +263,7 @@ function ContentMd({
               font={config.titleFont}
               color="inherit"
               maxLines={titleMaxLines}
+              strikethrough={strikethrough}
               title={toPlainString(title)}
               onClick={editable ? handleTitleClick : undefined}
             >

--- a/web/lib/opal/src/layouts/content/ContentSm.tsx
+++ b/web/lib/opal/src/layouts/content/ContentSm.tsx
@@ -38,6 +38,9 @@ interface ContentSmProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** ARIA role forwarded to the title text element. */
   role?: string;
 
@@ -78,6 +81,7 @@ function ContentSm({
   orientation = "inline",
   titleMaxLines,
   role,
+  strikethrough,
   ref,
 }: ContentSmProps) {
   const config = CONTENT_SM_PRESETS[sizePreset];
@@ -105,6 +109,7 @@ function ContentSm({
         font={config.titleFont}
         color="inherit"
         maxLines={titleMaxLines}
+        strikethrough={strikethrough}
         title={toPlainString(title)}
         role={role}
       >

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -48,6 +48,9 @@ interface ContentXlProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /** Strike the title through, for a row whose option is switched off. */
+  strikethrough?: boolean;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -108,6 +111,7 @@ function ContentXl({
   description,
   titleMaxLines,
   descriptionMaxLines,
+  strikethrough,
   editable,
   onTitleChange,
   moreIcon1: MoreIcon1,
@@ -214,6 +218,7 @@ function ContentXl({
             font={config.titleFont}
             color="inherit"
             maxLines={titleMaxLines}
+            strikethrough={strikethrough}
             title={toPlainString(title)}
             onClick={editable ? startEditing : undefined}
           >

--- a/web/lib/opal/src/layouts/content/README.md
+++ b/web/lib/opal/src/layouts/content/README.md
@@ -65,6 +65,7 @@ Invalid combinations (e.g. `sizePreset="headline" + variant="body"`) are exclude
 | `moreIcon1` | `IconFunctionComponent` | — | Secondary icon in icon row (ContentXl only) |
 | `moreIcon2` | `IconFunctionComponent` | — | Tertiary icon in icon row (ContentXl only) |
 | `color` | `ColorTypes` | `"default"` | Icon and title color pair. `"muted-success"` / `"muted-warning"` color only the icon and leave the text at `text-03` |
+| `strikethrough` | `boolean` | `false` | Strike the title through, for a title whose option is switched off |
 
 ## Internal Layouts
 

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -49,6 +49,12 @@ interface ContentBaseProps {
   /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
+  /**
+   * Strike the title through — a presentational state (e.g. an option that is
+   * switched off), not content, so callers keep passing a plain string.
+   */
+  strikethrough?: boolean;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 


### PR DESCRIPTION
## Description

A row whose option is switched off reads as struck through, and Opal had no
way to say that — the state lived only on the legacy
`refresh-components/buttons/LineItem`, as one of its variants. Rows migrating
off that component need it.

It is a presentational state, not content, so it is a prop rather than `~~`
wrapped around the title. Callers keep passing a plain string, and a title
holding markdown characters (`*`, backticks, `[...](...)`) needs no escaping
to survive — which matters here, because these titles are admin-authored tool
names.

`strikethrough` sits on `ContentBaseProps` and is threaded through all four
internal layouts (`ContentXl`, `ContentLg`, `ContentMd`, `ContentSm`), so a
caller reaches it without first working out which one its preset resolves to.
Each layout already rendered its title through the same Opal `Text`, so each
is a one-line pass-through.

One deliberate exception: the inline-edit `<input>` in Xl/Lg/Md keeps its
plain styling. Text being edited is not struck through.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `strikethrough` prop to Opal's `Content` title so rows can display an option as switched off. Previously this state only existed in the legacy `LineItem` button component; callers now pass the plain title string plus a boolean, no markdown escaping required.

<sup>Written for commit 39c5c40175ab758c7302e6a867922cfd5e350879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->