### PR TITLE
feat(web): per-block RTL rendering for chat messages

### DIFF
--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -51,7 +51,7 @@ export default function WelcomeMessage({
         width="fit"
       >
         <SvgEyeClosed size={32} className="text-text-04" />
-        <Text as="p" headingH2>
+        <Text as="p" dir="auto" headingH2>
           {t("incognito.title")}
         </Text>
       </Section>
@@ -66,7 +66,7 @@ export default function WelcomeMessage({
         width="fit"
       >
         <Logo folded size={32} />
-        <Text as="p" headingH2>
+        <Text as="p" dir="auto" headingH2>
           {greeting}
         </Text>
       </Section>
@@ -81,7 +81,7 @@ export default function WelcomeMessage({
         width="fit"
       >
         <AgentAvatar agent={agent} size={36} />
-        <Text as="p" headingH2>
+        <Text as="p" dir="auto" headingH2>
           {agent.name}
         </Text>
       </Section>

--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -68,7 +68,10 @@ export const CodeBlock = memo(function CodeBlock({
 
   if (typeof children === "string" && !language) {
     return (
+      // dir="ltr": code is always LTR, even inside RTL prose. The dir
+      // attribute also bidi-isolates the run from the surrounding text.
       <span
+        dir="ltr"
         data-testid="code-block"
         className={cn(
           "font-mono",
@@ -97,7 +100,10 @@ export const CodeBlock = memo(function CodeBlock({
   const CodeContent = () => {
     if (!language) {
       return (
+        // dir="ltr" on both pre branches: code is always LTR, even when
+        // the surrounding message resolved to RTL.
         <pre
+          dir="ltr"
           className={cn(
             "p-2! m-0 overflow-x-auto w-0 min-w-full hljs",
             innerRounding
@@ -116,6 +122,7 @@ export const CodeBlock = memo(function CodeBlock({
 
     return (
       <pre
+        dir="ltr"
         className={cn(
           "p-2! m-0 overflow-x-auto w-0 min-w-full hljs",
           innerRounding

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -55,6 +55,7 @@ function MessageEditing({
       >
         <textarea
           ref={textareaRef}
+          dir="auto"
           className={cn(
             "w-full h-full resize-none outline-hidden bg-transparent overflow-y-scroll whitespace-normal break-word"
           )}
@@ -247,6 +248,7 @@ const HumanMessage = React.memo(function HumanMessage({
               >
                 <Text
                   as="p"
+                  dir="auto"
                   className="inline-block align-middle"
                   mainContentBody
                   text04

--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -231,15 +231,25 @@ export const MemoizedLink = memo(
 
 interface MemoizedParagraphProps {
   className?: string;
+  // Stamped per-paragraph by the rehypeDirection plugin so RTL and LTR
+  // paragraphs align independently. "auto" covers non-markdown callers.
+  dir?: React.HTMLAttributes<HTMLElement>["dir"];
   children?: React.ReactNode;
 }
 
 export const MemoizedParagraph = memo(function MemoizedParagraph({
   className,
+  dir,
   children,
 }: MemoizedParagraphProps) {
   return (
-    <Text as="p" mainContentBody text04 className={className}>
+    <Text
+      as="p"
+      dir={dir ?? "auto"}
+      mainContentBody
+      text04
+      className={className}
+    >
       {children}
     </Text>
   );

--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -232,7 +232,8 @@ export const MemoizedLink = memo(
 interface MemoizedParagraphProps {
   className?: string;
   // Stamped per-paragraph by the rehypeDirection plugin so RTL and LTR
-  // paragraphs align independently. "auto" covers non-markdown callers.
+  // paragraphs align independently. Unstamped paragraphs inherit their
+  // container's direction.
   dir?: React.HTMLAttributes<HTMLElement>["dir"];
   children?: React.ReactNode;
 }
@@ -243,13 +244,7 @@ export const MemoizedParagraph = memo(function MemoizedParagraph({
   children,
 }: MemoizedParagraphProps) {
   return (
-    <Text
-      as="p"
-      dir={dir ?? "auto"}
-      mainContentBody
-      text04
-      className={className}
-    >
+    <Text as="p" dir={dir} mainContentBody text04 className={className}>
       {children}
     </Text>
   );

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -319,13 +319,13 @@ pre[class*="language-"] {
   background: var(--border-03);
 }
 
-/* Fade the right edge via an ::after overlay on the non-scrolling card.
-   Stays pinned while table scrolls; doesn't affect the sticky column. */
+/* Fade the scroll-end edge via an ::after overlay on the non-scrolling
+   card. Stays pinned while table scrolls; not on the sticky column. */
 .markdown-table-card::after {
   content: "";
   position: absolute;
   top: 0;
-  right: 0;
+  inset-inline-end: 0;
   bottom: 0;
   width: 2rem;
   pointer-events: none;
@@ -339,6 +339,14 @@ pre[class*="language-"] {
   opacity: 0;
   transition: opacity 0.15s;
 }
+.markdown-table-card:dir(rtl)::after {
+  background: linear-gradient(
+    to left,
+    transparent,
+    var(--background-neutral-01)
+  );
+  border-radius: 0.5rem 0 0 0.5rem;
+}
 .markdown-table-card[data-overflows="true"]::after {
   opacity: 1;
 }
@@ -348,14 +356,14 @@ pre[class*="language-"] {
 .markdown-table-breakout th:first-child,
 .markdown-table-breakout td:first-child {
   position: sticky;
-  left: 0;
+  inset-inline-start: 0;
   z-index: 1;
-  padding-left: 0.75rem;
+  padding-inline-start: 0.75rem;
   background: var(--background-neutral-01);
 }
 .markdown-table-breakout th:last-child,
 .markdown-table-breakout td:last-child {
-  padding-right: 0.75rem;
+  padding-inline-end: 0.75rem;
 }
 
 /* Shadow on sticky column when scrolled. Uses an ::after pseudo-element
@@ -365,13 +373,17 @@ pre[class*="language-"] {
   content: "";
   position: absolute;
   top: 0;
-  right: -6px;
+  inset-inline-end: -6px;
   bottom: 0;
   width: 6px;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.15s;
   box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-25);
+}
+.markdown-table-breakout:dir(rtl) th:first-child::after,
+.markdown-table-breakout:dir(rtl) td:first-child::after {
+  box-shadow: inset -6px 0 8px -4px var(--alpha-grey-100-25);
 }
 .dark .markdown-table-breakout th:first-child::after,
 .dark .markdown-table-breakout td:first-child::after {

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -49,16 +49,16 @@ export function ScrollableTable({
 
     const check = () => {
       const overflows = el.scrollWidth > el.clientWidth;
-      // RTL scrollers run scrollLeft from 0 down to negative values, so
-      // normalize to distance from the physical left edge.
+      // Logical distance from the scroll start. RTL scrollLeft runs from
+      // 0 down to negative, and the CSS paints on inline edges to match.
       const maxScroll = el.scrollWidth - el.clientWidth;
-      const fromLeft =
+      const fromStart =
         getComputedStyle(el).direction === "rtl"
-          ? maxScroll + el.scrollLeft
+          ? -el.scrollLeft
           : el.scrollLeft;
-      const atEnd = fromLeft >= maxScroll - 2;
+      const atEnd = fromStart >= maxScroll - 2;
       wrap.dataset.overflows = overflows && !atEnd ? "true" : "false";
-      el.dataset.scrolled = fromLeft > 0 ? "true" : "false";
+      el.dataset.scrolled = fromStart > 0 ? "true" : "false";
     };
 
     check();

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -48,9 +48,16 @@ export function ScrollableTable({
 
     const check = () => {
       const overflows = el.scrollWidth > el.clientWidth;
-      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 2;
+      // RTL scrollers run scrollLeft from 0 down to negative values, so
+      // normalize to distance from the physical left edge.
+      const maxScroll = el.scrollWidth - el.clientWidth;
+      const fromLeft =
+        getComputedStyle(el).direction === "rtl"
+          ? maxScroll + el.scrollLeft
+          : el.scrollLeft;
+      const atEnd = fromLeft >= maxScroll - 2;
       wrap.dataset.overflows = overflows && !atEnd ? "true" : "false";
-      el.dataset.scrolled = el.scrollLeft > 0 ? "true" : "false";
+      el.dataset.scrolled = fromLeft > 0 ? "true" : "false";
     };
 
     check();

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -34,6 +34,7 @@ interface ScrollableTableProps extends React.TableHTMLAttributes<HTMLTableElemen
 export function ScrollableTable({
   className,
   children,
+  dir,
   ...props
 }: ScrollableTableProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -75,7 +76,9 @@ export function ScrollableTable({
   }, []);
 
   return (
-    <div ref={wrapRef} className="markdown-table-card">
+    // The stamped table dir lifts onto the scroller so scrollLeft semantics
+    // and the initial scroll edge follow the table's own direction.
+    <div ref={wrapRef} dir={dir} className="markdown-table-card">
       <div ref={scrollRef} className="markdown-table-breakout">
         <table
           ref={tableRef}

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/app/app/message/codeUtils";
 import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { transformLinkUri } from "@/lib/utils";
+import { rehypeDirection } from "@/lib/rehypeDirection";
 import { cn } from "@opal/utils";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
@@ -133,7 +134,7 @@ export const useMarkdownComponents = (
 ) => {
   const paragraphCallback = useCallback(
     (props: any) => (
-      <MemoizedParagraph className={className}>
+      <MemoizedParagraph dir={props.dir} className={className}>
         {props.children}
       </MemoizedParagraph>
     ),
@@ -249,8 +250,8 @@ export const renderMarkdown = (
         ]}
         rehypePlugins={
           languages
-            ? [[rehypeHighlight, { languages }], rehypeKatex]
-            : [rehypeKatex]
+            ? [[rehypeHighlight, { languages }], rehypeKatex, rehypeDirection]
+            : [rehypeKatex, rehypeDirection]
         }
         urlTransform={transformLinkUri}
       >

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -30,6 +30,7 @@ import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
 import { transformLinkUri } from "@/lib/utils";
+import { rehypeDirection } from "@/lib/rehypeDirection";
 import { cn } from "@opal/utils";
 import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
 import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
@@ -83,7 +84,7 @@ const STREAMING_REMARK_PLUGINS: PluggableList = [
   remarkGfm,
   [remarkMath, { singleDollarTextMath: true }],
 ];
-const STREAMING_REHYPE_PLUGINS: PluggableList = [rehypeKatex];
+const STREAMING_REHYPE_PLUGINS: PluggableList = [rehypeKatex, rehypeDirection];
 const FULL_REMARK_PLUGINS: PluggableList = STREAMING_REMARK_PLUGINS;
 
 export const MessageTextRenderer: MessageRenderer<
@@ -285,7 +286,11 @@ export const MessageTextRenderer: MessageRenderer<
   const fullRehypePlugins = useMemo<PluggableList>(
     () =>
       highlightLanguages
-        ? [[rehypeHighlight, { languages: highlightLanguages }], rehypeKatex]
+        ? [
+            [rehypeHighlight, { languages: highlightLanguages }],
+            rehypeKatex,
+            rehypeDirection,
+          ]
         : STREAMING_REHYPE_PLUGINS,
     [highlightLanguages]
   );
@@ -375,8 +380,8 @@ export const MessageTextRenderer: MessageRenderer<
           </MemoizedAnchor>
         );
       },
-      p: ({ children }) => (
-        <MemoizedParagraph className="font-main-content-body">
+      p: ({ children, dir }) => (
+        <MemoizedParagraph dir={dir} className="font-main-content-body">
           {children}
         </MemoizedParagraph>
       ),

--- a/web/src/app/app/message/messageComponents/timeline/renderers/sharedMarkdownComponents.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/sharedMarkdownComponents.tsx
@@ -3,13 +3,19 @@ import Text from "@/refresh-components/texts/Text";
 
 // Expanded view: normal spacing between paragraphs/lists
 export const mutedTextMarkdownComponents = {
-  p: ({ children }: { children?: React.ReactNode }) => (
-    <Text as="p" text03 mainUiMuted className="my-1!">
+  p: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <Text as="p" dir={dir} text03 mainUiMuted className="my-1!">
       {children}
     </Text>
   ),
-  li: ({ children }: { children?: React.ReactNode }) => (
-    <Text as="li" text03 mainUiMuted className="my-0! py-0! leading-normal">
+  li: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <Text
+      as="li"
+      dir={dir}
+      text03
+      mainUiMuted
+      className="my-0! py-0! leading-normal"
+    >
       {children}
     </Text>
   ),
@@ -33,21 +39,31 @@ export const mutedTextMarkdownComponents = {
 
 // Collapsed view: no spacing for compact display
 export const collapsedMarkdownComponents = {
-  p: ({ children }: { children?: React.ReactNode }) => (
-    <Text as="p" text03 mainUiMuted className="my-0!">
+  p: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <Text as="p" dir={dir} text03 mainUiMuted className="my-0!">
       {children}
     </Text>
   ),
-  li: ({ children }: { children?: React.ReactNode }) => (
-    <Text as="li" text03 mainUiMuted className="my-0! py-0! leading-normal">
+  li: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <Text
+      as="li"
+      dir={dir}
+      text03
+      mainUiMuted
+      className="my-0! py-0! leading-normal"
+    >
       {children}
     </Text>
   ),
-  ul: ({ children }: { children?: React.ReactNode }) => (
-    <ul className="pl-0! ml-0! my-0! list-inside">{children}</ul>
+  ul: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <ul dir={dir} className="pl-0! ml-0! my-0! list-inside">
+      {children}
+    </ul>
   ),
-  ol: ({ children }: { children?: React.ReactNode }) => (
-    <ol className="pl-0! ml-0! my-0! list-inside">{children}</ol>
+  ol: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <ol dir={dir} className="pl-0! ml-0! my-0! list-inside">
+      {children}
+    </ol>
   ),
   a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
     <a

--- a/web/src/app/app/message/messageComponents/timeline/renderers/sharedMarkdownComponents.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/sharedMarkdownComponents.tsx
@@ -19,11 +19,15 @@ export const mutedTextMarkdownComponents = {
       {children}
     </Text>
   ),
-  ul: ({ children }: { children?: React.ReactNode }) => (
-    <ul className="pl-0! ml-0! my-0.5! list-inside">{children}</ul>
+  ul: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <ul dir={dir} className="ps-0! ms-0! my-0.5! list-inside">
+      {children}
+    </ul>
   ),
-  ol: ({ children }: { children?: React.ReactNode }) => (
-    <ol className="pl-0! ml-0! my-0.5! list-inside">{children}</ol>
+  ol: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
+    <ol dir={dir} className="ps-0! ms-0! my-0.5! list-inside">
+      {children}
+    </ol>
   ),
   a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
     <a
@@ -56,12 +60,12 @@ export const collapsedMarkdownComponents = {
     </Text>
   ),
   ul: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
-    <ul dir={dir} className="pl-0! ml-0! my-0! list-inside">
+    <ul dir={dir} className="ps-0! ms-0! my-0! list-inside">
       {children}
     </ul>
   ),
   ol: ({ children, dir }: { children?: React.ReactNode; dir?: string }) => (
-    <ol dir={dir} className="pl-0! ml-0! my-0! list-inside">
+    <ol dir={dir} className="ps-0! ms-0! my-0! list-inside">
       {children}
     </ol>
   ),

--- a/web/src/app/craft/components/ThinkingCard.tsx
+++ b/web/src/app/craft/components/ThinkingCard.tsx
@@ -15,24 +15,17 @@ import MinimalMarkdown from "@/components/chat/MinimalMarkdown";
 // MinimalMarkdown's default `p` goes through MemoizedParagraph which forces
 // the Opal `mainContentBody` preset (~16px). Override every text-bearing
 // element here so reasoning renders at a uniform smaller size.
-const thinkingP = ({
-  children,
-  dir,
-}: {
+interface ThinkingBlockProps {
   children?: ReactNode;
   dir?: string;
-}) => (
+}
+
+const thinkingP = ({ children, dir }: ThinkingBlockProps) => (
   <p dir={dir} className="text-sm leading-relaxed text-text-03 my-1">
     {children}
   </p>
 );
-const thinkingHeader = ({
-  children,
-  dir,
-}: {
-  children?: ReactNode;
-  dir?: string;
-}) => (
+const thinkingHeader = ({ children, dir }: ThinkingBlockProps) => (
   <p
     dir={dir}
     className="text-sm leading-relaxed text-text-03 font-semibold mt-4 mb-2"
@@ -53,46 +46,22 @@ function normalizeThinking(text: string): string {
   out = out.replace(/(\*\*[^*\n]+\*\*)(?=[A-Z([])/g, "$1\n\n");
   return out;
 }
-const thinkingLi = ({
-  children,
-  dir,
-}: {
-  children?: ReactNode;
-  dir?: string;
-}) => (
+const thinkingLi = ({ children, dir }: ThinkingBlockProps) => (
   <li dir={dir} className="text-sm leading-relaxed text-text-03 my-0.5">
     {children}
   </li>
 );
-const thinkingUl = ({
-  children,
-  dir,
-}: {
-  children?: ReactNode;
-  dir?: string;
-}) => (
+const thinkingUl = ({ children, dir }: ThinkingBlockProps) => (
   <ul dir={dir} className="list-disc ms-4 my-1 text-sm">
     {children}
   </ul>
 );
-const thinkingOl = ({
-  children,
-  dir,
-}: {
-  children?: ReactNode;
-  dir?: string;
-}) => (
+const thinkingOl = ({ children, dir }: ThinkingBlockProps) => (
   <ol dir={dir} className="list-decimal ms-4 my-1 text-sm">
     {children}
   </ol>
 );
-const thinkingBlockquote = ({
-  children,
-  dir,
-}: {
-  children?: ReactNode;
-  dir?: string;
-}) => (
+const thinkingBlockquote = ({ children, dir }: ThinkingBlockProps) => (
   <blockquote
     dir={dir}
     className="text-sm text-text-02 border-s-2 border-border-02 ps-2 my-1"

--- a/web/src/app/craft/components/ThinkingCard.tsx
+++ b/web/src/app/craft/components/ThinkingCard.tsx
@@ -86,8 +86,17 @@ const thinkingOl = ({
     {children}
   </ol>
 );
-const thinkingBlockquote = ({ children }: { children?: ReactNode }) => (
-  <blockquote className="text-sm text-text-02 border-l-2 border-border-02 pl-2 my-1">
+const thinkingBlockquote = ({
+  children,
+  dir,
+}: {
+  children?: ReactNode;
+  dir?: string;
+}) => (
+  <blockquote
+    dir={dir}
+    className="text-sm text-text-02 border-s-2 border-border-02 ps-2 my-1"
+  >
     {children}
   </blockquote>
 );

--- a/web/src/app/craft/components/ThinkingCard.tsx
+++ b/web/src/app/craft/components/ThinkingCard.tsx
@@ -15,11 +15,28 @@ import MinimalMarkdown from "@/components/chat/MinimalMarkdown";
 // MinimalMarkdown's default `p` goes through MemoizedParagraph which forces
 // the Opal `mainContentBody` preset (~16px). Override every text-bearing
 // element here so reasoning renders at a uniform smaller size.
-const thinkingP = ({ children }: { children?: ReactNode }) => (
-  <p className="text-sm leading-relaxed text-text-03 my-1">{children}</p>
+const thinkingP = ({
+  children,
+  dir,
+}: {
+  children?: ReactNode;
+  dir?: string;
+}) => (
+  <p dir={dir} className="text-sm leading-relaxed text-text-03 my-1">
+    {children}
+  </p>
 );
-const thinkingHeader = ({ children }: { children?: ReactNode }) => (
-  <p className="text-sm leading-relaxed text-text-03 font-semibold mt-4 mb-2">
+const thinkingHeader = ({
+  children,
+  dir,
+}: {
+  children?: ReactNode;
+  dir?: string;
+}) => (
+  <p
+    dir={dir}
+    className="text-sm leading-relaxed text-text-03 font-semibold mt-4 mb-2"
+  >
     {children}
   </p>
 );
@@ -36,14 +53,38 @@ function normalizeThinking(text: string): string {
   out = out.replace(/(\*\*[^*\n]+\*\*)(?=[A-Z([])/g, "$1\n\n");
   return out;
 }
-const thinkingLi = ({ children }: { children?: ReactNode }) => (
-  <li className="text-sm leading-relaxed text-text-03 my-0.5">{children}</li>
+const thinkingLi = ({
+  children,
+  dir,
+}: {
+  children?: ReactNode;
+  dir?: string;
+}) => (
+  <li dir={dir} className="text-sm leading-relaxed text-text-03 my-0.5">
+    {children}
+  </li>
 );
-const thinkingUl = ({ children }: { children?: ReactNode }) => (
-  <ul className="list-disc ml-4 my-1 text-sm">{children}</ul>
+const thinkingUl = ({
+  children,
+  dir,
+}: {
+  children?: ReactNode;
+  dir?: string;
+}) => (
+  <ul dir={dir} className="list-disc ms-4 my-1 text-sm">
+    {children}
+  </ul>
 );
-const thinkingOl = ({ children }: { children?: ReactNode }) => (
-  <ol className="list-decimal ml-4 my-1 text-sm">{children}</ol>
+const thinkingOl = ({
+  children,
+  dir,
+}: {
+  children?: ReactNode;
+  dir?: string;
+}) => (
+  <ol dir={dir} className="list-decimal ms-4 my-1 text-sm">
+    {children}
+  </ol>
 );
 const thinkingBlockquote = ({ children }: { children?: ReactNode }) => (
   <blockquote className="text-sm text-text-02 border-l-2 border-border-02 pl-2 my-1">

--- a/web/src/app/css/content-editable.css
+++ b/web/src/app/css/content-editable.css
@@ -8,7 +8,7 @@
   pointer-events: none;
   position: absolute;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   padding: inherit;
 }
 

--- a/web/src/components/chat/MinimalMarkdown.tsx
+++ b/web/src/components/chat/MinimalMarkdown.tsx
@@ -80,17 +80,24 @@ export default function MinimalMarkdown({
   }, [content, components, showHeader]);
 
   return (
-    <ReactMarkdown
-      className={cn(
-        "prose dark:prose-invert max-w-full text-sm wrap-break-word",
-        className
-      )}
-      components={markdownComponents}
-      rehypePlugins={rehypePlugins}
-      remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
-      urlTransform={transformLinkUri}
-    >
-      {content}
-    </ReactMarkdown>
+    // dir="auto" backstops component overrides that do not forward the
+    // per-block dir stamped by rehypeDirection.
+    <div dir="auto">
+      <ReactMarkdown
+        className={cn(
+          "prose dark:prose-invert max-w-full text-sm wrap-break-word",
+          className
+        )}
+        components={markdownComponents}
+        rehypePlugins={rehypePlugins}
+        remarkPlugins={[
+          remarkGfm,
+          [remarkMath, { singleDollarTextMath: false }],
+        ]}
+        urlTransform={transformLinkUri}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
   );
 }

--- a/web/src/components/chat/MinimalMarkdown.tsx
+++ b/web/src/components/chat/MinimalMarkdown.tsx
@@ -14,6 +14,7 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { transformLinkUri } from "@/lib/utils";
+import { rehypeDirection } from "@/lib/rehypeDirection";
 import { cn } from "@opal/utils";
 
 type MinimalMarkdownComponentOverrides = Partial<Components>;
@@ -45,8 +46,9 @@ export default function MinimalMarkdown({
         ? [
             [rehypeHighlight, { detect: true, languages: highlightLanguages }],
             rehypeKatex,
+            rehypeDirection,
           ]
-        : [rehypeKatex],
+        : [rehypeKatex, rehypeDirection],
     [streaming, highlightLanguages]
   );
   const markdownComponents = useMemo(() => {

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -77,6 +77,9 @@ describe("rehypeDirection", () => {
 
   it("treats strong RTL punctuation and NKo digits as strong", () => {
     const q = el("p", [txt("\u061F Error")]);
+    const afghani = el("p", [txt("\u060B 100 invoice")]);
+    run(afghani);
+    expect(dirOf(afghani)).toBe("rtl");
     run(q);
     expect(dirOf(q)).toBe("rtl");
     const nko = el("p", [txt("\u07C1 x")]);

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -83,6 +83,9 @@ describe("rehypeDirection", () => {
     run(q);
     expect(dirOf(q)).toBe("rtl");
     const nko = el("p", [txt("\u07C1 x")]);
+    const garay = el("p", [txt("\u{10D41} x")]);
+    run(garay);
+    expect(dirOf(garay)).toBe("rtl");
     run(nko);
     expect(dirOf(nko)).toBe("rtl");
   });

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -69,6 +69,12 @@ describe("rehypeDirection", () => {
     expect(dirOf(p)).toBe("ltr");
   });
 
+  it("detects less common RTL scripts by script property", () => {
+    const p = el("p", [txt("\u{10E88}\u{10E8A} note")]);
+    run(p);
+    expect(dirOf(p)).toBe("rtl");
+  });
+
   it("honors an LRM before any letter", () => {
     const p = el("p", [txt("\u200E\u0645\u0631\u062d\u0628\u0627")]);
     run(p);

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -69,6 +69,12 @@ describe("rehypeDirection", () => {
     expect(dirOf(p)).toBe("ltr");
   });
 
+  it("honors an LRM before any letter", () => {
+    const p = el("p", [txt("\u200E\u0645\u0631\u062d\u0628\u0627")]);
+    run(p);
+    expect(dirOf(p)).toBe("ltr");
+  });
+
   it("leaves blocks without any letters unstamped", () => {
     const p = el("p", [txt("1234 :-)")]);
     run(p);

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -63,6 +63,12 @@ describe("rehypeDirection", () => {
     expect(dirOf(p)).toBe("rtl");
   });
 
+  it("treats Arabic-Indic digits as weak, deciding by the first letter", () => {
+    const p = el("p", [txt("\u0662\u0660\u0662\u0666 report")]);
+    run(p);
+    expect(dirOf(p)).toBe("ltr");
+  });
+
   it("leaves blocks without any letters unstamped", () => {
     const p = el("p", [txt("1234 :-)")]);
     run(p);

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -83,9 +83,12 @@ describe("rehypeDirection", () => {
     run(q);
     expect(dirOf(q)).toBe("rtl");
     const nko = el("p", [txt("\u07C1 x")]);
-    const garay = el("p", [txt("\u{10D41} x")]);
+    const garay = el("p", [txt("\u{10D50} x")]);
     run(garay);
     expect(dirOf(garay)).toBe("rtl");
+    const garayDigits = el("p", [txt("\u{10D41}\u{10D42} report")]);
+    run(garayDigits);
+    expect(dirOf(garayDigits)).toBe("ltr");
     run(nko);
     expect(dirOf(nko)).toBe("rtl");
   });

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -1,0 +1,71 @@
+import type { Element, ElementContent, Root } from "hast";
+
+import { rehypeDirection } from "@/lib/rehypeDirection";
+
+function el(tagName: string, children: ElementContent[] = []): Element {
+  return { type: "element", tagName, properties: {}, children };
+}
+
+function txt(value: string): ElementContent {
+  return { type: "text", value };
+}
+
+function run(...children: ElementContent[]): Root {
+  const tree: Root = { type: "root", children };
+  rehypeDirection()(tree);
+  return tree;
+}
+
+function dirOf(node: ElementContent): unknown {
+  return node.type === "element" ? node.properties.dir : undefined;
+}
+
+describe("rehypeDirection", () => {
+  it("stamps rtl on blocks led by RTL text, in any RTL script", () => {
+    const arabic = el("p", [txt("مرحبا بالعالم")]);
+    const hebrew = el("p", [txt("שלום עולם")]);
+    const farsi = el("h2", [txt("سلام دنیا")]);
+    run(arabic, hebrew, farsi);
+    expect(dirOf(arabic)).toBe("rtl");
+    expect(dirOf(hebrew)).toBe("rtl");
+    expect(dirOf(farsi)).toBe("rtl");
+  });
+
+  it("stamps ltr on blocks led by LTR text", () => {
+    const p = el("p", [txt("Hello world")]);
+    run(p);
+    expect(dirOf(p)).toBe("ltr");
+  });
+
+  it("resolves loose-list items through their inline p children", () => {
+    // Markdown loose lists render li > p. dir="auto" on the li would skip
+    // the dir-carrying p and fall back to LTR. The plugin must not.
+    const arabicItem = el("li", [txt("\n"), el("p", [txt("اقرأ الكود")])]);
+    const englishItem = el("li", [txt("\n"), el("p", [txt("Read code")])]);
+    const list = el("ul", [englishItem, arabicItem]);
+    run(list);
+    expect(dirOf(list)).toBe("ltr");
+    expect(dirOf(englishItem)).toBe("ltr");
+    expect(dirOf(arabicItem)).toBe("rtl");
+  });
+
+  it("ignores code when resolving direction and pins pre to ltr", () => {
+    const item = el("li", [el("code", [txt("foo")]), txt(" تعني كذا")]);
+    const pre = el("pre", [el("code", [txt("const x = 1;")])]);
+    run(item, pre);
+    expect(dirOf(item)).toBe("rtl");
+    expect(dirOf(pre)).toBe("ltr");
+  });
+
+  it("skips weak characters (digits, punctuation) before the first letter", () => {
+    const p = el("p", [txt('42% — "עברית"')]);
+    run(p);
+    expect(dirOf(p)).toBe("rtl");
+  });
+
+  it("leaves blocks without any letters unstamped", () => {
+    const p = el("p", [txt("1234 :-)")]);
+    run(p);
+    expect(dirOf(p)).toBeUndefined();
+  });
+});

--- a/web/src/lib/rehypeDirection.test.ts
+++ b/web/src/lib/rehypeDirection.test.ts
@@ -75,6 +75,15 @@ describe("rehypeDirection", () => {
     expect(dirOf(p)).toBe("rtl");
   });
 
+  it("treats strong RTL punctuation and NKo digits as strong", () => {
+    const q = el("p", [txt("\u061F Error")]);
+    run(q);
+    expect(dirOf(q)).toBe("rtl");
+    const nko = el("p", [txt("\u07C1 x")]);
+    run(nko);
+    expect(dirOf(nko)).toBe("rtl");
+  });
+
   it("honors an LRM before any letter", () => {
     const p = el("p", [txt("\u200E\u0645\u0631\u062d\u0628\u0627")]);
     run(p);

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -27,6 +27,10 @@ const OPAQUE_TAGS = new Set(["code", "pre"]);
 // engines). Digits and punctuation are weak, mirroring first-strong.
 const RTL_MARK = /[\u200F\u061C]/u;
 const LTR_MARK = /\u200E/u;
+// Strong R and AL code points that are not letters: Hebrew and Arabic
+// punctuation, Syriac punctuation, and NKo digits.
+const RTL_STRONG_PUNCT =
+  /[\u05BE\u05C0\u05C3\u05C6\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E]/u;
 const RTL_SCRIPT =
   /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}\p{Script=Chorasmian}\p{Script=Old_Uyghur}]/u;
 const ANY_LETTER = /\p{L}/u;
@@ -36,8 +40,9 @@ export function firstStrongTextDir(value: string): "ltr" | "rtl" | null {
   for (const char of value) {
     if (RTL_MARK.test(char)) return "rtl";
     if (LTR_MARK.test(char)) return "ltr";
-    // Only letters are strong. Arabic-Indic digits sit in Script=Arabic
-    // but are directionally weak, so they must not decide direction.
+    if (RTL_STRONG_PUNCT.test(char)) return "rtl";
+    // Otherwise only letters are strong. Arabic-Indic digits sit in
+    // Script=Arabic but are weak, so they must not decide direction.
     if (!ANY_LETTER.test(char)) continue;
     return RTL_SCRIPT.test(char) ? "rtl" : "ltr";
   }

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -1,7 +1,7 @@
 import type { Element, ElementContent, Root } from "hast";
 
 // Blocks get an explicit direction so mixed RTL/LTR messages align per
-// block. dir="auto" fails on loose-list li (their inline p carries dir,
+// block. dir="auto" fails on loose-list li (their child p carries dir,
 // which the auto algorithm skips), so the direction is computed here.
 const DIRECTIONAL_TAGS = new Set([
   "p",
@@ -22,10 +22,11 @@ const DIRECTIONAL_TAGS = new Set([
 // influence the direction of the block containing it.
 const OPAQUE_TAGS = new Set(["code", "pre"]);
 
-// Strong RTL letters from every right-to-left script, plus the RLM and ALM
-// marks. Script-based, so any RTL language matches. Digits and punctuation
-// are weak and skipped, mirroring browsers' first-strong dir="auto".
+// Strong letters from the major RTL scripts, plus the RLM/ALM and LRM
+// marks. Script-based, so detection needs no locale list. Digits and
+// punctuation are weak and skipped, mirroring first-strong dir="auto".
 const RTL_MARK = /[\u200F\u061C]/u;
+const LTR_MARK = /\u200E/u;
 const RTL_SCRIPT =
   /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
 const ANY_LETTER = /\p{L}/u;
@@ -35,6 +36,7 @@ function firstStrongDir(nodes: ElementContent[]): "ltr" | "rtl" | null {
     if (node.type === "text") {
       for (const char of node.value) {
         if (RTL_MARK.test(char)) return "rtl";
+        if (LTR_MARK.test(char)) return "ltr";
         // Only letters are strong. Arabic-Indic digits sit in Script=Arabic
         // but are directionally weak, so they must not decide direction.
         if (!ANY_LETTER.test(char)) continue;
@@ -54,8 +56,8 @@ function stampDir(node: Root | Element): void {
       node.properties = { ...node.properties, dir: "ltr" };
     } else if (DIRECTIONAL_TAGS.has(node.tagName)) {
       const dir = firstStrongDir(node.children);
-      // No letters at all (bare numbers, emoji): leave it to inherit from
-      // the surrounding dir="auto" message container.
+      // No letters at all (bare numbers, emoji): leave the block
+      // unstamped so it inherits its container's direction.
       if (dir) {
         node.properties = { ...node.properties, dir };
       }
@@ -70,7 +72,7 @@ function stampDir(node: Root | Element): void {
 
 // Rehype plugin: stamp each block with the direction of its first strong
 // character and pin `pre` to LTR. Component maps that intercept these
-// tags must forward `dir` (MemoizedParagraph and CodeBlock do).
+// tags must forward `dir`, or a dir="auto" wrapper must backstop them.
 export function rehypeDirection() {
   return (tree: Root) => stampDir(tree);
 }

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -31,17 +31,24 @@ const RTL_SCRIPT =
   /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}\p{Script=Chorasmian}\p{Script=Old_Uyghur}]/u;
 const ANY_LETTER = /\p{L}/u;
 
+/** First-strong direction of plain text, or null when no letter decides. */
+export function firstStrongTextDir(value: string): "ltr" | "rtl" | null {
+  for (const char of value) {
+    if (RTL_MARK.test(char)) return "rtl";
+    if (LTR_MARK.test(char)) return "ltr";
+    // Only letters are strong. Arabic-Indic digits sit in Script=Arabic
+    // but are directionally weak, so they must not decide direction.
+    if (!ANY_LETTER.test(char)) continue;
+    return RTL_SCRIPT.test(char) ? "rtl" : "ltr";
+  }
+  return null;
+}
+
 function firstStrongDir(nodes: ElementContent[]): "ltr" | "rtl" | null {
   for (const node of nodes) {
     if (node.type === "text") {
-      for (const char of node.value) {
-        if (RTL_MARK.test(char)) return "rtl";
-        if (LTR_MARK.test(char)) return "ltr";
-        // Only letters are strong. Arabic-Indic digits sit in Script=Arabic
-        // but are directionally weak, so they must not decide direction.
-        if (!ANY_LETTER.test(char)) continue;
-        return RTL_SCRIPT.test(char) ? "rtl" : "ltr";
-      }
+      const dir = firstStrongTextDir(node.value);
+      if (dir) return dir;
     } else if (node.type === "element" && !OPAQUE_TAGS.has(node.tagName)) {
       const dir = firstStrongDir(node.children);
       if (dir) return dir;

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -23,12 +23,12 @@ const DIRECTIONAL_TAGS = new Set([
 const OPAQUE_TAGS = new Set(["code", "pre"]);
 
 // Strong letters from the scripts whose letters carry Bidi_Class R or AL
-// (JS regexes cannot query Bidi_Class directly), plus the RLM/ALM and LRM
-// marks. Digits and punctuation are weak, mirroring first-strong dir="auto".
+// (JS regexes cannot query Bidi_Class directly, and Garay needs Unicode 16
+// engines). Digits and punctuation are weak, mirroring first-strong.
 const RTL_MARK = /[\u200F\u061C]/u;
 const LTR_MARK = /\u200E/u;
 const RTL_SCRIPT =
-  /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}]/u;
+  /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}\p{Script=Chorasmian}\p{Script=Old_Uyghur}]/u;
 const ANY_LETTER = /\p{L}/u;
 
 function firstStrongDir(nodes: ElementContent[]): "ltr" | "rtl" | null {

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -1,0 +1,72 @@
+import type { Element, ElementContent, Root } from "hast";
+
+// Blocks get an explicit direction so mixed RTL/LTR messages align per
+// block. dir="auto" fails on loose-list li (their inline p carries dir,
+// which the auto algorithm skips), so the direction is computed here.
+const DIRECTIONAL_TAGS = new Set([
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "ul",
+  "ol",
+  "li",
+  "blockquote",
+  "table",
+]);
+
+// Code is always LTR and often leads an RTL sentence, so it must not
+// influence the direction of the block containing it.
+const OPAQUE_TAGS = new Set(["code", "pre"]);
+
+// Strong RTL letters from every right-to-left script, plus the RLM and ALM
+// marks. Script-based, so any RTL language matches. Digits and punctuation
+// are weak and skipped, mirroring browsers' first-strong dir="auto".
+const RTL_LETTER =
+  /[\u200F\u061C\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
+const ANY_LETTER = /\p{L}/u;
+
+function firstStrongDir(nodes: ElementContent[]): "ltr" | "rtl" | null {
+  for (const node of nodes) {
+    if (node.type === "text") {
+      for (const char of node.value) {
+        if (RTL_LETTER.test(char)) return "rtl";
+        if (ANY_LETTER.test(char)) return "ltr";
+      }
+    } else if (node.type === "element" && !OPAQUE_TAGS.has(node.tagName)) {
+      const dir = firstStrongDir(node.children);
+      if (dir) return dir;
+    }
+  }
+  return null;
+}
+
+function stampDir(node: Root | Element): void {
+  if (node.type === "element") {
+    if (node.tagName === "pre") {
+      node.properties = { ...node.properties, dir: "ltr" };
+    } else if (DIRECTIONAL_TAGS.has(node.tagName)) {
+      const dir = firstStrongDir(node.children);
+      // No letters at all (bare numbers, emoji): leave it to inherit from
+      // the surrounding dir="auto" message container.
+      if (dir) {
+        node.properties = { ...node.properties, dir };
+      }
+    }
+  }
+  for (const child of node.children) {
+    if (child.type === "element") {
+      stampDir(child);
+    }
+  }
+}
+
+// Rehype plugin: stamp each block with the direction of its first strong
+// character and pin `pre` to LTR. Component maps that intercept these
+// tags must forward `dir` (MemoizedParagraph and CodeBlock do).
+export function rehypeDirection() {
+  return (tree: Root) => stampDir(tree);
+}

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -22,13 +22,13 @@ const DIRECTIONAL_TAGS = new Set([
 // influence the direction of the block containing it.
 const OPAQUE_TAGS = new Set(["code", "pre"]);
 
-// Strong letters from the major RTL scripts, plus the RLM/ALM and LRM
-// marks. Script-based, so detection needs no locale list. Digits and
-// punctuation are weak and skipped, mirroring first-strong dir="auto".
+// Strong letters from the scripts whose letters carry Bidi_Class R or AL
+// (JS regexes cannot query Bidi_Class directly), plus the RLM/ALM and LRM
+// marks. Digits and punctuation are weak, mirroring first-strong dir="auto".
 const RTL_MARK = /[\u200F\u061C]/u;
 const LTR_MARK = /\u200E/u;
 const RTL_SCRIPT =
-  /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
+  /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}]/u;
 const ANY_LETTER = /\p{L}/u;
 
 function firstStrongDir(nodes: ElementContent[]): "ltr" | "rtl" | null {

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -28,9 +28,9 @@ const OPAQUE_TAGS = new Set(["code", "pre"]);
 const RTL_MARK = /[\u200F\u061C]/u;
 const LTR_MARK = /\u200E/u;
 // Strong R and AL code points that are not letters: Hebrew and Arabic
-// punctuation, Syriac punctuation, and NKo digits.
+// punctuation and signs, Syriac punctuation, NKo digits, the rial sign.
 const RTL_STRONG_PUNCT =
-  /[\u05BE\u05C0\u05C3\u05C6\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E]/u;
+  /[\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0608\u060B\u060D\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E\uFDFC]/u;
 const RTL_SCRIPT =
   /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}\p{Script=Chorasmian}\p{Script=Old_Uyghur}]/u;
 const ANY_LETTER = /\p{L}/u;

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -27,10 +27,11 @@ const OPAQUE_TAGS = new Set(["code", "pre"]);
 // engines). Digits and punctuation are weak, mirroring first-strong.
 const RTL_MARK = /[\u200F\u061C]/u;
 const LTR_MARK = /\u200E/u;
-// Strong R and AL code points that are not letters: Hebrew and Arabic
-// punctuation and signs, Syriac punctuation, NKo digits, the rial sign.
-const RTL_STRONG_PUNCT =
-  /[\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0608\u060B\u060D\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E\uFDFC]/u;
+// Strong R and AL code points outside the script regex: Hebrew and
+// Arabic signs, Syriac punctuation, NKo digits, the rial sign, and
+// the Garay block by range, its script property needs Unicode 16.
+const RTL_STRONG_EXTRA =
+  /[\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0608\u060B\u060D\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E\uFDFC\u{10D40}-\u{10D8F}]/u;
 const RTL_SCRIPT =
   /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}\p{Script=Chorasmian}\p{Script=Old_Uyghur}]/u;
 const ANY_LETTER = /\p{L}/u;
@@ -40,7 +41,7 @@ export function firstStrongTextDir(value: string): "ltr" | "rtl" | null {
   for (const char of value) {
     if (RTL_MARK.test(char)) return "rtl";
     if (LTR_MARK.test(char)) return "ltr";
-    if (RTL_STRONG_PUNCT.test(char)) return "rtl";
+    if (RTL_STRONG_EXTRA.test(char)) return "rtl";
     // Otherwise only letters are strong. Arabic-Indic digits sit in
     // Script=Arabic but are weak, so they must not decide direction.
     if (!ANY_LETTER.test(char)) continue;

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -29,9 +29,9 @@ const RTL_MARK = /[\u200F\u061C]/u;
 const LTR_MARK = /\u200E/u;
 // Strong R and AL code points outside the script regex: Hebrew and
 // Arabic signs, Syriac punctuation, NKo digits, the rial sign, and
-// the Garay block by range, its script property needs Unicode 16.
+// Garay's strong ranges per UCD 16 (its digits are AN and stay weak).
 const RTL_STRONG_EXTRA =
-  /[\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0608\u060B\u060D\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E\uFDFC\u{10D40}-\u{10D8F}]/u;
+  /[\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0608\u060B\u060D\u061B\u061E\u061F\u066D\u06D4\u0700-\u070D\u07C0-\u07C9\u085E\uFDFC\u{10D4A}-\u{10D65}\u{10D6F}-\u{10D85}\u{10D8E}\u{10D8F}]/u;
 const RTL_SCRIPT =
   /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}\p{Script=Hanifi_Rohingya}\p{Script=Yezidi}\p{Script=Phoenician}\p{Script=Imperial_Aramaic}\p{Script=Old_South_Arabian}\p{Script=Old_North_Arabian}\p{Script=Avestan}\p{Script=Sogdian}\p{Script=Old_Sogdian}\p{Script=Manichaean}\p{Script=Psalter_Pahlavi}\p{Script=Inscriptional_Pahlavi}\p{Script=Inscriptional_Parthian}\p{Script=Nabataean}\p{Script=Palmyrene}\p{Script=Hatran}\p{Script=Elymaic}\p{Script=Lydian}\p{Script=Kharoshthi}\p{Script=Old_Hungarian}\p{Script=Old_Turkic}\p{Script=Cypriot}\p{Script=Mende_Kikakui}\p{Script=Meroitic_Cursive}\p{Script=Meroitic_Hieroglyphs}\p{Script=Chorasmian}\p{Script=Old_Uyghur}]/u;
 const ANY_LETTER = /\p{L}/u;

--- a/web/src/lib/rehypeDirection.ts
+++ b/web/src/lib/rehypeDirection.ts
@@ -25,16 +25,20 @@ const OPAQUE_TAGS = new Set(["code", "pre"]);
 // Strong RTL letters from every right-to-left script, plus the RLM and ALM
 // marks. Script-based, so any RTL language matches. Digits and punctuation
 // are weak and skipped, mirroring browsers' first-strong dir="auto".
-const RTL_LETTER =
-  /[\u200F\u061C\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
+const RTL_MARK = /[\u200F\u061C]/u;
+const RTL_SCRIPT =
+  /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}\p{Script=Nko}\p{Script=Samaritan}\p{Script=Mandaic}\p{Script=Adlam}]/u;
 const ANY_LETTER = /\p{L}/u;
 
 function firstStrongDir(nodes: ElementContent[]): "ltr" | "rtl" | null {
   for (const node of nodes) {
     if (node.type === "text") {
       for (const char of node.value) {
-        if (RTL_LETTER.test(char)) return "rtl";
-        if (ANY_LETTER.test(char)) return "ltr";
+        if (RTL_MARK.test(char)) return "rtl";
+        // Only letters are strong. Arabic-Indic digits sit in Script=Arabic
+        // but are directionally weak, so they must not decide direction.
+        if (!ANY_LETTER.test(char)) continue;
+        return RTL_SCRIPT.test(char) ? "rtl" : "ltr";
       }
     } else if (node.type === "element" && !OPAQUE_TAGS.has(node.tagName)) {
       const dir = firstStrongDir(node.children);

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -24,6 +24,7 @@ import { useDraft, draftKey } from "@/hooks/useDraft";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import { cn } from "@opal/utils";
+import { firstStrongTextDir } from "@/lib/rehypeDirection";
 import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
@@ -212,6 +213,17 @@ const AppInputBar = React.memo(
     const appMode = state.phase === "idle" ? state.appMode : undefined;
     const isSearchMode =
       (isNewSession && appMode === "search") || isSearchActive;
+
+    const activePlaceholder =
+      queuedMessages.length > 0 && !message
+        ? t("appInputBar.input.queuedPlaceholder")
+        : isRecording
+          ? t("appInputBar.input.listeningPlaceholder")
+          : isVoicePlaybackActive
+            ? t("appInputBar.input.speakingPlaceholder")
+            : isSearchMode
+              ? t("appInputBar.input.searchPlaceholder")
+              : t("appInputBar.input.placeholder");
 
     // Keyed by chat session id, or "new" until the session is created.
     const chatSessionId = appPosition.chat();
@@ -895,6 +907,14 @@ const AppInputBar = React.memo(
                       role="textbox"
                       aria-label={t("appInputBar.input.ariaLabel")}
                       contentEditable={!disabled}
+                      // Direction follows what the user types. While empty
+                      // it follows the placeholder so its punctuation sits
+                      // on the correct side in every locale.
+                      dir={
+                        message
+                          ? "auto"
+                          : (firstStrongTextDir(activePlaceholder) ?? "auto")
+                      }
                       suppressContentEditableWarning
                       onPaste={handlePaste}
                       onCopy={handleCopy}
@@ -915,17 +935,7 @@ const AppInputBar = React.memo(
                       aria-multiline={true}
                       aria-disabled={disabled}
                       aria-placeholder={t("appInputBar.input.placeholder")}
-                      data-placeholder={
-                        queuedMessages.length > 0 && !message
-                          ? t("appInputBar.input.queuedPlaceholder")
-                          : isRecording
-                            ? t("appInputBar.input.listeningPlaceholder")
-                            : isVoicePlaybackActive
-                              ? t("appInputBar.input.speakingPlaceholder")
-                              : isSearchMode
-                                ? t("appInputBar.input.searchPlaceholder")
-                                : t("appInputBar.input.placeholder")
-                      }
+                      data-placeholder={activePlaceholder}
                       data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
                         if (

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -16,6 +16,7 @@ import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { deleteTokenBeforeCursor, getTextContent } from "@/lib/contentEditable";
 import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import { cn } from "@opal/utils";
+import { firstStrongTextDir } from "@/lib/rehypeDirection";
 import { Disabled } from "@opal/core";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { Button, Text } from "@opal/components";
@@ -295,9 +296,14 @@ const BaseInputBar = memo(
               <div
                 ref={inputRef}
                 contentEditable={!disabled}
-                // dir="auto": input direction follows what the user types,
-                // so RTL text (Arabic, Hebrew, ...) right-aligns.
-                dir="auto"
+                // Direction follows what the user types. While empty it
+                // follows the placeholder so its punctuation sits on the
+                // correct side in every locale.
+                dir={
+                  message
+                    ? "auto"
+                    : (firstStrongTextDir(resolvedPlaceholder) ?? "auto")
+                }
                 suppressContentEditableWarning
                 onPaste={handlePaste}
                 onInput={handleInput}

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -295,6 +295,9 @@ const BaseInputBar = memo(
               <div
                 ref={inputRef}
                 contentEditable={!disabled}
+                // dir="auto": input direction follows what the user types,
+                // so RTL text (Arabic, Hebrew, ...) right-aligns.
+                dir="auto"
                 suppressContentEditableWarning
                 onPaste={handlePaste}
                 onInput={handleInput}


### PR DESCRIPTION
## Description

**Why:** Chat answers in Arabic, Hebrew, Farsi, or any other RTL language render left-aligned with bullet markers on the wrong side, and mixed RTL/LTR answers are unreadable. `dir="auto"` on the message container cannot fix this: the auto algorithm skips descendants that carry `dir`, which breaks loose list items.

**What:** A rehype plugin (`rehypeDirection`) stamps each block (paragraphs, headings, lists, list items, blockquotes, tables) with the direction of its first strong character, matching the browser's first-strong algorithm. Detection is script-based, so every RTL language works without a locale list. RLM/ALM/LRM marks are honored, digits and punctuation are weak, and code never influences direction. `pre` and code stay LTR. The chat input follows what the user types via `dir="auto"`. Direction is per block, so mixed messages align each paragraph and list independently, in either UI direction.

## How Has This Been Tested?

- `web/src/lib/rehypeDirection.test.ts`: 8 jest tests covering first-strong detection, the loose-list `li > p` regression, Arabic-Indic digits staying weak, LRM handling, and letterless blocks inheriting.
- Live in Chrome on the dev stack: mixed EN/AR message with paragraphs, bullet lists, and code, in both LTR and RTL shells.
- pre-commit (oxfmt, oxlint, tsc) clean on touched files.

| LTR app, mixed message | RTL app, mixed message |
|---|---|
| ![ltr](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/rtl-ui-screenshots/rtl-chat-mixed-ltr-shell.jpg) | ![rtl](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/rtl-ui-screenshots/rtl-chat-mixed-ar-shell.jpg) |

The RTL-shell capture uses the locale PRs stacked on this branch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
