### PR TITLE
feat(opal): let a LineItemButton be disabled

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -39,6 +39,7 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 | `target`        | `string`                           | —                | Anchor target (e.g. `"_blank"`)                   |
 | `group`         | `string`                           | —                | Interactive group key                             |
 | `ref`           | `React.Ref<HTMLElement>`           | —                | Forwarded ref                                     |
+| `disabled`      | `boolean`                          | `false`          | Disabled colors; suppresses the row's own click only — nested `rightChildren` stay clickable |
 
 ### Sizing
 

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -19,7 +19,14 @@ type ContentPassthroughProps = DistributiveOmit<
 
 type LineItemButtonOwnProps = Pick<
   InteractiveStatefulProps,
-  "state" | "interaction" | "onClick" | "href" | "target" | "group" | "ref"
+  | "state"
+  | "interaction"
+  | "onClick"
+  | "href"
+  | "target"
+  | "group"
+  | "ref"
+  | "disabled"
 > & {
   /** Interactive select variant. @default "select-light" */
   selectVariant?: "select-light" | "select-heavy";
@@ -89,6 +96,7 @@ function LineItemButton({
   target,
   group,
   ref,
+  disabled,
 
   // Sizing
   rounding = 3,
@@ -122,6 +130,7 @@ function LineItemButton({
       target={target}
       group={group}
       ref={ref}
+      disabled={disabled}
     >
       <Interactive.Container
         width={width}


### PR DESCRIPTION
## Description

`Interactive.Stateful` already had `disabled`. `LineItemButton` picks every
other prop off it — `state`, `interaction`, `onClick`, `href`, `target`,
`group`, `ref` — and left this one behind, so a row had no way to say it is
unavailable. Rows migrating off the legacy
`refresh-components/buttons/LineItem` need it, since that component carried a
disabled variant of its own.

It greys the row and drops the row's own click. It deliberately does not set
`pointer-events`: a disabled row can still hold a working action button in
`rightChildren` — an unavailable tool whose "Configure" button is the whole
point of showing the row. `Interactive.Stateful` already behaves this way
(`data-disabled` applies `cursor-not-allowed` and nothing more), so this is
pass-through rather than new behaviour, and it matches the legacy row.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `disabled` prop to `LineItemButton` so rows can show they're unavailable. The prop already existed on `Interactive.Stateful` but wasn't passed through, and rows migrating from the legacy `refresh-components/buttons/LineItem` need it.

**Behavior**
- A disabled row greys out and ignores its own clicks only; `pointer-events` is deliberately not set, so buttons in `rightChildren` remain clickable, matching the legacy row.
- No callers set the prop yet — the follow-up migrating the tools popover does.

<sup>Written for commit b1bac8d42416e537d51879b3f2f052ffd8e87174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

