### PR TITLE
feat(github): allow a per-credential base URL for GitHub Enterprise Server

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -633,7 +633,7 @@ class GithubConnector(
         # Prefer the per-credential URL so one deployment can index github.com
         # and a GitHub Enterprise Server at once; the env var is the fallback.
         # Normalize each side so a blank credential cannot shadow the env var.
-        base_url = normalize_github_base_url(
+        base_url: str | None = normalize_github_base_url(
             credentials.get("github_base_url")
         ) or normalize_github_base_url(GITHUB_CONNECTOR_BASE_URL)
 

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -32,6 +32,7 @@ from onyx.connectors.github.utils import (
     deserialize_repository,
     get_external_access_permission,
     normalize_github_base_url,
+    validate_credential_base_url,
 )
 from onyx.connectors.interfaces import (
     CheckpointedConnectorWithPermSync,
@@ -633,9 +634,16 @@ class GithubConnector(
         # Prefer the per-credential URL so one deployment can index github.com
         # and a GitHub Enterprise Server at once; the env var is the fallback.
         # Normalize each side so a blank credential cannot shadow the env var.
-        base_url: str | None = normalize_github_base_url(
+        credential_base_url: str | None = normalize_github_base_url(
             credentials.get("github_base_url")
-        ) or normalize_github_base_url(GITHUB_CONNECTOR_BASE_URL)
+        )
+        # Only the credential is user input, so only it needs the SSRF check.
+        if credential_base_url is not None:
+            validate_credential_base_url(credential_base_url)
+
+        base_url: str | None = credential_base_url or normalize_github_base_url(
+            GITHUB_CONNECTOR_BASE_URL
+        )
 
         # defaults to 30 items per page, can be set to as high as 100
         self.github_client = (

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -31,6 +31,7 @@ from onyx.connectors.github.rate_limit_utils import sleep_after_rate_limit_excep
 from onyx.connectors.github.utils import (
     deserialize_repository,
     get_external_access_permission,
+    normalize_github_base_url,
 )
 from onyx.connectors.interfaces import (
     CheckpointedConnectorWithPermSync,
@@ -629,14 +630,21 @@ class GithubConnector(
         self.github_client: Github | None = None
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        # Prefer the per-credential URL so one deployment can index github.com
+        # and a GitHub Enterprise Server at once; the env var is the fallback.
+        # Normalize each side so a blank credential cannot shadow the env var.
+        base_url = normalize_github_base_url(
+            credentials.get("github_base_url")
+        ) or normalize_github_base_url(GITHUB_CONNECTOR_BASE_URL)
+
         # defaults to 30 items per page, can be set to as high as 100
         self.github_client = (
             Github(
                 credentials["github_access_token"],
-                base_url=GITHUB_CONNECTOR_BASE_URL,
+                base_url=base_url,
                 per_page=ITEMS_PER_PAGE,
             )
-            if GITHUB_CONNECTOR_BASE_URL
+            if base_url
             else Github(credentials["github_access_token"], per_page=ITEMS_PER_PAGE)
         )
         return None

--- a/backend/onyx/connectors/github/utils.py
+++ b/backend/onyx/connectors/github/utils.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import cast
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from github import Github
 from github.Repository import Repository
@@ -31,19 +31,19 @@ def normalize_github_base_url(base_url: str | None) -> str | None:
     if base_url is None:
         return None
 
-    cleaned = base_url.strip()
+    cleaned: str = base_url.strip()
     if not cleaned:
         return None
 
     if "://" not in cleaned:
         cleaned = f"https://{cleaned}"
 
-    parsed = urlparse(cleaned)
+    parsed: ParseResult = urlparse(cleaned)
     if not parsed.hostname:
         raise ValueError(f"Invalid GitHub base URL: {base_url}")
 
     # An explicit path already points at an API root; leave it alone.
-    path = parsed.path.rstrip("/") or GHES_API_SUFFIX
+    path: str = parsed.path.rstrip("/") or GHES_API_SUFFIX
     return f"{parsed.scheme}://{parsed.netloc}{path}"
 
 

--- a/backend/onyx/connectors/github/utils.py
+++ b/backend/onyx/connectors/github/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from typing import cast
+from urllib.parse import urlparse
 
 from github import Github
 from github.Repository import Repository
@@ -13,6 +14,37 @@ from onyx.utils.variable_functionality import (
 )
 
 logger = setup_logger()
+
+
+# GitHub Enterprise Server exposes its REST API under /api/v3, while github.com
+# uses api.github.com. PyGithub needs the full API root, not the web host.
+GHES_API_SUFFIX = "/api/v3"
+
+
+def normalize_github_base_url(base_url: str | None) -> str | None:
+    """Turn a user-supplied GitHub Enterprise Server URL into a PyGithub base URL.
+
+    Accepts the web host (``https://ghes.example.com``) or the API root
+    (``https://ghes.example.com/api/v3``) and always returns the API root.
+    Returns None for blank input so callers can fall back to github.com.
+    """
+    if base_url is None:
+        return None
+
+    cleaned = base_url.strip()
+    if not cleaned:
+        return None
+
+    if "://" not in cleaned:
+        cleaned = f"https://{cleaned}"
+
+    parsed = urlparse(cleaned)
+    if not parsed.hostname:
+        raise ValueError(f"Invalid GitHub base URL: {base_url}")
+
+    # An explicit path already points at an API root; leave it alone.
+    path = parsed.path.rstrip("/") or GHES_API_SUFFIX
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
 
 
 def get_external_access_permission(

--- a/backend/onyx/connectors/github/utils.py
+++ b/backend/onyx/connectors/github/utils.py
@@ -6,8 +6,12 @@ from github import Github
 from github.Repository import Repository
 
 from onyx.access.models import ExternalAccess
+from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.github.models import SerializedRepository
+from onyx.server.security.models import web_connector_ssrf_enforced
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException, validate_outbound_http_url
 from onyx.utils.variable_functionality import (
     fetch_versioned_implementation,
     global_version,
@@ -45,6 +49,36 @@ def normalize_github_base_url(base_url: str | None) -> str | None:
     # An explicit path already points at an API root; leave it alone.
     path: str = parsed.path.rstrip("/") or GHES_API_SUFFIX
     return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def validate_credential_base_url(base_url: str) -> None:
+    """Reject a credential-supplied Enterprise Server URL that points at
+    internal infrastructure.
+
+    A workspace admin sets this field through the API, and PyGithub sends the
+    access token to whatever host it names, so it is both an SSRF surface and a
+    token-leak surface. ``GITHUB_CONNECTOR_BASE_URL`` is deployment config, set
+    by whoever runs the app, and stays exempt.
+
+    The SSRF protection level decides how strict this is, the same control the
+    web connector uses. At the default level only public hosts are reachable.
+    When an admin relaxes it, a private Enterprise Server becomes reachable but
+    cloud metadata stays blocked.
+    """
+    enforced: bool = web_connector_ssrf_enforced(
+        get_security_settings().ssrf_protection_level
+    )
+    try:
+        validate_outbound_http_url(
+            base_url,
+            https_only=True,
+            allow_private_network=not enforced,
+            block_link_local_only=not enforced,
+        )
+    except (SSRFException, ValueError) as e:
+        raise ConnectorValidationError(
+            f"Invalid GitHub Enterprise Server URL '{base_url}': {e}"
+        ) from e
 
 
 def get_external_access_permission(

--- a/backend/tests/unit/onyx/connectors/github/test_github_base_url.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_base_url.py
@@ -1,0 +1,95 @@
+import pytest
+
+from onyx.connectors.github.connector import GithubConnector
+from onyx.connectors.github.utils import normalize_github_base_url
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        # bare host gets the scheme and the GHES API root
+        ("github.example.com", "https://github.example.com/api/v3"),
+        ("https://github.example.com", "https://github.example.com/api/v3"),
+        ("https://github.example.com/", "https://github.example.com/api/v3"),
+        ("  https://github.example.com  ", "https://github.example.com/api/v3"),
+        # an explicit API root is left alone
+        ("https://github.example.com/api/v3", "https://github.example.com/api/v3"),
+        ("https://github.example.com/api/v3/", "https://github.example.com/api/v3"),
+        # non-standard paths and ports are preserved
+        ("https://example.com/github/api/v3", "https://example.com/github/api/v3"),
+        ("https://github.example.com:8443", "https://github.example.com:8443/api/v3"),
+    ],
+)
+def test_normalize_github_base_url(raw: str | None, expected: str | None) -> None:
+    assert normalize_github_base_url(raw) == expected
+
+
+def test_normalize_github_base_url_rejects_garbage() -> None:
+    with pytest.raises(ValueError):
+        normalize_github_base_url("https://")
+
+
+def _base_url_of(connector: GithubConnector) -> str:
+    assert connector.github_client is not None
+    return connector.github_client.requester.base_url
+
+
+def _connector() -> GithubConnector:
+    return GithubConnector(repo_owner="onyx-dot-app", repositories="onyx")
+
+
+def test_credential_base_url_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL", None
+    )
+    connector = _connector()
+    connector.load_credentials(
+        {
+            "github_access_token": "token",
+            "github_base_url": "https://github.example.com",
+        }
+    )
+    assert _base_url_of(connector) == "https://github.example.com/api/v3"
+
+
+def test_credential_base_url_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL",
+        "https://from-env.example.com/api/v3",
+    )
+    connector = _connector()
+    connector.load_credentials(
+        {
+            "github_access_token": "token",
+            "github_base_url": "https://from-cred.example.com",
+        }
+    )
+    assert _base_url_of(connector) == "https://from-cred.example.com/api/v3"
+
+
+@pytest.mark.parametrize("cred_value", [None, "", "   "])
+def test_env_base_url_is_the_fallback(
+    monkeypatch: pytest.MonkeyPatch, cred_value: str | None
+) -> None:
+    """Existing GHES deployments set only the env var and must keep working."""
+    monkeypatch.setattr(
+        "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL",
+        "https://from-env.example.com/api/v3",
+    )
+    connector = _connector()
+    connector.load_credentials(
+        {"github_access_token": "token", "github_base_url": cred_value}
+    )
+    assert _base_url_of(connector) == "https://from-env.example.com/api/v3"
+
+
+def test_defaults_to_github_dot_com(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL", None
+    )
+    connector = _connector()
+    connector.load_credentials({"github_access_token": "token"})
+    assert _base_url_of(connector) == "https://api.github.com"

--- a/backend/tests/unit/onyx/connectors/github/test_github_base_url.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_base_url.py
@@ -1,7 +1,28 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import pytest
 
+from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.github.connector import GithubConnector
 from onyx.connectors.github.utils import normalize_github_base_url
+from onyx.server.security.models import SSRFProtectionLevel
+
+PUBLIC_IP = "93.184.216.34"
+
+
+@contextmanager
+def _ssrf_env(
+    level: SSRFProtectionLevel = SSRFProtectionLevel.VALIDATE_ALL,
+    resolves_to: str = PUBLIC_IP,
+) -> Iterator[None]:
+    """Pin the SSRF policy and DNS so these tests never touch the network."""
+    with patch("onyx.connectors.github.utils.get_security_settings") as settings:
+        settings.return_value.ssrf_protection_level = level
+        with patch("onyx.utils.url.socket.getaddrinfo") as getaddrinfo:
+            getaddrinfo.return_value = [(2, 1, 6, "", (resolves_to, 443))]
+            yield
 
 
 @pytest.mark.parametrize(
@@ -46,12 +67,13 @@ def test_credential_base_url_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
         "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL", None
     )
     connector = _connector()
-    connector.load_credentials(
-        {
-            "github_access_token": "token",
-            "github_base_url": "https://github.example.com",
-        }
-    )
+    with _ssrf_env():
+        connector.load_credentials(
+            {
+                "github_access_token": "token",
+                "github_base_url": "https://github.example.com",
+            }
+        )
     assert _base_url_of(connector) == "https://github.example.com/api/v3"
 
 
@@ -61,12 +83,13 @@ def test_credential_base_url_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> N
         "https://from-env.example.com/api/v3",
     )
     connector = _connector()
-    connector.load_credentials(
-        {
-            "github_access_token": "token",
-            "github_base_url": "https://from-cred.example.com",
-        }
-    )
+    with _ssrf_env():
+        connector.load_credentials(
+            {
+                "github_access_token": "token",
+                "github_base_url": "https://from-cred.example.com",
+            }
+        )
     assert _base_url_of(connector) == "https://from-cred.example.com/api/v3"
 
 
@@ -80,9 +103,10 @@ def test_env_base_url_is_the_fallback(
         "https://from-env.example.com/api/v3",
     )
     connector = _connector()
-    connector.load_credentials(
-        {"github_access_token": "token", "github_base_url": cred_value}
-    )
+    with _ssrf_env():
+        connector.load_credentials(
+            {"github_access_token": "token", "github_base_url": cred_value}
+        )
     assert _base_url_of(connector) == "https://from-env.example.com/api/v3"
 
 
@@ -91,5 +115,77 @@ def test_defaults_to_github_dot_com(monkeypatch: pytest.MonkeyPatch) -> None:
         "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL", None
     )
     connector = _connector()
-    connector.load_credentials({"github_access_token": "token"})
+    with _ssrf_env():
+        connector.load_credentials({"github_access_token": "token"})
     assert _base_url_of(connector) == "https://api.github.com"
+
+
+class TestCredentialBaseUrlSSRF:
+    """The credential base URL is admin-supplied and PyGithub sends the access
+    token to whatever host it names, so it is an SSRF and token-leak surface."""
+
+    def _load(
+        self,
+        url: str,
+        level: SSRFProtectionLevel = SSRFProtectionLevel.VALIDATE_ALL,
+        resolves_to: str = PUBLIC_IP,
+    ) -> None:
+        connector = _connector()
+        with _ssrf_env(level=level, resolves_to=resolves_to):
+            connector.load_credentials(
+                {"github_access_token": "token", "github_base_url": url}
+            )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://github.example.com",  # plaintext would leak the token
+            "https://10.0.0.1",  # RFC1918
+            "https://192.168.1.1",
+            "https://127.0.0.1",  # loopback
+            "https://169.254.169.254",  # cloud metadata
+            "https://[::1]",
+            "https://metadata.google.internal",
+            "https://kubernetes.default.svc",
+            "https://localhost",
+        ],
+    )
+    def test_blocks_internal_targets(self, url: str) -> None:
+        with pytest.raises(ConnectorValidationError):
+            self._load(url)
+
+    def test_blocks_embedded_credentials(self) -> None:
+        with pytest.raises(ConnectorValidationError):
+            self._load("https://user:pass@github.example.com")
+
+    def test_blocks_hostname_that_resolves_to_a_private_ip(self) -> None:
+        """A public-looking name pointed at internal space is the real attack;
+        a hostname pattern check would not catch this."""
+        with pytest.raises(ConnectorValidationError):
+            self._load("https://github.example.com", resolves_to="10.0.0.1")
+
+    def test_allows_a_public_enterprise_server(self) -> None:
+        self._load("https://github.example.com")
+
+    def test_private_server_allowed_when_admin_relaxes_the_level(self) -> None:
+        """Self-hosted Onyx usually reaches Enterprise Server over the LAN."""
+        self._load("https://10.0.0.1", level=SSRFProtectionLevel.VALIDATE_LLM)
+
+    def test_metadata_stays_blocked_even_when_relaxed(self) -> None:
+        """Allowing the LAN must not open up the cloud metadata endpoint."""
+        with pytest.raises(ConnectorValidationError):
+            self._load(
+                "https://169.254.169.254", level=SSRFProtectionLevel.VALIDATE_LLM
+            )
+
+    def test_env_var_is_not_ssrf_checked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GITHUB_CONNECTOR_BASE_URL is deployment config, not user input.
+        Existing self-hosted Enterprise Server installs must keep working."""
+        monkeypatch.setattr(
+            "onyx.connectors.github.connector.GITHUB_CONNECTOR_BASE_URL",
+            "https://10.0.0.1/api/v3",
+        )
+        connector = _connector()
+        with _ssrf_env():
+            connector.load_credentials({"github_access_token": "token"})
+        assert _base_url_of(connector) == "https://10.0.0.1/api/v3"

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -47,6 +47,7 @@ export interface Credential<T> extends CredentialBase<T> {
 }
 export interface GithubCredentialJson {
   github_access_token: string;
+  github_base_url: string | null;
 }
 
 export interface GitbookCredentialJson {
@@ -318,7 +319,10 @@ export interface TestRailCredentialJson {
 }
 
 export const credentialTemplates: Record<ValidSources, any> = {
-  github: { github_access_token: "" } as GithubCredentialJson,
+  github: {
+    github_access_token: "",
+    github_base_url: null,
+  } as GithubCredentialJson,
   gitlab: {
     gitlab_url: "",
     gitlab_access_token: "",
@@ -547,6 +551,8 @@ export const credentialTemplates: Record<ValidSources, any> = {
 export const credentialDisplayNames: Record<string, string> = {
   // Github
   github_access_token: "GitHub Access Token",
+  github_base_url:
+    "GitHub Enterprise Server URL (optional; set your server host like https://github.example.com, leave blank for github.com)",
 
   // LumApps
   lumapps_application_id: "LumApps Application ID",


### PR DESCRIPTION
## Description

The GitHub API host comes from `GITHUB_CONNECTOR_BASE_URL`, an environment variable read once per process. Every GitHub connector in a deployment therefore points at the same host, so one instance can index github.com **or** a GitHub Enterprise Server, but never both. Multi-tenant deployments cannot use Enterprise Server at all, because a single env var cannot hold a value per tenant.

This adds an optional `github_base_url` field to the GitHub credential and prefers it over the environment variable. The env var stays as the fallback, so existing single-host deployments keep working with no change.

Notes on the approach:

- **Normalization.** Users give the web host, but PyGithub needs the API root. `normalize_github_base_url` appends `/api/v3` when the URL has no path, adds a missing scheme, and leaves an explicit API path alone. The credential and the env var are normalized separately, so a blank credential value cannot shadow the env var.
- **Document links need no change.** They come from `html_url` on the API response, so they already point at the right host.
- **Enterprise permission sync needs no change.** `doc_sync` and `group_sync` build a `GithubConnector`, call `load_credentials`, and reuse that client, so they inherit the per-credential URL.
- **Frontend is data only.** The credential form is generated from `credentialTemplates`; a `null` template value renders an optional text field. This follows the existing `gong_base_url` pattern, so no new components or validation code.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/onyx/connectors/github/test_github_base_url.py` (18 cases) cover:

- URL normalization: bare host, missing scheme, trailing slashes, an explicit `/api/v3` root, a custom path, and a non-standard port
- Rejecting a malformed URL with no host
- The credential URL taking precedence over the env var
- The env var still applying when the credential value is absent, empty, or whitespace (the backward-compatibility case for existing Enterprise Server deployments)
- Defaulting to `https://api.github.com` when neither is set

The full GitHub connector unit suite passes (81 tests), and `pre-commit` is clean on all touched files, including `ty` and the frontend TypeScript check.

Not verified against a live GitHub Enterprise Server — there is no GHES instance in CI. The change is behind an optional field and falls back to today's behavior when unset, but a real GHES run (especially permission sync) is still worth doing before we tell a customer it works.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `github_base_url` to GitHub credentials so a single deployment can index github.com and GitHub Enterprise Server at the same time; the `GITHUB_CONNECTOR_BASE_URL` env var stays as the fallback.

- `normalize_github_base_url` appends `/api/v3` to bare hosts, adds missing schemes, and leaves explicit API paths alone; a blank credential value falls back to the env var.
- The credential URL is SSRF-checked on load and rejects non-HTTPS, private/reserved hosts, and hostnames resolving into private space; strictness follows the existing SSRF protection level, and the env var stays exempt.
- The credential form renders the optional field from the `github_base_url` template, so no new UI code is needed.
- Document links and permission sync need no changes because they reuse the connector client and `html_url` response values.
- New unit tests cover URL normalization, credential-over-env precedence, env var fallback, defaulting to `api.github.com`, and SSRF blocking.
- Not verified against a live GitHub Enterprise Server; behavior is opt-in and falls back to today's default when unset.

<sup>Written for commit 7f6d8068a3c73363ac5a4320483ab0c873aa53af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

