### PR TITLE
fix(api): give every error response a machine-readable error_code

### DIFF
--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -110,6 +110,19 @@ class OnyxErrorCode(Enum):
         self.code = code
         self.status_code = status_code
 
+    @classmethod
+    def for_status(cls, status_code: int) -> "OnyxErrorCode":
+        """The code to report for an error raised without one.
+
+        A bare ``HTTPException`` or ``ValueError`` carries a status and a
+        sentence, so a machine client has nothing stable to match on. This
+        gives those responses the same code vocabulary as ``OnyxError``.
+        """
+        canonical = _CANONICAL_CODE_FOR_STATUS.get(status_code)
+        if canonical is not None:
+            return canonical
+        return cls.INTERNAL_ERROR if status_code >= 500 else cls.BAD_REQUEST
+
     def detail(self, message: str | None = None) -> dict[str, str]:
         """Build a structured error detail dict.
 
@@ -122,3 +135,22 @@ class OnyxErrorCode(Enum):
             "error_code": self.code,
             "detail": message or self.code,
         }
+
+
+# The code a status maps to when the raise site named none. Only statuses with
+# an unambiguous meaning are listed; anything else falls back by class.
+_CANONICAL_CODE_FOR_STATUS: dict[int, OnyxErrorCode] = {
+    400: OnyxErrorCode.BAD_REQUEST,
+    401: OnyxErrorCode.UNAUTHENTICATED,
+    403: OnyxErrorCode.UNAUTHORIZED,
+    404: OnyxErrorCode.NOT_FOUND,
+    409: OnyxErrorCode.CONFLICT,
+    413: OnyxErrorCode.PAYLOAD_TOO_LARGE,
+    422: OnyxErrorCode.VALIDATION_ERROR,
+    429: OnyxErrorCode.RATE_LIMITED,
+    500: OnyxErrorCode.INTERNAL_ERROR,
+    501: OnyxErrorCode.NOT_IMPLEMENTED,
+    502: OnyxErrorCode.BAD_GATEWAY,
+    503: OnyxErrorCode.SERVICE_UNAVAILABLE,
+    504: OnyxErrorCode.GATEWAY_TIMEOUT,
+}

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -60,6 +60,7 @@ from onyx.db.engine.async_sql_engine import (
 from onyx.db.engine.connection_warmup import warm_up_connections
 from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.sso_provider import seed_saml_provider_from_conf_dir
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.file_store.file_store import get_default_file_store
 from onyx.hooks.registry import validate_registry
@@ -215,7 +216,14 @@ def validation_exception_handler(request: Request, exc: Exception) -> JSONRespon
 
     exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
     logger.exception("%s: %s", request, exc_str)
-    content = {"status_code": 422, "message": exc_str, "data": None}
+    # message/status_code/data are kept for existing clients; error_code and
+    # detail make the body match every other error the API returns.
+    content = {
+        "status_code": 422,
+        "message": exc_str,
+        "data": None,
+        **OnyxErrorCode.VALIDATION_ERROR.detail(exc_str),
+    }
     return JSONResponse(content=content, status_code=422)
 
 
@@ -229,9 +237,14 @@ def value_error_handler(_: Request, exc: Exception) -> JSONResponse:
     except Exception:
         # log stacktrace
         logger.exception("ValueError")
+    # "message" is what this handler has always returned; the code and detail
+    # are added so a bare ValueError reads like any other Onyx error.
     return JSONResponse(
         status_code=400,
-        content={"message": str(exc)},
+        content={
+            "message": str(exc),
+            **OnyxErrorCode.BAD_REQUEST.detail(str(exc)),
+        },
     )
 
 
@@ -489,9 +502,14 @@ def log_http_error(request: Request, exc: Exception) -> JSONResponse:
         logger.error(error_msg)
 
     detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+    # Routes that raise HTTPException name no error code, so derive the
+    # canonical one for the status. Clients reading "detail" are unaffected.
     return JSONResponse(
         status_code=status_code,
-        content={"detail": detail},
+        content={
+            "error_code": OnyxErrorCode.for_status(status_code).code,
+            "detail": detail,
+        },
     )
 
 

--- a/backend/tests/unit/onyx/error_handling/test_error_contract.py
+++ b/backend/tests/unit/onyx/error_handling/test_error_contract.py
@@ -1,0 +1,130 @@
+"""Every error the API returns carries a machine-readable error_code.
+
+OnyxError always did (see test_exceptions.py). These are the three paths that
+did not: a bare HTTPException, a bare ValueError, and request validation. The
+fields each handler returned before are kept, so existing readers of "detail"
+and "message" are unaffected.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.main import log_http_error, validation_exception_handler, value_error_handler
+
+
+class _Body(BaseModel):
+    count: int
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    # Registered exactly as get_application does.
+    for status_code in (400, 401, 403, 404, 500):
+        app.add_exception_handler(status_code, log_http_error)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(ValueError, value_error_handler)
+
+    @app.get("/http-error")
+    def _http_error() -> None:
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    @app.get("/dict-detail")
+    def _dict_detail() -> None:
+        raise HTTPException(status_code=400, detail={"field": "name"})
+
+    @app.get("/value-error")
+    def _value_error() -> None:
+        raise ValueError("Model 'gpt-9' is not valid for provider_id=3")
+
+    @app.post("/validated")
+    def _validated(body: _Body) -> None:  # noqa: ARG001
+        return None
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestCanonicalCodeForStatus:
+    @pytest.mark.parametrize(
+        "status_code,expected",
+        [
+            (400, "BAD_REQUEST"),
+            (401, "UNAUTHENTICATED"),
+            (403, "UNAUTHORIZED"),
+            (404, "NOT_FOUND"),
+            (409, "CONFLICT"),
+            (422, "VALIDATION_ERROR"),
+            (500, "INTERNAL_ERROR"),
+            (503, "SERVICE_UNAVAILABLE"),
+        ],
+    )
+    def test_known_statuses(self, status_code: int, expected: str) -> None:
+        assert OnyxErrorCode.for_status(status_code).code == expected
+
+    def test_unlisted_statuses_fall_back_by_class(self) -> None:
+        assert OnyxErrorCode.for_status(418) is OnyxErrorCode.BAD_REQUEST
+        assert OnyxErrorCode.for_status(507) is OnyxErrorCode.INTERNAL_ERROR
+
+    def test_every_mapped_code_agrees_with_its_own_status(self) -> None:
+        """A status must not map to a code that reports a different status.
+
+        422 is the deliberate exception. VALIDATION_ERROR is declared 400,
+        which is the right default for an OnyxError raise site, and it is still
+        the right name for a rejected request body.
+        """
+        for status_code in (400, 401, 404, 409, 429, 500, 502, 503, 504):
+            assert OnyxErrorCode.for_status(status_code).status_code == status_code
+
+        assert OnyxErrorCode.for_status(422) is OnyxErrorCode.VALIDATION_ERROR
+
+
+class TestHTTPExceptionContract:
+    def test_body_carries_code_and_keeps_detail(self, client: TestClient) -> None:
+        response = client.get("/http-error")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error_code": "NOT_FOUND",
+            "detail": "Connector not found",
+        }
+
+    def test_a_non_string_detail_is_left_alone(self, client: TestClient) -> None:
+        """detail may be a dict; the code is added beside it, not over it."""
+        response = client.get("/dict-detail")
+
+        assert response.status_code == 400
+        body: dict[str, Any] = response.json()
+        assert body["detail"] == {"field": "name"}
+        assert body["error_code"] == "BAD_REQUEST"
+
+
+class TestValueErrorContract:
+    def test_body_gains_a_code_and_keeps_message(self, client: TestClient) -> None:
+        response = client.get("/value-error")
+
+        assert response.status_code == 400
+        body: dict[str, Any] = response.json()
+        # what this handler has always returned
+        assert body["message"] == "Model 'gpt-9' is not valid for provider_id=3"
+        # what a machine client can now match on
+        assert body["error_code"] == "BAD_REQUEST"
+        assert body["detail"] == body["message"]
+
+
+class TestValidationErrorContract:
+    def test_body_gains_a_code_and_keeps_its_fields(self, client: TestClient) -> None:
+        response = client.post("/validated", json={"count": "not-a-number"})
+
+        assert response.status_code == 422
+        body: dict[str, Any] = response.json()
+        assert body["status_code"] == 422
+        assert body["data"] is None
+        assert body["message"]
+        assert body["error_code"] == "VALIDATION_ERROR"
+        assert body["detail"] == body["message"]


### PR DESCRIPTION
## Description

`OnyxError` returns `{"error_code", "detail"}`, and `backend/CLAUDE.md` makes it the house
standard. Three paths bypass it and return no code at all:

| Path | Body today |
|---|---|
| a bare `HTTPException`, via `log_http_error` | `{"detail": ...}` |
| a bare `ValueError`, via `value_error_handler` | `{"message": ...}` — a *different key* from every other error |
| request validation | `{"status_code", "message", "data"}` |

A human reads the sentence and moves on. A machine client cannot: it has a status and prose,
so it cannot tell a bad request from a server fault, and it cannot decide whether to retry.
The Terraform provider is the case in hand, but this is the contract for any API client.

Rather than rewrite the ~430 raise sites, this fixes the three handlers they all land in.
`OnyxErrorCode.for_status` maps a status to its canonical code, falling back by class for
anything unlisted. `log_http_error` is registered for 400, 401, 403, 404 and 500 — about 404
of the ~430 status literals in the backend. The rest are rare and, per the house rule, should
be raising `OnyxError` anyway.

**This is additive.** Every existing field keeps its meaning:

- `detail` still carries the same text.
- `message` still exists on the `ValueError` and validation paths.
- No status code changes.
- `web/src/lib/fetchUtils.ts` already reads `message || detail`; `mobile/src/api/client.ts`
  reads `detail` then `message`, and both now carry the same string, so what users see is
  unchanged.

Where clients already branch on `error_code` (`RATE_LIMITED`, `CREDENTIAL_INVALID`,
`BAD_GATEWAY`, `GATEWAY_TIMEOUT`), none of those codes become newly reachable — their
statuses are not among the five registered. The codes that do appear (`BAD_REQUEST`,
`NOT_FOUND`, `VALIDATION_ERROR`, ...) are already in the chat error-title vocabulary in both
web and mobile, so the only visible effect is a more specific title where there was a generic
one.

SCIM is unaffected: it builds its own RFC 7644 envelopes and registers a handler only for
`ScimAuthError`.

### One deliberate inconsistency

422 maps to `VALIDATION_ERROR` even though that code declares 400. The declared status is the
default for an `OnyxError` raise site, not a claim about every response carrying the code —
`status_code_override` exists for that reason — and `VALIDATION_ERROR` is still the right name
for a rejected body. The test pins this so it is not rediscovered as a bug.

Part of ENG-4322.

## How Has This Been Tested?

- 22 new unit tests in `backend/tests/unit/onyx/error_handling/test_error_contract.py`: the
  status→code table with its fallbacks, and each of the three handlers wired onto a
  `TestClient` exactly as `get_application` wires them — including a non-string `detail`,
  which must pass through untouched.
- Asserted against the real app object that `log_http_error` is the handler actually
  registered for 400/401/403/404/500, that the validation and `ValueError` handlers are wired,
  and that the `OnyxError` handler is still registered alongside.
- Full unit suite A/B, same flags, baseline = `origin/main` versions of the two production
  files: **11 failed / 8825 passed both ways, identical failure sets.** The 11 are
  pre-existing license-reclaim and license-api failures, flaky through the time-based
  `claim_cooldown_is_active()` shared across tests.
- Swept the consumers of these bodies: web, mobile, desktop, e2e specs, integration-test
  helpers. All read `detail` or `message`; no strict/exact-shape parsing anywhere.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a machine-readable `error_code` to every API error response so clients can distinguish error types programmatically. Previously, bare `HTTPException`, `ValueError`, and validation errors returned bodies without a stable code, leaving machine clients unable to tell bad requests from server faults or decide whether to retry.

- The three handlers that produce those responses now derive a canonical code from the HTTP status via `OnyxErrorCode.for_status`, falling back by class for unlisted statuses.
- Existing fields are preserved: `detail` keeps its text, `message` stays on the `ValueError` and validation paths, and no status codes change.
- 422 intentionally maps to `VALIDATION_ERROR` even though that code declares 400; the declared status is only the default for `OnyxError` raise sites, and the name still fits a rejected body. A test pins this behavior.
- Part of ENG-4322.

<sup>Written for commit 66cde51551effaf2d170adaaaccf16ec5bc9c707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

