### PR TITLE
fix(opal): stop an explicit undefined replacing a component's default

### DIFF
--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -297,6 +297,15 @@ function InputSelectTrigger({
 function InputSelectContent({
   children,
   ref,
+  /*
+   * Defaulted here rather than written before the spread below: a spread
+   * copies a key even when its value is `undefined`, so a caller writing
+   * `prop={condition ? x : undefined}` would replace the default rather than
+   * fall back to it.
+   */
+  sideOffset = 4,
+  position = "popper",
+  onMouseDown,
   ...props
 }: WithoutStyles<React.ComponentProps<typeof SelectPrimitive.Content>>) {
   return (
@@ -309,11 +318,17 @@ function InputSelectContent({
           "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
           "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95"
         )}
-        sideOffset={4}
-        position="popper"
+        sideOffset={sideOffset}
+        position={position}
+        /*
+         * Chained rather than overwritable: swallowing the press is what keeps
+         * a click inside the list from reaching whatever is behind it, so a
+         * caller adding a handler must not silently drop it.
+         */
         onMouseDown={(e) => {
           e.stopPropagation();
           e.preventDefault();
+          onMouseDown?.(e);
         }}
         {...props}
       >

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -332,6 +332,15 @@ function ModalHeader({
   description,
   onClose,
   children,
+  /*
+   * Defaulted here rather than written before the spread below: a spread
+   * copies a key even when its value is `undefined`, so a caller writing
+   * `prop={condition ? x : undefined}` would replace the default rather than
+   * fall back to it.
+   */
+  padding = 2,
+  alignItems = "start",
+  height = "fit",
   ...props
 }: ModalHeaderProps) {
   const { closeButtonRef, setHasDescription } = useModalContext();
@@ -359,7 +368,13 @@ function ModalHeader({
   );
 
   return (
-    <Section ref={ref} padding={2} alignItems="start" height="fit" {...props}>
+    <Section
+      ref={ref}
+      padding={padding}
+      alignItems={alignItems}
+      height={height}
+      {...props}
+    >
       <Section
         flexDirection="row"
         justifyContent="between"
@@ -408,6 +423,16 @@ function ModalBody({
   ref,
   twoTone = true,
   children,
+  /*
+   * Defaulted here rather than written before the spread below: a spread
+   * copies a key even when its value is `undefined`, so a caller writing
+   * `prop={condition ? x : undefined}` would replace the default rather than
+   * fall back to it.
+   */
+  height = "auto",
+  padding = 4,
+  gap = 4,
+  alignItems = "start",
   ...props
 }: ModalBodyProps) {
   return (
@@ -416,7 +441,13 @@ function ModalBody({
       className="opal-modal-body"
       {...(twoTone && { "data-two-tone": "" })}
     >
-      <Section height="auto" padding={4} gap={4} alignItems="start" {...props}>
+      <Section
+        height={height}
+        padding={padding}
+        gap={gap}
+        alignItems={alignItems}
+        {...props}
+      >
         {children}
       </Section>
     </div>
@@ -427,15 +458,29 @@ interface ModalFooterProps extends WithoutStyles<SectionProps> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-function ModalFooter({ ref, ...props }: ModalFooterProps) {
+function ModalFooter({
+  ref,
+  /*
+   * Defaulted here rather than written before the spread below: a spread
+   * copies a key even when its value is `undefined`, so a caller writing
+   * `prop={condition ? x : undefined}` would replace the default rather than
+   * fall back to it.
+   */
+  flexDirection = "row",
+  justifyContent = "end",
+  gap = 2,
+  padding = 4,
+  height = "fit",
+  ...props
+}: ModalFooterProps) {
   return (
     <Section
       ref={ref}
-      flexDirection="row"
-      justifyContent="end"
-      gap={2}
-      padding={4}
-      height="fit"
+      flexDirection={flexDirection}
+      justifyContent={justifyContent}
+      gap={gap}
+      padding={padding}
+      height={height}
       {...props}
     />
   );

--- a/web/lib/opal/src/components/popover/components.tsx
+++ b/web/lib/opal/src/components/popover/components.tsx
@@ -129,6 +129,10 @@ function PopoverContent({
   container,
   align = "center",
   sideOffset = 4,
+  // Defaulted here rather than written before the spread: a spread copies a
+  // key even when its value is `undefined`, so `collisionPadding={maybe}`
+  // would replace this rather than fall back to it.
+  collisionPadding = 8,
   ref,
   ...props
 }: PopoverContentProps) {
@@ -138,7 +142,7 @@ function PopoverContent({
         ref={ref}
         align={align}
         sideOffset={sideOffset}
-        collisionPadding={8}
+        collisionPadding={collisionPadding}
         className={cn(
           "bg-background-neutral-00 p-1 z-popover rounded-12 border shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           "flex flex-col",


### PR DESCRIPTION
## Description

A component writes a default as a literal attribute and then spreads the
caller's props over it:

```tsx
<Thing collisionPadding={8} {...props} />
```

A spread copies a key even when its value is `undefined`, so
`collisionPadding={condition ? 16 : undefined}` — the obvious way to set
something conditionally — replaces the default rather than falling back to it.
Moving the prop into the destructure fixes it, because a destructuring default
treats `undefined` as absent.

| File | Was written before the spread |
|---|---|
| `popover/components.tsx` | `collisionPadding` |
| `modal/components.tsx` — header | `padding`, `alignItems`, `height` |
| `modal/components.tsx` — body | `height`, `padding`, `gap`, `alignItems` |
| `modal/components.tsx` — footer | `flexDirection`, `justifyContent`, `gap`, `padding`, `height` |
| `inputs/input-select/components.tsx` | `sideOffset`, `position`, `onMouseDown` |

Every one is genuinely reachable: each props type carries the key being
defaulted — `WithoutStyles<SectionProps>` for the three modal parts, Radix's
own content props for `Popover` and `InputSelect`.

`Popover` is the clearest case. The same function already defaults `align` and
`sideOffset` correctly in its destructure and only `collisionPadding` was left
as a literal, so it reads as an oversight rather than a deliberate convention.

`InputSelect`'s `onMouseDown` is **chained** rather than merely defaulted.
Swallowing the press is what stops a click inside the list reaching whatever
sits behind it, so a caller adding a handler must not silently drop that
behaviour.

### Severity

Lower than #14389. That one silently opted a row out of the entire interactive
colour system, so it stopped responding to hover, selection and disablement.
These drop one spacing or positioning value to a library default.

### What the sweep rejected

24 further candidates matched the shape and were dismissed after reading the
props types — the attribute is destructured out (`Content`'s `sizePreset`,
`Interactive`'s `href`/`target`/`rel`), or the props type cannot carry it.
`TextButton` writes `type`/`variant`/`prominence` but its props are
`HTMLAttributes<HTMLElement>` plus four named props; `Calendar`'s nav buttons
write `icon`/`prominence`/`size` against `ButtonHTMLAttributes`. `ref`,
`className` and `style` are excluded throughout by `WithoutStyles`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Opal components so an explicit `undefined` from caller props no longer replaces component defaults (e.g., spacing, alignment, positioning). Previously, defaults written as literal attributes were overridden when props were spread, even if the value was `undefined`. Now defaults are set via destructuring, so conditional props fall back to defaults as intended. No behavioral change unless a caller passes `undefined` for these values; then they now get the Opal default instead of the library default.

- `InputSelect` now chains `onMouseDown` with the default handler instead of allowing it to be replaced, preserving click-blocking behavior.

<sup>Written for commit e2eb58003243f2db2018e1313d8db3befd2cea22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->