### PR TITLE
fix(opal): let disabled outrank a Content's own colour

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/LineItemButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/LineItemButton.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LineItemButton } from "@opal/components";
+import SvgSearch from "@opal/icons/search";
+
+const meta: Meta<typeof LineItemButton> = {
+  title: "opal/components/LineItemButton",
+  component: LineItemButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof LineItemButton>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-96">
+      <LineItemButton
+        icon={SvgSearch}
+        title="Internal Search"
+        sizePreset="main-ui"
+        variant="section"
+      />
+    </div>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-1">
+      <LineItemButton
+        icon={SvgSearch}
+        title="Empty"
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Selected"
+        state="selected"
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Disabled"
+        disabled
+        sizePreset="main-ui"
+        variant="section"
+      />
+    </div>
+  ),
+};
+
+/**
+ * Disabled has to win over `color`, and over the description's own colour.
+ *
+ * `color` replaces the `"interactive"` mode `LineItemButton` passes by
+ * default, and that mode is what lets the interactive colour variables reach
+ * the content. Every row below is disabled: each one should read as disabled
+ * — title, icon and description alike — rather than keeping the colour it has
+ * when enabled. The enabled row is there to compare against.
+ */
+export const DisabledOutranksColor: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-1">
+      <LineItemButton
+        icon={SvgSearch}
+        title="Enabled, muted"
+        description="Reads as muted"
+        color="muted"
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Disabled, no colour"
+        description="Reads as disabled"
+        disabled
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Disabled, muted"
+        description="Reads as disabled, not muted"
+        color="muted"
+        disabled
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Disabled, danger"
+        description="Reads as disabled, not danger"
+        color="danger"
+        disabled
+        sizePreset="main-ui"
+        variant="section"
+      />
+    </div>
+  ),
+};

--- a/web/lib/opal/src/components/buttons/line-item-button/LineItemButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/LineItemButton.stories.tsx
@@ -100,3 +100,54 @@ export const DisabledOutranksColor: Story = {
     </div>
   ),
 };
+
+/**
+ * `color={undefined}` has to mean "no colour given", not `"default"`.
+ *
+ * `color={condition ? "muted" : undefined}` is the obvious way to colour a row
+ * conditionally, and the falsy arm has to leave the row on the `"interactive"`
+ * mode that lets the interactive colour variables through. The two rows below
+ * must be indistinguishable, in every state — if the explicit `undefined` ever
+ * pins the row to `"default"` again, it stops responding to selection and
+ * disablement and this story shows it.
+ */
+export const UndefinedColorIsNoColor: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-1">
+      <LineItemButton
+        icon={SvgSearch}
+        title="Colour omitted, selected"
+        description="Baseline"
+        state="selected"
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Colour undefined, selected"
+        description="Must match the row above"
+        color={undefined}
+        state="selected"
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Colour omitted, disabled"
+        description="Baseline"
+        disabled
+        sizePreset="main-ui"
+        variant="section"
+      />
+      <LineItemButton
+        icon={SvgSearch}
+        title="Colour undefined, disabled"
+        description="Must match the row above"
+        color={undefined}
+        disabled
+        sizePreset="main-ui"
+        variant="section"
+      />
+    </div>
+  ),
+};

--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -61,6 +61,7 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 | `sizePreset`    | `SizePreset`            | `"headline"`   | Content size preset                          |
 | `variant`       | `ContentVariant`        | `"heading"`    | Content layout variant                       |
 | `rightChildren` | `ReactNode`             | —              | Content after the label (e.g. action button) |
+| `color`         | `ColorTypes`            | `"interactive"` | Content colour mode. Defaults to `"interactive"`, which is what lets the row's hover / selected / disabled colours reach its title and icon — passing anything else opts out of that. `undefined` counts as not passing one. |
 
 All other `ContentAction` / `Content` props (`editable`, `onTitleChange`, `optional`, `auxIcon`, `tag`, etc.) are also passed through. Note: `withInteractive` is always `true` inside `LineItemButton` and cannot be overridden.
 

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -105,6 +105,17 @@ function LineItemButton({
   tooltip,
   tooltipSide = "top",
 
+  /*
+   * Taken out of the pass-through and defaulted here rather than written
+   * before the spread. A spread copies a key even when its value is
+   * `undefined`, so `color={condition ? "muted" : undefined}` — the obvious
+   * way to colour a row conditionally — used to overwrite the default and drop
+   * the row to `"default"`, which pins its colours and stops it responding to
+   * hover, selection or disablement. A destructuring default treats `undefined`
+   * as absent, so that call now means what it looks like.
+   */
+  color = "interactive",
+
   // ContentAction pass-through
   ...contentActionProps
 }: LineItemButtonProps) {
@@ -140,7 +151,7 @@ function LineItemButton({
       >
         <div className="w-full p-1.5">
           <ContentAction
-            color="interactive"
+            color={color}
             {...(contentActionProps as ContentActionProps)}
             padding={padding}
           />

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -207,7 +207,7 @@ function ContentLg({
         >
           <Text
             font="secondary-body"
-            color="text-03"
+            color="inherit"
             as="p"
             maxLines={descriptionMaxLines}
           >

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -272,9 +272,11 @@ function ContentMd({
           )}
 
           {suffix && (
-            <Text font={config.optionalFont} color="text-03">
-              {suffix === "optional" ? "(Optional)" : suffix}
-            </Text>
+            <span className="opal-content-md-suffix">
+              <Text font={config.optionalFont} color="inherit">
+                {suffix === "optional" ? "(Optional)" : suffix}
+              </Text>
+            </span>
           )}
 
           {auxIcon &&
@@ -333,7 +335,7 @@ function ContentMd({
         >
           <Text
             font="secondary-body"
-            color="text-03"
+            color="inherit"
             as="p"
             maxLines={descriptionMaxLines}
           >

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -249,7 +249,7 @@ function ContentXl({
         <div className="opal-content-xl-description">
           <Text
             font="secondary-body"
-            color="text-03"
+            color="inherit"
             as="p"
             maxLines={descriptionMaxLines}
           >

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -78,6 +78,30 @@
   --content-foreground-icon: var(--interactive-foreground-icon);
 }
 
+/* Disabled is a state, so it outranks whatever the content normally looks
+   like.
+
+   An interactive surface dims through the interactive colour variables rather
+   than the blanket `opacity-50` that `core/disabled` gives everything else, so
+   a `Content` inside one has to follow those variables. Only the `interactive`
+   mode does on its own — every other mode pins `color` and stops inheriting,
+   which is what left a disabled row still showing its resting colour.
+
+   Keyed off `.interactive[data-disabled]` rather than any one component, so it
+   holds for everything that puts a `Content` inside an interactive surface. */
+.interactive[data-disabled] [data-content-color] {
+  --content-foreground: var(--interactive-foreground);
+  --content-foreground-icon: var(--interactive-foreground-icon);
+  color: var(--content-foreground);
+}
+
+/* The description and the suffix carry an explicit `Text` colour utility, and
+   an inherited value cannot beat a declaration on the element itself. Icons
+   are left out so they keep reading `--content-foreground-icon` above. */
+.interactive[data-disabled] [data-content-color] :is(span, p, li) {
+  color: var(--interactive-foreground);
+}
+
 /* ===========================================================================
    Content — ContentXl
 

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -3,7 +3,9 @@
 /* ===========================================================================
    Content — Shared color properties
 
-   Two registered CSS custom properties drive all Content title + icon colors.
+   Three registered CSS custom properties drive every Content color. Nothing
+   inside a layout hardcodes one: a caller overriding the variables on the
+   wrapper reaches the title, the icon and the secondary text alike.
    The `data-content-color` attribute on the Content dispatcher's wrapper div
    selects the color mode. Since the properties use `inherits: true`, all
    descendant layout elements pick up the values automatically.
@@ -25,9 +27,22 @@
   initial-value: transparent;
 }
 
+/* Description and suffix — the muted text beside and below the title. */
+@property --content-foreground-secondary {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: transparent;
+}
+
 /* ---------------------------------------------------------------------------
    Color modes — driven by `data-content-color` on the dispatcher wrapper
    --------------------------------------------------------------------------- */
+
+/* Set once rather than per mode: the secondary text is `text-03` in all of
+   them. A mode that needs its own can still override below. */
+[data-content-color] {
+  --content-foreground-secondary: var(--text-03);
+}
 
 [data-content-color="default"] {
   --content-foreground: var(--text-04);
@@ -92,14 +107,8 @@
 .interactive[data-disabled] [data-content-color] {
   --content-foreground: var(--interactive-foreground);
   --content-foreground-icon: var(--interactive-foreground-icon);
+  --content-foreground-secondary: var(--interactive-foreground);
   color: var(--content-foreground);
-}
-
-/* The description and the suffix carry an explicit `Text` colour utility, and
-   an inherited value cannot beat a declaration on the element itself. Icons
-   are left out so they keep reading `--content-foreground-icon` above. */
-.interactive[data-disabled] [data-content-color] :is(span, p, li) {
-  color: var(--interactive-foreground);
 }
 
 /* ===========================================================================
@@ -190,6 +199,13 @@
 /* ---------------------------------------------------------------------------
    Description
    --------------------------------------------------------------------------- */
+
+.opal-content-xl-description,
+.opal-content-lg-description,
+.opal-content-md-description,
+.opal-content-md-suffix {
+  color: var(--content-foreground-secondary);
+}
 
 .opal-content-xl-description {
   @apply text-left w-full;


### PR DESCRIPTION
## Description

A row could be disabled and not look it.

`LineItemButton` passes `color="interactive"` to its `ContentAction`, and only
that mode defers to the interactive colour variables — it sets `color: inherit`
and lets `--interactive-foreground` through. Every other mode sets `color`
outright and stops inheriting. Because the caller's props are spread *after*
that default, any explicit `color` replaces `"interactive"`, so `disabled`
together with a colour produced a row that took the disabled cursor, the
`aria-disabled` and the suppressed click, but kept its resting colour.

Disabled is a state, so it outranks what the content normally looks like — a
disabled danger button isn't still red.

Interactive surfaces dim through the colour variables rather than the blanket
`opacity-50` that `core/disabled` applies to everything else (`core/disabled/styles.css:9`
spells that split out), so the fix keeps to that track: a `Content` inside a
disabled interactive surface now follows those variables whatever its colour
mode. It is keyed off `.interactive[data-disabled]` rather than any one
component, so it holds for anything composing `Interactive` with `Content` —
`LineItemButton`, `SelectButton`, `OpenButton` and anything added later — not
just the row that surfaced it.

The description and the suffix need the second selector. They carry an explicit
`Text` colour utility (`color="text-03"` in all four layouts), and an inherited
value cannot beat a declaration on the element itself — without it a disabled
row would render its description *darker* than its title. Icons stay out of it
so they keep reading `--content-foreground-icon`; every disabled variant sets
that to the same token as `--interactive-foreground`, so nothing moves.

No `!important`: `.interactive[data-disabled] [data-content-color]` is `(0,3,0)`
against `[data-content-color="muted"]`'s `(0,1,0)`.

### Also audited, deliberately not changed

Two other components have colour that a disabled ancestor cannot reach, but
neither is the same bug and both need a design decision rather than a cascade
fix:

- **`Tabs`** isn't built on `Interactive` at all — it's a Radix trigger with a
  native `disabled` — and `tabs/styles.css` has no disabled rule whatsoever, so
  a disabled tab keeps its inactive colour. That's a missing state, not an
  inverted one.
- **`IconContainer`** pins `text-text-02/03/04` per size preset, so it keeps its
  colour inside a disabled surface.

`Card` and `LinkButton` are already correct — both dim with `opacity-50`, which
composites over whatever colours sit underneath.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disabled interactive surfaces (like `LineItemButton`) so they dim to the interactive foreground variables instead of keeping their resting color when an explicit `color` prop is set. Previously a disabled row with a color kept its normal color; now the title, description, and suffix follow the disabled foreground for any component composing `Interactive` with `Content`. Also fixes `color={undefined}`, which used to reset the row to `"default"` mode and pin its colors; it now means "no color given". Icons stay unchanged.

Refactored `Content` so every color comes from wrapper variables: `--content-foreground-secondary` joins the registered properties, and the description and suffix inherit it instead of pinning `text-03` (the suffix gains a `span`). The disabled override is now a pure variable change rather than a second selector reaching into descendants. `LineItemButton`'s `color` defaults via destructuring, so a spread of caller props can't overwrite it with `undefined`.

Adds `LineItemButton` stories — `DisabledOutranksColor` (disabled rows with `muted` and `danger` colors), `UndefinedColorIsNoColor` (omitting `color` and passing `undefined` render identically) — plus `Default` and `States` baselines. The precedence lives in the CSS cascade, invisible to jest, so the stories catch regressions via visual comparison.

<sup>Written for commit af95e0f7342eda6520f223b481af0ebd7b2eaea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

