### PR TITLE
feat(web): complete the i18n string extraction across the product

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -88,36 +88,7 @@
       }
     },
     {
-      "files": [
-        "src/views/SettingsPage.tsx",
-        "src/views/AppPage.tsx",
-        "src/views/admin/**",
-        "src/sections/sidebar/**",
-        "src/sections/document-sidebar/**",
-        "src/sections/Suggestions.tsx",
-        "src/sections/modals/**",
-        "src/sections/actions/**",
-        "src/sections/knowledge/**",
-        "src/sections/onboarding/**",
-        "src/sections/usage/**",
-        "src/sections/cards/**",
-        "src/sections/agents/**",
-        "src/sections/skills/**",
-        "src/sections/settings/**",
-        "src/lib/agents/components/**",
-        "src/sections/banners/**",
-        "src/sections/chat/**",
-        "src/sections/input/**",
-        "src/sections/model-selector/**",
-        "src/components/chat/**",
-        "src/app/auth/**",
-        "src/app/admin/**",
-        "src/app/app/page.tsx",
-        "src/app/app/layout.tsx",
-        "src/app/app/components/**",
-        "src/app/app/message/**",
-        "src/app/app/shared/**"
-      ],
+      "files": ["src/**"],
       "rules": {
         "i18n/no-raw-jsx-text": "error"
       }

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -58,7 +58,6 @@ function SourceTileTooltipWrapper({
   slackCredentials?: Credential<any>[];
 }) {
   const t = useTranslations("admin.addConnector");
-  const adminRouteTitle = useAdminRouteTitle();
 
   // Check if there's already a federated connector for this source
   const existingFederatedConnector = useMemo(() => {

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import { SourceCategory, SourceMetadata } from "@/lib/search/interfaces";
@@ -57,6 +58,7 @@ function SourceTileTooltipWrapper({
   slackCredentials?: Credential<any>[];
 }) {
   const t = useTranslations("admin.addConnector");
+  const adminRouteTitle = useAdminRouteTitle();
 
   // Check if there's already a federated connector for this source
   const existingFederatedConnector = useMemo(() => {
@@ -139,6 +141,7 @@ function SourceTileTooltipWrapper({
 
 export default function Page() {
   const t = useTranslations("admin.addConnector");
+  const adminRouteTitle = useAdminRouteTitle();
   const sources = useMemo(() => listSourceMetadata(), []);
 
   const [rawSearchTerm, setSearchTerm] = useState("");
@@ -261,7 +264,7 @@ export default function Page() {
     <SettingsLayouts.Root width="full">
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         rightChildren={
           <Button href="/admin/indexing/status">
             {t("seeConnectorsButton.label")}

--- a/web/src/app/admin/agents/CollapsibleSection.tsx
+++ b/web/src/app/admin/agents/CollapsibleSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { ReactNode, useState } from "react";
 import { FiSettings } from "react-icons/fi";
+import { useTranslations } from "next-intl";
 import { clickOnKeyDown } from "@opal/utils";
 
 interface CollapsibleSectionProps {
@@ -14,6 +15,7 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
   prompt,
   className = "",
 }) => {
+  const t = useTranslations("admin.agents");
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
 
   const toggleCollapse = (e?: React.MouseEvent<HTMLDivElement>) => {
@@ -36,7 +38,11 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
         role="button"
         tabIndex={0}
         aria-expanded={!isCollapsed}
-        aria-label={isCollapsed ? "Expand section" : "Collapse section"}
+        aria-label={
+          isCollapsed
+            ? t("collapsibleSection.expand.ariaLabel")
+            : t("collapsibleSection.collapse.ariaLabel")
+        }
         onKeyDown={clickOnKeyDown(toggleCollapse)}
         className={`
           cursor-pointer

--- a/web/src/app/admin/bots/page.tsx
+++ b/web/src/app/admin/bots/page.tsx
@@ -17,7 +17,6 @@ const route = ADMIN_ROUTES.SLACK_BOTS;
 
 function Main() {
   const t = useTranslations("admin.slackBots");
-  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: slackBots,
     isLoading: isSlackBotsLoading,

--- a/web/src/app/admin/bots/page.tsx
+++ b/web/src/app/admin/bots/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { PageLoader } from "@opal/layouts";
@@ -16,6 +17,7 @@ const route = ADMIN_ROUTES.SLACK_BOTS;
 
 function Main() {
   const t = useTranslations("admin.slackBots");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: slackBots,
     isLoading: isSlackBotsLoading,
@@ -83,9 +85,14 @@ function Main() {
 }
 
 export default function Page() {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
       <SettingsLayouts.Body>
         <InstantSSRAutoRefresh />
         <Main />

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -84,7 +84,11 @@ export async function submitConnector<T>(
   connector: ConnectorBase<T>,
   connectorId?: number,
   fakeCredential?: boolean
-): Promise<{ message: string; isSuccess: boolean; response?: Connector<T> }> {
+): Promise<{
+  errorDetail?: string;
+  isSuccess: boolean;
+  response?: Connector<T>;
+}> {
   const isUpdate = connectorId !== undefined;
   if (!connector.connector_specific_config) {
     connector.connector_specific_config = {} as T;
@@ -104,10 +108,10 @@ export async function submitConnector<T>(
       );
       if (response.ok) {
         const responseJson = await response.json();
-        return { message: "Success!", isSuccess: true, response: responseJson };
+        return { isSuccess: true, response: responseJson };
       } else {
         const errorData = await response.json();
-        return { message: `Error: ${errorData.detail}`, isSuccess: false };
+        return { errorDetail: String(errorData.detail), isSuccess: false };
       }
     } else {
       const response = await fetch(
@@ -123,14 +127,14 @@ export async function submitConnector<T>(
 
       if (response.ok) {
         const responseJson = await response.json();
-        return { message: "Success!", isSuccess: true, response: responseJson };
+        return { isSuccess: true, response: responseJson };
       } else {
         const errorData = await response.json();
-        return { message: `Error: ${errorData.detail}`, isSuccess: false };
+        return { errorDetail: String(errorData.detail), isSuccess: false };
       }
     }
   } catch (error) {
-    return { message: `Error: ${error}`, isSuccess: false };
+    return { errorDetail: String(error), isSuccess: false };
   }
 }
 
@@ -444,21 +448,22 @@ export default function AddConnector({
           );
 
           const connectorCreationPromise = (async () => {
-            const { message, isSuccess, response } = await submitConnector<any>(
-              {
-                connector_specific_config: transformedConnectorSpecificConfig,
-                input_type: isLoadState(connector) ? "load_state" : "poll", // single case
-                name: name,
-                source: connector,
-                access_type: access_type,
-                refresh_freq: advancedConfiguration.refreshFreq || null,
-                prune_freq: advancedConfiguration.pruneFreq || null,
-                indexing_start: advancedConfiguration.indexingStart || null,
-                groups: groups,
-              },
-              undefined,
-              credentialActivated ? false : true
-            );
+            const { errorDetail, isSuccess, response } =
+              await submitConnector<any>(
+                {
+                  connector_specific_config: transformedConnectorSpecificConfig,
+                  input_type: isLoadState(connector) ? "load_state" : "poll", // single case
+                  name: name,
+                  source: connector,
+                  access_type: access_type,
+                  refresh_freq: advancedConfiguration.refreshFreq || null,
+                  prune_freq: advancedConfiguration.pruneFreq || null,
+                  indexing_start: advancedConfiguration.indexingStart || null,
+                  groups: groups,
+                },
+                undefined,
+                credentialActivated ? false : true
+              );
 
             // Store the connector id immediately for potential timeout
             if (response?.id) {
@@ -469,7 +474,9 @@ export default function AddConnector({
               if (isSuccess) {
                 onSuccess();
               } else {
-                toast.error(message);
+                toast.error(
+                  t("add.error.toast", { detail: errorDetail ?? "" })
+                );
               }
               timeoutErrorHappenedRef.current = false;
               return;
@@ -502,7 +509,7 @@ export default function AddConnector({
             } else if (isSuccess) {
               onSuccess();
             } else {
-              toast.error(message);
+              toast.error(t("add.error.toast", { detail: errorDetail ?? "" }));
             }
 
             timeoutErrorHappenedRef.current = false;

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
@@ -209,7 +209,7 @@ export const DriveAuthSection = ({
                 </Text>
                 <InputTypeInField
                   name="google_primary_admin"
-                  placeholder="admin@yourcompany.com"
+                  placeholder={t("gdrive.primaryAdmin.placeholder")}
                 />
                 <Text font="secondary-body" color="text-03">
                   {t("gdrive.primaryAdmin.description")}

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
@@ -220,7 +220,7 @@ export const GmailAuthSection = ({
                 </Text>
                 <InputTypeInField
                   name="google_primary_admin"
-                  placeholder="admin@yourcompany.com"
+                  placeholder={t("gmail.primaryAdmin.placeholder")}
                 />
                 <Text font="secondary-body" color="text-03">
                   {t("gmail.primaryAdmin.description")}

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -26,7 +26,6 @@ const route = ADMIN_ROUTES.DISCORD_BOTS;
 
 function DiscordBotContent() {
   const t = useTranslations("admin.discordBot");
-  const adminRouteTitle = useAdminRouteTitle();
   const { data: guilds, isLoading, error, refreshGuilds } = useDiscordGuilds();
   const { data: botConfig, isManaged } = useDiscordBotConfig();
   const [registrationKey, setRegistrationKey] = useState<string | null>(null);

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { PageLoader } from "@opal/layouts";
@@ -25,6 +26,7 @@ const route = ADMIN_ROUTES.DISCORD_BOTS;
 
 function DiscordBotContent() {
   const t = useTranslations("admin.discordBot");
+  const adminRouteTitle = useAdminRouteTitle();
   const { data: guilds, isLoading, error, refreshGuilds } = useDiscordGuilds();
   const { data: botConfig, isManaged } = useDiscordBotConfig();
   const [registrationKey, setRegistrationKey] = useState<string | null>(null);
@@ -126,12 +128,13 @@ function DiscordBotContent() {
 
 export default function Page() {
   const t = useTranslations("admin.discordBot");
+  const adminRouteTitle = useAdminRouteTitle();
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("page.header.description")}
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/document-processing/page.tsx
+++ b/web/src/app/admin/document-processing/page.tsx
@@ -19,7 +19,6 @@ const route = ADMIN_ROUTES.DOCUMENT_PROCESSING;
 
 function Main() {
   const t = useTranslations("admin.documentProcessing");
-  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: isApiKeySet,
     error,

--- a/web/src/app/admin/document-processing/page.tsx
+++ b/web/src/app/admin/document-processing/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import CardSection from "@/components/admin/CardSection";
@@ -18,6 +19,7 @@ const route = ADMIN_ROUTES.DOCUMENT_PROCESSING;
 
 function Main() {
   const t = useTranslations("admin.documentProcessing");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: isApiKeySet,
     error,
@@ -157,9 +159,14 @@ function Main() {
 }
 
 export default function Page() {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/documents/explorer/DocumentExplorerPage.tsx
+++ b/web/src/app/admin/documents/explorer/DocumentExplorerPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Explorer } from "./Explorer";
@@ -19,9 +20,14 @@ export default function DocumentExplorerPage({
   connectors,
   documentSets,
 }: DocumentExplorerPageProps) {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
 
       <SettingsLayouts.Body>
         <Explorer

--- a/web/src/app/admin/documents/feedback/page.tsx
+++ b/web/src/app/admin/documents/feedback/page.tsx
@@ -14,7 +14,6 @@ const route = ADMIN_ROUTES.DOCUMENT_FEEDBACK;
 
 function Main() {
   const t = useTranslations("admin.documents");
-  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: mostLikedDocuments,
     isLoading: isMostLikedDocumentsLoading,

--- a/web/src/app/admin/documents/feedback/page.tsx
+++ b/web/src/app/admin/documents/feedback/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { LoadingAnimation } from "@/components/Loading";
 import { useMostReactedToDocuments } from "@/lib/hooks";
@@ -13,6 +14,7 @@ const route = ADMIN_ROUTES.DOCUMENT_FEEDBACK;
 
 function Main() {
   const t = useTranslations("admin.documents");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: mostLikedDocuments,
     isLoading: isMostLikedDocumentsLoading,
@@ -66,9 +68,14 @@ function Main() {
 }
 
 export default function Page() {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -55,7 +55,6 @@ const FederatedConnectorTitle = ({
   isLink?: boolean;
 }) => {
   const t = useTranslations("admin.documents");
-  const adminRouteTitle = useAdminRouteTitle();
   const sourceType = federatedConnector.source.replace(/^federated_/, "");
 
   const mainSectionClassName = "text-blue-500 dark:text-blue-100 flex w-fit";
@@ -111,7 +110,6 @@ const EditRow = ({
   isEditable: boolean;
 }) => {
   const t = useTranslations("admin.documents");
-  const adminRouteTitle = useAdminRouteTitle();
   const router = useRouter();
 
   if (!isEditable) {
@@ -164,7 +162,6 @@ const DocumentSetTable = ({
   refresh,
 }: DocumentFeedbackTableProps) => {
   const t = useTranslations("admin.documents");
-  const adminRouteTitle = useAdminRouteTitle();
   const [page, setPage] = useState(1);
 
   // editable rows first, then by name — editability now rides on each row's
@@ -347,7 +344,6 @@ const DocumentSetTable = ({
 
 function Main() {
   const t = useTranslations("admin.documents");
-  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: documentSets,
     isLoading: isDocumentSetsLoading,

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { PageLoader } from "@opal/layouts";
 import { PageSelector } from "@/components/PageSelector";
@@ -40,6 +41,7 @@ import { SourceIcon } from "@/components/SourceIcon";
 import Link from "next/link";
 
 const route = ADMIN_ROUTES.DOCUMENT_SETS;
+
 const numToDisplay = 50;
 
 // Component to display federated connectors with consistent styling
@@ -53,6 +55,7 @@ const FederatedConnectorTitle = ({
   isLink?: boolean;
 }) => {
   const t = useTranslations("admin.documents");
+  const adminRouteTitle = useAdminRouteTitle();
   const sourceType = federatedConnector.source.replace(/^federated_/, "");
 
   const mainSectionClassName = "text-blue-500 dark:text-blue-100 flex w-fit";
@@ -108,6 +111,7 @@ const EditRow = ({
   isEditable: boolean;
 }) => {
   const t = useTranslations("admin.documents");
+  const adminRouteTitle = useAdminRouteTitle();
   const router = useRouter();
 
   if (!isEditable) {
@@ -160,6 +164,7 @@ const DocumentSetTable = ({
   refresh,
 }: DocumentFeedbackTableProps) => {
   const t = useTranslations("admin.documents");
+  const adminRouteTitle = useAdminRouteTitle();
   const [page, setPage] = useState(1);
 
   // editable rows first, then by name — editability now rides on each row's
@@ -342,6 +347,7 @@ const DocumentSetTable = ({
 
 function Main() {
   const t = useTranslations("admin.documents");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: documentSets,
     isLoading: isDocumentSetsLoading,
@@ -396,9 +402,14 @@ function Main() {
 }
 
 export default function Page() {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/indexing/status/page.tsx
+++ b/web/src/app/admin/indexing/status/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { CCPairIndexingStatusTable } from "./CCPairIndexingStatusTable";
 import { SearchAndFilterControls } from "./SearchAndFilterControls";
@@ -24,6 +25,7 @@ const route = ADMIN_ROUTES.INDEXING_STATUS;
 
 function Main() {
   const t = useTranslations("admin.indexing");
+  const adminRouteTitle = useAdminRouteTitle();
   const { vectorDbEnabled } = useSettings();
 
   // State for filter management
@@ -207,6 +209,7 @@ function Main() {
 
 export default function Status() {
   const t = useTranslations("admin.indexing");
+  const adminRouteTitle = useAdminRouteTitle();
 
   useToastFromQuery({
     "connector-created": {
@@ -219,7 +222,7 @@ export default function Status() {
     <SettingsLayouts.Root width="full">
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         rightChildren={
           <Button href="/admin/add-connector">
             {t("status.addConnectorButton.label")}

--- a/web/src/app/admin/indexing/status/page.tsx
+++ b/web/src/app/admin/indexing/status/page.tsx
@@ -25,7 +25,6 @@ const route = ADMIN_ROUTES.INDEXING_STATUS;
 
 function Main() {
   const t = useTranslations("admin.indexing");
-  const adminRouteTitle = useAdminRouteTitle();
   const { vectorDbEnabled } = useSettings();
 
   // State for filter management

--- a/web/src/app/admin/mcp-actions/page.tsx
+++ b/web/src/app/admin/mcp-actions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import MCPPageContent from "@/sections/actions/MCPPageContent";
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -9,12 +10,13 @@ const route = ADMIN_ROUTES.MCP_ACTIONS;
 
 export default function Main() {
   const t = useTranslations("admin.mcpActions");
+  const adminRouteTitle = useAdminRouteTitle();
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("header.description")}
         divider
       />

--- a/web/src/app/admin/oauth-test/page.tsx
+++ b/web/src/app/admin/oauth-test/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { PageLoader } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -58,6 +59,7 @@ function ClaimsTable({
   claims: Record<string, unknown>;
 }) {
   const t = useTranslations("admin.oauthTest");
+  const adminRouteTitle = useAdminRouteTitle();
   const entries = Object.entries(claims);
   return (
     <div className="flex flex-col gap-2">
@@ -99,6 +101,7 @@ function ClaimsTable({
 
 function Main() {
   const t = useTranslations("admin.oauthTest");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: snapshot,
     error,
@@ -199,9 +202,14 @@ function Main() {
 }
 
 export default function Page() {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/oauth-test/page.tsx
+++ b/web/src/app/admin/oauth-test/page.tsx
@@ -59,7 +59,6 @@ function ClaimsTable({
   claims: Record<string, unknown>;
 }) {
   const t = useTranslations("admin.oauthTest");
-  const adminRouteTitle = useAdminRouteTitle();
   const entries = Object.entries(claims);
   return (
     <div className="flex flex-col gap-2">
@@ -101,7 +100,6 @@ function ClaimsTable({
 
 function Main() {
   const t = useTranslations("admin.oauthTest");
-  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: snapshot,
     error,

--- a/web/src/app/admin/openapi-actions/page.tsx
+++ b/web/src/app/admin/openapi-actions/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import OpenApiPageContent from "@/sections/actions/OpenApiPageContent";
@@ -9,12 +10,13 @@ const route = ADMIN_ROUTES.OPENAPI_ACTIONS;
 
 export default function Main() {
   const t = useTranslations("admin.openapiActions");
+  const adminRouteTitle = useAdminRouteTitle();
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("header.description")}
         divider
       />

--- a/web/src/app/anonymous/[id]/AnonymousPage.tsx
+++ b/web/src/app/anonymous/[id]/AnonymousPage.tsx
@@ -1,12 +1,14 @@
 "use client";
 import { redirect } from "next/navigation";
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 
 export default function AnonymousPage({
   anonymousPath,
 }: {
   anonymousPath: string;
 }) {
+  const t = useTranslations("auth");
   const loginAsAnonymousUser = async () => {
     try {
       const response = await fetch(
@@ -42,13 +44,13 @@ export default function AnonymousPage({
     <div className="flex flex-col items-center justify-center min-h-screen bg-background-100">
       <div className="bg-white p-8 rounded-lg shadow-md">
         <h1 className="text-2xl font-bold mb-4 text-center">
-          Redirecting you to the chat page...
+          {t("anonymous.redirecting.title")}
         </h1>
         <div className="flex justify-center">
           <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-background-800"></div>
         </div>
         <p className="mt-4 text-text-600 text-center">
-          Please wait while we set up your anonymous session.
+          {t("anonymous.redirecting.description")}
         </p>
       </div>
     </div>

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import type { Route } from "next";
+import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
 import { SidebarTab, Text } from "@opal/components";
 import { SvgSliders } from "@opal/icons";
@@ -24,6 +25,7 @@ interface SettingsTab {
 }
 
 export default function Layout({ children }: LayoutProps) {
+  const t = useTranslations("settings.layout");
   const pathname = usePathname();
   const router = useRouter();
   const { user } = useUser();
@@ -37,16 +39,29 @@ export default function Layout({ children }: LayoutProps) {
   const showGatewayTab = gatewayTier && hasVisibleLLMModel(llmProviders);
 
   const tabs: SettingsTab[] = [
-    { href: "/app/settings/general", label: "General" },
-    { href: "/app/settings/chat-preferences", label: "Chat Preferences" },
+    { href: "/app/settings/general", label: t("tabs.general.label") },
+    {
+      href: "/app/settings/chat-preferences",
+      label: t("tabs.chatPreferences.label"),
+    },
     ...(showAccountsAccessTab
-      ? [{ href: "/app/settings/accounts-access", label: "Accounts & Access" }]
+      ? [
+          {
+            href: "/app/settings/accounts-access",
+            label: t("tabs.accountsAccess.label"),
+          },
+        ]
       : []),
     ...(showGatewayTab
-      ? [{ href: "/app/settings/llm-gateway", label: "LLM Gateway" }]
+      ? [
+          {
+            href: "/app/settings/llm-gateway",
+            label: t("tabs.llmGateway.label"),
+          },
+        ]
       : []),
-    { href: "/app/settings/connectors", label: "Connectors" },
-    { href: "/app/settings/usage", label: "Usage" },
+    { href: "/app/settings/connectors", label: t("tabs.connectors.label") },
+    { href: "/app/settings/usage", label: t("tabs.usage.label") },
   ];
 
   // Derive the trigger label from the pathname directly. InputSelect normally
@@ -57,7 +72,11 @@ export default function Layout({ children }: LayoutProps) {
 
   return (
     <SettingsLayouts.Root width="lg">
-      <SettingsLayouts.Header icon={SvgSliders} title="Settings" divider />
+      <SettingsLayouts.Header
+        icon={SvgSliders}
+        title={t("header.title")}
+        divider
+      />
 
       <SettingsLayouts.Body>
         <Section
@@ -78,7 +97,7 @@ export default function Layout({ children }: LayoutProps) {
                 router.push(href as Route, { scroll: false })
               }
             >
-              <InputSelect.Trigger placeholder="Select a section">
+              <InputSelect.Trigger placeholder={t("sectionSelect.placeholder")}>
                 {activeTab && (
                   <Text font="main-ui-body" color="text-04" nowrap>
                     {activeTab.label}

--- a/web/src/app/app/settings/llm-gateway/page.test.tsx
+++ b/web/src/app/app/settings/llm-gateway/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@tests/setup/test-utils";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { useSettings } from "@/lib/settings/hooks";

--- a/web/src/app/app/settings/llm-gateway/page.tsx
+++ b/web/src/app/app/settings/llm-gateway/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { EmptyMessageCard } from "@opal/components";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
@@ -11,6 +12,7 @@ import { LLM_GATEWAY_MIN_TIER } from "@/lib/tiers";
 import { LLMGatewaySettings } from "@/views/SettingsPage";
 
 export default function LLMGatewayPage() {
+  const t = useTranslations("settings.gateway");
   const router = useRouter();
   const gatewayTier = useTierAtLeast(LLM_GATEWAY_MIN_TIER);
   const settings = useSettings();
@@ -35,8 +37,8 @@ export default function LLMGatewayPage() {
     return (
       <EmptyMessageCard
         sizePreset="main-ui"
-        title="Could not load LLM Gateway"
-        description="Please refresh the page and try again."
+        title={t("loadError.title")}
+        description={t("loadError.description")}
       />
     );
   }

--- a/web/src/app/app/settings/usage/UsageSettings.test.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@tests/setup/test-utils";
 import userEvent from "@testing-library/user-event";
 import UsageSettings from "@/app/app/settings/usage/UsageSettings";
 import { useUserUsage } from "@/app/app/settings/usage/lib";

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -149,19 +149,24 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
                     color="text-03"
                     data-testid="usage-model-tokens"
                   >
-                    {`${formatTokens(row.input_tokens)} in · ${formatTokens(
-                      row.output_tokens
-                    )} out${
-                      hasCache
-                        ? ` · ${formatTokens(row.cache_read_tokens)} cache reads`
-                        : ""
-                    }${
-                      hasCacheWrites
-                        ? ` · ${formatTokens(
-                            row.cache_creation_tokens
-                          )} cache writes`
-                        : ""
-                    }`}
+                    {[
+                      t("modelUsage.tokensIn.label", {
+                        count: formatTokens(row.input_tokens),
+                      }),
+                      t("modelUsage.tokensOut.label", {
+                        count: formatTokens(row.output_tokens),
+                      }),
+                      hasCache &&
+                        t("modelUsage.cacheReads.label", {
+                          count: formatTokens(row.cache_read_tokens),
+                        }),
+                      hasCacheWrites &&
+                        t("modelUsage.cacheWrites.label", {
+                          count: formatTokens(row.cache_creation_tokens),
+                        }),
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
                   </Text>
                 </Section>
               </div>
@@ -225,9 +230,10 @@ function isSameModelPrice(
 function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
   const t = useTranslations("settings.usage");
   const groups = useMemo(() => {
+    // t is stable per locale, listed below to satisfy the deps lint.
     const byProvider = new Map<string, ModelPrice[]>();
     for (const price of prices) {
-      const key = price.provider ?? "Other";
+      const key = price.provider ?? t("modelPrices.otherProvider.label");
       const list = byProvider.get(key) ?? [];
       list.push(price);
       byProvider.set(key, list);
@@ -235,7 +241,7 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
     return Array.from(byProvider.entries())
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([provider, models]) => ({ provider, models }));
-  }, [prices]);
+  }, [prices, t]);
 
   // Expand the provider that holds the default model (else the first).
   const defaultProvider = useMemo(
@@ -309,7 +315,9 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
                         >
                           <Text font="secondary-body" color="text-05" nowrap>
                             {isSameModelPrice(price, defaultPrice)
-                              ? `${price.model} · default`
+                              ? t("modelPrices.defaultTag.label", {
+                                  model: price.model,
+                                })
                               : price.model}
                           </Text>
                           <Text font="secondary-body" color="text-03" nowrap>

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
@@ -44,6 +45,7 @@ interface WindowCostSectionProps {
 const COLLAPSED_USAGE_ROW_COUNT = 3;
 
 function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
+  const t = useTranslations("settings.usage");
   const [showAll, setShowAll] = useState(false);
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
   const hasCacheWrites = rows.some((row) => row.cache_creation_tokens > 0);
@@ -80,8 +82,10 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
     <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgBarChart}
-        title="Usage this period"
-        description={`${formatDollars(windowCostCents)} spent`}
+        title={t("usageThisPeriod.title")}
+        description={t("usageThisPeriod.description", {
+          amount: formatDollars(windowCostCents),
+        })}
         sizePreset="main-content"
         variant="section"
         width="full"
@@ -90,8 +94,8 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
       {rows.length === 0 ? (
         <EmptyMessageCard
           sizePreset="main-ui"
-          title="No usage recorded yet"
-          description="Your model usage and costs will show up here once you start chatting."
+          title={t("empty.title")}
+          description={t("empty.description")}
         />
       ) : (
         <Card>
@@ -178,12 +182,14 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
                 aria-expanded={showAll}
                 aria-label={
                   showAll
-                    ? "Show fewer models"
-                    : `Show ${hiddenRowCount} more models`
+                    ? t("showFewerModels.ariaLabel")
+                    : t("showMoreModels.ariaLabel", { count: hiddenRowCount })
                 }
                 onClick={() => setShowAll((value) => !value)}
               >
-                {showAll ? "Show less" : `Show ${hiddenRowCount} more`}
+                {showAll
+                  ? t("showLess.label")
+                  : t("showMore.label", { count: hiddenRowCount })}
               </Button>
             </div>
           )}
@@ -217,6 +223,7 @@ function isSameModelPrice(
 // collapsible menu per provider — click a provider to expand its models. Mirrors
 // the chat model selector so users can compare costs, not just the default.
 function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
+  const t = useTranslations("settings.usage");
   const groups = useMemo(() => {
     const byProvider = new Map<string, ModelPrice[]>();
     for (const price of prices) {
@@ -256,8 +263,8 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
     <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgCreditCard}
-        title="Model prices"
-        description="USD per 1M tokens (input · output · cache) for every available model"
+        title={t("modelPrices.title")}
+        description={t("modelPrices.description")}
         sizePreset="main-content"
         variant="section"
         width="full"
@@ -265,7 +272,7 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
       <Card>
         {groups.length === 0 ? (
           <Text font="main-ui-body" color="text-01">
-            Prices unavailable
+            {t("modelPrices.unavailable")}
           </Text>
         ) : (
           <Section gap={0.25} alignItems="stretch" justifyContent="start">
@@ -332,30 +339,29 @@ interface BudgetSectionProps {
   budgetResetAt: string | null;
 }
 
-function formatBudgetReset(resetAt: string | null): string | null {
-  return resetAt
-    ? `Resets on ${formatCalendarDay(resetAt.slice(0, 10))}`
-    : null;
-}
-
 function BudgetSection({
   budgetCents,
   budgetRemainingCents,
   budgetResetAt,
 }: BudgetSectionProps) {
+  const t = useTranslations("settings.usage");
   // budget_* are null when the user has no cost limit; show a graceful empty state.
   const hasBudget = budgetCents !== null;
   const remaining = budgetRemainingCents ?? 0;
   const spent = hasBudget ? Math.max(0, budgetCents - remaining) : 0;
   const usedFraction =
     hasBudget && budgetCents > 0 ? Math.min(1, spent / budgetCents) : 0;
-  const budgetReset = formatBudgetReset(budgetResetAt);
+  const budgetReset = budgetResetAt
+    ? t("budget.resetsOn", {
+        date: formatCalendarDay(budgetResetAt.slice(0, 10)),
+      })
+    : null;
 
   return (
     <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgWallet}
-        title="Budget"
+        title={t("budget.title")}
         sizePreset="main-content"
         variant="section"
         width="full"
@@ -365,7 +371,7 @@ function BudgetSection({
           <Section gap={0.5} alignItems="start" justifyContent="start">
             <div className="flex w-full flex-wrap items-baseline gap-x-4 gap-y-1">
               <Text font="main-ui-body" color="text-03">
-                {`${formatDollars(remaining)} remaining`}
+                {t("budget.remaining", { amount: formatDollars(remaining) })}
               </Text>
             </div>
             <div className="h-1.5 w-full overflow-hidden rounded-full bg-background-neutral-03">
@@ -386,13 +392,13 @@ function BudgetSection({
                 </Text>
               )}
               <Text font="secondary-body" color="text-03">
-                {`${formatDollars(budgetCents)} limit`}
+                {t("budget.limit", { amount: formatDollars(budgetCents) })}
               </Text>
             </div>
           </Section>
         ) : (
           <Text font="main-ui-body" color="text-01">
-            No budget set
+            {t("budget.none")}
           </Text>
         )}
       </Card>
@@ -401,6 +407,7 @@ function BudgetSection({
 }
 
 export default function UsageSettings() {
+  const t = useTranslations("settings.usage");
   const [dateRange, setDateRange] = useState<DateRange>(
     rangeForInclusiveDays(30)
   );
@@ -414,7 +421,7 @@ export default function UsageSettings() {
     <Section gap={2}>
       <Section gap={0.75} justifyContent="start">
         <div className="flex w-full flex-wrap items-center justify-between gap-3">
-          <Text font="heading-h3">Usage</Text>
+          <Text font="heading-h3">{t("header.title")}</Text>
           <DateRangePicker
             value={dateRange}
             onValueChange={setDateRange}
@@ -436,8 +443,8 @@ export default function UsageSettings() {
         ) : error || !data ? (
           <EmptyMessageCard
             sizePreset="main-ui"
-            title="Couldn't load usage"
-            description="Something went wrong fetching your usage. Try again in a moment."
+            title={t("loadError.title")}
+            description={t("loadError.description")}
           />
         ) : (
           <Section gap={2}>

--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -74,7 +74,7 @@ export default function ImpersonatePage() {
                 name="email"
                 type="email"
                 label={t("impersonate.emailField.label")}
-                placeholder="email@yourcompany.com"
+                placeholder={t("impersonate.emailField.placeholder")}
               />
 
               <TextFormField

--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -14,6 +14,7 @@ import {
   ChatBackgroundOption,
 } from "@/lib/constants/chatBackgrounds";
 import { ThemePreference } from "@/lib/types";
+import { useTranslations } from "next-intl";
 
 interface SettingRowProps {
   label: string;
@@ -51,40 +52,48 @@ const BackgroundThumbnail = ({
   isNone = false,
   isSelected,
   onClick,
-}: BackgroundThumbnailProps) => (
-  <button
-    onClick={onClick}
-    className="relative overflow-hidden rounded-xl transition-all aspect-video cursor-pointer border-none p-0 bg-transparent group"
-    title={label}
-    aria-label={`${label} background${isSelected ? " (selected)" : ""}`}
-  >
-    {isNone ? (
-      <div className="absolute inset-0 bg-background flex items-center justify-center">
-        <Text secondaryBody text03>
-          None
-        </Text>
-      </div>
-    ) : (
-      <div
-        className="absolute inset-0 bg-cover bg-center transition-transform duration-300 group-hover:scale-105"
-        style={{ backgroundImage: `url(${thumbnailUrl})` }}
-      />
-    )}
-    <div
-      className={cn(
-        "absolute inset-0 transition-all rounded-xl",
+}: BackgroundThumbnailProps) => {
+  const t = useTranslations("chat");
+  return (
+    /* raw-ok: pre-existing full-bleed image tile with selection ring, Button in components/buttons/button d.ts has no image-fill variant */
+    <button
+      onClick={onClick}
+      className="relative overflow-hidden rounded-xl transition-all aspect-video cursor-pointer border-none p-0 bg-transparent group"
+      title={label}
+      aria-label={
         isSelected
-          ? "ring-2 ring-inset ring-theme-primary-05"
-          : "ring-1 ring-inset ring-border-02 group-hover:ring-border-03"
+          ? t("nrf.settingsPanel.backgroundOptionSelected.ariaLabel", { label })
+          : t("nrf.settingsPanel.backgroundOption.ariaLabel", { label })
+      }
+    >
+      {isNone ? (
+        <div className="absolute inset-0 bg-background flex items-center justify-center">
+          <Text secondaryBody text03>
+            {t("nrf.settingsPanel.backgroundNone.label")}
+          </Text>
+        </div>
+      ) : (
+        <div
+          className="absolute inset-0 bg-cover bg-center transition-transform duration-300 group-hover:scale-105"
+          style={{ backgroundImage: `url(${thumbnailUrl})` }}
+        />
       )}
-    />
-    {isSelected && (
-      <div className="absolute top-2 end-2 w-5 h-5 rounded-full bg-theme-primary-05 flex items-center justify-center">
-        <SvgCheck className="w-3 h-3 stroke-text-inverted-05" />
-      </div>
-    )}
-  </button>
-);
+      <div
+        className={cn(
+          "absolute inset-0 transition-all rounded-xl",
+          isSelected
+            ? "ring-2 ring-inset ring-theme-primary-05"
+            : "ring-1 ring-inset ring-border-02 group-hover:ring-border-03"
+        )}
+      />
+      {isSelected && (
+        <div className="absolute top-2 end-2 w-5 h-5 rounded-full bg-theme-primary-05 flex items-center justify-center">
+          <SvgCheck className="w-3 h-3 stroke-text-inverted-05" />
+        </div>
+      )}
+    </button>
+  );
+};
 
 export const SettingsPanel = ({
   settingsOpen,
@@ -95,6 +104,16 @@ export const SettingsPanel = ({
   toggleSettings: () => void;
   handleUseOnyxToggle: (checked: boolean) => void;
 }) => {
+  const tBg = useTranslations("common.chatBackgrounds");
+  const bgLabels: Record<string, string> = {
+    none: tBg("none.label"),
+    clouds: tBg("clouds.label"),
+    hills: tBg("hills.label"),
+    plant: tBg("plant.label"),
+    mountains: tBg("mountains.label"),
+    night: tBg("night.label"),
+  };
+  const t = useTranslations("chat");
   const { useOnyxAsNewTab } = useNRFPreferences();
   const { theme, setTheme } = useTheme();
   const { user, updateUserChatBackground, updateUserThemePreference } =
@@ -164,7 +183,7 @@ export const SettingsPanel = ({
                 <SvgSettings className="w-5 h-5 stroke-text-03" />
               </div>
               <Text headingH3 text04>
-                Settings
+                {t("nrf.settingsPanel.header.title")}
               </Text>
             </div>
             <div className="flex items-center gap-3">
@@ -173,13 +192,15 @@ export const SettingsPanel = ({
                 icon={isDark ? SvgMoon : SvgSun}
                 onClick={toggleTheme}
                 prominence="tertiary"
-                tooltip={`Switch to ${isDark ? "light" : "dark"} theme`}
+                tooltip={t("nrf.settingsPanel.themeToggle.tooltip", {
+                  mode: isDark ? "light" : "dark",
+                })}
               />
               <Button
                 icon={SvgX}
                 onClick={toggleSettings}
                 prominence="tertiary"
-                tooltip="Close settings"
+                tooltip={t("nrf.settingsPanel.closeButton.tooltip")}
               />
             </div>
           </div>
@@ -189,10 +210,10 @@ export const SettingsPanel = ({
           {/* General Section */}
           <section className="flex flex-col gap-3">
             <Text secondaryAction text03 className="uppercase tracking-wider">
-              General
+              {t("nrf.settingsPanel.generalSection.title")}
             </Text>
             <div className="flex flex-col gap-1 bg-background-tint-01 rounded-2xl px-4">
-              <SettingRow label="Use Onyx as new tab page">
+              <SettingRow label={t("nrf.settingsPanel.newTabToggle.label")}>
                 <Switch
                   checked={useOnyxAsNewTab}
                   onCheckedChange={handleUseOnyxToggle}
@@ -204,14 +225,14 @@ export const SettingsPanel = ({
           {/* Background Section */}
           <section className="flex flex-col gap-3">
             <Text secondaryAction text03 className="uppercase tracking-wider">
-              Background
+              {t("nrf.settingsPanel.backgroundSection.title")}
             </Text>
             <div className="grid grid-cols-3 gap-2">
               {CHAT_BACKGROUND_OPTIONS.map((bg) => (
                 <BackgroundThumbnail
                   key={bg.id}
                   thumbnailUrl={bg.thumbnail}
-                  label={bg.label}
+                  label={bgLabels[bg.id] ?? bg.label}
                   isNone={bg.src === CHAT_BACKGROUND_NONE}
                   isSelected={currentBackgroundId === bg.id}
                   onClick={() => handleBackgroundChange(bg)}

--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -55,7 +55,7 @@ const BackgroundThumbnail = ({
 }: BackgroundThumbnailProps) => {
   const t = useTranslations("chat");
   return (
-    /* raw-ok: pre-existing full-bleed image tile with selection ring, Button in components/buttons/button d.ts has no image-fill variant */
+    /* raw-ok: full-bleed image tile with selection ring, the opal Button has no image-fill variant */
     <button
       onClick={onClick}
       className="relative overflow-hidden rounded-xl transition-all aspect-video cursor-pointer border-none p-0 bg-transparent group"

--- a/web/src/app/craft/components/AgentSwitcher.tsx
+++ b/web/src/app/craft/components/AgentSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Popover, PopoverMenu, Text, LineItemButton } from "@opal/components";
 import {
   SvgChevronDown,
@@ -46,6 +47,7 @@ function SubagentStatus({ subagent }: { subagent: SubagentState }) {
  * the main agent — there is no separate back button.
  */
 export default function AgentSwitcher() {
+  const t = useTranslations("craft.agentSwitcher");
   const title = useCurrentSessionTitle();
   const subagents = useSubagents();
   const viewedSubagentSessionId = useViewedSubagentSessionId();
@@ -86,7 +88,9 @@ export default function AgentSwitcher() {
   // is being viewed, otherwise the session title (the main agent).
   const triggerLabel =
     isViewingSubagent && viewedSubagent
-      ? viewedSubagent.name || viewedSubagent.subagentType || "subagent"
+      ? viewedSubagent.name ||
+        viewedSubagent.subagentType ||
+        t("subagentFallback.label")
       : titleLabel;
 
   // Nothing to show (untitled session, not viewing a subagent) — render nothing.
@@ -115,7 +119,7 @@ export default function AgentSwitcher() {
       <Popover.Trigger asChild>
         <button
           type="button"
-          aria-label="Switch agent"
+          aria-label={t("switch.ariaLabel")}
           className={cn(
             "flex items-center gap-1 min-w-0 px-1.5 py-1 rounded-08",
             "transition-colors hover:bg-background-tint-01",
@@ -136,7 +140,7 @@ export default function AgentSwitcher() {
               icon={SvgSparkle}
               state={!isViewingSubagent ? "selected" : "empty"}
               onClick={selectMainAgent}
-              title={titleLabel ?? "Main agent"}
+              title={titleLabel ?? t("mainAgent.label")}
             />,
             ...sorted.map((s) => (
               <LineItemButton
@@ -149,7 +153,7 @@ export default function AgentSwitcher() {
                 }
                 onClick={() => selectSubagent(s.sessionId)}
                 rightChildren={<SubagentStatus subagent={s} />}
-                title={s.name || s.subagentType || "subagent"}
+                title={s.name || s.subagentType || t("subagentFallback.label")}
               />
             )),
           ]}

--- a/web/src/app/craft/components/BuildLLMPopover.test.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@tests/setup/test-utils";
 import { BuildLLMPopover } from "@/app/craft/components/BuildLLMPopover";
 import type {
   LLMProviderDescriptor,

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { SvgCheck, SvgChevronDown, SvgChevronRight } from "@opal/icons";
 import { Text, Popover, PopoverMenu, LineItemButton } from "@opal/components";
 import { Switch } from "@opal/components";
@@ -75,6 +76,7 @@ export function BuildLLMPopover({
   disabled = false,
   persistSelection = true,
 }: BuildLLMPopoverProps) {
+  const t = useTranslations("craft.llmPopover");
   const { user } = useUser();
   const userId = user?.id;
   // Storage is the source of truth for the toggle (the user id it's keyed by
@@ -249,7 +251,9 @@ export function BuildLLMPopover({
       currentSelection?.provider === option.providerKey;
 
     // Build description with recommendation badge
-    const description = option.isRecommended ? "Recommended" : undefined;
+    const description = option.isRecommended
+      ? t("recommended.label")
+      : undefined;
 
     const rowIcon = getModelIcon(option.providerKey, option.modelName);
     const groupIcon = getModelIcon(option.providerKey);
@@ -285,7 +289,7 @@ export function BuildLLMPopover({
           <Section gap={2}>
             <div className="flex items-center justify-between py-3 gap-3 border-b border-border-01 px-1">
               <Text font="secondary-body" color="text-03">
-                Recommended Models Only
+                {t("recommendedOnly.label")}
               </Text>
               <Switch
                 checked={showRecommendedOnly}
@@ -298,7 +302,7 @@ export function BuildLLMPopover({
                 ? [
                     <div key="empty" className="py-3 px-2">
                       <Text font="secondary-body" color="text-03">
-                        No models found
+                        {t("noModels.label")}
                       </Text>
                     </div>,
                   ]

--- a/web/src/app/craft/components/BuildWelcome.tsx
+++ b/web/src/app/craft/components/BuildWelcome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { BuildFile } from "@/app/craft/contexts/UploadFilesContext";
 import { useVideoBackgroundToggleClick } from "@/app/craft/components/video-background/useVideoBackgroundToggleClick";
 import Text from "@/refresh-components/texts/Text";
@@ -37,6 +38,7 @@ export default function BuildWelcome({
   isRunning,
   sandboxInitializing = false,
 }: BuildWelcomeProps) {
+  const t = useTranslations("craft.welcome");
   const inputBarRef = useRef<CraftInputBarHandle>(null);
   const [selectedModel, setSelectedModel] = useState<BuildLlmSelection | null>(
     null
@@ -104,7 +106,7 @@ export default function BuildWelcome({
               onSubmit(message, files, selectedModel)
             }
             isRunning={isRunning}
-            placeholder="Analyze my data and create a dashboard..."
+            placeholder={t("input.placeholder")}
             sandboxInitializing={sandboxInitializing}
             disabled={!hasAnyProvider}
           />

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { track, AnalyticsEvent } from "@/lib/analytics/utils";
 import {
   useSession,
@@ -94,6 +95,7 @@ function toMessageAttachments(files: BuildFile[]): BuildMessageAttachment[] {
 export default function BuildChatPanel({
   existingSessionId,
 }: BuildChatPanelProps) {
+  const t = useTranslations("craft.chatPanel");
   const router = useRouter();
   const outputPanelOpen = useOutputPanelOpen();
   const session = useSession();
@@ -455,7 +457,7 @@ export default function BuildChatPanel({
       modelOverride?: BuildLlmSelection | null
     ) => {
       if (scheduledRunInFlight) {
-        toast.error("Please wait for the scheduled run to finish.");
+        toast.error(t("toast.scheduledRunWait"));
         return;
       }
 
@@ -467,7 +469,7 @@ export default function BuildChatPanel({
         // Existing session flow
         // Check if response is still streaming - show toast like main chat does
         if (isRunning) {
-          toast.error("Please wait for the current operation to complete.");
+          toast.error(t("toast.operationWait"));
           return;
         }
 
@@ -488,7 +490,7 @@ export default function BuildChatPanel({
         if (!newSessionId) {
           // This should not happen if UI properly disables input until ready
           console.error("[ChatPanel] No pre-provisioned session available");
-          toast.error("Please wait for sandbox to initialize");
+          toast.error(t("toast.sandboxWait"));
           return;
         }
 
@@ -578,6 +580,7 @@ export default function BuildChatPanel({
       router,
       hasUploadingFiles,
       selectedModel,
+      t,
     ]
   );
 
@@ -674,7 +677,7 @@ export default function BuildChatPanel({
                 {isMobile && leftSidebarFolded && (
                   <OpalButton
                     icon={SvgSidebar}
-                    aria-label="Open Sidebar"
+                    aria-label={t("openSidebar.ariaLabel")}
                     onClick={() => setLeftSidebarFolded(false)}
                     prominence="tertiary"
                     size="sm"
@@ -698,7 +701,9 @@ export default function BuildChatPanel({
                   icon={SvgSidebar}
                   onClick={toggleOutputPanel}
                   tooltip={
-                    outputPanelOpen ? "Close output panel" : "Open output panel"
+                    outputPanelOpen
+                      ? t("outputPanel.closeTooltip")
+                      : t("outputPanel.openTooltip")
                   }
                   tertiary
                   className={cn(
@@ -754,7 +759,7 @@ export default function BuildChatPanel({
                           {wasInterrupted && !displayIsRunning && (
                             <div className="flex items-center gap-2 text-sm text-text-03">
                               <SvgStopCircle className="size-4 shrink-0 stroke-text-03" />
-                              <span>Response stopped</span>
+                              <span>{t("responseStopped.label")}</span>
                             </div>
                           )}
                           <LiveApprovalsRegion
@@ -783,7 +788,10 @@ export default function BuildChatPanel({
                   {/* Scroll to bottom button - shown when user has scrolled away */}
                   {showScrollButton && (
                     <div className="absolute -top-12 left-1/2 -translate-x-1/2 z-10">
-                      <Tooltip tooltip="Scroll to bottom" delayDuration={200}>
+                      <Tooltip
+                        tooltip={t("scrollToBottom.label")}
+                        delayDuration={200}
+                      >
                         <button
                           onClick={scrollToBottom}
                           className={cn(
@@ -794,7 +802,7 @@ export default function BuildChatPanel({
                             "transition-all duration-200",
                             "hover:bg-background-tint-inverted-01"
                           )}
-                          aria-label="Scroll to bottom"
+                          aria-label={t("scrollToBottom.label")}
                         >
                           <SvgChevronDown
                             size={20}
@@ -847,10 +855,10 @@ export default function BuildChatPanel({
                     }
                     placeholder={
                       isViewingSubagent
-                        ? "Switch to the main agent to send a message"
+                        ? t("input.subagentPlaceholder")
                         : scheduledRunInFlight
-                          ? "Scheduled run in progress..."
-                          : "Continue the conversation..."
+                          ? t("input.scheduledRunPlaceholder")
+                          : t("input.continuePlaceholder")
                     }
                     queuedMessages={queuedMessages}
                     onQueueMessage={handleQueueMessage}

--- a/web/src/app/craft/components/CompactionMarker.tsx
+++ b/web/src/app/craft/components/CompactionMarker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import { SvgFold, SvgChevronDown } from "@opal/icons";
 import { cn } from "@opal/utils";
@@ -15,6 +16,7 @@ interface CompactionMarkerProps {
 }
 
 export default function CompactionMarker({ summary }: CompactionMarkerProps) {
+  const t = useTranslations("craft.compaction");
   const [open, setOpen] = useState(false);
   const summaryLines = useMemo(
     () => (summary?.trim() ? summary.replace(/\s+$/, "").split("\n") : []),
@@ -27,7 +29,7 @@ export default function CompactionMarker({ summary }: CompactionMarkerProps) {
       <span className="flex items-center gap-1.5">
         <SvgFold className="size-3.5 shrink-0 stroke-text-04" />
         <Text font="main-ui-muted" color="text-04" nowrap>
-          Context compacted to free up space
+          {t("marker.label")}
         </Text>
         {withChevron && (
           <SvgChevronDown

--- a/web/src/app/craft/components/ConnectDataBanner.tsx
+++ b/web/src/app/craft/components/ConnectDataBanner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import {
@@ -31,6 +32,7 @@ function IconWrapper({ children }: { children: React.ReactNode }) {
 export default function ConnectDataBanner({
   className,
 }: ConnectDataBannerProps) {
+  const t = useTranslations("craft.connectDataBanner");
   const { permissions } = useUser();
   const canManageConnectors = hasPermission(
     permissions,
@@ -84,7 +86,7 @@ export default function ConnectDataBanner({
 
         <div className="flex items-center justify-center gap-1">
           <Text font="secondary-body" color="text-03">
-            Connect your data
+            {t("cta.label")}
           </Text>
           <SvgChevronRight className="h-4 w-4 text-text-03" />
         </div>

--- a/web/src/app/craft/components/CraftInputBar.tsx
+++ b/web/src/app/craft/components/CraftInputBar.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import BaseInputBar, {
   type BaseInputBarHandle,
@@ -93,6 +94,8 @@ const CraftInputBar = memo(
       },
       ref
     ) => {
+      const t = useTranslations("craft.inputBar");
+      const entryMenuT = useTranslations("craft.entryMenu");
       const baseRef = useRef<BaseInputBarHandle>(null);
       const fileInputRef = useRef<HTMLInputElement>(null);
       const router = useRouter();
@@ -240,17 +243,21 @@ const CraftInputBar = memo(
 
       const plusMenuItems = useMemo(
         () =>
-          buildEntryMenuItems(pickerSections, {
-            onAttachFiles: () => fileInputRef.current?.click(),
-            onSelectEntry: addEntry,
-            onBrowseSkills: () => router.push("/craft/v1/skills"),
-            onBrowseApps: () => router.push("/craft/v1/apps"),
-            libraryFiles,
-            // Defer the modal until the + popover finishes closing, else it paints over it.
-            onManageLibrary: () =>
-              window.setTimeout(() => setLibraryModalOpen(true), 200),
-          }),
-        [pickerSections, addEntry, libraryFiles, router]
+          buildEntryMenuItems(
+            pickerSections,
+            {
+              onAttachFiles: () => fileInputRef.current?.click(),
+              onSelectEntry: addEntry,
+              onBrowseSkills: () => router.push("/craft/v1/skills"),
+              onBrowseApps: () => router.push("/craft/v1/apps"),
+              libraryFiles,
+              // Defer the modal until the + popover finishes closing, else it paints over it.
+              onManageLibrary: () =>
+                window.setTimeout(() => setLibraryModalOpen(true), 200),
+            },
+            entryMenuT
+          ),
+        [pickerSections, addEntry, libraryFiles, router, entryMenuT]
       );
 
       const bottomLeftSlot = (
@@ -258,7 +265,7 @@ const CraftInputBar = memo(
           <PlusMenuButton
             items={plusMenuItems}
             disabled={disabled}
-            tooltip="Add files or skills"
+            tooltip={t("plusMenu.tooltip")}
           />
           {interruptible && <InterruptHint interrupting={isInterrupting} />}
         </>
@@ -322,8 +329,8 @@ const CraftInputBar = memo(
                 entryInfo.entry.kind === "skill"
                   ? entryInfo.entry.description
                   : entryInfo.entry.authenticated
-                    ? "Connected"
-                    : "Connection required"
+                    ? t("entryInfo.connected")
+                    : t("entryInfo.connectionRequired")
               }
               tileElement={entryInfo.chipEl}
               onDismiss={dismissEntryInfo}

--- a/web/src/app/craft/components/CraftingLoader.tsx
+++ b/web/src/app/craft/components/CraftingLoader.tsx
@@ -1,25 +1,28 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useTranslations } from "next-intl";
 
-const messages = [
-  "Punching wood...",
-  "Gathering resources...",
-  "Placing blocks...",
-  "Crafting your workspace...",
-  "Mining for dependencies...",
-  "Smelting the code...",
-  "Enchanting with magic...",
-  "World generation complete...",
-  "/gamemode 1",
-];
-
-const MESSAGE_COUNT = messages.length;
 const TYPE_DELAY = 40;
 const LINE_PAUSE = 800;
 const RESET_DELAY = 2000;
 
 export default function CraftingLoader() {
+  const t = useTranslations("craft.craftingLoader");
+  const messages = useMemo(
+    () => [
+      t("messages.punchingWood"),
+      t("messages.gatheringResources"),
+      t("messages.placingBlocks"),
+      t("messages.craftingWorkspace"),
+      t("messages.miningDependencies"),
+      t("messages.smeltingCode"),
+      t("messages.enchanting"),
+      t("messages.worldGenerated"),
+      t("messages.gamemode"),
+    ],
+    [t]
+  );
   const [display, setDisplay] = useState({
     lines: [] as string[],
     currentText: "",
@@ -40,7 +43,7 @@ export default function CraftingLoader() {
       const lineIdx = lineIndexRef.current;
       const charIdx = charIndexRef.current;
 
-      if (lineIdx >= MESSAGE_COUNT) {
+      if (lineIdx >= messages.length) {
         timeoutRef.current = setTimeout(() => {
           if (!isActive) return;
           lineIndexRef.current = 0;
@@ -87,7 +90,7 @@ export default function CraftingLoader() {
       if (rafRef.current !== undefined) cancelAnimationFrame(rafRef.current);
       if (timeoutRef.current !== undefined) clearTimeout(timeoutRef.current);
     };
-  }, []);
+  }, [messages]);
 
   const { lines, currentText } = display;
   const hasCurrentText = currentText.length > 0;
@@ -127,7 +130,7 @@ export default function CraftingLoader() {
       </div>
 
       <p className="mt-6 text-neutral-500 text-sm font-mono">
-        Crafting your next great idea...
+        {t("tagline.label")}
       </p>
     </div>
   );

--- a/web/src/app/craft/components/InterruptHint.tsx
+++ b/web/src/app/craft/components/InterruptHint.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import Keycap from "@/refresh-components/Keycap";
 
@@ -11,10 +12,11 @@ interface InterruptHintProps {
  * requested it becomes `Stopping…`.
  */
 export default function InterruptHint({ interrupting }: InterruptHintProps) {
+  const t = useTranslations("craft.interruptHint");
   if (interrupting) {
     return (
       <Text font="secondary-body" color="text-02">
-        Stopping…
+        {t("stopping.label")}
       </Text>
     );
   }
@@ -23,7 +25,7 @@ export default function InterruptHint({ interrupting }: InterruptHintProps) {
     <div className="flex items-center gap-1 select-none">
       <Keycap>esc</Keycap>
       <Text font="secondary-body" color="text-02">
-        to interrupt
+        {t("toInterrupt.label")}
       </Text>
     </div>
   );

--- a/web/src/app/craft/components/IntroContent.tsx
+++ b/web/src/app/craft/components/IntroContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { motion } from "motion/react";
 import { track, AnalyticsEvent } from "@/lib/analytics/utils";
 import { OnyxLogoTypeIcon } from "@/components/icons/icons";
@@ -16,6 +17,7 @@ export default function BuildModeIntroContent({
   onClose,
   onTryBuildMode,
 }: BuildModeIntroContentProps) {
+  const t = useTranslations("craft.intro");
   // Track when user sees the craft intro
   useEffect(() => {
     track(AnalyticsEvent.SAW_CRAFT_INTRO);
@@ -49,14 +51,14 @@ export default function BuildModeIntroContent({
                       fontWeight: 500,
                     }}
                   >
-                    Craft
+                    {t("wordmark.label")}
                   </RefreshText>
                 </span>
                 <span
                   className="pointer-events-none absolute top-3 -end-14 text-[1em] uppercase tracking-[0.2em] text-white!"
                   style={{ fontFamily: "var(--font-kh-teka)", fontWeight: 500 }}
                 >
-                  BETA
+                  {t("beta.badge")}
                 </span>
               </div>
             </div>
@@ -77,7 +79,7 @@ export default function BuildModeIntroContent({
               onClose();
             }}
           >
-            Return Home
+            {t("returnHome.button")}
           </BigButton>
           <BigButton
             primary
@@ -88,7 +90,7 @@ export default function BuildModeIntroContent({
               onTryBuildMode();
             }}
           >
-            Start Crafting
+            {t("startCrafting.button")}
           </BigButton>
         </motion.div>
       </div>

--- a/web/src/app/craft/components/OpencodeDebugLogs.tsx
+++ b/web/src/app/craft/components/OpencodeDebugLogs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { SvgCheck, SvgCopy, SvgTerminal, SvgTrash } from "@opal/icons";
 import { Button, InputTypeIn, Text } from "@opal/components";
 import { Modal } from "@opal/components";
@@ -99,6 +100,7 @@ interface LogStreamPaneProps {
 }
 
 function LogStreamPane({ open }: LogStreamPaneProps) {
+  const t = useTranslations("craft.debugLogs");
   const [lines, setLines] = useState<LogLine[]>([]);
   const [status, setStatus] = useState<StreamStatus>("connecting");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -157,10 +159,10 @@ function LogStreamPane({ open }: LogStreamPaneProps) {
           setStatus("error");
           setErrorMessage(
             response.status === 404
-              ? "Debug endpoint disabled (ENABLE_OPENCODE_DEBUGGING=false)"
+              ? t("error.endpointDisabled")
               : response.status === 409
-                ? "No running sandbox to tail logs from"
-                : `HTTP ${response.status}`
+                ? t("error.noSandbox")
+                : t("error.http", { status: response.status })
           );
           return;
         }
@@ -213,7 +215,7 @@ function LogStreamPane({ open }: LogStreamPaneProps) {
       controller.abort();
       abortRef.current = null;
     };
-  }, [open, appendLine]);
+  }, [open, appendLine, t]);
 
   // Auto-scroll to bottom when follow=true and lines change.
   useEffect(() => {
@@ -301,12 +303,12 @@ function LogStreamPane({ open }: LogStreamPaneProps) {
         empty={
           lines.length === 0
             ? status === "connecting"
-              ? "Waiting for the first log line…"
+              ? t("empty.waiting")
               : status === "error"
-                ? (errorMessage ?? "Error")
-                : "No lines yet."
+                ? (errorMessage ?? t("status.error"))
+                : t("empty.noLines")
             : filter && filteredLines.length === 0
-              ? `No lines match "${filter}"`
+              ? t("empty.noMatch", { filter })
               : null
         }
       />
@@ -343,17 +345,18 @@ function StatusBar({
   copyJustSucceeded,
   onResume,
 }: StatusBarProps) {
+  const t = useTranslations("craft.debugLogs");
   const filtered = !!filter && visibleLines !== totalLines;
   const stateLabel =
     status === "error"
-      ? (errorMessage ?? "Error")
+      ? (errorMessage ?? t("status.error"))
       : status === "closed"
-        ? "Closed"
+        ? t("status.closed")
         : status === "connecting"
-          ? "Connecting"
+          ? t("status.connecting")
           : paused
-            ? "Paused"
-            : "Streaming";
+            ? t("status.paused")
+            : t("status.streaming");
 
   // Single-line toolbar: status pill (state + count) on the left, filter
   // input expanding through the middle, action icons on the right. This
@@ -374,8 +377,11 @@ function StatusBar({
             />
             <Text font="secondary-body" color="text-05" nowrap>
               {filtered
-                ? `${visibleLines.toLocaleString()} / ${totalLines.toLocaleString()} lines`
-                : `${totalLines.toLocaleString()} lines`}
+                ? t("lines.filteredCount", {
+                    visible: visibleLines,
+                    total: totalLines,
+                  })
+                : t("lines.count", { count: totalLines })}
             </Text>
           </>
         )}
@@ -389,7 +395,7 @@ function StatusBar({
               "hover:bg-status-warning-02 transition-colors"
             )}
           >
-            +{newSincePaused.toLocaleString()} new · jump
+            {t("newSincePaused.button", { count: newSincePaused })}
           </button>
         )}
       </div>
@@ -397,7 +403,7 @@ function StatusBar({
       <div className="flex-1 min-w-0">
         <InputTypeIn
           searchIcon
-          placeholder="Filter…"
+          placeholder={t("filter.placeholder")}
           value={filter}
           onChange={(e) => onFilterChange(e.target.value)}
           clearButton
@@ -411,7 +417,9 @@ function StatusBar({
           size="sm"
           icon={copyJustSucceeded ? SvgCheck : SvgCopy}
           onClick={onCopy}
-          tooltip={copyJustSucceeded ? "Copied" : "Copy visible"}
+          tooltip={
+            copyJustSucceeded ? t("copy.doneTooltip") : t("copy.tooltip")
+          }
         />
         <Button
           variant="default"
@@ -419,7 +427,7 @@ function StatusBar({
           size="sm"
           icon={SvgTrash}
           onClick={onClear}
-          tooltip="Clear"
+          tooltip={t("clear.tooltip")}
         />
       </div>
     </div>
@@ -487,6 +495,7 @@ interface OpencodeDebugLogsButtonProps {
 export default function OpencodeDebugLogsButton({
   folded = false,
 }: OpencodeDebugLogsButtonProps) {
+  const t = useTranslations("craft.debugLogs");
   const settings = useSettings();
   const [open, setOpen] = useState(false);
 
@@ -503,15 +512,15 @@ export default function OpencodeDebugLogsButton({
         icon={SvgTerminal}
         onClick={() => setOpen(true)}
       >
-        {folded ? "" : "Pod logs"}
+        {folded ? "" : t("open.button")}
       </Button>
       {open && (
         <Modal open onOpenChange={(o) => !o && setOpen(false)}>
           <Modal.Content width="xl" height="lg">
             <Modal.Header
               icon={SvgTerminal}
-              title="Opencode pod logs"
-              description="Live tail of the sandbox container — dev/debug only."
+              title={t("modal.title")}
+              description={t("modal.description")}
               onClose={() => setOpen(false)}
             />
             <Modal.Body>

--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { memo, useState, useEffect, useCallback, useRef } from "react";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -32,7 +33,6 @@ import CraftingLoader from "@/app/craft/components/CraftingLoader";
 import {
   getWebappState,
   isWebappPreviewEnabled,
-  NO_WEBAPP_LABEL,
   type WebappState,
 } from "@/app/craft/components/output-panel/interfaces";
 
@@ -107,6 +107,7 @@ function useJointMasks(): {
 }
 
 const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
+  const t = useTranslations("craft.outputPanel");
   const jointMasks = useJointMasks();
   const session = useSession();
   const preProvisionedSessionId = usePreProvisionedSessionId();
@@ -507,10 +508,10 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
                 tab.value === "preview" && webappState === "starting";
               const tooltip = isDisabled
                 ? tab.value === "preview"
-                  ? NO_WEBAPP_LABEL
-                  : "Start building something to see artifacts!"
+                  ? t("noWebapp.label")
+                  : t("artifactsEmpty.tooltip")
                 : isStarting
-                  ? "Starting the dev server..."
+                  ? t("devServerStarting.tooltip")
                   : undefined;
 
               const tabButton = (

--- a/web/src/app/craft/components/SandboxAsleepNotice.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { SvgMoon } from "@opal/icons";
 import {
@@ -13,6 +14,7 @@ import { Modal } from "@opal/components";
 // Waking is always user-initiated — never automatic — so we don't keep pods
 // alive forever and defeat idle reaping.
 export default function SandboxAsleepNotice() {
+  const t = useTranslations("craft.sandboxAsleep");
   const sessionId = useSessionId();
   const session = useSession();
   const loadSession = useBuildSessionStore((state) => state.loadSession);
@@ -41,8 +43,8 @@ export default function SandboxAsleepNotice() {
       <Modal.Content width="sm" preventAccidentalClose={false}>
         <Modal.Header
           icon={SvgMoon}
-          title="Your sandbox fell asleep"
-          description="It went to sleep after a period of inactivity — your work is saved. Wake it to keep going."
+          title={t("modal.title")}
+          description={t("modal.description")}
         />
         <Modal.Footer justifyContent="center">
           <Button
@@ -50,10 +52,10 @@ export default function SandboxAsleepNotice() {
             prominence="tertiary"
             onClick={() => setDismissed(true)}
           >
-            Dismiss
+            {t("dismiss.button")}
           </Button>
           <Button variant="default" prominence="primary" onClick={handleWake}>
-            Wake sandbox
+            {t("wake.button")}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/web/src/app/craft/components/ScheduledRunBanner.tsx
+++ b/web/src/app/craft/components/ScheduledRunBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { Text } from "@opal/components";
 import { SvgClock, SvgExternalLink } from "@opal/icons";
@@ -44,6 +45,7 @@ export default function ScheduledRunBanner({
   sessionId,
   context,
 }: ScheduledRunBannerProps) {
+  const t = useTranslations("craft.scheduledRun");
   // 404 is the expected "this session isn't scheduled" signal — the standard
   // fetcher throws on it, which lands in `error` and falls through the
   // `if (!data)` guard below to render nothing. `shouldRetryOnError: false`
@@ -57,12 +59,13 @@ export default function ScheduledRunBanner({
 
   const statusText =
     data.status === "RUNNING"
-      ? "This scheduled run is still running. Follow-up messages unlock when it finishes."
+      ? t("status.running")
       : data.status === "AWAITING_APPROVAL"
-        ? "This scheduled run is awaiting approval. Follow-up messages unlock after it resumes and finishes."
-        : `This session was started by scheduled task ${data.task_name} at ${formatAbsolute(
-            data.started_at
-          )}.`;
+        ? t("status.awaitingApproval")
+        : t("status.startedBy", {
+            task: data.task_name,
+            time: formatAbsolute(data.started_at),
+          });
 
   return (
     <div
@@ -84,7 +87,10 @@ export default function ScheduledRunBanner({
         )}
         data-testid="back-to-task-button"
         title={statusText}
-        aria-label={`View scheduled task ${data.task_name}. ${statusText}`}
+        aria-label={t("viewTask.ariaLabel", {
+          task: data.task_name,
+          status: statusText,
+        })}
       >
         <span className="grid shrink-0 translate-y-px items-center">
           <span
@@ -97,7 +103,7 @@ export default function ScheduledRunBanner({
             <SvgClock size={14} className="shrink-0 text-text-03" />
             <span className="flex h-5 shrink-0 items-center">
               <Text font="figure-small-label" color="text-03" nowrap>
-                Scheduled
+                {t("badge.label")}
               </Text>
             </span>
           </span>
@@ -111,7 +117,7 @@ export default function ScheduledRunBanner({
             <SvgExternalLink size={14} className="shrink-0 text-text-03" />
             <span className="flex h-5 shrink-0 items-center">
               <Text font="figure-small-label" color="text-03" nowrap>
-                View task
+                {t("viewTask.label")}
               </Text>
             </span>
           </span>
@@ -136,7 +142,7 @@ export default function ScheduledRunBanner({
           </span>
           <span className="hidden h-5 shrink-0 items-center xl:flex">
             <Text font="secondary-body" color="text-03" nowrap>
-              {`Started ${formatAbsolute(data.started_at)}`}
+              {t("startedAt.label", { time: formatAbsolute(data.started_at) })}
             </Text>
           </span>
         </div>

--- a/web/src/app/craft/components/ShareButton.tsx
+++ b/web/src/app/craft/components/ShareButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button, Popover, Text } from "@opal/components";
 import { SvgLink, SvgCopy, SvgCheck, SvgX } from "@opal/icons";
 import { setSessionSharing } from "@/app/craft/services/apiServices";
@@ -16,29 +17,30 @@ interface ShareButtonProps {
   onScopeChange?: () => void;
 }
 
-const SCOPE_OPTIONS: {
-  value: SharingScope;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: "private",
-    label: "Private",
-    description: "Only you can view this app.",
-  },
-  {
-    value: "public_org",
-    label: "Organization",
-    description: "Anyone logged into your Onyx can view this app.",
-  },
-];
-
 export default function ShareButton({
   sessionId,
   webappUrl,
   sharingScope: initialScope,
   onScopeChange,
 }: ShareButtonProps) {
+  const t = useTranslations("craft.share");
+  const scopeOptions = useMemo<
+    { value: SharingScope; label: string; description: string }[]
+  >(
+    () => [
+      {
+        value: "private",
+        label: t("private.label"),
+        description: t("private.description"),
+      },
+      {
+        value: "public_org",
+        label: t("organization.label"),
+        description: t("organization.description"),
+      },
+    ],
+    [t]
+  );
   const [isOpen, setIsOpen] = useState(false);
   const [sharingScope, setSharingScope] = useState<SharingScope>(initialScope);
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
@@ -98,9 +100,9 @@ export default function ShareButton({
             variant="action"
             prominence={isShared ? "primary" : "tertiary"}
             icon={SvgLink}
-            aria-label="Share webapp"
+            aria-label={t("trigger.ariaLabel")}
           >
-            {isShared ? "Shared" : "Share"}
+            {isShared ? t("shared.label") : t("share.label")}
           </Button>
         </Popover.Trigger>
         <Popover.Content side="bottom" align="end" width="lg" sideOffset={4}>
@@ -113,7 +115,7 @@ export default function ShareButton({
           >
             {/* Scope options */}
             <Section alignItems="stretch" gap={1} width="full">
-              {SCOPE_OPTIONS.map((opt) => (
+              {scopeOptions.map((opt) => (
                 <div
                   key={opt.value}
                   role="button"
@@ -169,7 +171,7 @@ export default function ShareButton({
                           : SvgCopy
                     }
                     onClick={handleCopy}
-                    aria-label="Copy link"
+                    aria-label={t("copyLink.ariaLabel")}
                   />
                 </Section>
               </div>

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useCallback, useState, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import type { Route } from "next";
 import { useRouter, usePathname } from "next/navigation";
 import { useBuildContext } from "@/app/craft/contexts/BuildContext";
@@ -71,9 +72,10 @@ export function CraftSessionDeleteModal({
   onClose,
   onConfirm,
 }: CraftSessionDeleteModalProps) {
+  const t = useTranslations("craft.sideBar");
   return (
     <ConfirmationModalLayout
-      title={`Delete "${sessionTitle}"?`}
+      title={t("deleteModal.title", { title: sessionTitle })}
       icon={SvgTrash}
       onClose={isDeleting ? undefined : onClose}
       submit={
@@ -84,12 +86,11 @@ export function CraftSessionDeleteModal({
           onClick={onConfirm}
           icon={isDeleting ? SvgSimpleLoader : undefined}
         >
-          {isDeleting ? "Deleting..." : "Delete"}
+          {isDeleting ? t("deleteModal.deleting") : t("deleteModal.confirm")}
         </Button>
       }
     >
-      This permanently removes the Craft session and all of its data. This
-      action cannot be undone.
+      {t("deleteModal.body")}
     </ConfirmationModalLayout>
   );
 }
@@ -111,6 +112,7 @@ function BuildSessionButton({
   onDelete,
   onDeleteActiveSession,
 }: BuildSessionButtonProps) {
+  const t = useTranslations("craft.sideBar");
   const [renaming, setRenaming] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -146,7 +148,7 @@ function BuildSessionButton({
       try {
         await onDelete();
         setIsDeleting(false);
-        toast.success(`Deleted "${historyItem.title}".`);
+        toast.success(t("toast.deleted", { title: historyItem.title }));
         closeModal();
         if (isActive && onDeleteActiveSession) {
           onDeleteActiveSession();
@@ -154,11 +156,18 @@ function BuildSessionButton({
       } catch (err) {
         setIsDeleting(false);
         toast.error(
-          err instanceof Error ? err.message : "Failed to delete session"
+          err instanceof Error ? err.message : t("toast.deleteFailed")
         );
       }
     },
-    [onDelete, historyItem.title, closeModal, isActive, onDeleteActiveSession]
+    [
+      onDelete,
+      historyItem.title,
+      closeModal,
+      isActive,
+      onDeleteActiveSession,
+      t,
+    ]
   );
 
   const rightMenu = (
@@ -188,7 +197,7 @@ function BuildSessionButton({
               key="rename"
               icon={SvgEdit}
               onClick={noProp(() => setRenaming(true))}
-              title="Rename"
+              title={t("rename.label")}
             />,
             null,
             <LineItemButton
@@ -198,7 +207,7 @@ function BuildSessionButton({
               icon={SvgTrash}
               onClick={noProp(() => setIsDeleteModalOpen(true))}
               color="danger"
-              title="Delete"
+              title={t("delete.label")}
             />,
           ]}
         </PopoverMenu>
@@ -269,6 +278,7 @@ function BuildSessionButton({
 // ============================================================================
 
 const MemoizedBuildSidebarInner = memo(() => {
+  const t = useTranslations("craft.sideBar");
   const { folded } = useSidebarState();
   const router = useRouter();
   const { requestNavigation } = useUnsavedChangesNavigation();
@@ -326,40 +336,38 @@ const MemoizedBuildSidebarInner = memo(() => {
       >
         <div className="flex flex-col gap-0.5">
           <SidebarTab icon={SvgEditBig} onClick={handleNewBuild}>
-            Start Crafting
+            {t("newSession.label")}
           </SidebarTab>
           <SidebarTab
             icon={SvgClock}
             onClick={() => navigate(CRAFT_TASKS_PATH)}
             selected={pathname.startsWith(CRAFT_TASKS_PATH)}
           >
-            Scheduled Tasks
+            {t("scheduledTasks.label")}
           </SidebarTab>
           <SidebarTab
             icon={SvgBlocks}
             onClick={() => navigate(CRAFT_SKILLS_PATH)}
             selected={pathname.startsWith(CRAFT_SKILLS_PATH)}
           >
-            Skills
+            {t("skills.label")}
           </SidebarTab>
           <SidebarTab
             icon={SvgPlug}
             onClick={() => navigate(CRAFT_APPS_PATH)}
             selected={pathname.startsWith(CRAFT_APPS_PATH)}
           >
-            Apps
+            {t("apps.label")}
           </SidebarTab>
         </div>
       </SidebarLayouts.Header>
       <SidebarLayouts.Body scrollKey="build-sidebar">
         {!folded && (
           <>
-            <SidebarLayouts.Section title="Sessions" />
+            <SidebarLayouts.Section title={t("sessions.title")} />
             {sessionHistory.length === 0 ? (
               <div className="ps-2 pe-1.5 py-1">
-                <Text color="text-01">
-                  Start building! Session history will appear here.
-                </Text>
+                <Text color="text-01">{t("sessions.empty")}</Text>
               </div>
             ) : (
               sessionHistory.map((historyItem) => (
@@ -391,7 +399,7 @@ const MemoizedBuildSidebarInner = memo(() => {
       <SidebarLayouts.Footer>
         <div>
           <SidebarTab icon={SvgArrowLeft} onClick={() => navigate("/app")}>
-            Back to Chat
+            {t("backToChat.label")}
           </SidebarTab>
           <OpencodeDebugLogsButton folded={folded} />
           <AccountPopover />

--- a/web/src/app/craft/components/SkillsStaleNotice.tsx
+++ b/web/src/app/craft/components/SkillsStaleNotice.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button, MessageCard } from "@opal/components";
 import { SvgRefreshCw } from "@opal/icons";
 import { toast } from "@opal/layouts";
@@ -16,6 +17,7 @@ export default function SkillsStaleNotice({
   sessionId,
   turnActive,
 }: SkillsStaleNoticeProps) {
+  const t = useTranslations("craft.skillsStale");
   const [reloading, setReloading] = useState(false);
   const updateSessionData = useBuildSessionStore(
     (state) => state.updateSessionData
@@ -27,7 +29,7 @@ export default function SkillsStaleNotice({
       updateSessionData(sessionId, { skillsStale: state.skills_stale });
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to reload session"
+        error instanceof Error ? error.message : t("toast.reloadFailed")
       );
     } finally {
       setReloading(false);
@@ -39,11 +41,11 @@ export default function SkillsStaleNotice({
   return (
     <MessageCard
       variant="warning"
-      title="Your agent’s capabilities have changed"
-      description="Reload this session to apply the latest skills and app access."
+      title={t("notice.title")}
+      description={t("notice.description")}
       rightChildren={
         <Button icon={SvgRefreshCw} onClick={reload} disabled={reloading}>
-          {reloading ? "Reloading…" : "Reload"}
+          {reloading ? t("reload.inProgress") : t("reload.button")}
         </Button>
       }
     />

--- a/web/src/app/craft/components/SubagentView.test.tsx
+++ b/web/src/app/craft/components/SubagentView.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render } from "@tests/setup/test-utils";
 import SubagentView from "@/app/craft/components/SubagentView";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 import type { BuildMessage } from "@/app/craft/types/streamingTypes";

--- a/web/src/app/craft/components/SubagentView.tsx
+++ b/web/src/app/craft/components/SubagentView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import { useSubagent } from "@/app/craft/hooks/useBuildSessionStore";
 import BuildMessageList from "@/app/craft/components/BuildMessageList";
@@ -23,6 +24,7 @@ interface SubagentViewProps {
  * styling, etc. all mirror the main conversation.
  */
 export default function SubagentView({ subagentSessionId }: SubagentViewProps) {
+  const t = useTranslations("craft.subagentView");
   const subagent = useSubagent(subagentSessionId);
   // Static transcript (autoScroll off) — ref only satisfies the prop contract.
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -70,7 +72,7 @@ export default function SubagentView({ subagentSessionId }: SubagentViewProps) {
     return (
       <div className="flex h-full items-center justify-center">
         <Text font="main-ui-body" color="text-02">
-          Subagent not found.
+          {t("notFound.label")}
         </Text>
       </div>
     );

--- a/web/src/app/craft/components/SuggestedPrompts.tsx
+++ b/web/src/app/craft/components/SuggestedPrompts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { AnimatePresence, motion } from "motion/react";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
@@ -17,6 +18,7 @@ interface SuggestedPromptsProps {
 export default function SuggestedPrompts({
   onPromptClick,
 }: SuggestedPromptsProps) {
+  const t = useTranslations("craft.suggestedPrompts");
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -95,7 +97,7 @@ export default function SuggestedPrompts({
               <button
                 type="button"
                 onClick={() => setExpandedId(null)}
-                aria-label="Close suggestions"
+                aria-label={t("close.ariaLabel")}
                 className="flex items-center justify-center cursor-pointer"
               >
                 <SvgX className="w-4 h-4 text-text-03" />

--- a/web/src/app/craft/components/TodoListCard.tsx
+++ b/web/src/app/craft/components/TodoListCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import {
@@ -80,6 +81,7 @@ export default function TodoListCard({
   todoList,
   defaultOpen = true,
 }: TodoListCardProps) {
+  const t = useTranslations("craft.todoList");
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   // Update isOpen when defaultOpen changes (for auto-collapse behavior)
@@ -126,12 +128,12 @@ export default function TodoListCard({
 
               {/* Title */}
               <Text font="main-ui-action" color="text-04" nowrap>
-                Tasks
+                {t("header.title")}
               </Text>
 
               {/* Progress count */}
               <Text font="secondary-body" color="text-03" nowrap>
-                {`${completed}/${total} completed`}
+                {t("progress.label", { completed, total })}
               </Text>
             </div>
 
@@ -153,7 +155,7 @@ export default function TodoListCard({
             {todoList.todos.length === 0 && (
               <span className="italic">
                 <Text font="main-ui-body" color="text-03">
-                  No tasks
+                  {t("empty.label")}
                 </Text>
               </span>
             )}

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { useFocusOnMount } from "@opal/hooks";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -95,6 +96,7 @@ export default function UserLibraryModal({
   onClose,
   onChanges,
 }: UserLibraryModalProps) {
+  const t = useTranslations("craft.userLibrary");
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
   const [isUploading, setIsUploading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -181,12 +183,14 @@ export default function UserLibraryModal({
         mutate();
         onChanges?.();
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : "Upload failed");
+        setActionError(
+          err instanceof Error ? err.message : t("errors.uploadFailed")
+        );
       } finally {
         setIsUploading(false);
       }
     },
-    [mutate, onChanges]
+    [mutate, onChanges, t]
   );
 
   const handleFileInputChange = useCallback(
@@ -248,11 +252,13 @@ export default function UserLibraryModal({
       mutate();
       onChanges?.();
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : "Failed to delete");
+      setActionError(
+        err instanceof Error ? err.message : t("errors.deleteFailed")
+      );
     } finally {
       setEntryToDelete(null);
     }
-  }, [entryToDelete, mutate, onChanges]);
+  }, [entryToDelete, mutate, onChanges, t]);
 
   const handleCreateDirectory = useCallback(async () => {
     const name = newFolderName.trim();
@@ -264,13 +270,13 @@ export default function UserLibraryModal({
       mutate();
     } catch (err) {
       setActionError(
-        err instanceof Error ? err.message : "Failed to create folder"
+        err instanceof Error ? err.message : t("errors.createFolderFailed")
       );
     } finally {
       setShowNewFolderModal(false);
       setNewFolderName("");
     }
-  }, [mutate, newFolderName]);
+  }, [mutate, newFolderName, t]);
 
   const isEmpty = hierarchicalTree.length === 0;
   const noMatches = !isEmpty && visibleTree.length === 0;
@@ -281,13 +287,13 @@ export default function UserLibraryModal({
         <Modal.Content width="sm" height="fit" preventAccidentalClose={false}>
           <Modal.Header
             icon={SvgFolder}
-            title="Library"
-            description="Files your agent can read in every session."
+            title={t("modal.title")}
+            description={t("modal.description")}
             onClose={onClose}
           >
             <Section flexDirection="row" gap={2}>
               <InputTypeIn
-                placeholder="Search files..."
+                placeholder={t("search.placeholder")}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 searchIcon
@@ -297,15 +303,15 @@ export default function UserLibraryModal({
                 prominence="secondary"
                 icon={SvgFolderPlus}
                 onClick={() => setShowNewFolderModal(true)}
-                tooltip="New folder"
-                aria-label="New folder"
+                tooltip={t("newFolder.label")}
+                aria-label={t("newFolder.label")}
               />
               <Button
                 icon={SvgUploadCloud}
                 disabled={isUploading}
                 onClick={() => handleUploadToFolder("/")}
               >
-                {isUploading ? "Uploading…" : "Upload"}
+                {isUploading ? t("upload.uploadingButton") : t("upload.button")}
               </Button>
             </Section>
           </Modal.Header>
@@ -339,13 +345,13 @@ export default function UserLibraryModal({
                 {isLoading ? (
                   <div className="flex items-center justify-center py-12">
                     <Text font="secondary-body" color="text-03">
-                      Loading files…
+                      {t("loading.label")}
                     </Text>
                   </div>
                 ) : error ? (
                   <div className="flex items-center justify-center py-12">
                     <Text font="secondary-body" color="status-error-05">
-                      Failed to load files
+                      {t("errors.loadFailed")}
                     </Text>
                   </div>
                 ) : isEmpty ? (
@@ -356,7 +362,7 @@ export default function UserLibraryModal({
                 ) : noMatches ? (
                   <div className="flex items-center justify-center py-12">
                     <Text font="secondary-body" color="text-03">
-                      No files match your search
+                      {t("search.noResults")}
                     </Text>
                   </div>
                 ) : (
@@ -378,7 +384,7 @@ export default function UserLibraryModal({
                 {isDragging && (
                   <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-12 border-2 border-dashed border-action-selection-04 bg-action-selection-01/90">
                     <Text font="main-ui-action" color="text-05">
-                      Drop files to upload
+                      {t("upload.dropOverlay")}
                     </Text>
                   </div>
                 )}
@@ -388,7 +394,7 @@ export default function UserLibraryModal({
 
           <Modal.Footer>
             <Button prominence="secondary" onClick={onClose}>
-              Done
+              {t("modal.doneButton")}
             </Button>
           </Modal.Footer>
         </Modal.Content>
@@ -398,14 +404,18 @@ export default function UserLibraryModal({
       {entryToDelete && (
         <ConfirmEntityModal
           danger
-          entityType={entryToDelete.is_directory ? "folder" : "file"}
+          entityType={
+            entryToDelete.is_directory
+              ? t("delete.entityTypeFolder")
+              : t("delete.entityTypeFile")
+          }
           entityName={entryToDelete.name}
-          action="delete"
-          actionButtonText="Delete"
+          action={t("delete.action")}
+          actionButtonText={t("delete.button")}
           additionalDetails={
             entryToDelete.is_directory
-              ? "This will delete the folder and all its contents."
-              : "This file will be removed from your library."
+              ? t("delete.folderDetails")
+              : t("delete.fileDetails")
           }
           onClose={() => setEntryToDelete(null)}
           onSubmit={handleDeleteConfirm}
@@ -425,7 +435,7 @@ export default function UserLibraryModal({
         <Modal.Content width="sm" height="fit">
           <Modal.Header
             icon={SvgFolder}
-            title="New folder"
+            title={t("newFolder.label")}
             onClose={() => {
               setShowNewFolderModal(false);
               setNewFolderName("");
@@ -434,12 +444,12 @@ export default function UserLibraryModal({
           <Modal.Body>
             <div className="flex flex-col items-stretch gap-2">
               <Text font="secondary-body" color="text-03">
-                Folder name
+                {t("newFolder.nameLabel")}
               </Text>
               <InputTypeIn
                 value={newFolderName}
                 onChange={(e) => setNewFolderName(e.target.value)}
-                placeholder="Enter folder name"
+                placeholder={t("newFolder.namePlaceholder")}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && newFolderName.trim()) {
                     handleCreateDirectory();
@@ -457,13 +467,13 @@ export default function UserLibraryModal({
                 setNewFolderName("");
               }}
             >
-              Cancel
+              {t("newFolder.cancelButton")}
             </Button>
             <Button
               disabled={!newFolderName.trim()}
               onClick={handleCreateDirectory}
             >
-              Create
+              {t("newFolder.createButton")}
             </Button>
           </Modal.Footer>
         </Modal.Content>
@@ -478,6 +488,7 @@ interface UploadDropzoneProps {
 }
 
 function UploadDropzone({ onClick, active }: UploadDropzoneProps) {
+  const t = useTranslations("craft.userLibrary");
   return (
     <div
       role="button"
@@ -498,10 +509,10 @@ function UploadDropzone({ onClick, active }: UploadDropzoneProps) {
     >
       <SvgUploadCloud size={28} className="stroke-text-03" />
       <Text font="main-ui-action" color="text-04">
-        Drag files here or click to upload
+        {t("dropzone.title")}
       </Text>
       <Text font="secondary-body" color="text-03">
-        Excel, Word, PowerPoint, PDF, or ZIP
+        {t("dropzone.formats")}
       </Text>
     </div>
   );
@@ -527,6 +538,7 @@ function LibraryTreeView({
   onUploadToFolder,
   depth = 0,
 }: LibraryTreeViewProps) {
+  const t = useTranslations("craft.userLibrary");
   // Sort entries: directories first, then alphabetically
   const sortedEntries = [...entries].sort((a, b) => {
     if (a.is_directory && !b.is_directory) return -1;
@@ -568,8 +580,16 @@ function LibraryTreeView({
                   e.stopPropagation();
                   onToggleFolder(entry.path);
                 }}
-                tooltip={isExpanded ? "Collapse" : "Expand"}
-                aria-label={isExpanded ? "Collapse" : "Expand"}
+                tooltip={
+                  isExpanded
+                    ? t("tree.collapseTooltip")
+                    : t("tree.expandTooltip")
+                }
+                aria-label={
+                  isExpanded
+                    ? t("tree.collapseTooltip")
+                    : t("tree.expandTooltip")
+                }
               />
             ) : (
               hasDirectories && <span aria-hidden className="w-5 shrink-0" />
@@ -613,8 +633,8 @@ function LibraryTreeView({
                       entry.path.replace(/^user_library/, "") || "/";
                     onUploadToFolder(uploadPath);
                   }}
-                  tooltip="Upload to this folder"
-                  aria-label="Upload to this folder"
+                  tooltip={t("tree.uploadToFolderTooltip")}
+                  aria-label={t("tree.uploadToFolderTooltip")}
                 />
               )}
               <Button
@@ -626,8 +646,8 @@ function LibraryTreeView({
                   e.stopPropagation();
                   onDelete(entry);
                 }}
-                tooltip="Delete"
-                aria-label="Delete"
+                tooltip={t("tree.deleteTooltip")}
+                aria-label={t("tree.deleteTooltip")}
               />
             </div>
           </>
@@ -642,7 +662,7 @@ function LibraryTreeView({
                 className={rowClassName}
                 role="button"
                 tabIndex={0}
-                aria-label={`Toggle ${entry.name}`}
+                aria-label={t("tree.toggleAriaLabel", { name: entry.name })}
                 onKeyDown={clickOnKeyDown(() => onToggleFolder(entry.path))}
                 onClick={() => onToggleFolder(entry.path)}
               >

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useSWRConfig } from "swr";
 
 import { Button, Text, Tooltip } from "@opal/components";
@@ -40,13 +41,24 @@ interface ApprovalCardProps {
   defaultDecision?: ApprovalSubmitDecision | null;
 }
 
+type ApprovalsTranslate = ReturnType<typeof useTranslations<"craft.approvals">>;
+
 // Single-action: name the action; multi-action: just count them. The
 // per-action breakdown (with descriptions) is always shown in the body.
-function approvalHeadline(approval: ApprovalView): string {
+function approvalHeadline(
+  approval: ApprovalView,
+  t: ApprovalsTranslate
+): string {
   if (approval.actions.length === 1) {
-    return `${approval.actions[0]!.display_name} in ${approval.app_name}`;
+    return t("headline.singleAction", {
+      action: approval.actions[0]!.display_name,
+      app: approval.app_name,
+    });
   }
-  return `${approval.actions.length} actions in ${approval.app_name}`;
+  return t("headline.multiAction", {
+    count: approval.actions.length,
+    app: approval.app_name,
+  });
 }
 
 function ActionList({ actions }: { actions: ApprovalAction[] }) {
@@ -79,6 +91,7 @@ export default function ApprovalCard({
   defaultOpen = false,
   defaultDecision = null,
 }: ApprovalCardProps) {
+  const t = useTranslations("craft.approvals");
   const { mutate } = useSWRConfig();
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -102,8 +115,8 @@ export default function ApprovalCard({
   const swrKey = SWR_KEYS.buildSessionLiveApprovals(approval.session_id);
   const decided = decision !== null;
   const approved = decision === "APPROVED";
-  const headline = approvalHeadline(approval);
-  const headerText = decided ? headline : `Approval required: ${headline}`;
+  const headline = approvalHeadline(approval, t);
+  const headerText = decided ? headline : t("header.required", { headline });
 
   async function submitDecision(
     next: ApprovalSubmitDecision,
@@ -137,7 +150,7 @@ export default function ApprovalCard({
       if (mountedRef.current) {
         setDecision(null);
         setErrorMessage(
-          e instanceof Error ? e.message : "Failed to submit decision"
+          e instanceof Error ? e.message : t("submit.errorFallback")
         );
         // Expand so the error message + the payload the user tried to
         // approve are both visible. Avoids the "click Approve in a
@@ -202,14 +215,18 @@ export default function ApprovalCard({
                 )}
               >
                 <Text font="main-ui-action" color="inherit" nowrap>
-                  {approved ? "Approved" : "Rejected"}
+                  {approved ? t("status.approved") : t("status.rejected")}
                 </Text>
               </div>
             ) : null}
             <CollapsibleTrigger asChild>
               <button
                 data-approval-trigger
-                aria-label={isOpen ? "Hide details" : "Show details"}
+                aria-label={
+                  isOpen
+                    ? t("details.hideAriaLabel")
+                    : t("details.showAriaLabel")
+                }
                 className="p-1.5"
               >
                 <SvgChevronDown
@@ -235,12 +252,12 @@ export default function ApprovalCard({
                     );
                   })
                 }
-                aria-label="Approve this action once"
+                aria-label={t("approveOnce.ariaLabel")}
               >
-                Approve once
+                {t("approveOnce.button")}
               </Button>
               <Tooltip
-                tooltip="Approve matching actions for this session"
+                tooltip={t("approveSession.tooltip")}
                 delayDuration={200}
               >
                 <Button
@@ -256,9 +273,9 @@ export default function ApprovalCard({
                       0
                     )
                   }
-                  aria-label="Approve matching actions for this session"
+                  aria-label={t("approveSession.tooltip")}
                 >
-                  Approve for session
+                  {t("approveSession.button")}
                 </Button>
               </Tooltip>
               <Button
@@ -273,9 +290,9 @@ export default function ApprovalCard({
                     );
                   })
                 }
-                aria-label="Reject this action"
+                aria-label={t("reject.ariaLabel")}
               >
-                Reject
+                {t("reject.button")}
               </Button>
             </div>
           )}

--- a/web/src/app/craft/components/approvals/PayloadView.tsx
+++ b/web/src/app/craft/components/approvals/PayloadView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useState } from "react";
+import { useTranslations } from "next-intl";
 
 import { Button, Text } from "@opal/components";
 import { cn } from "@opal/utils";
@@ -38,6 +39,7 @@ function InsetBlock({ children }: { children: React.ReactNode }) {
 }
 
 function StringValue({ text }: { text: string }) {
+  const t = useTranslations("craft.approvals.payload");
   const [expanded, setExpanded] = useState(false);
   const needsTruncation = text.length > STRING_TRUNCATE_AT && !expanded;
   const shown = needsTruncation
@@ -57,7 +59,7 @@ function StringValue({ text }: { text: string }) {
             size="sm"
             onClick={() => setExpanded((v) => !v)}
           >
-            {expanded ? "Show less" : "Show more"}
+            {expanded ? t("showLess.button") : t("showMore.button")}
           </Button>
         </div>
       )}
@@ -66,6 +68,7 @@ function StringValue({ text }: { text: string }) {
 }
 
 function NestedJsonValue({ value }: { value: unknown }) {
+  const t = useTranslations("craft.approvals.payload");
   const [expanded, setExpanded] = useState(false);
   const full = JSON.stringify(value, null, 2);
   const lines = full.split("\n");
@@ -90,7 +93,7 @@ function NestedJsonValue({ value }: { value: unknown }) {
             size="sm"
             onClick={() => setExpanded((v) => !v)}
           >
-            {expanded ? "Show less" : "Show more"}
+            {expanded ? t("showLess.button") : t("showMore.button")}
           </Button>
         </div>
       )}
@@ -153,6 +156,7 @@ function StructuredPayloadView({
 }: {
   payload: Record<string, unknown>;
 }) {
+  const t = useTranslations("craft.approvals.payload");
   const entries = Object.entries(payload).filter(
     ([, v]) => v !== null && v !== undefined
   );
@@ -160,7 +164,7 @@ function StructuredPayloadView({
     return (
       <InsetBlock>
         <Text font="secondary-body" color="text-03">
-          No payload.
+          {t("empty.label")}
         </Text>
       </InsetBlock>
     );

--- a/web/src/app/craft/components/buildEntryMenuItems.test.tsx
+++ b/web/src/app/craft/components/buildEntryMenuItems.test.tsx
@@ -1,4 +1,7 @@
-import { buildEntryMenuItems } from "@/app/craft/components/buildEntryMenuItems";
+import {
+  buildEntryMenuItems,
+  type EntryMenuTranslate,
+} from "@/app/craft/components/buildEntryMenuItems";
 import type { PickerSections } from "@/lib/skills/picker";
 
 function sections(over: Partial<PickerSections> = {}): PickerSections {
@@ -13,6 +16,9 @@ const ACME_APP = {
   authenticated: true,
 };
 
+// Identity translator keeps assertions on stable key names.
+const tStub = ((key: string) => key) as unknown as EntryMenuTranslate;
+
 const ASANA_MCP = {
   kind: "mcp" as const,
   mcpServerId: 8,
@@ -22,12 +28,16 @@ const ASANA_MCP = {
 };
 
 function appsFlyout(input: PickerSections) {
-  const items = buildEntryMenuItems(input, {
-    onAttachFiles: jest.fn(),
-    onSelectEntry: jest.fn(),
-    onBrowseSkills: jest.fn(),
-    onBrowseApps: jest.fn(),
-  });
+  const items = buildEntryMenuItems(
+    input,
+    {
+      onAttachFiles: jest.fn(),
+      onSelectEntry: jest.fn(),
+      onBrowseSkills: jest.fn(),
+      onBrowseApps: jest.fn(),
+    },
+    tStub
+  );
   const apps = items.find((item) => item?.key === "apps");
   return apps?.flyoutItems ?? [];
 }
@@ -48,7 +58,7 @@ describe("buildEntryMenuItems Apps flyout", () => {
 
     expect(flyout.map((item) => [item.key, item.description])).toEqual([
       ["app:3", undefined],
-      ["mcp:8", "MCP server"],
+      ["mcp:8", "mcpServer.description"],
     ]);
   });
 
@@ -73,7 +83,8 @@ describe("buildEntryMenuItems Apps flyout", () => {
         onSelectEntry,
         onBrowseSkills: jest.fn(),
         onBrowseApps: jest.fn(),
-      }
+      },
+      tStub
     );
     const flyout =
       items.find((item) => item?.key === "apps")?.flyoutItems ?? [];

--- a/web/src/app/craft/components/buildEntryMenuItems.tsx
+++ b/web/src/app/craft/components/buildEntryMenuItems.tsx
@@ -1,3 +1,4 @@
+import type { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import {
   SvgFileText,
@@ -16,6 +17,10 @@ import type {
   PlusMenuFlyoutItem,
   PlusMenuItem,
 } from "@/sections/input/PlusMenuButton";
+
+export type EntryMenuTranslate = ReturnType<
+  typeof useTranslations<"craft.entryMenu">
+>;
 
 interface LibraryFile {
   id: string;
@@ -43,21 +48,22 @@ export function buildEntryMenuItems(
     onBrowseApps,
     libraryFiles = [],
     onManageLibrary,
-  }: EntryMenuHandlers
+  }: EntryMenuHandlers,
+  t: EntryMenuTranslate
 ): Array<PlusMenuItem | null> {
   // Skills and Apps always show; when empty they prompt the user to browse/connect.
   const items: Array<PlusMenuItem | null> = [
     {
       key: "files",
       icon: SvgPaperclip,
-      label: "Add files or photos",
+      label: t("addFiles.label"),
       onSelect: onAttachFiles,
     },
     null,
     {
       key: "skills",
       icon: SvgSparkle,
-      label: "Skills",
+      label: t("skills.label"),
       flyoutItems:
         sections.skills.length > 0
           ? sections.skills.map((skill) => ({
@@ -71,7 +77,7 @@ export function buildEntryMenuItems(
               {
                 key: "skills-empty",
                 icon: SvgSparkle,
-                label: "Browse skills",
+                label: t("browseSkills.label"),
                 onSelect: onBrowseSkills,
               },
             ],
@@ -79,11 +85,15 @@ export function buildEntryMenuItems(
     {
       key: "apps",
       icon: SvgPlug,
-      label: "Apps",
-      flyoutItems: buildAppFlyoutItems(sections, {
-        onSelectEntry,
-        onBrowseApps,
-      }),
+      label: t("apps.label"),
+      flyoutItems: buildAppFlyoutItems(
+        sections,
+        {
+          onSelectEntry,
+          onBrowseApps,
+        },
+        t
+      ),
     },
   ];
 
@@ -91,7 +101,7 @@ export function buildEntryMenuItems(
     items.push({
       key: "library",
       icon: SvgFolder,
-      label: "Library",
+      label: t("library.label"),
       flyoutItems: [
         // TODO(craft-library): file rows open the manage modal until per-file attach is wired.
         ...libraryFiles.map((file) => ({
@@ -103,7 +113,7 @@ export function buildEntryMenuItems(
         {
           key: "manage",
           icon: SvgFolder,
-          label: "Manage library…",
+          label: t("manageLibrary.label"),
           onSelect: onManageLibrary,
         },
       ],
@@ -123,12 +133,13 @@ interface AppFlyoutHandlers {
  * two never read as one kind of thing. */
 function buildAppFlyoutItems(
   sections: PickerSections,
-  { onSelectEntry, onBrowseApps }: AppFlyoutHandlers
+  { onSelectEntry, onBrowseApps }: AppFlyoutHandlers,
+  t: EntryMenuTranslate
 ): PlusMenuFlyoutItem[] {
   const connectHint = (authenticated: boolean) =>
     authenticated ? undefined : (
       <Text font="secondary-body" color="text-03">
-        Connect
+        {t("connect.hint")}
       </Text>
     );
 
@@ -140,7 +151,7 @@ function buildAppFlyoutItems(
     icon: pickerEntryIcon(entry),
     label: entry.name,
     // Only MCP rows are labelled; apps are the default kind on this page.
-    description: entry.kind === "mcp" ? "MCP server" : undefined,
+    description: entry.kind === "mcp" ? t("mcpServer.description") : undefined,
     rightContent: connectHint(entry.authenticated),
     onSelect: () => onSelectEntry(entry),
   }));
@@ -151,7 +162,7 @@ function buildAppFlyoutItems(
         {
           key: "apps-empty",
           icon: SvgPlug,
-          label: "Connect an app",
+          label: t("connectApp.label"),
           onSelect: onBrowseApps,
         },
       ];

--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { Text, Button } from "@opal/components";
@@ -36,6 +37,7 @@ export default function ArtifactsTab({
   artifacts,
   sessionId,
 }: ArtifactsTabProps) {
+  const t = useTranslations("craft.artifactsTab");
   const webappArtifacts = artifacts.filter(
     (a) => a.type === "nextjs_app" || a.type === "web_app"
   );
@@ -148,10 +150,10 @@ export default function ArtifactsTab({
       >
         <SvgFiles size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
-          No artifacts yet
+          {t("empty.title")}
         </Text>
         <Text font="secondary-body" color="text-02">
-          Output files and web apps will appear here
+          {t("empty.description")}
         </Text>
       </Section>
     );
@@ -171,7 +173,7 @@ export default function ArtifactsTab({
               style={{ paddingLeft: 12 }}
               role="button"
               tabIndex={0}
-              aria-label={`Open ${artifact.name}`}
+              aria-label={t("openItem.ariaLabel", { name: artifact.name })}
               onKeyDown={clickOnKeyDown(handleWebappOpen)}
               onClick={handleWebappOpen}
             >
@@ -184,7 +186,7 @@ export default function ArtifactsTab({
                   {artifact.name}
                 </Text>
                 <Text font="secondary-body" color="text-02">
-                  Next.js Application
+                  {t("nextjsApp.label")}
                 </Text>
               </div>
 
@@ -198,7 +200,7 @@ export default function ArtifactsTab({
                     handleWebappDownload();
                   }}
                 >
-                  Download
+                  {t("download.button")}
                 </Button>
               </div>
             </div>
@@ -236,6 +238,7 @@ function OutputEntryRow({
   onDownload,
   onFileOpen,
 }: OutputEntryRowProps) {
+  const t = useTranslations("craft.artifactsTab");
   const [expanded, setExpanded] = useState(false);
   const [children, setChildren] = useState<FileSystemEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -270,7 +273,9 @@ function OutputEntryRow({
         role="button"
         tabIndex={0}
         aria-label={
-          entry.is_directory ? `Toggle ${entry.name}` : `Open ${entry.name}`
+          entry.is_directory
+            ? t("toggleItem.ariaLabel", { name: entry.name })
+            : t("openItem.ariaLabel", { name: entry.name })
         }
         onKeyDown={clickOnKeyDown(openEntry)}
         onClick={openEntry}
@@ -308,7 +313,7 @@ function OutputEntryRow({
               onDownload(entry.path, entry.is_directory);
             }}
           >
-            Download
+            {t("download.button")}
           </Button>
         </div>
       </div>

--- a/web/src/app/craft/components/output-panel/FilePreviewContent.test.tsx
+++ b/web/src/app/craft/components/output-panel/FilePreviewContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@tests/setup/test-utils";
 
 import { FilePreviewContent } from "@/app/craft/components/output-panel/FilePreviewContent";
 import { fetchFileContent } from "@/app/craft/services/apiServices";

--- a/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
+++ b/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { fetchFileContent } from "@/app/craft/services/apiServices";
@@ -154,6 +155,7 @@ function FetchedFilePreview({
   fullHeight,
   refreshKey,
 }: FetchedFilePreviewProps) {
+  const t = useTranslations("craft.filePreview");
   const { data, error, isLoading, mutate } = useSWR(
     SWR_KEYS.buildSessionArtifactFile(sessionId, filePath),
     () => fetchFileContent(sessionId, filePath),
@@ -180,7 +182,7 @@ function FetchedFilePreview({
           padding={8}
         >
           <Text font="secondary-body" color="text-03">
-            Loading file...
+            {t("loading.label")}
           </Text>
         </Section>
       );
@@ -188,7 +190,7 @@ function FetchedFilePreview({
     return (
       <div className="p-4">
         <Text font="secondary-body" color="text-03">
-          Loading file...
+          {t("loading.label")}
         </Text>
       </div>
     );
@@ -205,7 +207,7 @@ function FetchedFilePreview({
         >
           <SvgFileText size={48} className="stroke-text-02" />
           <Text font="heading-h3" color="text-03">
-            Error loading file
+            {t("error.title")}
           </Text>
           <Text font="secondary-body" color="text-02">
             {error.message}
@@ -216,7 +218,7 @@ function FetchedFilePreview({
     return (
       <div className="p-4">
         <Text font="secondary-body" color="text-02">
-          {`Error: ${error.message}`}
+          {t("error.inline", { message: error.message })}
         </Text>
       </div>
     );
@@ -232,7 +234,7 @@ function FetchedFilePreview({
           padding={8}
         >
           <Text font="secondary-body" color="text-03">
-            No content
+            {t("noContent.label")}
           </Text>
         </Section>
       );
@@ -240,7 +242,7 @@ function FetchedFilePreview({
     return (
       <div className="p-4">
         <Text font="secondary-body" color="text-03">
-          No content
+          {t("noContent.label")}
         </Text>
       </div>
     );
@@ -257,7 +259,7 @@ function FetchedFilePreview({
         >
           <SvgFileText size={48} className="stroke-text-02" />
           <Text font="heading-h3" color="text-03">
-            Cannot preview file
+            {t("cannotPreview.title")}
           </Text>
           <div className="text-center max-w-md">
             <Text font="secondary-body" color="text-02">

--- a/web/src/app/craft/components/output-panel/FilesTab.test.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.test.tsx
@@ -5,7 +5,7 @@ import {
   render,
   screen,
   waitFor,
-} from "@testing-library/react";
+} from "@tests/setup/test-utils";
 import { SWRConfig } from "swr";
 
 import FilesTab from "@/app/craft/components/output-panel/FilesTab";

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
@@ -42,6 +43,7 @@ export default function FilesTab({
   isPreProvisioned = false,
   isProvisioning = false,
 }: FilesTabProps) {
+  const t = useTranslations("craft.filesTab");
   // Get persisted state from store (only used when not pre-provisioned)
   const filesTabState = useFilesTabState();
   const updateFilesTabState = useBuildSessionStore(
@@ -349,12 +351,10 @@ export default function FilesTab({
       >
         <SvgHardDrive size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
-          {isProvisioning ? "Preparing sandbox..." : "No files yet"}
+          {isProvisioning ? t("preparing.title") : t("empty.title")}
         </Text>
         <Text font="secondary-body" color="text-02">
-          {isProvisioning
-            ? "Setting up your development environment"
-            : "Files created during the build will appear here"}
+          {isProvisioning ? t("preparing.description") : t("empty.description")}
         </Text>
       </Section>
     );
@@ -370,7 +370,7 @@ export default function FilesTab({
       >
         <SvgHardDrive size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
-          Error loading files
+          {t("error.title")}
         </Text>
         <Text font="secondary-body" color="text-02">
           {error.message}
@@ -388,7 +388,7 @@ export default function FilesTab({
         padding={8}
       >
         <Text font="secondary-body" color="text-03">
-          Loading files...
+          {t("loading.label")}
         </Text>
       </Section>
     );
@@ -445,7 +445,7 @@ export default function FilesTab({
             padding={8}
           >
             <Text font="secondary-body" color="text-03">
-              No files in this directory
+              {t("emptyDirectory.label")}
             </Text>
           </Section>
         ) : (
@@ -493,6 +493,7 @@ function FileTreeNode({
   formatFileSize,
   parentIsLast = [],
 }: FileTreeNodeProps) {
+  const t = useTranslations("craft.filesTab");
   // Sort entries: directories first, then alphabetically
   const sortedEntries = [...entries].sort((a, b) => {
     if (a.is_directory && !b.is_directory) return -1;
@@ -639,7 +640,7 @@ function FileTreeNode({
                   style={{ paddingLeft: `${(depth + 1) * 20 + 24}px` }}
                 >
                   <Text font="secondary-body" color="text-02">
-                    Loading...
+                    {t("loadingChildren.label")}
                   </Text>
                 </div>
               )}

--- a/web/src/app/craft/components/output-panel/ImagePreview.tsx
+++ b/web/src/app/craft/components/output-panel/ImagePreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import { SvgImage } from "@opal/icons";
@@ -16,6 +17,7 @@ interface ImagePreviewProps {
  * Includes proper accessibility attributes
  */
 export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
+  const t = useTranslations("craft.imagePreview");
   const [imageLoading, setImageLoading] = useState(true);
   const [imageError, setImageError] = useState(false);
 
@@ -38,10 +40,10 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
       >
         <SvgImage size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
-          Failed to load image
+          {t("error.title")}
         </Text>
         <Text font="secondary-body" color="text-02">
-          The image could not be displayed
+          {t("error.description")}
         </Text>
       </Section>
     );
@@ -53,7 +55,7 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
         {imageLoading && (
           <div className="absolute">
             <Text font="secondary-body" color="text-03">
-              Loading image...
+              {t("loading.label")}
             </Text>
           </div>
         )}
@@ -61,7 +63,7 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
           src={src}
           alt={displayName}
 
-          aria-label={`Preview of ${displayName}`}
+          aria-label={t("preview.ariaLabel", { name: displayName })}
           className={cn(
             "max-w-full max-h-full object-contain transition-opacity",
             imageLoading ? "opacity-0" : "opacity-100"

--- a/web/src/app/craft/components/output-panel/PdfPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PdfPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import { SvgFileText } from "@opal/icons";
@@ -24,6 +25,7 @@ export default function PdfPreview({
   filePath,
   refreshKey,
 }: PdfPreviewProps) {
+  const t = useTranslations("craft.pdfPreview");
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -83,11 +85,11 @@ export default function PdfPreview({
       >
         <SvgFileText size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
-          Cannot preview PDF
+          {t("error.title")}
         </Text>
         <div className="text-center max-w-md">
           <Text font="secondary-body" color="text-02">
-            The PDF file could not be loaded.
+            {t("error.description")}
           </Text>
         </div>
       </Section>
@@ -103,7 +105,7 @@ export default function PdfPreview({
         padding={8}
       >
         <Text font="secondary-body" color="text-03">
-          Loading PDF...
+          {t("loading.label")}
         </Text>
       </Section>
     );
@@ -112,7 +114,7 @@ export default function PdfPreview({
   return (
     <iframe
       src={blobUrl}
-      title={filePath.split("/").pop() || "PDF Preview"}
+      title={filePath.split("/").pop() || t("frame.title")}
       className={cn("w-full h-full border-none")}
     />
   );

--- a/web/src/app/craft/components/output-panel/PptxPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PptxPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { cn } from "@opal/utils";
@@ -26,6 +27,7 @@ export default function PptxPreview({
   filePath,
   refreshKey,
 }: PptxPreviewProps) {
+  const t = useTranslations("craft.pptxPreview");
   const [currentSlide, setCurrentSlide] = useState(0);
   const [imageLoading, setImageLoading] = useState(true);
 
@@ -89,7 +91,7 @@ export default function PptxPreview({
         padding={8}
       >
         <Text font="secondary-body" color="text-03">
-          Converting presentation...
+          {t("converting.label")}
         </Text>
       </Section>
     );
@@ -105,7 +107,7 @@ export default function PptxPreview({
       >
         <SvgFileText size={48} className="stroke-text-02" />
         <Text font="heading-h3" color="text-03">
-          Cannot preview presentation
+          {t("error.title")}
         </Text>
         <div className="text-center max-w-md">
           <Text font="secondary-body" color="text-02">
@@ -126,7 +128,7 @@ export default function PptxPreview({
       >
         <SvgFileText size={48} className="stroke-text-02" />
         <Text font="secondary-body" color="text-03">
-          No slides in this presentation
+          {t("empty.label")}
         </Text>
       </Section>
     );
@@ -142,13 +144,16 @@ export default function PptxPreview({
         {imageLoading && (
           <div className="absolute">
             <Text font="secondary-body" color="text-03">
-              Loading slide...
+              {t("loadingSlide.label")}
             </Text>
           </div>
         )}
         <img
           src={slideUrl}
-          alt={`Slide ${currentSlide + 1} of ${slideCount}`}
+          alt={t("slide.counter", {
+            current: currentSlide + 1,
+            total: slideCount,
+          })}
           className={cn(
             "max-w-full max-h-full object-contain transition-opacity",
             imageLoading ? "opacity-0" : "opacity-100"
@@ -174,7 +179,10 @@ export default function PptxPreview({
             <SvgChevronLeft size={16} className="stroke-text-02" />
           </button>
           <Text font="secondary-body" color="text-03">
-            {`Slide ${currentSlide + 1} of ${slideCount}`}
+            {t("slide.counter", {
+              current: currentSlide + 1,
+              total: slideCount,
+            })}
           </Text>
           <button
             onClick={goToNext}

--- a/web/src/app/craft/components/output-panel/PreviewTab.tsx
+++ b/web/src/app/craft/components/output-panel/PreviewTab.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { SvgGlobe, SvgLoader } from "@opal/icons";
-import {
-  NO_WEBAPP_LABEL,
-  type WebappState,
-} from "@/app/craft/components/output-panel/interfaces";
+import { type WebappState } from "@/app/craft/components/output-panel/interfaces";
 
 interface PreviewTabProps {
   webappUrl: string | null;
@@ -25,6 +23,8 @@ export default function PreviewTab({
   webappState,
   refreshKey,
 }: PreviewTabProps) {
+  const t = useTranslations("craft.previewTab");
+  const tOutput = useTranslations("craft.outputPanel");
   const [iframeLoaded, setIframeLoaded] = useState(false);
 
   // Reset loaded state when URL or refreshKey changes
@@ -42,10 +42,10 @@ export default function PreviewTab({
       >
         <SvgGlobe size={48} className="stroke-text-02" aria-hidden />
         <Text font="heading-h3" color="text-03">
-          {NO_WEBAPP_LABEL}
+          {tOutput("noWebapp.label")}
         </Text>
         <Text font="secondary-body" color="text-02">
-          A live preview appears here once a web app is running.
+          {t("empty.description")}
         </Text>
       </Section>
     );
@@ -66,10 +66,10 @@ export default function PreviewTab({
           aria-hidden
         />
         <Text font="heading-h3" color="text-03">
-          Starting the dev server...
+          {t("starting.title")}
         </Text>
         <Text font="secondary-body" color="text-02">
-          Installing dependencies and booting.
+          {t("starting.description")}
         </Text>
       </Section>
     );
@@ -100,7 +100,7 @@ export default function PreviewTab({
               iframeLoaded ? "opacity-100" : "opacity-0"
             )}
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
-            title="Web App Preview"
+            title={t("frame.title")}
           />
         )}
       </div>

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import { cn, copyText } from "@opal/utils";
 import { Text, Button } from "@opal/components";
 import {
@@ -66,7 +67,7 @@ export default function UrlBar({
   onForward,
   previewUrl,
   onDownloadRaw,
-  downloadRawTooltip = "Download file",
+  downloadRawTooltip,
   onDownload,
   isDownloading = false,
   onRefresh,
@@ -75,6 +76,8 @@ export default function UrlBar({
   sharingScope = "private",
   onScopeChange,
 }: UrlBarProps) {
+  const t = useTranslations("craft.urlBar");
+  const rawTooltip = downloadRawTooltip ?? t("downloadFile.tooltip");
   const [copiedUrl, setCopiedUrl] = React.useState<string | null>(null);
   const [copyFeedbackKey, setCopyFeedbackKey] = React.useState(0);
   const isDisplayUrlCopyable = React.useMemo(() => {
@@ -134,7 +137,7 @@ export default function UrlBar({
                   ? "hover:bg-background-tint-03 text-text-03"
                   : "text-text-02 cursor-not-allowed"
               )}
-              aria-label="Go back"
+              aria-label={t("back.ariaLabel")}
             >
               <SvgArrowLeft size={16} />
             </button>
@@ -147,7 +150,7 @@ export default function UrlBar({
                   ? "hover:bg-background-tint-03 text-text-03"
                   : "text-text-02 cursor-not-allowed"
               )}
-              aria-label="Go forward"
+              aria-label={t("forward.ariaLabel")}
             >
               <SvgArrowRight size={16} />
             </button>
@@ -159,7 +162,7 @@ export default function UrlBar({
                   "p-1.5 rounded-full transition-colors text-text-03",
                   isRefreshing ? "cursor-wait" : "hover:bg-background-tint-03"
                 )}
-                aria-label="Refresh"
+                aria-label={t("refresh.ariaLabel")}
                 aria-busy={isRefreshing}
               >
                 {isRefreshing ? (
@@ -178,11 +181,11 @@ export default function UrlBar({
         >
           {/* Download raw file button */}
           {onDownloadRaw && (
-            <Tooltip tooltip={downloadRawTooltip} delayDuration={200}>
+            <Tooltip tooltip={rawTooltip} delayDuration={200}>
               <button
                 onClick={onDownloadRaw}
                 className="shrink-0 p-0.5 rounded-sm transition-colors hover:bg-background-tint-03 text-text-03"
-                aria-label={downloadRawTooltip}
+                aria-label={rawTooltip}
               >
                 <SvgDownloadCloud size={14} />
               </button>
@@ -190,11 +193,11 @@ export default function UrlBar({
           )}
           {/* Open in new tab button - only shown for Preview tab with valid URL */}
           {previewUrl && (
-            <Tooltip tooltip="open in a new tab" delayDuration={200}>
+            <Tooltip tooltip={t("openInNewTab.tooltip")} delayDuration={200}>
               <button
                 onClick={handleOpenInNewTab}
                 className="shrink-0 p-0.5 rounded-sm transition-colors hover:bg-background-tint-03 text-text-03"
-                aria-label="open in a new tab"
+                aria-label={t("openInNewTab.tooltip")}
                 data-copy-state={isUrlCopied ? "copied" : "idle"}
               >
                 {isUrlCopied ? (
@@ -230,7 +233,7 @@ export default function UrlBar({
                   type="button"
                   onClick={handleCopyUrl}
                   className="block w-full min-w-0 cursor-pointer text-start focus:outline-hidden"
-                  aria-label={`Copy URL: ${displayUrl}`}
+                  aria-label={t("copyUrl.ariaLabel", { url: displayUrl })}
                 >
                   {urlText}
                 </button>
@@ -249,7 +252,7 @@ export default function UrlBar({
             icon={isDownloading ? SpinningLoader : SvgExternalLink}
             onClick={onDownload}
           >
-            {isDownloading ? "Exporting..." : "Export to .docx"}
+            {isDownloading ? t("export.inProgress") : t("export.button")}
           </Button>
         )}
         {/* Share button — shown when webapp preview is active */}

--- a/web/src/app/craft/components/setup-requests/SetupCard.tsx
+++ b/web/src/app/craft/components/setup-requests/SetupCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useSWRConfig } from "swr";
 
 import { Button, Text } from "@opal/components";
@@ -50,6 +51,7 @@ export default function SetupCard({
   reason,
   userApp,
 }: SetupCardProps) {
+  const t = useTranslations("craft.setupCard");
   const { mutate } = useSWRConfig();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -66,7 +68,8 @@ export default function SetupCard({
     };
   }, []);
 
-  const appName = userApp?.name ?? `External app ${externalAppId}`;
+  const appName =
+    userApp?.name ?? t("appFallback.label", { id: externalAppId });
   const supportsOauth = userApp?.supports_oauth ?? false;
   const appLoading = userApp === undefined;
 
@@ -78,8 +81,7 @@ export default function SetupCard({
       // POST failed (network error, or already resolved on another device).
       // Keep the card actionable so the user can retry.
       console.error("Failed to resolve connect-app request:", e);
-      if (mountedRef.current)
-        setError("Something went wrong. Please try again.");
+      if (mountedRef.current) setError(t("error.generic"));
       return;
     }
     if (!mountedRef.current) return;
@@ -149,7 +151,7 @@ export default function SetupCard({
     // Capabilities are unknown until the app row loads (the button is disabled).
     if (appLoading) return;
     if (!userApp) {
-      setError("This app can't be set up from here.");
+      setError(t("error.notConfigurable"));
       return;
     }
     if (!supportsOauth) {
@@ -165,15 +167,13 @@ export default function SetupCard({
       const popup = window.open(authorize_url, "_blank", POPUP_FEATURES);
       if (!popup) {
         setBusy(false);
-        setError(
-          "Couldn't open the setup window — allow popups and try again."
-        );
+        setError(t("error.popupBlocked"));
         return;
       }
       awaitOAuthCompletion(popup);
     } catch (e) {
       setBusy(false);
-      setError(e instanceof Error ? e.message : "Failed to start setup");
+      setError(e instanceof Error ? e.message : t("error.startFailed"));
     }
   }
 
@@ -204,8 +204,8 @@ export default function SetupCard({
             color={connected ? "muted" : "danger"}
             title={
               connected
-                ? `${appName} connected.`
-                : `Skipped connecting ${appName}.`
+                ? t("connected.title", { app: appName })
+                : t("skipped.title", { app: appName })
             }
           />
         </div>
@@ -223,10 +223,8 @@ export default function SetupCard({
           sizePreset="main-ui"
           variant="section"
           icon={Logo}
-          title={`Connect ${appName}`}
-          description={
-            reason ?? `The agent needs ${appName} to continue this task.`
-          }
+          title={t("connect.title", { app: appName })}
+          description={reason ?? t("reason.fallback", { app: appName })}
         />
         {error && (
           <Text font="secondary-body" color="text-03">
@@ -240,7 +238,7 @@ export default function SetupCard({
             disabled={busy}
             onClick={() => void resolve("declined")}
           >
-            Not now
+            {t("notNow.button")}
           </Button>
           <Button
             prominence="primary"
@@ -248,7 +246,11 @@ export default function SetupCard({
             disabled={busy || appLoading}
             onClick={() => void connect()}
           >
-            {busy ? "Waiting…" : appLoading ? "Loading…" : `Connect ${appName}`}
+            {busy
+              ? t("waiting.button")
+              : appLoading
+                ? t("loading.button")
+                : t("connect.title", { app: appName })}
           </Button>
         </div>
         {userApp && (

--- a/web/src/app/craft/components/tool-cards/BashBody.tsx
+++ b/web/src/app/craft/components/tool-cards/BashBody.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import { useCodeHighlighter } from "@/app/craft/hooks/useCodeHighlighter";
 import ToolCardSurface, {
@@ -15,6 +16,7 @@ import type { ToolCardBodyProps } from "@/app/craft/components/tool-cards/interf
  * monospace size so the result never looks larger than the command.
  */
 export default function BashBody({ toolCall }: ToolCardBodyProps) {
+  const t = useTranslations("craft.toolCards.bash");
   const command = toolCall.command;
   const output = toolCall.rawOutput;
   const highlight = useCodeHighlighter(!!command);
@@ -51,7 +53,7 @@ export default function BashBody({ toolCall }: ToolCardBodyProps) {
       {!command && !output && (
         <ToolCardSection>
           <Text font="secondary-mono" color="text-03">
-            No output
+            {t("noOutput.label")}
           </Text>
         </ToolCardSection>
       )}

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Tag, Text } from "@opal/components";
 import { cn } from "@opal/utils";
 import { SvgCheckAll, SvgChevronDown } from "@opal/icons";
@@ -53,6 +54,7 @@ export default function CraftToolGroup({
   autoCollapse = false,
   defaultOpen,
 }: CraftToolGroupProps) {
+  const t = useTranslations("craft.toolCards.group");
   const aggregate = aggregateStatus(toolCalls);
   // Open while the run is active so streaming calls stay visible and nothing
   // collapses as new calls append; settled groups start collapsed.
@@ -92,18 +94,18 @@ export default function CraftToolGroup({
               <div className="flex items-center gap-2 min-w-0 w-full">
                 {renderStatusIcon(toolCalls)}
                 <Text font="main-ui-muted" color="text-04" nowrap>
-                  Working
+                  {t("working.label")}
                 </Text>
                 <span className="ms-auto shrink-0 flex items-center gap-2">
                   {failedCount > 0 && (
                     <Tag
-                      title={`${failedCount} failed`}
+                      title={t("failed.tag", { count: failedCount })}
                       size="sm"
                       color="red"
                     />
                   )}
                   <Tag
-                    title={`${toolCalls.length} calls`}
+                    title={t("calls.tag", { count: toolCalls.length })}
                     size="sm"
                     color="gray"
                   />

--- a/web/src/app/craft/components/tool-cards/DiffBody.tsx
+++ b/web/src/app/craft/components/tool-cards/DiffBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { Text, Button } from "@opal/components";
 import { SvgColumn, SvgMenu } from "@opal/icons";
@@ -103,6 +104,7 @@ function computeDiff(oldText: string, newText: string): DiffLine[] {
 
 function collapseUnchanged(
   lines: DiffLine[],
+  formatUnchanged: (count: number) => string,
   contextLines: number = 3
 ): DiffLine[] {
   const result: DiffLine[] = [];
@@ -116,7 +118,7 @@ function collapseUnchanged(
 
   if (changeIndices.length === 0) {
     if (lines.length > 10) {
-      return [{ type: "header", content: `${lines.length} unchanged lines` }];
+      return [{ type: "header", content: formatUnchanged(lines.length) }];
     }
     return lines;
   }
@@ -136,7 +138,7 @@ function collapseUnchanged(
     if (count <= 0) return;
     result.push({
       type: "header",
-      content: `${count} unchanged line${count > 1 ? "s" : ""}`,
+      content: formatUnchanged(count),
     });
   };
 
@@ -277,13 +279,16 @@ function SideBySideDiff({ lines }: { lines: DiffLine[] }) {
  * larger than SIDE_BY_SIDE_AUTO_THRESHOLD.
  */
 export default function DiffBody({ toolCall }: ToolCardBodyProps) {
+  const t = useTranslations("craft.toolCards.diff");
   const oldContent = toolCall.oldContent ?? "";
   const newContent = toolCall.newContent ?? "";
 
   const diffLines = useMemo(() => {
     const rawDiff = computeDiff(oldContent, newContent);
-    return collapseUnchanged(rawDiff);
-  }, [oldContent, newContent]);
+    return collapseUnchanged(rawDiff, (count) =>
+      t("unchangedLines.label", { count })
+    );
+  }, [oldContent, newContent, t]);
 
   const stats = useMemo(() => {
     const added = diffLines.filter((l) => l.type === "added").length;
@@ -341,8 +346,8 @@ export default function DiffBody({ toolCall }: ToolCardBodyProps) {
             }
             tooltip={
               mode === "unified"
-                ? "Switch to side-by-side"
-                : "Switch to unified"
+                ? t("viewToggle.sideBySideTooltip")
+                : t("viewToggle.unifiedTooltip")
             }
           />
         </div>

--- a/web/src/app/craft/components/tool-cards/GenericBody.tsx
+++ b/web/src/app/craft/components/tool-cards/GenericBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Text } from "@opal/components";
+import { useTranslations } from "next-intl";
 import { getLanguageFromPath } from "@/app/craft/utils/codeLanguage";
 import { useCodeHighlighter } from "@/app/craft/hooks/useCodeHighlighter";
 import { getLanguageHint } from "@/app/craft/components/tool-cards/helpers";
@@ -16,6 +17,7 @@ import type { ToolCardBodyProps } from "@/app/craft/components/tool-cards/interf
  * highlighting when a language can be derived.
  */
 export default function GenericBody({ toolCall }: ToolCardBodyProps) {
+  const t = useTranslations("craft.toolCards.generic");
   const content = toolCall.rawOutput;
   const hint = getLanguageHint(toolCall);
   const lang = hint?.includes(".") ? getLanguageFromPath(hint) : hint;
@@ -39,7 +41,7 @@ export default function GenericBody({ toolCall }: ToolCardBodyProps) {
           )
         ) : (
           <Text font="secondary-mono" color="text-02">
-            No output yet...
+            {t("noOutput.label")}
           </Text>
         )}
       </ToolCardSection>

--- a/web/src/app/craft/components/tool-cards/ReadBody.tsx
+++ b/web/src/app/craft/components/tool-cards/ReadBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Text, Button } from "@opal/components";
 import { SvgChevronDown } from "@opal/icons";
 import { getLanguageFromPath } from "@/app/craft/utils/codeLanguage";
@@ -22,6 +23,7 @@ const PREVIEW_LINE_COUNT = 8;
  * registered language.
  */
 export default function ReadBody({ toolCall }: ToolCardBodyProps) {
+  const t = useTranslations("craft.toolCards.read");
   const [expanded, setExpanded] = useState(false);
   // The Read tool stores file content in rawOutput. The Write tool (when
   // routed here for new files) stores it in newContent instead. Fall back
@@ -38,7 +40,7 @@ export default function ReadBody({ toolCall }: ToolCardBodyProps) {
       <ToolCardSurface scroll={false}>
         <ToolCardSection>
           <Text font="secondary-mono" color="text-03">
-            (empty file)
+            {t("emptyFile.label")}
           </Text>
         </ToolCardSection>
       </ToolCardSurface>
@@ -92,7 +94,7 @@ export default function ReadBody({ toolCall }: ToolCardBodyProps) {
           className="py-0.5 px-2 flex items-center justify-between"
         >
           <Text font="secondary-body" color="text-02">
-            {`${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`}
+            {t("moreLines.label", { count: hiddenCount })}
           </Text>
           <Button
             variant="default"
@@ -101,7 +103,7 @@ export default function ReadBody({ toolCall }: ToolCardBodyProps) {
             icon={SvgChevronDown}
             onClick={() => setExpanded(true)}
           >
-            Show all
+            {t("showAll.button")}
           </Button>
         </ToolCardSection>
       )}

--- a/web/src/app/craft/components/tool-cards/SearchBody.tsx
+++ b/web/src/app/craft/components/tool-cards/SearchBody.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Text } from "@opal/components";
+import { useTranslations } from "next-intl";
 import ToolCardSurface, {
   ToolCardSection,
 } from "@/app/craft/components/tool-cards/ToolCardSurface";
@@ -12,6 +13,7 @@ import type { ToolCardBodyProps } from "@/app/craft/components/tool-cards/interf
  * (grep) exactly as the tool emitted it — no per-line icon rows.
  */
 export default function SearchBody({ toolCall }: ToolCardBodyProps) {
+  const t = useTranslations("craft.toolCards.search");
   const output = toolCall.rawOutput?.trim();
 
   if (!output) {
@@ -19,7 +21,7 @@ export default function SearchBody({ toolCall }: ToolCardBodyProps) {
       <ToolCardSurface>
         <ToolCardSection>
           <Text font="secondary-mono" color="text-02">
-            No matches
+            {t("noMatches.label")}
           </Text>
         </ToolCardSection>
       </ToolCardSurface>

--- a/web/src/app/craft/contexts/UploadFilesContext.tsx
+++ b/web/src/app/craft/contexts/UploadFilesContext.tsx
@@ -10,6 +10,7 @@ import {
   useEffect,
   type ReactNode,
 } from "react";
+import { useTranslations } from "next-intl";
 import {
   uploadFile as uploadFileApi,
   deleteFile as deleteFileApi,
@@ -86,16 +87,20 @@ interface FileValidationResult {
   error?: string;
 }
 
+/** Translator bound to the craft.uploadFiles namespace */
+type UploadTranslate = ReturnType<typeof useTranslations<"craft.uploadFiles">>;
+
 /** Validate a single file before upload */
-function validateFile(file: File): FileValidationResult {
+function validateFile(file: File, t: UploadTranslate): FileValidationResult {
   // Check file size. Extension/type are intentionally not restricted - uploaded
   // files only run inside the isolated sandbox, which is the security boundary.
   if (file.size > MAX_FILE_SIZE_BYTES) {
     return {
       valid: false,
-      error: `File too large (${formatBytes(
-        file.size
-      )}). Maximum is ${formatBytes(MAX_FILE_SIZE_BYTES)}.`,
+      error: t("errors.fileTooLarge", {
+        size: formatBytes(file.size),
+        max: formatBytes(MAX_FILE_SIZE_BYTES),
+      }),
     };
   }
 
@@ -105,13 +110,14 @@ function validateFile(file: File): FileValidationResult {
 /** Validate total files and size constraints */
 function validateBatch(
   newFiles: File[],
-  existingFiles: BuildFile[]
+  existingFiles: BuildFile[],
+  t: UploadTranslate
 ): FileValidationResult {
   const totalCount = existingFiles.length + newFiles.length;
   if (totalCount > MAX_FILES_PER_SESSION) {
     return {
       valid: false,
-      error: `Too many files. Maximum is ${MAX_FILES_PER_SESSION} files per session.`,
+      error: t("errors.tooManyFiles", { max: MAX_FILES_PER_SESSION }),
     };
   }
 
@@ -122,9 +128,9 @@ function validateBatch(
   if (totalSize > MAX_TOTAL_SIZE_BYTES) {
     return {
       valid: false,
-      error: `Total size exceeds limit. Maximum is ${formatBytes(
-        MAX_TOTAL_SIZE_BYTES
-      )} per session.`,
+      error: t("errors.totalSizeExceeded", {
+        max: formatBytes(MAX_TOTAL_SIZE_BYTES),
+      }),
     };
   }
 
@@ -169,27 +175,36 @@ export enum UploadErrorType {
   UNKNOWN = "UNKNOWN",
 }
 
-function classifyError(error: unknown): {
+function classifyError(
+  error: unknown,
+  t: UploadTranslate
+): {
   type: UploadErrorType;
   message: string;
 } {
   if (error instanceof Error) {
     const message = error.message.toLowerCase();
     if (message.includes("401") || message.includes("unauthorized")) {
-      return { type: UploadErrorType.AUTH, message: "Session expired" };
+      return {
+        type: UploadErrorType.AUTH,
+        message: t("errors.sessionExpired"),
+      };
     }
     if (message.includes("404") || message.includes("not found")) {
-      return { type: UploadErrorType.NOT_FOUND, message: "Resource not found" };
+      return {
+        type: UploadErrorType.NOT_FOUND,
+        message: t("errors.notFound"),
+      };
     }
     if (message.includes("500") || message.includes("server")) {
-      return { type: UploadErrorType.SERVER, message: "Server error" };
+      return { type: UploadErrorType.SERVER, message: t("errors.server") };
     }
     if (message.includes("network") || message.includes("fetch")) {
-      return { type: UploadErrorType.NETWORK, message: "Network error" };
+      return { type: UploadErrorType.NETWORK, message: t("errors.network") };
     }
     return { type: UploadErrorType.UNKNOWN, message: error.message };
   }
-  return { type: UploadErrorType.UNKNOWN, message: "Upload failed" };
+  return { type: UploadErrorType.UNKNOWN, message: t("errors.uploadFailed") };
 }
 
 /**
@@ -263,6 +278,7 @@ export interface UploadFilesProviderProps {
 }
 
 export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
+  const t = useTranslations("craft.uploadFiles");
   // =========================================================================
   // State
   // =========================================================================
@@ -349,7 +365,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
               const result = await uploadFileApi(sessionId, file.file!);
               return { id: file.id, success: true as const, result };
             } catch (error) {
-              const { message } = classifyError(error);
+              const { message } = classifyError(error, t);
               return {
                 id: file.id,
                 success: false as const,
@@ -389,7 +405,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
         isUploadingPendingRef.current = false;
       }
     },
-    [triggerFilesRefresh]
+    [triggerFilesRefresh, t]
   );
 
   /**
@@ -452,7 +468,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
           });
         }
       } catch (error) {
-        const { type } = classifyError(error);
+        const { type } = classifyError(error, t);
         if (type !== UploadErrorType.NOT_FOUND) {
           console.error(
             "[UploadFilesContext] fetchExistingAttachments error:",
@@ -475,7 +491,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
         fetchingSessionRef.current = null;
       }
     },
-    []
+    [t]
   );
 
   // =========================================================================
@@ -585,7 +601,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
       const existingFiles = currentMessageFiles;
 
       // Validate batch constraints first
-      const batchValidation = validateBatch(files, existingFiles);
+      const batchValidation = validateBatch(files, existingFiles, t);
       if (!batchValidation.valid) {
         // Create failed files for all with the batch error
         const failedFiles = files.map((f) =>
@@ -600,7 +616,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
       const failedFiles: BuildFile[] = [];
 
       for (const file of files) {
-        const validation = validateFile(file);
+        const validation = validateFile(file, t);
         if (validation.valid) {
           validFiles.push(file);
         } else {
@@ -637,7 +653,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
               result,
             };
           } catch (error) {
-            const { message } = classifyError(error);
+            const { message } = classifyError(error, t);
             return {
               id: optimisticFile.id,
               success: false as const,
@@ -690,7 +706,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
 
       return [...failedFiles, ...optimisticFiles];
     },
-    [activeSessionId, currentMessageFiles, triggerFilesRefresh]
+    [activeSessionId, currentMessageFiles, triggerFilesRefresh, t]
   );
 
   /**

--- a/web/src/app/craft/onboarding/components/CraftLlmLockedState.tsx
+++ b/web/src/app/craft/onboarding/components/CraftLlmLockedState.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { SvgLock } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
@@ -9,6 +10,7 @@ import { ContentAction } from "@opal/layouts";
  * no supported provider available — only admins can configure one.
  */
 export default function CraftLlmLockedState() {
+  const t = useTranslations("craft.onboarding.llmLocked");
   return (
     <div
       className="flex flex-col w-full p-1 rounded-16 border border-border-01 bg-background-tint-00"
@@ -16,14 +18,14 @@ export default function CraftLlmLockedState() {
     >
       <ContentAction
         icon={SvgLock}
-        title="An LLM provider is required"
-        description="Onyx Craft needs a model provider, and only admins can set one up. Ask your admin to connect Anthropic, OpenAI, or OpenRouter."
+        title={t("title")}
+        description={t("description")}
         sizePreset="main-ui"
         variant="section"
         padding={2}
         rightChildren={
           <Button prominence="tertiary" href="/app">
-            Back to Chat
+            {t("backToChatButton")}
           </Button>
         }
       />

--- a/web/src/app/craft/onboarding/components/CraftLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/CraftLlmSetup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { SvgCpu } from "@opal/icons";
 import { Divider } from "@opal/components";
 import { ContentAction } from "@opal/layouts";
@@ -23,6 +24,7 @@ import { useOnboarding } from "@/app/craft/onboarding/BuildOnboardingProvider";
 const craftKeys: string[] = CRAFT_PROVIDERS;
 
 export default function CraftLlmSetup() {
+  const t = useTranslations("craft.onboarding.llmSetup");
   const { openProviderModal } = useOnboarding();
   const { llmProviderOptions } = useLLMProviderOptions();
 
@@ -40,8 +42,8 @@ export default function CraftLlmSetup() {
     >
       <ContentAction
         icon={SvgCpu}
-        title="Connect a model provider"
-        description="Craft agents need a model provider to build."
+        title={t("title")}
+        description={t("description")}
         sizePreset="main-ui"
         variant="section"
         padding={2}

--- a/web/src/app/craft/onboarding/components/LivingMapDiagram.tsx
+++ b/web/src/app/craft/onboarding/components/LivingMapDiagram.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { KeyboardEvent, ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Text } from "@opal/components";
 import {
@@ -56,31 +57,15 @@ export type LivingMapStageId =
 
 export interface LivingMapStage {
   id: LivingMapStageId;
-  title: string;
-  caption: string;
 }
 
+// Stage title/caption copy lives in the craft.onboarding.livingMap.stages
+// message namespace, keyed by stage id.
 export const LIVING_MAP_STAGES: LivingMapStage[] = [
-  {
-    id: "prompt",
-    title: "Give Craft real work.",
-    caption: "Describe the outcome — Craft does the rest.",
-  },
-  {
-    id: "machine",
-    title: "It works on its own machine.",
-    caption: "Reading what you can see. Never your secrets.",
-  },
-  {
-    id: "output",
-    title: "Finished work comes out.",
-    caption: "On demand — or on a schedule, while you're away.",
-  },
-  {
-    id: "constellation",
-    title: "That's Craft. Your turn.",
-    caption: "Click any part of the map to revisit it.",
-  },
+  { id: "prompt" },
+  { id: "machine" },
+  { id: "output" },
+  { id: "constellation" },
 ];
 
 /** What the camera frames per stage: center + visible world width. */
@@ -214,13 +199,13 @@ const TERMINAL_LINES: string[] = [
 // Typed lines plus the trailing approval pill.
 const TERMINAL_STEPS = TERMINAL_LINES.length + 1;
 
-const EXAMPLE_PROMPTS: string[] = [
-  "“Summarize our Q2 vendor spend as a doc in Drive.”",
-  "“Condense our Slack discussion into Linear tickets.”",
-  "“Build the spring launch deck from the brief in Drive.”",
-  "“Fix the flaky retry test and open a PR.”",
-  "“Fill out the RFP in my email with our security details.”",
-];
+const EXAMPLE_PROMPT_KEYS = [
+  "vendorSpend",
+  "slackToLinear",
+  "launchDeck",
+  "flakyRetryTest",
+  "rfpSecurity",
+] as const;
 
 const PROMPT_ROTATION_MS = 3000;
 
@@ -249,22 +234,16 @@ interface OutputCardSpec {
   tint?: boolean;
 }
 
-const OUTPUT_CARDS: OutputCardSpec[] = [
-  {
-    y: 170,
-    label: "Google Doc",
-    caption: "Written to your Drive",
-    icon: SvgGoogleDocs,
-  },
-  {
-    y: 280,
-    label: "Live app",
-    caption: "Hosted — share by link",
-    icon: SvgDashboard,
-    tint: true,
-  },
-  { y: 390, label: "GitHub PR", caption: "Open for review", icon: SvgGithub },
-];
+const OUTPUT_CARD_KEYS = ["googleDoc", "liveApp", "githubPr"] as const;
+
+const OUTPUT_CARD_LAYOUT: Record<
+  (typeof OUTPUT_CARD_KEYS)[number],
+  Omit<OutputCardSpec, "label" | "caption">
+> = {
+  googleDoc: { y: 170, icon: SvgGoogleDocs },
+  liveApp: { y: 280, icon: SvgDashboard, tint: true },
+  githubPr: { y: 390, icon: SvgGithub },
+};
 
 // ---------------------------------------------------------------------------
 // Building blocks
@@ -394,6 +373,7 @@ export default function LivingMapDiagram({
   diving = false,
   onSelectStage,
 }: LivingMapDiagramProps) {
+  const t = useTranslations("craft.onboarding.livingMap");
   const reduceMotion = useReducedMotion() ?? false;
 
   const sharpGroups = STAGE_SHARP[stage];
@@ -431,7 +411,7 @@ export default function LivingMapDiagram({
   useEffect(() => {
     if (reduceMotion) return undefined;
     const timer = setInterval(() => {
-      setPromptIdx((i) => (i + 1) % EXAMPLE_PROMPTS.length);
+      setPromptIdx((i) => (i + 1) % EXAMPLE_PROMPT_KEYS.length);
     }, PROMPT_ROTATION_MS);
     return () => clearInterval(timer);
   }, [reduceMotion]);
@@ -444,7 +424,7 @@ export default function LivingMapDiagram({
     return () => onSelectStage(GROUP_STAGE[group]);
   }
 
-  const examplePrompt = EXAMPLE_PROMPTS[promptIdx]!;
+  const examplePrompt = t(`examplePrompts.${EXAMPLE_PROMPT_KEYS[promptIdx]!}`);
 
   return (
     <div
@@ -484,6 +464,10 @@ export default function LivingMapDiagram({
         {/* Connected sources + uploaded files */}
         {SOURCE_CHIPS.map((source) => {
           const SourceIcon = source.icon;
+          const isFilesChip = source.label === "Your files";
+          const displayLabel = isFilesChip
+            ? t("sources.yourFiles.label")
+            : source.label;
           return (
             <MapNode
               key={source.label}
@@ -491,9 +475,9 @@ export default function LivingMapDiagram({
               y={48}
               sharp={sharp("sources")}
               label={
-                source.label === "Your files"
-                  ? "Your uploaded files"
-                  : `Connected source: ${source.label}`
+                isFilesChip
+                  ? t("sources.yourFiles.ariaLabel")
+                  : t("sources.connectedAriaLabel", { name: source.label })
               }
               reduceMotion={reduceMotion}
               onSelect={select("sources")}
@@ -503,7 +487,7 @@ export default function LivingMapDiagram({
                   className={cn("h-3.5 w-3.5", source.tint && "stroke-text-04")}
                 />
                 <Text font="secondary-action" color="text-04" nowrap>
-                  {source.label}
+                  {displayLabel}
                 </Text>
               </div>
             </MapNode>
@@ -515,7 +499,7 @@ export default function LivingMapDiagram({
           x={130}
           y={280}
           sharp={sharp("prompt")}
-          label="Your prompt"
+          label={t("prompt.label")}
           reduceMotion={reduceMotion}
           onSelect={select("prompt")}
         >
@@ -523,7 +507,7 @@ export default function LivingMapDiagram({
             <div className="flex items-center gap-1.5">
               <SvgBubbleText className="h-3.5 w-3.5 stroke-text-04" />
               <Text font="secondary-action" color="text-04" nowrap>
-                Your prompt
+                {t("prompt.label")}
               </Text>
             </div>
             <div className="relative h-16 w-full">
@@ -564,7 +548,7 @@ export default function LivingMapDiagram({
           <motion.div
             role="button"
             tabIndex={0}
-            aria-label="Craft's workspace"
+            aria-label={t("workspace.label")}
             initial={false}
             animate={{
               filter: sharp("workspace") ? "blur(0px)" : "blur(5px)",
@@ -585,13 +569,13 @@ export default function LivingMapDiagram({
                 <div className="flex items-center gap-1.5">
                   <SvgCpu className="h-3.5 w-3.5 stroke-text-04" />
                   <Text font="secondary-action" color="text-04" nowrap>
-                    Craft&apos;s workspace
+                    {t("workspace.label")}
                   </Text>
                 </div>
                 <div className="flex items-center gap-1">
                   <SvgShield className="h-3 w-3 stroke-text-03" />
                   <Text font="figure-small-label" color="text-03" nowrap>
-                    Isolated sandbox
+                    {t("workspace.sandboxBadge")}
                   </Text>
                 </div>
               </div>
@@ -631,7 +615,7 @@ export default function LivingMapDiagram({
                 >
                   <SvgAlertCircle className="h-3 w-3 shrink-0 stroke-text-04" />
                   <Text font="figure-small-label" color="text-04" nowrap>
-                    Waiting for your approval
+                    {t("workspace.approvalPill")}
                   </Text>
                 </motion.div>
               </div>
@@ -640,15 +624,21 @@ export default function LivingMapDiagram({
         </div>
 
         {/* The outputs */}
-        {OUTPUT_CARDS.map((output) => {
-          const OutputIcon = output.icon;
+        {OUTPUT_CARD_KEYS.map((cardKey) => {
+          const layout = OUTPUT_CARD_LAYOUT[cardKey];
+          const OutputIcon = layout.icon;
+          const output = {
+            ...layout,
+            label: t(`outputs.${cardKey}.label`),
+            caption: t(`outputs.${cardKey}.caption`),
+          };
           return (
             <MapNode
-              key={output.label}
+              key={cardKey}
               x={740}
               y={output.y}
               sharp={sharp("outputs")}
-              label={`Output: ${output.label}`}
+              label={t("outputs.ariaLabel", { name: output.label })}
               reduceMotion={reduceMotion}
               onSelect={select("outputs")}
             >
@@ -677,7 +667,7 @@ export default function LivingMapDiagram({
           x={320}
           y={495}
           sharp={sharp("schedule")}
-          label="Scheduled task — re-runs this prompt on a timer"
+          label={t("schedule.ariaLabel")}
           reduceMotion={reduceMotion}
           onSelect={select("schedule")}
         >
@@ -685,11 +675,11 @@ export default function LivingMapDiagram({
             <div className="flex items-center gap-1.5">
               <SvgClock className="h-3.5 w-3.5 stroke-text-04" />
               <Text font="secondary-action" color="text-04" nowrap>
-                Every Monday, 8:00
+                {t("schedule.label")}
               </Text>
             </div>
             <Text font="figure-small-label" color="text-03" nowrap>
-              Runs while you&apos;re away
+              {t("schedule.caption")}
             </Text>
           </div>
         </MapNode>
@@ -699,7 +689,7 @@ export default function LivingMapDiagram({
           x={760}
           y={500}
           sharp={sharp("team")}
-          label="Your team — one link shares Craft's work"
+          label={t("team.ariaLabel")}
           reduceMotion={reduceMotion}
           onSelect={select("team")}
         >
@@ -707,11 +697,11 @@ export default function LivingMapDiagram({
             <div className="flex items-center gap-1.5">
               <SvgUsers className="h-3.5 w-3.5 stroke-text-04" />
               <Text font="secondary-action" color="text-04" nowrap>
-                Your team
+                {t("team.label")}
               </Text>
             </div>
             <Text font="figure-small-label" color="text-03" nowrap>
-              One link shares it
+              {t("team.caption")}
             </Text>
           </div>
         </MapNode>

--- a/web/src/app/craft/onboarding/components/LivingMapModal.tsx
+++ b/web/src/app/craft/onboarding/components/LivingMapModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Modal } from "@opal/components";
 import { Button, Text } from "@opal/components";
@@ -39,6 +40,7 @@ export default function LivingMapModal({
   onDismiss = onComplete,
   initialStage = "prompt",
 }: LivingMapModalProps) {
+  const t = useTranslations("craft.onboarding.livingMap");
   const reduceMotion = useReducedMotion() ?? false;
   const [stageIdx, setStageIdx] = useState(() => stageIndex(initialStage));
   const [diving, setDiving] = useState(false);
@@ -87,7 +89,7 @@ export default function LivingMapModal({
       >
         {/* The X routes through Radix → onOpenChange, which owns dismissal;
             a real handler here would double-fire onDismiss. */}
-        <Modal.Header title="Meet Craft" onClose={() => {}} />
+        <Modal.Header title={t("modal.title")} onClose={() => {}} />
         <Modal.Body padding={6}>
           <div className="flex w-full flex-col gap-3">
             {/* Stage copy crossfades above a scene that never unmounts. */}
@@ -102,10 +104,10 @@ export default function LivingMapModal({
                   className="absolute inset-0 flex flex-col items-center justify-center gap-0.5 text-center"
                 >
                   <Text font="heading-h3" color="text-05">
-                    {stage.title}
+                    {t(`stages.${stage.id}.title`)}
                   </Text>
                   <Text font="secondary-body" color="text-03">
-                    {stage.caption}
+                    {t(`stages.${stage.id}.caption`)}
                   </Text>
                 </motion.div>
               </AnimatePresence>
@@ -128,7 +130,7 @@ export default function LivingMapModal({
                 disabled={diving}
                 onClick={() => setStageIdx(stageIdx - 1)}
               >
-                Back
+                {t("modal.backButton")}
               </Button>
             )}
           </div>
@@ -146,14 +148,14 @@ export default function LivingMapModal({
           <div className="flex-1 flex justify-end">
             {isLastStage ? (
               <Button disabled={diving} onClick={finish}>
-                Put Craft to work
+                {t("modal.ctaButton")}
               </Button>
             ) : (
               <Button
                 rightIcon={SvgArrowRight}
                 onClick={() => setStageIdx(stageIdx + 1)}
               >
-                Next
+                {t("modal.nextButton")}
               </Button>
             )}
           </div>

--- a/web/src/app/craft/onboarding/explorations/WelcomePageMock.tsx
+++ b/web/src/app/craft/onboarding/explorations/WelcomePageMock.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Text } from "@opal/components";
 import { SvgArrowUp, SvgPlus } from "@opal/icons";
 import { cn } from "@opal/utils";
 import { Logo } from "@/lib/app/components";
+
+const PROMPT_PILL_KEYS = [
+  "engineering",
+  "sales",
+  "marketing",
+  "product",
+] as const;
 
 interface WelcomePageMockProps {
   /** Overlay content (e.g. a modal) rendered on top of the page. */
@@ -27,6 +35,7 @@ export default function WelcomePageMock({
   bottomSlot,
   dimmed = false,
 }: WelcomePageMockProps) {
+  const t = useTranslations("craft.onboarding.welcomeMock");
   return (
     <div className="relative w-full h-screen bg-background-tint-00 overflow-hidden">
       <div
@@ -58,7 +67,7 @@ export default function WelcomePageMock({
               <div className="flex items-center gap-2 px-3 py-1.5 rounded-12 border border-border-01 bg-background-tint-00">
                 <div className="w-4 h-4 rounded-full bg-theme-primary-05" />
                 <Text font="main-ui-body" color="text-04">
-                  Claude Opus 4.8
+                  {t("modelPill.label")}
                 </Text>
               </div>
             </div>
@@ -70,7 +79,7 @@ export default function WelcomePageMock({
           <div className="w-full max-w-3xl">
             <div className="flex flex-col gap-3 p-4 rounded-16 border border-border-01 bg-background-tint-00 shadow-sm">
               <Text font="main-content-body" color="text-02">
-                Analyze my data and create a dashboard...
+                {t("input.placeholder")}
               </Text>
               <div className="flex items-center justify-between">
                 <SvgPlus className="w-5 h-5 stroke-text-03" />
@@ -87,18 +96,18 @@ export default function WelcomePageMock({
           <div className="w-full max-w-3xl">
             {bottomSlot ?? (
               <div className="mt-4 flex flex-row flex-wrap items-center justify-center gap-2">
-                {["Engineering", "Sales", "Marketing", "Product"].map(
-                  (label) => (
-                    <div
-                      key={label}
-                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-12 border border-border-01 bg-background-tint-00"
-                    >
-                      <Text font="main-ui-body" color="text-04">
-                        {label}
-                      </Text>
-                    </div>
-                  )
-                )}
+                {PROMPT_PILL_KEYS.map((pillKey) =>
+                  t(`promptPills.${pillKey}`)
+                ).map((label) => (
+                  <div
+                    key={label}
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-12 border border-border-01 bg-background-tint-00"
+                  >
+                    <Text font="main-ui-body" color="text-04">
+                      {label}
+                    </Text>
+                  </div>
+                ))}
               </div>
             )}
           </div>

--- a/web/src/app/craft/page.tsx
+++ b/web/src/app/craft/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { CRAFT_PATH } from "@/app/craft/v1/constants";
 
 /**
@@ -11,6 +12,7 @@ import { CRAFT_PATH } from "@/app/craft/v1/constants";
  * This page exists for backwards compatibility.
  */
 export default function BuildPage() {
+  const t = useTranslations("craft.redirect");
   const router = useRouter();
 
   useEffect(() => {
@@ -19,7 +21,7 @@ export default function BuildPage() {
 
   return (
     <div className="flex items-center justify-center h-screen">
-      <div className="animate-pulse text-text-03">Redirecting...</div>
+      <div className="animate-pulse text-text-03">{t("redirecting.label")}</div>
     </div>
   );
 }

--- a/web/src/app/craft/utils/scheduledTaskRuns.test.ts
+++ b/web/src/app/craft/utils/scheduledTaskRuns.test.ts
@@ -1,3 +1,4 @@
+import { type RunReasonTranslate } from "@/app/craft/v1/tasks/utils";
 import {
   getNonClickableReason,
   isScheduledRunContextInFlight,
@@ -36,24 +37,24 @@ function context(status: ScheduledTaskRunStatus): ScheduledRunContextResponse {
   };
 }
 
+const tStub = ((key: string) => key) as RunReasonTranslate;
+
 describe("scheduled task run utils", () => {
   it.each(["RUNNING", "AWAITING_APPROVAL", "SUCCEEDED", "FAILED"] as const)(
     "allows opening %s runs with linked sessions",
     (status) => {
-      expect(getNonClickableReason(run(status, "session-1"))).toBeNull();
+      expect(getNonClickableReason(run(status, "session-1"), tStub)).toBeNull();
     }
   );
 
   it("keeps queued and skipped runs blocked", () => {
-    expect(getNonClickableReason(run("QUEUED", null))).toContain(
-      "hasn't started"
-    );
-    expect(getNonClickableReason(run("SKIPPED", null))).toContain("skipped");
+    expect(getNonClickableReason(run("QUEUED", null), tStub)).toBe("queued");
+    expect(getNonClickableReason(run("SKIPPED", null), tStub)).toBe("skipped");
   });
 
   it("blocks openable statuses until a session exists", () => {
-    expect(getNonClickableReason(run("RUNNING", null))).toContain(
-      "has not created a session"
+    expect(getNonClickableReason(run("RUNNING", null), tStub)).toBe(
+      "noSession"
     );
   });
 

--- a/web/src/app/craft/v1/apps/UserCredentialsModal.tsx
+++ b/web/src/app/craft/v1/apps/UserCredentialsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Modal } from "@opal/components";
 import {
   Button,
@@ -49,6 +50,7 @@ export default function UserCredentialsModal({
   credentialValues,
   save,
 }: UserCredentialsModalProps) {
+  const t = useTranslations("craft.apps.userCredentials");
   const [values, setValues] = useState<Record<string, string>>({});
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,8 +90,8 @@ export default function UserCredentialsModal({
       <Modal.Content width="md">
         <Modal.Header
           icon={Logo}
-          title={`Connect ${name}`}
-          description="Enter your credentials to authorize this app for your account."
+          title={t("title", { name })}
+          description={t("description")}
         />
         <Modal.Body>
           <div className="flex flex-col gap-4 w-full">
@@ -111,7 +113,7 @@ export default function UserCredentialsModal({
             {error && (
               <MessageCard
                 variant="error"
-                title="Couldn't connect"
+                title={t("errors.connectFailedTitle")}
                 description={error}
               />
             )}
@@ -124,10 +126,10 @@ export default function UserCredentialsModal({
               onClick={onClose}
               disabled={isSaving}
             >
-              Cancel
+              {t("cancelButton")}
             </Button>
             <Button onClick={saveValues} disabled={!canSave}>
-              {isSaving ? "Connecting…" : "Connect"}
+              {isSaving ? t("connectingButton") : t("connectButton")}
             </Button>
           </div>
         </Modal.Footer>

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useFocusOnMount } from "@opal/hooks";
 import isEqual from "lodash/isEqual";
 import {
@@ -98,6 +99,7 @@ export default function ActionPolicyEditorModal({
   allowPristineSave = false,
   closeAfterSave = true,
 }: ActionPolicyEditorModalProps) {
+  const t = useTranslations("craft.apps.policyEditor");
   const focusFirstField =
     useFocusOnMount<HTMLInputElement>(autoFocusFirstField);
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({
@@ -218,7 +220,7 @@ export default function ActionPolicyEditorModal({
 
                 {policyItems === undefined ? (
                   <Text font="main-content-body" color="text-03">
-                    Loading…
+                    {t("loading.label")}
                   </Text>
                 ) : policyItems.length === 0 ? (
                   <Text font="secondary-body" color="text-03">
@@ -248,10 +250,10 @@ export default function ActionPolicyEditorModal({
                   onClick={() => unsavedChanges.requestLeave(onClose)}
                   disabled={isSaving}
                 >
-                  Cancel
+                  {t("cancelButton")}
                 </Button>
                 <Button onClick={save} disabled={!canSave}>
-                  {isSaving ? "Saving…" : saveLabel}
+                  {isSaving ? t("savingButton") : saveLabel}
                 </Button>
               </div>
             </Modal.Footer>
@@ -290,6 +292,7 @@ interface PolicyEditorProps {
 /** Approval-policy section of the editor: a bulk Auto-approve/Ask selector
  * plus an Advanced section with a per-item three-state toggle. */
 function PolicyEditor({ items, policies, onChange }: PolicyEditorProps) {
+  const t = useTranslations("craft.apps.policyEditor");
   const bulkValue = bulkPolicyOf(items, policies);
   const [advancedOpen, setAdvancedOpen] = useState(bulkValue === "CUSTOM");
 
@@ -306,11 +309,9 @@ function PolicyEditor({ items, policies, onChange }: PolicyEditorProps) {
 
   return (
     <div className="flex flex-col gap-2 pt-2">
-      <Text font="main-ui-action">Permissions</Text>
+      <Text font="main-ui-action">{t("permissions.title")}</Text>
       <Text font="secondary-body" color="text-03">
-        Choose what the agent may do. “Ask” prompts you in chat before each
-        action runs; “Auto-approve” lets it run without prompting. Use Advanced
-        to set a policy per action.
+        {t("permissions.description")}
       </Text>
 
       <InputSelect
@@ -319,17 +320,21 @@ function PolicyEditor({ items, policies, onChange }: PolicyEditorProps) {
           if (value === "ALWAYS" || value === "ASK") applyBulk(value);
         }}
       >
-        <InputSelect.Trigger placeholder="Custom" />
+        <InputSelect.Trigger placeholder={t("permissions.customOption")} />
         <InputSelect.Content>
-          <InputSelect.Item value="ALWAYS">Auto-approve</InputSelect.Item>
-          <InputSelect.Item value="ASK">Ask</InputSelect.Item>
+          <InputSelect.Item value="ALWAYS">
+            {t("permissions.autoApproveOption")}
+          </InputSelect.Item>
+          <InputSelect.Item value="ASK">
+            {t("permissions.askOption")}
+          </InputSelect.Item>
         </InputSelect.Content>
       </InputSelect>
 
       <SimpleCollapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
         <SimpleCollapsible.Header
-          title="Advanced"
-          description="Set a policy for each action individually."
+          title={t("advanced.title")}
+          description={t("advanced.description")}
         />
         <SimpleCollapsible.Content>
           <div className="flex flex-col gap-2">

--- a/web/src/app/craft/v1/apps/admin/AddAppCatalogModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/AddAppCatalogModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button, Card, Divider, Modal, Text } from "@opal/components";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
@@ -25,12 +26,13 @@ export default function AddAppCatalogModal({
   onPickProvider,
   onPickCustom,
 }: AddAppCatalogModalProps) {
+  const t = useTranslations("craft.apps.addCatalog");
   return (
     <Modal open onOpenChange={(open) => !open && onClose()}>
       <Modal.Content width="lg" height="fit">
         <Modal.Header
-          title="Add an app"
-          description="Make an integration available to your whole organization. Built-in providers come with actions that teach the Craft agent how to use them; already-configured providers are not listed."
+          title={t("modal.title")}
+          description={t("modal.description")}
         />
         <Modal.Body>
           <div className="flex flex-col gap-4">
@@ -40,30 +42,29 @@ export default function AddAppCatalogModal({
                   key={descriptor.app_type}
                   icon={getAppTypeLogo(descriptor.app_type)}
                   title={descriptor.name}
-                  actionLabel="Add"
+                  actionLabel={t("addButton")}
                   onClick={() => onPickProvider(descriptor)}
                 />
               ))}
               <CatalogCard
                 icon={SvgPlug}
-                title="Custom app"
-                description="Credentials and network access for your own integration."
-                actionLabel="Create"
+                title={t("customApp.title")}
+                description={t("customApp.description")}
+                actionLabel={t("createButton")}
                 onClick={onPickCustom}
               />
             </div>
             <Divider />
             <div className="flex items-center justify-between gap-2">
               <Text font="secondary-body" color="text-03">
-                Need an MCP server instead? Connect it in Actions, then enable
-                it for Craft here.
+                {t("mcpHint.label")}
               </Text>
               <Button
                 prominence="tertiary"
                 href={ADMIN_ROUTES.MCP_ACTIONS.path}
                 icon={SvgSettings}
               >
-                Open Actions
+                {t("mcpHint.openActionsButton")}
               </Button>
             </div>
           </div>

--- a/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
+++ b/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   Card,
@@ -38,6 +39,7 @@ export default function AssociatedSkillsEditor({
   onCreateSkill,
   onUploadSkill,
 }: AssociatedSkillsEditorProps) {
+  const t = useTranslations("craft.apps.associatedSkills");
   const { data, isLoading } = useUserSkills();
   const [query, setQuery] = useState("");
   const [associateOpen, setAssociateOpen] = useState(false);
@@ -84,16 +86,16 @@ export default function AssociatedSkillsEditor({
   }, [app.id, customSkills, query]);
   function unavailableReason(skill: Skill): string | null {
     if (skill.is_valid === false) {
-      return "Invalid skill — fix it before associating.";
+      return t("unavailable.invalid");
     }
     if (
       skill.external_app !== null &&
       skill.external_app.external_app_id !== app.id
     ) {
-      return `Already associated with app “${skill.external_app.name}”.`;
+      return t("unavailable.otherApp", { name: skill.external_app.name });
     }
     if (!selectedIds.has(skill.id) && selectedNames.has(skill.name)) {
-      return `A skill named “${skill.name}” is already associated.`;
+      return t("unavailable.duplicateName", { name: skill.name });
     }
     return null;
   }
@@ -116,11 +118,9 @@ export default function AssociatedSkillsEditor({
     <div className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-0.5">
-          <Text font="main-ui-action">Associated skills</Text>
+          <Text font="main-ui-action">{t("title")}</Text>
           <Text font="secondary-body" color="text-03">
-            Skills give Craft instructions for using this app. They are
-            organization-wide; users may need to enable all of them for the app
-            to work correctly.
+            {t("description")}
           </Text>
         </div>
         <div className="flex shrink-0 gap-2">
@@ -133,7 +133,7 @@ export default function AssociatedSkillsEditor({
             }}
           >
             <Popover.Trigger asChild>
-              <Button prominence="secondary">Associate existing</Button>
+              <Button prominence="secondary">{t("associateButton")}</Button>
             </Popover.Trigger>
             <Popover.Content align="end" sideOffset={4} width="xl">
               <div className="flex max-h-[min(20rem,calc(var(--radix-popover-content-available-height)-0.5rem))] flex-col gap-2 overflow-hidden p-2">
@@ -141,17 +141,17 @@ export default function AssociatedSkillsEditor({
                   searchIcon
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Search editable skills..."
+                  placeholder={t("search.placeholder")}
                   variant="internal"
                 />
                 <div className="flex min-h-0 flex-col gap-1 overflow-y-auto overscroll-contain">
                   {isLoading ? (
                     <Text font="secondary-body" color="text-03">
-                      Loading skills…
+                      {t("loading.label")}
                     </Text>
                   ) : selectableSkills.length === 0 ? (
                     <Text font="secondary-body" color="text-03">
-                      No editable skills found.
+                      {t("empty.label")}
                     </Text>
                   ) : (
                     selectableSkills.map((skill) => {
@@ -168,7 +168,9 @@ export default function AssociatedSkillsEditor({
                               <SvgCheck className="size-4 stroke-action-selection-05" />
                             ) : undefined
                           }
-                          aria-label={`Associate ${skill.name}`}
+                          aria-label={t("associateAriaLabel", {
+                            name: skill.name,
+                          })}
                         >
                           {skill.name}
                         </LineItem>
@@ -179,18 +181,17 @@ export default function AssociatedSkillsEditor({
                 {pendingPromotion && (
                   <div className="flex flex-col gap-2 border-t border-border-01 pt-2">
                     <Text font="main-ui-action">
-                      {`Make “${pendingPromotion.name}” organization-wide?`}
+                      {t("promote.title", { name: pendingPromotion.name })}
                     </Text>
                     <Text font="secondary-body" color="text-03">
-                      App-associated skills must be available to everyone. This
-                      change is applied when you save the app.
+                      {t("promote.description")}
                     </Text>
                     <div className="flex justify-end gap-2">
                       <Button
                         prominence="secondary"
                         onClick={() => setPendingPromotion(null)}
                       >
-                        Cancel
+                        {t("promote.cancelButton")}
                       </Button>
                       <Button
                         onClick={() => {
@@ -199,7 +200,7 @@ export default function AssociatedSkillsEditor({
                           setAssociateOpen(false);
                         }}
                       >
-                        Make organization-wide
+                        {t("promote.confirmButton")}
                       </Button>
                     </div>
                   </div>
@@ -209,7 +210,7 @@ export default function AssociatedSkillsEditor({
           </Popover>
           <Popover modal open={createOpen} onOpenChange={setCreateOpen}>
             <Popover.Trigger asChild>
-              <Button icon={SvgPlus}>Create skill</Button>
+              <Button icon={SvgPlus}>{t("createSkillButton")}</Button>
             </Popover.Trigger>
             <Popover.Content align="end" sideOffset={4} width="lg">
               <Popover.Menu>
@@ -219,10 +220,10 @@ export default function AssociatedSkillsEditor({
                     setCreateOpen(false);
                     onCreateSkill();
                   }}
-                  description="Write instructions and add supporting files."
+                  description={t("create.scratch.description")}
                   wrapDescription
                 >
-                  Start from scratch
+                  {t("create.scratch.label")}
                 </LineItem>
                 <LineItem
                   icon={SvgUploadCloud}
@@ -230,18 +231,18 @@ export default function AssociatedSkillsEditor({
                     setCreateOpen(false);
                     onUploadSkill();
                   }}
-                  description="Import a SKILL.md file, ZIP file, or skill folder."
+                  description={t("create.upload.description")}
                   wrapDescription
                 >
-                  Upload a skill
+                  {t("create.upload.label")}
                 </LineItem>
                 <LineItem
                   icon={SvgGithub}
                   disabled
-                  description="If your skills are in GitHub, import them on the Skills page first, then associate them with this app."
+                  description={t("create.github.description")}
                   wrapDescription
                 >
-                  Import from GitHub
+                  {t("create.github.label")}
                 </LineItem>
               </Popover.Menu>
             </Popover.Content>
@@ -252,8 +253,7 @@ export default function AssociatedSkillsEditor({
       {selectedSkillIds.length === 0 ? (
         <Card border="solid" rounding={4} padding={2}>
           <Text font="secondary-body" color="text-03">
-            No skills are associated yet. This app can still be saved and used
-            without one.
+            {t("noneAssociated.label")}
           </Text>
         </Card>
       ) : (
@@ -277,7 +277,7 @@ export default function AssociatedSkillsEditor({
                   >
                     <div className="min-w-0 flex-1">
                       <Text font="secondary-body">
-                        {`Unlink “${pendingUnlink.name}” from this app?`}
+                        {t("unlink.confirm", { name: pendingUnlink.name })}
                       </Text>
                     </div>
                     <Button
@@ -285,7 +285,7 @@ export default function AssociatedSkillsEditor({
                       prominence="secondary"
                       onClick={() => setPendingUnlink(null)}
                     >
-                      Cancel
+                      {t("unlink.cancelButton")}
                     </Button>
                     <Button
                       size="md"
@@ -299,7 +299,7 @@ export default function AssociatedSkillsEditor({
                         setPendingUnlink(null);
                       }}
                     >
-                      Unlink
+                      {t("unlink.button")}
                     </Button>
                   </div>
                 );
@@ -313,20 +313,20 @@ export default function AssociatedSkillsEditor({
                     <Text font="main-ui-action">{name}</Text>
                   </div>
                   {(skill?.is_valid ?? summary?.is_valid) === false && (
-                    <Tag title="Invalid" color="amber" />
+                    <Tag title={t("invalidTag")} color="amber" />
                   )}
                   <Button
                     size="md"
                     prominence="tertiary"
                     onClick={() => onOpenSkill(skillId)}
                   >
-                    {canEdit ? "Edit" : "View"}
+                    {canEdit ? t("editButton") : t("viewButton")}
                   </Button>
                   <Button
                     size="md"
                     prominence="tertiary"
                     icon={SvgX}
-                    aria-label={`Unlink ${name}`}
+                    aria-label={t("unlinkAriaLabel", { name })}
                     onClick={() => {
                       setPendingUnlink({ id: skillId, name });
                     }}

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import isEqual from "lodash/isEqual";
 import { Divider } from "@opal/components";
 import ActionPolicyEditorModal, {
@@ -51,6 +52,8 @@ export default function ConfigureProviderModal({
   descriptor,
   existingApp,
 }: ConfigureProviderModalProps) {
+  const t = useTranslations("craft.apps.configureProvider");
+  const tApps = useTranslations("craft.apps");
   const router = useRouter();
   const upload = useSkillUploadModal();
   const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
@@ -76,8 +79,8 @@ export default function ConfigureProviderModal({
     : [
         {
           key: NAME_KEY,
-          label: "Name",
-          description: `A label for this connection. Use a distinct name when adding multiple instances of the same provider (e.g. "${descriptor.name} — Engineering").`,
+          label: t("fields.name.label"),
+          description: t("fields.name.description", { name: descriptor.name }),
           placeholder: descriptor.name,
           secret: false,
         },
@@ -171,7 +174,10 @@ export default function ConfigureProviderModal({
     return existingApp?.associated_skills.some(
       (skill) => skill.name === draft.contents.name
     )
-      ? `App “${existingApp.name}” already has an associated skill named “${draft.contents.name}”. Upload a skill with a different name.`
+      ? tApps("errors.duplicateSkillName", {
+          appName: existingApp.name,
+          skillName: draft.contents.name,
+        })
       : null;
   }
 
@@ -218,18 +224,14 @@ export default function ConfigureProviderModal({
       isAdditionalContentDirty={existingAssociationDirty}
       onClose={upload.isOpen ? upload.requestDismiss : onClose}
       title={
-        existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
+        existingApp
+          ? t("editTitle", { name: existingApp.name })
+          : t("addTitle", { name: descriptor.name })
       }
       description={
-        managed
-          ? "Provided by Onyx — configure what the agent may do."
-          : descriptor.setup_instructions
+        managed ? t("managedDescription") : descriptor.setup_instructions
       }
-      note={
-        managed
-          ? "This app is provided by Onyx — credentials are managed for you. Choose what the agent may do below. Users connect it from the Apps page."
-          : undefined
-      }
+      note={managed ? t("managedNote") : undefined}
       fields={fields}
       initialFieldValues={initialFieldValues}
       policyItems={descriptor.actions.map((action) => ({
@@ -239,8 +241,8 @@ export default function ConfigureProviderModal({
         defaultPolicy: action.default_policy,
       }))}
       initialPolicies={initialPolicies}
-      emptyPoliciesMessage="This provider has no actions to configure."
-      saveLabel={existingApp ? "Save" : "Add"}
+      emptyPoliciesMessage={t("emptyPolicies")}
+      saveLabel={existingApp ? t("saveButton") : t("addButton")}
       autoFocusFirstField={existingApp === null}
       allowPristineSave={existingApp === null}
       onSave={save}

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { useFocusOnMount } from "@opal/hooks";
 import { useRouter } from "next/navigation";
 import isEqual from "lodash/isEqual";
@@ -70,6 +71,8 @@ export default function CreateCustomAppModal({
   onSaved,
   existingApp,
 }: CreateCustomAppModalProps) {
+  const t = useTranslations("craft.apps.customApp");
+  const tApps = useTranslations("craft.apps");
   const isEdit = existingApp !== null;
   const router = useRouter();
   // Focus the name field for new apps only; edits keep the natural tab order.
@@ -123,13 +126,13 @@ export default function CreateCustomAppModal({
   // Headers and org credentials are optional; name + at least one upstream
   // pattern are required.
   const disabledCreateReason = (() => {
-    if (isSaving) return "Save is already in progress.";
-    if (isEdit && !configDirty) return "Make a change before saving.";
+    if (isSaving) return t("disabled.saving");
+    if (isEdit && !configDirty) return t("disabled.pristine");
     if (name.trim().length === 0) {
-      return "Enter a name before creating this custom app.";
+      return t("disabled.nameMissing");
     }
     if (upstreamPatterns.length === 0) {
-      return "Add at least one upstream URL pattern. Type a pattern and press Enter.";
+      return t("disabled.patternMissing");
     }
     return null;
   })();
@@ -137,11 +140,11 @@ export default function CreateCustomAppModal({
     <Button onClick={saveConfig} disabled={disabledCreateReason !== null}>
       {isSaving
         ? isEdit
-          ? "Saving…"
-          : "Creating…"
+          ? t("savingButton")
+          : t("creatingButton")
         : isEdit
-          ? "Save"
-          : "Create"}
+          ? t("saveButton")
+          : t("createButton")}
     </Button>
   );
 
@@ -261,7 +264,10 @@ export default function CreateCustomAppModal({
                 existingApp.associated_skills.some(
                   (skill) => skill.name === draft.contents.name
                 )
-                  ? `App “${existingApp.name}” already has an associated skill named “${draft.contents.name}”. Upload a skill with a different name.`
+                  ? tApps("errors.duplicateSkillName", {
+                      appName: existingApp.name,
+                      skillName: draft.contents.name,
+                    })
                   : null
               }
               onContinue={openSkillEditor}
@@ -274,32 +280,32 @@ export default function CreateCustomAppModal({
           <>
             <Modal.Header
               title={
-                existingApp ? `Edit ${existingApp.name}` : "Create custom app"
+                existingApp
+                  ? t("editTitle", { name: existingApp.name })
+                  : t("createTitle")
               }
               description={
-                isEdit
-                  ? "Update gateway settings and manage associated skills."
-                  : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
+                isEdit ? t("editDescription") : t("createDescription")
               }
             />
             <Modal.Body>
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1">
-                  <Text font="main-ui-action">Name</Text>
+                  <Text font="main-ui-action">{t("fields.name.label")}</Text>
                   <InputTypeIn
                     ref={focusNameOnMount}
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    placeholder="My Custom App"
+                    placeholder={t("fields.name.placeholder")}
                   />
                 </div>
 
                 <div className="flex flex-col gap-1">
-                  <Text font="main-ui-action">Upstream URL patterns</Text>
+                  <Text font="main-ui-action">
+                    {t("fields.upstreamPatterns.label")}
+                  </Text>
                   <Text font="secondary-body" color="text-03">
-                    {
-                      "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
-                    }
+                    {t("fields.upstreamPatterns.description")}
                   </Text>
                   <ListFieldInput
                     values={upstreamPatterns}
@@ -309,38 +315,38 @@ export default function CreateCustomAppModal({
                 </div>
 
                 <div className="flex flex-col gap-1">
-                  <Text font="main-ui-action">Header credential pattern</Text>
+                  <Text font="main-ui-action">{t("fields.headers.label")}</Text>
                   <Text font="secondary-body" color="text-03">
-                    {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
+                    {t("fields.headers.description")}
                   </Text>
                   <InputKeyValue
-                    keyTitle="Header"
-                    valueTitle="Value"
+                    keyTitle={t("fields.headers.keyTitle")}
+                    valueTitle={t("fields.headers.valueTitle")}
                     keyPlaceholder="Authorization"
                     valuePlaceholder="Bearer {api_key}"
                     items={headers}
                     onChange={setHeaders}
                     mode="line"
-                    addButtonLabel="Add header"
+                    addButtonLabel={t("fields.headers.addButton")}
                   />
                 </div>
 
                 <div className="flex flex-col gap-1">
-                  <Text font="main-ui-action">Organization credentials</Text>
+                  <Text font="main-ui-action">
+                    {t("fields.orgCredentials.label")}
+                  </Text>
                   <Text font="secondary-body" color="text-03">
-                    Optional — values your org pre-fills for every user. Leave
-                    empty for apps where each user supplies their own
-                    credentials.
+                    {t("fields.orgCredentials.description")}
                   </Text>
                   <InputKeyValue
-                    keyTitle="Credential key"
-                    valueTitle="Value"
+                    keyTitle={t("fields.orgCredentials.keyTitle")}
+                    valueTitle={t("fields.orgCredentials.valueTitle")}
                     keyPlaceholder="api_key"
                     valuePlaceholder="sk-…"
                     items={orgCredentials}
                     onChange={setOrgCredentials}
                     mode="line"
-                    addButtonLabel="Add credential"
+                    addButtonLabel={t("fields.orgCredentials.addButton")}
                   />
                 </div>
 
@@ -361,7 +367,7 @@ export default function CreateCustomAppModal({
                 {error && (
                   <MessageCard
                     variant="error"
-                    title="Couldn't save"
+                    title={t("errors.saveFailedTitle")}
                     description={error}
                   />
                 )}
@@ -374,7 +380,7 @@ export default function CreateCustomAppModal({
                   onClick={() => unsavedChanges.requestLeave(onClose)}
                   disabled={isSaving}
                 >
-                  Cancel
+                  {t("cancelButton")}
                 </Button>
                 {disabledCreateReason ? (
                   <Tooltip tooltip={disabledCreateReason}>

--- a/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import isEqual from "lodash/isEqual";
 import { Button, MessageCard, Modal } from "@opal/components";
 import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
@@ -33,6 +34,8 @@ export default function ExternalAppSkillsStepModal({
   onClose,
   onSaved,
 }: ExternalAppSkillsStepModalProps) {
+  const t = useTranslations("craft.apps.skillsStep");
+  const tApps = useTranslations("craft.apps");
   const router = useRouter();
   const [selectedSkillIds, setSelectedSkillIds] =
     useSyncedAssociatedSkillIds(app);
@@ -120,7 +123,10 @@ export default function ExternalAppSkillsStepModal({
                 app.associated_skills.some(
                   (skill) => skill.name === draft.contents.name
                 )
-                  ? `App “${app.name}” already has an associated skill named “${draft.contents.name}”. Upload a skill with a different name.`
+                  ? tApps("errors.duplicateSkillName", {
+                      appName: app.name,
+                      skillName: draft.contents.name,
+                    })
                   : null
               }
               onContinue={(draft) =>
@@ -134,8 +140,8 @@ export default function ExternalAppSkillsStepModal({
         ) : (
           <>
             <Modal.Header
-              title={`Add skills to ${app.name}`}
-              description="Optional — associate existing skills or create one for this app."
+              title={t("title", { name: app.name })}
+              description={t("description")}
             />
             <Modal.Body>
               <div className="flex flex-col gap-3">
@@ -156,7 +162,7 @@ export default function ExternalAppSkillsStepModal({
                 {error && (
                   <MessageCard
                     variant="error"
-                    title="Couldn't save"
+                    title={t("errors.saveFailedTitle")}
                     description={error}
                   />
                 )}
@@ -169,13 +175,13 @@ export default function ExternalAppSkillsStepModal({
                   onClick={() => unsavedChanges.requestLeave(onClose)}
                   disabled={isSaving}
                 >
-                  Skip for now
+                  {t("skipButton")}
                 </Button>
                 <Button
                   disabled={isSaving || !isDirty}
                   onClick={() => void save()}
                 >
-                  {isSaving ? "Saving…" : "Save skills"}
+                  {isSaving ? t("savingButton") : t("saveButton")}
                 </Button>
               </div>
             </Modal.Footer>

--- a/web/src/app/craft/v1/apps/admin/McpServerPolicyModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/McpServerPolicyModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useSWR from "swr";
+import { useTranslations } from "next-intl";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { MCPServer, ToolSnapshot } from "@/lib/tools/types";
@@ -22,6 +23,7 @@ export default function McpServerPolicyModal({
   onSaved,
   server,
 }: McpServerPolicyModalProps) {
+  const t = useTranslations("craft.apps.mcpPolicy");
   const { data: toolSnapshots } = useSWR<ToolSnapshot[]>(
     SWR_KEYS.adminMcpServerToolSnapshots(server.id),
     errorHandlingFetcher
@@ -41,8 +43,8 @@ export default function McpServerPolicyModal({
   return (
     <ActionPolicyEditorModal
       onClose={onClose}
-      title={`Edit ${server.name}`}
-      description="Configure what the Craft agent may do with this MCP server's tools."
+      title={t("title", { name: server.name })}
+      description={t("description")}
       fields={[]}
       initialFieldValues={{}}
       // Policies are keyed by the tool's raw name (what the backend validates
@@ -55,8 +57,8 @@ export default function McpServerPolicyModal({
         defaultPolicy: "ASK",
       }))}
       initialPolicies={{ ...server.tool_policies }}
-      emptyPoliciesMessage="No enabled tools on this server. Enable tools on the MCP actions page first."
-      saveLabel="Save"
+      emptyPoliciesMessage={t("emptyPolicies")}
+      saveLabel={t("saveButton")}
       onSave={save}
     />
   );

--- a/web/src/app/craft/v1/apps/oauth/callback/page.tsx
+++ b/web/src/app/craft/v1/apps/oauth/callback/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { Route } from "next";
 import { mutate as globalMutate } from "swr";
@@ -15,6 +16,7 @@ import { OAUTH_POPUP_MESSAGE_SOURCE } from "@/app/craft/types/setupRequests";
 type Status = "exchanging" | "success" | "error";
 
 export default function ExternalAppsOAuthCallbackPage() {
+  const t = useTranslations("craft.apps.oauthCallback");
   const router = useRouter();
   const params = useSearchParams();
   const code = params?.get("code") ?? null;
@@ -31,12 +33,12 @@ export default function ExternalAppsOAuthCallbackPage() {
   useEffect(() => {
     if (slackError) {
       setStatus("error");
-      setErrorMessage(`OAuth was cancelled or denied: ${slackError}`);
+      setErrorMessage(t("errors.cancelled", { reason: slackError }));
       return;
     }
     if (!code || !state) {
       setStatus("error");
-      setErrorMessage("Missing code or state in callback URL.");
+      setErrorMessage(t("errors.missingParams"));
       return;
     }
     if (hasExchanged.current) return;
@@ -72,31 +74,27 @@ export default function ExternalAppsOAuthCallbackPage() {
     }
 
     exchange();
-  }, [code, state, slackError, router]);
+  }, [code, state, slackError, router, t]);
 
   return (
     <SettingsLayouts.Root width="sm">
       <SettingsLayouts.Header
         icon={SvgPlug}
-        title="Connecting your app"
-        description="Finishing the OAuth handshake…"
+        title={t("title")}
+        description={t("description")}
       />
       <SettingsLayouts.Body>
         <Card background="light" border="solid" rounding={4}>
           <div className="flex flex-col gap-2">
             {status === "exchanging" && (
-              <Text font="main-content-body">
-                Exchanging authorization code…
-              </Text>
+              <Text font="main-content-body">{t("exchanging.label")}</Text>
             )}
             {status === "success" && (
-              <Text font="main-content-body">
-                Connected. Redirecting back to your apps…
-              </Text>
+              <Text font="main-content-body">{t("success.label")}</Text>
             )}
             {status === "error" && (
               <>
-                <Text font="main-content-body">Connection failed.</Text>
+                <Text font="main-content-body">{t("errors.failed")}</Text>
                 {errorMessage && (
                   <Text font="secondary-body" color="text-03">
                     {errorMessage}
@@ -104,7 +102,7 @@ export default function ExternalAppsOAuthCallbackPage() {
                 )}
                 <div className="pt-2">
                   <Button onClick={() => router.push(CRAFT_APPS_PATH as Route)}>
-                    Back to My Apps
+                    {t("backButton")}
                   </Button>
                 </div>
               </>

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -42,34 +43,12 @@ import { compareByName } from "@/lib/skills/picker";
 
 // Apps and MCP servers are connected, governed, and taught to the agent
 // differently, so each kind gets its own tab rather than one blended list.
-const KIND_COPY: Record<
-  ConnectableKind,
-  {
-    label: string;
-    blurb: string;
-    emptyTitle: string;
-    empty: string;
-  }
-> = {
-  app: {
-    label: "Apps",
-    blurb:
-      "Integrations Onyx supports directly. Each comes with skills that teach Craft how to use it — start here.",
-    emptyTitle: "No apps yet",
-    empty: "No apps are configured for your organization yet.",
-  },
-  mcp: {
-    label: "MCP servers",
-    blurb:
-      "Servers an admin made available to Craft. Use these when the app you need isn't listed under Apps, or when you specifically want a server's own MCP tools.",
-    emptyTitle: "No MCP servers yet",
-    empty: "No MCP servers have been made available to Craft.",
-  },
-};
+// Per-kind copy lives in the craft.apps.page.kinds message namespace.
 
 // The user's own app connections. Org-wide configuration lives in the admin
 // panel's Craft section; admins get a shortcut button to it here.
 export default function ExternalAppsPage() {
+  const t = useTranslations("craft.apps.page");
   const { isAdmin } = useUser();
   const [query, setQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -85,8 +64,8 @@ export default function ExternalAppsPage() {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgPlug}
-        title="Apps"
-        description="Connect the tools Onyx Craft can use as context while it works."
+        title={t("header.title")}
+        description={t("header.description")}
         rightChildren={
           isAdmin ? (
             <Button
@@ -94,14 +73,14 @@ export default function ExternalAppsPage() {
               prominence="secondary"
               icon={SvgSettings}
             >
-              Manage apps
+              {t("header.manageButton")}
             </Button>
           ) : undefined
         }
       >
         <InputTypeIn
           ref={searchInputRef}
-          placeholder="Search apps..."
+          placeholder={t("header.searchPlaceholder")}
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           searchIcon
@@ -119,6 +98,7 @@ interface AppConnectionsProps {
 }
 
 function AppConnections({ query }: AppConnectionsProps) {
+  const t = useTranslations("craft.apps.page");
   const { data: externalApps, mutate: mutateApps } = useSWR<
     ExternalAppUserResponse[]
   >(SWR_KEYS.buildExternalApps, errorHandlingFetcher, {
@@ -180,7 +160,7 @@ function AppConnections({ query }: AppConnectionsProps) {
   if (isLoading) {
     return (
       <Card background="none" border="dashed" rounding={4}>
-        <Text font="main-content-body">Loading…</Text>
+        <Text font="main-content-body">{t("loading.label")}</Text>
       </Card>
     );
   }
@@ -189,8 +169,8 @@ function AppConnections({ query }: AppConnectionsProps) {
     return (
       <IllustrationContent
         illustration={SvgUnPlugged}
-        title="Nothing to connect yet"
-        description="No apps or MCP servers are configured for your organization yet."
+        title={t("empty.title")}
+        description={t("empty.description")}
       />
     );
   }
@@ -204,16 +184,15 @@ function AppConnections({ query }: AppConnectionsProps) {
     >
       <Tabs.List>
         {KIND_ORDER.map((kind) => (
-          <Tabs.Trigger
-            key={kind}
-            value={kind}
-          >{`${KIND_COPY[kind].label} · ${byKind[kind].length}`}</Tabs.Trigger>
+          <Tabs.Trigger key={kind} value={kind}>
+            {t(`kinds.${kind}.tabLabel`, { count: byKind[kind].length })}
+          </Tabs.Trigger>
         ))}
       </Tabs.List>
       <KindSlot tab={tab}>
         {(kind) => (
           <Text font="secondary-body" color="text-03">
-            {KIND_COPY[kind].blurb}
+            {t(`kinds.${kind}.blurb`)}
           </Text>
         )}
       </KindSlot>
@@ -295,20 +274,20 @@ function ConnectableList({
   appsNeedingSkillSetup,
   onChange,
 }: ConnectableListProps) {
-  const copy = KIND_COPY[kind];
+  const t = useTranslations("craft.apps.page");
 
   if (items.length === 0) {
     return searching ? (
       <IllustrationContent
         illustration={SvgNoResult}
-        title="No matches"
-        description="Nothing here matches your search."
+        title={t("search.noMatchesTitle")}
+        description={t("search.noMatchesDescription")}
       />
     ) : (
       <IllustrationContent
         illustration={SvgUnPlugged}
-        title={copy.emptyTitle}
-        description={copy.empty}
+        title={t(`kinds.${kind}.emptyTitle`)}
+        description={t(`kinds.${kind}.empty`)}
       />
     );
   }
@@ -339,17 +318,21 @@ function ConnectableList({
  * The card's one-line status. Connecting swaps this and the action beside it;
  * clamped to a single line, it is also what holds every card to one height.
  */
-function statusLine(app: ConnectableApp, needsSkillSetup: boolean): string {
+function statusLine(
+  app: ConnectableApp,
+  needsSkillSetup: boolean,
+  t: ReturnType<typeof useTranslations<"craft.apps.page">>
+): string {
   if (app.authenticated) {
     return needsSkillSetup
-      ? "Connected · not all associated skills are enabled"
-      : "Connected";
+      ? t("status.connectedNeedsSkills")
+      : t("status.connected");
   }
   // Org-managed and not usable by this account (e.g. an admin config that
   // yields no credentials, or pass-through OAuth for a password-login user).
   // There is no user-side action.
   if (app.connectMode === null) {
-    return "Not available for your account — ask an admin";
+    return t("status.notAvailable");
   }
   return app.description;
 }
@@ -373,6 +356,7 @@ function ConnectableCard({
   needsSkillSetup = false,
   onChange,
 }: ConnectableCardProps) {
+  const t = useTranslations("craft.apps.page");
   const [isStarting, setIsStarting] = useState(false);
   const [credModalOpen, setCredModalOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -396,9 +380,7 @@ function ConnectableCard({
     try {
       window.location.href = await app.startOAuth();
     } catch (e) {
-      toast.error(
-        e instanceof Error ? e.message : "Failed to start authorization"
-      );
+      toast.error(e instanceof Error ? e.message : t("errors.startAuthFailed"));
       setIsStarting(false);
     }
   }
@@ -410,7 +392,9 @@ function ConnectableCard({
       await app.disconnect();
       onChange();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to disconnect");
+      toast.error(
+        e instanceof Error ? e.message : t("errors.disconnectFailed")
+      );
     } finally {
       setIsStarting(false);
     }
@@ -436,7 +420,7 @@ function ConnectableCard({
             icon={Logo}
             title={app.name}
             titleMaxLines={1}
-            description={statusLine(app, needsSkillSetup)}
+            description={statusLine(app, needsSkillSetup, t)}
             descriptionMaxLines={1}
             rightChildren={
               <Section flexDirection="row" width="fit" height="fit" gap={2}>
@@ -445,11 +429,11 @@ function ConnectableCard({
                     {/* Only the problem state gets a glyph — "Connected" in the
                         status line already says the happy path. */}
                     {needsSkillSetup && (
-                      <Tooltip tooltip="Not all associated skills are enabled. This app may not work correctly.">
+                      <Tooltip tooltip={t("status.skillWarningTooltip")}>
                         <SvgAlertCircle
                           size={16}
                           className="text-status-warning-05"
-                          aria-label="Skill setup required"
+                          aria-label={t("status.skillWarningAriaLabel")}
                         />
                       </Tooltip>
                     )}
@@ -458,7 +442,7 @@ function ConnectableCard({
                         prominence="secondary"
                         href={`/craft/v1/skills?externalAppId=${app.externalAppId}`}
                       >
-                        Review skills
+                        {t("reviewSkillsButton")}
                       </Button>
                     )}
                     {app.disconnect && (
@@ -467,14 +451,14 @@ function ConnectableCard({
                         disabled={isStarting}
                         onClick={disconnect}
                       >
-                        {isStarting ? "…" : "Disconnect"}
+                        {isStarting ? "…" : t("disconnectButton")}
                       </Button>
                     )}
                   </>
                 ) : (
                   app.connectMode !== null && (
                     <Button disabled={isStarting} onClick={connect}>
-                      {isStarting ? "Redirecting…" : "Connect"}
+                      {isStarting ? t("connectingButton") : t("connectButton")}
                     </Button>
                   )
                 )}

--- a/web/src/app/craft/v1/tasks/[id]/edit/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SettingsLayouts } from "@opal/layouts";
@@ -16,6 +17,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 
 export default function EditScheduledTaskPage() {
+  const t = useTranslations("craft.tasks.editPage");
   const params = useParams<{ id: string }>();
   const router = useRouter();
   const taskId = params?.id;
@@ -36,13 +38,13 @@ export default function EditScheduledTaskPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
           icon={SvgClock}
-          title="Edit scheduled task"
+          title={t("fallbackTitle")}
           backButton={handleBack}
           divider
         />
         <SettingsLayouts.Body>
           <Text font="main-ui-body" color="text-03">
-            Missing task id.
+            {t("missingTaskId")}
           </Text>
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
@@ -54,7 +56,7 @@ export default function EditScheduledTaskPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
           icon={SvgClock}
-          title={data ? `Edit "${data.name}"` : "Edit scheduled task"}
+          title={data ? t("title", { name: data.name }) : t("fallbackTitle")}
           backButton={handleBack}
           divider
         />
@@ -65,7 +67,7 @@ export default function EditScheduledTaskPage() {
             </div>
           ) : (
             <Text font="main-ui-body" color="text-03">
-              Failed to load scheduled task.
+              {t("loadFailed")}
             </Text>
           )}
         </SettingsLayouts.Body>
@@ -77,7 +79,7 @@ export default function EditScheduledTaskPage() {
     <ScheduleTaskForm
       initial={toFormInitial(data)}
       isEdit
-      title={`Edit "${data.name}"`}
+      title={t("title", { name: data.name })}
       onBack={handleBack}
     />
   );

--- a/web/src/app/craft/v1/tasks/[id]/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import { SettingsLayouts, toast } from "@opal/layouts";
@@ -32,6 +33,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 
 export default function ScheduledTaskDetailPage() {
+  const t = useTranslations("craft.tasks.detailPage");
   const params = useParams<{ id: string }>();
   const router = useRouter();
   const taskId = params?.id;
@@ -62,22 +64,24 @@ export default function ScheduledTaskDetailPage() {
     try {
       const updated = await updateScheduledTask(data.id, { status: next });
       await mutate(updated, { revalidate: false });
-      toast.success(next === "ACTIVE" ? "Task resumed." : "Task paused.");
+      toast.success(
+        next === "ACTIVE" ? t("toasts.resumed") : t("toasts.paused")
+      );
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to update status"
+        err instanceof Error ? err.message : t("toasts.statusUpdateFailed")
       );
     } finally {
       setBusy(false);
     }
-  }, [data, mutate]);
+  }, [data, mutate, t]);
 
   const handleRunNow = useCallback(async () => {
     if (!data) return;
     setBusy(true);
     try {
       await runScheduledTaskNow(data.id);
-      toast.success(`Queued run for "${data.name}".`);
+      toast.success(t("toasts.runQueued", { name: data.name }));
       void mutate();
       // The run history table owns paginated SWR keys under this prefix —
       // invalidate every variant so the new ``manual_run_now`` row appears.
@@ -86,36 +90,40 @@ export default function ScheduledTaskDetailPage() {
         (key) => typeof key === "string" && key.startsWith(runsPrefix)
       );
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to start run");
+      toast.error(
+        err instanceof Error ? err.message : t("toasts.runStartFailed")
+      );
     } finally {
       setBusy(false);
     }
-  }, [data, mutate, globalMutate]);
+  }, [data, mutate, globalMutate, t]);
 
   const handleDelete = useCallback(async () => {
     if (!data) return;
     setBusy(true);
     try {
       await deleteScheduledTask(data.id);
-      toast.success(`Deleted "${data.name}".`);
+      toast.success(t("toasts.deleted", { name: data.name }));
       router.push(TASKS_PATH);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to delete task");
+      toast.error(
+        err instanceof Error ? err.message : t("toasts.deleteFailed")
+      );
       setBusy(false);
     }
-  }, [data, router]);
+  }, [data, router, t]);
 
   if (!taskId) {
     return (
       <SettingsLayouts.Root width="lg">
         <SettingsLayouts.Header
           icon={SvgClock}
-          title="Scheduled task"
+          title={t("fallbackTitle")}
           backButton={handleBack}
         />
         <SettingsLayouts.Body>
           <Text font="main-ui-body" color="text-03">
-            Missing task id.
+            {t("missingTaskId")}
           </Text>
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
@@ -126,7 +134,7 @@ export default function ScheduledTaskDetailPage() {
     <SettingsLayouts.Root width="lg">
       <SettingsLayouts.Header
         icon={SvgClock}
-        title={data?.name ?? "Scheduled task"}
+        title={data?.name ?? t("fallbackTitle")}
         description={scheduleDescription}
         backButton={handleBack}
         rightChildren={
@@ -141,7 +149,7 @@ export default function ScheduledTaskDetailPage() {
                 disabled={busy}
                 data-testid="run-now-button"
               >
-                Run now
+                {t("runNowButton")}
               </Button>
               <Button
                 icon={data.status === "ACTIVE" ? SvgPauseCircle : SvgPlayCircle}
@@ -151,7 +159,9 @@ export default function ScheduledTaskDetailPage() {
                 disabled={busy}
                 data-testid="status-toggle"
               >
-                {data.status === "ACTIVE" ? "Pause" : "Resume"}
+                {data.status === "ACTIVE"
+                  ? t("pauseButton")
+                  : t("resumeButton")}
               </Button>
               <Button
                 icon={SvgEdit}
@@ -160,7 +170,7 @@ export default function ScheduledTaskDetailPage() {
                 href={taskEditPath(data.id)}
                 disabled={busy}
               >
-                Edit
+                {t("editButton")}
               </Button>
               <Button
                 icon={SvgTrash}
@@ -170,7 +180,7 @@ export default function ScheduledTaskDetailPage() {
                 disabled={busy}
                 data-testid="delete-button"
               >
-                Delete
+                {t("deleteButton")}
               </Button>
             </div>
           ) : undefined
@@ -183,7 +193,7 @@ export default function ScheduledTaskDetailPage() {
           </div>
         ) : error || !data ? (
           <Text font="main-ui-body" color="text-03">
-            Failed to load scheduled task.
+            {t("loadFailed")}
           </Text>
         ) : (
           <div className="flex flex-col gap-6">
@@ -202,8 +212,8 @@ export default function ScheduledTaskDetailPage() {
       {confirmDelete && data && (
         <ConfirmationModalLayout
           icon={SvgTrash}
-          title={`Delete "${data.name}"?`}
-          description="This stops future runs and removes the task. Past run history (and the underlying sessions) will be preserved for audit."
+          title={t("confirmDelete.title", { name: data.name })}
+          description={t("confirmDelete.description")}
           onClose={() => setConfirmDelete(false)}
           submit={
             <Button
@@ -213,7 +223,9 @@ export default function ScheduledTaskDetailPage() {
               disabled={busy}
               data-testid="confirm-delete-task"
             >
-              {busy ? "Deleting..." : "Delete"}
+              {busy
+                ? t("confirmDelete.deletingButton")
+                : t("confirmDelete.deleteButton")}
             </Button>
           }
         />

--- a/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Card, Checkbox, Text } from "@opal/components";
 import { SvgMcp } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
@@ -28,6 +29,7 @@ export default function PreApprovalPicker({
   onAppChange,
   onMcpServerChange,
 }: PreApprovalPickerProps) {
+  const t = useTranslations("craft.tasks.preApproval");
   const {
     data: apps,
     isLoading: appsLoading,
@@ -42,7 +44,9 @@ export default function PreApprovalPicker({
   const appOptions: PreApprovalOption[] = (apps ?? []).map((app) => ({
     id: app.id,
     name: app.name,
-    status: app.authenticated ? "Connected" : "Connection required",
+    status: app.authenticated
+      ? t("status.connected")
+      : t("status.connectionRequired"),
     icon: getAppTypeLogo(app.app_type),
     testId: `pre-approval-app-${app.id}`,
   }));
@@ -54,7 +58,9 @@ export default function PreApprovalPicker({
     ...visibleMcpServers.map((server) => ({
       id: server.id,
       name: server.name,
-      status: server.craft_connected ? "Connected" : "Connection required",
+      status: server.craft_connected
+        ? t("status.connected")
+        : t("status.connectionRequired"),
       icon: getActionIcon(server.server_url, server.name),
       testId: `pre-approval-mcp-server-${server.id}`,
     })),
@@ -63,8 +69,8 @@ export default function PreApprovalPicker({
           .filter((id) => !visibleMcpServerIds.has(id))
           .map((id) => ({
             id,
-            name: `MCP server #${id}`,
-            status: "No longer available",
+            name: t("mcpServerFallbackName", { id }),
+            status: t("status.unavailable"),
             icon: SvgMcp,
             testId: `pre-approval-mcp-server-${id}`,
           }))
@@ -76,7 +82,7 @@ export default function PreApprovalPicker({
     return (
       <Card background="none" border="dashed" rounding={4}>
         <Text font="secondary-body" color="text-03">
-          Loading apps and MCP servers…
+          {t("loading.label")}
         </Text>
       </Card>
     );
@@ -86,7 +92,7 @@ export default function PreApprovalPicker({
     return (
       <Card background="none" border="dashed" rounding={4}>
         <Text font="secondary-body" color="text-03">
-          Couldn’t load apps and MCP servers. Refresh to try again.
+          {t("errors.loadFailed")}
         </Text>
       </Card>
     );
@@ -96,7 +102,7 @@ export default function PreApprovalPicker({
     return (
       <Card background="none" border="dashed" rounding={4}>
         <Text font="secondary-body" color="text-03">
-          No apps or MCP servers are available in Craft yet.
+          {t("empty.label")}
         </Text>
       </Card>
     );
@@ -110,13 +116,13 @@ export default function PreApprovalPicker({
       {(appsError || mcpError) && (
         <Card background="none" border="dashed" rounding={4}>
           <Text font="secondary-body" color="text-03">
-            Some pre-approval options couldn’t load. Refresh to try again.
+            {t("errors.partialLoadFailed")}
           </Text>
         </Card>
       )}
       {appOptions.length > 0 && (
         <PreApprovalGroup
-          title="Apps"
+          title={t("appsGroupTitle")}
           options={appOptions}
           selectedIds={selectedAppIds}
           onToggle={(id) => onAppChange(toggledIds(selectedAppIds, id))}
@@ -124,7 +130,7 @@ export default function PreApprovalPicker({
       )}
       {mcpOptions.length > 0 && (
         <PreApprovalGroup
-          title="MCP servers"
+          title={t("mcpGroupTitle")}
           options={mcpOptions}
           selectedIds={selectedMcpServerIds}
           onToggle={(id) =>

--- a/web/src/app/craft/v1/tasks/components/PreApprovalSummary.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovalSummary.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Tag, Text } from "@opal/components";
 import useUserExternalApps from "@/hooks/useUserExternalApps";
 import { useCraftMcpServers } from "@/lib/tools/hooks";
@@ -15,6 +16,7 @@ export default function PreApprovalSummary({
   appIds,
   mcpServerIds,
 }: PreApprovalSummaryProps) {
+  const t = useTranslations("craft.tasks.preApproval");
   const hasAppIds = appIds.length > 0;
   const hasMcpServerIds = mcpServerIds.length > 0;
   const {
@@ -44,11 +46,11 @@ export default function PreApprovalSummary({
   return (
     <div className="flex flex-col gap-2">
       <Text font="main-ui-action" color="text-03">
-        Pre-approved apps and MCP servers
+        {t("summary.title")}
       </Text>
       {(appsFailed || mcpServersFailed) && (
         <Text font="secondary-body" color="status-error-05">
-          Some pre-approval details couldn’t load. Refresh to try again.
+          {t("summary.partialLoadFailed")}
         </Text>
       )}
       <div className="flex flex-wrap gap-2">
@@ -60,7 +62,7 @@ export default function PreApprovalSummary({
             <Tag
               key={`app-${id}`}
               icon={app ? getAppTypeLogo(app.app_type) : undefined}
-              title={app?.name ?? `App #${id}`}
+              title={app?.name ?? t("appFallbackName", { id })}
             />
           );
         })}
@@ -76,7 +78,7 @@ export default function PreApprovalSummary({
                   ? getActionIcon(server.server_url, server.name)
                   : undefined
               }
-              title={server?.name ?? `MCP server #${id}`}
+              title={server?.name ?? t("mcpServerFallbackName", { id })}
             />
           );
         })}

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import useSWR from "swr";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import {
   Button,
@@ -36,6 +37,7 @@ import {
   formatRelativeShort,
   formatRunDuration,
   getNonClickableReason,
+  type RunReasonTranslate,
 } from "@/app/craft/v1/tasks/utils";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -45,6 +47,9 @@ interface RunHistoryTableProps {
 }
 
 const tc = createTableColumns<ScheduledRunSummary>();
+type RunHistoryTranslate = ReturnType<
+  typeof useTranslations<"craft.tasks.runHistory">
+>;
 const RUN_HISTORY_REFRESH_INTERVAL_MS = 5000;
 const SUMMARY_TOOLTIP_THRESHOLD_CHARS = 80;
 const SUMMARY_TOOLTIP_MAX_CHARS = 400;
@@ -84,7 +89,8 @@ interface SummaryCellProps {
 }
 
 function SummaryCell({ row }: SummaryCellProps) {
-  const reason = getNonClickableReason(row);
+  const tReason = useTranslations("craft.tasks.runHistory.nonClickable");
+  const reason = getNonClickableReason(row, tReason);
   const raw = row.summary ?? row.skip_reason ?? row.error_class;
   // Heading strip must run before toPlainString collapses newlines.
   const stripped = raw
@@ -118,14 +124,14 @@ function SummaryCell({ row }: SummaryCellProps) {
   );
 }
 
-function buildColumns() {
+function buildColumns(t: RunHistoryTranslate, tReason: RunReasonTranslate) {
   return [
     tc.column("started_at", {
-      header: "Started",
+      header: t("columns.started"),
       weight: 22,
       enableSorting: false,
       cell: (value, row) => (
-        <NonClickableCell reason={getNonClickableReason(row)}>
+        <NonClickableCell reason={getNonClickableReason(row, tReason)}>
           <div className="flex flex-col gap-0.5">
             <Text font="main-ui-body" color="text-05" nowrap>
               {formatAbsolute(value)}
@@ -138,11 +144,11 @@ function buildColumns() {
       ),
     }),
     tc.column("status", {
-      header: "Status",
+      header: t("columns.status"),
       weight: 14,
       enableSorting: false,
       cell: (status, row) => {
-        const reason = getNonClickableReason(row);
+        const reason = getNonClickableReason(row, tReason);
         return (
           // Wrapper exposes the status to Playwright (and lets the row's
           // ``onRowClick`` still navigate via event bubbling).
@@ -156,7 +162,7 @@ function buildColumns() {
                 <SvgLock
                   size={12}
                   className="text-text-03"
-                  aria-label="Not openable"
+                  aria-label={t("status.notOpenableAriaLabel")}
                 />
               )}
             </div>
@@ -166,10 +172,10 @@ function buildColumns() {
     }),
     tc.displayColumn({
       id: "duration",
-      header: "Duration",
+      header: t("columns.duration"),
       width: { weight: 12 },
       cell: (row) => (
-        <NonClickableCell reason={getNonClickableReason(row)}>
+        <NonClickableCell reason={getNonClickableReason(row, tReason)}>
           <Text font="main-ui-body" color="text-03" nowrap>
             {formatRunDuration(row.started_at, row.finished_at)}
           </Text>
@@ -178,18 +184,20 @@ function buildColumns() {
     }),
     tc.displayColumn({
       id: "summary",
-      header: "Summary",
+      header: t("columns.summary"),
       width: { weight: 38 },
       cell: (row) => <SummaryCell row={row} />,
     }),
     tc.column("trigger_source", {
-      header: "Trigger",
+      header: t("columns.trigger"),
       weight: 14,
       enableSorting: false,
       cell: (value, row) => (
-        <NonClickableCell reason={getNonClickableReason(row)}>
+        <NonClickableCell reason={getNonClickableReason(row, tReason)}>
           <Text font="main-ui-body" color="text-03" nowrap>
-            {value === "MANUAL_RUN_NOW" ? "Run Now" : "Schedule"}
+            {value === "MANUAL_RUN_NOW"
+              ? t("trigger.runNow")
+              : t("trigger.schedule")}
           </Text>
         </NonClickableCell>
       ),
@@ -198,6 +206,7 @@ function buildColumns() {
 }
 
 export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
+  const t = useTranslations("craft.tasks.runHistory");
   const router = useRouter();
   const [olderPages, setOlderPages] = useState<ScheduledRunSummary[][]>([]);
   const [olderNextCursor, setOlderNextCursor] = useState<string | null>(null);
@@ -242,7 +251,8 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
     void mutate();
   }, [mutate]);
 
-  const columns = useMemo(() => buildColumns(), []);
+  const tReason = useTranslations("craft.tasks.runHistory.nonClickable");
+  const columns = useMemo(() => buildColumns(t, tReason), [t, tReason]);
 
   const allRuns = useMemo(() => {
     const runs: ScheduledRunSummary[] = [];
@@ -276,7 +286,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
     return (
       <Section gap={2}>
         <Text font="main-ui-body" color="text-03">
-          Failed to load run history.
+          {t("errors.loadFailed")}
         </Text>
         <Button
           variant="default"
@@ -284,7 +294,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
           onClick={refresh}
           size="sm"
         >
-          Try again
+          {t("errors.tryAgainButton")}
         </Button>
       </Section>
     );
@@ -294,8 +304,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
     return (
       <div className="py-6 text-center">
         <Text font="main-ui-body" color="text-03">
-          No runs yet. The task will create one each time it fires, or use Run
-          Now above.
+          {t("empty.label")}
         </Text>
       </div>
     );
@@ -309,7 +318,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
         getRowId={(row) => row.id}
         selectionBehavior="single-select"
         onRowClick={(row) => {
-          if (!getNonClickableReason(row) && row.session_id) {
+          if (!getNonClickableReason(row, tReason) && row.session_id) {
             router.push(buildSessionPath(row.session_id));
           }
         }}
@@ -322,7 +331,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
             onClick={() => void loadMore()}
             disabled={loadingMore}
           >
-            {loadingMore ? "Loading..." : "Load more"}
+            {loadingMore ? t("loadMore.loadingButton") : t("loadMore.button")}
           </Button>
         </div>
       )}

--- a/web/src/app/craft/v1/tasks/components/ScheduleEditor.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { InputTypeIn, Tabs, Text } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { Section } from "@/layouts/general-layouts";
@@ -13,21 +14,19 @@ import type {
   IntervalUnit,
 } from "@/app/craft/v1/tasks/interfaces";
 
-// 0=Sun..6=Sat (cron convention).
-const WEEKDAY_LABELS: ReadonlyArray<{ value: number; short: string }> = [
-  { value: 0, short: "Sun" },
-  { value: 1, short: "Mon" },
-  { value: 2, short: "Tue" },
-  { value: 3, short: "Wed" },
-  { value: 4, short: "Thu" },
-  { value: 5, short: "Fri" },
-  { value: 6, short: "Sat" },
-];
+// 0=Sun..6=Sat (cron convention). Short labels come from the
+// craft.tasks.scheduleEditor.weekdays message namespace.
+const WEEKDAY_LABELS = [
+  { value: 0, key: "sun" },
+  { value: 1, key: "mon" },
+  { value: 2, key: "tue" },
+  { value: 3, key: "wed" },
+  { value: 4, key: "thu" },
+  { value: 5, key: "fri" },
+  { value: 6, key: "sat" },
+] as const;
 
-const INTERVAL_UNITS: ReadonlyArray<{ value: IntervalUnit; label: string }> = [
-  { value: "minutes", label: "minutes" },
-  { value: "hours", label: "hours" },
-];
+const INTERVAL_UNITS: ReadonlyArray<IntervalUnit> = ["minutes", "hours"];
 
 export interface ScheduleEditorProps {
   mode: EditorMode;
@@ -45,12 +44,13 @@ export default function ScheduleEditor({
   onPayloadChange,
   error,
 }: ScheduleEditorProps) {
+  const t = useTranslations("craft.tasks.scheduleEditor");
   // Cache the active payload per mode so flipping tabs back and forth doesn't
   // wipe out a partially-filled form on the other tab.
   const tabContent = useMemo(
     () => ({
       interval: {
-        name: "Interval",
+        name: t("tabs.interval"),
         content: (
           <IntervalEditor
             payload={
@@ -63,7 +63,7 @@ export default function ScheduleEditor({
         ),
       },
       daily_weekly: {
-        name: "Daily / Weekly",
+        name: t("tabs.dailyWeekly"),
         content: (
           <DailyWeeklyEditor
             payload={
@@ -76,7 +76,7 @@ export default function ScheduleEditor({
         ),
       },
     }),
-    [mode, payload, onPayloadChange]
+    [mode, payload, onPayloadChange, t]
   );
 
   const tabEntries = Object.entries(tabContent);
@@ -153,11 +153,12 @@ interface IntervalEditorProps {
 }
 
 function IntervalEditor({ payload, onChange }: IntervalEditorProps) {
+  const t = useTranslations("craft.tasks.scheduleEditor");
   return (
     <Section gap={2}>
       <div className="flex items-center gap-2 flex-wrap">
         <Text font="main-ui-body" color="text-05">
-          Every
+          {t("interval.everyLabel")}
         </Text>
         <div className="w-28">
           <InputTypeIn
@@ -179,9 +180,9 @@ function IntervalEditor({ payload, onChange }: IntervalEditorProps) {
           >
             <InputSelect.Trigger />
             <InputSelect.Content>
-              {INTERVAL_UNITS.map((u) => (
-                <InputSelect.Item key={u.value} value={u.value}>
-                  {u.label}
+              {INTERVAL_UNITS.map((unit) => (
+                <InputSelect.Item key={unit} value={unit}>
+                  {t(`intervalUnits.${unit}`)}
                 </InputSelect.Item>
               ))}
             </InputSelect.Content>
@@ -202,19 +203,20 @@ interface DailyWeeklyEditorProps {
 }
 
 function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
+  const t = useTranslations("craft.tasks.scheduleEditor");
   const weekdaySet = new Set(payload.weekdays ?? []);
   const selectedDays = WEEKDAY_LABELS.filter((d) =>
     weekdaySet.has(d.value)
-  ).map((d) => d.short);
+  ).map((d) => t(`weekdays.${d.key}`));
   const scheduleNote =
     selectedDays.length === 0
-      ? "Runs every day"
-      : `Runs on ${selectedDays.join(", ")}`;
+      ? t("dailyWeekly.runsEveryDay")
+      : t("dailyWeekly.runsOn", { days: selectedDays.join(", ") });
   return (
     <Section gap={2}>
       <div className="flex items-center gap-2">
         <Text font="main-ui-body" color="text-05">
-          At
+          {t("dailyWeekly.atLabel")}
         </Text>
         <div className="w-44">
           <InputTypeIn
@@ -229,7 +231,7 @@ function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
       </div>
       <div className="flex flex-col gap-1">
         <Text font="secondary-body" color="text-03">
-          On these days
+          {t("dailyWeekly.daysLabel")}
         </Text>
         <div className="flex items-center gap-1 flex-wrap">
           {WEEKDAY_LABELS.map((day) => {
@@ -256,7 +258,7 @@ function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
                     : "bg-background-neutral-00 border-border-02 text-text-03 hover:bg-background-tint-01"
                 )}
               >
-                {day.short}
+                {t(`weekdays.${day.key}`)}
               </button>
             );
           })}

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useSWRConfig } from "swr";
 import {
@@ -75,6 +76,7 @@ export default function ScheduleTaskForm({
   description,
   onBack,
 }: ScheduleTaskFormProps) {
+  const t = useTranslations("craft.tasks.form");
   const router = useRouter();
   const { mutate } = useSWRConfig();
   const [name, setName] = useState(initial.name);
@@ -184,8 +186,9 @@ export default function ScheduleTaskForm({
   // Validation states. These gate submission regardless of interaction, but
   // are only surfaced inline once the user has touched (blurred) the field so
   // a pristine form doesn't render red on load.
-  const nameError = trimmedName.length === 0 ? "Name is required." : null;
-  const promptError = trimmedPrompt.length === 0 ? "Prompt is required." : null;
+  const nameError = trimmedName.length === 0 ? t("errors.nameRequired") : null;
+  const promptError =
+    trimmedPrompt.length === 0 ? t("errors.promptRequired") : null;
   const scheduleError = !compiled.ok ? compiled.error : null;
 
   const shownNameError = nameTouched ? nameError : null;
@@ -197,7 +200,7 @@ export default function ScheduleTaskForm({
   // tooltip. A natively-disabled <button> is inert and never fires hover
   // events, so the tooltip must live on the (interactive) wrapper instead.
   const disabledReason = saving
-    ? "Saving..."
+    ? t("savingLabel")
     : (nameError ?? promptError ?? scheduleError ?? undefined);
 
   const submit = useCallback(
@@ -223,7 +226,7 @@ export default function ScheduleTaskForm({
             revalidate: false,
           });
           await mutate(SWR_KEYS.scheduledTasks);
-          toast.success("Scheduled task updated.");
+          toast.success(t("toasts.updated"));
           router.push(taskDetailPath(updated.id));
         } else {
           const body: ScheduledTaskCreateBody = {
@@ -238,15 +241,13 @@ export default function ScheduleTaskForm({
           await createScheduledTask(body);
           await mutate(SWR_KEYS.scheduledTasks);
           toast.success(
-            runImmediately
-              ? "Scheduled task created and queued."
-              : "Scheduled task created."
+            runImmediately ? t("toasts.createdAndQueued") : t("toasts.created")
           );
           router.push(TASKS_PATH);
         }
       } catch (err) {
         toast.error(
-          err instanceof Error ? err.message : "Failed to save scheduled task"
+          err instanceof Error ? err.message : t("toasts.saveFailed")
         );
       } finally {
         setSaving(false);
@@ -264,6 +265,7 @@ export default function ScheduleTaskForm({
       router,
       trimmedName,
       trimmedPrompt,
+      t,
     ]
   );
 
@@ -284,7 +286,7 @@ export default function ScheduleTaskForm({
               onClick={() => router.push(TASKS_PATH)}
               disabled={saving}
             >
-              Cancel
+              {t("cancelButton")}
             </Button>
             {!isEdit && (
               <Disabled
@@ -300,7 +302,7 @@ export default function ScheduleTaskForm({
                   onClick={() => void submit(true)}
                   data-testid="save-and-run-now"
                 >
-                  Save and run now
+                  {t("saveAndRunNowButton")}
                 </Button>
               </Disabled>
             )}
@@ -317,7 +319,7 @@ export default function ScheduleTaskForm({
                 onClick={() => void submit(false)}
                 data-testid="save-task"
               >
-                {isEdit ? "Save changes" : "Save"}
+                {isEdit ? t("saveChangesButton") : t("saveButton")}
               </Button>
             </Disabled>
           </div>
@@ -326,12 +328,12 @@ export default function ScheduleTaskForm({
 
       <SettingsLayouts.Body>
         <GeneralLayouts.Section>
-          <InputVertical withLabel title="Name">
+          <InputVertical withLabel title={t("fields.name.label")}>
             <InputTypeIn
               value={name}
               onChange={(e) => setName(e.target.value)}
               onBlur={() => setNameTouched(true)}
-              placeholder="e.g. Weekly customer escalations digest"
+              placeholder={t("fields.name.placeholder")}
               data-testid="task-name-input"
               variant={shownNameError ? "error" : undefined}
             />
@@ -344,8 +346,8 @@ export default function ScheduleTaskForm({
 
           <InputVertical
             withLabel
-            title="Prompt"
-            description="This message is sent to Craft each time the task fires."
+            title={t("fields.prompt.label")}
+            description={t("fields.prompt.description")}
           >
             <InputTextArea
               ref={promptTextareaRef}
@@ -354,7 +356,7 @@ export default function ScheduleTaskForm({
               onKeyUp={handlePromptCursorChange}
               onClick={handlePromptCursorChange}
               onBlur={() => setPromptTouched(true)}
-              placeholder="Describe what Craft should do on each run..."
+              placeholder={t("fields.prompt.placeholder")}
               rows={6}
               autoResize
               maxRows={12}
@@ -380,7 +382,7 @@ export default function ScheduleTaskForm({
         <Divider paddingParallel={0} paddingPerpendicular={0} />
 
         <GeneralLayouts.Section>
-          <InputVertical title="Schedule">
+          <InputVertical title={t("fields.schedule.label")}>
             <ScheduleEditor
               mode={mode}
               onModeChange={setMode}
@@ -395,8 +397,8 @@ export default function ScheduleTaskForm({
 
         <GeneralLayouts.Section>
           <InputVertical
-            title="Pre-approved apps and MCP servers"
-            description="Craft can use selected apps and MCP servers without pausing when this task runs unattended. Other approval requests pause the run and can cause it to fail."
+            title={t("fields.preApproval.label")}
+            description={t("fields.preApproval.description")}
           >
             <PreApprovalPicker
               selectedAppIds={preApprovedAppIds}

--- a/web/src/app/craft/v1/tasks/new/page.tsx
+++ b/web/src/app/craft/v1/tasks/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import ScheduleTaskForm, {
   defaultFormInitial,
@@ -18,6 +19,7 @@ const VALID_MODES: ReadonlySet<EditorMode> = new Set<EditorMode>([
 ]);
 
 export default function NewScheduledTaskPage() {
+  const t = useTranslations("craft.tasks.newPage");
   const router = useRouter();
   const searchParams = useSearchParams();
   const handleBack = useCallback(() => {
@@ -59,8 +61,8 @@ export default function NewScheduledTaskPage() {
     <ScheduleTaskForm
       initial={initial}
       isEdit={false}
-      title="New Scheduled Task"
-      description="Save a prompt + schedule. Craft will run it on a timer."
+      title={t("title")}
+      description={t("description")}
       onBack={handleBack}
     />
   );

--- a/web/src/app/craft/v1/tasks/page.tsx
+++ b/web/src/app/craft/v1/tasks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import useSWR from "swr";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
@@ -45,16 +46,19 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 
 const tc = createTableColumns<ScheduledTaskListItem>();
+type TasksListTranslate = ReturnType<
+  typeof useTranslations<"craft.tasks.listPage">
+>;
 
 interface RowActionHandlers {
   busyTaskId: string | null;
   onDelete: (task: ScheduledTaskListItem) => void;
 }
 
-function buildColumns(handlers: RowActionHandlers) {
+function buildColumns(handlers: RowActionHandlers, t: TasksListTranslate) {
   return [
     tc.column("name", {
-      header: "Name",
+      header: t("columns.name"),
       weight: 25,
       enableSorting: false,
       cell: (value) => (
@@ -64,7 +68,7 @@ function buildColumns(handlers: RowActionHandlers) {
       ),
     }),
     tc.column("human_readable_schedule", {
-      header: "Schedule",
+      header: t("columns.schedule"),
       weight: 22,
       enableSorting: false,
       cell: (value) => (
@@ -74,13 +78,13 @@ function buildColumns(handlers: RowActionHandlers) {
       ),
     }),
     tc.column("status", {
-      header: "Status",
+      header: t("columns.status"),
       weight: 12,
       enableSorting: false,
       cell: (status) => <TaskStatusBadge status={status} />,
     }),
     tc.column("last_run", {
-      header: "Last run",
+      header: t("columns.lastRun"),
       weight: 18,
       enableSorting: false,
       cell: (lastRun) => {
@@ -102,7 +106,7 @@ function buildColumns(handlers: RowActionHandlers) {
       },
     }),
     tc.column("next_run_at", {
-      header: "Next run",
+      header: t("columns.nextRun"),
       weight: 13,
       enableSorting: false,
       cell: (nextRunAt) => {
@@ -131,6 +135,7 @@ function buildColumns(handlers: RowActionHandlers) {
 }
 
 export default function ScheduledTasksListPage() {
+  const t = useTranslations("craft.tasks.listPage");
   const router = useRouter();
   const { data, error, isLoading, mutate } = useSWR<ScheduledTaskListResponse>(
     SWR_KEYS.scheduledTasks,
@@ -161,23 +166,28 @@ export default function ScheduledTasksListPage() {
     setBusyTaskId(pendingDelete.id);
     try {
       await deleteScheduledTask(pendingDelete.id);
-      toast.success(`Deleted "${pendingDelete.name}".`);
+      toast.success(t("toasts.deleted", { name: pendingDelete.name }));
       setPendingDelete(null);
       refresh();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to delete task");
+      toast.error(
+        err instanceof Error ? err.message : t("toasts.deleteFailed")
+      );
     } finally {
       setBusyTaskId(null);
     }
-  }, [pendingDelete, refresh]);
+  }, [pendingDelete, refresh, t]);
 
   const columns = useMemo(
     () =>
-      buildColumns({
-        busyTaskId,
-        onDelete: (task) => setPendingDelete(task),
-      }),
-    [busyTaskId]
+      buildColumns(
+        {
+          busyTaskId,
+          onDelete: (task) => setPendingDelete(task),
+        },
+        t
+      ),
+    [busyTaskId, t]
   );
 
   const headerActions = useMemo(
@@ -189,18 +199,18 @@ export default function ScheduledTasksListPage() {
         href={NEW_TASK_PATH}
         data-testid="new-task-button"
       >
-        New Scheduled Task
+        {t("newTaskButton")}
       </Button>
     ),
-    []
+    [t]
   );
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgClock}
-        title="Scheduled Tasks"
-        description="Run Craft prompts on a timer. Each fire creates a fresh session that runs in the background."
+        title={t("header.title")}
+        description={t("header.description")}
         rightChildren={headerActions}
       />
       <SettingsLayouts.Body>
@@ -211,7 +221,7 @@ export default function ScheduledTasksListPage() {
         ) : error ? (
           <Section gap={2}>
             <Text font="main-ui-body" color="text-03">
-              Failed to load scheduled tasks.
+              {t("errors.loadFailed")}
             </Text>
             <Button
               variant="default"
@@ -219,7 +229,7 @@ export default function ScheduledTasksListPage() {
               icon={SvgRefreshCw}
               onClick={refresh}
             >
-              Try again
+              {t("errors.tryAgainButton")}
             </Button>
           </Section>
         ) : (
@@ -235,8 +245,8 @@ export default function ScheduledTasksListPage() {
             emptyState={
               <IllustrationContent
                 illustration={SvgNoResult}
-                title="No scheduled tasks found"
-                description="No scheduled tasks have been created yet."
+                title={t("empty.title")}
+                description={t("empty.description")}
               />
             }
           />
@@ -246,8 +256,8 @@ export default function ScheduledTasksListPage() {
       {pendingDelete && (
         <ConfirmationModalLayout
           icon={SvgTrash}
-          title={`Delete "${pendingDelete.name}"?`}
-          description="This stops future runs and removes the task. Past run history (and the underlying sessions) will be preserved for audit."
+          title={t("confirmDelete.title", { name: pendingDelete.name })}
+          description={t("confirmDelete.description")}
           onClose={() => setPendingDelete(null)}
           submit={
             <Button
@@ -257,7 +267,9 @@ export default function ScheduledTasksListPage() {
               disabled={busyTaskId === pendingDelete.id}
               data-testid="confirm-delete-task"
             >
-              {busyTaskId === pendingDelete.id ? "Deleting..." : "Delete"}
+              {busyTaskId === pendingDelete.id
+                ? t("confirmDelete.deletingButton")
+                : t("confirmDelete.deleteButton")}
             </Button>
           }
         />
@@ -276,10 +288,11 @@ interface TaskRowActionsProps {
 }
 
 function TaskRowActions({ task, handlers }: TaskRowActionsProps) {
+  const t = useTranslations("craft.tasks.listPage");
   const disabled = handlers.busyTaskId === task.id;
   return (
     <div className="flex items-center gap-0.5">
-      <Tooltip tooltip="Delete" side="top">
+      <Tooltip tooltip={t("rowActions.deleteTooltip")} side="top">
         <Button
           icon={SvgTrash}
           variant="danger"

--- a/web/src/app/craft/v1/tasks/utils.ts
+++ b/web/src/app/craft/v1/tasks/utils.ts
@@ -58,21 +58,28 @@ export function formatRunDuration(
  * A row is clickable once there is a session to open. Queued rows have not
  * created one yet; skipped rows deliberately never create one.
  */
-export function getNonClickableReason(run: ScheduledRunSummary): string | null {
+export type RunReasonTranslate = (
+  key: "noSession" | "queued" | "skipped"
+) => string;
+
+export function getNonClickableReason(
+  run: ScheduledRunSummary,
+  t: RunReasonTranslate
+): string | null {
   if (
     run.status === "RUNNING" ||
     run.status === "AWAITING_APPROVAL" ||
     run.status === "SUCCEEDED" ||
     run.status === "FAILED"
   ) {
-    return run.session_id ? null : "This run has not created a session yet.";
+    return run.session_id ? null : t("noSession");
   }
 
   switch (run.status) {
     case "QUEUED":
-      return "This run hasn't started yet — no session to open.";
+      return t("queued");
     case "SKIPPED":
-      return "This run was skipped because a prior run was still in flight — no session was created.";
+      return t("skipped");
   }
   return null;
 }

--- a/web/src/app/ee/admin/billing/BillingInformationPage.tsx
+++ b/web/src/app/ee/admin/billing/BillingInformationPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "@opal/layouts";
 import {
   createCustomerPortalSession,
@@ -20,6 +21,7 @@ import { SubscriptionSummary } from "./SubscriptionSummary";
 import { BillingAlerts } from "./BillingAlerts";
 import { SvgClipboard, SvgWallet } from "@opal/icons";
 export default function BillingInformationPage() {
+  const t = useTranslations("admin.billing.info");
   const {
     data: billingInformation,
     error,
@@ -29,31 +31,27 @@ export default function BillingInformationPage() {
   useEffect(() => {
     const url = new URL(window.location.href);
     if (url.searchParams.has("session_id")) {
-      toast.success(
-        "Congratulations! Your subscription has been updated successfully."
-      );
+      toast.success(t("updatedToast.message"));
       url.searchParams.delete("session_id");
       window.history.replaceState({}, "", url.toString());
     }
-  }, []);
+  }, [t]);
 
   if (isLoading) {
-    return <div className="text-center py-8">Loading...</div>;
+    return <div className="text-center py-8">{t("loading.label")}</div>;
   }
 
   if (error) {
     console.error("Failed to fetch billing information:", error);
     return (
       <div className="text-center py-8 text-red-500">
-        Error loading billing information. Please try again later.
+        {t("loadError.message")}
       </div>
     );
   }
 
   if (!billingInformation || !hasActiveSubscription(billingInformation)) {
-    return (
-      <div className="text-center py-8">No billing information available.</div>
-    );
+    return <div className="text-center py-8">{t("empty.message")}</div>;
   }
 
   const handleManageSubscription = async () => {
@@ -66,7 +64,7 @@ export default function BillingInformationPage() {
       window.location.href = response.stripe_customer_portal_url;
     } catch (error) {
       console.error("Error creating customer portal session:", error);
-      toast.error("Error creating customer portal session");
+      toast.error(t("portalError.message"));
     }
   };
 
@@ -76,7 +74,7 @@ export default function BillingInformationPage() {
         <CardHeader>
           <CardTitle className="text-2xl font-bold flex items-center">
             <SvgWallet className="me-4 text-muted-foreground h-6 w-6" />
-            Subscription Details
+            {t("subscriptionDetails.title")}
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -88,10 +86,10 @@ export default function BillingInformationPage() {
       <Card className="shadow-md">
         <CardHeader>
           <CardTitle className="text-xl font-semibold">
-            Manage Subscription
+            {t("manageSubscription.title")}
           </CardTitle>
           <CardDescription>
-            View your plan, update payment, or change subscription
+            {t("manageSubscription.description")}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -100,7 +98,7 @@ export default function BillingInformationPage() {
             width="full"
             icon={SvgClipboard}
           >
-            Manage Subscription
+            {t("manageSubscription.title")}
           </Button>
         </CardContent>
       </Card>

--- a/web/src/app/ee/admin/billing/SubscriptionSummary.tsx
+++ b/web/src/app/ee/admin/billing/SubscriptionSummary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslations } from "next-intl";
 import { InfoItem } from "./InfoItem";
 import { statusToDisplay, BillingInformation } from "@/lib/billing";
 import { formatDateShort } from "@/lib/dateUtils";
@@ -10,22 +11,23 @@ interface SubscriptionSummaryProps {
 export function SubscriptionSummary({
   billingInformation,
 }: SubscriptionSummaryProps) {
+  const t = useTranslations("admin.billing.info");
   return (
     <div className="grid grid-cols-2 gap-4">
       <InfoItem
-        title="Subscription Status"
+        title={t("summary.status.label")}
         value={statusToDisplay(billingInformation.status)}
       />
       <InfoItem
-        title="Seats"
+        title={t("summary.seats.label")}
         value={billingInformation.seats?.toString() ?? "—"}
       />
       <InfoItem
-        title="Billing Start"
+        title={t("summary.billingStart.label")}
         value={formatDateShort(billingInformation.current_period_start)}
       />
       <InfoItem
-        title="Billing End"
+        title={t("summary.billingEnd.label")}
         value={formatDateShort(billingInformation.current_period_end)}
       />
     </div>

--- a/web/src/app/ee/admin/billing/page.tsx
+++ b/web/src/app/ee/admin/billing/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { SettingsLayouts } from "@opal/layouts";
 import BillingInformationPage from "./BillingInformationPage";
 import { SvgCreditCard } from "@opal/icons";
@@ -16,12 +17,13 @@ export interface BillingInformation {
   payment_method_enabled: boolean;
 }
 
-export default function page() {
+export default async function page() {
+  const t = await getTranslations("admin.billing.info");
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={SvgCreditCard}
-        title="Billing Information"
+        title={t("page.title")}
         divider
       />
       <SettingsLayouts.Body>

--- a/web/src/app/ee/admin/export-logs/page.tsx
+++ b/web/src/app/ee/admin/export-logs/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { ContentAction, SettingsLayouts, toast } from "@opal/layouts";
 import { Button, Card, MessageCard, Text } from "@opal/components";
@@ -13,8 +15,6 @@ import { Section } from "@/layouts/general-layouts";
 
 const route = ADMIN_ROUTES.EXPORT_LOGS;
 
-const DESCRIPTION =
-  "Download a zip of server log files to attach to an Onyx support thread.";
 const EXPORT_URL = "/api/admin/log-export";
 const EXPORT_ID_QUERY_PARAM = "export";
 // Export ids are uuid4().hex values; anything else found in the URL is noise.
@@ -66,18 +66,25 @@ function writeExportIdToUrl(exportId: string | null): void {
   window.history.replaceState({}, "", url.toString());
 }
 
-function receiptLabel(receipt: LogExportReceipt): string {
+type ExportLogsTranslate = ReturnType<
+  typeof useTranslations<"admin.exportLogs">
+>;
+
+function receiptLabel(
+  receipt: LogExportReceipt,
+  t: ExportLogsTranslate
+): string {
   switch (receipt.status) {
     case "uploaded":
-      return `uploaded ${receipt.file_count} file${
-        receipt.file_count === 1 ? "" : "s"
-      }`;
+      return t("receipt.uploaded.label", { count: receipt.file_count });
     case "duplicate_host":
-      return "covered by another worker on the same host";
+      return t("receipt.duplicateHost.label");
     case "no_logs_found":
-      return "no log files found";
+      return t("receipt.noLogs.label");
     case "failed":
-      return receipt.error ? `failed: ${receipt.error}` : "failed";
+      return receipt.error
+        ? t("receipt.failedWithError.label", { error: receipt.error })
+        : t("receipt.failed.label");
     default: {
       const exhaustive: never = receipt.status;
       return exhaustive;
@@ -107,6 +114,8 @@ function WorkerStatusRow({
 }
 
 export default function ExportLogsPage() {
+  const t = useTranslations("admin.exportLogs");
+  const adminRouteTitle = useAdminRouteTitle();
   const [exportId, setExportId] = useState<string | null>(null);
   const [isStarting, setIsStarting] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -170,21 +179,19 @@ export default function ExportLogsPage() {
       // An id restored from the URL can be stale (export already swept, or
       // never real); it has no status yet, so scrub it without a toast.
       if (status !== undefined) {
-        toast.error("Lost access to the running export. Start a new one.");
+        toast.error(t("toasts.lostAccess.message"));
       }
     } else if (
       consecutivePollFailuresRef.current >= MAX_CONSECUTIVE_POLL_FAILURES
     ) {
-      toast.error(
-        "Cannot reach the server to check export progress. Start a new export once it is back."
-      );
+      toast.error(t("toasts.unreachable.message"));
     } else {
       return;
     }
     consecutivePollFailuresRef.current = 0;
     writeExportIdToUrl(null);
     setExportId(null);
-  }, [status, statusError]);
+  }, [status, statusError, t]);
 
   useEffect(() => {
     return () => {
@@ -196,46 +203,49 @@ export default function ExportLogsPage() {
     };
   }, []);
 
-  const downloadBundle = useCallback(async (id: string): Promise<void> => {
-    // Mark before any await: an attempt is in flight or succeeded, and only
-    // failure re-arms the auto-download below. Owning this here keeps every
-    // call site (auto-fire, manual retry) consistent.
-    downloadedExportIdRef.current = id;
-    setIsDownloading(true);
-    try {
-      const response = await fetch(`${EXPORT_URL}/${id}/download`);
-      if (!response.ok) {
-        throw new Error(
-          `Log export download failed with status ${response.status}`
-        );
+  const downloadBundle = useCallback(
+    async (id: string): Promise<void> => {
+      // Mark before any await: an attempt is in flight or succeeded, and only
+      // failure re-arms the auto-download below. Owning this here keeps every
+      // call site (auto-fire, manual retry) consistent.
+      downloadedExportIdRef.current = id;
+      setIsDownloading(true);
+      try {
+        const response = await fetch(`${EXPORT_URL}/${id}/download`);
+        if (!response.ok) {
+          throw new Error(
+            `Log export download failed with status ${response.status}`
+          );
+        }
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        downloadFile(extractFilename(response), { url });
+        // Deferred like downloadFile's content mode: the click's download
+        // dereferences the blob URL asynchronously.
+        if (pendingRevokeRef.current !== null) {
+          clearTimeout(pendingRevokeRef.current.timer);
+          URL.revokeObjectURL(pendingRevokeRef.current.url);
+        }
+        // Released on unmount and on replacement. The rule cannot trace the
+        // handle through the pendingRevokeRef object.
+        // oxlint-disable-next-line react-doctor/effect-needs-cleanup
+        const timer = setTimeout(() => {
+          URL.revokeObjectURL(url);
+          pendingRevokeRef.current = null;
+        }, 0);
+        pendingRevokeRef.current = { url, timer };
+      } catch (error) {
+        console.error("Error downloading log export:", error);
+        toast.error(t("toasts.downloadFailed.message"));
+        // Un-mark the export so the download can be retried. The bundle stays
+        // available in the file store until retention sweeps it.
+        downloadedExportIdRef.current = null;
+      } finally {
+        setIsDownloading(false);
       }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      downloadFile(extractFilename(response), { url });
-      // Deferred like downloadFile's content mode: the click's download
-      // dereferences the blob URL asynchronously.
-      if (pendingRevokeRef.current !== null) {
-        clearTimeout(pendingRevokeRef.current.timer);
-        URL.revokeObjectURL(pendingRevokeRef.current.url);
-      }
-      // Released on unmount and on replacement. The rule cannot trace the
-      // handle through the pendingRevokeRef object.
-      // oxlint-disable-next-line react-doctor/effect-needs-cleanup
-      const timer = setTimeout(() => {
-        URL.revokeObjectURL(url);
-        pendingRevokeRef.current = null;
-      }, 0);
-      pendingRevokeRef.current = { url, timer };
-    } catch (error) {
-      console.error("Error downloading log export:", error);
-      toast.error("Failed to download the log export.");
-      // Un-mark the export so the download can be retried; the bundle stays
-      // available in the file store until retention sweeps it.
-      downloadedExportIdRef.current = null;
-    } finally {
-      setIsDownloading(false);
-    }
-  }, []);
+    },
+    [t]
+  );
 
   // Download exactly once per export, as soon as it is ready. Arming happens
   // while the export is still collecting (or at start, in handleExport), so
@@ -262,7 +272,7 @@ export default function ExportLogsPage() {
     try {
       const response = await fetch(EXPORT_URL, { method: "POST" });
       if (response.status === 429) {
-        toast.error("A log export is already in progress. Try again shortly.");
+        toast.error(t("toasts.alreadyRunning.message"));
         return;
       }
       if (!response.ok) {
@@ -276,7 +286,7 @@ export default function ExportLogsPage() {
       writeExportIdToUrl(body.export_id);
     } catch (error) {
       console.error("Error starting log export:", error);
-      toast.error("Failed to start the log export.");
+      toast.error(t("toasts.startFailed.message"));
     } finally {
       setIsStarting(false);
     }
@@ -290,7 +300,7 @@ export default function ExportLogsPage() {
       : [
           ...status.receipts.map((receipt) => ({
             workerName: receipt.worker_name,
-            label: receiptLabel(receipt),
+            label: receiptLabel(receipt, t),
             pending: false,
           })),
           ...status.pending_worker_names.map((workerName) => ({
@@ -299,33 +309,33 @@ export default function ExportLogsPage() {
             // worker's logs are not in the bundle.
             label:
               status.state === "ready"
-                ? "did not report before the deadline"
-                : "collecting...",
+                ? t("worker.missedDeadline.label")
+                : t("worker.collecting.label"),
             pending: true,
           })),
         ].sort((a, b) => a.workerName.localeCompare(b.workerName));
 
   const buttonLabel = isStarting
-    ? "Starting..."
+    ? t("button.starting.label")
     : isCollecting
-      ? "Collecting..."
+      ? t("button.collecting.label")
       : isDownloading
-        ? "Downloading..."
-        : "Export Logs";
+        ? t("button.downloading.label")
+        : t("button.export.label");
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
-        description={DESCRIPTION}
+        title={adminRouteTitle(route)}
+        description={t("header.description")}
         divider
       />
       <SettingsLayouts.Body>
         <MessageCard
           variant="warning"
-          title="Logs may contain sensitive data"
-          description="Log files can include user emails, document titles, search queries, and error payloads. Review the contents before sharing them outside your organization."
+          title={t("sensitiveWarning.title")}
+          description={t("sensitiveWarning.description")}
         />
         <Card border="solid" rounding={4}>
           <Section alignItems="start" height="fit">
@@ -333,8 +343,8 @@ export default function ExportLogsPage() {
               sizePreset="main-ui"
               variant="section"
               icon={SvgDownload}
-              title="Export logs"
-              description="Collects log files from the API server and background workers into a single zip. The download starts automatically once collection finishes."
+              title={t("exportCard.title")}
+              description={t("exportCard.description")}
               rightChildren={
                 <Button
                   icon={SvgDownload}
@@ -352,7 +362,7 @@ export default function ExportLogsPage() {
             <Section alignItems="start" height="fit">
               {workerRows.length === 0 ? (
                 <Text font="main-ui-body" color="text-02">
-                  Starting collection...
+                  {t("status.startingCollection.label")}
                 </Text>
               ) : (
                 workerRows.map((row) => (
@@ -372,7 +382,7 @@ export default function ExportLogsPage() {
                     onClick={() => void downloadBundle(status.export_id)}
                     disabled={isDownloading}
                   >
-                    Download
+                    {t("downloadButton.label")}
                   </Button>
                 </Section>
               )}

--- a/web/src/app/ee/admin/performance/custom-analytics/CustomAnalyticsUpdateForm.tsx
+++ b/web/src/app/ee/admin/performance/custom-analytics/CustomAnalyticsUpdateForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Label, SubLabel } from "@/components/Field";
 import { toast } from "@opal/layouts";
 import { useCustomAnalyticsScript } from "@/lib/analytics/hooks";
@@ -9,6 +10,7 @@ import { useState } from "react";
 import { Spacer } from "@opal/components";
 
 export default function CustomAnalyticsUpdateForm() {
+  const t = useTranslations("admin.customAnalytics");
   const customAnalyticsScript = useCustomAnalyticsScript();
 
   const [newCustomAnalyticsScript, setNewCustomAnalyticsScript] =
@@ -35,28 +37,19 @@ export default function CustomAnalyticsUpdateForm() {
             }
           );
           if (response.ok) {
-            toast.success("Custom analytics script updated successfully!");
+            toast.success(t("updateSuccess.message"));
           } else {
             const errorMsg = (await response.json()).detail;
-            toast.error(
-              `Failed to update custom analytics script: "${errorMsg}"`
-            );
+            toast.error(t("updateFailed.message", { error: errorMsg }));
           }
           setSecretKey("");
         }}
       >
         <div className="mb-4">
-          <Label>Script</Label>
-          <Text as="p">
-            Specify the Javascript that should run on page load in order to
-            initialize your custom tracking/analytics.
-          </Text>
+          <Label>{t("script.label")}</Label>
+          <Text as="p">{t("script.description")}</Text>
           <Spacer rem={0.75} />
-          <Text as="p">
-            {markdown(
-              "Do not include the `<script></script>` tags. If you upload a script below but you are not receiving any events in your analytics platform, try removing all extra whitespace before each line of JavaScript."
-            )}
-          </Text>
+          <Text as="p">{markdown(t("script.instructions"))}</Text>
           <Spacer rem={0.5} />
           <InputTextArea
             value={newCustomAnalyticsScript}
@@ -66,13 +59,12 @@ export default function CustomAnalyticsUpdateForm() {
           />
         </div>
 
-        <Label>Secret Key</Label>
+        <Label>{t("secretKey.label")}</Label>
         <SubLabel>
           <>
-            For security reasons, you must provide a secret key to update this
-            script. This should be the value of the{" "}
-            <i>CUSTOM_ANALYTICS_SECRET_KEY</i> environment variable set when
-            initially setting up Onyx.
+            {t.rich("secretKey.description", {
+              i: (chunks) => <i>{chunks}</i>,
+            })}
           </>
         </SubLabel>
         <input
@@ -89,7 +81,7 @@ export default function CustomAnalyticsUpdateForm() {
           onChange={(e) => setSecretKey(e.target.value)}
         />
         <Spacer rem={1} />
-        <Button type="submit">Update</Button>
+        <Button type="submit">{t("updateButton.label")}</Button>
       </form>
     </div>
   );

--- a/web/src/app/ee/admin/performance/custom-analytics/page.tsx
+++ b/web/src/app/ee/admin/performance/custom-analytics/page.tsx
@@ -1,3 +1,5 @@
+import { getAdminNavId } from "@/lib/adminNavLabels";
+import { getTranslations } from "next-intl/server";
 import { SettingsLayouts } from "@opal/layouts";
 import { CUSTOM_ANALYTICS_ENABLED } from "@/lib/constants";
 import { Callout } from "@/components/ui/callout";
@@ -8,15 +10,17 @@ import CustomAnalyticsUpdateForm from "./CustomAnalyticsUpdateForm";
 
 const route = ADMIN_ROUTES.CUSTOM_ANALYTICS;
 
-function Main() {
+async function Main() {
+  const t = await getTranslations("admin.customAnalytics");
+
   if (!CUSTOM_ANALYTICS_ENABLED) {
     return (
       <div>
         <div className="mt-4">
-          <Callout type="danger" title="Custom Analytics is not enabled.">
-            To set up custom analytics scripts, please work with the team who
-            setup Onyx in your team to set the{" "}
-            <i>CUSTOM_ANALYTICS_SECRET_KEY</i> environment variable.
+          <Callout type="danger" title={t("notEnabled.title")}>
+            {t.rich("notEnabled.description", {
+              i: (chunks) => <i>{chunks}</i>,
+            })}
           </Callout>
         </div>
       </div>
@@ -25,11 +29,7 @@ function Main() {
 
   return (
     <div>
-      <Text as="p">
-        {
-          "This allows you to bring your own analytics tool to Onyx! Copy the Web snippet from your analytics provider into the box below, and we'll start sending usage events."
-        }
-      </Text>
+      <Text as="p">{t("intro.description")}</Text>
       <Spacer rem={2} />
 
       <CustomAnalyticsUpdateForm />
@@ -37,10 +37,17 @@ function Main() {
   );
 }
 
-export default function Page() {
+export default async function Page() {
+  const tSidebar = await getTranslations("sidebar");
+  const navId = getAdminNavId(route);
+  const routeTitle = navId
+    ? tSidebar(
+        `adminNav.items.${navId}.label` as Parameters<typeof tSidebar>[0]
+      )
+    : route.title;
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header icon={route.icon} title={routeTitle} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/ee/admin/performance/custom-analytics/page.tsx
+++ b/web/src/app/ee/admin/performance/custom-analytics/page.tsx
@@ -1,4 +1,4 @@
-import { getAdminNavId } from "@/lib/adminNavLabels";
+import { getAdminNavId } from "@/lib/admin-sidebar-utils";
 import { getTranslations } from "next-intl/server";
 import { SettingsLayouts } from "@opal/layouts";
 import { CUSTOM_ANALYTICS_ENABLED } from "@/lib/constants";

--- a/web/src/app/ee/admin/performance/query-history/FeedbackBadge.tsx
+++ b/web/src/app/ee/admin/performance/query-history/FeedbackBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Feedback } from "@/lib/types";
 
@@ -6,33 +7,34 @@ export function FeedbackBadge({
 }: {
   feedback?: Feedback | "mixed" | null;
 }) {
+  const t = useTranslations("admin.queryHistory");
   let feedbackBadge;
   switch (feedback) {
     case "like":
       feedbackBadge = (
         <Badge variant="success" className="text-sm">
-          Like
+          {t("feedback.like.label")}
         </Badge>
       );
       break;
     case "dislike":
       feedbackBadge = (
         <Badge variant="destructive" className="text-sm">
-          Dislike
+          {t("feedback.dislike.label")}
         </Badge>
       );
       break;
     case "mixed":
       feedbackBadge = (
         <Badge variant="purple" className="text-sm">
-          Mixed
+          {t("feedback.mixed.label")}
         </Badge>
       );
       break;
     default:
       feedbackBadge = (
         <Badge variant="outline" className="text-sm">
-          N/A
+          {t("feedback.na.label")}
         </Badge>
       );
       break;

--- a/web/src/app/ee/admin/performance/query-history/KickoffCSVExport.tsx
+++ b/web/src/app/ee/admin/performance/query-history/KickoffCSVExport.tsx
@@ -3,13 +3,13 @@
 import { toast } from "@opal/layouts";
 import { Button } from "@opal/components";
 import { useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import type { DateRange } from "@/refresh-components/DateRangePicker";
 import { withRequestId, withDateRange } from "./utils";
 import {
   CHECK_QUERY_HISTORY_EXPORT_STATUS_URL,
   DOWNLOAD_QUERY_HISTORY_URL,
   MAX_RETRIES,
-  PREVIOUS_CSV_TASK_BUTTON_NAME,
   RETRY_COOLDOWN_MILLISECONDS,
 } from "./constants";
 import {
@@ -24,6 +24,7 @@ export default function KickoffCSVExport({
 }: {
   dateRange: DateRange;
 }) {
+  const t = useTranslations("admin.queryHistory");
   const timerIdRef = useRef<null | number>(null);
   const retryCount = useRef<number>(0);
   const [, rerender] = useState<void>();
@@ -38,7 +39,7 @@ export default function KickoffCSVExport({
     retryCount.current = 0;
 
     if (failure) {
-      toast.error("Failed to download the query-history.");
+      toast.error(t("export.downloadFailed.message"));
     }
 
     rerender();
@@ -53,7 +54,9 @@ export default function KickoffCSVExport({
 
     setSpinnerStatus("spinning");
     toast.info(
-      `Generating CSV report. Click the '${PREVIOUS_CSV_TASK_BUTTON_NAME}' button to see all jobs.`
+      t("export.generating.message", {
+        button: t("previousExports.label"),
+      })
     );
     const response = await fetch(withDateRange(dateRange), {
       method: "POST",
@@ -121,7 +124,9 @@ export default function KickoffCSVExport({
           variant={spinnerStatus === "spinning" ? "danger" : "default"}
           icon={spinnerStatus === "spinning" ? SvgSimpleLoader : SvgPlayCircle}
         >
-          {spinnerStatus === "spinning" ? "Cancel" : "Kickoff Export"}
+          {spinnerStatus === "spinning"
+            ? t("export.cancel.label")
+            : t("export.kickoff.label")}
         </Button>
       </div>
     </div>

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableHead,
@@ -35,7 +36,6 @@ import {
   NUM_IN_PAGE,
   ITEMS_PER_PAGE,
   PAGES_PER_BATCH,
-  PREVIOUS_CSV_TASK_BUTTON_NAME,
 } from "@/app/ee/admin/performance/query-history/constants";
 import { humanReadableFormatWithTime } from "@opal/time";
 import { Modal } from "@opal/components";
@@ -55,6 +55,7 @@ function QueryHistoryTableRow({
 }: {
   chatSessionMinimal: ChatSessionMinimal;
 }) {
+  const t = useTranslations("admin.queryHistory");
   return (
     <TableRow
       key={chatSessionMinimal.id}
@@ -76,7 +77,9 @@ function QueryHistoryTableRow({
         <FeedbackBadge feedback={chatSessionMinimal.feedback_type} />
       </TableCell>
       <TableCell>{chatSessionMinimal.user_email || "-"}</TableCell>
-      <TableCell>{chatSessionMinimal.assistant_name || "Unknown"}</TableCell>
+      <TableCell>
+        {chatSessionMinimal.assistant_name || t("assistant.unknown.label")}
+      </TableCell>
       <TableCell>
         {timestampToReadableDate(chatSessionMinimal.time_created)}
       </TableCell>
@@ -100,10 +103,11 @@ function SelectFeedbackType({
   value: Feedback | "all";
   onValueChange: (value: Feedback | "all") => void;
 }) {
+  const t = useTranslations("admin.queryHistory");
   return (
     <Section alignItems="start" gap={1}>
       <Text as="p" className="font-medium">
-        Feedback Type
+        {t("filters.feedbackType.label")}
       </Text>
       <InputSelect
         value={value}
@@ -113,16 +117,16 @@ function SelectFeedbackType({
 
         <InputSelect.Content>
           <InputSelect.Item value="all" icon={SvgMinusCircle}>
-            Any
+            {t("filters.any.label")}
           </InputSelect.Item>
           <InputSelect.Item value="like" icon={SvgThumbsUp}>
-            Like
+            {t("feedback.like.label")}
           </InputSelect.Item>
           <InputSelect.Item value="dislike" icon={SvgThumbsDown}>
-            Dislike
+            {t("feedback.dislike.label")}
           </InputSelect.Item>
           <InputSelect.Item value="mixed" icon={SvgMinus}>
-            Mixed
+            {t("feedback.mixed.label")}
           </InputSelect.Item>
         </InputSelect.Content>
       </InputSelect>
@@ -131,11 +135,17 @@ function SelectFeedbackType({
 }
 
 function ExportBadge({ status }: { status: TaskStatus }) {
-  if (status === "SUCCESS") return <Badge variant="success">Success</Badge>;
+  const t = useTranslations("admin.queryHistory");
+  if (status === "SUCCESS")
+    return <Badge variant="success">{t("exportStatus.success.label")}</Badge>;
   else if (status === "FAILURE")
-    return <Badge variant="destructive">Failure</Badge>;
+    return (
+      <Badge variant="destructive">{t("exportStatus.failure.label")}</Badge>
+    );
   else if (status === "PENDING" || status === "STARTED")
-    return <Badge variant="in_progress">Pending</Badge>;
+    return (
+      <Badge variant="in_progress">{t("exportStatus.pending.label")}</Badge>
+    );
   else return <></>;
 }
 
@@ -144,6 +154,7 @@ function PreviousQueryHistoryExportsModal({
 }: {
   setShowModal: Dispatch<SetStateAction<boolean>>;
 }) {
+  const t = useTranslations("admin.queryHistory");
   const { data: queryHistoryTasks } = useSWR<TaskQueueState[]>(
     LIST_QUERY_HISTORY_URL,
     errorHandlingFetcher,
@@ -179,18 +190,18 @@ function PreviousQueryHistoryExportsModal({
       <Modal.Content width="full" height="full">
         <Modal.Header
           icon={SvgFileText}
-          title="Previous Query History Exports"
+          title={t("exportsModal.header.title")}
           onClose={() => setShowModal(false)}
         />
         <Modal.Body>
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Generated At</TableHead>
-                <TableHead>Start Range</TableHead>
-                <TableHead>End Range</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Download</TableHead>
+                <TableHead>{t("exportsModal.generatedAt.header")}</TableHead>
+                <TableHead>{t("exportsModal.startRange.header")}</TableHead>
+                <TableHead>{t("exportsModal.endRange.header")}</TableHead>
+                <TableHead>{t("exportsModal.status.header")}</TableHead>
+                <TableHead>{t("exportsModal.download.header")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -213,7 +224,7 @@ function PreviousQueryHistoryExportsModal({
                       disabled={task.status !== "SUCCESS"}
                       tooltip={
                         task.status !== "SUCCESS"
-                          ? "Export is not yet ready"
+                          ? t("exportsModal.notReady.tooltip")
                           : undefined
                       }
                       href={
@@ -264,6 +275,7 @@ export function QueryHistoryTable({
   filters,
   setFilters,
 }: QueryHistoryTableProps) {
+  const t = useTranslations("admin.queryHistory");
   const [showModal, setShowModal] = useState(false);
 
   const {
@@ -283,7 +295,7 @@ export function QueryHistoryTable({
   if (error) {
     return (
       <ErrorCallout
-        errorTitle="Error fetching query history"
+        errorTitle={t("table.fetchError.title")}
         errorMsg={error?.message}
       />
     );
@@ -312,7 +324,7 @@ export function QueryHistoryTable({
           <div className="flex flex-row w-full items-center gap-x-2">
             <KickoffCSVExport dateRange={dateRange} />
             <Button prominence="secondary" onClick={() => setShowModal(true)}>
-              {PREVIOUS_CSV_TASK_BUTTON_NAME}
+              {t("previousExports.label")}
             </Button>
           </div>
         </div>
@@ -321,12 +333,12 @@ export function QueryHistoryTable({
           <Table className="mt-5">
             <TableHeader>
               <TableRow>
-                <TableHead>First User Message</TableHead>
-                <TableHead>First AI Response</TableHead>
-                <TableHead>Feedback</TableHead>
-                <TableHead>User</TableHead>
-                <TableHead>Persona</TableHead>
-                <TableHead>Date</TableHead>
+                <TableHead>{t("table.firstUserMessage.header")}</TableHead>
+                <TableHead>{t("table.firstAiResponse.header")}</TableHead>
+                <TableHead>{t("table.feedback.header")}</TableHead>
+                <TableHead>{t("table.user.header")}</TableHead>
+                <TableHead>{t("table.persona.header")}</TableHead>
+                <TableHead>{t("table.date.header")}</TableHead>
               </TableRow>
             </TableHeader>
             {isLoading ? (

--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { use } from "react";
+import { useTranslations } from "next-intl";
 
 import { Divider, Text } from "@opal/components";
 import Title from "@/components/ui/title";
@@ -17,15 +18,20 @@ import { PageLoader } from "@opal/layouts";
 import CardSection from "@/components/admin/CardSection";
 
 function MessageDisplay({ message }: { message: MessageSnapshot }) {
+  const t = useTranslations("admin.queryHistory");
   return (
     <div>
       <p className="text-xs font-bold mb-1">
-        {message.message_type === "user" ? "User" : "AI"}
+        {message.message_type === "user"
+          ? t("detail.user.label")
+          : t("detail.ai.label")}
       </p>
       <Text as="p">{message.message}</Text>
       {message.documents.length > 0 && (
         <div className="flex flex-col gap-y-2 mt-2">
-          <p className="font-bold text-xs">Reference Documents</p>
+          <p className="font-bold text-xs">
+            {t("detail.referenceDocuments.title")}
+          </p>
           {message.documents.slice(0, 5).map((document) => {
             return (
               <div className="text-sm flex" key={document.document_id}>
@@ -53,7 +59,7 @@ function MessageDisplay({ message }: { message: MessageSnapshot }) {
       )}
       {message.feedback_type && (
         <div className="mt-2">
-          <p className="font-bold text-xs">Feedback</p>
+          <p className="font-bold text-xs">{t("detail.feedback.title")}</p>
           {message.feedback_text && <Text as="p">{message.feedback_text}</Text>}
           <div className="mt-1">
             <FeedbackBadge feedback={message.feedback_type} />
@@ -66,6 +72,7 @@ function MessageDisplay({ message }: { message: MessageSnapshot }) {
 }
 
 export default function QueryPage(props: { params: Promise<{ id: string }> }) {
+  const t = useTranslations("admin.queryHistory");
   const params = use(props.params);
   const {
     data: chatSessionSnapshot,
@@ -83,8 +90,8 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
   if (!chatSessionSnapshot || error) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch chat session - ${error}`}
+        errorTitle={t("detail.errorTitle.title")}
+        errorMsg={t("detail.fetchFailed.message", { error: String(error) })}
       />
     );
   }
@@ -94,7 +101,7 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
       <BackButton />
 
       <CardSection className="mt-4">
-        <Title>Chat Session Details</Title>
+        <Title>{t("detail.header.title")}</Title>
 
         <Spacer rem={0.25} />
         {chatSessionSnapshot.assistant_name && (

--- a/web/src/app/ee/admin/performance/query-history/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { SettingsLayouts } from "@opal/layouts";
 import {
   QueryHistoryFilters,
@@ -16,6 +17,7 @@ import { useCallback, useState } from "react";
 const route = ADMIN_ROUTES.QUERY_HISTORY;
 
 export default function QueryHistoryPage() {
+  const adminRouteTitle = useAdminRouteTitle();
   const initialRange = rangeForInclusiveDays(30);
   const [dateRange, setDateRange] = useState<DateRange>(initialRange);
   const [filters, setFilters] = useState<QueryHistoryFilters>(() => {
@@ -49,7 +51,7 @@ export default function QueryHistoryPage() {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         divider
         rightChildren={
           <DateRangePicker

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
+import { useTranslations } from "next-intl";
 import { DateRangePicker } from "@/refresh-components/DateRangePicker";
 import { useTimeRange } from "@/lib/usage/hooks";
 import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
@@ -11,14 +13,16 @@ import TokenRateLimitsPanel from "@/app/admin/token-rate-limits/TokenRateLimitsP
 const route = ADMIN_ROUTES.USAGE;
 
 export default function UsagePage() {
+  const t = useTranslations("admin.usage");
+  const adminRouteTitle = useAdminRouteTitle();
   const [timeRange, setTimeRange] = useTimeRange();
 
   return (
     <SettingsLayouts.Root width="lg">
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
-        description="Monitor workspace spend and review usage by user."
+        title={adminRouteTitle(route)}
+        description={t("page.description")}
         divider
         rightChildren={
           <DateRangePicker

--- a/web/src/app/ee/admin/standard-answer/StandardAnswerCreationForm.tsx
+++ b/web/src/app/ee/admin/standard-answer/StandardAnswerCreationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "@opal/layouts";
 import { StandardAnswerCategory, StandardAnswer } from "@/lib/types";
 import CardSection from "@/components/admin/CardSection";
@@ -39,6 +40,7 @@ export const StandardAnswerCreationForm = ({
   standardAnswerCategories: StandardAnswerCategory[];
   existingStandardAnswer?: StandardAnswer;
 }) => {
+  const t = useTranslations("admin.standardAnswers");
   const isUpdate = existingStandardAnswer !== undefined;
   const router = useRouter();
   const [categoryInput, setCategoryInput] = useState("");
@@ -66,13 +68,15 @@ export const StandardAnswerCreationForm = ({
           }}
           validationSchema={Yup.object().shape({
             keyword: Yup.string()
-              .required("Keywords or pattern is required")
+              .required(t("form.validation.keywordRequired"))
               .max(255)
               .min(1),
-            answer: Yup.string().required("Answer is required").min(1),
+            answer: Yup.string()
+              .required(t("form.validation.answerRequired"))
+              .min(1),
             categories: Yup.array()
               .required()
-              .min(1, "At least one category is required"),
+              .min(1, t("form.validation.categoryRequired")),
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
@@ -102,8 +106,8 @@ export const StandardAnswerCreationForm = ({
               const errorMsg = responseJson.detail || responseJson.message;
               toast.error(
                 isUpdate
-                  ? `Error updating Standard Answer - ${errorMsg}`
-                  : `Error creating Standard Answer - ${errorMsg}`
+                  ? t("form.toasts.updateFailed.message", { error: errorMsg })
+                  : t("form.toasts.createFailed.message", { error: errorMsg })
               );
             }
           }}
@@ -113,45 +117,45 @@ export const StandardAnswerCreationForm = ({
               {values.matchRegex ? (
                 <TextFormField
                   name="keyword"
-                  label="Regex pattern"
+                  label={t("form.regexPattern.label")}
                   isCode
-                  tooltip="Triggers if the question matches this regex pattern (using Python `re.search()`)"
+                  tooltip={t("form.regexPattern.tooltip")}
                   placeholder="(?:it|support)\s*ticket"
                 />
               ) : values.matchAnyKeywords == "any" ? (
                 <TextFormField
                   name="keyword"
-                  label="Any of these keywords, separated by spaces"
-                  tooltip="A question must match these keywords in order to trigger the answer."
-                  placeholder="ticket problem issue"
+                  label={t("form.anyKeywords.label")}
+                  tooltip={t("form.keywords.tooltip")}
+                  placeholder={t("form.anyKeywords.placeholder")}
                 />
               ) : (
                 <TextFormField
                   name="keyword"
-                  label="All of these keywords, in any order, separated by spaces"
-                  tooltip="A question must match these keywords in order to trigger the answer."
-                  placeholder="it ticket"
+                  label={t("form.allKeywords.label")}
+                  tooltip={t("form.keywords.tooltip")}
+                  placeholder={t("form.allKeywords.placeholder")}
                 />
               )}
               <BooleanFormField
-                subtext="Match a regex pattern instead of an exact keyword"
+                subtext={t("form.matchRegex.description")}
                 optional
-                label="Match regex"
+                label={t("form.matchRegex.label")}
                 name="matchRegex"
               />
               {values.matchRegex ? null : (
                 <SelectorFormField
                   defaultValue={`all`}
-                  label="Keyword detection strategy"
-                  subtext="Choose whether to require the user's question to contain any or all of the keywords above to show this answer."
+                  label={t("form.strategy.label")}
+                  subtext={t("form.strategy.description")}
                   name="matchAnyKeywords"
                   options={[
                     {
-                      name: "All keywords",
+                      name: t("form.strategy.all.label"),
                       value: "all",
                     },
                     {
-                      name: "Any keywords",
+                      name: t("form.strategy.any.label"),
                       value: "any",
                     },
                   ]}
@@ -163,14 +167,14 @@ export const StandardAnswerCreationForm = ({
               <div className="w-full">
                 <MarkdownFormField
                   name="answer"
-                  label="Answer"
-                  placeholder="The answer in Markdown. Example: If you need any help from the IT team, please email internalsupport@company.com"
+                  label={t("form.answer.label")}
+                  placeholder={t("form.answer.placeholder")}
                 />
               </div>
               <div className="w-4/12 flex flex-col gap-2">
-                <Label>Categories:</Label>
+                <Label>{t("form.categories.label")}</Label>
                 <InputChipField
-                  placeholder="Type a category and press Enter…"
+                  placeholder={t("form.categories.placeholder")}
                   value={categoryInput}
                   onChange={setCategoryInput}
                   chips={values.categories.map((category) => ({
@@ -220,7 +224,10 @@ export const StandardAnswerCreationForm = ({
                       const errorMsg =
                         responseJson.detail || responseJson.message;
                       toast.error(
-                        `Error creating category "${name}" - ${errorMsg}`
+                        t("form.toasts.categoryCreateFailed.message", {
+                          name,
+                          error: errorMsg,
+                        })
                       );
                       return;
                     }
@@ -243,7 +250,9 @@ export const StandardAnswerCreationForm = ({
               </div>
               <div className="py-4 mx-auto w-64">
                 <Button type="submit" disabled={isSubmitting} width="full">
-                  {isUpdate ? "Update!" : "Create!"}
+                  {isUpdate
+                    ? t("form.updateButton.label")
+                    : t("form.createButton.label")}
                 </Button>
               </div>
             </Form>

--- a/web/src/app/ee/admin/standard-answer/[id]/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
 import { StandardAnswerCreationForm } from "@/app/ee/admin/standard-answer/StandardAnswerCreationForm";
 import {
@@ -14,6 +15,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 const route = ADMIN_ROUTES.STANDARD_ANSWERS;
 
 function Body({ id }: { id: string }) {
+  const t = useTranslations("admin.standardAnswers");
   const {
     data: standardAnswers,
     isLoading: answersLoading,
@@ -32,8 +34,8 @@ function Body({ id }: { id: string }) {
   if (answersError || categoriesError || !standardAnswerCategories) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg="Failed to fetch standard answers"
+        errorTitle={t("errors.genericTitle.title")}
+        errorMsg={t("errors.fetchAnswersFailed.message")}
       />
     );
   }
@@ -45,8 +47,8 @@ function Body({ id }: { id: string }) {
   if (!standardAnswer) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Did not find standard answer with ID: ${id}`}
+        errorTitle={t("errors.genericTitle.title")}
+        errorMsg={t("errors.notFound.message", { id })}
       />
     );
   }
@@ -60,13 +62,14 @@ function Body({ id }: { id: string }) {
 }
 
 export default function Page() {
+  const t = useTranslations("admin.standardAnswers");
   const params = useParams<{ id: string }>();
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title="Edit Standard Answer"
+        title={t("editPage.title")}
         backButton
         divider
       />

--- a/web/src/app/ee/admin/standard-answer/new/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { StandardAnswerCreationForm } from "@/app/ee/admin/standard-answer/StandardAnswerCreationForm";
 import { useStandardAnswerCategories } from "@/app/ee/admin/standard-answer/hooks";
 import { ErrorCallout } from "@/components/ErrorCallout";
@@ -10,6 +11,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 const route = ADMIN_ROUTES.STANDARD_ANSWERS;
 
 function Body() {
+  const t = useTranslations("admin.standardAnswers");
   const {
     data: standardAnswerCategories,
     isLoading,
@@ -23,8 +25,8 @@ function Body() {
   if (error || !standardAnswerCategories) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg="Failed to fetch standard answer categories"
+        errorTitle={t("errors.genericTitle.title")}
+        errorMsg={t("errors.fetchCategoriesFailed.message")}
       />
     );
   }
@@ -37,11 +39,12 @@ function Body() {
 }
 
 export default function Page() {
+  const t = useTranslations("admin.standardAnswers");
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title="New Standard Answer"
+        title={t("newStandardAnswer.label")}
         backButton
         divider
       />

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
+import { useTranslations } from "next-intl";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import { useStandardAnswers, useStandardAnswerCategories } from "./hooks";
 import { PageLoader } from "@opal/layouts";
@@ -71,6 +73,8 @@ const CategoryBubble = ({
   name: string;
   onDelete?: () => void;
 }) => {
+  const t = useTranslations("admin.standardAnswers");
+  const adminRouteTitle = useAdminRouteTitle();
   const className = cn(
     "inline-block px-2 py-1 me-1 mb-1 text-xs font-semibold text-emphasis bg-accent-background-hovered rounded-full items-center w-fit",
     onDelete && "cursor-pointer"
@@ -85,14 +89,14 @@ const CategoryBubble = ({
       className={className}
       role="button"
       tabIndex={0}
-      aria-label={`Remove category ${name}`}
+      aria-label={t("categoryBubble.remove.ariaLabel", { name })}
       onKeyDown={clickOnKeyDown(onDelete)}
       onClick={onDelete}
     >
       {name}
       <button
         className="ms-1 text-subtle hover:text-emphasis"
-        aria-label="Remove category"
+        aria-label={t("categoryBubble.removeButton.ariaLabel")}
       >
         &times;
       </button>
@@ -107,6 +111,8 @@ const StandardAnswersTableRow = ({
   standardAnswer: StandardAnswer;
   handleDelete: (id: number) => void;
 }) => {
+  const t = useTranslations("admin.standardAnswers");
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <RowTemplate
       id={standardAnswer.id}
@@ -132,9 +138,13 @@ const StandardAnswersTableRow = ({
           className="flex items-center"
         >
           {standardAnswer.match_regex ? (
-            <span className="text-green-500 font-medium">Yes</span>
+            <span className="text-green-500 font-medium">
+              {t("table.matchRegexYes.label")}
+            </span>
           ) : (
-            <span className="text-gray-500">No</span>
+            <span className="text-gray-500">
+              {t("table.matchRegexNo.label")}
+            </span>
           )}
         </div>,
         <ReactMarkdown
@@ -163,6 +173,8 @@ const StandardAnswersTable = ({
   standardAnswerCategories: StandardAnswerCategory[];
   refresh: () => void;
 }) => {
+  const t = useTranslations("admin.standardAnswers");
+  const adminRouteTitle = useAdminRouteTitle();
   const [query, setQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategories, setSelectedCategories] = useState<
@@ -171,10 +183,10 @@ const StandardAnswersTable = ({
   const focusOnMount = useFocusOnMount<HTMLTextAreaElement>();
   const columns = [
     { name: "", key: "edit" },
-    { name: "Categories", key: "category" },
-    { name: "Keywords/Pattern", key: "keyword" },
-    { name: "Match regex?", key: "match_regex" },
-    { name: "Answer", key: "answer" },
+    { name: t("table.categories.header"), key: "category" },
+    { name: t("table.keywords.header"), key: "keyword" },
+    { name: t("table.matchRegex.header"), key: "match_regex" },
+    { name: t("table.answer.header"), key: "answer" },
     { name: "", key: "delete" },
   ];
 
@@ -216,10 +228,10 @@ const StandardAnswersTable = ({
   const handleDelete = async (id: number) => {
     const response = await deleteStandardAnswer(id);
     if (response.ok) {
-      toast.success(`Standard answer ${id} deleted`);
+      toast.success(t("toasts.deleted.message", { id }));
     } else {
       const errorMsg = await response.text();
-      toast.error(`Failed to delete standard answer - ${errorMsg}`);
+      toast.error(t("toasts.deleteFailed.message", { error: errorMsg }));
     }
     refresh();
   };
@@ -241,7 +253,7 @@ const StandardAnswersTable = ({
         <textarea
           ref={focusOnMount}
           className="grow ms-2 h-6 bg-transparent outline-hidden placeholder-subtle overflow-hidden whitespace-normal resize-none"
-          placeholder="Find standard answers by keyword/phrase..."
+          placeholder={t("search.placeholder")}
           value={query}
           onChange={(event) => {
             setQuery(event.target.value);
@@ -276,7 +288,7 @@ const StandardAnswersTable = ({
               <FiTag size={16} />
             </div>
           }
-          defaultDisplay="All Categories"
+          defaultDisplay={t("filter.allCategories.label")}
         />
         <div className="flex flex-wrap pb-4 mt-3">
           {selectedCategories.map((category) => (
@@ -315,18 +327,14 @@ const StandardAnswersTable = ({
         <div>
           {paginatedStandardAnswers.length === 0 && (
             <div className="flex justify-center">
-              <Text as="p">No matching standard answers found...</Text>
+              <Text as="p">{t("table.empty.message")}</Text>
             </div>
           )}
         </div>
         {paginatedStandardAnswers.length > 0 && (
           <>
             <div className="mt-4">
-              <Text as="p">
-                {markdown(
-                  "Ensure that you have added the category to the relevant [Slack Bot](/admin/bots)."
-                )}
-              </Text>
+              <Text as="p">{markdown(t("table.slackNote.message"))}</Text>
             </div>
             <div className="mt-4 flex justify-center">
               <PageSelector
@@ -344,6 +352,8 @@ const StandardAnswersTable = ({
 };
 
 function Main() {
+  const t = useTranslations("admin.standardAnswers");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: standardAnswers,
     error: standardAnswersError,
@@ -363,7 +373,7 @@ function Main() {
   if (standardAnswersError || !standardAnswers) {
     return (
       <ErrorCallout
-        errorTitle="Error loading standard answers"
+        errorTitle={t("errors.loadAnswersFailed.title")}
         errorMsg={
           standardAnswersError.info?.detail ||
           standardAnswersError.info?.message
@@ -375,7 +385,7 @@ function Main() {
   if (standardAnswerCategoriesError || !standardAnswerCategories) {
     return (
       <ErrorCallout
-        errorTitle="Error loading standard answer categories"
+        errorTitle={t("errors.loadCategoriesFailed.title")}
         errorMsg={
           standardAnswerCategoriesError.info?.detail ||
           standardAnswerCategoriesError.info?.message
@@ -386,15 +396,11 @@ function Main() {
 
   return (
     <div className="mb-8">
-      <Text as="p">
-        {markdown(
-          "Manage the standard answers for pre-defined questions.\nNote: Currently, only questions asked from Slack can receive standard answers."
-        )}
-      </Text>
+      <Text as="p">{markdown(t("intro.description"))}</Text>
       <Spacer rem={0.5} />
       {standardAnswers.length == 0 && (
         <>
-          <Text as="p">Add your first standard answer below!</Text>
+          <Text as="p">{t("intro.addFirst.message")}</Text>
           <Spacer rem={0.5} />
         </>
       )}
@@ -405,7 +411,7 @@ function Main() {
         prominence="secondary"
         href="/admin/standard-answer/new"
       >
-        New Standard Answer
+        {t("newStandardAnswer.label")}
       </Button>
 
       <Divider />
@@ -422,9 +428,14 @@ function Main() {
 }
 
 export default function Page() {
+  const adminRouteTitle = useAdminRouteTitle();
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -74,7 +74,6 @@ const CategoryBubble = ({
   onDelete?: () => void;
 }) => {
   const t = useTranslations("admin.standardAnswers");
-  const adminRouteTitle = useAdminRouteTitle();
   const className = cn(
     "inline-block px-2 py-1 me-1 mb-1 text-xs font-semibold text-emphasis bg-accent-background-hovered rounded-full items-center w-fit",
     onDelete && "cursor-pointer"
@@ -112,7 +111,6 @@ const StandardAnswersTableRow = ({
   handleDelete: (id: number) => void;
 }) => {
   const t = useTranslations("admin.standardAnswers");
-  const adminRouteTitle = useAdminRouteTitle();
   return (
     <RowTemplate
       id={standardAnswer.id}
@@ -174,7 +172,6 @@ const StandardAnswersTable = ({
   refresh: () => void;
 }) => {
   const t = useTranslations("admin.standardAnswers");
-  const adminRouteTitle = useAdminRouteTitle();
   const [query, setQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategories, setSelectedCategories] = useState<
@@ -353,7 +350,6 @@ const StandardAnswersTable = ({
 
 function Main() {
   const t = useTranslations("admin.standardAnswers");
-  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: standardAnswers,
     error: standardAnswersError,

--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { FormField } from "@/refresh-components/form/FormField";
 import {
   Button,
@@ -59,6 +60,7 @@ export const AppearanceThemeSettings = forwardRef<
   { selectedLogo, setSelectedLogo, logoVersion, charLimits },
   ref
 ) {
+  const t = useTranslations("admin.theme");
   const { values, errors, setFieldValue } = useFormikContext<any>();
   const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -264,7 +266,7 @@ export const AppearanceThemeSettings = forwardRef<
                 />
               }
             >
-              Application Display Name
+              {t("appName.label")}
             </FormField.Label>
             <FormField.Control asChild>
               <InputTypeIn
@@ -280,7 +282,7 @@ export const AppearanceThemeSettings = forwardRef<
               />
             </FormField.Control>
             <FormField.Description>
-              This name will show across the app and replace "Onyx" in the UI.
+              {t("appName.description")}
             </FormField.Description>
             <FormField.Message
               messages={{ error: errors.application_name as string }}
@@ -288,7 +290,7 @@ export const AppearanceThemeSettings = forwardRef<
           </FormField>
 
           <FormField state="idle">
-            <FormField.Label>Logo Display Style</FormField.Label>
+            <FormField.Label>{t("logoStyle.label")}</FormField.Label>
             <FormField.Control>
               <Tabs
                 value={values.logo_display_style}
@@ -299,50 +301,49 @@ export const AppearanceThemeSettings = forwardRef<
                 <Tabs.List>
                   <Tabs.Trigger
                     value="logo_and_name"
-                    tooltip="Show both your application logo and name."
+                    tooltip={t("logoStyle.both.tooltip")}
                     tooltipSide="top"
                     {...getPreviewHandlers("sidebar")}
                   >
-                    Logo & Name
+                    {t("logoStyle.both.label")}
                   </Tabs.Trigger>
                   <Tabs.Trigger
                     value="logo_only"
                     disabled={!hasLogo}
                     tooltip={
                       hasLogo
-                        ? "Show only your application logo."
-                        : "Upload a logo to enable this option."
+                        ? t("logoStyle.logoOnly.tooltip")
+                        : t("logoStyle.logoOnly.disabledTooltip")
                     }
                     tooltipSide="top"
                     {...getPreviewHandlers("sidebar")}
                   >
-                    Logo Only
+                    {t("logoStyle.logoOnly.label")}
                   </Tabs.Trigger>
                   <Tabs.Trigger
                     value="name_only"
                     disabled={!hasApplicationName}
                     tooltip={
                       hasApplicationName
-                        ? "Show only your application name."
-                        : "Enter an application name to enable this option."
+                        ? t("logoStyle.nameOnly.tooltip")
+                        : t("logoStyle.nameOnly.disabledTooltip")
                     }
                     tooltipSide="top"
                     {...getPreviewHandlers("sidebar")}
                   >
-                    Name Only
+                    {t("logoStyle.nameOnly.label")}
                   </Tabs.Trigger>
                 </Tabs.List>
               </Tabs>
             </FormField.Control>
             <FormField.Description>
-              Choose what to display at the top of the sidebar. Options become
-              available once you add a logo or application name.
+              {t("logoStyle.description")}
             </FormField.Description>
           </FormField>
         </div>
 
         <FormField state="idle">
-          <FormField.Label>Application Logo</FormField.Label>
+          <FormField.Label>{t("logo.label")}</FormField.Label>
           <FormField.Control>
             <InputImage
               src={logoSrc}
@@ -362,7 +363,7 @@ export const AppearanceThemeSettings = forwardRef<
               onClick={handleLogoEdit}
               icon={SvgEdit}
             >
-              Update
+              {t("logo.updateButton.label")}
             </Button>
           </div>
         </FormField>
@@ -375,13 +376,14 @@ export const AppearanceThemeSettings = forwardRef<
         logoDisplayStyle={values.logo_display_style}
         applicationDisplayName={values.application_name ?? ""}
         chat_footer_content={
-          values.custom_lower_disclaimer_content || "Chat Footer Content"
+          values.custom_lower_disclaimer_content ||
+          t("preview.chatFooter.placeholder")
         }
         chat_header_content={
-          values.custom_header_content || "Chat Header Content"
+          values.custom_header_content || t("preview.chatHeader.placeholder")
         }
         greeting_message={
-          values.custom_greeting_message || "Welcome to Acme Chat"
+          values.custom_greeting_message || t("preview.greeting.placeholder")
         }
         logoSrc={logoSrc}
         highlightTarget={highlightTarget}
@@ -396,7 +398,7 @@ export const AppearanceThemeSettings = forwardRef<
             />
           }
         >
-          Greeting Message
+          {t("greeting.label")}
         </FormField.Label>
         <FormField.Control asChild>
           <InputTypeIn
@@ -412,7 +414,7 @@ export const AppearanceThemeSettings = forwardRef<
           />
         </FormField.Control>
         <FormField.Description>
-          Add a short message to the home page.
+          {t("greeting.description")}
         </FormField.Description>
         <FormField.Message
           messages={{ error: errors.custom_greeting_message as string }}
@@ -428,7 +430,7 @@ export const AppearanceThemeSettings = forwardRef<
             />
           }
         >
-          Chat Header Text
+          {t("chatHeader.label")}
         </FormField.Label>
         <FormField.Control asChild>
           <InputTypeIn
@@ -459,14 +461,14 @@ export const AppearanceThemeSettings = forwardRef<
             />
           }
         >
-          Chat Footer Text
+          {t("chatFooter.label")}
         </FormField.Label>
         <FormField.Control asChild>
           <InputTextArea
             ref={lowerDisclaimerInputRef}
             data-label="chat-footer-textarea"
             rows={3}
-            placeholder="Add markdown content"
+            placeholder={t("markdownContent.placeholder")}
             variant={
               errors.custom_lower_disclaimer_content ? "error" : undefined
             }
@@ -478,7 +480,7 @@ export const AppearanceThemeSettings = forwardRef<
           />
         </FormField.Control>
         <FormField.Description>
-          Add markdown content for disclaimers or additional information.
+          {t("chatFooter.description")}
         </FormField.Description>
         <FormField.Message
           messages={{ error: errors.custom_lower_disclaimer_content as string }}
@@ -494,7 +496,7 @@ export const AppearanceThemeSettings = forwardRef<
             />
           }
         >
-          Login Page Subtitle
+          {t("loginSubtitle.label")}
         </FormField.Label>
         <FormField.Control asChild>
           <InputTypeIn
@@ -510,7 +512,7 @@ export const AppearanceThemeSettings = forwardRef<
           />
         </FormField.Control>
         <FormField.Description>
-          Replace the tagline under the welcome heading on the login page.
+          {t("loginSubtitle.description")}
         </FormField.Description>
         <FormField.Message
           messages={{ error: errors.custom_login_subtitle as string }}
@@ -519,7 +521,7 @@ export const AppearanceThemeSettings = forwardRef<
 
       <Disabled
         disabled={!enterpriseTier}
-        tooltip="Custom help link is an Enterprise Plan feature."
+        tooltip={t("helpLink.enterpriseTooltip")}
       >
         <div className="flex gap-2 items-start">
           <FormField
@@ -527,7 +529,7 @@ export const AppearanceThemeSettings = forwardRef<
             className="flex-1"
           >
             <FormField.Label>
-              Custom Help Link
+              {t("helpLink.label")}
               {!enterpriseTier && (
                 <Tag {...planTagProps("enterprise")} size="sm" />
               )}
@@ -552,8 +554,7 @@ export const AppearanceThemeSettings = forwardRef<
               />
             </FormField.Control>
             <FormField.Description>
-              Add a custom help link in the user menu in addition to the Onyx
-              documentation.
+              {t("helpLink.description")}
             </FormField.Description>
             <FormField.Message
               messages={{ error: errors.custom_help_link_url as string }}
@@ -561,14 +562,14 @@ export const AppearanceThemeSettings = forwardRef<
           </FormField>
           <FormField state="idle" className="flex-1">
             <FormField.Label className="invisible" aria-hidden="true">
-              Custom Help Link Label
+              {t("helpLinkLabel.label")}
             </FormField.Label>
             <FormField.Control asChild>
               <InputTypeIn
-                aria-label="Custom Help Link Label"
+                aria-label={t("helpLinkLabel.label")}
                 data-label="custom-help-link-label-input"
                 clearButton
-                placeholder="Link label"
+                placeholder={t("helpLinkLabel.placeholder")}
                 variant={!enterpriseTier ? "disabled" : undefined}
                 value={values.custom_help_link_label}
                 onChange={(e) =>
@@ -582,19 +583,19 @@ export const AppearanceThemeSettings = forwardRef<
 
       <Disabled
         disabled={!enterpriseTier}
-        tooltip="Hiding Onyx branding is an Enterprise Plan feature."
+        tooltip={t("branding.enterpriseTooltip")}
       >
         <FormField state="idle" className="gap-0">
           <div className="flex justify-between items-center">
             <FormField.Label>
-              Hide Onyx Branding
+              {t("branding.label")}
               {!enterpriseTier && (
                 <Tag {...planTagProps("enterprise")} size="sm" />
               )}
             </FormField.Label>
             <FormField.Control>
               <Switch
-                aria-label="Hide Onyx Branding"
+                aria-label={t("branding.label")}
                 data-label="hide-onyx-branding-toggle"
                 checked={values.hide_onyx_branding}
                 onCheckedChange={(checked) =>
@@ -605,8 +606,7 @@ export const AppearanceThemeSettings = forwardRef<
             </FormField.Control>
           </div>
           <FormField.Description>
-            Remove &ldquo;powered by Onyx&rdquo; and other Onyx branding
-            presence in the app.
+            {t("branding.description")}
           </FormField.Description>
         </FormField>
       </Disabled>
@@ -616,10 +616,10 @@ export const AppearanceThemeSettings = forwardRef<
       <div className="flex flex-col gap-4 p-4 bg-background-tint-00 rounded-16">
         <FormField state="idle" className="gap-0">
           <div className="flex justify-between items-center">
-            <FormField.Label>Show First Visit Notice</FormField.Label>
+            <FormField.Label>{t("firstVisit.label")}</FormField.Label>
             <FormField.Control>
               <Switch
-                aria-label="Show First Visit Notice"
+                aria-label={t("firstVisit.label")}
                 data-label="first-visit-notice-toggle"
                 checked={values.show_first_visit_notice}
                 onCheckedChange={(checked) =>
@@ -629,7 +629,7 @@ export const AppearanceThemeSettings = forwardRef<
             </FormField.Control>
           </div>
           <FormField.Description>
-            Show a one-time pop-up for new users at their first visit.
+            {t("firstVisit.description")}
           </FormField.Description>
         </FormField>
 
@@ -645,7 +645,7 @@ export const AppearanceThemeSettings = forwardRef<
                   />
                 }
               >
-                Notice Header
+                {t("noticeHeader.label")}
               </FormField.Label>
               <FormField.Control asChild>
                 <InputTypeIn
@@ -674,14 +674,14 @@ export const AppearanceThemeSettings = forwardRef<
                   />
                 }
               >
-                Notice Content
+                {t("noticeContent.label")}
               </FormField.Label>
               <FormField.Control asChild>
                 <InputTextArea
                   ref={noticeContentInputRef}
                   data-label="notice-content-textarea"
                   rows={3}
-                  placeholder="Add markdown content"
+                  placeholder={t("markdownContent.placeholder")}
                   variant={errors.custom_popup_content ? "error" : undefined}
                   value={values.custom_popup_content}
                   onChange={(e) =>
@@ -696,10 +696,10 @@ export const AppearanceThemeSettings = forwardRef<
 
             <FormField state="idle" className="gap-0">
               <div className="flex justify-between items-center">
-                <FormField.Label>Require Consent to Notice</FormField.Label>
+                <FormField.Label>{t("consent.label")}</FormField.Label>
                 <FormField.Control>
                   <Switch
-                    aria-label="Require Consent to Notice"
+                    aria-label={t("consent.label")}
                     data-label="require-consent-toggle"
                     checked={values.enable_consent_screen}
                     onCheckedChange={(checked) =>
@@ -709,8 +709,7 @@ export const AppearanceThemeSettings = forwardRef<
                 </FormField.Control>
               </div>
               <FormField.Description>
-                Require the user to read and agree to the notice before
-                accessing the application.
+                {t("consent.description")}
               </FormField.Description>
             </FormField>
 
@@ -727,14 +726,14 @@ export const AppearanceThemeSettings = forwardRef<
                     />
                   }
                 >
-                  Notice Consent Prompt
+                  {t("consentPrompt.label")}
                 </FormField.Label>
                 <FormField.Control asChild>
                   <InputTextArea
                     ref={consentPromptTextAreaRef}
                     data-label="consent-prompt-textarea"
                     rows={3}
-                    placeholder="Add markdown content"
+                    placeholder={t("markdownContent.placeholder")}
                     variant={errors.consent_screen_prompt ? "error" : undefined}
                     value={values.consent_screen_prompt}
                     onChange={(e) => {
@@ -754,10 +753,10 @@ export const AppearanceThemeSettings = forwardRef<
       <div className="flex flex-col gap-4 p-4 bg-background-tint-00 rounded-16">
         <FormField state="idle" className="gap-0">
           <div className="flex justify-between items-center">
-            <FormField.Label>System Announcement</FormField.Label>
+            <FormField.Label>{t("announcement.label")}</FormField.Label>
             <FormField.Control>
               <Switch
-                aria-label="System Announcement"
+                aria-label={t("announcement.label")}
                 data-label="system-announcement-toggle"
                 checked={values.system_announcement_enabled}
                 onCheckedChange={(checked) =>
@@ -767,7 +766,7 @@ export const AppearanceThemeSettings = forwardRef<
             </FormField.Control>
           </div>
           <FormField.Description>
-            Show a persistent system announcement that users can dismiss.
+            {t("announcement.description")}
           </FormField.Description>
         </FormField>
 
@@ -785,14 +784,14 @@ export const AppearanceThemeSettings = forwardRef<
                   />
                 }
               >
-                Notice Header
+                {t("noticeHeader.label")}
               </FormField.Label>
               <FormField.Control asChild>
                 <InputTypeIn
                   ref={systemAnnouncementHeaderInputRef}
                   data-label="system-announcement-header-input"
                   clearButton
-                  placeholder="Add an announcement"
+                  placeholder={t("announcement.header.placeholder")}
                   variant={
                     errors.system_announcement_header ? "error" : undefined
                   }
@@ -821,14 +820,14 @@ export const AppearanceThemeSettings = forwardRef<
                   />
                 }
               >
-                Notice Content
+                {t("noticeContent.label")}
               </FormField.Label>
               <FormField.Control asChild>
                 <InputTextArea
                   ref={systemAnnouncementContentInputRef}
                   data-label="system-announcement-content-textarea"
                   rows={3}
-                  placeholder="Add markdown content"
+                  placeholder={t("markdownContent.placeholder")}
                   variant={
                     errors.system_announcement_content ? "error" : undefined
                   }
@@ -847,10 +846,12 @@ export const AppearanceThemeSettings = forwardRef<
 
             <FormField state="idle" className="gap-0">
               <div className="flex justify-between items-center">
-                <FormField.Label>Pop-up Notice at First Visit</FormField.Label>
+                <FormField.Label>
+                  {t("announcementPopup.label")}
+                </FormField.Label>
                 <FormField.Control>
                   <Switch
-                    aria-label="Pop-up Notice at First Visit"
+                    aria-label={t("announcementPopup.label")}
                     data-label="system-announcement-popup-toggle"
                     checked={values.system_announcement_show_as_popup}
                     onCheckedChange={(checked) =>
@@ -863,8 +864,7 @@ export const AppearanceThemeSettings = forwardRef<
                 </FormField.Control>
               </div>
               <FormField.Description>
-                Also show this notice as a full-screen pop-up at first visit for
-                all users. Use with caution.
+                {t("announcementPopup.description")}
               </FormField.Description>
             </FormField>
           </>

--- a/web/src/app/ee/admin/theme/Preview.tsx
+++ b/web/src/app/ee/admin/theme/Preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import type { Components } from "react-markdown";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
@@ -66,10 +67,11 @@ function PreviewLogo({
   size: number;
   className?: string;
 }) {
+  const t = useTranslations("admin.theme");
   return logoSrc && !forceOnyxIcon ? (
     <img
       src={logoSrc}
-      alt="Logo"
+      alt={t("preview.logo.alt")}
       style={{
         objectFit: "cover",
         height: `${size}px`,

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
+import { useTranslations } from "next-intl";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Button } from "@opal/components";
@@ -34,6 +36,8 @@ const CHAR_LIMITS = {
 };
 
 export default function ThemePage() {
+  const t = useTranslations("admin.theme");
+  const adminRouteTitle = useAdminRouteTitle();
   const settings = useSettings();
   const enterpriseSettings = settings.enterprise;
   const [selectedLogo, setSelectedLogo] = useState<File | null>(null);
@@ -68,7 +72,7 @@ export default function ThemePage() {
       return true;
     } else {
       const errorMsg = (await response.json()).detail;
-      alert(`Failed to update settings. ${errorMsg}`);
+      alert(t("page.settingsSaveFailed.message", { error: errorMsg }));
       return false;
     }
   }
@@ -90,12 +94,15 @@ export default function ThemePage() {
     return true;
   }
 
+  const maxCharsMessage = (count: number) =>
+    t("page.validation.maxChars", { count });
+
   const validationSchema = Yup.object().shape({
     application_name: Yup.string()
       .trim()
       .max(
         CHAR_LIMITS.application_name,
-        `Maximum ${CHAR_LIMITS.application_name} characters`
+        maxCharsMessage(CHAR_LIMITS.application_name)
       )
       .nullable(),
     logo_display_style: Yup.string()
@@ -105,57 +112,60 @@ export default function ThemePage() {
     custom_greeting_message: Yup.string()
       .max(
         CHAR_LIMITS.custom_greeting_message,
-        `Maximum ${CHAR_LIMITS.custom_greeting_message} characters`
+        maxCharsMessage(CHAR_LIMITS.custom_greeting_message)
       )
       .nullable(),
     custom_login_subtitle: Yup.string()
       .max(
         CHAR_LIMITS.custom_login_subtitle,
-        `Maximum ${CHAR_LIMITS.custom_login_subtitle} characters`
+        maxCharsMessage(CHAR_LIMITS.custom_login_subtitle)
       )
       .nullable(),
     custom_header_content: Yup.string()
       .max(
         CHAR_LIMITS.custom_header_content,
-        `Maximum ${CHAR_LIMITS.custom_header_content} characters`
+        maxCharsMessage(CHAR_LIMITS.custom_header_content)
       )
       .nullable(),
     custom_lower_disclaimer_content: Yup.string()
       .max(
         CHAR_LIMITS.custom_lower_disclaimer_content,
-        `Maximum ${CHAR_LIMITS.custom_lower_disclaimer_content} characters`
+        maxCharsMessage(CHAR_LIMITS.custom_lower_disclaimer_content)
       )
       .nullable(),
     show_first_visit_notice: Yup.boolean().nullable(),
     custom_popup_header: Yup.string()
       .max(
         CHAR_LIMITS.custom_popup_header,
-        `Maximum ${CHAR_LIMITS.custom_popup_header} characters`
+        maxCharsMessage(CHAR_LIMITS.custom_popup_header)
       )
       .when("show_first_visit_notice", {
         is: true,
-        then: (schema) => schema.required("Notice Header is required"),
+        then: (schema) =>
+          schema.required(t("page.validation.noticeHeaderRequired")),
         otherwise: (schema) => schema.nullable(),
       }),
     custom_popup_content: Yup.string()
       .max(
         CHAR_LIMITS.custom_popup_content,
-        `Maximum ${CHAR_LIMITS.custom_popup_content} characters`
+        maxCharsMessage(CHAR_LIMITS.custom_popup_content)
       )
       .when("show_first_visit_notice", {
         is: true,
-        then: (schema) => schema.required("Notice Content is required"),
+        then: (schema) =>
+          schema.required(t("page.validation.noticeContentRequired")),
         otherwise: (schema) => schema.nullable(),
       }),
     enable_consent_screen: Yup.boolean().nullable(),
     consent_screen_prompt: Yup.string()
       .max(
         CHAR_LIMITS.consent_screen_prompt,
-        `Maximum ${CHAR_LIMITS.consent_screen_prompt} characters`
+        maxCharsMessage(CHAR_LIMITS.consent_screen_prompt)
       )
       .when("enable_consent_screen", {
         is: true,
-        then: (schema) => schema.required("Notice Consent Prompt is required"),
+        then: (schema) =>
+          schema.required(t("page.validation.consentPromptRequired")),
         otherwise: (schema) => schema.nullable(),
       }),
     custom_help_link_label: Yup.string().nullable(),
@@ -166,12 +176,12 @@ export default function ThemePage() {
           typeof label === "string" && label.trim().length > 0,
         then: (schema) =>
           schema
-            .required("URL is required when a label is set")
-            .url("Must be a valid URL"),
+            .required(t("page.validation.urlRequiredWithLabel"))
+            .url(t("page.validation.invalidUrl")),
         otherwise: (schema) =>
           schema.test(
             "optional-url",
-            "Must be a valid URL",
+            t("page.validation.invalidUrl"),
             (value) =>
               value == null ||
               value === "" ||
@@ -184,22 +194,24 @@ export default function ThemePage() {
       .trim()
       .max(
         CHAR_LIMITS.system_announcement_header,
-        `Maximum ${CHAR_LIMITS.system_announcement_header} characters`
+        maxCharsMessage(CHAR_LIMITS.system_announcement_header)
       )
       .when("system_announcement_enabled", {
         is: true,
-        then: (schema) => schema.required("Notice Header is required"),
+        then: (schema) =>
+          schema.required(t("page.validation.noticeHeaderRequired")),
         otherwise: (schema) => schema.nullable(),
       }),
     system_announcement_content: Yup.string()
       .trim()
       .max(
         CHAR_LIMITS.system_announcement_content,
-        `Maximum ${CHAR_LIMITS.system_announcement_content} characters`
+        maxCharsMessage(CHAR_LIMITS.system_announcement_content)
       )
       .when("system_announcement_enabled", {
         is: true,
-        then: (schema) => schema.required("Notice Content is required"),
+        then: (schema) =>
+          schema.required(t("page.validation.noticeContentRequired")),
         otherwise: (schema) => schema.nullable(),
       }),
     system_announcement_show_as_popup: Yup.boolean().nullable(),
@@ -252,7 +264,7 @@ export default function ThemePage() {
           });
           if (!response.ok) {
             const errorMsg = (await response.json()).detail;
-            alert(`Failed to upload logo. ${errorMsg}`);
+            alert(t("page.logoUploadFailed.message", { error: errorMsg }));
             formikHelpers.setSubmitting(false);
             return;
           }
@@ -311,12 +323,12 @@ export default function ThemePage() {
                   show_as_popup: values.system_announcement_show_as_popup,
                 }),
               },
-              "Failed to save announcement."
+              t("page.announcementSaveFailed.message")
             );
           } else if (currentBanner) {
             bannerOk = await mutateAdminBanner(
               { method: "DELETE" },
-              "Failed to clear announcement."
+              t("page.announcementClearFailed.message")
             );
           }
         }
@@ -328,7 +340,7 @@ export default function ThemePage() {
           if (logoUploaded) {
             setLogoVersion((v) => v + 1);
           }
-          toast.success("Appearance settings saved successfully!");
+          toast.success(t("page.saveSuccess.message"));
         }
 
         formikHelpers.setSubmitting(false);
@@ -349,8 +361,8 @@ export default function ThemePage() {
           <Form className="w-full h-full">
             <SettingsLayouts.Root>
               <SettingsLayouts.Header
-                title={route.title}
-                description="Customize how the application appears to users across your organization."
+                title={adminRouteTitle(route)}
+                description={t("page.description")}
                 icon={route.icon}
                 rightChildren={
                   <Button
@@ -366,7 +378,9 @@ export default function ThemePage() {
                       await submitForm();
                     }}
                   >
-                    {isSubmitting ? "Applying..." : "Apply Changes"}
+                    {isSubmitting
+                      ? t("page.applying.label")
+                      : t("page.applyButton.label")}
                   </Button>
                 }
               />

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { Card, Text } from "@opal/components";
 import { Section } from "@opal/layouts";
 import {
@@ -56,6 +57,7 @@ interface AgentStatsProps {
 }
 
 export function AgentStats({ agentId }: AgentStatsProps) {
+  const t = useTranslations("admin");
   const [agentStats, setAgentStats] = useState<AgentStatsResponse | null>(null);
   const { agents } = useAgents();
   const [isLoading, setIsLoading] = useState(false);
@@ -83,16 +85,18 @@ export function AgentStats({ agentId }: AgentStatsProps) {
 
         if (!res.ok) {
           if (res.status === 403) {
-            throw new Error("You don't have permission to view these stats.");
+            throw new Error(t("agentStats.permissionDenied.message"));
           }
-          throw new Error("Failed to fetch agent stats");
+          throw new Error(t("agentStats.fetchFailed.message"));
         }
 
         const data = (await res.json()) as AgentStatsResponse;
         setAgentStats(data);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "An unknown error occurred"
+          err instanceof Error
+            ? err.message
+            : t("agentStats.unknownError.message")
         );
       } finally {
         setIsLoading(false);
@@ -100,24 +104,23 @@ export function AgentStats({ agentId }: AgentStatsProps) {
     }
 
     fetchStats();
-  }, [agentId, dateRange]);
+  }, [agentId, dateRange, t]);
 
   const state: ChartState = error
     ? { status: "error", message: error }
     : resolveChartState({
         isLoading: isLoading || !agent,
         error: null,
-        errorMessage: "Failed to fetch agent stats.",
-        emptyMessage:
-          "No data found for this agent in the selected date range.",
+        errorMessage: t("agentStats.fetchFailed.message"),
+        emptyMessage: t("agentStats.empty.message"),
         series: [
           chartSeries(
-            "Messages",
+            t("analytics.agentChart.series.messages.label"),
             agentStats?.daily_stats,
             (entry) => entry.total_messages
           ),
           chartSeries(
-            "Unique Users",
+            t("analytics.agentChart.series.uniqueUsers.label"),
             agentStats?.daily_stats,
             (entry) => entry.total_unique_users
           ),
@@ -135,7 +138,7 @@ export function AgentStats({ agentId }: AgentStatsProps) {
     >
       {/* sm:flex-row / sm:items-center / sm:justify-between have no Section equivalent, kept as a raw div */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <Text font="heading-h2">Agent Analytics</Text>
+        <Text font="heading-h2">{t("analytics.agentChart.title")}</Text>
         <DateRangePicker value={dateRange} onValueChange={setDateRange} />
       </div>
 
@@ -186,11 +189,11 @@ export function AgentStats({ agentId }: AgentStatsProps) {
               height="fit"
             >
               <SummaryMetric
-                label="Total Messages"
+                label={t("agentStats.totalMessages.label")}
                 value={agentStats?.total_messages ?? 0}
               />
               <SummaryMetric
-                label="Total Unique Users"
+                label={t("agentStats.totalUniqueUsers.label")}
                 value={agentStats?.total_unique_users ?? 0}
               />
             </Section>
@@ -199,8 +202,8 @@ export function AgentStats({ agentId }: AgentStatsProps) {
       </Section>
 
       <AnalyticsChart
-        title="Messages and unique users"
-        description="Per day for the selected range"
+        title={t("agentStats.chart.title")}
+        description={t("agentStats.chart.description")}
         timeRange={dateRange}
         state={state}
       />

--- a/web/src/app/federated/oauth/callback/page.tsx
+++ b/web/src/app/federated/oauth/callback/page.tsx
@@ -1,26 +1,26 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import OAuthCallbackPage from "@/components/oauth/OAuthCallbackPage";
 import { getSourceDisplayName } from "@/lib/sources";
 
 export default function FederatedOAuthCallbackPage() {
+  const t = useTranslations("admin.federatedCallback");
   const federatedConfig = {
-    processingMessage: "Processing...",
-    processingDetails: "Please wait while we complete the setup.",
-    successMessage: "Success!",
-    successDetailsTemplate:
-      "Your {serviceName} authorization completed successfully. You can now use this connector for search.",
-    errorMessage: "Something Went Wrong",
-    backButtonText: "Back to Chat",
-    redirectingMessage: "Redirecting to chat in 2 seconds...",
+    processingMessage: t("processing.title"),
+    processingDetails: t("processing.details"),
+    successMessage: t("success.title"),
+    successDetailsTemplate: t.raw("success.detailsTemplate"),
+    errorMessage: t("error.title"),
+    backButtonText: t("backButton.label"),
+    redirectingMessage: t("redirecting.text"),
     autoRedirectDelay: 2000,
     defaultRedirectPath: "/app",
     callbackApiUrl: "/api/federated/callback",
     errorMessageMap: {
-      "validation errors":
-        "Configuration error - please check your connector settings",
-      client_secret: "Authentication credentials are missing or invalid",
-      oauth: "OAuth authorization failed",
+      "validation errors": t("errors.validation"),
+      client_secret: t("errors.clientSecret"),
+      oauth: t("errors.oauth"),
     },
   };
 

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -209,7 +209,9 @@ export default function MCPOAuthCallbackPage() {
                 <IllustrationContent
                   illustration={SvgConnected}
                   title={t("mcpOauthCallback.success.title", {
-                    serverName: state.serverName,
+                    // FSI/PDI isolate the name so a mixed-direction server
+                    // name cannot reorder the surrounding sentence.
+                    serverName: `\u2068${state.serverName}\u2069`,
                   })}
                   description={t("mcpOauthCallback.success.description")}
                 />

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -14,9 +14,12 @@ import {
 } from "@opal/illustrations";
 import type { IconFunctionComponent } from "@opal/types";
 import { completeMCPUserOAuth } from "@/lib/tools/svc";
+import { useTranslations } from "next-intl";
 
 const AUTO_REDIRECT_DELAY_MS = 2000;
 const DEFAULT_REDIRECT_PATH = "/app";
+
+type CallbackTranslate = ReturnType<typeof useTranslations<"actions">>;
 
 interface CallbackError {
   illustration: IconFunctionComponent;
@@ -29,47 +32,47 @@ type CallbackState =
   | { phase: "success"; serverName: string; redirectPath: string }
   | { phase: "error"; error: CallbackError };
 
-function cancelledError(errorDescription: string | null): CallbackError {
+function cancelledError(
+  t: CallbackTranslate,
+  errorDescription: string | null
+): CallbackError {
   return {
     illustration: SvgUnPlugged,
-    title: "Authorization cancelled",
+    title: t("mcpOauthCallback.cancelled.title"),
     description:
-      errorDescription ||
-      "The authorization was cancelled or denied, so no connection was made. " +
-        "To try again, restart the connection from the MCP server's authentication settings.",
+      errorDescription || t("mcpOauthCallback.cancelled.description"),
   };
 }
 
-const INVALID_LINK_ERROR: CallbackError = {
-  illustration: SvgBrokenKey,
-  title: "Invalid authorization link",
-  description:
-    "This link is missing the required authorization parameters. " +
-    "Restart the connection from the MCP server's authentication settings.",
-};
+function invalidLinkError(t: CallbackTranslate): CallbackError {
+  return {
+    illustration: SvgBrokenKey,
+    title: t("mcpOauthCallback.invalidLink.title"),
+    description: t("mcpOauthCallback.invalidLink.description"),
+  };
+}
 
 // Maps the backend's error `detail` strings to actionable guidance. Order
 // matters: "No tokens found" must match before the generic "token" and
 // "not found" checks.
-function classifyCallbackError(detail: string): CallbackError {
+function classifyCallbackError(
+  t: CallbackTranslate,
+  detail: string
+): CallbackError {
   const lowerDetail = detail.toLowerCase();
 
   if (lowerDetail.includes("state")) {
     return {
       illustration: SvgBrokenKey,
-      title: "Authorization session expired",
-      description:
-        "This authorization link is invalid, has expired, or was already used. " +
-        "Restart the connection from the MCP server's authentication settings.",
+      title: t("mcpOauthCallback.sessionExpired.title"),
+      description: t("mcpOauthCallback.sessionExpired.description"),
     };
   }
   if (lowerDetail.includes("no tokens found")) {
     return {
       illustration: SvgTimeout,
-      title: "Authorization timed out",
-      description:
-        "The MCP server didn't confirm the authorization in time. Try connecting " +
-        "again — if this keeps happening, verify the server's OAuth configuration.",
+      title: t("mcpOauthCallback.timedOut.title"),
+      description: t("mcpOauthCallback.timedOut.description"),
     };
   }
   if (
@@ -78,11 +81,8 @@ function classifyCallbackError(detail: string): CallbackError {
   ) {
     return {
       illustration: SvgPlugBroken,
-      title: "Token exchange failed",
-      description:
-        "The provider approved the authorization but a valid access token could " +
-        "not be obtained. Check the server's OAuth client credentials and " +
-        "endpoints, then try connecting again.",
+      title: t("mcpOauthCallback.tokenExchangeFailed.title"),
+      description: t("mcpOauthCallback.tokenExchangeFailed.description"),
     };
   }
   if (
@@ -91,15 +91,13 @@ function classifyCallbackError(detail: string): CallbackError {
   ) {
     return {
       illustration: SvgPlugBroken,
-      title: "MCP server not found",
-      description:
-        "The MCP server this authorization belongs to no longer exists or is no " +
-        "longer configured. Recreate or reconfigure the server, then connect again.",
+      title: t("mcpOauthCallback.serverNotFound.title"),
+      description: t("mcpOauthCallback.serverNotFound.description"),
     };
   }
   return {
     illustration: SvgPlugBroken,
-    title: "Something went wrong",
+    title: t("mcpOauthCallback.genericError.title"),
     description: detail,
   };
 }
@@ -117,6 +115,7 @@ function buildRedirectPath(rawPath: string): string {
 }
 
 export default function MCPOAuthCallbackPage() {
+  const t = useTranslations("actions");
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -146,12 +145,12 @@ export default function MCPOAuthCallbackPage() {
 
     // The provider redirected back with an error (e.g. the user cancelled)
     if (providerError) {
-      setState({ phase: "error", error: cancelledError(errorDescription) });
+      setState({ phase: "error", error: cancelledError(t, errorDescription) });
       return;
     }
 
     if (!code || !stateParam) {
-      setState({ phase: "error", error: INVALID_LINK_ERROR });
+      setState({ phase: "error", error: invalidLinkError(t) });
       return;
     }
 
@@ -169,9 +168,10 @@ export default function MCPOAuthCallbackPage() {
         setState({
           phase: "error",
           error: classifyCallbackError(
+            t,
             error instanceof Error
               ? error.message
-              : "Failed to complete authorization"
+              : t("mcpOauthCallback.genericError.fallbackDetail")
           ),
         });
       }
@@ -195,11 +195,10 @@ export default function MCPOAuthCallbackPage() {
                 </div>
                 <div className="flex flex-col items-center text-center">
                   <Text font="main-content-emphasis" color="text-04" as="p">
-                    Completing authorization
+                    {t("mcpOauthCallback.processing.title")}
                   </Text>
                   <Text font="secondary-body" color="text-03" as="p">
-                    Finishing the connection to your MCP server. This may take a
-                    few moments…
+                    {t("mcpOauthCallback.processing.description")}
                   </Text>
                 </div>
               </div>
@@ -209,18 +208,20 @@ export default function MCPOAuthCallbackPage() {
               <>
                 <IllustrationContent
                   illustration={SvgConnected}
-                  title={`Connected to ${state.serverName}`}
-                  description="Authorization completed successfully. You can now use this server's tools in chat."
+                  title={t("mcpOauthCallback.success.title", {
+                    serverName: state.serverName,
+                  })}
+                  description={t("mcpOauthCallback.success.description")}
                 />
                 <Button
                   width="full"
                   onClick={() => router.push(state.redirectPath as Route)}
                 >
-                  Continue
+                  {t("mcpOauthCallback.continueButton.label")}
                 </Button>
                 <div className="flex justify-center">
                   <Text font="secondary-body" color="text-03" as="p">
-                    Taking you back automatically…
+                    {t("mcpOauthCallback.autoRedirect.text")}
                   </Text>
                 </div>
               </>
@@ -237,7 +238,7 @@ export default function MCPOAuthCallbackPage() {
                   width="full"
                   onClick={() => router.push(DEFAULT_REDIRECT_PATH as Route)}
                 >
-                  Back to Chat
+                  {t("mcpOauthCallback.backToChatButton.label")}
                 </Button>
               </>
             )}

--- a/web/src/app/nrf/NRFChrome.tsx
+++ b/web/src/app/nrf/NRFChrome.tsx
@@ -17,6 +17,7 @@ import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { useSidebarState } from "@opal/layouts";
 import useScreenSize from "@/hooks/useScreenSize";
+import { useTranslations } from "next-intl";
 
 const footerMarkdownComponents = {
   p: ({ children }: { children?: React.ReactNode }) => (
@@ -57,6 +58,7 @@ const footerMarkdownComponents = {
  * extension doesn't need.
  */
 export default function NRFChrome() {
+  const t = useTranslations("chat");
   const businessTier = useTierAtLeast(Tier.BUSINESS);
   const { state, setAppMode } = useQueryController();
   const isSearchModeAvailable = useIsSearchModeAvailable();
@@ -89,7 +91,7 @@ export default function NRFChrome() {
             <Button
               prominence="internal"
               icon={SvgSidebar}
-              aria-label="Open Sidebar"
+              aria-label={t("appChrome.openSidebar.ariaLabel")}
               onClick={() => setFolded(false)}
             />
           )}
@@ -101,7 +103,9 @@ export default function NRFChrome() {
                     effectiveMode === "search" ? SvgSearchMenu : SvgBubbleText
                   }
                 >
-                  {effectiveMode === "search" ? "Search" : "Chat"}
+                  {effectiveMode === "search"
+                    ? t("appChrome.mode.search.label")
+                    : t("appChrome.mode.chat.label")}
                 </OpenButton>
               </Popover.Trigger>
               <Popover.Content align="start" width="lg">
@@ -111,24 +115,24 @@ export default function NRFChrome() {
                     rounding={2}
                     icon={SvgSearchMenu}
                     state={effectiveMode === "search" ? "selected" : "empty"}
-                    description="Quick search for documents"
+                    description={t("appChrome.mode.search.description")}
                     onClick={noProp(() => {
                       setAppMode("search");
                       setModePopoverOpen(false);
                     })}
-                    title="Search"
+                    title={t("appChrome.mode.search.label")}
                   />
                   <LineItemButton
                     sizePreset="main-ui"
                     rounding={2}
                     icon={SvgBubbleText}
                     state={effectiveMode === "chat" ? "selected" : "empty"}
-                    description="Conversation and research"
+                    description={t("appChrome.mode.chat.description")}
                     onClick={noProp(() => {
                       setAppMode("chat");
                       setModePopoverOpen(false);
                     })}
-                    title="Chat"
+                    title={t("appChrome.mode.chat.label")}
                   />
                 </Popover.Menu>
               </Popover.Content>

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -49,6 +49,7 @@ import EESearchUI from "@/ee/sections/SearchUI";
 import useMultiModelChat from "@/hooks/useMultiModelChat";
 import MultiModelSelector from "@/sections/model-selector/MultiModelSelector";
 import { Section } from "@/layouts/general-layouts";
+import { useTranslations } from "next-intl";
 
 const SearchUI = paidTierGated(EESearchUI);
 
@@ -60,6 +61,7 @@ interface NRFPageProps {
 const AVAILABLE_CONTEXT_TOKENS = Number(DEFAULT_CONTEXT_TOKENS) * 0.5;
 
 export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
+  const t = useTranslations("chat");
   const { setUseOnyxAsNewTab } = useNRFPreferences();
 
   const searchParams = useSearchParams();
@@ -86,13 +88,14 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
     if (lastFailedFiles && lastFailedFiles.length > 0) {
       const names = lastFailedFiles.map((f) => f.name).join(", ");
       toast.error(
-        lastFailedFiles.length === 1
-          ? `File failed and was removed: ${names}`
-          : `Files failed and were removed: ${names}`
+        t("nrf.page.filesFailed.toast", {
+          count: lastFailedFiles.length,
+          names,
+        })
       );
       clearLastFailedFiles();
     }
-  }, [lastFailedFiles, clearLastFailedFiles]);
+  }, [lastFailedFiles, clearLastFailedFiles, t]);
 
   // Assistant controller
   const activeAgent = useActiveAgent();
@@ -364,7 +367,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
       .reverse()
       .find((m) => m.type === "user");
     if (!lastUserMsg) {
-      toast.error("No previously-submitted user message found.");
+      toast.error(t("nrf.page.noResubmitMessage.toast"));
       return;
     }
 
@@ -380,6 +383,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
     currentMessageFiles,
     deepResearchEnabled,
     multiModel.isMultiModelActive,
+    t,
   ]);
 
   // Start a new chat session in the side panel
@@ -451,7 +455,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
             prominence="secondary"
             icon={SvgMenu}
             onClick={toggleSettings}
-            tooltip="Open settings"
+            tooltip={t("nrf.page.settingsButton.tooltip")}
           />
         </div>
       )}
@@ -616,8 +620,8 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
             <Modal.Content width="sm">
               <Modal.Header
                 icon={SvgAlertTriangle}
-                title="Turn off Onyx new tab page?"
-                description="You'll see your browser's default new tab page instead. You can turn it back on anytime in your Onyx settings."
+                title={t("nrf.page.turnOffModal.title")}
+                description={t("nrf.page.turnOffModal.description")}
                 onClose={() => setShowTurnOffModal(false)}
               />
               <Modal.Footer>
@@ -625,10 +629,10 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
                   prominence="secondary"
                   onClick={() => setShowTurnOffModal(false)}
                 >
-                  Cancel
+                  {t("nrf.page.turnOffModal.cancelButton.label")}
                 </Button>
                 <Button variant="danger" onClick={confirmTurnOff}>
-                  Turn off
+                  {t("nrf.page.turnOffModal.confirmButton.label")}
                 </Button>
               </Modal.Footer>
             </Modal.Content>
@@ -639,7 +643,10 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
       {!user && (
         <Modal open onOpenChange={() => {}}>
           <Modal.Content width="sm" height="sm">
-            <Modal.Header icon={SvgUser} title="Welcome to Onyx" />
+            <Modal.Header
+              icon={SvgUser}
+              title={t("nrf.page.loginModal.title")}
+            />
             <Modal.Body>
               {authTypeMetadata?.multiTenant === false ? (
                 <LoginPage
@@ -660,7 +667,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
                       }
                     }}
                   >
-                    Log in
+                    {t("nrf.page.loginModal.loginButton.label")}
                   </Button>
                 </div>
               )}
@@ -677,7 +684,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
             window.location.href = ADMIN_ROUTES.LLM_MODELS.path;
           }}
         >
-          Set up an LLM.
+          {t("nrf.page.setupLlmButton.label")}
         </Button>
       )}
     </div>

--- a/web/src/app/nrf/side-panel/SidePanelHeader.tsx
+++ b/web/src/app/nrf/side-panel/SidePanelHeader.tsx
@@ -3,6 +3,7 @@
 import { Logo } from "@/lib/app/components";
 import { Button } from "@opal/components";
 import { SvgEditBig, SvgExternalLink } from "@opal/icons";
+import { useTranslations } from "next-intl";
 
 interface SidePanelHeaderProps {
   onNewChat: () => void;
@@ -13,6 +14,7 @@ export default function SidePanelHeader({
   onNewChat,
   chatSessionId,
 }: SidePanelHeaderProps) {
+  const t = useTranslations("chat");
   const handleOpenInOnyx = () => {
     const path = chatSessionId ? `/app?chatId=${chatSessionId}` : "/app";
     window.open(`${window.location.origin}${path}`, "_blank");
@@ -26,13 +28,13 @@ export default function SidePanelHeader({
           prominence="tertiary"
           icon={SvgEditBig}
           onClick={onNewChat}
-          tooltip="New chat"
+          tooltip={t("nrf.sidePanelHeader.newChatButton.tooltip")}
         />
         <Button
           prominence="tertiary"
           icon={SvgExternalLink}
           onClick={handleOpenInOnyx}
-          tooltip="Open in Onyx"
+          tooltip={t("nrf.sidePanelHeader.openInOnyxButton.tooltip")}
         />
       </div>
     </header>

--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { ConnectorStatus } from "@/lib/types";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { Label } from "@opal/layouts";
@@ -28,9 +29,10 @@ export const ConnectorMultiSelect = ({
   selectedIds,
   onChange,
   disabled = false,
-  placeholder = "Search connectors...",
+  placeholder,
   showError = false,
 }: ConnectorMultiSelectProps) => {
+  const t = useTranslations("common.connectorMultiSelect");
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -103,8 +105,8 @@ export const ConnectorMultiSelect = ({
   };
 
   const effectivePlaceholder = allConnectorsSelected
-    ? "All connectors selected"
-    : placeholder;
+    ? t("allSelected.placeholder")
+    : (placeholder ?? t("search.placeholder"));
 
   const isInputDisabled = disabled;
 
@@ -117,8 +119,7 @@ export const ConnectorMultiSelect = ({
       )}
 
       <Text as="p" mainUiMuted text03>
-        All documents indexed by the selected connectors will be part of this
-        document set.
+        {t("documentSetHint.description")}
       </Text>
       <div className="relative">
         <InputTypeIn
@@ -148,18 +149,17 @@ export const ConnectorMultiSelect = ({
             {allConnectorsSelected ? (
               <div className="py-4 px-3">
                 <Text as="p" text03 className="text-center text-xs">
-                  All available connectors have been selected. Remove connectors
-                  below to add different ones.
+                  {t("allSelected.description")}
                 </Text>
               </div>
             ) : filteredUnselectedConnectors.length === 0 ? (
               <div className="py-4 px-3">
                 <Text as="p" text03 className="text-center text-xs">
                   {searchQuery
-                    ? "No matching connectors found"
+                    ? t("noMatches.text")
                     : connectors.length === 0
-                      ? "No private connectors available. Create a private connector first."
-                      : "No more connectors available"}
+                      ? t("noPrivateConnectors.text")
+                      : t("noMoreConnectors.text")}
                 </Text>
               </div>
             ) : (
@@ -211,8 +211,8 @@ export const ConnectorMultiSelect = ({
                   prominence="tertiary"
                   size="sm"
                   type="button"
-                  aria-label="Remove connector"
-                  tooltip="Remove connector"
+                  aria-label={t("removeConnector.tooltip")}
+                  tooltip={t("removeConnector.tooltip")}
                   onClick={() => removeConnector(connector.cc_pair_id)}
                   icon={SvgX}
                 />
@@ -222,7 +222,7 @@ export const ConnectorMultiSelect = ({
         </div>
       ) : (
         <div className="mt-3 p-3 border border-dashed border-border-02 rounded-12 bg-background-neutral-01 text-text-03 text-xs">
-          No connectors selected. Search and select connectors above.
+          {t("noneSelected.text")}
         </div>
       )}
 

--- a/web/src/components/DeleteButton.tsx
+++ b/web/src/components/DeleteButton.tsx
@@ -1,5 +1,6 @@
 import { SvgTrash } from "@opal/icons";
 import { Button } from "@opal/components";
+import { useTranslations } from "next-intl";
 
 export interface DeleteButtonProps {
   onClick?: (event: React.MouseEvent<HTMLElement>) => void | Promise<void>;
@@ -7,13 +8,14 @@ export interface DeleteButtonProps {
 }
 
 export function DeleteButton({ onClick, disabled }: DeleteButtonProps) {
+  const t = useTranslations("common.deleteButton");
   return (
     <Button
       disabled={disabled}
       onClick={onClick}
       icon={SvgTrash}
-      tooltip="Delete"
-      aria-label="Delete"
+      tooltip={t("button.tooltip")}
+      aria-label={t("button.tooltip")}
       data-testid="delete-button"
       prominence="tertiary"
       size="sm"

--- a/web/src/components/Dropdown.tsx
+++ b/web/src/components/Dropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef, useEffect, useRef, useState, JSX } from "react";
+import { useTranslations } from "next-intl";
 import { FiCheck, FiChevronDown, FiInfo } from "react-icons/fi";
 import { Popover } from "@opal/components";
 import { Tooltip } from "@opal/components";
@@ -162,6 +163,7 @@ export const DefaultDropdown = forwardRef<HTMLDivElement, DefaultDropdownProps>(
     },
     ref
   ) => {
+    const t = useTranslations("common.dropdown");
     const selectedOption = options.find((option) => option.value === selected);
     const [isOpen, setIsOpen] = useState(false);
 
@@ -189,8 +191,8 @@ export const DefaultDropdown = forwardRef<HTMLDivElement, DefaultDropdownProps>(
             <p className="line-clamp-1">
               {selectedOption?.name ||
                 (includeDefault
-                  ? defaultValue || "Default"
-                  : "Select an option...")}
+                  ? defaultValue || t("default.label")
+                  : t("selectOption.placeholder"))}
             </p>
             <FiChevronDown className="my-auto ms-auto" />
           </div>
@@ -215,7 +217,7 @@ export const DefaultDropdown = forwardRef<HTMLDivElement, DefaultDropdownProps>(
             {includeDefault && (
               <DefaultDropdownElement
                 key={-1}
-                name="Default"
+                name={t("default.label")}
                 onSelect={() => handleSelect(null)}
                 isSelected={selected === null}
               />

--- a/web/src/components/EditableStringFieldDisplay.tsx
+++ b/web/src/components/EditableStringFieldDisplay.tsx
@@ -1,5 +1,6 @@
 import { SvgEdit } from "@opal/icons";
 import { Button } from "@opal/components";
+import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@opal/utils";
@@ -19,6 +20,7 @@ export function EditableStringFieldDisplay({
   textClassName,
   scale = 1,
 }: EditableStringFieldDisplayProps) {
+  const t = useTranslations("common.editable");
   const [isEditing, setIsEditing] = useState(false);
   const [editableValue, setEditableValue] = useState(value);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
@@ -132,7 +134,7 @@ export function EditableStringFieldDisplay({
           <button
             type="button"
             onClick={() => setIsEditing(true)}
-            aria-label="Rename"
+            aria-label={t("rename.ariaLabel")}
             className="group flex cursor-pointer"
             style={{ fontSize: `${scale}rem` }}
           >

--- a/web/src/components/EditableValue.tsx
+++ b/web/src/components/EditableValue.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { FiEdit2 } from "react-icons/fi";
 import { SvgCheck } from "@opal/icons";
 
@@ -15,6 +16,7 @@ export function EditableValue({
   emptyDisplay?: string;
   consistentWidth?: boolean;
 }) {
+  const t = useTranslations("common.editable");
   const [isOpen, setIsOpen] = useState(false);
   const [editedValue, setEditedValue] = useState(initialValue);
 
@@ -42,7 +44,7 @@ export function EditableValue({
         />
         <button
           type="button"
-          aria-label="Save"
+          aria-label={t("save.ariaLabel")}
           onClick={async () => {
             const success = await onSubmit(editedValue);
             if (success) {
@@ -61,7 +63,7 @@ export function EditableValue({
     <div className="h-full flex flex-col">
       <button
         type="button"
-        aria-label="Edit"
+        aria-label={t("edit.ariaLabel")}
         className="flex my-auto cursor-pointer hover:bg-accent-background-hovered rounded-sm"
         onClick={() => setIsOpen(true)}
       >

--- a/web/src/components/FederatedConnectorSelector.tsx
+++ b/web/src/components/FederatedConnectorSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import {
   FederatedConnectorDetail,
   FederatedConnectorConfig,
@@ -30,9 +31,10 @@ export const FederatedConnectorSelector = ({
   selectedConfigs,
   onChange,
   disabled = false,
-  placeholder = "Search federated connectors...",
+  placeholder,
   showError = false,
 }: FederatedConnectorSelectorProps) => {
+  const t = useTranslations("common.federatedConnectorSelector");
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -121,8 +123,8 @@ export const FederatedConnectorSelector = ({
   };
 
   const effectivePlaceholder = allConnectorsSelected
-    ? "All federated connectors selected"
-    : placeholder;
+    ? t("allSelected.placeholder")
+    : (placeholder ?? t("search.placeholder"));
 
   const isInputDisabled = disabled || allConnectorsSelected;
 
@@ -135,8 +137,7 @@ export const FederatedConnectorSelector = ({
       )}
 
       <Text as="p" mainUiMuted text03>
-        Documents from selected federated connectors will be searched in
-        real-time during queries.
+        {t("realtimeSearchHint.description")}
       </Text>
       <div className="relative">
         <InputTypeIn
@@ -164,9 +165,7 @@ export const FederatedConnectorSelector = ({
           >
             {filteredUnselectedConnectors.length === 0 ? (
               <div className="py-4 text-center text-xs text-text-03">
-                {searchQuery
-                  ? "No matching federated connectors found"
-                  : "No more federated connectors available"}
+                {searchQuery ? t("noMatches.text") : t("noMoreConnectors.text")}
               </div>
             ) : (
               <div>
@@ -227,7 +226,7 @@ export const FederatedConnectorSelector = ({
                     {hasEntitiesConfigured && (
                       <div
                         className="ms-1 w-2 h-2 bg-green-500 rounded-full shrink-0"
-                        title="Entities configured"
+                        title={t("entitiesConfigured.tooltip")}
                       />
                     )}
                   </div>
@@ -236,8 +235,8 @@ export const FederatedConnectorSelector = ({
                       prominence="tertiary"
                       size="sm"
                       type="button"
-                      aria-label="Remove connector"
-                      tooltip="Remove connector"
+                      aria-label={t("removeConnector.tooltip")}
+                      tooltip={t("removeConnector.tooltip")}
                       onClick={() => removeConnector(connector.id)}
                       icon={SvgX}
                     />
@@ -249,7 +248,7 @@ export const FederatedConnectorSelector = ({
         </div>
       ) : (
         <div className="mt-3 p-3 border border-dashed border-border-02 rounded-12 bg-background-neutral-01 text-text-03 text-xs">
-          No federated connectors selected. Search and select connectors above.
+          {t("noneSelected.text")}
         </div>
       )}
 

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FiInfo, FiX } from "react-icons/fi";
+import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import { FaMarkdown } from "react-icons/fa";
 import { useState, useEffect, memo, JSX } from "react";
@@ -175,37 +176,40 @@ export const FieldLabel = ({
   label: string;
   removeLabel?: boolean;
   vertical?: boolean;
-}) => (
-  <>
-    <div
-      className={`flex ${
-        vertical ? "flex-col" : "flex-row"
-      } gap-x-2 items-start`}
-    >
-      <div className="flex gap-x-2 items-center">
-        {!removeLabel && (
-          <Label small={false} htmlFor={name}>
-            {label}
-          </Label>
+}) => {
+  const t = useTranslations("common.field");
+  return (
+    <>
+      <div
+        className={`flex ${
+          vertical ? "flex-col" : "flex-row"
+        } gap-x-2 items-start`}
+      >
+        <div className="flex gap-x-2 items-center">
+          {!removeLabel && (
+            <Label small={false} htmlFor={name}>
+              {label}
+            </Label>
+          )}
+          {optional ? <span>{t("optionalIndicator.text")} </span> : ""}
+          {tooltip && <ToolTipDetails>{tooltip}</ToolTipDetails>}
+        </div>
+        {error ? (
+          <ManualErrorMessage>{error}</ManualErrorMessage>
+        ) : (
+          !hideError && (
+            <ErrorMessage
+              name={name}
+              component="div"
+              className="text-action-danger-05 my-auto text-sm"
+            />
+          )
         )}
-        {optional ? <span>(optional) </span> : ""}
-        {tooltip && <ToolTipDetails>{tooltip}</ToolTipDetails>}
       </div>
-      {error ? (
-        <ManualErrorMessage>{error}</ManualErrorMessage>
-      ) : (
-        !hideError && (
-          <ErrorMessage
-            name={name}
-            component="div"
-            className="text-action-danger-05 my-auto text-sm"
-          />
-        )
-      )}
-    </div>
-    {subtext && <SubLabel>{subtext}</SubLabel>}
-  </>
-);
+      {subtext && <SubLabel>{subtext}</SubLabel>}
+    </>
+  );
+};
 
 export function TextFormField({
   name,
@@ -264,6 +268,7 @@ export function TextFormField({
   className?: string;
   showPasswordToggle?: boolean;
 }) {
+  const t = useTranslations("common.field");
   let heightString = defaultHeight || "";
   if (isTextArea && !heightString) {
     heightString = "h-28";
@@ -372,7 +377,11 @@ export function TextFormField({
         {!isTextArea && isPasswordField && showPasswordToggle && (
           <button
             type="button"
-            aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+            aria-label={
+              isPasswordVisible
+                ? t("passwordToggle.hideAriaLabel")
+                : t("passwordToggle.showAriaLabel")
+            }
             className="absolute end-3 top-1/2 -translate-y-1/2 stroke-text-02 hover:stroke-text-03 mt-0.5"
             onClick={() => setIsPasswordVisible((v) => !v)}
             tabIndex={0}
@@ -435,6 +444,7 @@ export function TypedFileUploadFormField({
   label: string;
   subtext?: string | JSX.Element;
 }) {
+  const t = useTranslations("common.field");
   const [field, , helpers] = useField<TypedFile | null>(name);
   const [customError, setCustomError] = useState<string>("");
   const [isValidating, setIsValidating] = useState(false);
@@ -463,12 +473,16 @@ export function TypedFileUploadFormField({
         if (validation?.isValid) {
           setCustomError("");
         } else {
-          setCustomError(validation?.errors.join(", ") || "Unknown error");
+          setCustomError(
+            validation?.errors.join(", ") || t("fileValidation.unknownError")
+          );
           helpers.setValue(null);
         }
       } catch (error) {
         setCustomError(
-          error instanceof Error ? error.message : "Validation error"
+          error instanceof Error
+            ? error.message
+            : t("fileValidation.validationError")
         );
         helpers.setValue(null);
       } finally {
@@ -477,7 +491,7 @@ export function TypedFileUploadFormField({
     };
 
     validateFile();
-  }, [field.value, helpers]);
+  }, [field.value, helpers, t]);
 
   const handleFileSelection = async (files: File[]) => {
     if (files.length === 0) {
@@ -488,14 +502,14 @@ export function TypedFileUploadFormField({
 
     const file = files[0];
     if (!file) {
-      setCustomError("File selection error");
+      setCustomError(t("fileValidation.selectionError"));
       return;
     }
 
     const typeDefinitionKey = getFileTypeDefinitionForField(name);
 
     if (!typeDefinitionKey) {
-      setCustomError(`No file type definition found for field: ${name}`);
+      setCustomError(t("fileValidation.noTypeDefinition", { name }));
       return;
     }
 
@@ -504,7 +518,11 @@ export function TypedFileUploadFormField({
       helpers.setValue(typedFile);
       setCustomError("");
     } catch (error) {
-      setCustomError(error instanceof Error ? error.message : "Unknown error");
+      setCustomError(
+        error instanceof Error
+          ? error.message
+          : t("fileValidation.unknownError")
+      );
       helpers.setValue(null);
     } finally {
       setIsValidating(false);
@@ -525,7 +543,7 @@ export function TypedFileUploadFormField({
       {/* Validation feedback */}
       {isValidating && (
         <div className="text-status-info-05 text-sm mt-1">
-          Validating file...
+          {t("fileValidation.validating")}
         </div>
       )}
 
@@ -624,8 +642,9 @@ export const MarkdownFormField = ({
   name,
   label,
   error,
-  placeholder = "Enter your markdown here...",
+  placeholder,
 }: MarkdownPreviewProps) => {
+  const t = useTranslations("common.field");
   const [field] = useField(name);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
@@ -640,14 +659,16 @@ export const MarkdownFormField = ({
         <div className="flex items-center justify-between px-4 py-2 bg-background-neutral-02 rounded-t-md">
           <div className="flex items-center space-x-2">
             <FaMarkdown className="text-text-03" />
-            <span className="text-sm font-semibold text-text-04">Markdown</span>
+            <span className="text-sm font-semibold text-text-04">
+              {t("markdown.editorLabel")}
+            </span>
           </div>
           <button
             type="button"
             onClick={togglePreview}
             className="text-sm font-semibold text-text-04 hover:text-text-05 focus:outline-hidden"
           >
-            {isPreviewOpen ? "Write" : "Preview"}
+            {isPreviewOpen ? t("markdown.writeTab") : t("markdown.previewTab")}
           </button>
         </div>
         {isPreviewOpen ? (
@@ -665,7 +686,7 @@ export const MarkdownFormField = ({
             <textarea
               {...field}
               rows={2}
-              placeholder={placeholder}
+              placeholder={placeholder ?? t("markdown.placeholder")}
               className={`w-full p-2 border border-border-02 rounded-md`}
             />
           </div>
@@ -713,6 +734,7 @@ export const BooleanFormField = memo(function BooleanFormField({
   disabledTooltipSide,
   onChange,
 }: BooleanFormFieldProps) {
+  const t = useTranslations("common.field");
   // Generate a stable, valid id from the field name for label association
   const checkboxId = `checkbox-${name.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
 
@@ -771,9 +793,11 @@ export const BooleanFormField = memo(function BooleanFormField({
                     onClick={toggle}
                   >
                     <div className="flex items-center gap-x-2">
-                      <Label small={small}>{`${label}${
-                        optional ? " (Optional)" : ""
-                      }`}</Label>
+                      <Label small={small}>
+                        {optional
+                          ? t("booleanField.optionalLabel", { label })
+                          : label}
+                      </Label>
                       {tooltip && <ToolTipDetails>{tooltip}</ToolTipDetails>}
                     </div>
                     {subtext && <SubLabel>{subtext}</SubLabel>}
@@ -817,6 +841,7 @@ export function TextArrayField<T extends Yup.AnyObject>({
   placeholder = "",
   disabled = false,
 }: TextArrayFieldProps<T>) {
+  const t = useTranslations("common.field");
   return (
     <div className="mb-4">
       <div className="flex gap-x-2 items-center">
@@ -888,7 +913,7 @@ export function TextArrayField<T extends Yup.AnyObject>({
               type="button"
               disabled={disabled}
             >
-              Add New
+              {t("arrayField.addButton")}
             </Button>
           </div>
         )}
@@ -946,6 +971,7 @@ export function SelectorFormField({
   small = false,
   disabled = false,
 }: SelectorFormFieldProps) {
+  const t = useTranslations("common.field");
   const [field] = useField<string>(name);
   const { setFieldValue } = useFormikContext();
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
@@ -999,7 +1025,7 @@ export function SelectorFormField({
           disabled={disabled}
         >
           <SelectTrigger className={sizeClass.input} disabled={disabled}>
-            <SelectValue placeholder="Select...">
+            <SelectValue placeholder={t("selector.placeholder")}>
               {currentlySelected?.name || defaultValue || ""}
             </SelectValue>
           </SelectTrigger>
@@ -1015,7 +1041,9 @@ export function SelectorFormField({
               container={container}
             >
               {options.length === 0 ? (
-                <SelectItem value="default">Select...</SelectItem>
+                <SelectItem value="default">
+                  {t("selector.placeholder")}
+                </SelectItem>
               ) : (
                 options.map((option) => (
                   <SelectItem
@@ -1034,7 +1062,7 @@ export function SelectorFormField({
                   value={"__none__"}
                   onSelect={() => setFieldValue(name, null)}
                 >
-                  None
+                  {t("selector.noneOption")}
                 </SelectItem>
               )}
             </SelectContent>

--- a/web/src/components/GenericMultiSelect.tsx
+++ b/web/src/components/GenericMultiSelect.tsx
@@ -1,4 +1,5 @@
 import { FormikProps, ErrorMessage } from "formik";
+import { useTranslations } from "next-intl";
 import Text from "@/refresh-components/texts/Text";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox/InputComboBox";
 import { Tag } from "@opal/components";
@@ -43,6 +44,7 @@ export function GenericMultiSelect<
   disabled = false,
   disabledMessage,
 }: GenericMultiSelectProps<T, F>) {
+  const t = useTranslations("common.genericMultiSelect");
   if (isLoading) {
     return (
       <div className="flex flex-col gap-2 w-full">
@@ -61,7 +63,7 @@ export function GenericMultiSelect<
           {label}
         </Text>
         <Text as="p" text03 className="text-action-danger-05">
-          Failed to load {label.toLowerCase()}. Please try again.
+          {t("loadFailed.text", { label: label.toLowerCase() })}
         </Text>
       </div>
     );
@@ -115,7 +117,7 @@ export function GenericMultiSelect<
       <Disabled disabled={disabled}>
         <div>
           <InputComboBox
-            placeholder="Search..."
+            placeholder={t("search.placeholder")}
             value=""
             onChange={() => {}}
             onValueChange={(selectedValue) => {

--- a/web/src/components/GroupsMultiSelect.tsx
+++ b/web/src/components/GroupsMultiSelect.tsx
@@ -1,4 +1,5 @@
 import { FormikProps } from "formik";
+import { useTranslations } from "next-intl";
 import { Label } from "@/components/Field";
 import { useUserGroups } from "@/lib/hooks";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
@@ -19,11 +20,14 @@ interface GroupsMultiSelectProps<T extends GroupsMultiSelectFormType> {
 
 export function GroupsMultiSelect<T extends GroupsMultiSelectFormType>({
   formikProps,
-  label = "User Groups",
-  subtext = "Select which user groups can access this resource",
+  label,
+  subtext,
   disabled = false,
   disabledMessage,
 }: GroupsMultiSelectProps<T>) {
+  const t = useTranslations("common.groupsMultiSelect");
+  const effectiveLabel = label ?? t("userGroups.label");
+  const effectiveSubtext = subtext ?? t("userGroups.subtext");
   const {
     data: userGroups,
     isLoading: userGroupsIsLoading,
@@ -35,7 +39,7 @@ export function GroupsMultiSelect<T extends GroupsMultiSelectFormType>({
   if (userGroupsIsLoading || businessTier === undefined) {
     return (
       <div className="mb-4">
-        <Label>{label}</Label>
+        <Label>{effectiveLabel}</Label>
         <div className="animate-pulse bg-background-200 h-10 w-full rounded-lg mt-2"></div>
       </div>
     );
@@ -49,12 +53,12 @@ export function GroupsMultiSelect<T extends GroupsMultiSelectFormType>({
     <GenericMultiSelect
       formikProps={formikProps}
       fieldName="groups"
-      label={label}
-      subtext={subtext}
+      label={effectiveLabel}
+      subtext={effectiveSubtext}
       items={userGroups}
       isLoading={false}
       error={error}
-      emptyMessage="No user groups available. Please create a user group first."
+      emptyMessage={t("noGroups.emptyMessage")}
       disabled={disabled}
       disabledMessage={disabledMessage}
     />

--- a/web/src/components/IsPublicGroupSelector.tsx
+++ b/web/src/components/IsPublicGroupSelector.tsx
@@ -1,6 +1,7 @@
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import React, { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { FormikProps } from "formik";
 import { useUserGroups } from "@/lib/hooks";
 import { BooleanFormField } from "@/components/Field";
@@ -17,7 +18,7 @@ export type IsPublicGroupSelectorFormType = {
 export const IsPublicGroupSelector = <T extends IsPublicGroupSelectorFormType>({
   formikProps,
   objectName,
-  publicToWhom = "Users",
+  publicToWhom,
   removeIndent = false,
   enforceGroupSelection = true,
   smallLabels = false,
@@ -34,6 +35,8 @@ export const IsPublicGroupSelector = <T extends IsPublicGroupSelectorFormType>({
   // caller supplies its own; falls back to admin when omitted.
   isGlobalHolder?: boolean;
 }) => {
+  const t = useTranslations("common.isPublicSelector");
+  const effectivePublicToWhom = publicToWhom ?? t("usersFallback.text");
   const { data: userGroups, isLoading: userGroupsIsLoading } = useUserGroups();
   const { isAdmin, user } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
@@ -52,7 +55,7 @@ export const IsPublicGroupSelector = <T extends IsPublicGroupSelectorFormType>({
   }, [user, userGroups, businessTier, canActGlobally]);
 
   if (userGroupsIsLoading) {
-    return <div>Loading...</div>;
+    return <div>{t("loading.text")}</div>;
   }
   if (!businessTier) {
     return null;
@@ -66,13 +69,14 @@ export const IsPublicGroupSelector = <T extends IsPublicGroupSelectorFormType>({
             name="is_public"
             removeIndent={removeIndent}
             small={smallLabels}
-            label={`Make this ${objectName} Public?`}
+            label={t("makePublic.label", { objectName })}
             subtext={
               <span className="block mt-2 text-sm text-text-600 dark:text-neutral-400">
-                If set, then this {objectName} will be usable by{" "}
-                <b>All {publicToWhom}</b>. Otherwise, only <b>Admins</b> and{" "}
-                <b>{publicToWhom}</b> who have explicitly been given access to
-                this {objectName} (e.g. via a User Group) will have access.
+                {t.rich("makePublic.subtext", {
+                  objectName,
+                  publicToWhom: effectivePublicToWhom,
+                  b: (chunks) => <b>{chunks}</b>,
+                })}
               </span>
             }
           />
@@ -81,14 +85,14 @@ export const IsPublicGroupSelector = <T extends IsPublicGroupSelectorFormType>({
 
       <GroupsMultiSelect
         formikProps={formikProps}
-        label={`Assign group access for this ${objectName}`}
+        label={t("assignGroups.label", { objectName })}
         subtext={
           canActGlobally || !enforceGroupSelection
-            ? `This ${objectName} will be visible/accessible by the groups selected below`
-            : `Select one or more of the groups you manage to give access to this ${objectName}`
+            ? t("assignGroups.visibleSubtext", { objectName })
+            : t("assignGroups.scopedSubtext", { objectName })
         }
         disabled={formikProps.values.is_public}
-        disabledMessage={`This ${objectName} is public and available to all users.`}
+        disabledMessage={t("publicDisabled.message", { objectName })}
       />
     </div>
   );

--- a/web/src/components/NonSelectableConnectors.tsx
+++ b/web/src/components/NonSelectableConnectors.tsx
@@ -1,4 +1,5 @@
 import { ConnectorStatus } from "@/lib/types";
+import { useTranslations } from "next-intl";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { Content } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
@@ -14,6 +15,7 @@ export const NonSelectableConnectors = ({
   title,
   description,
 }: NonSelectableConnectorsProps) => {
+  const t = useTranslations("common.nonSelectableConnectors");
   if (connectors.length === 0) {
     return null;
   }
@@ -31,7 +33,7 @@ export const NonSelectableConnectors = ({
         <div className="mb-2 flex items-center gap-1.5">
           <SvgLock className="h-3.5 w-3.5 stroke-text-03" />
           <Text as="p" figureSmallLabel text04 className="mb-0!">
-            Unavailable connectors:
+            {t("unavailable.label")}
           </Text>
         </div>
         <div className="flex flex-wrap gap-1.5">

--- a/web/src/components/OnyxInitializingLoader.tsx
+++ b/web/src/components/OnyxInitializingLoader.tsx
@@ -2,14 +2,18 @@
 
 import { Logo } from "@/lib/app/components";
 import { useSettings } from "@/lib/settings/hooks";
+import { useTranslations } from "next-intl";
 
 export default function OnyxInitializingLoader() {
+  const t = useTranslations("common.initializingLoader");
   const { appName } = useSettings();
 
   return (
     <div className="mx-auto my-auto animate-pulse">
       <Logo folded size={96} className="mx-auto mb-3" />
-      <p className="text-lg text-text font-semibold">Initializing {appName}</p>
+      <p className="text-lg text-text font-semibold">
+        {t("initializing.text", { appName })}
+      </p>
     </div>
   );
 }

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { ValidStatuses } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { timeAgo } from "@opal/time";
@@ -40,43 +41,44 @@ export function IndexAttemptStatus({
   status: ValidStatuses | null;
   errorMsg?: string | null;
 }) {
+  const t = useTranslations("admin.status.badges");
   let badge;
 
   if (status === "failed") {
     badge = badgeWithErrorTooltip(
       <Badge variant="destructive" icon={FiAlertTriangle}>
-        Failed
+        {t("failed")}
       </Badge>,
       errorMsg
     );
   } else if (status === "completed_with_errors") {
     badge = (
       <Badge variant="secondary" icon={FiAlertTriangle}>
-        Completed with errors
+        {t("completedWithErrors")}
       </Badge>
     );
   } else if (status === "success") {
     badge = (
       <Badge variant="success" icon={FiCheckCircle}>
-        Succeeded
+        {t("succeeded")}
       </Badge>
     );
   } else if (status === "in_progress") {
     badge = (
       <Badge variant="in_progress" icon={FiClock}>
-        In Progress
+        {t("inProgress")}
       </Badge>
     );
   } else if (status === "not_started") {
     badge = (
       <Badge variant="not_started" icon={FiClock}>
-        Scheduled
+        {t("scheduled")}
       </Badge>
     );
   } else if (status === "canceled") {
     badge = (
       <Badge variant="canceled" icon={FiClock}>
-        Canceled
+        {t("canceled")}
       </Badge>
     );
   } else if (status === "interrupted") {
@@ -84,20 +86,20 @@ export function IndexAttemptStatus({
     // resumes automatically. Neutral badge with the reason on hover, never red.
     badge = badgeWithErrorTooltip(
       <Badge variant="canceled" icon={FiClock}>
-        Interrupted
+        {t("interrupted")}
       </Badge>,
       errorMsg
     );
   } else if (status === "invalid") {
     badge = (
       <Badge variant="invalid" icon={FiAlertTriangle}>
-        Invalid
+        {t("invalid")}
       </Badge>
     );
   } else {
     badge = (
       <Badge variant="outline" icon={FiMinus}>
-        None
+        {t("none")}
       </Badge>
     );
   }
@@ -112,12 +114,13 @@ export function PermissionSyncStatus({
   status: PermissionSyncStatusEnum | null;
   errorMsg?: string | null;
 }) {
+  const t = useTranslations("admin.status.badges");
   let badge;
 
   if (status === PermissionSyncStatusEnum.FAILED) {
     const icon = (
       <Badge variant="destructive" icon={FiAlertTriangle}>
-        Failed
+        {t("failed")}
       </Badge>
     );
     if (errorMsg) {
@@ -132,31 +135,31 @@ export function PermissionSyncStatus({
   } else if (status === PermissionSyncStatusEnum.COMPLETED_WITH_ERRORS) {
     badge = (
       <Badge variant="secondary" icon={FiAlertTriangle}>
-        Completed with errors
+        {t("completedWithErrors")}
       </Badge>
     );
   } else if (status === PermissionSyncStatusEnum.SUCCESS) {
     badge = (
       <Badge variant="success" icon={FiCheckCircle}>
-        Succeeded
+        {t("succeeded")}
       </Badge>
     );
   } else if (status === PermissionSyncStatusEnum.IN_PROGRESS) {
     badge = (
       <Badge variant="in_progress" icon={FiClock}>
-        In Progress
+        {t("inProgress")}
       </Badge>
     );
   } else if (status === PermissionSyncStatusEnum.NOT_STARTED) {
     badge = (
       <Badge variant="not_started" icon={FiClock}>
-        Scheduled
+        {t("scheduled")}
       </Badge>
     );
   } else {
     badge = (
       <Badge variant="secondary" icon={FiClock}>
-        Not Started
+        {t("notStarted")}
       </Badge>
     );
   }
@@ -175,18 +178,19 @@ export function CCPairStatus({
   lastIndexAttemptStatus: ValidStatuses | undefined | null;
   size?: "xs" | "sm" | "md" | "lg";
 }) {
+  const t = useTranslations("admin.status.badges");
   let badge;
 
   if (ccPairStatus == ConnectorCredentialPairStatus.DELETING) {
     badge = (
       <Badge variant="destructive" icon={FiAlertTriangle}>
-        Deleting
+        {t("deleting")}
       </Badge>
     );
   } else if (ccPairStatus == ConnectorCredentialPairStatus.PAUSED) {
     badge = (
       <Badge variant="paused" icon={FiPauseCircle}>
-        Paused
+        {t("paused")}
       </Badge>
     );
   } else if (inRepeatedErrorState && lastIndexAttemptStatus !== "in_progress") {
@@ -194,36 +198,32 @@ export function CCPairStatus({
     // once that attempt is no longer running.
     badge = (
       <Badge variant="destructive" icon={FiAlertTriangle}>
-        Error
+        {t("error")}
       </Badge>
     );
   } else if (ccPairStatus == ConnectorCredentialPairStatus.SCHEDULED) {
     badge = (
       <Badge variant="not_started" icon={FiClock}>
-        Scheduled
+        {t("scheduled")}
       </Badge>
     );
   } else if (ccPairStatus == ConnectorCredentialPairStatus.INITIAL_INDEXING) {
     badge = (
       <Badge variant="in_progress" icon={FiClock}>
-        Initial Indexing
+        {t("initialIndexing")}
       </Badge>
     );
   } else if (ccPairStatus == ConnectorCredentialPairStatus.INVALID) {
     badge = (
-      <Badge
-        tooltip="Connector is in an invalid state. Please update the credentials or create a new connector."
-        circle
-        variant="invalid"
-      >
-        Invalid
+      <Badge tooltip={t("invalidConnectorTooltip")} circle variant="invalid">
+        {t("invalid")}
       </Badge>
     );
   } else {
     if (lastIndexAttemptStatus && lastIndexAttemptStatus === "in_progress") {
       badge = (
         <Badge variant="in_progress" icon={FiClock}>
-          Indexing
+          {t("indexing")}
         </Badge>
       );
     } else if (
@@ -232,7 +232,7 @@ export function CCPairStatus({
     ) {
       badge = (
         <Badge variant="not_started" icon={FiClock}>
-          Scheduled
+          {t("scheduled")}
         </Badge>
       );
     } else if (
@@ -241,20 +241,20 @@ export function CCPairStatus({
     ) {
       badge = (
         <Badge variant="canceled" icon={FiClock}>
-          Canceled
+          {t("canceled")}
         </Badge>
       );
     } else if (lastIndexAttemptStatus === "interrupted") {
       // resumes automatically, so it's neutral rather than the green "Indexed"
       badge = (
         <Badge variant="canceled" icon={FiClock}>
-          Interrupted
+          {t("interrupted")}
         </Badge>
       );
     } else {
       badge = (
         <Badge variant="success" icon={FiCheckCircle}>
-          Indexed
+          {t("indexed")}
         </Badge>
       );
     }

--- a/web/src/components/admin/connectors/AccessTypeForm.test.tsx
+++ b/web/src/components/admin/connectors/AccessTypeForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@tests/setup/test-utils";
 import { Formik } from "formik";
 import { AccessTypeForm } from "@/components/admin/connectors/AccessTypeForm";
 import { ConfigurableSources, ValidSources } from "@/lib/types";

--- a/web/src/components/admin/connectors/AccessTypeForm.tsx
+++ b/web/src/components/admin/connectors/AccessTypeForm.tsx
@@ -6,6 +6,7 @@ import {
   validAutoSyncSources,
 } from "@/lib/types";
 import { useField } from "formik";
+import { useTranslations } from "next-intl";
 import { AutoSyncOptions } from "./AutoSyncOptions";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
@@ -28,6 +29,7 @@ export function AccessTypeForm({
   connector: ConfigurableSources;
   currentCredential?: Credential<any> | null;
 }) {
+  const t = useTranslations("admin.connector.accessType");
   const [access_type, meta, access_type_helpers] =
     useField<AccessType>("access_type");
   const { isScopedManager } = usePermissionAuthority(
@@ -74,10 +76,9 @@ export function AccessTypeForm({
 
     if (businessTier) {
       built.push({
-        name: "Private",
+        name: t("privateOption.name"),
         value: "private",
-        description:
-          "Only users who have explicitly been given access to this connector (through the User Groups page) can access the documents pulled in by this connector",
+        description: t("privateOption.description"),
         disabled: false,
         disabledReason: "",
       });
@@ -88,10 +89,9 @@ export function AccessTypeForm({
     // Offering the option would only produce a 403 on submit.
     if (!isScopedManager) {
       built.push({
-        name: "Public",
+        name: t("publicOption.name"),
         value: "public",
-        description:
-          "Everyone with an account on Onyx can access the documents pulled in by this connector",
+        description: t("publicOption.description"),
         disabled: false,
         disabledReason: "",
       });
@@ -99,18 +99,16 @@ export function AccessTypeForm({
 
     if (showAutoSync) {
       built.push({
-        name: "Auto Sync Permissions",
+        name: t("autoSyncOption.name"),
         value: "sync",
-        description:
-          "We will automatically sync permissions from the source. A document will be searchable in Onyx if and only if the user performing the search has permission to access the document in the source.",
+        description: t("autoSyncOption.description"),
         disabled: isSyncDisabledByAuth,
-        disabledReason:
-          "Current credential auth method doesn't support Auto Sync Permissions. Please change the credential auth method to a supported one.",
+        disabledReason: t("autoSyncOption.disabledReason"),
       });
     }
 
     return built;
-  }, [businessTier, isScopedManager, showAutoSync, isSyncDisabledByAuth]);
+  }, [businessTier, isScopedManager, showAutoSync, isSyncDisabledByAuth, t]);
 
   useEffect(() => {
     if (!businessTier || !options.length) return;
@@ -133,10 +131,8 @@ export function AccessTypeForm({
   return (
     <>
       <div>
-        <p className="text-text-950 font-medium">Document Access</p>
-        <p className="text-sm text-text-500">
-          Control who has access to the documents indexed by this connector.
-        </p>
+        <p className="text-text-950 font-medium">{t("heading.title")}</p>
+        <p className="text-sm text-text-500">{t("heading.description")}</p>
       </div>
       <DefaultDropdown
         options={options}

--- a/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
+++ b/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
@@ -1,6 +1,7 @@
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import React, { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { FieldArray, ArrayHelpers, ErrorMessage, useField } from "formik";
 import Text from "@/refresh-components/texts/Text";
 import { Button, Divider } from "@opal/components";
@@ -34,6 +35,7 @@ export function AccessTypeGroupSelector({
 }: {
   connector: ConfigurableSources;
 }) {
+  const t = useTranslations("admin.connector.groupSelector");
   const { data: userGroups, isLoading: userGroupsIsLoading } = useUserGroups();
   const { isScopedManager } = usePermissionAuthority(
     Permission.MANAGE_CONNECTORS
@@ -83,8 +85,8 @@ export function AccessTypeGroupSelector({
             <div className="flex flex-col gap-3 pt-4">
               <Text as="p" mainUiAction text05>
                 {access_type.value === "sync"
-                  ? "Assign this Connector to a group"
-                  : "Assign group access for this Connector"}
+                  ? t("assignToGroup.title")
+                  : t("assignGroupAccess.title")}
               </Text>
               {userGroupsIsLoading ? (
                 <div className="animate-pulse bg-background-200 h-8 w-32 rounded-sm" />
@@ -93,10 +95,10 @@ export function AccessTypeGroupSelector({
                   {access_type.value === "sync"
                     ? // Groups never widen or narrow a synced connector's document
                       // access — the source system's permissions decide that.
-                      "The groups below control who can manage this Connector. Access to its documents is inherited from the source's own permissions."
+                      t("syncGroups.description")
                     : isScopedManager
-                      ? "Select one or more of the groups you manage to give access to this Connector"
-                      : "This Connector will be visible/accessible by the groups selected below"}
+                      ? t("scopedManagerGroups.description")
+                      : t("visibleToGroups.description")}
                 </Text>
               )}
             </div>

--- a/web/src/components/admin/connectors/ConnectorDocsLink.tsx
+++ b/web/src/components/admin/connectors/ConnectorDocsLink.tsx
@@ -1,5 +1,6 @@
 import { ValidSources } from "@/lib/types";
 import { getSourceDocLink } from "@/lib/sources";
+import { useTranslations } from "next-intl";
 
 export default function ConnectorDocsLink({
   sourceType,
@@ -8,6 +9,7 @@ export default function ConnectorDocsLink({
   sourceType: ValidSources;
   className?: string;
 }) {
+  const t = useTranslations("admin.connector.docsLink");
   const docsLink = getSourceDocLink(sourceType);
 
   if (!docsLink) {
@@ -18,17 +20,18 @@ export default function ConnectorDocsLink({
 
   return (
     <p className={paragraphClass}>
-      Check out
-      <a
-        className="text-blue-600 hover:underline"
-        target="_blank"
-        rel="noopener"
-        href={docsLink}
-      >
-        {" "}
-        our docs{" "}
-      </a>
-      for more info on configuring this connector.
+      {t.rich("checkOutDocs.text", {
+        link: (chunks) => (
+          <a
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener"
+            href={docsLink}
+          >
+            {chunks}
+          </a>
+        ),
+      })}
     </p>
   );
 }

--- a/web/src/components/admin/connectors/ConnectorTitle.tsx
+++ b/web/src/components/admin/connectors/ConnectorTitle.tsx
@@ -8,6 +8,7 @@ import {
   ZulipConfig,
 } from "@/lib/connectors/connectors";
 import { getSourceMetadata } from "@/lib/sources";
+import { useTranslations } from "next-intl";
 
 import Link from "next/link";
 
@@ -32,17 +33,18 @@ export const ConnectorTitle = ({
   showMetadata = true,
   className = "",
 }: ConnectorTitleProps) => {
+  const t = useTranslations("admin.connectorTitle.metadata");
   const sourceMetadata = getSourceMetadata(connector.source);
 
   let additionalMetadata = new Map<string, string>();
   if (connector.source === "github") {
     const typedConnector = connector as Connector<GithubConfig>;
     additionalMetadata.set(
-      "Repo",
+      t("repo"),
       typedConnector.connector_specific_config.repositories
         ? `${typedConnector.connector_specific_config.repo_owner}/${
             typedConnector.connector_specific_config.repositories.includes(",")
-              ? "multiple repos"
+              ? t("multipleRepos")
               : typedConnector.connector_specific_config.repositories
           }`
         : `${typedConnector.connector_specific_config.repo_owner}/*`
@@ -50,7 +52,7 @@ export const ConnectorTitle = ({
   } else if (connector.source === "gitlab") {
     const typedConnector = connector as Connector<GitlabConfig>;
     additionalMetadata.set(
-      "Repo",
+      t("repo"),
       `${typedConnector.connector_specific_config.project_owner}/${typedConnector.connector_specific_config.project_name}`
     );
   } else if (connector.source === "confluence") {
@@ -58,17 +60,17 @@ export const ConnectorTitle = ({
     const wikiUrl = typedConnector.connector_specific_config.is_cloud
       ? `${typedConnector.connector_specific_config.wiki_base}/wiki/spaces/${typedConnector.connector_specific_config.space}`
       : `${typedConnector.connector_specific_config.wiki_base}/spaces/${typedConnector.connector_specific_config.space}`;
-    additionalMetadata.set("Wiki URL", wikiUrl);
+    additionalMetadata.set(t("wikiUrl"), wikiUrl);
     if (typedConnector.connector_specific_config.page_id) {
       additionalMetadata.set(
-        "Page ID",
+        t("pageId"),
         typedConnector.connector_specific_config.page_id
       );
     }
   } else if (connector.source === "jira") {
     const typedConnector = connector as Connector<JiraConfig>;
     additionalMetadata.set(
-      "Jira Project URL",
+      t("jiraProjectUrl"),
       typedConnector.connector_specific_config.jira_project_url
     );
   } else if (connector.source === "slack") {
@@ -78,34 +80,34 @@ export const ConnectorTitle = ({
       typedConnector.connector_specific_config?.channels.length > 0
     ) {
       additionalMetadata.set(
-        "Channels",
+        t("channels"),
         typedConnector.connector_specific_config.channels.join(", ")
       );
     }
     if (typedConnector.connector_specific_config.channel_regex_enabled) {
-      additionalMetadata.set("Channel Regex Enabled", "True");
+      additionalMetadata.set(t("channelRegexEnabled"), t("enabledTrue"));
     }
     if (
       typedConnector.connector_specific_config?.exclude_channels &&
       typedConnector.connector_specific_config.exclude_channels.length > 0
     ) {
       additionalMetadata.set(
-        "Excluded Channels",
+        t("excludedChannels"),
         typedConnector.connector_specific_config.exclude_channels.join(", ")
       );
     }
     if (
       typedConnector.connector_specific_config.exclude_channel_regex_enabled
     ) {
-      additionalMetadata.set("Exclude Channel Regex Enabled", "True");
+      additionalMetadata.set(t("excludeChannelRegexEnabled"), t("enabledTrue"));
     }
     if (typedConnector.connector_specific_config.include_bot_messages) {
-      additionalMetadata.set("Include Bot Messages", "True");
+      additionalMetadata.set(t("includeBotMessages"), t("enabledTrue"));
     }
   } else if (connector.source === "zulip") {
     const typedConnector = connector as Connector<ZulipConfig>;
     additionalMetadata.set(
-      "Realm",
+      t("realm"),
       typedConnector.connector_specific_config.realm_name
     );
   }

--- a/web/src/components/admin/connectors/CredentialForm.tsx
+++ b/web/src/components/admin/connectors/CredentialForm.tsx
@@ -2,6 +2,7 @@ import React, { JSX } from "react";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { toast } from "@opal/layouts";
+import { useTranslations } from "next-intl";
 import { ValidSources } from "@/lib/types";
 
 import {
@@ -16,13 +17,24 @@ import {
 
 const PRIVATE_KEY_FIELD_KEY = "private_key";
 
+// Localized message builders. Callers inside components pass translated
+// strings. The English defaults cover legacy call sites.
+interface SubmitCredentialMessages {
+  success: () => string;
+  error: (detail: string) => string;
+}
+
 export async function submitCredential<T>(
-  credential: CredentialBase<T> | CredentialWithPrivateKey<T>
+  credential: CredentialBase<T> | CredentialWithPrivateKey<T>,
+  messages?: SubmitCredentialMessages
 ): Promise<{
   credential?: Credential<any>;
   message: string;
   isSuccess: boolean;
 }> {
+  const buildSuccess = messages?.success ?? (() => "Success!");
+  const buildError =
+    messages?.error ?? ((detail: string) => `Error: ${detail}`);
   let isSuccess = false;
   try {
     let response: Response;
@@ -37,13 +49,16 @@ export async function submitCredential<T>(
       const parsed_response = await response.json();
       const credential = parsed_response.credential;
       isSuccess = true;
-      return { credential, message: "Success!", isSuccess: true };
+      return { credential, message: buildSuccess(), isSuccess: true };
     } else {
       const errorData = await response.json();
-      return { message: `Error: ${errorData.detail}`, isSuccess: false };
+      return {
+        message: buildError(String(errorData.detail)),
+        isSuccess: false,
+      };
     }
   } catch (error) {
-    return { message: `Error: ${error}`, isSuccess: false };
+    return { message: buildError(String(error)), isSuccess: false };
   }
 }
 
@@ -62,6 +77,7 @@ export function CredentialForm<T extends Yup.AnyObject>({
   source,
   onSubmit,
 }: Props<T>): JSX.Element {
+  const t = useTranslations("admin.connector.credentialForm");
   return (
     <>
       <Formik
@@ -69,13 +85,19 @@ export function CredentialForm<T extends Yup.AnyObject>({
         validationSchema={validationSchema}
         onSubmit={(values, formikHelpers) => {
           formikHelpers.setSubmitting(true);
-          submitCredential<T>({
-            credential_json: values,
-            admin_public: true,
-            curator_public: false,
-            groups: [],
-            source: source,
-          }).then(({ message, isSuccess }) => {
+          submitCredential<T>(
+            {
+              credential_json: values,
+              admin_public: true,
+              curator_public: false,
+              groups: [],
+              source: source,
+            },
+            {
+              success: () => t("successToast"),
+              error: (detail) => t("errorToast", { detail }),
+            }
+          ).then(({ message, isSuccess }) => {
             if (isSuccess) {
               toast.success(message);
             } else {
@@ -100,9 +122,9 @@ export function CredentialForm<T extends Yup.AnyObject>({
                 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring
                 disabled:pointer-events-none disabled:opacity-50
                 shadow hover:bg-primary/90 h-9 px-4 py-2"
-                aria-label="Update credentials"
+                aria-label={t("updateButton.ariaLabel")}
               >
-                Update
+                {t("updateButton.label")}
               </button>
             </div>
           </Form>

--- a/web/src/components/admin/connectors/CredentialForm.tsx
+++ b/web/src/components/admin/connectors/CredentialForm.tsx
@@ -18,7 +18,7 @@ import {
 const PRIVATE_KEY_FIELD_KEY = "private_key";
 
 // Localized message builders. Callers inside components pass translated
-// strings. The English defaults cover legacy call sites.
+// strings. The English defaults cover call sites that pass no messages.
 interface SubmitCredentialMessages {
   success: () => string;
   error: (detail: string) => string;

--- a/web/src/components/admin/connectors/FileUpload.tsx
+++ b/web/src/components/admin/connectors/FileUpload.tsx
@@ -2,6 +2,7 @@ import { useFormikContext } from "formik";
 import { FC, useState } from "react";
 import React from "react";
 import Dropzone from "react-dropzone";
+import { useTranslations } from "next-intl";
 
 interface FileUploadProps {
   selectedFiles: File[];
@@ -20,6 +21,7 @@ export const FileUpload: FC<FileUploadProps> = ({
   multiple = true,
   accept,
 }) => {
+  const t = useTranslations("admin.connector.fileUpload");
   const [dragActive, setDragActive] = useState(false);
   const { setFieldValue } = useFormikContext();
 
@@ -64,9 +66,9 @@ export const FileUpload: FC<FileUploadProps> = ({
               <input {...getInputProps()} />
               <b className="text-text-darker">
                 {message ||
-                  `Drag and drop ${
-                    multiple ? "some files" : "a file"
-                  } here, or click to select ${multiple ? "files" : "a file"}`}
+                  t("dropzone.message", {
+                    multiple: multiple ? "true" : "false",
+                  })}
               </b>
             </div>
           </section>
@@ -76,7 +78,9 @@ export const FileUpload: FC<FileUploadProps> = ({
       {selectedFiles.length > 0 && (
         <div className="mt-4">
           <h2 className="text-sm font-bold">
-            Selected File{multiple ? "s" : ""}
+            {t("selectedFiles.heading", {
+              multiple: multiple ? "true" : "false",
+            })}
           </h2>
           <ul>
             {selectedFiles.map((file) => (

--- a/web/src/components/admin/federated/FederatedConnectorForm.tsx
+++ b/web/src/components/admin/federated/FederatedConnectorForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Button, Checkbox, Divider, Tooltip } from "@opal/components";
 import {
   ConfigurableSources,
@@ -56,9 +57,14 @@ interface FormState {
   connectorError: string | null;
 }
 
+type FederatedFormTranslate = ReturnType<
+  typeof useTranslations<"admin.federated.form">
+>;
+
 async function validateCredentials(
   source: string,
-  credentials: CredentialForm
+  credentials: CredentialForm,
+  t: FederatedFormTranslate
 ): Promise<{ success: boolean; message: string }> {
   try {
     const response = await fetch(
@@ -77,23 +83,28 @@ async function validateCredentials(
       return {
         success: false,
         message:
-          errorData.detail || `Validation failed: ${response.statusText}`,
+          errorData.detail ||
+          t("validation.failedStatus", { statusText: response.statusText }),
       };
     }
 
     const result = await response.json();
     return {
       success: result,
-      message: result ? "Credentials are valid" : "Credentials are invalid",
+      message: result ? t("validation.valid") : t("validation.invalid"),
     };
   } catch (error) {
-    return { success: false, message: `Validation error: ${error}` };
+    return {
+      success: false,
+      message: t("validation.error", { error: String(error) }),
+    };
   }
 }
 
 async function createFederatedConnector(
   source: string,
   credentials: CredentialForm,
+  t: FederatedFormTranslate,
   config?: ConfigForm
 ): Promise<{ success: boolean; message: string }> {
   try {
@@ -112,23 +123,27 @@ async function createFederatedConnector(
     if (response.ok) {
       return {
         success: true,
-        message: "Federated connector created successfully!",
+        message: t("create.success"),
       };
     } else {
       const errorData = await response.json();
       return {
         success: false,
-        message: errorData.detail || "Failed to create federated connector",
+        message: errorData.detail || t("create.failed"),
       };
     }
   } catch (error) {
-    return { success: false, message: `Error: ${error}` };
+    return {
+      success: false,
+      message: t("genericError.text", { error: String(error) }),
+    };
   }
 }
 
 async function updateFederatedConnector(
   id: number,
   credentials: CredentialForm | null,
+  t: FederatedFormTranslate,
   config?: ConfigForm
 ): Promise<{ success: boolean; message: string }> {
   try {
@@ -146,22 +161,26 @@ async function updateFederatedConnector(
     if (response.ok) {
       return {
         success: true,
-        message: "Federated connector updated successfully!",
+        message: t("update.success"),
       };
     } else {
       const errorData = await response.json();
       return {
         success: false,
-        message: errorData.detail || "Failed to update federated connector",
+        message: errorData.detail || t("update.failed"),
       };
     }
   } catch (error) {
-    return { success: false, message: `Error: ${error}` };
+    return {
+      success: false,
+      message: t("genericError.text", { error: String(error) }),
+    };
   }
 }
 
 async function deleteFederatedConnector(
-  id: number
+  id: number,
+  t: FederatedFormTranslate
 ): Promise<{ success: boolean; message: string }> {
   try {
     const response = await fetch(`/api/federated/${id}`, {
@@ -171,17 +190,20 @@ async function deleteFederatedConnector(
     if (response.ok) {
       return {
         success: true,
-        message: "Federated connector deleted successfully!",
+        message: t("delete.success"),
       };
     } else {
       const errorData = await response.json();
       return {
         success: false,
-        message: errorData.detail || "Failed to delete federated connector",
+        message: errorData.detail || t("delete.failed"),
       };
     }
   } catch (error) {
-    return { success: false, message: `Error: ${error}` };
+    return {
+      success: false,
+      message: t("genericError.text", { error: String(error) }),
+    };
   }
 }
 
@@ -191,6 +213,7 @@ export function FederatedConnectorForm({
   preloadedConnectorData,
   preloadedCredentialSchema,
 }: FederatedConnectorFormProps) {
+  const t = useTranslations("admin.federated.form");
   const router = useRouter();
   const sourceMetadata = getSourceMetadata(connector);
   const isEditMode = connectorId !== undefined;
@@ -245,7 +268,7 @@ export function FederatedConnectorForm({
           console.error("Error fetching credential schema:", error);
           setFormState((prev) => ({
             ...prev,
-            schemaError: `Failed to load credential schema: ${error}`,
+            schemaError: t("schemaLoadError.message", { error: String(error) }),
           }));
         } finally {
           setIsLoadingSchema(false);
@@ -303,7 +326,9 @@ export function FederatedConnectorForm({
         console.error("Error fetching configuration schema:", error);
         setFormState((prev) => ({
           ...prev,
-          configurationSchemaError: `Failed to load configuration schema: ${error}`,
+          configurationSchemaError: t("configSchemaLoadError.message", {
+            error: String(error),
+          }),
         }));
       }
     };
@@ -319,10 +344,10 @@ export function FederatedConnectorForm({
           <Loader2 className="h-8 w-8 animate-spin text-blue-500 mb-4" />
           <div className="text-center">
             <p className="text-lg font-medium text-gray-700 mb-2">
-              Loading credential schema...
+              {t("loadingSchema.title")}
             </p>
             <p className="text-sm text-gray-500">
-              Retrieving required fields for this connector type
+              {t("loadingSchema.description")}
             </p>
           </div>
         </div>
@@ -354,7 +379,7 @@ export function FederatedConnectorForm({
   const handleValidateCredentials = async () => {
     if (!formState.schema) return;
     if (isEditMode && !credentialsModified) {
-      setSubmitMessage("Enter new credential values before validating.");
+      setSubmitMessage(t("validateBeforeEdit.message"));
       setSubmitSuccess(false);
       return;
     }
@@ -366,12 +391,13 @@ export function FederatedConnectorForm({
     try {
       const result = await validateCredentials(
         connector,
-        formState.credentials
+        formState.credentials,
+        t
       );
       setSubmitMessage(result.message);
       setSubmitSuccess(result.success);
     } catch (error) {
-      setSubmitMessage(`Validation error: ${error}`);
+      setSubmitMessage(t("validation.error", { error: String(error) }));
       setSubmitSuccess(false);
     } finally {
       setIsValidating(false);
@@ -381,16 +407,14 @@ export function FederatedConnectorForm({
   const handleDeleteConnector = async () => {
     if (!connectorId) return;
 
-    const confirmed = window.confirm(
-      "Are you sure you want to delete this federated connector? This action cannot be undone."
-    );
+    const confirmed = window.confirm(t("deleteConfirm.message"));
 
     if (!confirmed) return;
 
     setIsDeleting(true);
 
     try {
-      const result = await deleteFederatedConnector(connectorId);
+      const result = await deleteFederatedConnector(connectorId, t);
 
       if (result.success) {
         toast.success(result.message);
@@ -402,7 +426,7 @@ export function FederatedConnectorForm({
         toast.error(result.message);
       }
     } catch (error) {
-      toast.error(`Error deleting connector: ${error}`);
+      toast.error(t("deleteError.toast", { error: String(error) }));
     } finally {
       setIsDeleting(false);
     }
@@ -427,7 +451,7 @@ export function FederatedConnectorForm({
 
         if (missingRequired.length > 0) {
           setSubmitMessage(
-            `Missing required fields: ${missingRequired.join(", ")}`
+            t("missingFields.message", { fields: missingRequired.join(", ") })
           );
           setSubmitSuccess(false);
           setIsSubmitting(false);
@@ -452,11 +476,14 @@ export function FederatedConnectorForm({
       if (shouldValidateCredentials) {
         const validation = await validateCredentials(
           connector,
-          formState.credentials
+          formState.credentials,
+          t
         );
         if (!validation.success) {
           setSubmitMessage(
-            `Credential validation failed: ${validation.message}`
+            t("credentialValidationFailed.message", {
+              message: validation.message,
+            })
           );
           setSubmitSuccess(false);
           setIsSubmitting(false);
@@ -470,11 +497,13 @@ export function FederatedConnectorForm({
           ? await updateFederatedConnector(
               connectorId,
               credentialsModified ? formState.credentials : null,
+              t,
               formState.config
             )
           : await createFederatedConnector(
               connector,
               formState.credentials,
+              t,
               formState.config
             );
 
@@ -489,7 +518,7 @@ export function FederatedConnectorForm({
         }, 500);
       }
     } catch (error) {
-      setSubmitMessage(`Error: ${error}`);
+      setSubmitMessage(t("genericError.text", { error: String(error) }));
       setSubmitSuccess(false);
       setIsSubmitting(false);
     }
@@ -517,7 +546,7 @@ export function FederatedConnectorForm({
     if (!formState.schema) {
       return (
         <div className="text-sm text-gray-500">
-          No credential schema available for this connector type.
+          {t("noCredentialSchema.message")}
         </div>
       );
     }
@@ -549,7 +578,7 @@ export function FederatedConnectorForm({
               type={fieldSpec.secret ? "password" : "text"}
               placeholder={
                 isEditMode && !credentialsModified
-                  ? "••••••••  (leave blank to keep current value)"
+                  ? t("credentialField.keepCurrentPlaceholder")
                   : fieldSpec.example
                     ? String(fieldSpec.example)
                     : fieldSpec.description
@@ -595,8 +624,7 @@ export function FederatedConnectorForm({
           !Array.isArray(formState.config.channels) ||
           formState.config.channels.length === 0)
       ) {
-        errors.channels =
-          "At least one channel is required when 'Search All Channels' is disabled";
+        errors.channels = t("channelsRequired.error");
       }
     }
 
@@ -616,13 +644,12 @@ export function FederatedConnectorForm({
     if (!formState.configurationSchema) {
       return (
         <div className="text-sm text-gray-500">
-          No search configuration available for this connector type.
+          {t("noConfigSchema.message")}
         </div>
       );
     }
 
-    const channelInputPlaceholder =
-      "Type channel name or regex pattern and press Enter";
+    const channelInputPlaceholder = t("channelInput.placeholder");
 
     return (
       <>
@@ -696,7 +723,7 @@ export function FederatedConnectorForm({
                             fieldKey === "channels" ||
                             fieldKey === "exclude_channels"
                               ? channelInputPlaceholder
-                              : "Type and press Enter to add an item"
+                              : t("listInput.placeholder")
                           }
                           disabled={disableSlackChannelInput(fieldKey)}
                           error={!!configValidationErrors[fieldKey]}
@@ -771,15 +798,16 @@ export function FederatedConnectorForm({
         <div className="ms-2 overflow-hidden text-ellipsis whitespace-nowrap flex-1 me-4">
           <div className="text-2xl font-bold text-text-default flex items-center gap-2">
             <span>
-              {isEditMode ? "Edit" : "Setup"} {sourceMetadata.displayName}
+              {isEditMode
+                ? t("title.edit", { name: sourceMetadata.displayName })
+                : t("title.setup", { name: sourceMetadata.displayName })}
             </span>
             <Badge variant="outline" className="text-xs">
-              Federated
+              {t("federatedBadge.label")}
             </Badge>
             <Tooltip
               tooltip={
-                sourceMetadata.federatedTooltip ||
-                "This is a federated connector. It will result in greater latency and lower search quality compared to regular connectors."
+                sourceMetadata.federatedTooltip || t("federatedTooltip.default")
               }
               side="bottom"
             >
@@ -794,7 +822,7 @@ export function FederatedConnectorForm({
               <DropdownMenuTrigger asChild>
                 <div>
                   <Button prominence="secondary" icon={SvgSettings}>
-                    Manage
+                    {t("manageButton.label")}
                   </Button>
                 </div>
               </DropdownMenuTrigger>
@@ -803,10 +831,16 @@ export function FederatedConnectorForm({
                   onClick={handleDeleteConnector}
                   disabled={isDeleting}
                   className="flex items-center gap-x-2 cursor-pointer px-3 py-2 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                  tooltip={isDeleting ? "Deletion in progress" : undefined}
+                  tooltip={
+                    isDeleting ? t("deleteItem.inProgressTooltip") : undefined
+                  }
                 >
                   <Trash2Icon className="h-4 w-4" />
-                  <span>{isDeleting ? "Deleting..." : "Delete"}</span>
+                  <span>
+                    {isDeleting
+                      ? t("deleteItem.deleting")
+                      : t("deleteItem.label")}
+                  </span>
                 </DropdownMenuItemWithTooltip>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -815,22 +849,22 @@ export function FederatedConnectorForm({
       </div>
 
       <Title className="mb-2 mt-6" size="md">
-        Federated Connector Configuration
+        {t("configTitle.text")}
       </Title>
 
       <Card className="px-8 py-4">
         <CardContent className="p-0">
           <form onSubmit={handleSubmit}>
             <Text as="p" headingH3>
-              Credentials
+              {t("credentials.heading")}
             </Text>
             <Text as="p" mainUiMuted>
-              Enter the credentials for this connector.
+              {t("credentials.description")}
             </Text>
             <div className="space-y-4">{renderCredentialFields()}</div>
             <Divider />
             <Text as="p" headingH3>
-              Configuration
+              {t("configuration.heading")}
             </Text>
             <div className="space-y-4">{renderConfigFields()}</div>
 
@@ -859,7 +893,9 @@ export function FederatedConnectorForm({
                   onClick={handleValidateCredentials}
                   disabled={isValidating || !formState.schema}
                 >
-                  {isValidating ? "Validating..." : "Validate"}
+                  {isValidating
+                    ? t("validateButton.validating")
+                    : t("validateButton.label")}
                 </Button>
               </div>
               <Button
@@ -869,11 +905,11 @@ export function FederatedConnectorForm({
               >
                 {isSubmitting
                   ? isEditMode
-                    ? "Updating..."
-                    : "Creating..."
+                    ? t("submitButton.updating")
+                    : t("submitButton.creating")
                   : isEditMode
-                    ? "Update"
-                    : "Create"}
+                    ? t("submitButton.update")
+                    : t("submitButton.create")}
               </Button>
             </div>
           </form>

--- a/web/src/components/auth/AuthErrorDisplay.tsx
+++ b/web/src/components/auth/AuthErrorDisplay.tsx
@@ -1,27 +1,26 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "@opal/layouts";
-
-const ERROR_MESSAGES = {
-  Anonymous: "Your team does not have anonymous access enabled.",
-};
 
 export default function AuthErrorDisplay({
   searchParams,
 }: {
   searchParams: any;
 }) {
+  const t = useTranslations("auth.errorDisplay");
   const error = searchParams?.error;
 
   useEffect(() => {
     if (error) {
       toast.error(
-        ERROR_MESSAGES[error as keyof typeof ERROR_MESSAGES] ||
-          "An error occurred."
+        error === "Anonymous"
+          ? t("anonymousDisabled.toast")
+          : t("generic.toast")
       );
     }
-  }, [error]);
+  }, [error, t]);
 
   return null;
 }

--- a/web/src/components/auth/AuthFlowContainer.tsx
+++ b/web/src/components/auth/AuthFlowContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { SvgOnyxLogo } from "@opal/logos";
 import { useSettings } from "@/lib/settings/hooks";
 import { Text } from "@opal/components";
@@ -14,6 +15,7 @@ export default function AuthFlowContainer({
   authState?: "signup" | "login" | "join";
   footerContent?: React.ReactNode;
 }) {
+  const t = useTranslations("auth.flowContainer");
   const { appName, logoUrl } = useSettings();
   return (
     <div className="p-4 flex flex-col items-center justify-center min-h-screen bg-background">
@@ -27,7 +29,7 @@ export default function AuthFlowContainer({
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              alt="Logo"
+              alt={t("logo.alt")}
               src={logoUrl}
               className="object-cover object-center w-full h-full"
             />
@@ -42,13 +44,13 @@ export default function AuthFlowContainer({
           {footerContent ?? (
             <>
               <Text font="main-ui-body" color="text-03">
-                {`New to ${appName}?`}
+                {t("signupPrompt.text", { appName })}
               </Text>{" "}
               <Link
                 href="/auth/signup"
                 className="text-text-05 mainUiAction underline transition-colors duration-200"
               >
-                Create an Account
+                {t("createAccountLink.label")}
               </Link>
             </>
           )}
@@ -56,12 +58,12 @@ export default function AuthFlowContainer({
       )}
       {authState === "signup" && (
         <div className="text-sm mt-6 text-center w-full text-text-03 mainUiBody mx-auto">
-          Already have an account?{" "}
+          {t("signinPrompt.text")}{" "}
           <Link
             href="/auth/login?autoRedirectToSignup=false"
             className="text-text-05 mainUiAction underline transition-colors duration-200"
           >
-            Sign In
+            {t("signInLink.label")}
           </Link>
         </div>
       )}

--- a/web/src/components/dateRangeSelectors/SearchDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/SearchDateRangeSelector.tsx
@@ -1,4 +1,5 @@
 import { DateRangePickerValue } from "@/refresh-components/DateRangePicker";
+import { useTranslations } from "next-intl";
 import { FiCalendar, FiChevronDown, FiXCircle } from "react-icons/fi";
 import { CustomDropdown } from "../Dropdown";
 import { timeRangeValues } from "@/app/config/timeRange";
@@ -16,6 +17,7 @@ export function SearchDateRangeSelector({
   isHorizontal?: boolean;
   className?: string;
 }) {
+  const t = useTranslations("common.dateRange");
   return (
     <div>
       <CustomDropdown
@@ -47,17 +49,17 @@ export function SearchDateRangeSelector({
           <FiCalendar className="flex-none my-auto me-2" />{" "}
           <p className="line-clamp-1">
             {isHorizontal ? (
-              "Date"
+              t("date.label")
             ) : value?.selectValue ? (
               <div className="text-text-darker">{value.selectValue}</div>
             ) : (
-              "Any time..."
+              t("anyTime.text")
             )}
           </p>
           {value?.selectValue ? (
             <button
               type="button"
-              aria-label="Clear"
+              aria-label={t("clearButton.ariaLabel")}
               className="my-auto ms-auto p-0.5 rounded-full w-fit"
               onClick={(e) => {
                 onValueChange(null);

--- a/web/src/components/errorPages/AccessRestrictedPage.tsx
+++ b/web/src/components/errorPages/AccessRestrictedPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 import { Button } from "@opal/components";
@@ -37,6 +38,7 @@ const fetchResubscriptionSession =
   };
 
 export default function AccessRestricted() {
+  const t = useTranslations("common.errorPages");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { data: license } = useLicense();
@@ -49,20 +51,21 @@ export default function AccessRestricted() {
 
   function getSeatLimitMessage() {
     const { used_seats, seat_count } = settings;
-    const counts =
-      used_seats != null && seat_count != null
-        ? ` (${used_seats} users / ${seat_count} seats)`
-        : "";
-    return `Your organization has exceeded its licensed seat count${counts}. Access is restricted until the number of users is reduced or your license is upgraded.`;
+    return used_seats != null && seat_count != null
+      ? t("accessRestricted.seatLimitWithCounts.description", {
+          used: used_seats,
+          seats: seat_count,
+        })
+      : t("accessRestricted.seatLimit.description");
   }
 
   const initialModalMessage = isSeatLimitExceeded
     ? getSeatLimitMessage()
     : showRenewalMessage
       ? NEXT_PUBLIC_CLOUD_ENABLED
-        ? "Your access to Onyx has been temporarily suspended due to a lapse in your subscription."
-        : "Your access to Onyx has been temporarily suspended due to a lapse in your license."
-      : "A license is required to use Onyx. Your data is protected and will be available once a license is activated.";
+        ? t("accessRestricted.subscriptionLapse.description")
+        : t("accessRestricted.licenseLapse.description")
+      : t("accessRestricted.licenseRequired.description");
 
   const handleResubscribe = async () => {
     setIsLoading(true);
@@ -76,7 +79,7 @@ export default function AccessRestricted() {
       window.location.href = url;
     } catch (error) {
       console.error("Error creating resubscription session:", error);
-      setError("Error opening resubscription page. Please try again later.");
+      setError(t("accessRestricted.resubscribeError.text"));
       setIsLoading(false);
     }
   };
@@ -84,7 +87,7 @@ export default function AccessRestricted() {
   return (
     <ErrorPageLayout>
       <div className="flex items-center gap-2">
-        <Text headingH2>Access Restricted</Text>
+        <Text headingH2>{t("accessRestricted.heading.title")}</Text>
         <SvgLock className="stroke-status-error-05 w-6 h-6" />
       </div>
 
@@ -93,15 +96,18 @@ export default function AccessRestricted() {
       {isSeatLimitExceeded ? (
         <>
           <Text text03>
-            If you are an administrator, you can manage users on the{" "}
-            <Link className={linkClassName} href="/admin/users">
-              User Management
-            </Link>{" "}
-            page or upgrade your license on the{" "}
-            <Link className={linkClassName} href="/admin/billing">
-              Admin Billing
-            </Link>{" "}
-            page.
+            {t.rich("accessRestricted.seatLimitAdminHint.text", {
+              userLink: (chunks) => (
+                <Link className={linkClassName} href="/admin/users">
+                  {chunks}
+                </Link>
+              ),
+              billingLink: (chunks) => (
+                <Link className={linkClassName} href="/admin/billing">
+                  {chunks}
+                </Link>
+              ),
+            })}
           </Text>
 
           <div className="flex flex-row gap-2">
@@ -111,26 +117,23 @@ export default function AccessRestricted() {
                 window.location.reload();
               }}
             >
-              Log out
+              {t("accessRestricted.logoutButton.label")}
             </Button>
           </div>
         </>
       ) : NEXT_PUBLIC_CLOUD_ENABLED ? (
         <>
-          <Text text03>
-            To reinstate your access and continue benefiting from Onyx&apos;s
-            powerful features, please update your payment information.
-          </Text>
+          <Text text03>{t("accessRestricted.updatePayment.description")}</Text>
 
           <Text text03>
-            If you&apos;re an admin, you can manage your subscription by
-            clicking the button below. For other users, please reach out to your
-            administrator to address this matter.
+            {t("accessRestricted.manageSubscription.description")}
           </Text>
 
           <div className="flex flex-row gap-2">
             <Button disabled={isLoading} onClick={handleResubscribe}>
-              {isLoading ? "Loading..." : "Resubscribe"}
+              {isLoading
+                ? t("accessRestricted.resubscribeButton.loading")
+                : t("accessRestricted.resubscribeButton.label")}
             </Button>
             <Button
               prominence="secondary"
@@ -139,7 +142,7 @@ export default function AccessRestricted() {
                 window.location.reload();
               }}
             >
-              Log out
+              {t("accessRestricted.logoutButton.label")}
             </Button>
           </div>
 
@@ -149,21 +152,24 @@ export default function AccessRestricted() {
         <>
           <Text text03>
             {hadPreviousLicense
-              ? "To reinstate your access and continue using Onyx, please contact your system administrator to renew your license."
-              : "To get started, please contact your system administrator to obtain a license."}
+              ? t("accessRestricted.renewLicense.description")
+              : t("accessRestricted.obtainLicense.description")}
           </Text>
 
           <Text text03>
-            If you are the administrator, please visit the{" "}
-            <Link className={linkClassName} href="/admin/billing">
-              Admin Billing
-            </Link>{" "}
-            page to {hadPreviousLicense ? "renew" : "activate"} your license,
-            sign up through Stripe or reach out to{" "}
-            <a className={linkClassName} href="mailto:support@onyx.app">
-              support@onyx.app
-            </a>{" "}
-            for billing assistance.
+            {t.rich("accessRestricted.billingAdminHint.text", {
+              hadLicense: hadPreviousLicense ? "true" : "false",
+              billingLink: (chunks) => (
+                <Link className={linkClassName} href="/admin/billing">
+                  {chunks}
+                </Link>
+              ),
+              supportLink: (chunks) => (
+                <a className={linkClassName} href="mailto:support@onyx.app">
+                  {chunks}
+                </a>
+              ),
+            })}
           </Text>
 
           <div className="flex flex-row gap-2">
@@ -173,21 +179,23 @@ export default function AccessRestricted() {
                 window.location.reload();
               }}
             >
-              Log out
+              {t("accessRestricted.logoutButton.label")}
             </Button>
           </div>
         </>
       )}
 
       <Text text03>
-        Need help? Join our{" "}
-        <InlineExternalLink
-          className={linkClassName}
-          href="https://discord.gg/4NA5SbzrWb"
-        >
-          Discord community
-        </InlineExternalLink>{" "}
-        for support.
+        {t.rich("needHelp.text", {
+          discordLink: (chunks) => (
+            <InlineExternalLink
+              className={linkClassName}
+              href="https://discord.gg/4NA5SbzrWb"
+            >
+              {chunks}
+            </InlineExternalLink>
+          ),
+        })}
       </Text>
     </ErrorPageLayout>
   );

--- a/web/src/components/errorPages/CloudErrorPage.tsx
+++ b/web/src/components/errorPages/CloudErrorPage.tsx
@@ -1,21 +1,21 @@
+import { useTranslations } from "next-intl";
 import Text from "@/refresh-components/texts/Text";
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 
 export default function CloudError() {
+  const t = useTranslations("common.errorPages.maintenance");
   return (
     <ErrorPageLayout>
       <Text as="p" headingH2>
-        Maintenance in Progress
+        {t("heading.title")}
       </Text>
 
       <Text as="p" text03>
-        Onyx is currently in a maintenance window. Please check back in a couple
-        of minutes.
+        {t("checkBack.description")}
       </Text>
 
       <Text as="p" text03>
-        We apologize for any inconvenience this may cause and appreciate your
-        patience.
+        {t("apology.description")}
       </Text>
     </ErrorPageLayout>
   );

--- a/web/src/components/errorPages/ErrorPage.tsx
+++ b/web/src/components/errorPages/ErrorPage.tsx
@@ -1,48 +1,52 @@
+import { useTranslations } from "next-intl";
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 import Text from "@/refresh-components/texts/Text";
 import { DOCS_BASE_URL } from "@/lib/constants";
 import { SvgAlertCircle } from "@opal/icons";
 
 export default function Error() {
+  const t = useTranslations("common.errorPages");
   return (
     <ErrorPageLayout>
       <div className="flex flex-row items-center gap-2">
         <Text as="p" headingH2>
-          We encountered an issue
+          {t("configError.heading.title")}
         </Text>
         <SvgAlertCircle className="w-6 h-6 stroke-text-04" />
       </div>
 
       <Text as="p" text03>
-        It seems there was a problem loading your Onyx settings. This could be
-        due to a configuration issue or incomplete setup.
+        {t("configError.heading.description")}
       </Text>
 
       <Text as="p" text03>
-        If you&apos;re an admin, please review our{" "}
-        <a
-          className="text-action-selection-05"
-          href={`${DOCS_BASE_URL}?utm_source=app&utm_medium=error_page&utm_campaign=config_error`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          documentation
-        </a>{" "}
-        for proper configuration steps. If you&apos;re a user, please contact
-        your admin for assistance.
+        {t.rich("configError.adminHint.text", {
+          docsLink: (chunks) => (
+            <a
+              className="text-action-selection-05"
+              href={`${DOCS_BASE_URL}?utm_source=app&utm_medium=error_page&utm_campaign=config_error`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
       </Text>
 
       <Text as="p" text03>
-        Need help? Join our{" "}
-        <a
-          className="text-action-selection-05"
-          href="https://discord.gg/4NA5SbzrWb"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Discord community
-        </a>{" "}
-        for support.
+        {t.rich("needHelp.text", {
+          discordLink: (chunks) => (
+            <a
+              className="text-action-selection-05"
+              href="https://discord.gg/4NA5SbzrWb"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
       </Text>
     </ErrorPageLayout>
   );

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { StaticImageData } from "next/image";
+import { useTranslations } from "next-intl";
 import googleCloudStorageIcon from "@public/GoogleCloudStorage.png";
 import openSourceIcon from "@public/OpenSource.png";
 import r2Icon from "@public/r2.png";
@@ -26,16 +27,19 @@ export const LogoIcon = ({
   size = 16,
   className = defaultTailwindCSS,
   src,
-}: LogoIconProps) => (
-  <Image
-    style={{ width: `${size}px`, height: `${size}px` }}
-    className={`w-[${size}px] h-[${size}px] object-contain ` + className}
-    src={src}
-    alt="Logo"
-    width="96"
-    height="96"
-  />
-);
+}: LogoIconProps) => {
+  const t = useTranslations("common.icons");
+  return (
+    <Image
+      style={{ width: `${size}px`, height: `${size}px` }}
+      className={`w-[${size}px] h-[${size}px] object-contain ` + className}
+      src={src}
+      alt={t("logo.alt")}
+      width="96"
+      height="96"
+    />
+  );
+};
 
 // Helper to create simple icon components from react-icon libraries
 export function createIcon(

--- a/web/src/components/oauth/OAuthCallbackPage.tsx
+++ b/web/src/components/oauth/OAuthCallbackPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { Route } from "next";
 import { SvgCheck, SvgAlertTriangle } from "@opal/icons";
@@ -33,14 +34,15 @@ interface OAuthCallbackPageProps {
 }
 
 export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
+  const t = useTranslations("common.oauthCallback");
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const [statusMessage, setStatusMessage] = useState(
-    config.processingMessage || "Processing..."
+    config.processingMessage || t("processing.title")
   );
   const [statusDetails, setStatusDetails] = useState(
-    config.processingDetails || "Please wait while we complete the setup."
+    config.processingDetails || t("processing.description")
   );
   const [isError, setIsError] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -96,10 +98,9 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
     const handleOAuthCallback = async () => {
       // Handle OAuth error from provider
       if (error) {
-        setStatusMessage(config.errorMessage || "Authorization Failed");
+        setStatusMessage(config.errorMessage || t("authorizationFailed.title"));
         setStatusDetails(
-          errorDescription ||
-            "The authorization was cancelled or failed. Please try again."
+          errorDescription || t("authorizationFailed.description")
         );
         setIsError(true);
         setIsLoading(false);
@@ -108,10 +109,8 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
 
       // Validate required parameters
       if (!code || !state) {
-        setStatusMessage("Invalid Request");
-        setStatusDetails(
-          "The authorization request was incomplete. Please try again."
-        );
+        setStatusMessage(t("invalidRequest.title"));
+        setStatusDetails(t("invalidRequest.description"));
         setIsError(true);
         setIsLoading(false);
         return;
@@ -132,7 +131,7 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
         });
 
         if (!response.ok) {
-          let errorMessage = "Failed to complete authorization";
+          let errorMessage = t("completeFailed.message");
           try {
             const errorData = await response.json();
             if (errorData.detail && config.errorMessageMap) {
@@ -179,16 +178,12 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
         const redirectUrl = new URL(sanitizedPath, window.location.origin);
         redirectUrl.searchParams.set("message", "oauth_connected");
         setRedirectPath(redirectUrl.pathname + redirectUrl.search);
-        setStatusMessage(config.successMessage || "Success!");
+        setStatusMessage(config.successMessage || t("success.title"));
 
+        const serviceName = result.serviceName || t("serviceFallback.text");
         const successDetails = config.successDetailsTemplate
-          ? config.successDetailsTemplate.replace(
-              "{serviceName}",
-              result.serviceName || "service"
-            )
-          : `Your ${
-              result.serviceName || "service"
-            } authorization completed successfully.`;
+          ? config.successDetailsTemplate.replace("{serviceName}", serviceName)
+          : t("success.detailsTemplate", { serviceName });
 
         setStatusDetails(successDetails);
         setIsSuccess(true);
@@ -196,11 +191,9 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
         setIsLoading(false);
       } catch (error) {
         console.error("OAuth callback error:", error);
-        setStatusMessage(config.errorMessage || "Something Went Wrong");
+        setStatusMessage(config.errorMessage || t("genericError.title"));
         setStatusDetails(
-          error instanceof Error
-            ? error.message
-            : "An error occurred during the OAuth process. Please try again."
+          error instanceof Error ? error.message : t("genericError.description")
         );
         setIsError(true);
         setIsLoading(false);
@@ -261,8 +254,7 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
             {isSuccess && secondsLeft !== null && (
               <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 mb-6">
                 <p className="text-green-800 dark:text-green-200 text-sm">
-                  Redirecting in {secondsLeft}{" "}
-                  {secondsLeft === 1 ? "second" : "seconds"}...
+                  {t("redirecting.text", { count: secondsLeft })}
                 </p>
               </div>
             )}
@@ -278,14 +270,14 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
                     }}
                     width="full"
                   >
-                    {config.backButtonText || "Back to Chat"}
+                    {config.backButtonText || t("backButton.label")}
                   </Button>
                 </div>
               )}
 
               {isLoading && (
                 <p className="text-sm text-gray-500 dark:text-gray-400">
-                  This may take a few moments...
+                  {t("loadingHint.text")}
                 </p>
               )}
             </div>

--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { JSX } from "react";
+import { useTranslations } from "next-intl";
 import { MinimalOnyxDocument, OnyxDocument } from "@/lib/search/interfaces";
 import { SourceIcon } from "../SourceIcon";
 import { WebResultIcon } from "../WebResultIcon";
@@ -131,6 +132,7 @@ export function CompactDocumentCard({
   document,
   updatePresentingDocument,
 }: CompactDocumentCardProps) {
+  const t = useTranslations("common.documentDisplay");
   const isWebSource =
     document.is_internet || document.source_type === ValidSources.Web;
 
@@ -141,9 +143,9 @@ export function CompactDocumentCard({
           openDocument(document, updatePresentingDocument);
         }}
         className="max-w-80 p-3 flex flex-col gap-1"
-        aria-label={`Open document: ${
-          document.semantic_identifier ?? document.document_id
-        }`}
+        aria-label={t("openDocument.ariaLabel", {
+          title: document.semantic_identifier ?? document.document_id,
+        })}
       >
         <div className="flex flex-row gap-2 items-center w-full">
           {isWebSource && document.link ? (
@@ -175,7 +177,9 @@ export function CompactDocumentCard({
               figureSmallLabel
               className="line-clamp-2 text-start m-0!"
             >
-              Updated {new Date(document.updated_at).toLocaleDateString()}
+              {t("updated.text", {
+                date: new Date(document.updated_at).toLocaleDateString(),
+              })}
             </Text>
           )}
       </button>
@@ -192,6 +196,7 @@ export function CompactQuestionCard({
   question,
   openQuestion,
 }: CompactQuestionCardProps) {
+  const t = useTranslations("common.documentDisplay");
   return (
     <button
       type="button"
@@ -199,18 +204,20 @@ export function CompactQuestionCard({
       className="max-w-[350px] gap-y-1 cursor-pointer pb-0 pt-0 mt-0 flex gap-y-0 flex-col content-start items-start gap-0"
     >
       <div className="text-sm pb-0! mb-0! font-semibold flex items-center gap-x-1 text-text-900 pt-0 mt-0 truncate w-full">
-        Question
+        {t("question.title")}
       </div>
       <div className="text-xs mb-0 text-text-600 line-clamp-2">
         {question.question}
       </div>
       <div className="flex mt-0 pt-0 items-center justify-between w-full">
         <span className="text-xs text-text-500">
-          {question.context_docs?.top_documents.length || 0} context docs
+          {t("contextDocs.text", {
+            count: question.context_docs?.top_documents.length || 0,
+          })}
         </span>
         {question.sub_queries && (
           <span className="text-xs text-text-500">
-            {question.sub_queries.length} subqueries
+            {t("subqueries.text", { count: question.sub_queries.length })}
           </span>
         )}
       </div>

--- a/web/src/components/search/filtering/FilterDropdown.tsx
+++ b/web/src/components/search/filtering/FilterDropdown.tsx
@@ -1,4 +1,5 @@
 import { JSX } from "react";
+import { useTranslations } from "next-intl";
 import { FiCheck, FiChevronDown, FiXCircle } from "react-icons/fi";
 import { CustomDropdown } from "../../Dropdown";
 
@@ -33,6 +34,7 @@ export function FilterDropdown({
   backgroundColor?: string;
   dropdownColor?: string;
 }) {
+  const t = useTranslations("common.filters");
   return (
     <div>
       <CustomDropdown
@@ -121,7 +123,7 @@ export function FilterDropdown({
           {resetValues && selected.length !== 0 ? (
             <button
               type="button"
-              aria-label="Clear"
+              aria-label={t("clearButton.ariaLabel")}
               className="my-auto ms-auto p-0.5 rounded-full w-fit"
               onClick={(e) => {
                 resetValues();

--- a/web/src/components/standardAnswers/StandardAnswerCategoryDropdown.tsx
+++ b/web/src/components/standardAnswers/StandardAnswerCategoryDropdown.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+import { useTranslations } from "next-intl";
 import { StandardAnswerCategoryResponse } from "./getStandardAnswerCategoriesIfEE";
 import { Label } from "@/components/Field";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox/InputComboBox";
@@ -16,6 +17,8 @@ interface StandardAnswerCategoryDropdownFieldProps {
 export const StandardAnswerCategoryDropdownField: FC<
   StandardAnswerCategoryDropdownFieldProps
 > = ({ standardAnswerCategoryResponse, categories, setCategories }) => {
+  const t = useTranslations("admin.standardAnswers.categoryDropdown");
+
   if (!standardAnswerCategoryResponse.paidEnterpriseFeaturesEnabled) {
     return null;
   }
@@ -23,8 +26,10 @@ export const StandardAnswerCategoryDropdownField: FC<
   if (standardAnswerCategoryResponse.error != null) {
     return (
       <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch standard answer categories - ${standardAnswerCategoryResponse.error.message}`}
+        errorTitle={t("fetchError.title")}
+        errorMsg={t("fetchError.message", {
+          message: standardAnswerCategoryResponse.error.message,
+        })}
       />
     );
   }
@@ -38,10 +43,10 @@ export const StandardAnswerCategoryDropdownField: FC<
 
   return (
     <div>
-      <Label>Standard Answer Categories</Label>
+      <Label>{t("categories.label")}</Label>
       <div className="w-64 flex flex-col gap-2">
         <InputComboBox
-          placeholder="Search categories..."
+          placeholder={t("search.placeholder")}
           value=""
           onChange={() => {}}
           onValueChange={(value) => {

--- a/web/src/components/tools/ExpandableContentWrapper.tsx
+++ b/web/src/components/tools/ExpandableContentWrapper.tsx
@@ -1,5 +1,6 @@
 // ExpandableContentWrapper
 import React, { useState } from "react";
+import { useTranslations } from "next-intl";
 import { SvgDownloadCloud, SvgFold, SvgMaximize2, SvgX } from "@opal/icons";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@opal/components";
@@ -25,6 +26,7 @@ export default function ExpandableContentWrapper({
   close,
   ContentComponent,
 }: ExpandableContentWrapperProps) {
+  const t = useTranslations("common.expandableContent");
   const [expanded, setExpanded] = useState(false);
 
   const toggleExpand = () => setExpanded((prev) => !prev);
@@ -44,7 +46,7 @@ export default function ExpandableContentWrapper({
       <CardHeader className="w-full bg-background-tint-02 top-0 p-3">
         <div className="flex justify-between items-center">
           <Text className="text-ellipsis line-clamp-1" text03 mainUiAction>
-            {fileDescriptor.name || "Untitled"}
+            {fileDescriptor.name || t("file.untitledFallback")}
           </Text>
           <div className="flex flex-row items-center justify-end gap-1">
             <Button
@@ -52,21 +54,25 @@ export default function ExpandableContentWrapper({
               size="sm"
               onClick={downloadFile}
               icon={SvgDownloadCloud}
-              tooltip="Download file"
+              tooltip={t("downloadButton.tooltip")}
             />
             <Button
               prominence="tertiary"
               size="sm"
               onClick={toggleExpand}
               icon={expanded ? SvgFold : SvgMaximize2}
-              tooltip={expanded ? "Minimize" : "Full screen"}
+              tooltip={
+                expanded
+                  ? t("minimizeButton.tooltip")
+                  : t("fullScreenButton.tooltip")
+              }
             />
             <Button
               prominence="tertiary"
               size="sm"
               onClick={close}
               icon={SvgX}
-              tooltip="Hide"
+              tooltip={t("hideButton.tooltip")}
             />
           </div>
         </div>

--- a/web/src/components/tools/SpreadsheetContent.tsx
+++ b/web/src/components/tools/SpreadsheetContent.tsx
@@ -4,6 +4,7 @@
 // passed through raw by the backend and rendered as a single CSV sheet, so
 // routing here never depends solely on the file's display name.
 import React, { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -65,6 +66,7 @@ interface SheetTableProps {
 }
 
 function SheetTable({ sheet }: SheetTableProps) {
+  const t = useTranslations("common.spreadsheet");
   let rows: string[][] = [];
   try {
     // Drop at most one trailing newline; trimming any further would mutate
@@ -83,9 +85,7 @@ function SheetTable({ sheet }: SheetTableProps) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 py-8">
         <Text as="p" font="main-ui-body" color="text-03">
-          {sheet.truncated
-            ? "This sheet is too large to preview — download the file to view it."
-            : "This sheet is empty."}
+          {sheet.truncated ? t("sheet.tooLarge") : t("sheet.empty")}
         </Text>
       </div>
     );
@@ -125,7 +125,7 @@ function SheetTable({ sheet }: SheetTableProps) {
           <TableRow>
             <TableCell colSpan={headers.length} className="py-2 px-4">
               <Text as="p" font="secondary-body" color="text-04">
-                Preview truncated — download the file to see all rows.
+                {t("preview.truncated")}
               </Text>
             </TableCell>
           </TableRow>
@@ -144,6 +144,7 @@ export function SpreadsheetSheetsView({
   sheets,
   className,
 }: SpreadsheetSheetsViewProps) {
+  const t = useTranslations("common.spreadsheet");
   const [activeSheetIndex, setActiveSheetIndex] = useState(0);
   const activeSheet = sheets[activeSheetIndex] ?? sheets[0];
 
@@ -152,7 +153,7 @@ export function SpreadsheetSheetsView({
       <div className="flex flex-col items-center justify-center gap-2 py-8">
         <SvgAlertCircle className="w-8 h-8 stroke-error" />
         <Text as="p" font="main-ui-body" color="text-03">
-          Unable to preview this spreadsheet.
+          {t("preview.unavailable")}
         </Text>
       </div>
     );
@@ -185,6 +186,7 @@ function SpreadsheetContent({
   fileDescriptor,
   expanded = false,
 }: ContentComponentProps) {
+  const t = useTranslations("common.spreadsheet");
   const [sheets, setSheets] = useState<SpreadsheetSheet[] | null>(null);
   const [isFetching, setIsFetching] = useState(true);
 
@@ -229,7 +231,11 @@ function SpreadsheetContent({
             );
           }
           fetchedSheets = [
-            { name: "Sheet 1", csv: await response.text(), truncated: false },
+            {
+              name: t("sheet.defaultName"),
+              csv: await response.text(),
+              truncated: false,
+            },
           ];
         }
 
@@ -252,7 +258,7 @@ function SpreadsheetContent({
     return () => {
       cancelled = true;
     };
-  }, [cacheKey]);
+  }, [cacheKey, t]);
 
   if (isFetching) {
     return (
@@ -267,10 +273,10 @@ function SpreadsheetContent({
       <div className="flex flex-col items-center justify-center gap-2 py-8">
         <SvgAlertCircle className="w-8 h-8 stroke-error" />
         <Text as="p" font="main-ui-body" color="text-03">
-          Error loading spreadsheet
+          {t("error.title")}
         </Text>
         <Text as="p" font="main-ui-body" color="text-04">
-          The spreadsheet may be corrupted or couldn&apos;t be loaded properly.
+          {t("error.description")}
         </Text>
       </div>
     );

--- a/web/src/ee/providers/QueryControllerProvider.tsx
+++ b/web/src/ee/providers/QueryControllerProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import {
   BaseFilters,
   SearchDocWithContent,
@@ -27,6 +28,7 @@ interface QueryControllerProviderProps {
 export function QueryControllerProvider({
   children,
 }: QueryControllerProviderProps) {
+  const t = useTranslations("admin.search");
   const appPosition = useAppPosition();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
   const searchUiEnabled = useIsSearchModeAvailable();
@@ -124,12 +126,12 @@ export function QueryControllerProvider({
           throw err;
         }
 
-        setError("Document search failed. Please try again.");
+        setError(t("errors.searchFailed.message"));
         setSearchResults([]);
         setLlmSelectedDocIds(null);
       }
     },
-    []
+    [t]
   );
 
   /**
@@ -157,11 +159,11 @@ export function QueryControllerProvider({
           throw error;
         }
 
-        setError("Query classification failed. Falling back to chat.");
+        setError(t("errors.classificationFailed.message"));
         return "chat";
       }
     },
-    []
+    [t]
   );
 
   /**

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   BaseFilters,
   MinimalOnyxDocument,
@@ -42,14 +43,16 @@ export interface SearchResultsProps {
 
 const RESULTS_PER_PAGE = 20;
 
-const TIME_FILTER_OPTIONS: { value: TimeFilter; label: string }[] = [
-  { value: "day", label: "Past 24 hours" },
-  { value: "week", label: "Past week" },
-  { value: "month", label: "Past month" },
-  { value: "year", label: "Past year" },
-];
-
 export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
+  const t = useTranslations("admin.search");
+
+  const timeFilterOptions: { value: TimeFilter; label: string }[] = [
+    { value: "day", label: t("timeFilter.day.label") },
+    { value: "week", label: t("timeFilter.week.label") },
+    { value: "month", label: t("timeFilter.month.label") },
+    { value: "year", label: t("timeFilter.year.label") },
+  ];
+
   // Available tags from backend
   const { tags: availableTags } = useTags();
   const {
@@ -226,13 +229,13 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
                     onRefineSearch(buildFilters({ time: null }));
                   }}
                 >
-                  {TIME_FILTER_OPTIONS.find((o) => o.value === timeFilter)
-                    ?.label ?? "All Time"}
+                  {timeFilterOptions.find((o) => o.value === timeFilter)
+                    ?.label ?? t("timeFilter.all.label")}
                 </FilterButton>
               </Popover.Trigger>
               <Popover.Content align="start" width="md">
                 <PopoverMenu>
-                  {TIME_FILTER_OPTIONS.map((opt) => (
+                  {timeFilterOptions.map((opt) => (
                     <LineItemButton
                       key={opt.value}
                       onClick={() => {
@@ -263,17 +266,17 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
                   }}
                 >
                   {selectedTags.length > 0
-                    ? `${selectedTags.length} Tag${
-                        selectedTags.length > 1 ? "s" : ""
-                      }`
-                    : "Tags"}
+                    ? t("tagFilter.count.label", {
+                        count: selectedTags.length,
+                      })
+                    : t("tagFilter.empty.label")}
                 </FilterButton>
               </Popover.Trigger>
               <Popover.Content align="start" width="lg">
                 <PopoverMenu>
                   <InputTypeIn
                     searchIcon
-                    placeholder="Filter tags..."
+                    placeholder={t("tagFilter.search.placeholder")}
                     value={tagQuery}
                     onChange={(e) => setTagQuery(e.target.value)}
                     clearButton
@@ -319,7 +322,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           <div className="flex-1 flex flex-col justify-end gap-3">
             <Section alignItems="start">
               <Text text03 mainUiMuted>
-                {results.length} Results
+                {t("results.count.label", { count: results.length })}
               </Text>
             </Section>
 
@@ -339,7 +342,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           {error ? (
             <EmptyMessageCard
               sizePreset="main-ui"
-              title="Search failed"
+              title={t("results.failed.title")}
               description={error}
             />
           ) : paginatedResults.length > 0 ? (
@@ -360,8 +363,8 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
           ) : (
             <IllustrationContent
               illustration={SvgNoResult}
-              title="No results found"
-              description="Check your connectors/filters or try a different search term."
+              title={t("results.empty.title")}
+              description={t("results.empty.description")}
             />
           )}
         </div>

--- a/web/src/ee/views/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookFormModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Formik, Form, useFormikContext } from "formik";
 import * as Yup from "yup";
 import { Button, LinkButton, Text } from "@opal/components";
@@ -50,8 +51,7 @@ interface HookFormModalProps {
 
 const MAX_TIMEOUT_SECONDS = 600;
 
-const SOFT_DESCRIPTION =
-  "If the endpoint returns an error, Onyx logs it and continues the pipeline as normal, ignoring the hook result.";
+type HooksTranslate = ReturnType<typeof useTranslations<"admin.hooks">>;
 
 function buildInitialValues(
   hook: HookResponse | undefined,
@@ -75,18 +75,20 @@ function buildInitialValues(
   };
 }
 
-function buildValidationSchema(isEdit: boolean) {
+function buildValidationSchema(isEdit: boolean, t: HooksTranslate) {
   return Yup.object().shape({
-    name: Yup.string().trim().required("Display name cannot be empty."),
-    endpoint_url: Yup.string().trim().required("Endpoint URL cannot be empty."),
+    name: Yup.string().trim().required(t("form.validation.nameRequired")),
+    endpoint_url: Yup.string()
+      .trim()
+      .required(t("form.validation.endpointRequired")),
     api_key: isEdit
       ? Yup.string()
-      : Yup.string().trim().required("API key cannot be empty."),
+      : Yup.string().trim().required(t("form.validation.apiKeyRequired")),
     timeout_seconds: Yup.string()
-      .required("Timeout is required.")
+      .required(t("form.validation.timeoutRequired"))
       .test(
         "valid-timeout",
-        `Must be greater than 0 and at most ${MAX_TIMEOUT_SECONDS} seconds.`,
+        t("form.validation.timeoutRange", { max: MAX_TIMEOUT_SECONDS }),
         (val) => {
           const num = parseFloat(val ?? "");
           return !isNaN(num) && num > 0 && num <= MAX_TIMEOUT_SECONDS;
@@ -104,15 +106,18 @@ interface TimeoutFieldProps {
 }
 
 function TimeoutField({ spec }: TimeoutFieldProps) {
+  const t = useTranslations("admin.hooks");
   const { values, setFieldValue, isSubmitting } =
     useFormikContext<HookFormState>();
 
   return (
     <InputVertical
       withLabel="timeout_seconds"
-      title="Timeout"
-      suffix="(seconds)"
-      subDescription={`Maximum time Onyx will wait for the endpoint to respond before applying the fail strategy. Must be greater than 0 and at most ${MAX_TIMEOUT_SECONDS} seconds.`}
+      title={t("form.timeout.title")}
+      suffix={t("form.timeout.suffix")}
+      subDescription={t("form.timeout.description", {
+        max: MAX_TIMEOUT_SECONDS,
+      })}
     >
       <div className="[&_input]:!font-main-ui-mono [&_input::placeholder]:!font-main-ui-mono [&_input]:[appearance:textfield]! [&_input::-webkit-outer-spin-button]:appearance-none! [&_input::-webkit-inner-spin-button]:appearance-none! w-full">
         <InputTypeInField
@@ -127,7 +132,7 @@ function TimeoutField({ spec }: TimeoutFieldProps) {
                 prominence="tertiary"
                 size="xs"
                 icon={SvgRevert}
-                tooltip="Revert to Default"
+                tooltip={t("form.timeout.revert.tooltip")}
                 onClick={() =>
                   setFieldValue(
                     "timeout_seconds",
@@ -154,12 +159,13 @@ export default function HookFormModal({
   spec,
   onSuccess,
 }: HookFormModalProps) {
+  const t = useTranslations("admin.hooks");
   const isEdit = !!hook;
   const [isConnected, setIsConnected] = useState(false);
   const [apiKeyCleared, setApiKeyCleared] = useState(false);
 
   const initialValues = buildInitialValues(hook, spec);
-  const validationSchema = buildValidationSchema(isEdit);
+  const validationSchema = buildValidationSchema(isEdit, t);
 
   function handleClose() {
     onOpenChange(false);
@@ -202,7 +208,7 @@ export default function HookFormModal({
                 result = await updateHook(hook.id, req);
               } else {
                 if (!spec) {
-                  toast.error("No hook point specified.");
+                  toast.error(t("form.toasts.noHookPoint.message"));
                   return;
                 }
                 result = await createHook({
@@ -214,7 +220,11 @@ export default function HookFormModal({
                   timeout_seconds: parseFloat(values.timeout_seconds),
                 });
               }
-              toast.success(isEdit ? "Hook updated." : "Hook created.");
+              toast.success(
+                isEdit
+                  ? t("form.toasts.updated.message")
+                  : t("form.toasts.created.message")
+              );
               onSuccess(result);
               if (!isEdit) {
                 setIsConnected(true);
@@ -223,20 +233,23 @@ export default function HookFormModal({
               handleClose();
             } catch (err) {
               if (err instanceof HookAuthError) {
-                helpers.setFieldError("api_key", "Invalid API key.");
+                helpers.setFieldError(
+                  "api_key",
+                  t("form.errors.invalidApiKey")
+                );
               } else if (err instanceof HookTimeoutError) {
                 helpers.setFieldError(
                   "timeout_seconds",
-                  "Connection timed out. Try increasing the timeout."
+                  t("form.errors.timeout")
                 );
               } else if (err instanceof HookConnectError) {
                 helpers.setFieldError(
                   "endpoint_url",
-                  err.message || "Could not connect to endpoint."
+                  err.message || t("form.errors.connect")
                 );
               } else {
                 toast.error(
-                  err instanceof Error ? err.message : "Something went wrong."
+                  err instanceof Error ? err.message : t("form.errors.generic")
                 );
               }
             } finally {
@@ -247,7 +260,7 @@ export default function HookFormModal({
           {({ values, setFieldValue, isSubmitting, isValid, dirty }) => {
             const failStrategyDescription =
               values.fail_strategy === "soft"
-                ? SOFT_DESCRIPTION
+                ? t("form.softStrategy.description")
                 : spec?.fail_hard_description;
 
             return (
@@ -255,12 +268,12 @@ export default function HookFormModal({
                 <Modal.Header
                   icon={SvgShareWebhook}
                   title={
-                    isEdit ? "Manage Hook Extension" : "Set Up Hook Extension"
+                    isEdit
+                      ? t("form.editHeader.title")
+                      : t("form.createHeader.title")
                   }
                   description={
-                    isEdit
-                      ? undefined
-                      : "Connect an external API endpoint to extend the hook point."
+                    isEdit ? undefined : t("form.createHeader.description")
                   }
                   onClose={handleClose}
                 />
@@ -279,24 +292,24 @@ export default function HookFormModal({
                           sizePreset="secondary"
                           variant="body"
                           icon={SvgShareWebhook}
-                          title="Hook Point"
+                          title={t("form.hookPoint.label")}
                           color="muted"
                           width="fit"
                         />
                         {docsUrl && (
                           <LinkButton href={docsUrl} target="_blank">
-                            Documentation
+                            {t("docsLink.label")}
                           </LinkButton>
                         )}
                       </div>
                     }
                   />
 
-                  <InputVertical withLabel="name" title="Display Name">
+                  <InputVertical withLabel="name" title={t("form.name.title")}>
                     <div className="[&_input::placeholder]:!font-main-ui-muted w-full">
                       <InputTypeInField
                         name="name"
-                        placeholder="Name your extension at this hook point"
+                        placeholder={t("form.name.placeholder")}
                         variant={isSubmitting ? "disabled" : undefined}
                       />
                     </div>
@@ -304,7 +317,7 @@ export default function HookFormModal({
 
                   <InputVertical
                     withLabel="fail_strategy"
-                    title="Fail Strategy"
+                    title={t("form.failStrategy.title")}
                     subDescription={failStrategyDescription}
                   >
                     <InputSelect
@@ -314,23 +327,29 @@ export default function HookFormModal({
                       }
                       disabled={isSubmitting}
                     >
-                      <InputSelect.Trigger placeholder="Select strategy" />
+                      <InputSelect.Trigger
+                        placeholder={t("form.failStrategy.placeholder")}
+                      />
                       <InputSelect.Content>
                         <InputSelect.Item value="soft">
-                          Log Error and Continue
+                          {t("form.failStrategy.soft.label")}
                           {spec?.default_fail_strategy === "soft" && (
                             <>
                               {" "}
-                              <Text color="text-03">(Default)</Text>
+                              <Text color="text-03">
+                                {t("form.failStrategy.default.label")}
+                              </Text>
                             </>
                           )}
                         </InputSelect.Item>
                         <InputSelect.Item value="hard">
-                          Block Pipeline on Failure
+                          {t("form.failStrategy.hard.label")}
                           {spec?.default_fail_strategy === "hard" && (
                             <>
                               {" "}
-                              <Text color="text-03">(Default)</Text>
+                              <Text color="text-03">
+                                {t("form.failStrategy.default.label")}
+                              </Text>
                             </>
                           )}
                         </InputSelect.Item>
@@ -342,8 +361,8 @@ export default function HookFormModal({
 
                   <InputVertical
                     withLabel="endpoint_url"
-                    title="External API Endpoint URL"
-                    subDescription="Only connect to servers you trust. You are responsible for actions taken and data shared with this connection."
+                    title={t("form.endpoint.title")}
+                    subDescription={t("form.endpoint.description")}
                   >
                     <div className="[&_input::placeholder]:!font-main-ui-muted w-full">
                       <InputTypeInField
@@ -356,15 +375,15 @@ export default function HookFormModal({
 
                   <InputVertical
                     withLabel="api_key"
-                    title="API Key"
-                    subDescription="Onyx will use this key to authenticate with your API endpoint."
+                    title={t("form.apiKey.title")}
+                    subDescription={t("form.apiKey.description")}
                   >
                     <PasswordInputTypeInField
                       name="api_key"
                       placeholder={
                         isEdit
                           ? (hook?.api_key_masked ??
-                            "Leave blank to keep current key")
+                            t("form.apiKey.keepCurrent.placeholder"))
                           : undefined
                       }
                       disabled={isSubmitting}
@@ -400,8 +419,8 @@ export default function HookFormModal({
                       </div>
                       <Text font="secondary-body" color="text-03">
                         {isConnected
-                          ? "Connection valid."
-                          : "Verifying connection…"}
+                          ? t("form.connectionValid.label")
+                          : t("form.verifying.label")}
                       </Text>
                     </Section>
                   )}
@@ -415,7 +434,7 @@ export default function HookFormModal({
                         prominence="secondary"
                         onClick={handleClose}
                       >
-                        Cancel
+                        {t("modals.cancel.label")}
                       </Button>
                     }
                     submit={
@@ -434,7 +453,9 @@ export default function HookFormModal({
                             : undefined
                         }
                       >
-                        {isEdit ? "Save Changes" : "Connect"}
+                        {isEdit
+                          ? t("form.save.label")
+                          : t("connectButton.label")}
                       </Button>
                     }
                   />

--- a/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { SvgDownload, SvgTextLines, SvgSimpleLoader } from "@opal/icons";
 import { Modal } from "@opal/components";
@@ -41,6 +42,7 @@ function SectionHeader({ label }: { label: string }) {
 }
 
 function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
+  const t = useTranslations("admin.hooks");
   return (
     <Hoverable.Root group={group}>
       <Section
@@ -60,7 +62,7 @@ function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
         {/* 2. Error message */}
         <span className="flex-1 min-w-0 break-all whitespace-pre-wrap text-code-code">
           <Text font="secondary-mono" color="inherit">
-            {log.error_message ?? "Unknown error"}
+            {log.error_message ?? t("logs.unknownError.label")}
           </Text>
         </span>
         {/* 3. Copy button */}
@@ -75,6 +77,7 @@ function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
 }
 
 export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
+  const t = useTranslations("admin.hooks");
   const onClose = useModalClose();
 
   const { recentErrors, olderErrors, isLoading, error } = useHookExecutionLogs(
@@ -90,7 +93,7 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
       .map(
         (log) =>
           `${formatDateTimeLog(log.created_at)} ${
-            log.error_message ?? "Unknown error"
+            log.error_message ?? t("logs.unknownError.label")
           }`
       )
       .join("\n");
@@ -105,10 +108,11 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
       <Modal.Content width="md" height="fit">
         <Modal.Header
           icon={(props) => <SvgTextLines {...props} />}
-          title="Recent Errors"
-          description={`Hook: ${hook.name} • Hook Point: ${
-            spec?.display_name ?? hook.hook_point
-          }`}
+          title={t("logs.header.title")}
+          description={t("logs.header.description", {
+            name: hook.name,
+            point: spec?.display_name ?? hook.hook_point,
+          })}
           onClose={onClose}
         />
         <Modal.Body>
@@ -118,17 +122,17 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
             </Section>
           ) : error ? (
             <Text font="main-ui-body" color="text-03">
-              Failed to load logs.
+              {t("logs.loadFailed.message")}
             </Text>
           ) : totalLines === 0 ? (
             <Text font="main-ui-body" color="text-03">
-              No errors in the past 30 days.
+              {t("logs.empty.message")}
             </Text>
           ) : (
             <>
               {recentErrors.length > 0 && (
                 <>
-                  <SectionHeader label="Past Hour" />
+                  <SectionHeader label={t("logs.pastHour.label")} />
                   {recentErrors.map((log, idx) => (
                     <LogRow
                       key={log.created_at + String(idx)}
@@ -140,7 +144,7 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
               )}
               {olderErrors.length > 0 && (
                 <>
-                  <SectionHeader label="Older" />
+                  <SectionHeader label={t("logs.older.label")} />
                   {olderErrors.map((log, idx) => (
                     <LogRow
                       key={log.created_at + String(idx)}
@@ -161,7 +165,7 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
           className="bg-background-tint-01"
         >
           <Text font="main-ui-body" color="text-03">
-            {`${totalLines} ${totalLines === 1 ? "line" : "lines"}`}
+            {t("logs.lineCount.label", { count: totalLines })}
           </Text>
           <Section
             flexDirection="row"
@@ -171,12 +175,16 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
             padding={1}
             className="rounded-xl bg-background-tint-00"
           >
-            <CopyButton size="sm" tooltip="Copy" getCopyText={getLogsText} />
+            <CopyButton
+              size="sm"
+              tooltip={t("logs.copy.tooltip")}
+              getCopyText={getLogsText}
+            />
             <Button
               prominence="tertiary"
               size="sm"
               icon={SvgDownload}
-              tooltip="Download"
+              tooltip={t("logs.download.tooltip")}
               onClick={handleDownload}
             />
           </Section>

--- a/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookStatusPopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   CopyButton,
@@ -37,6 +38,7 @@ function ErrorLogRow({
   log: { created_at: string; error_message: string | null };
   group: string;
 }) {
+  const t = useTranslations("admin.hooks");
   return (
     <Hoverable.Root group={group}>
       <Section
@@ -65,7 +67,7 @@ function ErrorLogRow({
         </Section>
         <span className="break-all">
           <Text font="secondary-mono" color="text-03">
-            {log.error_message ?? "Unknown error"}
+            {log.error_message ?? t("logs.unknownError.label")}
           </Text>
         </span>
       </Section>
@@ -84,6 +86,7 @@ export default function HookStatusPopover({
   spec,
   isBusy,
 }: HookStatusPopoverProps) {
+  const t = useTranslations("admin.hooks");
   const logsModal = useCreateModal();
   const [open, setOpen] = useState(false);
   // true = opened by click (stays until dismissed); false = opened by hover (closes after 1s)
@@ -201,7 +204,9 @@ export default function HookStatusPopover({
             onClick={noProp(handleTriggerClick)}
             disabled={isBusy}
           >
-            {hook.is_reachable === false ? "Connection Lost" : "Connected"}
+            {hook.is_reachable === false
+              ? t("status.connectionLost.label")
+              : t("status.connected.label")}
           </Button>
         </Popover.Anchor>
 
@@ -234,7 +239,7 @@ export default function HookStatusPopover({
               </Section>
             ) : error ? (
               <Text font="secondary-body" color="text-03">
-                Failed to load logs.
+                {t("logs.loadFailed.message")}
               </Text>
             ) : hook.is_reachable === false ? (
               <>
@@ -248,7 +253,7 @@ export default function HookStatusPopover({
                         className="text-status-error-05"
                       />
                     )}
-                    title="Most Recent Errors"
+                    title={t("status.recentErrors.title")}
                   />
                 </div>
 
@@ -286,7 +291,7 @@ export default function HookStatusPopover({
                     handleOpenChange(false);
                     logsModal.toggle(true);
                   })}
-                  title="View More Lines"
+                  title={t("status.viewMore.label")}
                 />
               </>
             ) : hasRecentErrors ? (
@@ -303,12 +308,12 @@ export default function HookStatusPopover({
                     )}
                     title={
                       recentErrors.length <= 3
-                        ? `${recentErrors.length} ${
-                            recentErrors.length === 1 ? "Error" : "Errors"
-                          }`
-                        : "Most Recent Errors"
+                        ? t("status.errorCount.title", {
+                            count: recentErrors.length,
+                          })
+                        : t("status.recentErrors.title")
                     }
-                    description="in the past hour"
+                    description={t("status.pastHour.description")}
                   />
                 </div>
 
@@ -342,7 +347,7 @@ export default function HookStatusPopover({
                     handleOpenChange(false);
                     logsModal.toggle(true);
                   })}
-                  title="View More Lines"
+                  title={t("status.viewMore.label")}
                 />
               </>
             ) : (
@@ -353,8 +358,8 @@ export default function HookStatusPopover({
                     sizePreset="secondary"
                     variant="section"
                     icon={SvgCheckCircle}
-                    title="No Error"
-                    description="in the past hour"
+                    title={t("status.noError.title")}
+                    description={t("status.pastHour.description")}
                   />
                 </div>
 
@@ -370,7 +375,7 @@ export default function HookStatusPopover({
                     handleOpenChange(false);
                     logsModal.toggle(true);
                   })}
-                  title="View Older Errors"
+                  title={t("status.viewOlder.label")}
                 />
               </>
             )}

--- a/web/src/ee/views/admin/HooksPage/index.tsx
+++ b/web/src/ee/views/admin/HooksPage/index.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -74,6 +76,7 @@ function DisconnectConfirmModal({
   onDisconnect,
   onDisconnectAndDelete,
 }: DisconnectConfirmModalProps) {
+  const t = useTranslations("admin.hooks");
   const onClose = useModalClose();
 
   return (
@@ -82,34 +85,36 @@ function DisconnectConfirmModal({
         <Modal.Header
           // TODO(@raunakab): replace the colour of this SVG with red.
           icon={SvgUnplug}
-          title={markdown(`Disconnect *${hook.name}*`)}
+          title={markdown(
+            t("disconnectModal.header.title", { name: hook.name })
+          )}
           onClose={onClose}
         />
         <Modal.Body>
           <div className="flex flex-col gap-2">
             <Text font="main-ui-body" color="text-03">
               {markdown(
-                `Onyx will stop calling this endpoint for hook ***${hook.name}***. In-flight requests will continue to run. The external endpoint may still retain data previously sent to it. You can reconnect this hook later if needed.`
+                t("disconnectModal.body.description", { name: hook.name })
               )}
             </Text>
             <Text font="main-ui-body" color="text-03">
-              You can also delete this hook. Deletion cannot be undone.
+              {t("disconnectModal.deleteNote.description")}
             </Text>
           </div>
         </Modal.Body>
         <Modal.Footer>
           <Button prominence="secondary" onClick={onClose}>
-            Cancel
+            {t("modals.cancel.label")}
           </Button>
           <Button
             variant="danger"
             prominence="secondary"
             onClick={onDisconnectAndDelete}
           >
-            Disconnect &amp; Delete
+            {t("disconnectModal.disconnectAndDelete.label")}
           </Button>
           <Button variant="danger" prominence="primary" onClick={onDisconnect}>
-            Disconnect
+            {t("disconnectModal.disconnect.label")}
           </Button>
         </Modal.Footer>
       </Modal.Content>
@@ -127,6 +132,7 @@ interface DeleteConfirmModalProps {
 }
 
 function DeleteConfirmModal({ hook, onDelete }: DeleteConfirmModalProps) {
+  const t = useTranslations("admin.hooks");
   const onClose = useModalClose();
 
   return (
@@ -135,27 +141,25 @@ function DeleteConfirmModal({ hook, onDelete }: DeleteConfirmModalProps) {
         <Modal.Header
           // TODO(@raunakab): replace the colour of this SVG with red.
           icon={SvgTrash}
-          title={markdown(`Delete *${hook.name}*`)}
+          title={markdown(t("deleteModal.header.title", { name: hook.name }))}
           onClose={onClose}
         />
         <Modal.Body>
           <div className="flex flex-col gap-2">
             <Text font="main-ui-body" color="text-03">
-              {markdown(
-                `Hook ***${hook.name}*** will be permanently removed from this hook point. The external endpoint may still retain data previously sent to it.`
-              )}
+              {markdown(t("deleteModal.body.description", { name: hook.name }))}
             </Text>
             <Text font="main-ui-body" color="text-03">
-              Deletion cannot be undone.
+              {t("deleteModal.permanent.description")}
             </Text>
           </div>
         </Modal.Body>
         <Modal.Footer>
           <Button prominence="secondary" onClick={onClose}>
-            Cancel
+            {t("modals.cancel.label")}
           </Button>
           <Button variant="danger" prominence="primary" onClick={onDelete}>
-            Delete
+            {t("deleteModal.delete.label")}
           </Button>
         </Modal.Footer>
       </Modal.Content>
@@ -173,6 +177,7 @@ interface UnconnectedHookCardProps {
 }
 
 function UnconnectedHookCard({ spec, onConnect }: UnconnectedHookCardProps) {
+  const t = useTranslations("admin.hooks");
   const Icon = getHookPointIcon(spec.hook_point);
 
   return (
@@ -190,7 +195,7 @@ function UnconnectedHookCard({ spec, onConnect }: UnconnectedHookCardProps) {
           {spec.docs_url && (
             <div className="ms-6">
               <LinkButton href={spec.docs_url} target="_blank">
-                Documentation
+                {t("docsLink.label")}
               </LinkButton>
             </div>
           )}
@@ -201,7 +206,7 @@ function UnconnectedHookCard({ spec, onConnect }: UnconnectedHookCardProps) {
           rightIcon={SvgArrowExchange}
           onClick={noProp(onConnect)}
         >
-          Connect
+          {t("connectButton.label")}
         </Button>
       </div>
     </SelectCard>
@@ -227,6 +232,8 @@ function ConnectedHookCard({
   onDeleted,
   onToggled,
 }: ConnectedHookCardProps) {
+  const t = useTranslations("admin.hooks");
+  const adminRouteTitle = useAdminRouteTitle();
   const [isBusy, setIsBusy] = useState(false);
   const disconnectModal = useCreateModal();
   const deleteModal = useCreateModal();
@@ -240,7 +247,7 @@ function ConnectedHookCard({
     } catch (err) {
       console.error("Failed to delete hook:", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to delete hook."
+        err instanceof Error ? err.message : t("toasts.deleteFailed.message")
       );
     } finally {
       setIsBusy(false);
@@ -255,7 +262,7 @@ function ConnectedHookCard({
     } catch (err) {
       console.error("Failed to reconnect hook:", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to reconnect hook."
+        err instanceof Error ? err.message : t("toasts.reconnectFailed.message")
       );
     } finally {
       setIsBusy(false);
@@ -271,7 +278,9 @@ function ConnectedHookCard({
     } catch (err) {
       console.error("Failed to deactivate hook:", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to deactivate hook."
+        err instanceof Error
+          ? err.message
+          : t("toasts.deactivateFailed.message")
       );
     } finally {
       setIsBusy(false);
@@ -289,7 +298,9 @@ function ConnectedHookCard({
     } catch (err) {
       console.error("Failed to disconnect hook:", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to disconnect hook."
+        err instanceof Error
+          ? err.message
+          : t("toasts.disconnectFailed.message")
       );
     } finally {
       setIsBusy(false);
@@ -301,16 +312,17 @@ function ConnectedHookCard({
     try {
       const result = await validateHook(hook.id);
       if (result.status === "passed") {
-        toast.success("Hook validated successfully.");
+        toast.success(t("toasts.validateSuccess.message"));
       } else {
         toast.error(
-          result.error_message ?? `Validation failed: ${result.status}`
+          result.error_message ??
+            t("toasts.validationFailed.message", { status: result.status })
         );
       }
     } catch (err) {
       console.error("Failed to validate hook:", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to validate hook."
+        err instanceof Error ? err.message : t("toasts.validateFailed.message")
       );
       return;
     } finally {
@@ -354,16 +366,20 @@ function ConnectedHookCard({
                     ? markdown(`~~${hook.name}~~`)
                     : hook.name
                 }
-                suffix={!hook.is_active ? "(Disconnected)" : undefined}
-                description={`Hook Point: ${
-                  spec?.display_name ?? hook.hook_point
-                }`}
+                suffix={
+                  !hook.is_active
+                    ? t("card.disconnectedSuffix.label")
+                    : undefined
+                }
+                description={t("card.hookPoint.description", {
+                  name: spec?.display_name ?? hook.hook_point,
+                })}
               />
 
               {spec?.docs_url && (
                 <div className="ms-6">
                   <LinkButton href={spec.docs_url} target="_blank">
-                    Documentation
+                    {t("docsLink.label")}
                   </LinkButton>
                 </div>
               )}
@@ -380,7 +396,7 @@ function ConnectedHookCard({
                     onClick={noProp(handleActivate)}
                     disabled={isBusy}
                   >
-                    Reconnect
+                    {t("card.reconnectButton.label")}
                   </Button>
                 )}
               </div>
@@ -398,8 +414,8 @@ function ConnectedHookCard({
                           size="md"
                           icon={SvgUnplug}
                           onClick={noProp(() => disconnectModal.toggle(true))}
-                          tooltip="Disconnect Hook"
-                          aria-label="Deactivate hook"
+                          tooltip={t("card.disconnect.tooltip")}
+                          aria-label={t("card.disconnect.ariaLabel")}
                         />
                       </Hoverable.Item>
                       <Button
@@ -407,8 +423,8 @@ function ConnectedHookCard({
                         size="md"
                         icon={SvgRefreshCw}
                         onClick={noProp(handleValidate)}
-                        tooltip="Test Connection"
-                        aria-label="Re-validate hook"
+                        tooltip={t("card.test.tooltip")}
+                        aria-label={t("card.test.ariaLabel")}
                       />
                     </>
                   ) : (
@@ -417,8 +433,8 @@ function ConnectedHookCard({
                       size="md"
                       icon={SvgTrash}
                       onClick={noProp(() => deleteModal.toggle(true))}
-                      tooltip="Delete"
-                      aria-label="Delete hook"
+                      tooltip={t("card.delete.tooltip")}
+                      aria-label={t("card.delete.ariaLabel")}
                     />
                   )}
                   <Button
@@ -426,8 +442,8 @@ function ConnectedHookCard({
                     size="md"
                     icon={SvgSettings}
                     onClick={noProp(onEdit)}
-                    tooltip="Manage"
-                    aria-label="Configure hook"
+                    tooltip={t("card.manage.tooltip")}
+                    aria-label={t("card.manage.ariaLabel")}
                   />
                 </div>
               </Disabled>
@@ -444,6 +460,8 @@ function ConnectedHookCard({
 // ---------------------------------------------------------------------------
 
 export default function HooksPage() {
+  const t = useTranslations("admin.hooks");
+  const adminRouteTitle = useAdminRouteTitle();
   const router = useRouter();
   const settings = useSettings();
   const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
@@ -505,13 +523,13 @@ export default function HooksPage() {
   useEffect(() => {
     if (settings.isLoading) return;
     if (!enterpriseTier) {
-      toast.info("Hook Extensions require an Enterprise license.");
+      toast.info(t("page.enterpriseRequired.message"));
       router.replace("/");
     } else if (!settings.hooks_enabled) {
-      toast.info("Hook Extensions are not enabled for this deployment.");
+      toast.info(t("page.notEnabled.message"));
       router.replace("/");
     }
-  }, [settings.isLoading, enterpriseTier, settings.hooks_enabled, router]);
+  }, [settings.isLoading, enterpriseTier, settings.hooks_enabled, router, t]);
 
   if (settings.isLoading || !enterpriseTier || !settings.hooks_enabled) {
     return <SvgSimpleLoader />;
@@ -574,8 +592,8 @@ export default function HooksPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
           icon={route.icon}
-          title={route.title}
-          description="Extend Onyx pipelines by registering external API endpoints as callbacks at predefined hook points."
+          title={adminRouteTitle(route)}
+          description={t("page.description")}
           divider
         />
         <SettingsLayouts.Body>
@@ -583,15 +601,15 @@ export default function HooksPage() {
             <SvgSimpleLoader />
           ) : specsError || hooksError ? (
             <Text font="secondary-body" color="text-03">
-              {`Failed to load${
-                specsError ? " hook specifications" : " hooks"
-              }. Please refresh the page.`}
+              {specsError
+                ? t("page.loadSpecsFailed.message")
+                : t("page.loadHooksFailed.message")}
             </Text>
           ) : (
             <div className="flex flex-col gap-3 h-full">
               <div className="pb-3">
                 <InputTypeIn
-                  placeholder="Search hooks..."
+                  placeholder={t("page.search.placeholder")}
                   value={search}
                   variant="internal"
                   searchIcon
@@ -603,10 +621,12 @@ export default function HooksPage() {
                 <div>
                   <IllustrationContent
                     title={
-                      search ? "No results found" : "No hook points available"
+                      search
+                        ? t("page.emptySearch.title")
+                        : t("page.empty.title")
                     }
                     description={
-                      search ? "Try using a different search term." : undefined
+                      search ? t("page.emptySearch.description") : undefined
                     }
                     illustration={search ? SvgNoResult : SvgEmpty}
                   />

--- a/web/src/ee/views/admin/HooksPage/index.tsx
+++ b/web/src/ee/views/admin/HooksPage/index.tsx
@@ -233,7 +233,6 @@ function ConnectedHookCard({
   onToggled,
 }: ConnectedHookCardProps) {
   const t = useTranslations("admin.hooks");
-  const adminRouteTitle = useAdminRouteTitle();
   const [isBusy, setIsBusy] = useState(false);
   const disconnectModal = useCreateModal();
   const deleteModal = useCreateModal();

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -12902,9 +12902,29 @@
         "title": "تعذّر تحميل الاستخدام"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · افتراضي"
+        },
         "description": "دولار لكل مليون رمز (إدخال · إخراج · ذاكرة مؤقتة) لكل نموذج متاح",
+        "otherProvider": {
+          "label": "أخرى"
+        },
         "title": "أسعار النماذج",
         "unavailable": "الأسعار غير متاحة"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "{count} قراءات من الذاكرة المؤقتة"
+        },
+        "cacheWrites": {
+          "label": "{count} كتابات في الذاكرة المؤقتة"
+        },
+        "tokensIn": {
+          "label": "{count} إدخال"
+        },
+        "tokensOut": {
+          "label": "{count} إخراج"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "عرض نماذج أقل"

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -60,6 +60,26 @@
         "ariaLabel": "بطاقة الإجراء {title}"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "إضافة موصّلات"
+      },
+      "configure": {
+        "tooltip": "تكوين"
+      },
+      "configureConnectors": {
+        "label": "تكوين الموصّلات"
+      },
+      "disable": {
+        "label": "تعطيل"
+      },
+      "enable": {
+        "label": "تمكين"
+      },
+      "projectSearch": {
+        "label": "بحث المشروع"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "اربط خادم MCP (بروتوكول سياق النموذج) لإضافة إجراءات مخصصة.",
@@ -355,6 +375,53 @@
         "tooltip": "تحديث الأدوات"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "ستتم إعادتك تلقائيًا…"
+      },
+      "backToChatButton": {
+        "label": "العودة إلى الدردشة"
+      },
+      "cancelled": {
+        "description": "تم إلغاء التفويض أو رفضه، لذا لم يتم إنشاء أي اتصال. للمحاولة مرة أخرى، أعد بدء الاتصال من إعدادات المصادقة الخاصة بخادم MCP.",
+        "title": "تم إلغاء التفويض"
+      },
+      "continueButton": {
+        "label": "متابعة"
+      },
+      "genericError": {
+        "fallbackDetail": "تعذر إكمال التفويض",
+        "title": "حدث خطأ ما"
+      },
+      "invalidLink": {
+        "description": "يفتقد هذا الرابط معلمات التفويض المطلوبة. أعد بدء الاتصال من إعدادات المصادقة الخاصة بخادم MCP.",
+        "title": "رابط تفويض غير صالح"
+      },
+      "processing": {
+        "description": "جارٍ إنهاء الاتصال بخادم MCP الخاص بك. قد يستغرق ذلك بضع لحظات…",
+        "title": "جارٍ إكمال التفويض"
+      },
+      "serverNotFound": {
+        "description": "خادم MCP الذي ينتمي إليه هذا التفويض لم يعد موجودًا أو لم يعد مكونًا. أعد إنشاء الخادم أو إعادة تكوينه، ثم اتصل مرة أخرى.",
+        "title": "لم يتم العثور على خادم MCP"
+      },
+      "sessionExpired": {
+        "description": "رابط التفويض هذا غير صالح أو انتهت صلاحيته أو تم استخدامه من قبل. أعد بدء الاتصال من إعدادات المصادقة الخاصة بخادم MCP.",
+        "title": "انتهت صلاحية جلسة التفويض"
+      },
+      "success": {
+        "description": "اكتمل التفويض بنجاح. يمكنك الآن استخدام أدوات هذا الخادم في الدردشة.",
+        "title": "تم الاتصال بـ {serverName}"
+      },
+      "timedOut": {
+        "description": "لم يؤكد خادم MCP التفويض في الوقت المحدد. حاول الاتصال مرة أخرى، وإذا استمرت المشكلة، فتحقق من إعدادات OAuth للخادم.",
+        "title": "انتهت مهلة التفويض"
+      },
+      "tokenExchangeFailed": {
+        "description": "وافق المزود على التفويض ولكن تعذر الحصول على رمز وصول صالح. تحقق من بيانات اعتماد عميل OAuth ونقاط النهاية الخاصة بالخادم، ثم حاول الاتصال مرة أخرى.",
+        "title": "فشل تبادل الرمز المميز"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "إضافة خادم MCP"
@@ -554,6 +621,20 @@
         "label": "رفض"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "رجوع"
+      },
+      "disableAll": {
+        "label": "تعطيل الكل"
+      },
+      "enableAll": {
+        "label": "تمكين الكل"
+      },
+      "toggle": {
+        "ariaLabel": "تبديل {name}"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "الأداة غير متاحة"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "عرض الأدوات المفعّلة فقط",
         "tooltip": "عرض المفعّلة فقط"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "تهيئة مفسر الأكواد"
+        },
+        "imageGeneration": {
+          "tooltip": "تهيئة توليد الصور"
+        },
+        "openapi": {
+          "tooltip": "إدارة إجراءات OpenAPI"
+        },
+        "webSearch": {
+          "tooltip": "تهيئة البحث في الويب"
+        }
+      },
+      "disableAllSources": {
+        "label": "تعطيل جميع المصادر"
+      },
+      "disableAllTools": {
+        "label": "تعطيل جميع الأدوات"
+      },
+      "enableAllSources": {
+        "label": "تمكين جميع المصادر"
+      },
+      "enableAllTools": {
+        "label": "تمكين جميع الأدوات"
+      },
+      "manageActions": {
+        "tooltip": "إدارة الإجراءات"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "البحث في أدوات {server}"
+      },
+      "moreActions": {
+        "label": "المزيد من الإجراءات"
+      },
+      "reauthenticate": {
+        "label": "إعادة المصادقة"
+      },
+      "search": {
+        "placeholder": "البحث في الإجراءات..."
+      },
+      "serverFallback": {
+        "label": "الخادم"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "البحث في عوامل التصفية"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "اطلب من مسؤول تهيئته."
+        },
+        "codingAgent": {
+          "description": "استقصِ مستودع GitHub وأجب عن أسئلة حول كوده."
+        },
+        "configureSuffix": {
+          "text": "اضغط على ترس الإعدادات للتفعيل."
+        },
+        "default": {
+          "description": "هذا الإجراء غير مهيأ بعد."
+        },
+        "imageGeneration": {
+          "description": "ولّد صورًا بناءً على مطالبة."
+        },
+        "python": {
+          "description": "نفّذ الأكواد لإجراء تحليلات معقدة."
+        },
+        "search": {
+          "description": "ابحث في المعرفة المتصلة لدعم الإجابة."
+        },
+        "webSearch": {
+          "description": "ابحث في الويب عن معلومات محدّثة."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "يوميًا للنطاق المحدد",
+        "title": "الرسائل والمستخدمون الفريدون"
+      },
+      "empty": {
+        "message": "لم يتم العثور على بيانات لهذا الوكيل في نطاق التاريخ المحدد."
+      },
+      "fetchFailed": {
+        "message": "فشل جلب إحصاءات الوكيل."
+      },
+      "permissionDenied": {
+        "message": "ليست لديك صلاحية لعرض هذه الإحصاءات."
+      },
+      "totalMessages": {
+        "label": "إجمالي الرسائل"
+      },
+      "totalUniqueUsers": {
+        "label": "إجمالي المستخدمين الفريدين"
+      },
+      "unknownError": {
+        "message": "حدث خطأ غير معروف"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "طي القسم"
+        },
+        "expand": {
+          "ariaLabel": "توسيع القسم"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "هل أنت متأكد من رغبتك في حذف <emphasis>{name}</emphasis>؟ لا يمكن التراجع عن هذا الإجراء."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "عرض الخطط"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "لا تتوفر معلومات فوترة."
+        },
+        "loadError": {
+          "message": "حدث خطأ أثناء تحميل معلومات الفوترة. يرجى المحاولة مرة أخرى لاحقًا."
+        },
+        "loading": {
+          "label": "جارٍ التحميل..."
+        },
+        "manageSubscription": {
+          "description": "اعرض خطتك أو حدِّث الدفع أو غيِّر الاشتراك",
+          "title": "إدارة الاشتراك"
+        },
+        "page": {
+          "title": "معلومات الفوترة"
+        },
+        "portalError": {
+          "message": "حدث خطأ أثناء إنشاء جلسة بوابة العملاء"
+        },
+        "subscriptionDetails": {
+          "title": "تفاصيل الاشتراك"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "نهاية الفوترة"
+          },
+          "billingStart": {
+            "label": "بداية الفوترة"
+          },
+          "seats": {
+            "label": "المقاعد"
+          },
+          "status": {
+            "label": "حالة الاشتراك"
+          }
+        },
+        "updatedToast": {
+          "message": "تهانينا! تم تحديث اشتراكك بنجاح."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "سنقوم بمزامنة الأذونات تلقائيًا من المصدر. لن يكون المستند قابلًا للبحث في Onyx إلا إذا كان المستخدم الذي يجري البحث يملك إذن الوصول إلى المستند في المصدر.",
+          "disabledReason": "طريقة مصادقة بيانات الاعتماد الحالية لا تدعم مزامنة الأذونات تلقائيًا. يرجى تغيير طريقة المصادقة إلى طريقة مدعومة.",
+          "name": "مزامنة الأذونات تلقائيًا"
+        },
+        "heading": {
+          "description": "تحكّم في من يمكنه الوصول إلى المستندات المفهرسة بواسطة هذا الموصّل.",
+          "title": "الوصول إلى المستندات"
+        },
+        "privateOption": {
+          "description": "لا يمكن الوصول إلى المستندات التي يجلبها هذا الموصّل إلا للمستخدمين الذين مُنحوا حق الوصول إليه صراحةً (عبر صفحة مجموعات المستخدمين)",
+          "name": "خاص"
+        },
+        "publicOption": {
+          "description": "يمكن لأي شخص لديه حساب على Onyx الوصول إلى المستندات التي يجلبها هذا الموصّل",
+          "name": "عام"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# يوم} other {# أيام}}",
@@ -1546,6 +1794,14 @@
           "label": "عرض أقل"
         }
       },
+      "credentialForm": {
+        "errorToast": "خطأ: {detail}",
+        "successToast": "تم بنجاح!",
+        "updateButton": {
+          "ariaLabel": "تحديث بيانات الاعتماد",
+          "label": "تحديث"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "يؤدي حذف هذا الموصل إلى جدولة مهمة حذف تزيل مستنداته المفهرسة وتحذفه لجميع المستخدمين.",
         "entityType": "موصل"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "خطأ في مزامنة أذونات المستندات"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "راجع <link>مستنداتنا</link> لمزيد من المعلومات حول إعداد هذا الموصّل."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "فشل تحديث الملفات"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "اسحب وأفلت {multiple, select, true {ملفات} other {ملفًا}} هنا، أو انقر لتحديد {multiple, select, true {ملفات} other {ملف}}"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {الملفات المحددة} other {الملف المحدد}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "رسالة الخطأ",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "خطأ في مزامنة عضويات المجموعات"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "إسناد وصول المجموعات لهذا الموصّل"
+        },
+        "assignToGroup": {
+          "title": "إسناد هذا الموصّل إلى مجموعة"
+        },
+        "scopedManagerGroups": {
+          "description": "حدد مجموعة أو أكثر من المجموعات التي تديرها لمنح حق الوصول إلى هذا الموصّل"
+        },
+        "syncGroups": {
+          "description": "تتحكم المجموعات أدناه في من يمكنه إدارة هذا الموصّل. يُورَّث الوصول إلى مستنداته من أذونات المصدر نفسه."
+        },
+        "visibleToGroups": {
+          "description": "سيكون هذا الموصّل مرئيًا ومتاحًا للمجموعات المحددة أدناه"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "أُرسلت إعادة الفهرسة الموجهة لـ {count, plural, one {مستند واحد} other {# مستندات}}. ستُمحى الأخطاء من القائمة مع انتهاء إعادة فهرسة المستندات."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "التعبير النمطي للقنوات مفعّل",
+        "channels": "القنوات",
+        "enabledTrue": "نعم",
+        "excludeChannelRegexEnabled": "التعبير النمطي لاستبعاد القنوات مفعّل",
+        "excludedChannels": "القنوات المستبعدة",
+        "includeBotMessages": "تضمين رسائل الروبوتات",
+        "jiraProjectUrl": "عنوان URL لمشروع Jira",
+        "multipleRepos": "مستودعات متعددة",
+        "pageId": "معرّف الصفحة",
+        "realm": "النطاق",
+        "repo": "المستودع",
+        "wikiUrl": "عنوان URL للويكي"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "أدخل بريد مسؤول أو مالك مؤسسة Google التي تملك حسابات Google Drive المراد فهرستها.",
           "invalidEmail": "يجب أن يكون بريدًا إلكترونيًا صالحًا",
           "label": "بريد المسؤول الرئيسي",
+          "placeholder": "admin@yourcompany.com",
           "required": "مطلوب"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "أدخل بريد مسؤول أو مالك مؤسسة Google التي تملك حسابات Gmail المراد فهرستها.",
           "invalidEmail": "يجب أن يكون بريدًا إلكترونيًا صالحًا",
           "label": "بريد المسؤول الرئيسي",
+          "placeholder": "admin@yourcompany.com",
           "required": "مطلوب"
         },
         "section": {
@@ -2602,6 +2906,171 @@
       "unavailable": {
         "description": "يُفعَّل Craft لكل نشر بواسطة Onyx. تواصل مع ممثل Onyx الخاص بك للحصول على صلاحية الوصول.",
         "title": "Craft غير متاح في هذا النشر"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "تم الإنشاء في <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "تم الإنشاء في <i>{date}</i> بواسطة <i>{email}</i>"
+        },
+        "unnamed": {
+          "label": "بيانات الاعتماد رقم {id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "إنشاء"
+        },
+        "created": {
+          "toast": "تم إنشاء بيانات اعتماد جديدة!"
+        },
+        "name": {
+          "label": "الاسم:",
+          "placeholder": "(اختياري) اسم بيانات الاعتماد..."
+        },
+        "submitError": {
+          "toast": "حدث خطأ أثناء إرسال بيانات الاعتماد"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "إلغاء"
+        },
+        "confirmBody": {
+          "message": "هل أنت متأكد من رغبتك في حذف بيانات الاعتماد هذه؟ لا يمكنك حذف بيانات اعتماد مرتبطة بموصّلات نشطة."
+        },
+        "confirmButton": {
+          "label": "تأكيد"
+        },
+        "confirmTitle": "تأكيد الحذف"
+      },
+      "edit": {
+        "name": {
+          "label": "الاسم (اختياري):"
+        },
+        "permissions": {
+          "note": "تأكد من التحديث إلى بيانات اعتماد ذات الأذونات المناسبة!"
+        },
+        "resetButton": {
+          "label": "إعادة تعيين التغييرات"
+        },
+        "updateButton": {
+          "label": "تحديث"
+        },
+        "updateError": {
+          "toast": "حدث خطأ أثناء تحديث بيانات الاعتماد"
+        }
+      },
+      "modal": {
+        "createTitle": "إنشاء بيانات اعتماد {source}",
+        "editTitle": "تعديل بيانات الاعتماد",
+        "updateTitle": "تحديث بيانات الاعتماد"
+      },
+      "modify": {
+        "createButton": {
+          "label": "إنشاء"
+        },
+        "instructions": {
+          "message": "حدد بيانات اعتماد حسب الحاجة! تأكد من تحديد بيانات اعتماد ذات الأذونات المناسبة لهذا الموصّل!"
+        },
+        "selectButton": {
+          "label": "تحديد"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "اتصال"
+        },
+        "connectError": {
+          "title": "تعذر الاتصال"
+        },
+        "redirectFailed": {
+          "message": "تعذر إعادة توجيهك لتسجيل الدخول باستخدام {source}. يرجى المحاولة مرة أخرى."
+        },
+        "retryButton": {
+          "label": "إعادة المحاولة"
+        },
+        "startError": {
+          "message": "تعذر بدء OAuth"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "مشكلة في تبديل بيانات الاعتماد: {detail}"
+        },
+        "success": {
+          "toast": "تم تبديل بيانات الاعتماد بنجاح!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "الإجراءات"
+        },
+        "created": {
+          "header": "تاريخ الإنشاء"
+        },
+        "edit": {
+          "ariaLabel": "تعديل بيانات الاعتماد"
+        },
+        "empty": {
+          "message": "لا توجد بيانات اعتماد لهذا الموصّل!"
+        },
+        "id": {
+          "header": "المعرّف"
+        },
+        "lastUpdated": {
+          "header": "آخر تحديث"
+        },
+        "name": {
+          "header": "الاسم"
+        },
+        "select": {
+          "label": "تحديد"
+        },
+        "selected": {
+          "badge": "محدد"
+        },
+        "untitled": {
+          "label": "بدون عنوان"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "مشكلة في تحديث بيانات الاعتماد"
+        },
+        "success": {
+          "toast": "تم تحديث بيانات الاعتماد"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "يتيح لك هذا استخدام أداة التحليلات الخاصة بك مع Onyx! انسخ مقتطف الويب من مزود التحليلات لديك في المربع أدناه، وسنبدأ في إرسال أحداث الاستخدام."
+      },
+      "notEnabled": {
+        "description": "لإعداد نصوص التحليلات المخصصة، يرجى التعاون مع الفريق الذي قام بإعداد Onyx لديكم لتعيين متغير البيئة <i>CUSTOM_ANALYTICS_SECRET_KEY</i>.",
+        "title": "التحليلات المخصصة غير مفعّلة."
+      },
+      "script": {
+        "description": "حدد كود Javascript الذي يجب تشغيله عند تحميل الصفحة لتهيئة التتبع/التحليلات المخصصة لديك.",
+        "instructions": "لا تُدرج وسمي `<script></script>`. إذا رفعت نصًا برمجيًا أدناه ولم تتلقَّ أي أحداث في منصة التحليلات لديك، فجرّب إزالة جميع المسافات الزائدة قبل كل سطر من JavaScript.",
+        "label": "النص البرمجي"
+      },
+      "secretKey": {
+        "description": "لأسباب أمنية، يجب تقديم مفتاح سري لتحديث هذا النص البرمجي. يجب أن يكون هذا هو قيمة متغير البيئة <i>CUSTOM_ANALYTICS_SECRET_KEY</i> الذي تم تعيينه عند إعداد Onyx لأول مرة.",
+        "label": "المفتاح السري"
+      },
+      "updateButton": {
+        "label": "تحديث"
+      },
+      "updateFailed": {
+        "message": "فشل تحديث نص التحليلات المخصص: \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "تم تحديث نص التحليلات المخصص بنجاح!"
       }
     },
     "discordBot": {
@@ -3059,6 +3528,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "جارٍ الجمع..."
+        },
+        "downloading": {
+          "label": "جارٍ التنزيل..."
+        },
+        "export": {
+          "label": "تصدير السجلات"
+        },
+        "starting": {
+          "label": "جارٍ البدء..."
+        }
+      },
+      "downloadButton": {
+        "label": "تنزيل"
+      },
+      "exportCard": {
+        "description": "يجمع ملفات السجلات من خادم API والعمال في الخلفية في ملف zip واحد. يبدأ التنزيل تلقائيًا بمجرد انتهاء الجمع.",
+        "title": "تصدير السجلات"
+      },
+      "header": {
+        "description": "نزِّل ملف zip يحتوي على ملفات سجلات الخادم لإرفاقه بمحادثة دعم Onyx."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "مشمول بواسطة عامل آخر على المضيف نفسه"
+        },
+        "failed": {
+          "label": "فشل"
+        },
+        "failedWithError": {
+          "label": "فشل: {error}"
+        },
+        "noLogs": {
+          "label": "لم يتم العثور على ملفات سجلات"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {تم رفع # ملف} other {تم رفع # ملفات}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "قد تتضمن ملفات السجلات رسائل البريد الإلكتروني للمستخدمين وعناوين المستندات واستعلامات البحث ومحتوى الأخطاء. راجع المحتويات قبل مشاركتها خارج مؤسستك.",
+        "title": "قد تحتوي السجلات على بيانات حساسة"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "جارٍ بدء الجمع..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "هناك عملية تصدير سجلات جارية بالفعل. حاول مرة أخرى بعد قليل."
+        },
+        "downloadFailed": {
+          "message": "فشل تنزيل تصدير السجلات."
+        },
+        "lostAccess": {
+          "message": "فُقد الوصول إلى عملية التصدير الجارية. ابدأ عملية جديدة."
+        },
+        "startFailed": {
+          "message": "فشل بدء تصدير السجلات."
+        },
+        "unreachable": {
+          "message": "تعذر الوصول إلى الخادم للتحقق من تقدم التصدير. ابدأ عملية تصدير جديدة بعد عودته."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "جارٍ الجمع..."
+        },
+        "missedDeadline": {
+          "label": "لم يقدم تقريرًا قبل الموعد النهائي"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3165,9 +3711,137 @@
         "loadFailed": "فشل تحميل الموصل: {details}",
         "title": "خطأ"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "اكتب اسم القناة أو نمط تعبير نمطي ثم اضغط Enter"
+        },
+        "channelsRequired": {
+          "error": "مطلوب قناة واحدة على الأقل عند تعطيل 'البحث في جميع القنوات'"
+        },
+        "configSchemaLoadError": {
+          "message": "فشل تحميل مخطط الإعدادات: {error}"
+        },
+        "configTitle": {
+          "text": "إعدادات الموصّل الموحّد"
+        },
+        "configuration": {
+          "heading": "الإعدادات"
+        },
+        "create": {
+          "failed": "فشل إنشاء الموصّل الموحّد",
+          "success": "تم إنشاء الموصّل الموحّد بنجاح!"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (اتركه فارغًا للاحتفاظ بالقيمة الحالية)"
+        },
+        "credentialValidationFailed": {
+          "message": "فشل التحقق من بيانات الاعتماد: {message}"
+        },
+        "credentials": {
+          "description": "أدخل بيانات الاعتماد لهذا الموصّل.",
+          "heading": "بيانات الاعتماد"
+        },
+        "delete": {
+          "failed": "فشل حذف الموصّل الموحّد",
+          "success": "تم حذف الموصّل الموحّد بنجاح!"
+        },
+        "deleteConfirm": {
+          "message": "هل أنت متأكد من رغبتك في حذف هذا الموصّل الموحّد؟ لا يمكن التراجع عن هذا الإجراء."
+        },
+        "deleteError": {
+          "toast": "خطأ أثناء حذف الموصّل: {error}"
+        },
+        "deleteItem": {
+          "deleting": "جارٍ الحذف...",
+          "inProgressTooltip": "جارٍ الحذف",
+          "label": "حذف"
+        },
+        "federatedBadge": {
+          "label": "موحّد"
+        },
+        "federatedTooltip": {
+          "default": "هذا موصّل موحّد. سيؤدي إلى زمن استجابة أطول وجودة بحث أقل مقارنةً بالموصّلات العادية."
+        },
+        "genericError": {
+          "text": "خطأ: {error}"
+        },
+        "listInput": {
+          "placeholder": "اكتب واضغط Enter لإضافة عنصر"
+        },
+        "loadingSchema": {
+          "description": "جارٍ استرداد الحقول المطلوبة لهذا النوع من الموصّلات",
+          "title": "جارٍ تحميل مخطط بيانات الاعتماد..."
+        },
+        "manageButton": {
+          "label": "إدارة"
+        },
+        "missingFields": {
+          "message": "حقول مطلوبة مفقودة: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "لا توجد إعدادات بحث متاحة لهذا النوع من الموصّلات."
+        },
+        "noCredentialSchema": {
+          "message": "لا يوجد مخطط بيانات اعتماد متاح لهذا النوع من الموصّلات."
+        },
+        "schemaLoadError": {
+          "message": "فشل تحميل مخطط بيانات الاعتماد: {error}"
+        },
+        "submitButton": {
+          "create": "إنشاء",
+          "creating": "جارٍ الإنشاء...",
+          "update": "تحديث",
+          "updating": "جارٍ التحديث..."
+        },
+        "title": {
+          "edit": "تعديل {name}",
+          "setup": "إعداد {name}"
+        },
+        "update": {
+          "failed": "فشل تحديث الموصّل الموحّد",
+          "success": "تم تحديث الموصّل الموحّد بنجاح!"
+        },
+        "validateBeforeEdit": {
+          "message": "أدخل قيم بيانات اعتماد جديدة قبل التحقق."
+        },
+        "validateButton": {
+          "label": "تحقق",
+          "validating": "جارٍ التحقق..."
+        },
+        "validation": {
+          "error": "خطأ في التحقق: {error}",
+          "failedStatus": "فشل التحقق: {statusText}",
+          "invalid": "بيانات الاعتماد غير صالحة",
+          "valid": "بيانات الاعتماد صالحة"
+        }
+      },
       "loading": {
         "description": "جارٍ جلب تفاصيل الموصل ومخطط بيانات الاعتماد",
         "title": "جارٍ تحميل تهيئة الموصل..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "العودة إلى المحادثة"
+      },
+      "error": {
+        "title": "حدث خطأ ما"
+      },
+      "errors": {
+        "clientSecret": "بيانات اعتماد المصادقة مفقودة أو غير صالحة",
+        "oauth": "فشل تفويض OAuth",
+        "validation": "خطأ في التهيئة - يرجى التحقق من إعدادات الموصل"
+      },
+      "processing": {
+        "details": "يرجى الانتظار بينما نكمل الإعداد.",
+        "title": "جارٍ المعالجة..."
+      },
+      "redirecting": {
+        "text": "جارٍ التحويل إلى المحادثة خلال ثانيتين..."
+      },
+      "success": {
+        "detailsTemplate": "اكتمل تفويض {serviceName} بنجاح. يمكنك الآن استخدام هذا الموصل للبحث.",
+        "title": "نجاح!"
       }
     },
     "groups": {
@@ -3430,6 +4104,265 @@
           "header": "حد الرموز",
           "placeholder": "حد الرموز (بالآلاف)",
           "unit": "(بالآلاف)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "حذف الخطاف",
+          "tooltip": "حذف"
+        },
+        "disconnect": {
+          "ariaLabel": "إلغاء تنشيط الخطاف",
+          "tooltip": "فصل الخطاف"
+        },
+        "disconnectedSuffix": {
+          "label": "(مفصول)"
+        },
+        "hookPoint": {
+          "description": "نقطة الخطاف: {name}"
+        },
+        "manage": {
+          "ariaLabel": "تكوين الخطاف",
+          "tooltip": "إدارة"
+        },
+        "reconnectButton": {
+          "label": "إعادة الاتصال"
+        },
+        "test": {
+          "ariaLabel": "إعادة التحقق من الخطاف",
+          "tooltip": "اختبار الاتصال"
+        }
+      },
+      "connectButton": {
+        "label": "اتصال"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "سيُزال الخطاف ***{name}*** نهائيًا من نقطة الخطاف هذه. قد تحتفظ نقطة النهاية الخارجية بالبيانات المرسلة إليها سابقًا."
+        },
+        "delete": {
+          "label": "حذف"
+        },
+        "header": {
+          "title": "حذف *{name}*"
+        },
+        "permanent": {
+          "description": "لا يمكن التراجع عن الحذف."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "سيتوقف Onyx عن استدعاء نقطة النهاية هذه للخطاف ***{name}***. ستستمر الطلبات الجارية في التنفيذ. قد تحتفظ نقطة النهاية الخارجية بالبيانات المرسلة إليها سابقًا. يمكنك إعادة توصيل هذا الخطاف لاحقًا إذا لزم الأمر."
+        },
+        "deleteNote": {
+          "description": "يمكنك أيضًا حذف هذا الخطاف. لا يمكن التراجع عن الحذف."
+        },
+        "disconnect": {
+          "label": "فصل"
+        },
+        "disconnectAndDelete": {
+          "label": "فصل وحذف"
+        },
+        "header": {
+          "title": "فصل *{name}*"
+        }
+      },
+      "docsLink": {
+        "label": "الوثائق"
+      },
+      "form": {
+        "apiKey": {
+          "description": "سيستخدم Onyx هذا المفتاح للمصادقة مع نقطة نهاية API الخاصة بك.",
+          "keepCurrent": {
+            "placeholder": "اتركه فارغًا للاحتفاظ بالمفتاح الحالي"
+          },
+          "title": "مفتاح API"
+        },
+        "connectionValid": {
+          "label": "الاتصال صالح."
+        },
+        "createHeader": {
+          "description": "اربط نقطة نهاية API خارجية لتوسيع نقطة الخطاف.",
+          "title": "إعداد امتداد الخطاف"
+        },
+        "editHeader": {
+          "title": "إدارة امتداد الخطاف"
+        },
+        "endpoint": {
+          "description": "اتصل فقط بالخوادم التي تثق بها. أنت مسؤول عن الإجراءات المتخذة والبيانات المشاركة عبر هذا الاتصال.",
+          "title": "عنوان URL لنقطة نهاية API الخارجية"
+        },
+        "errors": {
+          "connect": "تعذر الاتصال بنقطة النهاية.",
+          "generic": "حدث خطأ ما.",
+          "invalidApiKey": "مفتاح API غير صالح.",
+          "timeout": "انتهت مهلة الاتصال. جرّب زيادة المهلة."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(افتراضي)"
+          },
+          "hard": {
+            "label": "إيقاف المسار عند الفشل"
+          },
+          "placeholder": "اختر استراتيجية",
+          "soft": {
+            "label": "تسجيل الخطأ والمتابعة"
+          },
+          "title": "استراتيجية الفشل"
+        },
+        "hookPoint": {
+          "label": "نقطة الخطاف"
+        },
+        "name": {
+          "placeholder": "سمِّ الامتداد الخاص بك عند نقطة الخطاف هذه",
+          "title": "اسم العرض"
+        },
+        "save": {
+          "label": "حفظ التغييرات"
+        },
+        "softStrategy": {
+          "description": "إذا أعادت نقطة النهاية خطأ، يسجّله Onyx ويواصل المسار كالمعتاد متجاهلاً نتيجة الخطاف."
+        },
+        "timeout": {
+          "description": "أقصى وقت ينتظره Onyx لاستجابة نقطة النهاية قبل تطبيق استراتيجية الفشل. يجب أن يكون أكبر من 0 وبحد أقصى {max} ثانية.",
+          "revert": {
+            "tooltip": "الرجوع إلى الافتراضي"
+          },
+          "suffix": "(ثوانٍ)",
+          "title": "المهلة"
+        },
+        "toasts": {
+          "created": {
+            "message": "تم إنشاء الخطاف."
+          },
+          "noHookPoint": {
+            "message": "لم يتم تحديد نقطة خطاف."
+          },
+          "updated": {
+            "message": "تم تحديث الخطاف."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "لا يمكن أن يكون مفتاح API فارغًا.",
+          "endpointRequired": "لا يمكن أن يكون عنوان URL لنقطة النهاية فارغًا.",
+          "nameRequired": "لا يمكن أن يكون اسم العرض فارغًا.",
+          "timeoutRange": "يجب أن تكون أكبر من 0 وبحد أقصى {max} ثانية.",
+          "timeoutRequired": "المهلة مطلوبة."
+        },
+        "verifying": {
+          "label": "جارٍ التحقق من الاتصال…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "نسخ"
+        },
+        "download": {
+          "tooltip": "تنزيل"
+        },
+        "empty": {
+          "message": "لا توجد أخطاء خلال آخر 30 يومًا."
+        },
+        "header": {
+          "description": "الخطاف: {name} • نقطة الخطاف: {point}",
+          "title": "الأخطاء الأخيرة"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# سطر} other {# أسطر}}"
+        },
+        "loadFailed": {
+          "message": "فشل تحميل السجلات."
+        },
+        "older": {
+          "label": "أقدم"
+        },
+        "pastHour": {
+          "label": "الساعة الماضية"
+        },
+        "unknownError": {
+          "label": "خطأ غير معروف"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "إلغاء"
+        }
+      },
+      "page": {
+        "description": "وسّع مسارات Onyx بتسجيل نقاط نهاية API خارجية كاستدعاءات عند نقاط خطافات محددة مسبقًا.",
+        "empty": {
+          "title": "لا توجد نقاط خطافات متاحة"
+        },
+        "emptySearch": {
+          "description": "جرّب مصطلح بحث مختلفًا.",
+          "title": "لم يتم العثور على نتائج"
+        },
+        "enterpriseRequired": {
+          "message": "تتطلب امتدادات الخطافات ترخيص Enterprise."
+        },
+        "loadHooksFailed": {
+          "message": "فشل تحميل الخطافات. يرجى تحديث الصفحة."
+        },
+        "loadSpecsFailed": {
+          "message": "فشل تحميل مواصفات الخطافات. يرجى تحديث الصفحة."
+        },
+        "notEnabled": {
+          "message": "امتدادات الخطافات غير مفعّلة لهذا النشر."
+        },
+        "search": {
+          "placeholder": "ابحث في الخطافات..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "متصل"
+        },
+        "connectionLost": {
+          "label": "انقطع الاتصال"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# خطأ} other {# أخطاء}}"
+        },
+        "noError": {
+          "title": "لا يوجد خطأ"
+        },
+        "pastHour": {
+          "description": "خلال الساعة الماضية"
+        },
+        "recentErrors": {
+          "title": "أحدث الأخطاء"
+        },
+        "viewMore": {
+          "label": "عرض المزيد من الأسطر"
+        },
+        "viewOlder": {
+          "label": "عرض الأخطاء الأقدم"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "فشل إلغاء تنشيط الخطاف."
+        },
+        "deleteFailed": {
+          "message": "فشل حذف الخطاف."
+        },
+        "disconnectFailed": {
+          "message": "فشل فصل الخطاف."
+        },
+        "reconnectFailed": {
+          "message": "فشلت إعادة توصيل الخطاف."
+        },
+        "validateFailed": {
+          "message": "فشل التحقق من الخطاف."
+        },
+        "validateSuccess": {
+          "message": "تم التحقق من الخطاف بنجاح."
+        },
+        "validationFailed": {
+          "message": "فشل التحقق: {status}"
         }
       }
     },
@@ -4309,6 +5242,9 @@
               "label": "إضافة سطر"
             },
             "description": "أضف خصائص إضافية بحسب حاجة موفر النموذج. تُمرَّر هذه إلى استدعاء `completion()` في LiteLLM كـ[متغيرات بيئة](https://docs.litellm.ai/docs/set_keys#environment-variables). راجع [الوثائق](https://docs.onyx.app/admins/ai_models/custom_inference_provider) لمزيد من التعليمات.",
+            "keyInput": {
+              "placeholder": "مثل OPENAI_ORGANIZATION"
+            },
             "title": "متغيرات البيئة"
           },
           "modelRow": {
@@ -4820,6 +5756,132 @@
         "title": "المستخدمون"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "غير معروف"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "الذكاء الاصطناعي"
+        },
+        "errorTitle": {
+          "title": "حدث خطأ ما :("
+        },
+        "feedback": {
+          "title": "الملاحظات"
+        },
+        "fetchFailed": {
+          "message": "فشل جلب جلسة الدردشة - {error}"
+        },
+        "header": {
+          "title": "تفاصيل جلسة الدردشة"
+        },
+        "referenceDocuments": {
+          "title": "المستندات المرجعية"
+        },
+        "user": {
+          "label": "المستخدم"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "إلغاء"
+        },
+        "downloadFailed": {
+          "message": "فشل تنزيل سجل الاستعلامات."
+        },
+        "generating": {
+          "message": "جارٍ إنشاء تقرير CSV. انقر على زر \"{button}\" لعرض جميع المهام."
+        },
+        "kickoff": {
+          "label": "بدء التصدير"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "فشل"
+        },
+        "pending": {
+          "label": "قيد الانتظار"
+        },
+        "success": {
+          "label": "نجاح"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "تنزيل"
+        },
+        "endRange": {
+          "header": "نهاية النطاق"
+        },
+        "generatedAt": {
+          "header": "وقت الإنشاء"
+        },
+        "header": {
+          "title": "عمليات تصدير سجل الاستعلامات السابقة"
+        },
+        "notReady": {
+          "tooltip": "التصدير غير جاهز بعد"
+        },
+        "startRange": {
+          "header": "بداية النطاق"
+        },
+        "status": {
+          "header": "الحالة"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "عدم إعجاب"
+        },
+        "like": {
+          "label": "إعجاب"
+        },
+        "mixed": {
+          "label": "مختلط"
+        },
+        "na": {
+          "label": "غير متاح"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "الكل"
+        },
+        "feedbackType": {
+          "label": "نوع الملاحظات"
+        }
+      },
+      "previousExports": {
+        "label": "عرض عمليات التصدير"
+      },
+      "table": {
+        "date": {
+          "header": "التاريخ"
+        },
+        "feedback": {
+          "header": "الملاحظات"
+        },
+        "fetchError": {
+          "title": "خطأ في جلب سجل الاستعلامات"
+        },
+        "firstAiResponse": {
+          "header": "أول رد من الذكاء الاصطناعي"
+        },
+        "firstUserMessage": {
+          "header": "أول رسالة من المستخدم"
+        },
+        "persona": {
+          "header": "الشخصية"
+        },
+        "user": {
+          "header": "المستخدم"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4874,6 +5936,56 @@
         "generateFailed": "فشل توليد الرمز: {detail}",
         "genericError": "حدث خطأ ما. يرجى المحاولة مرة أخرى.",
         "regenerated": "أُعيد توليد الرمز"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "فشل تصنيف الاستعلام. سيتم الرجوع إلى الدردشة."
+        },
+        "searchFailed": {
+          "message": "فشل البحث في المستندات. يرجى المحاولة مرة أخرى."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# نتيجة} other {# نتائج}}"
+        },
+        "empty": {
+          "description": "تحقق من الموصلات/عوامل التصفية أو جرّب مصطلح بحث مختلفًا.",
+          "title": "لم يتم العثور على نتائج"
+        },
+        "failed": {
+          "title": "فشل البحث"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# وسم} other {# وسوم}}"
+        },
+        "empty": {
+          "label": "الوسوم"
+        },
+        "search": {
+          "placeholder": "تصفية الوسوم..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "كل الفترات"
+        },
+        "day": {
+          "label": "آخر 24 ساعة"
+        },
+        "month": {
+          "label": "الشهر الماضي"
+        },
+        "week": {
+          "label": "الأسبوع الماضي"
+        },
+        "year": {
+          "label": "العام الماضي"
+        }
       }
     },
     "security": {
@@ -5765,6 +6877,163 @@
         "unexpectedError": "حدث خطأ غير متوقع."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "إزالة الفئة {name}"
+        },
+        "removeButton": {
+          "ariaLabel": "إزالة الفئة"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "فئات الإجابات القياسية"
+        },
+        "fetchError": {
+          "message": "فشل جلب فئات الإجابات القياسية - {message}",
+          "title": "حدث خطأ ما :("
+        },
+        "search": {
+          "placeholder": "البحث في الفئات..."
+        }
+      },
+      "editPage": {
+        "title": "تعديل الإجابة القياسية"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "فشل جلب الإجابات القياسية"
+        },
+        "fetchCategoriesFailed": {
+          "message": "فشل جلب فئات الإجابات القياسية"
+        },
+        "genericTitle": {
+          "title": "حدث خطأ ما :("
+        },
+        "loadAnswersFailed": {
+          "title": "خطأ في تحميل الإجابات القياسية"
+        },
+        "loadCategoriesFailed": {
+          "title": "خطأ في تحميل فئات الإجابات القياسية"
+        },
+        "notFound": {
+          "message": "لم يتم العثور على إجابة قياسية بالمعرف: {id}"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "جميع الفئات"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "كل هذه الكلمات المفتاحية، بأي ترتيب، مفصولة بمسافات",
+          "placeholder": "تذكرة تقنية"
+        },
+        "answer": {
+          "label": "الإجابة",
+          "placeholder": "الإجابة بصيغة Markdown. مثال: إذا احتجت إلى مساعدة من فريق تقنية المعلومات، فيرجى مراسلة internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "أي من هذه الكلمات المفتاحية، مفصولة بمسافات",
+          "placeholder": "تذكرة مشكلة عطل"
+        },
+        "categories": {
+          "label": "الفئات:",
+          "placeholder": "اكتب فئة واضغط Enter…"
+        },
+        "createButton": {
+          "label": "إنشاء!"
+        },
+        "keywords": {
+          "tooltip": "يجب أن يتطابق السؤال مع هذه الكلمات المفتاحية لتفعيل الإجابة."
+        },
+        "matchRegex": {
+          "description": "طابق نمط regex بدلاً من كلمة مفتاحية محددة",
+          "label": "مطابقة regex"
+        },
+        "regexPattern": {
+          "label": "نمط regex",
+          "tooltip": "يتم التفعيل إذا تطابق السؤال مع نمط regex هذا (باستخدام `re.search()` في Python)"
+        },
+        "strategy": {
+          "all": {
+            "label": "كل الكلمات المفتاحية"
+          },
+          "any": {
+            "label": "أي كلمات مفتاحية"
+          },
+          "description": "اختر ما إذا كان يجب أن يحتوي سؤال المستخدم على أيٍّ من الكلمات المفتاحية أعلاه أو كلها لعرض هذه الإجابة.",
+          "label": "استراتيجية اكتشاف الكلمات المفتاحية"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "خطأ في إنشاء الفئة \"{name}\" - {error}"
+          },
+          "createFailed": {
+            "message": "خطأ في إنشاء الإجابة القياسية - {error}"
+          },
+          "updateFailed": {
+            "message": "خطأ في تحديث الإجابة القياسية - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "تحديث!"
+        },
+        "validation": {
+          "answerRequired": "الإجابة مطلوبة",
+          "categoryRequired": "مطلوب فئة واحدة على الأقل",
+          "keywordRequired": "الكلمات المفتاحية أو النمط مطلوب"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "أضف أول إجابة قياسية لك أدناه!"
+        },
+        "description": "أدر الإجابات القياسية للأسئلة المحددة مسبقًا.\nملاحظة: حاليًا، الأسئلة المطروحة من Slack فقط يمكن أن تتلقى إجابات قياسية."
+      },
+      "newStandardAnswer": {
+        "label": "إجابة قياسية جديدة"
+      },
+      "search": {
+        "placeholder": "ابحث عن الإجابات القياسية بكلمة مفتاحية أو عبارة..."
+      },
+      "table": {
+        "answer": {
+          "header": "الإجابة"
+        },
+        "categories": {
+          "header": "الفئات"
+        },
+        "empty": {
+          "message": "لم يتم العثور على إجابات قياسية مطابقة..."
+        },
+        "keywords": {
+          "header": "الكلمات المفتاحية/النمط"
+        },
+        "matchRegex": {
+          "header": "مطابقة regex؟"
+        },
+        "matchRegexNo": {
+          "label": "لا"
+        },
+        "matchRegexYes": {
+          "label": "نعم"
+        },
+        "slackNote": {
+          "message": "تأكد من أنك أضفت الفئة إلى [بوت Slack](/admin/bots) المعني."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "فشل حذف الإجابة القياسية - {error}"
+        },
+        "deleted": {
+          "message": "تم حذف الإجابة القياسية {id}"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "ملغاة",
@@ -5795,6 +7064,142 @@
       },
       "webVersion": {
         "label": "إصدار الويب: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "اعرض إعلان نظام دائمًا يمكن للمستخدمين إغلاقه.",
+        "header": {
+          "placeholder": "أضف إعلانًا"
+        },
+        "label": "إعلان النظام"
+      },
+      "announcementPopup": {
+        "description": "اعرض هذا الإشعار أيضًا كنافذة منبثقة بملء الشاشة عند الزيارة الأولى لجميع المستخدمين. استخدمه بحذر.",
+        "label": "إشعار منبثق عند الزيارة الأولى"
+      },
+      "appName": {
+        "description": "سيظهر هذا الاسم في جميع أنحاء التطبيق وسيحل محل \"Onyx\" في الواجهة.",
+        "label": "اسم عرض التطبيق"
+      },
+      "branding": {
+        "description": "أزل عبارة \"powered by Onyx\" وغيرها من عناصر علامة Onyx التجارية في التطبيق.",
+        "enterpriseTooltip": "إخفاء علامة Onyx التجارية هو ميزة في خطة Enterprise.",
+        "label": "إخفاء علامة Onyx التجارية"
+      },
+      "chatFooter": {
+        "description": "أضف محتوى ماركداون لإخلاء المسؤولية أو معلومات إضافية.",
+        "label": "نص تذييل الدردشة"
+      },
+      "chatHeader": {
+        "label": "نص ترويسة الدردشة"
+      },
+      "consent": {
+        "description": "اطلب من المستخدم قراءة الإشعار والموافقة عليه قبل الوصول إلى التطبيق.",
+        "label": "طلب الموافقة على الإشعار"
+      },
+      "consentPrompt": {
+        "label": "نص الموافقة على الإشعار"
+      },
+      "firstVisit": {
+        "description": "اعرض نافذة منبثقة لمرة واحدة للمستخدمين الجدد عند زيارتهم الأولى.",
+        "label": "عرض إشعار الزيارة الأولى"
+      },
+      "greeting": {
+        "description": "أضف رسالة قصيرة إلى الصفحة الرئيسية.",
+        "label": "رسالة الترحيب"
+      },
+      "helpLink": {
+        "description": "أضف رابط مساعدة مخصصًا في قائمة المستخدم بالإضافة إلى وثائق Onyx.",
+        "enterpriseTooltip": "رابط المساعدة المخصص هو ميزة في خطة Enterprise.",
+        "label": "رابط مساعدة مخصص"
+      },
+      "helpLinkLabel": {
+        "label": "تسمية رابط المساعدة المخصص",
+        "placeholder": "تسمية الرابط"
+      },
+      "loginSubtitle": {
+        "description": "استبدل الشعار النصي أسفل عنوان الترحيب في صفحة تسجيل الدخول.",
+        "label": "العنوان الفرعي لصفحة تسجيل الدخول"
+      },
+      "logo": {
+        "label": "شعار التطبيق",
+        "updateButton": {
+          "label": "تحديث"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "الشعار والاسم",
+          "tooltip": "اعرض شعار تطبيقك واسمه معًا."
+        },
+        "description": "اختر ما يظهر في أعلى الشريط الجانبي. تصبح الخيارات متاحة بمجرد إضافة شعار أو اسم تطبيق.",
+        "label": "نمط عرض الشعار",
+        "logoOnly": {
+          "disabledTooltip": "ارفع شعارًا لتفعيل هذا الخيار.",
+          "label": "الشعار فقط",
+          "tooltip": "اعرض شعار تطبيقك فقط."
+        },
+        "nameOnly": {
+          "disabledTooltip": "أدخل اسم تطبيق لتفعيل هذا الخيار.",
+          "label": "الاسم فقط",
+          "tooltip": "اعرض اسم تطبيقك فقط."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "أضف محتوى ماركداون"
+      },
+      "noticeContent": {
+        "label": "محتوى الإشعار"
+      },
+      "noticeHeader": {
+        "label": "ترويسة الإشعار"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "فشل مسح الإعلان."
+        },
+        "announcementSaveFailed": {
+          "message": "فشل حفظ الإعلان."
+        },
+        "applyButton": {
+          "label": "تطبيق التغييرات"
+        },
+        "applying": {
+          "label": "جارٍ التطبيق..."
+        },
+        "description": "خصص كيفية ظهور التطبيق للمستخدمين في مؤسستك.",
+        "logoUploadFailed": {
+          "message": "فشل رفع الشعار. {error}"
+        },
+        "saveSuccess": {
+          "message": "تم حفظ إعدادات المظهر بنجاح!"
+        },
+        "settingsSaveFailed": {
+          "message": "فشل تحديث الإعدادات. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "نص الموافقة على الإشعار مطلوب",
+          "invalidUrl": "يجب أن يكون عنوان URL صالحًا",
+          "maxChars": "{count} حرفًا كحد أقصى",
+          "noticeContentRequired": "محتوى الإشعار مطلوب",
+          "noticeHeaderRequired": "ترويسة الإشعار مطلوبة",
+          "urlRequiredWithLabel": "عنوان URL مطلوب عند تعيين تسمية"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "محتوى تذييل الدردشة"
+        },
+        "chatHeader": {
+          "placeholder": "محتوى ترويسة الدردشة"
+        },
+        "greeting": {
+          "placeholder": "مرحبًا بك في Acme Chat"
+        },
+        "logo": {
+          "alt": "الشعار"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6059,6 +7464,9 @@
             "label": "الإنفاق"
           }
         }
+      },
+      "page": {
+        "description": "راقب إنفاق مساحة العمل وراجع الاستخدام حسب المستخدم."
       },
       "spendByUser": {
         "columns": {
@@ -6656,6 +8064,204 @@
         "tooltip": "عرض إحصاءات الوكيل"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "أنشئ التعليمات البرمجية وشغّلها.",
+          "title": "مفسر التعليمات البرمجية"
+        },
+        "codingAgent": {
+          "description": "افحص مستودع GitHub وأجب عن الأسئلة المتعلقة بكوده.",
+          "title": "وكيل البرمجة"
+        },
+        "description": "الأدوات والقدرات المتاحة لهذا الوكيل لاستخدامها.",
+        "imageGeneration": {
+          "description": "أنشئ الصور وعالجها باستخدام أدوات مدعومة بالذكاء الاصطناعي.",
+          "title": "توليد الصور",
+          "unavailable": {
+            "tooltip": "يتطلب توليد الصور نموذجًا مهيأً. إذا كان لديك وصول، فقم بإعداد نموذج ضمن الإعدادات > توليد الصور، أو اطلب من المسؤول."
+          }
+        },
+        "openUrl": {
+          "description": "اجلب المحتوى من عناوين URL على الويب واقرأه.",
+          "title": "فتح عنوان URL"
+        },
+        "title": "الإجراءات",
+        "webSearch": {
+          "description": "ابحث في الويب عن معلومات فورية ونتائج محدثة.",
+          "title": "البحث على الويب"
+        }
+      },
+      "advanced": {
+        "description": "اضبط موجهات الوكيل ومعرفته بدقة.",
+        "overwritePrompt": {
+          "suffix": "(غير موصى به)",
+          "title": "استبدال موجه النظام"
+        },
+        "reminders": {
+          "description": "أضف تذكيرًا موجزًا إلى رسائل الموجه. استخدم هذا لتذكير الوكيل إذا وجدت أنه يميل إلى نسيان تعليمات معينة مع تقدم المحادثة. يجب أن يكون موجزًا وألا يتعارض مع رسائل المستخدم.",
+          "placeholder": "تذكر، أريد منك دائمًا تنسيق ردك كقائمة مرقمة.",
+          "title": "التذكيرات"
+        },
+        "title": "خيارات متقدمة"
+      },
+      "avatar": {
+        "edit": {
+          "label": "تعديل"
+        },
+        "uploadImage": {
+          "label": "رفع صورة"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "حذف الوكيل"
+        },
+        "description": "لن يتمكن أي شخص يستخدم هذا الوكيل من الوصول إليه بعد الآن.",
+        "title": "حذف هذا الوكيل"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "هل أنت متأكد من رغبتك في حذف هذا الوكيل؟",
+          "warning": "لن يتمكن أي شخص يستخدم هذا الوكيل من الوصول إليه بعد الآن. لا يمكن التراجع عن الحذف."
+        },
+        "title": "حذف الوكيل"
+      },
+      "filesModal": {
+        "description": "جميع الملفات المحددة لهذا الوكيل",
+        "placeholderName": "ملف {id}",
+        "title": "ملفات المستخدم"
+      },
+      "general": {
+        "avatar": {
+          "title": "الصورة الرمزية للوكيل"
+        },
+        "descriptionField": {
+          "placeholder": "ماذا يفعل هذا الوكيل؟",
+          "title": "الوصف"
+        },
+        "name": {
+          "placeholder": "سمِّ وكيلك",
+          "title": "الاسم"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "إلغاء"
+        },
+        "create": {
+          "label": "إنشاء"
+        },
+        "createTitle": "إنشاء وكيل",
+        "editTitle": "تعديل الوكيل",
+        "save": {
+          "label": "حفظ"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "لم يعد لديك وصول إلى خادم MCP هذا. سيتم الاحتفاظ بأدواته الحالية."
+        },
+        "searchTools": {
+          "placeholder": "البحث عن أدوات..."
+        }
+      },
+      "page": {
+        "ariaLabel": "صفحة محرر الوكلاء"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "أضف تعليمات لتخصيص استجابة هذا الوكيل.",
+          "placeholder": "فكر خطوة بخطوة وأظهر الاستدلال في المشكلات المعقدة. استخدم أمثلة محددة. أكّد على بنود العمل واترك فراغات ليملأها الإنسان عند وجود مجهول. استخدم نبرة مهذبة ومتحمسة.",
+          "title": "التعليمات"
+        },
+        "starters": {
+          "description": "رسائل نموذجية تساعد المستخدمين على فهم ما يمكن لهذا الوكيل فعله وكيفية التفاعل معه بفعالية.",
+          "title": "بادئات المحادثة"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "يرجى إصلاح الأخطاء في النموذج قبل الحفظ.",
+        "noChanges": "لم يتم إجراء أي تغييرات.",
+        "saving": "جارٍ حفظ التغييرات...",
+        "uploading": "يرجى الانتظار حتى انتهاء رفع الملفات."
+      },
+      "share": {
+        "feature": {
+          "description": "اعرض هذا الوكيل في أعلى قائمة استكشاف الوكلاء وثبّته تلقائيًا في الشريط الجانبي للمستخدمين الجدد الذين لديهم وصول.",
+          "privateNotice": {
+            "title": "هذا الوكيل خاص بك وسيظهر مميزًا لك وحدك."
+          },
+          "title": "تمييز هذا الوكيل",
+          "unlistedWarning": {
+            "title": "هذا الوكيل غير مدرج ولن يظهر في قائمة المميزين."
+          }
+        },
+        "labels": {
+          "description": "أضف تسميات وفئات لمساعدة الآخرين على اكتشاف هذا الوكيل بشكل أفضل.",
+          "placeholder": "إضافة تسميات..."
+        },
+        "share": {
+          "button": {
+            "label": "مشاركة"
+          },
+          "description": "مع مستخدمين آخرين أو مجموعات أو الجميع في مؤسستك.",
+          "title": "مشاركة هذا الوكيل"
+        },
+        "title": "مشاركة الوكيل"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "اجمع قائمة بأهدافنا الهندسية لهذا الربع.",
+          "overview": "أعطني نظرة عامة على بعض المستندات.",
+          "salesReport": "اعثر على أحدث تقرير مبيعات.",
+          "todayGoals": "لخّص أهدافي لليوم."
+        },
+        "placeholder": "أدخل بادئ محادثة..."
+      },
+      "suffix": {
+        "optional": "اختياري"
+      },
+      "toasts": {
+        "createFailed": "فشل إنشاء الوكيل - {detail}",
+        "created": "تم إنشاء الوكيل \"{name}\" بنجاح",
+        "deleteFailed": "فشل حذف الوكيل: {error}",
+        "deleted": "تم حذف الوكيل بنجاح",
+        "genericError": "حدث خطأ: {error}",
+        "noResponse": "لم يتم تلقي استجابة",
+        "sharingFailed": "تم إنشاء الوكيل، لكن فشلت المشاركة: {error}",
+        "toggleListedFailed": "فشل تبديل حالة الظهور",
+        "unknownDetail": "خطأ غير معروف",
+        "unknownError": "خطأ غير معروف",
+        "updateFailed": "فشل تحديث الوكيل - {detail}",
+        "updated": "تم تحديث الوكيل \"{name}\" بنجاح"
+      },
+      "validation": {
+        "cutoffInFuture": "يجب أن يكون تاريخ انقطاع المعرفة اليوم أو قبله.",
+        "descriptionMax": "يجب ألا يتجاوز الوصف {max} حرفًا",
+        "nameRequired": "اسم الوكيل مطلوب.",
+        "starterMax": "يجب ألا يتجاوز بادئ المحادثة {max} حرفًا"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "إعادة إدراج الوكيل"
+          },
+          "description": "يظهر الوكلاء المعاد إدراجهم في قائمة استكشاف الوكلاء مجددًا.",
+          "title": "إعادة إدراج هذا الوكيل"
+        },
+        "unlist": {
+          "button": {
+            "label": "إلغاء إدراج الوكيل"
+          },
+          "description": "الوكلاء غير المدرجين لا يظهرون في قائمة استكشاف الوكلاء لكن يظل الوصول إليهم ممكنًا.",
+          "title": "إلغاء إدراج هذا الوكيل"
+        }
+      },
+      "warnings": {
+        "openUrl": "قد يؤدي البحث على الويب دون القدرة على فتح عناوين URL إلى نتائج ويب أسوأ بكثير."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6838,6 +8444,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {وكيل} other {وكلاء}}"
+      },
+      "empty": {
+        "description": "لم يتم العثور على وكلاء"
+      },
+      "header": {
+        "description": "خصص سلوك الذكاء الاصطناعي ومعرفته لحالات الاستخدام الخاصة بك وبفريقك.",
+        "title": "الوكلاء"
+      },
+      "newAgent": {
+        "label": "وكيل جديد",
+        "noPermission": {
+          "tooltip": "ليست لديك صلاحية إنشاء الوكلاء. تواصل مع المسؤول لطلب الوصول."
+        }
+      },
+      "page": {
+        "ariaLabel": "صفحة الوكلاء"
+      },
+      "search": {
+        "placeholder": "البحث عن وكلاء..."
+      },
+      "sections": {
+        "all": {
+          "title": "جميع الوكلاء"
+        },
+        "featured": {
+          "description": "مختارة من فريقك",
+          "title": "الوكلاء المميزون"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "جميع الوكلاء"
+        },
+        "your": {
+          "label": "وكلاؤك"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "إدراج متغير مستخدم"
@@ -6845,6 +8492,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "يرجى الانتظار بينما نقوم بإعداد جلستك المجهولة.",
+        "title": "جارٍ إعادة توجيهك إلى صفحة الدردشة..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "إنشاء مؤسسة جديدة"
@@ -6866,6 +8519,55 @@
       },
       "signInLink": {
         "label": "تسجيل الدخول"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "يوجد حساب بالفعل بالبريد الإلكتروني المحدد."
+      },
+      "continueAsGuest": {
+        "label": "أو تابع كضيف"
+      },
+      "email": {
+        "label": "عنوان البريد الإلكتروني",
+        "placeholder": "email@yourcompany.com"
+      },
+      "forgotPassword": {
+        "link": "[هل نسيت كلمة المرور؟]({url})"
+      },
+      "invalidCredentials": {
+        "error": "البريد الإلكتروني أو كلمة المرور غير صالحة"
+      },
+      "noPassword": {
+        "error": "أنشئ حسابًا لتعيين كلمة مرور"
+      },
+      "password": {
+        "label": "كلمة المرور",
+        "placeholder": "كلمة المرور"
+      },
+      "passwordDigit": {
+        "error": "يجب أن تحتوي كلمة المرور على رقم واحد على الأقل"
+      },
+      "passwordLength": {
+        "error": "يجب أن تتكون كلمة المرور من {min}–{max} حرفًا"
+      },
+      "passwordLoginDisabled": {
+        "error": "تسجيل الدخول بكلمة المرور معطّل. سجّل الدخول باستخدام موفّر الهوية الخاص بك."
+      },
+      "passwordLowercase": {
+        "error": "يجب أن تحتوي كلمة المرور على حرف صغير واحد على الأقل"
+      },
+      "passwordRequirements": {
+        "label": "متطلبات كلمة المرور:"
+      },
+      "passwordSpecialChar": {
+        "error": "يجب أن تحتوي كلمة المرور على رمز خاص واحد على الأقل"
+      },
+      "passwordUppercase": {
+        "error": "يجب أن تحتوي كلمة المرور على حرف كبير واحد على الأقل"
+      },
+      "tooManyRequests": {
+        "error": "عدد كبير جدًا من الطلبات. يرجى المحاولة مرة أخرى لاحقًا."
       }
     },
     "error": {
@@ -6906,6 +8608,31 @@
         "description": "انقطاع مؤقت في نظام المصادقة"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "فريقك لم يفعّل الوصول المجهول."
+      },
+      "generic": {
+        "toast": "حدث خطأ."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "إنشاء حساب"
+      },
+      "logo": {
+        "alt": "الشعار"
+      },
+      "signInLink": {
+        "label": "تسجيل الدخول"
+      },
+      "signinPrompt": {
+        "text": "هل لديك حساب بالفعل؟"
+      },
+      "signupPrompt": {
+        "text": "جديد على {appName}؟"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[العودة إلى تسجيل الدخول](/auth/login)"
@@ -6938,7 +8665,8 @@
         "placeholder": "أدخل مفتاح API"
       },
       "emailField": {
-        "label": "البريد الإلكتروني"
+        "label": "البريد الإلكتروني",
+        "placeholder": "email@yourcompany.com"
       },
       "genericError": {
         "toast": "فشل انتحال هوية المستخدم"
@@ -6999,6 +8727,23 @@
         "label": "البريد الإلكتروني للعمل"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "يحتوي على رقم."
+      },
+      "length": {
+        "label": "{min}–{max} حرفًا"
+      },
+      "lowercase": {
+        "label": "يحتوي على حرف صغير."
+      },
+      "specialChar": {
+        "label": "يحتوي على رمز خاص."
+      },
+      "uppercase": {
+        "label": "يحتوي على حرف كبير."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[العودة إلى تسجيل الدخول](/auth/login)"
@@ -7040,6 +8785,31 @@
       },
       "unexpectedError": {
         "toast": "حدث خطأ غير متوقع. يرجى المحاولة مرة أخرى."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "انتهت صلاحية جلستك. يرجى تسجيل الدخول مرة أخرى للمتابعة."
+      },
+      "loginButton": {
+        "label": "تسجيل الدخول"
+      },
+      "modal": {
+        "title": "لقد تم تسجيل خروجك"
+      },
+      "terminated": {
+        "message": "تم تسجيل الخروج من هذه الجلسة. يرجى تسجيل الدخول مرة أخرى للمتابعة."
+      },
+      "unrecognized": {
+        "message": "تم تسجيل خروجك بشكل غير متوقع. يرجى تسجيل الدخول مرة أخرى للمتابعة. إذا استمر حدوث ذلك، فاتصل بالمسؤول."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "لم تُرجع grecaptcha.execute أي رمز مميز"
+      },
+      "google": {
+        "label": "المتابعة باستخدام Google"
       }
     },
     "signup": {
@@ -8471,6 +10241,75 @@
         "tooltip": "تعديل هذا الإعداد غير مدعوم لهذا النموذج."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {فشل الملف وتمت إزالته: {names}} other {فشلت الملفات وتمت إزالتها: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "تسجيل الدخول"
+          },
+          "title": "مرحبًا بك في Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "لم يتم العثور على رسالة مرسلة سابقًا."
+        },
+        "settingsButton": {
+          "tooltip": "فتح الإعدادات"
+        },
+        "setupLlmButton": {
+          "label": "قم بإعداد LLM."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "إلغاء"
+          },
+          "confirmButton": {
+            "label": "إيقاف"
+          },
+          "description": "سترى صفحة علامة التبويب الجديدة الافتراضية لمتصفحك بدلًا من ذلك. يمكنك إعادة تشغيلها في أي وقت من إعدادات Onyx.",
+          "title": "هل تريد إيقاف صفحة علامة التبويب الجديدة من Onyx؟"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "بدون"
+        },
+        "backgroundOption": {
+          "ariaLabel": "خلفية {label}"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "خلفية {label} (محددة)"
+        },
+        "backgroundSection": {
+          "title": "الخلفية"
+        },
+        "closeButton": {
+          "tooltip": "إغلاق الإعدادات"
+        },
+        "generalSection": {
+          "title": "عام"
+        },
+        "header": {
+          "title": "الإعدادات"
+        },
+        "newTabToggle": {
+          "label": "استخدام Onyx كصفحة علامة تبويب جديدة"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {التبديل إلى المظهر الفاتح} other {التبديل إلى المظهر الداكن}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "دردشة جديدة"
+        },
+        "openInOnyxButton": {
+          "tooltip": "فتح في Onyx"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "مربع الموافقة"
@@ -8486,6 +10325,128 @@
       },
       "startButton": {
         "label": "ابدأ"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "آخر رسالة {time}"
+        },
+        "projectFallback": {
+          "label": "المشروع"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "إضافة ملفات"
+        },
+        "contextExceeded": {
+          "message": "يتجاوز هذا المشروع حدود سياق النموذج. ستبحث الجلسات تلقائيًا عن الملفات ذات الصلة أولاً قبل إنشاء الاستجابة."
+        },
+        "dropFiles": {
+          "message": "أسقط الملفات هنا لإضافتها إلى هذا المشروع"
+        },
+        "emptyFiles": {
+          "message": "أضف مستندات أو نصوصًا أو صورًا لاستخدامها في المشروع. السحب والإفلات مدعوم."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# ملف} other {# ملفات}}"
+        },
+        "fileCountOverflow": {
+          "description": "أكثر من 100 ملف"
+        },
+        "files": {
+          "description": "يمكن للمحادثات في هذا المشروع الوصول إلى هذه الملفات.",
+          "title": "الملفات"
+        },
+        "filesModal": {
+          "description": "يمكن للجلسات في هذا المشروع الوصول إلى الملفات هنا.",
+          "title": "ملفات المشروع"
+        },
+        "instructions": {
+          "emptyDescription": "أضف تعليمات لتخصيص الاستجابة في هذا المشروع.",
+          "title": "التعليمات"
+        },
+        "loadingProject": {
+          "label": "جارٍ تحميل المشروع..."
+        },
+        "setInstructionsButton": {
+          "label": "تعيين التعليمات"
+        },
+        "viewAll": {
+          "label": "عرض الكل"
+        },
+        "viewFiles": {
+          "label": "عرض الملفات"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "إلغاء"
+        },
+        "createError": {
+          "toast": "فشل إنشاء المشروع {name}"
+        },
+        "description": "استخدم المشاريع لتنظيم ملفاتك ومحادثاتك في مكان واحد، وأضف تعليمات مخصصة للعمل الجاري.",
+        "name": {
+          "label": "اسم المشروع",
+          "placeholder": "على ماذا تعمل؟"
+        },
+        "nameRequired": {
+          "error": "اسم المشروع مطلوب"
+        },
+        "submitButton": {
+          "label": "إنشاء المشروع"
+        },
+        "title": "إنشاء مشروع جديد"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "لم يتم العثور على مشاريع"
+        },
+        "search": {
+          "placeholder": "البحث في المشاريع..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "طي المشروع"
+        },
+        "delete": {
+          "label": "حذف المشروع"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "حذف"
+          },
+          "message": "هل أنت متأكد من رغبتك في حذف هذا المشروع؟ لا يمكن التراجع عن هذا الإجراء.",
+          "title": "حذف المشروع"
+        },
+        "expand": {
+          "ariaLabel": "توسيع المشروع"
+        },
+        "rename": {
+          "label": "إعادة تسمية المشروع"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "لا توجد محادثات بعد."
+        },
+        "recentChats": {
+          "title": "المحادثات الأخيرة"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "فشل رفع الملفات"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {تم تخطي # ملف كبير الحجم} other {تم تخطي # ملفات كبيرة الحجم}} (>{max} ميغابايت): {names}"
+        },
+        "rejected": {
+          "toast": "لم يتم رفع بعض الملفات. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8518,6 +10479,1773 @@
       },
       "incognito": {
         "title": "أنت في وضع التخفي"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "فتح الشريط الجانبي"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "تحديث معلومات الفوترة"
+        },
+        "text": "**تحذير:** تنتهي فترتك التجريبية خلال أقل من 5 أيام ولم تتم إضافة أي طريقة دفع."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "الصورة الرمزية للوكيل"
+      },
+      "logo": {
+        "alt": "الشعار"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "مستند"
+      },
+      "expandButton": {
+        "ariaLabel": "توسيع المستند"
+      }
+    },
+    "backButton": {
+      "label": "رجوع"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "غيوم"
+      },
+      "hills": {
+        "label": "تلال"
+      },
+      "mountains": {
+        "label": "جبال"
+      },
+      "night": {
+        "label": "ليل"
+      },
+      "none": {
+        "label": "بدون"
+      },
+      "plant": {
+        "label": "نباتات"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "اب"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} \"{value}\"",
+        "defaultPrefix": "إنشاء"
+      },
+      "dropdown": {
+        "closeAriaLabel": "إغلاق القائمة المنسدلة",
+        "openAriaLabel": "فتح القائمة المنسدلة"
+      },
+      "options": {
+        "empty": "لم يتم العثور على خيارات"
+      },
+      "separator": {
+        "label": "خيارات أخرى"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "إغلاق القائمة"
+      },
+      "dialog": {
+        "title": "قائمة الأوامر"
+      },
+      "options": {
+        "ariaLabel": "خيارات قائمة الأوامر"
+      },
+      "search": {
+        "placeholder": "بحث..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "تم تحديد جميع الموصّلات المتاحة. أزل موصّلات أدناه لإضافة موصّلات أخرى.",
+        "placeholder": "تم تحديد جميع الموصّلات"
+      },
+      "documentSetHint": {
+        "description": "جميع المستندات المفهرسة بواسطة الموصّلات المحددة ستكون جزءًا من مجموعة المستندات هذه."
+      },
+      "noMatches": {
+        "text": "لم يتم العثور على موصّلات مطابقة"
+      },
+      "noMoreConnectors": {
+        "text": "لا توجد موصّلات أخرى متاحة"
+      },
+      "noPrivateConnectors": {
+        "text": "لا توجد موصّلات خاصة متاحة. أنشئ موصّلًا خاصًا أولًا."
+      },
+      "noneSelected": {
+        "text": "لم يتم تحديد أي موصّلات. ابحث وحدد الموصّلات أعلاه."
+      },
+      "removeConnector": {
+        "tooltip": "إزالة الموصّل"
+      },
+      "search": {
+        "placeholder": "البحث عن الموصّلات..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "تحديد التاريخ"
+      },
+      "todayButton": {
+        "label": "اليوم"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "أي وقت..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "اختيار نطاق مخصص"
+      },
+      "clearButton": {
+        "ariaLabel": "مسح"
+      },
+      "custom": {
+        "label": "مخصص"
+      },
+      "customRange": {
+        "ariaLabel": "نطاق مخصص: من {from} إلى {to}"
+      },
+      "date": {
+        "label": "التاريخ"
+      },
+      "group": {
+        "ariaLabel": "النطاق الزمني"
+      },
+      "preset": {
+        "oneDay": "يوم",
+        "oneMonth": "شهر",
+        "sevenDays": "7 أيام",
+        "threeMonths": "3 أشهر"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "حذف"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# مستند سياق} other {# مستندات سياق}}"
+      },
+      "openDocument": {
+        "ariaLabel": "فتح المستند: {title}"
+      },
+      "question": {
+        "title": "سؤال"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# استعلام فرعي} other {# استعلامات فرعية}}"
+      },
+      "updated": {
+        "text": "آخر تحديث {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "افتراضي"
+      },
+      "selectOption": {
+        "placeholder": "اختر خيارًا..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "تعديل"
+      },
+      "rename": {
+        "ariaLabel": "إعادة تسمية"
+      },
+      "save": {
+        "ariaLabel": "حفظ"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "إذا كنت المسؤول، فيرجى زيارة صفحة <billingLink>فوترة المسؤول</billingLink> من أجل {hadLicense, select, true {تجديد} other {تفعيل}} ترخيصك، أو التسجيل عبر Stripe، أو التواصل مع <supportLink>support@onyx.app</supportLink> للمساعدة في الفوترة."
+        },
+        "heading": {
+          "title": "الوصول مقيّد"
+        },
+        "licenseLapse": {
+          "description": "تم تعليق وصولك إلى Onyx مؤقتًا بسبب انقطاع ترخيصك."
+        },
+        "licenseRequired": {
+          "description": "يلزم وجود ترخيص لاستخدام Onyx. بياناتك محمية وستكون متاحة بمجرد تفعيل الترخيص."
+        },
+        "logoutButton": {
+          "label": "تسجيل الخروج"
+        },
+        "manageSubscription": {
+          "description": "إذا كنت مسؤولًا، فيمكنك إدارة اشتراكك بالنقر على الزر أدناه. أما المستخدمون الآخرون، فيرجى التواصل مع المسؤول لديكم لمعالجة هذا الأمر."
+        },
+        "obtainLicense": {
+          "description": "للبدء، يرجى التواصل مع مسؤول النظام للحصول على ترخيص."
+        },
+        "renewLicense": {
+          "description": "لاستعادة وصولك ومواصلة استخدام Onyx، يرجى التواصل مع مسؤول النظام لتجديد الترخيص."
+        },
+        "resubscribeButton": {
+          "label": "إعادة الاشتراك",
+          "loading": "جارٍ التحميل..."
+        },
+        "resubscribeError": {
+          "text": "حدث خطأ أثناء فتح صفحة إعادة الاشتراك. يرجى المحاولة مرة أخرى لاحقًا."
+        },
+        "seatLimit": {
+          "description": "تجاوزت مؤسستك عدد المقاعد المرخّصة. سيظل الوصول مقيّدًا حتى يتم تقليل عدد المستخدمين أو ترقية الترخيص."
+        },
+        "seatLimitAdminHint": {
+          "text": "إذا كنت مسؤولًا، فيمكنك إدارة المستخدمين من صفحة <userLink>إدارة المستخدمين</userLink> أو ترقية ترخيصك من صفحة <billingLink>فوترة المسؤول</billingLink>."
+        },
+        "seatLimitWithCounts": {
+          "description": "تجاوزت مؤسستك عدد المقاعد المرخّصة ({used} مستخدمين / {seats} مقاعد). سيظل الوصول مقيّدًا حتى يتم تقليل عدد المستخدمين أو ترقية الترخيص."
+        },
+        "subscriptionLapse": {
+          "description": "تم تعليق وصولك إلى Onyx مؤقتًا بسبب انقطاع اشتراكك."
+        },
+        "updatePayment": {
+          "description": "لاستعادة وصولك ومواصلة الاستفادة من ميزات Onyx القوية، يرجى تحديث معلومات الدفع الخاصة بك."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "إذا كنت مسؤولًا، فيرجى مراجعة <docsLink>مستنداتنا</docsLink> لمعرفة خطوات الإعداد الصحيحة. إذا كنت مستخدمًا، فيرجى التواصل مع المسؤول لديك للمساعدة."
+        },
+        "heading": {
+          "description": "يبدو أنه حدثت مشكلة في تحميل إعدادات Onyx. قد يكون السبب مشكلة في الإعداد أو إعدادًا غير مكتمل.",
+          "title": "واجهنا مشكلة"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "نعتذر عن أي إزعاج قد يسببه ذلك ونقدّر صبركم."
+        },
+        "checkBack": {
+          "description": "Onyx حاليًا في فترة صيانة. يرجى المحاولة مرة أخرى بعد بضع دقائق."
+        },
+        "heading": {
+          "title": "الصيانة جارية"
+        }
+      },
+      "needHelp": {
+        "text": "هل تحتاج إلى مساعدة؟ انضم إلى <discordLink>مجتمعنا على Discord</discordLink> للحصول على الدعم."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "خطأ غير معروف"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "تنزيل الملف"
+      },
+      "file": {
+        "untitledFallback": "بدون عنوان"
+      },
+      "fullScreenButton": {
+        "tooltip": "ملء الشاشة"
+      },
+      "hideButton": {
+        "tooltip": "إخفاء"
+      },
+      "minimizeButton": {
+        "tooltip": "تصغير"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "نسخ"
+      },
+      "downloadButton": {
+        "tooltip": "تنزيل"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {سطر واحد} other {# أسطر}}"
+      },
+      "size": {
+        "bytes": "{count} بايت",
+        "kilobytes": "{size} كيلوبايت"
+      },
+      "viewFullButton": {
+        "tooltip": "عرض النص الكامل"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "تم تحديد جميع الموصّلات الموحّدة"
+      },
+      "entitiesConfigured": {
+        "tooltip": "تم إعداد الكيانات"
+      },
+      "noMatches": {
+        "text": "لم يتم العثور على موصّلات موحّدة مطابقة"
+      },
+      "noMoreConnectors": {
+        "text": "لا توجد موصّلات موحّدة أخرى متاحة"
+      },
+      "noneSelected": {
+        "text": "لم يتم تحديد أي موصّلات موحّدة. ابحث وحدد الموصّلات أعلاه."
+      },
+      "realtimeSearchHint": {
+        "description": "سيتم البحث في مستندات الموصّلات الموحّدة المحددة في الوقت الفعلي أثناء الاستعلامات."
+      },
+      "removeConnector": {
+        "tooltip": "إزالة الموصّل"
+      },
+      "search": {
+        "placeholder": "البحث عن الموصّلات الموحّدة..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "إضافة جديد"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (اختياري)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "لم يتم العثور على تعريف نوع الملف للحقل: {name}",
+        "selectionError": "خطأ في تحديد الملف",
+        "unknownError": "خطأ غير معروف",
+        "validating": "جارٍ التحقق من الملف...",
+        "validationError": "خطأ في التحقق"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "أدخل نص Markdown هنا...",
+        "previewTab": "معاينة",
+        "writeTab": "كتابة"
+      },
+      "optionalIndicator": {
+        "text": "(اختياري)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "إخفاء كلمة المرور",
+        "showAriaLabel": "إظهار كلمة المرور"
+      },
+      "selector": {
+        "noneOption": "بلا",
+        "placeholder": "اختر..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "جميع الملفات الأخيرة"
+      },
+      "recentFiles": {
+        "title": "الملفات الأخيرة"
+      },
+      "recentFilesModal": {
+        "description": "ارفع ملفات أو اختر من ملفاتك الأخيرة."
+      },
+      "toasts": {
+        "associatedAssistants": "لا يمكن حذف الملف. إنه مرتبط بالمساعدين التاليين: {assistants}",
+        "associatedBoth": "لا يمكن حذف الملف. إنه مرتبط بالمشاريع: {projects} والمساعدين: {assistants}",
+        "associatedProjects": "لا يمكن حذف الملف. إنه مرتبط بالمشاريع التالية: {projects}",
+        "deleteFailed": "فشل حذف الملف. يرجى المحاولة مرة أخرى.",
+        "deleteSuccess": "تم حذف الملف بنجاح"
+      },
+      "uploadFiles": {
+        "description": "ارفع ملفًا من جهازك",
+        "title": "رفع الملفات"
+      },
+      "viewFileButton": {
+        "tooltip": "عرض الملف"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "الملف"
+      },
+      "open": {
+        "ariaLabel": "فتح {title}"
+      },
+      "removeButton": {
+        "label": "إزالة"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "مسح"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(اختياري)"
+      },
+      "required": {
+        "label": "(مطلوب)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "فشل تحميل {label}. يرجى المحاولة مرة أخرى."
+      },
+      "search": {
+        "placeholder": "بحث..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "لا توجد مجموعات مستخدمين متاحة. يرجى إنشاء مجموعة مستخدمين أولًا."
+      },
+      "userGroups": {
+        "label": "مجموعات المستخدمين",
+        "subtext": "حدد مجموعات المستخدمين التي يمكنها الوصول إلى هذا المورد"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "الشعار"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "جارٍ تهيئة {appName}"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "إزالة"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "إرفاق ملف"
+      },
+      "clearButton": {
+        "ariaLabel": "مسح الملف"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "تم رفض الملف"
+      },
+      "editButton": {
+        "ariaLabel": "تعديل الصورة"
+      },
+      "editOverlay": {
+        "label": "تعديل"
+      },
+      "image": {
+        "altFallback": "صورة"
+      },
+      "removeButton": {
+        "ariaLabel": "إزالة الصورة"
+      },
+      "uploadButton": {
+        "ariaLabel": "رفع صورة"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "حدد خيارًا"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "إسناد وصول المجموعات إلى {objectName} هذا",
+        "scopedSubtext": "حدد مجموعة أو أكثر من المجموعات التي تديرها لمنح حق الوصول إلى {objectName} هذا",
+        "visibleSubtext": "سيكون {objectName} هذا مرئيًا ومتاحًا للمجموعات المحددة أدناه"
+      },
+      "loading": {
+        "text": "جارٍ التحميل..."
+      },
+      "makePublic": {
+        "label": "هل تريد جعل {objectName} هذا عامًا؟",
+        "subtext": "إذا تم التفعيل، فسيكون {objectName} هذا متاحًا لـ<b>جميع {publicToWhom}</b>. وإلا، فلن يتمكن من الوصول إليه سوى <b>المسؤولين</b> و<b>{publicToWhom}</b> الذين مُنحوا حق الوصول إلى {objectName} هذا صراحةً (مثلًا عبر مجموعة مستخدمين)."
+      },
+      "publicDisabled": {
+        "message": "{objectName} هذا عام ومتاح لجميع المستخدمين."
+      },
+      "usersFallback": {
+        "text": "المستخدمون"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "إضافة زوج {keyTitle} و{valueTitle}",
+        "label": "إضافة سطر"
+      },
+      "empty": {
+        "title": "لم تتم إضافة أي عناصر بعد."
+      },
+      "error": {
+        "duplicateKey": "مفتاح مكرر",
+        "duplicateSummary": "{count, plural, one {تم العثور على مفتاح مكرر واحد} other {تم العثور على # من المفاتيح المكررة}}",
+        "emptyKey": "لا يمكن ترك المفتاح فارغًا",
+        "emptySummary": "{count, plural, one {تم العثور على مفتاح فارغ واحد} other {تم العثور على # من المفاتيح الفارغة}}",
+        "validationSummary": "{count, plural, one {تم العثور على خطأ تحقق واحد} other {تم العثور على # من أخطاء التحقق}}"
+      },
+      "group": {
+        "ariaLabel": "أزواج {keyTitle} و{valueTitle}"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "المفتاح"
+      },
+      "pair": {
+        "fallbackLabel": "مفتاح-قيمة"
+      },
+      "removeButton": {
+        "ariaLabel": "إزالة زوج {label} رقم {index}"
+      },
+      "valueColumn": {
+        "title": "القيمة"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "الشعار"
+      },
+      "poweredBy": {
+        "label": "مدعوم من Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "الموصّلات غير المتاحة:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "تم إلغاء التفويض أو فشل. يرجى المحاولة مرة أخرى.",
+        "title": "فشل التفويض"
+      },
+      "backButton": {
+        "label": "العودة إلى الدردشة"
+      },
+      "completeFailed": {
+        "message": "فشل إكمال التفويض"
+      },
+      "genericError": {
+        "description": "حدث خطأ أثناء عملية OAuth. يرجى المحاولة مرة أخرى.",
+        "title": "حدث خطأ ما"
+      },
+      "invalidRequest": {
+        "description": "كان طلب التفويض غير مكتمل. يرجى المحاولة مرة أخرى.",
+        "title": "طلب غير صالح"
+      },
+      "loadingHint": {
+        "text": "قد يستغرق هذا بضع لحظات..."
+      },
+      "processing": {
+        "description": "يرجى الانتظار بينما نكمل الإعداد.",
+        "title": "جارٍ المعالجة..."
+      },
+      "redirecting": {
+        "text": "إعادة التوجيه خلال {count, plural, one {# ثانية} other {# ثوانٍ}}..."
+      },
+      "serviceFallback": {
+        "text": "الخدمة"
+      },
+      "success": {
+        "detailsTemplate": "اكتمل تفويض {serviceName} بنجاح.",
+        "title": "تم بنجاح!"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "قد يكون جدول البيانات تالفًا أو تعذر تحميله بشكل صحيح.",
+        "title": "خطأ في تحميل جدول البيانات"
+      },
+      "preview": {
+        "truncated": "المعاينة مقتطعة. نزّل الملف لرؤية جميع الصفوف.",
+        "unavailable": "يتعذر معاينة جدول البيانات هذا."
+      },
+      "sheet": {
+        "defaultName": "الورقة 1",
+        "empty": "هذه الورقة فارغة.",
+        "tooLarge": "هذه الورقة كبيرة جدًا بحيث يتعذر معاينتها. نزّل الملف لعرضها."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "الوكيل الرئيسي"
+      },
+      "subagentFallback": {
+        "label": "وكيل فرعي"
+      },
+      "switch": {
+        "ariaLabel": "تبديل الوكيل"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "الموافقة على هذا الإجراء مرة واحدة",
+        "button": "الموافقة مرة واحدة"
+      },
+      "approveSession": {
+        "button": "الموافقة للجلسة",
+        "tooltip": "الموافقة على الإجراءات المطابقة لهذه الجلسة"
+      },
+      "details": {
+        "hideAriaLabel": "إخفاء التفاصيل",
+        "showAriaLabel": "عرض التفاصيل"
+      },
+      "header": {
+        "required": "الموافقة مطلوبة: {headline}"
+      },
+      "headline": {
+        "multiAction": "{count, plural, one {# إجراء} other {# إجراءات}} في {app}",
+        "singleAction": "{action} في {app}"
+      },
+      "payload": {
+        "empty": {
+          "label": "لا توجد بيانات."
+        },
+        "showLess": {
+          "button": "عرض أقل"
+        },
+        "showMore": {
+          "button": "عرض المزيد"
+        }
+      },
+      "reject": {
+        "ariaLabel": "رفض هذا الإجراء",
+        "button": "رفض"
+      },
+      "status": {
+        "approved": "تمت الموافقة",
+        "rejected": "مرفوض"
+      },
+      "submit": {
+        "errorFallback": "فشل إرسال القرار"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "إضافة",
+        "createButton": "إنشاء",
+        "customApp": {
+          "description": "بيانات الاعتماد والوصول إلى الشبكة لتكاملك الخاص.",
+          "title": "تطبيق مخصص"
+        },
+        "mcpHint": {
+          "label": "هل تحتاج إلى خادم MCP بدلًا من ذلك؟ قم بتوصيله في «الإجراءات»، ثم فعّله لـ Craft هنا.",
+          "openActionsButton": "فتح الإجراءات"
+        },
+        "modal": {
+          "description": "أتح تكاملًا لمؤسستك بأكملها. يأتي المزوّدون المدمجون بإجراءات تعلّم وكيل Craft كيفية استخدامها؛ ولا يتم إدراج المزوّدين الذين تم إعدادهم بالفعل.",
+          "title": "إضافة تطبيق"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "ربط {name}",
+        "associateButton": "ربط مهارة موجودة",
+        "create": {
+          "github": {
+            "description": "إذا كانت مهاراتك على GitHub، فاستوردها أولًا من صفحة المهارات، ثم اربطها بهذا التطبيق.",
+            "label": "استيراد من GitHub"
+          },
+          "scratch": {
+            "description": "اكتب التعليمات وأضف الملفات الداعمة.",
+            "label": "البدء من الصفر"
+          },
+          "upload": {
+            "description": "استورد ملف SKILL.md أو ملف ZIP أو مجلد مهارة.",
+            "label": "رفع مهارة"
+          }
+        },
+        "createSkillButton": "إنشاء مهارة",
+        "description": "تمنح المهارات Craft تعليمات لاستخدام هذا التطبيق. وهي على مستوى المؤسسة؛ قد يحتاج المستخدمون إلى تفعيلها جميعًا ليعمل التطبيق بشكل صحيح.",
+        "editButton": "تعديل",
+        "empty": {
+          "label": "لم يتم العثور على مهارات قابلة للتعديل."
+        },
+        "invalidTag": "غير صالحة",
+        "loading": {
+          "label": "جارٍ تحميل المهارات…"
+        },
+        "noneAssociated": {
+          "label": "لا توجد مهارات مرتبطة بعد. يمكن حفظ هذا التطبيق واستخدامه دون مهارة."
+        },
+        "promote": {
+          "cancelButton": "إلغاء",
+          "confirmButton": "إتاحتها على مستوى المؤسسة",
+          "description": "يجب أن تكون المهارات المرتبطة بالتطبيق متاحة للجميع. يُطبَّق هذا التغيير عند حفظ التطبيق.",
+          "title": "هل تريد جعل «{name}» متاحة على مستوى المؤسسة؟"
+        },
+        "search": {
+          "placeholder": "البحث في المهارات القابلة للتعديل..."
+        },
+        "title": "المهارات المرتبطة",
+        "unavailable": {
+          "duplicateName": "توجد مهارة باسم «{name}» مرتبطة بالفعل.",
+          "invalid": "مهارة غير صالحة: أصلحها قبل ربطها.",
+          "otherApp": "مرتبطة بالفعل بالتطبيق «{name}»."
+        },
+        "unlink": {
+          "button": "إلغاء الربط",
+          "cancelButton": "إلغاء",
+          "confirm": "هل تريد إلغاء ربط «{name}» بهذا التطبيق؟"
+        },
+        "unlinkAriaLabel": "إلغاء ربط {name}",
+        "viewButton": "عرض"
+      },
+      "configureProvider": {
+        "addButton": "إضافة",
+        "addTitle": "إضافة {name}",
+        "editTitle": "تعديل {name}",
+        "emptyPolicies": "لا توجد إجراءات لإعدادها لدى هذا المزوّد.",
+        "fields": {
+          "name": {
+            "description": "تسمية لهذا الاتصال. استخدم اسمًا مميزًا عند إضافة عدة نسخ من المزوّد نفسه (مثل \"{name} — الهندسة\").",
+            "label": "الاسم"
+          }
+        },
+        "managedDescription": "مقدَّم من Onyx: قم بإعداد ما يمكن للوكيل فعله.",
+        "managedNote": "هذا التطبيق مقدَّم من Onyx، وتُدار بيانات الاعتماد نيابةً عنك. اختر أدناه ما يمكن للوكيل فعله. يقوم المستخدمون بتوصيله من صفحة التطبيقات.",
+        "saveButton": "حفظ"
+      },
+      "customApp": {
+        "cancelButton": "إلغاء",
+        "createButton": "إنشاء",
+        "createDescription": "قم بإعداد كيفية وصول وكيل الخروج إلى هذا التطبيق ومصادقته. لا يُشترط وجود مهارة.",
+        "createTitle": "إنشاء تطبيق مخصص",
+        "creatingButton": "جارٍ الإنشاء…",
+        "disabled": {
+          "nameMissing": "أدخل اسمًا قبل إنشاء هذا التطبيق المخصص.",
+          "patternMissing": "أضف نمط URL واحدًا على الأقل. اكتب النمط واضغط Enter.",
+          "pristine": "قم بإجراء تغيير قبل الحفظ.",
+          "saving": "الحفظ قيد التنفيذ بالفعل."
+        },
+        "editDescription": "حدّث إعدادات البوابة وأدر المهارات المرتبطة.",
+        "editTitle": "تعديل {name}",
+        "errors": {
+          "saveFailedTitle": "تعذّر الحفظ"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "إضافة ترويسة",
+            "description": "اختياري: ترويسات تُحقن في الطلبات الصادرة. استخدم '{placeholder}' للقيم التي يوفّرها المستخدم (أو المؤسسة أدناه)، مثل \"Bearer '{api_key}'\". اتركه فارغًا للسماح بأنماط الوجهة دون حقن بيانات اعتماد.",
+            "keyTitle": "الترويسة",
+            "label": "نمط بيانات الاعتماد في الترويسة",
+            "valueTitle": "القيمة"
+          },
+          "name": {
+            "label": "الاسم",
+            "placeholder": "تطبيقي المخصص"
+          },
+          "orgCredentials": {
+            "addButton": "إضافة بيانات اعتماد",
+            "description": "اختياري: قيم تملؤها مؤسستك مسبقًا لكل مستخدم. اتركه فارغًا للتطبيقات التي يقدّم فيها كل مستخدم بيانات اعتماده الخاصة.",
+            "keyTitle": "مفتاح بيانات الاعتماد",
+            "label": "بيانات اعتماد المؤسسة",
+            "valueTitle": "القيمة"
+          },
+          "upstreamPatterns": {
+            "description": "عناوين URL الصادرة التي يمكن للوكيل حقن بيانات الاعتماد فيها. استخدم * لمطابقة أي أحرف (مثل https://api.example.com/* لتغطية كل المسارات على ذلك المضيف). يجب أن يكون المضيف حرفيًا، دون أحرف بدل قبل الشرطة المائلة الأولى. اكتب النمط واضغط Enter.",
+            "label": "أنماط URL الخارجية"
+          }
+        },
+        "saveButton": "حفظ",
+        "savingButton": "جارٍ الحفظ…"
+      },
+      "errors": {
+        "duplicateSkillName": "التطبيق «{appName}» لديه بالفعل مهارة مرتبطة باسم «{skillName}». ارفع مهارة باسم مختلف."
+      },
+      "mcpPolicy": {
+        "description": "قم بإعداد ما يمكن لوكيل Craft فعله بأدوات خادم MCP هذا.",
+        "emptyPolicies": "لا توجد أدوات مفعّلة على هذا الخادم. فعّل الأدوات أولًا من صفحة إجراءات MCP.",
+        "saveButton": "حفظ",
+        "title": "تعديل {name}"
+      },
+      "oauthCallback": {
+        "backButton": "العودة إلى تطبيقاتي",
+        "description": "جارٍ إتمام مصافحة OAuth…",
+        "errors": {
+          "cancelled": "تم إلغاء OAuth أو رفضه: {reason}",
+          "failed": "فشل الاتصال.",
+          "missingParams": "الرمز (code) أو الحالة (state) مفقودان في عنوان URL للاستدعاء."
+        },
+        "exchanging": {
+          "label": "جارٍ تبادل رمز التفويض…"
+        },
+        "success": {
+          "label": "تم الاتصال. جارٍ إعادة التوجيه إلى تطبيقاتك…"
+        },
+        "title": "جارٍ توصيل تطبيقك"
+      },
+      "page": {
+        "connectButton": "اتصال",
+        "connectingButton": "جارٍ إعادة التوجيه…",
+        "disconnectButton": "قطع الاتصال",
+        "empty": {
+          "description": "لم يتم إعداد أي تطبيقات أو خوادم MCP لمؤسستك بعد.",
+          "title": "لا يوجد ما يمكن توصيله بعد"
+        },
+        "errors": {
+          "disconnectFailed": "فشل قطع الاتصال",
+          "startAuthFailed": "فشل بدء التفويض"
+        },
+        "header": {
+          "description": "قم بتوصيل الأدوات التي يمكن لـ Onyx Craft استخدامها كسياق أثناء عمله.",
+          "manageButton": "إدارة التطبيقات",
+          "searchPlaceholder": "البحث في التطبيقات...",
+          "title": "التطبيقات"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "تكاملات تدعمها Onyx مباشرةً. يأتي كل منها بمهارات تعلّم Craft كيفية استخدامه، ابدأ من هنا.",
+            "empty": "لم يتم إعداد أي تطبيقات لمؤسستك بعد.",
+            "emptyTitle": "لا توجد تطبيقات بعد",
+            "tabLabel": "التطبيقات · {count}"
+          },
+          "mcp": {
+            "blurb": "خوادم أتاحها مسؤول لـ Craft. استخدمها عندما لا يكون التطبيق الذي تحتاجه مدرجًا ضمن التطبيقات، أو عندما تريد تحديدًا أدوات MCP الخاصة بخادم ما.",
+            "empty": "لم تتم إتاحة أي خوادم MCP لـ Craft.",
+            "emptyTitle": "لا توجد خوادم MCP بعد",
+            "tabLabel": "خوادم MCP · {count}"
+          }
+        },
+        "loading": {
+          "label": "جارٍ التحميل…"
+        },
+        "reviewSkillsButton": "مراجعة المهارات",
+        "search": {
+          "noMatchesDescription": "لا شيء هنا يطابق بحثك.",
+          "noMatchesTitle": "لا توجد نتائج مطابقة"
+        },
+        "status": {
+          "connected": "متصل",
+          "connectedNeedsSkills": "متصل · ليست كل المهارات المرتبطة مفعّلة",
+          "notAvailable": "غير متاح لحسابك، اسأل أحد المسؤولين",
+          "skillWarningAriaLabel": "مطلوب إعداد المهارات",
+          "skillWarningTooltip": "ليست كل المهارات المرتبطة مفعّلة. قد لا يعمل هذا التطبيق بشكل صحيح."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "عيّن سياسة لكل إجراء على حدة.",
+          "title": "متقدم"
+        },
+        "cancelButton": "إلغاء",
+        "loading": {
+          "label": "جارٍ التحميل…"
+        },
+        "permissions": {
+          "askOption": "اسأل",
+          "autoApproveOption": "موافقة تلقائية",
+          "customOption": "مخصص",
+          "description": "اختر ما يمكن للوكيل فعله. «اسأل» يطلب موافقتك في الدردشة قبل تشغيل كل إجراء؛ و«الموافقة التلقائية» يشغّله دون سؤال. استخدم «متقدم» لتعيين سياسة لكل إجراء.",
+          "title": "الأذونات"
+        },
+        "savingButton": "جارٍ الحفظ…"
+      },
+      "skillsStep": {
+        "description": "اختياري: اربط مهارات موجودة أو أنشئ واحدة لهذا التطبيق.",
+        "errors": {
+          "saveFailedTitle": "تعذّر الحفظ"
+        },
+        "saveButton": "حفظ المهارات",
+        "savingButton": "جارٍ الحفظ…",
+        "skipButton": "التخطي الآن",
+        "title": "إضافة مهارات إلى {name}"
+      },
+      "userCredentials": {
+        "cancelButton": "إلغاء",
+        "connectButton": "اتصال",
+        "connectingButton": "جارٍ الاتصال…",
+        "description": "أدخل بيانات اعتمادك لتفويض هذا التطبيق لحسابك.",
+        "errors": {
+          "connectFailedTitle": "تعذّر الاتصال"
+        },
+        "title": "توصيل {name}"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "تنزيل"
+      },
+      "empty": {
+        "description": "ستظهر ملفات الإخراج وتطبيقات الويب هنا",
+        "title": "لا توجد مخرجات بعد"
+      },
+      "nextjsApp": {
+        "label": "تطبيق Next.js"
+      },
+      "openItem": {
+        "ariaLabel": "فتح {name}"
+      },
+      "toggleItem": {
+        "ariaLabel": "تبديل {name}"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "تابع المحادثة...",
+        "scheduledRunPlaceholder": "التشغيل المجدول قيد التقدم...",
+        "subagentPlaceholder": "بدّل إلى الوكيل الرئيسي لإرسال رسالة"
+      },
+      "openSidebar": {
+        "ariaLabel": "فتح الشريط الجانبي"
+      },
+      "outputPanel": {
+        "closeTooltip": "إغلاق لوحة الإخراج",
+        "openTooltip": "فتح لوحة الإخراج"
+      },
+      "responseStopped": {
+        "label": "تم إيقاف الاستجابة"
+      },
+      "scrollToBottom": {
+        "label": "الانتقال إلى الأسفل"
+      },
+      "toast": {
+        "operationWait": "يرجى الانتظار حتى تكتمل العملية الحالية.",
+        "sandboxWait": "يرجى الانتظار حتى تتم تهيئة بيئة الاختبار",
+        "scheduledRunWait": "يرجى الانتظار حتى ينتهي التشغيل المجدول."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "تم ضغط السياق لتوفير مساحة"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "اربط بياناتك"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "جارٍ صنع مساحة عملك...",
+        "enchanting": "جارٍ السحر بالتعويذات...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "جارٍ جمع الموارد...",
+        "miningDependencies": "جارٍ التنقيب عن التبعيات...",
+        "placingBlocks": "جارٍ وضع المكعبات...",
+        "punchingWood": "جارٍ تكسير الخشب...",
+        "smeltingCode": "جارٍ صهر الشيفرة...",
+        "worldGenerated": "اكتمل إنشاء العالم..."
+      },
+      "tagline": {
+        "label": "جارٍ صنع فكرتك الرائعة التالية..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "مسح"
+      },
+      "copy": {
+        "doneTooltip": "تم النسخ",
+        "tooltip": "نسخ الظاهر"
+      },
+      "empty": {
+        "noLines": "لا توجد أسطر بعد.",
+        "noMatch": "لا توجد أسطر تطابق \"{filter}\"",
+        "waiting": "في انتظار أول سطر من السجل…"
+      },
+      "error": {
+        "endpointDisabled": "نقطة نهاية التصحيح معطلة (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "لا توجد بيئة اختبار قيد التشغيل لمتابعة سجلاتها"
+      },
+      "filter": {
+        "placeholder": "تصفية…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# سطر} other {# أسطر}}",
+        "filteredCount": "{visible, number} / {total, number} سطر"
+      },
+      "modal": {
+        "description": "متابعة مباشرة لحاوية بيئة الاختبار — للتطوير/التصحيح فقط.",
+        "title": "سجلات حاوية Opencode"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} جديد · انتقال"
+      },
+      "open": {
+        "button": "سجلات الحاوية"
+      },
+      "status": {
+        "closed": "مغلق",
+        "connecting": "جارٍ الاتصال",
+        "error": "خطأ",
+        "paused": "متوقف مؤقتًا",
+        "streaming": "بث مباشر"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "إضافة ملفات أو صور"
+      },
+      "apps": {
+        "label": "التطبيقات"
+      },
+      "browseSkills": {
+        "label": "تصفح المهارات"
+      },
+      "connect": {
+        "hint": "ربط"
+      },
+      "connectApp": {
+        "label": "ربط تطبيق"
+      },
+      "library": {
+        "label": "المكتبة"
+      },
+      "manageLibrary": {
+        "label": "إدارة المكتبة…"
+      },
+      "mcpServer": {
+        "description": "خادم MCP"
+      },
+      "skills": {
+        "label": "المهارات"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "تعذّرت معاينة الملف"
+      },
+      "error": {
+        "inline": "خطأ: {message}",
+        "title": "خطأ في تحميل الملف"
+      },
+      "loading": {
+        "label": "جارٍ تحميل الملف..."
+      },
+      "noContent": {
+        "label": "لا يوجد محتوى"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "ستظهر الملفات المُنشأة أثناء البناء هنا",
+        "title": "لا توجد ملفات بعد"
+      },
+      "emptyDirectory": {
+        "label": "لا توجد ملفات في هذا المجلد"
+      },
+      "error": {
+        "title": "خطأ في تحميل الملفات"
+      },
+      "loading": {
+        "label": "جارٍ تحميل الملفات..."
+      },
+      "loadingChildren": {
+        "label": "جارٍ التحميل..."
+      },
+      "preparing": {
+        "description": "جارٍ إعداد بيئة التطوير الخاصة بك",
+        "title": "جارٍ تجهيز بيئة الاختبار..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "تعذّر عرض الصورة",
+        "title": "فشل تحميل الصورة"
+      },
+      "loading": {
+        "label": "جارٍ تحميل الصورة..."
+      },
+      "preview": {
+        "ariaLabel": "معاينة {name}"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "متصل",
+        "connectionRequired": "الاتصال مطلوب"
+      },
+      "plusMenu": {
+        "tooltip": "إضافة ملفات أو مهارات"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "جارٍ الإيقاف…"
+      },
+      "toInterrupt": {
+        "label": "للمقاطعة"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "تجريبي"
+      },
+      "returnHome": {
+        "button": "العودة إلى الرئيسية"
+      },
+      "startCrafting": {
+        "button": "ابدأ الصنع"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "لم يتم العثور على نماذج"
+      },
+      "recommended": {
+        "label": "موصى به"
+      },
+      "recommendedOnly": {
+        "label": "النماذج الموصى بها فقط"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "«أصلح اختبار إعادة المحاولة غير المستقر وافتح طلب دمج (PR).»",
+          "launchDeck": "«أنشئ عرض إطلاق الربيع من الموجز الموجود على Drive.»",
+          "rfpSecurity": "«املأ طلب العروض (RFP) الموجود في بريدي بتفاصيل الأمان لدينا.»",
+          "slackToLinear": "«اختصر نقاشنا على Slack في تذاكر Linear.»",
+          "vendorSpend": "«لخّص إنفاقنا على المورّدين للربع الثاني في مستند على Drive.»"
+        },
+        "modal": {
+          "backButton": "رجوع",
+          "ctaButton": "ضع Craft في العمل",
+          "nextButton": "التالي",
+          "title": "تعرّف على Craft"
+        },
+        "outputs": {
+          "ariaLabel": "الناتج: {name}",
+          "githubPr": {
+            "caption": "مفتوح للمراجعة",
+            "label": "طلب دمج على GitHub"
+          },
+          "googleDoc": {
+            "caption": "محفوظ في Drive الخاص بك",
+            "label": "مستند Google"
+          },
+          "liveApp": {
+            "caption": "مستضاف، شاركه عبر رابط",
+            "label": "تطبيق مباشر"
+          }
+        },
+        "prompt": {
+          "label": "موجّهك"
+        },
+        "schedule": {
+          "ariaLabel": "مهمة مجدولة: تعيد تشغيل هذا الموجّه وفق مؤقّت",
+          "caption": "يعمل أثناء غيابك",
+          "label": "كل يوم اثنين، 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "مصدر متصل: {name}",
+          "yourFiles": {
+            "ariaLabel": "ملفاتك المرفوعة",
+            "label": "ملفاتك"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "انقر على أي جزء من الخريطة لإعادة زيارته.",
+            "title": "هذا هو Craft. حان دورك."
+          },
+          "machine": {
+            "caption": "يقرأ ما يمكنك رؤيته. وليس أسرارك أبدًا.",
+            "title": "يعمل على جهازه الخاص."
+          },
+          "output": {
+            "caption": "عند الطلب، أو وفق جدول أثناء غيابك.",
+            "title": "يخرج العمل مكتملًا."
+          },
+          "prompt": {
+            "caption": "صف النتيجة المطلوبة، وسيتولى Craft الباقي.",
+            "title": "أوكل إلى Craft عملًا حقيقيًا."
+          }
+        },
+        "team": {
+          "ariaLabel": "فريقك: رابط واحد يشارك عمل Craft",
+          "caption": "رابط واحد يكفي للمشاركة",
+          "label": "فريقك"
+        },
+        "workspace": {
+          "approvalPill": "في انتظار موافقتك",
+          "label": "مساحة عمل Craft",
+          "sandboxBadge": "بيئة معزولة (Sandbox)"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "العودة إلى الدردشة",
+        "description": "يحتاج Onyx Craft إلى مزوّد نماذج، ولا يمكن إعداده إلا من قبل المسؤولين. اطلب من المسؤول توصيل Anthropic أو OpenAI أو OpenRouter.",
+        "title": "مطلوب مزوّد LLM"
+      },
+      "llmSetup": {
+        "description": "يحتاج وكلاء Craft إلى مزوّد نماذج للبناء.",
+        "title": "توصيل مزوّد نماذج"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "حلّل بياناتي وأنشئ لوحة معلومات..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "الهندسة",
+          "marketing": "التسويق",
+          "product": "المنتج",
+          "sales": "المبيعات"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "ابدأ ببناء شيء ما لرؤية المخرجات!"
+      },
+      "devServerStarting": {
+        "tooltip": "جارٍ تشغيل خادم التطوير..."
+      },
+      "noWebapp": {
+        "label": "لا يوجد تطبيق ويب في هذه الجلسة بعد"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "تعذّر تحميل ملف PDF.",
+        "title": "تعذّرت معاينة ملف PDF"
+      },
+      "frame": {
+        "title": "معاينة PDF"
+      },
+      "loading": {
+        "label": "جارٍ تحميل PDF..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "جارٍ تحويل العرض التقديمي..."
+      },
+      "empty": {
+        "label": "لا توجد شرائح في هذا العرض التقديمي"
+      },
+      "error": {
+        "title": "تعذّرت معاينة العرض التقديمي"
+      },
+      "loadingSlide": {
+        "label": "جارٍ تحميل الشريحة..."
+      },
+      "slide": {
+        "counter": "الشريحة {current} من {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "ستظهر معاينة مباشرة هنا بمجرد تشغيل تطبيق ويب."
+      },
+      "frame": {
+        "title": "معاينة تطبيق الويب"
+      },
+      "starting": {
+        "description": "جارٍ تثبيت التبعيات وبدء التشغيل.",
+        "title": "جارٍ تشغيل خادم التطوير..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "جارٍ إعادة التوجيه..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "تجاهل"
+      },
+      "modal": {
+        "description": "دخلت في وضع السكون بعد فترة من عدم النشاط. عملك محفوظ. أيقظها للمتابعة.",
+        "title": "دخلت بيئة الاختبار في وضع السكون"
+      },
+      "wake": {
+        "button": "إيقاظ بيئة الاختبار"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "مجدولة"
+      },
+      "startedAt": {
+        "label": "بدأت {time}"
+      },
+      "status": {
+        "awaitingApproval": "هذا التشغيل المجدول في انتظار الموافقة. ستُتاح رسائل المتابعة بعد استئنافه وانتهائه.",
+        "running": "لا يزال هذا التشغيل المجدول قيد التنفيذ. ستُتاح رسائل المتابعة عند انتهائه.",
+        "startedBy": "بدأت هذه الجلسة بواسطة المهمة المجدولة {task} في {time}."
+      },
+      "viewTask": {
+        "ariaLabel": "عرض المهمة المجدولة {task}. {status}",
+        "label": "عرض المهمة"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "تطبيق خارجي {id}"
+      },
+      "connect": {
+        "title": "ربط {app}"
+      },
+      "connected": {
+        "title": "تم ربط {app}."
+      },
+      "error": {
+        "generic": "حدث خطأ ما. يرجى المحاولة مرة أخرى.",
+        "notConfigurable": "لا يمكن إعداد هذا التطبيق من هنا.",
+        "popupBlocked": "تعذّر فتح نافذة الإعداد. اسمح بالنوافذ المنبثقة وحاول مرة أخرى.",
+        "startFailed": "فشل بدء الإعداد"
+      },
+      "loading": {
+        "button": "جارٍ التحميل…"
+      },
+      "notNow": {
+        "button": "ليس الآن"
+      },
+      "reason": {
+        "fallback": "يحتاج الوكيل إلى {app} لمتابعة هذه المهمة."
+      },
+      "skipped": {
+        "title": "تم تخطي ربط {app}."
+      },
+      "waiting": {
+        "button": "في الانتظار…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "نسخ الرابط"
+      },
+      "organization": {
+        "description": "يمكن لأي شخص مسجّل الدخول إلى Onyx لديك عرض هذا التطبيق.",
+        "label": "المؤسسة"
+      },
+      "private": {
+        "description": "أنت وحدك من يمكنه عرض هذا التطبيق.",
+        "label": "خاص"
+      },
+      "share": {
+        "label": "مشاركة"
+      },
+      "shared": {
+        "label": "تمت المشاركة"
+      },
+      "trigger": {
+        "ariaLabel": "مشاركة تطبيق الويب"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "التطبيقات"
+      },
+      "backToChat": {
+        "label": "العودة إلى الدردشة"
+      },
+      "delete": {
+        "label": "حذف"
+      },
+      "deleteModal": {
+        "body": "سيؤدي هذا إلى إزالة جلسة Craft وجميع بياناتها نهائيًا. لا يمكن التراجع عن هذا الإجراء.",
+        "confirm": "حذف",
+        "deleting": "جارٍ الحذف...",
+        "title": "هل تريد حذف \"{title}\"؟"
+      },
+      "newSession": {
+        "label": "ابدأ الصنع"
+      },
+      "rename": {
+        "label": "إعادة تسمية"
+      },
+      "scheduledTasks": {
+        "label": "المهام المجدولة"
+      },
+      "sessions": {
+        "empty": "ابدأ البناء! سيظهر سجل الجلسات هنا.",
+        "title": "الجلسات"
+      },
+      "skills": {
+        "label": "المهارات"
+      },
+      "toast": {
+        "deleteFailed": "فشل حذف الجلسة",
+        "deleted": "تم حذف \"{title}\"."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "أعد تحميل هذه الجلسة لتطبيق أحدث المهارات وصلاحيات التطبيقات.",
+        "title": "تغيّرت قدرات وكيلك"
+      },
+      "reload": {
+        "button": "إعادة تحميل",
+        "inProgress": "جارٍ إعادة التحميل…"
+      },
+      "toast": {
+        "reloadFailed": "فشل إعادة تحميل الجلسة"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "لم يتم العثور على الوكيل الفرعي."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "إغلاق الاقتراحات"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "حذف",
+          "deletingButton": "جارٍ الحذف...",
+          "description": "سيوقف هذا عمليات التشغيل المستقبلية ويزيل المهمة. سيتم الاحتفاظ بسجل التشغيل السابق (والجلسات المرتبطة به) لأغراض التدقيق.",
+          "title": "هل تريد حذف «{name}»؟"
+        },
+        "deleteButton": "حذف",
+        "editButton": "تعديل",
+        "fallbackTitle": "المهمة المجدولة",
+        "loadFailed": "فشل تحميل المهمة المجدولة.",
+        "missingTaskId": "معرّف المهمة مفقود.",
+        "pauseButton": "إيقاف مؤقت",
+        "resumeButton": "استئناف",
+        "runNowButton": "التشغيل الآن",
+        "toasts": {
+          "deleteFailed": "فشل حذف المهمة",
+          "deleted": "تم حذف «{name}».",
+          "paused": "تم إيقاف المهمة مؤقتًا.",
+          "resumed": "تم استئناف المهمة.",
+          "runQueued": "تمت إضافة تشغيل «{name}» إلى قائمة الانتظار.",
+          "runStartFailed": "فشل بدء التشغيل",
+          "statusUpdateFailed": "فشل تحديث الحالة"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "تعديل المهمة المجدولة",
+        "loadFailed": "فشل تحميل المهمة المجدولة.",
+        "missingTaskId": "معرّف المهمة مفقود.",
+        "title": "تعديل «{name}»"
+      },
+      "form": {
+        "cancelButton": "إلغاء",
+        "errors": {
+          "nameRequired": "الاسم مطلوب.",
+          "promptRequired": "الموجّه مطلوب."
+        },
+        "fields": {
+          "name": {
+            "label": "الاسم",
+            "placeholder": "مثال: ملخص أسبوعي لتصعيدات العملاء"
+          },
+          "preApproval": {
+            "description": "يمكن لـ Craft استخدام التطبيقات وخوادم MCP المحددة دون توقف عندما تعمل هذه المهمة دون إشراف. طلبات الموافقة الأخرى توقف التشغيل مؤقتًا وقد تتسبب في فشله.",
+            "label": "التطبيقات وخوادم MCP الموافَق عليها مسبقًا"
+          },
+          "prompt": {
+            "description": "تُرسل هذه الرسالة إلى Craft في كل مرة تنطلق فيها المهمة.",
+            "label": "الموجّه",
+            "placeholder": "صف ما ينبغي أن يفعله Craft في كل تشغيل..."
+          },
+          "schedule": {
+            "label": "الجدولة"
+          }
+        },
+        "saveAndRunNowButton": "الحفظ والتشغيل الآن",
+        "saveButton": "حفظ",
+        "saveChangesButton": "حفظ التغييرات",
+        "savingLabel": "جارٍ الحفظ...",
+        "toasts": {
+          "created": "تم إنشاء المهمة المجدولة.",
+          "createdAndQueued": "تم إنشاء المهمة المجدولة ووضعها في قائمة الانتظار.",
+          "saveFailed": "فشل حفظ المهمة المجدولة",
+          "updated": "تم تحديث المهمة المجدولة."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "آخر تشغيل",
+          "name": "الاسم",
+          "nextRun": "التشغيل التالي",
+          "schedule": "الجدولة",
+          "status": "الحالة"
+        },
+        "confirmDelete": {
+          "deleteButton": "حذف",
+          "deletingButton": "جارٍ الحذف...",
+          "description": "سيوقف هذا عمليات التشغيل المستقبلية ويزيل المهمة. سيتم الاحتفاظ بسجل التشغيل السابق (والجلسات المرتبطة به) لأغراض التدقيق.",
+          "title": "هل تريد حذف «{name}»؟"
+        },
+        "empty": {
+          "description": "لم يتم إنشاء أي مهام مجدولة بعد.",
+          "title": "لم يتم العثور على مهام مجدولة"
+        },
+        "errors": {
+          "loadFailed": "فشل تحميل المهام المجدولة.",
+          "tryAgainButton": "إعادة المحاولة"
+        },
+        "header": {
+          "description": "شغّل موجّهات Craft وفق مؤقّت. كل انطلاقة تنشئ جلسة جديدة تعمل في الخلفية.",
+          "title": "المهام المجدولة"
+        },
+        "newTaskButton": "مهمة مجدولة جديدة",
+        "rowActions": {
+          "deleteTooltip": "حذف"
+        },
+        "toasts": {
+          "deleteFailed": "فشل حذف المهمة",
+          "deleted": "تم حذف «{name}»."
+        }
+      },
+      "newPage": {
+        "description": "احفظ موجّهًا وجدولًا. سيشغّله Craft وفق مؤقّت.",
+        "title": "مهمة مجدولة جديدة"
+      },
+      "preApproval": {
+        "appFallbackName": "التطبيق رقم {id}",
+        "appsGroupTitle": "التطبيقات",
+        "empty": {
+          "label": "لا توجد تطبيقات أو خوادم MCP متاحة في Craft بعد."
+        },
+        "errors": {
+          "loadFailed": "تعذّر تحميل التطبيقات وخوادم MCP. حدّث الصفحة للمحاولة مرة أخرى.",
+          "partialLoadFailed": "تعذّر تحميل بعض خيارات الموافقة المسبقة. حدّث الصفحة للمحاولة مرة أخرى."
+        },
+        "loading": {
+          "label": "جارٍ تحميل التطبيقات وخوادم MCP…"
+        },
+        "mcpGroupTitle": "خوادم MCP",
+        "mcpServerFallbackName": "خادم MCP رقم {id}",
+        "status": {
+          "connected": "متصل",
+          "connectionRequired": "الاتصال مطلوب",
+          "unavailable": "لم يعد متاحًا"
+        },
+        "summary": {
+          "partialLoadFailed": "تعذّر تحميل بعض تفاصيل الموافقة المسبقة. حدّث الصفحة للمحاولة مرة أخرى.",
+          "title": "التطبيقات وخوادم MCP الموافَق عليها مسبقًا"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "المدة",
+          "started": "البدء",
+          "status": "الحالة",
+          "summary": "الملخص",
+          "trigger": "المشغّل"
+        },
+        "empty": {
+          "label": "لا توجد عمليات تشغيل بعد. ستنشئ المهمة واحدة في كل مرة تنطلق فيها، أو استخدم «التشغيل الآن» أعلاه."
+        },
+        "errors": {
+          "loadFailed": "فشل تحميل سجل التشغيل.",
+          "tryAgainButton": "إعادة المحاولة"
+        },
+        "loadMore": {
+          "button": "تحميل المزيد",
+          "loadingButton": "جارٍ التحميل..."
+        },
+        "nonClickable": {
+          "noSession": "لم ينشئ هذا التشغيل جلسة بعد.",
+          "queued": "لم يبدأ هذا التشغيل بعد، لذا لا توجد جلسة لفتحها.",
+          "skipped": "تم تخطي هذا التشغيل لأن تشغيلًا سابقًا كان لا يزال جاريًا، لذا لم تُنشأ جلسة."
+        },
+        "status": {
+          "notOpenableAriaLabel": "لا يمكن فتحه"
+        },
+        "trigger": {
+          "runNow": "التشغيل الآن",
+          "schedule": "الجدولة"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "في",
+          "daysLabel": "في هذه الأيام",
+          "runsEveryDay": "يعمل كل يوم",
+          "runsOn": "يعمل أيام {days}"
+        },
+        "interval": {
+          "everyLabel": "كل"
+        },
+        "intervalUnits": {
+          "days": "أيام",
+          "hours": "ساعات",
+          "minutes": "دقائق"
+        },
+        "tabs": {
+          "dailyWeekly": "يومي / أسبوعي",
+          "interval": "الفاصل الزمني"
+        },
+        "weekdays": {
+          "fri": "الجمعة",
+          "mon": "الاثنين",
+          "sat": "السبت",
+          "sun": "الأحد",
+          "thu": "الخميس",
+          "tue": "الثلاثاء",
+          "wed": "الأربعاء"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "لا توجد مهام"
+      },
+      "header": {
+        "title": "المهام"
+      },
+      "progress": {
+        "label": "اكتمل {completed}/{total}"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "لا يوجد إخراج"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# سطر دون تغيير} other {# أسطر دون تغيير}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "التبديل إلى العرض جنبًا إلى جنب",
+          "unifiedTooltip": "التبديل إلى العرض الموحد"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "لا توجد مخرجات بعد..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# استدعاء} other {# استدعاءات}}"
+        },
+        "failed": {
+          "tag": "فشل {count}"
+        },
+        "working": {
+          "label": "قيد العمل"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(ملف فارغ)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {سطر إضافي واحد (#)} other {# أسطر إضافية}}"
+        },
+        "showAll": {
+          "button": "عرض الكل"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "لا توجد نتائج مطابقة"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "الملف كبير جدًا ({size}). الحد الأقصى هو {max}.",
+        "network": "خطأ في الشبكة",
+        "notFound": "المورد غير موجود",
+        "server": "خطأ في الخادم",
+        "sessionExpired": "انتهت صلاحية الجلسة",
+        "tooManyFiles": "عدد الملفات كبير جدًا. الحد الأقصى هو {max} ملفًا لكل جلسة.",
+        "totalSizeExceeded": "الحجم الإجمالي يتجاوز الحد. الحد الأقصى هو {max} لكل جلسة.",
+        "uploadFailed": "فشل الرفع"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "رجوع"
+      },
+      "copyUrl": {
+        "ariaLabel": "نسخ الرابط: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "تنزيل الملف"
+      },
+      "export": {
+        "button": "تصدير إلى ‎.docx",
+        "inProgress": "جارٍ التصدير..."
+      },
+      "forward": {
+        "ariaLabel": "تقدّم"
+      },
+      "openInNewTab": {
+        "tooltip": "فتح في تبويب جديد"
+      },
+      "refresh": {
+        "ariaLabel": "تحديث"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "حذف",
+        "button": "حذف",
+        "entityTypeFile": "ملف",
+        "entityTypeFolder": "مجلد",
+        "fileDetails": "ستتم إزالة هذا الملف من مكتبتك.",
+        "folderDetails": "سيؤدي هذا إلى حذف المجلد وجميع محتوياته."
+      },
+      "dropzone": {
+        "formats": "Excel أو Word أو PowerPoint أو PDF أو ZIP",
+        "title": "اسحب الملفات إلى هنا أو انقر للرفع"
+      },
+      "errors": {
+        "createFolderFailed": "فشل إنشاء المجلد",
+        "deleteFailed": "فشل الحذف",
+        "loadFailed": "فشل تحميل الملفات",
+        "uploadFailed": "فشل الرفع"
+      },
+      "loading": {
+        "label": "جارٍ تحميل الملفات…"
+      },
+      "modal": {
+        "description": "الملفات التي يمكن لوكيلك قراءتها في كل جلسة.",
+        "doneButton": "تم",
+        "title": "المكتبة"
+      },
+      "newFolder": {
+        "cancelButton": "إلغاء",
+        "createButton": "إنشاء",
+        "label": "مجلد جديد",
+        "nameLabel": "اسم المجلد",
+        "namePlaceholder": "أدخل اسم المجلد"
+      },
+      "search": {
+        "noResults": "لا توجد ملفات مطابقة لبحثك",
+        "placeholder": "البحث في الملفات..."
+      },
+      "tree": {
+        "collapseTooltip": "طي",
+        "deleteTooltip": "حذف",
+        "expandTooltip": "توسيع",
+        "toggleAriaLabel": "تبديل {name}",
+        "uploadToFolderTooltip": "الرفع إلى هذا المجلد"
+      },
+      "upload": {
+        "button": "رفع",
+        "dropOverlay": "أفلت الملفات لرفعها",
+        "uploadingButton": "جارٍ الرفع…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "حلّل بياناتي وأنشئ لوحة معلومات..."
       }
     }
   },
@@ -8825,6 +12553,13 @@
           "networkError": "حدث خطأ أثناء تغيير كلمة المرور",
           "updateFailed": "فشل تغيير كلمة المرور",
           "updated": "تم تحديث كلمة المرور بنجاح"
+        },
+        "validation": {
+          "confirmRequired": "يرجى تأكيد كلمة المرور الجديدة",
+          "currentRequired": "كلمة المرور الحالية مطلوبة",
+          "minLength": "يجب أن تتكون كلمة المرور من {min} أحرف على الأقل",
+          "mismatch": "كلمتا المرور غير متطابقتين",
+          "newRequired": "كلمة المرور الجديدة مطلوبة"
         }
       },
       "title": "الحسابات"
@@ -8866,6 +12601,7 @@
         "empty": "لم يتم إنشاء رموز وصول.",
         "expiresIn": "{count, plural, one {تنتهي الصلاحية خلال يوم واحد} other {تنتهي الصلاحية خلال # أيام}}",
         "loading": "جارٍ تحميل الرموز...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "لا تنتهي صلاحيته أبدًا",
         "newTokenButton": "رمز وصول جديد",
         "noPermissionTooltip": "ليس لديك إذن لإنشاء رموز وصول",
@@ -9012,6 +12748,10 @@
       },
       "description": "اربط الأدوات الخارجية بالنماذج المتاحة لك في Onyx.",
       "guideButton": "الدليل",
+      "loadError": {
+        "description": "يرجى تحديث الصفحة والمحاولة مرة أخرى.",
+        "title": "تعذر تحميل بوابة LLM"
+      },
       "models": {
         "description": "{count, plural, one {# نموذج متاح لحسابك. افتح موفرًا لنسخ المعرّف.} other {# نماذج متاحة لحسابك. افتح موفرًا لنسخ المعرّف.}}",
         "title": "النماذج"
@@ -9064,14 +12804,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "إضافة سطر",
+        "maxReached": "تم بلوغ الحد الأقصى البالغ {count} من الذكريات"
+      },
       "empty": {
-        "description": "أضف ملاحظة شخصية أو ذكرى يجب أن يتذكرها Onyx."
+        "description": "أضف ملاحظة شخصية أو ذكرى يجب أن يتذكرها Onyx.",
+        "getStarted": "لا توجد ذكريات بعد. انقر على \"إضافة سطر\" للبدء.",
+        "noMatches": "لا توجد ذكريات تطابق بحثك."
+      },
+      "item": {
+        "placeholder": "اكتب أو الصق ملاحظة شخصية أو ذكرى"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {سطر} other {أسطر}}"
+      },
+      "modal": {
+        "description": "اسمح لـ Onyx بالرجوع إلى هذه الملاحظات والذكريات المحفوظة في المحادثات.",
+        "searchPlaceholder": "بحث..."
       },
       "referenceStoredMemories": {
         "description": "اسمح لـ Onyx بالرجوع إلى الذكريات المخزنة في المحادثات.",
         "title": "الرجوع إلى الذكريات المخزنة"
       },
+      "removeLineButton": {
+        "label": "إزالة السطر"
+      },
       "title": "الذاكرة",
+      "toasts": {
+        "saveFailed": "فشل حفظ التفضيلات",
+        "saved": "تم حفظ التفضيلات"
+      },
       "updateMemories": {
         "description": "اسمح لـ Onyx بتوليد الذكريات المخزنة وتحديثها.",
         "title": "تحديث الذكريات"
@@ -9491,6 +13254,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "التطبيق “{appName}” لديه بالفعل مهارة مرتبطة باسم “{skillName}”.",
+        "title": "اختر اسم مهارة مختلفًا"
+      },
+      "confirmUpload": {
+        "importBody": "يتضمن هذا الرفع ملف SKILL.md. ستؤدي المتابعة إلى استبدال الاسم والوصف والتعليمات والملفات الحالية بالحزمة المرفوعة.",
+        "importSubmit": {
+          "label": "استيراد المهارة"
+        },
+        "importTitle": "استيراد هذه المهارة؟",
+        "replaceBody": "يجب أن يستخدم هذا الرفع اسم المهارة نفسه. ستؤدي المتابعة إلى استبدال الوصف والتعليمات والملفات بالحزمة المرفوعة.",
+        "replaceSubmit": {
+          "label": "استبدال المحتوى"
+        },
+        "replaceTitle": "استبدال محتوى المهارة؟"
+      },
+      "delete": {
+        "button": {
+          "label": "حذف المهارة"
+        },
+        "description": "سيفقد كل من يستخدم هذه المهارة إمكانية الوصول إليها. لا يمكن التراجع عن الحذف.",
+        "title": "حذف هذه المهارة"
+      },
+      "deleteModal": {
+        "entityType": "مهارة",
+        "label": "حذف",
+        "pendingLabel": "جارٍ الحذف..."
+      },
+      "details": {
+        "description": "حدد متى وكيف ينبغي لـ Craft استخدام هذه المهارة.",
+        "descriptionField": {
+          "description": "صف متى ينبغي استخدام هذه المهارة.",
+          "placeholder": "بمَ تساعد هذه المهارة؟",
+          "title": "الوصف"
+        },
+        "name": {
+          "createDescription": "استخدم أحرفًا صغيرة وأرقامًا وشرطات مفردة.",
+          "lockedDescription": "لا يمكن تغيير أسماء المهارات بعد إنشائها.",
+          "placeholder": "سمِّ مهارتك",
+          "title": "الاسم"
+        },
+        "title": "التفاصيل"
+      },
+      "files": {
+        "busyLabel": "جارٍ الرفع...",
+        "description": "أضف مراجع أو نصوصًا برمجية أو أصولًا أو ملفات أخرى تستخدمها هذه المهارة. يتم فك ضغط ملفات ZIP تلقائيًا.",
+        "input": {
+          "ariaLabel": "إضافة ملفات داعمة"
+        },
+        "pendingUpload": {
+          "emptyMessage": "ستظهر ملفات هذا الرفع بعد إنشاء المهارة."
+        },
+        "title": "الملفات الداعمة"
+      },
+      "filesTooltip": {
+        "noPermission": "ليست لديك صلاحية تحديث ملفات هذه المهارة.",
+        "saveFirst": "احفظ تغييرات التفاصيل قبل تحديث ملفات المهارة.",
+        "updating": "جارٍ تحديث ملفات المهارة..."
+      },
+      "header": {
+        "appFallbackName": "تطبيق خارجي",
+        "cancel": {
+          "label": "إلغاء"
+        },
+        "createDescription": "أنشئ مهارة شخصية",
+        "createForAppDescription": "أضف مهارة مؤسسة إلى التطبيق “{appName}”",
+        "createTitle": "إنشاء مهارة",
+        "editDescription": "حدّث تفاصيل المهارة وملفاتها",
+        "editTitle": "تعديل المهارة",
+        "save": {
+          "label": "حفظ",
+          "pendingLabel": "جارٍ الحفظ..."
+        }
+      },
+      "import": {
+        "busyLabel": "جارٍ الاستيراد...",
+        "button": {
+          "label": "استيراد مهارة"
+        },
+        "description": "استورد ملف SKILL.md أو ملف ZIP أو مجلد مهارة لملء النموذج مسبقًا وتضمين ملفاته.",
+        "input": {
+          "ariaLabel": "استيراد مهارة موجودة"
+        },
+        "prompt": "اختر ملف SKILL.md أو ZIP، أو أسقط مجلد مهارة هنا.",
+        "title": "لديك مهارة موجودة بالفعل؟"
+      },
+      "instructions": {
+        "description": "اكتب السلوك وسير العمل الذي تضيفه هذه المهارة إلى Craft.",
+        "emptyFallback": "لا توجد تعليمات بعد.",
+        "placeholder": "اكتب تعليمات المهارة.",
+        "title": "التعليمات"
+      },
+      "loadError": {
+        "description": "قد لا تكون هذه المهارة موجودة، أو قد تكون مدمجة، أو قد لا يكون حسابك قادرًا على تعديلها.",
+        "title": "المهارة غير متاحة"
+      },
+      "management": {
+        "description": "تحكم في من يمكنه استخدام هذه المهارة.",
+        "externalApp": {
+          "manage": {
+            "label": "الإدارة في إعدادات التطبيق"
+          },
+          "readyDescription": "تستخدم هذه المهارة التطبيق “{appName}”.",
+          "title": "تطبيق خارجي"
+        },
+        "sharing": {
+          "edit": {
+            "label": "تعديل المشاركة"
+          },
+          "title": "المشاركة"
+        },
+        "title": "الإدارة"
+      },
+      "saveTooltip": {
+        "missingDescription": "أضف وصفًا قبل الحفظ.",
+        "missingInstructions": "أضف تعليمات قبل الحفظ.",
+        "missingName": "أضف اسمًا قبل الحفظ.",
+        "noChanges": "لم يتم إجراء أي تغييرات.",
+        "noPermission": "ليست لديك صلاحية تعديل تفاصيل هذه المهارة.",
+        "savingChanges": "جارٍ حفظ التغييرات...",
+        "savingSkill": "جارٍ حفظ المهارة..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "يمكن لجميع أعضاء مؤسستك استخدام هذه المهارة وتعديلها.",
+          "title": "المؤسسة",
+          "viewerDescription": "يمكن لجميع أعضاء مؤسستك استخدام هذه المهارة."
+        },
+        "personal": {
+          "description": "أنت وحدك من يمكنه استخدام هذه المهارة.",
+          "title": "شخصي"
+        },
+        "shares": {
+          "description": "يمكن فقط للمستخدمين والمجموعات المحددة استخدام هذه المهارة.",
+          "title": "{count, plural, one {# مشاركة} other {# مشاركات}}"
+        }
+      },
+      "toasts": {
+        "created": "تم إنشاء \"{name}\"",
+        "deleteFailed": "فشل حذف المهارة",
+        "deleted": "تم حذف \"{name}\"",
+        "fileRemoveFailed": "فشلت إزالة ملف المهارة",
+        "fileRemoved": "تمت إزالة \"{path}\"",
+        "filesUpdateFailed": "فشل تحديث ملفات المهارة",
+        "filesUpdated": "تم تحديث ملفات \"{name}\"",
+        "importMissingSkillMd": "استورد ملف SKILL.md أو ملف ZIP أو مجلدًا يحتوي على SKILL.md.",
+        "inspectFailed": "فشل فحص حزمة المهارة",
+        "saveFailed": "فشل حفظ المهارة",
+        "saved": "تم حفظ \"{name}\""
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9691,6 +13606,76 @@
         "transferredToast": {
           "message": "تم نقل الملكية."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "تصفح المهارات"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {مهارة} other {مهارات}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "استورد مهارة واحدة أو أكثر من مستودع.",
+          "title": "استيراد من GitHub"
+        },
+        "scratch": {
+          "description": "اكتب التعليمات وأضف الملفات الداعمة في Onyx.",
+          "title": "البدء من الصفر"
+        },
+        "trigger": {
+          "label": "إنشاء مهارة"
+        },
+        "upload": {
+          "description": "استورد ملف SKILL.md أو ملف ZIP أو مجلد مهارة.",
+          "title": "رفع مهارة"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "جرّب بحثًا مختلفًا.",
+          "title": "لا توجد مهارات مطابقة"
+        },
+        "noSkills": {
+          "description": "لم تتم مشاركة أي مهارات مخصصة معك بعد، ولا توجد مهارات مدمجة مهيأة.",
+          "title": "لا توجد مهارات متاحة"
+        }
+      },
+      "focusedApp": {
+        "description": "فعّل كل المهارات المرتبطة بالتطبيق “{appName}”. قد لا يعمل التطبيق بشكل صحيح بدونها. إذا كانت مهارة أخرى بالاسم نفسه مفعّلة، فإن تفعيل مهارة التطبيق سيعطّل المهارة الأخرى لك.",
+        "showAll": {
+          "label": "عرض جميع المهارات"
+        },
+        "title": "مهارات التطبيق “{appName}”"
+      },
+      "header": {
+        "description": "حزم قدرات يمكن لوكيل Craft الخاص بك استخدامها. تعرض هذه الصفحة المهارات المدمجة والمهارات المشاركة معك ومهاراتك الشخصية.",
+        "title": "المهارات"
+      },
+      "loadError": {
+        "description": "راجع وحدة التحكم لمعرفة التفاصيل وحاول تحديث الصفحة.",
+        "title": "فشل تحميل المهارات"
+      },
+      "preview": {
+        "unavailableFallback": "هذه المهارة غير متاحة حاليًا."
+      },
+      "search": {
+        "placeholder": "البحث عن مهارات..."
+      },
+      "switchModal": {
+        "body": "ستؤدي المتابعة إلى تعطيل المهارة المفعّلة حاليًا وتفعيل هذه المهارة.",
+        "description": "يمكن تفعيل مهارة واحدة فقط باسم “{name}” في كل مرة.",
+        "submit": {
+          "label": "تبديل المهارة",
+          "pendingLabel": "جارٍ التبديل..."
+        },
+        "title": "التبديل إلى المهارة “{name}”؟"
+      },
+      "toasts": {
+        "disableFailed": "فشل تعطيل {name}",
+        "enableFailed": "فشل تفعيل {name}",
+        "refreshFailed": "تم تحديث {name}، لكن تعذّر تحديث قائمة المهارات."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -5765,6 +5765,27 @@
         "unexpectedError": "حدث خطأ غير متوقع."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "ملغاة",
+        "completedWithErrors": "اكتملت مع أخطاء",
+        "deleting": "جارٍ الحذف",
+        "error": "خطأ",
+        "failed": "فشلت",
+        "inProgress": "قيد التنفيذ",
+        "indexed": "مفهرس",
+        "indexing": "جارٍ الفهرسة",
+        "initialIndexing": "فهرسة أولية",
+        "interrupted": "متقطعة",
+        "invalid": "غير صالحة",
+        "invalidConnectorTooltip": "الموصل في حالة غير صالحة. يرجى تحديث بيانات الاعتماد أو إنشاء موصل جديد.",
+        "none": "بدون",
+        "notStarted": "لم تبدأ",
+        "paused": "موقوف مؤقتًا",
+        "scheduled": "مجدولة",
+        "succeeded": "نجحت"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "إصدار الخادم الخلفي: "
@@ -7204,6 +7225,70 @@
       },
       "sourcesModal": {
         "title": "المصادر"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "حذف"
+      },
+      "deleteModal": {
+        "description": "هل أنت متأكد من رغبتك في حذف هذه المحادثة؟ لا يمكن التراجع عن هذا الإجراء.",
+        "submitButton": {
+          "label": "حذف"
+        },
+        "title": "حذف المحادثة"
+      },
+      "exportAs": {
+        "label": "تصدير باسم…"
+      },
+      "exportFailed": {
+        "message": "فشل تصدير المحادثة. يرجى المحاولة مرة أخرى."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "نص عادي"
+      },
+      "fullWidth": {
+        "ariaLabel": "تبديل عرض المحادثة الكامل",
+        "fitTooltip": "ملاءمة العرض",
+        "fullTooltip": "عرض كامل"
+      },
+      "incognitoExit": {
+        "ariaLabel": "الخروج من محادثة التخفي",
+        "tooltip": "الخروج من محادثة التخفي"
+      },
+      "incognitoPill": {
+        "ariaLabel": "محادثة تخفٍ",
+        "label": "محادثة تخفٍ"
+      },
+      "incognitoStart": {
+        "ariaLabel": "بدء محادثة تخفٍ",
+        "lockedTooltip": "لا يمكن تفعيل التخفي إلا قبل بدء المحادثة",
+        "tooltip": "محادثة تخفٍ"
+      },
+      "mode": {
+        "chat": {
+          "description": "محادثة وبحث",
+          "label": "محادثة"
+        },
+        "search": {
+          "description": "بحث سريع في المستندات",
+          "label": "بحث"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "تغيير وضع التطبيق"
+      },
+      "moveToProject": {
+        "label": "نقل إلى مشروع"
+      },
+      "openSidebar": {
+        "ariaLabel": "فتح الشريط الجانبي"
+      },
+      "share": {
+        "label": "مشاركة"
       }
     },
     "banners": {
@@ -8950,6 +9035,34 @@
         "updateFailed": "فشل تحديث تفضيل اللغة"
       }
     },
+    "layout": {
+      "header": {
+        "title": "الإعدادات"
+      },
+      "sectionSelect": {
+        "placeholder": "اختر قسمًا"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "الحسابات والوصول"
+        },
+        "chatPreferences": {
+          "label": "تفضيلات المحادثة"
+        },
+        "connectors": {
+          "label": "الموصلات"
+        },
+        "general": {
+          "label": "عام"
+        },
+        "llmGateway": {
+          "label": "بوابة LLM"
+        },
+        "usage": {
+          "label": "الاستخدام"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "أضف ملاحظة شخصية أو ذكرى يجب أن يتذكرها Onyx."
@@ -9010,6 +9123,47 @@
       "toggle": {
         "description": "فعّل الاختصارات لإدراج المطالبات الشائعة بسرعة.",
         "title": "استخدام اختصارات المطالبات"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "الحد {amount}",
+        "none": "لا ميزانية معيّنة",
+        "remaining": "المتبقي {amount}",
+        "resetsOn": "يُعاد الضبط في {date}",
+        "title": "الميزانية"
+      },
+      "empty": {
+        "description": "سيظهر استخدامك للنماذج وتكاليفها هنا بمجرد بدء المحادثة.",
+        "title": "لم يُسجل استخدام بعد"
+      },
+      "header": {
+        "title": "الاستخدام"
+      },
+      "loadError": {
+        "description": "حدث خطأ أثناء جلب استخدامك. حاول مرة أخرى بعد قليل.",
+        "title": "تعذّر تحميل الاستخدام"
+      },
+      "modelPrices": {
+        "description": "دولار لكل مليون رمز (إدخال · إخراج · ذاكرة مؤقتة) لكل نموذج متاح",
+        "title": "أسعار النماذج",
+        "unavailable": "الأسعار غير متاحة"
+      },
+      "showFewerModels": {
+        "ariaLabel": "عرض نماذج أقل"
+      },
+      "showLess": {
+        "label": "عرض أقل"
+      },
+      "showMore": {
+        "label": "عرض {count} إضافية"
+      },
+      "showMoreModels": {
+        "ariaLabel": "عرض {count} نماذج إضافية"
+      },
+      "usageThisPeriod": {
+        "description": "أُنفق {amount}",
+        "title": "الاستخدام في هذه الفترة"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "رجوع"
       },
-      "disableAll": {
-        "label": "تعطيل الكل"
-      },
-      "enableAll": {
-        "label": "تمكين الكل"
-      },
       "toggle": {
         "ariaLabel": "تبديل {name}"
       }
@@ -12947,6 +12941,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "مستكشف المستندات"
+        },
+        "documentFeedback": {
+          "title": "ملاحظات المستندات"
+        },
+        "documentProcessing": {
+          "title": "معالجة المستندات"
+        },
+        "oauthTest": {
+          "title": "اختبار OAuth"
+        },
+        "standardAnswers": {
+          "title": "الإجابات القياسية"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "إضافة موصل"

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -12902,9 +12902,29 @@
         "title": "Nutzung konnte nicht geladen werden"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · Standard"
+        },
         "description": "USD pro 1 Mio. Tokens (Eingabe · Ausgabe · Cache) für jedes verfügbare Modell",
+        "otherProvider": {
+          "label": "Andere"
+        },
         "title": "Modellpreise",
         "unavailable": "Preise nicht verfügbar"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "{count} Cache-Lesevorgänge"
+        },
+        "cacheWrites": {
+          "label": "{count} Cache-Schreibvorgänge"
+        },
+        "tokensIn": {
+          "label": "{count} Eingabe"
+        },
+        "tokensOut": {
+          "label": "{count} Ausgabe"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "Weniger Modelle anzeigen"

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "Zurück"
       },
-      "disableAll": {
-        "label": "Alle deaktivieren"
-      },
-      "enableAll": {
-        "label": "Alle aktivieren"
-      },
       "toggle": {
         "ariaLabel": "{name} umschalten"
       }
@@ -12947,6 +12941,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "Dokument-Explorer"
+        },
+        "documentFeedback": {
+          "title": "Dokument-Feedback"
+        },
+        "documentProcessing": {
+          "title": "Dokumentverarbeitung"
+        },
+        "oauthTest": {
+          "title": "OAuth-Test"
+        },
+        "standardAnswers": {
+          "title": "Standardantworten"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "Konnektor hinzufügen"

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -5765,6 +5765,27 @@
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "Abgebrochen",
+        "completedWithErrors": "Mit Fehlern abgeschlossen",
+        "deleting": "Wird gelöscht",
+        "error": "Fehler",
+        "failed": "Fehlgeschlagen",
+        "inProgress": "In Bearbeitung",
+        "indexed": "Indexiert",
+        "indexing": "Indexierung",
+        "initialIndexing": "Erstindexierung",
+        "interrupted": "Unterbrochen",
+        "invalid": "Ungültig",
+        "invalidConnectorTooltip": "Der Konnektor befindet sich in einem ungültigen Zustand. Aktualisieren Sie die Zugangsdaten oder erstellen Sie einen neuen Konnektor.",
+        "none": "Keine",
+        "notStarted": "Nicht gestartet",
+        "paused": "Pausiert",
+        "scheduled": "Geplant",
+        "succeeded": "Erfolgreich"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "Backend-Version: "
@@ -7204,6 +7225,70 @@
       },
       "sourcesModal": {
         "title": "Quellen"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "Löschen"
+      },
+      "deleteModal": {
+        "description": "Möchten Sie diesen Chat wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "submitButton": {
+          "label": "Löschen"
+        },
+        "title": "Chat löschen"
+      },
+      "exportAs": {
+        "label": "Exportieren als…"
+      },
+      "exportFailed": {
+        "message": "Chat konnte nicht exportiert werden. Bitte erneut versuchen."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "Nur Text"
+      },
+      "fullWidth": {
+        "ariaLabel": "Chat in voller Breite umschalten",
+        "fitTooltip": "Breite anpassen",
+        "fullTooltip": "Volle Breite"
+      },
+      "incognitoExit": {
+        "ariaLabel": "Inkognito-Chat verlassen",
+        "tooltip": "Inkognito-Chat verlassen"
+      },
+      "incognitoPill": {
+        "ariaLabel": "Inkognito-Chat",
+        "label": "Inkognito-Chat"
+      },
+      "incognitoStart": {
+        "ariaLabel": "Inkognito-Chat starten",
+        "lockedTooltip": "Inkognito kann nur vor Beginn des Chats aktiviert werden",
+        "tooltip": "Inkognito-Chat"
+      },
+      "mode": {
+        "chat": {
+          "description": "Unterhaltung und Recherche",
+          "label": "Chat"
+        },
+        "search": {
+          "description": "Schnellsuche nach Dokumenten",
+          "label": "Suche"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "App-Modus ändern"
+      },
+      "moveToProject": {
+        "label": "In Projekt verschieben"
+      },
+      "openSidebar": {
+        "ariaLabel": "Seitenleiste öffnen"
+      },
+      "share": {
+        "label": "Teilen"
       }
     },
     "banners": {
@@ -8950,6 +9035,34 @@
         "updateFailed": "Die Spracheinstellung konnte nicht aktualisiert werden"
       }
     },
+    "layout": {
+      "header": {
+        "title": "Einstellungen"
+      },
+      "sectionSelect": {
+        "placeholder": "Bereich auswählen"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "Konten & Zugriff"
+        },
+        "chatPreferences": {
+          "label": "Chat-Einstellungen"
+        },
+        "connectors": {
+          "label": "Konnektoren"
+        },
+        "general": {
+          "label": "Allgemein"
+        },
+        "llmGateway": {
+          "label": "LLM-Gateway"
+        },
+        "usage": {
+          "label": "Nutzung"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Fügen Sie eine persönliche Notiz oder Erinnerung hinzu, die sich Onyx merken soll."
@@ -9010,6 +9123,47 @@
       "toggle": {
         "description": "Aktivieren Sie Shortcuts, um häufig verwendete Prompts schnell einzufügen.",
         "title": "Prompt-Shortcuts verwenden"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "Limit: {amount}",
+        "none": "Kein Budget festgelegt",
+        "remaining": "{amount} verbleibend",
+        "resetsOn": "Zurücksetzung am {date}",
+        "title": "Budget"
+      },
+      "empty": {
+        "description": "Ihre Modellnutzung und Kosten erscheinen hier, sobald Sie mit dem Chatten beginnen.",
+        "title": "Noch keine Nutzung erfasst"
+      },
+      "header": {
+        "title": "Nutzung"
+      },
+      "loadError": {
+        "description": "Beim Abrufen Ihrer Nutzung ist ein Fehler aufgetreten. Versuchen Sie es gleich erneut.",
+        "title": "Nutzung konnte nicht geladen werden"
+      },
+      "modelPrices": {
+        "description": "USD pro 1 Mio. Tokens (Eingabe · Ausgabe · Cache) für jedes verfügbare Modell",
+        "title": "Modellpreise",
+        "unavailable": "Preise nicht verfügbar"
+      },
+      "showFewerModels": {
+        "ariaLabel": "Weniger Modelle anzeigen"
+      },
+      "showLess": {
+        "label": "Weniger anzeigen"
+      },
+      "showMore": {
+        "label": "{count} weitere anzeigen"
+      },
+      "showMoreModels": {
+        "ariaLabel": "{count} weitere Modelle anzeigen"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} ausgegeben",
+        "title": "Nutzung in diesem Zeitraum"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -60,6 +60,26 @@
         "ariaLabel": "Aktionskarte {title}"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "Konnektoren hinzufügen"
+      },
+      "configure": {
+        "tooltip": "Konfigurieren"
+      },
+      "configureConnectors": {
+        "label": "Konnektoren konfigurieren"
+      },
+      "disable": {
+        "label": "Deaktivieren"
+      },
+      "enable": {
+        "label": "Aktivieren"
+      },
+      "projectSearch": {
+        "label": "Projektsuche"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "Verbinden Sie einen MCP-Server (Model Context Protocol), um benutzerdefinierte Aktionen hinzuzufügen.",
@@ -355,6 +375,53 @@
         "tooltip": "Tools aktualisieren"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "Sie werden automatisch zurückgeleitet …"
+      },
+      "backToChatButton": {
+        "label": "Zurück zum Chat"
+      },
+      "cancelled": {
+        "description": "Die Autorisierung wurde abgebrochen oder verweigert, daher wurde keine Verbindung hergestellt. Um es erneut zu versuchen, starten Sie die Verbindung über die Authentifizierungseinstellungen des MCP-Servers neu.",
+        "title": "Autorisierung abgebrochen"
+      },
+      "continueButton": {
+        "label": "Weiter"
+      },
+      "genericError": {
+        "fallbackDetail": "Autorisierung konnte nicht abgeschlossen werden",
+        "title": "Etwas ist schiefgelaufen"
+      },
+      "invalidLink": {
+        "description": "Diesem Link fehlen die erforderlichen Autorisierungsparameter. Starten Sie die Verbindung über die Authentifizierungseinstellungen des MCP-Servers neu.",
+        "title": "Ungültiger Autorisierungslink"
+      },
+      "processing": {
+        "description": "Die Verbindung zu Ihrem MCP-Server wird hergestellt. Dies kann einen Moment dauern …",
+        "title": "Autorisierung wird abgeschlossen"
+      },
+      "serverNotFound": {
+        "description": "Der MCP-Server, zu dem diese Autorisierung gehört, existiert nicht mehr oder ist nicht mehr konfiguriert. Erstellen oder konfigurieren Sie den Server neu und stellen Sie dann erneut eine Verbindung her.",
+        "title": "MCP-Server nicht gefunden"
+      },
+      "sessionExpired": {
+        "description": "Dieser Autorisierungslink ist ungültig, abgelaufen oder wurde bereits verwendet. Starten Sie die Verbindung über die Authentifizierungseinstellungen des MCP-Servers neu.",
+        "title": "Autorisierungssitzung abgelaufen"
+      },
+      "success": {
+        "description": "Die Autorisierung wurde erfolgreich abgeschlossen. Sie können die Tools dieses Servers jetzt im Chat verwenden.",
+        "title": "Mit {serverName} verbunden"
+      },
+      "timedOut": {
+        "description": "Der MCP-Server hat die Autorisierung nicht rechtzeitig bestätigt. Versuchen Sie erneut, eine Verbindung herzustellen. Falls das Problem weiterhin auftritt, überprüfen Sie die OAuth-Konfiguration des Servers.",
+        "title": "Zeitüberschreitung bei der Autorisierung"
+      },
+      "tokenExchangeFailed": {
+        "description": "Der Anbieter hat die Autorisierung genehmigt, aber es konnte kein gültiges Zugriffstoken abgerufen werden. Überprüfen Sie die OAuth-Client-Anmeldedaten und -Endpunkte des Servers und versuchen Sie dann erneut, eine Verbindung herzustellen.",
+        "title": "Token-Austausch fehlgeschlagen"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "MCP-Server hinzufügen"
@@ -554,6 +621,20 @@
         "label": "Ablehnen"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "Zurück"
+      },
+      "disableAll": {
+        "label": "Alle deaktivieren"
+      },
+      "enableAll": {
+        "label": "Alle aktivieren"
+      },
+      "toggle": {
+        "ariaLabel": "{name} umschalten"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "Tool nicht verfügbar"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "Nur aktivierte Tools anzeigen",
         "tooltip": "Nur aktivierte anzeigen"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "Code-Interpreter konfigurieren"
+        },
+        "imageGeneration": {
+          "tooltip": "Bilderzeugung konfigurieren"
+        },
+        "openapi": {
+          "tooltip": "OpenAPI-Aktionen verwalten"
+        },
+        "webSearch": {
+          "tooltip": "Websuche konfigurieren"
+        }
+      },
+      "disableAllSources": {
+        "label": "Alle Quellen deaktivieren"
+      },
+      "disableAllTools": {
+        "label": "Alle Tools deaktivieren"
+      },
+      "enableAllSources": {
+        "label": "Alle Quellen aktivieren"
+      },
+      "enableAllTools": {
+        "label": "Alle Tools aktivieren"
+      },
+      "manageActions": {
+        "tooltip": "Aktionen verwalten"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "{server}-Tools durchsuchen"
+      },
+      "moreActions": {
+        "label": "Weitere Aktionen"
+      },
+      "reauthenticate": {
+        "label": "Erneut authentifizieren"
+      },
+      "search": {
+        "placeholder": "Aktionen durchsuchen..."
+      },
+      "serverFallback": {
+        "label": "Server"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "Filter durchsuchen"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "Bitten Sie einen Admin um die Konfiguration."
+        },
+        "codingAgent": {
+          "description": "Untersucht ein GitHub-Repository und beantwortet Fragen zu dessen Code."
+        },
+        "configureSuffix": {
+          "text": "Zum Aktivieren auf das Zahnrad tippen."
+        },
+        "default": {
+          "description": "Diese Aktion ist noch nicht konfiguriert."
+        },
+        "imageGeneration": {
+          "description": "Erzeugt Bilder auf Basis eines Prompts."
+        },
+        "python": {
+          "description": "Führt Code für komplexe Analysen aus."
+        },
+        "search": {
+          "description": "Durchsucht das verbundene Wissen, um die Antwort zu stützen."
+        },
+        "webSearch": {
+          "description": "Durchsucht das Web nach aktuellen Informationen."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "Pro Tag für den ausgewählten Zeitraum",
+        "title": "Nachrichten und eindeutige Benutzer"
+      },
+      "empty": {
+        "message": "Keine Daten für diesen Agenten im ausgewählten Zeitraum gefunden."
+      },
+      "fetchFailed": {
+        "message": "Agentenstatistiken konnten nicht geladen werden."
+      },
+      "permissionDenied": {
+        "message": "Sie haben keine Berechtigung, diese Statistiken anzusehen."
+      },
+      "totalMessages": {
+        "label": "Nachrichten gesamt"
+      },
+      "totalUniqueUsers": {
+        "label": "Eindeutige Benutzer gesamt"
+      },
+      "unknownError": {
+        "message": "Ein unbekannter Fehler ist aufgetreten"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "Abschnitt einklappen"
+        },
+        "expand": {
+          "ariaLabel": "Abschnitt ausklappen"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "Möchten Sie <emphasis>{name}</emphasis> wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "Tarife anzeigen"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "Keine Abrechnungsinformationen verfügbar."
+        },
+        "loadError": {
+          "message": "Fehler beim Laden der Abrechnungsinformationen. Bitte versuchen Sie es später erneut."
+        },
+        "loading": {
+          "label": "Wird geladen..."
+        },
+        "manageSubscription": {
+          "description": "Plan ansehen, Zahlung aktualisieren oder Abonnement ändern",
+          "title": "Abonnement verwalten"
+        },
+        "page": {
+          "title": "Abrechnungsinformationen"
+        },
+        "portalError": {
+          "message": "Fehler beim Erstellen der Kundenportal-Sitzung"
+        },
+        "subscriptionDetails": {
+          "title": "Abonnementdetails"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "Abrechnungsende"
+          },
+          "billingStart": {
+            "label": "Abrechnungsbeginn"
+          },
+          "seats": {
+            "label": "Plätze"
+          },
+          "status": {
+            "label": "Abonnementstatus"
+          }
+        },
+        "updatedToast": {
+          "message": "Glückwunsch! Ihr Abonnement wurde erfolgreich aktualisiert."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "Wir synchronisieren Berechtigungen automatisch aus der Quelle. Ein Dokument ist in Onyx nur dann auffindbar, wenn der suchende Benutzer in der Quelle Zugriff auf das Dokument hat.",
+          "disabledReason": "Die aktuelle Authentifizierungsmethode der Zugangsdaten unterstützt keine automatische Berechtigungssynchronisierung. Bitte wechsle zu einer unterstützten Authentifizierungsmethode.",
+          "name": "Berechtigungen automatisch synchronisieren"
+        },
+        "heading": {
+          "description": "Lege fest, wer Zugriff auf die von diesem Konnektor indexierten Dokumente hat.",
+          "title": "Dokumentzugriff"
+        },
+        "privateOption": {
+          "description": "Nur Benutzer, denen explizit Zugriff auf diesen Konnektor gewährt wurde (über die Seite Benutzergruppen), können auf die von diesem Konnektor importierten Dokumente zugreifen",
+          "name": "Privat"
+        },
+        "publicOption": {
+          "description": "Jeder mit einem Onyx-Konto kann auf die von diesem Konnektor importierten Dokumente zugreifen",
+          "name": "Öffentlich"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# Tag} other {# Tage}}",
@@ -1546,6 +1794,14 @@
           "label": "Weniger anzeigen"
         }
       },
+      "credentialForm": {
+        "errorToast": "Fehler: {detail}",
+        "successToast": "Erfolgreich!",
+        "updateButton": {
+          "ariaLabel": "Zugangsdaten aktualisieren",
+          "label": "Aktualisieren"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "Beim Löschen dieses Konnektors wird ein Löschauftrag geplant, der seine indizierten Dokumente entfernt und ihn für alle Benutzer löscht.",
         "entityType": "Konnektor"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "Fehler bei der Synchronisierung der Dokumentberechtigungen"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "In <link>unserer Dokumentation</link> findest du weitere Informationen zur Konfiguration dieses Konnektors."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "Die Dateien konnten nicht aktualisiert werden"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "{multiple, select, true {Dateien} other {Eine Datei}} hierher ziehen oder klicken, um {multiple, select, true {Dateien} other {eine Datei}} auszuwählen"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {Ausgewählte Dateien} other {Ausgewählte Datei}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "Fehlermeldung",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "Fehler bei der Synchronisierung der Gruppenmitgliedschaften"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "Gruppenzugriff für diesen Konnektor zuweisen"
+        },
+        "assignToGroup": {
+          "title": "Diesen Konnektor einer Gruppe zuweisen"
+        },
+        "scopedManagerGroups": {
+          "description": "Wähle eine oder mehrere der von dir verwalteten Gruppen aus, um Zugriff auf diesen Konnektor zu gewähren"
+        },
+        "syncGroups": {
+          "description": "Die folgenden Gruppen legen fest, wer diesen Konnektor verwalten kann. Der Zugriff auf seine Dokumente wird von den Berechtigungen der Quelle selbst übernommen."
+        },
+        "visibleToGroups": {
+          "description": "Dieser Konnektor ist für die unten ausgewählten Gruppen sichtbar/zugänglich"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "Gezielte Neuindizierung für {count, plural, one {# Dokument} other {# Dokumente}} übermittelt. Die Fehler verschwinden aus der Liste, sobald die Dokumente neu indiziert sind."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "Kanal-Regex aktiviert",
+        "channels": "Kanäle",
+        "enabledTrue": "Ja",
+        "excludeChannelRegexEnabled": "Kanal-Ausschluss-Regex aktiviert",
+        "excludedChannels": "Ausgeschlossene Kanäle",
+        "includeBotMessages": "Bot-Nachrichten einschließen",
+        "jiraProjectUrl": "Jira-Projekt-URL",
+        "multipleRepos": "mehrere Repositories",
+        "pageId": "Seiten-ID",
+        "realm": "Realm",
+        "repo": "Repository",
+        "wikiUrl": "Wiki-URL"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "Geben Sie die E-Mail-Adresse eines Administrators oder Eigentümers der Google-Organisation ein, der die Google Drives gehören, die Sie indizieren möchten.",
           "invalidEmail": "Muss eine gültige E-Mail-Adresse sein",
           "label": "E-Mail-Adresse des Hauptadministrators",
+          "placeholder": "admin@ihrunternehmen.com",
           "required": "Erforderlich"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "Geben Sie die E-Mail-Adresse eines Administrators oder Eigentümers der Google-Organisation ein, der die Gmail-Konten gehören, die Sie indizieren möchten.",
           "invalidEmail": "Muss eine gültige E-Mail-Adresse sein",
           "label": "E-Mail-Adresse des Hauptadministrators",
+          "placeholder": "admin@ihrunternehmen.com",
           "required": "Erforderlich"
         },
         "section": {
@@ -2602,6 +2906,171 @@
       "unavailable": {
         "description": "Craft wird von Onyx pro Bereitstellung aktiviert. Wenden Sie sich an Ihren Onyx-Ansprechpartner, um Zugriff zu erhalten.",
         "title": "Craft ist in dieser Bereitstellung nicht verfügbar"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "Erstellt am <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "Erstellt am <i>{date}</i> von <i>{email}</i>"
+        },
+        "unnamed": {
+          "label": "Anmeldedaten Nr. {id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "Erstellen"
+        },
+        "created": {
+          "toast": "Neue Anmeldedaten erstellt!"
+        },
+        "name": {
+          "label": "Name:",
+          "placeholder": "(Optional) Name der Anmeldedaten..."
+        },
+        "submitError": {
+          "toast": "Fehler beim Übermitteln der Anmeldedaten"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "Abbrechen"
+        },
+        "confirmBody": {
+          "message": "Möchten Sie diese Anmeldedaten wirklich löschen? Anmeldedaten, die mit aktiven Konnektoren verknüpft sind, können nicht gelöscht werden."
+        },
+        "confirmButton": {
+          "label": "Bestätigen"
+        },
+        "confirmTitle": "Löschen bestätigen"
+      },
+      "edit": {
+        "name": {
+          "label": "Name (optional):"
+        },
+        "permissions": {
+          "note": "Stellen Sie sicher, dass Sie auf Anmeldedaten mit den richtigen Berechtigungen aktualisieren!"
+        },
+        "resetButton": {
+          "label": "Änderungen zurücksetzen"
+        },
+        "updateButton": {
+          "label": "Aktualisieren"
+        },
+        "updateError": {
+          "toast": "Fehler beim Aktualisieren der Anmeldedaten"
+        }
+      },
+      "modal": {
+        "createTitle": "{source}-Anmeldedaten erstellen",
+        "editTitle": "Anmeldedaten bearbeiten",
+        "updateTitle": "Anmeldedaten aktualisieren"
+      },
+      "modify": {
+        "createButton": {
+          "label": "Erstellen"
+        },
+        "instructions": {
+          "message": "Wählen Sie bei Bedarf Anmeldedaten aus! Stellen Sie sicher, dass Sie Anmeldedaten mit den richtigen Berechtigungen für diesen Konnektor ausgewählt haben!"
+        },
+        "selectButton": {
+          "label": "Auswählen"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "Verbinden"
+        },
+        "connectError": {
+          "title": "Verbindung nicht möglich"
+        },
+        "redirectFailed": {
+          "message": "Wir konnten Sie nicht zur Anmeldung mit {source} weiterleiten. Bitte versuchen Sie es erneut."
+        },
+        "retryButton": {
+          "label": "Erneut versuchen"
+        },
+        "startError": {
+          "message": "OAuth konnte nicht gestartet werden"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "Problem beim Wechseln der Anmeldedaten: {detail}"
+        },
+        "success": {
+          "toast": "Anmeldedaten erfolgreich gewechselt!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "Aktionen"
+        },
+        "created": {
+          "header": "Erstellt"
+        },
+        "edit": {
+          "ariaLabel": "Anmeldedaten bearbeiten"
+        },
+        "empty": {
+          "message": "Für diesen Konnektor sind keine Anmeldedaten vorhanden!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "Zuletzt aktualisiert"
+        },
+        "name": {
+          "header": "Name"
+        },
+        "select": {
+          "label": "Auswählen"
+        },
+        "selected": {
+          "badge": "ausgewählt"
+        },
+        "untitled": {
+          "label": "Ohne Titel"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "Problem beim Aktualisieren der Anmeldedaten"
+        },
+        "success": {
+          "toast": "Anmeldedaten aktualisiert"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "Damit können Sie Ihr eigenes Analytics-Tool mit Onyx nutzen! Kopieren Sie das Web-Snippet Ihres Analytics-Anbieters in das Feld unten, und wir beginnen, Nutzungsereignisse zu senden."
+      },
+      "notEnabled": {
+        "description": "Um benutzerdefinierte Analytics-Skripte einzurichten, wenden Sie sich an das Team, das Onyx eingerichtet hat, um die Umgebungsvariable <i>CUSTOM_ANALYTICS_SECRET_KEY</i> zu setzen.",
+        "title": "Benutzerdefinierte Analytics sind nicht aktiviert."
+      },
+      "script": {
+        "description": "Geben Sie das Javascript an, das beim Laden der Seite ausgeführt werden soll, um Ihr benutzerdefiniertes Tracking/Analytics zu initialisieren.",
+        "instructions": "Fügen Sie die `<script></script>`-Tags nicht ein. Wenn Sie unten ein Skript hochladen, aber keine Ereignisse in Ihrer Analytics-Plattform ankommen, entfernen Sie testweise alle zusätzlichen Leerzeichen vor jeder JavaScript-Zeile.",
+        "label": "Skript"
+      },
+      "secretKey": {
+        "description": "Aus Sicherheitsgründen müssen Sie einen geheimen Schlüssel angeben, um dieses Skript zu aktualisieren. Dies sollte der Wert der Umgebungsvariablen <i>CUSTOM_ANALYTICS_SECRET_KEY</i> sein, die bei der Ersteinrichtung von Onyx gesetzt wurde.",
+        "label": "Geheimer Schlüssel"
+      },
+      "updateButton": {
+        "label": "Aktualisieren"
+      },
+      "updateFailed": {
+        "message": "Benutzerdefiniertes Analytics-Skript konnte nicht aktualisiert werden: \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "Benutzerdefiniertes Analytics-Skript erfolgreich aktualisiert!"
       }
     },
     "discordBot": {
@@ -3059,6 +3528,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "Sammeln..."
+        },
+        "downloading": {
+          "label": "Wird heruntergeladen..."
+        },
+        "export": {
+          "label": "Logs exportieren"
+        },
+        "starting": {
+          "label": "Wird gestartet..."
+        }
+      },
+      "downloadButton": {
+        "label": "Herunterladen"
+      },
+      "exportCard": {
+        "description": "Sammelt Logdateien vom API-Server und den Hintergrund-Workern in einem einzigen Zip-Archiv. Der Download startet automatisch, sobald die Sammlung abgeschlossen ist.",
+        "title": "Logs exportieren"
+      },
+      "header": {
+        "description": "Laden Sie ein Zip-Archiv der Server-Logdateien herunter, um es an einen Onyx-Support-Thread anzuhängen."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "von einem anderen Worker auf demselben Host abgedeckt"
+        },
+        "failed": {
+          "label": "fehlgeschlagen"
+        },
+        "failedWithError": {
+          "label": "fehlgeschlagen: {error}"
+        },
+        "noLogs": {
+          "label": "keine Logdateien gefunden"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {# Datei hochgeladen} other {# Dateien hochgeladen}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "Logdateien können Benutzer-E-Mails, Dokumenttitel, Suchanfragen und Fehlerdaten enthalten. Prüfen Sie den Inhalt, bevor Sie sie außerhalb Ihrer Organisation weitergeben.",
+        "title": "Logs können sensible Daten enthalten"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "Sammlung wird gestartet..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "Ein Log-Export läuft bereits. Versuchen Sie es in Kürze erneut."
+        },
+        "downloadFailed": {
+          "message": "Der Log-Export konnte nicht heruntergeladen werden."
+        },
+        "lostAccess": {
+          "message": "Zugriff auf den laufenden Export verloren. Starten Sie einen neuen."
+        },
+        "startFailed": {
+          "message": "Der Log-Export konnte nicht gestartet werden."
+        },
+        "unreachable": {
+          "message": "Der Server ist zur Prüfung des Exportfortschritts nicht erreichbar. Starten Sie einen neuen Export, sobald er wieder verfügbar ist."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "wird gesammelt..."
+        },
+        "missedDeadline": {
+          "label": "hat sich nicht vor Ablauf der Frist gemeldet"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3165,9 +3711,137 @@
         "loadFailed": "Der Konnektor konnte nicht geladen werden: {details}",
         "title": "Fehler"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "Kanalnamen oder Regex-Muster eingeben und Enter drücken"
+        },
+        "channelsRequired": {
+          "error": "Mindestens ein Kanal ist erforderlich, wenn 'Alle Kanäle durchsuchen' deaktiviert ist"
+        },
+        "configSchemaLoadError": {
+          "message": "Konfigurationsschema konnte nicht geladen werden: {error}"
+        },
+        "configTitle": {
+          "text": "Konfiguration des föderierten Konnektors"
+        },
+        "configuration": {
+          "heading": "Konfiguration"
+        },
+        "create": {
+          "failed": "Föderierter Konnektor konnte nicht erstellt werden",
+          "success": "Föderierter Konnektor erfolgreich erstellt!"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (leer lassen, um den aktuellen Wert zu behalten)"
+        },
+        "credentialValidationFailed": {
+          "message": "Validierung der Zugangsdaten fehlgeschlagen: {message}"
+        },
+        "credentials": {
+          "description": "Gib die Zugangsdaten für diesen Konnektor ein.",
+          "heading": "Zugangsdaten"
+        },
+        "delete": {
+          "failed": "Föderierter Konnektor konnte nicht gelöscht werden",
+          "success": "Föderierter Konnektor erfolgreich gelöscht!"
+        },
+        "deleteConfirm": {
+          "message": "Möchtest du diesen föderierten Konnektor wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+        },
+        "deleteError": {
+          "toast": "Fehler beim Löschen des Konnektors: {error}"
+        },
+        "deleteItem": {
+          "deleting": "Wird gelöscht...",
+          "inProgressTooltip": "Löschung läuft",
+          "label": "Löschen"
+        },
+        "federatedBadge": {
+          "label": "Föderiert"
+        },
+        "federatedTooltip": {
+          "default": "Dies ist ein föderierter Konnektor. Er führt zu höherer Latenz und geringerer Suchqualität als reguläre Konnektoren."
+        },
+        "genericError": {
+          "text": "Fehler: {error}"
+        },
+        "listInput": {
+          "placeholder": "Tippen und Enter drücken, um einen Eintrag hinzuzufügen"
+        },
+        "loadingSchema": {
+          "description": "Erforderliche Felder für diesen Konnektortyp werden abgerufen",
+          "title": "Zugangsdaten-Schema wird geladen..."
+        },
+        "manageButton": {
+          "label": "Verwalten"
+        },
+        "missingFields": {
+          "message": "Fehlende Pflichtfelder: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "Für diesen Konnektortyp ist keine Suchkonfiguration verfügbar."
+        },
+        "noCredentialSchema": {
+          "message": "Für diesen Konnektortyp ist kein Zugangsdaten-Schema verfügbar."
+        },
+        "schemaLoadError": {
+          "message": "Zugangsdaten-Schema konnte nicht geladen werden: {error}"
+        },
+        "submitButton": {
+          "create": "Erstellen",
+          "creating": "Wird erstellt...",
+          "update": "Aktualisieren",
+          "updating": "Wird aktualisiert..."
+        },
+        "title": {
+          "edit": "{name} bearbeiten",
+          "setup": "{name} einrichten"
+        },
+        "update": {
+          "failed": "Föderierter Konnektor konnte nicht aktualisiert werden",
+          "success": "Föderierter Konnektor erfolgreich aktualisiert!"
+        },
+        "validateBeforeEdit": {
+          "message": "Gib vor der Validierung neue Zugangsdaten ein."
+        },
+        "validateButton": {
+          "label": "Validieren",
+          "validating": "Wird validiert..."
+        },
+        "validation": {
+          "error": "Validierungsfehler: {error}",
+          "failedStatus": "Validierung fehlgeschlagen: {statusText}",
+          "invalid": "Zugangsdaten sind ungültig",
+          "valid": "Zugangsdaten sind gültig"
+        }
+      },
       "loading": {
         "description": "Konnektordetails und Schema der Anmeldedaten werden abgerufen",
         "title": "Konnektorkonfiguration wird geladen..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "Zurück zum Chat"
+      },
+      "error": {
+        "title": "Etwas ist schiefgelaufen"
+      },
+      "errors": {
+        "clientSecret": "Anmeldedaten fehlen oder sind ungültig",
+        "oauth": "OAuth-Autorisierung fehlgeschlagen",
+        "validation": "Konfigurationsfehler - bitte prüfen Sie Ihre Konnektor-Einstellungen"
+      },
+      "processing": {
+        "details": "Bitte warten Sie, während wir die Einrichtung abschließen.",
+        "title": "Wird verarbeitet..."
+      },
+      "redirecting": {
+        "text": "Weiterleitung zum Chat in 2 Sekunden..."
+      },
+      "success": {
+        "detailsTemplate": "Ihre {serviceName}-Autorisierung wurde erfolgreich abgeschlossen. Sie können diesen Konnektor jetzt für die Suche verwenden.",
+        "title": "Erfolg!"
       }
     },
     "groups": {
@@ -3430,6 +4104,265 @@
           "header": "Token-Limit",
           "placeholder": "Token-Limit (Tausend)",
           "unit": "(Tausend)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "Hook löschen",
+          "tooltip": "Löschen"
+        },
+        "disconnect": {
+          "ariaLabel": "Hook deaktivieren",
+          "tooltip": "Hook trennen"
+        },
+        "disconnectedSuffix": {
+          "label": "(Getrennt)"
+        },
+        "hookPoint": {
+          "description": "Hook-Punkt: {name}"
+        },
+        "manage": {
+          "ariaLabel": "Hook konfigurieren",
+          "tooltip": "Verwalten"
+        },
+        "reconnectButton": {
+          "label": "Wieder verbinden"
+        },
+        "test": {
+          "ariaLabel": "Hook erneut validieren",
+          "tooltip": "Verbindung testen"
+        }
+      },
+      "connectButton": {
+        "label": "Verbinden"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "Hook ***{name}*** wird dauerhaft von diesem Hook-Punkt entfernt. Der externe Endpunkt kann zuvor gesendete Daten weiterhin speichern."
+        },
+        "delete": {
+          "label": "Löschen"
+        },
+        "header": {
+          "title": "*{name}* löschen"
+        },
+        "permanent": {
+          "description": "Das Löschen kann nicht rückgängig gemacht werden."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyx ruft diesen Endpunkt für Hook ***{name}*** nicht mehr auf. Laufende Anfragen werden weiter ausgeführt. Der externe Endpunkt kann zuvor gesendete Daten weiterhin speichern. Sie können diesen Hook bei Bedarf später wieder verbinden."
+        },
+        "deleteNote": {
+          "description": "Sie können diesen Hook auch löschen. Das Löschen kann nicht rückgängig gemacht werden."
+        },
+        "disconnect": {
+          "label": "Trennen"
+        },
+        "disconnectAndDelete": {
+          "label": "Trennen & löschen"
+        },
+        "header": {
+          "title": "*{name}* trennen"
+        }
+      },
+      "docsLink": {
+        "label": "Dokumentation"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyx verwendet diesen Schlüssel zur Authentifizierung bei Ihrem API-Endpunkt.",
+          "keepCurrent": {
+            "placeholder": "Leer lassen, um den aktuellen Schlüssel zu behalten"
+          },
+          "title": "API-Schlüssel"
+        },
+        "connectionValid": {
+          "label": "Verbindung gültig."
+        },
+        "createHeader": {
+          "description": "Verbinden Sie einen externen API-Endpunkt, um den Hook-Punkt zu erweitern.",
+          "title": "Hook-Erweiterung einrichten"
+        },
+        "editHeader": {
+          "title": "Hook-Erweiterung verwalten"
+        },
+        "endpoint": {
+          "description": "Verbinden Sie sich nur mit Servern, denen Sie vertrauen. Sie sind für die durchgeführten Aktionen und die über diese Verbindung geteilten Daten verantwortlich.",
+          "title": "Externe API-Endpunkt-URL"
+        },
+        "errors": {
+          "connect": "Verbindung zum Endpunkt nicht möglich.",
+          "generic": "Etwas ist schiefgelaufen.",
+          "invalidApiKey": "Ungültiger API-Schlüssel.",
+          "timeout": "Zeitüberschreitung der Verbindung. Versuchen Sie, das Timeout zu erhöhen."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(Standard)"
+          },
+          "hard": {
+            "label": "Pipeline bei Fehler blockieren"
+          },
+          "placeholder": "Strategie auswählen",
+          "soft": {
+            "label": "Fehler protokollieren und fortfahren"
+          },
+          "title": "Fehlerstrategie"
+        },
+        "hookPoint": {
+          "label": "Hook-Punkt"
+        },
+        "name": {
+          "placeholder": "Benennen Sie Ihre Erweiterung an diesem Hook-Punkt",
+          "title": "Anzeigename"
+        },
+        "save": {
+          "label": "Änderungen speichern"
+        },
+        "softStrategy": {
+          "description": "Wenn der Endpunkt einen Fehler zurückgibt, protokolliert Onyx ihn und setzt die Pipeline normal fort, wobei das Hook-Ergebnis ignoriert wird."
+        },
+        "timeout": {
+          "description": "Maximale Zeit, die Onyx auf eine Antwort des Endpunkts wartet, bevor die Fehlerstrategie angewendet wird. Muss größer als 0 und höchstens {max} Sekunden sein.",
+          "revert": {
+            "tooltip": "Auf Standard zurücksetzen"
+          },
+          "suffix": "(Sekunden)",
+          "title": "Timeout"
+        },
+        "toasts": {
+          "created": {
+            "message": "Hook erstellt."
+          },
+          "noHookPoint": {
+            "message": "Kein Hook-Punkt angegeben."
+          },
+          "updated": {
+            "message": "Hook aktualisiert."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "Der API-Schlüssel darf nicht leer sein.",
+          "endpointRequired": "Die Endpunkt-URL darf nicht leer sein.",
+          "nameRequired": "Der Anzeigename darf nicht leer sein.",
+          "timeoutRange": "Muss größer als 0 und höchstens {max} Sekunden sein.",
+          "timeoutRequired": "Timeout ist erforderlich."
+        },
+        "verifying": {
+          "label": "Verbindung wird überprüft…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "Kopieren"
+        },
+        "download": {
+          "tooltip": "Herunterladen"
+        },
+        "empty": {
+          "message": "Keine Fehler in den letzten 30 Tagen."
+        },
+        "header": {
+          "description": "Hook: {name} • Hook-Punkt: {point}",
+          "title": "Aktuelle Fehler"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# Zeile} other {# Zeilen}}"
+        },
+        "loadFailed": {
+          "message": "Logs konnten nicht geladen werden."
+        },
+        "older": {
+          "label": "Ältere"
+        },
+        "pastHour": {
+          "label": "Letzte Stunde"
+        },
+        "unknownError": {
+          "label": "Unbekannter Fehler"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "Abbrechen"
+        }
+      },
+      "page": {
+        "description": "Erweitern Sie Onyx-Pipelines, indem Sie externe API-Endpunkte als Callbacks an vordefinierten Hook-Punkten registrieren.",
+        "empty": {
+          "title": "Keine Hook-Punkte verfügbar"
+        },
+        "emptySearch": {
+          "description": "Versuchen Sie einen anderen Suchbegriff.",
+          "title": "Keine Ergebnisse gefunden"
+        },
+        "enterpriseRequired": {
+          "message": "Hook-Erweiterungen erfordern eine Enterprise-Lizenz."
+        },
+        "loadHooksFailed": {
+          "message": "Hooks konnten nicht geladen werden. Bitte aktualisieren Sie die Seite."
+        },
+        "loadSpecsFailed": {
+          "message": "Hook-Spezifikationen konnten nicht geladen werden. Bitte aktualisieren Sie die Seite."
+        },
+        "notEnabled": {
+          "message": "Hook-Erweiterungen sind für diese Bereitstellung nicht aktiviert."
+        },
+        "search": {
+          "placeholder": "Hooks suchen..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "Verbunden"
+        },
+        "connectionLost": {
+          "label": "Verbindung verloren"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# Fehler} other {# Fehler}}"
+        },
+        "noError": {
+          "title": "Kein Fehler"
+        },
+        "pastHour": {
+          "description": "in der letzten Stunde"
+        },
+        "recentErrors": {
+          "title": "Neueste Fehler"
+        },
+        "viewMore": {
+          "label": "Mehr Zeilen anzeigen"
+        },
+        "viewOlder": {
+          "label": "Ältere Fehler anzeigen"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "Hook konnte nicht deaktiviert werden."
+        },
+        "deleteFailed": {
+          "message": "Hook konnte nicht gelöscht werden."
+        },
+        "disconnectFailed": {
+          "message": "Hook konnte nicht getrennt werden."
+        },
+        "reconnectFailed": {
+          "message": "Hook konnte nicht wieder verbunden werden."
+        },
+        "validateFailed": {
+          "message": "Hook konnte nicht validiert werden."
+        },
+        "validateSuccess": {
+          "message": "Hook erfolgreich validiert."
+        },
+        "validationFailed": {
+          "message": "Validierung fehlgeschlagen: {status}"
         }
       }
     },
@@ -4309,6 +5242,9 @@
               "label": "Zeile hinzufügen"
             },
             "description": "Fügen Sie weitere Eigenschaften hinzu, die der Modellanbieter benötigt. Diese werden dem `completion()`-Aufruf von LiteLLM als [Umgebungsvariablen](https://docs.litellm.ai/docs/set_keys#environment-variables) übergeben. Weitere Anweisungen finden Sie in der [Dokumentation](https://docs.onyx.app/admins/ai_models/custom_inference_provider).",
+            "keyInput": {
+              "placeholder": "z. B. OPENAI_ORGANIZATION"
+            },
             "title": "Umgebungsvariablen"
           },
           "modelRow": {
@@ -4820,6 +5756,132 @@
         "title": "Benutzer"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "Unbekannt"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "KI"
+        },
+        "errorTitle": {
+          "title": "Etwas ist schiefgelaufen :("
+        },
+        "feedback": {
+          "title": "Feedback"
+        },
+        "fetchFailed": {
+          "message": "Chat-Sitzung konnte nicht geladen werden - {error}"
+        },
+        "header": {
+          "title": "Details der Chat-Sitzung"
+        },
+        "referenceDocuments": {
+          "title": "Referenzdokumente"
+        },
+        "user": {
+          "label": "Benutzer"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "Abbrechen"
+        },
+        "downloadFailed": {
+          "message": "Der Abfrageverlauf konnte nicht heruntergeladen werden."
+        },
+        "generating": {
+          "message": "CSV-Bericht wird erstellt. Klicken Sie auf \"{button}\", um alle Aufträge zu sehen."
+        },
+        "kickoff": {
+          "label": "Export starten"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "Fehlgeschlagen"
+        },
+        "pending": {
+          "label": "Ausstehend"
+        },
+        "success": {
+          "label": "Erfolgreich"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "Herunterladen"
+        },
+        "endRange": {
+          "header": "Ende des Zeitraums"
+        },
+        "generatedAt": {
+          "header": "Erstellt am"
+        },
+        "header": {
+          "title": "Frühere Exporte des Abfrageverlaufs"
+        },
+        "notReady": {
+          "tooltip": "Der Export ist noch nicht bereit"
+        },
+        "startRange": {
+          "header": "Beginn des Zeitraums"
+        },
+        "status": {
+          "header": "Status"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "Gefällt mir nicht"
+        },
+        "like": {
+          "label": "Gefällt mir"
+        },
+        "mixed": {
+          "label": "Gemischt"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "Alle"
+        },
+        "feedbackType": {
+          "label": "Feedback-Typ"
+        }
+      },
+      "previousExports": {
+        "label": "Exporte anzeigen"
+      },
+      "table": {
+        "date": {
+          "header": "Datum"
+        },
+        "feedback": {
+          "header": "Feedback"
+        },
+        "fetchError": {
+          "title": "Fehler beim Laden des Abfrageverlaufs"
+        },
+        "firstAiResponse": {
+          "header": "Erste KI-Antwort"
+        },
+        "firstUserMessage": {
+          "header": "Erste Benutzernachricht"
+        },
+        "persona": {
+          "header": "Persona"
+        },
+        "user": {
+          "header": "Benutzer"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4874,6 +5936,56 @@
         "generateFailed": "Der Token konnte nicht erzeugt werden: {detail}",
         "genericError": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
         "regenerated": "Token neu erzeugt"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "Die Klassifizierung der Anfrage ist fehlgeschlagen. Es wird auf den Chat zurückgegriffen."
+        },
+        "searchFailed": {
+          "message": "Die Dokumentsuche ist fehlgeschlagen. Bitte versuchen Sie es erneut."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# Ergebnis} other {# Ergebnisse}}"
+        },
+        "empty": {
+          "description": "Prüfen Sie Ihre Konnektoren/Filter oder versuchen Sie einen anderen Suchbegriff.",
+          "title": "Keine Ergebnisse gefunden"
+        },
+        "failed": {
+          "title": "Suche fehlgeschlagen"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# Tag} other {# Tags}}"
+        },
+        "empty": {
+          "label": "Tags"
+        },
+        "search": {
+          "placeholder": "Tags filtern..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "Gesamter Zeitraum"
+        },
+        "day": {
+          "label": "Letzte 24 Stunden"
+        },
+        "month": {
+          "label": "Letzter Monat"
+        },
+        "week": {
+          "label": "Letzte Woche"
+        },
+        "year": {
+          "label": "Letztes Jahr"
+        }
       }
     },
     "security": {
@@ -5765,6 +6877,163 @@
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "Kategorie {name} entfernen"
+        },
+        "removeButton": {
+          "ariaLabel": "Kategorie entfernen"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "Kategorien für Standardantworten"
+        },
+        "fetchError": {
+          "message": "Kategorien für Standardantworten konnten nicht geladen werden - {message}",
+          "title": "Etwas ist schiefgelaufen :("
+        },
+        "search": {
+          "placeholder": "Kategorien suchen..."
+        }
+      },
+      "editPage": {
+        "title": "Standardantwort bearbeiten"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "Standardantworten konnten nicht geladen werden"
+        },
+        "fetchCategoriesFailed": {
+          "message": "Kategorien der Standardantworten konnten nicht geladen werden"
+        },
+        "genericTitle": {
+          "title": "Etwas ist schiefgelaufen :("
+        },
+        "loadAnswersFailed": {
+          "title": "Fehler beim Laden der Standardantworten"
+        },
+        "loadCategoriesFailed": {
+          "title": "Fehler beim Laden der Kategorien der Standardantworten"
+        },
+        "notFound": {
+          "message": "Keine Standardantwort mit ID {id} gefunden"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "Alle Kategorien"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "Alle diese Schlüsselwörter, in beliebiger Reihenfolge, durch Leerzeichen getrennt",
+          "placeholder": "IT-Ticket"
+        },
+        "answer": {
+          "label": "Antwort",
+          "placeholder": "Die Antwort in Markdown. Beispiel: Wenn Sie Hilfe vom IT-Team benötigen, schreiben Sie an internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "Beliebige dieser Schlüsselwörter, durch Leerzeichen getrennt",
+          "placeholder": "Ticket Problem Störung"
+        },
+        "categories": {
+          "label": "Kategorien:",
+          "placeholder": "Kategorie eingeben und Enter drücken…"
+        },
+        "createButton": {
+          "label": "Erstellen!"
+        },
+        "keywords": {
+          "tooltip": "Eine Frage muss diesen Schlüsselwörtern entsprechen, um die Antwort auszulösen."
+        },
+        "matchRegex": {
+          "description": "Ein Regex-Muster statt eines exakten Schlüsselworts abgleichen",
+          "label": "Regex abgleichen"
+        },
+        "regexPattern": {
+          "label": "Regex-Muster",
+          "tooltip": "Wird ausgelöst, wenn die Frage diesem Regex-Muster entspricht (mit Pythons `re.search()`)"
+        },
+        "strategy": {
+          "all": {
+            "label": "Alle Schlüsselwörter"
+          },
+          "any": {
+            "label": "Beliebige Schlüsselwörter"
+          },
+          "description": "Wählen Sie, ob die Frage des Benutzers einige oder alle der obigen Schlüsselwörter enthalten muss, damit diese Antwort angezeigt wird.",
+          "label": "Strategie zur Schlüsselworterkennung"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "Fehler beim Erstellen der Kategorie \"{name}\" - {error}"
+          },
+          "createFailed": {
+            "message": "Fehler beim Erstellen der Standardantwort - {error}"
+          },
+          "updateFailed": {
+            "message": "Fehler beim Aktualisieren der Standardantwort - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "Aktualisieren!"
+        },
+        "validation": {
+          "answerRequired": "Antwort ist erforderlich",
+          "categoryRequired": "Mindestens eine Kategorie ist erforderlich",
+          "keywordRequired": "Schlüsselwörter oder Muster sind erforderlich"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "Fügen Sie unten Ihre erste Standardantwort hinzu!"
+        },
+        "description": "Verwalten Sie die Standardantworten für vordefinierte Fragen.\nHinweis: Derzeit können nur über Slack gestellte Fragen Standardantworten erhalten."
+      },
+      "newStandardAnswer": {
+        "label": "Neue Standardantwort"
+      },
+      "search": {
+        "placeholder": "Standardantworten nach Schlüsselwort/Phrase suchen..."
+      },
+      "table": {
+        "answer": {
+          "header": "Antwort"
+        },
+        "categories": {
+          "header": "Kategorien"
+        },
+        "empty": {
+          "message": "Keine passenden Standardantworten gefunden..."
+        },
+        "keywords": {
+          "header": "Schlüsselwörter/Muster"
+        },
+        "matchRegex": {
+          "header": "Regex-Abgleich?"
+        },
+        "matchRegexNo": {
+          "label": "Nein"
+        },
+        "matchRegexYes": {
+          "label": "Ja"
+        },
+        "slackNote": {
+          "message": "Stellen Sie sicher, dass Sie die Kategorie dem entsprechenden [Slack-Bot](/admin/bots) hinzugefügt haben."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "Standardantwort konnte nicht gelöscht werden - {error}"
+        },
+        "deleted": {
+          "message": "Standardantwort {id} gelöscht"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "Abgebrochen",
@@ -5795,6 +7064,142 @@
       },
       "webVersion": {
         "label": "Web-Version: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "Zeigt eine dauerhafte Systemankündigung an, die Benutzer schließen können.",
+        "header": {
+          "placeholder": "Ankündigung hinzufügen"
+        },
+        "label": "Systemankündigung"
+      },
+      "announcementPopup": {
+        "description": "Diesen Hinweis beim ersten Besuch aller Benutzer zusätzlich als Vollbild-Pop-up anzeigen. Mit Vorsicht verwenden.",
+        "label": "Pop-up-Hinweis beim ersten Besuch"
+      },
+      "appName": {
+        "description": "Dieser Name wird in der gesamten App angezeigt und ersetzt \"Onyx\" in der Benutzeroberfläche.",
+        "label": "Anzeigename der Anwendung"
+      },
+      "branding": {
+        "description": "Entfernen Sie \"powered by Onyx\" und andere Onyx-Branding-Elemente in der App.",
+        "enterpriseTooltip": "Das Ausblenden des Onyx-Brandings ist eine Funktion des Enterprise-Plans.",
+        "label": "Onyx-Branding ausblenden"
+      },
+      "chatFooter": {
+        "description": "Fügen Sie Markdown-Inhalte für Haftungsausschlüsse oder zusätzliche Informationen hinzu.",
+        "label": "Text der Chat-Fußzeile"
+      },
+      "chatHeader": {
+        "label": "Text der Chat-Kopfzeile"
+      },
+      "consent": {
+        "description": "Verlangt, dass der Benutzer den Hinweis liest und ihm zustimmt, bevor er auf die Anwendung zugreift.",
+        "label": "Zustimmung zum Hinweis verlangen"
+      },
+      "consentPrompt": {
+        "label": "Zustimmungsaufforderung zum Hinweis"
+      },
+      "firstVisit": {
+        "description": "Zeigt neuen Benutzern beim ersten Besuch ein einmaliges Pop-up an.",
+        "label": "Hinweis beim ersten Besuch anzeigen"
+      },
+      "greeting": {
+        "description": "Fügen Sie der Startseite eine kurze Nachricht hinzu.",
+        "label": "Begrüßungsnachricht"
+      },
+      "helpLink": {
+        "description": "Fügen Sie im Benutzermenü zusätzlich zur Onyx-Dokumentation einen benutzerdefinierten Hilfelink hinzu.",
+        "enterpriseTooltip": "Der benutzerdefinierte Hilfelink ist eine Funktion des Enterprise-Plans.",
+        "label": "Benutzerdefinierter Hilfelink"
+      },
+      "helpLinkLabel": {
+        "label": "Beschriftung des benutzerdefinierten Hilfelinks",
+        "placeholder": "Link-Beschriftung"
+      },
+      "loginSubtitle": {
+        "description": "Ersetzen Sie den Untertitel unter der Willkommensüberschrift auf der Anmeldeseite.",
+        "label": "Untertitel der Anmeldeseite"
+      },
+      "logo": {
+        "label": "Anwendungslogo",
+        "updateButton": {
+          "label": "Aktualisieren"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "Logo & Name",
+          "tooltip": "Zeigt sowohl das Logo als auch den Namen Ihrer Anwendung an."
+        },
+        "description": "Wählen Sie, was oben in der Seitenleiste angezeigt wird. Die Optionen werden verfügbar, sobald Sie ein Logo oder einen Anwendungsnamen hinzufügen.",
+        "label": "Anzeigestil des Logos",
+        "logoOnly": {
+          "disabledTooltip": "Laden Sie ein Logo hoch, um diese Option zu aktivieren.",
+          "label": "Nur Logo",
+          "tooltip": "Zeigt nur das Logo Ihrer Anwendung an."
+        },
+        "nameOnly": {
+          "disabledTooltip": "Geben Sie einen Anwendungsnamen ein, um diese Option zu aktivieren.",
+          "label": "Nur Name",
+          "tooltip": "Zeigt nur den Namen Ihrer Anwendung an."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "Markdown-Inhalt hinzufügen"
+      },
+      "noticeContent": {
+        "label": "Hinweis-Inhalt"
+      },
+      "noticeHeader": {
+        "label": "Hinweis-Überschrift"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "Ankündigung konnte nicht entfernt werden."
+        },
+        "announcementSaveFailed": {
+          "message": "Ankündigung konnte nicht gespeichert werden."
+        },
+        "applyButton": {
+          "label": "Änderungen übernehmen"
+        },
+        "applying": {
+          "label": "Wird übernommen..."
+        },
+        "description": "Passen Sie an, wie die Anwendung für die Benutzer Ihrer Organisation aussieht.",
+        "logoUploadFailed": {
+          "message": "Logo konnte nicht hochgeladen werden. {error}"
+        },
+        "saveSuccess": {
+          "message": "Darstellungseinstellungen erfolgreich gespeichert!"
+        },
+        "settingsSaveFailed": {
+          "message": "Einstellungen konnten nicht aktualisiert werden. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "Zustimmungsaufforderung zum Hinweis ist erforderlich",
+          "invalidUrl": "Muss eine gültige URL sein",
+          "maxChars": "Maximal {count} Zeichen",
+          "noticeContentRequired": "Hinweis-Inhalt ist erforderlich",
+          "noticeHeaderRequired": "Hinweis-Überschrift ist erforderlich",
+          "urlRequiredWithLabel": "URL ist erforderlich, wenn eine Beschriftung gesetzt ist"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "Inhalt der Chat-Fußzeile"
+        },
+        "chatHeader": {
+          "placeholder": "Inhalt der Chat-Kopfzeile"
+        },
+        "greeting": {
+          "placeholder": "Willkommen bei Acme Chat"
+        },
+        "logo": {
+          "alt": "Logo"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6059,6 +7464,9 @@
             "label": "Ausgaben"
           }
         }
+      },
+      "page": {
+        "description": "Überwachen Sie die Ausgaben des Arbeitsbereichs und prüfen Sie die Nutzung pro Benutzer."
       },
       "spendByUser": {
         "columns": {
@@ -6656,6 +8064,204 @@
         "tooltip": "Agenten-Statistiken anzeigen"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "Generieren und führen Sie Code aus.",
+          "title": "Code-Interpreter"
+        },
+        "codingAgent": {
+          "description": "Untersuchen Sie ein GitHub-Repository und beantworten Sie Fragen zu dessen Code.",
+          "title": "Coding-Agent"
+        },
+        "description": "Tools und Fähigkeiten, die dieser Agent nutzen kann.",
+        "imageGeneration": {
+          "description": "Erstellen und bearbeiten Sie Bilder mit KI-gestützten Tools.",
+          "title": "Bildgenerierung",
+          "unavailable": {
+            "tooltip": "Die Bildgenerierung erfordert ein konfiguriertes Modell. Wenn Sie Zugriff haben, richten Sie eines unter Einstellungen > Bildgenerierung ein oder fragen Sie einen Administrator."
+          }
+        },
+        "openUrl": {
+          "description": "Rufen Sie Inhalte von Web-URLs ab und lesen Sie sie.",
+          "title": "URL öffnen"
+        },
+        "title": "Aktionen",
+        "webSearch": {
+          "description": "Durchsuchen Sie das Web nach Echtzeitinformationen und aktuellen Ergebnissen.",
+          "title": "Websuche"
+        }
+      },
+      "advanced": {
+        "description": "Feinabstimmung der Prompts und des Wissens des Agenten.",
+        "overwritePrompt": {
+          "suffix": "(Nicht empfohlen)",
+          "title": "System-Prompt überschreiben"
+        },
+        "reminders": {
+          "description": "Hängen Sie eine kurze Erinnerung an die Prompt-Nachrichten an. Verwenden Sie dies, um den Agenten zu erinnern, wenn er bestimmte Anweisungen im Laufe des Chats vergisst. Sie sollte kurz sein und die Benutzernachrichten nicht stören.",
+          "placeholder": "Denken Sie daran, ich möchte, dass Sie Ihre Antwort immer als nummerierte Liste formatieren.",
+          "title": "Erinnerungen"
+        },
+        "title": "Erweiterte Optionen"
+      },
+      "avatar": {
+        "edit": {
+          "label": "Bearbeiten"
+        },
+        "uploadImage": {
+          "label": "Bild hochladen"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "Agent löschen"
+        },
+        "description": "Jeder, der diesen Agenten verwendet, kann nicht mehr darauf zugreifen.",
+        "title": "Diesen Agenten löschen"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "Möchten Sie diesen Agenten wirklich löschen?",
+          "warning": "Jeder, der diesen Agenten verwendet, kann nicht mehr darauf zugreifen. Das Löschen kann nicht rückgängig gemacht werden."
+        },
+        "title": "Agent löschen"
+      },
+      "filesModal": {
+        "description": "Alle für diesen Agenten ausgewählten Dateien",
+        "placeholderName": "Datei {id}",
+        "title": "Benutzerdateien"
+      },
+      "general": {
+        "avatar": {
+          "title": "Agenten-Avatar"
+        },
+        "descriptionField": {
+          "placeholder": "Was macht dieser Agent?",
+          "title": "Beschreibung"
+        },
+        "name": {
+          "placeholder": "Benennen Sie Ihren Agenten",
+          "title": "Name"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "Abbrechen"
+        },
+        "create": {
+          "label": "Erstellen"
+        },
+        "createTitle": "Agent erstellen",
+        "editTitle": "Agent bearbeiten",
+        "save": {
+          "label": "Speichern"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "Sie haben keinen Zugriff mehr auf diesen MCP-Server. Seine vorhandenen Tools bleiben erhalten."
+        },
+        "searchTools": {
+          "placeholder": "Tools suchen..."
+        }
+      },
+      "page": {
+        "ariaLabel": "Agenten-Editor-Seite"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "Fügen Sie Anweisungen hinzu, um die Antworten dieses Agenten anzupassen.",
+          "placeholder": "Denken Sie Schritt für Schritt und zeigen Sie die Argumentation bei komplexen Problemen. Verwenden Sie konkrete Beispiele. Betonen Sie Aktionspunkte und lassen Sie Lücken, die der Mensch bei Unbekanntem ausfüllen kann. Verwenden Sie einen höflichen, begeisterten Ton.",
+          "title": "Anweisungen"
+        },
+        "starters": {
+          "description": "Beispielnachrichten, die Benutzern helfen zu verstehen, was dieser Agent kann und wie sie effektiv mit ihm interagieren.",
+          "title": "Gesprächseinstiege"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "Bitte beheben Sie die Fehler im Formular, bevor Sie speichern.",
+        "noChanges": "Es wurden keine Änderungen vorgenommen.",
+        "saving": "Änderungen werden gespeichert...",
+        "uploading": "Bitte warten Sie, bis die Dateien fertig hochgeladen sind."
+      },
+      "share": {
+        "feature": {
+          "description": "Zeigen Sie diesen Agenten oben in der Agenten-Übersicht an und heften Sie ihn für neue Benutzer mit Zugriff automatisch an die Seitenleiste.",
+          "privateNotice": {
+            "title": "Dieser Agent ist privat und wird nur für Sie empfohlen."
+          },
+          "title": "Diesen Agenten empfehlen",
+          "unlistedWarning": {
+            "title": "Dieser Agent ist nicht gelistet und wird nicht in der Empfohlen-Liste angezeigt."
+          }
+        },
+        "labels": {
+          "description": "Fügen Sie Labels und Kategorien hinzu, damit dieser Agent besser gefunden wird.",
+          "placeholder": "Labels hinzufügen..."
+        },
+        "share": {
+          "button": {
+            "label": "Teilen"
+          },
+          "description": "mit anderen Benutzern, Gruppen oder allen in Ihrer Organisation.",
+          "title": "Diesen Agenten teilen"
+        },
+        "title": "Agent teilen"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "Stelle eine Liste unserer Engineering-Ziele für dieses Quartal zusammen.",
+          "overview": "Gib mir einen Überblick über einige Dokumente.",
+          "salesReport": "Finde den neuesten Verkaufsbericht.",
+          "todayGoals": "Fasse meine heutigen Ziele zusammen."
+        },
+        "placeholder": "Geben Sie einen Gesprächseinstieg ein..."
+      },
+      "suffix": {
+        "optional": "optional"
+      },
+      "toasts": {
+        "createFailed": "Agent konnte nicht erstellt werden - {detail}",
+        "created": "Agent „{name}“ erfolgreich erstellt",
+        "deleteFailed": "Agent konnte nicht gelöscht werden: {error}",
+        "deleted": "Agent erfolgreich gelöscht",
+        "genericError": "Ein Fehler ist aufgetreten: {error}",
+        "noResponse": "keine Antwort erhalten",
+        "sharingFailed": "Agent erstellt, aber die Freigabe ist fehlgeschlagen: {error}",
+        "toggleListedFailed": "Sichtbarkeit konnte nicht umgeschaltet werden",
+        "unknownDetail": "unbekannter Fehler",
+        "unknownError": "Unbekannter Fehler",
+        "updateFailed": "Agent konnte nicht aktualisiert werden - {detail}",
+        "updated": "Agent „{name}“ erfolgreich aktualisiert"
+      },
+      "validation": {
+        "cutoffInFuture": "Das Wissensstichdatum muss heute oder früher sein.",
+        "descriptionMax": "Die Beschreibung darf höchstens {max} Zeichen lang sein",
+        "nameRequired": "Der Agentenname ist erforderlich.",
+        "starterMax": "Der Gesprächseinstieg darf höchstens {max} Zeichen lang sein"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "Agent wieder listen"
+          },
+          "description": "Wieder gelistete Agenten erscheinen erneut in der Agenten-Übersicht.",
+          "title": "Diesen Agenten wieder listen"
+        },
+        "unlist": {
+          "button": {
+            "label": "Agent auslisten"
+          },
+          "description": "Ausgelistete Agenten erscheinen nicht in der Agenten-Übersicht, bleiben aber zugänglich.",
+          "title": "Diesen Agenten auslisten"
+        }
+      },
+      "warnings": {
+        "openUrl": "Websuche ohne die Möglichkeit, URLs zu öffnen, kann zu deutlich schlechteren webbasierten Ergebnissen führen."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6838,6 +8444,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {Agent} other {Agenten}}"
+      },
+      "empty": {
+        "description": "Keine Agenten gefunden"
+      },
+      "header": {
+        "description": "Passen Sie das Verhalten und Wissen der KI für Ihre Anwendungsfälle und die Ihres Teams an.",
+        "title": "Agenten"
+      },
+      "newAgent": {
+        "label": "Neuer Agent",
+        "noPermission": {
+          "tooltip": "Sie haben keine Berechtigung, Agenten zu erstellen. Wenden Sie sich an Ihren Administrator, um Zugriff anzufordern."
+        }
+      },
+      "page": {
+        "ariaLabel": "Agenten-Seite"
+      },
+      "search": {
+        "placeholder": "Agenten suchen..."
+      },
+      "sections": {
+        "all": {
+          "title": "Alle Agenten"
+        },
+        "featured": {
+          "description": "Von Ihrem Team ausgewählt",
+          "title": "Empfohlene Agenten"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "Alle Agenten"
+        },
+        "your": {
+          "label": "Ihre Agenten"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "Benutzervariable einfügen"
@@ -6845,6 +8492,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "Bitte warten Sie, während wir Ihre anonyme Sitzung einrichten.",
+        "title": "Sie werden zur Chat-Seite weitergeleitet ..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "Neue Organisation erstellen"
@@ -6866,6 +8519,55 @@
       },
       "signInLink": {
         "label": "Anmelden"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "Mit der angegebenen E-Mail-Adresse existiert bereits ein Konto."
+      },
+      "continueAsGuest": {
+        "label": "oder als Gast fortfahren"
+      },
+      "email": {
+        "label": "E-Mail-Adresse",
+        "placeholder": "email@ihrunternehmen.de"
+      },
+      "forgotPassword": {
+        "link": "[Passwort vergessen?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "Ungültige E-Mail-Adresse oder ungültiges Passwort"
+      },
+      "noPassword": {
+        "error": "Erstellen Sie ein Konto, um ein Passwort festzulegen"
+      },
+      "password": {
+        "label": "Passwort",
+        "placeholder": "Passwort"
+      },
+      "passwordDigit": {
+        "error": "Das Passwort muss mindestens eine Zahl enthalten"
+      },
+      "passwordLength": {
+        "error": "Das Passwort muss zwischen {min} und {max} Zeichen lang sein"
+      },
+      "passwordLoginDisabled": {
+        "error": "Die Passwort-Anmeldung ist deaktiviert. Melden Sie sich über Ihren Identitätsanbieter an."
+      },
+      "passwordLowercase": {
+        "error": "Das Passwort muss mindestens einen Kleinbuchstaben enthalten"
+      },
+      "passwordRequirements": {
+        "label": "Passwortanforderungen:"
+      },
+      "passwordSpecialChar": {
+        "error": "Das Passwort muss mindestens ein Sonderzeichen enthalten"
+      },
+      "passwordUppercase": {
+        "error": "Das Passwort muss mindestens einen Großbuchstaben enthalten"
+      },
+      "tooManyRequests": {
+        "error": "Zu viele Anfragen. Bitte versuchen Sie es später erneut."
       }
     },
     "error": {
@@ -6906,6 +8608,31 @@
         "description": "Vorübergehende Störung des Authentifizierungssystems"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "Für dein Team ist der anonyme Zugriff nicht aktiviert."
+      },
+      "generic": {
+        "toast": "Ein Fehler ist aufgetreten."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "Konto erstellen"
+      },
+      "logo": {
+        "alt": "Logo"
+      },
+      "signInLink": {
+        "label": "Anmelden"
+      },
+      "signinPrompt": {
+        "text": "Hast du bereits ein Konto?"
+      },
+      "signupPrompt": {
+        "text": "Neu bei {appName}?"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[Zurück zur Anmeldung](/auth/login)"
@@ -6938,7 +8665,8 @@
         "placeholder": "API-Schlüssel eingeben"
       },
       "emailField": {
-        "label": "E-Mail"
+        "label": "E-Mail",
+        "placeholder": "email@ihrefirma.com"
       },
       "genericError": {
         "toast": "Benutzer konnte nicht übernommen werden"
@@ -6999,6 +8727,23 @@
         "label": "Geschäftliche E-Mail"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "Enthält eine Zahl."
+      },
+      "length": {
+        "label": "{min}–{max} Zeichen"
+      },
+      "lowercase": {
+        "label": "Enthält einen Kleinbuchstaben."
+      },
+      "specialChar": {
+        "label": "Enthält ein Sonderzeichen."
+      },
+      "uppercase": {
+        "label": "Enthält einen Großbuchstaben."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[Zurück zur Anmeldung](/auth/login)"
@@ -7040,6 +8785,31 @@
       },
       "unexpectedError": {
         "toast": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an, um fortzufahren."
+      },
+      "loginButton": {
+        "label": "Anmelden"
+      },
+      "modal": {
+        "title": "Sie wurden abgemeldet"
+      },
+      "terminated": {
+        "message": "Diese Sitzung wurde abgemeldet. Bitte melden Sie sich erneut an, um fortzufahren."
+      },
+      "unrecognized": {
+        "message": "Sie wurden unerwartet abgemeldet. Bitte melden Sie sich erneut an, um fortzufahren. Wenn dies weiterhin auftritt, wenden Sie sich an Ihren Administrator."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute hat kein Token zurückgegeben"
+      },
+      "google": {
+        "label": "Mit Google fortfahren"
       }
     },
     "signup": {
@@ -8471,6 +10241,75 @@
         "tooltip": "Das Ändern dieser Einstellung wird für dieses Modell nicht unterstützt."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {Datei fehlgeschlagen und entfernt: {names}} other {Dateien fehlgeschlagen und entfernt: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "Anmelden"
+          },
+          "title": "Willkommen bei Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "Keine zuvor gesendete Nachricht gefunden."
+        },
+        "settingsButton": {
+          "tooltip": "Einstellungen öffnen"
+        },
+        "setupLlmButton": {
+          "label": "Richten Sie ein LLM ein."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "Abbrechen"
+          },
+          "confirmButton": {
+            "label": "Deaktivieren"
+          },
+          "description": "Stattdessen sehen Sie die Standard-Neuer-Tab-Seite Ihres Browsers. Sie können sie jederzeit in Ihren Onyx-Einstellungen wieder aktivieren.",
+          "title": "Onyx als Neuer-Tab-Seite deaktivieren?"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "Keiner"
+        },
+        "backgroundOption": {
+          "ariaLabel": "Hintergrund {label}"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "Hintergrund {label} (ausgewählt)"
+        },
+        "backgroundSection": {
+          "title": "Hintergrund"
+        },
+        "closeButton": {
+          "tooltip": "Einstellungen schließen"
+        },
+        "generalSection": {
+          "title": "Allgemein"
+        },
+        "header": {
+          "title": "Einstellungen"
+        },
+        "newTabToggle": {
+          "label": "Onyx als Neuer-Tab-Seite verwenden"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {Zum hellen Design wechseln} other {Zum dunklen Design wechseln}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "Neuer Chat"
+        },
+        "openInOnyxButton": {
+          "tooltip": "In Onyx öffnen"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "Einwilligungs-Kontrollkästchen"
@@ -8486,6 +10325,128 @@
       },
       "startButton": {
         "label": "Starten"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "Letzte Nachricht {time}"
+        },
+        "projectFallback": {
+          "label": "Projekt"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "Dateien hinzufügen"
+        },
+        "contextExceeded": {
+          "message": "Dieses Projekt überschreitet die Kontextgrenzen des Modells. Sitzungen suchen automatisch zuerst nach relevanten Dateien, bevor eine Antwort generiert wird."
+        },
+        "dropFiles": {
+          "message": "Dateien hier ablegen, um sie diesem Projekt hinzuzufügen"
+        },
+        "emptyFiles": {
+          "message": "Fügen Sie Dokumente, Texte oder Bilder zur Verwendung im Projekt hinzu. Drag & Drop wird unterstützt."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# Datei} other {# Dateien}}"
+        },
+        "fileCountOverflow": {
+          "description": "Über 100 Dateien"
+        },
+        "files": {
+          "description": "Chats in diesem Projekt können auf diese Dateien zugreifen.",
+          "title": "Dateien"
+        },
+        "filesModal": {
+          "description": "Sitzungen in diesem Projekt können auf die Dateien hier zugreifen.",
+          "title": "Projektdateien"
+        },
+        "instructions": {
+          "emptyDescription": "Fügen Sie Anweisungen hinzu, um die Antworten in diesem Projekt anzupassen.",
+          "title": "Anweisungen"
+        },
+        "loadingProject": {
+          "label": "Projekt wird geladen..."
+        },
+        "setInstructionsButton": {
+          "label": "Anweisungen festlegen"
+        },
+        "viewAll": {
+          "label": "Alle anzeigen"
+        },
+        "viewFiles": {
+          "label": "Dateien anzeigen"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "Abbrechen"
+        },
+        "createError": {
+          "toast": "Projekt {name} konnte nicht erstellt werden"
+        },
+        "description": "Verwenden Sie Projekte, um Ihre Dateien und Chats an einem Ort zu organisieren und benutzerdefinierte Anweisungen für laufende Arbeiten hinzuzufügen.",
+        "name": {
+          "label": "Projektname",
+          "placeholder": "Woran arbeiten Sie?"
+        },
+        "nameRequired": {
+          "error": "Projektname ist erforderlich"
+        },
+        "submitButton": {
+          "label": "Projekt erstellen"
+        },
+        "title": "Neues Projekt erstellen"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "Keine Projekte gefunden"
+        },
+        "search": {
+          "placeholder": "Projekte durchsuchen..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "Projekt einklappen"
+        },
+        "delete": {
+          "label": "Projekt löschen"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "Löschen"
+          },
+          "message": "Möchten Sie dieses Projekt wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+          "title": "Projekt löschen"
+        },
+        "expand": {
+          "ariaLabel": "Projekt ausklappen"
+        },
+        "rename": {
+          "label": "Projekt umbenennen"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "Noch keine Chats."
+        },
+        "recentChats": {
+          "title": "Letzte Chats"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "Dateien konnten nicht hochgeladen werden"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {# zu große Datei übersprungen} other {# zu große Dateien übersprungen}} (>{max} MB): {names}"
+        },
+        "rejected": {
+          "toast": "Einige Dateien wurden nicht hochgeladen. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8518,6 +10479,1773 @@
       },
       "incognito": {
         "title": "Sie sind inkognito"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "Seitenleiste öffnen"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "Zahlungsinformationen aktualisieren"
+        },
+        "text": "**Warnung:** Ihr Testzeitraum endet in weniger als 5 Tagen und es wurde keine Zahlungsmethode hinzugefügt."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "Agent-Avatar"
+      },
+      "logo": {
+        "alt": "Logo"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "Dokument"
+      },
+      "expandButton": {
+        "ariaLabel": "Dokument erweitern"
+      }
+    },
+    "backButton": {
+      "label": "Zurück"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "Wolken"
+      },
+      "hills": {
+        "label": "Hügel"
+      },
+      "mountains": {
+        "label": "Berge"
+      },
+      "night": {
+        "label": "Nacht"
+      },
+      "none": {
+        "label": "Keiner"
+      },
+      "plant": {
+        "label": "Pflanzen"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "Aa"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} „{value}“",
+        "defaultPrefix": "Erstellen"
+      },
+      "dropdown": {
+        "closeAriaLabel": "Dropdown schließen",
+        "openAriaLabel": "Dropdown öffnen"
+      },
+      "options": {
+        "empty": "Keine Optionen gefunden"
+      },
+      "separator": {
+        "label": "Weitere Optionen"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "Menü schließen"
+      },
+      "dialog": {
+        "title": "Befehlsmenü"
+      },
+      "options": {
+        "ariaLabel": "Optionen des Befehlsmenüs"
+      },
+      "search": {
+        "placeholder": "Suchen..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "Alle verfügbaren Konnektoren wurden ausgewählt. Entferne unten Konnektoren, um andere hinzuzufügen.",
+        "placeholder": "Alle Konnektoren ausgewählt"
+      },
+      "documentSetHint": {
+        "description": "Alle von den ausgewählten Konnektoren indexierten Dokumente werden Teil dieses Dokumentensatzes."
+      },
+      "noMatches": {
+        "text": "Keine passenden Konnektoren gefunden"
+      },
+      "noMoreConnectors": {
+        "text": "Keine weiteren Konnektoren verfügbar"
+      },
+      "noPrivateConnectors": {
+        "text": "Keine privaten Konnektoren verfügbar. Erstelle zuerst einen privaten Konnektor."
+      },
+      "noneSelected": {
+        "text": "Keine Konnektoren ausgewählt. Suche und wähle oben Konnektoren aus."
+      },
+      "removeConnector": {
+        "tooltip": "Konnektor entfernen"
+      },
+      "search": {
+        "placeholder": "Konnektoren durchsuchen..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "Datum auswählen"
+      },
+      "todayButton": {
+        "label": "Heute"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "Beliebiger Zeitraum..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "Benutzerdefinierten Zeitraum wählen"
+      },
+      "clearButton": {
+        "ariaLabel": "Zurücksetzen"
+      },
+      "custom": {
+        "label": "Benutzerdefiniert"
+      },
+      "customRange": {
+        "ariaLabel": "Benutzerdefinierter Zeitraum: {from} bis {to}"
+      },
+      "date": {
+        "label": "Datum"
+      },
+      "group": {
+        "ariaLabel": "Datumsbereich"
+      },
+      "preset": {
+        "oneDay": "1T",
+        "oneMonth": "1M",
+        "sevenDays": "7T",
+        "threeMonths": "3M"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "Löschen"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# Kontextdokument} other {# Kontextdokumente}}"
+      },
+      "openDocument": {
+        "ariaLabel": "Dokument öffnen: {title}"
+      },
+      "question": {
+        "title": "Frage"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# Teilabfrage} other {# Teilabfragen}}"
+      },
+      "updated": {
+        "text": "Aktualisiert am {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "Standard"
+      },
+      "selectOption": {
+        "placeholder": "Option auswählen..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "Bearbeiten"
+      },
+      "rename": {
+        "ariaLabel": "Umbenennen"
+      },
+      "save": {
+        "ariaLabel": "Speichern"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "Wenn du der Administrator bist, besuche bitte die Seite <billingLink>Admin-Abrechnung</billingLink>, um deine Lizenz zu {hadLicense, select, true {verlängern} other {aktivieren}}, registriere dich über Stripe oder wende dich an <supportLink>support@onyx.app</supportLink> für Unterstützung bei der Abrechnung."
+        },
+        "heading": {
+          "title": "Zugriff eingeschränkt"
+        },
+        "licenseLapse": {
+          "description": "Dein Zugriff auf Onyx wurde wegen einer abgelaufenen Lizenz vorübergehend ausgesetzt."
+        },
+        "licenseRequired": {
+          "description": "Für die Nutzung von Onyx ist eine Lizenz erforderlich. Deine Daten sind geschützt und stehen zur Verfügung, sobald eine Lizenz aktiviert ist."
+        },
+        "logoutButton": {
+          "label": "Abmelden"
+        },
+        "manageSubscription": {
+          "description": "Als Administrator kannst du dein Abonnement über die Schaltfläche unten verwalten. Alle anderen Benutzer wenden sich bitte an ihren Administrator."
+        },
+        "obtainLicense": {
+          "description": "Um loszulegen, wende dich bitte an deinen Systemadministrator, um eine Lizenz zu erhalten."
+        },
+        "renewLicense": {
+          "description": "Um deinen Zugriff wiederherzustellen und Onyx weiter zu nutzen, wende dich bitte an deinen Systemadministrator, um die Lizenz zu verlängern."
+        },
+        "resubscribeButton": {
+          "label": "Erneut abonnieren",
+          "loading": "Wird geladen..."
+        },
+        "resubscribeError": {
+          "text": "Fehler beim Öffnen der Seite zur erneuten Abonnierung. Bitte versuche es später erneut."
+        },
+        "seatLimit": {
+          "description": "Deine Organisation hat die lizenzierte Anzahl an Plätzen überschritten. Der Zugriff ist eingeschränkt, bis die Benutzerzahl reduziert oder die Lizenz erweitert wird."
+        },
+        "seatLimitAdminHint": {
+          "text": "Als Administrator kannst du Benutzer auf der Seite <userLink>Benutzerverwaltung</userLink> verwalten oder deine Lizenz auf der Seite <billingLink>Admin-Abrechnung</billingLink> erweitern."
+        },
+        "seatLimitWithCounts": {
+          "description": "Deine Organisation hat die lizenzierte Anzahl an Plätzen überschritten ({used} Benutzer / {seats} Plätze). Der Zugriff ist eingeschränkt, bis die Benutzerzahl reduziert oder die Lizenz erweitert wird."
+        },
+        "subscriptionLapse": {
+          "description": "Dein Zugriff auf Onyx wurde wegen eines abgelaufenen Abonnements vorübergehend ausgesetzt."
+        },
+        "updatePayment": {
+          "description": "Um deinen Zugriff wiederherzustellen und die leistungsstarken Funktionen von Onyx weiter zu nutzen, aktualisiere bitte deine Zahlungsinformationen."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "Wenn du Administrator bist, findest du in unserer <docsLink>Dokumentation</docsLink> die richtigen Konfigurationsschritte. Wenn du Benutzer bist, wende dich bitte an deinen Administrator."
+        },
+        "heading": {
+          "description": "Beim Laden deiner Onyx-Einstellungen ist offenbar ein Problem aufgetreten. Das kann an einem Konfigurationsproblem oder einer unvollständigen Einrichtung liegen.",
+          "title": "Es ist ein Problem aufgetreten"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "Wir entschuldigen uns für etwaige Unannehmlichkeiten und danken für deine Geduld."
+        },
+        "checkBack": {
+          "description": "Onyx befindet sich derzeit in einem Wartungsfenster. Bitte schau in ein paar Minuten wieder vorbei."
+        },
+        "heading": {
+          "title": "Wartung läuft"
+        }
+      },
+      "needHelp": {
+        "text": "Brauchst du Hilfe? Tritt unserer <discordLink>Discord-Community</discordLink> bei, um Unterstützung zu erhalten."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "Unbekannter Fehler"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "Datei herunterladen"
+      },
+      "file": {
+        "untitledFallback": "Ohne Titel"
+      },
+      "fullScreenButton": {
+        "tooltip": "Vollbild"
+      },
+      "hideButton": {
+        "tooltip": "Ausblenden"
+      },
+      "minimizeButton": {
+        "tooltip": "Minimieren"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "Kopieren"
+      },
+      "downloadButton": {
+        "tooltip": "Herunterladen"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {# Zeile} other {# Zeilen}}"
+      },
+      "size": {
+        "bytes": "{count} Bytes",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "Vollständigen Text anzeigen"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "Alle föderierten Konnektoren ausgewählt"
+      },
+      "entitiesConfigured": {
+        "tooltip": "Entitäten konfiguriert"
+      },
+      "noMatches": {
+        "text": "Keine passenden föderierten Konnektoren gefunden"
+      },
+      "noMoreConnectors": {
+        "text": "Keine weiteren föderierten Konnektoren verfügbar"
+      },
+      "noneSelected": {
+        "text": "Keine föderierten Konnektoren ausgewählt. Suche und wähle oben Konnektoren aus."
+      },
+      "realtimeSearchHint": {
+        "description": "Dokumente aus den ausgewählten föderierten Konnektoren werden bei Abfragen in Echtzeit durchsucht."
+      },
+      "removeConnector": {
+        "tooltip": "Konnektor entfernen"
+      },
+      "search": {
+        "placeholder": "Föderierte Konnektoren durchsuchen..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "Neu hinzufügen"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (optional)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "Keine Dateityp-Definition für das Feld gefunden: {name}",
+        "selectionError": "Fehler bei der Dateiauswahl",
+        "unknownError": "Unbekannter Fehler",
+        "validating": "Datei wird validiert...",
+        "validationError": "Validierungsfehler"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "Gib hier dein Markdown ein...",
+        "previewTab": "Vorschau",
+        "writeTab": "Schreiben"
+      },
+      "optionalIndicator": {
+        "text": "(optional)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "Passwort verbergen",
+        "showAriaLabel": "Passwort anzeigen"
+      },
+      "selector": {
+        "noneOption": "Keine",
+        "placeholder": "Auswählen..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "Alle zuletzt verwendeten Dateien"
+      },
+      "recentFiles": {
+        "title": "Zuletzt verwendete Dateien"
+      },
+      "recentFilesModal": {
+        "description": "Laden Sie Dateien hoch oder wählen Sie aus Ihren zuletzt verwendeten Dateien."
+      },
+      "toasts": {
+        "associatedAssistants": "Datei kann nicht gelöscht werden. Sie ist mit folgenden Assistenten verknüpft: {assistants}",
+        "associatedBoth": "Datei kann nicht gelöscht werden. Sie ist mit folgenden Projekten: {projects} und Assistenten: {assistants} verknüpft",
+        "associatedProjects": "Datei kann nicht gelöscht werden. Sie ist mit folgenden Projekten verknüpft: {projects}",
+        "deleteFailed": "Datei konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
+        "deleteSuccess": "Datei erfolgreich gelöscht"
+      },
+      "uploadFiles": {
+        "description": "Laden Sie eine Datei von Ihrem Gerät hoch",
+        "title": "Dateien hochladen"
+      },
+      "viewFileButton": {
+        "tooltip": "Datei anzeigen"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "Datei"
+      },
+      "open": {
+        "ariaLabel": "{title} öffnen"
+      },
+      "removeButton": {
+        "label": "Entfernen"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "Zurücksetzen"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(Optional)"
+      },
+      "required": {
+        "label": "(Erforderlich)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "{label} konnte nicht geladen werden. Bitte versuche es erneut."
+      },
+      "search": {
+        "placeholder": "Suchen..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "Keine Benutzergruppen verfügbar. Bitte erstelle zuerst eine Benutzergruppe."
+      },
+      "userGroups": {
+        "label": "Benutzergruppen",
+        "subtext": "Wähle aus, welche Benutzergruppen auf diese Ressource zugreifen können"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "Logo"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "{appName} wird initialisiert"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "Entfernen"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "Datei anhängen"
+      },
+      "clearButton": {
+        "ariaLabel": "Datei entfernen"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "Datei abgelehnt"
+      },
+      "editButton": {
+        "ariaLabel": "Bild bearbeiten"
+      },
+      "editOverlay": {
+        "label": "Bearbeiten"
+      },
+      "image": {
+        "altFallback": "Bild"
+      },
+      "removeButton": {
+        "ariaLabel": "Bild entfernen"
+      },
+      "uploadButton": {
+        "ariaLabel": "Bild hochladen"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "Option auswählen"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "Gruppenzugriff für diesen {objectName} zuweisen",
+        "scopedSubtext": "Wähle eine oder mehrere der von dir verwalteten Gruppen aus, um Zugriff auf diesen {objectName} zu gewähren",
+        "visibleSubtext": "Dieser {objectName} ist für die unten ausgewählten Gruppen sichtbar/zugänglich"
+      },
+      "loading": {
+        "text": "Wird geladen..."
+      },
+      "makePublic": {
+        "label": "Diesen {objectName} öffentlich machen?",
+        "subtext": "Wenn aktiviert, kann dieser {objectName} von <b>allen {publicToWhom}</b> verwendet werden. Andernfalls haben nur <b>Administratoren</b> und <b>{publicToWhom}</b>, denen explizit Zugriff auf diesen {objectName} gewährt wurde (z. B. über eine Benutzergruppe), Zugriff."
+      },
+      "publicDisabled": {
+        "message": "Dieser {objectName} ist öffentlich und für alle Benutzer verfügbar."
+      },
+      "usersFallback": {
+        "text": "Benutzer"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "Paar aus {keyTitle} und {valueTitle} hinzufügen",
+        "label": "Zeile hinzufügen"
+      },
+      "empty": {
+        "title": "Noch keine Einträge hinzugefügt."
+      },
+      "error": {
+        "duplicateKey": "Doppelter Schlüssel",
+        "duplicateSummary": "{count, plural, one {# doppelter Schlüssel gefunden} other {# doppelte Schlüssel gefunden}}",
+        "emptyKey": "Der Schlüssel darf nicht leer sein",
+        "emptySummary": "{count, plural, one {# leerer Schlüssel gefunden} other {# leere Schlüssel gefunden}}",
+        "validationSummary": "{count, plural, one {# Validierungsfehler gefunden} other {# Validierungsfehler gefunden}}"
+      },
+      "group": {
+        "ariaLabel": "Paare aus {keyTitle} und {valueTitle}"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "Schlüssel"
+      },
+      "pair": {
+        "fallbackLabel": "Schlüssel-Wert"
+      },
+      "removeButton": {
+        "ariaLabel": "{label}-Paar {index} entfernen"
+      },
+      "valueColumn": {
+        "title": "Wert"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "Logo"
+      },
+      "poweredBy": {
+        "label": "Bereitgestellt von Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "Nicht verfügbare Konnektoren:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "Die Autorisierung wurde abgebrochen oder ist fehlgeschlagen. Bitte versuche es erneut.",
+        "title": "Autorisierung fehlgeschlagen"
+      },
+      "backButton": {
+        "label": "Zurück zum Chat"
+      },
+      "completeFailed": {
+        "message": "Autorisierung konnte nicht abgeschlossen werden"
+      },
+      "genericError": {
+        "description": "Während des OAuth-Vorgangs ist ein Fehler aufgetreten. Bitte versuche es erneut.",
+        "title": "Etwas ist schiefgelaufen"
+      },
+      "invalidRequest": {
+        "description": "Die Autorisierungsanfrage war unvollständig. Bitte versuche es erneut.",
+        "title": "Ungültige Anfrage"
+      },
+      "loadingHint": {
+        "text": "Das kann einen Moment dauern..."
+      },
+      "processing": {
+        "description": "Bitte warte, während wir die Einrichtung abschließen.",
+        "title": "Wird verarbeitet..."
+      },
+      "redirecting": {
+        "text": "Weiterleitung in {count, plural, one {# Sekunde} other {# Sekunden}}..."
+      },
+      "serviceFallback": {
+        "text": "Dienst"
+      },
+      "success": {
+        "detailsTemplate": "Deine {serviceName}-Autorisierung wurde erfolgreich abgeschlossen.",
+        "title": "Erfolgreich!"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "Die Tabelle ist möglicherweise beschädigt oder konnte nicht richtig geladen werden.",
+        "title": "Fehler beim Laden der Tabelle"
+      },
+      "preview": {
+        "truncated": "Vorschau gekürzt. Laden Sie die Datei herunter, um alle Zeilen zu sehen.",
+        "unavailable": "Diese Tabelle kann nicht in der Vorschau angezeigt werden."
+      },
+      "sheet": {
+        "defaultName": "Blatt 1",
+        "empty": "Dieses Blatt ist leer.",
+        "tooLarge": "Dieses Blatt ist zu groß für die Vorschau. Laden Sie die Datei herunter, um es anzusehen."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "Hauptagent"
+      },
+      "subagentFallback": {
+        "label": "Subagent"
+      },
+      "switch": {
+        "ariaLabel": "Agent wechseln"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "Diese Aktion einmalig genehmigen",
+        "button": "Einmalig genehmigen"
+      },
+      "approveSession": {
+        "button": "Für Sitzung genehmigen",
+        "tooltip": "Übereinstimmende Aktionen für diese Sitzung genehmigen"
+      },
+      "details": {
+        "hideAriaLabel": "Details ausblenden",
+        "showAriaLabel": "Details anzeigen"
+      },
+      "header": {
+        "required": "Genehmigung erforderlich: {headline}"
+      },
+      "headline": {
+        "multiAction": "{count, plural, one {# Aktion} other {# Aktionen}} in {app}",
+        "singleAction": "{action} in {app}"
+      },
+      "payload": {
+        "empty": {
+          "label": "Keine Nutzdaten."
+        },
+        "showLess": {
+          "button": "Weniger anzeigen"
+        },
+        "showMore": {
+          "button": "Mehr anzeigen"
+        }
+      },
+      "reject": {
+        "ariaLabel": "Diese Aktion ablehnen",
+        "button": "Ablehnen"
+      },
+      "status": {
+        "approved": "Genehmigt",
+        "rejected": "Abgelehnt"
+      },
+      "submit": {
+        "errorFallback": "Entscheidung konnte nicht übermittelt werden"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "Hinzufügen",
+        "createButton": "Erstellen",
+        "customApp": {
+          "description": "Zugangsdaten und Netzwerkzugriff für deine eigene Integration.",
+          "title": "Benutzerdefinierte App"
+        },
+        "mcpHint": {
+          "label": "Brauchst du stattdessen einen MCP-Server? Verbinde ihn unter „Aktionen“ und aktiviere ihn hier für Craft.",
+          "openActionsButton": "Aktionen öffnen"
+        },
+        "modal": {
+          "description": "Stelle eine Integration deiner gesamten Organisation zur Verfügung. Integrierte Anbieter bringen Aktionen mit, die dem Craft-Agenten deren Nutzung beibringen; bereits konfigurierte Anbieter werden nicht aufgeführt.",
+          "title": "App hinzufügen"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "{name} verknüpfen",
+        "associateButton": "Vorhandenen verknüpfen",
+        "create": {
+          "github": {
+            "description": "Wenn deine Skills in GitHub liegen, importiere sie zuerst auf der Skills-Seite und verknüpfe sie dann mit dieser App.",
+            "label": "Aus GitHub importieren"
+          },
+          "scratch": {
+            "description": "Schreibe Anweisungen und füge unterstützende Dateien hinzu.",
+            "label": "Von Grund auf beginnen"
+          },
+          "upload": {
+            "description": "Importiere eine SKILL.md-Datei, eine ZIP-Datei oder einen Skill-Ordner.",
+            "label": "Skill hochladen"
+          }
+        },
+        "createSkillButton": "Skill erstellen",
+        "description": "Skills geben Craft Anweisungen zur Nutzung dieser App. Sie gelten organisationsweit; Nutzer müssen ggf. alle aktivieren, damit die App richtig funktioniert.",
+        "editButton": "Bearbeiten",
+        "empty": {
+          "label": "Keine bearbeitbaren Skills gefunden."
+        },
+        "invalidTag": "Ungültig",
+        "loading": {
+          "label": "Skills werden geladen…"
+        },
+        "noneAssociated": {
+          "label": "Noch keine Skills verknüpft. Die App kann auch ohne gespeichert und genutzt werden."
+        },
+        "promote": {
+          "cancelButton": "Abbrechen",
+          "confirmButton": "Organisationsweit verfügbar machen",
+          "description": "Mit Apps verknüpfte Skills müssen für alle verfügbar sein. Diese Änderung wird beim Speichern der App übernommen.",
+          "title": "„{name}“ organisationsweit verfügbar machen?"
+        },
+        "search": {
+          "placeholder": "Bearbeitbare Skills suchen..."
+        },
+        "title": "Verknüpfte Skills",
+        "unavailable": {
+          "duplicateName": "Ein Skill namens „{name}“ ist bereits verknüpft.",
+          "invalid": "Ungültiger Skill: Behebe das Problem, bevor du ihn verknüpfst.",
+          "otherApp": "Bereits mit der App „{name}“ verknüpft."
+        },
+        "unlink": {
+          "button": "Trennen",
+          "cancelButton": "Abbrechen",
+          "confirm": "„{name}“ von dieser App trennen?"
+        },
+        "unlinkAriaLabel": "{name} trennen",
+        "viewButton": "Ansehen"
+      },
+      "configureProvider": {
+        "addButton": "Hinzufügen",
+        "addTitle": "{name} hinzufügen",
+        "editTitle": "{name} bearbeiten",
+        "emptyPolicies": "Dieser Anbieter hat keine Aktionen zum Konfigurieren.",
+        "fields": {
+          "name": {
+            "description": "Eine Bezeichnung für diese Verbindung. Verwende einen eindeutigen Namen, wenn du mehrere Instanzen desselben Anbieters hinzufügst (z. B. \"{name} — Engineering\").",
+            "label": "Name"
+          }
+        },
+        "managedDescription": "Von Onyx bereitgestellt: Lege fest, was der Agent tun darf.",
+        "managedNote": "Diese App wird von Onyx bereitgestellt; die Zugangsdaten werden für dich verwaltet. Lege unten fest, was der Agent tun darf. Nutzer verbinden sie über die Apps-Seite.",
+        "saveButton": "Speichern"
+      },
+      "customApp": {
+        "cancelButton": "Abbrechen",
+        "createButton": "Erstellen",
+        "createDescription": "Konfiguriere, wie der Egress-Proxy diese App erreicht und sich authentifiziert. Ein Skill ist nicht erforderlich.",
+        "createTitle": "Benutzerdefinierte App erstellen",
+        "creatingButton": "Wird erstellt…",
+        "disabled": {
+          "nameMissing": "Gib einen Namen ein, bevor du diese benutzerdefinierte App erstellst.",
+          "patternMissing": "Füge mindestens ein Upstream-URL-Muster hinzu. Gib ein Muster ein und drücke die Eingabetaste.",
+          "pristine": "Nimm vor dem Speichern eine Änderung vor.",
+          "saving": "Ein Speichervorgang läuft bereits."
+        },
+        "editDescription": "Aktualisiere die Gateway-Einstellungen und verwalte verknüpfte Skills.",
+        "editTitle": "{name} bearbeiten",
+        "errors": {
+          "saveFailedTitle": "Speichern nicht möglich"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "Header hinzufügen",
+            "description": "Optional: Header, die in ausgehende Anfragen eingefügt werden. Verwende '{placeholder}' für Werte, die der Nutzer (oder unten die Organisation) liefert, z. B. \"Bearer '{api_key}'\". Leer lassen, um die Upstream-Muster ohne Zugangsdaten freizugeben.",
+            "keyTitle": "Header",
+            "label": "Header-Zugangsdaten-Muster",
+            "valueTitle": "Wert"
+          },
+          "name": {
+            "label": "Name",
+            "placeholder": "Meine benutzerdefinierte App"
+          },
+          "orgCredentials": {
+            "addButton": "Zugangsdaten hinzufügen",
+            "description": "Optional: Werte, die deine Organisation für alle Nutzer vorausfüllt. Leer lassen, wenn jeder Nutzer eigene Zugangsdaten angibt.",
+            "keyTitle": "Zugangsdaten-Schlüssel",
+            "label": "Organisations-Zugangsdaten",
+            "valueTitle": "Wert"
+          },
+          "upstreamPatterns": {
+            "description": "Ausgehende URLs, in die der Proxy Zugangsdaten einfügen darf. Verwende * für beliebige Zeichen (z. B. deckt https://api.example.com/* jeden Pfad dieses Hosts ab). Der Host muss wörtlich angegeben sein, keine Platzhalter vor dem ersten Schrägstrich. Gib ein Muster ein und drücke die Eingabetaste.",
+            "label": "Upstream-URL-Muster"
+          }
+        },
+        "saveButton": "Speichern",
+        "savingButton": "Wird gespeichert…"
+      },
+      "errors": {
+        "duplicateSkillName": "Die App „{appName}“ hat bereits einen verknüpften Skill namens „{skillName}“. Lade einen Skill mit anderem Namen hoch."
+      },
+      "mcpPolicy": {
+        "description": "Lege fest, was der Craft-Agent mit den Tools dieses MCP-Servers tun darf.",
+        "emptyPolicies": "Keine aktivierten Tools auf diesem Server. Aktiviere Tools zuerst auf der MCP-Aktionsseite.",
+        "saveButton": "Speichern",
+        "title": "{name} bearbeiten"
+      },
+      "oauthCallback": {
+        "backButton": "Zurück zu meinen Apps",
+        "description": "OAuth-Handshake wird abgeschlossen…",
+        "errors": {
+          "cancelled": "OAuth wurde abgebrochen oder abgelehnt: {reason}",
+          "failed": "Verbindung fehlgeschlagen.",
+          "missingParams": "Code oder State fehlt in der Callback-URL."
+        },
+        "exchanging": {
+          "label": "Autorisierungscode wird eingetauscht…"
+        },
+        "success": {
+          "label": "Verbunden. Weiterleitung zurück zu deinen Apps…"
+        },
+        "title": "App wird verbunden"
+      },
+      "page": {
+        "connectButton": "Verbinden",
+        "connectingButton": "Weiterleitung…",
+        "disconnectButton": "Trennen",
+        "empty": {
+          "description": "Für deine Organisation sind noch keine Apps oder MCP-Server konfiguriert.",
+          "title": "Noch nichts zu verbinden"
+        },
+        "errors": {
+          "disconnectFailed": "Trennen fehlgeschlagen",
+          "startAuthFailed": "Autorisierung konnte nicht gestartet werden"
+        },
+        "header": {
+          "description": "Verbinde die Tools, die Onyx Craft während der Arbeit als Kontext nutzen kann.",
+          "manageButton": "Apps verwalten",
+          "searchPlaceholder": "Apps suchen...",
+          "title": "Apps"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Integrationen, die Onyx direkt unterstützt. Jede bringt Skills mit, die Craft die Nutzung beibringen: Starte hier.",
+            "empty": "Für deine Organisation sind noch keine Apps konfiguriert.",
+            "emptyTitle": "Noch keine Apps",
+            "tabLabel": "Apps · {count}"
+          },
+          "mcp": {
+            "blurb": "Server, die ein Admin für Craft verfügbar gemacht hat. Nutze sie, wenn die benötigte App nicht unter Apps aufgeführt ist oder du gezielt die eigenen MCP-Tools eines Servers willst.",
+            "empty": "Es wurden noch keine MCP-Server für Craft verfügbar gemacht.",
+            "emptyTitle": "Noch keine MCP-Server",
+            "tabLabel": "MCP-Server · {count}"
+          }
+        },
+        "loading": {
+          "label": "Wird geladen…"
+        },
+        "reviewSkillsButton": "Skills überprüfen",
+        "search": {
+          "noMatchesDescription": "Nichts hier entspricht deiner Suche.",
+          "noMatchesTitle": "Keine Treffer"
+        },
+        "status": {
+          "connected": "Verbunden",
+          "connectedNeedsSkills": "Verbunden · nicht alle verknüpften Skills sind aktiviert",
+          "notAvailable": "Für dein Konto nicht verfügbar: Frag einen Admin",
+          "skillWarningAriaLabel": "Skill-Einrichtung erforderlich",
+          "skillWarningTooltip": "Nicht alle verknüpften Skills sind aktiviert. Diese App funktioniert möglicherweise nicht richtig."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "Lege für jede Aktion einzeln eine Richtlinie fest.",
+          "title": "Erweitert"
+        },
+        "cancelButton": "Abbrechen",
+        "loading": {
+          "label": "Wird geladen…"
+        },
+        "permissions": {
+          "askOption": "Nachfragen",
+          "autoApproveOption": "Automatisch genehmigen",
+          "customOption": "Benutzerdefiniert",
+          "description": "Lege fest, was der Agent tun darf. „Nachfragen“ fragt dich im Chat vor jeder Aktion; „Automatisch genehmigen“ führt sie ohne Rückfrage aus. Mit „Erweitert“ legst du eine Richtlinie pro Aktion fest.",
+          "title": "Berechtigungen"
+        },
+        "savingButton": "Wird gespeichert…"
+      },
+      "skillsStep": {
+        "description": "Optional: Verknüpfe vorhandene Skills oder erstelle einen für diese App.",
+        "errors": {
+          "saveFailedTitle": "Speichern nicht möglich"
+        },
+        "saveButton": "Skills speichern",
+        "savingButton": "Wird gespeichert…",
+        "skipButton": "Vorerst überspringen",
+        "title": "Skills zu {name} hinzufügen"
+      },
+      "userCredentials": {
+        "cancelButton": "Abbrechen",
+        "connectButton": "Verbinden",
+        "connectingButton": "Wird verbunden…",
+        "description": "Gib deine Zugangsdaten ein, um diese App für dein Konto zu autorisieren.",
+        "errors": {
+          "connectFailedTitle": "Verbindung nicht möglich"
+        },
+        "title": "{name} verbinden"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "Herunterladen"
+      },
+      "empty": {
+        "description": "Ausgabedateien und Web-Apps erscheinen hier",
+        "title": "Noch keine Artefakte"
+      },
+      "nextjsApp": {
+        "label": "Next.js-Anwendung"
+      },
+      "openItem": {
+        "ariaLabel": "{name} öffnen"
+      },
+      "toggleItem": {
+        "ariaLabel": "{name} umschalten"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "Setze das Gespräch fort...",
+        "scheduledRunPlaceholder": "Geplante Ausführung läuft...",
+        "subagentPlaceholder": "Wechsle zum Hauptagenten, um eine Nachricht zu senden"
+      },
+      "openSidebar": {
+        "ariaLabel": "Seitenleiste öffnen"
+      },
+      "outputPanel": {
+        "closeTooltip": "Ausgabebereich schließen",
+        "openTooltip": "Ausgabebereich öffnen"
+      },
+      "responseStopped": {
+        "label": "Antwort gestoppt"
+      },
+      "scrollToBottom": {
+        "label": "Nach unten scrollen"
+      },
+      "toast": {
+        "operationWait": "Bitte warte, bis der aktuelle Vorgang abgeschlossen ist.",
+        "sandboxWait": "Bitte warte, bis die Sandbox initialisiert ist",
+        "scheduledRunWait": "Bitte warte, bis die geplante Ausführung abgeschlossen ist."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "Kontext komprimiert, um Platz freizugeben"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "Verbinde deine Daten"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "Dein Arbeitsbereich wird gefertigt...",
+        "enchanting": "Mit Magie verzaubern...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "Ressourcen sammeln...",
+        "miningDependencies": "Abhängigkeiten schürfen...",
+        "placingBlocks": "Blöcke platzieren...",
+        "punchingWood": "Holz hacken...",
+        "smeltingCode": "Code verhütten...",
+        "worldGenerated": "Weltgenerierung abgeschlossen..."
+      },
+      "tagline": {
+        "label": "Deine nächste große Idee wird gefertigt..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "Leeren"
+      },
+      "copy": {
+        "doneTooltip": "Kopiert",
+        "tooltip": "Sichtbares kopieren"
+      },
+      "empty": {
+        "noLines": "Noch keine Zeilen.",
+        "noMatch": "Keine Zeilen entsprechen \"{filter}\"",
+        "waiting": "Warten auf die erste Logzeile…"
+      },
+      "error": {
+        "endpointDisabled": "Debug-Endpunkt deaktiviert (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "Keine laufende Sandbox, deren Logs verfolgt werden können"
+      },
+      "filter": {
+        "placeholder": "Filtern…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# Zeile} other {# Zeilen}}",
+        "filteredCount": "{visible, number} / {total, number} Zeilen"
+      },
+      "modal": {
+        "description": "Live-Verfolgung des Sandbox-Containers — nur für Dev/Debug.",
+        "title": "Opencode-Pod-Logs"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} neu · springen"
+      },
+      "open": {
+        "button": "Pod-Logs"
+      },
+      "status": {
+        "closed": "Geschlossen",
+        "connecting": "Verbinden",
+        "error": "Fehler",
+        "paused": "Pausiert",
+        "streaming": "Streaming"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "Dateien oder Fotos hinzufügen"
+      },
+      "apps": {
+        "label": "Apps"
+      },
+      "browseSkills": {
+        "label": "Skills durchsuchen"
+      },
+      "connect": {
+        "hint": "Verbinden"
+      },
+      "connectApp": {
+        "label": "App verbinden"
+      },
+      "library": {
+        "label": "Bibliothek"
+      },
+      "manageLibrary": {
+        "label": "Bibliothek verwalten…"
+      },
+      "mcpServer": {
+        "description": "MCP-Server"
+      },
+      "skills": {
+        "label": "Skills"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "Datei kann nicht in der Vorschau angezeigt werden"
+      },
+      "error": {
+        "inline": "Fehler: {message}",
+        "title": "Fehler beim Laden der Datei"
+      },
+      "loading": {
+        "label": "Datei wird geladen..."
+      },
+      "noContent": {
+        "label": "Kein Inhalt"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "Während des Builds erstellte Dateien erscheinen hier",
+        "title": "Noch keine Dateien"
+      },
+      "emptyDirectory": {
+        "label": "Keine Dateien in diesem Verzeichnis"
+      },
+      "error": {
+        "title": "Fehler beim Laden der Dateien"
+      },
+      "loading": {
+        "label": "Dateien werden geladen..."
+      },
+      "loadingChildren": {
+        "label": "Wird geladen..."
+      },
+      "preparing": {
+        "description": "Deine Entwicklungsumgebung wird eingerichtet",
+        "title": "Sandbox wird vorbereitet..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "Das Bild konnte nicht angezeigt werden",
+        "title": "Bild konnte nicht geladen werden"
+      },
+      "loading": {
+        "label": "Bild wird geladen..."
+      },
+      "preview": {
+        "ariaLabel": "Vorschau von {name}"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "Verbunden",
+        "connectionRequired": "Verbindung erforderlich"
+      },
+      "plusMenu": {
+        "tooltip": "Dateien oder Skills hinzufügen"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "Wird gestoppt…"
+      },
+      "toInterrupt": {
+        "label": "zum Unterbrechen"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "Zur Startseite"
+      },
+      "startCrafting": {
+        "button": "Loslegen"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "Keine Modelle gefunden"
+      },
+      "recommended": {
+        "label": "Empfohlen"
+      },
+      "recommendedOnly": {
+        "label": "Nur empfohlene Modelle"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "„Behebe den instabilen Retry-Test und öffne einen PR.“",
+          "launchDeck": "„Erstelle das Launch-Deck für den Frühling aus dem Briefing in Drive.“",
+          "rfpSecurity": "„Fülle die RFP in meiner E-Mail mit unseren Sicherheitsangaben aus.“",
+          "slackToLinear": "„Verdichte unsere Slack-Diskussion zu Linear-Tickets.“",
+          "vendorSpend": "„Fasse unsere Lieferantenausgaben für Q2 als Dokument in Drive zusammen.“"
+        },
+        "modal": {
+          "backButton": "Zurück",
+          "ctaButton": "Craft an die Arbeit schicken",
+          "nextButton": "Weiter",
+          "title": "Lerne Craft kennen"
+        },
+        "outputs": {
+          "ariaLabel": "Ergebnis: {name}",
+          "githubPr": {
+            "caption": "Offen zur Überprüfung",
+            "label": "GitHub-PR"
+          },
+          "googleDoc": {
+            "caption": "In deinem Drive gespeichert",
+            "label": "Google-Dokument"
+          },
+          "liveApp": {
+            "caption": "Gehostet, per Link teilbar",
+            "label": "Live-App"
+          }
+        },
+        "prompt": {
+          "label": "Dein Prompt"
+        },
+        "schedule": {
+          "ariaLabel": "Geplante Aufgabe: führt diesen Prompt nach Zeitplan erneut aus",
+          "caption": "Läuft, während du weg bist",
+          "label": "Jeden Montag, 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "Verbundene Quelle: {name}",
+          "yourFiles": {
+            "ariaLabel": "Deine hochgeladenen Dateien",
+            "label": "Deine Dateien"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "Klicke auf einen beliebigen Teil der Karte, um ihn erneut anzusehen.",
+            "title": "Das ist Craft. Du bist dran."
+          },
+          "machine": {
+            "caption": "Liest, was du sehen kannst. Nie deine Geheimnisse.",
+            "title": "Es arbeitet auf seiner eigenen Maschine."
+          },
+          "output": {
+            "caption": "Auf Abruf oder nach Zeitplan, während du weg bist.",
+            "title": "Fertige Arbeit kommt heraus."
+          },
+          "prompt": {
+            "caption": "Beschreibe das Ergebnis, Craft erledigt den Rest.",
+            "title": "Gib Craft echte Arbeit."
+          }
+        },
+        "team": {
+          "ariaLabel": "Dein Team: Ein Link teilt Crafts Arbeit",
+          "caption": "Ein Link teilt alles",
+          "label": "Dein Team"
+        },
+        "workspace": {
+          "approvalPill": "Wartet auf deine Freigabe",
+          "label": "Crafts Arbeitsbereich",
+          "sandboxBadge": "Isolierte Sandbox"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "Zurück zum Chat",
+        "description": "Onyx Craft benötigt einen Modellanbieter, den nur Admins einrichten können. Bitte deinen Admin, Anthropic, OpenAI oder OpenRouter zu verbinden.",
+        "title": "Ein LLM-Anbieter ist erforderlich"
+      },
+      "llmSetup": {
+        "description": "Craft-Agenten benötigen zum Bauen einen Modellanbieter.",
+        "title": "Modellanbieter verbinden"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "Analysiere meine Daten und erstelle ein Dashboard..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "Engineering",
+          "marketing": "Marketing",
+          "product": "Produkt",
+          "sales": "Vertrieb"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "Beginnen Sie etwas zu bauen, um Artefakte zu sehen!"
+      },
+      "devServerStarting": {
+        "tooltip": "Entwicklungsserver wird gestartet..."
+      },
+      "noWebapp": {
+        "label": "Noch keine Web-App in dieser Sitzung"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "Die PDF-Datei konnte nicht geladen werden.",
+        "title": "PDF kann nicht in der Vorschau angezeigt werden"
+      },
+      "frame": {
+        "title": "PDF-Vorschau"
+      },
+      "loading": {
+        "label": "PDF wird geladen..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "Präsentation wird konvertiert..."
+      },
+      "empty": {
+        "label": "Keine Folien in dieser Präsentation"
+      },
+      "error": {
+        "title": "Präsentation kann nicht in der Vorschau angezeigt werden"
+      },
+      "loadingSlide": {
+        "label": "Folie wird geladen..."
+      },
+      "slide": {
+        "counter": "Folie {current} von {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "Hier erscheint eine Live-Vorschau, sobald eine Web-App läuft."
+      },
+      "frame": {
+        "title": "Web-App-Vorschau"
+      },
+      "starting": {
+        "description": "Abhängigkeiten werden installiert und gestartet.",
+        "title": "Dev-Server wird gestartet..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "Weiterleitung..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "Schließen"
+      },
+      "modal": {
+        "description": "Sie ist nach einer Phase der Inaktivität eingeschlafen. Deine Arbeit ist gespeichert. Wecke sie, um weiterzumachen.",
+        "title": "Deine Sandbox ist eingeschlafen"
+      },
+      "wake": {
+        "button": "Sandbox aufwecken"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "Geplant"
+      },
+      "startedAt": {
+        "label": "Gestartet {time}"
+      },
+      "status": {
+        "awaitingApproval": "Diese geplante Ausführung wartet auf Genehmigung. Folgemeldungen werden freigeschaltet, nachdem sie fortgesetzt und abgeschlossen wurde.",
+        "running": "Diese geplante Ausführung läuft noch. Folgemeldungen werden freigeschaltet, sobald sie abgeschlossen ist.",
+        "startedBy": "Diese Sitzung wurde von der geplanten Aufgabe {task} um {time} gestartet."
+      },
+      "viewTask": {
+        "ariaLabel": "Geplante Aufgabe {task} anzeigen. {status}",
+        "label": "Aufgabe anzeigen"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "Externe App {id}"
+      },
+      "connect": {
+        "title": "{app} verbinden"
+      },
+      "connected": {
+        "title": "{app} verbunden."
+      },
+      "error": {
+        "generic": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+        "notConfigurable": "Diese App kann von hier aus nicht eingerichtet werden.",
+        "popupBlocked": "Das Einrichtungsfenster konnte nicht geöffnet werden. Erlaube Pop-ups und versuche es erneut.",
+        "startFailed": "Einrichtung konnte nicht gestartet werden"
+      },
+      "loading": {
+        "button": "Wird geladen…"
+      },
+      "notNow": {
+        "button": "Nicht jetzt"
+      },
+      "reason": {
+        "fallback": "Der Agent benötigt {app}, um diese Aufgabe fortzusetzen."
+      },
+      "skipped": {
+        "title": "Verbindung von {app} übersprungen."
+      },
+      "waiting": {
+        "button": "Warten…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "Link kopieren"
+      },
+      "organization": {
+        "description": "Jeder, der in deinem Onyx angemeldet ist, kann diese App sehen.",
+        "label": "Organisation"
+      },
+      "private": {
+        "description": "Nur du kannst diese App sehen.",
+        "label": "Privat"
+      },
+      "share": {
+        "label": "Teilen"
+      },
+      "shared": {
+        "label": "Geteilt"
+      },
+      "trigger": {
+        "ariaLabel": "Web-App teilen"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "Apps"
+      },
+      "backToChat": {
+        "label": "Zurück zum Chat"
+      },
+      "delete": {
+        "label": "Löschen"
+      },
+      "deleteModal": {
+        "body": "Dies entfernt die Craft-Sitzung und alle zugehörigen Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Löschen",
+        "deleting": "Wird gelöscht...",
+        "title": "\"{title}\" löschen?"
+      },
+      "newSession": {
+        "label": "Loslegen"
+      },
+      "rename": {
+        "label": "Umbenennen"
+      },
+      "scheduledTasks": {
+        "label": "Geplante Aufgaben"
+      },
+      "sessions": {
+        "empty": "Leg los! Der Sitzungsverlauf erscheint hier.",
+        "title": "Sitzungen"
+      },
+      "skills": {
+        "label": "Skills"
+      },
+      "toast": {
+        "deleteFailed": "Sitzung konnte nicht gelöscht werden",
+        "deleted": "\"{title}\" gelöscht."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "Lade diese Sitzung neu, um die neuesten Skills und App-Zugriffe zu übernehmen.",
+        "title": "Die Fähigkeiten deines Agenten haben sich geändert"
+      },
+      "reload": {
+        "button": "Neu laden",
+        "inProgress": "Wird neu geladen…"
+      },
+      "toast": {
+        "reloadFailed": "Sitzung konnte nicht neu geladen werden"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "Subagent nicht gefunden."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "Vorschläge schließen"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "Löschen",
+          "deletingButton": "Wird gelöscht...",
+          "description": "Dies stoppt künftige Ausführungen und entfernt die Aufgabe. Der bisherige Ausführungsverlauf (und die zugehörigen Sitzungen) bleiben zu Prüfzwecken erhalten.",
+          "title": "„{name}“ löschen?"
+        },
+        "deleteButton": "Löschen",
+        "editButton": "Bearbeiten",
+        "fallbackTitle": "Geplante Aufgabe",
+        "loadFailed": "Geplante Aufgabe konnte nicht geladen werden.",
+        "missingTaskId": "Aufgaben-ID fehlt.",
+        "pauseButton": "Pausieren",
+        "resumeButton": "Fortsetzen",
+        "runNowButton": "Jetzt ausführen",
+        "toasts": {
+          "deleteFailed": "Aufgabe konnte nicht gelöscht werden",
+          "deleted": "„{name}“ gelöscht.",
+          "paused": "Aufgabe pausiert.",
+          "resumed": "Aufgabe fortgesetzt.",
+          "runQueued": "Ausführung für „{name}“ eingereiht.",
+          "runStartFailed": "Ausführung konnte nicht gestartet werden",
+          "statusUpdateFailed": "Status konnte nicht aktualisiert werden"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "Geplante Aufgabe bearbeiten",
+        "loadFailed": "Geplante Aufgabe konnte nicht geladen werden.",
+        "missingTaskId": "Aufgaben-ID fehlt.",
+        "title": "„{name}“ bearbeiten"
+      },
+      "form": {
+        "cancelButton": "Abbrechen",
+        "errors": {
+          "nameRequired": "Name ist erforderlich.",
+          "promptRequired": "Prompt ist erforderlich."
+        },
+        "fields": {
+          "name": {
+            "label": "Name",
+            "placeholder": "z. B. Wöchentliche Übersicht der Kunden-Eskalationen"
+          },
+          "preApproval": {
+            "description": "Craft kann ausgewählte Apps und MCP-Server ohne Unterbrechung nutzen, wenn diese Aufgabe unbeaufsichtigt läuft. Andere Genehmigungsanfragen pausieren die Ausführung und können sie fehlschlagen lassen.",
+            "label": "Vorab genehmigte Apps und MCP-Server"
+          },
+          "prompt": {
+            "description": "Diese Nachricht wird bei jedem Auslösen der Aufgabe an Craft gesendet.",
+            "label": "Prompt",
+            "placeholder": "Beschreibe, was Craft bei jeder Ausführung tun soll..."
+          },
+          "schedule": {
+            "label": "Zeitplan"
+          }
+        },
+        "saveAndRunNowButton": "Speichern und jetzt ausführen",
+        "saveButton": "Speichern",
+        "saveChangesButton": "Änderungen speichern",
+        "savingLabel": "Wird gespeichert...",
+        "toasts": {
+          "created": "Geplante Aufgabe erstellt.",
+          "createdAndQueued": "Geplante Aufgabe erstellt und eingereiht.",
+          "saveFailed": "Geplante Aufgabe konnte nicht gespeichert werden",
+          "updated": "Geplante Aufgabe aktualisiert."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "Letzte Ausführung",
+          "name": "Name",
+          "nextRun": "Nächste Ausführung",
+          "schedule": "Zeitplan",
+          "status": "Status"
+        },
+        "confirmDelete": {
+          "deleteButton": "Löschen",
+          "deletingButton": "Wird gelöscht...",
+          "description": "Dies stoppt künftige Ausführungen und entfernt die Aufgabe. Der bisherige Ausführungsverlauf (und die zugehörigen Sitzungen) bleiben zu Prüfzwecken erhalten.",
+          "title": "„{name}“ löschen?"
+        },
+        "empty": {
+          "description": "Es wurden noch keine geplanten Aufgaben erstellt.",
+          "title": "Keine geplanten Aufgaben gefunden"
+        },
+        "errors": {
+          "loadFailed": "Geplante Aufgaben konnten nicht geladen werden.",
+          "tryAgainButton": "Erneut versuchen"
+        },
+        "header": {
+          "description": "Führe Craft-Prompts nach Timer aus. Jedes Auslösen erstellt eine neue Sitzung, die im Hintergrund läuft.",
+          "title": "Geplante Aufgaben"
+        },
+        "newTaskButton": "Neue geplante Aufgabe",
+        "rowActions": {
+          "deleteTooltip": "Löschen"
+        },
+        "toasts": {
+          "deleteFailed": "Aufgabe konnte nicht gelöscht werden",
+          "deleted": "„{name}“ gelöscht."
+        }
+      },
+      "newPage": {
+        "description": "Speichere Prompt und Zeitplan. Craft führt sie nach Timer aus.",
+        "title": "Neue geplante Aufgabe"
+      },
+      "preApproval": {
+        "appFallbackName": "App Nr. {id}",
+        "appsGroupTitle": "Apps",
+        "empty": {
+          "label": "In Craft sind noch keine Apps oder MCP-Server verfügbar."
+        },
+        "errors": {
+          "loadFailed": "Apps und MCP-Server konnten nicht geladen werden. Aktualisiere, um es erneut zu versuchen.",
+          "partialLoadFailed": "Einige Vorabgenehmigungs-Optionen konnten nicht geladen werden. Aktualisiere, um es erneut zu versuchen."
+        },
+        "loading": {
+          "label": "Apps und MCP-Server werden geladen…"
+        },
+        "mcpGroupTitle": "MCP-Server",
+        "mcpServerFallbackName": "MCP-Server Nr. {id}",
+        "status": {
+          "connected": "Verbunden",
+          "connectionRequired": "Verbindung erforderlich",
+          "unavailable": "Nicht mehr verfügbar"
+        },
+        "summary": {
+          "partialLoadFailed": "Einige Vorabgenehmigungs-Details konnten nicht geladen werden. Aktualisiere, um es erneut zu versuchen.",
+          "title": "Vorab genehmigte Apps und MCP-Server"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "Dauer",
+          "started": "Gestartet",
+          "status": "Status",
+          "summary": "Zusammenfassung",
+          "trigger": "Auslöser"
+        },
+        "empty": {
+          "label": "Noch keine Ausführungen. Die Aufgabe erstellt bei jedem Auslösen eine, oder nutze oben „Jetzt ausführen“."
+        },
+        "errors": {
+          "loadFailed": "Ausführungsverlauf konnte nicht geladen werden.",
+          "tryAgainButton": "Erneut versuchen"
+        },
+        "loadMore": {
+          "button": "Mehr laden",
+          "loadingButton": "Wird geladen..."
+        },
+        "nonClickable": {
+          "noSession": "Dieser Lauf hat noch keine Sitzung erstellt.",
+          "queued": "Dieser Lauf hat noch nicht begonnen, daher gibt es keine Sitzung zum Öffnen.",
+          "skipped": "Dieser Lauf wurde übersprungen, weil ein früherer noch lief, daher wurde keine Sitzung erstellt."
+        },
+        "status": {
+          "notOpenableAriaLabel": "Nicht öffenbar"
+        },
+        "trigger": {
+          "runNow": "Jetzt ausführen",
+          "schedule": "Zeitplan"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "Um",
+          "daysLabel": "An diesen Tagen",
+          "runsEveryDay": "Läuft jeden Tag",
+          "runsOn": "Läuft am {days}"
+        },
+        "interval": {
+          "everyLabel": "Alle"
+        },
+        "intervalUnits": {
+          "days": "Tage",
+          "hours": "Stunden",
+          "minutes": "Minuten"
+        },
+        "tabs": {
+          "dailyWeekly": "Täglich / Wöchentlich",
+          "interval": "Intervall"
+        },
+        "weekdays": {
+          "fri": "Fr",
+          "mon": "Mo",
+          "sat": "Sa",
+          "sun": "So",
+          "thu": "Do",
+          "tue": "Di",
+          "wed": "Mi"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "Keine Aufgaben"
+      },
+      "header": {
+        "title": "Aufgaben"
+      },
+      "progress": {
+        "label": "{completed}/{total} erledigt"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "Keine Ausgabe"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# unveränderte Zeile} other {# unveränderte Zeilen}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "Zur nebeneinanderliegenden Ansicht wechseln",
+          "unifiedTooltip": "Zur einheitlichen Ansicht wechseln"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "Noch keine Ausgabe..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# Aufruf} other {# Aufrufe}}"
+        },
+        "failed": {
+          "tag": "{count} fehlgeschlagen"
+        },
+        "working": {
+          "label": "In Arbeit"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(leere Datei)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {# weitere Zeile} other {# weitere Zeilen}}"
+        },
+        "showAll": {
+          "button": "Alle anzeigen"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "Keine Treffer"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "Datei zu groß ({size}). Das Maximum ist {max}.",
+        "network": "Netzwerkfehler",
+        "notFound": "Ressource nicht gefunden",
+        "server": "Serverfehler",
+        "sessionExpired": "Sitzung abgelaufen",
+        "tooManyFiles": "Zu viele Dateien. Das Maximum sind {max} Dateien pro Sitzung.",
+        "totalSizeExceeded": "Die Gesamtgröße überschreitet das Limit. Das Maximum ist {max} pro Sitzung.",
+        "uploadFailed": "Hochladen fehlgeschlagen"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "Zurück"
+      },
+      "copyUrl": {
+        "ariaLabel": "URL kopieren: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "Datei herunterladen"
+      },
+      "export": {
+        "button": "Als .docx exportieren",
+        "inProgress": "Wird exportiert..."
+      },
+      "forward": {
+        "ariaLabel": "Vorwärts"
+      },
+      "openInNewTab": {
+        "tooltip": "in neuem Tab öffnen"
+      },
+      "refresh": {
+        "ariaLabel": "Aktualisieren"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "löschen",
+        "button": "Löschen",
+        "entityTypeFile": "Datei",
+        "entityTypeFolder": "Ordner",
+        "fileDetails": "Diese Datei wird aus deiner Bibliothek entfernt.",
+        "folderDetails": "Dadurch werden der Ordner und sein gesamter Inhalt gelöscht."
+      },
+      "dropzone": {
+        "formats": "Excel, Word, PowerPoint, PDF oder ZIP",
+        "title": "Dateien hierher ziehen oder zum Hochladen klicken"
+      },
+      "errors": {
+        "createFolderFailed": "Ordner konnte nicht erstellt werden",
+        "deleteFailed": "Löschen fehlgeschlagen",
+        "loadFailed": "Dateien konnten nicht geladen werden",
+        "uploadFailed": "Hochladen fehlgeschlagen"
+      },
+      "loading": {
+        "label": "Dateien werden geladen…"
+      },
+      "modal": {
+        "description": "Dateien, die dein Agent in jeder Sitzung lesen kann.",
+        "doneButton": "Fertig",
+        "title": "Bibliothek"
+      },
+      "newFolder": {
+        "cancelButton": "Abbrechen",
+        "createButton": "Erstellen",
+        "label": "Neuer Ordner",
+        "nameLabel": "Ordnername",
+        "namePlaceholder": "Ordnernamen eingeben"
+      },
+      "search": {
+        "noResults": "Keine Dateien entsprechen deiner Suche",
+        "placeholder": "Dateien suchen..."
+      },
+      "tree": {
+        "collapseTooltip": "Einklappen",
+        "deleteTooltip": "Löschen",
+        "expandTooltip": "Ausklappen",
+        "toggleAriaLabel": "{name} umschalten",
+        "uploadToFolderTooltip": "In diesen Ordner hochladen"
+      },
+      "upload": {
+        "button": "Hochladen",
+        "dropOverlay": "Dateien zum Hochladen ablegen",
+        "uploadingButton": "Wird hochgeladen…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "Analysiere meine Daten und erstelle ein Dashboard..."
       }
     }
   },
@@ -8825,6 +12553,13 @@
           "networkError": "Beim Ändern des Passworts ist ein Fehler aufgetreten",
           "updateFailed": "Passwort konnte nicht geändert werden",
           "updated": "Passwort erfolgreich aktualisiert"
+        },
+        "validation": {
+          "confirmRequired": "Bitte bestätigen Sie Ihr neues Passwort",
+          "currentRequired": "Aktuelles Passwort ist erforderlich",
+          "minLength": "Das Passwort muss mindestens {min} Zeichen lang sein",
+          "mismatch": "Die Passwörter stimmen nicht überein",
+          "newRequired": "Neues Passwort ist erforderlich"
         }
       },
       "title": "Konten"
@@ -8866,6 +12601,7 @@
         "empty": "Keine Zugriffstoken erstellt.",
         "expiresIn": "{count, plural, one {Läuft in # Tag ab} other {Läuft in # Tagen ab}}",
         "loading": "Token werden geladen...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "Läuft nie ab",
         "newTokenButton": "Neues Zugriffstoken",
         "noPermissionTooltip": "Sie haben keine Berechtigung, Zugriffstoken zu erstellen",
@@ -9012,6 +12748,10 @@
       },
       "description": "Verbinden Sie externe Tools mit den Modellen, die Ihnen in Onyx zur Verfügung stehen.",
       "guideButton": "Anleitung",
+      "loadError": {
+        "description": "Bitte laden Sie die Seite neu und versuchen Sie es erneut.",
+        "title": "LLM Gateway konnte nicht geladen werden"
+      },
       "models": {
         "description": "{count, plural, one {# Modell ist für Ihr Konto verfügbar. Öffnen Sie einen Anbieter, um eine ID zu kopieren.} other {# Modelle sind für Ihr Konto verfügbar. Öffnen Sie einen Anbieter, um eine ID zu kopieren.}}",
         "title": "Modelle"
@@ -9064,14 +12804,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "Zeile hinzufügen",
+        "maxReached": "Maximum von {count} Erinnerungen erreicht"
+      },
       "empty": {
-        "description": "Fügen Sie eine persönliche Notiz oder Erinnerung hinzu, die sich Onyx merken soll."
+        "description": "Fügen Sie eine persönliche Notiz oder Erinnerung hinzu, die sich Onyx merken soll.",
+        "getStarted": "Noch keine Erinnerungen. Klicken Sie auf „Zeile hinzufügen“, um zu beginnen.",
+        "noMatches": "Keine Erinnerungen entsprechen Ihrer Suche."
+      },
+      "item": {
+        "placeholder": "Geben Sie eine persönliche Notiz oder Erinnerung ein oder fügen Sie sie ein"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {Zeile} other {Zeilen}}"
+      },
+      "modal": {
+        "description": "Lassen Sie Onyx diese gespeicherten Notizen und Erinnerungen in Chats verwenden.",
+        "searchPlaceholder": "Suchen..."
       },
       "referenceStoredMemories": {
         "description": "Lassen Sie Onyx gespeicherte Erinnerungen in Chats verwenden.",
         "title": "Gespeicherte Erinnerungen verwenden"
       },
+      "removeLineButton": {
+        "label": "Zeile entfernen"
+      },
       "title": "Erinnerungen",
+      "toasts": {
+        "saveFailed": "Einstellungen konnten nicht gespeichert werden",
+        "saved": "Einstellungen gespeichert"
+      },
       "updateMemories": {
         "description": "Lassen Sie Onyx gespeicherte Erinnerungen erstellen und aktualisieren.",
         "title": "Erinnerungen aktualisieren"
@@ -9491,6 +13254,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "Die App „{appName}“ hat bereits einen zugehörigen Skill namens „{skillName}“.",
+        "title": "Wählen Sie einen anderen Skill-Namen"
+      },
+      "confirmUpload": {
+        "importBody": "Dieser Upload enthält SKILL.md. Wenn Sie fortfahren, werden der aktuelle Name, die Beschreibung, die Anweisungen und die Dateien durch das hochgeladene Paket ersetzt.",
+        "importSubmit": {
+          "label": "Skill importieren"
+        },
+        "importTitle": "Diesen Skill importieren?",
+        "replaceBody": "Dieser Upload muss denselben Skill-Namen verwenden. Wenn Sie fortfahren, werden die Beschreibung, die Anweisungen und die Dateien durch das hochgeladene Paket ersetzt.",
+        "replaceSubmit": {
+          "label": "Inhalt ersetzen"
+        },
+        "replaceTitle": "Skill-Inhalt ersetzen?"
+      },
+      "delete": {
+        "button": {
+          "label": "Skill löschen"
+        },
+        "description": "Jeder, der diesen Skill verwendet, verliert den Zugriff. Das Löschen kann nicht rückgängig gemacht werden.",
+        "title": "Diesen Skill löschen"
+      },
+      "deleteModal": {
+        "entityType": "Skill",
+        "label": "Löschen",
+        "pendingLabel": "Wird gelöscht..."
+      },
+      "details": {
+        "description": "Legen Sie fest, wann und wie Craft diesen Skill verwenden soll.",
+        "descriptionField": {
+          "description": "Beschreiben Sie, wann dieser Skill verwendet werden soll.",
+          "placeholder": "Wobei hilft dieser Skill?",
+          "title": "Beschreibung"
+        },
+        "name": {
+          "createDescription": "Verwenden Sie Kleinbuchstaben, Zahlen und einzelne Bindestriche.",
+          "lockedDescription": "Skill-Namen können nach der Erstellung nicht geändert werden.",
+          "placeholder": "Benennen Sie Ihren Skill",
+          "title": "Name"
+        },
+        "title": "Details"
+      },
+      "files": {
+        "busyLabel": "Wird hochgeladen...",
+        "description": "Fügen Sie Referenzen, Skripte, Assets oder andere von diesem Skill verwendete Dateien hinzu. ZIP-Dateien werden automatisch entpackt.",
+        "input": {
+          "ariaLabel": "Unterstützende Dateien hinzufügen"
+        },
+        "pendingUpload": {
+          "emptyMessage": "Dateien aus diesem Upload erscheinen, nachdem Sie den Skill erstellt haben."
+        },
+        "title": "Unterstützende Dateien"
+      },
+      "filesTooltip": {
+        "noPermission": "Sie haben keine Berechtigung, die Dateien dieses Skills zu aktualisieren.",
+        "saveFirst": "Speichern Sie die Detailänderungen, bevor Sie die Skill-Dateien aktualisieren.",
+        "updating": "Skill-Dateien werden aktualisiert..."
+      },
+      "header": {
+        "appFallbackName": "Externe App",
+        "cancel": {
+          "label": "Abbrechen"
+        },
+        "createDescription": "Erstellen Sie einen persönlichen Skill",
+        "createForAppDescription": "Fügen Sie der App „{appName}“ einen Organisations-Skill hinzu",
+        "createTitle": "Skill erstellen",
+        "editDescription": "Aktualisieren Sie Skill-Details und -Dateien",
+        "editTitle": "Skill bearbeiten",
+        "save": {
+          "label": "Speichern",
+          "pendingLabel": "Wird gespeichert..."
+        }
+      },
+      "import": {
+        "busyLabel": "Wird importiert...",
+        "button": {
+          "label": "Skill importieren"
+        },
+        "description": "Importieren Sie eine SKILL.md, eine ZIP-Datei oder einen Skill-Ordner, um das Formular vorauszufüllen und die Dateien einzubeziehen.",
+        "input": {
+          "ariaLabel": "Vorhandenen Skill importieren"
+        },
+        "prompt": "Wählen Sie eine SKILL.md oder ZIP-Datei oder ziehen Sie einen Skill-Ordner hierher.",
+        "title": "Haben Sie bereits einen Skill?"
+      },
+      "instructions": {
+        "description": "Beschreiben Sie das Verhalten und den Workflow, den dieser Skill zu Craft hinzufügt.",
+        "emptyFallback": "Noch keine Anweisungen.",
+        "placeholder": "Schreiben Sie die Skill-Anweisungen.",
+        "title": "Anweisungen"
+      },
+      "loadError": {
+        "description": "Dieser Skill existiert möglicherweise nicht, ist integriert oder kann mit Ihrem Konto nicht bearbeitet werden.",
+        "title": "Skill nicht verfügbar"
+      },
+      "management": {
+        "description": "Steuern Sie, wer diesen Skill verwenden kann.",
+        "externalApp": {
+          "manage": {
+            "label": "In App-Einstellungen verwalten"
+          },
+          "readyDescription": "Dieser Skill verwendet die App „{appName}“.",
+          "title": "Externe App"
+        },
+        "sharing": {
+          "edit": {
+            "label": "Freigabe bearbeiten"
+          },
+          "title": "Freigabe"
+        },
+        "title": "Verwaltung"
+      },
+      "saveTooltip": {
+        "missingDescription": "Fügen Sie vor dem Speichern eine Beschreibung hinzu.",
+        "missingInstructions": "Fügen Sie vor dem Speichern Anweisungen hinzu.",
+        "missingName": "Fügen Sie vor dem Speichern einen Namen hinzu.",
+        "noChanges": "Es wurden keine Änderungen vorgenommen.",
+        "noPermission": "Sie haben keine Berechtigung, die Details dieses Skills zu bearbeiten.",
+        "savingChanges": "Änderungen werden gespeichert...",
+        "savingSkill": "Skill wird gespeichert..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "Jeder in Ihrer Organisation kann diesen Skill verwenden und bearbeiten.",
+          "title": "Organisation",
+          "viewerDescription": "Jeder in Ihrer Organisation kann diesen Skill verwenden."
+        },
+        "personal": {
+          "description": "Nur Sie können diesen Skill verwenden.",
+          "title": "Persönlich"
+        },
+        "shares": {
+          "description": "Nur ausgewählte Benutzer und Gruppen können diesen Skill verwenden.",
+          "title": "{count, plural, one {# Freigabe} other {# Freigaben}}"
+        }
+      },
+      "toasts": {
+        "created": "„{name}“ erstellt",
+        "deleteFailed": "Skill konnte nicht gelöscht werden",
+        "deleted": "„{name}“ gelöscht",
+        "fileRemoveFailed": "Skill-Datei konnte nicht entfernt werden",
+        "fileRemoved": "„{path}“ entfernt",
+        "filesUpdateFailed": "Skill-Dateien konnten nicht aktualisiert werden",
+        "filesUpdated": "Dateien für „{name}“ aktualisiert",
+        "importMissingSkillMd": "Importieren Sie eine SKILL.md, eine ZIP-Datei oder einen Ordner mit SKILL.md.",
+        "inspectFailed": "Skill-Paket konnte nicht geprüft werden",
+        "saveFailed": "Skill konnte nicht gespeichert werden",
+        "saved": "„{name}“ gespeichert"
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9691,6 +13606,76 @@
         "transferredToast": {
           "message": "Eigentum übertragen."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "Skills durchsuchen"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {Skill} other {Skills}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "Importieren Sie einen oder mehrere Skills aus einem Repository.",
+          "title": "Aus GitHub importieren"
+        },
+        "scratch": {
+          "description": "Schreiben Sie die Anweisungen und fügen Sie unterstützende Dateien in Onyx hinzu.",
+          "title": "Von Grund auf neu beginnen"
+        },
+        "trigger": {
+          "label": "Skill erstellen"
+        },
+        "upload": {
+          "description": "Importieren Sie eine SKILL.md-Datei, eine ZIP-Datei oder einen Skill-Ordner.",
+          "title": "Skill hochladen"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "Versuchen Sie eine andere Suche.",
+          "title": "Keine passenden Skills"
+        },
+        "noSkills": {
+          "description": "Es wurden noch keine benutzerdefinierten Skills mit Ihnen geteilt und es sind keine integrierten Skills konfiguriert.",
+          "title": "Keine Skills verfügbar"
+        }
+      },
+      "focusedApp": {
+        "description": "Aktivieren Sie alle Skills, die mit der App „{appName}“ verknüpft sind. Ohne sie funktioniert die App möglicherweise nicht richtig. Wenn ein anderer Skill mit demselben Namen aktiviert ist, wird dieser durch das Aktivieren des App-Skills für Sie deaktiviert.",
+        "showAll": {
+          "label": "Alle Skills anzeigen"
+        },
+        "title": "Skills für App „{appName}“"
+      },
+      "header": {
+        "description": "Fähigkeitspakete, auf die Ihr Craft-Agent zugreifen kann. Diese Seite zeigt integrierte Skills, mit Ihnen geteilte Skills und Ihre persönlichen Skills.",
+        "title": "Skills"
+      },
+      "loadError": {
+        "description": "Prüfen Sie die Konsole für Details und versuchen Sie, die Seite zu aktualisieren.",
+        "title": "Skills konnten nicht geladen werden"
+      },
+      "preview": {
+        "unavailableFallback": "Dieser Skill ist derzeit nicht verfügbar."
+      },
+      "search": {
+        "placeholder": "Skills suchen..."
+      },
+      "switchModal": {
+        "body": "Wenn Sie fortfahren, wird der derzeit aktivierte Skill deaktiviert und dieser aktiviert.",
+        "description": "Es kann jeweils nur ein Skill mit dem Namen „{name}“ aktiviert sein.",
+        "submit": {
+          "label": "Skill wechseln",
+          "pendingLabel": "Wird gewechselt..."
+        },
+        "title": "Skill „{name}“ wechseln?"
+      },
+      "toasts": {
+        "disableFailed": "{name} konnte nicht deaktiviert werden",
+        "enableFailed": "{name} konnte nicht aktiviert werden",
+        "refreshFailed": "{name} wurde aktualisiert, aber die Skill-Liste konnte nicht aktualisiert werden."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "Back"
       },
-      "disableAll": {
-        "label": "Disable All"
-      },
-      "enableAll": {
-        "label": "Enable All"
-      },
       "toggle": {
         "ariaLabel": "Toggle {name}"
       }
@@ -11255,7 +11249,7 @@
             "valueTitle": "Value"
           },
           "upstreamPatterns": {
-            "description": "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter.",
+            "description": "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal, with no wildcards before the first slash. Type a pattern and press Enter.",
             "label": "Upstream URL patterns"
           }
         },
@@ -12947,6 +12941,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "Document Explorer"
+        },
+        "documentFeedback": {
+          "title": "Document Feedback"
+        },
+        "documentProcessing": {
+          "title": "Document Processing"
+        },
+        "oauthTest": {
+          "title": "OAuth Test"
+        },
+        "standardAnswers": {
+          "title": "Standard Answers"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "Add Connector"

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -5765,6 +5765,27 @@
         "unexpectedError": "Unexpected error occurred."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "Canceled",
+        "completedWithErrors": "Completed with errors",
+        "deleting": "Deleting",
+        "error": "Error",
+        "failed": "Failed",
+        "inProgress": "In Progress",
+        "indexed": "Indexed",
+        "indexing": "Indexing",
+        "initialIndexing": "Initial Indexing",
+        "interrupted": "Interrupted",
+        "invalid": "Invalid",
+        "invalidConnectorTooltip": "Connector is in an invalid state. Please update the credentials or create a new connector.",
+        "none": "None",
+        "notStarted": "Not Started",
+        "paused": "Paused",
+        "scheduled": "Scheduled",
+        "succeeded": "Succeeded"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "Backend Version: "
@@ -7204,6 +7225,70 @@
       },
       "sourcesModal": {
         "title": "Sources"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "Delete"
+      },
+      "deleteModal": {
+        "description": "Are you sure you want to delete this chat? This action cannot be undone.",
+        "submitButton": {
+          "label": "Delete"
+        },
+        "title": "Delete Chat"
+      },
+      "exportAs": {
+        "label": "Export As…"
+      },
+      "exportFailed": {
+        "message": "Failed to export chat. Please try again."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "Plaintext"
+      },
+      "fullWidth": {
+        "ariaLabel": "Toggle full width chat",
+        "fitTooltip": "Fit width",
+        "fullTooltip": "Full width"
+      },
+      "incognitoExit": {
+        "ariaLabel": "Exit incognito chat",
+        "tooltip": "Exit Incognito Chat"
+      },
+      "incognitoPill": {
+        "ariaLabel": "Incognito chat",
+        "label": "Incognito Chat"
+      },
+      "incognitoStart": {
+        "ariaLabel": "Start incognito chat",
+        "lockedTooltip": "Incognito can only be set before the chat starts",
+        "tooltip": "Incognito Chat"
+      },
+      "mode": {
+        "chat": {
+          "description": "Conversation and research",
+          "label": "Chat"
+        },
+        "search": {
+          "description": "Quick search for documents",
+          "label": "Search"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "Change app mode"
+      },
+      "moveToProject": {
+        "label": "Move to Project"
+      },
+      "openSidebar": {
+        "ariaLabel": "Open Sidebar"
+      },
+      "share": {
+        "label": "Share"
       }
     },
     "banners": {
@@ -8950,6 +9035,34 @@
         "updateFailed": "Failed to update language preference"
       }
     },
+    "layout": {
+      "header": {
+        "title": "Settings"
+      },
+      "sectionSelect": {
+        "placeholder": "Select a section"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "Accounts & Access"
+        },
+        "chatPreferences": {
+          "label": "Chat Preferences"
+        },
+        "connectors": {
+          "label": "Connectors"
+        },
+        "general": {
+          "label": "General"
+        },
+        "llmGateway": {
+          "label": "LLM Gateway"
+        },
+        "usage": {
+          "label": "Usage"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Add personal note or memory that Onyx should remember."
@@ -9010,6 +9123,47 @@
       "toggle": {
         "description": "Enable shortcuts to quickly insert common prompts.",
         "title": "Use Prompt Shortcuts"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "{amount} limit",
+        "none": "No budget set",
+        "remaining": "{amount} remaining",
+        "resetsOn": "Resets on {date}",
+        "title": "Budget"
+      },
+      "empty": {
+        "description": "Your model usage and costs will show up here once you start chatting.",
+        "title": "No usage recorded yet"
+      },
+      "header": {
+        "title": "Usage"
+      },
+      "loadError": {
+        "description": "Something went wrong fetching your usage. Try again in a moment.",
+        "title": "Couldn't load usage"
+      },
+      "modelPrices": {
+        "description": "USD per 1M tokens (input · output · cache) for every available model",
+        "title": "Model prices",
+        "unavailable": "Prices unavailable"
+      },
+      "showFewerModels": {
+        "ariaLabel": "Show fewer models"
+      },
+      "showLess": {
+        "label": "Show less"
+      },
+      "showMore": {
+        "label": "Show {count} more"
+      },
+      "showMoreModels": {
+        "ariaLabel": "Show {count} more models"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} spent",
+        "title": "Usage this period"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -60,6 +60,26 @@
         "ariaLabel": "{title} action card"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "Add Connectors"
+      },
+      "configure": {
+        "tooltip": "Configure"
+      },
+      "configureConnectors": {
+        "label": "Configure Connectors"
+      },
+      "disable": {
+        "label": "Disable"
+      },
+      "enable": {
+        "label": "Enable"
+      },
+      "projectSearch": {
+        "label": "Project Search"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "Connect MCP (Model Context Protocol) server to add custom actions.",
@@ -355,6 +375,53 @@
         "tooltip": "Refresh tools"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "Taking you back automatically…"
+      },
+      "backToChatButton": {
+        "label": "Back to Chat"
+      },
+      "cancelled": {
+        "description": "The authorization was cancelled or denied, so no connection was made. To try again, restart the connection from the MCP server's authentication settings.",
+        "title": "Authorization cancelled"
+      },
+      "continueButton": {
+        "label": "Continue"
+      },
+      "genericError": {
+        "fallbackDetail": "Failed to complete authorization",
+        "title": "Something went wrong"
+      },
+      "invalidLink": {
+        "description": "This link is missing the required authorization parameters. Restart the connection from the MCP server's authentication settings.",
+        "title": "Invalid authorization link"
+      },
+      "processing": {
+        "description": "Finishing the connection to your MCP server. This may take a few moments…",
+        "title": "Completing authorization"
+      },
+      "serverNotFound": {
+        "description": "The MCP server this authorization belongs to no longer exists or is no longer configured. Recreate or reconfigure the server, then connect again.",
+        "title": "MCP server not found"
+      },
+      "sessionExpired": {
+        "description": "This authorization link is invalid, has expired, or was already used. Restart the connection from the MCP server's authentication settings.",
+        "title": "Authorization session expired"
+      },
+      "success": {
+        "description": "Authorization completed successfully. You can now use this server's tools in chat.",
+        "title": "Connected to {serverName}"
+      },
+      "timedOut": {
+        "description": "The MCP server didn't confirm the authorization in time. Try connecting again — if this keeps happening, verify the server's OAuth configuration.",
+        "title": "Authorization timed out"
+      },
+      "tokenExchangeFailed": {
+        "description": "The provider approved the authorization but a valid access token could not be obtained. Check the server's OAuth client credentials and endpoints, then try connecting again.",
+        "title": "Token exchange failed"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "Add MCP Server"
@@ -554,6 +621,20 @@
         "label": "Deny"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "Back"
+      },
+      "disableAll": {
+        "label": "Disable All"
+      },
+      "enableAll": {
+        "label": "Enable All"
+      },
+      "toggle": {
+        "ariaLabel": "Toggle {name}"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "Tool unavailable"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "Show only enabled tools",
         "tooltip": "Show only enabled"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "Configure Code Interpreter"
+        },
+        "imageGeneration": {
+          "tooltip": "Configure Image Generation"
+        },
+        "openapi": {
+          "tooltip": "Manage OpenAPI Actions"
+        },
+        "webSearch": {
+          "tooltip": "Configure Web Search"
+        }
+      },
+      "disableAllSources": {
+        "label": "Disable All Sources"
+      },
+      "disableAllTools": {
+        "label": "Disable All Tools"
+      },
+      "enableAllSources": {
+        "label": "Enable All Sources"
+      },
+      "enableAllTools": {
+        "label": "Enable All Tools"
+      },
+      "manageActions": {
+        "tooltip": "Manage Actions"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "Search {server} tools"
+      },
+      "moreActions": {
+        "label": "More Actions"
+      },
+      "reauthenticate": {
+        "label": "Re-authenticate"
+      },
+      "search": {
+        "placeholder": "Search actions..."
+      },
+      "serverFallback": {
+        "label": "server"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "Search Filters"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "Ask an admin to configure."
+        },
+        "codingAgent": {
+          "description": "Investigate a GitHub repository and answer questions about its code."
+        },
+        "configureSuffix": {
+          "text": "Press the settings cog to enable."
+        },
+        "default": {
+          "description": "This action is not configured yet."
+        },
+        "imageGeneration": {
+          "description": "Generate images based on a prompt."
+        },
+        "python": {
+          "description": "Execute code for complex analysis."
+        },
+        "search": {
+          "description": "Search through connected knowledge to inform the answer."
+        },
+        "webSearch": {
+          "description": "Search the web for up-to-date information."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "Per day for the selected range",
+        "title": "Messages and unique users"
+      },
+      "empty": {
+        "message": "No data found for this agent in the selected date range."
+      },
+      "fetchFailed": {
+        "message": "Failed to fetch agent stats."
+      },
+      "permissionDenied": {
+        "message": "You don't have permission to view these stats."
+      },
+      "totalMessages": {
+        "label": "Total Messages"
+      },
+      "totalUniqueUsers": {
+        "label": "Total Unique Users"
+      },
+      "unknownError": {
+        "message": "An unknown error occurred"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "Collapse section"
+        },
+        "expand": {
+          "ariaLabel": "Expand section"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "Are you sure you want to delete <emphasis>{name}</emphasis>? This action cannot be undone."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "View Plans"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "No billing information available."
+        },
+        "loadError": {
+          "message": "Error loading billing information. Please try again later."
+        },
+        "loading": {
+          "label": "Loading..."
+        },
+        "manageSubscription": {
+          "description": "View your plan, update payment, or change subscription",
+          "title": "Manage Subscription"
+        },
+        "page": {
+          "title": "Billing Information"
+        },
+        "portalError": {
+          "message": "Error creating customer portal session"
+        },
+        "subscriptionDetails": {
+          "title": "Subscription Details"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "Billing End"
+          },
+          "billingStart": {
+            "label": "Billing Start"
+          },
+          "seats": {
+            "label": "Seats"
+          },
+          "status": {
+            "label": "Subscription Status"
+          }
+        },
+        "updatedToast": {
+          "message": "Congratulations! Your subscription has been updated successfully."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "We will automatically sync permissions from the source. A document will be searchable in Onyx if and only if the user performing the search has permission to access the document in the source.",
+          "disabledReason": "Current credential auth method doesn't support Auto Sync Permissions. Please change the credential auth method to a supported one.",
+          "name": "Auto Sync Permissions"
+        },
+        "heading": {
+          "description": "Control who has access to the documents indexed by this connector.",
+          "title": "Document Access"
+        },
+        "privateOption": {
+          "description": "Only users who have explicitly been given access to this connector (through the User Groups page) can access the documents pulled in by this connector",
+          "name": "Private"
+        },
+        "publicOption": {
+          "description": "Everyone with an account on Onyx can access the documents pulled in by this connector",
+          "name": "Public"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# day} other {# days}}",
@@ -1546,6 +1794,14 @@
           "label": "Show less"
         }
       },
+      "credentialForm": {
+        "errorToast": "Error: {detail}",
+        "successToast": "Success!",
+        "updateButton": {
+          "ariaLabel": "Update credentials",
+          "label": "Update"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "Deleting this connector schedules a deletion job that removes its indexed documents and deletes it for every user.",
         "entityType": "connector"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "Document Permission Sync Error"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "Check out <link>our docs</link> for more info on configuring this connector."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "Failed to update files"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "Drag and drop {multiple, select, true {some files} other {a file}} here, or click to select {multiple, select, true {files} other {a file}}"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {Selected Files} other {Selected File}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "Error Message",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "Group Membership Sync Error"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "Assign group access for this Connector"
+        },
+        "assignToGroup": {
+          "title": "Assign this Connector to a group"
+        },
+        "scopedManagerGroups": {
+          "description": "Select one or more of the groups you manage to give access to this Connector"
+        },
+        "syncGroups": {
+          "description": "The groups below control who can manage this Connector. Access to its documents is inherited from the source's own permissions."
+        },
+        "visibleToGroups": {
+          "description": "This Connector will be visible/accessible by the groups selected below"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "Targeted reindex submitted for {count, plural, one {# document} other {# documents}}. Errors will clear from the list as documents finish reindexing."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "Channel Regex Enabled",
+        "channels": "Channels",
+        "enabledTrue": "True",
+        "excludeChannelRegexEnabled": "Exclude Channel Regex Enabled",
+        "excludedChannels": "Excluded Channels",
+        "includeBotMessages": "Include Bot Messages",
+        "jiraProjectUrl": "Jira Project URL",
+        "multipleRepos": "multiple repos",
+        "pageId": "Page ID",
+        "realm": "Realm",
+        "repo": "Repo",
+        "wikiUrl": "Wiki URL"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "Enter the email of an admin or owner of the Google Organization that owns the Google Drive(s) you want to index.",
           "invalidEmail": "Must be a valid email",
           "label": "Primary Admin Email",
+          "placeholder": "admin@yourcompany.com",
           "required": "Required"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "Enter the email of an admin or owner of the Google Organization that owns the Gmail account(s) you want to index.",
           "invalidEmail": "Must be a valid email",
           "label": "Primary Admin Email",
+          "placeholder": "admin@yourcompany.com",
           "required": "Required"
         },
         "section": {
@@ -2602,6 +2906,171 @@
       "unavailable": {
         "description": "Craft is enabled per deployment by Onyx. Contact your Onyx representative to get access.",
         "title": "Craft isn't available on this deployment"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "Created <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "Created <i>{date}</i> by <i>{email}</i>"
+        },
+        "unnamed": {
+          "label": "Credential #{id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "Create"
+        },
+        "created": {
+          "toast": "Created new credential!"
+        },
+        "name": {
+          "label": "Name:",
+          "placeholder": "(Optional) credential name.."
+        },
+        "submitError": {
+          "toast": "Error submitting credential"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "Cancel"
+        },
+        "confirmBody": {
+          "message": "Are you sure you want to delete this credential? You cannot delete credentials that are linked to live connectors."
+        },
+        "confirmButton": {
+          "label": "Confirm"
+        },
+        "confirmTitle": "Confirm Deletion"
+      },
+      "edit": {
+        "name": {
+          "label": "Name (optional):"
+        },
+        "permissions": {
+          "note": "Ensure that you update to a credential with the proper permissions!"
+        },
+        "resetButton": {
+          "label": "Reset Changes"
+        },
+        "updateButton": {
+          "label": "Update"
+        },
+        "updateError": {
+          "toast": "Error updating credential"
+        }
+      },
+      "modal": {
+        "createTitle": "Create {source} Credential",
+        "editTitle": "Edit Credential",
+        "updateTitle": "Update Credentials"
+      },
+      "modify": {
+        "createButton": {
+          "label": "Create"
+        },
+        "instructions": {
+          "message": "Select a credential as needed! Ensure that you have selected a credential with the proper permissions for this connector!"
+        },
+        "selectButton": {
+          "label": "Select"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "Connect"
+        },
+        "connectError": {
+          "title": "Could not connect"
+        },
+        "redirectFailed": {
+          "message": "We couldn't redirect you to sign in with {source}. Please try again."
+        },
+        "retryButton": {
+          "label": "Retry"
+        },
+        "startError": {
+          "message": "Unable to start OAuth"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "Issue swapping credential: {detail}"
+        },
+        "success": {
+          "toast": "Swapped credential successfully!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "Actions"
+        },
+        "created": {
+          "header": "Created"
+        },
+        "edit": {
+          "ariaLabel": "Edit credential"
+        },
+        "empty": {
+          "message": "No credentials exist for this connector!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "Last Updated"
+        },
+        "name": {
+          "header": "Name"
+        },
+        "select": {
+          "label": "Select"
+        },
+        "selected": {
+          "badge": "selected"
+        },
+        "untitled": {
+          "label": "Untitled"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "Issue updating credential"
+        },
+        "success": {
+          "toast": "Updated credential"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "This allows you to bring your own analytics tool to Onyx! Copy the Web snippet from your analytics provider into the box below, and we'll start sending usage events."
+      },
+      "notEnabled": {
+        "description": "To set up custom analytics scripts, please work with the team who setup Onyx in your team to set the <i>CUSTOM_ANALYTICS_SECRET_KEY</i> environment variable.",
+        "title": "Custom Analytics is not enabled."
+      },
+      "script": {
+        "description": "Specify the Javascript that should run on page load in order to initialize your custom tracking/analytics.",
+        "instructions": "Do not include the `<script></script>` tags. If you upload a script below but you are not receiving any events in your analytics platform, try removing all extra whitespace before each line of JavaScript.",
+        "label": "Script"
+      },
+      "secretKey": {
+        "description": "For security reasons, you must provide a secret key to update this script. This should be the value of the <i>CUSTOM_ANALYTICS_SECRET_KEY</i> environment variable set when initially setting up Onyx.",
+        "label": "Secret Key"
+      },
+      "updateButton": {
+        "label": "Update"
+      },
+      "updateFailed": {
+        "message": "Failed to update custom analytics script: \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "Custom analytics script updated successfully!"
       }
     },
     "discordBot": {
@@ -3059,6 +3528,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "Collecting..."
+        },
+        "downloading": {
+          "label": "Downloading..."
+        },
+        "export": {
+          "label": "Export Logs"
+        },
+        "starting": {
+          "label": "Starting..."
+        }
+      },
+      "downloadButton": {
+        "label": "Download"
+      },
+      "exportCard": {
+        "description": "Collects log files from the API server and background workers into a single zip. The download starts automatically once collection finishes.",
+        "title": "Export logs"
+      },
+      "header": {
+        "description": "Download a zip of server log files to attach to an Onyx support thread."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "covered by another worker on the same host"
+        },
+        "failed": {
+          "label": "failed"
+        },
+        "failedWithError": {
+          "label": "failed: {error}"
+        },
+        "noLogs": {
+          "label": "no log files found"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {uploaded # file} other {uploaded # files}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "Log files can include user emails, document titles, search queries, and error payloads. Review the contents before sharing them outside your organization.",
+        "title": "Logs may contain sensitive data"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "Starting collection..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "A log export is already in progress. Try again shortly."
+        },
+        "downloadFailed": {
+          "message": "Failed to download the log export."
+        },
+        "lostAccess": {
+          "message": "Lost access to the running export. Start a new one."
+        },
+        "startFailed": {
+          "message": "Failed to start the log export."
+        },
+        "unreachable": {
+          "message": "Cannot reach the server to check export progress. Start a new export once it is back."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "collecting..."
+        },
+        "missedDeadline": {
+          "label": "did not report before the deadline"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3165,9 +3711,137 @@
         "loadFailed": "Failed to load connector: {details}",
         "title": "Error"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "Type channel name or regex pattern and press Enter"
+        },
+        "channelsRequired": {
+          "error": "At least one channel is required when 'Search All Channels' is disabled"
+        },
+        "configSchemaLoadError": {
+          "message": "Failed to load configuration schema: {error}"
+        },
+        "configTitle": {
+          "text": "Federated Connector Configuration"
+        },
+        "configuration": {
+          "heading": "Configuration"
+        },
+        "create": {
+          "failed": "Failed to create federated connector",
+          "success": "Federated connector created successfully!"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (leave blank to keep current value)"
+        },
+        "credentialValidationFailed": {
+          "message": "Credential validation failed: {message}"
+        },
+        "credentials": {
+          "description": "Enter the credentials for this connector.",
+          "heading": "Credentials"
+        },
+        "delete": {
+          "failed": "Failed to delete federated connector",
+          "success": "Federated connector deleted successfully!"
+        },
+        "deleteConfirm": {
+          "message": "Are you sure you want to delete this federated connector? This action cannot be undone."
+        },
+        "deleteError": {
+          "toast": "Error deleting connector: {error}"
+        },
+        "deleteItem": {
+          "deleting": "Deleting...",
+          "inProgressTooltip": "Deletion in progress",
+          "label": "Delete"
+        },
+        "federatedBadge": {
+          "label": "Federated"
+        },
+        "federatedTooltip": {
+          "default": "This is a federated connector. It will result in greater latency and lower search quality compared to regular connectors."
+        },
+        "genericError": {
+          "text": "Error: {error}"
+        },
+        "listInput": {
+          "placeholder": "Type and press Enter to add an item"
+        },
+        "loadingSchema": {
+          "description": "Retrieving required fields for this connector type",
+          "title": "Loading credential schema..."
+        },
+        "manageButton": {
+          "label": "Manage"
+        },
+        "missingFields": {
+          "message": "Missing required fields: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "No search configuration available for this connector type."
+        },
+        "noCredentialSchema": {
+          "message": "No credential schema available for this connector type."
+        },
+        "schemaLoadError": {
+          "message": "Failed to load credential schema: {error}"
+        },
+        "submitButton": {
+          "create": "Create",
+          "creating": "Creating...",
+          "update": "Update",
+          "updating": "Updating..."
+        },
+        "title": {
+          "edit": "Edit {name}",
+          "setup": "Setup {name}"
+        },
+        "update": {
+          "failed": "Failed to update federated connector",
+          "success": "Federated connector updated successfully!"
+        },
+        "validateBeforeEdit": {
+          "message": "Enter new credential values before validating."
+        },
+        "validateButton": {
+          "label": "Validate",
+          "validating": "Validating..."
+        },
+        "validation": {
+          "error": "Validation error: {error}",
+          "failedStatus": "Validation failed: {statusText}",
+          "invalid": "Credentials are invalid",
+          "valid": "Credentials are valid"
+        }
+      },
       "loading": {
         "description": "Retrieving connector details and credential schema",
         "title": "Loading connector configuration..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "Back to Chat"
+      },
+      "error": {
+        "title": "Something Went Wrong"
+      },
+      "errors": {
+        "clientSecret": "Authentication credentials are missing or invalid",
+        "oauth": "OAuth authorization failed",
+        "validation": "Configuration error - please check your connector settings"
+      },
+      "processing": {
+        "details": "Please wait while we complete the setup.",
+        "title": "Processing..."
+      },
+      "redirecting": {
+        "text": "Redirecting to chat in 2 seconds..."
+      },
+      "success": {
+        "detailsTemplate": "Your {serviceName} authorization completed successfully. You can now use this connector for search.",
+        "title": "Success!"
       }
     },
     "groups": {
@@ -3430,6 +4104,265 @@
           "header": "Token Limit",
           "placeholder": "Token limit (thousands)",
           "unit": "(thousands)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "Delete hook",
+          "tooltip": "Delete"
+        },
+        "disconnect": {
+          "ariaLabel": "Deactivate hook",
+          "tooltip": "Disconnect Hook"
+        },
+        "disconnectedSuffix": {
+          "label": "(Disconnected)"
+        },
+        "hookPoint": {
+          "description": "Hook Point: {name}"
+        },
+        "manage": {
+          "ariaLabel": "Configure hook",
+          "tooltip": "Manage"
+        },
+        "reconnectButton": {
+          "label": "Reconnect"
+        },
+        "test": {
+          "ariaLabel": "Re-validate hook",
+          "tooltip": "Test Connection"
+        }
+      },
+      "connectButton": {
+        "label": "Connect"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "Hook ***{name}*** will be permanently removed from this hook point. The external endpoint may still retain data previously sent to it."
+        },
+        "delete": {
+          "label": "Delete"
+        },
+        "header": {
+          "title": "Delete *{name}*"
+        },
+        "permanent": {
+          "description": "Deletion cannot be undone."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyx will stop calling this endpoint for hook ***{name}***. In-flight requests will continue to run. The external endpoint may still retain data previously sent to it. You can reconnect this hook later if needed."
+        },
+        "deleteNote": {
+          "description": "You can also delete this hook. Deletion cannot be undone."
+        },
+        "disconnect": {
+          "label": "Disconnect"
+        },
+        "disconnectAndDelete": {
+          "label": "Disconnect & Delete"
+        },
+        "header": {
+          "title": "Disconnect *{name}*"
+        }
+      },
+      "docsLink": {
+        "label": "Documentation"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyx will use this key to authenticate with your API endpoint.",
+          "keepCurrent": {
+            "placeholder": "Leave blank to keep current key"
+          },
+          "title": "API Key"
+        },
+        "connectionValid": {
+          "label": "Connection valid."
+        },
+        "createHeader": {
+          "description": "Connect an external API endpoint to extend the hook point.",
+          "title": "Set Up Hook Extension"
+        },
+        "editHeader": {
+          "title": "Manage Hook Extension"
+        },
+        "endpoint": {
+          "description": "Only connect to servers you trust. You are responsible for actions taken and data shared with this connection.",
+          "title": "External API Endpoint URL"
+        },
+        "errors": {
+          "connect": "Could not connect to endpoint.",
+          "generic": "Something went wrong.",
+          "invalidApiKey": "Invalid API key.",
+          "timeout": "Connection timed out. Try increasing the timeout."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(Default)"
+          },
+          "hard": {
+            "label": "Block Pipeline on Failure"
+          },
+          "placeholder": "Select strategy",
+          "soft": {
+            "label": "Log Error and Continue"
+          },
+          "title": "Fail Strategy"
+        },
+        "hookPoint": {
+          "label": "Hook Point"
+        },
+        "name": {
+          "placeholder": "Name your extension at this hook point",
+          "title": "Display Name"
+        },
+        "save": {
+          "label": "Save Changes"
+        },
+        "softStrategy": {
+          "description": "If the endpoint returns an error, Onyx logs it and continues the pipeline as normal, ignoring the hook result."
+        },
+        "timeout": {
+          "description": "Maximum time Onyx will wait for the endpoint to respond before applying the fail strategy. Must be greater than 0 and at most {max} seconds.",
+          "revert": {
+            "tooltip": "Revert to Default"
+          },
+          "suffix": "(seconds)",
+          "title": "Timeout"
+        },
+        "toasts": {
+          "created": {
+            "message": "Hook created."
+          },
+          "noHookPoint": {
+            "message": "No hook point specified."
+          },
+          "updated": {
+            "message": "Hook updated."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "API key cannot be empty.",
+          "endpointRequired": "Endpoint URL cannot be empty.",
+          "nameRequired": "Display name cannot be empty.",
+          "timeoutRange": "Must be greater than 0 and at most {max} seconds.",
+          "timeoutRequired": "Timeout is required."
+        },
+        "verifying": {
+          "label": "Verifying connection…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "Copy"
+        },
+        "download": {
+          "tooltip": "Download"
+        },
+        "empty": {
+          "message": "No errors in the past 30 days."
+        },
+        "header": {
+          "description": "Hook: {name} • Hook Point: {point}",
+          "title": "Recent Errors"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# line} other {# lines}}"
+        },
+        "loadFailed": {
+          "message": "Failed to load logs."
+        },
+        "older": {
+          "label": "Older"
+        },
+        "pastHour": {
+          "label": "Past Hour"
+        },
+        "unknownError": {
+          "label": "Unknown error"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "Cancel"
+        }
+      },
+      "page": {
+        "description": "Extend Onyx pipelines by registering external API endpoints as callbacks at predefined hook points.",
+        "empty": {
+          "title": "No hook points available"
+        },
+        "emptySearch": {
+          "description": "Try using a different search term.",
+          "title": "No results found"
+        },
+        "enterpriseRequired": {
+          "message": "Hook Extensions require an Enterprise license."
+        },
+        "loadHooksFailed": {
+          "message": "Failed to load hooks. Please refresh the page."
+        },
+        "loadSpecsFailed": {
+          "message": "Failed to load hook specifications. Please refresh the page."
+        },
+        "notEnabled": {
+          "message": "Hook Extensions are not enabled for this deployment."
+        },
+        "search": {
+          "placeholder": "Search hooks..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "Connected"
+        },
+        "connectionLost": {
+          "label": "Connection Lost"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# Error} other {# Errors}}"
+        },
+        "noError": {
+          "title": "No Error"
+        },
+        "pastHour": {
+          "description": "in the past hour"
+        },
+        "recentErrors": {
+          "title": "Most Recent Errors"
+        },
+        "viewMore": {
+          "label": "View More Lines"
+        },
+        "viewOlder": {
+          "label": "View Older Errors"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "Failed to deactivate hook."
+        },
+        "deleteFailed": {
+          "message": "Failed to delete hook."
+        },
+        "disconnectFailed": {
+          "message": "Failed to disconnect hook."
+        },
+        "reconnectFailed": {
+          "message": "Failed to reconnect hook."
+        },
+        "validateFailed": {
+          "message": "Failed to validate hook."
+        },
+        "validateSuccess": {
+          "message": "Hook validated successfully."
+        },
+        "validationFailed": {
+          "message": "Validation failed: {status}"
         }
       }
     },
@@ -4309,6 +5242,9 @@
               "label": "Add Line"
             },
             "description": "Add extra properties as needed by the model provider. These are passed to LiteLLM's `completion()` call as [environment variables](https://docs.litellm.ai/docs/set_keys#environment-variables). See [documentation](https://docs.onyx.app/admins/ai_models/custom_inference_provider) for more instructions.",
+            "keyInput": {
+              "placeholder": "e.g. OPENAI_ORGANIZATION"
+            },
             "title": "Environment Variables"
           },
           "modelRow": {
@@ -4820,6 +5756,132 @@
         "title": "Users"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "Unknown"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "AI"
+        },
+        "errorTitle": {
+          "title": "Something went wrong :("
+        },
+        "feedback": {
+          "title": "Feedback"
+        },
+        "fetchFailed": {
+          "message": "Failed to fetch chat session - {error}"
+        },
+        "header": {
+          "title": "Chat Session Details"
+        },
+        "referenceDocuments": {
+          "title": "Reference Documents"
+        },
+        "user": {
+          "label": "User"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "Cancel"
+        },
+        "downloadFailed": {
+          "message": "Failed to download the query-history."
+        },
+        "generating": {
+          "message": "Generating CSV report. Click the ''{button}'' button to see all jobs."
+        },
+        "kickoff": {
+          "label": "Kickoff Export"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "Failure"
+        },
+        "pending": {
+          "label": "Pending"
+        },
+        "success": {
+          "label": "Success"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "Download"
+        },
+        "endRange": {
+          "header": "End Range"
+        },
+        "generatedAt": {
+          "header": "Generated At"
+        },
+        "header": {
+          "title": "Previous Query History Exports"
+        },
+        "notReady": {
+          "tooltip": "Export is not yet ready"
+        },
+        "startRange": {
+          "header": "Start Range"
+        },
+        "status": {
+          "header": "Status"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "Dislike"
+        },
+        "like": {
+          "label": "Like"
+        },
+        "mixed": {
+          "label": "Mixed"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "Any"
+        },
+        "feedbackType": {
+          "label": "Feedback Type"
+        }
+      },
+      "previousExports": {
+        "label": "View Exports"
+      },
+      "table": {
+        "date": {
+          "header": "Date"
+        },
+        "feedback": {
+          "header": "Feedback"
+        },
+        "fetchError": {
+          "title": "Error fetching query history"
+        },
+        "firstAiResponse": {
+          "header": "First AI Response"
+        },
+        "firstUserMessage": {
+          "header": "First User Message"
+        },
+        "persona": {
+          "header": "Persona"
+        },
+        "user": {
+          "header": "User"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4874,6 +5936,56 @@
         "generateFailed": "Failed to generate token: {detail}",
         "genericError": "Something went wrong. Please try again.",
         "regenerated": "Token regenerated"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "Query classification failed. Falling back to chat."
+        },
+        "searchFailed": {
+          "message": "Document search failed. Please try again."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# Result} other {# Results}}"
+        },
+        "empty": {
+          "description": "Check your connectors/filters or try a different search term.",
+          "title": "No results found"
+        },
+        "failed": {
+          "title": "Search failed"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# Tag} other {# Tags}}"
+        },
+        "empty": {
+          "label": "Tags"
+        },
+        "search": {
+          "placeholder": "Filter tags..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "All Time"
+        },
+        "day": {
+          "label": "Past 24 hours"
+        },
+        "month": {
+          "label": "Past month"
+        },
+        "week": {
+          "label": "Past week"
+        },
+        "year": {
+          "label": "Past year"
+        }
       }
     },
     "security": {
@@ -5765,6 +6877,163 @@
         "unexpectedError": "Unexpected error occurred."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "Remove category {name}"
+        },
+        "removeButton": {
+          "ariaLabel": "Remove category"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "Standard Answer Categories"
+        },
+        "fetchError": {
+          "message": "Failed to fetch standard answer categories - {message}",
+          "title": "Something went wrong :("
+        },
+        "search": {
+          "placeholder": "Search categories..."
+        }
+      },
+      "editPage": {
+        "title": "Edit Standard Answer"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "Failed to fetch standard answers"
+        },
+        "fetchCategoriesFailed": {
+          "message": "Failed to fetch standard answer categories"
+        },
+        "genericTitle": {
+          "title": "Something went wrong :("
+        },
+        "loadAnswersFailed": {
+          "title": "Error loading standard answers"
+        },
+        "loadCategoriesFailed": {
+          "title": "Error loading standard answer categories"
+        },
+        "notFound": {
+          "message": "Did not find standard answer with ID: {id}"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "All Categories"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "All of these keywords, in any order, separated by spaces",
+          "placeholder": "it ticket"
+        },
+        "answer": {
+          "label": "Answer",
+          "placeholder": "The answer in Markdown. Example: If you need any help from the IT team, please email internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "Any of these keywords, separated by spaces",
+          "placeholder": "ticket problem issue"
+        },
+        "categories": {
+          "label": "Categories:",
+          "placeholder": "Type a category and press Enter…"
+        },
+        "createButton": {
+          "label": "Create!"
+        },
+        "keywords": {
+          "tooltip": "A question must match these keywords in order to trigger the answer."
+        },
+        "matchRegex": {
+          "description": "Match a regex pattern instead of an exact keyword",
+          "label": "Match regex"
+        },
+        "regexPattern": {
+          "label": "Regex pattern",
+          "tooltip": "Triggers if the question matches this regex pattern (using Python `re.search()`)"
+        },
+        "strategy": {
+          "all": {
+            "label": "All keywords"
+          },
+          "any": {
+            "label": "Any keywords"
+          },
+          "description": "Choose whether to require the user's question to contain any or all of the keywords above to show this answer.",
+          "label": "Keyword detection strategy"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "Error creating category \"{name}\" - {error}"
+          },
+          "createFailed": {
+            "message": "Error creating Standard Answer - {error}"
+          },
+          "updateFailed": {
+            "message": "Error updating Standard Answer - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "Update!"
+        },
+        "validation": {
+          "answerRequired": "Answer is required",
+          "categoryRequired": "At least one category is required",
+          "keywordRequired": "Keywords or pattern is required"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "Add your first standard answer below!"
+        },
+        "description": "Manage the standard answers for pre-defined questions.\nNote: Currently, only questions asked from Slack can receive standard answers."
+      },
+      "newStandardAnswer": {
+        "label": "New Standard Answer"
+      },
+      "search": {
+        "placeholder": "Find standard answers by keyword/phrase..."
+      },
+      "table": {
+        "answer": {
+          "header": "Answer"
+        },
+        "categories": {
+          "header": "Categories"
+        },
+        "empty": {
+          "message": "No matching standard answers found..."
+        },
+        "keywords": {
+          "header": "Keywords/Pattern"
+        },
+        "matchRegex": {
+          "header": "Match regex?"
+        },
+        "matchRegexNo": {
+          "label": "No"
+        },
+        "matchRegexYes": {
+          "label": "Yes"
+        },
+        "slackNote": {
+          "message": "Ensure that you have added the category to the relevant [Slack Bot](/admin/bots)."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "Failed to delete standard answer - {error}"
+        },
+        "deleted": {
+          "message": "Standard answer {id} deleted"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "Canceled",
@@ -5795,6 +7064,142 @@
       },
       "webVersion": {
         "label": "Web Version: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "Show a persistent system announcement that users can dismiss.",
+        "header": {
+          "placeholder": "Add an announcement"
+        },
+        "label": "System Announcement"
+      },
+      "announcementPopup": {
+        "description": "Also show this notice as a full-screen pop-up at first visit for all users. Use with caution.",
+        "label": "Pop-up Notice at First Visit"
+      },
+      "appName": {
+        "description": "This name will show across the app and replace \"Onyx\" in the UI.",
+        "label": "Application Display Name"
+      },
+      "branding": {
+        "description": "Remove “powered by Onyx” and other Onyx branding presence in the app.",
+        "enterpriseTooltip": "Hiding Onyx branding is an Enterprise Plan feature.",
+        "label": "Hide Onyx Branding"
+      },
+      "chatFooter": {
+        "description": "Add markdown content for disclaimers or additional information.",
+        "label": "Chat Footer Text"
+      },
+      "chatHeader": {
+        "label": "Chat Header Text"
+      },
+      "consent": {
+        "description": "Require the user to read and agree to the notice before accessing the application.",
+        "label": "Require Consent to Notice"
+      },
+      "consentPrompt": {
+        "label": "Notice Consent Prompt"
+      },
+      "firstVisit": {
+        "description": "Show a one-time pop-up for new users at their first visit.",
+        "label": "Show First Visit Notice"
+      },
+      "greeting": {
+        "description": "Add a short message to the home page.",
+        "label": "Greeting Message"
+      },
+      "helpLink": {
+        "description": "Add a custom help link in the user menu in addition to the Onyx documentation.",
+        "enterpriseTooltip": "Custom help link is an Enterprise Plan feature.",
+        "label": "Custom Help Link"
+      },
+      "helpLinkLabel": {
+        "label": "Custom Help Link Label",
+        "placeholder": "Link label"
+      },
+      "loginSubtitle": {
+        "description": "Replace the tagline under the welcome heading on the login page.",
+        "label": "Login Page Subtitle"
+      },
+      "logo": {
+        "label": "Application Logo",
+        "updateButton": {
+          "label": "Update"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "Logo & Name",
+          "tooltip": "Show both your application logo and name."
+        },
+        "description": "Choose what to display at the top of the sidebar. Options become available once you add a logo or application name.",
+        "label": "Logo Display Style",
+        "logoOnly": {
+          "disabledTooltip": "Upload a logo to enable this option.",
+          "label": "Logo Only",
+          "tooltip": "Show only your application logo."
+        },
+        "nameOnly": {
+          "disabledTooltip": "Enter an application name to enable this option.",
+          "label": "Name Only",
+          "tooltip": "Show only your application name."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "Add markdown content"
+      },
+      "noticeContent": {
+        "label": "Notice Content"
+      },
+      "noticeHeader": {
+        "label": "Notice Header"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "Failed to clear announcement."
+        },
+        "announcementSaveFailed": {
+          "message": "Failed to save announcement."
+        },
+        "applyButton": {
+          "label": "Apply Changes"
+        },
+        "applying": {
+          "label": "Applying..."
+        },
+        "description": "Customize how the application appears to users across your organization.",
+        "logoUploadFailed": {
+          "message": "Failed to upload logo. {error}"
+        },
+        "saveSuccess": {
+          "message": "Appearance settings saved successfully!"
+        },
+        "settingsSaveFailed": {
+          "message": "Failed to update settings. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "Notice Consent Prompt is required",
+          "invalidUrl": "Must be a valid URL",
+          "maxChars": "Maximum {count} characters",
+          "noticeContentRequired": "Notice Content is required",
+          "noticeHeaderRequired": "Notice Header is required",
+          "urlRequiredWithLabel": "URL is required when a label is set"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "Chat Footer Content"
+        },
+        "chatHeader": {
+          "placeholder": "Chat Header Content"
+        },
+        "greeting": {
+          "placeholder": "Welcome to Acme Chat"
+        },
+        "logo": {
+          "alt": "Logo"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6059,6 +7464,9 @@
             "label": "Spend"
           }
         }
+      },
+      "page": {
+        "description": "Monitor workspace spend and review usage by user."
       },
       "spendByUser": {
         "columns": {
@@ -6656,6 +8064,204 @@
         "tooltip": "View Agent Stats"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "Generate and run code.",
+          "title": "Code Interpreter"
+        },
+        "codingAgent": {
+          "description": "Investigate a GitHub repository and answer questions about its code.",
+          "title": "Coding Agent"
+        },
+        "description": "Tools and capabilities available for this agent to use.",
+        "imageGeneration": {
+          "description": "Generate and manipulate images using AI-powered tools.",
+          "title": "Image Generation",
+          "unavailable": {
+            "tooltip": "Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin."
+          }
+        },
+        "openUrl": {
+          "description": "Fetch and read content from web URLs.",
+          "title": "Open URL"
+        },
+        "title": "Actions",
+        "webSearch": {
+          "description": "Search the web for real-time information and up-to-date results.",
+          "title": "Web Search"
+        }
+      },
+      "advanced": {
+        "description": "Fine-tune agent prompts and knowledge.",
+        "overwritePrompt": {
+          "suffix": "(Not Recommended)",
+          "title": "Overwrite System Prompt"
+        },
+        "reminders": {
+          "description": "Append a brief reminder to the prompt messages. Use this to remind the agent if you find that it tends to forget certain instructions as the chat progresses. This should be brief and not interfere with the user messages.",
+          "placeholder": "Remember, I want you to always format your response as a numbered list.",
+          "title": "Reminders"
+        },
+        "title": "Advanced Options"
+      },
+      "avatar": {
+        "edit": {
+          "label": "Edit"
+        },
+        "uploadImage": {
+          "label": "Upload Image"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "Delete Agent"
+        },
+        "description": "Anyone using this agent will no longer be able to access it.",
+        "title": "Delete This Agent"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "Are you sure you want to delete this agent?",
+          "warning": "Anyone using this agent will no longer be able to access it. Deletion cannot be undone."
+        },
+        "title": "Delete Agent"
+      },
+      "filesModal": {
+        "description": "All files selected for this agent",
+        "placeholderName": "File {id}",
+        "title": "User Files"
+      },
+      "general": {
+        "avatar": {
+          "title": "Agent Avatar"
+        },
+        "descriptionField": {
+          "placeholder": "What does this agent do?",
+          "title": "Description"
+        },
+        "name": {
+          "placeholder": "Name your agent",
+          "title": "Name"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "Cancel"
+        },
+        "create": {
+          "label": "Create"
+        },
+        "createTitle": "Create Agent",
+        "editTitle": "Edit Agent",
+        "save": {
+          "label": "Save"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "You no longer have access to this MCP server. Its existing tools will be preserved."
+        },
+        "searchTools": {
+          "placeholder": "Search tools..."
+        }
+      },
+      "page": {
+        "ariaLabel": "Agents Editor Page"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "Add instructions to tailor the response for this agent.",
+          "placeholder": "Think step by step and show reasoning for complex problems. Use specific examples. Emphasize action items, and leave blanks for the human to fill in when you have unknown. Use a polite enthusiastic tone.",
+          "title": "Instructions"
+        },
+        "starters": {
+          "description": "Example messages that help users understand what this agent can do and how to interact with it effectively.",
+          "title": "Conversation Starters"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "Please fix the errors in the form before saving.",
+        "noChanges": "No changes have been made.",
+        "saving": "Saving changes...",
+        "uploading": "Please wait for files to finish uploading."
+      },
+      "share": {
+        "feature": {
+          "description": "Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access.",
+          "privateNotice": {
+            "title": "This agent is private to you and will only be featured for yourself."
+          },
+          "title": "Feature This Agent",
+          "unlistedWarning": {
+            "title": "This agent is unlisted and won't be shown in the featured list."
+          }
+        },
+        "labels": {
+          "description": "Add labels and categories to help people better discover this agent.",
+          "placeholder": "Add labels..."
+        },
+        "share": {
+          "button": {
+            "label": "Share"
+          },
+          "description": "with other users, groups, or everyone in your organization.",
+          "title": "Share This Agent"
+        },
+        "title": "Share Agent"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "Compile a list of our engineering goals for this quarter.",
+          "overview": "Give me an overview of some documents.",
+          "salesReport": "Find the latest sales report.",
+          "todayGoals": "Summarize my goals for today."
+        },
+        "placeholder": "Enter a conversation starter..."
+      },
+      "suffix": {
+        "optional": "optional"
+      },
+      "toasts": {
+        "createFailed": "Failed to create agent - {detail}",
+        "created": "Agent \"{name}\" created successfully",
+        "deleteFailed": "Failed to delete agent: {error}",
+        "deleted": "Agent deleted successfully",
+        "genericError": "An error occurred: {error}",
+        "noResponse": "no response received",
+        "sharingFailed": "Agent created, but sharing failed: {error}",
+        "toggleListedFailed": "Failed to toggle visibility",
+        "unknownDetail": "unknown error",
+        "unknownError": "Unknown error",
+        "updateFailed": "Failed to update agent - {detail}",
+        "updated": "Agent \"{name}\" updated successfully"
+      },
+      "validation": {
+        "cutoffInFuture": "Knowledge cutoff date must be today or earlier.",
+        "descriptionMax": "Description must be {max} characters or less",
+        "nameRequired": "Agent name is required.",
+        "starterMax": "Conversation starter must be {max} characters or less"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "Relist Agent"
+          },
+          "description": "Relisted agents appear in the explore agents list again.",
+          "title": "Relist This Agent"
+        },
+        "unlist": {
+          "button": {
+            "label": "Unlist Agent"
+          },
+          "description": "Unlisted agents don't appear in the explore agents list but remain accessible.",
+          "title": "Unlist This Agent"
+        }
+      },
+      "warnings": {
+        "openUrl": "Web Search without the ability to open URLs can lead to significantly worse web based results."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6838,6 +8444,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {Agent} other {Agents}}"
+      },
+      "empty": {
+        "description": "No Agents found"
+      },
+      "header": {
+        "description": "Customize AI behavior and knowledge for you and your team's use cases.",
+        "title": "Agents"
+      },
+      "newAgent": {
+        "label": "New Agent",
+        "noPermission": {
+          "tooltip": "You don't have permission to create agents. Contact your admin to request access."
+        }
+      },
+      "page": {
+        "ariaLabel": "Agents Page"
+      },
+      "search": {
+        "placeholder": "Search agents..."
+      },
+      "sections": {
+        "all": {
+          "title": "All Agents"
+        },
+        "featured": {
+          "description": "Curated by your team",
+          "title": "Featured Agents"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "All Agents"
+        },
+        "your": {
+          "label": "Your Agents"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "Insert user variable"
@@ -6845,6 +8492,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "Please wait while we set up your anonymous session.",
+        "title": "Redirecting you to the chat page..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "Create New Organization"
@@ -6866,6 +8519,55 @@
       },
       "signInLink": {
         "label": "Sign in"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "An account already exists with the specified email."
+      },
+      "continueAsGuest": {
+        "label": "or continue as guest"
+      },
+      "email": {
+        "label": "Email Address",
+        "placeholder": "email@yourcompany.com"
+      },
+      "forgotPassword": {
+        "link": "[Forgot password?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "Invalid email or password"
+      },
+      "noPassword": {
+        "error": "Create an account to set a password"
+      },
+      "password": {
+        "label": "Password",
+        "placeholder": "Password"
+      },
+      "passwordDigit": {
+        "error": "Password must contain at least one number"
+      },
+      "passwordLength": {
+        "error": "Password must be between {min}–{max} characters"
+      },
+      "passwordLoginDisabled": {
+        "error": "Password login is turned off. Sign in with your identity provider."
+      },
+      "passwordLowercase": {
+        "error": "Password must contain at least one lowercase letter"
+      },
+      "passwordRequirements": {
+        "label": "Password requirements:"
+      },
+      "passwordSpecialChar": {
+        "error": "Password must contain at least one special character"
+      },
+      "passwordUppercase": {
+        "error": "Password must contain at least one uppercase letter"
+      },
+      "tooManyRequests": {
+        "error": "Too many requests. Please try again later."
       }
     },
     "error": {
@@ -6906,6 +8608,31 @@
         "description": "Temporary authentication system disruption"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "Your team does not have anonymous access enabled."
+      },
+      "generic": {
+        "toast": "An error occurred."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "Create an Account"
+      },
+      "logo": {
+        "alt": "Logo"
+      },
+      "signInLink": {
+        "label": "Sign In"
+      },
+      "signinPrompt": {
+        "text": "Already have an account?"
+      },
+      "signupPrompt": {
+        "text": "New to {appName}?"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[Back to Login](/auth/login)"
@@ -6938,7 +8665,8 @@
         "placeholder": "Enter API Key"
       },
       "emailField": {
-        "label": "Email"
+        "label": "Email",
+        "placeholder": "email@yourcompany.com"
       },
       "genericError": {
         "toast": "Failed to impersonate user"
@@ -6999,6 +8727,23 @@
         "label": "Work Email"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "Contains number."
+      },
+      "length": {
+        "label": "{min}–{max} characters"
+      },
+      "lowercase": {
+        "label": "Contains lowercase letter."
+      },
+      "specialChar": {
+        "label": "Contains special character."
+      },
+      "uppercase": {
+        "label": "Contains uppercase letter."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[Back to Login](/auth/login)"
@@ -7040,6 +8785,31 @@
       },
       "unexpectedError": {
         "toast": "An unexpected error occurred. Please try again."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "Your session has expired. Please log in again to continue."
+      },
+      "loginButton": {
+        "label": "Log In"
+      },
+      "modal": {
+        "title": "You Have Been Logged Out"
+      },
+      "terminated": {
+        "message": "This session was signed out. Please log in again to continue."
+      },
+      "unrecognized": {
+        "message": "You were signed out unexpectedly. Please log in again to continue. If this keeps happening, contact your administrator."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute returned no token"
+      },
+      "google": {
+        "label": "Continue with Google"
       }
     },
     "signup": {
@@ -8471,6 +10241,75 @@
         "tooltip": "Modifying this setting is not supported for this model."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {File failed and was removed: {names}} other {Files failed and were removed: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "Log in"
+          },
+          "title": "Welcome to Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "No previously-submitted user message found."
+        },
+        "settingsButton": {
+          "tooltip": "Open settings"
+        },
+        "setupLlmButton": {
+          "label": "Set up an LLM."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "Cancel"
+          },
+          "confirmButton": {
+            "label": "Turn off"
+          },
+          "description": "You'll see your browser's default new tab page instead. You can turn it back on anytime in your Onyx settings.",
+          "title": "Turn off Onyx new tab page?"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "None"
+        },
+        "backgroundOption": {
+          "ariaLabel": "{label} background"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "{label} background (selected)"
+        },
+        "backgroundSection": {
+          "title": "Background"
+        },
+        "closeButton": {
+          "tooltip": "Close settings"
+        },
+        "generalSection": {
+          "title": "General"
+        },
+        "header": {
+          "title": "Settings"
+        },
+        "newTabToggle": {
+          "label": "Use Onyx as new tab page"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {Switch to light theme} other {Switch to dark theme}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "New chat"
+        },
+        "openInOnyxButton": {
+          "tooltip": "Open in Onyx"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "Consent checkbox"
@@ -8486,6 +10325,128 @@
       },
       "startButton": {
         "label": "Start"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "Last message {time}"
+        },
+        "projectFallback": {
+          "label": "Project"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "Add Files"
+        },
+        "contextExceeded": {
+          "message": "This project exceeds the model's context limits. Sessions will automatically search for relevant files first before generating response."
+        },
+        "dropFiles": {
+          "message": "Drop files here to add to this project"
+        },
+        "emptyFiles": {
+          "message": "Add documents, texts, or images to use in the project. Drag & drop supported."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# file} other {# files}}"
+        },
+        "fileCountOverflow": {
+          "description": "100+ files"
+        },
+        "files": {
+          "description": "Chats in this project can access these files.",
+          "title": "Files"
+        },
+        "filesModal": {
+          "description": "Sessions in this project can access the files here.",
+          "title": "Project Files"
+        },
+        "instructions": {
+          "emptyDescription": "Add instructions to tailor the response in this project.",
+          "title": "Instructions"
+        },
+        "loadingProject": {
+          "label": "Loading project..."
+        },
+        "setInstructionsButton": {
+          "label": "Set Instructions"
+        },
+        "viewAll": {
+          "label": "View All"
+        },
+        "viewFiles": {
+          "label": "View files"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "Cancel"
+        },
+        "createError": {
+          "toast": "Failed to create the project {name}"
+        },
+        "description": "Use projects to organize your files and chats in one place, and add custom instructions for ongoing work.",
+        "name": {
+          "label": "Project Name",
+          "placeholder": "What are you working on?"
+        },
+        "nameRequired": {
+          "error": "Project name is required"
+        },
+        "submitButton": {
+          "label": "Create Project"
+        },
+        "title": "Create New Project"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "No projects found"
+        },
+        "search": {
+          "placeholder": "Search projects..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "Collapse project"
+        },
+        "delete": {
+          "label": "Delete Project"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "Delete"
+          },
+          "message": "Are you sure you want to delete this project? This action cannot be undone.",
+          "title": "Delete Project"
+        },
+        "expand": {
+          "ariaLabel": "Expand project"
+        },
+        "rename": {
+          "label": "Rename Project"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "No chats yet."
+        },
+        "recentChats": {
+          "title": "Recent Chats"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "Failed to upload files"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {Skipped # oversized file} other {Skipped # oversized files}} (>{max} MB): {names}"
+        },
+        "rejected": {
+          "toast": "Some files were not uploaded. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8518,6 +10479,1773 @@
       },
       "incognito": {
         "title": "You're incognito"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "Open Sidebar"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "Update Billing Information"
+        },
+        "text": "**Warning:** Your trial ends in less than 5 days and no payment method has been added."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "Agent avatar"
+      },
+      "logo": {
+        "alt": "Logo"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "Document"
+      },
+      "expandButton": {
+        "ariaLabel": "Expand document"
+      }
+    },
+    "backButton": {
+      "label": "Back"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "Clouds"
+      },
+      "hills": {
+        "label": "Hills"
+      },
+      "mountains": {
+        "label": "Mountains"
+      },
+      "night": {
+        "label": "Night"
+      },
+      "none": {
+        "label": "None"
+      },
+      "plant": {
+        "label": "Plants"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "Aa"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} \"{value}\"",
+        "defaultPrefix": "Create"
+      },
+      "dropdown": {
+        "closeAriaLabel": "Close dropdown",
+        "openAriaLabel": "Open dropdown"
+      },
+      "options": {
+        "empty": "No options found"
+      },
+      "separator": {
+        "label": "Other options"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "Close menu"
+      },
+      "dialog": {
+        "title": "Command Menu"
+      },
+      "options": {
+        "ariaLabel": "Command menu options"
+      },
+      "search": {
+        "placeholder": "Search..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "All available connectors have been selected. Remove connectors below to add different ones.",
+        "placeholder": "All connectors selected"
+      },
+      "documentSetHint": {
+        "description": "All documents indexed by the selected connectors will be part of this document set."
+      },
+      "noMatches": {
+        "text": "No matching connectors found"
+      },
+      "noMoreConnectors": {
+        "text": "No more connectors available"
+      },
+      "noPrivateConnectors": {
+        "text": "No private connectors available. Create a private connector first."
+      },
+      "noneSelected": {
+        "text": "No connectors selected. Search and select connectors above."
+      },
+      "removeConnector": {
+        "tooltip": "Remove connector"
+      },
+      "search": {
+        "placeholder": "Search connectors..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "Select Date"
+      },
+      "todayButton": {
+        "label": "Today"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "Any time..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "Choose a custom range"
+      },
+      "clearButton": {
+        "ariaLabel": "Clear"
+      },
+      "custom": {
+        "label": "Custom"
+      },
+      "customRange": {
+        "ariaLabel": "Custom range: {from} to {to}"
+      },
+      "date": {
+        "label": "Date"
+      },
+      "group": {
+        "ariaLabel": "Date range"
+      },
+      "preset": {
+        "oneDay": "1D",
+        "oneMonth": "1M",
+        "sevenDays": "7D",
+        "threeMonths": "3M"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "Delete"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# context doc} other {# context docs}}"
+      },
+      "openDocument": {
+        "ariaLabel": "Open document: {title}"
+      },
+      "question": {
+        "title": "Question"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# subquery} other {# subqueries}}"
+      },
+      "updated": {
+        "text": "Updated {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "Default"
+      },
+      "selectOption": {
+        "placeholder": "Select an option..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "Edit"
+      },
+      "rename": {
+        "ariaLabel": "Rename"
+      },
+      "save": {
+        "ariaLabel": "Save"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "If you are the administrator, please visit the <billingLink>Admin Billing</billingLink> page to {hadLicense, select, true {renew} other {activate}} your license, sign up through Stripe or reach out to <supportLink>support@onyx.app</supportLink> for billing assistance."
+        },
+        "heading": {
+          "title": "Access Restricted"
+        },
+        "licenseLapse": {
+          "description": "Your access to Onyx has been temporarily suspended due to a lapse in your license."
+        },
+        "licenseRequired": {
+          "description": "A license is required to use Onyx. Your data is protected and will be available once a license is activated."
+        },
+        "logoutButton": {
+          "label": "Log out"
+        },
+        "manageSubscription": {
+          "description": "If you're an admin, you can manage your subscription by clicking the button below. For other users, please reach out to your administrator to address this matter."
+        },
+        "obtainLicense": {
+          "description": "To get started, please contact your system administrator to obtain a license."
+        },
+        "renewLicense": {
+          "description": "To reinstate your access and continue using Onyx, please contact your system administrator to renew your license."
+        },
+        "resubscribeButton": {
+          "label": "Resubscribe",
+          "loading": "Loading..."
+        },
+        "resubscribeError": {
+          "text": "Error opening resubscription page. Please try again later."
+        },
+        "seatLimit": {
+          "description": "Your organization has exceeded its licensed seat count. Access is restricted until the number of users is reduced or your license is upgraded."
+        },
+        "seatLimitAdminHint": {
+          "text": "If you are an administrator, you can manage users on the <userLink>User Management</userLink> page or upgrade your license on the <billingLink>Admin Billing</billingLink> page."
+        },
+        "seatLimitWithCounts": {
+          "description": "Your organization has exceeded its licensed seat count ({used} users / {seats} seats). Access is restricted until the number of users is reduced or your license is upgraded."
+        },
+        "subscriptionLapse": {
+          "description": "Your access to Onyx has been temporarily suspended due to a lapse in your subscription."
+        },
+        "updatePayment": {
+          "description": "To reinstate your access and continue benefiting from Onyx's powerful features, please update your payment information."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "If you're an admin, please review our <docsLink>documentation</docsLink> for proper configuration steps. If you're a user, please contact your admin for assistance."
+        },
+        "heading": {
+          "description": "It seems there was a problem loading your Onyx settings. This could be due to a configuration issue or incomplete setup.",
+          "title": "We encountered an issue"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "We apologize for any inconvenience this may cause and appreciate your patience."
+        },
+        "checkBack": {
+          "description": "Onyx is currently in a maintenance window. Please check back in a couple of minutes."
+        },
+        "heading": {
+          "title": "Maintenance in Progress"
+        }
+      },
+      "needHelp": {
+        "text": "Need help? Join our <discordLink>Discord community</discordLink> for support."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "Unknown error"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "Download file"
+      },
+      "file": {
+        "untitledFallback": "Untitled"
+      },
+      "fullScreenButton": {
+        "tooltip": "Full screen"
+      },
+      "hideButton": {
+        "tooltip": "Hide"
+      },
+      "minimizeButton": {
+        "tooltip": "Minimize"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "Copy"
+      },
+      "downloadButton": {
+        "tooltip": "Download"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {# line} other {# lines}}"
+      },
+      "size": {
+        "bytes": "{count} Bytes",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "View Full Text"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "All federated connectors selected"
+      },
+      "entitiesConfigured": {
+        "tooltip": "Entities configured"
+      },
+      "noMatches": {
+        "text": "No matching federated connectors found"
+      },
+      "noMoreConnectors": {
+        "text": "No more federated connectors available"
+      },
+      "noneSelected": {
+        "text": "No federated connectors selected. Search and select connectors above."
+      },
+      "realtimeSearchHint": {
+        "description": "Documents from selected federated connectors will be searched in real-time during queries."
+      },
+      "removeConnector": {
+        "tooltip": "Remove connector"
+      },
+      "search": {
+        "placeholder": "Search federated connectors..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "Add New"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (Optional)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "No file type definition found for field: {name}",
+        "selectionError": "File selection error",
+        "unknownError": "Unknown error",
+        "validating": "Validating file...",
+        "validationError": "Validation error"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "Enter your markdown here...",
+        "previewTab": "Preview",
+        "writeTab": "Write"
+      },
+      "optionalIndicator": {
+        "text": "(optional)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "Hide password",
+        "showAriaLabel": "Show password"
+      },
+      "selector": {
+        "noneOption": "None",
+        "placeholder": "Select..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "All Recent Files"
+      },
+      "recentFiles": {
+        "title": "Recent Files"
+      },
+      "recentFilesModal": {
+        "description": "Upload files or pick from your recent files."
+      },
+      "toasts": {
+        "associatedAssistants": "Cannot delete file. It is associated with assistants: {assistants}",
+        "associatedBoth": "Cannot delete file. It is associated with projects: {projects} and assistants: {assistants}",
+        "associatedProjects": "Cannot delete file. It is associated with projects: {projects}",
+        "deleteFailed": "Failed to delete file. Please try again.",
+        "deleteSuccess": "File deleted successfully"
+      },
+      "uploadFiles": {
+        "description": "Upload a file from your device",
+        "title": "Upload Files"
+      },
+      "viewFileButton": {
+        "tooltip": "View File"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "file"
+      },
+      "open": {
+        "ariaLabel": "Open {title}"
+      },
+      "removeButton": {
+        "label": "Remove"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "Clear"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(Optional)"
+      },
+      "required": {
+        "label": "(Required)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "Failed to load {label}. Please try again."
+      },
+      "search": {
+        "placeholder": "Search..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "No user groups available. Please create a user group first."
+      },
+      "userGroups": {
+        "label": "User Groups",
+        "subtext": "Select which user groups can access this resource"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "Logo"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "Initializing {appName}"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "Remove"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "Attach file"
+      },
+      "clearButton": {
+        "ariaLabel": "Clear file"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "File rejected"
+      },
+      "editButton": {
+        "ariaLabel": "Edit image"
+      },
+      "editOverlay": {
+        "label": "Edit"
+      },
+      "image": {
+        "altFallback": "Image"
+      },
+      "removeButton": {
+        "ariaLabel": "Remove image"
+      },
+      "uploadButton": {
+        "ariaLabel": "Upload image"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "Select an option"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "Assign group access for this {objectName}",
+        "scopedSubtext": "Select one or more of the groups you manage to give access to this {objectName}",
+        "visibleSubtext": "This {objectName} will be visible/accessible by the groups selected below"
+      },
+      "loading": {
+        "text": "Loading..."
+      },
+      "makePublic": {
+        "label": "Make this {objectName} Public?",
+        "subtext": "If set, then this {objectName} will be usable by <b>All {publicToWhom}</b>. Otherwise, only <b>Admins</b> and <b>{publicToWhom}</b> who have explicitly been given access to this {objectName} (e.g. via a User Group) will have access."
+      },
+      "publicDisabled": {
+        "message": "This {objectName} is public and available to all users."
+      },
+      "usersFallback": {
+        "text": "Users"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "Add {keyTitle} and {valueTitle} pair",
+        "label": "Add Line"
+      },
+      "empty": {
+        "title": "No items added yet."
+      },
+      "error": {
+        "duplicateKey": "Duplicate key",
+        "duplicateSummary": "{count, plural, one {# duplicate key found} other {# duplicate keys found}}",
+        "emptyKey": "Key cannot be empty",
+        "emptySummary": "{count, plural, one {# empty key found} other {# empty keys found}}",
+        "validationSummary": "{count, plural, one {# validation error found} other {# validation errors found}}"
+      },
+      "group": {
+        "ariaLabel": "{keyTitle} and {valueTitle} pairs"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "Key"
+      },
+      "pair": {
+        "fallbackLabel": "key-value"
+      },
+      "removeButton": {
+        "ariaLabel": "Remove {label} pair {index}"
+      },
+      "valueColumn": {
+        "title": "Value"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "Logo"
+      },
+      "poweredBy": {
+        "label": "Powered by Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "Unavailable connectors:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "The authorization was cancelled or failed. Please try again.",
+        "title": "Authorization Failed"
+      },
+      "backButton": {
+        "label": "Back to Chat"
+      },
+      "completeFailed": {
+        "message": "Failed to complete authorization"
+      },
+      "genericError": {
+        "description": "An error occurred during the OAuth process. Please try again.",
+        "title": "Something Went Wrong"
+      },
+      "invalidRequest": {
+        "description": "The authorization request was incomplete. Please try again.",
+        "title": "Invalid Request"
+      },
+      "loadingHint": {
+        "text": "This may take a few moments..."
+      },
+      "processing": {
+        "description": "Please wait while we complete the setup.",
+        "title": "Processing..."
+      },
+      "redirecting": {
+        "text": "Redirecting in {count, plural, one {# second} other {# seconds}}..."
+      },
+      "serviceFallback": {
+        "text": "service"
+      },
+      "success": {
+        "detailsTemplate": "Your {serviceName} authorization completed successfully.",
+        "title": "Success!"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "The spreadsheet may be corrupted or couldn't be loaded properly.",
+        "title": "Error loading spreadsheet"
+      },
+      "preview": {
+        "truncated": "Preview truncated — download the file to see all rows.",
+        "unavailable": "Unable to preview this spreadsheet."
+      },
+      "sheet": {
+        "defaultName": "Sheet 1",
+        "empty": "This sheet is empty.",
+        "tooLarge": "This sheet is too large to preview — download the file to view it."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "Main agent"
+      },
+      "subagentFallback": {
+        "label": "subagent"
+      },
+      "switch": {
+        "ariaLabel": "Switch agent"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "Approve this action once",
+        "button": "Approve once"
+      },
+      "approveSession": {
+        "button": "Approve for session",
+        "tooltip": "Approve matching actions for this session"
+      },
+      "details": {
+        "hideAriaLabel": "Hide details",
+        "showAriaLabel": "Show details"
+      },
+      "header": {
+        "required": "Approval required: {headline}"
+      },
+      "headline": {
+        "multiAction": "{count, plural, one {# action} other {# actions}} in {app}",
+        "singleAction": "{action} in {app}"
+      },
+      "payload": {
+        "empty": {
+          "label": "No payload."
+        },
+        "showLess": {
+          "button": "Show less"
+        },
+        "showMore": {
+          "button": "Show more"
+        }
+      },
+      "reject": {
+        "ariaLabel": "Reject this action",
+        "button": "Reject"
+      },
+      "status": {
+        "approved": "Approved",
+        "rejected": "Rejected"
+      },
+      "submit": {
+        "errorFallback": "Failed to submit decision"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "Add",
+        "createButton": "Create",
+        "customApp": {
+          "description": "Credentials and network access for your own integration.",
+          "title": "Custom app"
+        },
+        "mcpHint": {
+          "label": "Need an MCP server instead? Connect it in Actions, then enable it for Craft here.",
+          "openActionsButton": "Open Actions"
+        },
+        "modal": {
+          "description": "Make an integration available to your whole organization. Built-in providers come with actions that teach the Craft agent how to use them; already-configured providers are not listed.",
+          "title": "Add an app"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "Associate {name}",
+        "associateButton": "Associate existing",
+        "create": {
+          "github": {
+            "description": "If your skills are in GitHub, import them on the Skills page first, then associate them with this app.",
+            "label": "Import from GitHub"
+          },
+          "scratch": {
+            "description": "Write instructions and add supporting files.",
+            "label": "Start from scratch"
+          },
+          "upload": {
+            "description": "Import a SKILL.md file, ZIP file, or skill folder.",
+            "label": "Upload a skill"
+          }
+        },
+        "createSkillButton": "Create skill",
+        "description": "Skills give Craft instructions for using this app. They are organization-wide; users may need to enable all of them for the app to work correctly.",
+        "editButton": "Edit",
+        "empty": {
+          "label": "No editable skills found."
+        },
+        "invalidTag": "Invalid",
+        "loading": {
+          "label": "Loading skills…"
+        },
+        "noneAssociated": {
+          "label": "No skills are associated yet. This app can still be saved and used without one."
+        },
+        "promote": {
+          "cancelButton": "Cancel",
+          "confirmButton": "Make organization-wide",
+          "description": "App-associated skills must be available to everyone. This change is applied when you save the app.",
+          "title": "Make “{name}” organization-wide?"
+        },
+        "search": {
+          "placeholder": "Search editable skills..."
+        },
+        "title": "Associated skills",
+        "unavailable": {
+          "duplicateName": "A skill named “{name}” is already associated.",
+          "invalid": "Invalid skill — fix it before associating.",
+          "otherApp": "Already associated with app “{name}”."
+        },
+        "unlink": {
+          "button": "Unlink",
+          "cancelButton": "Cancel",
+          "confirm": "Unlink “{name}” from this app?"
+        },
+        "unlinkAriaLabel": "Unlink {name}",
+        "viewButton": "View"
+      },
+      "configureProvider": {
+        "addButton": "Add",
+        "addTitle": "Add {name}",
+        "editTitle": "Edit {name}",
+        "emptyPolicies": "This provider has no actions to configure.",
+        "fields": {
+          "name": {
+            "description": "A label for this connection. Use a distinct name when adding multiple instances of the same provider (e.g. \"{name} — Engineering\").",
+            "label": "Name"
+          }
+        },
+        "managedDescription": "Provided by Onyx — configure what the agent may do.",
+        "managedNote": "This app is provided by Onyx — credentials are managed for you. Choose what the agent may do below. Users connect it from the Apps page.",
+        "saveButton": "Save"
+      },
+      "customApp": {
+        "cancelButton": "Cancel",
+        "createButton": "Create",
+        "createDescription": "Configure how the egress proxy reaches and authenticates this app. A skill is not required.",
+        "createTitle": "Create custom app",
+        "creatingButton": "Creating…",
+        "disabled": {
+          "nameMissing": "Enter a name before creating this custom app.",
+          "patternMissing": "Add at least one upstream URL pattern. Type a pattern and press Enter.",
+          "pristine": "Make a change before saving.",
+          "saving": "Save is already in progress."
+        },
+        "editDescription": "Update gateway settings and manage associated skills.",
+        "editTitle": "Edit {name}",
+        "errors": {
+          "saveFailedTitle": "Couldn't save"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "Add header",
+            "description": "Optional — headers injected into outbound requests. Use '{placeholder}' for values the user (or org below) supplies, e.g. \"Bearer '{api_key}'\". Leave empty to allowlist the upstream patterns without injecting credentials.",
+            "keyTitle": "Header",
+            "label": "Header credential pattern",
+            "valueTitle": "Value"
+          },
+          "name": {
+            "label": "Name",
+            "placeholder": "My Custom App"
+          },
+          "orgCredentials": {
+            "addButton": "Add credential",
+            "description": "Optional — values your org pre-fills for every user. Leave empty for apps where each user supplies their own credentials.",
+            "keyTitle": "Credential key",
+            "label": "Organization credentials",
+            "valueTitle": "Value"
+          },
+          "upstreamPatterns": {
+            "description": "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter.",
+            "label": "Upstream URL patterns"
+          }
+        },
+        "saveButton": "Save",
+        "savingButton": "Saving…"
+      },
+      "errors": {
+        "duplicateSkillName": "App “{appName}” already has an associated skill named “{skillName}”. Upload a skill with a different name."
+      },
+      "mcpPolicy": {
+        "description": "Configure what the Craft agent may do with this MCP server's tools.",
+        "emptyPolicies": "No enabled tools on this server. Enable tools on the MCP actions page first.",
+        "saveButton": "Save",
+        "title": "Edit {name}"
+      },
+      "oauthCallback": {
+        "backButton": "Back to My Apps",
+        "description": "Finishing the OAuth handshake…",
+        "errors": {
+          "cancelled": "OAuth was cancelled or denied: {reason}",
+          "failed": "Connection failed.",
+          "missingParams": "Missing code or state in callback URL."
+        },
+        "exchanging": {
+          "label": "Exchanging authorization code…"
+        },
+        "success": {
+          "label": "Connected. Redirecting back to your apps…"
+        },
+        "title": "Connecting your app"
+      },
+      "page": {
+        "connectButton": "Connect",
+        "connectingButton": "Redirecting…",
+        "disconnectButton": "Disconnect",
+        "empty": {
+          "description": "No apps or MCP servers are configured for your organization yet.",
+          "title": "Nothing to connect yet"
+        },
+        "errors": {
+          "disconnectFailed": "Failed to disconnect",
+          "startAuthFailed": "Failed to start authorization"
+        },
+        "header": {
+          "description": "Connect the tools Onyx Craft can use as context while it works.",
+          "manageButton": "Manage apps",
+          "searchPlaceholder": "Search apps...",
+          "title": "Apps"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Integrations Onyx supports directly. Each comes with skills that teach Craft how to use it — start here.",
+            "empty": "No apps are configured for your organization yet.",
+            "emptyTitle": "No apps yet",
+            "tabLabel": "Apps · {count}"
+          },
+          "mcp": {
+            "blurb": "Servers an admin made available to Craft. Use these when the app you need isn't listed under Apps, or when you specifically want a server's own MCP tools.",
+            "empty": "No MCP servers have been made available to Craft.",
+            "emptyTitle": "No MCP servers yet",
+            "tabLabel": "MCP servers · {count}"
+          }
+        },
+        "loading": {
+          "label": "Loading…"
+        },
+        "reviewSkillsButton": "Review skills",
+        "search": {
+          "noMatchesDescription": "Nothing here matches your search.",
+          "noMatchesTitle": "No matches"
+        },
+        "status": {
+          "connected": "Connected",
+          "connectedNeedsSkills": "Connected · not all associated skills are enabled",
+          "notAvailable": "Not available for your account — ask an admin",
+          "skillWarningAriaLabel": "Skill setup required",
+          "skillWarningTooltip": "Not all associated skills are enabled. This app may not work correctly."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "Set a policy for each action individually.",
+          "title": "Advanced"
+        },
+        "cancelButton": "Cancel",
+        "loading": {
+          "label": "Loading…"
+        },
+        "permissions": {
+          "askOption": "Ask",
+          "autoApproveOption": "Auto-approve",
+          "customOption": "Custom",
+          "description": "Choose what the agent may do. “Ask” prompts you in chat before each action runs; “Auto-approve” lets it run without prompting. Use Advanced to set a policy per action.",
+          "title": "Permissions"
+        },
+        "savingButton": "Saving…"
+      },
+      "skillsStep": {
+        "description": "Optional — associate existing skills or create one for this app.",
+        "errors": {
+          "saveFailedTitle": "Couldn't save"
+        },
+        "saveButton": "Save skills",
+        "savingButton": "Saving…",
+        "skipButton": "Skip for now",
+        "title": "Add skills to {name}"
+      },
+      "userCredentials": {
+        "cancelButton": "Cancel",
+        "connectButton": "Connect",
+        "connectingButton": "Connecting…",
+        "description": "Enter your credentials to authorize this app for your account.",
+        "errors": {
+          "connectFailedTitle": "Couldn't connect"
+        },
+        "title": "Connect {name}"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "Download"
+      },
+      "empty": {
+        "description": "Output files and web apps will appear here",
+        "title": "No artifacts yet"
+      },
+      "nextjsApp": {
+        "label": "Next.js Application"
+      },
+      "openItem": {
+        "ariaLabel": "Open {name}"
+      },
+      "toggleItem": {
+        "ariaLabel": "Toggle {name}"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "Continue the conversation...",
+        "scheduledRunPlaceholder": "Scheduled run in progress...",
+        "subagentPlaceholder": "Switch to the main agent to send a message"
+      },
+      "openSidebar": {
+        "ariaLabel": "Open Sidebar"
+      },
+      "outputPanel": {
+        "closeTooltip": "Close output panel",
+        "openTooltip": "Open output panel"
+      },
+      "responseStopped": {
+        "label": "Response stopped"
+      },
+      "scrollToBottom": {
+        "label": "Scroll to bottom"
+      },
+      "toast": {
+        "operationWait": "Please wait for the current operation to complete.",
+        "sandboxWait": "Please wait for sandbox to initialize",
+        "scheduledRunWait": "Please wait for the scheduled run to finish."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "Context compacted to free up space"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "Connect your data"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "Crafting your workspace...",
+        "enchanting": "Enchanting with magic...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "Gathering resources...",
+        "miningDependencies": "Mining for dependencies...",
+        "placingBlocks": "Placing blocks...",
+        "punchingWood": "Punching wood...",
+        "smeltingCode": "Smelting the code...",
+        "worldGenerated": "World generation complete..."
+      },
+      "tagline": {
+        "label": "Crafting your next great idea..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "Clear"
+      },
+      "copy": {
+        "doneTooltip": "Copied",
+        "tooltip": "Copy visible"
+      },
+      "empty": {
+        "noLines": "No lines yet.",
+        "noMatch": "No lines match \"{filter}\"",
+        "waiting": "Waiting for the first log line…"
+      },
+      "error": {
+        "endpointDisabled": "Debug endpoint disabled (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "No running sandbox to tail logs from"
+      },
+      "filter": {
+        "placeholder": "Filter…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# line} other {# lines}}",
+        "filteredCount": "{visible, number} / {total, number} lines"
+      },
+      "modal": {
+        "description": "Live tail of the sandbox container — dev/debug only.",
+        "title": "Opencode pod logs"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} new · jump"
+      },
+      "open": {
+        "button": "Pod logs"
+      },
+      "status": {
+        "closed": "Closed",
+        "connecting": "Connecting",
+        "error": "Error",
+        "paused": "Paused",
+        "streaming": "Streaming"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "Add files or photos"
+      },
+      "apps": {
+        "label": "Apps"
+      },
+      "browseSkills": {
+        "label": "Browse skills"
+      },
+      "connect": {
+        "hint": "Connect"
+      },
+      "connectApp": {
+        "label": "Connect an app"
+      },
+      "library": {
+        "label": "Library"
+      },
+      "manageLibrary": {
+        "label": "Manage library…"
+      },
+      "mcpServer": {
+        "description": "MCP server"
+      },
+      "skills": {
+        "label": "Skills"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "Cannot preview file"
+      },
+      "error": {
+        "inline": "Error: {message}",
+        "title": "Error loading file"
+      },
+      "loading": {
+        "label": "Loading file..."
+      },
+      "noContent": {
+        "label": "No content"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "Files created during the build will appear here",
+        "title": "No files yet"
+      },
+      "emptyDirectory": {
+        "label": "No files in this directory"
+      },
+      "error": {
+        "title": "Error loading files"
+      },
+      "loading": {
+        "label": "Loading files..."
+      },
+      "loadingChildren": {
+        "label": "Loading..."
+      },
+      "preparing": {
+        "description": "Setting up your development environment",
+        "title": "Preparing sandbox..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "The image could not be displayed",
+        "title": "Failed to load image"
+      },
+      "loading": {
+        "label": "Loading image..."
+      },
+      "preview": {
+        "ariaLabel": "Preview of {name}"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "Connected",
+        "connectionRequired": "Connection required"
+      },
+      "plusMenu": {
+        "tooltip": "Add files or skills"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "Stopping…"
+      },
+      "toInterrupt": {
+        "label": "to interrupt"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "Return Home"
+      },
+      "startCrafting": {
+        "button": "Start Crafting"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "No models found"
+      },
+      "recommended": {
+        "label": "Recommended"
+      },
+      "recommendedOnly": {
+        "label": "Recommended Models Only"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "“Fix the flaky retry test and open a PR.”",
+          "launchDeck": "“Build the spring launch deck from the brief in Drive.”",
+          "rfpSecurity": "“Fill out the RFP in my email with our security details.”",
+          "slackToLinear": "“Condense our Slack discussion into Linear tickets.”",
+          "vendorSpend": "“Summarize our Q2 vendor spend as a doc in Drive.”"
+        },
+        "modal": {
+          "backButton": "Back",
+          "ctaButton": "Put Craft to work",
+          "nextButton": "Next",
+          "title": "Meet Craft"
+        },
+        "outputs": {
+          "ariaLabel": "Output: {name}",
+          "githubPr": {
+            "caption": "Open for review",
+            "label": "GitHub PR"
+          },
+          "googleDoc": {
+            "caption": "Written to your Drive",
+            "label": "Google Doc"
+          },
+          "liveApp": {
+            "caption": "Hosted — share by link",
+            "label": "Live app"
+          }
+        },
+        "prompt": {
+          "label": "Your prompt"
+        },
+        "schedule": {
+          "ariaLabel": "Scheduled task — re-runs this prompt on a timer",
+          "caption": "Runs while you're away",
+          "label": "Every Monday, 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "Connected source: {name}",
+          "yourFiles": {
+            "ariaLabel": "Your uploaded files",
+            "label": "Your files"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "Click any part of the map to revisit it.",
+            "title": "That's Craft. Your turn."
+          },
+          "machine": {
+            "caption": "Reading what you can see. Never your secrets.",
+            "title": "It works on its own machine."
+          },
+          "output": {
+            "caption": "On demand — or on a schedule, while you're away.",
+            "title": "Finished work comes out."
+          },
+          "prompt": {
+            "caption": "Describe the outcome — Craft does the rest.",
+            "title": "Give Craft real work."
+          }
+        },
+        "team": {
+          "ariaLabel": "Your team — one link shares Craft's work",
+          "caption": "One link shares it",
+          "label": "Your team"
+        },
+        "workspace": {
+          "approvalPill": "Waiting for your approval",
+          "label": "Craft's workspace",
+          "sandboxBadge": "Isolated sandbox"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "Back to Chat",
+        "description": "Onyx Craft needs a model provider, and only admins can set one up. Ask your admin to connect Anthropic, OpenAI, or OpenRouter.",
+        "title": "An LLM provider is required"
+      },
+      "llmSetup": {
+        "description": "Craft agents need a model provider to build.",
+        "title": "Connect a model provider"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "Analyze my data and create a dashboard..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "Engineering",
+          "marketing": "Marketing",
+          "product": "Product",
+          "sales": "Sales"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "Start building something to see artifacts!"
+      },
+      "devServerStarting": {
+        "tooltip": "Starting the dev server..."
+      },
+      "noWebapp": {
+        "label": "No web app in this session yet"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "The PDF file could not be loaded.",
+        "title": "Cannot preview PDF"
+      },
+      "frame": {
+        "title": "PDF Preview"
+      },
+      "loading": {
+        "label": "Loading PDF..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "Converting presentation..."
+      },
+      "empty": {
+        "label": "No slides in this presentation"
+      },
+      "error": {
+        "title": "Cannot preview presentation"
+      },
+      "loadingSlide": {
+        "label": "Loading slide..."
+      },
+      "slide": {
+        "counter": "Slide {current} of {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "A live preview appears here once a web app is running."
+      },
+      "frame": {
+        "title": "Web App Preview"
+      },
+      "starting": {
+        "description": "Installing dependencies and booting.",
+        "title": "Starting the dev server..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "Redirecting..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "Dismiss"
+      },
+      "modal": {
+        "description": "It went to sleep after a period of inactivity — your work is saved. Wake it to keep going.",
+        "title": "Your sandbox fell asleep"
+      },
+      "wake": {
+        "button": "Wake sandbox"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "Scheduled"
+      },
+      "startedAt": {
+        "label": "Started {time}"
+      },
+      "status": {
+        "awaitingApproval": "This scheduled run is awaiting approval. Follow-up messages unlock after it resumes and finishes.",
+        "running": "This scheduled run is still running. Follow-up messages unlock when it finishes.",
+        "startedBy": "This session was started by scheduled task {task} at {time}."
+      },
+      "viewTask": {
+        "ariaLabel": "View scheduled task {task}. {status}",
+        "label": "View task"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "External app {id}"
+      },
+      "connect": {
+        "title": "Connect {app}"
+      },
+      "connected": {
+        "title": "{app} connected."
+      },
+      "error": {
+        "generic": "Something went wrong. Please try again.",
+        "notConfigurable": "This app can't be set up from here.",
+        "popupBlocked": "Couldn't open the setup window — allow popups and try again.",
+        "startFailed": "Failed to start setup"
+      },
+      "loading": {
+        "button": "Loading…"
+      },
+      "notNow": {
+        "button": "Not now"
+      },
+      "reason": {
+        "fallback": "The agent needs {app} to continue this task."
+      },
+      "skipped": {
+        "title": "Skipped connecting {app}."
+      },
+      "waiting": {
+        "button": "Waiting…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "Copy link"
+      },
+      "organization": {
+        "description": "Anyone logged into your Onyx can view this app.",
+        "label": "Organization"
+      },
+      "private": {
+        "description": "Only you can view this app.",
+        "label": "Private"
+      },
+      "share": {
+        "label": "Share"
+      },
+      "shared": {
+        "label": "Shared"
+      },
+      "trigger": {
+        "ariaLabel": "Share webapp"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "Apps"
+      },
+      "backToChat": {
+        "label": "Back to Chat"
+      },
+      "delete": {
+        "label": "Delete"
+      },
+      "deleteModal": {
+        "body": "This permanently removes the Craft session and all of its data. This action cannot be undone.",
+        "confirm": "Delete",
+        "deleting": "Deleting...",
+        "title": "Delete \"{title}\"?"
+      },
+      "newSession": {
+        "label": "Start Crafting"
+      },
+      "rename": {
+        "label": "Rename"
+      },
+      "scheduledTasks": {
+        "label": "Scheduled Tasks"
+      },
+      "sessions": {
+        "empty": "Start building! Session history will appear here.",
+        "title": "Sessions"
+      },
+      "skills": {
+        "label": "Skills"
+      },
+      "toast": {
+        "deleteFailed": "Failed to delete session",
+        "deleted": "Deleted \"{title}\"."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "Reload this session to apply the latest skills and app access.",
+        "title": "Your agent’s capabilities have changed"
+      },
+      "reload": {
+        "button": "Reload",
+        "inProgress": "Reloading…"
+      },
+      "toast": {
+        "reloadFailed": "Failed to reload session"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "Subagent not found."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "Close suggestions"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "Delete",
+          "deletingButton": "Deleting...",
+          "description": "This stops future runs and removes the task. Past run history (and the underlying sessions) will be preserved for audit.",
+          "title": "Delete \"{name}\"?"
+        },
+        "deleteButton": "Delete",
+        "editButton": "Edit",
+        "fallbackTitle": "Scheduled task",
+        "loadFailed": "Failed to load scheduled task.",
+        "missingTaskId": "Missing task id.",
+        "pauseButton": "Pause",
+        "resumeButton": "Resume",
+        "runNowButton": "Run now",
+        "toasts": {
+          "deleteFailed": "Failed to delete task",
+          "deleted": "Deleted \"{name}\".",
+          "paused": "Task paused.",
+          "resumed": "Task resumed.",
+          "runQueued": "Queued run for \"{name}\".",
+          "runStartFailed": "Failed to start run",
+          "statusUpdateFailed": "Failed to update status"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "Edit scheduled task",
+        "loadFailed": "Failed to load scheduled task.",
+        "missingTaskId": "Missing task id.",
+        "title": "Edit \"{name}\""
+      },
+      "form": {
+        "cancelButton": "Cancel",
+        "errors": {
+          "nameRequired": "Name is required.",
+          "promptRequired": "Prompt is required."
+        },
+        "fields": {
+          "name": {
+            "label": "Name",
+            "placeholder": "e.g. Weekly customer escalations digest"
+          },
+          "preApproval": {
+            "description": "Craft can use selected apps and MCP servers without pausing when this task runs unattended. Other approval requests pause the run and can cause it to fail.",
+            "label": "Pre-approved apps and MCP servers"
+          },
+          "prompt": {
+            "description": "This message is sent to Craft each time the task fires.",
+            "label": "Prompt",
+            "placeholder": "Describe what Craft should do on each run..."
+          },
+          "schedule": {
+            "label": "Schedule"
+          }
+        },
+        "saveAndRunNowButton": "Save and run now",
+        "saveButton": "Save",
+        "saveChangesButton": "Save changes",
+        "savingLabel": "Saving...",
+        "toasts": {
+          "created": "Scheduled task created.",
+          "createdAndQueued": "Scheduled task created and queued.",
+          "saveFailed": "Failed to save scheduled task",
+          "updated": "Scheduled task updated."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "Last run",
+          "name": "Name",
+          "nextRun": "Next run",
+          "schedule": "Schedule",
+          "status": "Status"
+        },
+        "confirmDelete": {
+          "deleteButton": "Delete",
+          "deletingButton": "Deleting...",
+          "description": "This stops future runs and removes the task. Past run history (and the underlying sessions) will be preserved for audit.",
+          "title": "Delete \"{name}\"?"
+        },
+        "empty": {
+          "description": "No scheduled tasks have been created yet.",
+          "title": "No scheduled tasks found"
+        },
+        "errors": {
+          "loadFailed": "Failed to load scheduled tasks.",
+          "tryAgainButton": "Try again"
+        },
+        "header": {
+          "description": "Run Craft prompts on a timer. Each fire creates a fresh session that runs in the background.",
+          "title": "Scheduled Tasks"
+        },
+        "newTaskButton": "New Scheduled Task",
+        "rowActions": {
+          "deleteTooltip": "Delete"
+        },
+        "toasts": {
+          "deleteFailed": "Failed to delete task",
+          "deleted": "Deleted \"{name}\"."
+        }
+      },
+      "newPage": {
+        "description": "Save a prompt + schedule. Craft will run it on a timer.",
+        "title": "New Scheduled Task"
+      },
+      "preApproval": {
+        "appFallbackName": "App #{id}",
+        "appsGroupTitle": "Apps",
+        "empty": {
+          "label": "No apps or MCP servers are available in Craft yet."
+        },
+        "errors": {
+          "loadFailed": "Couldn’t load apps and MCP servers. Refresh to try again.",
+          "partialLoadFailed": "Some pre-approval options couldn’t load. Refresh to try again."
+        },
+        "loading": {
+          "label": "Loading apps and MCP servers…"
+        },
+        "mcpGroupTitle": "MCP servers",
+        "mcpServerFallbackName": "MCP server #{id}",
+        "status": {
+          "connected": "Connected",
+          "connectionRequired": "Connection required",
+          "unavailable": "No longer available"
+        },
+        "summary": {
+          "partialLoadFailed": "Some pre-approval details couldn’t load. Refresh to try again.",
+          "title": "Pre-approved apps and MCP servers"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "Duration",
+          "started": "Started",
+          "status": "Status",
+          "summary": "Summary",
+          "trigger": "Trigger"
+        },
+        "empty": {
+          "label": "No runs yet. The task will create one each time it fires, or use Run Now above."
+        },
+        "errors": {
+          "loadFailed": "Failed to load run history.",
+          "tryAgainButton": "Try again"
+        },
+        "loadMore": {
+          "button": "Load more",
+          "loadingButton": "Loading..."
+        },
+        "nonClickable": {
+          "noSession": "This run has not created a session yet.",
+          "queued": "This run hasn't started yet, so there is no session to open.",
+          "skipped": "This run was skipped because a prior run was still in flight, so no session was created."
+        },
+        "status": {
+          "notOpenableAriaLabel": "Not openable"
+        },
+        "trigger": {
+          "runNow": "Run Now",
+          "schedule": "Schedule"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "At",
+          "daysLabel": "On these days",
+          "runsEveryDay": "Runs every day",
+          "runsOn": "Runs on {days}"
+        },
+        "interval": {
+          "everyLabel": "Every"
+        },
+        "intervalUnits": {
+          "days": "days",
+          "hours": "hours",
+          "minutes": "minutes"
+        },
+        "tabs": {
+          "dailyWeekly": "Daily / Weekly",
+          "interval": "Interval"
+        },
+        "weekdays": {
+          "fri": "Fri",
+          "mon": "Mon",
+          "sat": "Sat",
+          "sun": "Sun",
+          "thu": "Thu",
+          "tue": "Tue",
+          "wed": "Wed"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "No tasks"
+      },
+      "header": {
+        "title": "Tasks"
+      },
+      "progress": {
+        "label": "{completed}/{total} completed"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "No output"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# unchanged line} other {# unchanged lines}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "Switch to side-by-side",
+          "unifiedTooltip": "Switch to unified"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "No output yet..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# call} other {# calls}}"
+        },
+        "failed": {
+          "tag": "{count} failed"
+        },
+        "working": {
+          "label": "Working"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(empty file)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {# more line} other {# more lines}}"
+        },
+        "showAll": {
+          "button": "Show all"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "No matches"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "File too large ({size}). Maximum is {max}.",
+        "network": "Network error",
+        "notFound": "Resource not found",
+        "server": "Server error",
+        "sessionExpired": "Session expired",
+        "tooManyFiles": "Too many files. Maximum is {max} files per session.",
+        "totalSizeExceeded": "Total size exceeds limit. Maximum is {max} per session.",
+        "uploadFailed": "Upload failed"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "Go back"
+      },
+      "copyUrl": {
+        "ariaLabel": "Copy URL: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "Download file"
+      },
+      "export": {
+        "button": "Export to .docx",
+        "inProgress": "Exporting..."
+      },
+      "forward": {
+        "ariaLabel": "Go forward"
+      },
+      "openInNewTab": {
+        "tooltip": "open in a new tab"
+      },
+      "refresh": {
+        "ariaLabel": "Refresh"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "delete",
+        "button": "Delete",
+        "entityTypeFile": "file",
+        "entityTypeFolder": "folder",
+        "fileDetails": "This file will be removed from your library.",
+        "folderDetails": "This will delete the folder and all its contents."
+      },
+      "dropzone": {
+        "formats": "Excel, Word, PowerPoint, PDF, or ZIP",
+        "title": "Drag files here or click to upload"
+      },
+      "errors": {
+        "createFolderFailed": "Failed to create folder",
+        "deleteFailed": "Failed to delete",
+        "loadFailed": "Failed to load files",
+        "uploadFailed": "Upload failed"
+      },
+      "loading": {
+        "label": "Loading files…"
+      },
+      "modal": {
+        "description": "Files your agent can read in every session.",
+        "doneButton": "Done",
+        "title": "Library"
+      },
+      "newFolder": {
+        "cancelButton": "Cancel",
+        "createButton": "Create",
+        "label": "New folder",
+        "nameLabel": "Folder name",
+        "namePlaceholder": "Enter folder name"
+      },
+      "search": {
+        "noResults": "No files match your search",
+        "placeholder": "Search files..."
+      },
+      "tree": {
+        "collapseTooltip": "Collapse",
+        "deleteTooltip": "Delete",
+        "expandTooltip": "Expand",
+        "toggleAriaLabel": "Toggle {name}",
+        "uploadToFolderTooltip": "Upload to this folder"
+      },
+      "upload": {
+        "button": "Upload",
+        "dropOverlay": "Drop files to upload",
+        "uploadingButton": "Uploading…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "Analyze my data and create a dashboard..."
       }
     }
   },
@@ -8825,6 +12553,13 @@
           "networkError": "An error occurred while changing the password",
           "updateFailed": "Failed to change password",
           "updated": "Password updated successfully"
+        },
+        "validation": {
+          "confirmRequired": "Please confirm your new password",
+          "currentRequired": "Current password is required",
+          "minLength": "Password must be at least {min} characters",
+          "mismatch": "Passwords do not match",
+          "newRequired": "New password is required"
         }
       },
       "title": "Accounts"
@@ -8866,6 +12601,7 @@
         "empty": "No access tokens created.",
         "expiresIn": "{count, plural, one {Expires in # day} other {Expires in # days}}",
         "loading": "Loading tokens...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "Never expires",
         "newTokenButton": "New Access Token",
         "noPermissionTooltip": "You don't have permission to create access tokens",
@@ -9012,6 +12748,10 @@
       },
       "description": "Connect external tools to the models available to you in Onyx.",
       "guideButton": "Guide",
+      "loadError": {
+        "description": "Please refresh the page and try again.",
+        "title": "Could not load LLM Gateway"
+      },
       "models": {
         "description": "{count, plural, one {# model is available to your account. Open a provider to copy an ID.} other {# models are available to your account. Open a provider to copy an ID.}}",
         "title": "Models"
@@ -9064,14 +12804,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "Add Line",
+        "maxReached": "Maximum of {count} memories reached"
+      },
       "empty": {
-        "description": "Add personal note or memory that Onyx should remember."
+        "description": "Add personal note or memory that Onyx should remember.",
+        "getStarted": "No memories yet. Click \"Add Line\" to get started.",
+        "noMatches": "No memories match your search."
+      },
+      "item": {
+        "placeholder": "Type or paste in a personal note or memory"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {Line} other {Lines}}"
+      },
+      "modal": {
+        "description": "Let Onyx reference these stored notes and memories in chats.",
+        "searchPlaceholder": "Search..."
       },
       "referenceStoredMemories": {
         "description": "Let Onyx reference stored memories in chats.",
         "title": "Reference Stored Memories"
       },
+      "removeLineButton": {
+        "label": "Remove Line"
+      },
       "title": "Memory",
+      "toasts": {
+        "saveFailed": "Failed to save preferences",
+        "saved": "Preferences saved"
+      },
       "updateMemories": {
         "description": "Let Onyx generate and update stored memories.",
         "title": "Update Memories"
@@ -9491,6 +13254,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "App “{appName}” already has an associated skill named “{skillName}”.",
+        "title": "Choose a different skill name"
+      },
+      "confirmUpload": {
+        "importBody": "This upload includes SKILL.md. Continuing will replace the current name, description, instructions, and files with the uploaded bundle.",
+        "importSubmit": {
+          "label": "Import skill"
+        },
+        "importTitle": "Import this skill?",
+        "replaceBody": "This upload must use the same skill name. Continuing will replace the description, instructions, and files with the uploaded bundle.",
+        "replaceSubmit": {
+          "label": "Replace content"
+        },
+        "replaceTitle": "Replace skill content?"
+      },
+      "delete": {
+        "button": {
+          "label": "Delete skill"
+        },
+        "description": "Anyone using this skill will lose access. Deletion cannot be undone.",
+        "title": "Delete this skill"
+      },
+      "deleteModal": {
+        "entityType": "skill",
+        "label": "Delete",
+        "pendingLabel": "Deleting..."
+      },
+      "details": {
+        "description": "Define when and how Craft should use this skill.",
+        "descriptionField": {
+          "description": "Describe when this skill should be used.",
+          "placeholder": "What does this skill help with?",
+          "title": "Description"
+        },
+        "name": {
+          "createDescription": "Use lowercase letters, numbers, and single hyphens.",
+          "lockedDescription": "Skill names cannot be changed after creation.",
+          "placeholder": "Name your skill",
+          "title": "Name"
+        },
+        "title": "Details"
+      },
+      "files": {
+        "busyLabel": "Uploading...",
+        "description": "Add references, scripts, assets, or other files used by this skill. ZIP files are unpacked automatically.",
+        "input": {
+          "ariaLabel": "Add supporting files"
+        },
+        "pendingUpload": {
+          "emptyMessage": "Files from this upload will appear after you create the skill."
+        },
+        "title": "Supporting files"
+      },
+      "filesTooltip": {
+        "noPermission": "You don't have permission to update this skill's files.",
+        "saveFirst": "Save detail changes before updating skill files.",
+        "updating": "Updating skill files..."
+      },
+      "header": {
+        "appFallbackName": "External app",
+        "cancel": {
+          "label": "Cancel"
+        },
+        "createDescription": "Build a personal skill",
+        "createForAppDescription": "Add an organization skill to app “{appName}”",
+        "createTitle": "Create skill",
+        "editDescription": "Update skill details and files",
+        "editTitle": "Edit skill",
+        "save": {
+          "label": "Save",
+          "pendingLabel": "Saving..."
+        }
+      },
+      "import": {
+        "busyLabel": "Importing...",
+        "button": {
+          "label": "Import skill"
+        },
+        "description": "Import a SKILL.md, ZIP, or skill folder to prefill the form and include its files.",
+        "input": {
+          "ariaLabel": "Import existing skill"
+        },
+        "prompt": "Choose a SKILL.md or ZIP, or drop a skill folder here.",
+        "title": "Have an existing skill?"
+      },
+      "instructions": {
+        "description": "Write the behavior and workflow this skill adds to Craft.",
+        "emptyFallback": "No instructions yet.",
+        "placeholder": "Write the skill instructions.",
+        "title": "Instructions"
+      },
+      "loadError": {
+        "description": "This skill may not exist, may be built-in, or may not be editable by your account.",
+        "title": "Skill unavailable"
+      },
+      "management": {
+        "description": "Control who can use this skill.",
+        "externalApp": {
+          "manage": {
+            "label": "Manage in app settings"
+          },
+          "readyDescription": "This skill uses app “{appName}”.",
+          "title": "External app"
+        },
+        "sharing": {
+          "edit": {
+            "label": "Edit sharing"
+          },
+          "title": "Sharing"
+        },
+        "title": "Management"
+      },
+      "saveTooltip": {
+        "missingDescription": "Add a description before saving.",
+        "missingInstructions": "Add instructions before saving.",
+        "missingName": "Add a name before saving.",
+        "noChanges": "No changes have been made.",
+        "noPermission": "You don't have permission to edit this skill's details.",
+        "savingChanges": "Saving changes...",
+        "savingSkill": "Saving skill..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "Everyone in your organization can use and edit this skill.",
+          "title": "Organization",
+          "viewerDescription": "Everyone in your organization can use this skill."
+        },
+        "personal": {
+          "description": "Only you can use this skill.",
+          "title": "Personal"
+        },
+        "shares": {
+          "description": "Only selected users and groups can use this skill.",
+          "title": "{count, plural, one {# share} other {# shares}}"
+        }
+      },
+      "toasts": {
+        "created": "Created \"{name}\"",
+        "deleteFailed": "Failed to delete skill",
+        "deleted": "Deleted \"{name}\"",
+        "fileRemoveFailed": "Failed to remove skill file",
+        "fileRemoved": "Removed \"{path}\"",
+        "filesUpdateFailed": "Failed to update skill files",
+        "filesUpdated": "Updated files for \"{name}\"",
+        "importMissingSkillMd": "Import a SKILL.md, ZIP, or folder containing SKILL.md.",
+        "inspectFailed": "Failed to inspect skill bundle",
+        "saveFailed": "Failed to save skill",
+        "saved": "Saved \"{name}\""
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9691,6 +13606,76 @@
         "transferredToast": {
           "message": "Ownership transferred."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "Browse skills"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {Skill} other {Skills}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "Import one or more skills from a repository.",
+          "title": "Import from GitHub"
+        },
+        "scratch": {
+          "description": "Write the instructions and add supporting files in Onyx.",
+          "title": "Start from scratch"
+        },
+        "trigger": {
+          "label": "Create skill"
+        },
+        "upload": {
+          "description": "Import a SKILL.md file, ZIP file, or skill folder.",
+          "title": "Upload a skill"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "Try a different search.",
+          "title": "No matching skills"
+        },
+        "noSkills": {
+          "description": "No custom skills have been shared with you yet, and no built-ins are configured.",
+          "title": "No skills available"
+        }
+      },
+      "focusedApp": {
+        "description": "Enable every skill associated with app “{appName}”. The app may not work correctly without them. If another skill with the same name is enabled, enabling the app-associated skill disables the other skill for you.",
+        "showAll": {
+          "label": "Show all skills"
+        },
+        "title": "Skills for app “{appName}”"
+      },
+      "header": {
+        "description": "Capability bundles your Craft agent can reach for. This page shows built-in skills, skills shared with you, and your own personal skills.",
+        "title": "Skills"
+      },
+      "loadError": {
+        "description": "Check the console for details and try refreshing the page.",
+        "title": "Failed to load skills"
+      },
+      "preview": {
+        "unavailableFallback": "This skill is currently unavailable."
+      },
+      "search": {
+        "placeholder": "Search skills..."
+      },
+      "switchModal": {
+        "body": "Continuing will disable the currently enabled skill and enable this one.",
+        "description": "Only one skill named “{name}” can be enabled at a time.",
+        "submit": {
+          "label": "Switch skill",
+          "pendingLabel": "Switching..."
+        },
+        "title": "Switch “{name}” skill?"
+      },
+      "toasts": {
+        "disableFailed": "Failed to disable {name}",
+        "enableFailed": "Failed to enable {name}",
+        "refreshFailed": "{name} was updated, but the skill list could not be refreshed."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -12902,9 +12902,29 @@
         "title": "Couldn't load usage"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · default"
+        },
         "description": "USD per 1M tokens (input · output · cache) for every available model",
+        "otherProvider": {
+          "label": "Other"
+        },
         "title": "Model prices",
         "unavailable": "Prices unavailable"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "{count} cache reads"
+        },
+        "cacheWrites": {
+          "label": "{count} cache writes"
+        },
+        "tokensIn": {
+          "label": "{count} in"
+        },
+        "tokensOut": {
+          "label": "{count} out"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "Show fewer models"

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -60,6 +60,26 @@
         "ariaLabel": "Tarjeta de acción de {title}"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "Añadir conectores"
+      },
+      "configure": {
+        "tooltip": "Configurar"
+      },
+      "configureConnectors": {
+        "label": "Configurar conectores"
+      },
+      "disable": {
+        "label": "Desactivar"
+      },
+      "enable": {
+        "label": "Activar"
+      },
+      "projectSearch": {
+        "label": "Búsqueda del proyecto"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "Conecta un servidor MCP (Model Context Protocol) para añadir acciones personalizadas.",
@@ -355,6 +375,53 @@
         "tooltip": "Actualizar las herramientas"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "Te llevaremos de vuelta automáticamente…"
+      },
+      "backToChatButton": {
+        "label": "Volver al chat"
+      },
+      "cancelled": {
+        "description": "La autorización fue cancelada o denegada, por lo que no se estableció ninguna conexión. Para intentarlo de nuevo, reinicia la conexión desde la configuración de autenticación del servidor MCP.",
+        "title": "Autorización cancelada"
+      },
+      "continueButton": {
+        "label": "Continuar"
+      },
+      "genericError": {
+        "fallbackDetail": "No se pudo completar la autorización",
+        "title": "Algo salió mal"
+      },
+      "invalidLink": {
+        "description": "A este enlace le faltan los parámetros de autorización necesarios. Reinicia la conexión desde la configuración de autenticación del servidor MCP.",
+        "title": "Enlace de autorización no válido"
+      },
+      "processing": {
+        "description": "Finalizando la conexión con tu servidor MCP. Esto puede tardar unos momentos…",
+        "title": "Completando la autorización"
+      },
+      "serverNotFound": {
+        "description": "El servidor MCP al que pertenece esta autorización ya no existe o ya no está configurado. Vuelve a crear o configurar el servidor y conéctate de nuevo.",
+        "title": "Servidor MCP no encontrado"
+      },
+      "sessionExpired": {
+        "description": "Este enlace de autorización no es válido, expiró o ya fue utilizado. Reinicia la conexión desde la configuración de autenticación del servidor MCP.",
+        "title": "La sesión de autorización expiró"
+      },
+      "success": {
+        "description": "La autorización se completó correctamente. Ya puedes usar las herramientas de este servidor en el chat.",
+        "title": "Conectado a {serverName}"
+      },
+      "timedOut": {
+        "description": "El servidor MCP no confirmó la autorización a tiempo. Intenta conectarte de nuevo. Si esto sigue ocurriendo, verifica la configuración de OAuth del servidor.",
+        "title": "Se agotó el tiempo de autorización"
+      },
+      "tokenExchangeFailed": {
+        "description": "El proveedor aprobó la autorización, pero no se pudo obtener un token de acceso válido. Revisa las credenciales y los endpoints del cliente OAuth del servidor y vuelve a intentar la conexión.",
+        "title": "Falló el intercambio de tokens"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "Añadir un servidor MCP"
@@ -554,6 +621,20 @@
         "label": "Denegar"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "Atrás"
+      },
+      "disableAll": {
+        "label": "Desactivar todo"
+      },
+      "enableAll": {
+        "label": "Activar todo"
+      },
+      "toggle": {
+        "ariaLabel": "Alternar {name}"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "Herramienta no disponible"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "Mostrar solo las herramientas activadas",
         "tooltip": "Mostrar solo las activadas"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "Configurar el intérprete de código"
+        },
+        "imageGeneration": {
+          "tooltip": "Configurar la generación de imágenes"
+        },
+        "openapi": {
+          "tooltip": "Gestionar acciones OpenAPI"
+        },
+        "webSearch": {
+          "tooltip": "Configurar la búsqueda web"
+        }
+      },
+      "disableAllSources": {
+        "label": "Desactivar todas las fuentes"
+      },
+      "disableAllTools": {
+        "label": "Desactivar todas las herramientas"
+      },
+      "enableAllSources": {
+        "label": "Activar todas las fuentes"
+      },
+      "enableAllTools": {
+        "label": "Activar todas las herramientas"
+      },
+      "manageActions": {
+        "tooltip": "Gestionar acciones"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "Buscar herramientas de {server}"
+      },
+      "moreActions": {
+        "label": "Más acciones"
+      },
+      "reauthenticate": {
+        "label": "Volver a autenticar"
+      },
+      "search": {
+        "placeholder": "Buscar acciones..."
+      },
+      "serverFallback": {
+        "label": "servidor"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "Buscar filtros"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "Pide a un administrador que lo configure."
+        },
+        "codingAgent": {
+          "description": "Investiga un repositorio de GitHub y responde preguntas sobre su código."
+        },
+        "configureSuffix": {
+          "text": "Pulsa el engranaje de configuración para activarlo."
+        },
+        "default": {
+          "description": "Esta acción aún no está configurada."
+        },
+        "imageGeneration": {
+          "description": "Genera imágenes a partir de una instrucción."
+        },
+        "python": {
+          "description": "Ejecuta código para análisis complejos."
+        },
+        "search": {
+          "description": "Busca en el conocimiento conectado para fundamentar la respuesta."
+        },
+        "webSearch": {
+          "description": "Busca en la web información actualizada."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "Por día para el rango seleccionado",
+        "title": "Mensajes y usuarios únicos"
+      },
+      "empty": {
+        "message": "No se encontraron datos para este agente en el rango de fechas seleccionado."
+      },
+      "fetchFailed": {
+        "message": "No se pudieron obtener las estadísticas del agente."
+      },
+      "permissionDenied": {
+        "message": "No tienes permiso para ver estas estadísticas."
+      },
+      "totalMessages": {
+        "label": "Mensajes totales"
+      },
+      "totalUniqueUsers": {
+        "label": "Usuarios únicos totales"
+      },
+      "unknownError": {
+        "message": "Ocurrió un error desconocido"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "Contraer sección"
+        },
+        "expand": {
+          "ariaLabel": "Expandir sección"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "¿Seguro que quieres eliminar <emphasis>{name}</emphasis>? Esta acción no se puede deshacer."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "Ver los planes"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "No hay información de facturación disponible."
+        },
+        "loadError": {
+          "message": "Error al cargar la información de facturación. Inténtalo de nuevo más tarde."
+        },
+        "loading": {
+          "label": "Cargando..."
+        },
+        "manageSubscription": {
+          "description": "Consulta tu plan, actualiza el pago o cambia la suscripción",
+          "title": "Gestionar suscripción"
+        },
+        "page": {
+          "title": "Información de facturación"
+        },
+        "portalError": {
+          "message": "Error al crear la sesión del portal de clientes"
+        },
+        "subscriptionDetails": {
+          "title": "Detalles de la suscripción"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "Fin de facturación"
+          },
+          "billingStart": {
+            "label": "Inicio de facturación"
+          },
+          "seats": {
+            "label": "Puestos"
+          },
+          "status": {
+            "label": "Estado de la suscripción"
+          }
+        },
+        "updatedToast": {
+          "message": "¡Felicidades! Tu suscripción se ha actualizado correctamente."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "Sincronizaremos automáticamente los permisos desde la fuente. Un documento solo se podrá buscar en Onyx si el usuario que realiza la búsqueda tiene permiso para acceder al documento en la fuente.",
+          "disabledReason": "El método de autenticación de la credencial actual no admite la sincronización automática de permisos. Cambia el método de autenticación de la credencial a uno compatible.",
+          "name": "Sincronización automática de permisos"
+        },
+        "heading": {
+          "description": "Controla quién tiene acceso a los documentos indexados por este conector.",
+          "title": "Acceso a documentos"
+        },
+        "privateOption": {
+          "description": "Solo los usuarios a los que se les haya dado acceso explícito a este conector (a través de la página de Grupos de usuarios) pueden acceder a los documentos que importa este conector",
+          "name": "Privado"
+        },
+        "publicOption": {
+          "description": "Cualquier persona con una cuenta en Onyx puede acceder a los documentos que importa este conector",
+          "name": "Público"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# día} other {# días}}",
@@ -1546,6 +1794,14 @@
           "label": "Mostrar menos"
         }
       },
+      "credentialForm": {
+        "errorToast": "Error: {detail}",
+        "successToast": "¡Listo!",
+        "updateButton": {
+          "ariaLabel": "Actualizar credenciales",
+          "label": "Actualizar"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "Al eliminar este conector se programa una tarea de eliminación que quita sus documentos indexados y lo elimina para todos los usuarios.",
         "entityType": "conector"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "Error de sincronización de permisos de documentos"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "Consulta <link>nuestra documentación</link> para más información sobre cómo configurar este conector."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "No se pudieron actualizar los archivos"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "Arrastra y suelta {multiple, select, true {archivos} other {un archivo}} aquí, o haz clic para seleccionar {multiple, select, true {archivos} other {un archivo}}"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {Archivos seleccionados} other {Archivo seleccionado}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "Mensaje de error",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "Error de sincronización de pertenencia a grupos"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "Asignar acceso de grupos a este conector"
+        },
+        "assignToGroup": {
+          "title": "Asignar este conector a un grupo"
+        },
+        "scopedManagerGroups": {
+          "description": "Selecciona uno o más de los grupos que administras para dar acceso a este conector"
+        },
+        "syncGroups": {
+          "description": "Los grupos siguientes controlan quién puede administrar este conector. El acceso a sus documentos se hereda de los permisos de la propia fuente."
+        },
+        "visibleToGroups": {
+          "description": "Este conector será visible/accesible para los grupos seleccionados a continuación"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "Se envió la reindexación selectiva de {count, plural, one {# documento} other {# documentos}}. Los errores desaparecerán de la lista a medida que los documentos terminen de reindexarse."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "Regex de canales habilitada",
+        "channels": "Canales",
+        "enabledTrue": "Sí",
+        "excludeChannelRegexEnabled": "Regex de exclusión de canales habilitada",
+        "excludedChannels": "Canales excluidos",
+        "includeBotMessages": "Incluir mensajes de bots",
+        "jiraProjectUrl": "URL del proyecto de Jira",
+        "multipleRepos": "varios repositorios",
+        "pageId": "ID de página",
+        "realm": "Realm",
+        "repo": "Repositorio",
+        "wikiUrl": "URL del wiki"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "Introduce el correo de un administrador o propietario de la organización de Google que posee los Google Drive que quieres indexar.",
           "invalidEmail": "Debe ser un correo válido",
           "label": "Correo del administrador principal",
+          "placeholder": "admin@tuempresa.com",
           "required": "Obligatorio"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "Introduce el correo de un administrador o propietario de la organización de Google que posee las cuentas de Gmail que quieres indexar.",
           "invalidEmail": "Debe ser un correo válido",
           "label": "Correo del administrador principal",
+          "placeholder": "admin@tuempresa.com",
           "required": "Obligatorio"
         },
         "section": {
@@ -2602,6 +2906,171 @@
       "unavailable": {
         "description": "Onyx activa Craft en cada instalación. Contacta con tu representante de Onyx para obtener acceso.",
         "title": "Craft no está disponible en esta instalación"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "Creada el <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "Creada el <i>{date}</i> por <i>{email}</i>"
+        },
+        "unnamed": {
+          "label": "Credencial n.º {id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "Crear"
+        },
+        "created": {
+          "toast": "¡Nueva credencial creada!"
+        },
+        "name": {
+          "label": "Nombre:",
+          "placeholder": "(Opcional) nombre de la credencial..."
+        },
+        "submitError": {
+          "toast": "Error al enviar la credencial"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "confirmBody": {
+          "message": "¿Seguro que quieres eliminar esta credencial? No puedes eliminar credenciales vinculadas a conectores activos."
+        },
+        "confirmButton": {
+          "label": "Confirmar"
+        },
+        "confirmTitle": "Confirmar eliminación"
+      },
+      "edit": {
+        "name": {
+          "label": "Nombre (opcional):"
+        },
+        "permissions": {
+          "note": "¡Asegúrate de actualizar a una credencial con los permisos adecuados!"
+        },
+        "resetButton": {
+          "label": "Restablecer cambios"
+        },
+        "updateButton": {
+          "label": "Actualizar"
+        },
+        "updateError": {
+          "toast": "Error al actualizar la credencial"
+        }
+      },
+      "modal": {
+        "createTitle": "Crear credencial de {source}",
+        "editTitle": "Editar credencial",
+        "updateTitle": "Actualizar credenciales"
+      },
+      "modify": {
+        "createButton": {
+          "label": "Crear"
+        },
+        "instructions": {
+          "message": "¡Selecciona una credencial según sea necesario! ¡Asegúrate de haber seleccionado una credencial con los permisos adecuados para este conector!"
+        },
+        "selectButton": {
+          "label": "Seleccionar"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "Conectar"
+        },
+        "connectError": {
+          "title": "No se pudo conectar"
+        },
+        "redirectFailed": {
+          "message": "No pudimos redirigirte para iniciar sesión con {source}. Inténtalo de nuevo."
+        },
+        "retryButton": {
+          "label": "Reintentar"
+        },
+        "startError": {
+          "message": "No se pudo iniciar OAuth"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "Problema al cambiar la credencial: {detail}"
+        },
+        "success": {
+          "toast": "¡Credencial cambiada correctamente!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "Acciones"
+        },
+        "created": {
+          "header": "Creado"
+        },
+        "edit": {
+          "ariaLabel": "Editar credencial"
+        },
+        "empty": {
+          "message": "¡No existen credenciales para este conector!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "Última actualización"
+        },
+        "name": {
+          "header": "Nombre"
+        },
+        "select": {
+          "label": "Seleccionar"
+        },
+        "selected": {
+          "badge": "seleccionada"
+        },
+        "untitled": {
+          "label": "Sin título"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "Problema al actualizar la credencial"
+        },
+        "success": {
+          "toast": "Credencial actualizada"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "¡Esto te permite usar tu propia herramienta de analítica con Onyx! Copia el fragmento web de tu proveedor de analítica en el cuadro de abajo y empezaremos a enviar eventos de uso."
+      },
+      "notEnabled": {
+        "description": "Para configurar scripts de analítica personalizada, colabora con el equipo que instaló Onyx en tu organización para definir la variable de entorno <i>CUSTOM_ANALYTICS_SECRET_KEY</i>.",
+        "title": "La analítica personalizada no está habilitada."
+      },
+      "script": {
+        "description": "Especifica el Javascript que debe ejecutarse al cargar la página para inicializar tu seguimiento/analítica personalizada.",
+        "instructions": "No incluyas las etiquetas `<script></script>`. Si subes un script abajo pero no recibes eventos en tu plataforma de analítica, prueba a eliminar todos los espacios en blanco adicionales al inicio de cada línea de JavaScript.",
+        "label": "Script"
+      },
+      "secretKey": {
+        "description": "Por motivos de seguridad, debes proporcionar una clave secreta para actualizar este script. Debe ser el valor de la variable de entorno <i>CUSTOM_ANALYTICS_SECRET_KEY</i> configurada al instalar Onyx inicialmente.",
+        "label": "Clave secreta"
+      },
+      "updateButton": {
+        "label": "Actualizar"
+      },
+      "updateFailed": {
+        "message": "No se pudo actualizar el script de analítica personalizada: \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "¡El script de analítica personalizada se actualizó correctamente!"
       }
     },
     "discordBot": {
@@ -3059,6 +3528,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "Recopilando..."
+        },
+        "downloading": {
+          "label": "Descargando..."
+        },
+        "export": {
+          "label": "Exportar registros"
+        },
+        "starting": {
+          "label": "Iniciando..."
+        }
+      },
+      "downloadButton": {
+        "label": "Descargar"
+      },
+      "exportCard": {
+        "description": "Reúne los archivos de registro del servidor de API y de los workers en segundo plano en un único zip. La descarga comienza automáticamente cuando termina la recopilación.",
+        "title": "Exportar registros"
+      },
+      "header": {
+        "description": "Descarga un zip con los archivos de registro del servidor para adjuntarlo a un hilo de soporte de Onyx."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "cubierto por otro worker en el mismo host"
+        },
+        "failed": {
+          "label": "falló"
+        },
+        "failedWithError": {
+          "label": "falló: {error}"
+        },
+        "noLogs": {
+          "label": "no se encontraron archivos de registro"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {subió # archivo} other {subió # archivos}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "Los archivos de registro pueden incluir correos de usuarios, títulos de documentos, consultas de búsqueda y contenidos de errores. Revisa el contenido antes de compartirlos fuera de tu organización.",
+        "title": "Los registros pueden contener datos sensibles"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "Iniciando la recopilación..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "Ya hay una exportación de registros en curso. Inténtalo de nuevo en breve."
+        },
+        "downloadFailed": {
+          "message": "No se pudo descargar la exportación de registros."
+        },
+        "lostAccess": {
+          "message": "Se perdió el acceso a la exportación en curso. Inicia una nueva."
+        },
+        "startFailed": {
+          "message": "No se pudo iniciar la exportación de registros."
+        },
+        "unreachable": {
+          "message": "No se puede contactar con el servidor para comprobar el progreso de la exportación. Inicia una nueva exportación cuando vuelva a estar disponible."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "recopilando..."
+        },
+        "missedDeadline": {
+          "label": "no informó antes del plazo límite"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3165,9 +3711,137 @@
         "loadFailed": "No se pudo cargar el conector: {details}",
         "title": "Error"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "Escribe el nombre del canal o un patrón regex y pulsa Enter"
+        },
+        "channelsRequired": {
+          "error": "Se requiere al menos un canal cuando 'Buscar en todos los canales' está desactivado"
+        },
+        "configSchemaLoadError": {
+          "message": "No se pudo cargar el esquema de configuración: {error}"
+        },
+        "configTitle": {
+          "text": "Configuración del conector federado"
+        },
+        "configuration": {
+          "heading": "Configuración"
+        },
+        "create": {
+          "failed": "No se pudo crear el conector federado",
+          "success": "¡Conector federado creado correctamente!"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (deja en blanco para conservar el valor actual)"
+        },
+        "credentialValidationFailed": {
+          "message": "La validación de credenciales falló: {message}"
+        },
+        "credentials": {
+          "description": "Introduce las credenciales de este conector.",
+          "heading": "Credenciales"
+        },
+        "delete": {
+          "failed": "No se pudo eliminar el conector federado",
+          "success": "¡Conector federado eliminado correctamente!"
+        },
+        "deleteConfirm": {
+          "message": "¿Seguro que quieres eliminar este conector federado? Esta acción no se puede deshacer."
+        },
+        "deleteError": {
+          "toast": "Error al eliminar el conector: {error}"
+        },
+        "deleteItem": {
+          "deleting": "Eliminando...",
+          "inProgressTooltip": "Eliminación en curso",
+          "label": "Eliminar"
+        },
+        "federatedBadge": {
+          "label": "Federado"
+        },
+        "federatedTooltip": {
+          "default": "Este es un conector federado. Tendrá mayor latencia y menor calidad de búsqueda en comparación con los conectores normales."
+        },
+        "genericError": {
+          "text": "Error: {error}"
+        },
+        "listInput": {
+          "placeholder": "Escribe y pulsa Enter para añadir un elemento"
+        },
+        "loadingSchema": {
+          "description": "Obteniendo los campos requeridos para este tipo de conector",
+          "title": "Cargando el esquema de credenciales..."
+        },
+        "manageButton": {
+          "label": "Administrar"
+        },
+        "missingFields": {
+          "message": "Faltan campos obligatorios: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "No hay configuración de búsqueda disponible para este tipo de conector."
+        },
+        "noCredentialSchema": {
+          "message": "No hay esquema de credenciales disponible para este tipo de conector."
+        },
+        "schemaLoadError": {
+          "message": "No se pudo cargar el esquema de credenciales: {error}"
+        },
+        "submitButton": {
+          "create": "Crear",
+          "creating": "Creando...",
+          "update": "Actualizar",
+          "updating": "Actualizando..."
+        },
+        "title": {
+          "edit": "Editar {name}",
+          "setup": "Configurar {name}"
+        },
+        "update": {
+          "failed": "No se pudo actualizar el conector federado",
+          "success": "¡Conector federado actualizado correctamente!"
+        },
+        "validateBeforeEdit": {
+          "message": "Introduce nuevos valores de credenciales antes de validar."
+        },
+        "validateButton": {
+          "label": "Validar",
+          "validating": "Validando..."
+        },
+        "validation": {
+          "error": "Error de validación: {error}",
+          "failedStatus": "La validación falló: {statusText}",
+          "invalid": "Las credenciales no son válidas",
+          "valid": "Las credenciales son válidas"
+        }
+      },
       "loading": {
         "description": "Obteniendo los detalles del conector y el esquema de credenciales",
         "title": "Cargando la configuración del conector..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "Volver al chat"
+      },
+      "error": {
+        "title": "Algo salió mal"
+      },
+      "errors": {
+        "clientSecret": "Faltan las credenciales de autenticación o no son válidas",
+        "oauth": "La autorización OAuth falló",
+        "validation": "Error de configuración: revisa los ajustes de tu conector"
+      },
+      "processing": {
+        "details": "Espera mientras completamos la configuración.",
+        "title": "Procesando..."
+      },
+      "redirecting": {
+        "text": "Redirigiendo al chat en 2 segundos..."
+      },
+      "success": {
+        "detailsTemplate": "Tu autorización de {serviceName} se completó correctamente. Ya puedes usar este conector para buscar.",
+        "title": "¡Éxito!"
       }
     },
     "groups": {
@@ -3430,6 +4104,265 @@
           "header": "Límite de tokens",
           "placeholder": "Límite de tokens (en miles)",
           "unit": "(en miles)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "Eliminar hook",
+          "tooltip": "Eliminar"
+        },
+        "disconnect": {
+          "ariaLabel": "Desactivar hook",
+          "tooltip": "Desconectar hook"
+        },
+        "disconnectedSuffix": {
+          "label": "(Desconectado)"
+        },
+        "hookPoint": {
+          "description": "Punto de extensión: {name}"
+        },
+        "manage": {
+          "ariaLabel": "Configurar hook",
+          "tooltip": "Gestionar"
+        },
+        "reconnectButton": {
+          "label": "Reconectar"
+        },
+        "test": {
+          "ariaLabel": "Revalidar hook",
+          "tooltip": "Probar conexión"
+        }
+      },
+      "connectButton": {
+        "label": "Conectar"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "El hook ***{name}*** se eliminará de forma permanente de este punto de extensión. El endpoint externo puede conservar los datos que se le enviaron anteriormente."
+        },
+        "delete": {
+          "label": "Eliminar"
+        },
+        "header": {
+          "title": "Eliminar *{name}*"
+        },
+        "permanent": {
+          "description": "La eliminación no se puede deshacer."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyx dejará de llamar a este endpoint para el hook ***{name}***. Las solicitudes en curso seguirán ejecutándose. El endpoint externo puede conservar los datos que se le enviaron anteriormente. Puedes reconectar este hook más adelante si lo necesitas."
+        },
+        "deleteNote": {
+          "description": "También puedes eliminar este hook. La eliminación no se puede deshacer."
+        },
+        "disconnect": {
+          "label": "Desconectar"
+        },
+        "disconnectAndDelete": {
+          "label": "Desconectar y eliminar"
+        },
+        "header": {
+          "title": "Desconectar *{name}*"
+        }
+      },
+      "docsLink": {
+        "label": "Documentación"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyx usará esta clave para autenticarse en tu endpoint de API.",
+          "keepCurrent": {
+            "placeholder": "Déjalo en blanco para conservar la clave actual"
+          },
+          "title": "Clave de API"
+        },
+        "connectionValid": {
+          "label": "Conexión válida."
+        },
+        "createHeader": {
+          "description": "Conecta un endpoint de API externo para extender el punto de extensión.",
+          "title": "Configurar extensión de hook"
+        },
+        "editHeader": {
+          "title": "Gestionar extensión de hook"
+        },
+        "endpoint": {
+          "description": "Conéctate solo a servidores de confianza. Eres responsable de las acciones realizadas y de los datos compartidos con esta conexión.",
+          "title": "URL del endpoint de API externo"
+        },
+        "errors": {
+          "connect": "No se pudo conectar con el endpoint.",
+          "generic": "Algo salió mal.",
+          "invalidApiKey": "Clave de API no válida.",
+          "timeout": "La conexión agotó el tiempo de espera. Prueba a aumentar el tiempo de espera."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(Predeterminado)"
+          },
+          "hard": {
+            "label": "Bloquear el pipeline en caso de fallo"
+          },
+          "placeholder": "Selecciona una estrategia",
+          "soft": {
+            "label": "Registrar el error y continuar"
+          },
+          "title": "Estrategia de fallo"
+        },
+        "hookPoint": {
+          "label": "Punto de extensión"
+        },
+        "name": {
+          "placeholder": "Ponle nombre a tu extensión en este punto de extensión",
+          "title": "Nombre visible"
+        },
+        "save": {
+          "label": "Guardar cambios"
+        },
+        "softStrategy": {
+          "description": "Si el endpoint devuelve un error, Onyx lo registra y continúa el pipeline con normalidad, ignorando el resultado del hook."
+        },
+        "timeout": {
+          "description": "Tiempo máximo que Onyx esperará a que el endpoint responda antes de aplicar la estrategia de fallo. Debe ser mayor que 0 y como máximo {max} segundos.",
+          "revert": {
+            "tooltip": "Restablecer el valor predeterminado"
+          },
+          "suffix": "(segundos)",
+          "title": "Tiempo de espera"
+        },
+        "toasts": {
+          "created": {
+            "message": "Hook creado."
+          },
+          "noHookPoint": {
+            "message": "No se especificó un punto de extensión."
+          },
+          "updated": {
+            "message": "Hook actualizado."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "La clave de API no puede estar vacía.",
+          "endpointRequired": "La URL del endpoint no puede estar vacía.",
+          "nameRequired": "El nombre visible no puede estar vacío.",
+          "timeoutRange": "Debe ser mayor que 0 y como máximo {max} segundos.",
+          "timeoutRequired": "El tiempo de espera es obligatorio."
+        },
+        "verifying": {
+          "label": "Verificando la conexión…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "Copiar"
+        },
+        "download": {
+          "tooltip": "Descargar"
+        },
+        "empty": {
+          "message": "Sin errores en los últimos 30 días."
+        },
+        "header": {
+          "description": "Hook: {name} • Punto de extensión: {point}",
+          "title": "Errores recientes"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# línea} other {# líneas}}"
+        },
+        "loadFailed": {
+          "message": "No se pudieron cargar los registros."
+        },
+        "older": {
+          "label": "Anteriores"
+        },
+        "pastHour": {
+          "label": "Última hora"
+        },
+        "unknownError": {
+          "label": "Error desconocido"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "Cancelar"
+        }
+      },
+      "page": {
+        "description": "Extiende los pipelines de Onyx registrando endpoints de API externos como callbacks en puntos de extensión predefinidos.",
+        "empty": {
+          "title": "No hay puntos de extensión disponibles"
+        },
+        "emptySearch": {
+          "description": "Prueba con otro término de búsqueda.",
+          "title": "No se encontraron resultados"
+        },
+        "enterpriseRequired": {
+          "message": "Las extensiones de hooks requieren una licencia Enterprise."
+        },
+        "loadHooksFailed": {
+          "message": "No se pudieron cargar los hooks. Actualiza la página."
+        },
+        "loadSpecsFailed": {
+          "message": "No se pudieron cargar las especificaciones de hooks. Actualiza la página."
+        },
+        "notEnabled": {
+          "message": "Las extensiones de hooks no están habilitadas en esta implementación."
+        },
+        "search": {
+          "placeholder": "Buscar hooks..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "Conectado"
+        },
+        "connectionLost": {
+          "label": "Conexión perdida"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# error} other {# errores}}"
+        },
+        "noError": {
+          "title": "Sin errores"
+        },
+        "pastHour": {
+          "description": "en la última hora"
+        },
+        "recentErrors": {
+          "title": "Errores más recientes"
+        },
+        "viewMore": {
+          "label": "Ver más líneas"
+        },
+        "viewOlder": {
+          "label": "Ver errores anteriores"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "No se pudo desactivar el hook."
+        },
+        "deleteFailed": {
+          "message": "No se pudo eliminar el hook."
+        },
+        "disconnectFailed": {
+          "message": "No se pudo desconectar el hook."
+        },
+        "reconnectFailed": {
+          "message": "No se pudo reconectar el hook."
+        },
+        "validateFailed": {
+          "message": "No se pudo validar el hook."
+        },
+        "validateSuccess": {
+          "message": "El hook se validó correctamente."
+        },
+        "validationFailed": {
+          "message": "La validación falló: {status}"
         }
       }
     },
@@ -4309,6 +5242,9 @@
               "label": "Añadir una línea"
             },
             "description": "Añade las propiedades adicionales que necesite el proveedor de modelos. Se pasan a la llamada `completion()` de LiteLLM como [variables de entorno](https://docs.litellm.ai/docs/set_keys#environment-variables). Consulta la [documentación](https://docs.onyx.app/admins/ai_models/custom_inference_provider) para ver más instrucciones.",
+            "keyInput": {
+              "placeholder": "p. ej., OPENAI_ORGANIZATION"
+            },
             "title": "Variables de entorno"
           },
           "modelRow": {
@@ -4820,6 +5756,132 @@
         "title": "Usuarios"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "Desconocido"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "IA"
+        },
+        "errorTitle": {
+          "title": "Algo salió mal :("
+        },
+        "feedback": {
+          "title": "Comentarios"
+        },
+        "fetchFailed": {
+          "message": "No se pudo obtener la sesión de chat - {error}"
+        },
+        "header": {
+          "title": "Detalles de la sesión de chat"
+        },
+        "referenceDocuments": {
+          "title": "Documentos de referencia"
+        },
+        "user": {
+          "label": "Usuario"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "downloadFailed": {
+          "message": "No se pudo descargar el historial de consultas."
+        },
+        "generating": {
+          "message": "Generando informe CSV. Haz clic en el botón \"{button}\" para ver todos los trabajos."
+        },
+        "kickoff": {
+          "label": "Iniciar exportación"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "Error"
+        },
+        "pending": {
+          "label": "Pendiente"
+        },
+        "success": {
+          "label": "Éxito"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "Descargar"
+        },
+        "endRange": {
+          "header": "Fin del rango"
+        },
+        "generatedAt": {
+          "header": "Generado el"
+        },
+        "header": {
+          "title": "Exportaciones anteriores del historial de consultas"
+        },
+        "notReady": {
+          "tooltip": "La exportación aún no está lista"
+        },
+        "startRange": {
+          "header": "Inicio del rango"
+        },
+        "status": {
+          "header": "Estado"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "No me gusta"
+        },
+        "like": {
+          "label": "Me gusta"
+        },
+        "mixed": {
+          "label": "Mixto"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "Cualquiera"
+        },
+        "feedbackType": {
+          "label": "Tipo de comentario"
+        }
+      },
+      "previousExports": {
+        "label": "Ver exportaciones"
+      },
+      "table": {
+        "date": {
+          "header": "Fecha"
+        },
+        "feedback": {
+          "header": "Comentarios"
+        },
+        "fetchError": {
+          "title": "Error al obtener el historial de consultas"
+        },
+        "firstAiResponse": {
+          "header": "Primera respuesta de la IA"
+        },
+        "firstUserMessage": {
+          "header": "Primer mensaje del usuario"
+        },
+        "persona": {
+          "header": "Persona"
+        },
+        "user": {
+          "header": "Usuario"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4874,6 +5936,56 @@
         "generateFailed": "No se pudo generar el token: {detail}",
         "genericError": "Algo salió mal. Inténtalo de nuevo.",
         "regenerated": "Token regenerado"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "La clasificación de la consulta falló. Se usará el chat."
+        },
+        "searchFailed": {
+          "message": "La búsqueda de documentos falló. Inténtalo de nuevo."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# resultado} other {# resultados}}"
+        },
+        "empty": {
+          "description": "Revisa tus conectores/filtros o prueba con otro término de búsqueda.",
+          "title": "No se encontraron resultados"
+        },
+        "failed": {
+          "title": "La búsqueda falló"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# etiqueta} other {# etiquetas}}"
+        },
+        "empty": {
+          "label": "Etiquetas"
+        },
+        "search": {
+          "placeholder": "Filtrar etiquetas..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "Todo el tiempo"
+        },
+        "day": {
+          "label": "Últimas 24 horas"
+        },
+        "month": {
+          "label": "Último mes"
+        },
+        "week": {
+          "label": "Última semana"
+        },
+        "year": {
+          "label": "Último año"
+        }
       }
     },
     "security": {
@@ -5765,6 +6877,163 @@
         "unexpectedError": "Ocurrió un error inesperado."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "Eliminar la categoría {name}"
+        },
+        "removeButton": {
+          "ariaLabel": "Eliminar categoría"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "Categorías de respuestas estándar"
+        },
+        "fetchError": {
+          "message": "No se pudieron obtener las categorías de respuestas estándar - {message}",
+          "title": "Algo salió mal :("
+        },
+        "search": {
+          "placeholder": "Buscar categorías..."
+        }
+      },
+      "editPage": {
+        "title": "Editar respuesta estándar"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "No se pudieron obtener las respuestas estándar"
+        },
+        "fetchCategoriesFailed": {
+          "message": "No se pudieron obtener las categorías de respuestas estándar"
+        },
+        "genericTitle": {
+          "title": "Algo salió mal :("
+        },
+        "loadAnswersFailed": {
+          "title": "Error al cargar las respuestas estándar"
+        },
+        "loadCategoriesFailed": {
+          "title": "Error al cargar las categorías de respuestas estándar"
+        },
+        "notFound": {
+          "message": "No se encontró una respuesta estándar con ID: {id}"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "Todas las categorías"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "Todas estas palabras clave, en cualquier orden, separadas por espacios",
+          "placeholder": "ticket TI"
+        },
+        "answer": {
+          "label": "Respuesta",
+          "placeholder": "La respuesta en Markdown. Ejemplo: si necesitas ayuda del equipo de TI, escribe a internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "Cualquiera de estas palabras clave, separadas por espacios",
+          "placeholder": "ticket problema incidencia"
+        },
+        "categories": {
+          "label": "Categorías:",
+          "placeholder": "Escribe una categoría y presiona Enter…"
+        },
+        "createButton": {
+          "label": "¡Crear!"
+        },
+        "keywords": {
+          "tooltip": "Una pregunta debe coincidir con estas palabras clave para activar la respuesta."
+        },
+        "matchRegex": {
+          "description": "Coincide con un patrón regex en lugar de una palabra clave exacta",
+          "label": "Coincidir con regex"
+        },
+        "regexPattern": {
+          "label": "Patrón regex",
+          "tooltip": "Se activa si la pregunta coincide con este patrón regex (usando `re.search()` de Python)"
+        },
+        "strategy": {
+          "all": {
+            "label": "Todas las palabras clave"
+          },
+          "any": {
+            "label": "Cualquier palabra clave"
+          },
+          "description": "Elige si la pregunta del usuario debe contener alguna o todas las palabras clave anteriores para mostrar esta respuesta.",
+          "label": "Estrategia de detección de palabras clave"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "Error al crear la categoría \"{name}\" - {error}"
+          },
+          "createFailed": {
+            "message": "Error al crear la respuesta estándar - {error}"
+          },
+          "updateFailed": {
+            "message": "Error al actualizar la respuesta estándar - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "¡Actualizar!"
+        },
+        "validation": {
+          "answerRequired": "La respuesta es obligatoria",
+          "categoryRequired": "Se requiere al menos una categoría",
+          "keywordRequired": "Se requieren palabras clave o un patrón"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "¡Agrega tu primera respuesta estándar abajo!"
+        },
+        "description": "Administra las respuestas estándar para preguntas predefinidas.\nNota: actualmente solo las preguntas hechas desde Slack pueden recibir respuestas estándar."
+      },
+      "newStandardAnswer": {
+        "label": "Nueva respuesta estándar"
+      },
+      "search": {
+        "placeholder": "Busca respuestas estándar por palabra clave o frase..."
+      },
+      "table": {
+        "answer": {
+          "header": "Respuesta"
+        },
+        "categories": {
+          "header": "Categorías"
+        },
+        "empty": {
+          "message": "No se encontraron respuestas estándar coincidentes..."
+        },
+        "keywords": {
+          "header": "Palabras clave/patrón"
+        },
+        "matchRegex": {
+          "header": "¿Coincidencia regex?"
+        },
+        "matchRegexNo": {
+          "label": "No"
+        },
+        "matchRegexYes": {
+          "label": "Sí"
+        },
+        "slackNote": {
+          "message": "Asegúrate de haber agregado la categoría al [bot de Slack](/admin/bots) correspondiente."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "No se pudo eliminar la respuesta estándar - {error}"
+        },
+        "deleted": {
+          "message": "Respuesta estándar {id} eliminada"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "Cancelado",
@@ -5795,6 +7064,142 @@
       },
       "webVersion": {
         "label": "Versión web: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "Muestra un anuncio del sistema persistente que los usuarios pueden descartar.",
+        "header": {
+          "placeholder": "Agrega un anuncio"
+        },
+        "label": "Anuncio del sistema"
+      },
+      "announcementPopup": {
+        "description": "Muestra también este aviso como una ventana emergente a pantalla completa en la primera visita de todos los usuarios. Úsalo con precaución.",
+        "label": "Aviso emergente en la primera visita"
+      },
+      "appName": {
+        "description": "Este nombre se mostrará en toda la aplicación y reemplazará a \"Onyx\" en la interfaz.",
+        "label": "Nombre visible de la aplicación"
+      },
+      "branding": {
+        "description": "Elimina \"powered by Onyx\" y otras menciones de la marca Onyx en la aplicación.",
+        "enterpriseTooltip": "Ocultar la marca de Onyx es una función del plan Enterprise.",
+        "label": "Ocultar la marca de Onyx"
+      },
+      "chatFooter": {
+        "description": "Agrega contenido en markdown para avisos legales o información adicional.",
+        "label": "Texto del pie del chat"
+      },
+      "chatHeader": {
+        "label": "Texto del encabezado del chat"
+      },
+      "consent": {
+        "description": "Exige que el usuario lea y acepte el aviso antes de acceder a la aplicación.",
+        "label": "Requerir consentimiento del aviso"
+      },
+      "consentPrompt": {
+        "label": "Mensaje de consentimiento del aviso"
+      },
+      "firstVisit": {
+        "description": "Muestra una ventana emergente única para los nuevos usuarios en su primera visita.",
+        "label": "Mostrar aviso en la primera visita"
+      },
+      "greeting": {
+        "description": "Agrega un mensaje corto a la página de inicio.",
+        "label": "Mensaje de bienvenida"
+      },
+      "helpLink": {
+        "description": "Agrega un enlace de ayuda personalizado en el menú del usuario además de la documentación de Onyx.",
+        "enterpriseTooltip": "El enlace de ayuda personalizado es una función del plan Enterprise.",
+        "label": "Enlace de ayuda personalizado"
+      },
+      "helpLinkLabel": {
+        "label": "Etiqueta del enlace de ayuda personalizado",
+        "placeholder": "Etiqueta del enlace"
+      },
+      "loginSubtitle": {
+        "description": "Reemplaza el eslogan bajo el encabezado de bienvenida en la página de inicio de sesión.",
+        "label": "Subtítulo de la página de inicio de sesión"
+      },
+      "logo": {
+        "label": "Logo de la aplicación",
+        "updateButton": {
+          "label": "Actualizar"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "Logo y nombre",
+          "tooltip": "Muestra el logo y el nombre de tu aplicación."
+        },
+        "description": "Elige qué mostrar en la parte superior de la barra lateral. Las opciones estarán disponibles cuando agregues un logo o un nombre de aplicación.",
+        "label": "Estilo de visualización del logo",
+        "logoOnly": {
+          "disabledTooltip": "Sube un logo para habilitar esta opción.",
+          "label": "Solo logo",
+          "tooltip": "Muestra solo el logo de tu aplicación."
+        },
+        "nameOnly": {
+          "disabledTooltip": "Introduce un nombre de aplicación para habilitar esta opción.",
+          "label": "Solo nombre",
+          "tooltip": "Muestra solo el nombre de tu aplicación."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "Agrega contenido en markdown"
+      },
+      "noticeContent": {
+        "label": "Contenido del aviso"
+      },
+      "noticeHeader": {
+        "label": "Encabezado del aviso"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "No se pudo eliminar el anuncio."
+        },
+        "announcementSaveFailed": {
+          "message": "No se pudo guardar el anuncio."
+        },
+        "applyButton": {
+          "label": "Aplicar cambios"
+        },
+        "applying": {
+          "label": "Aplicando..."
+        },
+        "description": "Personaliza cómo se muestra la aplicación a los usuarios de tu organización.",
+        "logoUploadFailed": {
+          "message": "No se pudo subir el logo. {error}"
+        },
+        "saveSuccess": {
+          "message": "¡La configuración de apariencia se guardó correctamente!"
+        },
+        "settingsSaveFailed": {
+          "message": "No se pudo actualizar la configuración. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "El mensaje de consentimiento del aviso es obligatorio",
+          "invalidUrl": "Debe ser una URL válida",
+          "maxChars": "Máximo de {count} caracteres",
+          "noticeContentRequired": "El contenido del aviso es obligatorio",
+          "noticeHeaderRequired": "El encabezado del aviso es obligatorio",
+          "urlRequiredWithLabel": "La URL es obligatoria cuando se define una etiqueta"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "Contenido del pie del chat"
+        },
+        "chatHeader": {
+          "placeholder": "Contenido del encabezado del chat"
+        },
+        "greeting": {
+          "placeholder": "Bienvenido a Acme Chat"
+        },
+        "logo": {
+          "alt": "Logo"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6059,6 +7464,9 @@
             "label": "Gasto"
           }
         }
+      },
+      "page": {
+        "description": "Supervisa el gasto del espacio de trabajo y revisa el uso por usuario."
       },
       "spendByUser": {
         "columns": {
@@ -6656,6 +8064,204 @@
         "tooltip": "Ver las estadísticas del agente"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "Genera y ejecuta código.",
+          "title": "Intérprete de código"
+        },
+        "codingAgent": {
+          "description": "Investiga un repositorio de GitHub y responde preguntas sobre su código.",
+          "title": "Agente de programación"
+        },
+        "description": "Herramientas y capacidades disponibles para que este agente las use.",
+        "imageGeneration": {
+          "description": "Genera y manipula imágenes con herramientas impulsadas por IA.",
+          "title": "Generación de imágenes",
+          "unavailable": {
+            "tooltip": "La generación de imágenes requiere un modelo configurado. Si tienes acceso, configura uno en Configuración > Generación de imágenes, o pídeselo a un administrador."
+          }
+        },
+        "openUrl": {
+          "description": "Obtén y lee contenido de URLs web.",
+          "title": "Abrir URL"
+        },
+        "title": "Acciones",
+        "webSearch": {
+          "description": "Busca en la web información en tiempo real y resultados actualizados.",
+          "title": "Búsqueda web"
+        }
+      },
+      "advanced": {
+        "description": "Ajusta los prompts y el conocimiento del agente.",
+        "overwritePrompt": {
+          "suffix": "(No recomendado)",
+          "title": "Sobrescribir el prompt del sistema"
+        },
+        "reminders": {
+          "description": "Añade un breve recordatorio a los mensajes del prompt. Úsalo para recordarle al agente si notas que tiende a olvidar ciertas instrucciones a medida que avanza el chat. Debe ser breve y no interferir con los mensajes del usuario.",
+          "placeholder": "Recuerda, quiero que siempre des formato de lista numerada a tu respuesta.",
+          "title": "Recordatorios"
+        },
+        "title": "Opciones avanzadas"
+      },
+      "avatar": {
+        "edit": {
+          "label": "Editar"
+        },
+        "uploadImage": {
+          "label": "Subir imagen"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "Eliminar agente"
+        },
+        "description": "Cualquiera que use este agente ya no podrá acceder a él.",
+        "title": "Eliminar este agente"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "¿Seguro que quieres eliminar este agente?",
+          "warning": "Cualquiera que use este agente ya no podrá acceder a él. La eliminación no se puede deshacer."
+        },
+        "title": "Eliminar agente"
+      },
+      "filesModal": {
+        "description": "Todos los archivos seleccionados para este agente",
+        "placeholderName": "Archivo {id}",
+        "title": "Archivos del usuario"
+      },
+      "general": {
+        "avatar": {
+          "title": "Avatar del agente"
+        },
+        "descriptionField": {
+          "placeholder": "¿Qué hace este agente?",
+          "title": "Descripción"
+        },
+        "name": {
+          "placeholder": "Nombra tu agente",
+          "title": "Nombre"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "create": {
+          "label": "Crear"
+        },
+        "createTitle": "Crear agente",
+        "editTitle": "Editar agente",
+        "save": {
+          "label": "Guardar"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "Ya no tienes acceso a este servidor MCP. Sus herramientas existentes se conservarán."
+        },
+        "searchTools": {
+          "placeholder": "Buscar herramientas..."
+        }
+      },
+      "page": {
+        "ariaLabel": "Página del editor de agentes"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "Agrega instrucciones para personalizar las respuestas de este agente.",
+          "placeholder": "Piensa paso a paso y muestra el razonamiento en problemas complejos. Usa ejemplos específicos. Enfatiza los elementos de acción y deja espacios en blanco para que la persona los complete cuando haya incógnitas. Usa un tono cortés y entusiasta.",
+          "title": "Instrucciones"
+        },
+        "starters": {
+          "description": "Mensajes de ejemplo que ayudan a los usuarios a entender qué puede hacer este agente y cómo interactuar con él de manera efectiva.",
+          "title": "Iniciadores de conversación"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "Corrige los errores del formulario antes de guardar.",
+        "noChanges": "No se han realizado cambios.",
+        "saving": "Guardando los cambios...",
+        "uploading": "Espera a que los archivos terminen de subirse."
+      },
+      "share": {
+        "feature": {
+          "description": "Muestra este agente en la parte superior de la lista de exploración de agentes y fíjalo automáticamente en la barra lateral para los nuevos usuarios con acceso.",
+          "privateNotice": {
+            "title": "Este agente es privado y solo se destacará para ti."
+          },
+          "title": "Destacar este agente",
+          "unlistedWarning": {
+            "title": "Este agente no está listado y no se mostrará en la lista de destacados."
+          }
+        },
+        "labels": {
+          "description": "Agrega etiquetas y categorías para ayudar a las personas a descubrir mejor este agente.",
+          "placeholder": "Agregar etiquetas..."
+        },
+        "share": {
+          "button": {
+            "label": "Compartir"
+          },
+          "description": "con otros usuarios, grupos o todos en tu organización.",
+          "title": "Compartir este agente"
+        },
+        "title": "Compartir agente"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "Elabora una lista de nuestros objetivos de ingeniería para este trimestre.",
+          "overview": "Dame un resumen de algunos documentos.",
+          "salesReport": "Encuentra el último informe de ventas.",
+          "todayGoals": "Resume mis objetivos de hoy."
+        },
+        "placeholder": "Escribe un iniciador de conversación..."
+      },
+      "suffix": {
+        "optional": "opcional"
+      },
+      "toasts": {
+        "createFailed": "No se pudo crear el agente - {detail}",
+        "created": "El agente \"{name}\" se creó correctamente",
+        "deleteFailed": "No se pudo eliminar el agente: {error}",
+        "deleted": "El agente se eliminó correctamente",
+        "genericError": "Ocurrió un error: {error}",
+        "noResponse": "no se recibió respuesta",
+        "sharingFailed": "Se creó el agente, pero falló el uso compartido: {error}",
+        "toggleListedFailed": "No se pudo cambiar la visibilidad",
+        "unknownDetail": "error desconocido",
+        "unknownError": "Error desconocido",
+        "updateFailed": "No se pudo actualizar el agente - {detail}",
+        "updated": "El agente \"{name}\" se actualizó correctamente"
+      },
+      "validation": {
+        "cutoffInFuture": "La fecha límite de conocimiento debe ser hoy o anterior.",
+        "descriptionMax": "La descripción debe tener {max} caracteres o menos",
+        "nameRequired": "El nombre del agente es obligatorio.",
+        "starterMax": "El iniciador de conversación debe tener {max} caracteres o menos"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "Volver a listar"
+          },
+          "description": "Los agentes vueltos a listar aparecen de nuevo en la lista de exploración de agentes.",
+          "title": "Volver a listar este agente"
+        },
+        "unlist": {
+          "button": {
+            "label": "Quitar de la lista"
+          },
+          "description": "Los agentes no listados no aparecen en la lista de exploración de agentes, pero siguen siendo accesibles.",
+          "title": "Quitar este agente de la lista"
+        }
+      },
+      "warnings": {
+        "openUrl": "La búsqueda web sin la capacidad de abrir URLs puede producir resultados web significativamente peores."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6838,6 +8444,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {Agente} other {Agentes}}"
+      },
+      "empty": {
+        "description": "No se encontraron agentes"
+      },
+      "header": {
+        "description": "Personaliza el comportamiento y el conocimiento de la IA para tus casos de uso y los de tu equipo.",
+        "title": "Agentes"
+      },
+      "newAgent": {
+        "label": "Nuevo agente",
+        "noPermission": {
+          "tooltip": "No tienes permiso para crear agentes. Contacta a tu administrador para solicitar acceso."
+        }
+      },
+      "page": {
+        "ariaLabel": "Página de agentes"
+      },
+      "search": {
+        "placeholder": "Buscar agentes..."
+      },
+      "sections": {
+        "all": {
+          "title": "Todos los agentes"
+        },
+        "featured": {
+          "description": "Seleccionados por tu equipo",
+          "title": "Agentes destacados"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "Todos los agentes"
+        },
+        "your": {
+          "label": "Tus agentes"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "Insertar una variable de usuario"
@@ -6845,6 +8492,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "Espera mientras configuramos tu sesión anónima.",
+        "title": "Redirigiéndote a la página de chat..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "Crear nueva organización"
@@ -6866,6 +8519,55 @@
       },
       "signInLink": {
         "label": "Iniciar sesión"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "Ya existe una cuenta con el correo electrónico indicado."
+      },
+      "continueAsGuest": {
+        "label": "o continúa como invitado"
+      },
+      "email": {
+        "label": "Correo electrónico",
+        "placeholder": "correo@tuempresa.com"
+      },
+      "forgotPassword": {
+        "link": "[¿Olvidaste tu contraseña?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "Correo electrónico o contraseña no válidos"
+      },
+      "noPassword": {
+        "error": "Crea una cuenta para establecer una contraseña"
+      },
+      "password": {
+        "label": "Contraseña",
+        "placeholder": "Contraseña"
+      },
+      "passwordDigit": {
+        "error": "La contraseña debe contener al menos un número"
+      },
+      "passwordLength": {
+        "error": "La contraseña debe tener entre {min} y {max} caracteres"
+      },
+      "passwordLoginDisabled": {
+        "error": "El inicio de sesión con contraseña está desactivado. Inicia sesión con tu proveedor de identidad."
+      },
+      "passwordLowercase": {
+        "error": "La contraseña debe contener al menos una letra minúscula"
+      },
+      "passwordRequirements": {
+        "label": "Requisitos de la contraseña:"
+      },
+      "passwordSpecialChar": {
+        "error": "La contraseña debe contener al menos un carácter especial"
+      },
+      "passwordUppercase": {
+        "error": "La contraseña debe contener al menos una letra mayúscula"
+      },
+      "tooManyRequests": {
+        "error": "Demasiadas solicitudes. Inténtalo de nuevo más tarde."
       }
     },
     "error": {
@@ -6906,6 +8608,31 @@
         "description": "Interrupción temporal del sistema de autenticación"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "Tu equipo no tiene habilitado el acceso anónimo."
+      },
+      "generic": {
+        "toast": "Se produjo un error."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "Crear una cuenta"
+      },
+      "logo": {
+        "alt": "Logotipo"
+      },
+      "signInLink": {
+        "label": "Iniciar sesión"
+      },
+      "signinPrompt": {
+        "text": "¿Ya tienes una cuenta?"
+      },
+      "signupPrompt": {
+        "text": "¿Nuevo en {appName}?"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[Volver al inicio de sesión](/auth/login)"
@@ -6938,7 +8665,8 @@
         "placeholder": "Introduce la clave de API"
       },
       "emailField": {
-        "label": "Correo electrónico"
+        "label": "Correo electrónico",
+        "placeholder": "email@tuempresa.com"
       },
       "genericError": {
         "toast": "No se pudo suplantar al usuario"
@@ -6999,6 +8727,23 @@
         "label": "Correo de trabajo"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "Contiene un número."
+      },
+      "length": {
+        "label": "{min}–{max} caracteres"
+      },
+      "lowercase": {
+        "label": "Contiene una letra minúscula."
+      },
+      "specialChar": {
+        "label": "Contiene un carácter especial."
+      },
+      "uppercase": {
+        "label": "Contiene una letra mayúscula."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[Volver al inicio de sesión](/auth/login)"
@@ -7040,6 +8785,31 @@
       },
       "unexpectedError": {
         "toast": "Ocurrió un error inesperado. Inténtalo de nuevo."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "Tu sesión ha caducado. Inicia sesión de nuevo para continuar."
+      },
+      "loginButton": {
+        "label": "Iniciar sesión"
+      },
+      "modal": {
+        "title": "Se ha cerrado tu sesión"
+      },
+      "terminated": {
+        "message": "Se cerró esta sesión. Inicia sesión de nuevo para continuar."
+      },
+      "unrecognized": {
+        "message": "Se cerró tu sesión de forma inesperada. Inicia sesión de nuevo para continuar. Si esto sigue ocurriendo, contacta a tu administrador."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute no devolvió ningún token"
+      },
+      "google": {
+        "label": "Continuar con Google"
       }
     },
     "signup": {
@@ -8471,6 +10241,75 @@
         "tooltip": "Modificar esta configuración no es compatible con este modelo."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {El archivo falló y fue eliminado: {names}} other {Los archivos fallaron y fueron eliminados: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "Iniciar sesión"
+          },
+          "title": "Te damos la bienvenida a Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "No se encontró ningún mensaje enviado previamente."
+        },
+        "settingsButton": {
+          "tooltip": "Abrir configuración"
+        },
+        "setupLlmButton": {
+          "label": "Configura un LLM."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "Cancelar"
+          },
+          "confirmButton": {
+            "label": "Desactivar"
+          },
+          "description": "Verás la página de nueva pestaña predeterminada de tu navegador. Puedes volver a activarla en cualquier momento desde la configuración de Onyx.",
+          "title": "¿Desactivar Onyx como página de nueva pestaña?"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "Ninguno"
+        },
+        "backgroundOption": {
+          "ariaLabel": "Fondo {label}"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "Fondo {label} (seleccionado)"
+        },
+        "backgroundSection": {
+          "title": "Fondo"
+        },
+        "closeButton": {
+          "tooltip": "Cerrar configuración"
+        },
+        "generalSection": {
+          "title": "General"
+        },
+        "header": {
+          "title": "Configuración"
+        },
+        "newTabToggle": {
+          "label": "Usar Onyx como página de nueva pestaña"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {Cambiar al tema claro} other {Cambiar al tema oscuro}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "Nuevo chat"
+        },
+        "openInOnyxButton": {
+          "tooltip": "Abrir en Onyx"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "Casilla de consentimiento"
@@ -8486,6 +10325,128 @@
       },
       "startButton": {
         "label": "Comenzar"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "Último mensaje {time}"
+        },
+        "projectFallback": {
+          "label": "Proyecto"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "Añadir archivos"
+        },
+        "contextExceeded": {
+          "message": "Este proyecto supera los límites de contexto del modelo. Las sesiones buscarán automáticamente los archivos relevantes antes de generar una respuesta."
+        },
+        "dropFiles": {
+          "message": "Suelta archivos aquí para añadirlos a este proyecto"
+        },
+        "emptyFiles": {
+          "message": "Añade documentos, textos o imágenes para usarlos en el proyecto. Se admite arrastrar y soltar."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# archivo} other {# archivos}}"
+        },
+        "fileCountOverflow": {
+          "description": "Más de 100 archivos"
+        },
+        "files": {
+          "description": "Los chats de este proyecto pueden acceder a estos archivos.",
+          "title": "Archivos"
+        },
+        "filesModal": {
+          "description": "Las sesiones de este proyecto pueden acceder a los archivos aquí.",
+          "title": "Archivos del proyecto"
+        },
+        "instructions": {
+          "emptyDescription": "Añade instrucciones para adaptar las respuestas en este proyecto.",
+          "title": "Instrucciones"
+        },
+        "loadingProject": {
+          "label": "Cargando proyecto..."
+        },
+        "setInstructionsButton": {
+          "label": "Establecer instrucciones"
+        },
+        "viewAll": {
+          "label": "Ver todo"
+        },
+        "viewFiles": {
+          "label": "Ver archivos"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "createError": {
+          "toast": "No se pudo crear el proyecto {name}"
+        },
+        "description": "Usa los proyectos para organizar tus archivos y chats en un solo lugar, y añade instrucciones personalizadas para el trabajo en curso.",
+        "name": {
+          "label": "Nombre del proyecto",
+          "placeholder": "¿En qué estás trabajando?"
+        },
+        "nameRequired": {
+          "error": "El nombre del proyecto es obligatorio"
+        },
+        "submitButton": {
+          "label": "Crear proyecto"
+        },
+        "title": "Crear nuevo proyecto"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "No se encontraron proyectos"
+        },
+        "search": {
+          "placeholder": "Buscar proyectos..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "Contraer proyecto"
+        },
+        "delete": {
+          "label": "Eliminar proyecto"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "Eliminar"
+          },
+          "message": "¿Seguro que quieres eliminar este proyecto? Esta acción no se puede deshacer.",
+          "title": "Eliminar proyecto"
+        },
+        "expand": {
+          "ariaLabel": "Expandir proyecto"
+        },
+        "rename": {
+          "label": "Renombrar proyecto"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "Aún no hay chats."
+        },
+        "recentChats": {
+          "title": "Chats recientes"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "No se pudieron subir los archivos"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {Se omitió # archivo demasiado grande} other {Se omitieron # archivos demasiado grandes}} (>{max} MB): {names}"
+        },
+        "rejected": {
+          "toast": "Algunos archivos no se subieron. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8518,6 +10479,1773 @@
       },
       "incognito": {
         "title": "Estás en modo incógnito"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "Abrir barra lateral"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "Actualizar información de facturación"
+        },
+        "text": "**Advertencia:** Tu período de prueba termina en menos de 5 días y no se ha agregado ningún método de pago."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "Avatar del agente"
+      },
+      "logo": {
+        "alt": "Logotipo"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "Documento"
+      },
+      "expandButton": {
+        "ariaLabel": "Expandir documento"
+      }
+    },
+    "backButton": {
+      "label": "Atrás"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "Nubes"
+      },
+      "hills": {
+        "label": "Colinas"
+      },
+      "mountains": {
+        "label": "Montañas"
+      },
+      "night": {
+        "label": "Noche"
+      },
+      "none": {
+        "label": "Ninguno"
+      },
+      "plant": {
+        "label": "Plantas"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "Aa"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} \"{value}\"",
+        "defaultPrefix": "Crear"
+      },
+      "dropdown": {
+        "closeAriaLabel": "Cerrar desplegable",
+        "openAriaLabel": "Abrir desplegable"
+      },
+      "options": {
+        "empty": "No se encontraron opciones"
+      },
+      "separator": {
+        "label": "Otras opciones"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "Cerrar menú"
+      },
+      "dialog": {
+        "title": "Menú de comandos"
+      },
+      "options": {
+        "ariaLabel": "Opciones del menú de comandos"
+      },
+      "search": {
+        "placeholder": "Buscar..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "Se han seleccionado todos los conectores disponibles. Quita conectores abajo para añadir otros.",
+        "placeholder": "Todos los conectores seleccionados"
+      },
+      "documentSetHint": {
+        "description": "Todos los documentos indexados por los conectores seleccionados formarán parte de este conjunto de documentos."
+      },
+      "noMatches": {
+        "text": "No se encontraron conectores coincidentes"
+      },
+      "noMoreConnectors": {
+        "text": "No hay más conectores disponibles"
+      },
+      "noPrivateConnectors": {
+        "text": "No hay conectores privados disponibles. Crea primero un conector privado."
+      },
+      "noneSelected": {
+        "text": "No hay conectores seleccionados. Busca y selecciona conectores arriba."
+      },
+      "removeConnector": {
+        "tooltip": "Quitar conector"
+      },
+      "search": {
+        "placeholder": "Buscar conectores..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "Seleccionar fecha"
+      },
+      "todayButton": {
+        "label": "Hoy"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "Cualquier fecha..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "Elegir un rango personalizado"
+      },
+      "clearButton": {
+        "ariaLabel": "Borrar"
+      },
+      "custom": {
+        "label": "Personalizado"
+      },
+      "customRange": {
+        "ariaLabel": "Rango personalizado: {from} a {to}"
+      },
+      "date": {
+        "label": "Fecha"
+      },
+      "group": {
+        "ariaLabel": "Rango de fechas"
+      },
+      "preset": {
+        "oneDay": "1D",
+        "oneMonth": "1M",
+        "sevenDays": "7D",
+        "threeMonths": "3M"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "Eliminar"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# documento de contexto} other {# documentos de contexto}}"
+      },
+      "openDocument": {
+        "ariaLabel": "Abrir documento: {title}"
+      },
+      "question": {
+        "title": "Pregunta"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# subconsulta} other {# subconsultas}}"
+      },
+      "updated": {
+        "text": "Actualizado el {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "Predeterminado"
+      },
+      "selectOption": {
+        "placeholder": "Selecciona una opción..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "Editar"
+      },
+      "rename": {
+        "ariaLabel": "Renombrar"
+      },
+      "save": {
+        "ariaLabel": "Guardar"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "Si eres el administrador, visita la página de <billingLink>Facturación de administración</billingLink> para {hadLicense, select, true {renovar} other {activar}} tu licencia, regístrate a través de Stripe o escribe a <supportLink>support@onyx.app</supportLink> para obtener ayuda con la facturación."
+        },
+        "heading": {
+          "title": "Acceso restringido"
+        },
+        "licenseLapse": {
+          "description": "Tu acceso a Onyx se ha suspendido temporalmente debido a un vencimiento de tu licencia."
+        },
+        "licenseRequired": {
+          "description": "Se requiere una licencia para usar Onyx. Tus datos están protegidos y estarán disponibles cuando se active una licencia."
+        },
+        "logoutButton": {
+          "label": "Cerrar sesión"
+        },
+        "manageSubscription": {
+          "description": "Si eres administrador, puedes gestionar tu suscripción haciendo clic en el botón de abajo. Los demás usuarios deben contactar a su administrador para resolver este asunto."
+        },
+        "obtainLicense": {
+          "description": "Para empezar, contacta a tu administrador del sistema para obtener una licencia."
+        },
+        "renewLicense": {
+          "description": "Para restablecer tu acceso y seguir usando Onyx, contacta a tu administrador del sistema para renovar la licencia."
+        },
+        "resubscribeButton": {
+          "label": "Renovar suscripción",
+          "loading": "Cargando..."
+        },
+        "resubscribeError": {
+          "text": "Error al abrir la página de renovación de suscripción. Inténtalo de nuevo más tarde."
+        },
+        "seatLimit": {
+          "description": "Tu organización ha superado el número de puestos con licencia. El acceso está restringido hasta que se reduzca el número de usuarios o se amplíe la licencia."
+        },
+        "seatLimitAdminHint": {
+          "text": "Si eres administrador, puedes gestionar usuarios en la página de <userLink>Gestión de usuarios</userLink> o ampliar tu licencia en la página de <billingLink>Facturación de administración</billingLink>."
+        },
+        "seatLimitWithCounts": {
+          "description": "Tu organización ha superado el número de puestos con licencia ({used} usuarios / {seats} puestos). El acceso está restringido hasta que se reduzca el número de usuarios o se amplíe la licencia."
+        },
+        "subscriptionLapse": {
+          "description": "Tu acceso a Onyx se ha suspendido temporalmente debido a un vencimiento de tu suscripción."
+        },
+        "updatePayment": {
+          "description": "Para restablecer tu acceso y seguir aprovechando las potentes funciones de Onyx, actualiza tu información de pago."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "Si eres administrador, revisa nuestra <docsLink>documentación</docsLink> para conocer los pasos de configuración correctos. Si eres usuario, contacta a tu administrador para obtener ayuda."
+        },
+        "heading": {
+          "description": "Parece que hubo un problema al cargar tu configuración de Onyx. Puede deberse a un problema de configuración o a una instalación incompleta.",
+          "title": "Se produjo un problema"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "Pedimos disculpas por las molestias y agradecemos tu paciencia."
+        },
+        "checkBack": {
+          "description": "Onyx está actualmente en una ventana de mantenimiento. Vuelve a intentarlo en unos minutos."
+        },
+        "heading": {
+          "title": "Mantenimiento en curso"
+        }
+      },
+      "needHelp": {
+        "text": "¿Necesitas ayuda? Únete a nuestra <discordLink>comunidad de Discord</discordLink> para obtener soporte."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "Error desconocido"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "Descargar archivo"
+      },
+      "file": {
+        "untitledFallback": "Sin título"
+      },
+      "fullScreenButton": {
+        "tooltip": "Pantalla completa"
+      },
+      "hideButton": {
+        "tooltip": "Ocultar"
+      },
+      "minimizeButton": {
+        "tooltip": "Minimizar"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "Copiar"
+      },
+      "downloadButton": {
+        "tooltip": "Descargar"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {# línea} other {# líneas}}"
+      },
+      "size": {
+        "bytes": "{count} bytes",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "Ver texto completo"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "Todos los conectores federados seleccionados"
+      },
+      "entitiesConfigured": {
+        "tooltip": "Entidades configuradas"
+      },
+      "noMatches": {
+        "text": "No se encontraron conectores federados coincidentes"
+      },
+      "noMoreConnectors": {
+        "text": "No hay más conectores federados disponibles"
+      },
+      "noneSelected": {
+        "text": "No hay conectores federados seleccionados. Busca y selecciona conectores arriba."
+      },
+      "realtimeSearchHint": {
+        "description": "Los documentos de los conectores federados seleccionados se buscarán en tiempo real durante las consultas."
+      },
+      "removeConnector": {
+        "tooltip": "Quitar conector"
+      },
+      "search": {
+        "placeholder": "Buscar conectores federados..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "Añadir nuevo"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (opcional)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "No se encontró una definición de tipo de archivo para el campo: {name}",
+        "selectionError": "Error al seleccionar el archivo",
+        "unknownError": "Error desconocido",
+        "validating": "Validando el archivo...",
+        "validationError": "Error de validación"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "Escribe tu markdown aquí...",
+        "previewTab": "Vista previa",
+        "writeTab": "Escribir"
+      },
+      "optionalIndicator": {
+        "text": "(opcional)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "Ocultar contraseña",
+        "showAriaLabel": "Mostrar contraseña"
+      },
+      "selector": {
+        "noneOption": "Ninguno",
+        "placeholder": "Seleccionar..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "Todos los archivos recientes"
+      },
+      "recentFiles": {
+        "title": "Archivos recientes"
+      },
+      "recentFilesModal": {
+        "description": "Sube archivos o elige entre tus archivos recientes."
+      },
+      "toasts": {
+        "associatedAssistants": "No se puede eliminar el archivo. Está asociado a los asistentes: {assistants}",
+        "associatedBoth": "No se puede eliminar el archivo. Está asociado a los proyectos: {projects} y a los asistentes: {assistants}",
+        "associatedProjects": "No se puede eliminar el archivo. Está asociado a los proyectos: {projects}",
+        "deleteFailed": "No se pudo eliminar el archivo. Inténtalo de nuevo.",
+        "deleteSuccess": "Archivo eliminado correctamente"
+      },
+      "uploadFiles": {
+        "description": "Sube un archivo desde tu dispositivo",
+        "title": "Subir archivos"
+      },
+      "viewFileButton": {
+        "tooltip": "Ver archivo"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "archivo"
+      },
+      "open": {
+        "ariaLabel": "Abrir {title}"
+      },
+      "removeButton": {
+        "label": "Eliminar"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "Borrar"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(Opcional)"
+      },
+      "required": {
+        "label": "(Obligatorio)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "No se pudo cargar {label}. Inténtalo de nuevo."
+      },
+      "search": {
+        "placeholder": "Buscar..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "No hay grupos de usuarios disponibles. Crea primero un grupo de usuarios."
+      },
+      "userGroups": {
+        "label": "Grupos de usuarios",
+        "subtext": "Selecciona qué grupos de usuarios pueden acceder a este recurso"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "Logotipo"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "Inicializando {appName}"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "Eliminar"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "Adjuntar archivo"
+      },
+      "clearButton": {
+        "ariaLabel": "Quitar archivo"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "Archivo rechazado"
+      },
+      "editButton": {
+        "ariaLabel": "Editar imagen"
+      },
+      "editOverlay": {
+        "label": "Editar"
+      },
+      "image": {
+        "altFallback": "Imagen"
+      },
+      "removeButton": {
+        "ariaLabel": "Quitar imagen"
+      },
+      "uploadButton": {
+        "ariaLabel": "Subir imagen"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "Selecciona una opción"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "Asignar acceso de grupos a este {objectName}",
+        "scopedSubtext": "Selecciona uno o más de los grupos que administras para dar acceso a este {objectName}",
+        "visibleSubtext": "Este {objectName} será visible/accesible para los grupos seleccionados a continuación"
+      },
+      "loading": {
+        "text": "Cargando..."
+      },
+      "makePublic": {
+        "label": "¿Hacer público este {objectName}?",
+        "subtext": "Si se activa, este {objectName} podrá ser utilizado por <b>todos los {publicToWhom}</b>. De lo contrario, solo los <b>administradores</b> y los <b>{publicToWhom}</b> a los que se les haya dado acceso explícito a este {objectName} (p. ej., mediante un grupo de usuarios) tendrán acceso."
+      },
+      "publicDisabled": {
+        "message": "Este {objectName} es público y está disponible para todos los usuarios."
+      },
+      "usersFallback": {
+        "text": "Usuarios"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "Añadir par de {keyTitle} y {valueTitle}",
+        "label": "Añadir línea"
+      },
+      "empty": {
+        "title": "Aún no se han añadido elementos."
+      },
+      "error": {
+        "duplicateKey": "Clave duplicada",
+        "duplicateSummary": "{count, plural, one {# clave duplicada encontrada} other {# claves duplicadas encontradas}}",
+        "emptyKey": "La clave no puede estar vacía",
+        "emptySummary": "{count, plural, one {# clave vacía encontrada} other {# claves vacías encontradas}}",
+        "validationSummary": "{count, plural, one {# error de validación encontrado} other {# errores de validación encontrados}}"
+      },
+      "group": {
+        "ariaLabel": "Pares de {keyTitle} y {valueTitle}"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "Clave"
+      },
+      "pair": {
+        "fallbackLabel": "clave-valor"
+      },
+      "removeButton": {
+        "ariaLabel": "Eliminar par de {label} {index}"
+      },
+      "valueColumn": {
+        "title": "Valor"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "Logotipo"
+      },
+      "poweredBy": {
+        "label": "Con tecnología de Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "Conectores no disponibles:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "La autorización se canceló o falló. Inténtalo de nuevo.",
+        "title": "La autorización falló"
+      },
+      "backButton": {
+        "label": "Volver al chat"
+      },
+      "completeFailed": {
+        "message": "No se pudo completar la autorización"
+      },
+      "genericError": {
+        "description": "Se produjo un error durante el proceso de OAuth. Inténtalo de nuevo.",
+        "title": "Algo salió mal"
+      },
+      "invalidRequest": {
+        "description": "La solicitud de autorización estaba incompleta. Inténtalo de nuevo.",
+        "title": "Solicitud no válida"
+      },
+      "loadingHint": {
+        "text": "Esto puede tardar unos momentos..."
+      },
+      "processing": {
+        "description": "Espera mientras completamos la configuración.",
+        "title": "Procesando..."
+      },
+      "redirecting": {
+        "text": "Redirigiendo en {count, plural, one {# segundo} other {# segundos}}..."
+      },
+      "serviceFallback": {
+        "text": "servicio"
+      },
+      "success": {
+        "detailsTemplate": "La autorización de {serviceName} se completó correctamente.",
+        "title": "¡Listo!"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "Es posible que la hoja de cálculo esté dañada o no se haya podido cargar correctamente.",
+        "title": "Error al cargar la hoja de cálculo"
+      },
+      "preview": {
+        "truncated": "Vista previa truncada. Descarga el archivo para ver todas las filas.",
+        "unavailable": "No se puede previsualizar esta hoja de cálculo."
+      },
+      "sheet": {
+        "defaultName": "Hoja 1",
+        "empty": "Esta hoja está vacía.",
+        "tooLarge": "Esta hoja es demasiado grande para la vista previa. Descarga el archivo para verla."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "Agente principal"
+      },
+      "subagentFallback": {
+        "label": "subagente"
+      },
+      "switch": {
+        "ariaLabel": "Cambiar de agente"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "Aprobar esta acción una vez",
+        "button": "Aprobar una vez"
+      },
+      "approveSession": {
+        "button": "Aprobar para la sesión",
+        "tooltip": "Aprobar acciones coincidentes para esta sesión"
+      },
+      "details": {
+        "hideAriaLabel": "Ocultar detalles",
+        "showAriaLabel": "Mostrar detalles"
+      },
+      "header": {
+        "required": "Se requiere aprobación: {headline}"
+      },
+      "headline": {
+        "multiAction": "{count, plural, one {# acción} other {# acciones}} en {app}",
+        "singleAction": "{action} en {app}"
+      },
+      "payload": {
+        "empty": {
+          "label": "Sin contenido."
+        },
+        "showLess": {
+          "button": "Mostrar menos"
+        },
+        "showMore": {
+          "button": "Mostrar más"
+        }
+      },
+      "reject": {
+        "ariaLabel": "Rechazar esta acción",
+        "button": "Rechazar"
+      },
+      "status": {
+        "approved": "Aprobado",
+        "rejected": "Rechazado"
+      },
+      "submit": {
+        "errorFallback": "No se pudo enviar la decisión"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "Añadir",
+        "createButton": "Crear",
+        "customApp": {
+          "description": "Credenciales y acceso de red para tu propia integración.",
+          "title": "App personalizada"
+        },
+        "mcpHint": {
+          "label": "¿Necesitas un servidor MCP en su lugar? Conéctalo en Acciones y luego habilítalo para Craft aquí.",
+          "openActionsButton": "Abrir Acciones"
+        },
+        "modal": {
+          "description": "Pon una integración a disposición de toda tu organización. Los proveedores integrados incluyen acciones que enseñan al agente de Craft a usarlos; los proveedores ya configurados no aparecen en la lista.",
+          "title": "Añadir una app"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "Asociar {name}",
+        "associateButton": "Asociar existente",
+        "create": {
+          "github": {
+            "description": "Si tus habilidades están en GitHub, impórtalas primero en la página de Habilidades y luego asócialas con esta app.",
+            "label": "Importar desde GitHub"
+          },
+          "scratch": {
+            "description": "Escribe instrucciones y añade archivos de apoyo.",
+            "label": "Empezar desde cero"
+          },
+          "upload": {
+            "description": "Importa un archivo SKILL.md, un archivo ZIP o una carpeta de habilidad.",
+            "label": "Subir una habilidad"
+          }
+        },
+        "createSkillButton": "Crear habilidad",
+        "description": "Las habilidades dan a Craft instrucciones para usar esta app. Son para toda la organización; puede que los usuarios deban habilitarlas todas para que la app funcione correctamente.",
+        "editButton": "Editar",
+        "empty": {
+          "label": "No se encontraron habilidades editables."
+        },
+        "invalidTag": "No válida",
+        "loading": {
+          "label": "Cargando habilidades…"
+        },
+        "noneAssociated": {
+          "label": "Aún no hay habilidades asociadas. Esta app puede guardarse y usarse sin una."
+        },
+        "promote": {
+          "cancelButton": "Cancelar",
+          "confirmButton": "Hacer para toda la organización",
+          "description": "Las habilidades asociadas a una app deben estar disponibles para todos. Este cambio se aplica al guardar la app.",
+          "title": "¿Hacer que «{name}» sea para toda la organización?"
+        },
+        "search": {
+          "placeholder": "Buscar habilidades editables..."
+        },
+        "title": "Habilidades asociadas",
+        "unavailable": {
+          "duplicateName": "Ya hay asociada una habilidad llamada «{name}».",
+          "invalid": "Habilidad no válida: corrígela antes de asociarla.",
+          "otherApp": "Ya está asociada con la app «{name}»."
+        },
+        "unlink": {
+          "button": "Desvincular",
+          "cancelButton": "Cancelar",
+          "confirm": "¿Desvincular «{name}» de esta app?"
+        },
+        "unlinkAriaLabel": "Desvincular {name}",
+        "viewButton": "Ver"
+      },
+      "configureProvider": {
+        "addButton": "Añadir",
+        "addTitle": "Añadir {name}",
+        "editTitle": "Editar {name}",
+        "emptyPolicies": "Este proveedor no tiene acciones que configurar.",
+        "fields": {
+          "name": {
+            "description": "Una etiqueta para esta conexión. Usa un nombre distinto al añadir varias instancias del mismo proveedor (p. ej., \"{name} — Ingeniería\").",
+            "label": "Nombre"
+          }
+        },
+        "managedDescription": "Proporcionado por Onyx: configura qué puede hacer el agente.",
+        "managedNote": "Esta app la proporciona Onyx: las credenciales se gestionan por ti. Elige abajo qué puede hacer el agente. Los usuarios la conectan desde la página de Apps.",
+        "saveButton": "Guardar"
+      },
+      "customApp": {
+        "cancelButton": "Cancelar",
+        "createButton": "Crear",
+        "createDescription": "Configura cómo el proxy de salida alcanza y autentica esta app. No se requiere una habilidad.",
+        "createTitle": "Crear app personalizada",
+        "creatingButton": "Creando…",
+        "disabled": {
+          "nameMissing": "Escribe un nombre antes de crear esta app personalizada.",
+          "patternMissing": "Añade al menos un patrón de URL de destino. Escribe un patrón y pulsa Intro.",
+          "pristine": "Haz un cambio antes de guardar.",
+          "saving": "Ya hay un guardado en curso."
+        },
+        "editDescription": "Actualiza la configuración del gateway y gestiona las habilidades asociadas.",
+        "editTitle": "Editar {name}",
+        "errors": {
+          "saveFailedTitle": "No se pudo guardar"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "Añadir encabezado",
+            "description": "Opcional: encabezados inyectados en las solicitudes salientes. Usa '{placeholder}' para los valores que aporta el usuario (o la organización abajo), p. ej., \"Bearer '{api_key}'\". Déjalo vacío para permitir los patrones de destino sin inyectar credenciales.",
+            "keyTitle": "Encabezado",
+            "label": "Patrón de credenciales en encabezados",
+            "valueTitle": "Valor"
+          },
+          "name": {
+            "label": "Nombre",
+            "placeholder": "Mi app personalizada"
+          },
+          "orgCredentials": {
+            "addButton": "Añadir credencial",
+            "description": "Opcional: valores que tu organización rellena para todos los usuarios. Déjalo vacío para apps donde cada usuario aporta sus propias credenciales.",
+            "keyTitle": "Clave de credencial",
+            "label": "Credenciales de la organización",
+            "valueTitle": "Valor"
+          },
+          "upstreamPatterns": {
+            "description": "URLs salientes en las que el proxy puede inyectar credenciales. Usa * para coincidir con cualquier carácter (p. ej., https://api.example.com/* cubre todas las rutas de ese host). El host debe ser literal, sin comodines antes de la primera barra. Escribe un patrón y pulsa Intro.",
+            "label": "Patrones de URL de destino"
+          }
+        },
+        "saveButton": "Guardar",
+        "savingButton": "Guardando…"
+      },
+      "errors": {
+        "duplicateSkillName": "La app «{appName}» ya tiene una habilidad asociada llamada «{skillName}». Sube una habilidad con otro nombre."
+      },
+      "mcpPolicy": {
+        "description": "Configura qué puede hacer el agente de Craft con las herramientas de este servidor MCP.",
+        "emptyPolicies": "No hay herramientas habilitadas en este servidor. Habilita primero las herramientas en la página de acciones MCP.",
+        "saveButton": "Guardar",
+        "title": "Editar {name}"
+      },
+      "oauthCallback": {
+        "backButton": "Volver a mis apps",
+        "description": "Finalizando el intercambio OAuth…",
+        "errors": {
+          "cancelled": "OAuth fue cancelado o denegado: {reason}",
+          "failed": "Error de conexión.",
+          "missingParams": "Falta code o state en la URL de retorno."
+        },
+        "exchanging": {
+          "label": "Intercambiando el código de autorización…"
+        },
+        "success": {
+          "label": "Conectado. Volviendo a tus apps…"
+        },
+        "title": "Conectando tu app"
+      },
+      "page": {
+        "connectButton": "Conectar",
+        "connectingButton": "Redirigiendo…",
+        "disconnectButton": "Desconectar",
+        "empty": {
+          "description": "Aún no hay apps ni servidores MCP configurados para tu organización.",
+          "title": "Aún no hay nada que conectar"
+        },
+        "errors": {
+          "disconnectFailed": "No se pudo desconectar",
+          "startAuthFailed": "No se pudo iniciar la autorización"
+        },
+        "header": {
+          "description": "Conecta las herramientas que Onyx Craft puede usar como contexto mientras trabaja.",
+          "manageButton": "Gestionar apps",
+          "searchPlaceholder": "Buscar apps...",
+          "title": "Apps"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Integraciones que Onyx soporta directamente. Cada una incluye habilidades que enseñan a Craft a usarla: empieza aquí.",
+            "empty": "Aún no hay apps configuradas para tu organización.",
+            "emptyTitle": "Aún no hay apps",
+            "tabLabel": "Apps · {count}"
+          },
+          "mcp": {
+            "blurb": "Servidores que un administrador puso a disposición de Craft. Úsalos cuando la app que necesitas no aparece en Apps, o cuando quieras específicamente las herramientas MCP propias de un servidor.",
+            "empty": "No se ha puesto ningún servidor MCP a disposición de Craft.",
+            "emptyTitle": "Aún no hay servidores MCP",
+            "tabLabel": "Servidores MCP · {count}"
+          }
+        },
+        "loading": {
+          "label": "Cargando…"
+        },
+        "reviewSkillsButton": "Revisar habilidades",
+        "search": {
+          "noMatchesDescription": "Nada aquí coincide con tu búsqueda.",
+          "noMatchesTitle": "Sin coincidencias"
+        },
+        "status": {
+          "connected": "Conectada",
+          "connectedNeedsSkills": "Conectada · no todas las habilidades asociadas están habilitadas",
+          "notAvailable": "No disponible para tu cuenta: consulta a un administrador",
+          "skillWarningAriaLabel": "Se requiere configurar las habilidades",
+          "skillWarningTooltip": "No todas las habilidades asociadas están habilitadas. Puede que esta app no funcione correctamente."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "Define una política para cada acción de forma individual.",
+          "title": "Avanzado"
+        },
+        "cancelButton": "Cancelar",
+        "loading": {
+          "label": "Cargando…"
+        },
+        "permissions": {
+          "askOption": "Preguntar",
+          "autoApproveOption": "Aprobar automáticamente",
+          "customOption": "Personalizado",
+          "description": "Elige qué puede hacer el agente. «Preguntar» te consulta en el chat antes de ejecutar cada acción; «Aprobar automáticamente» la ejecuta sin preguntar. Usa Avanzado para definir una política por acción.",
+          "title": "Permisos"
+        },
+        "savingButton": "Guardando…"
+      },
+      "skillsStep": {
+        "description": "Opcional: asocia habilidades existentes o crea una para esta app.",
+        "errors": {
+          "saveFailedTitle": "No se pudo guardar"
+        },
+        "saveButton": "Guardar habilidades",
+        "savingButton": "Guardando…",
+        "skipButton": "Omitir por ahora",
+        "title": "Añadir habilidades a {name}"
+      },
+      "userCredentials": {
+        "cancelButton": "Cancelar",
+        "connectButton": "Conectar",
+        "connectingButton": "Conectando…",
+        "description": "Introduce tus credenciales para autorizar esta app en tu cuenta.",
+        "errors": {
+          "connectFailedTitle": "No se pudo conectar"
+        },
+        "title": "Conectar {name}"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "Descargar"
+      },
+      "empty": {
+        "description": "Los archivos de salida y las aplicaciones web aparecerán aquí",
+        "title": "Aún no hay artefactos"
+      },
+      "nextjsApp": {
+        "label": "Aplicación Next.js"
+      },
+      "openItem": {
+        "ariaLabel": "Abrir {name}"
+      },
+      "toggleItem": {
+        "ariaLabel": "Alternar {name}"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "Continúa la conversación...",
+        "scheduledRunPlaceholder": "Ejecución programada en curso...",
+        "subagentPlaceholder": "Cambia al agente principal para enviar un mensaje"
+      },
+      "openSidebar": {
+        "ariaLabel": "Abrir barra lateral"
+      },
+      "outputPanel": {
+        "closeTooltip": "Cerrar panel de salida",
+        "openTooltip": "Abrir panel de salida"
+      },
+      "responseStopped": {
+        "label": "Respuesta detenida"
+      },
+      "scrollToBottom": {
+        "label": "Ir al final"
+      },
+      "toast": {
+        "operationWait": "Espera a que se complete la operación actual.",
+        "sandboxWait": "Espera a que se inicialice el sandbox",
+        "scheduledRunWait": "Espera a que termine la ejecución programada."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "Contexto compactado para liberar espacio"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "Conecta tus datos"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "Creando tu espacio de trabajo...",
+        "enchanting": "Encantando con magia...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "Recolectando recursos...",
+        "miningDependencies": "Minando dependencias...",
+        "placingBlocks": "Colocando bloques...",
+        "punchingWood": "Golpeando madera...",
+        "smeltingCode": "Fundiendo el código...",
+        "worldGenerated": "Generación del mundo completada..."
+      },
+      "tagline": {
+        "label": "Creando tu próxima gran idea..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "Limpiar"
+      },
+      "copy": {
+        "doneTooltip": "Copiado",
+        "tooltip": "Copiar visible"
+      },
+      "empty": {
+        "noLines": "Aún no hay líneas.",
+        "noMatch": "Ninguna línea coincide con \"{filter}\"",
+        "waiting": "Esperando la primera línea de registro…"
+      },
+      "error": {
+        "endpointDisabled": "Endpoint de depuración deshabilitado (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "No hay sandbox en ejecución del cual leer registros"
+      },
+      "filter": {
+        "placeholder": "Filtrar…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# línea} other {# líneas}}",
+        "filteredCount": "{visible, number} / {total, number} líneas"
+      },
+      "modal": {
+        "description": "Seguimiento en vivo del contenedor sandbox — solo dev/depuración.",
+        "title": "Registros del pod de Opencode"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} nuevas · ir"
+      },
+      "open": {
+        "button": "Registros del pod"
+      },
+      "status": {
+        "closed": "Cerrado",
+        "connecting": "Conectando",
+        "error": "Error",
+        "paused": "Pausado",
+        "streaming": "Transmitiendo"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "Añadir archivos o fotos"
+      },
+      "apps": {
+        "label": "Aplicaciones"
+      },
+      "browseSkills": {
+        "label": "Explorar habilidades"
+      },
+      "connect": {
+        "hint": "Conectar"
+      },
+      "connectApp": {
+        "label": "Conectar una aplicación"
+      },
+      "library": {
+        "label": "Biblioteca"
+      },
+      "manageLibrary": {
+        "label": "Gestionar biblioteca…"
+      },
+      "mcpServer": {
+        "description": "Servidor MCP"
+      },
+      "skills": {
+        "label": "Habilidades"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "No se puede previsualizar el archivo"
+      },
+      "error": {
+        "inline": "Error: {message}",
+        "title": "Error al cargar el archivo"
+      },
+      "loading": {
+        "label": "Cargando archivo..."
+      },
+      "noContent": {
+        "label": "Sin contenido"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "Los archivos creados durante la compilación aparecerán aquí",
+        "title": "Aún no hay archivos"
+      },
+      "emptyDirectory": {
+        "label": "No hay archivos en este directorio"
+      },
+      "error": {
+        "title": "Error al cargar los archivos"
+      },
+      "loading": {
+        "label": "Cargando archivos..."
+      },
+      "loadingChildren": {
+        "label": "Cargando..."
+      },
+      "preparing": {
+        "description": "Configurando tu entorno de desarrollo",
+        "title": "Preparando sandbox..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "No se pudo mostrar la imagen",
+        "title": "No se pudo cargar la imagen"
+      },
+      "loading": {
+        "label": "Cargando imagen..."
+      },
+      "preview": {
+        "ariaLabel": "Vista previa de {name}"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "Conectado",
+        "connectionRequired": "Conexión requerida"
+      },
+      "plusMenu": {
+        "tooltip": "Añadir archivos o habilidades"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "Deteniendo…"
+      },
+      "toInterrupt": {
+        "label": "para interrumpir"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "Volver al inicio"
+      },
+      "startCrafting": {
+        "button": "Empezar a crear"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "No se encontraron modelos"
+      },
+      "recommended": {
+        "label": "Recomendado"
+      },
+      "recommendedOnly": {
+        "label": "Solo modelos recomendados"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "«Arregla el test de reintentos inestable y abre un PR.»",
+          "launchDeck": "«Crea la presentación del lanzamiento de primavera a partir del brief en Drive.»",
+          "rfpSecurity": "«Completa la RFP de mi correo con nuestros datos de seguridad.»",
+          "slackToLinear": "«Convierte nuestra conversación de Slack en tickets de Linear.»",
+          "vendorSpend": "«Resume nuestro gasto en proveedores del T2 como un documento en Drive.»"
+        },
+        "modal": {
+          "backButton": "Atrás",
+          "ctaButton": "Pon Craft a trabajar",
+          "nextButton": "Siguiente",
+          "title": "Conoce Craft"
+        },
+        "outputs": {
+          "ariaLabel": "Resultado: {name}",
+          "githubPr": {
+            "caption": "Abierto para revisión",
+            "label": "PR de GitHub"
+          },
+          "googleDoc": {
+            "caption": "Guardado en tu Drive",
+            "label": "Documento de Google"
+          },
+          "liveApp": {
+            "caption": "Alojada, se comparte por enlace",
+            "label": "App en vivo"
+          }
+        },
+        "prompt": {
+          "label": "Tu prompt"
+        },
+        "schedule": {
+          "ariaLabel": "Tarea programada: vuelve a ejecutar este prompt según un temporizador",
+          "caption": "Se ejecuta mientras no estás",
+          "label": "Cada lunes a las 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "Fuente conectada: {name}",
+          "yourFiles": {
+            "ariaLabel": "Tus archivos subidos",
+            "label": "Tus archivos"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "Haz clic en cualquier parte del mapa para volver a verla.",
+            "title": "Eso es Craft. Te toca."
+          },
+          "machine": {
+            "caption": "Lee lo que tú puedes ver. Nunca tus secretos.",
+            "title": "Trabaja en su propia máquina."
+          },
+          "output": {
+            "caption": "Bajo demanda, o según un horario mientras no estás.",
+            "title": "El trabajo sale terminado."
+          },
+          "prompt": {
+            "caption": "Describe el resultado, Craft hace el resto.",
+            "title": "Dale a Craft trabajo real."
+          }
+        },
+        "team": {
+          "ariaLabel": "Tu equipo: un solo enlace comparte el trabajo de Craft",
+          "caption": "Un enlace lo comparte",
+          "label": "Tu equipo"
+        },
+        "workspace": {
+          "approvalPill": "Esperando tu aprobación",
+          "label": "Espacio de trabajo de Craft",
+          "sandboxBadge": "Sandbox aislado"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "Volver al chat",
+        "description": "Onyx Craft necesita un proveedor de modelos y solo los administradores pueden configurarlo. Pide a tu administrador que conecte Anthropic, OpenAI u OpenRouter.",
+        "title": "Se requiere un proveedor de LLM"
+      },
+      "llmSetup": {
+        "description": "Los agentes de Craft necesitan un proveedor de modelos para construir.",
+        "title": "Conecta un proveedor de modelos"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "Analiza mis datos y crea un panel..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "Ingeniería",
+          "marketing": "Marketing",
+          "product": "Producto",
+          "sales": "Ventas"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "¡Empieza a construir algo para ver artefactos!"
+      },
+      "devServerStarting": {
+        "tooltip": "Iniciando el servidor de desarrollo..."
+      },
+      "noWebapp": {
+        "label": "Aún no hay ninguna aplicación web en esta sesión"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "No se pudo cargar el archivo PDF.",
+        "title": "No se puede previsualizar el PDF"
+      },
+      "frame": {
+        "title": "Vista previa de PDF"
+      },
+      "loading": {
+        "label": "Cargando PDF..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "Convirtiendo presentación..."
+      },
+      "empty": {
+        "label": "Esta presentación no tiene diapositivas"
+      },
+      "error": {
+        "title": "No se puede previsualizar la presentación"
+      },
+      "loadingSlide": {
+        "label": "Cargando diapositiva..."
+      },
+      "slide": {
+        "counter": "Diapositiva {current} de {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "Aquí aparecerá una vista previa en vivo cuando una aplicación web esté en ejecución."
+      },
+      "frame": {
+        "title": "Vista previa de la aplicación web"
+      },
+      "starting": {
+        "description": "Instalando dependencias e iniciando.",
+        "title": "Iniciando el servidor de desarrollo..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "Redirigiendo..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "Descartar"
+      },
+      "modal": {
+        "description": "Se durmió tras un período de inactividad. Tu trabajo está guardado. Despiértalo para continuar.",
+        "title": "Tu sandbox se durmió"
+      },
+      "wake": {
+        "button": "Despertar sandbox"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "Programada"
+      },
+      "startedAt": {
+        "label": "Iniciada {time}"
+      },
+      "status": {
+        "awaitingApproval": "Esta ejecución programada está a la espera de aprobación. Los mensajes de seguimiento se desbloquearán cuando se reanude y termine.",
+        "running": "Esta ejecución programada sigue en curso. Los mensajes de seguimiento se desbloquearán cuando termine.",
+        "startedBy": "Esta sesión fue iniciada por la tarea programada {task} a las {time}."
+      },
+      "viewTask": {
+        "ariaLabel": "Ver la tarea programada {task}. {status}",
+        "label": "Ver tarea"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "Aplicación externa {id}"
+      },
+      "connect": {
+        "title": "Conectar {app}"
+      },
+      "connected": {
+        "title": "{app} conectado."
+      },
+      "error": {
+        "generic": "Algo salió mal. Inténtalo de nuevo.",
+        "notConfigurable": "Esta aplicación no se puede configurar desde aquí.",
+        "popupBlocked": "No se pudo abrir la ventana de configuración. Permite las ventanas emergentes e inténtalo de nuevo.",
+        "startFailed": "No se pudo iniciar la configuración"
+      },
+      "loading": {
+        "button": "Cargando…"
+      },
+      "notNow": {
+        "button": "Ahora no"
+      },
+      "reason": {
+        "fallback": "El agente necesita {app} para continuar con esta tarea."
+      },
+      "skipped": {
+        "title": "Se omitió la conexión de {app}."
+      },
+      "waiting": {
+        "button": "Esperando…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "Copiar enlace"
+      },
+      "organization": {
+        "description": "Cualquier persona con sesión iniciada en tu Onyx puede ver esta aplicación.",
+        "label": "Organización"
+      },
+      "private": {
+        "description": "Solo tú puedes ver esta aplicación.",
+        "label": "Privado"
+      },
+      "share": {
+        "label": "Compartir"
+      },
+      "shared": {
+        "label": "Compartido"
+      },
+      "trigger": {
+        "ariaLabel": "Compartir aplicación web"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "Aplicaciones"
+      },
+      "backToChat": {
+        "label": "Volver al chat"
+      },
+      "delete": {
+        "label": "Eliminar"
+      },
+      "deleteModal": {
+        "body": "Esto elimina permanentemente la sesión de Craft y todos sus datos. Esta acción no se puede deshacer.",
+        "confirm": "Eliminar",
+        "deleting": "Eliminando...",
+        "title": "¿Eliminar \"{title}\"?"
+      },
+      "newSession": {
+        "label": "Empezar a crear"
+      },
+      "rename": {
+        "label": "Renombrar"
+      },
+      "scheduledTasks": {
+        "label": "Tareas programadas"
+      },
+      "sessions": {
+        "empty": "¡Empieza a construir! El historial de sesiones aparecerá aquí.",
+        "title": "Sesiones"
+      },
+      "skills": {
+        "label": "Habilidades"
+      },
+      "toast": {
+        "deleteFailed": "No se pudo eliminar la sesión",
+        "deleted": "Se eliminó \"{title}\"."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "Recarga esta sesión para aplicar las últimas habilidades y accesos a aplicaciones.",
+        "title": "Las capacidades de tu agente han cambiado"
+      },
+      "reload": {
+        "button": "Recargar",
+        "inProgress": "Recargando…"
+      },
+      "toast": {
+        "reloadFailed": "No se pudo recargar la sesión"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "Subagente no encontrado."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "Cerrar sugerencias"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "Eliminar",
+          "deletingButton": "Eliminando...",
+          "description": "Esto detiene las ejecuciones futuras y elimina la tarea. El historial de ejecuciones pasadas (y las sesiones subyacentes) se conservará para auditoría.",
+          "title": "¿Eliminar «{name}»?"
+        },
+        "deleteButton": "Eliminar",
+        "editButton": "Editar",
+        "fallbackTitle": "Tarea programada",
+        "loadFailed": "No se pudo cargar la tarea programada.",
+        "missingTaskId": "Falta el id de la tarea.",
+        "pauseButton": "Pausar",
+        "resumeButton": "Reanudar",
+        "runNowButton": "Ejecutar ahora",
+        "toasts": {
+          "deleteFailed": "No se pudo eliminar la tarea",
+          "deleted": "«{name}» eliminada.",
+          "paused": "Tarea pausada.",
+          "resumed": "Tarea reanudada.",
+          "runQueued": "Ejecución de «{name}» puesta en cola.",
+          "runStartFailed": "No se pudo iniciar la ejecución",
+          "statusUpdateFailed": "No se pudo actualizar el estado"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "Editar tarea programada",
+        "loadFailed": "No se pudo cargar la tarea programada.",
+        "missingTaskId": "Falta el id de la tarea.",
+        "title": "Editar «{name}»"
+      },
+      "form": {
+        "cancelButton": "Cancelar",
+        "errors": {
+          "nameRequired": "El nombre es obligatorio.",
+          "promptRequired": "El prompt es obligatorio."
+        },
+        "fields": {
+          "name": {
+            "label": "Nombre",
+            "placeholder": "p. ej., Resumen semanal de escalaciones de clientes"
+          },
+          "preApproval": {
+            "description": "Craft puede usar las apps y servidores MCP seleccionados sin pausas cuando esta tarea se ejecuta sin supervisión. Otras solicitudes de aprobación pausan la ejecución y pueden hacer que falle.",
+            "label": "Apps y servidores MCP preaprobados"
+          },
+          "prompt": {
+            "description": "Este mensaje se envía a Craft cada vez que la tarea se dispara.",
+            "label": "Prompt",
+            "placeholder": "Describe qué debe hacer Craft en cada ejecución..."
+          },
+          "schedule": {
+            "label": "Programación"
+          }
+        },
+        "saveAndRunNowButton": "Guardar y ejecutar ahora",
+        "saveButton": "Guardar",
+        "saveChangesButton": "Guardar cambios",
+        "savingLabel": "Guardando...",
+        "toasts": {
+          "created": "Tarea programada creada.",
+          "createdAndQueued": "Tarea programada creada y puesta en cola.",
+          "saveFailed": "No se pudo guardar la tarea programada",
+          "updated": "Tarea programada actualizada."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "Última ejecución",
+          "name": "Nombre",
+          "nextRun": "Próxima ejecución",
+          "schedule": "Programación",
+          "status": "Estado"
+        },
+        "confirmDelete": {
+          "deleteButton": "Eliminar",
+          "deletingButton": "Eliminando...",
+          "description": "Esto detiene las ejecuciones futuras y elimina la tarea. El historial de ejecuciones pasadas (y las sesiones subyacentes) se conservará para auditoría.",
+          "title": "¿Eliminar «{name}»?"
+        },
+        "empty": {
+          "description": "Aún no se ha creado ninguna tarea programada.",
+          "title": "No se encontraron tareas programadas"
+        },
+        "errors": {
+          "loadFailed": "No se pudieron cargar las tareas programadas.",
+          "tryAgainButton": "Reintentar"
+        },
+        "header": {
+          "description": "Ejecuta prompts de Craft según un temporizador. Cada disparo crea una sesión nueva que se ejecuta en segundo plano.",
+          "title": "Tareas programadas"
+        },
+        "newTaskButton": "Nueva tarea programada",
+        "rowActions": {
+          "deleteTooltip": "Eliminar"
+        },
+        "toasts": {
+          "deleteFailed": "No se pudo eliminar la tarea",
+          "deleted": "«{name}» eliminada."
+        }
+      },
+      "newPage": {
+        "description": "Guarda un prompt y una programación. Craft lo ejecutará según un temporizador.",
+        "title": "Nueva tarea programada"
+      },
+      "preApproval": {
+        "appFallbackName": "App n.º {id}",
+        "appsGroupTitle": "Apps",
+        "empty": {
+          "label": "Aún no hay apps ni servidores MCP disponibles en Craft."
+        },
+        "errors": {
+          "loadFailed": "No se pudieron cargar las apps y los servidores MCP. Actualiza para volver a intentarlo.",
+          "partialLoadFailed": "Algunas opciones de aprobación previa no se pudieron cargar. Actualiza para volver a intentarlo."
+        },
+        "loading": {
+          "label": "Cargando apps y servidores MCP…"
+        },
+        "mcpGroupTitle": "Servidores MCP",
+        "mcpServerFallbackName": "Servidor MCP n.º {id}",
+        "status": {
+          "connected": "Conectado",
+          "connectionRequired": "Se requiere conexión",
+          "unavailable": "Ya no está disponible"
+        },
+        "summary": {
+          "partialLoadFailed": "Algunos detalles de aprobación previa no se pudieron cargar. Actualiza para volver a intentarlo.",
+          "title": "Apps y servidores MCP preaprobados"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "Duración",
+          "started": "Inicio",
+          "status": "Estado",
+          "summary": "Resumen",
+          "trigger": "Origen"
+        },
+        "empty": {
+          "label": "Aún no hay ejecuciones. La tarea creará una cada vez que se dispare, o usa Ejecutar ahora arriba."
+        },
+        "errors": {
+          "loadFailed": "No se pudo cargar el historial de ejecuciones.",
+          "tryAgainButton": "Reintentar"
+        },
+        "loadMore": {
+          "button": "Cargar más",
+          "loadingButton": "Cargando..."
+        },
+        "nonClickable": {
+          "noSession": "Esta ejecución aún no ha creado una sesión.",
+          "queued": "Esta ejecución aún no ha comenzado, así que no hay sesión que abrir.",
+          "skipped": "Esta ejecución se omitió porque una anterior seguía en curso, así que no se creó ninguna sesión."
+        },
+        "status": {
+          "notOpenableAriaLabel": "No se puede abrir"
+        },
+        "trigger": {
+          "runNow": "Ejecutar ahora",
+          "schedule": "Programación"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "A las",
+          "daysLabel": "En estos días",
+          "runsEveryDay": "Se ejecuta todos los días",
+          "runsOn": "Se ejecuta los {days}"
+        },
+        "interval": {
+          "everyLabel": "Cada"
+        },
+        "intervalUnits": {
+          "days": "días",
+          "hours": "horas",
+          "minutes": "minutos"
+        },
+        "tabs": {
+          "dailyWeekly": "Diario / Semanal",
+          "interval": "Intervalo"
+        },
+        "weekdays": {
+          "fri": "Vie",
+          "mon": "Lun",
+          "sat": "Sáb",
+          "sun": "Dom",
+          "thu": "Jue",
+          "tue": "Mar",
+          "wed": "Mié"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "Sin tareas"
+      },
+      "header": {
+        "title": "Tareas"
+      },
+      "progress": {
+        "label": "{completed}/{total} completadas"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "Sin salida"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# línea sin cambios} other {# líneas sin cambios}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "Cambiar a vista en paralelo",
+          "unifiedTooltip": "Cambiar a vista unificada"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "Aún no hay resultados..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# llamada} other {# llamadas}}"
+        },
+        "failed": {
+          "tag": "{count} con error"
+        },
+        "working": {
+          "label": "Trabajando"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(archivo vacío)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {# línea más} other {# líneas más}}"
+        },
+        "showAll": {
+          "button": "Mostrar todo"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "Sin coincidencias"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "Archivo demasiado grande ({size}). El máximo es {max}.",
+        "network": "Error de red",
+        "notFound": "Recurso no encontrado",
+        "server": "Error del servidor",
+        "sessionExpired": "La sesión expiró",
+        "tooManyFiles": "Demasiados archivos. El máximo es {max} archivos por sesión.",
+        "totalSizeExceeded": "El tamaño total supera el límite. El máximo es {max} por sesión.",
+        "uploadFailed": "Error al subir"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "Ir atrás"
+      },
+      "copyUrl": {
+        "ariaLabel": "Copiar URL: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "Descargar archivo"
+      },
+      "export": {
+        "button": "Exportar a .docx",
+        "inProgress": "Exportando..."
+      },
+      "forward": {
+        "ariaLabel": "Ir adelante"
+      },
+      "openInNewTab": {
+        "tooltip": "abrir en una pestaña nueva"
+      },
+      "refresh": {
+        "ariaLabel": "Actualizar"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "eliminar",
+        "button": "Eliminar",
+        "entityTypeFile": "archivo",
+        "entityTypeFolder": "carpeta",
+        "fileDetails": "Este archivo se eliminará de tu biblioteca.",
+        "folderDetails": "Esto eliminará la carpeta y todo su contenido."
+      },
+      "dropzone": {
+        "formats": "Excel, Word, PowerPoint, PDF o ZIP",
+        "title": "Arrastra archivos aquí o haz clic para subirlos"
+      },
+      "errors": {
+        "createFolderFailed": "No se pudo crear la carpeta",
+        "deleteFailed": "No se pudo eliminar",
+        "loadFailed": "No se pudieron cargar los archivos",
+        "uploadFailed": "Error al subir"
+      },
+      "loading": {
+        "label": "Cargando archivos…"
+      },
+      "modal": {
+        "description": "Archivos que tu agente puede leer en cada sesión.",
+        "doneButton": "Listo",
+        "title": "Biblioteca"
+      },
+      "newFolder": {
+        "cancelButton": "Cancelar",
+        "createButton": "Crear",
+        "label": "Nueva carpeta",
+        "nameLabel": "Nombre de la carpeta",
+        "namePlaceholder": "Escribe el nombre de la carpeta"
+      },
+      "search": {
+        "noResults": "Ningún archivo coincide con tu búsqueda",
+        "placeholder": "Buscar archivos..."
+      },
+      "tree": {
+        "collapseTooltip": "Contraer",
+        "deleteTooltip": "Eliminar",
+        "expandTooltip": "Expandir",
+        "toggleAriaLabel": "Alternar {name}",
+        "uploadToFolderTooltip": "Subir a esta carpeta"
+      },
+      "upload": {
+        "button": "Subir",
+        "dropOverlay": "Suelta los archivos para subirlos",
+        "uploadingButton": "Subiendo…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "Analiza mis datos y crea un panel..."
       }
     }
   },
@@ -8825,6 +12553,13 @@
           "networkError": "Se produjo un error al cambiar la contraseña",
           "updateFailed": "No se pudo cambiar la contraseña",
           "updated": "Contraseña actualizada correctamente"
+        },
+        "validation": {
+          "confirmRequired": "Confirma tu nueva contraseña",
+          "currentRequired": "La contraseña actual es obligatoria",
+          "minLength": "La contraseña debe tener al menos {min} caracteres",
+          "mismatch": "Las contraseñas no coinciden",
+          "newRequired": "La nueva contraseña es obligatoria"
         }
       },
       "title": "Cuentas"
@@ -8866,6 +12601,7 @@
         "empty": "No se crearon tokens de acceso.",
         "expiresIn": "{count, plural, one {Vence en # día} other {Vence en # días}}",
         "loading": "Cargando tokens...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "Nunca vence",
         "newTokenButton": "Nuevo token de acceso",
         "noPermissionTooltip": "No tienes permiso para crear tokens de acceso",
@@ -9012,6 +12748,10 @@
       },
       "description": "Conecta herramientas externas a los modelos disponibles para ti en Onyx.",
       "guideButton": "Guía",
+      "loadError": {
+        "description": "Actualiza la página e inténtalo de nuevo.",
+        "title": "No se pudo cargar LLM Gateway"
+      },
       "models": {
         "description": "{count, plural, one {Hay # modelo disponible para tu cuenta. Abre un proveedor para copiar un ID.} other {Hay # modelos disponibles para tu cuenta. Abre un proveedor para copiar un ID.}}",
         "title": "Modelos"
@@ -9064,14 +12804,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "Añadir línea",
+        "maxReached": "Se alcanzó el máximo de {count} memorias"
+      },
       "empty": {
-        "description": "Añade una nota personal o una memoria que Onyx deba recordar."
+        "description": "Añade una nota personal o una memoria que Onyx deba recordar.",
+        "getStarted": "Aún no hay memorias. Haz clic en \"Añadir línea\" para empezar.",
+        "noMatches": "Ninguna memoria coincide con tu búsqueda."
+      },
+      "item": {
+        "placeholder": "Escribe o pega una nota o memoria personal"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {Línea} other {Líneas}}"
+      },
+      "modal": {
+        "description": "Permite que Onyx haga referencia a estas notas y memorias guardadas en los chats.",
+        "searchPlaceholder": "Buscar..."
       },
       "referenceStoredMemories": {
         "description": "Permite que Onyx haga referencia a las memorias guardadas en los chats.",
         "title": "Hacer referencia a las memorias guardadas"
       },
+      "removeLineButton": {
+        "label": "Eliminar línea"
+      },
       "title": "Memoria",
+      "toasts": {
+        "saveFailed": "No se pudieron guardar las preferencias",
+        "saved": "Preferencias guardadas"
+      },
       "updateMemories": {
         "description": "Permite que Onyx genere y actualice las memorias guardadas.",
         "title": "Actualizar memorias"
@@ -9491,6 +13254,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "La aplicación “{appName}” ya tiene una habilidad asociada llamada “{skillName}”.",
+        "title": "Elige otro nombre para la habilidad"
+      },
+      "confirmUpload": {
+        "importBody": "Esta carga incluye SKILL.md. Al continuar se reemplazarán el nombre, la descripción, las instrucciones y los archivos actuales con el paquete cargado.",
+        "importSubmit": {
+          "label": "Importar habilidad"
+        },
+        "importTitle": "¿Importar esta habilidad?",
+        "replaceBody": "Esta carga debe usar el mismo nombre de habilidad. Al continuar se reemplazarán la descripción, las instrucciones y los archivos con el paquete cargado.",
+        "replaceSubmit": {
+          "label": "Reemplazar contenido"
+        },
+        "replaceTitle": "¿Reemplazar el contenido de la habilidad?"
+      },
+      "delete": {
+        "button": {
+          "label": "Eliminar habilidad"
+        },
+        "description": "Cualquiera que use esta habilidad perderá el acceso. La eliminación no se puede deshacer.",
+        "title": "Eliminar esta habilidad"
+      },
+      "deleteModal": {
+        "entityType": "habilidad",
+        "label": "Eliminar",
+        "pendingLabel": "Eliminando..."
+      },
+      "details": {
+        "description": "Define cuándo y cómo Craft debe usar esta habilidad.",
+        "descriptionField": {
+          "description": "Describe cuándo se debe usar esta habilidad.",
+          "placeholder": "¿En qué ayuda esta habilidad?",
+          "title": "Descripción"
+        },
+        "name": {
+          "createDescription": "Usa letras minúsculas, números y guiones simples.",
+          "lockedDescription": "Los nombres de las habilidades no se pueden cambiar después de crearlas.",
+          "placeholder": "Nombra tu habilidad",
+          "title": "Nombre"
+        },
+        "title": "Detalles"
+      },
+      "files": {
+        "busyLabel": "Subiendo...",
+        "description": "Agrega referencias, scripts, recursos u otros archivos que use esta habilidad. Los archivos ZIP se descomprimen automáticamente.",
+        "input": {
+          "ariaLabel": "Agregar archivos de apoyo"
+        },
+        "pendingUpload": {
+          "emptyMessage": "Los archivos de esta carga aparecerán después de crear la habilidad."
+        },
+        "title": "Archivos de apoyo"
+      },
+      "filesTooltip": {
+        "noPermission": "No tienes permiso para actualizar los archivos de esta habilidad.",
+        "saveFirst": "Guarda los cambios de los detalles antes de actualizar los archivos de la habilidad.",
+        "updating": "Actualizando los archivos de la habilidad..."
+      },
+      "header": {
+        "appFallbackName": "Aplicación externa",
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "createDescription": "Crea una habilidad personal",
+        "createForAppDescription": "Agrega una habilidad de organización a la aplicación “{appName}”",
+        "createTitle": "Crear habilidad",
+        "editDescription": "Actualiza los detalles y archivos de la habilidad",
+        "editTitle": "Editar habilidad",
+        "save": {
+          "label": "Guardar",
+          "pendingLabel": "Guardando..."
+        }
+      },
+      "import": {
+        "busyLabel": "Importando...",
+        "button": {
+          "label": "Importar habilidad"
+        },
+        "description": "Importa un SKILL.md, un ZIP o una carpeta de habilidad para completar el formulario e incluir sus archivos.",
+        "input": {
+          "ariaLabel": "Importar habilidad existente"
+        },
+        "prompt": "Elige un SKILL.md o ZIP, o arrastra una carpeta de habilidad aquí.",
+        "title": "¿Ya tienes una habilidad?"
+      },
+      "instructions": {
+        "description": "Escribe el comportamiento y el flujo de trabajo que esta habilidad agrega a Craft.",
+        "emptyFallback": "Aún no hay instrucciones.",
+        "placeholder": "Escribe las instrucciones de la habilidad.",
+        "title": "Instrucciones"
+      },
+      "loadError": {
+        "description": "Es posible que esta habilidad no exista, sea integrada o no pueda editarse con tu cuenta.",
+        "title": "Habilidad no disponible"
+      },
+      "management": {
+        "description": "Controla quién puede usar esta habilidad.",
+        "externalApp": {
+          "manage": {
+            "label": "Gestionar en la configuración de la aplicación"
+          },
+          "readyDescription": "Esta habilidad usa la aplicación “{appName}”.",
+          "title": "Aplicación externa"
+        },
+        "sharing": {
+          "edit": {
+            "label": "Editar uso compartido"
+          },
+          "title": "Uso compartido"
+        },
+        "title": "Gestión"
+      },
+      "saveTooltip": {
+        "missingDescription": "Agrega una descripción antes de guardar.",
+        "missingInstructions": "Agrega instrucciones antes de guardar.",
+        "missingName": "Agrega un nombre antes de guardar.",
+        "noChanges": "No se han realizado cambios.",
+        "noPermission": "No tienes permiso para editar los detalles de esta habilidad.",
+        "savingChanges": "Guardando los cambios...",
+        "savingSkill": "Guardando la habilidad..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "Todos en tu organización pueden usar y editar esta habilidad.",
+          "title": "Organización",
+          "viewerDescription": "Todos en tu organización pueden usar esta habilidad."
+        },
+        "personal": {
+          "description": "Solo tú puedes usar esta habilidad.",
+          "title": "Personal"
+        },
+        "shares": {
+          "description": "Solo los usuarios y grupos seleccionados pueden usar esta habilidad.",
+          "title": "{count, plural, one {# uso compartido} other {# usos compartidos}}"
+        }
+      },
+      "toasts": {
+        "created": "Se creó \"{name}\"",
+        "deleteFailed": "No se pudo eliminar la habilidad",
+        "deleted": "Se eliminó \"{name}\"",
+        "fileRemoveFailed": "No se pudo eliminar el archivo de la habilidad",
+        "fileRemoved": "Se eliminó \"{path}\"",
+        "filesUpdateFailed": "No se pudieron actualizar los archivos de la habilidad",
+        "filesUpdated": "Se actualizaron los archivos de \"{name}\"",
+        "importMissingSkillMd": "Importa un SKILL.md, un ZIP o una carpeta que contenga SKILL.md.",
+        "inspectFailed": "No se pudo inspeccionar el paquete de la habilidad",
+        "saveFailed": "No se pudo guardar la habilidad",
+        "saved": "Se guardó \"{name}\""
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9691,6 +13606,76 @@
         "transferredToast": {
           "message": "Propiedad transferida."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "Explorar habilidades"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {Habilidad} other {Habilidades}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "Importa una o más habilidades desde un repositorio.",
+          "title": "Importar desde GitHub"
+        },
+        "scratch": {
+          "description": "Escribe las instrucciones y agrega archivos de apoyo en Onyx.",
+          "title": "Empezar desde cero"
+        },
+        "trigger": {
+          "label": "Crear habilidad"
+        },
+        "upload": {
+          "description": "Importa un archivo SKILL.md, un archivo ZIP o una carpeta de habilidad.",
+          "title": "Subir una habilidad"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "Prueba con otra búsqueda.",
+          "title": "No hay habilidades coincidentes"
+        },
+        "noSkills": {
+          "description": "Aún no se han compartido habilidades personalizadas contigo y no hay habilidades integradas configuradas.",
+          "title": "No hay habilidades disponibles"
+        }
+      },
+      "focusedApp": {
+        "description": "Activa todas las habilidades asociadas con la aplicación “{appName}”. La aplicación puede no funcionar correctamente sin ellas. Si hay otra habilidad activada con el mismo nombre, activar la habilidad asociada a la aplicación desactivará la otra habilidad para ti.",
+        "showAll": {
+          "label": "Mostrar todas las habilidades"
+        },
+        "title": "Habilidades para la aplicación “{appName}”"
+      },
+      "header": {
+        "description": "Paquetes de capacidades que tu agente de Craft puede utilizar. Esta página muestra las habilidades integradas, las compartidas contigo y tus habilidades personales.",
+        "title": "Habilidades"
+      },
+      "loadError": {
+        "description": "Revisa la consola para más detalles e intenta actualizar la página.",
+        "title": "No se pudieron cargar las habilidades"
+      },
+      "preview": {
+        "unavailableFallback": "Esta habilidad no está disponible actualmente."
+      },
+      "search": {
+        "placeholder": "Buscar habilidades..."
+      },
+      "switchModal": {
+        "body": "Al continuar se desactivará la habilidad actualmente activada y se activará esta.",
+        "description": "Solo se puede activar una habilidad llamada “{name}” a la vez.",
+        "submit": {
+          "label": "Cambiar habilidad",
+          "pendingLabel": "Cambiando..."
+        },
+        "title": "¿Cambiar la habilidad “{name}”?"
+      },
+      "toasts": {
+        "disableFailed": "No se pudo desactivar {name}",
+        "enableFailed": "No se pudo activar {name}",
+        "refreshFailed": "{name} se actualizó, pero no se pudo actualizar la lista de habilidades."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -5765,6 +5765,27 @@
         "unexpectedError": "Ocurrió un error inesperado."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "Cancelado",
+        "completedWithErrors": "Completado con errores",
+        "deleting": "Eliminando",
+        "error": "Error",
+        "failed": "Fallido",
+        "inProgress": "En progreso",
+        "indexed": "Indexado",
+        "indexing": "Indexando",
+        "initialIndexing": "Indexación inicial",
+        "interrupted": "Interrumpido",
+        "invalid": "No válido",
+        "invalidConnectorTooltip": "El conector está en un estado no válido. Actualiza las credenciales o crea un conector nuevo.",
+        "none": "Ninguno",
+        "notStarted": "No iniciado",
+        "paused": "En pausa",
+        "scheduled": "Programado",
+        "succeeded": "Exitoso"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "Versión del backend: "
@@ -7204,6 +7225,70 @@
       },
       "sourcesModal": {
         "title": "Fuentes"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "Eliminar"
+      },
+      "deleteModal": {
+        "description": "¿Seguro que quieres eliminar este chat? Esta acción no se puede deshacer.",
+        "submitButton": {
+          "label": "Eliminar"
+        },
+        "title": "Eliminar chat"
+      },
+      "exportAs": {
+        "label": "Exportar como…"
+      },
+      "exportFailed": {
+        "message": "No se pudo exportar el chat. Inténtalo de nuevo."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "Texto sin formato"
+      },
+      "fullWidth": {
+        "ariaLabel": "Alternar chat de ancho completo",
+        "fitTooltip": "Ajustar ancho",
+        "fullTooltip": "Ancho completo"
+      },
+      "incognitoExit": {
+        "ariaLabel": "Salir del chat de incógnito",
+        "tooltip": "Salir del chat de incógnito"
+      },
+      "incognitoPill": {
+        "ariaLabel": "Chat de incógnito",
+        "label": "Chat de incógnito"
+      },
+      "incognitoStart": {
+        "ariaLabel": "Iniciar chat de incógnito",
+        "lockedTooltip": "El modo incógnito solo puede activarse antes de que empiece el chat",
+        "tooltip": "Chat de incógnito"
+      },
+      "mode": {
+        "chat": {
+          "description": "Conversación e investigación",
+          "label": "Chat"
+        },
+        "search": {
+          "description": "Búsqueda rápida de documentos",
+          "label": "Búsqueda"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "Cambiar modo de la aplicación"
+      },
+      "moveToProject": {
+        "label": "Mover a proyecto"
+      },
+      "openSidebar": {
+        "ariaLabel": "Abrir barra lateral"
+      },
+      "share": {
+        "label": "Compartir"
       }
     },
     "banners": {
@@ -8950,6 +9035,34 @@
         "updateFailed": "No se pudo actualizar la preferencia de idioma"
       }
     },
+    "layout": {
+      "header": {
+        "title": "Configuración"
+      },
+      "sectionSelect": {
+        "placeholder": "Selecciona una sección"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "Cuentas y acceso"
+        },
+        "chatPreferences": {
+          "label": "Preferencias de chat"
+        },
+        "connectors": {
+          "label": "Conectores"
+        },
+        "general": {
+          "label": "General"
+        },
+        "llmGateway": {
+          "label": "Puerta de enlace LLM"
+        },
+        "usage": {
+          "label": "Uso"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Añade una nota personal o una memoria que Onyx deba recordar."
@@ -9010,6 +9123,47 @@
       "toggle": {
         "description": "Activa los atajos para insertar rápidamente prompts comunes.",
         "title": "Usar atajos de prompt"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "Límite de {amount}",
+        "none": "Sin presupuesto establecido",
+        "remaining": "{amount} restante",
+        "resetsOn": "Se restablece el {date}",
+        "title": "Presupuesto"
+      },
+      "empty": {
+        "description": "El uso y los costes de tus modelos aparecerán aquí cuando empieces a chatear.",
+        "title": "Aún no hay uso registrado"
+      },
+      "header": {
+        "title": "Uso"
+      },
+      "loadError": {
+        "description": "Algo salió mal al obtener tu uso. Inténtalo de nuevo en un momento.",
+        "title": "No se pudo cargar el uso"
+      },
+      "modelPrices": {
+        "description": "USD por 1M de tokens (entrada · salida · caché) para cada modelo disponible",
+        "title": "Precios de los modelos",
+        "unavailable": "Precios no disponibles"
+      },
+      "showFewerModels": {
+        "ariaLabel": "Mostrar menos modelos"
+      },
+      "showLess": {
+        "label": "Mostrar menos"
+      },
+      "showMore": {
+        "label": "Mostrar {count} más"
+      },
+      "showMoreModels": {
+        "ariaLabel": "Mostrar {count} modelos más"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} gastado",
+        "title": "Uso en este período"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "Atrás"
       },
-      "disableAll": {
-        "label": "Desactivar todo"
-      },
-      "enableAll": {
-        "label": "Activar todo"
-      },
       "toggle": {
         "ariaLabel": "Alternar {name}"
       }
@@ -12947,6 +12941,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "Explorador de documentos"
+        },
+        "documentFeedback": {
+          "title": "Comentarios sobre documentos"
+        },
+        "documentProcessing": {
+          "title": "Procesamiento de documentos"
+        },
+        "oauthTest": {
+          "title": "Prueba de OAuth"
+        },
+        "standardAnswers": {
+          "title": "Respuestas estándar"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "Añadir conector"

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -12902,9 +12902,29 @@
         "title": "No se pudo cargar el uso"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · predeterminado"
+        },
         "description": "USD por 1M de tokens (entrada · salida · caché) para cada modelo disponible",
+        "otherProvider": {
+          "label": "Otros"
+        },
         "title": "Precios de los modelos",
         "unavailable": "Precios no disponibles"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "{count} lecturas de caché"
+        },
+        "cacheWrites": {
+          "label": "{count} escrituras de caché"
+        },
+        "tokensIn": {
+          "label": "{count} de entrada"
+        },
+        "tokensOut": {
+          "label": "{count} de salida"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "Mostrar menos modelos"

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -60,6 +60,26 @@
         "ariaLabel": "Carte de l'action {title}"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "Ajouter des connecteurs"
+      },
+      "configure": {
+        "tooltip": "Configurer"
+      },
+      "configureConnectors": {
+        "label": "Configurer les connecteurs"
+      },
+      "disable": {
+        "label": "Désactiver"
+      },
+      "enable": {
+        "label": "Activer"
+      },
+      "projectSearch": {
+        "label": "Recherche du projet"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "Connectez un serveur MCP (Model Context Protocol) pour ajouter des actions personnalisées.",
@@ -355,6 +375,53 @@
         "tooltip": "Actualiser les outils"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "Redirection automatique en cours…"
+      },
+      "backToChatButton": {
+        "label": "Retour au chat"
+      },
+      "cancelled": {
+        "description": "L'autorisation a été annulée ou refusée, aucune connexion n'a donc été établie. Pour réessayer, relancez la connexion depuis les paramètres d'authentification du serveur MCP.",
+        "title": "Autorisation annulée"
+      },
+      "continueButton": {
+        "label": "Continuer"
+      },
+      "genericError": {
+        "fallbackDetail": "Impossible de terminer l'autorisation",
+        "title": "Une erreur s'est produite"
+      },
+      "invalidLink": {
+        "description": "Ce lien ne contient pas les paramètres d'autorisation requis. Relancez la connexion depuis les paramètres d'authentification du serveur MCP.",
+        "title": "Lien d'autorisation non valide"
+      },
+      "processing": {
+        "description": "Finalisation de la connexion à votre serveur MCP. Cela peut prendre quelques instants…",
+        "title": "Finalisation de l'autorisation"
+      },
+      "serverNotFound": {
+        "description": "Le serveur MCP auquel appartient cette autorisation n'existe plus ou n'est plus configuré. Recréez ou reconfigurez le serveur, puis reconnectez-vous.",
+        "title": "Serveur MCP introuvable"
+      },
+      "sessionExpired": {
+        "description": "Ce lien d'autorisation est non valide, a expiré ou a déjà été utilisé. Relancez la connexion depuis les paramètres d'authentification du serveur MCP.",
+        "title": "Session d'autorisation expirée"
+      },
+      "success": {
+        "description": "L'autorisation a été effectuée avec succès. Vous pouvez maintenant utiliser les outils de ce serveur dans le chat.",
+        "title": "Connecté à {serverName}"
+      },
+      "timedOut": {
+        "description": "Le serveur MCP n'a pas confirmé l'autorisation à temps. Réessayez de vous connecter. Si le problème persiste, vérifiez la configuration OAuth du serveur.",
+        "title": "Délai d'autorisation dépassé"
+      },
+      "tokenExchangeFailed": {
+        "description": "Le fournisseur a approuvé l'autorisation, mais aucun jeton d'accès valide n'a pu être obtenu. Vérifiez les identifiants et les points de terminaison du client OAuth du serveur, puis réessayez de vous connecter.",
+        "title": "Échec de l'échange de jetons"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "Ajouter un serveur MCP"
@@ -554,6 +621,20 @@
         "label": "Refuser"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "Retour"
+      },
+      "disableAll": {
+        "label": "Tout désactiver"
+      },
+      "enableAll": {
+        "label": "Tout activer"
+      },
+      "toggle": {
+        "ariaLabel": "Activer/désactiver {name}"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "Outil indisponible"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "Afficher uniquement les outils activés",
         "tooltip": "Afficher uniquement les activés"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "Configurer l'interpréteur de code"
+        },
+        "imageGeneration": {
+          "tooltip": "Configurer la génération d'images"
+        },
+        "openapi": {
+          "tooltip": "Gérer les actions OpenAPI"
+        },
+        "webSearch": {
+          "tooltip": "Configurer la recherche web"
+        }
+      },
+      "disableAllSources": {
+        "label": "Désactiver toutes les sources"
+      },
+      "disableAllTools": {
+        "label": "Désactiver tous les outils"
+      },
+      "enableAllSources": {
+        "label": "Activer toutes les sources"
+      },
+      "enableAllTools": {
+        "label": "Activer tous les outils"
+      },
+      "manageActions": {
+        "tooltip": "Gérer les actions"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "Rechercher les outils de {server}"
+      },
+      "moreActions": {
+        "label": "Plus d'actions"
+      },
+      "reauthenticate": {
+        "label": "Se réauthentifier"
+      },
+      "search": {
+        "placeholder": "Rechercher des actions..."
+      },
+      "serverFallback": {
+        "label": "serveur"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "Rechercher des filtres"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "Demandez à un administrateur de le configurer."
+        },
+        "codingAgent": {
+          "description": "Explore un dépôt GitHub et répond aux questions sur son code."
+        },
+        "configureSuffix": {
+          "text": "Appuyez sur la roue dentée des réglages pour l'activer."
+        },
+        "default": {
+          "description": "Cette action n'est pas encore configurée."
+        },
+        "imageGeneration": {
+          "description": "Génère des images à partir d'une consigne."
+        },
+        "python": {
+          "description": "Exécute du code pour des analyses complexes."
+        },
+        "search": {
+          "description": "Recherche dans les connaissances connectées pour éclairer la réponse."
+        },
+        "webSearch": {
+          "description": "Recherche sur le web des informations à jour."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "Par jour pour la plage sélectionnée",
+        "title": "Messages et utilisateurs uniques"
+      },
+      "empty": {
+        "message": "Aucune donnée trouvée pour cet agent dans la plage de dates sélectionnée."
+      },
+      "fetchFailed": {
+        "message": "Échec de la récupération des statistiques de l'agent."
+      },
+      "permissionDenied": {
+        "message": "Vous n'avez pas la permission de voir ces statistiques."
+      },
+      "totalMessages": {
+        "label": "Messages au total"
+      },
+      "totalUniqueUsers": {
+        "label": "Utilisateurs uniques au total"
+      },
+      "unknownError": {
+        "message": "Une erreur inconnue est survenue"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "Réduire la section"
+        },
+        "expand": {
+          "ariaLabel": "Développer la section"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "Voulez-vous vraiment supprimer <emphasis>{name}</emphasis> ? Cette action est irréversible."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "Voir les forfaits"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "Aucune information de facturation disponible."
+        },
+        "loadError": {
+          "message": "Erreur lors du chargement des informations de facturation. Veuillez réessayer plus tard."
+        },
+        "loading": {
+          "label": "Chargement..."
+        },
+        "manageSubscription": {
+          "description": "Consultez votre forfait, mettez à jour le paiement ou modifiez l'abonnement",
+          "title": "Gérer l'abonnement"
+        },
+        "page": {
+          "title": "Informations de facturation"
+        },
+        "portalError": {
+          "message": "Erreur lors de la création de la session du portail client"
+        },
+        "subscriptionDetails": {
+          "title": "Détails de l'abonnement"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "Fin de facturation"
+          },
+          "billingStart": {
+            "label": "Début de facturation"
+          },
+          "seats": {
+            "label": "Sièges"
+          },
+          "status": {
+            "label": "Statut de l'abonnement"
+          }
+        },
+        "updatedToast": {
+          "message": "Félicitations ! Votre abonnement a été mis à jour avec succès."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "Nous synchroniserons automatiquement les permissions depuis la source. Un document ne sera consultable dans Onyx que si l'utilisateur effectuant la recherche est autorisé à y accéder dans la source.",
+          "disabledReason": "La méthode d'authentification de l'identifiant actuel ne prend pas en charge la synchronisation automatique des permissions. Veuillez passer à une méthode d'authentification prise en charge.",
+          "name": "Synchronisation automatique des permissions"
+        },
+        "heading": {
+          "description": "Contrôlez qui a accès aux documents indexés par ce connecteur.",
+          "title": "Accès aux documents"
+        },
+        "privateOption": {
+          "description": "Seuls les utilisateurs ayant reçu un accès explicite à ce connecteur (via la page Groupes d'utilisateurs) peuvent accéder aux documents importés par ce connecteur",
+          "name": "Privé"
+        },
+        "publicOption": {
+          "description": "Toute personne disposant d'un compte Onyx peut accéder aux documents importés par ce connecteur",
+          "name": "Public"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# jour} other {# jours}}",
@@ -1546,6 +1794,14 @@
           "label": "Afficher moins"
         }
       },
+      "credentialForm": {
+        "errorToast": "Erreur : {detail}",
+        "successToast": "Réussi !",
+        "updateButton": {
+          "ariaLabel": "Mettre à jour les identifiants",
+          "label": "Mettre à jour"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "La suppression de ce connecteur planifie une tâche de suppression qui retire ses documents indexés et le supprime pour tous les utilisateurs.",
         "entityType": "le connecteur"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "Erreur de synchronisation des autorisations des documents"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "Consultez <link>notre documentation</link> pour plus d'informations sur la configuration de ce connecteur."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "Échec de la mise à jour des fichiers"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "Glissez-déposez {multiple, select, true {des fichiers} other {un fichier}} ici, ou cliquez pour sélectionner {multiple, select, true {des fichiers} other {un fichier}}"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {Fichiers sélectionnés} other {Fichier sélectionné}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "Message d'erreur",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "Erreur de synchronisation de l'appartenance aux groupes"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "Attribuer l'accès des groupes à ce connecteur"
+        },
+        "assignToGroup": {
+          "title": "Attribuer ce connecteur à un groupe"
+        },
+        "scopedManagerGroups": {
+          "description": "Sélectionnez un ou plusieurs des groupes que vous gérez pour donner accès à ce connecteur"
+        },
+        "syncGroups": {
+          "description": "Les groupes ci-dessous contrôlent qui peut gérer ce connecteur. L'accès à ses documents est hérité des permissions de la source elle-même."
+        },
+        "visibleToGroups": {
+          "description": "Ce connecteur sera visible/accessible par les groupes sélectionnés ci-dessous"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "Réindexation ciblée envoyée pour {count, plural, one {# document} other {# documents}}. Les erreurs disparaîtront de la liste au fur et à mesure de la réindexation des documents."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "Regex de canaux activée",
+        "channels": "Canaux",
+        "enabledTrue": "Oui",
+        "excludeChannelRegexEnabled": "Regex d'exclusion de canaux activée",
+        "excludedChannels": "Canaux exclus",
+        "includeBotMessages": "Inclure les messages des bots",
+        "jiraProjectUrl": "URL du projet Jira",
+        "multipleRepos": "plusieurs dépôts",
+        "pageId": "ID de page",
+        "realm": "Realm",
+        "repo": "Dépôt",
+        "wikiUrl": "URL du wiki"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "Saisissez l'e-mail d'un administrateur ou d'un propriétaire de l'organisation Google qui possède le ou les Google Drive que vous voulez indexer.",
           "invalidEmail": "Doit être un e-mail valide",
           "label": "E-mail de l'administrateur principal",
+          "placeholder": "admin@votreentreprise.com",
           "required": "Obligatoire"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "Saisissez l'e-mail d'un administrateur ou d'un propriétaire de l'organisation Google qui possède le ou les comptes Gmail que vous voulez indexer.",
           "invalidEmail": "Doit être un e-mail valide",
           "label": "E-mail de l'administrateur principal",
+          "placeholder": "admin@votreentreprise.com",
           "required": "Obligatoire"
         },
         "section": {
@@ -2602,6 +2906,171 @@
       "unavailable": {
         "description": "Craft est activé déploiement par déploiement par Onyx. Contactez votre représentant Onyx pour y accéder.",
         "title": "Craft n'est pas disponible sur ce déploiement"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "Créé le <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "Créé le <i>{date}</i> par <i>{email}</i>"
+        },
+        "unnamed": {
+          "label": "Identifiant n° {id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "Créer"
+        },
+        "created": {
+          "toast": "Nouvel identifiant créé !"
+        },
+        "name": {
+          "label": "Nom :",
+          "placeholder": "(Facultatif) nom de l'identifiant..."
+        },
+        "submitError": {
+          "toast": "Erreur lors de l'envoi de l'identifiant"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "Annuler"
+        },
+        "confirmBody": {
+          "message": "Voulez-vous vraiment supprimer cet identifiant ? Vous ne pouvez pas supprimer des identifiants liés à des connecteurs actifs."
+        },
+        "confirmButton": {
+          "label": "Confirmer"
+        },
+        "confirmTitle": "Confirmer la suppression"
+      },
+      "edit": {
+        "name": {
+          "label": "Nom (facultatif) :"
+        },
+        "permissions": {
+          "note": "Assurez-vous de passer à un identifiant disposant des autorisations appropriées !"
+        },
+        "resetButton": {
+          "label": "Réinitialiser les modifications"
+        },
+        "updateButton": {
+          "label": "Mettre à jour"
+        },
+        "updateError": {
+          "toast": "Erreur lors de la mise à jour de l'identifiant"
+        }
+      },
+      "modal": {
+        "createTitle": "Créer un identifiant {source}",
+        "editTitle": "Modifier l'identifiant",
+        "updateTitle": "Mettre à jour les identifiants"
+      },
+      "modify": {
+        "createButton": {
+          "label": "Créer"
+        },
+        "instructions": {
+          "message": "Sélectionnez un identifiant selon vos besoins ! Assurez-vous d'avoir sélectionné un identifiant disposant des autorisations appropriées pour ce connecteur !"
+        },
+        "selectButton": {
+          "label": "Sélectionner"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "Connecter"
+        },
+        "connectError": {
+          "title": "Connexion impossible"
+        },
+        "redirectFailed": {
+          "message": "Nous n'avons pas pu vous rediriger pour vous connecter avec {source}. Veuillez réessayer."
+        },
+        "retryButton": {
+          "label": "Réessayer"
+        },
+        "startError": {
+          "message": "Impossible de démarrer OAuth"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "Problème lors du remplacement de l'identifiant : {detail}"
+        },
+        "success": {
+          "toast": "Identifiant remplacé avec succès !"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "Actions"
+        },
+        "created": {
+          "header": "Créé"
+        },
+        "edit": {
+          "ariaLabel": "Modifier l'identifiant"
+        },
+        "empty": {
+          "message": "Aucun identifiant n'existe pour ce connecteur !"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "Dernière mise à jour"
+        },
+        "name": {
+          "header": "Nom"
+        },
+        "select": {
+          "label": "Sélectionner"
+        },
+        "selected": {
+          "badge": "sélectionné"
+        },
+        "untitled": {
+          "label": "Sans titre"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "Problème lors de la mise à jour de l'identifiant"
+        },
+        "success": {
+          "toast": "Identifiant mis à jour"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "Cela vous permet d'utiliser votre propre outil d'analytique avec Onyx ! Copiez l'extrait Web de votre fournisseur d'analytique dans le champ ci-dessous, et nous commencerons à envoyer des événements d'utilisation."
+      },
+      "notEnabled": {
+        "description": "Pour configurer des scripts d'analytique personnalisés, adressez-vous à l'équipe qui a installé Onyx afin de définir la variable d'environnement <i>CUSTOM_ANALYTICS_SECRET_KEY</i>.",
+        "title": "L'analytique personnalisée n'est pas activée."
+      },
+      "script": {
+        "description": "Indiquez le Javascript à exécuter au chargement de la page pour initialiser votre suivi/analytique personnalisé.",
+        "instructions": "N'incluez pas les balises `<script></script>`. Si vous téléversez un script ci-dessous mais que vous ne recevez aucun événement dans votre plateforme d'analytique, essayez de supprimer tous les espaces superflus au début de chaque ligne de JavaScript.",
+        "label": "Script"
+      },
+      "secretKey": {
+        "description": "Pour des raisons de sécurité, vous devez fournir une clé secrète pour mettre à jour ce script. Il doit s'agir de la valeur de la variable d'environnement <i>CUSTOM_ANALYTICS_SECRET_KEY</i> définie lors de la configuration initiale d'Onyx.",
+        "label": "Clé secrète"
+      },
+      "updateButton": {
+        "label": "Mettre à jour"
+      },
+      "updateFailed": {
+        "message": "Échec de la mise à jour du script d'analytique personnalisé : \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "Script d'analytique personnalisé mis à jour avec succès !"
       }
     },
     "discordBot": {
@@ -3059,6 +3528,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "Collecte..."
+        },
+        "downloading": {
+          "label": "Téléchargement..."
+        },
+        "export": {
+          "label": "Exporter les journaux"
+        },
+        "starting": {
+          "label": "Démarrage..."
+        }
+      },
+      "downloadButton": {
+        "label": "Télécharger"
+      },
+      "exportCard": {
+        "description": "Rassemble les fichiers journaux du serveur d'API et des workers en arrière-plan dans une seule archive zip. Le téléchargement démarre automatiquement une fois la collecte terminée.",
+        "title": "Exporter les journaux"
+      },
+      "header": {
+        "description": "Téléchargez une archive zip des fichiers journaux du serveur à joindre à une demande de support Onyx."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "couvert par un autre worker sur le même hôte"
+        },
+        "failed": {
+          "label": "échec"
+        },
+        "failedWithError": {
+          "label": "échec : {error}"
+        },
+        "noLogs": {
+          "label": "aucun fichier journal trouvé"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {# fichier téléversé} other {# fichiers téléversés}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "Les fichiers journaux peuvent inclure des e-mails d'utilisateurs, des titres de documents, des requêtes de recherche et des détails d'erreurs. Vérifiez leur contenu avant de les partager en dehors de votre organisation.",
+        "title": "Les journaux peuvent contenir des données sensibles"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "Démarrage de la collecte..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "Un export des journaux est déjà en cours. Réessayez dans un instant."
+        },
+        "downloadFailed": {
+          "message": "Échec du téléchargement de l'export des journaux."
+        },
+        "lostAccess": {
+          "message": "Accès à l'export en cours perdu. Lancez-en un nouveau."
+        },
+        "startFailed": {
+          "message": "Échec du démarrage de l'export des journaux."
+        },
+        "unreachable": {
+          "message": "Impossible de joindre le serveur pour vérifier la progression de l'export. Lancez un nouvel export dès qu'il sera de retour."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "collecte en cours..."
+        },
+        "missedDeadline": {
+          "label": "n'a pas répondu avant l'échéance"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3165,9 +3711,137 @@
         "loadFailed": "Échec du chargement du connecteur : {details}",
         "title": "Erreur"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "Saisissez le nom du canal ou un motif regex, puis appuyez sur Entrée"
+        },
+        "channelsRequired": {
+          "error": "Au moins un canal est requis lorsque 'Rechercher dans tous les canaux' est désactivé"
+        },
+        "configSchemaLoadError": {
+          "message": "Impossible de charger le schéma de configuration : {error}"
+        },
+        "configTitle": {
+          "text": "Configuration du connecteur fédéré"
+        },
+        "configuration": {
+          "heading": "Configuration"
+        },
+        "create": {
+          "failed": "Impossible de créer le connecteur fédéré",
+          "success": "Connecteur fédéré créé avec succès !"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (laisser vide pour conserver la valeur actuelle)"
+        },
+        "credentialValidationFailed": {
+          "message": "Échec de la validation des identifiants : {message}"
+        },
+        "credentials": {
+          "description": "Saisissez les identifiants de ce connecteur.",
+          "heading": "Identifiants"
+        },
+        "delete": {
+          "failed": "Impossible de supprimer le connecteur fédéré",
+          "success": "Connecteur fédéré supprimé avec succès !"
+        },
+        "deleteConfirm": {
+          "message": "Voulez-vous vraiment supprimer ce connecteur fédéré ? Cette action est irréversible."
+        },
+        "deleteError": {
+          "toast": "Erreur lors de la suppression du connecteur : {error}"
+        },
+        "deleteItem": {
+          "deleting": "Suppression...",
+          "inProgressTooltip": "Suppression en cours",
+          "label": "Supprimer"
+        },
+        "federatedBadge": {
+          "label": "Fédéré"
+        },
+        "federatedTooltip": {
+          "default": "Ceci est un connecteur fédéré. Il entraînera une latence plus élevée et une qualité de recherche moindre par rapport aux connecteurs classiques."
+        },
+        "genericError": {
+          "text": "Erreur : {error}"
+        },
+        "listInput": {
+          "placeholder": "Saisissez du texte et appuyez sur Entrée pour ajouter un élément"
+        },
+        "loadingSchema": {
+          "description": "Récupération des champs requis pour ce type de connecteur",
+          "title": "Chargement du schéma des identifiants..."
+        },
+        "manageButton": {
+          "label": "Gérer"
+        },
+        "missingFields": {
+          "message": "Champs obligatoires manquants : {fields}"
+        },
+        "noConfigSchema": {
+          "message": "Aucune configuration de recherche disponible pour ce type de connecteur."
+        },
+        "noCredentialSchema": {
+          "message": "Aucun schéma d'identifiants disponible pour ce type de connecteur."
+        },
+        "schemaLoadError": {
+          "message": "Impossible de charger le schéma des identifiants : {error}"
+        },
+        "submitButton": {
+          "create": "Créer",
+          "creating": "Création...",
+          "update": "Mettre à jour",
+          "updating": "Mise à jour..."
+        },
+        "title": {
+          "edit": "Modifier {name}",
+          "setup": "Configurer {name}"
+        },
+        "update": {
+          "failed": "Impossible de mettre à jour le connecteur fédéré",
+          "success": "Connecteur fédéré mis à jour avec succès !"
+        },
+        "validateBeforeEdit": {
+          "message": "Saisissez de nouvelles valeurs d'identifiants avant de valider."
+        },
+        "validateButton": {
+          "label": "Valider",
+          "validating": "Validation..."
+        },
+        "validation": {
+          "error": "Erreur de validation : {error}",
+          "failedStatus": "Échec de la validation : {statusText}",
+          "invalid": "Les identifiants ne sont pas valides",
+          "valid": "Les identifiants sont valides"
+        }
+      },
       "loading": {
         "description": "Récupération des détails du connecteur et du schéma des identifiants",
         "title": "Chargement de la configuration du connecteur..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "Retour au chat"
+      },
+      "error": {
+        "title": "Une erreur s'est produite"
+      },
+      "errors": {
+        "clientSecret": "Les identifiants d'authentification sont manquants ou non valides",
+        "oauth": "L'autorisation OAuth a échoué",
+        "validation": "Erreur de configuration - vérifiez les paramètres de votre connecteur"
+      },
+      "processing": {
+        "details": "Veuillez patienter pendant que nous terminons la configuration.",
+        "title": "Traitement en cours..."
+      },
+      "redirecting": {
+        "text": "Redirection vers le chat dans 2 secondes..."
+      },
+      "success": {
+        "detailsTemplate": "Votre autorisation {serviceName} s'est terminée avec succès. Vous pouvez maintenant utiliser ce connecteur pour la recherche.",
+        "title": "Réussi !"
       }
     },
     "groups": {
@@ -3430,6 +4104,265 @@
           "header": "Limite de jetons",
           "placeholder": "Limite de jetons (milliers)",
           "unit": "(milliers)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "Supprimer le hook",
+          "tooltip": "Supprimer"
+        },
+        "disconnect": {
+          "ariaLabel": "Désactiver le hook",
+          "tooltip": "Déconnecter le hook"
+        },
+        "disconnectedSuffix": {
+          "label": "(Déconnecté)"
+        },
+        "hookPoint": {
+          "description": "Point d'ancrage : {name}"
+        },
+        "manage": {
+          "ariaLabel": "Configurer le hook",
+          "tooltip": "Gérer"
+        },
+        "reconnectButton": {
+          "label": "Reconnecter"
+        },
+        "test": {
+          "ariaLabel": "Revalider le hook",
+          "tooltip": "Tester la connexion"
+        }
+      },
+      "connectButton": {
+        "label": "Connecter"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "Le hook ***{name}*** sera définitivement supprimé de ce point d'ancrage. Le point de terminaison externe peut conserver les données qui lui ont été envoyées."
+        },
+        "delete": {
+          "label": "Supprimer"
+        },
+        "header": {
+          "title": "Supprimer *{name}*"
+        },
+        "permanent": {
+          "description": "La suppression est irréversible."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyx cessera d'appeler ce point de terminaison pour le hook ***{name}***. Les requêtes en cours continueront de s'exécuter. Le point de terminaison externe peut conserver les données qui lui ont été envoyées. Vous pourrez reconnecter ce hook plus tard si nécessaire."
+        },
+        "deleteNote": {
+          "description": "Vous pouvez également supprimer ce hook. La suppression est irréversible."
+        },
+        "disconnect": {
+          "label": "Déconnecter"
+        },
+        "disconnectAndDelete": {
+          "label": "Déconnecter et supprimer"
+        },
+        "header": {
+          "title": "Déconnecter *{name}*"
+        }
+      },
+      "docsLink": {
+        "label": "Documentation"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyx utilisera cette clé pour s'authentifier auprès de votre point de terminaison d'API.",
+          "keepCurrent": {
+            "placeholder": "Laissez vide pour conserver la clé actuelle"
+          },
+          "title": "Clé API"
+        },
+        "connectionValid": {
+          "label": "Connexion valide."
+        },
+        "createHeader": {
+          "description": "Connectez un point de terminaison d'API externe pour étendre le point d'ancrage.",
+          "title": "Configurer l'extension de hook"
+        },
+        "editHeader": {
+          "title": "Gérer l'extension de hook"
+        },
+        "endpoint": {
+          "description": "Ne vous connectez qu'à des serveurs de confiance. Vous êtes responsable des actions effectuées et des données partagées via cette connexion.",
+          "title": "URL du point de terminaison d'API externe"
+        },
+        "errors": {
+          "connect": "Impossible de se connecter au point de terminaison.",
+          "generic": "Une erreur est survenue.",
+          "invalidApiKey": "Clé API non valide.",
+          "timeout": "La connexion a expiré. Essayez d'augmenter le délai d'attente."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(Par défaut)"
+          },
+          "hard": {
+            "label": "Bloquer le pipeline en cas d'échec"
+          },
+          "placeholder": "Sélectionnez une stratégie",
+          "soft": {
+            "label": "Journaliser l'erreur et continuer"
+          },
+          "title": "Stratégie d'échec"
+        },
+        "hookPoint": {
+          "label": "Point d'ancrage"
+        },
+        "name": {
+          "placeholder": "Nommez votre extension à ce point d'ancrage",
+          "title": "Nom d'affichage"
+        },
+        "save": {
+          "label": "Enregistrer les modifications"
+        },
+        "softStrategy": {
+          "description": "Si le point de terminaison renvoie une erreur, Onyx la journalise et poursuit le pipeline normalement, en ignorant le résultat du hook."
+        },
+        "timeout": {
+          "description": "Durée maximale pendant laquelle Onyx attend la réponse du point de terminaison avant d'appliquer la stratégie d'échec. Doit être supérieure à 0 et au plus {max} secondes.",
+          "revert": {
+            "tooltip": "Rétablir la valeur par défaut"
+          },
+          "suffix": "(secondes)",
+          "title": "Délai d'attente"
+        },
+        "toasts": {
+          "created": {
+            "message": "Hook créé."
+          },
+          "noHookPoint": {
+            "message": "Aucun point d'ancrage spécifié."
+          },
+          "updated": {
+            "message": "Hook mis à jour."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "La clé API ne peut pas être vide.",
+          "endpointRequired": "L'URL du point de terminaison ne peut pas être vide.",
+          "nameRequired": "Le nom d'affichage ne peut pas être vide.",
+          "timeoutRange": "Doit être supérieur à 0 et au plus {max} secondes.",
+          "timeoutRequired": "Le délai d'attente est requis."
+        },
+        "verifying": {
+          "label": "Vérification de la connexion…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "Copier"
+        },
+        "download": {
+          "tooltip": "Télécharger"
+        },
+        "empty": {
+          "message": "Aucune erreur au cours des 30 derniers jours."
+        },
+        "header": {
+          "description": "Hook : {name} • Point d'ancrage : {point}",
+          "title": "Erreurs récentes"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# ligne} other {# lignes}}"
+        },
+        "loadFailed": {
+          "message": "Échec du chargement des journaux."
+        },
+        "older": {
+          "label": "Plus anciens"
+        },
+        "pastHour": {
+          "label": "Dernière heure"
+        },
+        "unknownError": {
+          "label": "Erreur inconnue"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "Annuler"
+        }
+      },
+      "page": {
+        "description": "Étendez les pipelines Onyx en enregistrant des points de terminaison d'API externes comme callbacks à des points d'ancrage prédéfinis.",
+        "empty": {
+          "title": "Aucun point d'ancrage disponible"
+        },
+        "emptySearch": {
+          "description": "Essayez un autre terme de recherche.",
+          "title": "Aucun résultat trouvé"
+        },
+        "enterpriseRequired": {
+          "message": "Les extensions de hooks nécessitent une licence Enterprise."
+        },
+        "loadHooksFailed": {
+          "message": "Échec du chargement des hooks. Veuillez actualiser la page."
+        },
+        "loadSpecsFailed": {
+          "message": "Échec du chargement des spécifications de hooks. Veuillez actualiser la page."
+        },
+        "notEnabled": {
+          "message": "Les extensions de hooks ne sont pas activées pour ce déploiement."
+        },
+        "search": {
+          "placeholder": "Rechercher des hooks..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "Connecté"
+        },
+        "connectionLost": {
+          "label": "Connexion perdue"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# erreur} other {# erreurs}}"
+        },
+        "noError": {
+          "title": "Aucune erreur"
+        },
+        "pastHour": {
+          "description": "au cours de la dernière heure"
+        },
+        "recentErrors": {
+          "title": "Erreurs les plus récentes"
+        },
+        "viewMore": {
+          "label": "Voir plus de lignes"
+        },
+        "viewOlder": {
+          "label": "Voir les erreurs plus anciennes"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "Échec de la désactivation du hook."
+        },
+        "deleteFailed": {
+          "message": "Échec de la suppression du hook."
+        },
+        "disconnectFailed": {
+          "message": "Échec de la déconnexion du hook."
+        },
+        "reconnectFailed": {
+          "message": "Échec de la reconnexion du hook."
+        },
+        "validateFailed": {
+          "message": "Échec de la validation du hook."
+        },
+        "validateSuccess": {
+          "message": "Hook validé avec succès."
+        },
+        "validationFailed": {
+          "message": "Échec de la validation : {status}"
         }
       }
     },
@@ -4309,6 +5242,9 @@
               "label": "Ajouter une ligne"
             },
             "description": "Ajoutez les propriétés supplémentaires exigées par le fournisseur de modèles. Elles sont transmises à l'appel `completion()` de LiteLLM comme [variables d'environnement](https://docs.litellm.ai/docs/set_keys#environment-variables). Consultez la [documentation](https://docs.onyx.app/admins/ai_models/custom_inference_provider) pour plus d'instructions.",
+            "keyInput": {
+              "placeholder": "par ex. OPENAI_ORGANIZATION"
+            },
             "title": "Variables d'environnement"
           },
           "modelRow": {
@@ -4820,6 +5756,132 @@
         "title": "Utilisateurs"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "Inconnu"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "IA"
+        },
+        "errorTitle": {
+          "title": "Une erreur est survenue :("
+        },
+        "feedback": {
+          "title": "Retour"
+        },
+        "fetchFailed": {
+          "message": "Échec de la récupération de la session de chat - {error}"
+        },
+        "header": {
+          "title": "Détails de la session de chat"
+        },
+        "referenceDocuments": {
+          "title": "Documents de référence"
+        },
+        "user": {
+          "label": "Utilisateur"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "Annuler"
+        },
+        "downloadFailed": {
+          "message": "Échec du téléchargement de l'historique des requêtes."
+        },
+        "generating": {
+          "message": "Génération du rapport CSV. Cliquez sur le bouton « {button} » pour voir toutes les tâches."
+        },
+        "kickoff": {
+          "label": "Lancer l'export"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "Échec"
+        },
+        "pending": {
+          "label": "En attente"
+        },
+        "success": {
+          "label": "Succès"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "Télécharger"
+        },
+        "endRange": {
+          "header": "Fin de la plage"
+        },
+        "generatedAt": {
+          "header": "Généré le"
+        },
+        "header": {
+          "title": "Exports précédents de l'historique des requêtes"
+        },
+        "notReady": {
+          "tooltip": "L'export n'est pas encore prêt"
+        },
+        "startRange": {
+          "header": "Début de la plage"
+        },
+        "status": {
+          "header": "Statut"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "Je n'aime pas"
+        },
+        "like": {
+          "label": "J'aime"
+        },
+        "mixed": {
+          "label": "Mitigé"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "Tous"
+        },
+        "feedbackType": {
+          "label": "Type de retour"
+        }
+      },
+      "previousExports": {
+        "label": "Voir les exports"
+      },
+      "table": {
+        "date": {
+          "header": "Date"
+        },
+        "feedback": {
+          "header": "Retour"
+        },
+        "fetchError": {
+          "title": "Erreur lors de la récupération de l'historique des requêtes"
+        },
+        "firstAiResponse": {
+          "header": "Première réponse de l'IA"
+        },
+        "firstUserMessage": {
+          "header": "Premier message de l'utilisateur"
+        },
+        "persona": {
+          "header": "Persona"
+        },
+        "user": {
+          "header": "Utilisateur"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4874,6 +5936,56 @@
         "generateFailed": "Échec de la génération du jeton : {detail}",
         "genericError": "Une erreur s'est produite. Veuillez réessayer.",
         "regenerated": "Jeton régénéré"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "La classification de la requête a échoué. Retour au chat."
+        },
+        "searchFailed": {
+          "message": "La recherche de documents a échoué. Veuillez réessayer."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# résultat} other {# résultats}}"
+        },
+        "empty": {
+          "description": "Vérifiez vos connecteurs/filtres ou essayez un autre terme de recherche.",
+          "title": "Aucun résultat trouvé"
+        },
+        "failed": {
+          "title": "Échec de la recherche"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# tag} other {# tags}}"
+        },
+        "empty": {
+          "label": "Tags"
+        },
+        "search": {
+          "placeholder": "Filtrer les tags..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "Toutes périodes"
+        },
+        "day": {
+          "label": "Dernières 24 heures"
+        },
+        "month": {
+          "label": "Mois dernier"
+        },
+        "week": {
+          "label": "Semaine dernière"
+        },
+        "year": {
+          "label": "Année dernière"
+        }
       }
     },
     "security": {
@@ -5765,6 +6877,163 @@
         "unexpectedError": "Une erreur inattendue est survenue."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "Supprimer la catégorie {name}"
+        },
+        "removeButton": {
+          "ariaLabel": "Supprimer la catégorie"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "Catégories de réponses standard"
+        },
+        "fetchError": {
+          "message": "Échec de la récupération des catégories de réponses standard - {message}",
+          "title": "Une erreur est survenue :("
+        },
+        "search": {
+          "placeholder": "Rechercher des catégories..."
+        }
+      },
+      "editPage": {
+        "title": "Modifier la réponse standard"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "Échec de la récupération des réponses standard"
+        },
+        "fetchCategoriesFailed": {
+          "message": "Échec de la récupération des catégories de réponses standard"
+        },
+        "genericTitle": {
+          "title": "Une erreur est survenue :("
+        },
+        "loadAnswersFailed": {
+          "title": "Erreur lors du chargement des réponses standard"
+        },
+        "loadCategoriesFailed": {
+          "title": "Erreur lors du chargement des catégories de réponses standard"
+        },
+        "notFound": {
+          "message": "Aucune réponse standard trouvée avec l'ID : {id}"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "Toutes les catégories"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "Tous ces mots-clés, dans n'importe quel ordre, séparés par des espaces",
+          "placeholder": "ticket informatique"
+        },
+        "answer": {
+          "label": "Réponse",
+          "placeholder": "La réponse en Markdown. Exemple : si vous avez besoin d'aide de l'équipe informatique, écrivez à internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "N'importe lequel de ces mots-clés, séparés par des espaces",
+          "placeholder": "ticket problème incident"
+        },
+        "categories": {
+          "label": "Catégories :",
+          "placeholder": "Saisissez une catégorie et appuyez sur Entrée…"
+        },
+        "createButton": {
+          "label": "Créer !"
+        },
+        "keywords": {
+          "tooltip": "Une question doit correspondre à ces mots-clés pour déclencher la réponse."
+        },
+        "matchRegex": {
+          "description": "Faire correspondre un motif regex plutôt qu'un mot-clé exact",
+          "label": "Correspondance regex"
+        },
+        "regexPattern": {
+          "label": "Motif regex",
+          "tooltip": "Se déclenche si la question correspond à ce motif regex (via `re.search()` de Python)"
+        },
+        "strategy": {
+          "all": {
+            "label": "Tous les mots-clés"
+          },
+          "any": {
+            "label": "N'importe quel mot-clé"
+          },
+          "description": "Choisissez si la question de l'utilisateur doit contenir un ou tous les mots-clés ci-dessus pour afficher cette réponse.",
+          "label": "Stratégie de détection des mots-clés"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "Erreur lors de la création de la catégorie « {name} » - {error}"
+          },
+          "createFailed": {
+            "message": "Erreur lors de la création de la réponse standard - {error}"
+          },
+          "updateFailed": {
+            "message": "Erreur lors de la mise à jour de la réponse standard - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "Mettre à jour !"
+        },
+        "validation": {
+          "answerRequired": "La réponse est requise",
+          "categoryRequired": "Au moins une catégorie est requise",
+          "keywordRequired": "Des mots-clés ou un motif sont requis"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "Ajoutez votre première réponse standard ci-dessous !"
+        },
+        "description": "Gérez les réponses standard pour des questions prédéfinies.\nRemarque : actuellement, seules les questions posées depuis Slack peuvent recevoir des réponses standard."
+      },
+      "newStandardAnswer": {
+        "label": "Nouvelle réponse standard"
+      },
+      "search": {
+        "placeholder": "Rechercher des réponses standard par mot-clé/phrase..."
+      },
+      "table": {
+        "answer": {
+          "header": "Réponse"
+        },
+        "categories": {
+          "header": "Catégories"
+        },
+        "empty": {
+          "message": "Aucune réponse standard correspondante trouvée..."
+        },
+        "keywords": {
+          "header": "Mots-clés/motif"
+        },
+        "matchRegex": {
+          "header": "Correspondance regex ?"
+        },
+        "matchRegexNo": {
+          "label": "Non"
+        },
+        "matchRegexYes": {
+          "label": "Oui"
+        },
+        "slackNote": {
+          "message": "Assurez-vous d'avoir ajouté la catégorie au [bot Slack](/admin/bots) concerné."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "Échec de la suppression de la réponse standard - {error}"
+        },
+        "deleted": {
+          "message": "Réponse standard {id} supprimée"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "Annulé",
@@ -5795,6 +7064,142 @@
       },
       "webVersion": {
         "label": "Version web : "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "Affiche une annonce système persistante que les utilisateurs peuvent fermer.",
+        "header": {
+          "placeholder": "Ajoutez une annonce"
+        },
+        "label": "Annonce système"
+      },
+      "announcementPopup": {
+        "description": "Affichez également cet avis en pop-up plein écran lors de la première visite de tous les utilisateurs. À utiliser avec prudence.",
+        "label": "Avis contextuel lors de la première visite"
+      },
+      "appName": {
+        "description": "Ce nom apparaîtra dans toute l'application et remplacera \"Onyx\" dans l'interface.",
+        "label": "Nom d'affichage de l'application"
+      },
+      "branding": {
+        "description": "Supprimez « powered by Onyx » et les autres présences de la marque Onyx dans l'application.",
+        "enterpriseTooltip": "Masquer la marque Onyx est une fonctionnalité du forfait Enterprise.",
+        "label": "Masquer la marque Onyx"
+      },
+      "chatFooter": {
+        "description": "Ajoutez du contenu markdown pour des avertissements ou des informations supplémentaires.",
+        "label": "Texte du pied de page du chat"
+      },
+      "chatHeader": {
+        "label": "Texte de l'en-tête du chat"
+      },
+      "consent": {
+        "description": "Exige que l'utilisateur lise et accepte l'avis avant d'accéder à l'application.",
+        "label": "Exiger le consentement à l'avis"
+      },
+      "consentPrompt": {
+        "label": "Invite de consentement de l'avis"
+      },
+      "firstVisit": {
+        "description": "Affiche une fenêtre contextuelle unique pour les nouveaux utilisateurs lors de leur première visite.",
+        "label": "Afficher l'avis lors de la première visite"
+      },
+      "greeting": {
+        "description": "Ajoutez un court message à la page d'accueil.",
+        "label": "Message d'accueil"
+      },
+      "helpLink": {
+        "description": "Ajoutez un lien d'aide personnalisé dans le menu utilisateur en plus de la documentation Onyx.",
+        "enterpriseTooltip": "Le lien d'aide personnalisé est une fonctionnalité du forfait Enterprise.",
+        "label": "Lien d'aide personnalisé"
+      },
+      "helpLinkLabel": {
+        "label": "Libellé du lien d'aide personnalisé",
+        "placeholder": "Libellé du lien"
+      },
+      "loginSubtitle": {
+        "description": "Remplacez le slogan sous le titre de bienvenue sur la page de connexion.",
+        "label": "Sous-titre de la page de connexion"
+      },
+      "logo": {
+        "label": "Logo de l'application",
+        "updateButton": {
+          "label": "Mettre à jour"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "Logo et nom",
+          "tooltip": "Affiche à la fois le logo et le nom de votre application."
+        },
+        "description": "Choisissez ce qui s'affiche en haut de la barre latérale. Les options deviennent disponibles dès que vous ajoutez un logo ou un nom d'application.",
+        "label": "Style d'affichage du logo",
+        "logoOnly": {
+          "disabledTooltip": "Téléversez un logo pour activer cette option.",
+          "label": "Logo uniquement",
+          "tooltip": "Affiche uniquement le logo de votre application."
+        },
+        "nameOnly": {
+          "disabledTooltip": "Saisissez un nom d'application pour activer cette option.",
+          "label": "Nom uniquement",
+          "tooltip": "Affiche uniquement le nom de votre application."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "Ajoutez du contenu markdown"
+      },
+      "noticeContent": {
+        "label": "Contenu de l'avis"
+      },
+      "noticeHeader": {
+        "label": "En-tête de l'avis"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "Échec de la suppression de l'annonce."
+        },
+        "announcementSaveFailed": {
+          "message": "Échec de l'enregistrement de l'annonce."
+        },
+        "applyButton": {
+          "label": "Appliquer les modifications"
+        },
+        "applying": {
+          "label": "Application..."
+        },
+        "description": "Personnalisez l'apparence de l'application pour les utilisateurs de votre organisation.",
+        "logoUploadFailed": {
+          "message": "Échec du téléversement du logo. {error}"
+        },
+        "saveSuccess": {
+          "message": "Paramètres d'apparence enregistrés avec succès !"
+        },
+        "settingsSaveFailed": {
+          "message": "Échec de la mise à jour des paramètres. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "L'invite de consentement de l'avis est requise",
+          "invalidUrl": "Doit être une URL valide",
+          "maxChars": "Maximum {count} caractères",
+          "noticeContentRequired": "Le contenu de l'avis est requis",
+          "noticeHeaderRequired": "L'en-tête de l'avis est requis",
+          "urlRequiredWithLabel": "L'URL est requise lorsqu'un libellé est défini"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "Contenu du pied de page du chat"
+        },
+        "chatHeader": {
+          "placeholder": "Contenu de l'en-tête du chat"
+        },
+        "greeting": {
+          "placeholder": "Bienvenue sur Acme Chat"
+        },
+        "logo": {
+          "alt": "Logo"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6059,6 +7464,9 @@
             "label": "Dépenses"
           }
         }
+      },
+      "page": {
+        "description": "Suivez les dépenses de l'espace de travail et consultez l'utilisation par utilisateur."
       },
       "spendByUser": {
         "columns": {
@@ -6656,6 +8064,204 @@
         "tooltip": "Voir les statistiques de l'agent"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "Générez et exécutez du code.",
+          "title": "Interpréteur de code"
+        },
+        "codingAgent": {
+          "description": "Explorez un dépôt GitHub et répondez aux questions sur son code.",
+          "title": "Agent de codage"
+        },
+        "description": "Outils et capacités que cet agent peut utiliser.",
+        "imageGeneration": {
+          "description": "Générez et manipulez des images à l'aide d'outils basés sur l'IA.",
+          "title": "Génération d'images",
+          "unavailable": {
+            "tooltip": "La génération d'images nécessite un modèle configuré. Si vous y avez accès, configurez-en un dans Paramètres > Génération d'images, ou demandez à un administrateur."
+          }
+        },
+        "openUrl": {
+          "description": "Récupérez et lisez le contenu d'URL Web.",
+          "title": "Ouvrir une URL"
+        },
+        "title": "Actions",
+        "webSearch": {
+          "description": "Recherchez sur le Web des informations en temps réel et des résultats à jour.",
+          "title": "Recherche Web"
+        }
+      },
+      "advanced": {
+        "description": "Affinez les prompts et les connaissances de l'agent.",
+        "overwritePrompt": {
+          "suffix": "(Non recommandé)",
+          "title": "Remplacer le prompt système"
+        },
+        "reminders": {
+          "description": "Ajoutez un bref rappel aux messages du prompt. Utilisez-le pour rappeler à l'agent certaines instructions s'il a tendance à les oublier au fil de la discussion. Il doit rester bref et ne pas interférer avec les messages de l'utilisateur.",
+          "placeholder": "N'oubliez pas, je veux que vous formatiez toujours votre réponse sous forme de liste numérotée.",
+          "title": "Rappels"
+        },
+        "title": "Options avancées"
+      },
+      "avatar": {
+        "edit": {
+          "label": "Modifier"
+        },
+        "uploadImage": {
+          "label": "Téléverser une image"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "Supprimer l'agent"
+        },
+        "description": "Toute personne utilisant cet agent ne pourra plus y accéder.",
+        "title": "Supprimer cet agent"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "Voulez-vous vraiment supprimer cet agent ?",
+          "warning": "Toute personne utilisant cet agent ne pourra plus y accéder. La suppression est irréversible."
+        },
+        "title": "Supprimer l'agent"
+      },
+      "filesModal": {
+        "description": "Tous les fichiers sélectionnés pour cet agent",
+        "placeholderName": "Fichier {id}",
+        "title": "Fichiers de l'utilisateur"
+      },
+      "general": {
+        "avatar": {
+          "title": "Avatar de l'agent"
+        },
+        "descriptionField": {
+          "placeholder": "Que fait cet agent ?",
+          "title": "Description"
+        },
+        "name": {
+          "placeholder": "Nommez votre agent",
+          "title": "Nom"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "Annuler"
+        },
+        "create": {
+          "label": "Créer"
+        },
+        "createTitle": "Créer un agent",
+        "editTitle": "Modifier l'agent",
+        "save": {
+          "label": "Enregistrer"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "Vous n'avez plus accès à ce serveur MCP. Ses outils existants seront conservés."
+        },
+        "searchTools": {
+          "placeholder": "Rechercher des outils..."
+        }
+      },
+      "page": {
+        "ariaLabel": "Page de l'éditeur d'agents"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "Ajoutez des instructions pour adapter les réponses de cet agent.",
+          "placeholder": "Réfléchissez étape par étape et montrez le raisonnement pour les problèmes complexes. Utilisez des exemples précis. Mettez l'accent sur les actions à mener et laissez des blancs à compléter par l'humain en cas d'inconnu. Adoptez un ton poli et enthousiaste.",
+          "title": "Instructions"
+        },
+        "starters": {
+          "description": "Exemples de messages aidant les utilisateurs à comprendre ce que cet agent peut faire et comment interagir efficacement avec lui.",
+          "title": "Amorces de conversation"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "Veuillez corriger les erreurs du formulaire avant d'enregistrer.",
+        "noChanges": "Aucune modification n'a été apportée.",
+        "saving": "Enregistrement des modifications...",
+        "uploading": "Veuillez attendre la fin du téléversement des fichiers."
+      },
+      "share": {
+        "feature": {
+          "description": "Affichez cet agent en haut de la liste d'exploration des agents et épinglez-le automatiquement dans la barre latérale pour les nouveaux utilisateurs y ayant accès.",
+          "privateNotice": {
+            "title": "Cet agent vous est privé et ne sera mis en avant que pour vous."
+          },
+          "title": "Mettre cet agent à la une",
+          "unlistedWarning": {
+            "title": "Cet agent est masqué et n'apparaîtra pas dans la liste à la une."
+          }
+        },
+        "labels": {
+          "description": "Ajoutez des étiquettes et des catégories pour aider les gens à mieux découvrir cet agent.",
+          "placeholder": "Ajouter des étiquettes..."
+        },
+        "share": {
+          "button": {
+            "label": "Partager"
+          },
+          "description": "avec d'autres utilisateurs, des groupes ou tous les membres de votre organisation.",
+          "title": "Partager cet agent"
+        },
+        "title": "Partager l'agent"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "Établis la liste de nos objectifs d'ingénierie pour ce trimestre.",
+          "overview": "Donne-moi un aperçu de quelques documents.",
+          "salesReport": "Trouve le dernier rapport de ventes.",
+          "todayGoals": "Résume mes objectifs du jour."
+        },
+        "placeholder": "Saisissez une amorce de conversation..."
+      },
+      "suffix": {
+        "optional": "facultatif"
+      },
+      "toasts": {
+        "createFailed": "Échec de la création de l'agent - {detail}",
+        "created": "Agent « {name} » créé avec succès",
+        "deleteFailed": "Échec de la suppression de l'agent : {error}",
+        "deleted": "Agent supprimé avec succès",
+        "genericError": "Une erreur s'est produite : {error}",
+        "noResponse": "aucune réponse reçue",
+        "sharingFailed": "Agent créé, mais le partage a échoué : {error}",
+        "toggleListedFailed": "Échec du changement de visibilité",
+        "unknownDetail": "erreur inconnue",
+        "unknownError": "Erreur inconnue",
+        "updateFailed": "Échec de la mise à jour de l'agent - {detail}",
+        "updated": "Agent « {name} » mis à jour avec succès"
+      },
+      "validation": {
+        "cutoffInFuture": "La date limite des connaissances doit être aujourd'hui ou antérieure.",
+        "descriptionMax": "La description doit comporter au plus {max} caractères",
+        "nameRequired": "Le nom de l'agent est requis.",
+        "starterMax": "L'amorce de conversation doit comporter au plus {max} caractères"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "Republier l'agent"
+          },
+          "description": "Les agents republiés apparaissent à nouveau dans la liste d'exploration des agents.",
+          "title": "Republier cet agent"
+        },
+        "unlist": {
+          "button": {
+            "label": "Masquer l'agent"
+          },
+          "description": "Les agents masqués n'apparaissent pas dans la liste d'exploration des agents mais restent accessibles.",
+          "title": "Masquer cet agent"
+        }
+      },
+      "warnings": {
+        "openUrl": "La recherche Web sans la possibilité d'ouvrir des URL peut donner des résultats Web nettement moins bons."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6838,6 +8444,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {Agent} other {Agents}}"
+      },
+      "empty": {
+        "description": "Aucun agent trouvé"
+      },
+      "header": {
+        "description": "Personnalisez le comportement et les connaissances de l'IA pour vos cas d'usage et ceux de votre équipe.",
+        "title": "Agents"
+      },
+      "newAgent": {
+        "label": "Nouvel agent",
+        "noPermission": {
+          "tooltip": "Vous n'avez pas l'autorisation de créer des agents. Contactez votre administrateur pour demander l'accès."
+        }
+      },
+      "page": {
+        "ariaLabel": "Page des agents"
+      },
+      "search": {
+        "placeholder": "Rechercher des agents..."
+      },
+      "sections": {
+        "all": {
+          "title": "Tous les agents"
+        },
+        "featured": {
+          "description": "Sélectionnés par votre équipe",
+          "title": "Agents à la une"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "Tous les agents"
+        },
+        "your": {
+          "label": "Vos agents"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "Insérer une variable utilisateur"
@@ -6845,6 +8492,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "Veuillez patienter pendant que nous configurons votre session anonyme.",
+        "title": "Redirection vers la page de chat..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "Créer une nouvelle organisation"
@@ -6866,6 +8519,55 @@
       },
       "signInLink": {
         "label": "Se connecter"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "Un compte existe déjà avec l'adresse e-mail indiquée."
+      },
+      "continueAsGuest": {
+        "label": "ou continuer en tant qu'invité"
+      },
+      "email": {
+        "label": "Adresse e-mail",
+        "placeholder": "email@votreentreprise.com"
+      },
+      "forgotPassword": {
+        "link": "[Mot de passe oublié ?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "Adresse e-mail ou mot de passe non valide"
+      },
+      "noPassword": {
+        "error": "Créez un compte pour définir un mot de passe"
+      },
+      "password": {
+        "label": "Mot de passe",
+        "placeholder": "Mot de passe"
+      },
+      "passwordDigit": {
+        "error": "Le mot de passe doit contenir au moins un chiffre"
+      },
+      "passwordLength": {
+        "error": "Le mot de passe doit contenir entre {min} et {max} caractères"
+      },
+      "passwordLoginDisabled": {
+        "error": "La connexion par mot de passe est désactivée. Connectez-vous avec votre fournisseur d'identité."
+      },
+      "passwordLowercase": {
+        "error": "Le mot de passe doit contenir au moins une lettre minuscule"
+      },
+      "passwordRequirements": {
+        "label": "Exigences du mot de passe :"
+      },
+      "passwordSpecialChar": {
+        "error": "Le mot de passe doit contenir au moins un caractère spécial"
+      },
+      "passwordUppercase": {
+        "error": "Le mot de passe doit contenir au moins une lettre majuscule"
+      },
+      "tooManyRequests": {
+        "error": "Trop de requêtes. Veuillez réessayer plus tard."
       }
     },
     "error": {
@@ -6906,6 +8608,31 @@
         "description": "Perturbation temporaire du système d'authentification"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "Votre équipe n'a pas activé l'accès anonyme."
+      },
+      "generic": {
+        "toast": "Une erreur est survenue."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "Créer un compte"
+      },
+      "logo": {
+        "alt": "Logo"
+      },
+      "signInLink": {
+        "label": "Se connecter"
+      },
+      "signinPrompt": {
+        "text": "Vous avez déjà un compte ?"
+      },
+      "signupPrompt": {
+        "text": "Nouveau sur {appName} ?"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[Retour à la connexion](/auth/login)"
@@ -6938,7 +8665,8 @@
         "placeholder": "Saisissez la clé d'API"
       },
       "emailField": {
-        "label": "E-mail"
+        "label": "E-mail",
+        "placeholder": "email@votreentreprise.com"
       },
       "genericError": {
         "toast": "Impossible d'emprunter l'identité de l'utilisateur"
@@ -6999,6 +8727,23 @@
         "label": "E-mail professionnel"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "Contient un chiffre."
+      },
+      "length": {
+        "label": "{min}–{max} caractères"
+      },
+      "lowercase": {
+        "label": "Contient une lettre minuscule."
+      },
+      "specialChar": {
+        "label": "Contient un caractère spécial."
+      },
+      "uppercase": {
+        "label": "Contient une lettre majuscule."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[Retour à la connexion](/auth/login)"
@@ -7040,6 +8785,31 @@
       },
       "unexpectedError": {
         "toast": "Une erreur inattendue est survenue. Veuillez réessayer."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "Votre session a expiré. Veuillez vous reconnecter pour continuer."
+      },
+      "loginButton": {
+        "label": "Se connecter"
+      },
+      "modal": {
+        "title": "Vous avez été déconnecté"
+      },
+      "terminated": {
+        "message": "Cette session a été déconnectée. Veuillez vous reconnecter pour continuer."
+      },
+      "unrecognized": {
+        "message": "Vous avez été déconnecté de manière inattendue. Veuillez vous reconnecter pour continuer. Si cela se reproduit, contactez votre administrateur."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute n'a renvoyé aucun jeton"
+      },
+      "google": {
+        "label": "Continuer avec Google"
       }
     },
     "signup": {
@@ -8471,6 +10241,75 @@
         "tooltip": "La modification de ce paramètre n'est pas prise en charge pour ce modèle."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {Le fichier a échoué et a été supprimé : {names}} other {Les fichiers ont échoué et ont été supprimés : {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "Se connecter"
+          },
+          "title": "Bienvenue sur Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "Aucun message envoyé précédemment n'a été trouvé."
+        },
+        "settingsButton": {
+          "tooltip": "Ouvrir les paramètres"
+        },
+        "setupLlmButton": {
+          "label": "Configurez un LLM."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "Annuler"
+          },
+          "confirmButton": {
+            "label": "Désactiver"
+          },
+          "description": "Vous verrez la page de nouvel onglet par défaut de votre navigateur. Vous pouvez la réactiver à tout moment dans les paramètres d'Onyx.",
+          "title": "Désactiver Onyx comme page de nouvel onglet ?"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "Aucun"
+        },
+        "backgroundOption": {
+          "ariaLabel": "Arrière-plan {label}"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "Arrière-plan {label} (sélectionné)"
+        },
+        "backgroundSection": {
+          "title": "Arrière-plan"
+        },
+        "closeButton": {
+          "tooltip": "Fermer les paramètres"
+        },
+        "generalSection": {
+          "title": "Général"
+        },
+        "header": {
+          "title": "Paramètres"
+        },
+        "newTabToggle": {
+          "label": "Utiliser Onyx comme page de nouvel onglet"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {Passer au thème clair} other {Passer au thème sombre}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "Nouveau chat"
+        },
+        "openInOnyxButton": {
+          "tooltip": "Ouvrir dans Onyx"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "Case de consentement"
@@ -8486,6 +10325,128 @@
       },
       "startButton": {
         "label": "Commencer"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "Dernier message {time}"
+        },
+        "projectFallback": {
+          "label": "Projet"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "Ajouter des fichiers"
+        },
+        "contextExceeded": {
+          "message": "Ce projet dépasse les limites de contexte du modèle. Les sessions rechercheront automatiquement les fichiers pertinents avant de générer une réponse."
+        },
+        "dropFiles": {
+          "message": "Déposez des fichiers ici pour les ajouter à ce projet"
+        },
+        "emptyFiles": {
+          "message": "Ajoutez des documents, des textes ou des images à utiliser dans le projet. Le glisser-déposer est pris en charge."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# fichier} other {# fichiers}}"
+        },
+        "fileCountOverflow": {
+          "description": "Plus de 100 fichiers"
+        },
+        "files": {
+          "description": "Les conversations de ce projet peuvent accéder à ces fichiers.",
+          "title": "Fichiers"
+        },
+        "filesModal": {
+          "description": "Les sessions de ce projet peuvent accéder aux fichiers ici.",
+          "title": "Fichiers du projet"
+        },
+        "instructions": {
+          "emptyDescription": "Ajoutez des instructions pour adapter les réponses dans ce projet.",
+          "title": "Instructions"
+        },
+        "loadingProject": {
+          "label": "Chargement du projet..."
+        },
+        "setInstructionsButton": {
+          "label": "Définir les instructions"
+        },
+        "viewAll": {
+          "label": "Tout voir"
+        },
+        "viewFiles": {
+          "label": "Voir les fichiers"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "Annuler"
+        },
+        "createError": {
+          "toast": "Échec de la création du projet {name}"
+        },
+        "description": "Utilisez les projets pour organiser vos fichiers et conversations en un seul endroit, et ajoutez des instructions personnalisées pour le travail en cours.",
+        "name": {
+          "label": "Nom du projet",
+          "placeholder": "Sur quoi travaillez-vous ?"
+        },
+        "nameRequired": {
+          "error": "Le nom du projet est requis"
+        },
+        "submitButton": {
+          "label": "Créer le projet"
+        },
+        "title": "Créer un nouveau projet"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "Aucun projet trouvé"
+        },
+        "search": {
+          "placeholder": "Rechercher des projets..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "Réduire le projet"
+        },
+        "delete": {
+          "label": "Supprimer le projet"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "Supprimer"
+          },
+          "message": "Voulez-vous vraiment supprimer ce projet ? Cette action est irréversible.",
+          "title": "Supprimer le projet"
+        },
+        "expand": {
+          "ariaLabel": "Développer le projet"
+        },
+        "rename": {
+          "label": "Renommer le projet"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "Aucune conversation pour le moment."
+        },
+        "recentChats": {
+          "title": "Conversations récentes"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "Échec du téléversement des fichiers"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {# fichier trop volumineux ignoré} other {# fichiers trop volumineux ignorés}} (>{max} Mo) : {names}"
+        },
+        "rejected": {
+          "toast": "Certains fichiers n'ont pas été téléversés. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8518,6 +10479,1773 @@
       },
       "incognito": {
         "title": "Vous êtes en navigation privée"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "Ouvrir la barre latérale"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "Mettre à jour les informations de facturation"
+        },
+        "text": "**Attention :** votre période d'essai se termine dans moins de 5 jours et aucun moyen de paiement n'a été ajouté."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "Avatar de l'agent"
+      },
+      "logo": {
+        "alt": "Logo"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "Document"
+      },
+      "expandButton": {
+        "ariaLabel": "Agrandir le document"
+      }
+    },
+    "backButton": {
+      "label": "Retour"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "Nuages"
+      },
+      "hills": {
+        "label": "Collines"
+      },
+      "mountains": {
+        "label": "Montagnes"
+      },
+      "night": {
+        "label": "Nuit"
+      },
+      "none": {
+        "label": "Aucun"
+      },
+      "plant": {
+        "label": "Plantes"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "Aa"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} « {value} »",
+        "defaultPrefix": "Créer"
+      },
+      "dropdown": {
+        "closeAriaLabel": "Fermer la liste déroulante",
+        "openAriaLabel": "Ouvrir la liste déroulante"
+      },
+      "options": {
+        "empty": "Aucune option trouvée"
+      },
+      "separator": {
+        "label": "Autres options"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "Fermer le menu"
+      },
+      "dialog": {
+        "title": "Menu de commandes"
+      },
+      "options": {
+        "ariaLabel": "Options du menu de commandes"
+      },
+      "search": {
+        "placeholder": "Rechercher..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "Tous les connecteurs disponibles ont été sélectionnés. Retirez des connecteurs ci-dessous pour en ajouter d'autres.",
+        "placeholder": "Tous les connecteurs sélectionnés"
+      },
+      "documentSetHint": {
+        "description": "Tous les documents indexés par les connecteurs sélectionnés feront partie de cet ensemble de documents."
+      },
+      "noMatches": {
+        "text": "Aucun connecteur correspondant trouvé"
+      },
+      "noMoreConnectors": {
+        "text": "Aucun autre connecteur disponible"
+      },
+      "noPrivateConnectors": {
+        "text": "Aucun connecteur privé disponible. Créez d'abord un connecteur privé."
+      },
+      "noneSelected": {
+        "text": "Aucun connecteur sélectionné. Recherchez et sélectionnez des connecteurs ci-dessus."
+      },
+      "removeConnector": {
+        "tooltip": "Retirer le connecteur"
+      },
+      "search": {
+        "placeholder": "Rechercher des connecteurs..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "Sélectionner une date"
+      },
+      "todayButton": {
+        "label": "Aujourd'hui"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "N'importe quand..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "Choisir une plage personnalisée"
+      },
+      "clearButton": {
+        "ariaLabel": "Effacer"
+      },
+      "custom": {
+        "label": "Personnalisé"
+      },
+      "customRange": {
+        "ariaLabel": "Plage personnalisée : {from} à {to}"
+      },
+      "date": {
+        "label": "Date"
+      },
+      "group": {
+        "ariaLabel": "Plage de dates"
+      },
+      "preset": {
+        "oneDay": "1J",
+        "oneMonth": "1M",
+        "sevenDays": "7J",
+        "threeMonths": "3M"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "Supprimer"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# document de contexte} other {# documents de contexte}}"
+      },
+      "openDocument": {
+        "ariaLabel": "Ouvrir le document : {title}"
+      },
+      "question": {
+        "title": "Question"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# sous-requête} other {# sous-requêtes}}"
+      },
+      "updated": {
+        "text": "Mis à jour le {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "Par défaut"
+      },
+      "selectOption": {
+        "placeholder": "Sélectionnez une option..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "Modifier"
+      },
+      "rename": {
+        "ariaLabel": "Renommer"
+      },
+      "save": {
+        "ariaLabel": "Enregistrer"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "Si vous êtes l'administrateur, rendez-vous sur la page <billingLink>Facturation admin</billingLink> pour {hadLicense, select, true {renouveler} other {activer}} votre licence, inscrivez-vous via Stripe ou contactez <supportLink>support@onyx.app</supportLink> pour toute question de facturation."
+        },
+        "heading": {
+          "title": "Accès restreint"
+        },
+        "licenseLapse": {
+          "description": "Votre accès à Onyx a été temporairement suspendu en raison d'une interruption de votre licence."
+        },
+        "licenseRequired": {
+          "description": "Une licence est requise pour utiliser Onyx. Vos données sont protégées et seront disponibles dès qu'une licence sera activée."
+        },
+        "logoutButton": {
+          "label": "Se déconnecter"
+        },
+        "manageSubscription": {
+          "description": "Si vous êtes administrateur, vous pouvez gérer votre abonnement en cliquant sur le bouton ci-dessous. Les autres utilisateurs doivent contacter leur administrateur pour régler ce problème."
+        },
+        "obtainLicense": {
+          "description": "Pour commencer, veuillez contacter votre administrateur système afin d'obtenir une licence."
+        },
+        "renewLicense": {
+          "description": "Pour rétablir votre accès et continuer à utiliser Onyx, veuillez contacter votre administrateur système afin de renouveler votre licence."
+        },
+        "resubscribeButton": {
+          "label": "Se réabonner",
+          "loading": "Chargement..."
+        },
+        "resubscribeError": {
+          "text": "Erreur lors de l'ouverture de la page de réabonnement. Veuillez réessayer plus tard."
+        },
+        "seatLimit": {
+          "description": "Votre organisation a dépassé le nombre de sièges sous licence. L'accès est restreint jusqu'à ce que le nombre d'utilisateurs soit réduit ou que votre licence soit mise à niveau."
+        },
+        "seatLimitAdminHint": {
+          "text": "Si vous êtes administrateur, vous pouvez gérer les utilisateurs sur la page <userLink>Gestion des utilisateurs</userLink> ou mettre à niveau votre licence sur la page <billingLink>Facturation admin</billingLink>."
+        },
+        "seatLimitWithCounts": {
+          "description": "Votre organisation a dépassé le nombre de sièges sous licence ({used} utilisateurs / {seats} sièges). L'accès est restreint jusqu'à ce que le nombre d'utilisateurs soit réduit ou que votre licence soit mise à niveau."
+        },
+        "subscriptionLapse": {
+          "description": "Votre accès à Onyx a été temporairement suspendu en raison d'une interruption de votre abonnement."
+        },
+        "updatePayment": {
+          "description": "Pour rétablir votre accès et continuer à profiter des fonctionnalités puissantes d'Onyx, veuillez mettre à jour vos informations de paiement."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "Si vous êtes administrateur, consultez notre <docsLink>documentation</docsLink> pour connaître les étapes de configuration. Si vous êtes utilisateur, contactez votre administrateur pour obtenir de l'aide."
+        },
+        "heading": {
+          "description": "Un problème est survenu lors du chargement de vos paramètres Onyx. Cela peut être dû à un problème de configuration ou à une installation incomplète.",
+          "title": "Nous avons rencontré un problème"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "Nous nous excusons pour la gêne occasionnée et vous remercions de votre patience."
+        },
+        "checkBack": {
+          "description": "Onyx est actuellement en maintenance. Veuillez réessayer dans quelques minutes."
+        },
+        "heading": {
+          "title": "Maintenance en cours"
+        }
+      },
+      "needHelp": {
+        "text": "Besoin d'aide ? Rejoignez notre <discordLink>communauté Discord</discordLink> pour obtenir de l'assistance."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "Erreur inconnue"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "Télécharger le fichier"
+      },
+      "file": {
+        "untitledFallback": "Sans titre"
+      },
+      "fullScreenButton": {
+        "tooltip": "Plein écran"
+      },
+      "hideButton": {
+        "tooltip": "Masquer"
+      },
+      "minimizeButton": {
+        "tooltip": "Réduire"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "Copier"
+      },
+      "downloadButton": {
+        "tooltip": "Télécharger"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {# ligne} other {# lignes}}"
+      },
+      "size": {
+        "bytes": "{count} octets",
+        "kilobytes": "{size} Ko"
+      },
+      "viewFullButton": {
+        "tooltip": "Voir le texte intégral"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "Tous les connecteurs fédérés sélectionnés"
+      },
+      "entitiesConfigured": {
+        "tooltip": "Entités configurées"
+      },
+      "noMatches": {
+        "text": "Aucun connecteur fédéré correspondant trouvé"
+      },
+      "noMoreConnectors": {
+        "text": "Aucun autre connecteur fédéré disponible"
+      },
+      "noneSelected": {
+        "text": "Aucun connecteur fédéré sélectionné. Recherchez et sélectionnez des connecteurs ci-dessus."
+      },
+      "realtimeSearchHint": {
+        "description": "Les documents des connecteurs fédérés sélectionnés seront recherchés en temps réel lors des requêtes."
+      },
+      "removeConnector": {
+        "tooltip": "Retirer le connecteur"
+      },
+      "search": {
+        "placeholder": "Rechercher des connecteurs fédérés..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "Ajouter"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (facultatif)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "Aucune définition de type de fichier trouvée pour le champ : {name}",
+        "selectionError": "Erreur de sélection du fichier",
+        "unknownError": "Erreur inconnue",
+        "validating": "Validation du fichier...",
+        "validationError": "Erreur de validation"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "Saisissez votre markdown ici...",
+        "previewTab": "Aperçu",
+        "writeTab": "Écrire"
+      },
+      "optionalIndicator": {
+        "text": "(facultatif)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "Masquer le mot de passe",
+        "showAriaLabel": "Afficher le mot de passe"
+      },
+      "selector": {
+        "noneOption": "Aucun",
+        "placeholder": "Sélectionner..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "Tous les fichiers récents"
+      },
+      "recentFiles": {
+        "title": "Fichiers récents"
+      },
+      "recentFilesModal": {
+        "description": "Téléversez des fichiers ou choisissez parmi vos fichiers récents."
+      },
+      "toasts": {
+        "associatedAssistants": "Impossible de supprimer le fichier. Il est associé aux assistants : {assistants}",
+        "associatedBoth": "Impossible de supprimer le fichier. Il est associé aux projets : {projects} et aux assistants : {assistants}",
+        "associatedProjects": "Impossible de supprimer le fichier. Il est associé aux projets : {projects}",
+        "deleteFailed": "Échec de la suppression du fichier. Veuillez réessayer.",
+        "deleteSuccess": "Fichier supprimé avec succès"
+      },
+      "uploadFiles": {
+        "description": "Téléversez un fichier depuis votre appareil",
+        "title": "Téléverser des fichiers"
+      },
+      "viewFileButton": {
+        "tooltip": "Voir le fichier"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "fichier"
+      },
+      "open": {
+        "ariaLabel": "Ouvrir {title}"
+      },
+      "removeButton": {
+        "label": "Supprimer"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "Effacer"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(Facultatif)"
+      },
+      "required": {
+        "label": "(Obligatoire)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "Impossible de charger {label}. Veuillez réessayer."
+      },
+      "search": {
+        "placeholder": "Rechercher..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "Aucun groupe d'utilisateurs disponible. Veuillez d'abord créer un groupe d'utilisateurs."
+      },
+      "userGroups": {
+        "label": "Groupes d'utilisateurs",
+        "subtext": "Sélectionnez les groupes d'utilisateurs pouvant accéder à cette ressource"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "Logo"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "Initialisation de {appName}"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "Supprimer"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "Joindre un fichier"
+      },
+      "clearButton": {
+        "ariaLabel": "Effacer le fichier"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "Fichier refusé"
+      },
+      "editButton": {
+        "ariaLabel": "Modifier l'image"
+      },
+      "editOverlay": {
+        "label": "Modifier"
+      },
+      "image": {
+        "altFallback": "Image"
+      },
+      "removeButton": {
+        "ariaLabel": "Supprimer l'image"
+      },
+      "uploadButton": {
+        "ariaLabel": "Téléverser une image"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "Sélectionnez une option"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "Attribuer l'accès des groupes à ce {objectName}",
+        "scopedSubtext": "Sélectionnez un ou plusieurs des groupes que vous gérez pour donner accès à ce {objectName}",
+        "visibleSubtext": "Ce {objectName} sera visible/accessible par les groupes sélectionnés ci-dessous"
+      },
+      "loading": {
+        "text": "Chargement..."
+      },
+      "makePublic": {
+        "label": "Rendre ce {objectName} public ?",
+        "subtext": "Si activé, ce {objectName} sera utilisable par <b>tous les {publicToWhom}</b>. Sinon, seuls les <b>administrateurs</b> et les <b>{publicToWhom}</b> ayant reçu un accès explicite à ce {objectName} (par ex. via un groupe d'utilisateurs) y auront accès."
+      },
+      "publicDisabled": {
+        "message": "Ce {objectName} est public et accessible à tous les utilisateurs."
+      },
+      "usersFallback": {
+        "text": "Utilisateurs"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "Ajouter une paire {keyTitle} et {valueTitle}",
+        "label": "Ajouter une ligne"
+      },
+      "empty": {
+        "title": "Aucun élément ajouté pour le moment."
+      },
+      "error": {
+        "duplicateKey": "Clé en double",
+        "duplicateSummary": "{count, plural, one {# clé en double trouvée} other {# clés en double trouvées}}",
+        "emptyKey": "La clé ne peut pas être vide",
+        "emptySummary": "{count, plural, one {# clé vide trouvée} other {# clés vides trouvées}}",
+        "validationSummary": "{count, plural, one {# erreur de validation trouvée} other {# erreurs de validation trouvées}}"
+      },
+      "group": {
+        "ariaLabel": "Paires {keyTitle} et {valueTitle}"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "Clé"
+      },
+      "pair": {
+        "fallbackLabel": "clé-valeur"
+      },
+      "removeButton": {
+        "ariaLabel": "Supprimer la paire {label} {index}"
+      },
+      "valueColumn": {
+        "title": "Valeur"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "Logo"
+      },
+      "poweredBy": {
+        "label": "Propulsé par Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "Connecteurs indisponibles :"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "L'autorisation a été annulée ou a échoué. Veuillez réessayer.",
+        "title": "Échec de l'autorisation"
+      },
+      "backButton": {
+        "label": "Retour au chat"
+      },
+      "completeFailed": {
+        "message": "Impossible de finaliser l'autorisation"
+      },
+      "genericError": {
+        "description": "Une erreur est survenue pendant le processus OAuth. Veuillez réessayer.",
+        "title": "Une erreur est survenue"
+      },
+      "invalidRequest": {
+        "description": "La demande d'autorisation était incomplète. Veuillez réessayer.",
+        "title": "Requête non valide"
+      },
+      "loadingHint": {
+        "text": "Cela peut prendre quelques instants..."
+      },
+      "processing": {
+        "description": "Veuillez patienter pendant que nous terminons la configuration.",
+        "title": "Traitement..."
+      },
+      "redirecting": {
+        "text": "Redirection dans {count, plural, one {# seconde} other {# secondes}}..."
+      },
+      "serviceFallback": {
+        "text": "service"
+      },
+      "success": {
+        "detailsTemplate": "L'autorisation de {serviceName} a été effectuée avec succès.",
+        "title": "Réussi !"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "La feuille de calcul est peut-être endommagée ou n'a pas pu être chargée correctement.",
+        "title": "Erreur lors du chargement de la feuille de calcul"
+      },
+      "preview": {
+        "truncated": "Aperçu tronqué. Téléchargez le fichier pour voir toutes les lignes.",
+        "unavailable": "Impossible d'afficher l'aperçu de cette feuille de calcul."
+      },
+      "sheet": {
+        "defaultName": "Feuille 1",
+        "empty": "Cette feuille est vide.",
+        "tooLarge": "Cette feuille est trop volumineuse pour l'aperçu. Téléchargez le fichier pour la consulter."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "Agent principal"
+      },
+      "subagentFallback": {
+        "label": "sous-agent"
+      },
+      "switch": {
+        "ariaLabel": "Changer d'agent"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "Approuver cette action une fois",
+        "button": "Approuver une fois"
+      },
+      "approveSession": {
+        "button": "Approuver pour la session",
+        "tooltip": "Approuver les actions correspondantes pour cette session"
+      },
+      "details": {
+        "hideAriaLabel": "Masquer les détails",
+        "showAriaLabel": "Afficher les détails"
+      },
+      "header": {
+        "required": "Approbation requise : {headline}"
+      },
+      "headline": {
+        "multiAction": "{count, plural, one {# action} other {# actions}} dans {app}",
+        "singleAction": "{action} dans {app}"
+      },
+      "payload": {
+        "empty": {
+          "label": "Aucune donnée."
+        },
+        "showLess": {
+          "button": "Afficher moins"
+        },
+        "showMore": {
+          "button": "Afficher plus"
+        }
+      },
+      "reject": {
+        "ariaLabel": "Rejeter cette action",
+        "button": "Rejeter"
+      },
+      "status": {
+        "approved": "Approuvé",
+        "rejected": "Rejeté"
+      },
+      "submit": {
+        "errorFallback": "Échec de l'envoi de la décision"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "Ajouter",
+        "createButton": "Créer",
+        "customApp": {
+          "description": "Identifiants et accès réseau pour votre propre intégration.",
+          "title": "App personnalisée"
+        },
+        "mcpHint": {
+          "label": "Besoin d'un serveur MCP à la place ? Connectez-le dans Actions, puis activez-le pour Craft ici.",
+          "openActionsButton": "Ouvrir Actions"
+        },
+        "modal": {
+          "description": "Rendez une intégration disponible pour toute votre organisation. Les fournisseurs intégrés incluent des actions qui apprennent à l'agent Craft à les utiliser ; les fournisseurs déjà configurés ne sont pas listés.",
+          "title": "Ajouter une app"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "Associer {name}",
+        "associateButton": "Associer une existante",
+        "create": {
+          "github": {
+            "description": "Si vos compétences sont sur GitHub, importez-les d'abord sur la page Compétences, puis associez-les à cette app.",
+            "label": "Importer depuis GitHub"
+          },
+          "scratch": {
+            "description": "Rédigez des instructions et ajoutez des fichiers annexes.",
+            "label": "Partir de zéro"
+          },
+          "upload": {
+            "description": "Importez un fichier SKILL.md, un fichier ZIP ou un dossier de compétence.",
+            "label": "Importer une compétence"
+          }
+        },
+        "createSkillButton": "Créer une compétence",
+        "description": "Les compétences donnent à Craft des instructions pour utiliser cette app. Elles s'appliquent à toute l'organisation ; les utilisateurs peuvent devoir toutes les activer pour que l'app fonctionne correctement.",
+        "editButton": "Modifier",
+        "empty": {
+          "label": "Aucune compétence modifiable trouvée."
+        },
+        "invalidTag": "Non valide",
+        "loading": {
+          "label": "Chargement des compétences…"
+        },
+        "noneAssociated": {
+          "label": "Aucune compétence associée pour le moment. Cette app peut quand même être enregistrée et utilisée sans."
+        },
+        "promote": {
+          "cancelButton": "Annuler",
+          "confirmButton": "Rendre disponible pour l'organisation",
+          "description": "Les compétences associées à une app doivent être disponibles pour tous. Ce changement est appliqué lorsque vous enregistrez l'app.",
+          "title": "Rendre « {name} » disponible pour toute l'organisation ?"
+        },
+        "search": {
+          "placeholder": "Rechercher des compétences modifiables..."
+        },
+        "title": "Compétences associées",
+        "unavailable": {
+          "duplicateName": "Une compétence nommée « {name} » est déjà associée.",
+          "invalid": "Compétence non valide : corrigez-la avant de l'associer.",
+          "otherApp": "Déjà associée à l'app « {name} »."
+        },
+        "unlink": {
+          "button": "Dissocier",
+          "cancelButton": "Annuler",
+          "confirm": "Dissocier « {name} » de cette app ?"
+        },
+        "unlinkAriaLabel": "Dissocier {name}",
+        "viewButton": "Afficher"
+      },
+      "configureProvider": {
+        "addButton": "Ajouter",
+        "addTitle": "Ajouter {name}",
+        "editTitle": "Modifier {name}",
+        "emptyPolicies": "Ce fournisseur n'a aucune action à configurer.",
+        "fields": {
+          "name": {
+            "description": "Un libellé pour cette connexion. Utilisez un nom distinct lorsque vous ajoutez plusieurs instances du même fournisseur (p. ex. « {name} — Ingénierie »).",
+            "label": "Nom"
+          }
+        },
+        "managedDescription": "Fourni par Onyx : configurez ce que l'agent peut faire.",
+        "managedNote": "Cette app est fournie par Onyx : les identifiants sont gérés pour vous. Choisissez ci-dessous ce que l'agent peut faire. Les utilisateurs la connectent depuis la page Apps.",
+        "saveButton": "Enregistrer"
+      },
+      "customApp": {
+        "cancelButton": "Annuler",
+        "createButton": "Créer",
+        "createDescription": "Configurez comment le proxy de sortie atteint et authentifie cette app. Une compétence n'est pas requise.",
+        "createTitle": "Créer une app personnalisée",
+        "creatingButton": "Création…",
+        "disabled": {
+          "nameMissing": "Saisissez un nom avant de créer cette app personnalisée.",
+          "patternMissing": "Ajoutez au moins un motif d'URL en amont. Saisissez un motif et appuyez sur Entrée.",
+          "pristine": "Effectuez une modification avant d'enregistrer.",
+          "saving": "Un enregistrement est déjà en cours."
+        },
+        "editDescription": "Mettez à jour les paramètres de la passerelle et gérez les compétences associées.",
+        "editTitle": "Modifier {name}",
+        "errors": {
+          "saveFailedTitle": "Impossible d'enregistrer"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "Ajouter un en-tête",
+            "description": "Facultatif : en-têtes injectés dans les requêtes sortantes. Utilisez '{placeholder}' pour les valeurs fournies par l'utilisateur (ou l'organisation ci-dessous), p. ex. « Bearer '{api_key}' ». Laissez vide pour autoriser les motifs en amont sans injecter d'identifiants.",
+            "keyTitle": "En-tête",
+            "label": "Motif d'identifiants d'en-tête",
+            "valueTitle": "Valeur"
+          },
+          "name": {
+            "label": "Nom",
+            "placeholder": "Mon app personnalisée"
+          },
+          "orgCredentials": {
+            "addButton": "Ajouter un identifiant",
+            "description": "Facultatif : valeurs que votre organisation préremplit pour chaque utilisateur. Laissez vide pour les apps où chaque utilisateur fournit ses propres identifiants.",
+            "keyTitle": "Clé d'identifiant",
+            "label": "Identifiants de l'organisation",
+            "valueTitle": "Valeur"
+          },
+          "upstreamPatterns": {
+            "description": "URL sortantes dans lesquelles le proxy peut injecter des identifiants. Utilisez * pour correspondre à n'importe quels caractères (p. ex. https://api.example.com/* couvre tous les chemins de cet hôte). L'hôte doit être littéral, sans joker avant la première barre oblique. Saisissez un motif et appuyez sur Entrée.",
+            "label": "Motifs d'URL en amont"
+          }
+        },
+        "saveButton": "Enregistrer",
+        "savingButton": "Enregistrement…"
+      },
+      "errors": {
+        "duplicateSkillName": "L'app « {appName} » a déjà une compétence associée nommée « {skillName} ». Importez une compétence avec un autre nom."
+      },
+      "mcpPolicy": {
+        "description": "Configurez ce que l'agent Craft peut faire avec les outils de ce serveur MCP.",
+        "emptyPolicies": "Aucun outil activé sur ce serveur. Activez d'abord les outils sur la page des actions MCP.",
+        "saveButton": "Enregistrer",
+        "title": "Modifier {name}"
+      },
+      "oauthCallback": {
+        "backButton": "Retour à mes apps",
+        "description": "Finalisation de l'échange OAuth…",
+        "errors": {
+          "cancelled": "OAuth a été annulé ou refusé : {reason}",
+          "failed": "Échec de la connexion.",
+          "missingParams": "Code ou state manquant dans l'URL de rappel."
+        },
+        "exchanging": {
+          "label": "Échange du code d'autorisation…"
+        },
+        "success": {
+          "label": "Connecté. Redirection vers vos apps…"
+        },
+        "title": "Connexion de votre app"
+      },
+      "page": {
+        "connectButton": "Connecter",
+        "connectingButton": "Redirection…",
+        "disconnectButton": "Déconnecter",
+        "empty": {
+          "description": "Aucune app ni serveur MCP n'est encore configuré pour votre organisation.",
+          "title": "Rien à connecter pour le moment"
+        },
+        "errors": {
+          "disconnectFailed": "Échec de la déconnexion",
+          "startAuthFailed": "Échec du démarrage de l'autorisation"
+        },
+        "header": {
+          "description": "Connectez les outils qu'Onyx Craft peut utiliser comme contexte pendant son travail.",
+          "manageButton": "Gérer les apps",
+          "searchPlaceholder": "Rechercher des apps...",
+          "title": "Apps"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Intégrations prises en charge directement par Onyx. Chacune inclut des compétences qui apprennent à Craft à l'utiliser : commencez ici.",
+            "empty": "Aucune app n'est encore configurée pour votre organisation.",
+            "emptyTitle": "Aucune app pour le moment",
+            "tabLabel": "Apps · {count}"
+          },
+          "mcp": {
+            "blurb": "Serveurs qu'un administrateur a rendus disponibles pour Craft. Utilisez-les lorsque l'app dont vous avez besoin n'est pas listée sous Apps, ou lorsque vous voulez précisément les outils MCP propres à un serveur.",
+            "empty": "Aucun serveur MCP n'a été rendu disponible pour Craft.",
+            "emptyTitle": "Aucun serveur MCP pour le moment",
+            "tabLabel": "Serveurs MCP · {count}"
+          }
+        },
+        "loading": {
+          "label": "Chargement…"
+        },
+        "reviewSkillsButton": "Vérifier les compétences",
+        "search": {
+          "noMatchesDescription": "Rien ici ne correspond à votre recherche.",
+          "noMatchesTitle": "Aucun résultat"
+        },
+        "status": {
+          "connected": "Connectée",
+          "connectedNeedsSkills": "Connectée · toutes les compétences associées ne sont pas activées",
+          "notAvailable": "Indisponible pour votre compte : contactez un administrateur",
+          "skillWarningAriaLabel": "Configuration des compétences requise",
+          "skillWarningTooltip": "Toutes les compétences associées ne sont pas activées. Cette app peut ne pas fonctionner correctement."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "Définissez une politique pour chaque action individuellement.",
+          "title": "Avancé"
+        },
+        "cancelButton": "Annuler",
+        "loading": {
+          "label": "Chargement…"
+        },
+        "permissions": {
+          "askOption": "Demander",
+          "autoApproveOption": "Approbation automatique",
+          "customOption": "Personnalisé",
+          "description": "Choisissez ce que l'agent peut faire. « Demander » vous sollicite dans le chat avant chaque action ; « Approbation automatique » l'exécute sans demander. Utilisez Avancé pour définir une politique par action.",
+          "title": "Autorisations"
+        },
+        "savingButton": "Enregistrement…"
+      },
+      "skillsStep": {
+        "description": "Facultatif : associez des compétences existantes ou créez-en une pour cette app.",
+        "errors": {
+          "saveFailedTitle": "Impossible d'enregistrer"
+        },
+        "saveButton": "Enregistrer les compétences",
+        "savingButton": "Enregistrement…",
+        "skipButton": "Ignorer pour l'instant",
+        "title": "Ajouter des compétences à {name}"
+      },
+      "userCredentials": {
+        "cancelButton": "Annuler",
+        "connectButton": "Connecter",
+        "connectingButton": "Connexion…",
+        "description": "Saisissez vos identifiants pour autoriser cette app sur votre compte.",
+        "errors": {
+          "connectFailedTitle": "Connexion impossible"
+        },
+        "title": "Connecter {name}"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "Télécharger"
+      },
+      "empty": {
+        "description": "Les fichiers de sortie et les applications web apparaîtront ici",
+        "title": "Aucun artefact pour l'instant"
+      },
+      "nextjsApp": {
+        "label": "Application Next.js"
+      },
+      "openItem": {
+        "ariaLabel": "Ouvrir {name}"
+      },
+      "toggleItem": {
+        "ariaLabel": "Basculer {name}"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "Poursuivez la conversation...",
+        "scheduledRunPlaceholder": "Exécution planifiée en cours...",
+        "subagentPlaceholder": "Passez à l'agent principal pour envoyer un message"
+      },
+      "openSidebar": {
+        "ariaLabel": "Ouvrir la barre latérale"
+      },
+      "outputPanel": {
+        "closeTooltip": "Fermer le panneau de sortie",
+        "openTooltip": "Ouvrir le panneau de sortie"
+      },
+      "responseStopped": {
+        "label": "Réponse arrêtée"
+      },
+      "scrollToBottom": {
+        "label": "Aller en bas"
+      },
+      "toast": {
+        "operationWait": "Veuillez attendre la fin de l'opération en cours.",
+        "sandboxWait": "Veuillez attendre l'initialisation du bac à sable",
+        "scheduledRunWait": "Veuillez attendre la fin de l'exécution planifiée."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "Contexte compacté pour libérer de l'espace"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "Connectez vos données"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "Fabrication de votre espace de travail...",
+        "enchanting": "Enchantement magique...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "Collecte des ressources...",
+        "miningDependencies": "Minage des dépendances...",
+        "placingBlocks": "Pose des blocs...",
+        "punchingWood": "On frappe du bois...",
+        "smeltingCode": "Fonte du code...",
+        "worldGenerated": "Génération du monde terminée..."
+      },
+      "tagline": {
+        "label": "Fabrication de votre prochaine grande idée..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "Effacer"
+      },
+      "copy": {
+        "doneTooltip": "Copié",
+        "tooltip": "Copier le visible"
+      },
+      "empty": {
+        "noLines": "Aucune ligne pour l'instant.",
+        "noMatch": "Aucune ligne ne correspond à \"{filter}\"",
+        "waiting": "En attente de la première ligne de journal…"
+      },
+      "error": {
+        "endpointDisabled": "Point de terminaison de débogage désactivé (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "Aucun bac à sable en cours d'exécution pour suivre les journaux"
+      },
+      "filter": {
+        "placeholder": "Filtrer…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# ligne} other {# lignes}}",
+        "filteredCount": "{visible, number} / {total, number} lignes"
+      },
+      "modal": {
+        "description": "Suivi en direct du conteneur bac à sable — dev/débogage uniquement.",
+        "title": "Journaux du pod Opencode"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} nouvelles · aller"
+      },
+      "open": {
+        "button": "Journaux du pod"
+      },
+      "status": {
+        "closed": "Fermé",
+        "connecting": "Connexion",
+        "error": "Erreur",
+        "paused": "En pause",
+        "streaming": "Diffusion"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "Ajouter des fichiers ou des photos"
+      },
+      "apps": {
+        "label": "Applications"
+      },
+      "browseSkills": {
+        "label": "Parcourir les compétences"
+      },
+      "connect": {
+        "hint": "Connecter"
+      },
+      "connectApp": {
+        "label": "Connecter une application"
+      },
+      "library": {
+        "label": "Bibliothèque"
+      },
+      "manageLibrary": {
+        "label": "Gérer la bibliothèque…"
+      },
+      "mcpServer": {
+        "description": "Serveur MCP"
+      },
+      "skills": {
+        "label": "Compétences"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "Impossible de prévisualiser le fichier"
+      },
+      "error": {
+        "inline": "Erreur : {message}",
+        "title": "Erreur de chargement du fichier"
+      },
+      "loading": {
+        "label": "Chargement du fichier..."
+      },
+      "noContent": {
+        "label": "Aucun contenu"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "Les fichiers créés pendant la construction apparaîtront ici",
+        "title": "Aucun fichier pour l'instant"
+      },
+      "emptyDirectory": {
+        "label": "Aucun fichier dans ce répertoire"
+      },
+      "error": {
+        "title": "Erreur de chargement des fichiers"
+      },
+      "loading": {
+        "label": "Chargement des fichiers..."
+      },
+      "loadingChildren": {
+        "label": "Chargement..."
+      },
+      "preparing": {
+        "description": "Configuration de votre environnement de développement",
+        "title": "Préparation du bac à sable..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "L'image n'a pas pu être affichée",
+        "title": "Échec du chargement de l'image"
+      },
+      "loading": {
+        "label": "Chargement de l'image..."
+      },
+      "preview": {
+        "ariaLabel": "Aperçu de {name}"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "Connecté",
+        "connectionRequired": "Connexion requise"
+      },
+      "plusMenu": {
+        "tooltip": "Ajouter des fichiers ou des compétences"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "Arrêt en cours…"
+      },
+      "toInterrupt": {
+        "label": "pour interrompre"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BÊTA"
+      },
+      "returnHome": {
+        "button": "Retour à l'accueil"
+      },
+      "startCrafting": {
+        "button": "Commencer à créer"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "Aucun modèle trouvé"
+      },
+      "recommended": {
+        "label": "Recommandé"
+      },
+      "recommendedOnly": {
+        "label": "Modèles recommandés uniquement"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "« Corrige le test de retry instable et ouvre une PR. »",
+          "launchDeck": "« Crée le deck du lancement de printemps à partir du brief sur Drive. »",
+          "rfpSecurity": "« Remplis l'appel d'offres reçu par e-mail avec nos informations de sécurité. »",
+          "slackToLinear": "« Condense notre discussion Slack en tickets Linear. »",
+          "vendorSpend": "« Résume nos dépenses fournisseurs du T2 dans un document sur Drive. »"
+        },
+        "modal": {
+          "backButton": "Retour",
+          "ctaButton": "Mettez Craft au travail",
+          "nextButton": "Suivant",
+          "title": "Découvrez Craft"
+        },
+        "outputs": {
+          "ariaLabel": "Résultat : {name}",
+          "githubPr": {
+            "caption": "Ouvert pour relecture",
+            "label": "PR GitHub"
+          },
+          "googleDoc": {
+            "caption": "Enregistré dans votre Drive",
+            "label": "Google Doc"
+          },
+          "liveApp": {
+            "caption": "Hébergée, partage par lien",
+            "label": "App en ligne"
+          }
+        },
+        "prompt": {
+          "label": "Votre prompt"
+        },
+        "schedule": {
+          "ariaLabel": "Tâche planifiée : relance ce prompt selon un minuteur",
+          "caption": "S'exécute pendant votre absence",
+          "label": "Tous les lundis à 8h00"
+        },
+        "sources": {
+          "connectedAriaLabel": "Source connectée : {name}",
+          "yourFiles": {
+            "ariaLabel": "Vos fichiers importés",
+            "label": "Vos fichiers"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "Cliquez sur n'importe quelle partie de la carte pour la revoir.",
+            "title": "Voilà Craft. À vous de jouer."
+          },
+          "machine": {
+            "caption": "Il lit ce que vous pouvez voir. Jamais vos secrets.",
+            "title": "Il travaille sur sa propre machine."
+          },
+          "output": {
+            "caption": "À la demande, ou selon un calendrier pendant votre absence.",
+            "title": "Le travail ressort terminé."
+          },
+          "prompt": {
+            "caption": "Décrivez le résultat, Craft s'occupe du reste.",
+            "title": "Confiez à Craft un vrai travail."
+          }
+        },
+        "team": {
+          "ariaLabel": "Votre équipe : un seul lien partage le travail de Craft",
+          "caption": "Un lien suffit pour partager",
+          "label": "Votre équipe"
+        },
+        "workspace": {
+          "approvalPill": "En attente de votre approbation",
+          "label": "Espace de travail de Craft",
+          "sandboxBadge": "Sandbox isolé"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "Retour au chat",
+        "description": "Onyx Craft a besoin d'un fournisseur de modèles, et seuls les administrateurs peuvent en configurer un. Demandez à votre administrateur de connecter Anthropic, OpenAI ou OpenRouter.",
+        "title": "Un fournisseur de LLM est requis"
+      },
+      "llmSetup": {
+        "description": "Les agents Craft ont besoin d'un fournisseur de modèles pour construire.",
+        "title": "Connectez un fournisseur de modèles"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "Analyse mes données et crée un tableau de bord..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "Ingénierie",
+          "marketing": "Marketing",
+          "product": "Produit",
+          "sales": "Ventes"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "Commencez à construire quelque chose pour voir des artefacts !"
+      },
+      "devServerStarting": {
+        "tooltip": "Démarrage du serveur de développement..."
+      },
+      "noWebapp": {
+        "label": "Pas encore d'application web dans cette session"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "Le fichier PDF n'a pas pu être chargé.",
+        "title": "Impossible de prévisualiser le PDF"
+      },
+      "frame": {
+        "title": "Aperçu PDF"
+      },
+      "loading": {
+        "label": "Chargement du PDF..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "Conversion de la présentation..."
+      },
+      "empty": {
+        "label": "Aucune diapositive dans cette présentation"
+      },
+      "error": {
+        "title": "Impossible de prévisualiser la présentation"
+      },
+      "loadingSlide": {
+        "label": "Chargement de la diapositive..."
+      },
+      "slide": {
+        "counter": "Diapositive {current} sur {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "Un aperçu en direct apparaîtra ici dès qu'une application web sera en cours d'exécution."
+      },
+      "frame": {
+        "title": "Aperçu de l'application web"
+      },
+      "starting": {
+        "description": "Installation des dépendances et démarrage.",
+        "title": "Démarrage du serveur de développement..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "Redirection..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "Ignorer"
+      },
+      "modal": {
+        "description": "Il s'est endormi après une période d'inactivité. Votre travail est sauvegardé. Réveillez-le pour continuer.",
+        "title": "Votre bac à sable s'est endormi"
+      },
+      "wake": {
+        "button": "Réveiller le bac à sable"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "Planifiée"
+      },
+      "startedAt": {
+        "label": "Démarrée {time}"
+      },
+      "status": {
+        "awaitingApproval": "Cette exécution planifiée attend une approbation. Les messages de suivi seront débloqués après sa reprise et sa fin.",
+        "running": "Cette exécution planifiée est toujours en cours. Les messages de suivi seront débloqués à la fin.",
+        "startedBy": "Cette session a été lancée par la tâche planifiée {task} à {time}."
+      },
+      "viewTask": {
+        "ariaLabel": "Voir la tâche planifiée {task}. {status}",
+        "label": "Voir la tâche"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "Application externe {id}"
+      },
+      "connect": {
+        "title": "Connecter {app}"
+      },
+      "connected": {
+        "title": "{app} connecté."
+      },
+      "error": {
+        "generic": "Une erreur s'est produite. Veuillez réessayer.",
+        "notConfigurable": "Cette application ne peut pas être configurée d'ici.",
+        "popupBlocked": "Impossible d'ouvrir la fenêtre de configuration. Autorisez les fenêtres contextuelles et réessayez.",
+        "startFailed": "Échec du démarrage de la configuration"
+      },
+      "loading": {
+        "button": "Chargement…"
+      },
+      "notNow": {
+        "button": "Pas maintenant"
+      },
+      "reason": {
+        "fallback": "L'agent a besoin de {app} pour poursuivre cette tâche."
+      },
+      "skipped": {
+        "title": "Connexion de {app} ignorée."
+      },
+      "waiting": {
+        "button": "En attente…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "Copier le lien"
+      },
+      "organization": {
+        "description": "Toute personne connectée à votre Onyx peut voir cette application.",
+        "label": "Organisation"
+      },
+      "private": {
+        "description": "Vous seul pouvez voir cette application.",
+        "label": "Privé"
+      },
+      "share": {
+        "label": "Partager"
+      },
+      "shared": {
+        "label": "Partagé"
+      },
+      "trigger": {
+        "ariaLabel": "Partager l'application web"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "Applications"
+      },
+      "backToChat": {
+        "label": "Retour au chat"
+      },
+      "delete": {
+        "label": "Supprimer"
+      },
+      "deleteModal": {
+        "body": "Cela supprime définitivement la session Craft et toutes ses données. Cette action est irréversible.",
+        "confirm": "Supprimer",
+        "deleting": "Suppression...",
+        "title": "Supprimer \"{title}\" ?"
+      },
+      "newSession": {
+        "label": "Commencer à créer"
+      },
+      "rename": {
+        "label": "Renommer"
+      },
+      "scheduledTasks": {
+        "label": "Tâches planifiées"
+      },
+      "sessions": {
+        "empty": "Commencez à construire ! L'historique des sessions apparaîtra ici.",
+        "title": "Sessions"
+      },
+      "skills": {
+        "label": "Compétences"
+      },
+      "toast": {
+        "deleteFailed": "Échec de la suppression de la session",
+        "deleted": "\"{title}\" supprimé."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "Rechargez cette session pour appliquer les dernières compétences et les derniers accès aux applications.",
+        "title": "Les capacités de votre agent ont changé"
+      },
+      "reload": {
+        "button": "Recharger",
+        "inProgress": "Rechargement…"
+      },
+      "toast": {
+        "reloadFailed": "Échec du rechargement de la session"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "Sous-agent introuvable."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "Fermer les suggestions"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "Supprimer",
+          "deletingButton": "Suppression...",
+          "description": "Cela arrête les exécutions futures et supprime la tâche. L'historique des exécutions passées (et les sessions sous-jacentes) sera conservé pour audit.",
+          "title": "Supprimer « {name} » ?"
+        },
+        "deleteButton": "Supprimer",
+        "editButton": "Modifier",
+        "fallbackTitle": "Tâche planifiée",
+        "loadFailed": "Échec du chargement de la tâche planifiée.",
+        "missingTaskId": "Id de tâche manquant.",
+        "pauseButton": "Mettre en pause",
+        "resumeButton": "Reprendre",
+        "runNowButton": "Exécuter maintenant",
+        "toasts": {
+          "deleteFailed": "Échec de la suppression de la tâche",
+          "deleted": "« {name} » supprimée.",
+          "paused": "Tâche mise en pause.",
+          "resumed": "Tâche reprise.",
+          "runQueued": "Exécution de « {name} » mise en file d'attente.",
+          "runStartFailed": "Échec du démarrage de l'exécution",
+          "statusUpdateFailed": "Échec de la mise à jour du statut"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "Modifier la tâche planifiée",
+        "loadFailed": "Échec du chargement de la tâche planifiée.",
+        "missingTaskId": "Id de tâche manquant.",
+        "title": "Modifier « {name} »"
+      },
+      "form": {
+        "cancelButton": "Annuler",
+        "errors": {
+          "nameRequired": "Le nom est requis.",
+          "promptRequired": "Le prompt est requis."
+        },
+        "fields": {
+          "name": {
+            "label": "Nom",
+            "placeholder": "p. ex. Synthèse hebdomadaire des escalades clients"
+          },
+          "preApproval": {
+            "description": "Craft peut utiliser les apps et serveurs MCP sélectionnés sans pause lorsque cette tâche s'exécute sans surveillance. Les autres demandes d'approbation mettent l'exécution en pause et peuvent la faire échouer.",
+            "label": "Apps et serveurs MCP pré-approuvés"
+          },
+          "prompt": {
+            "description": "Ce message est envoyé à Craft à chaque déclenchement de la tâche.",
+            "label": "Prompt",
+            "placeholder": "Décrivez ce que Craft doit faire à chaque exécution..."
+          },
+          "schedule": {
+            "label": "Planification"
+          }
+        },
+        "saveAndRunNowButton": "Enregistrer et exécuter maintenant",
+        "saveButton": "Enregistrer",
+        "saveChangesButton": "Enregistrer les modifications",
+        "savingLabel": "Enregistrement...",
+        "toasts": {
+          "created": "Tâche planifiée créée.",
+          "createdAndQueued": "Tâche planifiée créée et mise en file d'attente.",
+          "saveFailed": "Échec de l'enregistrement de la tâche planifiée",
+          "updated": "Tâche planifiée mise à jour."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "Dernière exécution",
+          "name": "Nom",
+          "nextRun": "Prochaine exécution",
+          "schedule": "Planification",
+          "status": "Statut"
+        },
+        "confirmDelete": {
+          "deleteButton": "Supprimer",
+          "deletingButton": "Suppression...",
+          "description": "Cela arrête les exécutions futures et supprime la tâche. L'historique des exécutions passées (et les sessions sous-jacentes) sera conservé pour audit.",
+          "title": "Supprimer « {name} » ?"
+        },
+        "empty": {
+          "description": "Aucune tâche planifiée n'a encore été créée.",
+          "title": "Aucune tâche planifiée trouvée"
+        },
+        "errors": {
+          "loadFailed": "Échec du chargement des tâches planifiées.",
+          "tryAgainButton": "Réessayer"
+        },
+        "header": {
+          "description": "Exécutez des prompts Craft selon un minuteur. Chaque déclenchement crée une nouvelle session qui s'exécute en arrière-plan.",
+          "title": "Tâches planifiées"
+        },
+        "newTaskButton": "Nouvelle tâche planifiée",
+        "rowActions": {
+          "deleteTooltip": "Supprimer"
+        },
+        "toasts": {
+          "deleteFailed": "Échec de la suppression de la tâche",
+          "deleted": "« {name} » supprimée."
+        }
+      },
+      "newPage": {
+        "description": "Enregistrez un prompt + une planification. Craft l'exécutera selon un minuteur.",
+        "title": "Nouvelle tâche planifiée"
+      },
+      "preApproval": {
+        "appFallbackName": "App nº {id}",
+        "appsGroupTitle": "Apps",
+        "empty": {
+          "label": "Aucune app ni serveur MCP n'est encore disponible dans Craft."
+        },
+        "errors": {
+          "loadFailed": "Impossible de charger les apps et les serveurs MCP. Actualisez pour réessayer.",
+          "partialLoadFailed": "Certaines options de pré-approbation n'ont pas pu être chargées. Actualisez pour réessayer."
+        },
+        "loading": {
+          "label": "Chargement des apps et des serveurs MCP…"
+        },
+        "mcpGroupTitle": "Serveurs MCP",
+        "mcpServerFallbackName": "Serveur MCP nº {id}",
+        "status": {
+          "connected": "Connecté",
+          "connectionRequired": "Connexion requise",
+          "unavailable": "N'est plus disponible"
+        },
+        "summary": {
+          "partialLoadFailed": "Certains détails de pré-approbation n'ont pas pu être chargés. Actualisez pour réessayer.",
+          "title": "Apps et serveurs MCP pré-approuvés"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "Durée",
+          "started": "Début",
+          "status": "Statut",
+          "summary": "Résumé",
+          "trigger": "Déclencheur"
+        },
+        "empty": {
+          "label": "Aucune exécution pour le moment. La tâche en créera une à chaque déclenchement, ou utilisez Exécuter maintenant ci-dessus."
+        },
+        "errors": {
+          "loadFailed": "Échec du chargement de l'historique des exécutions.",
+          "tryAgainButton": "Réessayer"
+        },
+        "loadMore": {
+          "button": "Charger plus",
+          "loadingButton": "Chargement..."
+        },
+        "nonClickable": {
+          "noSession": "Cette exécution n'a pas encore créé de session.",
+          "queued": "Cette exécution n'a pas encore commencé, il n'y a donc pas de session à ouvrir.",
+          "skipped": "Cette exécution a été ignorée car une précédente était encore en cours, aucune session n'a donc été créée."
+        },
+        "status": {
+          "notOpenableAriaLabel": "Impossible à ouvrir"
+        },
+        "trigger": {
+          "runNow": "Exécuter maintenant",
+          "schedule": "Planification"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "À",
+          "daysLabel": "Ces jours-là",
+          "runsEveryDay": "S'exécute tous les jours",
+          "runsOn": "S'exécute le {days}"
+        },
+        "interval": {
+          "everyLabel": "Toutes les"
+        },
+        "intervalUnits": {
+          "days": "jours",
+          "hours": "heures",
+          "minutes": "minutes"
+        },
+        "tabs": {
+          "dailyWeekly": "Quotidien / Hebdomadaire",
+          "interval": "Intervalle"
+        },
+        "weekdays": {
+          "fri": "Ven",
+          "mon": "Lun",
+          "sat": "Sam",
+          "sun": "Dim",
+          "thu": "Jeu",
+          "tue": "Mar",
+          "wed": "Mer"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "Aucune tâche"
+      },
+      "header": {
+        "title": "Tâches"
+      },
+      "progress": {
+        "label": "{completed}/{total} terminées"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "Aucune sortie"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# ligne inchangée} other {# lignes inchangées}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "Passer en vue côte à côte",
+          "unifiedTooltip": "Passer en vue unifiée"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "Pas encore de sortie..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# appel} other {# appels}}"
+        },
+        "failed": {
+          "tag": "{count} en échec"
+        },
+        "working": {
+          "label": "En cours"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(fichier vide)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {# ligne de plus} other {# lignes de plus}}"
+        },
+        "showAll": {
+          "button": "Tout afficher"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "Aucun résultat"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "Fichier trop volumineux ({size}). Le maximum est de {max}.",
+        "network": "Erreur réseau",
+        "notFound": "Ressource introuvable",
+        "server": "Erreur du serveur",
+        "sessionExpired": "Session expirée",
+        "tooManyFiles": "Trop de fichiers. Le maximum est de {max} fichiers par session.",
+        "totalSizeExceeded": "La taille totale dépasse la limite. Le maximum est de {max} par session.",
+        "uploadFailed": "Échec de l'importation"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "Revenir en arrière"
+      },
+      "copyUrl": {
+        "ariaLabel": "Copier l'URL : {url}"
+      },
+      "downloadFile": {
+        "tooltip": "Télécharger le fichier"
+      },
+      "export": {
+        "button": "Exporter en .docx",
+        "inProgress": "Exportation..."
+      },
+      "forward": {
+        "ariaLabel": "Aller en avant"
+      },
+      "openInNewTab": {
+        "tooltip": "ouvrir dans un nouvel onglet"
+      },
+      "refresh": {
+        "ariaLabel": "Actualiser"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "supprimer",
+        "button": "Supprimer",
+        "entityTypeFile": "fichier",
+        "entityTypeFolder": "dossier",
+        "fileDetails": "Ce fichier sera retiré de votre bibliothèque.",
+        "folderDetails": "Cela supprimera le dossier et tout son contenu."
+      },
+      "dropzone": {
+        "formats": "Excel, Word, PowerPoint, PDF ou ZIP",
+        "title": "Glissez des fichiers ici ou cliquez pour importer"
+      },
+      "errors": {
+        "createFolderFailed": "Échec de la création du dossier",
+        "deleteFailed": "Échec de la suppression",
+        "loadFailed": "Échec du chargement des fichiers",
+        "uploadFailed": "Échec de l'importation"
+      },
+      "loading": {
+        "label": "Chargement des fichiers…"
+      },
+      "modal": {
+        "description": "Fichiers que votre agent peut lire à chaque session.",
+        "doneButton": "Terminé",
+        "title": "Bibliothèque"
+      },
+      "newFolder": {
+        "cancelButton": "Annuler",
+        "createButton": "Créer",
+        "label": "Nouveau dossier",
+        "nameLabel": "Nom du dossier",
+        "namePlaceholder": "Saisissez le nom du dossier"
+      },
+      "search": {
+        "noResults": "Aucun fichier ne correspond à votre recherche",
+        "placeholder": "Rechercher des fichiers..."
+      },
+      "tree": {
+        "collapseTooltip": "Réduire",
+        "deleteTooltip": "Supprimer",
+        "expandTooltip": "Développer",
+        "toggleAriaLabel": "Basculer {name}",
+        "uploadToFolderTooltip": "Importer dans ce dossier"
+      },
+      "upload": {
+        "button": "Importer",
+        "dropOverlay": "Déposez les fichiers pour les importer",
+        "uploadingButton": "Importation…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "Analyse mes données et crée un tableau de bord..."
       }
     }
   },
@@ -8825,6 +12553,13 @@
           "networkError": "Une erreur s'est produite lors de la modification du mot de passe",
           "updateFailed": "Échec de la modification du mot de passe",
           "updated": "Mot de passe mis à jour avec succès"
+        },
+        "validation": {
+          "confirmRequired": "Veuillez confirmer votre nouveau mot de passe",
+          "currentRequired": "Le mot de passe actuel est requis",
+          "minLength": "Le mot de passe doit comporter au moins {min} caractères",
+          "mismatch": "Les mots de passe ne correspondent pas",
+          "newRequired": "Le nouveau mot de passe est requis"
         }
       },
       "title": "Comptes"
@@ -8866,6 +12601,7 @@
         "empty": "Aucun jeton d'accès créé.",
         "expiresIn": "{count, plural, one {Expire dans # jour} other {Expire dans # jours}}",
         "loading": "Chargement des jetons...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "N'expire jamais",
         "newTokenButton": "Nouveau jeton d'accès",
         "noPermissionTooltip": "Vous n'avez pas l'autorisation de créer des jetons d'accès",
@@ -9012,6 +12748,10 @@
       },
       "description": "Connectez des outils externes aux modèles disponibles pour vous dans Onyx.",
       "guideButton": "Guide",
+      "loadError": {
+        "description": "Veuillez actualiser la page et réessayer.",
+        "title": "Impossible de charger LLM Gateway"
+      },
       "models": {
         "description": "{count, plural, one {# modèle est disponible pour votre compte. Ouvrez un fournisseur pour copier un ID.} other {# modèles sont disponibles pour votre compte. Ouvrez un fournisseur pour copier un ID.}}",
         "title": "Modèles"
@@ -9064,14 +12804,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "Ajouter une ligne",
+        "maxReached": "Maximum de {count} souvenirs atteint"
+      },
       "empty": {
-        "description": "Ajoutez une note personnelle ou un souvenir que Onyx doit retenir."
+        "description": "Ajoutez une note personnelle ou un souvenir que Onyx doit retenir.",
+        "getStarted": "Aucun souvenir pour le moment. Cliquez sur « Ajouter une ligne » pour commencer.",
+        "noMatches": "Aucun souvenir ne correspond à votre recherche."
+      },
+      "item": {
+        "placeholder": "Saisissez ou collez une note ou un souvenir personnel"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {Ligne} other {Lignes}}"
+      },
+      "modal": {
+        "description": "Autorisez Onyx à faire référence à ces notes et souvenirs enregistrés dans les chats.",
+        "searchPlaceholder": "Rechercher..."
       },
       "referenceStoredMemories": {
         "description": "Autorisez Onyx à faire référence aux souvenirs enregistrés dans les chats.",
         "title": "Référencer les souvenirs enregistrés"
       },
+      "removeLineButton": {
+        "label": "Supprimer la ligne"
+      },
       "title": "Mémoire",
+      "toasts": {
+        "saveFailed": "Échec de l'enregistrement des préférences",
+        "saved": "Préférences enregistrées"
+      },
       "updateMemories": {
         "description": "Autorisez Onyx à générer et mettre à jour les souvenirs enregistrés.",
         "title": "Mettre à jour les souvenirs"
@@ -9491,6 +13254,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "L'application « {appName} » a déjà une compétence associée nommée « {skillName} ».",
+        "title": "Choisissez un autre nom de compétence"
+      },
+      "confirmUpload": {
+        "importBody": "Ce téléversement inclut SKILL.md. Continuer remplacera le nom, la description, les instructions et les fichiers actuels par le paquet téléversé.",
+        "importSubmit": {
+          "label": "Importer la compétence"
+        },
+        "importTitle": "Importer cette compétence ?",
+        "replaceBody": "Ce téléversement doit utiliser le même nom de compétence. Continuer remplacera la description, les instructions et les fichiers par le paquet téléversé.",
+        "replaceSubmit": {
+          "label": "Remplacer le contenu"
+        },
+        "replaceTitle": "Remplacer le contenu de la compétence ?"
+      },
+      "delete": {
+        "button": {
+          "label": "Supprimer la compétence"
+        },
+        "description": "Toute personne utilisant cette compétence perdra l'accès. La suppression est irréversible.",
+        "title": "Supprimer cette compétence"
+      },
+      "deleteModal": {
+        "entityType": "compétence",
+        "label": "Supprimer",
+        "pendingLabel": "Suppression..."
+      },
+      "details": {
+        "description": "Définissez quand et comment Craft doit utiliser cette compétence.",
+        "descriptionField": {
+          "description": "Décrivez quand cette compétence doit être utilisée.",
+          "placeholder": "À quoi sert cette compétence ?",
+          "title": "Description"
+        },
+        "name": {
+          "createDescription": "Utilisez des lettres minuscules, des chiffres et des traits d'union simples.",
+          "lockedDescription": "Les noms de compétences ne peuvent pas être modifiés après la création.",
+          "placeholder": "Nommez votre compétence",
+          "title": "Nom"
+        },
+        "title": "Détails"
+      },
+      "files": {
+        "busyLabel": "Téléversement...",
+        "description": "Ajoutez des références, scripts, ressources ou autres fichiers utilisés par cette compétence. Les fichiers ZIP sont décompressés automatiquement.",
+        "input": {
+          "ariaLabel": "Ajouter des fichiers annexes"
+        },
+        "pendingUpload": {
+          "emptyMessage": "Les fichiers de ce téléversement apparaîtront après la création de la compétence."
+        },
+        "title": "Fichiers annexes"
+      },
+      "filesTooltip": {
+        "noPermission": "Vous n'avez pas l'autorisation de mettre à jour les fichiers de cette compétence.",
+        "saveFirst": "Enregistrez les modifications des détails avant de mettre à jour les fichiers de la compétence.",
+        "updating": "Mise à jour des fichiers de la compétence..."
+      },
+      "header": {
+        "appFallbackName": "Application externe",
+        "cancel": {
+          "label": "Annuler"
+        },
+        "createDescription": "Créez une compétence personnelle",
+        "createForAppDescription": "Ajouter une compétence d'organisation à l'application « {appName} »",
+        "createTitle": "Créer une compétence",
+        "editDescription": "Mettez à jour les détails et fichiers de la compétence",
+        "editTitle": "Modifier la compétence",
+        "save": {
+          "label": "Enregistrer",
+          "pendingLabel": "Enregistrement..."
+        }
+      },
+      "import": {
+        "busyLabel": "Importation...",
+        "button": {
+          "label": "Importer une compétence"
+        },
+        "description": "Importez un SKILL.md, un ZIP ou un dossier de compétence pour préremplir le formulaire et inclure ses fichiers.",
+        "input": {
+          "ariaLabel": "Importer une compétence existante"
+        },
+        "prompt": "Choisissez un SKILL.md ou un ZIP, ou déposez un dossier de compétence ici.",
+        "title": "Vous avez déjà une compétence ?"
+      },
+      "instructions": {
+        "description": "Décrivez le comportement et le flux de travail que cette compétence ajoute à Craft.",
+        "emptyFallback": "Pas encore d'instructions.",
+        "placeholder": "Rédigez les instructions de la compétence.",
+        "title": "Instructions"
+      },
+      "loadError": {
+        "description": "Cette compétence n'existe peut-être pas, est peut-être intégrée ou n'est peut-être pas modifiable avec votre compte.",
+        "title": "Compétence indisponible"
+      },
+      "management": {
+        "description": "Contrôlez qui peut utiliser cette compétence.",
+        "externalApp": {
+          "manage": {
+            "label": "Gérer dans les paramètres de l'application"
+          },
+          "readyDescription": "Cette compétence utilise l'application « {appName} ».",
+          "title": "Application externe"
+        },
+        "sharing": {
+          "edit": {
+            "label": "Modifier le partage"
+          },
+          "title": "Partage"
+        },
+        "title": "Gestion"
+      },
+      "saveTooltip": {
+        "missingDescription": "Ajoutez une description avant d'enregistrer.",
+        "missingInstructions": "Ajoutez des instructions avant d'enregistrer.",
+        "missingName": "Ajoutez un nom avant d'enregistrer.",
+        "noChanges": "Aucune modification n'a été apportée.",
+        "noPermission": "Vous n'avez pas l'autorisation de modifier les détails de cette compétence.",
+        "savingChanges": "Enregistrement des modifications...",
+        "savingSkill": "Enregistrement de la compétence..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "Tous les membres de votre organisation peuvent utiliser et modifier cette compétence.",
+          "title": "Organisation",
+          "viewerDescription": "Tous les membres de votre organisation peuvent utiliser cette compétence."
+        },
+        "personal": {
+          "description": "Vous seul pouvez utiliser cette compétence.",
+          "title": "Personnel"
+        },
+        "shares": {
+          "description": "Seuls les utilisateurs et groupes sélectionnés peuvent utiliser cette compétence.",
+          "title": "{count, plural, one {# partage} other {# partages}}"
+        }
+      },
+      "toasts": {
+        "created": "« {name} » créée",
+        "deleteFailed": "Échec de la suppression de la compétence",
+        "deleted": "« {name} » supprimée",
+        "fileRemoveFailed": "Échec de la suppression du fichier de la compétence",
+        "fileRemoved": "« {path} » supprimé",
+        "filesUpdateFailed": "Échec de la mise à jour des fichiers de la compétence",
+        "filesUpdated": "Fichiers de « {name} » mis à jour",
+        "importMissingSkillMd": "Importez un SKILL.md, un ZIP ou un dossier contenant SKILL.md.",
+        "inspectFailed": "Échec de l'inspection du paquet de compétence",
+        "saveFailed": "Échec de l'enregistrement de la compétence",
+        "saved": "« {name} » enregistrée"
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9691,6 +13606,76 @@
         "transferredToast": {
           "message": "Propriété transférée."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "Parcourir les compétences"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {Compétence} other {Compétences}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "Importez une ou plusieurs compétences depuis un dépôt.",
+          "title": "Importer depuis GitHub"
+        },
+        "scratch": {
+          "description": "Rédigez les instructions et ajoutez des fichiers annexes dans Onyx.",
+          "title": "Partir de zéro"
+        },
+        "trigger": {
+          "label": "Créer une compétence"
+        },
+        "upload": {
+          "description": "Importez un fichier SKILL.md, un fichier ZIP ou un dossier de compétence.",
+          "title": "Téléverser une compétence"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "Essayez une autre recherche.",
+          "title": "Aucune compétence correspondante"
+        },
+        "noSkills": {
+          "description": "Aucune compétence personnalisée n'a encore été partagée avec vous et aucune compétence intégrée n'est configurée.",
+          "title": "Aucune compétence disponible"
+        }
+      },
+      "focusedApp": {
+        "description": "Activez toutes les compétences associées à l'application « {appName} ». L'application peut ne pas fonctionner correctement sans elles. Si une autre compétence du même nom est activée, activer la compétence associée à l'application désactive l'autre compétence pour vous.",
+        "showAll": {
+          "label": "Afficher toutes les compétences"
+        },
+        "title": "Compétences pour l'application « {appName} »"
+      },
+      "header": {
+        "description": "Ensembles de capacités que votre agent Craft peut mobiliser. Cette page présente les compétences intégrées, celles partagées avec vous et vos compétences personnelles.",
+        "title": "Compétences"
+      },
+      "loadError": {
+        "description": "Consultez la console pour plus de détails et essayez d'actualiser la page.",
+        "title": "Échec du chargement des compétences"
+      },
+      "preview": {
+        "unavailableFallback": "Cette compétence est actuellement indisponible."
+      },
+      "search": {
+        "placeholder": "Rechercher des compétences..."
+      },
+      "switchModal": {
+        "body": "Continuer désactivera la compétence actuellement activée et activera celle-ci.",
+        "description": "Une seule compétence nommée « {name} » peut être activée à la fois.",
+        "submit": {
+          "label": "Changer de compétence",
+          "pendingLabel": "Changement..."
+        },
+        "title": "Changer la compétence « {name} » ?"
+      },
+      "toasts": {
+        "disableFailed": "Échec de la désactivation de {name}",
+        "enableFailed": "Échec de l'activation de {name}",
+        "refreshFailed": "{name} a été mise à jour, mais la liste des compétences n'a pas pu être actualisée."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "Retour"
       },
-      "disableAll": {
-        "label": "Tout désactiver"
-      },
-      "enableAll": {
-        "label": "Tout activer"
-      },
       "toggle": {
         "ariaLabel": "Activer/désactiver {name}"
       }
@@ -12947,6 +12941,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "Explorateur de documents"
+        },
+        "documentFeedback": {
+          "title": "Retours sur les documents"
+        },
+        "documentProcessing": {
+          "title": "Traitement des documents"
+        },
+        "oauthTest": {
+          "title": "Test OAuth"
+        },
+        "standardAnswers": {
+          "title": "Réponses standard"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "Ajouter un connecteur"

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -12902,9 +12902,29 @@
         "title": "Impossible de charger l'utilisation"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · par défaut"
+        },
         "description": "USD par million de tokens (entrée · sortie · cache) pour chaque modèle disponible",
+        "otherProvider": {
+          "label": "Autres"
+        },
         "title": "Prix des modèles",
         "unavailable": "Prix indisponibles"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "{count} lectures de cache"
+        },
+        "cacheWrites": {
+          "label": "{count} écritures de cache"
+        },
+        "tokensIn": {
+          "label": "{count} en entrée"
+        },
+        "tokensOut": {
+          "label": "{count} en sortie"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "Afficher moins de modèles"

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -5765,6 +5765,27 @@
         "unexpectedError": "Une erreur inattendue est survenue."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "Annulé",
+        "completedWithErrors": "Terminé avec des erreurs",
+        "deleting": "Suppression",
+        "error": "Erreur",
+        "failed": "Échec",
+        "inProgress": "En cours",
+        "indexed": "Indexé",
+        "indexing": "Indexation",
+        "initialIndexing": "Indexation initiale",
+        "interrupted": "Interrompu",
+        "invalid": "Non valide",
+        "invalidConnectorTooltip": "Le connecteur est dans un état non valide. Mettez à jour les identifiants ou créez un nouveau connecteur.",
+        "none": "Aucun",
+        "notStarted": "Non démarré",
+        "paused": "En pause",
+        "scheduled": "Planifié",
+        "succeeded": "Réussi"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "Version du backend : "
@@ -7204,6 +7225,70 @@
       },
       "sourcesModal": {
         "title": "Sources"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "Supprimer"
+      },
+      "deleteModal": {
+        "description": "Voulez-vous vraiment supprimer ce chat ? Cette action est irréversible.",
+        "submitButton": {
+          "label": "Supprimer"
+        },
+        "title": "Supprimer le chat"
+      },
+      "exportAs": {
+        "label": "Exporter sous…"
+      },
+      "exportFailed": {
+        "message": "Échec de l'exportation du chat. Veuillez réessayer."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "Texte brut"
+      },
+      "fullWidth": {
+        "ariaLabel": "Basculer le chat en pleine largeur",
+        "fitTooltip": "Largeur ajustée",
+        "fullTooltip": "Pleine largeur"
+      },
+      "incognitoExit": {
+        "ariaLabel": "Quitter le chat incognito",
+        "tooltip": "Quitter le chat incognito"
+      },
+      "incognitoPill": {
+        "ariaLabel": "Chat incognito",
+        "label": "Chat incognito"
+      },
+      "incognitoStart": {
+        "ariaLabel": "Démarrer un chat incognito",
+        "lockedTooltip": "Le mode incognito ne peut être activé qu'avant le début du chat",
+        "tooltip": "Chat incognito"
+      },
+      "mode": {
+        "chat": {
+          "description": "Conversation et recherche",
+          "label": "Chat"
+        },
+        "search": {
+          "description": "Recherche rapide de documents",
+          "label": "Recherche"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "Changer le mode de l'application"
+      },
+      "moveToProject": {
+        "label": "Déplacer vers un projet"
+      },
+      "openSidebar": {
+        "ariaLabel": "Ouvrir la barre latérale"
+      },
+      "share": {
+        "label": "Partager"
       }
     },
     "banners": {
@@ -8950,6 +9035,34 @@
         "updateFailed": "Impossible de mettre à jour la préférence de langue"
       }
     },
+    "layout": {
+      "header": {
+        "title": "Paramètres"
+      },
+      "sectionSelect": {
+        "placeholder": "Sélectionnez une section"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "Comptes et accès"
+        },
+        "chatPreferences": {
+          "label": "Préférences de chat"
+        },
+        "connectors": {
+          "label": "Connecteurs"
+        },
+        "general": {
+          "label": "Général"
+        },
+        "llmGateway": {
+          "label": "Passerelle LLM"
+        },
+        "usage": {
+          "label": "Utilisation"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Ajoutez une note personnelle ou un souvenir que Onyx doit retenir."
@@ -9010,6 +9123,47 @@
       "toggle": {
         "description": "Activez les raccourcis pour insérer rapidement des invites courantes.",
         "title": "Utiliser les raccourcis d'invite"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "Limite de {amount}",
+        "none": "Aucun budget défini",
+        "remaining": "{amount} restant",
+        "resetsOn": "Réinitialisation le {date}",
+        "title": "Budget"
+      },
+      "empty": {
+        "description": "L'utilisation et les coûts de vos modèles apparaîtront ici dès que vous commencerez à discuter.",
+        "title": "Aucune utilisation enregistrée pour l'instant"
+      },
+      "header": {
+        "title": "Utilisation"
+      },
+      "loadError": {
+        "description": "Une erreur s'est produite lors de la récupération de votre utilisation. Réessayez dans un instant.",
+        "title": "Impossible de charger l'utilisation"
+      },
+      "modelPrices": {
+        "description": "USD par million de tokens (entrée · sortie · cache) pour chaque modèle disponible",
+        "title": "Prix des modèles",
+        "unavailable": "Prix indisponibles"
+      },
+      "showFewerModels": {
+        "ariaLabel": "Afficher moins de modèles"
+      },
+      "showLess": {
+        "label": "Afficher moins"
+      },
+      "showMore": {
+        "label": "Afficher {count} de plus"
+      },
+      "showMoreModels": {
+        "ariaLabel": "Afficher {count} modèles de plus"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} dépensé",
+        "title": "Utilisation sur cette période"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -5753,6 +5753,27 @@
         "unexpectedError": "予期しないエラーが発生しました。"
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "キャンセル済み",
+        "completedWithErrors": "エラーありで完了",
+        "deleting": "削除中",
+        "error": "エラー",
+        "failed": "失敗",
+        "inProgress": "進行中",
+        "indexed": "インデックス済み",
+        "indexing": "インデックス作成中",
+        "initialIndexing": "初回インデックス作成",
+        "interrupted": "中断",
+        "invalid": "無効",
+        "invalidConnectorTooltip": "コネクタが無効な状態です。認証情報を更新するか、新しいコネクタを作成してください。",
+        "none": "なし",
+        "notStarted": "未開始",
+        "paused": "一時停止中",
+        "scheduled": "予定済み",
+        "succeeded": "成功"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "バックエンドバージョン: "
@@ -7192,6 +7213,70 @@
       },
       "sourcesModal": {
         "title": "ソース"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "削除"
+      },
+      "deleteModal": {
+        "description": "このチャットを削除してもよろしいですか？この操作は元に戻せません。",
+        "submitButton": {
+          "label": "削除"
+        },
+        "title": "チャットを削除"
+      },
+      "exportAs": {
+        "label": "形式を指定してエクスポート…"
+      },
+      "exportFailed": {
+        "message": "チャットのエクスポートに失敗しました。もう一度お試しください。"
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "プレーンテキスト"
+      },
+      "fullWidth": {
+        "ariaLabel": "チャットの全幅表示を切り替え",
+        "fitTooltip": "幅を合わせる",
+        "fullTooltip": "全幅"
+      },
+      "incognitoExit": {
+        "ariaLabel": "シークレットチャットを終了",
+        "tooltip": "シークレットチャットを終了"
+      },
+      "incognitoPill": {
+        "ariaLabel": "シークレットチャット",
+        "label": "シークレットチャット"
+      },
+      "incognitoStart": {
+        "ariaLabel": "シークレットチャットを開始",
+        "lockedTooltip": "シークレットはチャット開始前にのみ設定できます",
+        "tooltip": "シークレットチャット"
+      },
+      "mode": {
+        "chat": {
+          "description": "会話とリサーチ",
+          "label": "チャット"
+        },
+        "search": {
+          "description": "ドキュメントのクイック検索",
+          "label": "検索"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "アプリモードを変更"
+      },
+      "moveToProject": {
+        "label": "プロジェクトに移動"
+      },
+      "openSidebar": {
+        "ariaLabel": "サイドバーを開く"
+      },
+      "share": {
+        "label": "共有"
       }
     },
     "banners": {
@@ -8938,6 +9023,34 @@
         "updateFailed": "言語設定を更新できませんでした"
       }
     },
+    "layout": {
+      "header": {
+        "title": "設定"
+      },
+      "sectionSelect": {
+        "placeholder": "セクションを選択"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "アカウントとアクセス"
+        },
+        "chatPreferences": {
+          "label": "チャット設定"
+        },
+        "connectors": {
+          "label": "コネクタ"
+        },
+        "general": {
+          "label": "一般"
+        },
+        "llmGateway": {
+          "label": "LLMゲートウェイ"
+        },
+        "usage": {
+          "label": "使用状況"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Onyx に覚えておいてほしい個人的なメモやメモリを追加します。"
@@ -8998,6 +9111,47 @@
       "toggle": {
         "description": "ショートカットを有効にすると、よく使うプロンプトをすばやく挿入できます。",
         "title": "プロンプトショートカットを使用"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "上限 {amount}",
+        "none": "予算が設定されていません",
+        "remaining": "残り {amount}",
+        "resetsOn": "{date} にリセット",
+        "title": "予算"
+      },
+      "empty": {
+        "description": "チャットを始めると、モデルの使用状況とコストがここに表示されます。",
+        "title": "まだ使用記録がありません"
+      },
+      "header": {
+        "title": "使用状況"
+      },
+      "loadError": {
+        "description": "使用状況の取得中に問題が発生しました。しばらくしてからもう一度お試しください。",
+        "title": "使用状況を読み込めませんでした"
+      },
+      "modelPrices": {
+        "description": "利用可能な各モデルの100万トークンあたりの料金（入力 · 出力 · キャッシュ、米ドル）",
+        "title": "モデル料金",
+        "unavailable": "料金情報がありません"
+      },
+      "showFewerModels": {
+        "ariaLabel": "表示するモデルを減らす"
+      },
+      "showLess": {
+        "label": "表示を減らす"
+      },
+      "showMore": {
+        "label": "さらに{count}件を表示"
+      },
+      "showMoreModels": {
+        "ariaLabel": "さらに{count}件のモデルを表示"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} 消費",
+        "title": "この期間の使用状況"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -60,6 +60,26 @@
         "ariaLabel": "{title} アクションカード"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "コネクタを追加"
+      },
+      "configure": {
+        "tooltip": "設定"
+      },
+      "configureConnectors": {
+        "label": "コネクタを設定"
+      },
+      "disable": {
+        "label": "無効にする"
+      },
+      "enable": {
+        "label": "有効にする"
+      },
+      "projectSearch": {
+        "label": "プロジェクト検索"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "MCP (Model Context Protocol) サーバーに接続して、カスタムアクションを追加します。",
@@ -355,6 +375,53 @@
         "tooltip": "ツールを更新"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "自動的に元のページに戻ります…"
+      },
+      "backToChatButton": {
+        "label": "チャットに戻る"
+      },
+      "cancelled": {
+        "description": "認可がキャンセルまたは拒否されたため、接続は確立されませんでした。再試行するには、MCP サーバーの認証設定から接続をやり直してください。",
+        "title": "認可がキャンセルされました"
+      },
+      "continueButton": {
+        "label": "続行"
+      },
+      "genericError": {
+        "fallbackDetail": "認可を完了できませんでした",
+        "title": "問題が発生しました"
+      },
+      "invalidLink": {
+        "description": "このリンクには必要な認可パラメータがありません。MCP サーバーの認証設定から接続をやり直してください。",
+        "title": "無効な認可リンク"
+      },
+      "processing": {
+        "description": "MCP サーバーへの接続を完了しています。しばらくお待ちください…",
+        "title": "認可を完了しています"
+      },
+      "serverNotFound": {
+        "description": "この認可が属する MCP サーバーは存在しないか、構成されていません。サーバーを再作成または再構成してから、もう一度接続してください。",
+        "title": "MCP サーバーが見つかりません"
+      },
+      "sessionExpired": {
+        "description": "この認可リンクは無効か、有効期限が切れているか、すでに使用されています。MCP サーバーの認証設定から接続をやり直してください。",
+        "title": "認可セッションの有効期限が切れました"
+      },
+      "success": {
+        "description": "認可が正常に完了しました。このサーバーのツールをチャットで使用できるようになりました。",
+        "title": "{serverName} に接続しました"
+      },
+      "timedOut": {
+        "description": "MCP サーバーが時間内に認可を確認しませんでした。もう一度接続してみてください。それでも解決しない場合は、サーバーの OAuth 設定を確認してください。",
+        "title": "認可がタイムアウトしました"
+      },
+      "tokenExchangeFailed": {
+        "description": "プロバイダーは認可を承認しましたが、有効なアクセストークンを取得できませんでした。サーバーの OAuth クライアント認証情報とエンドポイントを確認してから、もう一度接続してください。",
+        "title": "トークン交換に失敗しました"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "MCP サーバーを追加"
@@ -554,6 +621,20 @@
         "label": "拒否"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "戻る"
+      },
+      "disableAll": {
+        "label": "すべて無効にする"
+      },
+      "enableAll": {
+        "label": "すべて有効にする"
+      },
+      "toggle": {
+        "ariaLabel": "{name} を切り替える"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "ツールを利用できません"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "有効なツールのみ表示",
         "tooltip": "有効なもののみ表示"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "コードインタープリターを設定"
+        },
+        "imageGeneration": {
+          "tooltip": "画像生成を設定"
+        },
+        "openapi": {
+          "tooltip": "OpenAPIアクションを管理"
+        },
+        "webSearch": {
+          "tooltip": "ウェブ検索を設定"
+        }
+      },
+      "disableAllSources": {
+        "label": "すべてのソースを無効にする"
+      },
+      "disableAllTools": {
+        "label": "すべてのツールを無効にする"
+      },
+      "enableAllSources": {
+        "label": "すべてのソースを有効にする"
+      },
+      "enableAllTools": {
+        "label": "すべてのツールを有効にする"
+      },
+      "manageActions": {
+        "tooltip": "アクションを管理"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "{server} のツールを検索"
+      },
+      "moreActions": {
+        "label": "その他のアクション"
+      },
+      "reauthenticate": {
+        "label": "再認証"
+      },
+      "search": {
+        "placeholder": "アクションを検索..."
+      },
+      "serverFallback": {
+        "label": "サーバー"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "フィルターを検索"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "管理者に設定を依頼してください。"
+        },
+        "codingAgent": {
+          "description": "GitHubリポジトリを調査し、そのコードに関する質問に答えます。"
+        },
+        "configureSuffix": {
+          "text": "有効にするには設定の歯車を押してください。"
+        },
+        "default": {
+          "description": "このアクションはまだ設定されていません。"
+        },
+        "imageGeneration": {
+          "description": "プロンプトに基づいて画像を生成します。"
+        },
+        "python": {
+          "description": "複雑な分析のためにコードを実行します。"
+        },
+        "search": {
+          "description": "接続されたナレッジを検索して回答に役立てます。"
+        },
+        "webSearch": {
+          "description": "最新情報をウェブで検索します。"
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "選択した期間の日別",
+        "title": "メッセージとユニークユーザー"
+      },
+      "empty": {
+        "message": "選択した期間内にこのエージェントのデータは見つかりませんでした。"
+      },
+      "fetchFailed": {
+        "message": "エージェントの統計の取得に失敗しました。"
+      },
+      "permissionDenied": {
+        "message": "これらの統計を表示する権限がありません。"
+      },
+      "totalMessages": {
+        "label": "合計メッセージ数"
+      },
+      "totalUniqueUsers": {
+        "label": "合計ユニークユーザー数"
+      },
+      "unknownError": {
+        "message": "不明なエラーが発生しました"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "セクションを折りたたむ"
+        },
+        "expand": {
+          "ariaLabel": "セクションを展開"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "<emphasis>{name}</emphasis> を削除してもよろしいですか？この操作は取り消せません。"
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "プランを表示"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "請求情報はありません。"
+        },
+        "loadError": {
+          "message": "請求情報の読み込み中にエラーが発生しました。後でもう一度お試しください。"
+        },
+        "loading": {
+          "label": "読み込み中..."
+        },
+        "manageSubscription": {
+          "description": "プランの確認、支払いの更新、サブスクリプションの変更を行います",
+          "title": "サブスクリプションを管理"
+        },
+        "page": {
+          "title": "請求情報"
+        },
+        "portalError": {
+          "message": "カスタマーポータルセッションの作成中にエラーが発生しました"
+        },
+        "subscriptionDetails": {
+          "title": "サブスクリプションの詳細"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "請求終了日"
+          },
+          "billingStart": {
+            "label": "請求開始日"
+          },
+          "seats": {
+            "label": "シート数"
+          },
+          "status": {
+            "label": "サブスクリプションの状態"
+          }
+        },
+        "updatedToast": {
+          "message": "おめでとうございます!サブスクリプションが正常に更新されました。"
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "ソースから権限を自動的に同期します。検索を行うユーザーがソースでそのドキュメントへのアクセス権限を持つ場合に限り、Onyxで検索可能になります。",
+          "disabledReason": "現在の認証情報の認証方式は権限の自動同期に対応していません。対応している認証方式に変更してください。",
+          "name": "権限の自動同期"
+        },
+        "heading": {
+          "description": "このコネクタでインデックスされたドキュメントへのアクセス権を管理します。",
+          "title": "ドキュメントアクセス"
+        },
+        "privateOption": {
+          "description": "（ユーザーグループページで）このコネクタへのアクセスを明示的に付与されたユーザーのみが、このコネクタで取り込まれたドキュメントにアクセスできます",
+          "name": "非公開"
+        },
+        "publicOption": {
+          "description": "Onyxのアカウントを持つすべてのユーザーが、このコネクタで取り込まれたドキュメントにアクセスできます",
+          "name": "公開"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# 日} other {# 日}}",
@@ -1546,6 +1794,14 @@
           "label": "表示を減らす"
         }
       },
+      "credentialForm": {
+        "errorToast": "エラー: {detail}",
+        "successToast": "成功しました！",
+        "updateButton": {
+          "ariaLabel": "認証情報を更新",
+          "label": "更新"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "このコネクターを削除すると削除ジョブがスケジュールされ、インデックス済みのドキュメントが削除されます。また、すべてのユーザーからこのコネクターが削除されます。",
         "entityType": "コネクター"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "ドキュメント権限の同期エラー"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "このコネクタの設定について詳しくは<link>ドキュメント</link>をご覧ください。"
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "ファイルの更新に失敗しました"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "{multiple, select, true {ファイル} other {ファイル}}をここにドラッグ＆ドロップするか、クリックして{multiple, select, true {ファイル} other {ファイル}}を選択してください"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {選択されたファイル} other {選択されたファイル}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "エラーメッセージ",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "グループメンバーシップの同期エラー"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "このコネクタへのグループアクセスを割り当てる"
+        },
+        "assignToGroup": {
+          "title": "このコネクタをグループに割り当てる"
+        },
+        "scopedManagerGroups": {
+          "description": "このコネクタへのアクセスを付与するには、管理しているグループを1つ以上選択してください"
+        },
+        "syncGroups": {
+          "description": "以下のグループは、このコネクタを管理できるユーザーを制御します。ドキュメントへのアクセスはソース自体の権限から継承されます。"
+        },
+        "visibleToGroups": {
+          "description": "このコネクタは、以下で選択したグループに表示・アクセス可能になります"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "{count, plural, one {# 件のドキュメント} other {# 件のドキュメント}}について、対象を指定した再インデックス作成を送信しました。再インデックス作成が完了したドキュメントから、エラーは一覧から消えます。"
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "チャンネル正規表現が有効",
+        "channels": "チャンネル",
+        "enabledTrue": "有効",
+        "excludeChannelRegexEnabled": "除外チャンネル正規表現が有効",
+        "excludedChannels": "除外チャンネル",
+        "includeBotMessages": "ボットのメッセージを含む",
+        "jiraProjectUrl": "JiraプロジェクトURL",
+        "multipleRepos": "複数のリポジトリ",
+        "pageId": "ページID",
+        "realm": "レルム",
+        "repo": "リポジトリ",
+        "wikiUrl": "Wiki URL"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "インデックスを作成する Google Drive を所有する Google 組織の、管理者またはオーナーのメールアドレスを入力してください。",
           "invalidEmail": "有効なメールアドレスを入力してください",
           "label": "主管理者のメールアドレス",
+          "placeholder": "admin@yourcompany.com",
           "required": "必須です"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "インデックスを作成する Gmail アカウントを所有する Google 組織の、管理者またはオーナーのメールアドレスを入力してください。",
           "invalidEmail": "有効なメールアドレスを入力してください",
           "label": "主管理者のメールアドレス",
+          "placeholder": "admin@yourcompany.com",
           "required": "必須です"
         },
         "section": {
@@ -2590,6 +2894,171 @@
       "unavailable": {
         "description": "Craft はデプロイごとに Onyx が有効にします。利用するには、Onyx の担当者にお問い合わせください。",
         "title": "このデプロイでは Craft を利用できません"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "<i>{date}</i> に作成"
+        },
+        "createdOnBy": {
+          "label": "<i>{date}</i> に <i>{email}</i> が作成"
+        },
+        "unnamed": {
+          "label": "認証情報 #{id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "作成"
+        },
+        "created": {
+          "toast": "新しい認証情報を作成しました!"
+        },
+        "name": {
+          "label": "名前:",
+          "placeholder": "(任意) 認証情報の名前..."
+        },
+        "submitError": {
+          "toast": "認証情報の送信中にエラーが発生しました"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "confirmBody": {
+          "message": "この認証情報を削除してもよろしいですか?稼働中のコネクタに関連付けられた認証情報は削除できません。"
+        },
+        "confirmButton": {
+          "label": "確認"
+        },
+        "confirmTitle": "削除の確認"
+      },
+      "edit": {
+        "name": {
+          "label": "名前 (任意):"
+        },
+        "permissions": {
+          "note": "適切な権限を持つ認証情報に更新してください!"
+        },
+        "resetButton": {
+          "label": "変更をリセット"
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "updateError": {
+          "toast": "認証情報の更新中にエラーが発生しました"
+        }
+      },
+      "modal": {
+        "createTitle": "{source} の認証情報を作成",
+        "editTitle": "認証情報を編集",
+        "updateTitle": "認証情報を更新"
+      },
+      "modify": {
+        "createButton": {
+          "label": "作成"
+        },
+        "instructions": {
+          "message": "必要に応じて認証情報を選択してください!このコネクタに適切な権限を持つ認証情報を選択したことを確認してください!"
+        },
+        "selectButton": {
+          "label": "選択"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "接続"
+        },
+        "connectError": {
+          "title": "接続できませんでした"
+        },
+        "redirectFailed": {
+          "message": "{source} でのサインインにリダイレクトできませんでした。もう一度お試しください。"
+        },
+        "retryButton": {
+          "label": "再試行"
+        },
+        "startError": {
+          "message": "OAuth を開始できません"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "認証情報の切り替えに問題があります: {detail}"
+        },
+        "success": {
+          "toast": "認証情報を正常に切り替えました!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "操作"
+        },
+        "created": {
+          "header": "作成日"
+        },
+        "edit": {
+          "ariaLabel": "認証情報を編集"
+        },
+        "empty": {
+          "message": "このコネクタには認証情報がありません!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "最終更新"
+        },
+        "name": {
+          "header": "名前"
+        },
+        "select": {
+          "label": "選択"
+        },
+        "selected": {
+          "badge": "選択済み"
+        },
+        "untitled": {
+          "label": "無題"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "認証情報の更新に問題があります"
+        },
+        "success": {
+          "toast": "認証情報を更新しました"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "これにより、独自の分析ツールをOnyxで利用できます!分析プロバイダーのWebスニペットを下のボックスにコピーすると、使用イベントの送信を開始します。"
+      },
+      "notEnabled": {
+        "description": "カスタム分析スクリプトを設定するには、チームでOnyxをセットアップした担当者と連携して、環境変数<i>CUSTOM_ANALYTICS_SECRET_KEY</i>を設定してください。",
+        "title": "カスタム分析は有効になっていません。"
+      },
+      "script": {
+        "description": "カスタムのトラッキング/分析を初期化するために、ページ読み込み時に実行するJavascriptを指定します。",
+        "instructions": "`<script></script>`タグは含めないでください。以下にスクリプトをアップロードしても分析プラットフォームでイベントを受信できない場合は、JavaScriptの各行の前にある余分な空白をすべて削除してみてください。",
+        "label": "スクリプト"
+      },
+      "secretKey": {
+        "description": "セキュリティ上の理由から、このスクリプトを更新するにはシークレットキーの入力が必要です。これは、Onyxの初期セットアップ時に設定された環境変数<i>CUSTOM_ANALYTICS_SECRET_KEY</i>の値です。",
+        "label": "シークレットキー"
+      },
+      "updateButton": {
+        "label": "更新"
+      },
+      "updateFailed": {
+        "message": "カスタム分析スクリプトの更新に失敗しました:「{error}」"
+      },
+      "updateSuccess": {
+        "message": "カスタム分析スクリプトが正常に更新されました!"
       }
     },
     "discordBot": {
@@ -3047,6 +3516,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "収集中..."
+        },
+        "downloading": {
+          "label": "ダウンロード中..."
+        },
+        "export": {
+          "label": "ログをエクスポート"
+        },
+        "starting": {
+          "label": "開始中..."
+        }
+      },
+      "downloadButton": {
+        "label": "ダウンロード"
+      },
+      "exportCard": {
+        "description": "APIサーバーとバックグラウンドワーカーのログファイルを1つのzipにまとめます。収集が完了すると自動的にダウンロードが開始されます。",
+        "title": "ログをエクスポート"
+      },
+      "header": {
+        "description": "サーバーログファイルのzipをダウンロードして、Onyxサポートスレッドに添付できます。"
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "同じホスト上の別のワーカーによって処理済み"
+        },
+        "failed": {
+          "label": "失敗"
+        },
+        "failedWithError": {
+          "label": "失敗: {error}"
+        },
+        "noLogs": {
+          "label": "ログファイルが見つかりません"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {#件のファイルをアップロードしました} other {#件のファイルをアップロードしました}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "ログファイルには、ユーザーのメールアドレス、ドキュメントのタイトル、検索クエリ、エラー内容が含まれる場合があります。組織外に共有する前に内容を確認してください。",
+        "title": "ログには機密データが含まれる場合があります"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "収集を開始しています..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "ログエクスポートはすでに進行中です。しばらくしてからもう一度お試しください。"
+        },
+        "downloadFailed": {
+          "message": "ログエクスポートのダウンロードに失敗しました。"
+        },
+        "lostAccess": {
+          "message": "実行中のエクスポートへのアクセスが失われました。新しいエクスポートを開始してください。"
+        },
+        "startFailed": {
+          "message": "ログエクスポートの開始に失敗しました。"
+        },
+        "unreachable": {
+          "message": "サーバーに接続できないため、エクスポートの進行状況を確認できません。復旧後に新しいエクスポートを開始してください。"
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "収集中..."
+        },
+        "missedDeadline": {
+          "label": "期限までに報告がありませんでした"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3153,9 +3699,137 @@
         "loadFailed": "コネクターを読み込めませんでした: {details}",
         "title": "エラー"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "チャンネル名または正規表現パターンを入力してEnterキーを押してください"
+        },
+        "channelsRequired": {
+          "error": "「すべてのチャンネルを検索」が無効の場合、少なくとも1つのチャンネルが必要です"
+        },
+        "configSchemaLoadError": {
+          "message": "設定スキーマの読み込みに失敗しました: {error}"
+        },
+        "configTitle": {
+          "text": "フェデレーテッドコネクタの設定"
+        },
+        "configuration": {
+          "heading": "設定"
+        },
+        "create": {
+          "failed": "フェデレーテッドコネクタの作成に失敗しました",
+          "success": "フェデレーテッドコネクタが正常に作成されました！"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  （現在の値を保持するには空欄のままにしてください）"
+        },
+        "credentialValidationFailed": {
+          "message": "認証情報の検証に失敗しました: {message}"
+        },
+        "credentials": {
+          "description": "このコネクタの認証情報を入力してください。",
+          "heading": "認証情報"
+        },
+        "delete": {
+          "failed": "フェデレーテッドコネクタの削除に失敗しました",
+          "success": "フェデレーテッドコネクタが正常に削除されました！"
+        },
+        "deleteConfirm": {
+          "message": "このフェデレーテッドコネクタを削除してもよろしいですか？この操作は元に戻せません。"
+        },
+        "deleteError": {
+          "toast": "コネクタの削除中にエラーが発生しました: {error}"
+        },
+        "deleteItem": {
+          "deleting": "削除中...",
+          "inProgressTooltip": "削除処理中",
+          "label": "削除"
+        },
+        "federatedBadge": {
+          "label": "フェデレーテッド"
+        },
+        "federatedTooltip": {
+          "default": "これはフェデレーテッドコネクタです。通常のコネクタに比べて遅延が大きく、検索品質が低くなります。"
+        },
+        "genericError": {
+          "text": "エラー: {error}"
+        },
+        "listInput": {
+          "placeholder": "入力してEnterキーを押すと項目を追加できます"
+        },
+        "loadingSchema": {
+          "description": "このコネクタタイプに必要なフィールドを取得しています",
+          "title": "認証情報スキーマを読み込み中..."
+        },
+        "manageButton": {
+          "label": "管理"
+        },
+        "missingFields": {
+          "message": "必須フィールドが不足しています: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "このコネクタタイプで利用可能な検索設定はありません。"
+        },
+        "noCredentialSchema": {
+          "message": "このコネクタタイプで利用可能な認証情報スキーマはありません。"
+        },
+        "schemaLoadError": {
+          "message": "認証情報スキーマの読み込みに失敗しました: {error}"
+        },
+        "submitButton": {
+          "create": "作成",
+          "creating": "作成中...",
+          "update": "更新",
+          "updating": "更新中..."
+        },
+        "title": {
+          "edit": "{name}を編集",
+          "setup": "{name}をセットアップ"
+        },
+        "update": {
+          "failed": "フェデレーテッドコネクタの更新に失敗しました",
+          "success": "フェデレーテッドコネクタが正常に更新されました！"
+        },
+        "validateBeforeEdit": {
+          "message": "検証する前に新しい認証情報を入力してください。"
+        },
+        "validateButton": {
+          "label": "検証",
+          "validating": "検証中..."
+        },
+        "validation": {
+          "error": "検証エラー: {error}",
+          "failedStatus": "検証に失敗しました: {statusText}",
+          "invalid": "認証情報が無効です",
+          "valid": "認証情報は有効です"
+        }
+      },
       "loading": {
         "description": "コネクターの詳細と認証情報スキーマを取得しています",
         "title": "コネクター設定を読み込んでいます..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "チャットに戻る"
+      },
+      "error": {
+        "title": "問題が発生しました"
+      },
+      "errors": {
+        "clientSecret": "認証情報がないか無効です",
+        "oauth": "OAuth認可に失敗しました",
+        "validation": "設定エラー - コネクタの設定を確認してください"
+      },
+      "processing": {
+        "details": "セットアップが完了するまでお待ちください。",
+        "title": "処理中..."
+      },
+      "redirecting": {
+        "text": "2秒後にチャットへ移動します..."
+      },
+      "success": {
+        "detailsTemplate": "{serviceName} の認可が正常に完了しました。このコネクタを検索に使用できます。",
+        "title": "成功しました！"
       }
     },
     "groups": {
@@ -3418,6 +4092,265 @@
           "header": "Token 上限",
           "placeholder": "Token 上限 (千単位)",
           "unit": "(千単位)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "フックを削除",
+          "tooltip": "削除"
+        },
+        "disconnect": {
+          "ariaLabel": "フックを無効化",
+          "tooltip": "フックを切断"
+        },
+        "disconnectedSuffix": {
+          "label": "(切断済み)"
+        },
+        "hookPoint": {
+          "description": "フックポイント: {name}"
+        },
+        "manage": {
+          "ariaLabel": "フックを設定",
+          "tooltip": "管理"
+        },
+        "reconnectButton": {
+          "label": "再接続"
+        },
+        "test": {
+          "ariaLabel": "フックを再検証",
+          "tooltip": "接続をテスト"
+        }
+      },
+      "connectButton": {
+        "label": "接続"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "フック***{name}***は、このフックポイントから完全に削除されます。外部エンドポイントには、以前送信されたデータが残っている可能性があります。"
+        },
+        "delete": {
+          "label": "削除"
+        },
+        "header": {
+          "title": "*{name}*を削除"
+        },
+        "permanent": {
+          "description": "削除は元に戻せません。"
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyxはフック***{name}***に対するこのエンドポイントの呼び出しを停止します。実行中のリクエストは引き続き実行されます。外部エンドポイントには、以前送信されたデータが残っている可能性があります。必要に応じて、後でこのフックを再接続できます。"
+        },
+        "deleteNote": {
+          "description": "このフックを削除することもできます。削除は元に戻せません。"
+        },
+        "disconnect": {
+          "label": "切断"
+        },
+        "disconnectAndDelete": {
+          "label": "切断して削除"
+        },
+        "header": {
+          "title": "*{name}*を切断"
+        }
+      },
+      "docsLink": {
+        "label": "ドキュメント"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyxはこのキーを使用してAPIエンドポイントで認証を行います。",
+          "keepCurrent": {
+            "placeholder": "現在のキーを保持するには空欄のままにしてください"
+          },
+          "title": "APIキー"
+        },
+        "connectionValid": {
+          "label": "接続は有効です。"
+        },
+        "createHeader": {
+          "description": "外部APIエンドポイントを接続してフックポイントを拡張します。",
+          "title": "フック拡張機能を設定"
+        },
+        "editHeader": {
+          "title": "フック拡張機能を管理"
+        },
+        "endpoint": {
+          "description": "信頼できるサーバーにのみ接続してください。この接続で行われる操作と共有されるデータについては、お客様の責任となります。",
+          "title": "外部APIエンドポイントURL"
+        },
+        "errors": {
+          "connect": "エンドポイントに接続できませんでした。",
+          "generic": "問題が発生しました。",
+          "invalidApiKey": "APIキーが無効です。",
+          "timeout": "接続がタイムアウトしました。タイムアウトを長くしてみてください。"
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(デフォルト)"
+          },
+          "hard": {
+            "label": "失敗時にパイプラインをブロック"
+          },
+          "placeholder": "戦略を選択",
+          "soft": {
+            "label": "エラーを記録して続行"
+          },
+          "title": "フェイル戦略"
+        },
+        "hookPoint": {
+          "label": "フックポイント"
+        },
+        "name": {
+          "placeholder": "このフックポイントの拡張機能に名前を付けてください",
+          "title": "表示名"
+        },
+        "save": {
+          "label": "変更を保存"
+        },
+        "softStrategy": {
+          "description": "エンドポイントがエラーを返した場合、Onyxはそれをログに記録し、フックの結果を無視して通常どおりパイプラインを続行します。"
+        },
+        "timeout": {
+          "description": "フェイル戦略を適用する前に、Onyxがエンドポイントの応答を待つ最大時間です。0より大きく、最大{max}秒である必要があります。",
+          "revert": {
+            "tooltip": "デフォルトに戻す"
+          },
+          "suffix": "(秒)",
+          "title": "タイムアウト"
+        },
+        "toasts": {
+          "created": {
+            "message": "フックを作成しました。"
+          },
+          "noHookPoint": {
+            "message": "フックポイントが指定されていません。"
+          },
+          "updated": {
+            "message": "フックを更新しました。"
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "APIキーは空にできません。",
+          "endpointRequired": "エンドポイントURLは空にできません。",
+          "nameRequired": "表示名は空にできません。",
+          "timeoutRange": "0より大きく、最大{max}秒である必要があります。",
+          "timeoutRequired": "タイムアウトは必須です。"
+        },
+        "verifying": {
+          "label": "接続を確認しています…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "コピー"
+        },
+        "download": {
+          "tooltip": "ダウンロード"
+        },
+        "empty": {
+          "message": "過去30日間にエラーはありません。"
+        },
+        "header": {
+          "description": "フック: {name} • フックポイント: {point}",
+          "title": "最近のエラー"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {#行} other {#行}}"
+        },
+        "loadFailed": {
+          "message": "ログの読み込みに失敗しました。"
+        },
+        "older": {
+          "label": "それ以前"
+        },
+        "pastHour": {
+          "label": "過去1時間"
+        },
+        "unknownError": {
+          "label": "不明なエラー"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "キャンセル"
+        }
+      },
+      "page": {
+        "description": "事前定義されたフックポイントで外部APIエンドポイントをコールバックとして登録し、Onyxのパイプラインを拡張します。",
+        "empty": {
+          "title": "利用可能なフックポイントがありません"
+        },
+        "emptySearch": {
+          "description": "別の検索語をお試しください。",
+          "title": "結果が見つかりません"
+        },
+        "enterpriseRequired": {
+          "message": "フック拡張機能にはEnterpriseライセンスが必要です。"
+        },
+        "loadHooksFailed": {
+          "message": "フックの読み込みに失敗しました。ページを更新してください。"
+        },
+        "loadSpecsFailed": {
+          "message": "フック仕様の読み込みに失敗しました。ページを更新してください。"
+        },
+        "notEnabled": {
+          "message": "この環境ではフック拡張機能が有効になっていません。"
+        },
+        "search": {
+          "placeholder": "フックを検索..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "接続済み"
+        },
+        "connectionLost": {
+          "label": "接続が切断されました"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {#件のエラー} other {#件のエラー}}"
+        },
+        "noError": {
+          "title": "エラーなし"
+        },
+        "pastHour": {
+          "description": "過去1時間以内"
+        },
+        "recentErrors": {
+          "title": "直近のエラー"
+        },
+        "viewMore": {
+          "label": "さらに表示"
+        },
+        "viewOlder": {
+          "label": "以前のエラーを表示"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "フックの無効化に失敗しました。"
+        },
+        "deleteFailed": {
+          "message": "フックの削除に失敗しました。"
+        },
+        "disconnectFailed": {
+          "message": "フックの切断に失敗しました。"
+        },
+        "reconnectFailed": {
+          "message": "フックの再接続に失敗しました。"
+        },
+        "validateFailed": {
+          "message": "フックの検証に失敗しました。"
+        },
+        "validateSuccess": {
+          "message": "フックが正常に検証されました。"
+        },
+        "validationFailed": {
+          "message": "検証に失敗しました: {status}"
         }
       }
     },
@@ -4297,6 +5230,9 @@
               "label": "行を追加"
             },
             "description": "モデルプロバイダーが必要とする追加のプロパティを指定します。これらは [環境変数](https://docs.litellm.ai/docs/set_keys#environment-variables) として LiteLLM の `completion()` 呼び出しに渡されます。詳しい手順は [ドキュメント](https://docs.onyx.app/admins/ai_models/custom_inference_provider) を参照してください。",
+            "keyInput": {
+              "placeholder": "例: OPENAI_ORGANIZATION"
+            },
             "title": "環境変数"
           },
           "modelRow": {
@@ -4808,6 +5744,132 @@
         "title": "ユーザー"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "不明"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "AI"
+        },
+        "errorTitle": {
+          "title": "問題が発生しました :("
+        },
+        "feedback": {
+          "title": "フィードバック"
+        },
+        "fetchFailed": {
+          "message": "チャットセッションの取得に失敗しました - {error}"
+        },
+        "header": {
+          "title": "チャットセッションの詳細"
+        },
+        "referenceDocuments": {
+          "title": "参照ドキュメント"
+        },
+        "user": {
+          "label": "ユーザー"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "downloadFailed": {
+          "message": "クエリ履歴のダウンロードに失敗しました。"
+        },
+        "generating": {
+          "message": "CSVレポートを生成しています。「{button}」ボタンをクリックするとすべてのジョブを確認できます。"
+        },
+        "kickoff": {
+          "label": "エクスポートを開始"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "失敗"
+        },
+        "pending": {
+          "label": "保留中"
+        },
+        "success": {
+          "label": "成功"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "ダウンロード"
+        },
+        "endRange": {
+          "header": "終了範囲"
+        },
+        "generatedAt": {
+          "header": "生成日時"
+        },
+        "header": {
+          "title": "過去のクエリ履歴エクスポート"
+        },
+        "notReady": {
+          "tooltip": "エクスポートはまだ準備できていません"
+        },
+        "startRange": {
+          "header": "開始範囲"
+        },
+        "status": {
+          "header": "状態"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "低評価"
+        },
+        "like": {
+          "label": "高評価"
+        },
+        "mixed": {
+          "label": "混合"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "すべて"
+        },
+        "feedbackType": {
+          "label": "フィードバックの種類"
+        }
+      },
+      "previousExports": {
+        "label": "エクスポートを表示"
+      },
+      "table": {
+        "date": {
+          "header": "日付"
+        },
+        "feedback": {
+          "header": "フィードバック"
+        },
+        "fetchError": {
+          "title": "クエリ履歴の取得中にエラーが発生しました"
+        },
+        "firstAiResponse": {
+          "header": "最初のAI応答"
+        },
+        "firstUserMessage": {
+          "header": "最初のユーザーメッセージ"
+        },
+        "persona": {
+          "header": "ペルソナ"
+        },
+        "user": {
+          "header": "ユーザー"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4862,6 +5924,56 @@
         "generateFailed": "token を生成できませんでした：{detail}",
         "genericError": "問題が発生しました。もう一度お試しください。",
         "regenerated": "token を再生成しました"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "クエリの分類に失敗しました。チャットにフォールバックします。"
+        },
+        "searchFailed": {
+          "message": "ドキュメント検索に失敗しました。もう一度お試しください。"
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {#件の結果} other {#件の結果}}"
+        },
+        "empty": {
+          "description": "コネクタやフィルターを確認するか、別の検索語をお試しください。",
+          "title": "結果が見つかりません"
+        },
+        "failed": {
+          "title": "検索に失敗しました"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {#件のタグ} other {#件のタグ}}"
+        },
+        "empty": {
+          "label": "タグ"
+        },
+        "search": {
+          "placeholder": "タグを絞り込む..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "全期間"
+        },
+        "day": {
+          "label": "過去24時間"
+        },
+        "month": {
+          "label": "過去1か月"
+        },
+        "week": {
+          "label": "過去1週間"
+        },
+        "year": {
+          "label": "過去1年"
+        }
       }
     },
     "security": {
@@ -5753,6 +6865,163 @@
         "unexpectedError": "予期しないエラーが発生しました。"
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "カテゴリ {name} を削除"
+        },
+        "removeButton": {
+          "ariaLabel": "カテゴリを削除"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "定型回答カテゴリ"
+        },
+        "fetchError": {
+          "message": "定型回答カテゴリの取得に失敗しました - {message}",
+          "title": "問題が発生しました :("
+        },
+        "search": {
+          "placeholder": "カテゴリを検索..."
+        }
+      },
+      "editPage": {
+        "title": "標準回答を編集"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "標準回答の取得に失敗しました"
+        },
+        "fetchCategoriesFailed": {
+          "message": "標準回答カテゴリの取得に失敗しました"
+        },
+        "genericTitle": {
+          "title": "問題が発生しました :("
+        },
+        "loadAnswersFailed": {
+          "title": "標準回答の読み込み中にエラーが発生しました"
+        },
+        "loadCategoriesFailed": {
+          "title": "標準回答カテゴリの読み込み中にエラーが発生しました"
+        },
+        "notFound": {
+          "message": "ID: {id} の標準回答が見つかりませんでした"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "すべてのカテゴリ"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "これらのキーワードのすべて(順不同、スペース区切り)",
+          "placeholder": "IT チケット"
+        },
+        "answer": {
+          "label": "回答",
+          "placeholder": "Markdown形式の回答。例: ITチームのサポートが必要な場合は、internalsupport@company.com までメールでご連絡ください"
+        },
+        "anyKeywords": {
+          "label": "これらのキーワードのいずれか(スペース区切り)",
+          "placeholder": "チケット 問題 障害"
+        },
+        "categories": {
+          "label": "カテゴリ:",
+          "placeholder": "カテゴリを入力してEnterキーを押してください…"
+        },
+        "createButton": {
+          "label": "作成!"
+        },
+        "keywords": {
+          "tooltip": "回答をトリガーするには、質問がこれらのキーワードに一致する必要があります。"
+        },
+        "matchRegex": {
+          "description": "正確なキーワードの代わりに正規表現パターンで一致させます",
+          "label": "正規表現で一致"
+        },
+        "regexPattern": {
+          "label": "正規表現パターン",
+          "tooltip": "質問がこの正規表現パターンに一致した場合にトリガーされます(Pythonの`re.search()`を使用)"
+        },
+        "strategy": {
+          "all": {
+            "label": "すべてのキーワード"
+          },
+          "any": {
+            "label": "いずれかのキーワード"
+          },
+          "description": "この回答を表示するために、ユーザーの質問に上記のキーワードのいずれか、またはすべてが含まれる必要があるかを選択します。",
+          "label": "キーワード検出戦略"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "カテゴリ「{name}」の作成中にエラーが発生しました - {error}"
+          },
+          "createFailed": {
+            "message": "標準回答の作成中にエラーが発生しました - {error}"
+          },
+          "updateFailed": {
+            "message": "標準回答の更新中にエラーが発生しました - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "更新!"
+        },
+        "validation": {
+          "answerRequired": "回答は必須です",
+          "categoryRequired": "少なくとも1つのカテゴリが必要です",
+          "keywordRequired": "キーワードまたはパターンは必須です"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "以下から最初の標準回答を追加しましょう!"
+        },
+        "description": "事前定義された質問に対する標準回答を管理します。\n注: 現在、Slackからの質問のみが標準回答を受け取れます。"
+      },
+      "newStandardAnswer": {
+        "label": "新しい標準回答"
+      },
+      "search": {
+        "placeholder": "キーワードやフレーズで標準回答を検索..."
+      },
+      "table": {
+        "answer": {
+          "header": "回答"
+        },
+        "categories": {
+          "header": "カテゴリ"
+        },
+        "empty": {
+          "message": "一致する標準回答が見つかりません..."
+        },
+        "keywords": {
+          "header": "キーワード/パターン"
+        },
+        "matchRegex": {
+          "header": "正規表現で一致?"
+        },
+        "matchRegexNo": {
+          "label": "いいえ"
+        },
+        "matchRegexYes": {
+          "label": "はい"
+        },
+        "slackNote": {
+          "message": "該当する[Slackボット](/admin/bots)にカテゴリを追加したことを確認してください。"
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "標準回答の削除に失敗しました - {error}"
+        },
+        "deleted": {
+          "message": "標準回答 {id} を削除しました"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "キャンセル済み",
@@ -5783,6 +7052,142 @@
       },
       "webVersion": {
         "label": "Web バージョン: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "ユーザーが閉じることのできる常設のシステムアナウンスを表示します。",
+        "header": {
+          "placeholder": "アナウンスを追加"
+        },
+        "label": "システムアナウンス"
+      },
+      "announcementPopup": {
+        "description": "この通知を、すべてのユーザーの初回訪問時に全画面ポップアップとしても表示します。慎重に使用してください。",
+        "label": "初回訪問時のポップアップ通知"
+      },
+      "appName": {
+        "description": "この名前はアプリ全体に表示され、UI内の「Onyx」を置き換えます。",
+        "label": "アプリケーションの表示名"
+      },
+      "branding": {
+        "description": "アプリ内の「powered by Onyx」やその他のOnyxブランディングを削除します。",
+        "enterpriseTooltip": "Onyxブランディングの非表示はEnterpriseプランの機能です。",
+        "label": "Onyxブランディングを非表示"
+      },
+      "chatFooter": {
+        "description": "免責事項や追加情報のためのマークダウンコンテンツを追加します。",
+        "label": "チャットフッターのテキスト"
+      },
+      "chatHeader": {
+        "label": "チャットヘッダーのテキスト"
+      },
+      "consent": {
+        "description": "アプリケーションにアクセスする前に、ユーザーに通知を読んで同意することを求めます。",
+        "label": "通知への同意を必須にする"
+      },
+      "consentPrompt": {
+        "label": "通知の同意プロンプト"
+      },
+      "firstVisit": {
+        "description": "新規ユーザーの初回訪問時に一度だけポップアップを表示します。",
+        "label": "初回訪問時の通知を表示"
+      },
+      "greeting": {
+        "description": "ホームページに短いメッセージを追加します。",
+        "label": "あいさつメッセージ"
+      },
+      "helpLink": {
+        "description": "Onyxのドキュメントに加えて、ユーザーメニューにカスタムヘルプリンクを追加します。",
+        "enterpriseTooltip": "カスタムヘルプリンクはEnterpriseプランの機能です。",
+        "label": "カスタムヘルプリンク"
+      },
+      "helpLinkLabel": {
+        "label": "カスタムヘルプリンクのラベル",
+        "placeholder": "リンクのラベル"
+      },
+      "loginSubtitle": {
+        "description": "ログインページのウェルカム見出しの下のキャッチフレーズを置き換えます。",
+        "label": "ログインページのサブタイトル"
+      },
+      "logo": {
+        "label": "アプリケーションのロゴ",
+        "updateButton": {
+          "label": "更新"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "ロゴと名前",
+          "tooltip": "アプリケーションのロゴと名前の両方を表示します。"
+        },
+        "description": "サイドバーの上部に表示する内容を選択します。ロゴまたはアプリケーション名を追加するとオプションが利用可能になります。",
+        "label": "ロゴの表示スタイル",
+        "logoOnly": {
+          "disabledTooltip": "このオプションを有効にするにはロゴをアップロードしてください。",
+          "label": "ロゴのみ",
+          "tooltip": "アプリケーションのロゴのみを表示します。"
+        },
+        "nameOnly": {
+          "disabledTooltip": "このオプションを有効にするにはアプリケーション名を入力してください。",
+          "label": "名前のみ",
+          "tooltip": "アプリケーションの名前のみを表示します。"
+        }
+      },
+      "markdownContent": {
+        "placeholder": "マークダウンコンテンツを追加"
+      },
+      "noticeContent": {
+        "label": "通知の内容"
+      },
+      "noticeHeader": {
+        "label": "通知のヘッダー"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "アナウンスの削除に失敗しました。"
+        },
+        "announcementSaveFailed": {
+          "message": "アナウンスの保存に失敗しました。"
+        },
+        "applyButton": {
+          "label": "変更を適用"
+        },
+        "applying": {
+          "label": "適用中..."
+        },
+        "description": "組織内のユーザーに対するアプリケーションの表示をカスタマイズします。",
+        "logoUploadFailed": {
+          "message": "ロゴのアップロードに失敗しました。{error}"
+        },
+        "saveSuccess": {
+          "message": "外観設定が正常に保存されました!"
+        },
+        "settingsSaveFailed": {
+          "message": "設定の更新に失敗しました。{error}"
+        },
+        "validation": {
+          "consentPromptRequired": "通知の同意プロンプトは必須です",
+          "invalidUrl": "有効なURLである必要があります",
+          "maxChars": "最大{count}文字",
+          "noticeContentRequired": "通知の内容は必須です",
+          "noticeHeaderRequired": "通知のヘッダーは必須です",
+          "urlRequiredWithLabel": "ラベルを設定した場合はURLが必須です"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "チャットフッターの内容"
+        },
+        "chatHeader": {
+          "placeholder": "チャットヘッダーの内容"
+        },
+        "greeting": {
+          "placeholder": "Acme Chatへようこそ"
+        },
+        "logo": {
+          "alt": "ロゴ"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6047,6 +7452,9 @@
             "label": "支出"
           }
         }
+      },
+      "page": {
+        "description": "ワークスペースの支出を監視し、ユーザーごとの使用状況を確認します。"
       },
       "spendByUser": {
         "columns": {
@@ -6644,6 +8052,204 @@
         "tooltip": "エージェントの統計を表示"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "コードを生成して実行します。",
+          "title": "コードインタープリター"
+        },
+        "codingAgent": {
+          "description": "GitHubリポジトリを調査し、そのコードに関する質問に回答します。",
+          "title": "コーディングエージェント"
+        },
+        "description": "このエージェントが使用できるツールと機能です。",
+        "imageGeneration": {
+          "description": "AI搭載ツールで画像を生成・加工します。",
+          "title": "画像生成",
+          "unavailable": {
+            "tooltip": "画像生成には設定済みのモデルが必要です。アクセス権がある場合は、設定 > 画像生成でモデルを設定するか、管理者に依頼してください。"
+          }
+        },
+        "openUrl": {
+          "description": "ウェブURLからコンテンツを取得して読み取ります。",
+          "title": "URLを開く"
+        },
+        "title": "アクション",
+        "webSearch": {
+          "description": "リアルタイムの情報と最新の結果をウェブで検索します。",
+          "title": "ウェブ検索"
+        }
+      },
+      "advanced": {
+        "description": "エージェントのプロンプトと知識を微調整します。",
+        "overwritePrompt": {
+          "suffix": "（非推奨）",
+          "title": "システムプロンプトを上書き"
+        },
+        "reminders": {
+          "description": "プロンプトメッセージに短いリマインダーを追加します。チャットが進むにつれてエージェントが特定の指示を忘れがちな場合に使用してください。簡潔にし、ユーザーメッセージの妨げにならないようにしてください。",
+          "placeholder": "忘れないでください。回答は常に番号付きリストの形式にしてください。",
+          "title": "リマインダー"
+        },
+        "title": "詳細オプション"
+      },
+      "avatar": {
+        "edit": {
+          "label": "編集"
+        },
+        "uploadImage": {
+          "label": "画像をアップロード"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "エージェントを削除"
+        },
+        "description": "このエージェントを使用しているすべてのユーザーがアクセスできなくなります。",
+        "title": "このエージェントを削除"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "このエージェントを削除してもよろしいですか？",
+          "warning": "このエージェントを使用しているすべてのユーザーがアクセスできなくなります。削除は元に戻せません。"
+        },
+        "title": "エージェントを削除"
+      },
+      "filesModal": {
+        "description": "このエージェント用に選択されたすべてのファイル",
+        "placeholderName": "ファイル {id}",
+        "title": "ユーザーファイル"
+      },
+      "general": {
+        "avatar": {
+          "title": "エージェントのアバター"
+        },
+        "descriptionField": {
+          "placeholder": "このエージェントは何をしますか？",
+          "title": "説明"
+        },
+        "name": {
+          "placeholder": "エージェントに名前を付ける",
+          "title": "名前"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "create": {
+          "label": "作成"
+        },
+        "createTitle": "エージェントを作成",
+        "editTitle": "エージェントを編集",
+        "save": {
+          "label": "保存"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "このMCPサーバーへのアクセス権がなくなりました。既存のツールは保持されます。"
+        },
+        "searchTools": {
+          "placeholder": "ツールを検索..."
+        }
+      },
+      "page": {
+        "ariaLabel": "エージェントエディターページ"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "このエージェントの応答を調整するための指示を追加します。",
+          "placeholder": "複雑な問題では段階的に考え、推論を示してください。具体的な例を使用してください。アクション項目を強調し、不明な点は人間が記入できるよう空欄にしてください。丁寧で熱意のあるトーンを使用してください。",
+          "title": "指示"
+        },
+        "starters": {
+          "description": "このエージェントに何ができ、どのように効果的にやり取りできるかをユーザーが理解するのに役立つメッセージ例です。",
+          "title": "会話のきっかけ"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "保存する前にフォームのエラーを修正してください。",
+        "noChanges": "変更はありません。",
+        "saving": "変更を保存中...",
+        "uploading": "ファイルのアップロードが完了するまでお待ちください。"
+      },
+      "share": {
+        "feature": {
+          "description": "このエージェントをエージェント一覧の上部に表示し、アクセス権のある新規ユーザーのサイドバーに自動的にピン留めします。",
+          "privateNotice": {
+            "title": "このエージェントはあなた専用のため、あなたにのみ注目として表示されます。"
+          },
+          "title": "このエージェントを注目に設定",
+          "unlistedWarning": {
+            "title": "このエージェントは非掲載のため、注目リストには表示されません。"
+          }
+        },
+        "labels": {
+          "description": "ラベルとカテゴリを追加して、このエージェントを見つけやすくします。",
+          "placeholder": "ラベルを追加..."
+        },
+        "share": {
+          "button": {
+            "label": "共有"
+          },
+          "description": "他のユーザー、グループ、または組織全体と共有できます。",
+          "title": "このエージェントを共有"
+        },
+        "title": "エージェントを共有"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "今四半期のエンジニアリング目標のリストをまとめて。",
+          "overview": "いくつかのドキュメントの概要を教えて。",
+          "salesReport": "最新の売上レポートを探して。",
+          "todayGoals": "今日の目標をまとめて。"
+        },
+        "placeholder": "会話のきっかけを入力..."
+      },
+      "suffix": {
+        "optional": "任意"
+      },
+      "toasts": {
+        "createFailed": "エージェントの作成に失敗しました - {detail}",
+        "created": "エージェント「{name}」を作成しました",
+        "deleteFailed": "エージェントの削除に失敗しました：{error}",
+        "deleted": "エージェントを削除しました",
+        "genericError": "エラーが発生しました：{error}",
+        "noResponse": "応答がありません",
+        "sharingFailed": "エージェントは作成されましたが、共有に失敗しました：{error}",
+        "toggleListedFailed": "表示状態の切り替えに失敗しました",
+        "unknownDetail": "不明なエラー",
+        "unknownError": "不明なエラー",
+        "updateFailed": "エージェントの更新に失敗しました - {detail}",
+        "updated": "エージェント「{name}」を更新しました"
+      },
+      "validation": {
+        "cutoffInFuture": "知識のカットオフ日は今日以前である必要があります。",
+        "descriptionMax": "説明は{max}文字以内で入力してください",
+        "nameRequired": "エージェント名は必須です。",
+        "starterMax": "会話のきっかけは{max}文字以内で入力してください"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "再掲載する"
+          },
+          "description": "再掲載されたエージェントは、エージェント一覧に再び表示されます。",
+          "title": "このエージェントを再掲載する"
+        },
+        "unlist": {
+          "button": {
+            "label": "非掲載にする"
+          },
+          "description": "非掲載のエージェントはエージェント一覧に表示されませんが、引き続きアクセスできます。",
+          "title": "このエージェントを非掲載にする"
+        }
+      },
+      "warnings": {
+        "openUrl": "URLを開く機能なしのウェブ検索では、ウェブベースの結果が大幅に悪化する可能性があります。"
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6826,6 +8432,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {エージェント} other {エージェント}}"
+      },
+      "empty": {
+        "description": "エージェントが見つかりません"
+      },
+      "header": {
+        "description": "あなたとチームのユースケースに合わせてAIの動作と知識をカスタマイズします。",
+        "title": "エージェント"
+      },
+      "newAgent": {
+        "label": "新しいエージェント",
+        "noPermission": {
+          "tooltip": "エージェントを作成する権限がありません。アクセスをリクエストするには管理者に連絡してください。"
+        }
+      },
+      "page": {
+        "ariaLabel": "エージェントページ"
+      },
+      "search": {
+        "placeholder": "エージェントを検索..."
+      },
+      "sections": {
+        "all": {
+          "title": "すべてのエージェント"
+        },
+        "featured": {
+          "description": "チームが厳選",
+          "title": "注目のエージェント"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "すべてのエージェント"
+        },
+        "your": {
+          "label": "あなたのエージェント"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "ユーザー変数を挿入"
@@ -6833,6 +8480,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "匿名セッションを設定しています。しばらくお待ちください。",
+        "title": "チャットページにリダイレクトしています..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "新しい組織を作成"
@@ -6854,6 +8507,55 @@
       },
       "signInLink": {
         "label": "サインイン"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "指定されたメールアドレスのアカウントは既に存在します。"
+      },
+      "continueAsGuest": {
+        "label": "またはゲストとして続行"
+      },
+      "email": {
+        "label": "メールアドレス",
+        "placeholder": "email@yourcompany.com"
+      },
+      "forgotPassword": {
+        "link": "[パスワードをお忘れですか?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "メールアドレスまたはパスワードが無効です"
+      },
+      "noPassword": {
+        "error": "パスワードを設定するにはアカウントを作成してください"
+      },
+      "password": {
+        "label": "パスワード",
+        "placeholder": "パスワード"
+      },
+      "passwordDigit": {
+        "error": "パスワードには数字を少なくとも 1 文字含める必要があります"
+      },
+      "passwordLength": {
+        "error": "パスワードは {min}~{max} 文字にする必要があります"
+      },
+      "passwordLoginDisabled": {
+        "error": "パスワードによるログインは無効になっています。ID プロバイダーでサインインしてください。"
+      },
+      "passwordLowercase": {
+        "error": "パスワードには小文字を少なくとも 1 文字含める必要があります"
+      },
+      "passwordRequirements": {
+        "label": "パスワードの要件:"
+      },
+      "passwordSpecialChar": {
+        "error": "パスワードには特殊文字を少なくとも 1 文字含める必要があります"
+      },
+      "passwordUppercase": {
+        "error": "パスワードには大文字を少なくとも 1 文字含める必要があります"
+      },
+      "tooManyRequests": {
+        "error": "リクエストが多すぎます。しばらくしてからもう一度お試しください。"
       }
     },
     "error": {
@@ -6894,6 +8596,31 @@
         "description": "認証システムの一時的な障害"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "あなたのチームでは匿名アクセスが有効になっていません。"
+      },
+      "generic": {
+        "toast": "エラーが発生しました。"
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "アカウントを作成"
+      },
+      "logo": {
+        "alt": "ロゴ"
+      },
+      "signInLink": {
+        "label": "サインイン"
+      },
+      "signinPrompt": {
+        "text": "すでにアカウントをお持ちですか？"
+      },
+      "signupPrompt": {
+        "text": "{appName}は初めてですか？"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[ログインに戻る](/auth/login)"
@@ -6926,7 +8653,8 @@
         "placeholder": "API キーを入力"
       },
       "emailField": {
-        "label": "メールアドレス"
+        "label": "メールアドレス",
+        "placeholder": "email@yourcompany.com"
       },
       "genericError": {
         "toast": "ユーザーへのなりすましに失敗しました"
@@ -6987,6 +8715,23 @@
         "label": "職場のメールアドレス"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "数字を含む。"
+      },
+      "length": {
+        "label": "{min}~{max} 文字"
+      },
+      "lowercase": {
+        "label": "小文字を含む。"
+      },
+      "specialChar": {
+        "label": "特殊文字を含む。"
+      },
+      "uppercase": {
+        "label": "大文字を含む。"
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[ログインに戻る](/auth/login)"
@@ -7028,6 +8773,31 @@
       },
       "unexpectedError": {
         "toast": "予期しないエラーが発生しました。もう一度お試しください。"
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "セッションの有効期限が切れました。続行するには再度ログインしてください。"
+      },
+      "loginButton": {
+        "label": "ログイン"
+      },
+      "modal": {
+        "title": "ログアウトされました"
+      },
+      "terminated": {
+        "message": "このセッションはサインアウトされました。続行するには再度ログインしてください。"
+      },
+      "unrecognized": {
+        "message": "予期せずサインアウトされました。続行するには再度ログインしてください。この問題が続く場合は、管理者にお問い合わせください。"
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute がトークンを返しませんでした"
+      },
+      "google": {
+        "label": "Google で続行"
       }
     },
     "signup": {
@@ -8459,6 +10229,75 @@
         "tooltip": "このモデルでは、この設定の変更に対応していません。"
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {ファイルの処理に失敗したため削除されました: {names}} other {ファイルの処理に失敗したため削除されました: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "ログイン"
+          },
+          "title": "Onyx へようこそ"
+        },
+        "noResubmitMessage": {
+          "toast": "以前に送信されたメッセージが見つかりません。"
+        },
+        "settingsButton": {
+          "tooltip": "設定を開く"
+        },
+        "setupLlmButton": {
+          "label": "LLM を設定してください。"
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "キャンセル"
+          },
+          "confirmButton": {
+            "label": "オフにする"
+          },
+          "description": "代わりにブラウザのデフォルトの新しいタブページが表示されます。Onyx の設定からいつでも再度オンにできます。",
+          "title": "Onyx の新しいタブページをオフにしますか？"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "なし"
+        },
+        "backgroundOption": {
+          "ariaLabel": "{label}の背景"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "{label}の背景（選択中）"
+        },
+        "backgroundSection": {
+          "title": "背景"
+        },
+        "closeButton": {
+          "tooltip": "設定を閉じる"
+        },
+        "generalSection": {
+          "title": "一般"
+        },
+        "header": {
+          "title": "設定"
+        },
+        "newTabToggle": {
+          "label": "Onyx を新しいタブページとして使用"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {ライトテーマに切り替え} other {ダークテーマに切り替え}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "新しいチャット"
+        },
+        "openInOnyxButton": {
+          "tooltip": "Onyx で開く"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "同意チェックボックス"
@@ -8474,6 +10313,128 @@
       },
       "startButton": {
         "label": "開始"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "最後のメッセージ: {time}"
+        },
+        "projectFallback": {
+          "label": "プロジェクト"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "ファイルを追加"
+        },
+        "contextExceeded": {
+          "message": "このプロジェクトはモデルのコンテキスト制限を超えています。セッションは応答を生成する前に、関連するファイルを自動的に検索します。"
+        },
+        "dropFiles": {
+          "message": "ここにファイルをドロップしてこのプロジェクトに追加"
+        },
+        "emptyFiles": {
+          "message": "プロジェクトで使用するドキュメント、テキスト、画像を追加します。ドラッグ&ドロップに対応しています。"
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# 件のファイル} other {# 件のファイル}}"
+        },
+        "fileCountOverflow": {
+          "description": "100 件以上のファイル"
+        },
+        "files": {
+          "description": "このプロジェクトのチャットはこれらのファイルにアクセスできます。",
+          "title": "ファイル"
+        },
+        "filesModal": {
+          "description": "このプロジェクトのセッションはここにあるファイルにアクセスできます。",
+          "title": "プロジェクトのファイル"
+        },
+        "instructions": {
+          "emptyDescription": "このプロジェクトでの応答を調整するための指示を追加します。",
+          "title": "指示"
+        },
+        "loadingProject": {
+          "label": "プロジェクトを読み込み中..."
+        },
+        "setInstructionsButton": {
+          "label": "指示を設定"
+        },
+        "viewAll": {
+          "label": "すべて表示"
+        },
+        "viewFiles": {
+          "label": "ファイルを表示"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "キャンセル"
+        },
+        "createError": {
+          "toast": "プロジェクト {name} を作成できませんでした"
+        },
+        "description": "プロジェクトを使うと、ファイルとチャットを 1 か所にまとめて整理し、継続的な作業のためのカスタム指示を追加できます。",
+        "name": {
+          "label": "プロジェクト名",
+          "placeholder": "何に取り組んでいますか?"
+        },
+        "nameRequired": {
+          "error": "プロジェクト名は必須です"
+        },
+        "submitButton": {
+          "label": "プロジェクトを作成"
+        },
+        "title": "新しいプロジェクトを作成"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "プロジェクトが見つかりません"
+        },
+        "search": {
+          "placeholder": "プロジェクトを検索..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "プロジェクトを折りたたむ"
+        },
+        "delete": {
+          "label": "プロジェクトを削除"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "削除"
+          },
+          "message": "このプロジェクトを削除してもよろしいですか?この操作は元に戻せません。",
+          "title": "プロジェクトを削除"
+        },
+        "expand": {
+          "ariaLabel": "プロジェクトを展開する"
+        },
+        "rename": {
+          "label": "プロジェクト名を変更"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "まだチャットはありません。"
+        },
+        "recentChats": {
+          "title": "最近のチャット"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "ファイルをアップロードできませんでした"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {サイズ超過のファイル # 件をスキップしました} other {サイズ超過のファイル # 件をスキップしました}} (>{max} MB): {names}"
+        },
+        "rejected": {
+          "toast": "一部のファイルはアップロードされませんでした。{details}"
+        }
       }
     },
     "sharedChat": {
@@ -8506,6 +10467,1773 @@
       },
       "incognito": {
         "title": "シークレットモードです"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "サイドバーを開く"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "請求情報を更新"
+        },
+        "text": "**警告:** トライアル期間の終了まで 5 日を切りましたが、支払い方法が追加されていません。"
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "エージェントのアバター"
+      },
+      "logo": {
+        "alt": "ロゴ"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "ドキュメント"
+      },
+      "expandButton": {
+        "ariaLabel": "ドキュメントを拡大"
+      }
+    },
+    "backButton": {
+      "label": "戻る"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "雲"
+      },
+      "hills": {
+        "label": "丘"
+      },
+      "mountains": {
+        "label": "山"
+      },
+      "night": {
+        "label": "夜"
+      },
+      "none": {
+        "label": "なし"
+      },
+      "plant": {
+        "label": "植物"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "あア"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix}「{value}」",
+        "defaultPrefix": "作成"
+      },
+      "dropdown": {
+        "closeAriaLabel": "ドロップダウンを閉じる",
+        "openAriaLabel": "ドロップダウンを開く"
+      },
+      "options": {
+        "empty": "オプションが見つかりません"
+      },
+      "separator": {
+        "label": "その他のオプション"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "メニューを閉じる"
+      },
+      "dialog": {
+        "title": "コマンドメニュー"
+      },
+      "options": {
+        "ariaLabel": "コマンドメニューのオプション"
+      },
+      "search": {
+        "placeholder": "検索..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "利用可能なすべてのコネクタが選択されています。別のコネクタを追加するには、以下からコネクタを削除してください。",
+        "placeholder": "すべてのコネクタが選択されています"
+      },
+      "documentSetHint": {
+        "description": "選択したコネクタでインデックスされたすべてのドキュメントがこのドキュメントセットに含まれます。"
+      },
+      "noMatches": {
+        "text": "一致するコネクタが見つかりません"
+      },
+      "noMoreConnectors": {
+        "text": "利用可能なコネクタはこれ以上ありません"
+      },
+      "noPrivateConnectors": {
+        "text": "利用可能な非公開コネクタがありません。まず非公開コネクタを作成してください。"
+      },
+      "noneSelected": {
+        "text": "コネクタが選択されていません。上でコネクタを検索して選択してください。"
+      },
+      "removeConnector": {
+        "tooltip": "コネクタを削除"
+      },
+      "search": {
+        "placeholder": "コネクタを検索..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "日付を選択"
+      },
+      "todayButton": {
+        "label": "今日"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "期間指定なし..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "カスタム範囲を選択"
+      },
+      "clearButton": {
+        "ariaLabel": "クリア"
+      },
+      "custom": {
+        "label": "カスタム"
+      },
+      "customRange": {
+        "ariaLabel": "カスタム範囲: {from}〜{to}"
+      },
+      "date": {
+        "label": "日付"
+      },
+      "group": {
+        "ariaLabel": "日付範囲"
+      },
+      "preset": {
+        "oneDay": "1日",
+        "oneMonth": "1ヶ月",
+        "sevenDays": "7日",
+        "threeMonths": "3ヶ月"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "削除"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {#件のコンテキストドキュメント} other {#件のコンテキストドキュメント}}"
+      },
+      "openDocument": {
+        "ariaLabel": "ドキュメントを開く: {title}"
+      },
+      "question": {
+        "title": "質問"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {#件のサブクエリ} other {#件のサブクエリ}}"
+      },
+      "updated": {
+        "text": "更新日: {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "デフォルト"
+      },
+      "selectOption": {
+        "placeholder": "オプションを選択..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "編集"
+      },
+      "rename": {
+        "ariaLabel": "名前を変更"
+      },
+      "save": {
+        "ariaLabel": "保存"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "管理者の場合は、<billingLink>管理者請求</billingLink>ページでライセンスを{hadLicense, select, true {更新} other {有効化}}するか、Stripe経由で登録するか、請求に関するサポートは<supportLink>support@onyx.app</supportLink>までお問い合わせください。"
+        },
+        "heading": {
+          "title": "アクセスが制限されています"
+        },
+        "licenseLapse": {
+          "description": "ライセンスの失効により、Onyxへのアクセスが一時的に停止されています。"
+        },
+        "licenseRequired": {
+          "description": "Onyxの使用にはライセンスが必要です。データは保護されており、ライセンスが有効化されると利用できるようになります。"
+        },
+        "logoutButton": {
+          "label": "ログアウト"
+        },
+        "manageSubscription": {
+          "description": "管理者の場合は、下のボタンをクリックしてサブスクリプションを管理できます。その他のユーザーは、管理者にお問い合わせください。"
+        },
+        "obtainLicense": {
+          "description": "はじめるには、システム管理者に連絡してライセンスを取得してください。"
+        },
+        "renewLicense": {
+          "description": "アクセスを回復してOnyxを引き続き使用するには、システム管理者に連絡してライセンスを更新してください。"
+        },
+        "resubscribeButton": {
+          "label": "再購読",
+          "loading": "読み込み中..."
+        },
+        "resubscribeError": {
+          "text": "再購読ページを開く際にエラーが発生しました。後でもう一度お試しください。"
+        },
+        "seatLimit": {
+          "description": "組織がライセンスされたシート数を超過しています。ユーザー数を減らすか、ライセンスをアップグレードするまでアクセスは制限されます。"
+        },
+        "seatLimitAdminHint": {
+          "text": "管理者の場合は、<userLink>ユーザー管理</userLink>ページでユーザーを管理するか、<billingLink>管理者請求</billingLink>ページでライセンスをアップグレードできます。"
+        },
+        "seatLimitWithCounts": {
+          "description": "組織がライセンスされたシート数を超過しています（{used}ユーザー / {seats}シート）。ユーザー数を減らすか、ライセンスをアップグレードするまでアクセスは制限されます。"
+        },
+        "subscriptionLapse": {
+          "description": "サブスクリプションの失効により、Onyxへのアクセスが一時的に停止されています。"
+        },
+        "updatePayment": {
+          "description": "アクセスを回復してOnyxの強力な機能を引き続きご利用いただくには、お支払い情報を更新してください。"
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "管理者の方は、正しい設定手順について<docsLink>ドキュメント</docsLink>をご確認ください。ユーザーの方は、管理者にお問い合わせください。"
+        },
+        "heading": {
+          "description": "Onyxの設定の読み込みに問題が発生したようです。設定の問題またはセットアップが未完了であることが原因の可能性があります。",
+          "title": "問題が発生しました"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "ご不便をおかけして申し訳ありません。しばらくお待ちください。"
+        },
+        "checkBack": {
+          "description": "Onyxは現在メンテナンス中です。数分後にもう一度お試しください。"
+        },
+        "heading": {
+          "title": "メンテナンス中"
+        }
+      },
+      "needHelp": {
+        "text": "サポートが必要ですか？<discordLink>Discordコミュニティ</discordLink>にご参加ください。"
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "不明なエラー"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "ファイルをダウンロード"
+      },
+      "file": {
+        "untitledFallback": "無題"
+      },
+      "fullScreenButton": {
+        "tooltip": "全画面表示"
+      },
+      "hideButton": {
+        "tooltip": "非表示"
+      },
+      "minimizeButton": {
+        "tooltip": "最小化"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "コピー"
+      },
+      "downloadButton": {
+        "tooltip": "ダウンロード"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {#行} other {#行}}"
+      },
+      "size": {
+        "bytes": "{count}バイト",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "全文を表示"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "すべてのフェデレーテッドコネクタが選択されています"
+      },
+      "entitiesConfigured": {
+        "tooltip": "エンティティが設定済み"
+      },
+      "noMatches": {
+        "text": "一致するフェデレーテッドコネクタが見つかりません"
+      },
+      "noMoreConnectors": {
+        "text": "利用可能なフェデレーテッドコネクタはこれ以上ありません"
+      },
+      "noneSelected": {
+        "text": "フェデレーテッドコネクタが選択されていません。上でコネクタを検索して選択してください。"
+      },
+      "realtimeSearchHint": {
+        "description": "選択したフェデレーテッドコネクタのドキュメントは、クエリ実行時にリアルタイムで検索されます。"
+      },
+      "removeConnector": {
+        "tooltip": "コネクタを削除"
+      },
+      "search": {
+        "placeholder": "フェデレーテッドコネクタを検索..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "新規追加"
+      },
+      "booleanField": {
+        "optionalLabel": "{label}（任意）"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "フィールドのファイルタイプ定義が見つかりません: {name}",
+        "selectionError": "ファイル選択エラー",
+        "unknownError": "不明なエラー",
+        "validating": "ファイルを検証中...",
+        "validationError": "検証エラー"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "ここにMarkdownを入力してください...",
+        "previewTab": "プレビュー",
+        "writeTab": "書く"
+      },
+      "optionalIndicator": {
+        "text": "（任意）"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "パスワードを非表示",
+        "showAriaLabel": "パスワードを表示"
+      },
+      "selector": {
+        "noneOption": "なし",
+        "placeholder": "選択..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "最近のファイルをすべて表示"
+      },
+      "recentFiles": {
+        "title": "最近のファイル"
+      },
+      "recentFilesModal": {
+        "description": "ファイルをアップロードするか、最近のファイルから選択してください。"
+      },
+      "toasts": {
+        "associatedAssistants": "ファイルを削除できません。次のアシスタントに関連付けられています: {assistants}",
+        "associatedBoth": "ファイルを削除できません。次のプロジェクト: {projects} とアシスタント: {assistants} に関連付けられています",
+        "associatedProjects": "ファイルを削除できません。次のプロジェクトに関連付けられています: {projects}",
+        "deleteFailed": "ファイルの削除に失敗しました。もう一度お試しください。",
+        "deleteSuccess": "ファイルを削除しました"
+      },
+      "uploadFiles": {
+        "description": "デバイスからファイルをアップロード",
+        "title": "ファイルをアップロード"
+      },
+      "viewFileButton": {
+        "tooltip": "ファイルを表示"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "ファイル"
+      },
+      "open": {
+        "ariaLabel": "{title}を開く"
+      },
+      "removeButton": {
+        "label": "削除"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "クリア"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "（任意）"
+      },
+      "required": {
+        "label": "（必須）"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "{label}の読み込みに失敗しました。もう一度お試しください。"
+      },
+      "search": {
+        "placeholder": "検索..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "利用可能なユーザーグループがありません。まずユーザーグループを作成してください。"
+      },
+      "userGroups": {
+        "label": "ユーザーグループ",
+        "subtext": "このリソースにアクセスできるユーザーグループを選択してください"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "ロゴ"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "{appName}を初期化中"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "削除"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "ファイルを添付"
+      },
+      "clearButton": {
+        "ariaLabel": "ファイルをクリア"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "ファイルが拒否されました"
+      },
+      "editButton": {
+        "ariaLabel": "画像を編集"
+      },
+      "editOverlay": {
+        "label": "編集"
+      },
+      "image": {
+        "altFallback": "画像"
+      },
+      "removeButton": {
+        "ariaLabel": "画像を削除"
+      },
+      "uploadButton": {
+        "ariaLabel": "画像をアップロード"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "オプションを選択"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "この{objectName}へのグループアクセスを割り当てる",
+        "scopedSubtext": "この{objectName}へのアクセスを付与するには、管理しているグループを1つ以上選択してください",
+        "visibleSubtext": "この{objectName}は、以下で選択したグループに表示・アクセス可能になります"
+      },
+      "loading": {
+        "text": "読み込み中..."
+      },
+      "makePublic": {
+        "label": "この{objectName}を公開しますか？",
+        "subtext": "設定すると、この{objectName}は<b>すべての{publicToWhom}</b>が利用できるようになります。設定しない場合、<b>管理者</b>と、（ユーザーグループなどを通じて）この{objectName}へのアクセスを明示的に付与された<b>{publicToWhom}</b>のみがアクセスできます。"
+      },
+      "publicDisabled": {
+        "message": "この{objectName}は公開されており、すべてのユーザーが利用できます。"
+      },
+      "usersFallback": {
+        "text": "ユーザー"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "{keyTitle}と{valueTitle}のペアを追加",
+        "label": "行を追加"
+      },
+      "empty": {
+        "title": "まだ項目が追加されていません。"
+      },
+      "error": {
+        "duplicateKey": "キーが重複しています",
+        "duplicateSummary": "{count, plural, one {#件の重複キーが見つかりました} other {#件の重複キーが見つかりました}}",
+        "emptyKey": "キーを空にすることはできません",
+        "emptySummary": "{count, plural, one {#件の空のキーが見つかりました} other {#件の空のキーが見つかりました}}",
+        "validationSummary": "{count, plural, one {#件の検証エラーが見つかりました} other {#件の検証エラーが見つかりました}}"
+      },
+      "group": {
+        "ariaLabel": "{keyTitle}と{valueTitle}のペア"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "キー"
+      },
+      "pair": {
+        "fallbackLabel": "キーと値"
+      },
+      "removeButton": {
+        "ariaLabel": "{label}のペア{index}を削除"
+      },
+      "valueColumn": {
+        "title": "値"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "ロゴ"
+      },
+      "poweredBy": {
+        "label": "Powered by Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "利用できないコネクタ:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "認可がキャンセルされたか失敗しました。もう一度お試しください。",
+        "title": "認可に失敗しました"
+      },
+      "backButton": {
+        "label": "チャットに戻る"
+      },
+      "completeFailed": {
+        "message": "認可を完了できませんでした"
+      },
+      "genericError": {
+        "description": "OAuth処理中にエラーが発生しました。もう一度お試しください。",
+        "title": "問題が発生しました"
+      },
+      "invalidRequest": {
+        "description": "認可リクエストが不完全でした。もう一度お試しください。",
+        "title": "無効なリクエスト"
+      },
+      "loadingHint": {
+        "text": "少々お待ちください..."
+      },
+      "processing": {
+        "description": "セットアップが完了するまでお待ちください。",
+        "title": "処理中..."
+      },
+      "redirecting": {
+        "text": "{count, plural, one {#秒} other {#秒}}後にリダイレクトします..."
+      },
+      "serviceFallback": {
+        "text": "サービス"
+      },
+      "success": {
+        "detailsTemplate": "{serviceName}の認可が正常に完了しました。",
+        "title": "成功しました！"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "スプレッドシートが破損しているか、正しく読み込めませんでした。",
+        "title": "スプレッドシートの読み込みエラー"
+      },
+      "preview": {
+        "truncated": "プレビューは省略されています。すべての行を見るにはファイルをダウンロードしてください。",
+        "unavailable": "このスプレッドシートをプレビューできません。"
+      },
+      "sheet": {
+        "defaultName": "シート1",
+        "empty": "このシートは空です。",
+        "tooLarge": "このシートは大きすぎてプレビューできません。ファイルをダウンロードして表示してください。"
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "メインエージェント"
+      },
+      "subagentFallback": {
+        "label": "サブエージェント"
+      },
+      "switch": {
+        "ariaLabel": "エージェントを切り替える"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "このアクションを1回だけ承認",
+        "button": "1回だけ承認"
+      },
+      "approveSession": {
+        "button": "セッション全体で承認",
+        "tooltip": "このセッションの一致するアクションを承認"
+      },
+      "details": {
+        "hideAriaLabel": "詳細を隠す",
+        "showAriaLabel": "詳細を表示"
+      },
+      "header": {
+        "required": "承認が必要です: {headline}"
+      },
+      "headline": {
+        "multiAction": "{app} での {count, plural, one {# 件のアクション} other {# 件のアクション}}",
+        "singleAction": "{app} での {action}"
+      },
+      "payload": {
+        "empty": {
+          "label": "ペイロードはありません。"
+        },
+        "showLess": {
+          "button": "表示を減らす"
+        },
+        "showMore": {
+          "button": "もっと見る"
+        }
+      },
+      "reject": {
+        "ariaLabel": "このアクションを却下",
+        "button": "却下"
+      },
+      "status": {
+        "approved": "承認済み",
+        "rejected": "却下済み"
+      },
+      "submit": {
+        "errorFallback": "決定を送信できませんでした"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "追加",
+        "createButton": "作成",
+        "customApp": {
+          "description": "独自のインテグレーション向けの認証情報とネットワークアクセス。",
+          "title": "カスタムアプリ"
+        },
+        "mcpHint": {
+          "label": "MCP サーバーが必要な場合は、まず「アクション」で接続してから、ここで Craft 向けに有効化してください。",
+          "openActionsButton": "アクションを開く"
+        },
+        "modal": {
+          "description": "組織全体で使えるインテグレーションを追加します。組み込みプロバイダーには Craft エージェントに使い方を教えるアクションが付属しています。設定済みのプロバイダーは表示されません。",
+          "title": "アプリを追加"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "{name} を関連付け",
+        "associateButton": "既存のスキルを関連付け",
+        "create": {
+          "github": {
+            "description": "スキルが GitHub にある場合は、まずスキルページでインポートしてから、このアプリに関連付けてください。",
+            "label": "GitHub からインポート"
+          },
+          "scratch": {
+            "description": "手順を書き、補助ファイルを追加します。",
+            "label": "最初から作成"
+          },
+          "upload": {
+            "description": "SKILL.md ファイル、ZIP ファイル、またはスキルフォルダをインポートします。",
+            "label": "スキルをアップロード"
+          }
+        },
+        "createSkillButton": "スキルを作成",
+        "description": "スキルは、このアプリの使い方を Craft に指示します。スキルは組織全体で共有され、アプリが正しく動作するにはユーザーがすべて有効にする必要がある場合があります。",
+        "editButton": "編集",
+        "empty": {
+          "label": "編集可能なスキルが見つかりません。"
+        },
+        "invalidTag": "無効",
+        "loading": {
+          "label": "スキルを読み込み中…"
+        },
+        "noneAssociated": {
+          "label": "まだスキルが関連付けられていません。スキルがなくてもこのアプリは保存して使用できます。"
+        },
+        "promote": {
+          "cancelButton": "キャンセル",
+          "confirmButton": "組織全体で利用可能にする",
+          "description": "アプリに関連付けられたスキルは全員が利用できる必要があります。この変更はアプリの保存時に適用されます。",
+          "title": "「{name}」を組織全体で利用可能にしますか？"
+        },
+        "search": {
+          "placeholder": "編集可能なスキルを検索..."
+        },
+        "title": "関連付けられたスキル",
+        "unavailable": {
+          "duplicateName": "「{name}」という名前のスキルはすでに関連付けられています。",
+          "invalid": "無効なスキルです。関連付ける前に修正してください。",
+          "otherApp": "すでにアプリ「{name}」に関連付けられています。"
+        },
+        "unlink": {
+          "button": "切り離す",
+          "cancelButton": "キャンセル",
+          "confirm": "「{name}」をこのアプリから切り離しますか？"
+        },
+        "unlinkAriaLabel": "{name} を切り離す",
+        "viewButton": "表示"
+      },
+      "configureProvider": {
+        "addButton": "追加",
+        "addTitle": "{name} を追加",
+        "editTitle": "{name} を編集",
+        "emptyPolicies": "このプロバイダーには設定できるアクションがありません。",
+        "fields": {
+          "name": {
+            "description": "この接続のラベルです。同じプロバイダーを複数追加する場合は、区別できる名前を付けてください（例:「{name} — エンジニアリング」）。",
+            "label": "名前"
+          }
+        },
+        "managedDescription": "Onyx が提供。エージェントに許可する操作を設定してください。",
+        "managedNote": "このアプリは Onyx が提供し、認証情報は自動的に管理されます。以下でエージェントに許可する操作を選択してください。ユーザーはアプリページから接続します。",
+        "saveButton": "保存"
+      },
+      "customApp": {
+        "cancelButton": "キャンセル",
+        "createButton": "作成",
+        "createDescription": "エグレスプロキシがこのアプリに到達し認証する方法を設定します。スキルは必須ではありません。",
+        "createTitle": "カスタムアプリを作成",
+        "creatingButton": "作成中…",
+        "disabled": {
+          "nameMissing": "このカスタムアプリを作成する前に名前を入力してください。",
+          "patternMissing": "アップストリーム URL パターンを 1 つ以上追加してください。パターンを入力して Enter を押します。",
+          "pristine": "保存する前に変更を加えてください。",
+          "saving": "保存処理がすでに進行中です。"
+        },
+        "editDescription": "ゲートウェイ設定を更新し、関連スキルを管理します。",
+        "editTitle": "{name} を編集",
+        "errors": {
+          "saveFailedTitle": "保存できませんでした"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "ヘッダーを追加",
+            "description": "任意。送信リクエストに挿入されるヘッダーです。ユーザー（または下記の組織）が提供する値には '{placeholder}' を使います（例: \"Bearer '{api_key}'\"）。空のままにすると、認証情報を挿入せずにアップストリームパターンを許可します。",
+            "keyTitle": "ヘッダー",
+            "label": "ヘッダー認証情報パターン",
+            "valueTitle": "値"
+          },
+          "name": {
+            "label": "名前",
+            "placeholder": "マイカスタムアプリ"
+          },
+          "orgCredentials": {
+            "addButton": "認証情報を追加",
+            "description": "任意。組織が全ユーザー向けに事前入力する値です。各ユーザーが自分の認証情報を入力するアプリでは空のままにしてください。",
+            "keyTitle": "認証情報キー",
+            "label": "組織の認証情報",
+            "valueTitle": "値"
+          },
+          "upstreamPatterns": {
+            "description": "プロキシが認証情報を挿入できる送信先 URL です。* は任意の文字に一致します（例: https://api.example.com/* はそのホストのすべてのパスに一致）。ホストはリテラルで指定し、最初のスラッシュより前にワイルドカードは使えません。パターンを入力して Enter を押してください。",
+            "label": "アップストリーム URL パターン"
+          }
+        },
+        "saveButton": "保存",
+        "savingButton": "保存中…"
+      },
+      "errors": {
+        "duplicateSkillName": "アプリ「{appName}」には「{skillName}」という名前の関連スキルがすでにあります。別の名前のスキルをアップロードしてください。"
+      },
+      "mcpPolicy": {
+        "description": "この MCP サーバーのツールで Craft エージェントに許可する操作を設定します。",
+        "emptyPolicies": "このサーバーには有効なツールがありません。まず MCP アクションページでツールを有効にしてください。",
+        "saveButton": "保存",
+        "title": "{name} を編集"
+      },
+      "oauthCallback": {
+        "backButton": "マイアプリに戻る",
+        "description": "OAuth ハンドシェイクを完了しています…",
+        "errors": {
+          "cancelled": "OAuth がキャンセルまたは拒否されました: {reason}",
+          "failed": "接続に失敗しました。",
+          "missingParams": "コールバック URL に code または state がありません。"
+        },
+        "exchanging": {
+          "label": "認可コードを交換しています…"
+        },
+        "success": {
+          "label": "接続しました。アプリ一覧に戻ります…"
+        },
+        "title": "アプリを接続しています"
+      },
+      "page": {
+        "connectButton": "接続",
+        "connectingButton": "リダイレクト中…",
+        "disconnectButton": "接続を解除",
+        "empty": {
+          "description": "組織向けに設定されたアプリや MCP サーバーはまだありません。",
+          "title": "まだ接続できるものがありません"
+        },
+        "errors": {
+          "disconnectFailed": "接続を解除できませんでした",
+          "startAuthFailed": "認可を開始できませんでした"
+        },
+        "header": {
+          "description": "Onyx Craft が作業中にコンテキストとして使えるツールを接続します。",
+          "manageButton": "アプリを管理",
+          "searchPlaceholder": "アプリを検索...",
+          "title": "アプリ"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Onyx が直接サポートするインテグレーションです。それぞれに Craft へ使い方を教えるスキルが付属しています。まずはここから始めましょう。",
+            "empty": "組織向けに設定されたアプリはまだありません。",
+            "emptyTitle": "アプリはまだありません",
+            "tabLabel": "アプリ · {count}"
+          },
+          "mcp": {
+            "blurb": "管理者が Craft 向けに公開したサーバーです。必要なアプリが「アプリ」に見つからない場合や、サーバー独自の MCP ツールを使いたい場合に利用してください。",
+            "empty": "Craft 向けに公開された MCP サーバーはありません。",
+            "emptyTitle": "MCP サーバーはまだありません",
+            "tabLabel": "MCP サーバー · {count}"
+          }
+        },
+        "loading": {
+          "label": "読み込み中…"
+        },
+        "reviewSkillsButton": "スキルを確認",
+        "search": {
+          "noMatchesDescription": "検索に一致するものはありません。",
+          "noMatchesTitle": "一致なし"
+        },
+        "status": {
+          "connected": "接続済み",
+          "connectedNeedsSkills": "接続済み · 一部の関連スキルが無効です",
+          "notAvailable": "お使いのアカウントでは利用できません。管理者にお問い合わせください",
+          "skillWarningAriaLabel": "スキルの設定が必要です",
+          "skillWarningTooltip": "一部の関連スキルが無効です。このアプリは正しく動作しない可能性があります。"
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "アクションごとに個別のポリシーを設定します。",
+          "title": "詳細設定"
+        },
+        "cancelButton": "キャンセル",
+        "loading": {
+          "label": "読み込み中…"
+        },
+        "permissions": {
+          "askOption": "確認する",
+          "autoApproveOption": "自動承認",
+          "customOption": "カスタム",
+          "description": "エージェントに許可する操作を選択します。「確認する」は各アクションの実行前にチャットで確認し、「自動承認」は確認なしで実行します。アクションごとにポリシーを設定するには「詳細設定」を使用してください。",
+          "title": "権限"
+        },
+        "savingButton": "保存中…"
+      },
+      "skillsStep": {
+        "description": "任意。既存のスキルを関連付けるか、このアプリ用に新しく作成します。",
+        "errors": {
+          "saveFailedTitle": "保存できませんでした"
+        },
+        "saveButton": "スキルを保存",
+        "savingButton": "保存中…",
+        "skipButton": "今はスキップ",
+        "title": "{name} にスキルを追加"
+      },
+      "userCredentials": {
+        "cancelButton": "キャンセル",
+        "connectButton": "接続",
+        "connectingButton": "接続中…",
+        "description": "このアプリをアカウントで認可するには、認証情報を入力してください。",
+        "errors": {
+          "connectFailedTitle": "接続できませんでした"
+        },
+        "title": "{name} を接続"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "ダウンロード"
+      },
+      "empty": {
+        "description": "出力ファイルとウェブアプリがここに表示されます",
+        "title": "まだアーティファクトがありません"
+      },
+      "nextjsApp": {
+        "label": "Next.js アプリケーション"
+      },
+      "openItem": {
+        "ariaLabel": "{name} を開く"
+      },
+      "toggleItem": {
+        "ariaLabel": "{name} を開閉"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "会話を続ける...",
+        "scheduledRunPlaceholder": "スケジュール実行中...",
+        "subagentPlaceholder": "メッセージを送るにはメインエージェントに切り替えてください"
+      },
+      "openSidebar": {
+        "ariaLabel": "サイドバーを開く"
+      },
+      "outputPanel": {
+        "closeTooltip": "出力パネルを閉じる",
+        "openTooltip": "出力パネルを開く"
+      },
+      "responseStopped": {
+        "label": "応答を停止しました"
+      },
+      "scrollToBottom": {
+        "label": "一番下へ移動"
+      },
+      "toast": {
+        "operationWait": "現在の操作が完了するまでお待ちください。",
+        "sandboxWait": "サンドボックスの初期化をお待ちください",
+        "scheduledRunWait": "スケジュール実行が完了するまでお待ちください。"
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "スペース確保のためコンテキストを圧縮しました"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "データを接続"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "ワークスペースをクラフトしています...",
+        "enchanting": "魔法でエンチャントしています...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "資源を集めています...",
+        "miningDependencies": "依存関係を採掘しています...",
+        "placingBlocks": "ブロックを設置しています...",
+        "punchingWood": "木を殴っています...",
+        "smeltingCode": "コードを精錬しています...",
+        "worldGenerated": "ワールド生成が完了しました..."
+      },
+      "tagline": {
+        "label": "次の素晴らしいアイデアをクラフト中..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "クリア"
+      },
+      "copy": {
+        "doneTooltip": "コピーしました",
+        "tooltip": "表示中の行をコピー"
+      },
+      "empty": {
+        "noLines": "まだ行がありません。",
+        "noMatch": "\"{filter}\" に一致する行はありません",
+        "waiting": "最初のログ行を待っています…"
+      },
+      "error": {
+        "endpointDisabled": "デバッグエンドポイントが無効です (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "ログを取得できる実行中のサンドボックスがありません"
+      },
+      "filter": {
+        "placeholder": "フィルター…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# 行} other {# 行}}",
+        "filteredCount": "{visible, number} / {total, number} 行"
+      },
+      "modal": {
+        "description": "サンドボックスコンテナのライブテール — 開発/デバッグ専用。",
+        "title": "Opencode Pod ログ"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} 件の新着 · 移動"
+      },
+      "open": {
+        "button": "Pod ログ"
+      },
+      "status": {
+        "closed": "終了",
+        "connecting": "接続中",
+        "error": "エラー",
+        "paused": "一時停止中",
+        "streaming": "ストリーミング中"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "ファイルや写真を追加"
+      },
+      "apps": {
+        "label": "アプリ"
+      },
+      "browseSkills": {
+        "label": "スキルを見る"
+      },
+      "connect": {
+        "hint": "接続"
+      },
+      "connectApp": {
+        "label": "アプリを接続"
+      },
+      "library": {
+        "label": "ライブラリ"
+      },
+      "manageLibrary": {
+        "label": "ライブラリを管理…"
+      },
+      "mcpServer": {
+        "description": "MCP サーバー"
+      },
+      "skills": {
+        "label": "スキル"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "ファイルをプレビューできません"
+      },
+      "error": {
+        "inline": "エラー: {message}",
+        "title": "ファイルの読み込みエラー"
+      },
+      "loading": {
+        "label": "ファイルを読み込んでいます..."
+      },
+      "noContent": {
+        "label": "コンテンツがありません"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "ビルド中に作成されたファイルがここに表示されます",
+        "title": "まだファイルがありません"
+      },
+      "emptyDirectory": {
+        "label": "このディレクトリにはファイルがありません"
+      },
+      "error": {
+        "title": "ファイルの読み込みエラー"
+      },
+      "loading": {
+        "label": "ファイルを読み込んでいます..."
+      },
+      "loadingChildren": {
+        "label": "読み込み中..."
+      },
+      "preparing": {
+        "description": "開発環境をセットアップしています",
+        "title": "サンドボックスを準備しています..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "画像を表示できませんでした",
+        "title": "画像を読み込めませんでした"
+      },
+      "loading": {
+        "label": "画像を読み込んでいます..."
+      },
+      "preview": {
+        "ariaLabel": "{name} のプレビュー"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "接続済み",
+        "connectionRequired": "接続が必要です"
+      },
+      "plusMenu": {
+        "tooltip": "ファイルやスキルを追加"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "停止しています…"
+      },
+      "toInterrupt": {
+        "label": "で中断"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "ホームに戻る"
+      },
+      "startCrafting": {
+        "button": "クラフトを始める"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "モデルが見つかりません"
+      },
+      "recommended": {
+        "label": "おすすめ"
+      },
+      "recommendedOnly": {
+        "label": "おすすめのモデルのみ"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "「不安定なリトライテストを直して PR を作成して。」",
+          "launchDeck": "「Drive のブリーフから春のローンチ資料を作って。」",
+          "rfpSecurity": "「メールにある RFP に当社のセキュリティ情報を記入して。」",
+          "slackToLinear": "「Slack での議論を Linear のチケットにまとめて。」",
+          "vendorSpend": "「第2四半期のベンダー支出を Drive のドキュメントにまとめて。」"
+        },
+        "modal": {
+          "backButton": "戻る",
+          "ctaButton": "Craft に仕事を任せる",
+          "nextButton": "次へ",
+          "title": "Craft の紹介"
+        },
+        "outputs": {
+          "ariaLabel": "成果物: {name}",
+          "githubPr": {
+            "caption": "レビュー待ち",
+            "label": "GitHub PR"
+          },
+          "googleDoc": {
+            "caption": "あなたの Drive に保存",
+            "label": "Google ドキュメント"
+          },
+          "liveApp": {
+            "caption": "ホスト済み、リンクで共有",
+            "label": "ライブアプリ"
+          }
+        },
+        "prompt": {
+          "label": "あなたのプロンプト"
+        },
+        "schedule": {
+          "ariaLabel": "スケジュール済みタスク: このプロンプトをタイマーで再実行します",
+          "caption": "不在の間も実行されます",
+          "label": "毎週月曜 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "接続済みソース: {name}",
+          "yourFiles": {
+            "ariaLabel": "アップロードしたファイル",
+            "label": "あなたのファイル"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "マップの任意の場所をクリックすると、もう一度見られます。",
+            "title": "これが Craft です。次はあなたの番です。"
+          },
+          "machine": {
+            "caption": "あなたが見えるものだけを読み取り、秘密には触れません。",
+            "title": "専用のマシンで動作します。"
+          },
+          "output": {
+            "caption": "オンデマンドでも、不在の間のスケジュール実行でも。",
+            "title": "完成した成果物が出てきます。"
+          },
+          "prompt": {
+            "caption": "結果を伝えるだけで、あとは Craft が引き受けます。",
+            "title": "Craft に実際の仕事を任せましょう。"
+          }
+        },
+        "team": {
+          "ariaLabel": "あなたのチーム: リンク 1 つで Craft の成果を共有",
+          "caption": "リンク 1 つで共有",
+          "label": "あなたのチーム"
+        },
+        "workspace": {
+          "approvalPill": "あなたの承認を待っています",
+          "label": "Craft のワークスペース",
+          "sandboxBadge": "隔離されたサンドボックス"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "チャットに戻る",
+        "description": "Onyx Craft にはモデルプロバイダーが必要で、設定できるのは管理者のみです。管理者に Anthropic、OpenAI、または OpenRouter の接続を依頼してください。",
+        "title": "LLM プロバイダーが必要です"
+      },
+      "llmSetup": {
+        "description": "Craft エージェントがビルドするにはモデルプロバイダーが必要です。",
+        "title": "モデルプロバイダーを接続"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "データを分析してダッシュボードを作成..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "エンジニアリング",
+          "marketing": "マーケティング",
+          "product": "プロダクト",
+          "sales": "営業"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "何かを作り始めるとアーティファクトが表示されます！"
+      },
+      "devServerStarting": {
+        "tooltip": "開発サーバーを起動しています..."
+      },
+      "noWebapp": {
+        "label": "このセッションにはまだWebアプリがありません"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "PDF ファイルを読み込めませんでした。",
+        "title": "PDF をプレビューできません"
+      },
+      "frame": {
+        "title": "PDF プレビュー"
+      },
+      "loading": {
+        "label": "PDF を読み込んでいます..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "プレゼンテーションを変換しています..."
+      },
+      "empty": {
+        "label": "このプレゼンテーションにはスライドがありません"
+      },
+      "error": {
+        "title": "プレゼンテーションをプレビューできません"
+      },
+      "loadingSlide": {
+        "label": "スライドを読み込んでいます..."
+      },
+      "slide": {
+        "counter": "スライド {current} / {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "ウェブアプリが起動すると、ここにライブプレビューが表示されます。"
+      },
+      "frame": {
+        "title": "ウェブアプリのプレビュー"
+      },
+      "starting": {
+        "description": "依存関係をインストールして起動しています。",
+        "title": "開発サーバーを起動しています..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "リダイレクト中..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "閉じる"
+      },
+      "modal": {
+        "description": "しばらく操作がなかったためスリープしました。作業内容は保存されています。再開するには起動してください。",
+        "title": "サンドボックスがスリープしました"
+      },
+      "wake": {
+        "button": "サンドボックスを起動"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "スケジュール済み"
+      },
+      "startedAt": {
+        "label": "{time} に開始"
+      },
+      "status": {
+        "awaitingApproval": "このスケジュール実行は承認待ちです。再開して完了すると追加メッセージを送信できるようになります。",
+        "running": "このスケジュール実行はまだ進行中です。完了すると追加メッセージを送信できるようになります。",
+        "startedBy": "このセッションはスケジュールされたタスク {task} により {time} に開始されました。"
+      },
+      "viewTask": {
+        "ariaLabel": "スケジュールされたタスク {task} を表示。{status}",
+        "label": "タスクを表示"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "外部アプリ {id}"
+      },
+      "connect": {
+        "title": "{app} を接続"
+      },
+      "connected": {
+        "title": "{app} を接続しました。"
+      },
+      "error": {
+        "generic": "問題が発生しました。もう一度お試しください。",
+        "notConfigurable": "このアプリはここからは設定できません。",
+        "popupBlocked": "設定ウィンドウを開けませんでした。ポップアップを許可してからもう一度お試しください。",
+        "startFailed": "設定を開始できませんでした"
+      },
+      "loading": {
+        "button": "読み込み中…"
+      },
+      "notNow": {
+        "button": "今はしない"
+      },
+      "reason": {
+        "fallback": "このタスクを続けるにはエージェントに {app} が必要です。"
+      },
+      "skipped": {
+        "title": "{app} の接続をスキップしました。"
+      },
+      "waiting": {
+        "button": "待機中…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "リンクをコピー"
+      },
+      "organization": {
+        "description": "あなたの Onyx にログインしている人は誰でもこのアプリを表示できます。",
+        "label": "組織"
+      },
+      "private": {
+        "description": "このアプリを表示できるのはあなただけです。",
+        "label": "非公開"
+      },
+      "share": {
+        "label": "共有"
+      },
+      "shared": {
+        "label": "共有中"
+      },
+      "trigger": {
+        "ariaLabel": "ウェブアプリを共有"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "アプリ"
+      },
+      "backToChat": {
+        "label": "チャットに戻る"
+      },
+      "delete": {
+        "label": "削除"
+      },
+      "deleteModal": {
+        "body": "Craft セッションとそのすべてのデータが完全に削除されます。この操作は元に戻せません。",
+        "confirm": "削除",
+        "deleting": "削除しています...",
+        "title": "「{title}」を削除しますか？"
+      },
+      "newSession": {
+        "label": "クラフトを始める"
+      },
+      "rename": {
+        "label": "名前を変更"
+      },
+      "scheduledTasks": {
+        "label": "スケジュールされたタスク"
+      },
+      "sessions": {
+        "empty": "さあ、作り始めましょう！セッション履歴がここに表示されます。",
+        "title": "セッション"
+      },
+      "skills": {
+        "label": "スキル"
+      },
+      "toast": {
+        "deleteFailed": "セッションを削除できませんでした",
+        "deleted": "「{title}」を削除しました。"
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "最新のスキルとアプリアクセスを適用するには、このセッションを再読み込みしてください。",
+        "title": "エージェントの機能が変更されました"
+      },
+      "reload": {
+        "button": "再読み込み",
+        "inProgress": "再読み込み中…"
+      },
+      "toast": {
+        "reloadFailed": "セッションを再読み込みできませんでした"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "サブエージェントが見つかりません。"
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "候補を閉じる"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "削除",
+          "deletingButton": "削除中...",
+          "description": "今後の実行を停止し、タスクを削除します。過去の実行履歴（および関連セッション）は監査のため保持されます。",
+          "title": "「{name}」を削除しますか？"
+        },
+        "deleteButton": "削除",
+        "editButton": "編集",
+        "fallbackTitle": "スケジュール済みタスク",
+        "loadFailed": "スケジュール済みタスクを読み込めませんでした。",
+        "missingTaskId": "タスク ID がありません。",
+        "pauseButton": "一時停止",
+        "resumeButton": "再開",
+        "runNowButton": "今すぐ実行",
+        "toasts": {
+          "deleteFailed": "タスクを削除できませんでした",
+          "deleted": "「{name}」を削除しました。",
+          "paused": "タスクを一時停止しました。",
+          "resumed": "タスクを再開しました。",
+          "runQueued": "「{name}」の実行をキューに追加しました。",
+          "runStartFailed": "実行を開始できませんでした",
+          "statusUpdateFailed": "ステータスを更新できませんでした"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "スケジュール済みタスクを編集",
+        "loadFailed": "スケジュール済みタスクを読み込めませんでした。",
+        "missingTaskId": "タスク ID がありません。",
+        "title": "「{name}」を編集"
+      },
+      "form": {
+        "cancelButton": "キャンセル",
+        "errors": {
+          "nameRequired": "名前は必須です。",
+          "promptRequired": "プロンプトは必須です。"
+        },
+        "fields": {
+          "name": {
+            "label": "名前",
+            "placeholder": "例: 週次の顧客エスカレーションまとめ"
+          },
+          "preApproval": {
+            "description": "このタスクが無人で実行される際、Craft は選択したアプリと MCP サーバーを一時停止せずに使用できます。それ以外の承認要求は実行を一時停止させ、失敗の原因になることがあります。",
+            "label": "事前承認済みのアプリと MCP サーバー"
+          },
+          "prompt": {
+            "description": "このメッセージはタスクが発火するたびに Craft に送信されます。",
+            "label": "プロンプト",
+            "placeholder": "各実行で Craft が行うべきことを記述..."
+          },
+          "schedule": {
+            "label": "スケジュール"
+          }
+        },
+        "saveAndRunNowButton": "保存して今すぐ実行",
+        "saveButton": "保存",
+        "saveChangesButton": "変更を保存",
+        "savingLabel": "保存中...",
+        "toasts": {
+          "created": "スケジュール済みタスクを作成しました。",
+          "createdAndQueued": "スケジュール済みタスクを作成し、キューに追加しました。",
+          "saveFailed": "スケジュール済みタスクを保存できませんでした",
+          "updated": "スケジュール済みタスクを更新しました。"
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "前回の実行",
+          "name": "名前",
+          "nextRun": "次回の実行",
+          "schedule": "スケジュール",
+          "status": "ステータス"
+        },
+        "confirmDelete": {
+          "deleteButton": "削除",
+          "deletingButton": "削除中...",
+          "description": "今後の実行を停止し、タスクを削除します。過去の実行履歴（および関連セッション）は監査のため保持されます。",
+          "title": "「{name}」を削除しますか？"
+        },
+        "empty": {
+          "description": "スケジュール済みタスクはまだ作成されていません。",
+          "title": "スケジュール済みタスクが見つかりません"
+        },
+        "errors": {
+          "loadFailed": "スケジュール済みタスクを読み込めませんでした。",
+          "tryAgainButton": "再試行"
+        },
+        "header": {
+          "description": "Craft のプロンプトをタイマーで実行します。発火するたびに新しいセッションが作成され、バックグラウンドで実行されます。",
+          "title": "スケジュール済みタスク"
+        },
+        "newTaskButton": "新しいスケジュール済みタスク",
+        "rowActions": {
+          "deleteTooltip": "削除"
+        },
+        "toasts": {
+          "deleteFailed": "タスクを削除できませんでした",
+          "deleted": "「{name}」を削除しました。"
+        }
+      },
+      "newPage": {
+        "description": "プロンプトとスケジュールを保存すると、Craft がタイマーで実行します。",
+        "title": "新しいスケジュール済みタスク"
+      },
+      "preApproval": {
+        "appFallbackName": "アプリ #{id}",
+        "appsGroupTitle": "アプリ",
+        "empty": {
+          "label": "Craft で利用できるアプリや MCP サーバーはまだありません。"
+        },
+        "errors": {
+          "loadFailed": "アプリと MCP サーバーを読み込めませんでした。更新して再試行してください。",
+          "partialLoadFailed": "一部の事前承認オプションを読み込めませんでした。更新して再試行してください。"
+        },
+        "loading": {
+          "label": "アプリと MCP サーバーを読み込み中…"
+        },
+        "mcpGroupTitle": "MCP サーバー",
+        "mcpServerFallbackName": "MCP サーバー #{id}",
+        "status": {
+          "connected": "接続済み",
+          "connectionRequired": "接続が必要です",
+          "unavailable": "利用できなくなりました"
+        },
+        "summary": {
+          "partialLoadFailed": "一部の事前承認の詳細を読み込めませんでした。更新して再試行してください。",
+          "title": "事前承認済みのアプリと MCP サーバー"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "所要時間",
+          "started": "開始",
+          "status": "ステータス",
+          "summary": "概要",
+          "trigger": "トリガー"
+        },
+        "empty": {
+          "label": "まだ実行はありません。タスクは発火のたびに実行を作成します。上の「今すぐ実行」も使えます。"
+        },
+        "errors": {
+          "loadFailed": "実行履歴を読み込めませんでした。",
+          "tryAgainButton": "再試行"
+        },
+        "loadMore": {
+          "button": "さらに読み込む",
+          "loadingButton": "読み込み中..."
+        },
+        "nonClickable": {
+          "noSession": "この実行はまだセッションを作成していません。",
+          "queued": "この実行はまだ開始されていないため、開くセッションがありません。",
+          "skipped": "前の実行がまだ進行中だったためこの実行はスキップされ、セッションは作成されませんでした。"
+        },
+        "status": {
+          "notOpenableAriaLabel": "開けません"
+        },
+        "trigger": {
+          "runNow": "今すぐ実行",
+          "schedule": "スケジュール"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "時刻:",
+          "daysLabel": "実行する曜日",
+          "runsEveryDay": "毎日実行されます",
+          "runsOn": "{days} に実行されます"
+        },
+        "interval": {
+          "everyLabel": "実行間隔:"
+        },
+        "intervalUnits": {
+          "days": "日",
+          "hours": "時間",
+          "minutes": "分"
+        },
+        "tabs": {
+          "dailyWeekly": "毎日 / 毎週",
+          "interval": "間隔"
+        },
+        "weekdays": {
+          "fri": "金",
+          "mon": "月",
+          "sat": "土",
+          "sun": "日",
+          "thu": "木",
+          "tue": "火",
+          "wed": "水"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "タスクはありません"
+      },
+      "header": {
+        "title": "タスク"
+      },
+      "progress": {
+        "label": "{completed}/{total} 完了"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "出力はありません"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {変更なしの行 #行} other {変更なしの行 #行}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "並列表示に切り替え",
+          "unifiedTooltip": "統合表示に切り替え"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "まだ出力はありません..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# 件の呼び出し} other {# 件の呼び出し}}"
+        },
+        "failed": {
+          "tag": "{count} 件失敗"
+        },
+        "working": {
+          "label": "作業中"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "（空のファイル）"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {残り #行} other {残り #行}}"
+        },
+        "showAll": {
+          "button": "すべて表示"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "一致なし"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "ファイルが大きすぎます（{size}）。上限は {max} です。",
+        "network": "ネットワークエラー",
+        "notFound": "リソースが見つかりません",
+        "server": "サーバーエラー",
+        "sessionExpired": "セッションの有効期限が切れました",
+        "tooManyFiles": "ファイルが多すぎます。1 セッションあたり最大 {max} 件です。",
+        "totalSizeExceeded": "合計サイズが上限を超えています。1 セッションあたり最大 {max} です。",
+        "uploadFailed": "アップロードに失敗しました"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "戻る"
+      },
+      "copyUrl": {
+        "ariaLabel": "URL をコピー: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "ファイルをダウンロード"
+      },
+      "export": {
+        "button": ".docx にエクスポート",
+        "inProgress": "エクスポートしています..."
+      },
+      "forward": {
+        "ariaLabel": "進む"
+      },
+      "openInNewTab": {
+        "tooltip": "新しいタブで開く"
+      },
+      "refresh": {
+        "ariaLabel": "更新"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "削除",
+        "button": "削除",
+        "entityTypeFile": "ファイル",
+        "entityTypeFolder": "フォルダ",
+        "fileDetails": "このファイルはライブラリから削除されます。",
+        "folderDetails": "フォルダとその中身がすべて削除されます。"
+      },
+      "dropzone": {
+        "formats": "Excel、Word、PowerPoint、PDF、ZIP のいずれか",
+        "title": "ここにファイルをドラッグするか、クリックしてアップロード"
+      },
+      "errors": {
+        "createFolderFailed": "フォルダの作成に失敗しました",
+        "deleteFailed": "削除に失敗しました",
+        "loadFailed": "ファイルの読み込みに失敗しました",
+        "uploadFailed": "アップロードに失敗しました"
+      },
+      "loading": {
+        "label": "ファイルを読み込み中…"
+      },
+      "modal": {
+        "description": "エージェントがすべてのセッションで読み取れるファイルです。",
+        "doneButton": "完了",
+        "title": "ライブラリ"
+      },
+      "newFolder": {
+        "cancelButton": "キャンセル",
+        "createButton": "作成",
+        "label": "新しいフォルダ",
+        "nameLabel": "フォルダ名",
+        "namePlaceholder": "フォルダ名を入力"
+      },
+      "search": {
+        "noResults": "検索に一致するファイルがありません",
+        "placeholder": "ファイルを検索..."
+      },
+      "tree": {
+        "collapseTooltip": "折りたたむ",
+        "deleteTooltip": "削除",
+        "expandTooltip": "展開する",
+        "toggleAriaLabel": "{name} を開閉",
+        "uploadToFolderTooltip": "このフォルダにアップロード"
+      },
+      "upload": {
+        "button": "アップロード",
+        "dropOverlay": "ファイルをドロップしてアップロード",
+        "uploadingButton": "アップロード中…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "データを分析してダッシュボードを作成..."
       }
     }
   },
@@ -8813,6 +12541,13 @@
           "networkError": "パスワードの変更中にエラーが発生しました",
           "updateFailed": "パスワードを変更できませんでした",
           "updated": "パスワードを更新しました"
+        },
+        "validation": {
+          "confirmRequired": "新しいパスワードを確認してください",
+          "currentRequired": "現在のパスワードは必須です",
+          "minLength": "パスワードは{min}文字以上である必要があります",
+          "mismatch": "パスワードが一致しません",
+          "newRequired": "新しいパスワードは必須です"
         }
       },
       "title": "アカウント"
@@ -8854,6 +12589,7 @@
         "empty": "作成されたアクセストークンはありません。",
         "expiresIn": "{count, plural, one {あと # 日で期限切れ} other {あと # 日で期限切れ}}",
         "loading": "トークンを読み込み中...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "有効期限なし",
         "newTokenButton": "新しいアクセストークン",
         "noPermissionTooltip": "アクセストークンを作成する権限がありません",
@@ -9000,6 +12736,10 @@
       },
       "description": "Onyx で利用できるモデルに外部ツールを接続します。",
       "guideButton": "ガイド",
+      "loadError": {
+        "description": "ページを更新してからもう一度お試しください。",
+        "title": "LLM ゲートウェイを読み込めませんでした"
+      },
       "models": {
         "description": "{count, plural, one {お使いのアカウントで # 個のモデルを利用できます。プロバイダーを開いて ID をコピーしてください。} other {お使いのアカウントで # 個のモデルを利用できます。プロバイダーを開いて ID をコピーしてください。}}",
         "title": "モデル"
@@ -9052,14 +12792,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "行を追加",
+        "maxReached": "メモリの上限（{count}件）に達しました"
+      },
       "empty": {
-        "description": "Onyx に覚えておいてほしい個人的なメモやメモリを追加します。"
+        "description": "Onyx に覚えておいてほしい個人的なメモやメモリを追加します。",
+        "getStarted": "まだメモリがありません。「行を追加」をクリックして始めてください。",
+        "noMatches": "検索に一致するメモリはありません。"
+      },
+      "item": {
+        "placeholder": "個人的なメモやメモリを入力または貼り付けてください"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {行} other {行}}"
+      },
+      "modal": {
+        "description": "保存されたメモやメモリをチャットでOnyxに参照させます。",
+        "searchPlaceholder": "検索..."
       },
       "referenceStoredMemories": {
         "description": "チャットで保存済みのメモリを Onyx が参照できるようにします。",
         "title": "保存済みメモリを参照"
       },
+      "removeLineButton": {
+        "label": "行を削除"
+      },
       "title": "メモリ",
+      "toasts": {
+        "saveFailed": "設定の保存に失敗しました",
+        "saved": "設定を保存しました"
+      },
       "updateMemories": {
         "description": "Onyx が保存済みのメモリを生成・更新できるようにします。",
         "title": "メモリを更新"
@@ -9479,6 +13242,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "アプリ「{appName}」には既に「{skillName}」という名前の関連スキルがあります。",
+        "title": "別のスキル名を選択してください"
+      },
+      "confirmUpload": {
+        "importBody": "このアップロードにはSKILL.mdが含まれています。続行すると、現在の名前、説明、指示、ファイルがアップロードされたバンドルに置き換えられます。",
+        "importSubmit": {
+          "label": "スキルをインポート"
+        },
+        "importTitle": "このスキルをインポートしますか？",
+        "replaceBody": "このアップロードは同じスキル名を使用する必要があります。続行すると、説明、指示、ファイルがアップロードされたバンドルに置き換えられます。",
+        "replaceSubmit": {
+          "label": "内容を置き換え"
+        },
+        "replaceTitle": "スキルの内容を置き換えますか？"
+      },
+      "delete": {
+        "button": {
+          "label": "スキルを削除"
+        },
+        "description": "このスキルを使用しているすべてのユーザーがアクセスできなくなります。削除は元に戻せません。",
+        "title": "このスキルを削除"
+      },
+      "deleteModal": {
+        "entityType": "スキル",
+        "label": "削除",
+        "pendingLabel": "削除中..."
+      },
+      "details": {
+        "description": "Craftがこのスキルをいつどのように使用するかを定義します。",
+        "descriptionField": {
+          "description": "このスキルをいつ使用すべきかを説明します。",
+          "placeholder": "このスキルは何に役立ちますか？",
+          "title": "説明"
+        },
+        "name": {
+          "createDescription": "小文字、数字、単一のハイフンを使用してください。",
+          "lockedDescription": "スキル名は作成後に変更できません。",
+          "placeholder": "スキルに名前を付ける",
+          "title": "名前"
+        },
+        "title": "詳細"
+      },
+      "files": {
+        "busyLabel": "アップロード中...",
+        "description": "このスキルで使用する参照、スクリプト、アセット、その他のファイルを追加します。ZIPファイルは自動的に展開されます。",
+        "input": {
+          "ariaLabel": "サポートファイルを追加"
+        },
+        "pendingUpload": {
+          "emptyMessage": "このアップロードのファイルは、スキルの作成後に表示されます。"
+        },
+        "title": "サポートファイル"
+      },
+      "filesTooltip": {
+        "noPermission": "このスキルのファイルを更新する権限がありません。",
+        "saveFirst": "スキルファイルを更新する前に詳細の変更を保存してください。",
+        "updating": "スキルファイルを更新中..."
+      },
+      "header": {
+        "appFallbackName": "外部アプリ",
+        "cancel": {
+          "label": "キャンセル"
+        },
+        "createDescription": "個人スキルを作成",
+        "createForAppDescription": "アプリ「{appName}」に組織スキルを追加",
+        "createTitle": "スキルを作成",
+        "editDescription": "スキルの詳細とファイルを更新",
+        "editTitle": "スキルを編集",
+        "save": {
+          "label": "保存",
+          "pendingLabel": "保存中..."
+        }
+      },
+      "import": {
+        "busyLabel": "インポート中...",
+        "button": {
+          "label": "スキルをインポート"
+        },
+        "description": "SKILL.md、ZIP、またはスキルフォルダをインポートすると、フォームが事前入力され、ファイルが含まれます。",
+        "input": {
+          "ariaLabel": "既存のスキルをインポート"
+        },
+        "prompt": "SKILL.mdまたはZIPを選択するか、スキルフォルダをここにドロップしてください。",
+        "title": "既存のスキルがありますか？"
+      },
+      "instructions": {
+        "description": "このスキルがCraftに追加する動作とワークフローを記述します。",
+        "emptyFallback": "まだ指示がありません。",
+        "placeholder": "スキルの指示を書いてください。",
+        "title": "指示"
+      },
+      "loadError": {
+        "description": "このスキルは存在しないか、組み込みであるか、またはお使いのアカウントでは編集できない可能性があります。",
+        "title": "スキルを利用できません"
+      },
+      "management": {
+        "description": "このスキルを使用できるユーザーを管理します。",
+        "externalApp": {
+          "manage": {
+            "label": "アプリ設定で管理"
+          },
+          "readyDescription": "このスキルはアプリ「{appName}」を使用します。",
+          "title": "外部アプリ"
+        },
+        "sharing": {
+          "edit": {
+            "label": "共有を編集"
+          },
+          "title": "共有"
+        },
+        "title": "管理"
+      },
+      "saveTooltip": {
+        "missingDescription": "保存する前に説明を追加してください。",
+        "missingInstructions": "保存する前に指示を追加してください。",
+        "missingName": "保存する前に名前を追加してください。",
+        "noChanges": "変更はありません。",
+        "noPermission": "このスキルの詳細を編集する権限がありません。",
+        "savingChanges": "変更を保存中...",
+        "savingSkill": "スキルを保存中..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "組織内の全員がこのスキルを使用および編集できます。",
+          "title": "組織",
+          "viewerDescription": "組織内の全員がこのスキルを使用できます。"
+        },
+        "personal": {
+          "description": "このスキルを使用できるのはあなただけです。",
+          "title": "個人"
+        },
+        "shares": {
+          "description": "選択したユーザーとグループのみがこのスキルを使用できます。",
+          "title": "{count, plural, one {# 件の共有} other {# 件の共有}}"
+        }
+      },
+      "toasts": {
+        "created": "「{name}」を作成しました",
+        "deleteFailed": "スキルの削除に失敗しました",
+        "deleted": "「{name}」を削除しました",
+        "fileRemoveFailed": "スキルファイルの削除に失敗しました",
+        "fileRemoved": "「{path}」を削除しました",
+        "filesUpdateFailed": "スキルファイルの更新に失敗しました",
+        "filesUpdated": "「{name}」のファイルを更新しました",
+        "importMissingSkillMd": "SKILL.md、ZIP、またはSKILL.mdを含むフォルダをインポートしてください。",
+        "inspectFailed": "スキルバンドルの検査に失敗しました",
+        "saveFailed": "スキルの保存に失敗しました",
+        "saved": "「{name}」を保存しました"
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9679,6 +13594,76 @@
         "transferredToast": {
           "message": "所有権を譲渡しました。"
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "スキルを閲覧"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {スキル} other {スキル}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "リポジトリから1つ以上のスキルをインポートします。",
+          "title": "GitHubからインポート"
+        },
+        "scratch": {
+          "description": "Onyxで指示を書き、サポートファイルを追加します。",
+          "title": "最初から作成"
+        },
+        "trigger": {
+          "label": "スキルを作成"
+        },
+        "upload": {
+          "description": "SKILL.mdファイル、ZIPファイル、またはスキルフォルダをインポートします。",
+          "title": "スキルをアップロード"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "別の検索をお試しください。",
+          "title": "一致するスキルがありません"
+        },
+        "noSkills": {
+          "description": "まだ共有されたカスタムスキルはなく、組み込みスキルも設定されていません。",
+          "title": "利用可能なスキルがありません"
+        }
+      },
+      "focusedApp": {
+        "description": "アプリ「{appName}」に関連付けられたすべてのスキルを有効にします。これらがないとアプリが正しく動作しない場合があります。同名の別のスキルが有効な場合、アプリ関連スキルを有効にするともう一方のスキルは無効になります。",
+        "showAll": {
+          "label": "すべてのスキルを表示"
+        },
+        "title": "アプリ「{appName}」のスキル"
+      },
+      "header": {
+        "description": "Craftエージェントが利用できる機能バンドルです。このページには、組み込みスキル、共有されたスキル、あなたの個人スキルが表示されます。",
+        "title": "スキル"
+      },
+      "loadError": {
+        "description": "詳細はコンソールを確認し、ページを再読み込みしてください。",
+        "title": "スキルの読み込みに失敗しました"
+      },
+      "preview": {
+        "unavailableFallback": "このスキルは現在利用できません。"
+      },
+      "search": {
+        "placeholder": "スキルを検索..."
+      },
+      "switchModal": {
+        "body": "続行すると、現在有効なスキルが無効になり、このスキルが有効になります。",
+        "description": "「{name}」という名前のスキルは一度に1つだけ有効にできます。",
+        "submit": {
+          "label": "スキルを切り替え",
+          "pendingLabel": "切り替え中..."
+        },
+        "title": "スキル「{name}」を切り替えますか？"
+      },
+      "toasts": {
+        "disableFailed": "{name}を無効にできませんでした",
+        "enableFailed": "{name}を有効にできませんでした",
+        "refreshFailed": "{name}は更新されましたが、スキル一覧を更新できませんでした。"
       }
     },
     "sections": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "戻る"
       },
-      "disableAll": {
-        "label": "すべて無効にする"
-      },
-      "enableAll": {
-        "label": "すべて有効にする"
-      },
       "toggle": {
         "ariaLabel": "{name} を切り替える"
       }
@@ -12935,6 +12929,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "ドキュメントエクスプローラー"
+        },
+        "documentFeedback": {
+          "title": "ドキュメントフィードバック"
+        },
+        "documentProcessing": {
+          "title": "ドキュメント処理"
+        },
+        "oauthTest": {
+          "title": "OAuth テスト"
+        },
+        "standardAnswers": {
+          "title": "標準回答"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "コネクターを追加"

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -2820,25 +2820,37 @@
       }
     },
     "craftPreferences": {
-      "defaultModel": {
-        "clearButton": { "label": "クリア" },
-        "help": {
-          "description": "Craft は新しいセッションとスケジュール済みタスクにこのモデルを使います。未設定の場合、Craft はワークスペースの既定のチャットモデルに戻ります。"
-        },
-        "inheritedTag": { "label": "ワークスペースの既定値" },
-        "label": "既定のモデル",
-        "placeholder": "モデルを選択",
-        "resetError": { "message": "既定のモデルをクリアできませんでした" },
-        "resetSuccess": { "message": "Craft の既定のモデルをクリアしました" },
-        "saveError": { "message": "既定のモデルを保存できませんでした" },
-        "saveSuccess": { "message": "Craft の既定のモデルを保存しました" }
-      },
       "baseInstructions": {
         "description": "入力した指示が追加される、組み込みのプロンプトです。動的な部分はセッションごとに埋められます。",
         "loadError": {
           "description": "基本の指示を読み込めませんでした。"
         },
         "title": "基本の指示を表示"
+      },
+      "defaultModel": {
+        "clearButton": {
+          "label": "クリア"
+        },
+        "help": {
+          "description": "Craft は新しいセッションとスケジュール済みタスクにこのモデルを使います。未設定の場合、Craft はワークスペースの既定のチャットモデルに戻ります。"
+        },
+        "inheritedTag": {
+          "label": "ワークスペースの既定値"
+        },
+        "label": "既定のモデル",
+        "placeholder": "モデルを選択",
+        "resetError": {
+          "message": "既定のモデルをクリアできませんでした"
+        },
+        "resetSuccess": {
+          "message": "Craft の既定のモデルをクリアしました"
+        },
+        "saveError": {
+          "message": "既定のモデルを保存できませんでした"
+        },
+        "saveSuccess": {
+          "message": "Craft の既定のモデルを保存しました"
+        }
       },
       "header": {
         "description": "Craft の組み込み動作に加えて、すべての Craft エージェントが従う既定のモデルとワークスペース全体の指示です。",
@@ -12890,9 +12902,29 @@
         "title": "使用状況を読み込めませんでした"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · デフォルト"
+        },
         "description": "利用可能な各モデルの100万トークンあたりの料金（入力 · 出力 · キャッシュ、米ドル）",
+        "otherProvider": {
+          "label": "その他"
+        },
         "title": "モデル料金",
         "unavailable": "料金情報がありません"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "キャッシュ読み取り {count}"
+        },
+        "cacheWrites": {
+          "label": "キャッシュ書き込み {count}"
+        },
+        "tokensIn": {
+          "label": "入力 {count}"
+        },
+        "tokensOut": {
+          "label": "出力 {count}"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "表示するモデルを減らす"

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -60,6 +60,26 @@
         "ariaLabel": "{title} 액션 카드"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "커넥터 추가"
+      },
+      "configure": {
+        "tooltip": "구성"
+      },
+      "configureConnectors": {
+        "label": "커넥터 구성"
+      },
+      "disable": {
+        "label": "사용 안 함"
+      },
+      "enable": {
+        "label": "사용"
+      },
+      "projectSearch": {
+        "label": "프로젝트 검색"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "MCP(Model Context Protocol) 서버를 연결하여 사용자 지정 액션을 추가하세요.",
@@ -355,6 +375,53 @@
         "tooltip": "도구 새로 고침"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "자동으로 돌아갑니다…"
+      },
+      "backToChatButton": {
+        "label": "채팅으로 돌아가기"
+      },
+      "cancelled": {
+        "description": "인증이 취소되거나 거부되어 연결이 이루어지지 않았습니다. 다시 시도하려면 MCP 서버의 인증 설정에서 연결을 다시 시작하세요.",
+        "title": "인증이 취소되었습니다"
+      },
+      "continueButton": {
+        "label": "계속"
+      },
+      "genericError": {
+        "fallbackDetail": "인증을 완료하지 못했습니다",
+        "title": "문제가 발생했습니다"
+      },
+      "invalidLink": {
+        "description": "이 링크에 필요한 인증 매개변수가 없습니다. MCP 서버의 인증 설정에서 연결을 다시 시작하세요.",
+        "title": "잘못된 인증 링크"
+      },
+      "processing": {
+        "description": "MCP 서버와의 연결을 마무리하는 중입니다. 잠시 걸릴 수 있습니다…",
+        "title": "인증을 완료하는 중"
+      },
+      "serverNotFound": {
+        "description": "이 인증이 속한 MCP 서버가 더 이상 존재하지 않거나 구성되어 있지 않습니다. 서버를 다시 만들거나 다시 구성한 후 다시 연결하세요.",
+        "title": "MCP 서버를 찾을 수 없습니다"
+      },
+      "sessionExpired": {
+        "description": "이 인증 링크는 유효하지 않거나 만료되었거나 이미 사용되었습니다. MCP 서버의 인증 설정에서 연결을 다시 시작하세요.",
+        "title": "인증 세션이 만료되었습니다"
+      },
+      "success": {
+        "description": "인증이 성공적으로 완료되었습니다. 이제 채팅에서 이 서버의 도구를 사용할 수 있습니다.",
+        "title": "{serverName}에 연결됨"
+      },
+      "timedOut": {
+        "description": "MCP 서버가 제시간에 인증을 확인하지 않았습니다. 다시 연결해 보세요. 문제가 계속되면 서버의 OAuth 구성을 확인하세요.",
+        "title": "인증 시간이 초과되었습니다"
+      },
+      "tokenExchangeFailed": {
+        "description": "제공자가 인증을 승인했지만 유효한 액세스 토큰을 얻을 수 없었습니다. 서버의 OAuth 클라이언트 자격 증명과 엔드포인트를 확인한 후 다시 연결해 보세요.",
+        "title": "토큰 교환에 실패했습니다"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "MCP 서버 추가"
@@ -554,6 +621,20 @@
         "label": "거부"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "뒤로"
+      },
+      "disableAll": {
+        "label": "모두 사용 안 함"
+      },
+      "enableAll": {
+        "label": "모두 사용"
+      },
+      "toggle": {
+        "ariaLabel": "{name} 전환"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "도구를 사용할 수 없음"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "활성화된 도구만 표시",
         "tooltip": "활성화된 항목만 표시"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "코드 인터프리터 구성"
+        },
+        "imageGeneration": {
+          "tooltip": "이미지 생성 구성"
+        },
+        "openapi": {
+          "tooltip": "OpenAPI 작업 관리"
+        },
+        "webSearch": {
+          "tooltip": "웹 검색 구성"
+        }
+      },
+      "disableAllSources": {
+        "label": "모든 소스 사용 안 함"
+      },
+      "disableAllTools": {
+        "label": "모든 도구 사용 안 함"
+      },
+      "enableAllSources": {
+        "label": "모든 소스 사용"
+      },
+      "enableAllTools": {
+        "label": "모든 도구 사용"
+      },
+      "manageActions": {
+        "tooltip": "작업 관리"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "{server} 도구 검색"
+      },
+      "moreActions": {
+        "label": "추가 작업"
+      },
+      "reauthenticate": {
+        "label": "다시 인증"
+      },
+      "search": {
+        "placeholder": "작업 검색..."
+      },
+      "serverFallback": {
+        "label": "서버"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "필터 검색"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "관리자에게 구성을 요청하세요."
+        },
+        "codingAgent": {
+          "description": "GitHub 저장소를 조사하고 코드에 관한 질문에 답합니다."
+        },
+        "configureSuffix": {
+          "text": "활성화하려면 설정 톱니바퀴를 누르세요."
+        },
+        "default": {
+          "description": "이 작업은 아직 구성되지 않았습니다."
+        },
+        "imageGeneration": {
+          "description": "프롬프트를 기반으로 이미지를 생성합니다."
+        },
+        "python": {
+          "description": "복잡한 분석을 위해 코드를 실행합니다."
+        },
+        "search": {
+          "description": "연결된 지식을 검색하여 답변에 활용합니다."
+        },
+        "webSearch": {
+          "description": "웹에서 최신 정보를 검색합니다."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "선택한 범위의 일별",
+        "title": "메시지 및 고유 사용자"
+      },
+      "empty": {
+        "message": "선택한 날짜 범위에서 이 에이전트의 데이터를 찾을 수 없습니다."
+      },
+      "fetchFailed": {
+        "message": "에이전트 통계를 가져오지 못했습니다."
+      },
+      "permissionDenied": {
+        "message": "이 통계를 볼 권한이 없습니다."
+      },
+      "totalMessages": {
+        "label": "총 메시지"
+      },
+      "totalUniqueUsers": {
+        "label": "총 고유 사용자"
+      },
+      "unknownError": {
+        "message": "알 수 없는 오류가 발생했습니다"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "섹션 접기"
+        },
+        "expand": {
+          "ariaLabel": "섹션 펼치기"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "<emphasis>{name}</emphasis>을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "요금제 보기"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "결제 정보가 없습니다."
+        },
+        "loadError": {
+          "message": "결제 정보를 불러오는 중 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+        },
+        "loading": {
+          "label": "로딩 중..."
+        },
+        "manageSubscription": {
+          "description": "플랜 확인, 결제 업데이트 또는 구독 변경",
+          "title": "구독 관리"
+        },
+        "page": {
+          "title": "결제 정보"
+        },
+        "portalError": {
+          "message": "고객 포털 세션을 생성하는 중 오류가 발생했습니다"
+        },
+        "subscriptionDetails": {
+          "title": "구독 세부 정보"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "결제 종료일"
+          },
+          "billingStart": {
+            "label": "결제 시작일"
+          },
+          "seats": {
+            "label": "시트"
+          },
+          "status": {
+            "label": "구독 상태"
+          }
+        },
+        "updatedToast": {
+          "message": "축하합니다! 구독이 성공적으로 업데이트되었습니다."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "소스에서 권한을 자동으로 동기화합니다. 검색을 수행하는 사용자가 소스에서 해당 문서에 액세스할 권한이 있는 경우에만 Onyx에서 문서를 검색할 수 있습니다.",
+          "disabledReason": "현재 자격 증명의 인증 방식은 권한 자동 동기화를 지원하지 않습니다. 지원되는 인증 방식으로 변경해 주세요.",
+          "name": "권한 자동 동기화"
+        },
+        "heading": {
+          "description": "이 커넥터가 색인한 문서에 대한 액세스 권한을 관리합니다.",
+          "title": "문서 액세스"
+        },
+        "privateOption": {
+          "description": "(사용자 그룹 페이지를 통해) 이 커넥터에 대한 액세스 권한을 명시적으로 부여받은 사용자만 이 커넥터가 가져온 문서에 액세스할 수 있습니다",
+          "name": "비공개"
+        },
+        "publicOption": {
+          "description": "Onyx 계정이 있는 모든 사용자가 이 커넥터가 가져온 문서에 액세스할 수 있습니다",
+          "name": "공개"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {#일} other {#일}}",
@@ -1546,6 +1794,14 @@
           "label": "간략히 보기"
         }
       },
+      "credentialForm": {
+        "errorToast": "오류: {detail}",
+        "successToast": "성공했습니다!",
+        "updateButton": {
+          "ariaLabel": "자격 증명 업데이트",
+          "label": "업데이트"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "이 커넥터를 삭제하면 인덱싱된 문서를 제거하고 모든 사용자에게서 커넥터를 삭제하는 삭제 작업이 예약됩니다.",
         "entityType": "커넥터"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "문서 권한 동기화 오류"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "이 커넥터 구성에 대한 자세한 내용은 <link>문서</link>를 참조하세요."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "파일을 업데이트하지 못했습니다"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "{multiple, select, true {파일들을} other {파일을}} 여기에 끌어다 놓거나 클릭하여 {multiple, select, true {파일을} other {파일을}} 선택하세요"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {선택된 파일} other {선택된 파일}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "오류 메시지",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "그룹 멤버십 동기화 오류"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "이 커넥터에 대한 그룹 액세스 할당"
+        },
+        "assignToGroup": {
+          "title": "이 커넥터를 그룹에 할당"
+        },
+        "scopedManagerGroups": {
+          "description": "이 커넥터에 대한 액세스 권한을 부여하려면 관리 중인 그룹을 하나 이상 선택하세요"
+        },
+        "syncGroups": {
+          "description": "아래 그룹은 이 커넥터를 관리할 수 있는 사용자를 제어합니다. 문서에 대한 액세스는 소스 자체의 권한에서 상속됩니다."
+        },
+        "visibleToGroups": {
+          "description": "이 커넥터는 아래에서 선택한 그룹에 표시되고 액세스할 수 있습니다"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "{count, plural, one {문서 #개} other {문서 #개}}에 대해 대상 지정 재인덱싱을 요청했습니다. 문서의 재인덱싱이 끝나면 목록에서 오류가 사라집니다."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "채널 정규식 사용",
+        "channels": "채널",
+        "enabledTrue": "예",
+        "excludeChannelRegexEnabled": "채널 제외 정규식 사용",
+        "excludedChannels": "제외된 채널",
+        "includeBotMessages": "봇 메시지 포함",
+        "jiraProjectUrl": "Jira 프로젝트 URL",
+        "multipleRepos": "여러 리포지토리",
+        "pageId": "페이지 ID",
+        "realm": "렐름",
+        "repo": "리포지토리",
+        "wikiUrl": "위키 URL"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "인덱싱할 Google Drive를 소유한 Google 조직의 관리자 또는 소유자 이메일을 입력하세요.",
           "invalidEmail": "유효한 이메일이어야 합니다",
           "label": "기본 관리자 이메일",
+          "placeholder": "admin@yourcompany.com",
           "required": "필수 항목입니다"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "인덱싱할 Gmail 계정을 소유한 Google 조직의 관리자 또는 소유자 이메일을 입력하세요.",
           "invalidEmail": "유효한 이메일이어야 합니다",
           "label": "기본 관리자 이메일",
+          "placeholder": "admin@yourcompany.com",
           "required": "필수 항목입니다"
         },
         "section": {
@@ -2590,6 +2894,171 @@
       "unavailable": {
         "description": "Craft는 Onyx가 배포별로 사용 설정합니다. 접근하려면 Onyx 담당자에게 문의하세요.",
         "title": "이 배포에서는 Craft를 사용할 수 없습니다"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "<i>{date}</i>에 생성됨"
+        },
+        "createdOnBy": {
+          "label": "<i>{date}</i>에 <i>{email}</i>이(가) 생성함"
+        },
+        "unnamed": {
+          "label": "자격 증명 #{id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "생성"
+        },
+        "created": {
+          "toast": "새 자격 증명을 생성했습니다!"
+        },
+        "name": {
+          "label": "이름:",
+          "placeholder": "(선택 사항) 자격 증명 이름..."
+        },
+        "submitError": {
+          "toast": "자격 증명 제출 중 오류가 발생했습니다"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "confirmBody": {
+          "message": "이 자격 증명을 삭제하시겠습니까? 활성 커넥터에 연결된 자격 증명은 삭제할 수 없습니다."
+        },
+        "confirmButton": {
+          "label": "확인"
+        },
+        "confirmTitle": "삭제 확인"
+      },
+      "edit": {
+        "name": {
+          "label": "이름 (선택 사항):"
+        },
+        "permissions": {
+          "note": "적절한 권한이 있는 자격 증명으로 업데이트했는지 확인하세요!"
+        },
+        "resetButton": {
+          "label": "변경 사항 재설정"
+        },
+        "updateButton": {
+          "label": "업데이트"
+        },
+        "updateError": {
+          "toast": "자격 증명 업데이트 중 오류가 발생했습니다"
+        }
+      },
+      "modal": {
+        "createTitle": "{source} 자격 증명 생성",
+        "editTitle": "자격 증명 편집",
+        "updateTitle": "자격 증명 업데이트"
+      },
+      "modify": {
+        "createButton": {
+          "label": "생성"
+        },
+        "instructions": {
+          "message": "필요에 따라 자격 증명을 선택하세요! 이 커넥터에 적절한 권한이 있는 자격 증명을 선택했는지 확인하세요!"
+        },
+        "selectButton": {
+          "label": "선택"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "연결"
+        },
+        "connectError": {
+          "title": "연결할 수 없습니다"
+        },
+        "redirectFailed": {
+          "message": "{source} 로그인으로 리디렉션할 수 없습니다. 다시 시도해 주세요."
+        },
+        "retryButton": {
+          "label": "다시 시도"
+        },
+        "startError": {
+          "message": "OAuth를 시작할 수 없습니다"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "자격 증명 교체 중 문제가 발생했습니다: {detail}"
+        },
+        "success": {
+          "toast": "자격 증명을 성공적으로 교체했습니다!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "작업"
+        },
+        "created": {
+          "header": "생성됨"
+        },
+        "edit": {
+          "ariaLabel": "자격 증명 편집"
+        },
+        "empty": {
+          "message": "이 커넥터에 대한 자격 증명이 없습니다!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "마지막 업데이트"
+        },
+        "name": {
+          "header": "이름"
+        },
+        "select": {
+          "label": "선택"
+        },
+        "selected": {
+          "badge": "선택됨"
+        },
+        "untitled": {
+          "label": "제목 없음"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "자격 증명 업데이트 중 문제가 발생했습니다"
+        },
+        "success": {
+          "toast": "자격 증명을 업데이트했습니다"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "이를 통해 자체 분석 도구를 Onyx에 연결할 수 있습니다! 분석 제공업체의 웹 스니펫을 아래 상자에 복사하면 사용 이벤트 전송이 시작됩니다."
+      },
+      "notEnabled": {
+        "description": "사용자 지정 분석 스크립트를 설정하려면 팀에서 Onyx를 설치한 담당자와 협력하여 <i>CUSTOM_ANALYTICS_SECRET_KEY</i> 환경 변수를 설정하세요.",
+        "title": "사용자 지정 분석이 활성화되어 있지 않습니다."
+      },
+      "script": {
+        "description": "사용자 지정 추적/분석을 초기화하기 위해 페이지 로드 시 실행할 Javascript를 지정하세요.",
+        "instructions": "`<script></script>` 태그는 포함하지 마세요. 아래에 스크립트를 업로드했는데 분석 플랫폼에서 이벤트가 수신되지 않는 경우, 각 JavaScript 줄 앞의 불필요한 공백을 모두 제거해 보세요.",
+        "label": "스크립트"
+      },
+      "secretKey": {
+        "description": "보안상의 이유로 이 스크립트를 업데이트하려면 비밀 키를 입력해야 합니다. 이는 Onyx를 처음 설정할 때 지정한 <i>CUSTOM_ANALYTICS_SECRET_KEY</i> 환경 변수의 값이어야 합니다.",
+        "label": "비밀 키"
+      },
+      "updateButton": {
+        "label": "업데이트"
+      },
+      "updateFailed": {
+        "message": "사용자 지정 분석 스크립트 업데이트 실패: \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "사용자 지정 분석 스크립트가 성공적으로 업데이트되었습니다!"
       }
     },
     "discordBot": {
@@ -3047,6 +3516,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "수집 중..."
+        },
+        "downloading": {
+          "label": "다운로드 중..."
+        },
+        "export": {
+          "label": "로그 내보내기"
+        },
+        "starting": {
+          "label": "시작 중..."
+        }
+      },
+      "downloadButton": {
+        "label": "다운로드"
+      },
+      "exportCard": {
+        "description": "API 서버와 백그라운드 워커의 로그 파일을 하나의 zip으로 수집합니다. 수집이 완료되면 다운로드가 자동으로 시작됩니다.",
+        "title": "로그 내보내기"
+      },
+      "header": {
+        "description": "서버 로그 파일의 zip을 다운로드하여 Onyx 지원 스레드에 첨부하세요."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "동일한 호스트의 다른 워커가 처리함"
+        },
+        "failed": {
+          "label": "실패"
+        },
+        "failedWithError": {
+          "label": "실패: {error}"
+        },
+        "noLogs": {
+          "label": "로그 파일을 찾을 수 없음"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {파일 #개 업로드됨} other {파일 #개 업로드됨}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "로그 파일에는 사용자 이메일, 문서 제목, 검색어, 오류 내용이 포함될 수 있습니다. 조직 외부에 공유하기 전에 내용을 검토하세요.",
+        "title": "로그에 민감한 데이터가 포함될 수 있습니다"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "수집을 시작하는 중..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "로그 내보내기가 이미 진행 중입니다. 잠시 후 다시 시도하세요."
+        },
+        "downloadFailed": {
+          "message": "로그 내보내기 다운로드에 실패했습니다."
+        },
+        "lostAccess": {
+          "message": "실행 중인 내보내기에 대한 액세스가 끊어졌습니다. 새로 시작하세요."
+        },
+        "startFailed": {
+          "message": "로그 내보내기를 시작하지 못했습니다."
+        },
+        "unreachable": {
+          "message": "서버에 연결할 수 없어 내보내기 진행 상황을 확인할 수 없습니다. 서버가 복구되면 새로 내보내기를 시작하세요."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "수집 중..."
+        },
+        "missedDeadline": {
+          "label": "기한 내에 보고하지 않음"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3153,9 +3699,137 @@
         "loadFailed": "커넥터를 불러오지 못했습니다: {details}",
         "title": "오류"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "채널 이름 또는 정규식 패턴을 입력하고 Enter 키를 누르세요"
+        },
+        "channelsRequired": {
+          "error": "'모든 채널 검색'이 비활성화된 경우 채널이 하나 이상 필요합니다"
+        },
+        "configSchemaLoadError": {
+          "message": "구성 스키마를 불러오지 못했습니다: {error}"
+        },
+        "configTitle": {
+          "text": "페더레이션 커넥터 구성"
+        },
+        "configuration": {
+          "heading": "구성"
+        },
+        "create": {
+          "failed": "페더레이션 커넥터를 생성하지 못했습니다",
+          "success": "페더레이션 커넥터가 생성되었습니다!"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (현재 값을 유지하려면 비워 두세요)"
+        },
+        "credentialValidationFailed": {
+          "message": "자격 증명 검증 실패: {message}"
+        },
+        "credentials": {
+          "description": "이 커넥터의 자격 증명을 입력하세요.",
+          "heading": "자격 증명"
+        },
+        "delete": {
+          "failed": "페더레이션 커넥터를 삭제하지 못했습니다",
+          "success": "페더레이션 커넥터가 삭제되었습니다!"
+        },
+        "deleteConfirm": {
+          "message": "이 페더레이션 커넥터를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+        },
+        "deleteError": {
+          "toast": "커넥터 삭제 중 오류: {error}"
+        },
+        "deleteItem": {
+          "deleting": "삭제 중...",
+          "inProgressTooltip": "삭제 진행 중",
+          "label": "삭제"
+        },
+        "federatedBadge": {
+          "label": "페더레이션"
+        },
+        "federatedTooltip": {
+          "default": "이것은 페더레이션 커넥터입니다. 일반 커넥터에 비해 지연 시간이 길고 검색 품질이 낮습니다."
+        },
+        "genericError": {
+          "text": "오류: {error}"
+        },
+        "listInput": {
+          "placeholder": "입력 후 Enter 키를 눌러 항목을 추가하세요"
+        },
+        "loadingSchema": {
+          "description": "이 커넥터 유형에 필요한 필드를 가져오는 중",
+          "title": "자격 증명 스키마를 불러오는 중..."
+        },
+        "manageButton": {
+          "label": "관리"
+        },
+        "missingFields": {
+          "message": "필수 필드 누락: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "이 커넥터 유형에 사용할 수 있는 검색 구성이 없습니다."
+        },
+        "noCredentialSchema": {
+          "message": "이 커넥터 유형에 사용할 수 있는 자격 증명 스키마가 없습니다."
+        },
+        "schemaLoadError": {
+          "message": "자격 증명 스키마를 불러오지 못했습니다: {error}"
+        },
+        "submitButton": {
+          "create": "생성",
+          "creating": "생성 중...",
+          "update": "업데이트",
+          "updating": "업데이트 중..."
+        },
+        "title": {
+          "edit": "{name} 편집",
+          "setup": "{name} 설정"
+        },
+        "update": {
+          "failed": "페더레이션 커넥터를 업데이트하지 못했습니다",
+          "success": "페더레이션 커넥터가 업데이트되었습니다!"
+        },
+        "validateBeforeEdit": {
+          "message": "검증하기 전에 새 자격 증명 값을 입력하세요."
+        },
+        "validateButton": {
+          "label": "검증",
+          "validating": "검증 중..."
+        },
+        "validation": {
+          "error": "검증 오류: {error}",
+          "failedStatus": "검증 실패: {statusText}",
+          "invalid": "자격 증명이 유효하지 않습니다",
+          "valid": "자격 증명이 유효합니다"
+        }
+      },
       "loading": {
         "description": "커넥터 세부 정보와 자격 증명 스키마를 가져오는 중입니다",
         "title": "커넥터 구성을 불러오는 중..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "채팅으로 돌아가기"
+      },
+      "error": {
+        "title": "문제가 발생했습니다"
+      },
+      "errors": {
+        "clientSecret": "인증 자격 증명이 없거나 유효하지 않습니다",
+        "oauth": "OAuth 승인에 실패했습니다",
+        "validation": "구성 오류 - 커넥터 설정을 확인하세요"
+      },
+      "processing": {
+        "details": "설정을 완료하는 동안 기다려 주세요.",
+        "title": "처리 중..."
+      },
+      "redirecting": {
+        "text": "2초 후 채팅으로 이동합니다..."
+      },
+      "success": {
+        "detailsTemplate": "{serviceName} 승인이 성공적으로 완료되었습니다. 이제 이 커넥터를 검색에 사용할 수 있습니다.",
+        "title": "성공!"
       }
     },
     "groups": {
@@ -3418,6 +4092,265 @@
           "header": "Token 한도",
           "placeholder": "Token 한도(천 단위)",
           "unit": "(천 단위)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "훅 삭제",
+          "tooltip": "삭제"
+        },
+        "disconnect": {
+          "ariaLabel": "훅 비활성화",
+          "tooltip": "훅 연결 해제"
+        },
+        "disconnectedSuffix": {
+          "label": "(연결 해제됨)"
+        },
+        "hookPoint": {
+          "description": "훅 포인트: {name}"
+        },
+        "manage": {
+          "ariaLabel": "훅 구성",
+          "tooltip": "관리"
+        },
+        "reconnectButton": {
+          "label": "다시 연결"
+        },
+        "test": {
+          "ariaLabel": "훅 재검증",
+          "tooltip": "연결 테스트"
+        }
+      },
+      "connectButton": {
+        "label": "연결"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "훅 ***{name}***이(가) 이 훅 포인트에서 영구적으로 제거됩니다. 외부 엔드포인트는 이전에 전송된 데이터를 계속 보관할 수 있습니다."
+        },
+        "delete": {
+          "label": "삭제"
+        },
+        "header": {
+          "title": "*{name}* 삭제"
+        },
+        "permanent": {
+          "description": "삭제는 되돌릴 수 없습니다."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyx가 훅 ***{name}***에 대해 이 엔드포인트 호출을 중지합니다. 진행 중인 요청은 계속 실행됩니다. 외부 엔드포인트는 이전에 전송된 데이터를 계속 보관할 수 있습니다. 필요하면 나중에 이 훅을 다시 연결할 수 있습니다."
+        },
+        "deleteNote": {
+          "description": "이 훅을 삭제할 수도 있습니다. 삭제는 되돌릴 수 없습니다."
+        },
+        "disconnect": {
+          "label": "연결 해제"
+        },
+        "disconnectAndDelete": {
+          "label": "연결 해제 및 삭제"
+        },
+        "header": {
+          "title": "*{name}* 연결 해제"
+        }
+      },
+      "docsLink": {
+        "label": "문서"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyx는 이 키를 사용하여 API 엔드포인트에 인증합니다.",
+          "keepCurrent": {
+            "placeholder": "현재 키를 유지하려면 비워 두세요"
+          },
+          "title": "API 키"
+        },
+        "connectionValid": {
+          "label": "연결이 유효합니다."
+        },
+        "createHeader": {
+          "description": "외부 API 엔드포인트를 연결하여 훅 포인트를 확장하세요.",
+          "title": "훅 확장 설정"
+        },
+        "editHeader": {
+          "title": "훅 확장 관리"
+        },
+        "endpoint": {
+          "description": "신뢰할 수 있는 서버에만 연결하세요. 이 연결로 수행되는 작업과 공유되는 데이터에 대한 책임은 사용자에게 있습니다.",
+          "title": "외부 API 엔드포인트 URL"
+        },
+        "errors": {
+          "connect": "엔드포인트에 연결할 수 없습니다.",
+          "generic": "문제가 발생했습니다.",
+          "invalidApiKey": "잘못된 API 키입니다.",
+          "timeout": "연결 시간이 초과되었습니다. 시간 제한을 늘려 보세요."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(기본값)"
+          },
+          "hard": {
+            "label": "실패 시 파이프라인 차단"
+          },
+          "placeholder": "전략 선택",
+          "soft": {
+            "label": "오류 기록 후 계속"
+          },
+          "title": "실패 전략"
+        },
+        "hookPoint": {
+          "label": "훅 포인트"
+        },
+        "name": {
+          "placeholder": "이 훅 포인트의 확장 이름을 지정하세요",
+          "title": "표시 이름"
+        },
+        "save": {
+          "label": "변경 사항 저장"
+        },
+        "softStrategy": {
+          "description": "엔드포인트가 오류를 반환하면 Onyx는 이를 기록하고 훅 결과를 무시한 채 파이프라인을 정상적으로 계속합니다."
+        },
+        "timeout": {
+          "description": "실패 전략을 적용하기 전에 Onyx가 엔드포인트 응답을 기다리는 최대 시간입니다. 0보다 크고 최대 {max}초여야 합니다.",
+          "revert": {
+            "tooltip": "기본값으로 되돌리기"
+          },
+          "suffix": "(초)",
+          "title": "시간 제한"
+        },
+        "toasts": {
+          "created": {
+            "message": "훅이 생성되었습니다."
+          },
+          "noHookPoint": {
+            "message": "훅 포인트가 지정되지 않았습니다."
+          },
+          "updated": {
+            "message": "훅이 업데이트되었습니다."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "API 키는 비워 둘 수 없습니다.",
+          "endpointRequired": "엔드포인트 URL은 비워 둘 수 없습니다.",
+          "nameRequired": "표시 이름은 비워 둘 수 없습니다.",
+          "timeoutRange": "0보다 크고 최대 {max}초여야 합니다.",
+          "timeoutRequired": "시간 제한은 필수입니다."
+        },
+        "verifying": {
+          "label": "연결을 확인하는 중…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "복사"
+        },
+        "download": {
+          "tooltip": "다운로드"
+        },
+        "empty": {
+          "message": "지난 30일 동안 오류가 없습니다."
+        },
+        "header": {
+          "description": "훅: {name} • 훅 포인트: {point}",
+          "title": "최근 오류"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {#줄} other {#줄}}"
+        },
+        "loadFailed": {
+          "message": "로그를 불러오지 못했습니다."
+        },
+        "older": {
+          "label": "이전"
+        },
+        "pastHour": {
+          "label": "지난 1시간"
+        },
+        "unknownError": {
+          "label": "알 수 없는 오류"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "취소"
+        }
+      },
+      "page": {
+        "description": "미리 정의된 훅 포인트에 외부 API 엔드포인트를 콜백으로 등록하여 Onyx 파이프라인을 확장하세요.",
+        "empty": {
+          "title": "사용 가능한 훅 포인트가 없습니다"
+        },
+        "emptySearch": {
+          "description": "다른 검색어를 사용해 보세요.",
+          "title": "결과 없음"
+        },
+        "enterpriseRequired": {
+          "message": "훅 확장 기능에는 Enterprise 라이선스가 필요합니다."
+        },
+        "loadHooksFailed": {
+          "message": "훅을 불러오지 못했습니다. 페이지를 새로 고치세요."
+        },
+        "loadSpecsFailed": {
+          "message": "훅 사양을 불러오지 못했습니다. 페이지를 새로 고치세요."
+        },
+        "notEnabled": {
+          "message": "이 배포에서는 훅 확장 기능이 활성화되어 있지 않습니다."
+        },
+        "search": {
+          "placeholder": "훅 검색..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "연결됨"
+        },
+        "connectionLost": {
+          "label": "연결 끊김"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {오류 #개} other {오류 #개}}"
+        },
+        "noError": {
+          "title": "오류 없음"
+        },
+        "pastHour": {
+          "description": "지난 1시간 동안"
+        },
+        "recentErrors": {
+          "title": "가장 최근 오류"
+        },
+        "viewMore": {
+          "label": "더 많은 줄 보기"
+        },
+        "viewOlder": {
+          "label": "이전 오류 보기"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "훅 비활성화에 실패했습니다."
+        },
+        "deleteFailed": {
+          "message": "훅 삭제에 실패했습니다."
+        },
+        "disconnectFailed": {
+          "message": "훅 연결 해제에 실패했습니다."
+        },
+        "reconnectFailed": {
+          "message": "훅 다시 연결에 실패했습니다."
+        },
+        "validateFailed": {
+          "message": "훅 검증에 실패했습니다."
+        },
+        "validateSuccess": {
+          "message": "훅이 성공적으로 검증되었습니다."
+        },
+        "validationFailed": {
+          "message": "검증 실패: {status}"
         }
       }
     },
@@ -4297,6 +5230,9 @@
               "label": "줄 추가"
             },
             "description": "모델 제공자가 요구하는 추가 속성을 입력하세요. 이 값은 [환경 변수](https://docs.litellm.ai/docs/set_keys#environment-variables)로서 LiteLLM의 `completion()` 호출에 전달됩니다. 자세한 안내는 [문서](https://docs.onyx.app/admins/ai_models/custom_inference_provider)를 참고하세요.",
+            "keyInput": {
+              "placeholder": "예: OPENAI_ORGANIZATION"
+            },
             "title": "환경 변수"
           },
           "modelRow": {
@@ -4808,6 +5744,132 @@
         "title": "사용자"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "알 수 없음"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "AI"
+        },
+        "errorTitle": {
+          "title": "문제가 발생했습니다 :("
+        },
+        "feedback": {
+          "title": "피드백"
+        },
+        "fetchFailed": {
+          "message": "채팅 세션을 가져오지 못했습니다 - {error}"
+        },
+        "header": {
+          "title": "채팅 세션 세부 정보"
+        },
+        "referenceDocuments": {
+          "title": "참조 문서"
+        },
+        "user": {
+          "label": "사용자"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "취소"
+        },
+        "downloadFailed": {
+          "message": "질의 기록 다운로드에 실패했습니다."
+        },
+        "generating": {
+          "message": "CSV 보고서를 생성하는 중입니다. 모든 작업을 보려면 \"{button}\" 버튼을 클릭하세요."
+        },
+        "kickoff": {
+          "label": "내보내기 시작"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "실패"
+        },
+        "pending": {
+          "label": "대기 중"
+        },
+        "success": {
+          "label": "성공"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "다운로드"
+        },
+        "endRange": {
+          "header": "종료 범위"
+        },
+        "generatedAt": {
+          "header": "생성 시각"
+        },
+        "header": {
+          "title": "이전 질의 기록 내보내기"
+        },
+        "notReady": {
+          "tooltip": "내보내기가 아직 준비되지 않았습니다"
+        },
+        "startRange": {
+          "header": "시작 범위"
+        },
+        "status": {
+          "header": "상태"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "싫어요"
+        },
+        "like": {
+          "label": "좋아요"
+        },
+        "mixed": {
+          "label": "혼합"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "전체"
+        },
+        "feedbackType": {
+          "label": "피드백 유형"
+        }
+      },
+      "previousExports": {
+        "label": "내보내기 보기"
+      },
+      "table": {
+        "date": {
+          "header": "날짜"
+        },
+        "feedback": {
+          "header": "피드백"
+        },
+        "fetchError": {
+          "title": "질의 기록을 가져오는 중 오류가 발생했습니다"
+        },
+        "firstAiResponse": {
+          "header": "첫 AI 응답"
+        },
+        "firstUserMessage": {
+          "header": "첫 사용자 메시지"
+        },
+        "persona": {
+          "header": "페르소나"
+        },
+        "user": {
+          "header": "사용자"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4862,6 +5924,56 @@
         "generateFailed": "Token을 생성하지 못했습니다: {detail}",
         "genericError": "문제가 발생했습니다. 다시 시도하세요.",
         "regenerated": "Token을 재생성했습니다"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "질의 분류에 실패했습니다. 채팅으로 대체합니다."
+        },
+        "searchFailed": {
+          "message": "문서 검색에 실패했습니다. 다시 시도해 주세요."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {결과 #개} other {결과 #개}}"
+        },
+        "empty": {
+          "description": "커넥터/필터를 확인하거나 다른 검색어를 시도해 보세요.",
+          "title": "결과 없음"
+        },
+        "failed": {
+          "title": "검색 실패"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {태그 #개} other {태그 #개}}"
+        },
+        "empty": {
+          "label": "태그"
+        },
+        "search": {
+          "placeholder": "태그 필터링..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "전체 기간"
+        },
+        "day": {
+          "label": "지난 24시간"
+        },
+        "month": {
+          "label": "지난달"
+        },
+        "week": {
+          "label": "지난주"
+        },
+        "year": {
+          "label": "지난해"
+        }
       }
     },
     "security": {
@@ -5753,6 +6865,163 @@
         "unexpectedError": "예기치 않은 오류가 발생했습니다."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "카테고리 {name} 제거"
+        },
+        "removeButton": {
+          "ariaLabel": "카테고리 제거"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "표준 답변 카테고리"
+        },
+        "fetchError": {
+          "message": "표준 답변 카테고리를 가져오지 못했습니다 - {message}",
+          "title": "문제가 발생했습니다 :("
+        },
+        "search": {
+          "placeholder": "카테고리 검색..."
+        }
+      },
+      "editPage": {
+        "title": "표준 답변 편집"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "표준 답변을 가져오지 못했습니다"
+        },
+        "fetchCategoriesFailed": {
+          "message": "표준 답변 카테고리를 가져오지 못했습니다"
+        },
+        "genericTitle": {
+          "title": "문제가 발생했습니다 :("
+        },
+        "loadAnswersFailed": {
+          "title": "표준 답변을 불러오는 중 오류가 발생했습니다"
+        },
+        "loadCategoriesFailed": {
+          "title": "표준 답변 카테고리를 불러오는 중 오류가 발생했습니다"
+        },
+        "notFound": {
+          "message": "ID가 {id}인 표준 답변을 찾을 수 없습니다"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "모든 카테고리"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "다음 키워드 모두(순서 무관, 공백으로 구분)",
+          "placeholder": "IT 티켓"
+        },
+        "answer": {
+          "label": "답변",
+          "placeholder": "Markdown 형식의 답변입니다. 예: IT 팀의 도움이 필요하면 internalsupport@company.com 으로 이메일을 보내주세요"
+        },
+        "anyKeywords": {
+          "label": "다음 키워드 중 하나(공백으로 구분)",
+          "placeholder": "티켓 문제 이슈"
+        },
+        "categories": {
+          "label": "카테고리:",
+          "placeholder": "카테고리를 입력하고 Enter 키를 누르세요…"
+        },
+        "createButton": {
+          "label": "생성!"
+        },
+        "keywords": {
+          "tooltip": "질문이 이 키워드와 일치해야 답변이 트리거됩니다."
+        },
+        "matchRegex": {
+          "description": "정확한 키워드 대신 정규식 패턴으로 일치시킵니다",
+          "label": "정규식 일치"
+        },
+        "regexPattern": {
+          "label": "정규식 패턴",
+          "tooltip": "질문이 이 정규식 패턴과 일치하면 트리거됩니다(Python의 `re.search()` 사용)"
+        },
+        "strategy": {
+          "all": {
+            "label": "모든 키워드"
+          },
+          "any": {
+            "label": "아무 키워드"
+          },
+          "description": "이 답변을 표시하려면 사용자의 질문에 위 키워드 중 일부 또는 전부가 포함되어야 하는지 선택하세요.",
+          "label": "키워드 감지 전략"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "카테고리 \"{name}\" 생성 중 오류 발생 - {error}"
+          },
+          "createFailed": {
+            "message": "표준 답변 생성 중 오류 발생 - {error}"
+          },
+          "updateFailed": {
+            "message": "표준 답변 업데이트 중 오류 발생 - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "업데이트!"
+        },
+        "validation": {
+          "answerRequired": "답변은 필수입니다",
+          "categoryRequired": "최소 한 개의 카테고리가 필요합니다",
+          "keywordRequired": "키워드 또는 패턴은 필수입니다"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "아래에서 첫 번째 표준 답변을 추가하세요!"
+        },
+        "description": "미리 정의된 질문에 대한 표준 답변을 관리하세요.\n참고: 현재 Slack에서 한 질문만 표준 답변을 받을 수 있습니다."
+      },
+      "newStandardAnswer": {
+        "label": "새 표준 답변"
+      },
+      "search": {
+        "placeholder": "키워드/문구로 표준 답변 찾기..."
+      },
+      "table": {
+        "answer": {
+          "header": "답변"
+        },
+        "categories": {
+          "header": "카테고리"
+        },
+        "empty": {
+          "message": "일치하는 표준 답변이 없습니다..."
+        },
+        "keywords": {
+          "header": "키워드/패턴"
+        },
+        "matchRegex": {
+          "header": "정규식 일치?"
+        },
+        "matchRegexNo": {
+          "label": "아니요"
+        },
+        "matchRegexYes": {
+          "label": "예"
+        },
+        "slackNote": {
+          "message": "해당 [Slack 봇](/admin/bots)에 카테고리를 추가했는지 확인하세요."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "표준 답변 삭제 실패 - {error}"
+        },
+        "deleted": {
+          "message": "표준 답변 {id}이(가) 삭제되었습니다"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "취소됨",
@@ -5783,6 +7052,142 @@
       },
       "webVersion": {
         "label": "웹 버전: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "사용자가 닫을 수 있는 지속적인 시스템 공지를 표시합니다.",
+        "header": {
+          "placeholder": "공지 추가"
+        },
+        "label": "시스템 공지"
+      },
+      "announcementPopup": {
+        "description": "모든 사용자의 첫 방문 시 이 알림을 전체 화면 팝업으로도 표시합니다. 신중히 사용하세요.",
+        "label": "첫 방문 시 팝업 알림"
+      },
+      "appName": {
+        "description": "이 이름은 앱 전체에 표시되며 UI에서 \"Onyx\"를 대체합니다.",
+        "label": "애플리케이션 표시 이름"
+      },
+      "branding": {
+        "description": "앱에서 \"powered by Onyx\" 및 기타 Onyx 브랜딩을 제거합니다.",
+        "enterpriseTooltip": "Onyx 브랜딩 숨기기는 Enterprise 플랜 기능입니다.",
+        "label": "Onyx 브랜딩 숨기기"
+      },
+      "chatFooter": {
+        "description": "면책 조항이나 추가 정보를 위한 마크다운 콘텐츠를 추가하세요.",
+        "label": "채팅 푸터 텍스트"
+      },
+      "chatHeader": {
+        "label": "채팅 헤더 텍스트"
+      },
+      "consent": {
+        "description": "사용자가 애플리케이션에 액세스하기 전에 알림을 읽고 동의하도록 요구합니다.",
+        "label": "알림 동의 필수"
+      },
+      "consentPrompt": {
+        "label": "알림 동의 문구"
+      },
+      "firstVisit": {
+        "description": "신규 사용자의 첫 방문 시 일회성 팝업을 표시합니다.",
+        "label": "첫 방문 알림 표시"
+      },
+      "greeting": {
+        "description": "홈 페이지에 짧은 메시지를 추가하세요.",
+        "label": "환영 메시지"
+      },
+      "helpLink": {
+        "description": "Onyx 문서 외에 사용자 메뉴에 사용자 지정 도움말 링크를 추가하세요.",
+        "enterpriseTooltip": "사용자 지정 도움말 링크는 Enterprise 플랜 기능입니다.",
+        "label": "사용자 지정 도움말 링크"
+      },
+      "helpLinkLabel": {
+        "label": "사용자 지정 도움말 링크 레이블",
+        "placeholder": "링크 레이블"
+      },
+      "loginSubtitle": {
+        "description": "로그인 페이지의 환영 제목 아래 문구를 바꾸세요.",
+        "label": "로그인 페이지 부제목"
+      },
+      "logo": {
+        "label": "애플리케이션 로고",
+        "updateButton": {
+          "label": "업데이트"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "로고 및 이름",
+          "tooltip": "애플리케이션 로고와 이름을 모두 표시합니다."
+        },
+        "description": "사이드바 상단에 표시할 내용을 선택하세요. 로고나 애플리케이션 이름을 추가하면 옵션을 사용할 수 있습니다.",
+        "label": "로고 표시 스타일",
+        "logoOnly": {
+          "disabledTooltip": "이 옵션을 사용하려면 로고를 업로드하세요.",
+          "label": "로고만",
+          "tooltip": "애플리케이션 로고만 표시합니다."
+        },
+        "nameOnly": {
+          "disabledTooltip": "이 옵션을 사용하려면 애플리케이션 이름을 입력하세요.",
+          "label": "이름만",
+          "tooltip": "애플리케이션 이름만 표시합니다."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "마크다운 콘텐츠 추가"
+      },
+      "noticeContent": {
+        "label": "알림 내용"
+      },
+      "noticeHeader": {
+        "label": "알림 제목"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "공지 삭제에 실패했습니다."
+        },
+        "announcementSaveFailed": {
+          "message": "공지 저장에 실패했습니다."
+        },
+        "applyButton": {
+          "label": "변경 사항 적용"
+        },
+        "applying": {
+          "label": "적용 중..."
+        },
+        "description": "조직 내 사용자에게 애플리케이션이 표시되는 방식을 사용자 지정하세요.",
+        "logoUploadFailed": {
+          "message": "로고 업로드에 실패했습니다. {error}"
+        },
+        "saveSuccess": {
+          "message": "모양 설정이 성공적으로 저장되었습니다!"
+        },
+        "settingsSaveFailed": {
+          "message": "설정 업데이트에 실패했습니다. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "알림 동의 문구는 필수입니다",
+          "invalidUrl": "유효한 URL이어야 합니다",
+          "maxChars": "최대 {count}자",
+          "noticeContentRequired": "알림 내용은 필수입니다",
+          "noticeHeaderRequired": "알림 제목은 필수입니다",
+          "urlRequiredWithLabel": "레이블을 설정한 경우 URL은 필수입니다"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "채팅 푸터 내용"
+        },
+        "chatHeader": {
+          "placeholder": "채팅 헤더 내용"
+        },
+        "greeting": {
+          "placeholder": "Acme Chat에 오신 것을 환영합니다"
+        },
+        "logo": {
+          "alt": "로고"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6047,6 +7452,9 @@
             "label": "지출"
           }
         }
+      },
+      "page": {
+        "description": "워크스페이스 지출을 모니터링하고 사용자별 사용량을 검토하세요."
       },
       "spendByUser": {
         "columns": {
@@ -6644,6 +8052,204 @@
         "tooltip": "에이전트 통계 보기"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "코드를 생성하고 실행합니다.",
+          "title": "코드 인터프리터"
+        },
+        "codingAgent": {
+          "description": "GitHub 저장소를 조사하고 코드에 관한 질문에 답합니다.",
+          "title": "코딩 에이전트"
+        },
+        "description": "이 에이전트가 사용할 수 있는 도구와 기능입니다.",
+        "imageGeneration": {
+          "description": "AI 기반 도구로 이미지를 생성하고 편집합니다.",
+          "title": "이미지 생성",
+          "unavailable": {
+            "tooltip": "이미지 생성에는 구성된 모델이 필요합니다. 액세스 권한이 있다면 설정 > 이미지 생성에서 모델을 설정하거나 관리자에게 요청하세요."
+          }
+        },
+        "openUrl": {
+          "description": "웹 URL에서 콘텐츠를 가져와 읽습니다.",
+          "title": "URL 열기"
+        },
+        "title": "액션",
+        "webSearch": {
+          "description": "웹에서 실시간 정보와 최신 결과를 검색합니다.",
+          "title": "웹 검색"
+        }
+      },
+      "advanced": {
+        "description": "에이전트 프롬프트와 지식을 세밀하게 조정합니다.",
+        "overwritePrompt": {
+          "suffix": "(권장하지 않음)",
+          "title": "시스템 프롬프트 덮어쓰기"
+        },
+        "reminders": {
+          "description": "프롬프트 메시지에 짧은 리마인더를 추가합니다. 채팅이 진행되면서 에이전트가 특정 지침을 잊는 경향이 있을 때 사용하세요. 짧아야 하며 사용자 메시지를 방해하지 않아야 합니다.",
+          "placeholder": "기억하세요, 응답은 항상 번호가 매겨진 목록 형식으로 작성해 주세요.",
+          "title": "리마인더"
+        },
+        "title": "고급 옵션"
+      },
+      "avatar": {
+        "edit": {
+          "label": "편집"
+        },
+        "uploadImage": {
+          "label": "이미지 업로드"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "에이전트 삭제"
+        },
+        "description": "이 에이전트를 사용하는 모든 사용자가 더 이상 액세스할 수 없게 됩니다.",
+        "title": "이 에이전트 삭제"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "이 에이전트를 삭제하시겠습니까?",
+          "warning": "이 에이전트를 사용하는 모든 사용자가 더 이상 액세스할 수 없게 됩니다. 삭제는 되돌릴 수 없습니다."
+        },
+        "title": "에이전트 삭제"
+      },
+      "filesModal": {
+        "description": "이 에이전트에 대해 선택된 모든 파일",
+        "placeholderName": "파일 {id}",
+        "title": "사용자 파일"
+      },
+      "general": {
+        "avatar": {
+          "title": "에이전트 아바타"
+        },
+        "descriptionField": {
+          "placeholder": "이 에이전트는 어떤 역할을 하나요?",
+          "title": "설명"
+        },
+        "name": {
+          "placeholder": "에이전트 이름 지정",
+          "title": "이름"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "취소"
+        },
+        "create": {
+          "label": "만들기"
+        },
+        "createTitle": "에이전트 만들기",
+        "editTitle": "에이전트 편집",
+        "save": {
+          "label": "저장"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "더 이상 이 MCP 서버에 액세스할 수 없습니다. 기존 도구는 유지됩니다."
+        },
+        "searchTools": {
+          "placeholder": "도구 검색..."
+        }
+      },
+      "page": {
+        "ariaLabel": "에이전트 편집기 페이지"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "이 에이전트의 응답을 맞춤화할 지침을 추가하세요.",
+          "placeholder": "복잡한 문제는 단계별로 생각하고 추론을 보여 주세요. 구체적인 예를 사용하세요. 실행 항목을 강조하고, 알 수 없는 부분은 사람이 채울 수 있도록 빈칸으로 남겨 두세요. 정중하고 열정적인 어조를 사용하세요.",
+          "title": "지침"
+        },
+        "starters": {
+          "description": "사용자가 이 에이전트로 무엇을 할 수 있고 어떻게 효과적으로 상호작용할 수 있는지 이해하도록 돕는 예시 메시지입니다.",
+          "title": "대화 시작 문구"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "저장하기 전에 양식의 오류를 수정하세요.",
+        "noChanges": "변경된 사항이 없습니다.",
+        "saving": "변경 사항 저장 중...",
+        "uploading": "파일 업로드가 완료될 때까지 기다려 주세요."
+      },
+      "share": {
+        "feature": {
+          "description": "이 에이전트를 에이전트 탐색 목록 상단에 표시하고 액세스 권한이 있는 신규 사용자의 사이드바에 자동으로 고정합니다.",
+          "privateNotice": {
+            "title": "이 에이전트는 나에게만 비공개이며 나에게만 추천으로 표시됩니다."
+          },
+          "title": "이 에이전트 추천",
+          "unlistedWarning": {
+            "title": "이 에이전트는 목록에서 제외되어 추천 목록에 표시되지 않습니다."
+          }
+        },
+        "labels": {
+          "description": "레이블과 카테고리를 추가하여 사람들이 이 에이전트를 더 쉽게 찾을 수 있게 하세요.",
+          "placeholder": "레이블 추가..."
+        },
+        "share": {
+          "button": {
+            "label": "공유"
+          },
+          "description": "다른 사용자, 그룹 또는 조직의 모든 구성원과 공유합니다.",
+          "title": "이 에이전트 공유"
+        },
+        "title": "에이전트 공유"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "이번 분기 엔지니어링 목표 목록을 정리해줘.",
+          "overview": "몇 가지 문서의 개요를 알려줘.",
+          "salesReport": "최신 매출 보고서를 찾아줘.",
+          "todayGoals": "오늘의 목표를 요약해줘."
+        },
+        "placeholder": "대화 시작 문구를 입력하세요..."
+      },
+      "suffix": {
+        "optional": "선택 사항"
+      },
+      "toasts": {
+        "createFailed": "에이전트를 생성하지 못했습니다 - {detail}",
+        "created": "에이전트 \"{name}\"이(가) 생성되었습니다",
+        "deleteFailed": "에이전트를 삭제하지 못했습니다: {error}",
+        "deleted": "에이전트가 삭제되었습니다",
+        "genericError": "오류가 발생했습니다: {error}",
+        "noResponse": "응답을 받지 못했습니다",
+        "sharingFailed": "에이전트가 생성되었지만 공유에 실패했습니다: {error}",
+        "toggleListedFailed": "표시 여부를 전환하지 못했습니다",
+        "unknownDetail": "알 수 없는 오류",
+        "unknownError": "알 수 없는 오류",
+        "updateFailed": "에이전트를 업데이트하지 못했습니다 - {detail}",
+        "updated": "에이전트 \"{name}\"이(가) 업데이트되었습니다"
+      },
+      "validation": {
+        "cutoffInFuture": "지식 마감일은 오늘 또는 그 이전이어야 합니다.",
+        "descriptionMax": "설명은 {max}자 이하여야 합니다",
+        "nameRequired": "에이전트 이름은 필수입니다.",
+        "starterMax": "대화 시작 문구는 {max}자 이하여야 합니다"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "다시 목록에 추가"
+          },
+          "description": "다시 목록에 추가된 에이전트는 에이전트 탐색 목록에 다시 표시됩니다.",
+          "title": "이 에이전트 다시 목록에 추가"
+        },
+        "unlist": {
+          "button": {
+            "label": "목록에서 제외"
+          },
+          "description": "목록에서 제외된 에이전트는 에이전트 탐색 목록에 표시되지 않지만 계속 액세스할 수 있습니다.",
+          "title": "이 에이전트 목록에서 제외"
+        }
+      },
+      "warnings": {
+        "openUrl": "URL을 열 수 없는 웹 검색은 웹 기반 결과가 크게 나빠질 수 있습니다."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6826,6 +8432,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {에이전트} other {에이전트}}"
+      },
+      "empty": {
+        "description": "에이전트를 찾을 수 없음"
+      },
+      "header": {
+        "description": "나와 팀의 사용 사례에 맞게 AI의 동작과 지식을 맞춤 설정하세요.",
+        "title": "에이전트"
+      },
+      "newAgent": {
+        "label": "새 에이전트",
+        "noPermission": {
+          "tooltip": "에이전트를 생성할 권한이 없습니다. 관리자에게 문의하여 액세스를 요청하세요."
+        }
+      },
+      "page": {
+        "ariaLabel": "에이전트 페이지"
+      },
+      "search": {
+        "placeholder": "에이전트 검색..."
+      },
+      "sections": {
+        "all": {
+          "title": "모든 에이전트"
+        },
+        "featured": {
+          "description": "팀에서 선별함",
+          "title": "추천 에이전트"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "모든 에이전트"
+        },
+        "your": {
+          "label": "내 에이전트"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "사용자 변수 삽입"
@@ -6833,6 +8480,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "익명 세션을 설정하는 동안 잠시만 기다려 주세요.",
+        "title": "채팅 페이지로 이동하는 중..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "새 조직 만들기"
@@ -6854,6 +8507,55 @@
       },
       "signInLink": {
         "label": "로그인"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "지정한 이메일로 된 계정이 이미 존재합니다."
+      },
+      "continueAsGuest": {
+        "label": "또는 게스트로 계속하기"
+      },
+      "email": {
+        "label": "이메일 주소",
+        "placeholder": "email@yourcompany.com"
+      },
+      "forgotPassword": {
+        "link": "[비밀번호를 잊으셨나요?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "이메일 또는 비밀번호가 잘못되었습니다"
+      },
+      "noPassword": {
+        "error": "비밀번호를 설정하려면 계정을 만드세요"
+      },
+      "password": {
+        "label": "비밀번호",
+        "placeholder": "비밀번호"
+      },
+      "passwordDigit": {
+        "error": "비밀번호에는 숫자가 하나 이상 포함되어야 합니다"
+      },
+      "passwordLength": {
+        "error": "비밀번호는 {min}–{max}자여야 합니다"
+      },
+      "passwordLoginDisabled": {
+        "error": "비밀번호 로그인이 꺼져 있습니다. ID 공급자를 통해 로그인하세요."
+      },
+      "passwordLowercase": {
+        "error": "비밀번호에는 소문자가 하나 이상 포함되어야 합니다"
+      },
+      "passwordRequirements": {
+        "label": "비밀번호 요건:"
+      },
+      "passwordSpecialChar": {
+        "error": "비밀번호에는 특수 문자가 하나 이상 포함되어야 합니다"
+      },
+      "passwordUppercase": {
+        "error": "비밀번호에는 대문자가 하나 이상 포함되어야 합니다"
+      },
+      "tooManyRequests": {
+        "error": "요청이 너무 많습니다. 나중에 다시 시도해 주세요."
       }
     },
     "error": {
@@ -6894,6 +8596,31 @@
         "description": "일시적인 인증 시스템 장애"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "팀에서 익명 액세스가 활성화되어 있지 않습니다."
+      },
+      "generic": {
+        "toast": "오류가 발생했습니다."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "계정 만들기"
+      },
+      "logo": {
+        "alt": "로고"
+      },
+      "signInLink": {
+        "label": "로그인"
+      },
+      "signinPrompt": {
+        "text": "이미 계정이 있으신가요?"
+      },
+      "signupPrompt": {
+        "text": "{appName}이 처음이신가요?"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[로그인으로 돌아가기](/auth/login)"
@@ -6926,7 +8653,8 @@
         "placeholder": "API 키 입력"
       },
       "emailField": {
-        "label": "이메일"
+        "label": "이메일",
+        "placeholder": "email@yourcompany.com"
       },
       "genericError": {
         "toast": "사용자 가장에 실패했습니다"
@@ -6987,6 +8715,23 @@
         "label": "회사 이메일"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "숫자를 포함합니다."
+      },
+      "length": {
+        "label": "{min}–{max}자"
+      },
+      "lowercase": {
+        "label": "소문자를 포함합니다."
+      },
+      "specialChar": {
+        "label": "특수 문자를 포함합니다."
+      },
+      "uppercase": {
+        "label": "대문자를 포함합니다."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[로그인으로 돌아가기](/auth/login)"
@@ -7028,6 +8773,31 @@
       },
       "unexpectedError": {
         "toast": "예기치 않은 오류가 발생했습니다. 다시 시도하세요."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "세션이 만료되었습니다. 계속하려면 다시 로그인하세요."
+      },
+      "loginButton": {
+        "label": "로그인"
+      },
+      "modal": {
+        "title": "로그아웃되었습니다"
+      },
+      "terminated": {
+        "message": "이 세션이 로그아웃되었습니다. 계속하려면 다시 로그인하세요."
+      },
+      "unrecognized": {
+        "message": "예기치 않게 로그아웃되었습니다. 계속하려면 다시 로그인하세요. 이 문제가 계속되면 관리자에게 문의하세요."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute가 토큰을 반환하지 않았습니다"
+      },
+      "google": {
+        "label": "Google로 계속하기"
       }
     },
     "signup": {
@@ -8459,6 +10229,75 @@
         "tooltip": "이 모델은 이 설정의 변경을 지원하지 않습니다."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {파일 처리에 실패하여 제거되었습니다: {names}} other {파일 처리에 실패하여 제거되었습니다: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "로그인"
+          },
+          "title": "Onyx에 오신 것을 환영합니다"
+        },
+        "noResubmitMessage": {
+          "toast": "이전에 보낸 메시지를 찾을 수 없습니다."
+        },
+        "settingsButton": {
+          "tooltip": "설정 열기"
+        },
+        "setupLlmButton": {
+          "label": "LLM을 설정하세요."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "취소"
+          },
+          "confirmButton": {
+            "label": "끄기"
+          },
+          "description": "대신 브라우저의 기본 새 탭 페이지가 표시됩니다. Onyx 설정에서 언제든지 다시 켤 수 있습니다.",
+          "title": "Onyx 새 탭 페이지를 끄시겠습니까?"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "없음"
+        },
+        "backgroundOption": {
+          "ariaLabel": "{label} 배경"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "{label} 배경 (선택됨)"
+        },
+        "backgroundSection": {
+          "title": "배경"
+        },
+        "closeButton": {
+          "tooltip": "설정 닫기"
+        },
+        "generalSection": {
+          "title": "일반"
+        },
+        "header": {
+          "title": "설정"
+        },
+        "newTabToggle": {
+          "label": "Onyx를 새 탭 페이지로 사용"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {라이트 테마로 전환} other {다크 테마로 전환}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "새 채팅"
+        },
+        "openInOnyxButton": {
+          "tooltip": "Onyx에서 열기"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "동의 체크박스"
@@ -8474,6 +10313,128 @@
       },
       "startButton": {
         "label": "시작"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "마지막 메시지 {time}"
+        },
+        "projectFallback": {
+          "label": "프로젝트"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "파일 추가"
+        },
+        "contextExceeded": {
+          "message": "이 프로젝트는 모델의 컨텍스트 한도를 초과합니다. 세션은 응답을 생성하기 전에 관련 파일을 자동으로 먼저 검색합니다."
+        },
+        "dropFiles": {
+          "message": "이 프로젝트에 추가하려면 여기에 파일을 놓으세요"
+        },
+        "emptyFiles": {
+          "message": "프로젝트에서 사용할 문서, 텍스트 또는 이미지를 추가하세요. 드래그 앤 드롭을 지원합니다."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {파일 #개} other {파일 #개}}"
+        },
+        "fileCountOverflow": {
+          "description": "파일 100개 이상"
+        },
+        "files": {
+          "description": "이 프로젝트의 채팅은 이 파일들에 접근할 수 있습니다.",
+          "title": "파일"
+        },
+        "filesModal": {
+          "description": "이 프로젝트의 세션은 여기에 있는 파일에 접근할 수 있습니다.",
+          "title": "프로젝트 파일"
+        },
+        "instructions": {
+          "emptyDescription": "이 프로젝트의 응답을 맞춤 설정하려면 지침을 추가하세요.",
+          "title": "지침"
+        },
+        "loadingProject": {
+          "label": "프로젝트 로드 중..."
+        },
+        "setInstructionsButton": {
+          "label": "지침 설정"
+        },
+        "viewAll": {
+          "label": "전체 보기"
+        },
+        "viewFiles": {
+          "label": "파일 보기"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "취소"
+        },
+        "createError": {
+          "toast": "프로젝트 {name}을(를) 만들지 못했습니다"
+        },
+        "description": "프로젝트를 사용해 파일과 채팅을 한곳에 정리하고, 진행 중인 작업에 대한 사용자 지정 지침을 추가하세요.",
+        "name": {
+          "label": "프로젝트 이름",
+          "placeholder": "어떤 작업을 하고 계신가요?"
+        },
+        "nameRequired": {
+          "error": "프로젝트 이름은 필수입니다"
+        },
+        "submitButton": {
+          "label": "프로젝트 만들기"
+        },
+        "title": "새 프로젝트 만들기"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "프로젝트를 찾을 수 없습니다"
+        },
+        "search": {
+          "placeholder": "프로젝트 검색..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "프로젝트 접기"
+        },
+        "delete": {
+          "label": "프로젝트 삭제"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "삭제"
+          },
+          "message": "이 프로젝트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+          "title": "프로젝트 삭제"
+        },
+        "expand": {
+          "ariaLabel": "프로젝트 펼치기"
+        },
+        "rename": {
+          "label": "프로젝트 이름 바꾸기"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "아직 채팅이 없습니다."
+        },
+        "recentChats": {
+          "title": "최근 채팅"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "파일을 업로드하지 못했습니다"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {크기 초과 파일 #개를 건너뛰었습니다} other {크기 초과 파일 #개를 건너뛰었습니다}} (>{max} MB): {names}"
+        },
+        "rejected": {
+          "toast": "일부 파일이 업로드되지 않았습니다. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8506,6 +10467,1773 @@
       },
       "incognito": {
         "title": "시크릿 모드입니다"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "사이드바 열기"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "결제 정보 업데이트"
+        },
+        "text": "**경고:** 체험 기간이 5일 이내에 종료되지만 결제 수단이 추가되지 않았습니다."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "에이전트 아바타"
+      },
+      "logo": {
+        "alt": "로고"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "문서"
+      },
+      "expandButton": {
+        "ariaLabel": "문서 확대"
+      }
+    },
+    "backButton": {
+      "label": "뒤로"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "구름"
+      },
+      "hills": {
+        "label": "언덕"
+      },
+      "mountains": {
+        "label": "산"
+      },
+      "night": {
+        "label": "밤"
+      },
+      "none": {
+        "label": "없음"
+      },
+      "plant": {
+        "label": "식물"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "가"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} \"{value}\"",
+        "defaultPrefix": "만들기"
+      },
+      "dropdown": {
+        "closeAriaLabel": "드롭다운 닫기",
+        "openAriaLabel": "드롭다운 열기"
+      },
+      "options": {
+        "empty": "옵션을 찾을 수 없습니다"
+      },
+      "separator": {
+        "label": "기타 옵션"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "메뉴 닫기"
+      },
+      "dialog": {
+        "title": "명령 메뉴"
+      },
+      "options": {
+        "ariaLabel": "명령 메뉴 옵션"
+      },
+      "search": {
+        "placeholder": "검색..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "사용 가능한 모든 커넥터가 선택되었습니다. 다른 커넥터를 추가하려면 아래에서 커넥터를 제거하세요.",
+        "placeholder": "모든 커넥터가 선택되었습니다"
+      },
+      "documentSetHint": {
+        "description": "선택한 커넥터가 색인한 모든 문서가 이 문서 세트에 포함됩니다."
+      },
+      "noMatches": {
+        "text": "일치하는 커넥터가 없습니다"
+      },
+      "noMoreConnectors": {
+        "text": "더 이상 사용 가능한 커넥터가 없습니다"
+      },
+      "noPrivateConnectors": {
+        "text": "사용 가능한 비공개 커넥터가 없습니다. 먼저 비공개 커넥터를 만드세요."
+      },
+      "noneSelected": {
+        "text": "선택된 커넥터가 없습니다. 위에서 커넥터를 검색하고 선택하세요."
+      },
+      "removeConnector": {
+        "tooltip": "커넥터 제거"
+      },
+      "search": {
+        "placeholder": "커넥터 검색..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "날짜 선택"
+      },
+      "todayButton": {
+        "label": "오늘"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "모든 기간..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "사용자 지정 범위 선택"
+      },
+      "clearButton": {
+        "ariaLabel": "지우기"
+      },
+      "custom": {
+        "label": "사용자 지정"
+      },
+      "customRange": {
+        "ariaLabel": "사용자 지정 범위: {from}부터 {to}까지"
+      },
+      "date": {
+        "label": "날짜"
+      },
+      "group": {
+        "ariaLabel": "날짜 범위"
+      },
+      "preset": {
+        "oneDay": "1일",
+        "oneMonth": "1개월",
+        "sevenDays": "7일",
+        "threeMonths": "3개월"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "삭제"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {컨텍스트 문서 #개} other {컨텍스트 문서 #개}}"
+      },
+      "openDocument": {
+        "ariaLabel": "문서 열기: {title}"
+      },
+      "question": {
+        "title": "질문"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {하위 쿼리 #개} other {하위 쿼리 #개}}"
+      },
+      "updated": {
+        "text": "업데이트: {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "기본값"
+      },
+      "selectOption": {
+        "placeholder": "옵션을 선택하세요..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "편집"
+      },
+      "rename": {
+        "ariaLabel": "이름 바꾸기"
+      },
+      "save": {
+        "ariaLabel": "저장"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "관리자라면 <billingLink>관리자 결제</billingLink> 페이지에서 라이선스를 {hadLicense, select, true {갱신} other {활성화}}하거나 Stripe를 통해 가입하거나 결제 관련 지원은 <supportLink>support@onyx.app</supportLink>으로 문의하세요."
+        },
+        "heading": {
+          "title": "액세스 제한됨"
+        },
+        "licenseLapse": {
+          "description": "라이선스가 만료되어 Onyx에 대한 액세스가 일시적으로 중단되었습니다."
+        },
+        "licenseRequired": {
+          "description": "Onyx를 사용하려면 라이선스가 필요합니다. 데이터는 보호되며 라이선스가 활성화되면 사용할 수 있습니다."
+        },
+        "logoutButton": {
+          "label": "로그아웃"
+        },
+        "manageSubscription": {
+          "description": "관리자라면 아래 버튼을 클릭하여 구독을 관리할 수 있습니다. 다른 사용자는 관리자에게 문의해 주세요."
+        },
+        "obtainLicense": {
+          "description": "시작하려면 시스템 관리자에게 문의하여 라이선스를 받으세요."
+        },
+        "renewLicense": {
+          "description": "액세스를 복원하고 Onyx를 계속 사용하려면 시스템 관리자에게 문의하여 라이선스를 갱신하세요."
+        },
+        "resubscribeButton": {
+          "label": "다시 구독",
+          "loading": "불러오는 중..."
+        },
+        "resubscribeError": {
+          "text": "재구독 페이지를 여는 중 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+        },
+        "seatLimit": {
+          "description": "조직이 라이선스 시트 수를 초과했습니다. 사용자 수를 줄이거나 라이선스를 업그레이드할 때까지 액세스가 제한됩니다."
+        },
+        "seatLimitAdminHint": {
+          "text": "관리자라면 <userLink>사용자 관리</userLink> 페이지에서 사용자를 관리하거나 <billingLink>관리자 결제</billingLink> 페이지에서 라이선스를 업그레이드할 수 있습니다."
+        },
+        "seatLimitWithCounts": {
+          "description": "조직이 라이선스 시트 수를 초과했습니다({used}명 사용자 / {seats}개 시트). 사용자 수를 줄이거나 라이선스를 업그레이드할 때까지 액세스가 제한됩니다."
+        },
+        "subscriptionLapse": {
+          "description": "구독이 만료되어 Onyx에 대한 액세스가 일시적으로 중단되었습니다."
+        },
+        "updatePayment": {
+          "description": "액세스를 복원하고 Onyx의 강력한 기능을 계속 이용하려면 결제 정보를 업데이트해 주세요."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "관리자라면 올바른 구성 단계에 대해 <docsLink>문서</docsLink>를 확인해 주세요. 일반 사용자라면 관리자에게 문의하세요."
+        },
+        "heading": {
+          "description": "Onyx 설정을 불러오는 중 문제가 발생한 것 같습니다. 구성 문제이거나 설정이 완료되지 않았기 때문일 수 있습니다.",
+          "title": "문제가 발생했습니다"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "불편을 드려 죄송하며 양해해 주셔서 감사합니다."
+        },
+        "checkBack": {
+          "description": "Onyx는 현재 유지 보수 중입니다. 몇 분 후에 다시 확인해 주세요."
+        },
+        "heading": {
+          "title": "유지 보수 진행 중"
+        }
+      },
+      "needHelp": {
+        "text": "도움이 필요하신가요? <discordLink>Discord 커뮤니티</discordLink>에 참여하여 지원을 받으세요."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "알 수 없는 오류"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "파일 다운로드"
+      },
+      "file": {
+        "untitledFallback": "제목 없음"
+      },
+      "fullScreenButton": {
+        "tooltip": "전체 화면"
+      },
+      "hideButton": {
+        "tooltip": "숨기기"
+      },
+      "minimizeButton": {
+        "tooltip": "최소화"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "복사"
+      },
+      "downloadButton": {
+        "tooltip": "다운로드"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {#줄} other {#줄}}"
+      },
+      "size": {
+        "bytes": "{count}바이트",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "전체 텍스트 보기"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "모든 페더레이션 커넥터가 선택되었습니다"
+      },
+      "entitiesConfigured": {
+        "tooltip": "엔터티가 구성됨"
+      },
+      "noMatches": {
+        "text": "일치하는 페더레이션 커넥터가 없습니다"
+      },
+      "noMoreConnectors": {
+        "text": "더 이상 사용 가능한 페더레이션 커넥터가 없습니다"
+      },
+      "noneSelected": {
+        "text": "선택된 페더레이션 커넥터가 없습니다. 위에서 커넥터를 검색하고 선택하세요."
+      },
+      "realtimeSearchHint": {
+        "description": "선택한 페더레이션 커넥터의 문서는 쿼리 시 실시간으로 검색됩니다."
+      },
+      "removeConnector": {
+        "tooltip": "커넥터 제거"
+      },
+      "search": {
+        "placeholder": "페더레이션 커넥터 검색..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "새로 추가"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (선택 사항)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "필드에 대한 파일 형식 정의를 찾을 수 없습니다: {name}",
+        "selectionError": "파일 선택 오류",
+        "unknownError": "알 수 없는 오류",
+        "validating": "파일 검증 중...",
+        "validationError": "검증 오류"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "여기에 Markdown을 입력하세요...",
+        "previewTab": "미리보기",
+        "writeTab": "작성"
+      },
+      "optionalIndicator": {
+        "text": "(선택 사항)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "비밀번호 숨기기",
+        "showAriaLabel": "비밀번호 표시"
+      },
+      "selector": {
+        "noneOption": "없음",
+        "placeholder": "선택..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "모든 최근 파일"
+      },
+      "recentFiles": {
+        "title": "최근 파일"
+      },
+      "recentFilesModal": {
+        "description": "파일을 업로드하거나 최근 파일에서 선택하세요."
+      },
+      "toasts": {
+        "associatedAssistants": "파일을 삭제할 수 없습니다. 다음 어시스턴트와 연결되어 있습니다: {assistants}",
+        "associatedBoth": "파일을 삭제할 수 없습니다. 다음 프로젝트: {projects} 및 어시스턴트: {assistants}와 연결되어 있습니다",
+        "associatedProjects": "파일을 삭제할 수 없습니다. 다음 프로젝트와 연결되어 있습니다: {projects}",
+        "deleteFailed": "파일을 삭제하지 못했습니다. 다시 시도하세요.",
+        "deleteSuccess": "파일이 삭제되었습니다"
+      },
+      "uploadFiles": {
+        "description": "기기에서 파일 업로드",
+        "title": "파일 업로드"
+      },
+      "viewFileButton": {
+        "tooltip": "파일 보기"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "파일"
+      },
+      "open": {
+        "ariaLabel": "{title} 열기"
+      },
+      "removeButton": {
+        "label": "제거"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "지우기"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(선택)"
+      },
+      "required": {
+        "label": "(필수)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "{label}을(를) 불러오지 못했습니다. 다시 시도해 주세요."
+      },
+      "search": {
+        "placeholder": "검색..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "사용 가능한 사용자 그룹이 없습니다. 먼저 사용자 그룹을 만드세요."
+      },
+      "userGroups": {
+        "label": "사용자 그룹",
+        "subtext": "이 리소스에 액세스할 수 있는 사용자 그룹을 선택하세요"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "로고"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "{appName} 초기화 중"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "제거"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "파일 첨부"
+      },
+      "clearButton": {
+        "ariaLabel": "파일 지우기"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "파일이 거부되었습니다"
+      },
+      "editButton": {
+        "ariaLabel": "이미지 편집"
+      },
+      "editOverlay": {
+        "label": "편집"
+      },
+      "image": {
+        "altFallback": "이미지"
+      },
+      "removeButton": {
+        "ariaLabel": "이미지 제거"
+      },
+      "uploadButton": {
+        "ariaLabel": "이미지 업로드"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "옵션 선택"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "이 {objectName}에 대한 그룹 액세스 할당",
+        "scopedSubtext": "이 {objectName}에 대한 액세스 권한을 부여하려면 관리 중인 그룹을 하나 이상 선택하세요",
+        "visibleSubtext": "이 {objectName}은(는) 아래에서 선택한 그룹에 표시되고 액세스할 수 있습니다"
+      },
+      "loading": {
+        "text": "불러오는 중..."
+      },
+      "makePublic": {
+        "label": "이 {objectName}을(를) 공개하시겠습니까?",
+        "subtext": "설정하면 이 {objectName}은(는) <b>모든 {publicToWhom}</b>이 사용할 수 있습니다. 그렇지 않으면 <b>관리자</b>와 (예: 사용자 그룹을 통해) 이 {objectName}에 대한 액세스 권한을 명시적으로 부여받은 <b>{publicToWhom}</b>만 액세스할 수 있습니다."
+      },
+      "publicDisabled": {
+        "message": "이 {objectName}은(는) 공개되어 모든 사용자가 사용할 수 있습니다."
+      },
+      "usersFallback": {
+        "text": "사용자"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "{keyTitle} 및 {valueTitle} 쌍 추가",
+        "label": "줄 추가"
+      },
+      "empty": {
+        "title": "아직 추가된 항목이 없습니다."
+      },
+      "error": {
+        "duplicateKey": "중복된 키",
+        "duplicateSummary": "{count, plural, one {중복된 키 #개 발견} other {중복된 키 #개 발견}}",
+        "emptyKey": "키는 비워 둘 수 없습니다",
+        "emptySummary": "{count, plural, one {빈 키 #개 발견} other {빈 키 #개 발견}}",
+        "validationSummary": "{count, plural, one {유효성 검사 오류 #개 발견} other {유효성 검사 오류 #개 발견}}"
+      },
+      "group": {
+        "ariaLabel": "{keyTitle} 및 {valueTitle} 쌍"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "키"
+      },
+      "pair": {
+        "fallbackLabel": "키-값"
+      },
+      "removeButton": {
+        "ariaLabel": "{label} 쌍 {index} 제거"
+      },
+      "valueColumn": {
+        "title": "값"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "로고"
+      },
+      "poweredBy": {
+        "label": "Powered by Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "사용할 수 없는 커넥터:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "인증이 취소되었거나 실패했습니다. 다시 시도해 주세요.",
+        "title": "인증 실패"
+      },
+      "backButton": {
+        "label": "채팅으로 돌아가기"
+      },
+      "completeFailed": {
+        "message": "인증을 완료하지 못했습니다"
+      },
+      "genericError": {
+        "description": "OAuth 과정에서 오류가 발생했습니다. 다시 시도해 주세요.",
+        "title": "문제가 발생했습니다"
+      },
+      "invalidRequest": {
+        "description": "인증 요청이 완전하지 않았습니다. 다시 시도해 주세요.",
+        "title": "잘못된 요청"
+      },
+      "loadingHint": {
+        "text": "잠시 시간이 걸릴 수 있습니다..."
+      },
+      "processing": {
+        "description": "설정을 완료하는 동안 잠시 기다려 주세요.",
+        "title": "처리 중..."
+      },
+      "redirecting": {
+        "text": "{count, plural, one {#초} other {#초}} 후 이동합니다..."
+      },
+      "serviceFallback": {
+        "text": "서비스"
+      },
+      "success": {
+        "detailsTemplate": "{serviceName} 인증이 완료되었습니다.",
+        "title": "성공했습니다!"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "스프레드시트가 손상되었거나 제대로 불러오지 못했을 수 있습니다.",
+        "title": "스프레드시트 로드 오류"
+      },
+      "preview": {
+        "truncated": "미리보기가 잘렸습니다. 모든 행을 보려면 파일을 다운로드하세요.",
+        "unavailable": "이 스프레드시트를 미리 볼 수 없습니다."
+      },
+      "sheet": {
+        "defaultName": "시트 1",
+        "empty": "이 시트는 비어 있습니다.",
+        "tooLarge": "이 시트는 너무 커서 미리 볼 수 없습니다. 파일을 다운로드하여 확인하세요."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "메인 에이전트"
+      },
+      "subagentFallback": {
+        "label": "하위 에이전트"
+      },
+      "switch": {
+        "ariaLabel": "에이전트 전환"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "이 작업을 한 번만 승인",
+        "button": "한 번 승인"
+      },
+      "approveSession": {
+        "button": "세션 동안 승인",
+        "tooltip": "이 세션의 일치하는 작업 승인"
+      },
+      "details": {
+        "hideAriaLabel": "세부 정보 숨기기",
+        "showAriaLabel": "세부 정보 표시"
+      },
+      "header": {
+        "required": "승인 필요: {headline}"
+      },
+      "headline": {
+        "multiAction": "{app}의 {count, plural, one {작업 #개} other {작업 #개}}",
+        "singleAction": "{app}의 {action}"
+      },
+      "payload": {
+        "empty": {
+          "label": "페이로드가 없습니다."
+        },
+        "showLess": {
+          "button": "간략히 보기"
+        },
+        "showMore": {
+          "button": "더 보기"
+        }
+      },
+      "reject": {
+        "ariaLabel": "이 작업 거부",
+        "button": "거부"
+      },
+      "status": {
+        "approved": "승인됨",
+        "rejected": "거부됨"
+      },
+      "submit": {
+        "errorFallback": "결정을 제출하지 못했습니다"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "추가",
+        "createButton": "만들기",
+        "customApp": {
+          "description": "자체 통합을 위한 자격 증명 및 네트워크 액세스입니다.",
+          "title": "사용자 지정 앱"
+        },
+        "mcpHint": {
+          "label": "MCP 서버가 필요하신가요? 작업에서 연결한 다음 여기에서 Craft용으로 활성화하세요.",
+          "openActionsButton": "작업 열기"
+        },
+        "modal": {
+          "description": "조직 전체에서 사용할 통합을 추가하세요. 기본 제공 제공업체에는 Craft 에이전트에게 사용법을 알려주는 작업이 포함되어 있습니다. 이미 구성된 제공업체는 표시되지 않습니다.",
+          "title": "앱 추가"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "{name} 연결",
+        "associateButton": "기존 스킬 연결",
+        "create": {
+          "github": {
+            "description": "스킬이 GitHub에 있다면 먼저 스킬 페이지에서 가져온 다음 이 앱에 연결하세요.",
+            "label": "GitHub에서 가져오기"
+          },
+          "scratch": {
+            "description": "지침을 작성하고 보조 파일을 추가합니다.",
+            "label": "처음부터 만들기"
+          },
+          "upload": {
+            "description": "SKILL.md 파일, ZIP 파일 또는 스킬 폴더를 가져옵니다.",
+            "label": "스킬 업로드"
+          }
+        },
+        "createSkillButton": "스킬 만들기",
+        "description": "스킬은 Craft에게 이 앱의 사용법을 알려줍니다. 스킬은 조직 전체에 적용되며, 앱이 올바르게 작동하려면 사용자가 모두 활성화해야 할 수 있습니다.",
+        "editButton": "편집",
+        "empty": {
+          "label": "편집 가능한 스킬이 없습니다."
+        },
+        "invalidTag": "유효하지 않음",
+        "loading": {
+          "label": "스킬 불러오는 중…"
+        },
+        "noneAssociated": {
+          "label": "아직 연결된 스킬이 없습니다. 스킬 없이도 이 앱을 저장하고 사용할 수 있습니다."
+        },
+        "promote": {
+          "cancelButton": "취소",
+          "confirmButton": "조직 전체에 공개",
+          "description": "앱에 연결된 스킬은 모든 사용자가 사용할 수 있어야 합니다. 이 변경 사항은 앱을 저장할 때 적용됩니다.",
+          "title": "\"{name}\"을(를) 조직 전체에 공개할까요?"
+        },
+        "search": {
+          "placeholder": "편집 가능한 스킬 검색..."
+        },
+        "title": "연결된 스킬",
+        "unavailable": {
+          "duplicateName": "\"{name}\" 이름의 스킬이 이미 연결되어 있습니다.",
+          "invalid": "유효하지 않은 스킬입니다. 연결하기 전에 수정하세요.",
+          "otherApp": "이미 앱 \"{name}\"에 연결되어 있습니다."
+        },
+        "unlink": {
+          "button": "연결 해제",
+          "cancelButton": "취소",
+          "confirm": "\"{name}\"을(를) 이 앱에서 연결 해제할까요?"
+        },
+        "unlinkAriaLabel": "{name} 연결 해제",
+        "viewButton": "보기"
+      },
+      "configureProvider": {
+        "addButton": "추가",
+        "addTitle": "{name} 추가",
+        "editTitle": "{name} 편집",
+        "emptyPolicies": "이 제공업체에는 구성할 작업이 없습니다.",
+        "fields": {
+          "name": {
+            "description": "이 연결의 레이블입니다. 같은 제공업체의 인스턴스를 여러 개 추가할 때는 구별되는 이름을 사용하세요(예: \"{name} — 엔지니어링\").",
+            "label": "이름"
+          }
+        },
+        "managedDescription": "Onyx에서 제공합니다. 에이전트가 할 수 있는 작업을 구성하세요.",
+        "managedNote": "이 앱은 Onyx에서 제공하며 자격 증명은 자동으로 관리됩니다. 아래에서 에이전트가 할 수 있는 작업을 선택하세요. 사용자는 앱 페이지에서 연결합니다.",
+        "saveButton": "저장"
+      },
+      "customApp": {
+        "cancelButton": "취소",
+        "createButton": "만들기",
+        "createDescription": "이그레스 프록시가 이 앱에 연결하고 인증하는 방식을 구성합니다. 스킬은 필수가 아닙니다.",
+        "createTitle": "사용자 지정 앱 만들기",
+        "creatingButton": "만드는 중…",
+        "disabled": {
+          "nameMissing": "이 사용자 지정 앱을 만들기 전에 이름을 입력하세요.",
+          "patternMissing": "업스트림 URL 패턴을 하나 이상 추가하세요. 패턴을 입력하고 Enter를 누르세요.",
+          "pristine": "저장하기 전에 변경하세요.",
+          "saving": "이미 저장이 진행 중입니다."
+        },
+        "editDescription": "게이트웨이 설정을 업데이트하고 연결된 스킬을 관리합니다.",
+        "editTitle": "{name} 편집",
+        "errors": {
+          "saveFailedTitle": "저장할 수 없습니다"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "헤더 추가",
+            "description": "선택 사항. 아웃바운드 요청에 삽입되는 헤더입니다. 사용자(또는 아래의 조직)가 제공하는 값에는 '{placeholder}'를 사용하세요(예: \"Bearer '{api_key}'\"). 비워 두면 자격 증명을 삽입하지 않고 업스트림 패턴만 허용합니다.",
+            "keyTitle": "헤더",
+            "label": "헤더 자격 증명 패턴",
+            "valueTitle": "값"
+          },
+          "name": {
+            "label": "이름",
+            "placeholder": "내 사용자 지정 앱"
+          },
+          "orgCredentials": {
+            "addButton": "자격 증명 추가",
+            "description": "선택 사항. 조직이 모든 사용자를 위해 미리 채우는 값입니다. 각 사용자가 자체 자격 증명을 제공하는 앱은 비워 두세요.",
+            "keyTitle": "자격 증명 키",
+            "label": "조직 자격 증명",
+            "valueTitle": "값"
+          },
+          "upstreamPatterns": {
+            "description": "프록시가 자격 증명을 삽입할 수 있는 아웃바운드 URL입니다. *는 임의의 문자와 일치합니다(예: https://api.example.com/*는 해당 호스트의 모든 경로를 포함). 호스트는 리터럴이어야 하며 첫 슬래시 앞에는 와일드카드를 쓸 수 없습니다. 패턴을 입력하고 Enter를 누르세요.",
+            "label": "업스트림 URL 패턴"
+          }
+        },
+        "saveButton": "저장",
+        "savingButton": "저장 중…"
+      },
+      "errors": {
+        "duplicateSkillName": "앱 \"{appName}\"에는 이미 \"{skillName}\" 이름의 연결된 스킬이 있습니다. 다른 이름의 스킬을 업로드하세요."
+      },
+      "mcpPolicy": {
+        "description": "이 MCP 서버의 도구로 Craft 에이전트가 할 수 있는 작업을 구성합니다.",
+        "emptyPolicies": "이 서버에 활성화된 도구가 없습니다. 먼저 MCP 작업 페이지에서 도구를 활성화하세요.",
+        "saveButton": "저장",
+        "title": "{name} 편집"
+      },
+      "oauthCallback": {
+        "backButton": "내 앱으로 돌아가기",
+        "description": "OAuth 핸드셰이크를 마치는 중…",
+        "errors": {
+          "cancelled": "OAuth가 취소되었거나 거부되었습니다: {reason}",
+          "failed": "연결에 실패했습니다.",
+          "missingParams": "콜백 URL에 code 또는 state가 없습니다."
+        },
+        "exchanging": {
+          "label": "승인 코드를 교환하는 중…"
+        },
+        "success": {
+          "label": "연결되었습니다. 앱으로 돌아가는 중…"
+        },
+        "title": "앱 연결 중"
+      },
+      "page": {
+        "connectButton": "연결",
+        "connectingButton": "리디렉션 중…",
+        "disconnectButton": "연결 해제",
+        "empty": {
+          "description": "조직에 구성된 앱이나 MCP 서버가 아직 없습니다.",
+          "title": "아직 연결할 항목이 없습니다"
+        },
+        "errors": {
+          "disconnectFailed": "연결을 해제하지 못했습니다",
+          "startAuthFailed": "승인을 시작하지 못했습니다"
+        },
+        "header": {
+          "description": "Onyx Craft가 작업하는 동안 컨텍스트로 사용할 수 있는 도구를 연결하세요.",
+          "manageButton": "앱 관리",
+          "searchPlaceholder": "앱 검색...",
+          "title": "앱"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Onyx가 직접 지원하는 통합입니다. 각 통합에는 Craft에게 사용법을 알려주는 스킬이 포함되어 있습니다. 여기서 시작하세요.",
+            "empty": "조직에 구성된 앱이 아직 없습니다.",
+            "emptyTitle": "아직 앱이 없습니다",
+            "tabLabel": "앱 · {count}"
+          },
+          "mcp": {
+            "blurb": "관리자가 Craft에 공개한 서버입니다. 필요한 앱이 앱 목록에 없거나 서버 자체의 MCP 도구가 특별히 필요할 때 사용하세요.",
+            "empty": "Craft에 공개된 MCP 서버가 없습니다.",
+            "emptyTitle": "아직 MCP 서버가 없습니다",
+            "tabLabel": "MCP 서버 · {count}"
+          }
+        },
+        "loading": {
+          "label": "불러오는 중…"
+        },
+        "reviewSkillsButton": "스킬 검토",
+        "search": {
+          "noMatchesDescription": "검색과 일치하는 항목이 없습니다.",
+          "noMatchesTitle": "일치 항목 없음"
+        },
+        "status": {
+          "connected": "연결됨",
+          "connectedNeedsSkills": "연결됨 · 일부 연결된 스킬이 비활성화되어 있습니다",
+          "notAvailable": "회원님 계정에서는 사용할 수 없습니다. 관리자에게 문의하세요",
+          "skillWarningAriaLabel": "스킬 설정 필요",
+          "skillWarningTooltip": "일부 연결된 스킬이 비활성화되어 있습니다. 이 앱이 올바르게 작동하지 않을 수 있습니다."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "각 작업에 대해 개별적으로 정책을 설정합니다.",
+          "title": "고급"
+        },
+        "cancelButton": "취소",
+        "loading": {
+          "label": "불러오는 중…"
+        },
+        "permissions": {
+          "askOption": "묻기",
+          "autoApproveOption": "자동 승인",
+          "customOption": "사용자 지정",
+          "description": "에이전트가 할 수 있는 작업을 선택하세요. \"묻기\"는 각 작업 실행 전에 채팅에서 확인을 요청하고, \"자동 승인\"은 확인 없이 실행합니다. 작업별 정책은 고급 설정에서 지정하세요.",
+          "title": "권한"
+        },
+        "savingButton": "저장 중…"
+      },
+      "skillsStep": {
+        "description": "선택 사항. 기존 스킬을 연결하거나 이 앱을 위한 스킬을 만드세요.",
+        "errors": {
+          "saveFailedTitle": "저장할 수 없습니다"
+        },
+        "saveButton": "스킬 저장",
+        "savingButton": "저장 중…",
+        "skipButton": "지금은 건너뛰기",
+        "title": "{name}에 스킬 추가"
+      },
+      "userCredentials": {
+        "cancelButton": "취소",
+        "connectButton": "연결",
+        "connectingButton": "연결 중…",
+        "description": "계정에서 이 앱을 승인하려면 자격 증명을 입력하세요.",
+        "errors": {
+          "connectFailedTitle": "연결할 수 없습니다"
+        },
+        "title": "{name} 연결"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "다운로드"
+      },
+      "empty": {
+        "description": "출력 파일과 웹 앱이 여기에 표시됩니다",
+        "title": "아직 아티팩트가 없습니다"
+      },
+      "nextjsApp": {
+        "label": "Next.js 애플리케이션"
+      },
+      "openItem": {
+        "ariaLabel": "{name} 열기"
+      },
+      "toggleItem": {
+        "ariaLabel": "{name} 펼치기/접기"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "대화를 계속하세요...",
+        "scheduledRunPlaceholder": "예약된 실행 진행 중...",
+        "subagentPlaceholder": "메시지를 보내려면 메인 에이전트로 전환하세요"
+      },
+      "openSidebar": {
+        "ariaLabel": "사이드바 열기"
+      },
+      "outputPanel": {
+        "closeTooltip": "출력 패널 닫기",
+        "openTooltip": "출력 패널 열기"
+      },
+      "responseStopped": {
+        "label": "응답이 중지됨"
+      },
+      "scrollToBottom": {
+        "label": "맨 아래로 이동"
+      },
+      "toast": {
+        "operationWait": "현재 작업이 완료될 때까지 기다려 주세요.",
+        "sandboxWait": "샌드박스가 초기화될 때까지 기다려 주세요",
+        "scheduledRunWait": "예약된 실행이 완료될 때까지 기다려 주세요."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "공간 확보를 위해 컨텍스트를 압축했습니다"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "데이터 연결하기"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "작업 공간 제작 중...",
+        "enchanting": "마법 부여 중...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "자원 수집 중...",
+        "miningDependencies": "의존성 채굴 중...",
+        "placingBlocks": "블록 배치 중...",
+        "punchingWood": "나무 캐는 중...",
+        "smeltingCode": "코드 제련 중...",
+        "worldGenerated": "월드 생성 완료..."
+      },
+      "tagline": {
+        "label": "다음 멋진 아이디어를 만드는 중..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "지우기"
+      },
+      "copy": {
+        "doneTooltip": "복사됨",
+        "tooltip": "표시된 내용 복사"
+      },
+      "empty": {
+        "noLines": "아직 로그가 없습니다.",
+        "noMatch": "\"{filter}\"과(와) 일치하는 줄이 없습니다",
+        "waiting": "첫 로그 줄을 기다리는 중…"
+      },
+      "error": {
+        "endpointDisabled": "디버그 엔드포인트가 비활성화되어 있습니다 (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "로그를 가져올 실행 중인 샌드박스가 없습니다"
+      },
+      "filter": {
+        "placeholder": "필터…"
+      },
+      "lines": {
+        "count": "{count, plural, one {#줄} other {#줄}}",
+        "filteredCount": "{visible, number} / {total, number}줄"
+      },
+      "modal": {
+        "description": "샌드박스 컨테이너의 실시간 로그 — 개발/디버그 전용.",
+        "title": "Opencode Pod 로그"
+      },
+      "newSincePaused": {
+        "button": "+{count, number}개 신규 · 이동"
+      },
+      "open": {
+        "button": "Pod 로그"
+      },
+      "status": {
+        "closed": "종료됨",
+        "connecting": "연결 중",
+        "error": "오류",
+        "paused": "일시 중지됨",
+        "streaming": "스트리밍 중"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "파일 또는 사진 추가"
+      },
+      "apps": {
+        "label": "앱"
+      },
+      "browseSkills": {
+        "label": "스킬 둘러보기"
+      },
+      "connect": {
+        "hint": "연결"
+      },
+      "connectApp": {
+        "label": "앱 연결"
+      },
+      "library": {
+        "label": "라이브러리"
+      },
+      "manageLibrary": {
+        "label": "라이브러리 관리…"
+      },
+      "mcpServer": {
+        "description": "MCP 서버"
+      },
+      "skills": {
+        "label": "스킬"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "파일을 미리 볼 수 없습니다"
+      },
+      "error": {
+        "inline": "오류: {message}",
+        "title": "파일 불러오기 오류"
+      },
+      "loading": {
+        "label": "파일을 불러오는 중..."
+      },
+      "noContent": {
+        "label": "내용 없음"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "빌드 중 생성된 파일이 여기에 표시됩니다",
+        "title": "아직 파일이 없습니다"
+      },
+      "emptyDirectory": {
+        "label": "이 디렉터리에 파일이 없습니다"
+      },
+      "error": {
+        "title": "파일 불러오기 오류"
+      },
+      "loading": {
+        "label": "파일을 불러오는 중..."
+      },
+      "loadingChildren": {
+        "label": "불러오는 중..."
+      },
+      "preparing": {
+        "description": "개발 환경을 설정하는 중",
+        "title": "샌드박스 준비 중..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "이미지를 표시할 수 없습니다",
+        "title": "이미지를 불러오지 못했습니다"
+      },
+      "loading": {
+        "label": "이미지를 불러오는 중..."
+      },
+      "preview": {
+        "ariaLabel": "{name} 미리보기"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "연결됨",
+        "connectionRequired": "연결 필요"
+      },
+      "plusMenu": {
+        "tooltip": "파일 또는 스킬 추가"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "중지 중…"
+      },
+      "toInterrupt": {
+        "label": "키로 중단"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "홈으로 돌아가기"
+      },
+      "startCrafting": {
+        "button": "크래프트 시작"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "모델을 찾을 수 없습니다"
+      },
+      "recommended": {
+        "label": "추천"
+      },
+      "recommendedOnly": {
+        "label": "추천 모델만 표시"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "“불안정한 재시도 테스트를 고치고 PR을 올려 줘.”",
+          "launchDeck": "“Drive의 브리핑을 바탕으로 봄 출시 발표 자료를 만들어 줘.”",
+          "rfpSecurity": "“내 이메일에 있는 RFP에 우리 보안 정보를 채워 줘.”",
+          "slackToLinear": "“Slack 논의 내용을 Linear 티켓으로 정리해 줘.”",
+          "vendorSpend": "“2분기 공급업체 지출을 Drive 문서로 요약해 줘.”"
+        },
+        "modal": {
+          "backButton": "뒤로",
+          "ctaButton": "Craft에게 일 맡기기",
+          "nextButton": "다음",
+          "title": "Craft를 소개합니다"
+        },
+        "outputs": {
+          "ariaLabel": "결과물: {name}",
+          "githubPr": {
+            "caption": "리뷰 대기 중",
+            "label": "GitHub PR"
+          },
+          "googleDoc": {
+            "caption": "내 Drive에 저장됨",
+            "label": "Google 문서"
+          },
+          "liveApp": {
+            "caption": "호스팅됨, 링크로 공유",
+            "label": "라이브 앱"
+          }
+        },
+        "prompt": {
+          "label": "내 프롬프트"
+        },
+        "schedule": {
+          "ariaLabel": "예약된 작업: 이 프롬프트를 타이머에 따라 다시 실행합니다",
+          "caption": "자리를 비운 사이에 실행됩니다",
+          "label": "매주 월요일 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "연결된 소스: {name}",
+          "yourFiles": {
+            "ariaLabel": "업로드한 파일",
+            "label": "내 파일"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "지도의 아무 부분이나 클릭하면 다시 볼 수 있습니다.",
+            "title": "이것이 Craft입니다. 이제 회원님 차례입니다."
+          },
+          "machine": {
+            "caption": "회원님이 볼 수 있는 것만 읽습니다. 비밀은 절대 읽지 않습니다.",
+            "title": "자체 머신에서 작동합니다."
+          },
+          "output": {
+            "caption": "필요할 때 즉시, 또는 자리를 비운 사이 예약 실행으로.",
+            "title": "완성된 결과물이 나옵니다."
+          },
+          "prompt": {
+            "caption": "원하는 결과만 설명하면 나머지는 Craft가 합니다.",
+            "title": "Craft에게 실제 업무를 맡기세요."
+          }
+        },
+        "team": {
+          "ariaLabel": "내 팀: 링크 하나로 Craft의 결과물을 공유합니다",
+          "caption": "링크 하나로 공유",
+          "label": "내 팀"
+        },
+        "workspace": {
+          "approvalPill": "회원님의 승인을 기다리는 중",
+          "label": "Craft의 작업 공간",
+          "sandboxBadge": "격리된 샌드박스"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "채팅으로 돌아가기",
+        "description": "Onyx Craft에는 모델 제공업체가 필요하며 관리자만 설정할 수 있습니다. 관리자에게 Anthropic, OpenAI 또는 OpenRouter 연결을 요청하세요.",
+        "title": "LLM 제공업체가 필요합니다"
+      },
+      "llmSetup": {
+        "description": "Craft 에이전트가 빌드하려면 모델 제공업체가 필요합니다.",
+        "title": "모델 제공업체 연결"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "내 데이터를 분석하고 대시보드 만들기..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "엔지니어링",
+          "marketing": "마케팅",
+          "product": "제품",
+          "sales": "영업"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "무언가를 만들기 시작하면 아티팩트가 표시됩니다!"
+      },
+      "devServerStarting": {
+        "tooltip": "개발 서버를 시작하는 중..."
+      },
+      "noWebapp": {
+        "label": "이 세션에는 아직 웹 앱이 없습니다"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "PDF 파일을 불러올 수 없습니다.",
+        "title": "PDF를 미리 볼 수 없습니다"
+      },
+      "frame": {
+        "title": "PDF 미리보기"
+      },
+      "loading": {
+        "label": "PDF를 불러오는 중..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "프레젠테이션 변환 중..."
+      },
+      "empty": {
+        "label": "이 프레젠테이션에 슬라이드가 없습니다"
+      },
+      "error": {
+        "title": "프레젠테이션을 미리 볼 수 없습니다"
+      },
+      "loadingSlide": {
+        "label": "슬라이드를 불러오는 중..."
+      },
+      "slide": {
+        "counter": "슬라이드 {current} / {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "웹 앱이 실행되면 여기에 실시간 미리보기가 표시됩니다."
+      },
+      "frame": {
+        "title": "웹 앱 미리보기"
+      },
+      "starting": {
+        "description": "의존성을 설치하고 부팅하는 중입니다.",
+        "title": "개발 서버를 시작하는 중..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "리디렉션 중..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "닫기"
+      },
+      "modal": {
+        "description": "일정 시간 활동이 없어 잠들었습니다. 작업은 저장되어 있습니다. 계속하려면 깨워 주세요.",
+        "title": "샌드박스가 잠들었습니다"
+      },
+      "wake": {
+        "button": "샌드박스 깨우기"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "예약됨"
+      },
+      "startedAt": {
+        "label": "{time} 시작"
+      },
+      "status": {
+        "awaitingApproval": "이 예약된 실행은 승인 대기 중입니다. 재개되어 완료되면 후속 메시지를 보낼 수 있습니다.",
+        "running": "이 예약된 실행이 아직 진행 중입니다. 완료되면 후속 메시지를 보낼 수 있습니다.",
+        "startedBy": "이 세션은 예약된 작업 {task}에 의해 {time}에 시작되었습니다."
+      },
+      "viewTask": {
+        "ariaLabel": "예약된 작업 {task} 보기. {status}",
+        "label": "작업 보기"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "외부 앱 {id}"
+      },
+      "connect": {
+        "title": "{app} 연결"
+      },
+      "connected": {
+        "title": "{app}이(가) 연결되었습니다."
+      },
+      "error": {
+        "generic": "문제가 발생했습니다. 다시 시도해 주세요.",
+        "notConfigurable": "이 앱은 여기에서 설정할 수 없습니다.",
+        "popupBlocked": "설정 창을 열 수 없습니다. 팝업을 허용한 후 다시 시도해 주세요.",
+        "startFailed": "설정을 시작하지 못했습니다"
+      },
+      "loading": {
+        "button": "불러오는 중…"
+      },
+      "notNow": {
+        "button": "나중에"
+      },
+      "reason": {
+        "fallback": "이 작업을 계속하려면 에이전트에 {app}이(가) 필요합니다."
+      },
+      "skipped": {
+        "title": "{app} 연결을 건너뛰었습니다."
+      },
+      "waiting": {
+        "button": "대기 중…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "링크 복사"
+      },
+      "organization": {
+        "description": "귀하의 Onyx에 로그인한 누구나 이 앱을 볼 수 있습니다.",
+        "label": "조직"
+      },
+      "private": {
+        "description": "이 앱은 본인만 볼 수 있습니다.",
+        "label": "비공개"
+      },
+      "share": {
+        "label": "공유"
+      },
+      "shared": {
+        "label": "공유됨"
+      },
+      "trigger": {
+        "ariaLabel": "웹 앱 공유"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "앱"
+      },
+      "backToChat": {
+        "label": "채팅으로 돌아가기"
+      },
+      "delete": {
+        "label": "삭제"
+      },
+      "deleteModal": {
+        "body": "Craft 세션과 모든 데이터가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+        "confirm": "삭제",
+        "deleting": "삭제 중...",
+        "title": "\"{title}\"을(를) 삭제할까요?"
+      },
+      "newSession": {
+        "label": "크래프트 시작"
+      },
+      "rename": {
+        "label": "이름 바꾸기"
+      },
+      "scheduledTasks": {
+        "label": "예약된 작업"
+      },
+      "sessions": {
+        "empty": "빌드를 시작하세요! 세션 기록이 여기에 표시됩니다.",
+        "title": "세션"
+      },
+      "skills": {
+        "label": "스킬"
+      },
+      "toast": {
+        "deleteFailed": "세션을 삭제하지 못했습니다",
+        "deleted": "\"{title}\"이(가) 삭제되었습니다."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "최신 스킬과 앱 접근 권한을 적용하려면 이 세션을 다시 불러오세요.",
+        "title": "에이전트의 기능이 변경되었습니다"
+      },
+      "reload": {
+        "button": "다시 불러오기",
+        "inProgress": "다시 불러오는 중…"
+      },
+      "toast": {
+        "reloadFailed": "세션을 다시 불러오지 못했습니다"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "하위 에이전트를 찾을 수 없습니다."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "제안 닫기"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "삭제",
+          "deletingButton": "삭제 중...",
+          "description": "향후 실행을 중지하고 작업을 제거합니다. 과거 실행 기록(및 관련 세션)은 감사 목적으로 보존됩니다.",
+          "title": "\"{name}\"을(를) 삭제할까요?"
+        },
+        "deleteButton": "삭제",
+        "editButton": "편집",
+        "fallbackTitle": "예약된 작업",
+        "loadFailed": "예약된 작업을 불러오지 못했습니다.",
+        "missingTaskId": "작업 ID가 없습니다.",
+        "pauseButton": "일시 중지",
+        "resumeButton": "재개",
+        "runNowButton": "지금 실행",
+        "toasts": {
+          "deleteFailed": "작업을 삭제하지 못했습니다",
+          "deleted": "\"{name}\"이(가) 삭제되었습니다.",
+          "paused": "작업이 일시 중지되었습니다.",
+          "resumed": "작업이 재개되었습니다.",
+          "runQueued": "\"{name}\" 실행이 대기열에 추가되었습니다.",
+          "runStartFailed": "실행을 시작하지 못했습니다",
+          "statusUpdateFailed": "상태를 업데이트하지 못했습니다"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "예약된 작업 편집",
+        "loadFailed": "예약된 작업을 불러오지 못했습니다.",
+        "missingTaskId": "작업 ID가 없습니다.",
+        "title": "\"{name}\" 편집"
+      },
+      "form": {
+        "cancelButton": "취소",
+        "errors": {
+          "nameRequired": "이름은 필수입니다.",
+          "promptRequired": "프롬프트는 필수입니다."
+        },
+        "fields": {
+          "name": {
+            "label": "이름",
+            "placeholder": "예: 주간 고객 이슈 요약"
+          },
+          "preApproval": {
+            "description": "이 작업이 무인으로 실행될 때 Craft는 선택한 앱과 MCP 서버를 일시 중지 없이 사용할 수 있습니다. 그 외의 승인 요청은 실행을 일시 중지시키고 실패의 원인이 될 수 있습니다.",
+            "label": "사전 승인된 앱 및 MCP 서버"
+          },
+          "prompt": {
+            "description": "작업이 실행될 때마다 이 메시지가 Craft에 전송됩니다.",
+            "label": "프롬프트",
+            "placeholder": "Craft가 실행할 때마다 해야 할 일을 설명하세요..."
+          },
+          "schedule": {
+            "label": "예약"
+          }
+        },
+        "saveAndRunNowButton": "저장하고 지금 실행",
+        "saveButton": "저장",
+        "saveChangesButton": "변경 사항 저장",
+        "savingLabel": "저장 중...",
+        "toasts": {
+          "created": "예약된 작업이 생성되었습니다.",
+          "createdAndQueued": "예약된 작업이 생성되어 대기열에 추가되었습니다.",
+          "saveFailed": "예약된 작업을 저장하지 못했습니다",
+          "updated": "예약된 작업이 업데이트되었습니다."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "마지막 실행",
+          "name": "이름",
+          "nextRun": "다음 실행",
+          "schedule": "예약",
+          "status": "상태"
+        },
+        "confirmDelete": {
+          "deleteButton": "삭제",
+          "deletingButton": "삭제 중...",
+          "description": "향후 실행을 중지하고 작업을 제거합니다. 과거 실행 기록(및 관련 세션)은 감사 목적으로 보존됩니다.",
+          "title": "\"{name}\"을(를) 삭제할까요?"
+        },
+        "empty": {
+          "description": "아직 생성된 예약 작업이 없습니다.",
+          "title": "예약된 작업이 없습니다"
+        },
+        "errors": {
+          "loadFailed": "예약된 작업을 불러오지 못했습니다.",
+          "tryAgainButton": "다시 시도"
+        },
+        "header": {
+          "description": "Craft 프롬프트를 타이머에 따라 실행합니다. 실행될 때마다 백그라운드에서 동작하는 새 세션이 생성됩니다.",
+          "title": "예약된 작업"
+        },
+        "newTaskButton": "새 예약 작업",
+        "rowActions": {
+          "deleteTooltip": "삭제"
+        },
+        "toasts": {
+          "deleteFailed": "작업을 삭제하지 못했습니다",
+          "deleted": "\"{name}\"이(가) 삭제되었습니다."
+        }
+      },
+      "newPage": {
+        "description": "프롬프트와 일정을 저장하세요. Craft가 타이머에 따라 실행합니다.",
+        "title": "새 예약 작업"
+      },
+      "preApproval": {
+        "appFallbackName": "앱 #{id}",
+        "appsGroupTitle": "앱",
+        "empty": {
+          "label": "Craft에서 사용할 수 있는 앱이나 MCP 서버가 아직 없습니다."
+        },
+        "errors": {
+          "loadFailed": "앱과 MCP 서버를 불러오지 못했습니다. 새로고침하여 다시 시도하세요.",
+          "partialLoadFailed": "일부 사전 승인 옵션을 불러오지 못했습니다. 새로고침하여 다시 시도하세요."
+        },
+        "loading": {
+          "label": "앱과 MCP 서버를 불러오는 중…"
+        },
+        "mcpGroupTitle": "MCP 서버",
+        "mcpServerFallbackName": "MCP 서버 #{id}",
+        "status": {
+          "connected": "연결됨",
+          "connectionRequired": "연결 필요",
+          "unavailable": "더 이상 사용할 수 없음"
+        },
+        "summary": {
+          "partialLoadFailed": "일부 사전 승인 세부 정보를 불러오지 못했습니다. 새로고침하여 다시 시도하세요.",
+          "title": "사전 승인된 앱 및 MCP 서버"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "소요 시간",
+          "started": "시작",
+          "status": "상태",
+          "summary": "요약",
+          "trigger": "트리거"
+        },
+        "empty": {
+          "label": "아직 실행 기록이 없습니다. 작업이 실행될 때마다 기록이 생성되며, 위의 지금 실행을 사용할 수도 있습니다."
+        },
+        "errors": {
+          "loadFailed": "실행 기록을 불러오지 못했습니다.",
+          "tryAgainButton": "다시 시도"
+        },
+        "loadMore": {
+          "button": "더 보기",
+          "loadingButton": "불러오는 중..."
+        },
+        "nonClickable": {
+          "noSession": "이 실행은 아직 세션을 만들지 않았습니다.",
+          "queued": "이 실행은 아직 시작되지 않아 열 수 있는 세션이 없습니다.",
+          "skipped": "이전 실행이 아직 진행 중이어서 이 실행은 건너뛰었으며 세션이 생성되지 않았습니다."
+        },
+        "status": {
+          "notOpenableAriaLabel": "열 수 없음"
+        },
+        "trigger": {
+          "runNow": "지금 실행",
+          "schedule": "예약"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "시각",
+          "daysLabel": "다음 요일에",
+          "runsEveryDay": "매일 실행됩니다",
+          "runsOn": "{days}에 실행됩니다"
+        },
+        "interval": {
+          "everyLabel": "매"
+        },
+        "intervalUnits": {
+          "days": "일",
+          "hours": "시간",
+          "minutes": "분"
+        },
+        "tabs": {
+          "dailyWeekly": "매일 / 매주",
+          "interval": "간격"
+        },
+        "weekdays": {
+          "fri": "금",
+          "mon": "월",
+          "sat": "토",
+          "sun": "일",
+          "thu": "목",
+          "tue": "화",
+          "wed": "수"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "작업 없음"
+      },
+      "header": {
+        "title": "작업"
+      },
+      "progress": {
+        "label": "{completed}/{total} 완료"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "출력 없음"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {변경되지 않은 줄 #개} other {변경되지 않은 줄 #개}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "나란히 보기로 전환",
+          "unifiedTooltip": "통합 보기로 전환"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "아직 출력이 없습니다..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {호출 #건} other {호출 #건}}"
+        },
+        "failed": {
+          "tag": "{count}개 실패"
+        },
+        "working": {
+          "label": "작업 중"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(빈 파일)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {#개 줄 더 있음} other {#개 줄 더 있음}}"
+        },
+        "showAll": {
+          "button": "모두 표시"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "일치 항목 없음"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "파일이 너무 큽니다({size}). 최대 {max}입니다.",
+        "network": "네트워크 오류",
+        "notFound": "리소스를 찾을 수 없습니다",
+        "server": "서버 오류",
+        "sessionExpired": "세션이 만료되었습니다",
+        "tooManyFiles": "파일이 너무 많습니다. 세션당 최대 {max}개입니다.",
+        "totalSizeExceeded": "전체 크기가 제한을 초과합니다. 세션당 최대 {max}입니다.",
+        "uploadFailed": "업로드에 실패했습니다"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "뒤로 가기"
+      },
+      "copyUrl": {
+        "ariaLabel": "URL 복사: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "파일 다운로드"
+      },
+      "export": {
+        "button": ".docx로 내보내기",
+        "inProgress": "내보내는 중..."
+      },
+      "forward": {
+        "ariaLabel": "앞으로 가기"
+      },
+      "openInNewTab": {
+        "tooltip": "새 탭에서 열기"
+      },
+      "refresh": {
+        "ariaLabel": "새로 고침"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "삭제",
+        "button": "삭제",
+        "entityTypeFile": "파일",
+        "entityTypeFolder": "폴더",
+        "fileDetails": "이 파일은 라이브러리에서 제거됩니다.",
+        "folderDetails": "폴더와 그 안의 모든 내용이 삭제됩니다."
+      },
+      "dropzone": {
+        "formats": "Excel, Word, PowerPoint, PDF 또는 ZIP",
+        "title": "여기에 파일을 끌어다 놓거나 클릭하여 업로드"
+      },
+      "errors": {
+        "createFolderFailed": "폴더를 만들지 못했습니다",
+        "deleteFailed": "삭제하지 못했습니다",
+        "loadFailed": "파일을 불러오지 못했습니다",
+        "uploadFailed": "업로드에 실패했습니다"
+      },
+      "loading": {
+        "label": "파일 불러오는 중…"
+      },
+      "modal": {
+        "description": "에이전트가 모든 세션에서 읽을 수 있는 파일입니다.",
+        "doneButton": "완료",
+        "title": "라이브러리"
+      },
+      "newFolder": {
+        "cancelButton": "취소",
+        "createButton": "만들기",
+        "label": "새 폴더",
+        "nameLabel": "폴더 이름",
+        "namePlaceholder": "폴더 이름 입력"
+      },
+      "search": {
+        "noResults": "검색과 일치하는 파일이 없습니다",
+        "placeholder": "파일 검색..."
+      },
+      "tree": {
+        "collapseTooltip": "접기",
+        "deleteTooltip": "삭제",
+        "expandTooltip": "펼치기",
+        "toggleAriaLabel": "{name} 접기/펼치기",
+        "uploadToFolderTooltip": "이 폴더에 업로드"
+      },
+      "upload": {
+        "button": "업로드",
+        "dropOverlay": "파일을 놓아 업로드",
+        "uploadingButton": "업로드 중…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "데이터를 분석하고 대시보드를 만들어 주세요..."
       }
     }
   },
@@ -8813,6 +12541,13 @@
           "networkError": "비밀번호를 변경하는 중 오류가 발생했습니다",
           "updateFailed": "비밀번호를 변경하지 못했습니다",
           "updated": "비밀번호를 변경했습니다"
+        },
+        "validation": {
+          "confirmRequired": "새 비밀번호를 확인해 주세요",
+          "currentRequired": "현재 비밀번호는 필수입니다",
+          "minLength": "비밀번호는 최소 {min}자 이상이어야 합니다",
+          "mismatch": "비밀번호가 일치하지 않습니다",
+          "newRequired": "새 비밀번호는 필수입니다"
         }
       },
       "title": "계정"
@@ -8854,6 +12589,7 @@
         "empty": "생성된 액세스 token이 없습니다.",
         "expiresIn": "{count, plural, one {#일 후 만료} other {#일 후 만료}}",
         "loading": "token을 불러오는 중...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "만료되지 않음",
         "newTokenButton": "새 액세스 token",
         "noPermissionTooltip": "액세스 token을 생성할 권한이 없습니다",
@@ -9000,6 +12736,10 @@
       },
       "description": "Onyx에서 사용할 수 있는 모델에 외부 도구를 연결합니다.",
       "guideButton": "가이드",
+      "loadError": {
+        "description": "페이지를 새로고침한 후 다시 시도해 주세요.",
+        "title": "LLM 게이트웨이를 불러올 수 없습니다"
+      },
       "models": {
         "description": "{count, plural, one {계정에서 모델 #개를 사용할 수 있습니다. 제공자를 열어 ID를 복사하세요.} other {계정에서 모델 #개를 사용할 수 있습니다. 제공자를 열어 ID를 복사하세요.}}",
         "title": "모델"
@@ -9052,14 +12792,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "줄 추가",
+        "maxReached": "메모리 최대 {count}개에 도달했습니다"
+      },
       "empty": {
-        "description": "Onyx가 기억할 개인 메모나 메모리를 추가하세요."
+        "description": "Onyx가 기억할 개인 메모나 메모리를 추가하세요.",
+        "getStarted": "아직 메모리가 없습니다. \"줄 추가\"를 클릭하여 시작하세요.",
+        "noMatches": "검색과 일치하는 메모리가 없습니다."
+      },
+      "item": {
+        "placeholder": "개인 메모나 메모리를 입력하거나 붙여넣으세요"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {줄} other {줄}}"
+      },
+      "modal": {
+        "description": "Onyx가 채팅에서 이 저장된 메모와 메모리를 참조하도록 합니다.",
+        "searchPlaceholder": "검색..."
       },
       "referenceStoredMemories": {
         "description": "Onyx가 채팅에서 저장된 메모리를 참조하도록 합니다.",
         "title": "저장된 메모리 참조"
       },
+      "removeLineButton": {
+        "label": "줄 제거"
+      },
       "title": "메모리",
+      "toasts": {
+        "saveFailed": "환경설정을 저장하지 못했습니다",
+        "saved": "환경설정이 저장되었습니다"
+      },
       "updateMemories": {
         "description": "Onyx가 저장된 메모리를 생성하고 갱신하도록 합니다.",
         "title": "메모리 갱신"
@@ -9479,6 +13242,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "앱 “{appName}”에는 이미 “{skillName}” 이름의 연결된 스킬이 있습니다.",
+        "title": "다른 스킬 이름을 선택하세요"
+      },
+      "confirmUpload": {
+        "importBody": "이 업로드에는 SKILL.md가 포함되어 있습니다. 계속하면 현재 이름, 설명, 지침, 파일이 업로드된 번들로 교체됩니다.",
+        "importSubmit": {
+          "label": "스킬 가져오기"
+        },
+        "importTitle": "이 스킬을 가져올까요?",
+        "replaceBody": "이 업로드는 동일한 스킬 이름을 사용해야 합니다. 계속하면 설명, 지침, 파일이 업로드된 번들로 교체됩니다.",
+        "replaceSubmit": {
+          "label": "콘텐츠 교체"
+        },
+        "replaceTitle": "스킬 콘텐츠를 교체할까요?"
+      },
+      "delete": {
+        "button": {
+          "label": "스킬 삭제"
+        },
+        "description": "이 스킬을 사용하는 모든 사용자가 액세스 권한을 잃게 됩니다. 삭제는 되돌릴 수 없습니다.",
+        "title": "이 스킬 삭제"
+      },
+      "deleteModal": {
+        "entityType": "스킬",
+        "label": "삭제",
+        "pendingLabel": "삭제 중..."
+      },
+      "details": {
+        "description": "Craft가 이 스킬을 언제 어떻게 사용해야 하는지 정의하세요.",
+        "descriptionField": {
+          "description": "이 스킬을 언제 사용해야 하는지 설명하세요.",
+          "placeholder": "이 스킬은 어떤 도움을 주나요?",
+          "title": "설명"
+        },
+        "name": {
+          "createDescription": "소문자, 숫자, 단일 하이픈을 사용하세요.",
+          "lockedDescription": "스킬 이름은 생성 후 변경할 수 없습니다.",
+          "placeholder": "스킬 이름 지정",
+          "title": "이름"
+        },
+        "title": "세부 정보"
+      },
+      "files": {
+        "busyLabel": "업로드 중...",
+        "description": "이 스킬에서 사용하는 참조 자료, 스크립트, 에셋 또는 기타 파일을 추가하세요. ZIP 파일은 자동으로 압축이 풀립니다.",
+        "input": {
+          "ariaLabel": "지원 파일 추가"
+        },
+        "pendingUpload": {
+          "emptyMessage": "이 업로드의 파일은 스킬을 생성한 후에 표시됩니다."
+        },
+        "title": "지원 파일"
+      },
+      "filesTooltip": {
+        "noPermission": "이 스킬의 파일을 업데이트할 권한이 없습니다.",
+        "saveFirst": "스킬 파일을 업데이트하기 전에 세부 정보 변경 사항을 저장하세요.",
+        "updating": "스킬 파일 업데이트 중..."
+      },
+      "header": {
+        "appFallbackName": "외부 앱",
+        "cancel": {
+          "label": "취소"
+        },
+        "createDescription": "개인 스킬 만들기",
+        "createForAppDescription": "앱 “{appName}”에 조직 스킬 추가",
+        "createTitle": "스킬 만들기",
+        "editDescription": "스킬 세부 정보 및 파일 업데이트",
+        "editTitle": "스킬 편집",
+        "save": {
+          "label": "저장",
+          "pendingLabel": "저장 중..."
+        }
+      },
+      "import": {
+        "busyLabel": "가져오는 중...",
+        "button": {
+          "label": "스킬 가져오기"
+        },
+        "description": "SKILL.md, ZIP 또는 스킬 폴더를 가져와 양식을 미리 채우고 파일을 포함하세요.",
+        "input": {
+          "ariaLabel": "기존 스킬 가져오기"
+        },
+        "prompt": "SKILL.md 또는 ZIP을 선택하거나 스킬 폴더를 여기에 끌어다 놓으세요.",
+        "title": "기존 스킬이 있나요?"
+      },
+      "instructions": {
+        "description": "이 스킬이 Craft에 추가하는 동작과 워크플로를 작성하세요.",
+        "emptyFallback": "아직 지침이 없습니다.",
+        "placeholder": "스킬 지침을 작성하세요.",
+        "title": "지침"
+      },
+      "loadError": {
+        "description": "이 스킬이 존재하지 않거나, 기본 제공 스킬이거나, 내 계정으로 편집할 수 없는 스킬일 수 있습니다.",
+        "title": "스킬 사용 불가"
+      },
+      "management": {
+        "description": "이 스킬을 사용할 수 있는 사람을 관리하세요.",
+        "externalApp": {
+          "manage": {
+            "label": "앱 설정에서 관리"
+          },
+          "readyDescription": "이 스킬은 앱 “{appName}”을 사용합니다.",
+          "title": "외부 앱"
+        },
+        "sharing": {
+          "edit": {
+            "label": "공유 편집"
+          },
+          "title": "공유"
+        },
+        "title": "관리"
+      },
+      "saveTooltip": {
+        "missingDescription": "저장하기 전에 설명을 추가하세요.",
+        "missingInstructions": "저장하기 전에 지침을 추가하세요.",
+        "missingName": "저장하기 전에 이름을 추가하세요.",
+        "noChanges": "변경된 사항이 없습니다.",
+        "noPermission": "이 스킬의 세부 정보를 편집할 권한이 없습니다.",
+        "savingChanges": "변경 사항 저장 중...",
+        "savingSkill": "스킬 저장 중..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "조직의 모든 구성원이 이 스킬을 사용하고 편집할 수 있습니다.",
+          "title": "조직",
+          "viewerDescription": "조직의 모든 구성원이 이 스킬을 사용할 수 있습니다."
+        },
+        "personal": {
+          "description": "나만 이 스킬을 사용할 수 있습니다.",
+          "title": "개인"
+        },
+        "shares": {
+          "description": "선택한 사용자와 그룹만 이 스킬을 사용할 수 있습니다.",
+          "title": "{count, plural, one {공유 #건} other {공유 #건}}"
+        }
+      },
+      "toasts": {
+        "created": "\"{name}\"을(를) 생성했습니다",
+        "deleteFailed": "스킬을 삭제하지 못했습니다",
+        "deleted": "\"{name}\"을(를) 삭제했습니다",
+        "fileRemoveFailed": "스킬 파일을 제거하지 못했습니다",
+        "fileRemoved": "\"{path}\"을(를) 제거했습니다",
+        "filesUpdateFailed": "스킬 파일을 업데이트하지 못했습니다",
+        "filesUpdated": "\"{name}\"의 파일을 업데이트했습니다",
+        "importMissingSkillMd": "SKILL.md, ZIP 또는 SKILL.md가 포함된 폴더를 가져오세요.",
+        "inspectFailed": "스킬 번들을 검사하지 못했습니다",
+        "saveFailed": "스킬을 저장하지 못했습니다",
+        "saved": "\"{name}\"을(를) 저장했습니다"
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9679,6 +13594,76 @@
         "transferredToast": {
           "message": "소유권을 이전했습니다."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "스킬 둘러보기"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {스킬} other {스킬}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "저장소에서 하나 이상의 스킬을 가져오세요.",
+          "title": "GitHub에서 가져오기"
+        },
+        "scratch": {
+          "description": "Onyx에서 지침을 작성하고 지원 파일을 추가하세요.",
+          "title": "처음부터 만들기"
+        },
+        "trigger": {
+          "label": "스킬 만들기"
+        },
+        "upload": {
+          "description": "SKILL.md 파일, ZIP 파일 또는 스킬 폴더를 가져오세요.",
+          "title": "스킬 업로드"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "다른 검색어를 사용해 보세요.",
+          "title": "일치하는 스킬 없음"
+        },
+        "noSkills": {
+          "description": "아직 공유된 사용자 지정 스킬이 없으며 구성된 기본 제공 스킬도 없습니다.",
+          "title": "사용 가능한 스킬 없음"
+        }
+      },
+      "focusedApp": {
+        "description": "앱 “{appName}”과 연결된 모든 스킬을 활성화하세요. 이러한 스킬이 없으면 앱이 올바르게 작동하지 않을 수 있습니다. 같은 이름의 다른 스킬이 활성화되어 있는 경우, 앱 연결 스킬을 활성화하면 다른 스킬이 비활성화됩니다.",
+        "showAll": {
+          "label": "모든 스킬 보기"
+        },
+        "title": "앱 “{appName}”의 스킬"
+      },
+      "header": {
+        "description": "Craft 에이전트가 활용할 수 있는 기능 번들입니다. 이 페이지에는 기본 제공 스킬, 나와 공유된 스킬, 내 개인 스킬이 표시됩니다.",
+        "title": "스킬"
+      },
+      "loadError": {
+        "description": "자세한 내용은 콘솔을 확인하고 페이지를 새로고침해 보세요.",
+        "title": "스킬을 불러오지 못했습니다"
+      },
+      "preview": {
+        "unavailableFallback": "이 스킬은 현재 사용할 수 없습니다."
+      },
+      "search": {
+        "placeholder": "스킬 검색..."
+      },
+      "switchModal": {
+        "body": "계속하면 현재 활성화된 스킬이 비활성화되고 이 스킬이 활성화됩니다.",
+        "description": "“{name}” 이름의 스킬은 한 번에 하나만 활성화할 수 있습니다.",
+        "submit": {
+          "label": "스킬 전환",
+          "pendingLabel": "전환 중..."
+        },
+        "title": "“{name}” 스킬을 전환할까요?"
+      },
+      "toasts": {
+        "disableFailed": "{name}을(를) 비활성화하지 못했습니다",
+        "enableFailed": "{name}을(를) 활성화하지 못했습니다",
+        "refreshFailed": "{name}이(가) 업데이트되었지만 스킬 목록을 새로고침할 수 없습니다."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -5753,6 +5753,27 @@
         "unexpectedError": "예기치 않은 오류가 발생했습니다."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "취소됨",
+        "completedWithErrors": "오류와 함께 완료됨",
+        "deleting": "삭제 중",
+        "error": "오류",
+        "failed": "실패",
+        "inProgress": "진행 중",
+        "indexed": "인덱싱됨",
+        "indexing": "인덱싱 중",
+        "initialIndexing": "초기 인덱싱",
+        "interrupted": "중단됨",
+        "invalid": "유효하지 않음",
+        "invalidConnectorTooltip": "커넥터가 유효하지 않은 상태입니다. 자격 증명을 업데이트하거나 새 커넥터를 만드세요.",
+        "none": "없음",
+        "notStarted": "시작되지 않음",
+        "paused": "일시 중지됨",
+        "scheduled": "예약됨",
+        "succeeded": "성공"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "백엔드 버전: "
@@ -7192,6 +7213,70 @@
       },
       "sourcesModal": {
         "title": "출처"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "삭제"
+      },
+      "deleteModal": {
+        "description": "이 채팅을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+        "submitButton": {
+          "label": "삭제"
+        },
+        "title": "채팅 삭제"
+      },
+      "exportAs": {
+        "label": "다른 형식으로 내보내기…"
+      },
+      "exportFailed": {
+        "message": "채팅 내보내기에 실패했습니다. 다시 시도해 주세요."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "일반 텍스트"
+      },
+      "fullWidth": {
+        "ariaLabel": "전체 너비 채팅 전환",
+        "fitTooltip": "너비 맞춤",
+        "fullTooltip": "전체 너비"
+      },
+      "incognitoExit": {
+        "ariaLabel": "시크릿 채팅 종료",
+        "tooltip": "시크릿 채팅 종료"
+      },
+      "incognitoPill": {
+        "ariaLabel": "시크릿 채팅",
+        "label": "시크릿 채팅"
+      },
+      "incognitoStart": {
+        "ariaLabel": "시크릿 채팅 시작",
+        "lockedTooltip": "시크릿 모드는 채팅 시작 전에만 설정할 수 있습니다",
+        "tooltip": "시크릿 채팅"
+      },
+      "mode": {
+        "chat": {
+          "description": "대화 및 리서치",
+          "label": "채팅"
+        },
+        "search": {
+          "description": "문서 빠른 검색",
+          "label": "검색"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "앱 모드 변경"
+      },
+      "moveToProject": {
+        "label": "프로젝트로 이동"
+      },
+      "openSidebar": {
+        "ariaLabel": "사이드바 열기"
+      },
+      "share": {
+        "label": "공유"
       }
     },
     "banners": {
@@ -8938,6 +9023,34 @@
         "updateFailed": "언어 설정을 변경하지 못했습니다"
       }
     },
+    "layout": {
+      "header": {
+        "title": "설정"
+      },
+      "sectionSelect": {
+        "placeholder": "섹션 선택"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "계정 및 액세스"
+        },
+        "chatPreferences": {
+          "label": "채팅 환경설정"
+        },
+        "connectors": {
+          "label": "커넥터"
+        },
+        "general": {
+          "label": "일반"
+        },
+        "llmGateway": {
+          "label": "LLM 게이트웨이"
+        },
+        "usage": {
+          "label": "사용량"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Onyx가 기억할 개인 메모나 메모리를 추가하세요."
@@ -8998,6 +9111,47 @@
       "toggle": {
         "description": "단축어를 활성화하면 자주 쓰는 프롬프트를 빠르게 넣을 수 있습니다.",
         "title": "프롬프트 단축어 사용"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "한도 {amount}",
+        "none": "설정된 예산 없음",
+        "remaining": "{amount} 남음",
+        "resetsOn": "{date}에 재설정",
+        "title": "예산"
+      },
+      "empty": {
+        "description": "채팅을 시작하면 모델 사용량과 비용이 여기에 표시됩니다.",
+        "title": "아직 기록된 사용량이 없습니다"
+      },
+      "header": {
+        "title": "사용량"
+      },
+      "loadError": {
+        "description": "사용량을 가져오는 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+        "title": "사용량을 불러올 수 없습니다"
+      },
+      "modelPrices": {
+        "description": "사용 가능한 모든 모델의 100만 토큰당 USD(입력 · 출력 · 캐시)",
+        "title": "모델 가격",
+        "unavailable": "가격 정보 없음"
+      },
+      "showFewerModels": {
+        "ariaLabel": "모델 적게 표시"
+      },
+      "showLess": {
+        "label": "간략히 보기"
+      },
+      "showMore": {
+        "label": "{count}개 더 보기"
+      },
+      "showMoreModels": {
+        "ariaLabel": "모델 {count}개 더 보기"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} 사용",
+        "title": "이 기간의 사용량"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -2820,25 +2820,37 @@
       }
     },
     "craftPreferences": {
-      "defaultModel": {
-        "clearButton": { "label": "지우기" },
-        "help": {
-          "description": "Craft는 새 세션과 예약된 작업에 이 모델을 사용합니다. 설정하지 않으면 Craft는 워크스페이스 기본 채팅 모델을 사용합니다."
-        },
-        "inheritedTag": { "label": "워크스페이스 기본값" },
-        "label": "기본 모델",
-        "placeholder": "모델 선택",
-        "resetError": { "message": "기본 모델을 지우지 못했습니다" },
-        "resetSuccess": { "message": "Craft 기본 모델을 지웠습니다" },
-        "saveError": { "message": "기본 모델을 저장하지 못했습니다" },
-        "saveSuccess": { "message": "Craft 기본 모델을 저장했습니다" }
-      },
       "baseInstructions": {
         "description": "작성한 지침이 덧붙여지는 기본 프롬프트입니다. 동적 섹션은 세션마다 채워집니다.",
         "loadError": {
           "description": "기본 지침을 불러오지 못했습니다."
         },
         "title": "기본 지침 보기"
+      },
+      "defaultModel": {
+        "clearButton": {
+          "label": "지우기"
+        },
+        "help": {
+          "description": "Craft는 새 세션과 예약된 작업에 이 모델을 사용합니다. 설정하지 않으면 Craft는 워크스페이스 기본 채팅 모델을 사용합니다."
+        },
+        "inheritedTag": {
+          "label": "워크스페이스 기본값"
+        },
+        "label": "기본 모델",
+        "placeholder": "모델 선택",
+        "resetError": {
+          "message": "기본 모델을 지우지 못했습니다"
+        },
+        "resetSuccess": {
+          "message": "Craft 기본 모델을 지웠습니다"
+        },
+        "saveError": {
+          "message": "기본 모델을 저장하지 못했습니다"
+        },
+        "saveSuccess": {
+          "message": "Craft 기본 모델을 저장했습니다"
+        }
       },
       "header": {
         "description": "Craft의 기본 동작에 더해 모든 Craft 에이전트가 따르는 기본 모델과 워크스페이스 전체 지침입니다.",
@@ -12890,9 +12902,29 @@
         "title": "사용량을 불러올 수 없습니다"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · 기본"
+        },
         "description": "사용 가능한 모든 모델의 100만 토큰당 USD(입력 · 출력 · 캐시)",
+        "otherProvider": {
+          "label": "기타"
+        },
         "title": "모델 가격",
         "unavailable": "가격 정보 없음"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "캐시 읽기 {count}"
+        },
+        "cacheWrites": {
+          "label": "캐시 쓰기 {count}"
+        },
+        "tokensIn": {
+          "label": "입력 {count}"
+        },
+        "tokensOut": {
+          "label": "출력 {count}"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "모델 적게 표시"

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "뒤로"
       },
-      "disableAll": {
-        "label": "모두 사용 안 함"
-      },
-      "enableAll": {
-        "label": "모두 사용"
-      },
       "toggle": {
         "ariaLabel": "{name} 전환"
       }
@@ -12935,6 +12929,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "문서 탐색기"
+        },
+        "documentFeedback": {
+          "title": "문서 피드백"
+        },
+        "documentProcessing": {
+          "title": "문서 처리"
+        },
+        "oauthTest": {
+          "title": "OAuth 테스트"
+        },
+        "standardAnswers": {
+          "title": "표준 답변"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "커넥터 추가"

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "Voltar"
       },
-      "disableAll": {
-        "label": "Desativar tudo"
-      },
-      "enableAll": {
-        "label": "Ativar tudo"
-      },
       "toggle": {
         "ariaLabel": "Alternar {name}"
       }
@@ -12947,6 +12941,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "Explorador de documentos"
+        },
+        "documentFeedback": {
+          "title": "Feedback de documentos"
+        },
+        "documentProcessing": {
+          "title": "Processamento de documentos"
+        },
+        "oauthTest": {
+          "title": "Teste de OAuth"
+        },
+        "standardAnswers": {
+          "title": "Respostas padrão"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "Adicionar conector"

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -12902,9 +12902,29 @@
         "title": "Não foi possível carregar o uso"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · padrão"
+        },
         "description": "USD por 1M de tokens (entrada · saída · cache) para cada modelo disponível",
+        "otherProvider": {
+          "label": "Outros"
+        },
         "title": "Preços dos modelos",
         "unavailable": "Preços indisponíveis"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "{count} leituras de cache"
+        },
+        "cacheWrites": {
+          "label": "{count} escritas de cache"
+        },
+        "tokensIn": {
+          "label": "{count} de entrada"
+        },
+        "tokensOut": {
+          "label": "{count} de saída"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "Mostrar menos modelos"

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -60,6 +60,26 @@
         "ariaLabel": "Cartão de ação {title}"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "Adicionar conectores"
+      },
+      "configure": {
+        "tooltip": "Configurar"
+      },
+      "configureConnectors": {
+        "label": "Configurar conectores"
+      },
+      "disable": {
+        "label": "Desativar"
+      },
+      "enable": {
+        "label": "Ativar"
+      },
+      "projectSearch": {
+        "label": "Pesquisa do projeto"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "Conecte um servidor MCP (Model Context Protocol) para adicionar ações personalizadas.",
@@ -355,6 +375,53 @@
         "tooltip": "Atualizar ferramentas"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "Retornando automaticamente…"
+      },
+      "backToChatButton": {
+        "label": "Voltar ao chat"
+      },
+      "cancelled": {
+        "description": "A autorização foi cancelada ou negada, portanto nenhuma conexão foi estabelecida. Para tentar novamente, reinicie a conexão nas configurações de autenticação do servidor MCP.",
+        "title": "Autorização cancelada"
+      },
+      "continueButton": {
+        "label": "Continuar"
+      },
+      "genericError": {
+        "fallbackDetail": "Não foi possível concluir a autorização",
+        "title": "Algo deu errado"
+      },
+      "invalidLink": {
+        "description": "Este link não contém os parâmetros de autorização necessários. Reinicie a conexão nas configurações de autenticação do servidor MCP.",
+        "title": "Link de autorização inválido"
+      },
+      "processing": {
+        "description": "Finalizando a conexão com seu servidor MCP. Isso pode levar alguns instantes…",
+        "title": "Concluindo a autorização"
+      },
+      "serverNotFound": {
+        "description": "O servidor MCP ao qual esta autorização pertence não existe mais ou não está mais configurado. Recrie ou reconfigure o servidor e conecte novamente.",
+        "title": "Servidor MCP não encontrado"
+      },
+      "sessionExpired": {
+        "description": "Este link de autorização é inválido, expirou ou já foi utilizado. Reinicie a conexão nas configurações de autenticação do servidor MCP.",
+        "title": "A sessão de autorização expirou"
+      },
+      "success": {
+        "description": "A autorização foi concluída com sucesso. Agora você pode usar as ferramentas deste servidor no chat.",
+        "title": "Conectado a {serverName}"
+      },
+      "timedOut": {
+        "description": "O servidor MCP não confirmou a autorização a tempo. Tente conectar novamente. Se isso continuar acontecendo, verifique a configuração de OAuth do servidor.",
+        "title": "Tempo de autorização esgotado"
+      },
+      "tokenExchangeFailed": {
+        "description": "O provedor aprovou a autorização, mas não foi possível obter um token de acesso válido. Verifique as credenciais e os endpoints do cliente OAuth do servidor e tente conectar novamente.",
+        "title": "Falha na troca de token"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "Adicionar servidor MCP"
@@ -554,6 +621,20 @@
         "label": "Negar"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "Voltar"
+      },
+      "disableAll": {
+        "label": "Desativar tudo"
+      },
+      "enableAll": {
+        "label": "Ativar tudo"
+      },
+      "toggle": {
+        "ariaLabel": "Alternar {name}"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "Ferramenta indisponível"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "Mostrar apenas as ferramentas ativadas",
         "tooltip": "Mostrar apenas as ativadas"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "Configurar interpretador de código"
+        },
+        "imageGeneration": {
+          "tooltip": "Configurar geração de imagens"
+        },
+        "openapi": {
+          "tooltip": "Gerenciar ações OpenAPI"
+        },
+        "webSearch": {
+          "tooltip": "Configurar pesquisa na web"
+        }
+      },
+      "disableAllSources": {
+        "label": "Desativar todas as fontes"
+      },
+      "disableAllTools": {
+        "label": "Desativar todas as ferramentas"
+      },
+      "enableAllSources": {
+        "label": "Ativar todas as fontes"
+      },
+      "enableAllTools": {
+        "label": "Ativar todas as ferramentas"
+      },
+      "manageActions": {
+        "tooltip": "Gerenciar ações"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "Pesquisar ferramentas de {server}"
+      },
+      "moreActions": {
+        "label": "Mais ações"
+      },
+      "reauthenticate": {
+        "label": "Autenticar novamente"
+      },
+      "search": {
+        "placeholder": "Pesquisar ações..."
+      },
+      "serverFallback": {
+        "label": "servidor"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "Pesquisar filtros"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "Peça a um administrador para configurar."
+        },
+        "codingAgent": {
+          "description": "Investigue um repositório do GitHub e responda a perguntas sobre seu código."
+        },
+        "configureSuffix": {
+          "text": "Pressione a engrenagem de configurações para ativar."
+        },
+        "default": {
+          "description": "Esta ação ainda não está configurada."
+        },
+        "imageGeneration": {
+          "description": "Gere imagens com base em um prompt."
+        },
+        "python": {
+          "description": "Execute código para análises complexas."
+        },
+        "search": {
+          "description": "Pesquise no conhecimento conectado para embasar a resposta."
+        },
+        "webSearch": {
+          "description": "Pesquise na web informações atualizadas."
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "Por dia no intervalo selecionado",
+        "title": "Mensagens e usuários únicos"
+      },
+      "empty": {
+        "message": "Nenhum dado encontrado para este agente no intervalo de datas selecionado."
+      },
+      "fetchFailed": {
+        "message": "Falha ao buscar as estatísticas do agente."
+      },
+      "permissionDenied": {
+        "message": "Você não tem permissão para ver estas estatísticas."
+      },
+      "totalMessages": {
+        "label": "Total de mensagens"
+      },
+      "totalUniqueUsers": {
+        "label": "Total de usuários únicos"
+      },
+      "unknownError": {
+        "message": "Ocorreu um erro desconhecido"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "Recolher seção"
+        },
+        "expand": {
+          "ariaLabel": "Expandir seção"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "Tem certeza de que deseja excluir <emphasis>{name}</emphasis>? Esta ação não pode ser desfeita."
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "Ver planos"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "Nenhuma informação de cobrança disponível."
+        },
+        "loadError": {
+          "message": "Erro ao carregar as informações de cobrança. Tente novamente mais tarde."
+        },
+        "loading": {
+          "label": "Carregando..."
+        },
+        "manageSubscription": {
+          "description": "Veja seu plano, atualize o pagamento ou altere a assinatura",
+          "title": "Gerenciar assinatura"
+        },
+        "page": {
+          "title": "Informações de cobrança"
+        },
+        "portalError": {
+          "message": "Erro ao criar a sessão do portal do cliente"
+        },
+        "subscriptionDetails": {
+          "title": "Detalhes da assinatura"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "Fim da cobrança"
+          },
+          "billingStart": {
+            "label": "Início da cobrança"
+          },
+          "seats": {
+            "label": "Assentos"
+          },
+          "status": {
+            "label": "Status da assinatura"
+          }
+        },
+        "updatedToast": {
+          "message": "Parabéns! Sua assinatura foi atualizada com sucesso."
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "Sincronizaremos automaticamente as permissões da fonte. Um documento só poderá ser pesquisado no Onyx se o usuário que realiza a pesquisa tiver permissão para acessar o documento na fonte.",
+          "disabledReason": "O método de autenticação da credencial atual não oferece suporte à sincronização automática de permissões. Altere o método de autenticação da credencial para um compatível.",
+          "name": "Sincronização automática de permissões"
+        },
+        "heading": {
+          "description": "Controle quem tem acesso aos documentos indexados por este conector.",
+          "title": "Acesso a documentos"
+        },
+        "privateOption": {
+          "description": "Apenas usuários que receberam acesso explícito a este conector (pela página de Grupos de usuários) podem acessar os documentos importados por este conector",
+          "name": "Privado"
+        },
+        "publicOption": {
+          "description": "Qualquer pessoa com uma conta no Onyx pode acessar os documentos importados por este conector",
+          "name": "Público"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# dia} other {# dias}}",
@@ -1546,6 +1794,14 @@
           "label": "Mostrar menos"
         }
       },
+      "credentialForm": {
+        "errorToast": "Erro: {detail}",
+        "successToast": "Sucesso!",
+        "updateButton": {
+          "ariaLabel": "Atualizar credenciais",
+          "label": "Atualizar"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "Excluir este conector agenda uma tarefa de exclusão que remove os documentos indexados e o exclui para todos os usuários.",
         "entityType": "conector"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "Erro na sincronização das permissões dos documentos"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "Confira <link>nossa documentação</link> para mais informações sobre como configurar este conector."
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "Falha ao atualizar os arquivos"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "Arraste e solte {multiple, select, true {arquivos} other {um arquivo}} aqui, ou clique para selecionar {multiple, select, true {arquivos} other {um arquivo}}"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {Arquivos selecionados} other {Arquivo selecionado}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "Mensagem de erro",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "Erro na sincronização das associações de grupo"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "Atribuir acesso de grupos a este conector"
+        },
+        "assignToGroup": {
+          "title": "Atribuir este conector a um grupo"
+        },
+        "scopedManagerGroups": {
+          "description": "Selecione um ou mais dos grupos que você gerencia para dar acesso a este conector"
+        },
+        "syncGroups": {
+          "description": "Os grupos abaixo controlam quem pode gerenciar este conector. O acesso aos seus documentos é herdado das permissões da própria fonte."
+        },
+        "visibleToGroups": {
+          "description": "Este conector ficará visível/acessível para os grupos selecionados abaixo"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "Reindexação direcionada enviada para {count, plural, one {# documento} other {# documentos}}. Os erros vão sair da lista conforme os documentos terminarem de ser reindexados."
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "Regex de canais habilitada",
+        "channels": "Canais",
+        "enabledTrue": "Sim",
+        "excludeChannelRegexEnabled": "Regex de exclusão de canais habilitada",
+        "excludedChannels": "Canais excluídos",
+        "includeBotMessages": "Incluir mensagens de bots",
+        "jiraProjectUrl": "URL do projeto Jira",
+        "multipleRepos": "vários repositórios",
+        "pageId": "ID da página",
+        "realm": "Realm",
+        "repo": "Repositório",
+        "wikiUrl": "URL do wiki"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "Digite o e-mail de um administrador ou proprietário da organização Google que é dona dos Google Drives que você quer indexar.",
           "invalidEmail": "Precisa ser um e-mail válido",
           "label": "E-mail do administrador principal",
+          "placeholder": "admin@suaempresa.com",
           "required": "Obrigatório"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "Digite o e-mail de um administrador ou proprietário da organização Google que é dona das contas do Gmail que você quer indexar.",
           "invalidEmail": "Precisa ser um e-mail válido",
           "label": "E-mail do administrador principal",
+          "placeholder": "admin@suaempresa.com",
           "required": "Obrigatório"
         },
         "section": {
@@ -2602,6 +2906,171 @@
       "unavailable": {
         "description": "O Craft é ativado por implantação pela Onyx. Entre em contato com seu representante Onyx para obter acesso.",
         "title": "O Craft não está disponível nesta implantação"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "Criada em <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "Criada em <i>{date}</i> por <i>{email}</i>"
+        },
+        "unnamed": {
+          "label": "Credencial nº {id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "Criar"
+        },
+        "created": {
+          "toast": "Nova credencial criada!"
+        },
+        "name": {
+          "label": "Nome:",
+          "placeholder": "(Opcional) nome da credencial..."
+        },
+        "submitError": {
+          "toast": "Erro ao enviar a credencial"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "confirmBody": {
+          "message": "Tem certeza de que deseja excluir esta credencial? Não é possível excluir credenciais vinculadas a conectores ativos."
+        },
+        "confirmButton": {
+          "label": "Confirmar"
+        },
+        "confirmTitle": "Confirmar exclusão"
+      },
+      "edit": {
+        "name": {
+          "label": "Nome (opcional):"
+        },
+        "permissions": {
+          "note": "Certifique-se de atualizar para uma credencial com as permissões adequadas!"
+        },
+        "resetButton": {
+          "label": "Redefinir alterações"
+        },
+        "updateButton": {
+          "label": "Atualizar"
+        },
+        "updateError": {
+          "toast": "Erro ao atualizar a credencial"
+        }
+      },
+      "modal": {
+        "createTitle": "Criar credencial de {source}",
+        "editTitle": "Editar credencial",
+        "updateTitle": "Atualizar credenciais"
+      },
+      "modify": {
+        "createButton": {
+          "label": "Criar"
+        },
+        "instructions": {
+          "message": "Selecione uma credencial conforme necessário! Certifique-se de ter selecionado uma credencial com as permissões adequadas para este conector!"
+        },
+        "selectButton": {
+          "label": "Selecionar"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "Conectar"
+        },
+        "connectError": {
+          "title": "Não foi possível conectar"
+        },
+        "redirectFailed": {
+          "message": "Não foi possível redirecionar você para entrar com {source}. Tente novamente."
+        },
+        "retryButton": {
+          "label": "Tentar novamente"
+        },
+        "startError": {
+          "message": "Não foi possível iniciar o OAuth"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "Problema ao trocar a credencial: {detail}"
+        },
+        "success": {
+          "toast": "Credencial trocada com sucesso!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "Ações"
+        },
+        "created": {
+          "header": "Criado"
+        },
+        "edit": {
+          "ariaLabel": "Editar credencial"
+        },
+        "empty": {
+          "message": "Não existem credenciais para este conector!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "Última atualização"
+        },
+        "name": {
+          "header": "Nome"
+        },
+        "select": {
+          "label": "Selecionar"
+        },
+        "selected": {
+          "badge": "selecionada"
+        },
+        "untitled": {
+          "label": "Sem título"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "Problema ao atualizar a credencial"
+        },
+        "success": {
+          "toast": "Credencial atualizada"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "Isso permite usar sua própria ferramenta de análise com o Onyx! Copie o snippet Web do seu provedor de análise na caixa abaixo e começaremos a enviar eventos de uso."
+      },
+      "notEnabled": {
+        "description": "Para configurar scripts de análise personalizada, fale com a equipe que instalou o Onyx na sua organização para definir a variável de ambiente <i>CUSTOM_ANALYTICS_SECRET_KEY</i>.",
+        "title": "A análise personalizada não está habilitada."
+      },
+      "script": {
+        "description": "Especifique o Javascript que deve ser executado no carregamento da página para inicializar seu rastreamento/análise personalizada.",
+        "instructions": "Não inclua as tags `<script></script>`. Se você enviar um script abaixo mas não estiver recebendo eventos na sua plataforma de análise, tente remover todos os espaços em branco extras antes de cada linha de JavaScript.",
+        "label": "Script"
+      },
+      "secretKey": {
+        "description": "Por motivos de segurança, você deve fornecer uma chave secreta para atualizar este script. Deve ser o valor da variável de ambiente <i>CUSTOM_ANALYTICS_SECRET_KEY</i> definida na configuração inicial do Onyx.",
+        "label": "Chave secreta"
+      },
+      "updateButton": {
+        "label": "Atualizar"
+      },
+      "updateFailed": {
+        "message": "Falha ao atualizar o script de análise personalizada: \"{error}\""
+      },
+      "updateSuccess": {
+        "message": "Script de análise personalizada atualizado com sucesso!"
       }
     },
     "discordBot": {
@@ -3059,6 +3528,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "Coletando..."
+        },
+        "downloading": {
+          "label": "Baixando..."
+        },
+        "export": {
+          "label": "Exportar logs"
+        },
+        "starting": {
+          "label": "Iniciando..."
+        }
+      },
+      "downloadButton": {
+        "label": "Baixar"
+      },
+      "exportCard": {
+        "description": "Reúne os arquivos de log do servidor de API e dos workers em segundo plano em um único zip. O download começa automaticamente quando a coleta termina.",
+        "title": "Exportar logs"
+      },
+      "header": {
+        "description": "Baixe um zip com os arquivos de log do servidor para anexar a um chamado de suporte da Onyx."
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "coberto por outro worker no mesmo host"
+        },
+        "failed": {
+          "label": "falhou"
+        },
+        "failedWithError": {
+          "label": "falhou: {error}"
+        },
+        "noLogs": {
+          "label": "nenhum arquivo de log encontrado"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {enviou # arquivo} other {enviou # arquivos}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "Os arquivos de log podem incluir e-mails de usuários, títulos de documentos, consultas de pesquisa e conteúdos de erros. Revise o conteúdo antes de compartilhá-los fora da sua organização.",
+        "title": "Os logs podem conter dados sensíveis"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "Iniciando a coleta..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "Já existe uma exportação de logs em andamento. Tente novamente em instantes."
+        },
+        "downloadFailed": {
+          "message": "Falha ao baixar a exportação de logs."
+        },
+        "lostAccess": {
+          "message": "O acesso à exportação em andamento foi perdido. Inicie uma nova."
+        },
+        "startFailed": {
+          "message": "Falha ao iniciar a exportação de logs."
+        },
+        "unreachable": {
+          "message": "Não foi possível conectar ao servidor para verificar o progresso da exportação. Inicie uma nova exportação quando ele voltar."
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "coletando..."
+        },
+        "missedDeadline": {
+          "label": "não respondeu antes do prazo"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3165,9 +3711,137 @@
         "loadFailed": "Falha ao carregar o conector: {details}",
         "title": "Erro"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "Digite o nome do canal ou um padrão regex e pressione Enter"
+        },
+        "channelsRequired": {
+          "error": "É necessário pelo menos um canal quando 'Pesquisar em todos os canais' está desativado"
+        },
+        "configSchemaLoadError": {
+          "message": "Falha ao carregar o esquema de configuração: {error}"
+        },
+        "configTitle": {
+          "text": "Configuração do conector federado"
+        },
+        "configuration": {
+          "heading": "Configuração"
+        },
+        "create": {
+          "failed": "Falha ao criar o conector federado",
+          "success": "Conector federado criado com sucesso!"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  (deixe em branco para manter o valor atual)"
+        },
+        "credentialValidationFailed": {
+          "message": "Falha na validação das credenciais: {message}"
+        },
+        "credentials": {
+          "description": "Insira as credenciais deste conector.",
+          "heading": "Credenciais"
+        },
+        "delete": {
+          "failed": "Falha ao excluir o conector federado",
+          "success": "Conector federado excluído com sucesso!"
+        },
+        "deleteConfirm": {
+          "message": "Tem certeza de que deseja excluir este conector federado? Esta ação não pode ser desfeita."
+        },
+        "deleteError": {
+          "toast": "Erro ao excluir o conector: {error}"
+        },
+        "deleteItem": {
+          "deleting": "Excluindo...",
+          "inProgressTooltip": "Exclusão em andamento",
+          "label": "Excluir"
+        },
+        "federatedBadge": {
+          "label": "Federado"
+        },
+        "federatedTooltip": {
+          "default": "Este é um conector federado. Ele terá maior latência e menor qualidade de pesquisa em comparação com conectores comuns."
+        },
+        "genericError": {
+          "text": "Erro: {error}"
+        },
+        "listInput": {
+          "placeholder": "Digite e pressione Enter para adicionar um item"
+        },
+        "loadingSchema": {
+          "description": "Obtendo os campos obrigatórios para este tipo de conector",
+          "title": "Carregando o esquema de credenciais..."
+        },
+        "manageButton": {
+          "label": "Gerenciar"
+        },
+        "missingFields": {
+          "message": "Campos obrigatórios ausentes: {fields}"
+        },
+        "noConfigSchema": {
+          "message": "Nenhuma configuração de pesquisa disponível para este tipo de conector."
+        },
+        "noCredentialSchema": {
+          "message": "Nenhum esquema de credenciais disponível para este tipo de conector."
+        },
+        "schemaLoadError": {
+          "message": "Falha ao carregar o esquema de credenciais: {error}"
+        },
+        "submitButton": {
+          "create": "Criar",
+          "creating": "Criando...",
+          "update": "Atualizar",
+          "updating": "Atualizando..."
+        },
+        "title": {
+          "edit": "Editar {name}",
+          "setup": "Configurar {name}"
+        },
+        "update": {
+          "failed": "Falha ao atualizar o conector federado",
+          "success": "Conector federado atualizado com sucesso!"
+        },
+        "validateBeforeEdit": {
+          "message": "Insira novos valores de credenciais antes de validar."
+        },
+        "validateButton": {
+          "label": "Validar",
+          "validating": "Validando..."
+        },
+        "validation": {
+          "error": "Erro de validação: {error}",
+          "failedStatus": "Falha na validação: {statusText}",
+          "invalid": "As credenciais são inválidas",
+          "valid": "As credenciais são válidas"
+        }
+      },
       "loading": {
         "description": "Buscando os detalhes do conector e o esquema da credencial",
         "title": "Carregando a configuração do conector..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "Voltar ao chat"
+      },
+      "error": {
+        "title": "Algo deu errado"
+      },
+      "errors": {
+        "clientSecret": "As credenciais de autenticação estão ausentes ou são inválidas",
+        "oauth": "A autorização OAuth falhou",
+        "validation": "Erro de configuração - verifique as configurações do seu conector"
+      },
+      "processing": {
+        "details": "Aguarde enquanto concluímos a configuração.",
+        "title": "Processando..."
+      },
+      "redirecting": {
+        "text": "Redirecionando para o chat em 2 segundos..."
+      },
+      "success": {
+        "detailsTemplate": "Sua autorização do {serviceName} foi concluída com sucesso. Agora você pode usar este conector para pesquisa.",
+        "title": "Sucesso!"
       }
     },
     "groups": {
@@ -3430,6 +4104,265 @@
           "header": "Limite de tokens",
           "placeholder": "Limite de tokens (milhares)",
           "unit": "(milhares)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "Excluir hook",
+          "tooltip": "Excluir"
+        },
+        "disconnect": {
+          "ariaLabel": "Desativar hook",
+          "tooltip": "Desconectar hook"
+        },
+        "disconnectedSuffix": {
+          "label": "(Desconectado)"
+        },
+        "hookPoint": {
+          "description": "Ponto de extensão: {name}"
+        },
+        "manage": {
+          "ariaLabel": "Configurar hook",
+          "tooltip": "Gerenciar"
+        },
+        "reconnectButton": {
+          "label": "Reconectar"
+        },
+        "test": {
+          "ariaLabel": "Revalidar hook",
+          "tooltip": "Testar conexão"
+        }
+      },
+      "connectButton": {
+        "label": "Conectar"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "O hook ***{name}*** será removido permanentemente deste ponto de extensão. O endpoint externo ainda pode reter dados enviados anteriormente."
+        },
+        "delete": {
+          "label": "Excluir"
+        },
+        "header": {
+          "title": "Excluir *{name}*"
+        },
+        "permanent": {
+          "description": "A exclusão não pode ser desfeita."
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "O Onyx deixará de chamar este endpoint para o hook ***{name}***. As solicitações em andamento continuarão em execução. O endpoint externo ainda pode reter dados enviados anteriormente. Você pode reconectar este hook mais tarde, se necessário."
+        },
+        "deleteNote": {
+          "description": "Você também pode excluir este hook. A exclusão não pode ser desfeita."
+        },
+        "disconnect": {
+          "label": "Desconectar"
+        },
+        "disconnectAndDelete": {
+          "label": "Desconectar e excluir"
+        },
+        "header": {
+          "title": "Desconectar *{name}*"
+        }
+      },
+      "docsLink": {
+        "label": "Documentação"
+      },
+      "form": {
+        "apiKey": {
+          "description": "O Onyx usará esta chave para se autenticar no seu endpoint de API.",
+          "keepCurrent": {
+            "placeholder": "Deixe em branco para manter a chave atual"
+          },
+          "title": "Chave de API"
+        },
+        "connectionValid": {
+          "label": "Conexão válida."
+        },
+        "createHeader": {
+          "description": "Conecte um endpoint de API externo para estender o ponto de extensão.",
+          "title": "Configurar extensão de hook"
+        },
+        "editHeader": {
+          "title": "Gerenciar extensão de hook"
+        },
+        "endpoint": {
+          "description": "Conecte-se apenas a servidores confiáveis. Você é responsável pelas ações realizadas e pelos dados compartilhados com esta conexão.",
+          "title": "URL do endpoint de API externo"
+        },
+        "errors": {
+          "connect": "Não foi possível conectar ao endpoint.",
+          "generic": "Algo deu errado.",
+          "invalidApiKey": "Chave de API inválida.",
+          "timeout": "A conexão atingiu o tempo limite. Tente aumentar o tempo limite."
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(Padrão)"
+          },
+          "hard": {
+            "label": "Bloquear o pipeline em caso de falha"
+          },
+          "placeholder": "Selecione a estratégia",
+          "soft": {
+            "label": "Registrar erro e continuar"
+          },
+          "title": "Estratégia de falha"
+        },
+        "hookPoint": {
+          "label": "Ponto de extensão"
+        },
+        "name": {
+          "placeholder": "Dê um nome à sua extensão neste ponto de extensão",
+          "title": "Nome de exibição"
+        },
+        "save": {
+          "label": "Salvar alterações"
+        },
+        "softStrategy": {
+          "description": "Se o endpoint retornar um erro, o Onyx o registra e continua o pipeline normalmente, ignorando o resultado do hook."
+        },
+        "timeout": {
+          "description": "Tempo máximo que o Onyx aguardará a resposta do endpoint antes de aplicar a estratégia de falha. Deve ser maior que 0 e no máximo {max} segundos.",
+          "revert": {
+            "tooltip": "Reverter para o padrão"
+          },
+          "suffix": "(segundos)",
+          "title": "Tempo limite"
+        },
+        "toasts": {
+          "created": {
+            "message": "Hook criado."
+          },
+          "noHookPoint": {
+            "message": "Nenhum ponto de extensão especificado."
+          },
+          "updated": {
+            "message": "Hook atualizado."
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "A chave de API não pode estar vazia.",
+          "endpointRequired": "A URL do endpoint não pode estar vazia.",
+          "nameRequired": "O nome de exibição não pode estar vazio.",
+          "timeoutRange": "Deve ser maior que 0 e no máximo {max} segundos.",
+          "timeoutRequired": "O tempo limite é obrigatório."
+        },
+        "verifying": {
+          "label": "Verificando a conexão…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "Copiar"
+        },
+        "download": {
+          "tooltip": "Baixar"
+        },
+        "empty": {
+          "message": "Nenhum erro nos últimos 30 dias."
+        },
+        "header": {
+          "description": "Hook: {name} • Ponto de extensão: {point}",
+          "title": "Erros recentes"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# linha} other {# linhas}}"
+        },
+        "loadFailed": {
+          "message": "Falha ao carregar os logs."
+        },
+        "older": {
+          "label": "Mais antigos"
+        },
+        "pastHour": {
+          "label": "Última hora"
+        },
+        "unknownError": {
+          "label": "Erro desconhecido"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "Cancelar"
+        }
+      },
+      "page": {
+        "description": "Estenda os pipelines do Onyx registrando endpoints de API externos como callbacks em pontos de extensão predefinidos.",
+        "empty": {
+          "title": "Nenhum ponto de extensão disponível"
+        },
+        "emptySearch": {
+          "description": "Tente usar outro termo de pesquisa.",
+          "title": "Nenhum resultado encontrado"
+        },
+        "enterpriseRequired": {
+          "message": "As extensões de hooks exigem uma licença Enterprise."
+        },
+        "loadHooksFailed": {
+          "message": "Falha ao carregar os hooks. Atualize a página."
+        },
+        "loadSpecsFailed": {
+          "message": "Falha ao carregar as especificações de hooks. Atualize a página."
+        },
+        "notEnabled": {
+          "message": "As extensões de hooks não estão habilitadas nesta implantação."
+        },
+        "search": {
+          "placeholder": "Pesquisar hooks..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "Conectado"
+        },
+        "connectionLost": {
+          "label": "Conexão perdida"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# erro} other {# erros}}"
+        },
+        "noError": {
+          "title": "Nenhum erro"
+        },
+        "pastHour": {
+          "description": "na última hora"
+        },
+        "recentErrors": {
+          "title": "Erros mais recentes"
+        },
+        "viewMore": {
+          "label": "Ver mais linhas"
+        },
+        "viewOlder": {
+          "label": "Ver erros mais antigos"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "Falha ao desativar o hook."
+        },
+        "deleteFailed": {
+          "message": "Falha ao excluir o hook."
+        },
+        "disconnectFailed": {
+          "message": "Falha ao desconectar o hook."
+        },
+        "reconnectFailed": {
+          "message": "Falha ao reconectar o hook."
+        },
+        "validateFailed": {
+          "message": "Falha ao validar o hook."
+        },
+        "validateSuccess": {
+          "message": "Hook validado com sucesso."
+        },
+        "validationFailed": {
+          "message": "A validação falhou: {status}"
         }
       }
     },
@@ -4309,6 +5242,9 @@
               "label": "Adicionar linha"
             },
             "description": "Adicione propriedades extras conforme o provedor de modelos exigir. Elas são passadas para a chamada `completion()` do LiteLLM como [variáveis de ambiente](https://docs.litellm.ai/docs/set_keys#environment-variables). Consulte a [documentação](https://docs.onyx.app/admins/ai_models/custom_inference_provider) para mais instruções.",
+            "keyInput": {
+              "placeholder": "ex.: OPENAI_ORGANIZATION"
+            },
             "title": "Variáveis de ambiente"
           },
           "modelRow": {
@@ -4820,6 +5756,132 @@
         "title": "Usuários"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "Desconhecido"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "IA"
+        },
+        "errorTitle": {
+          "title": "Algo deu errado :("
+        },
+        "feedback": {
+          "title": "Feedback"
+        },
+        "fetchFailed": {
+          "message": "Falha ao buscar a sessão de chat - {error}"
+        },
+        "header": {
+          "title": "Detalhes da sessão de chat"
+        },
+        "referenceDocuments": {
+          "title": "Documentos de referência"
+        },
+        "user": {
+          "label": "Usuário"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "downloadFailed": {
+          "message": "Falha ao baixar o histórico de consultas."
+        },
+        "generating": {
+          "message": "Gerando relatório CSV. Clique no botão \"{button}\" para ver todos os trabalhos."
+        },
+        "kickoff": {
+          "label": "Iniciar exportação"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "Falha"
+        },
+        "pending": {
+          "label": "Pendente"
+        },
+        "success": {
+          "label": "Sucesso"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "Baixar"
+        },
+        "endRange": {
+          "header": "Fim do intervalo"
+        },
+        "generatedAt": {
+          "header": "Gerado em"
+        },
+        "header": {
+          "title": "Exportações anteriores do histórico de consultas"
+        },
+        "notReady": {
+          "tooltip": "A exportação ainda não está pronta"
+        },
+        "startRange": {
+          "header": "Início do intervalo"
+        },
+        "status": {
+          "header": "Status"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "Descurtir"
+        },
+        "like": {
+          "label": "Curtir"
+        },
+        "mixed": {
+          "label": "Misto"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "Qualquer"
+        },
+        "feedbackType": {
+          "label": "Tipo de feedback"
+        }
+      },
+      "previousExports": {
+        "label": "Ver exportações"
+      },
+      "table": {
+        "date": {
+          "header": "Data"
+        },
+        "feedback": {
+          "header": "Feedback"
+        },
+        "fetchError": {
+          "title": "Erro ao buscar o histórico de consultas"
+        },
+        "firstAiResponse": {
+          "header": "Primeira resposta da IA"
+        },
+        "firstUserMessage": {
+          "header": "Primeira mensagem do usuário"
+        },
+        "persona": {
+          "header": "Persona"
+        },
+        "user": {
+          "header": "Usuário"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4874,6 +5936,56 @@
         "generateFailed": "Falha ao gerar o token: {detail}",
         "genericError": "Algo deu errado. Tente novamente.",
         "regenerated": "Novo token gerado"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "A classificação da consulta falhou. Voltando para o chat."
+        },
+        "searchFailed": {
+          "message": "A pesquisa de documentos falhou. Tente novamente."
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# resultado} other {# resultados}}"
+        },
+        "empty": {
+          "description": "Verifique seus conectores/filtros ou tente outro termo de pesquisa.",
+          "title": "Nenhum resultado encontrado"
+        },
+        "failed": {
+          "title": "A pesquisa falhou"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# tag} other {# tags}}"
+        },
+        "empty": {
+          "label": "Tags"
+        },
+        "search": {
+          "placeholder": "Filtrar tags..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "Todo o período"
+        },
+        "day": {
+          "label": "Últimas 24 horas"
+        },
+        "month": {
+          "label": "Último mês"
+        },
+        "week": {
+          "label": "Última semana"
+        },
+        "year": {
+          "label": "Último ano"
+        }
       }
     },
     "security": {
@@ -5765,6 +6877,163 @@
         "unexpectedError": "Ocorreu um erro inesperado."
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "Remover a categoria {name}"
+        },
+        "removeButton": {
+          "ariaLabel": "Remover categoria"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "Categorias de respostas padrão"
+        },
+        "fetchError": {
+          "message": "Falha ao buscar as categorias de respostas padrão - {message}",
+          "title": "Algo deu errado :("
+        },
+        "search": {
+          "placeholder": "Pesquisar categorias..."
+        }
+      },
+      "editPage": {
+        "title": "Editar resposta padrão"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "Falha ao buscar as respostas padrão"
+        },
+        "fetchCategoriesFailed": {
+          "message": "Falha ao buscar as categorias de respostas padrão"
+        },
+        "genericTitle": {
+          "title": "Algo deu errado :("
+        },
+        "loadAnswersFailed": {
+          "title": "Erro ao carregar as respostas padrão"
+        },
+        "loadCategoriesFailed": {
+          "title": "Erro ao carregar as categorias de respostas padrão"
+        },
+        "notFound": {
+          "message": "Não foi encontrada uma resposta padrão com o ID: {id}"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "Todas as categorias"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "Todas estas palavras-chave, em qualquer ordem, separadas por espaços",
+          "placeholder": "ticket TI"
+        },
+        "answer": {
+          "label": "Resposta",
+          "placeholder": "A resposta em Markdown. Exemplo: se precisar de ajuda da equipe de TI, envie um e-mail para internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "Qualquer uma destas palavras-chave, separadas por espaços",
+          "placeholder": "ticket problema chamado"
+        },
+        "categories": {
+          "label": "Categorias:",
+          "placeholder": "Digite uma categoria e pressione Enter…"
+        },
+        "createButton": {
+          "label": "Criar!"
+        },
+        "keywords": {
+          "tooltip": "Uma pergunta deve corresponder a estas palavras-chave para acionar a resposta."
+        },
+        "matchRegex": {
+          "description": "Corresponda a um padrão regex em vez de uma palavra-chave exata",
+          "label": "Corresponder a regex"
+        },
+        "regexPattern": {
+          "label": "Padrão regex",
+          "tooltip": "É acionada se a pergunta corresponder a este padrão regex (usando `re.search()` do Python)"
+        },
+        "strategy": {
+          "all": {
+            "label": "Todas as palavras-chave"
+          },
+          "any": {
+            "label": "Qualquer palavra-chave"
+          },
+          "description": "Escolha se a pergunta do usuário deve conter alguma ou todas as palavras-chave acima para exibir esta resposta.",
+          "label": "Estratégia de detecção de palavras-chave"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "Erro ao criar a categoria \"{name}\" - {error}"
+          },
+          "createFailed": {
+            "message": "Erro ao criar a resposta padrão - {error}"
+          },
+          "updateFailed": {
+            "message": "Erro ao atualizar a resposta padrão - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "Atualizar!"
+        },
+        "validation": {
+          "answerRequired": "A resposta é obrigatória",
+          "categoryRequired": "É necessária pelo menos uma categoria",
+          "keywordRequired": "Palavras-chave ou padrão são obrigatórios"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "Adicione sua primeira resposta padrão abaixo!"
+        },
+        "description": "Gerencie as respostas padrão para perguntas predefinidas.\nObservação: atualmente, apenas perguntas feitas pelo Slack podem receber respostas padrão."
+      },
+      "newStandardAnswer": {
+        "label": "Nova resposta padrão"
+      },
+      "search": {
+        "placeholder": "Encontre respostas padrão por palavra-chave/frase..."
+      },
+      "table": {
+        "answer": {
+          "header": "Resposta"
+        },
+        "categories": {
+          "header": "Categorias"
+        },
+        "empty": {
+          "message": "Nenhuma resposta padrão correspondente encontrada..."
+        },
+        "keywords": {
+          "header": "Palavras-chave/padrão"
+        },
+        "matchRegex": {
+          "header": "Corresponder regex?"
+        },
+        "matchRegexNo": {
+          "label": "Não"
+        },
+        "matchRegexYes": {
+          "label": "Sim"
+        },
+        "slackNote": {
+          "message": "Verifique se você adicionou a categoria ao [bot do Slack](/admin/bots) correspondente."
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "Falha ao excluir a resposta padrão - {error}"
+        },
+        "deleted": {
+          "message": "Resposta padrão {id} excluída"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "Cancelado",
@@ -5795,6 +7064,142 @@
       },
       "webVersion": {
         "label": "Versão da web: "
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "Mostra um anúncio do sistema persistente que os usuários podem dispensar.",
+        "header": {
+          "placeholder": "Adicione um anúncio"
+        },
+        "label": "Anúncio do sistema"
+      },
+      "announcementPopup": {
+        "description": "Mostre também este aviso como um pop-up em tela cheia na primeira visita de todos os usuários. Use com cautela.",
+        "label": "Aviso pop-up na primeira visita"
+      },
+      "appName": {
+        "description": "Este nome aparecerá em todo o aplicativo e substituirá \"Onyx\" na interface.",
+        "label": "Nome de exibição do aplicativo"
+      },
+      "branding": {
+        "description": "Remova \"powered by Onyx\" e outras presenças da marca Onyx no aplicativo.",
+        "enterpriseTooltip": "Ocultar a marca Onyx é um recurso do plano Enterprise.",
+        "label": "Ocultar a marca Onyx"
+      },
+      "chatFooter": {
+        "description": "Adicione conteúdo em markdown para avisos legais ou informações adicionais.",
+        "label": "Texto do rodapé do chat"
+      },
+      "chatHeader": {
+        "label": "Texto do cabeçalho do chat"
+      },
+      "consent": {
+        "description": "Exige que o usuário leia e concorde com o aviso antes de acessar o aplicativo.",
+        "label": "Exigir consentimento do aviso"
+      },
+      "consentPrompt": {
+        "label": "Prompt de consentimento do aviso"
+      },
+      "firstVisit": {
+        "description": "Mostra um pop-up único para novos usuários na primeira visita.",
+        "label": "Mostrar aviso na primeira visita"
+      },
+      "greeting": {
+        "description": "Adicione uma mensagem curta à página inicial.",
+        "label": "Mensagem de saudação"
+      },
+      "helpLink": {
+        "description": "Adicione um link de ajuda personalizado no menu do usuário, além da documentação do Onyx.",
+        "enterpriseTooltip": "O link de ajuda personalizado é um recurso do plano Enterprise.",
+        "label": "Link de ajuda personalizado"
+      },
+      "helpLinkLabel": {
+        "label": "Rótulo do link de ajuda personalizado",
+        "placeholder": "Rótulo do link"
+      },
+      "loginSubtitle": {
+        "description": "Substitua o slogan abaixo do título de boas-vindas na página de login.",
+        "label": "Subtítulo da página de login"
+      },
+      "logo": {
+        "label": "Logotipo do aplicativo",
+        "updateButton": {
+          "label": "Atualizar"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "Logotipo e nome",
+          "tooltip": "Mostra o logotipo e o nome do seu aplicativo."
+        },
+        "description": "Escolha o que exibir no topo da barra lateral. As opções ficam disponíveis quando você adiciona um logotipo ou nome de aplicativo.",
+        "label": "Estilo de exibição do logotipo",
+        "logoOnly": {
+          "disabledTooltip": "Envie um logotipo para habilitar esta opção.",
+          "label": "Somente logotipo",
+          "tooltip": "Mostra somente o logotipo do seu aplicativo."
+        },
+        "nameOnly": {
+          "disabledTooltip": "Digite um nome de aplicativo para habilitar esta opção.",
+          "label": "Somente nome",
+          "tooltip": "Mostra somente o nome do seu aplicativo."
+        }
+      },
+      "markdownContent": {
+        "placeholder": "Adicione conteúdo em markdown"
+      },
+      "noticeContent": {
+        "label": "Conteúdo do aviso"
+      },
+      "noticeHeader": {
+        "label": "Cabeçalho do aviso"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "Falha ao remover o anúncio."
+        },
+        "announcementSaveFailed": {
+          "message": "Falha ao salvar o anúncio."
+        },
+        "applyButton": {
+          "label": "Aplicar alterações"
+        },
+        "applying": {
+          "label": "Aplicando..."
+        },
+        "description": "Personalize como o aplicativo aparece para os usuários da sua organização.",
+        "logoUploadFailed": {
+          "message": "Falha ao enviar o logotipo. {error}"
+        },
+        "saveSuccess": {
+          "message": "Configurações de aparência salvas com sucesso!"
+        },
+        "settingsSaveFailed": {
+          "message": "Falha ao atualizar as configurações. {error}"
+        },
+        "validation": {
+          "consentPromptRequired": "O prompt de consentimento do aviso é obrigatório",
+          "invalidUrl": "Deve ser uma URL válida",
+          "maxChars": "Máximo de {count} caracteres",
+          "noticeContentRequired": "O conteúdo do aviso é obrigatório",
+          "noticeHeaderRequired": "O cabeçalho do aviso é obrigatório",
+          "urlRequiredWithLabel": "A URL é obrigatória quando um rótulo é definido"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "Conteúdo do rodapé do chat"
+        },
+        "chatHeader": {
+          "placeholder": "Conteúdo do cabeçalho do chat"
+        },
+        "greeting": {
+          "placeholder": "Bem-vindo ao Acme Chat"
+        },
+        "logo": {
+          "alt": "Logotipo"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6059,6 +7464,9 @@
             "label": "Gasto"
           }
         }
+      },
+      "page": {
+        "description": "Monitore os gastos do workspace e revise o uso por usuário."
       },
       "spendByUser": {
         "columns": {
@@ -6656,6 +8064,204 @@
         "tooltip": "Ver estatísticas do agente"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "Gere e execute código.",
+          "title": "Interpretador de código"
+        },
+        "codingAgent": {
+          "description": "Investigue um repositório do GitHub e responda perguntas sobre seu código.",
+          "title": "Agente de programação"
+        },
+        "description": "Ferramentas e capacidades disponíveis para este agente usar.",
+        "imageGeneration": {
+          "description": "Gere e manipule imagens usando ferramentas com tecnologia de IA.",
+          "title": "Geração de imagens",
+          "unavailable": {
+            "tooltip": "A geração de imagens requer um modelo configurado. Se você tiver acesso, configure um em Configurações > Geração de imagens, ou peça a um administrador."
+          }
+        },
+        "openUrl": {
+          "description": "Busque e leia conteúdo de URLs da web.",
+          "title": "Abrir URL"
+        },
+        "title": "Ações",
+        "webSearch": {
+          "description": "Pesquise na web informações em tempo real e resultados atualizados.",
+          "title": "Pesquisa na web"
+        }
+      },
+      "advanced": {
+        "description": "Ajuste os prompts e o conhecimento do agente.",
+        "overwritePrompt": {
+          "suffix": "(Não recomendado)",
+          "title": "Substituir o prompt do sistema"
+        },
+        "reminders": {
+          "description": "Anexe um breve lembrete às mensagens do prompt. Use isto para lembrar o agente se você perceber que ele tende a esquecer certas instruções conforme o chat avança. Deve ser breve e não interferir nas mensagens do usuário.",
+          "placeholder": "Lembre-se, quero que você sempre formate sua resposta como uma lista numerada.",
+          "title": "Lembretes"
+        },
+        "title": "Opções avançadas"
+      },
+      "avatar": {
+        "edit": {
+          "label": "Editar"
+        },
+        "uploadImage": {
+          "label": "Enviar imagem"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "Excluir agente"
+        },
+        "description": "Qualquer pessoa que use este agente não poderá mais acessá-lo.",
+        "title": "Excluir este agente"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "Tem certeza de que deseja excluir este agente?",
+          "warning": "Qualquer pessoa que use este agente não poderá mais acessá-lo. A exclusão não pode ser desfeita."
+        },
+        "title": "Excluir agente"
+      },
+      "filesModal": {
+        "description": "Todos os arquivos selecionados para este agente",
+        "placeholderName": "Arquivo {id}",
+        "title": "Arquivos do usuário"
+      },
+      "general": {
+        "avatar": {
+          "title": "Avatar do agente"
+        },
+        "descriptionField": {
+          "placeholder": "O que este agente faz?",
+          "title": "Descrição"
+        },
+        "name": {
+          "placeholder": "Dê um nome ao seu agente",
+          "title": "Nome"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "create": {
+          "label": "Criar"
+        },
+        "createTitle": "Criar agente",
+        "editTitle": "Editar agente",
+        "save": {
+          "label": "Salvar"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "Você não tem mais acesso a este servidor MCP. Suas ferramentas existentes serão preservadas."
+        },
+        "searchTools": {
+          "placeholder": "Pesquisar ferramentas..."
+        }
+      },
+      "page": {
+        "ariaLabel": "Página do editor de agentes"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "Adicione instruções para personalizar as respostas deste agente.",
+          "placeholder": "Pense passo a passo e mostre o raciocínio em problemas complexos. Use exemplos específicos. Enfatize itens de ação e deixe lacunas para o humano preencher quando houver incertezas. Use um tom educado e entusiasmado.",
+          "title": "Instruções"
+        },
+        "starters": {
+          "description": "Mensagens de exemplo que ajudam os usuários a entender o que este agente pode fazer e como interagir com ele de forma eficaz.",
+          "title": "Iniciadores de conversa"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "Corrija os erros do formulário antes de salvar.",
+        "noChanges": "Nenhuma alteração foi feita.",
+        "saving": "Salvando as alterações...",
+        "uploading": "Aguarde os arquivos terminarem de ser enviados."
+      },
+      "share": {
+        "feature": {
+          "description": "Mostre este agente no topo da lista de exploração de agentes e fixe-o automaticamente na barra lateral para novos usuários com acesso.",
+          "privateNotice": {
+            "title": "Este agente é privado e será destacado apenas para você."
+          },
+          "title": "Destacar este agente",
+          "unlistedWarning": {
+            "title": "Este agente não está listado e não será mostrado na lista de destaques."
+          }
+        },
+        "labels": {
+          "description": "Adicione rótulos e categorias para ajudar as pessoas a descobrir melhor este agente.",
+          "placeholder": "Adicionar rótulos..."
+        },
+        "share": {
+          "button": {
+            "label": "Compartilhar"
+          },
+          "description": "com outros usuários, grupos ou todos na sua organização.",
+          "title": "Compartilhar este agente"
+        },
+        "title": "Compartilhar agente"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "Compile uma lista das nossas metas de engenharia para este trimestre.",
+          "overview": "Dê-me uma visão geral de alguns documentos.",
+          "salesReport": "Encontre o relatório de vendas mais recente.",
+          "todayGoals": "Resuma minhas metas de hoje."
+        },
+        "placeholder": "Digite um iniciador de conversa..."
+      },
+      "suffix": {
+        "optional": "opcional"
+      },
+      "toasts": {
+        "createFailed": "Falha ao criar o agente - {detail}",
+        "created": "Agente \"{name}\" criado com sucesso",
+        "deleteFailed": "Falha ao excluir o agente: {error}",
+        "deleted": "Agente excluído com sucesso",
+        "genericError": "Ocorreu um erro: {error}",
+        "noResponse": "nenhuma resposta recebida",
+        "sharingFailed": "Agente criado, mas o compartilhamento falhou: {error}",
+        "toggleListedFailed": "Falha ao alternar a visibilidade",
+        "unknownDetail": "erro desconhecido",
+        "unknownError": "Erro desconhecido",
+        "updateFailed": "Falha ao atualizar o agente - {detail}",
+        "updated": "Agente \"{name}\" atualizado com sucesso"
+      },
+      "validation": {
+        "cutoffInFuture": "A data de corte de conhecimento deve ser hoje ou anterior.",
+        "descriptionMax": "A descrição deve ter no máximo {max} caracteres",
+        "nameRequired": "O nome do agente é obrigatório.",
+        "starterMax": "O iniciador de conversa deve ter no máximo {max} caracteres"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "Reincluir na lista"
+          },
+          "description": "Agentes reincluídos aparecem novamente na lista de exploração de agentes.",
+          "title": "Reincluir este agente na lista"
+        },
+        "unlist": {
+          "button": {
+            "label": "Remover da lista"
+          },
+          "description": "Agentes não listados não aparecem na lista de exploração de agentes, mas continuam acessíveis.",
+          "title": "Remover este agente da lista"
+        }
+      },
+      "warnings": {
+        "openUrl": "A pesquisa na web sem a capacidade de abrir URLs pode levar a resultados da web significativamente piores."
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6838,6 +8444,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {Agente} other {Agentes}}"
+      },
+      "empty": {
+        "description": "Nenhum agente encontrado"
+      },
+      "header": {
+        "description": "Personalize o comportamento e o conhecimento da IA para os casos de uso seus e da sua equipe.",
+        "title": "Agentes"
+      },
+      "newAgent": {
+        "label": "Novo agente",
+        "noPermission": {
+          "tooltip": "Você não tem permissão para criar agentes. Entre em contato com seu administrador para solicitar acesso."
+        }
+      },
+      "page": {
+        "ariaLabel": "Página de agentes"
+      },
+      "search": {
+        "placeholder": "Pesquisar agentes..."
+      },
+      "sections": {
+        "all": {
+          "title": "Todos os agentes"
+        },
+        "featured": {
+          "description": "Selecionados pela sua equipe",
+          "title": "Agentes em destaque"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "Todos os agentes"
+        },
+        "your": {
+          "label": "Seus agentes"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "Inserir variável de usuário"
@@ -6845,6 +8492,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "Aguarde enquanto configuramos sua sessão anônima.",
+        "title": "Redirecionando você para a página de chat..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "Criar nova organização"
@@ -6866,6 +8519,55 @@
       },
       "signInLink": {
         "label": "Entrar"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "Já existe uma conta com o e-mail especificado."
+      },
+      "continueAsGuest": {
+        "label": "ou continue como convidado"
+      },
+      "email": {
+        "label": "Endereço de e-mail",
+        "placeholder": "email@suaempresa.com"
+      },
+      "forgotPassword": {
+        "link": "[Esqueceu a senha?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "E-mail ou senha inválidos"
+      },
+      "noPassword": {
+        "error": "Crie uma conta para definir uma senha"
+      },
+      "password": {
+        "label": "Senha",
+        "placeholder": "Senha"
+      },
+      "passwordDigit": {
+        "error": "A senha deve conter pelo menos um número"
+      },
+      "passwordLength": {
+        "error": "A senha deve ter entre {min} e {max} caracteres"
+      },
+      "passwordLoginDisabled": {
+        "error": "O login com senha está desativado. Entre com seu provedor de identidade."
+      },
+      "passwordLowercase": {
+        "error": "A senha deve conter pelo menos uma letra minúscula"
+      },
+      "passwordRequirements": {
+        "label": "Requisitos da senha:"
+      },
+      "passwordSpecialChar": {
+        "error": "A senha deve conter pelo menos um caractere especial"
+      },
+      "passwordUppercase": {
+        "error": "A senha deve conter pelo menos uma letra maiúscula"
+      },
+      "tooManyRequests": {
+        "error": "Muitas solicitações. Tente novamente mais tarde."
       }
     },
     "error": {
@@ -6906,6 +8608,31 @@
         "description": "Interrupção temporária do sistema de autenticação"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "Sua equipe não tem o acesso anônimo habilitado."
+      },
+      "generic": {
+        "toast": "Ocorreu um erro."
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "Criar uma conta"
+      },
+      "logo": {
+        "alt": "Logotipo"
+      },
+      "signInLink": {
+        "label": "Entrar"
+      },
+      "signinPrompt": {
+        "text": "Já tem uma conta?"
+      },
+      "signupPrompt": {
+        "text": "Novo no {appName}?"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[Voltar ao login](/auth/login)"
@@ -6938,7 +8665,8 @@
         "placeholder": "Insira a chave de API"
       },
       "emailField": {
-        "label": "E-mail"
+        "label": "E-mail",
+        "placeholder": "email@suaempresa.com"
       },
       "genericError": {
         "toast": "Não foi possível personificar o usuário"
@@ -6999,6 +8727,23 @@
         "label": "E-mail de trabalho"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "Contém número."
+      },
+      "length": {
+        "label": "{min}–{max} caracteres"
+      },
+      "lowercase": {
+        "label": "Contém letra minúscula."
+      },
+      "specialChar": {
+        "label": "Contém caractere especial."
+      },
+      "uppercase": {
+        "label": "Contém letra maiúscula."
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[Voltar ao login](/auth/login)"
@@ -7040,6 +8785,31 @@
       },
       "unexpectedError": {
         "toast": "Ocorreu um erro inesperado. Tente novamente."
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "Sua sessão expirou. Faça login novamente para continuar."
+      },
+      "loginButton": {
+        "label": "Entrar"
+      },
+      "modal": {
+        "title": "Você foi desconectado"
+      },
+      "terminated": {
+        "message": "Esta sessão foi encerrada. Faça login novamente para continuar."
+      },
+      "unrecognized": {
+        "message": "Você foi desconectado inesperadamente. Faça login novamente para continuar. Se isso continuar acontecendo, contate seu administrador."
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute não retornou nenhum token"
+      },
+      "google": {
+        "label": "Continuar com o Google"
       }
     },
     "signup": {
@@ -8471,6 +10241,75 @@
         "tooltip": "Modificar esta configuração não é compatível com este modelo."
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {O arquivo falhou e foi removido: {names}} other {Os arquivos falharam e foram removidos: {names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "Entrar"
+          },
+          "title": "Boas-vindas ao Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "Nenhuma mensagem enviada anteriormente foi encontrada."
+        },
+        "settingsButton": {
+          "tooltip": "Abrir configurações"
+        },
+        "setupLlmButton": {
+          "label": "Configure um LLM."
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "Cancelar"
+          },
+          "confirmButton": {
+            "label": "Desativar"
+          },
+          "description": "Você verá a página de nova guia padrão do seu navegador. Você pode reativá-la a qualquer momento nas configurações do Onyx.",
+          "title": "Desativar o Onyx como página de nova guia?"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "Nenhum"
+        },
+        "backgroundOption": {
+          "ariaLabel": "Fundo {label}"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "Fundo {label} (selecionado)"
+        },
+        "backgroundSection": {
+          "title": "Fundo"
+        },
+        "closeButton": {
+          "tooltip": "Fechar configurações"
+        },
+        "generalSection": {
+          "title": "Geral"
+        },
+        "header": {
+          "title": "Configurações"
+        },
+        "newTabToggle": {
+          "label": "Usar o Onyx como página de nova guia"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {Mudar para o tema claro} other {Mudar para o tema escuro}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "Novo chat"
+        },
+        "openInOnyxButton": {
+          "tooltip": "Abrir no Onyx"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "Caixa de consentimento"
@@ -8486,6 +10325,128 @@
       },
       "startButton": {
         "label": "Começar"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "Última mensagem {time}"
+        },
+        "projectFallback": {
+          "label": "Projeto"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "Adicionar arquivos"
+        },
+        "contextExceeded": {
+          "message": "Este projeto excede os limites de contexto do modelo. As sessões pesquisarão automaticamente os arquivos relevantes antes de gerar uma resposta."
+        },
+        "dropFiles": {
+          "message": "Solte arquivos aqui para adicioná-los a este projeto"
+        },
+        "emptyFiles": {
+          "message": "Adicione documentos, textos ou imagens para usar no projeto. Arrastar e soltar é compatível."
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# arquivo} other {# arquivos}}"
+        },
+        "fileCountOverflow": {
+          "description": "Mais de 100 arquivos"
+        },
+        "files": {
+          "description": "Os chats deste projeto podem acessar estes arquivos.",
+          "title": "Arquivos"
+        },
+        "filesModal": {
+          "description": "As sessões deste projeto podem acessar os arquivos aqui.",
+          "title": "Arquivos do projeto"
+        },
+        "instructions": {
+          "emptyDescription": "Adicione instruções para personalizar as respostas neste projeto.",
+          "title": "Instruções"
+        },
+        "loadingProject": {
+          "label": "Carregando projeto..."
+        },
+        "setInstructionsButton": {
+          "label": "Definir instruções"
+        },
+        "viewAll": {
+          "label": "Ver tudo"
+        },
+        "viewFiles": {
+          "label": "Ver arquivos"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "Cancelar"
+        },
+        "createError": {
+          "toast": "Falha ao criar o projeto {name}"
+        },
+        "description": "Use projetos para organizar seus arquivos e chats em um só lugar e adicionar instruções personalizadas para o trabalho em andamento.",
+        "name": {
+          "label": "Nome do projeto",
+          "placeholder": "No que você está trabalhando?"
+        },
+        "nameRequired": {
+          "error": "O nome do projeto é obrigatório"
+        },
+        "submitButton": {
+          "label": "Criar projeto"
+        },
+        "title": "Criar novo projeto"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "Nenhum projeto encontrado"
+        },
+        "search": {
+          "placeholder": "Pesquisar projetos..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "Recolher projeto"
+        },
+        "delete": {
+          "label": "Excluir projeto"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "Excluir"
+          },
+          "message": "Tem certeza de que deseja excluir este projeto? Esta ação não pode ser desfeita.",
+          "title": "Excluir projeto"
+        },
+        "expand": {
+          "ariaLabel": "Expandir projeto"
+        },
+        "rename": {
+          "label": "Renomear projeto"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "Ainda não há chats."
+        },
+        "recentChats": {
+          "title": "Chats recentes"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "Falha ao enviar os arquivos"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {# arquivo grande demais foi ignorado} other {# arquivos grandes demais foram ignorados}} (>{max} MB): {names}"
+        },
+        "rejected": {
+          "toast": "Alguns arquivos não foram enviados. {details}"
+        }
       }
     },
     "sharedChat": {
@@ -8518,6 +10479,1773 @@
       },
       "incognito": {
         "title": "Você está no modo anônimo"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "Abrir barra lateral"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "Atualizar informações de cobrança"
+        },
+        "text": "**Aviso:** Seu período de avaliação termina em menos de 5 dias e nenhum método de pagamento foi adicionado."
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "Avatar do agente"
+      },
+      "logo": {
+        "alt": "Logotipo"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "Documento"
+      },
+      "expandButton": {
+        "ariaLabel": "Expandir documento"
+      }
+    },
+    "backButton": {
+      "label": "Voltar"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "Nuvens"
+      },
+      "hills": {
+        "label": "Colinas"
+      },
+      "mountains": {
+        "label": "Montanhas"
+      },
+      "night": {
+        "label": "Noite"
+      },
+      "none": {
+        "label": "Nenhum"
+      },
+      "plant": {
+        "label": "Plantas"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "Aa"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix} \"{value}\"",
+        "defaultPrefix": "Criar"
+      },
+      "dropdown": {
+        "closeAriaLabel": "Fechar lista suspensa",
+        "openAriaLabel": "Abrir lista suspensa"
+      },
+      "options": {
+        "empty": "Nenhuma opção encontrada"
+      },
+      "separator": {
+        "label": "Outras opções"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "Fechar menu"
+      },
+      "dialog": {
+        "title": "Menu de comandos"
+      },
+      "options": {
+        "ariaLabel": "Opções do menu de comandos"
+      },
+      "search": {
+        "placeholder": "Pesquisar..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "Todos os conectores disponíveis foram selecionados. Remova conectores abaixo para adicionar outros.",
+        "placeholder": "Todos os conectores selecionados"
+      },
+      "documentSetHint": {
+        "description": "Todos os documentos indexados pelos conectores selecionados farão parte deste conjunto de documentos."
+      },
+      "noMatches": {
+        "text": "Nenhum conector correspondente encontrado"
+      },
+      "noMoreConnectors": {
+        "text": "Não há mais conectores disponíveis"
+      },
+      "noPrivateConnectors": {
+        "text": "Nenhum conector privado disponível. Crie um conector privado primeiro."
+      },
+      "noneSelected": {
+        "text": "Nenhum conector selecionado. Pesquise e selecione conectores acima."
+      },
+      "removeConnector": {
+        "tooltip": "Remover conector"
+      },
+      "search": {
+        "placeholder": "Pesquisar conectores..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "Selecionar data"
+      },
+      "todayButton": {
+        "label": "Hoje"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "Qualquer data..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "Escolher um intervalo personalizado"
+      },
+      "clearButton": {
+        "ariaLabel": "Limpar"
+      },
+      "custom": {
+        "label": "Personalizado"
+      },
+      "customRange": {
+        "ariaLabel": "Intervalo personalizado: {from} a {to}"
+      },
+      "date": {
+        "label": "Data"
+      },
+      "group": {
+        "ariaLabel": "Intervalo de datas"
+      },
+      "preset": {
+        "oneDay": "1D",
+        "oneMonth": "1M",
+        "sevenDays": "7D",
+        "threeMonths": "3M"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "Excluir"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# documento de contexto} other {# documentos de contexto}}"
+      },
+      "openDocument": {
+        "ariaLabel": "Abrir documento: {title}"
+      },
+      "question": {
+        "title": "Pergunta"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# subconsulta} other {# subconsultas}}"
+      },
+      "updated": {
+        "text": "Atualizado em {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "Padrão"
+      },
+      "selectOption": {
+        "placeholder": "Selecione uma opção..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "Editar"
+      },
+      "rename": {
+        "ariaLabel": "Renomear"
+      },
+      "save": {
+        "ariaLabel": "Salvar"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "Se você é o administrador, acesse a página de <billingLink>Faturamento do administrador</billingLink> para {hadLicense, select, true {renovar} other {ativar}} sua licença, cadastre-se pelo Stripe ou escreva para <supportLink>support@onyx.app</supportLink> para obter ajuda com o faturamento."
+        },
+        "heading": {
+          "title": "Acesso restrito"
+        },
+        "licenseLapse": {
+          "description": "Seu acesso ao Onyx foi suspenso temporariamente devido ao vencimento da sua licença."
+        },
+        "licenseRequired": {
+          "description": "É necessária uma licença para usar o Onyx. Seus dados estão protegidos e ficarão disponíveis assim que uma licença for ativada."
+        },
+        "logoutButton": {
+          "label": "Sair"
+        },
+        "manageSubscription": {
+          "description": "Se você é administrador, pode gerenciar sua assinatura clicando no botão abaixo. Os demais usuários devem entrar em contato com o administrador para resolver esta questão."
+        },
+        "obtainLicense": {
+          "description": "Para começar, entre em contato com o administrador do sistema para obter uma licença."
+        },
+        "renewLicense": {
+          "description": "Para restabelecer seu acesso e continuar usando o Onyx, entre em contato com o administrador do sistema para renovar sua licença."
+        },
+        "resubscribeButton": {
+          "label": "Assinar novamente",
+          "loading": "Carregando..."
+        },
+        "resubscribeError": {
+          "text": "Erro ao abrir a página de nova assinatura. Tente novamente mais tarde."
+        },
+        "seatLimit": {
+          "description": "Sua organização excedeu o número de assentos licenciados. O acesso ficará restrito até que o número de usuários seja reduzido ou sua licença seja atualizada."
+        },
+        "seatLimitAdminHint": {
+          "text": "Se você é administrador, pode gerenciar usuários na página de <userLink>Gerenciamento de usuários</userLink> ou atualizar sua licença na página de <billingLink>Faturamento do administrador</billingLink>."
+        },
+        "seatLimitWithCounts": {
+          "description": "Sua organização excedeu o número de assentos licenciados ({used} usuários / {seats} assentos). O acesso ficará restrito até que o número de usuários seja reduzido ou sua licença seja atualizada."
+        },
+        "subscriptionLapse": {
+          "description": "Seu acesso ao Onyx foi suspenso temporariamente devido ao vencimento da sua assinatura."
+        },
+        "updatePayment": {
+          "description": "Para restabelecer seu acesso e continuar aproveitando os recursos avançados do Onyx, atualize suas informações de pagamento."
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "Se você é administrador, consulte nossa <docsLink>documentação</docsLink> para as etapas corretas de configuração. Se você é usuário, entre em contato com seu administrador para obter ajuda."
+        },
+        "heading": {
+          "description": "Parece que houve um problema ao carregar suas configurações do Onyx. Isso pode ser causado por um problema de configuração ou uma instalação incompleta.",
+          "title": "Encontramos um problema"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "Pedimos desculpas por qualquer inconveniente e agradecemos sua paciência."
+        },
+        "checkBack": {
+          "description": "O Onyx está em uma janela de manutenção. Volte a verificar em alguns minutos."
+        },
+        "heading": {
+          "title": "Manutenção em andamento"
+        }
+      },
+      "needHelp": {
+        "text": "Precisa de ajuda? Junte-se à nossa <discordLink>comunidade no Discord</discordLink> para obter suporte."
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "Erro desconhecido"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "Baixar arquivo"
+      },
+      "file": {
+        "untitledFallback": "Sem título"
+      },
+      "fullScreenButton": {
+        "tooltip": "Tela cheia"
+      },
+      "hideButton": {
+        "tooltip": "Ocultar"
+      },
+      "minimizeButton": {
+        "tooltip": "Minimizar"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "Copiar"
+      },
+      "downloadButton": {
+        "tooltip": "Baixar"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {# linha} other {# linhas}}"
+      },
+      "size": {
+        "bytes": "{count} bytes",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "Ver texto completo"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "Todos os conectores federados selecionados"
+      },
+      "entitiesConfigured": {
+        "tooltip": "Entidades configuradas"
+      },
+      "noMatches": {
+        "text": "Nenhum conector federado correspondente encontrado"
+      },
+      "noMoreConnectors": {
+        "text": "Não há mais conectores federados disponíveis"
+      },
+      "noneSelected": {
+        "text": "Nenhum conector federado selecionado. Pesquise e selecione conectores acima."
+      },
+      "realtimeSearchHint": {
+        "description": "Os documentos dos conectores federados selecionados serão pesquisados em tempo real durante as consultas."
+      },
+      "removeConnector": {
+        "tooltip": "Remover conector"
+      },
+      "search": {
+        "placeholder": "Pesquisar conectores federados..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "Adicionar novo"
+      },
+      "booleanField": {
+        "optionalLabel": "{label} (opcional)"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "Nenhuma definição de tipo de arquivo encontrada para o campo: {name}",
+        "selectionError": "Erro na seleção do arquivo",
+        "unknownError": "Erro desconhecido",
+        "validating": "Validando o arquivo...",
+        "validationError": "Erro de validação"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "Digite seu markdown aqui...",
+        "previewTab": "Pré-visualizar",
+        "writeTab": "Escrever"
+      },
+      "optionalIndicator": {
+        "text": "(opcional)"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "Ocultar senha",
+        "showAriaLabel": "Mostrar senha"
+      },
+      "selector": {
+        "noneOption": "Nenhum",
+        "placeholder": "Selecionar..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "Todos os arquivos recentes"
+      },
+      "recentFiles": {
+        "title": "Arquivos recentes"
+      },
+      "recentFilesModal": {
+        "description": "Envie arquivos ou escolha entre seus arquivos recentes."
+      },
+      "toasts": {
+        "associatedAssistants": "Não é possível excluir o arquivo. Ele está associado aos assistentes: {assistants}",
+        "associatedBoth": "Não é possível excluir o arquivo. Ele está associado aos projetos: {projects} e aos assistentes: {assistants}",
+        "associatedProjects": "Não é possível excluir o arquivo. Ele está associado aos projetos: {projects}",
+        "deleteFailed": "Falha ao excluir o arquivo. Tente novamente.",
+        "deleteSuccess": "Arquivo excluído com sucesso"
+      },
+      "uploadFiles": {
+        "description": "Envie um arquivo do seu dispositivo",
+        "title": "Enviar arquivos"
+      },
+      "viewFileButton": {
+        "tooltip": "Ver arquivo"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "arquivo"
+      },
+      "open": {
+        "ariaLabel": "Abrir {title}"
+      },
+      "removeButton": {
+        "label": "Remover"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "Limpar"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "(Opcional)"
+      },
+      "required": {
+        "label": "(Obrigatório)"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "Falha ao carregar {label}. Tente novamente."
+      },
+      "search": {
+        "placeholder": "Pesquisar..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "Nenhum grupo de usuários disponível. Crie um grupo de usuários primeiro."
+      },
+      "userGroups": {
+        "label": "Grupos de usuários",
+        "subtext": "Selecione quais grupos de usuários podem acessar este recurso"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "Logotipo"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "Inicializando {appName}"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "Remover"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "Anexar arquivo"
+      },
+      "clearButton": {
+        "ariaLabel": "Limpar arquivo"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "Arquivo rejeitado"
+      },
+      "editButton": {
+        "ariaLabel": "Editar imagem"
+      },
+      "editOverlay": {
+        "label": "Editar"
+      },
+      "image": {
+        "altFallback": "Imagem"
+      },
+      "removeButton": {
+        "ariaLabel": "Remover imagem"
+      },
+      "uploadButton": {
+        "ariaLabel": "Enviar imagem"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "Selecione uma opção"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "Atribuir acesso de grupos a este {objectName}",
+        "scopedSubtext": "Selecione um ou mais dos grupos que você gerencia para dar acesso a este {objectName}",
+        "visibleSubtext": "Este {objectName} ficará visível/acessível para os grupos selecionados abaixo"
+      },
+      "loading": {
+        "text": "Carregando..."
+      },
+      "makePublic": {
+        "label": "Tornar este {objectName} público?",
+        "subtext": "Se ativado, este {objectName} poderá ser usado por <b>todos os {publicToWhom}</b>. Caso contrário, apenas <b>administradores</b> e <b>{publicToWhom}</b> que receberam acesso explícito a este {objectName} (por exemplo, por meio de um grupo de usuários) terão acesso."
+      },
+      "publicDisabled": {
+        "message": "Este {objectName} é público e está disponível para todos os usuários."
+      },
+      "usersFallback": {
+        "text": "Usuários"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "Adicionar par de {keyTitle} e {valueTitle}",
+        "label": "Adicionar linha"
+      },
+      "empty": {
+        "title": "Nenhum item adicionado ainda."
+      },
+      "error": {
+        "duplicateKey": "Chave duplicada",
+        "duplicateSummary": "{count, plural, one {# chave duplicada encontrada} other {# chaves duplicadas encontradas}}",
+        "emptyKey": "A chave não pode estar vazia",
+        "emptySummary": "{count, plural, one {# chave vazia encontrada} other {# chaves vazias encontradas}}",
+        "validationSummary": "{count, plural, one {# erro de validação encontrado} other {# erros de validação encontrados}}"
+      },
+      "group": {
+        "ariaLabel": "Pares de {keyTitle} e {valueTitle}"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "Chave"
+      },
+      "pair": {
+        "fallbackLabel": "chave-valor"
+      },
+      "removeButton": {
+        "ariaLabel": "Remover par de {label} {index}"
+      },
+      "valueColumn": {
+        "title": "Valor"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "Logotipo"
+      },
+      "poweredBy": {
+        "label": "Desenvolvido com Onyx"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "Conectores indisponíveis:"
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "A autorização foi cancelada ou falhou. Tente novamente.",
+        "title": "Falha na autorização"
+      },
+      "backButton": {
+        "label": "Voltar ao chat"
+      },
+      "completeFailed": {
+        "message": "Falha ao concluir a autorização"
+      },
+      "genericError": {
+        "description": "Ocorreu um erro durante o processo de OAuth. Tente novamente.",
+        "title": "Algo deu errado"
+      },
+      "invalidRequest": {
+        "description": "A solicitação de autorização estava incompleta. Tente novamente.",
+        "title": "Solicitação inválida"
+      },
+      "loadingHint": {
+        "text": "Isso pode levar alguns instantes..."
+      },
+      "processing": {
+        "description": "Aguarde enquanto concluímos a configuração.",
+        "title": "Processando..."
+      },
+      "redirecting": {
+        "text": "Redirecionando em {count, plural, one {# segundo} other {# segundos}}..."
+      },
+      "serviceFallback": {
+        "text": "serviço"
+      },
+      "success": {
+        "detailsTemplate": "A autorização de {serviceName} foi concluída com sucesso.",
+        "title": "Sucesso!"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "A planilha pode estar corrompida ou não pôde ser carregada corretamente.",
+        "title": "Erro ao carregar a planilha"
+      },
+      "preview": {
+        "truncated": "Pré-visualização truncada. Baixe o arquivo para ver todas as linhas.",
+        "unavailable": "Não é possível pré-visualizar esta planilha."
+      },
+      "sheet": {
+        "defaultName": "Folha 1",
+        "empty": "Esta folha está vazia.",
+        "tooLarge": "Esta folha é grande demais para a pré-visualização. Baixe o arquivo para visualizá-la."
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "Agente principal"
+      },
+      "subagentFallback": {
+        "label": "subagente"
+      },
+      "switch": {
+        "ariaLabel": "Trocar de agente"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "Aprovar esta ação uma vez",
+        "button": "Aprovar uma vez"
+      },
+      "approveSession": {
+        "button": "Aprovar para a sessão",
+        "tooltip": "Aprovar ações correspondentes para esta sessão"
+      },
+      "details": {
+        "hideAriaLabel": "Ocultar detalhes",
+        "showAriaLabel": "Mostrar detalhes"
+      },
+      "header": {
+        "required": "Aprovação necessária: {headline}"
+      },
+      "headline": {
+        "multiAction": "{count, plural, one {# ação} other {# ações}} em {app}",
+        "singleAction": "{action} em {app}"
+      },
+      "payload": {
+        "empty": {
+          "label": "Sem conteúdo."
+        },
+        "showLess": {
+          "button": "Mostrar menos"
+        },
+        "showMore": {
+          "button": "Mostrar mais"
+        }
+      },
+      "reject": {
+        "ariaLabel": "Rejeitar esta ação",
+        "button": "Rejeitar"
+      },
+      "status": {
+        "approved": "Aprovado",
+        "rejected": "Rejeitado"
+      },
+      "submit": {
+        "errorFallback": "Falha ao enviar a decisão"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "Adicionar",
+        "createButton": "Criar",
+        "customApp": {
+          "description": "Credenciais e acesso de rede para sua própria integração.",
+          "title": "App personalizado"
+        },
+        "mcpHint": {
+          "label": "Precisa de um servidor MCP? Conecte-o em Ações e depois habilite-o para o Craft aqui.",
+          "openActionsButton": "Abrir Ações"
+        },
+        "modal": {
+          "description": "Disponibilize uma integração para toda a sua organização. Provedores integrados vêm com ações que ensinam o agente do Craft a usá-los; provedores já configurados não são listados.",
+          "title": "Adicionar um app"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "Associar {name}",
+        "associateButton": "Associar existente",
+        "create": {
+          "github": {
+            "description": "Se suas habilidades estão no GitHub, importe-as primeiro na página de Habilidades e depois associe-as a este app.",
+            "label": "Importar do GitHub"
+          },
+          "scratch": {
+            "description": "Escreva instruções e adicione arquivos de apoio.",
+            "label": "Começar do zero"
+          },
+          "upload": {
+            "description": "Importe um arquivo SKILL.md, um arquivo ZIP ou uma pasta de habilidade.",
+            "label": "Enviar uma habilidade"
+          }
+        },
+        "createSkillButton": "Criar habilidade",
+        "description": "As habilidades dão ao Craft instruções para usar este app. Elas valem para toda a organização; os usuários podem precisar habilitar todas para o app funcionar corretamente.",
+        "editButton": "Editar",
+        "empty": {
+          "label": "Nenhuma habilidade editável encontrada."
+        },
+        "invalidTag": "Inválida",
+        "loading": {
+          "label": "Carregando habilidades…"
+        },
+        "noneAssociated": {
+          "label": "Nenhuma habilidade associada ainda. Este app ainda pode ser salvo e usado sem uma."
+        },
+        "promote": {
+          "cancelButton": "Cancelar",
+          "confirmButton": "Disponibilizar para toda a organização",
+          "description": "Habilidades associadas a um app devem estar disponíveis para todos. Esta alteração é aplicada quando você salva o app.",
+          "title": "Tornar “{name}” disponível para toda a organização?"
+        },
+        "search": {
+          "placeholder": "Pesquisar habilidades editáveis..."
+        },
+        "title": "Habilidades associadas",
+        "unavailable": {
+          "duplicateName": "Uma habilidade chamada “{name}” já está associada.",
+          "invalid": "Habilidade inválida: corrija-a antes de associar.",
+          "otherApp": "Já associada ao app “{name}”."
+        },
+        "unlink": {
+          "button": "Desvincular",
+          "cancelButton": "Cancelar",
+          "confirm": "Desvincular “{name}” deste app?"
+        },
+        "unlinkAriaLabel": "Desvincular {name}",
+        "viewButton": "Visualizar"
+      },
+      "configureProvider": {
+        "addButton": "Adicionar",
+        "addTitle": "Adicionar {name}",
+        "editTitle": "Editar {name}",
+        "emptyPolicies": "Este provedor não tem ações para configurar.",
+        "fields": {
+          "name": {
+            "description": "Um rótulo para esta conexão. Use um nome distinto ao adicionar várias instâncias do mesmo provedor (ex.: \"{name} — Engenharia\").",
+            "label": "Nome"
+          }
+        },
+        "managedDescription": "Fornecido pela Onyx: configure o que o agente pode fazer.",
+        "managedNote": "Este app é fornecido pela Onyx: as credenciais são gerenciadas para você. Escolha abaixo o que o agente pode fazer. Os usuários o conectam pela página de Apps.",
+        "saveButton": "Salvar"
+      },
+      "customApp": {
+        "cancelButton": "Cancelar",
+        "createButton": "Criar",
+        "createDescription": "Configure como o proxy de saída acessa e autentica este app. Uma habilidade não é obrigatória.",
+        "createTitle": "Criar app personalizado",
+        "creatingButton": "Criando…",
+        "disabled": {
+          "nameMissing": "Digite um nome antes de criar este app personalizado.",
+          "patternMissing": "Adicione ao menos um padrão de URL de destino. Digite um padrão e pressione Enter.",
+          "pristine": "Faça uma alteração antes de salvar.",
+          "saving": "Um salvamento já está em andamento."
+        },
+        "editDescription": "Atualize as configurações do gateway e gerencie as habilidades associadas.",
+        "editTitle": "Editar {name}",
+        "errors": {
+          "saveFailedTitle": "Não foi possível salvar"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "Adicionar cabeçalho",
+            "description": "Opcional: cabeçalhos injetados nas solicitações de saída. Use '{placeholder}' para valores fornecidos pelo usuário (ou pela organização abaixo), ex.: \"Bearer '{api_key}'\". Deixe vazio para liberar os padrões de destino sem injetar credenciais.",
+            "keyTitle": "Cabeçalho",
+            "label": "Padrão de credenciais no cabeçalho",
+            "valueTitle": "Valor"
+          },
+          "name": {
+            "label": "Nome",
+            "placeholder": "Meu app personalizado"
+          },
+          "orgCredentials": {
+            "addButton": "Adicionar credencial",
+            "description": "Opcional: valores que sua organização preenche para todos os usuários. Deixe vazio para apps em que cada usuário fornece suas próprias credenciais.",
+            "keyTitle": "Chave da credencial",
+            "label": "Credenciais da organização",
+            "valueTitle": "Valor"
+          },
+          "upstreamPatterns": {
+            "description": "URLs de saída nas quais o proxy pode injetar credenciais. Use * para corresponder a quaisquer caracteres (ex.: https://api.example.com/* cobre todos os caminhos desse host). O host deve ser literal, sem curingas antes da primeira barra. Digite um padrão e pressione Enter.",
+            "label": "Padrões de URL de destino"
+          }
+        },
+        "saveButton": "Salvar",
+        "savingButton": "Salvando…"
+      },
+      "errors": {
+        "duplicateSkillName": "O app “{appName}” já tem uma habilidade associada chamada “{skillName}”. Envie uma habilidade com outro nome."
+      },
+      "mcpPolicy": {
+        "description": "Configure o que o agente do Craft pode fazer com as ferramentas deste servidor MCP.",
+        "emptyPolicies": "Nenhuma ferramenta habilitada neste servidor. Habilite as ferramentas primeiro na página de ações MCP.",
+        "saveButton": "Salvar",
+        "title": "Editar {name}"
+      },
+      "oauthCallback": {
+        "backButton": "Voltar para meus apps",
+        "description": "Concluindo o handshake OAuth…",
+        "errors": {
+          "cancelled": "O OAuth foi cancelado ou negado: {reason}",
+          "failed": "Falha na conexão.",
+          "missingParams": "Faltando code ou state na URL de retorno."
+        },
+        "exchanging": {
+          "label": "Trocando o código de autorização…"
+        },
+        "success": {
+          "label": "Conectado. Redirecionando de volta para seus apps…"
+        },
+        "title": "Conectando seu app"
+      },
+      "page": {
+        "connectButton": "Conectar",
+        "connectingButton": "Redirecionando…",
+        "disconnectButton": "Desconectar",
+        "empty": {
+          "description": "Nenhum app ou servidor MCP configurado para sua organização ainda.",
+          "title": "Nada para conectar ainda"
+        },
+        "errors": {
+          "disconnectFailed": "Falha ao desconectar",
+          "startAuthFailed": "Falha ao iniciar a autorização"
+        },
+        "header": {
+          "description": "Conecte as ferramentas que o Onyx Craft pode usar como contexto enquanto trabalha.",
+          "manageButton": "Gerenciar apps",
+          "searchPlaceholder": "Pesquisar apps...",
+          "title": "Apps"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Integrações que a Onyx suporta diretamente. Cada uma vem com habilidades que ensinam o Craft a usá-la: comece por aqui.",
+            "empty": "Nenhum app configurado para sua organização ainda.",
+            "emptyTitle": "Nenhum app ainda",
+            "tabLabel": "Apps · {count}"
+          },
+          "mcp": {
+            "blurb": "Servidores que um administrador disponibilizou para o Craft. Use-os quando o app de que você precisa não estiver listado em Apps, ou quando quiser especificamente as ferramentas MCP próprias de um servidor.",
+            "empty": "Nenhum servidor MCP foi disponibilizado para o Craft.",
+            "emptyTitle": "Nenhum servidor MCP ainda",
+            "tabLabel": "Servidores MCP · {count}"
+          }
+        },
+        "loading": {
+          "label": "Carregando…"
+        },
+        "reviewSkillsButton": "Revisar habilidades",
+        "search": {
+          "noMatchesDescription": "Nada aqui corresponde à sua pesquisa.",
+          "noMatchesTitle": "Nenhuma correspondência"
+        },
+        "status": {
+          "connected": "Conectado",
+          "connectedNeedsSkills": "Conectado · nem todas as habilidades associadas estão habilitadas",
+          "notAvailable": "Não disponível para sua conta: fale com um administrador",
+          "skillWarningAriaLabel": "Configuração de habilidades necessária",
+          "skillWarningTooltip": "Nem todas as habilidades associadas estão habilitadas. Este app pode não funcionar corretamente."
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "Defina uma política para cada ação individualmente.",
+          "title": "Avançado"
+        },
+        "cancelButton": "Cancelar",
+        "loading": {
+          "label": "Carregando…"
+        },
+        "permissions": {
+          "askOption": "Perguntar",
+          "autoApproveOption": "Aprovar automaticamente",
+          "customOption": "Personalizado",
+          "description": "Escolha o que o agente pode fazer. “Perguntar” consulta você no chat antes de cada ação; “Aprovar automaticamente” executa sem perguntar. Use Avançado para definir uma política por ação.",
+          "title": "Permissões"
+        },
+        "savingButton": "Salvando…"
+      },
+      "skillsStep": {
+        "description": "Opcional: associe habilidades existentes ou crie uma para este app.",
+        "errors": {
+          "saveFailedTitle": "Não foi possível salvar"
+        },
+        "saveButton": "Salvar habilidades",
+        "savingButton": "Salvando…",
+        "skipButton": "Pular por enquanto",
+        "title": "Adicionar habilidades a {name}"
+      },
+      "userCredentials": {
+        "cancelButton": "Cancelar",
+        "connectButton": "Conectar",
+        "connectingButton": "Conectando…",
+        "description": "Insira suas credenciais para autorizar este app na sua conta.",
+        "errors": {
+          "connectFailedTitle": "Não foi possível conectar"
+        },
+        "title": "Conectar {name}"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "Baixar"
+      },
+      "empty": {
+        "description": "Arquivos de saída e aplicativos web aparecerão aqui",
+        "title": "Ainda não há artefatos"
+      },
+      "nextjsApp": {
+        "label": "Aplicativo Next.js"
+      },
+      "openItem": {
+        "ariaLabel": "Abrir {name}"
+      },
+      "toggleItem": {
+        "ariaLabel": "Alternar {name}"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "Continue a conversa...",
+        "scheduledRunPlaceholder": "Execução agendada em andamento...",
+        "subagentPlaceholder": "Mude para o agente principal para enviar uma mensagem"
+      },
+      "openSidebar": {
+        "ariaLabel": "Abrir barra lateral"
+      },
+      "outputPanel": {
+        "closeTooltip": "Fechar painel de saída",
+        "openTooltip": "Abrir painel de saída"
+      },
+      "responseStopped": {
+        "label": "Resposta interrompida"
+      },
+      "scrollToBottom": {
+        "label": "Ir para o fim"
+      },
+      "toast": {
+        "operationWait": "Aguarde a conclusão da operação atual.",
+        "sandboxWait": "Aguarde a inicialização do sandbox",
+        "scheduledRunWait": "Aguarde a conclusão da execução agendada."
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "Contexto compactado para liberar espaço"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "Conecte seus dados"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "Criando seu espaço de trabalho...",
+        "enchanting": "Encantando com magia...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "Coletando recursos...",
+        "miningDependencies": "Minerando dependências...",
+        "placingBlocks": "Colocando blocos...",
+        "punchingWood": "Socando madeira...",
+        "smeltingCode": "Fundindo o código...",
+        "worldGenerated": "Geração do mundo concluída..."
+      },
+      "tagline": {
+        "label": "Criando sua próxima grande ideia..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "Limpar"
+      },
+      "copy": {
+        "doneTooltip": "Copiado",
+        "tooltip": "Copiar visível"
+      },
+      "empty": {
+        "noLines": "Ainda não há linhas.",
+        "noMatch": "Nenhuma linha corresponde a \"{filter}\"",
+        "waiting": "Aguardando a primeira linha de log…"
+      },
+      "error": {
+        "endpointDisabled": "Endpoint de depuração desativado (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "Nenhum sandbox em execução para ler logs"
+      },
+      "filter": {
+        "placeholder": "Filtrar…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# linha} other {# linhas}}",
+        "filteredCount": "{visible, number} / {total, number} linhas"
+      },
+      "modal": {
+        "description": "Acompanhamento ao vivo do contêiner sandbox — apenas dev/depuração.",
+        "title": "Logs do pod do Opencode"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} novas · ir"
+      },
+      "open": {
+        "button": "Logs do pod"
+      },
+      "status": {
+        "closed": "Fechado",
+        "connecting": "Conectando",
+        "error": "Erro",
+        "paused": "Pausado",
+        "streaming": "Transmitindo"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "Adicionar arquivos ou fotos"
+      },
+      "apps": {
+        "label": "Aplicativos"
+      },
+      "browseSkills": {
+        "label": "Explorar habilidades"
+      },
+      "connect": {
+        "hint": "Conectar"
+      },
+      "connectApp": {
+        "label": "Conectar um aplicativo"
+      },
+      "library": {
+        "label": "Biblioteca"
+      },
+      "manageLibrary": {
+        "label": "Gerenciar biblioteca…"
+      },
+      "mcpServer": {
+        "description": "Servidor MCP"
+      },
+      "skills": {
+        "label": "Habilidades"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "Não é possível visualizar o arquivo"
+      },
+      "error": {
+        "inline": "Erro: {message}",
+        "title": "Erro ao carregar o arquivo"
+      },
+      "loading": {
+        "label": "Carregando arquivo..."
+      },
+      "noContent": {
+        "label": "Sem conteúdo"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "Arquivos criados durante a construção aparecerão aqui",
+        "title": "Ainda não há arquivos"
+      },
+      "emptyDirectory": {
+        "label": "Não há arquivos neste diretório"
+      },
+      "error": {
+        "title": "Erro ao carregar os arquivos"
+      },
+      "loading": {
+        "label": "Carregando arquivos..."
+      },
+      "loadingChildren": {
+        "label": "Carregando..."
+      },
+      "preparing": {
+        "description": "Configurando seu ambiente de desenvolvimento",
+        "title": "Preparando sandbox..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "Não foi possível exibir a imagem",
+        "title": "Falha ao carregar a imagem"
+      },
+      "loading": {
+        "label": "Carregando imagem..."
+      },
+      "preview": {
+        "ariaLabel": "Pré-visualização de {name}"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "Conectado",
+        "connectionRequired": "Conexão necessária"
+      },
+      "plusMenu": {
+        "tooltip": "Adicionar arquivos ou habilidades"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "Parando…"
+      },
+      "toInterrupt": {
+        "label": "para interromper"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "Voltar ao início"
+      },
+      "startCrafting": {
+        "button": "Começar a criar"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "Nenhum modelo encontrado"
+      },
+      "recommended": {
+        "label": "Recomendado"
+      },
+      "recommendedOnly": {
+        "label": "Apenas modelos recomendados"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "“Corrija o teste de retry instável e abra um PR.”",
+          "launchDeck": "“Monte a apresentação do lançamento de primavera a partir do briefing no Drive.”",
+          "rfpSecurity": "“Preencha a RFP no meu e-mail com nossos detalhes de segurança.”",
+          "slackToLinear": "“Condense nossa discussão do Slack em tickets do Linear.”",
+          "vendorSpend": "“Resuma nossos gastos com fornecedores do 2º trimestre em um documento no Drive.”"
+        },
+        "modal": {
+          "backButton": "Voltar",
+          "ctaButton": "Coloque o Craft para trabalhar",
+          "nextButton": "Avançar",
+          "title": "Conheça o Craft"
+        },
+        "outputs": {
+          "ariaLabel": "Resultado: {name}",
+          "githubPr": {
+            "caption": "Aberto para revisão",
+            "label": "PR no GitHub"
+          },
+          "googleDoc": {
+            "caption": "Salvo no seu Drive",
+            "label": "Documento Google"
+          },
+          "liveApp": {
+            "caption": "Hospedado, compartilhe por link",
+            "label": "App ao vivo"
+          }
+        },
+        "prompt": {
+          "label": "Seu prompt"
+        },
+        "schedule": {
+          "ariaLabel": "Tarefa agendada: executa este prompt novamente em um cronograma",
+          "caption": "Executa enquanto você está fora",
+          "label": "Toda segunda-feira, 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "Fonte conectada: {name}",
+          "yourFiles": {
+            "ariaLabel": "Seus arquivos enviados",
+            "label": "Seus arquivos"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "Clique em qualquer parte do mapa para revisitá-la.",
+            "title": "Esse é o Craft. Sua vez."
+          },
+          "machine": {
+            "caption": "Lê o que você pode ver. Nunca seus segredos.",
+            "title": "Ele trabalha em sua própria máquina."
+          },
+          "output": {
+            "caption": "Sob demanda, ou de forma agendada enquanto você está fora.",
+            "title": "O trabalho sai pronto."
+          },
+          "prompt": {
+            "caption": "Descreva o resultado, o Craft faz o resto.",
+            "title": "Dê ao Craft trabalho de verdade."
+          }
+        },
+        "team": {
+          "ariaLabel": "Sua equipe: um único link compartilha o trabalho do Craft",
+          "caption": "Um link compartilha tudo",
+          "label": "Sua equipe"
+        },
+        "workspace": {
+          "approvalPill": "Aguardando sua aprovação",
+          "label": "Espaço de trabalho do Craft",
+          "sandboxBadge": "Sandbox isolado"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "Voltar ao chat",
+        "description": "O Onyx Craft precisa de um provedor de modelos e somente administradores podem configurá-lo. Peça ao seu administrador para conectar Anthropic, OpenAI ou OpenRouter.",
+        "title": "É necessário um provedor de LLM"
+      },
+      "llmSetup": {
+        "description": "Os agentes do Craft precisam de um provedor de modelos para construir.",
+        "title": "Conecte um provedor de modelos"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "Analise meus dados e crie um painel..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "Engenharia",
+          "marketing": "Marketing",
+          "product": "Produto",
+          "sales": "Vendas"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "Comece a construir algo para ver artefatos!"
+      },
+      "devServerStarting": {
+        "tooltip": "Iniciando o servidor de desenvolvimento..."
+      },
+      "noWebapp": {
+        "label": "Ainda não há aplicativo web nesta sessão"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "Não foi possível carregar o arquivo PDF.",
+        "title": "Não é possível visualizar o PDF"
+      },
+      "frame": {
+        "title": "Pré-visualização de PDF"
+      },
+      "loading": {
+        "label": "Carregando PDF..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "Convertendo apresentação..."
+      },
+      "empty": {
+        "label": "Esta apresentação não tem slides"
+      },
+      "error": {
+        "title": "Não é possível visualizar a apresentação"
+      },
+      "loadingSlide": {
+        "label": "Carregando slide..."
+      },
+      "slide": {
+        "counter": "Slide {current} de {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "Uma pré-visualização ao vivo aparecerá aqui quando um aplicativo web estiver em execução."
+      },
+      "frame": {
+        "title": "Pré-visualização do aplicativo web"
+      },
+      "starting": {
+        "description": "Instalando dependências e inicializando.",
+        "title": "Iniciando o servidor de desenvolvimento..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "Redirecionando..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "Dispensar"
+      },
+      "modal": {
+        "description": "Ele adormeceu após um período de inatividade. Seu trabalho está salvo. Acorde-o para continuar.",
+        "title": "Seu sandbox adormeceu"
+      },
+      "wake": {
+        "button": "Acordar sandbox"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "Agendada"
+      },
+      "startedAt": {
+        "label": "Iniciada {time}"
+      },
+      "status": {
+        "awaitingApproval": "Esta execução agendada aguarda aprovação. As mensagens de acompanhamento serão desbloqueadas depois que ela for retomada e concluída.",
+        "running": "Esta execução agendada ainda está em andamento. As mensagens de acompanhamento serão desbloqueadas quando ela terminar.",
+        "startedBy": "Esta sessão foi iniciada pela tarefa agendada {task} às {time}."
+      },
+      "viewTask": {
+        "ariaLabel": "Ver a tarefa agendada {task}. {status}",
+        "label": "Ver tarefa"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "Aplicativo externo {id}"
+      },
+      "connect": {
+        "title": "Conectar {app}"
+      },
+      "connected": {
+        "title": "{app} conectado."
+      },
+      "error": {
+        "generic": "Algo deu errado. Tente novamente.",
+        "notConfigurable": "Este aplicativo não pode ser configurado a partir daqui.",
+        "popupBlocked": "Não foi possível abrir a janela de configuração. Permita pop-ups e tente novamente.",
+        "startFailed": "Falha ao iniciar a configuração"
+      },
+      "loading": {
+        "button": "Carregando…"
+      },
+      "notNow": {
+        "button": "Agora não"
+      },
+      "reason": {
+        "fallback": "O agente precisa de {app} para continuar esta tarefa."
+      },
+      "skipped": {
+        "title": "A conexão de {app} foi ignorada."
+      },
+      "waiting": {
+        "button": "Aguardando…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "Copiar link"
+      },
+      "organization": {
+        "description": "Qualquer pessoa conectada ao seu Onyx pode ver este aplicativo.",
+        "label": "Organização"
+      },
+      "private": {
+        "description": "Somente você pode ver este aplicativo.",
+        "label": "Privado"
+      },
+      "share": {
+        "label": "Compartilhar"
+      },
+      "shared": {
+        "label": "Compartilhado"
+      },
+      "trigger": {
+        "ariaLabel": "Compartilhar aplicativo web"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "Aplicativos"
+      },
+      "backToChat": {
+        "label": "Voltar ao chat"
+      },
+      "delete": {
+        "label": "Excluir"
+      },
+      "deleteModal": {
+        "body": "Isso remove permanentemente a sessão do Craft e todos os seus dados. Esta ação não pode ser desfeita.",
+        "confirm": "Excluir",
+        "deleting": "Excluindo...",
+        "title": "Excluir \"{title}\"?"
+      },
+      "newSession": {
+        "label": "Começar a criar"
+      },
+      "rename": {
+        "label": "Renomear"
+      },
+      "scheduledTasks": {
+        "label": "Tarefas agendadas"
+      },
+      "sessions": {
+        "empty": "Comece a construir! O histórico de sessões aparecerá aqui.",
+        "title": "Sessões"
+      },
+      "skills": {
+        "label": "Habilidades"
+      },
+      "toast": {
+        "deleteFailed": "Falha ao excluir a sessão",
+        "deleted": "\"{title}\" foi excluído."
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "Recarregue esta sessão para aplicar as habilidades e os acessos a aplicativos mais recentes.",
+        "title": "As capacidades do seu agente mudaram"
+      },
+      "reload": {
+        "button": "Recarregar",
+        "inProgress": "Recarregando…"
+      },
+      "toast": {
+        "reloadFailed": "Falha ao recarregar a sessão"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "Subagente não encontrado."
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "Fechar sugestões"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "Excluir",
+          "deletingButton": "Excluindo...",
+          "description": "Isso interrompe execuções futuras e remove a tarefa. O histórico de execuções passadas (e as sessões subjacentes) será preservado para auditoria.",
+          "title": "Excluir \"{name}\"?"
+        },
+        "deleteButton": "Excluir",
+        "editButton": "Editar",
+        "fallbackTitle": "Tarefa agendada",
+        "loadFailed": "Falha ao carregar a tarefa agendada.",
+        "missingTaskId": "Faltando o id da tarefa.",
+        "pauseButton": "Pausar",
+        "resumeButton": "Retomar",
+        "runNowButton": "Executar agora",
+        "toasts": {
+          "deleteFailed": "Falha ao excluir a tarefa",
+          "deleted": "\"{name}\" excluída.",
+          "paused": "Tarefa pausada.",
+          "resumed": "Tarefa retomada.",
+          "runQueued": "Execução de \"{name}\" enfileirada.",
+          "runStartFailed": "Falha ao iniciar a execução",
+          "statusUpdateFailed": "Falha ao atualizar o status"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "Editar tarefa agendada",
+        "loadFailed": "Falha ao carregar a tarefa agendada.",
+        "missingTaskId": "Faltando o id da tarefa.",
+        "title": "Editar \"{name}\""
+      },
+      "form": {
+        "cancelButton": "Cancelar",
+        "errors": {
+          "nameRequired": "O nome é obrigatório.",
+          "promptRequired": "O prompt é obrigatório."
+        },
+        "fields": {
+          "name": {
+            "label": "Nome",
+            "placeholder": "ex.: Resumo semanal de escalonamentos de clientes"
+          },
+          "preApproval": {
+            "description": "O Craft pode usar os apps e servidores MCP selecionados sem pausar quando esta tarefa é executada sem supervisão. Outras solicitações de aprovação pausam a execução e podem fazê-la falhar.",
+            "label": "Apps e servidores MCP pré-aprovados"
+          },
+          "prompt": {
+            "description": "Esta mensagem é enviada ao Craft cada vez que a tarefa dispara.",
+            "label": "Prompt",
+            "placeholder": "Descreva o que o Craft deve fazer em cada execução..."
+          },
+          "schedule": {
+            "label": "Agendamento"
+          }
+        },
+        "saveAndRunNowButton": "Salvar e executar agora",
+        "saveButton": "Salvar",
+        "saveChangesButton": "Salvar alterações",
+        "savingLabel": "Salvando...",
+        "toasts": {
+          "created": "Tarefa agendada criada.",
+          "createdAndQueued": "Tarefa agendada criada e enfileirada.",
+          "saveFailed": "Falha ao salvar a tarefa agendada",
+          "updated": "Tarefa agendada atualizada."
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "Última execução",
+          "name": "Nome",
+          "nextRun": "Próxima execução",
+          "schedule": "Agendamento",
+          "status": "Status"
+        },
+        "confirmDelete": {
+          "deleteButton": "Excluir",
+          "deletingButton": "Excluindo...",
+          "description": "Isso interrompe execuções futuras e remove a tarefa. O histórico de execuções passadas (e as sessões subjacentes) será preservado para auditoria.",
+          "title": "Excluir \"{name}\"?"
+        },
+        "empty": {
+          "description": "Nenhuma tarefa agendada foi criada ainda.",
+          "title": "Nenhuma tarefa agendada encontrada"
+        },
+        "errors": {
+          "loadFailed": "Falha ao carregar as tarefas agendadas.",
+          "tryAgainButton": "Tentar novamente"
+        },
+        "header": {
+          "description": "Execute prompts do Craft em um cronograma. Cada disparo cria uma nova sessão que roda em segundo plano.",
+          "title": "Tarefas agendadas"
+        },
+        "newTaskButton": "Nova tarefa agendada",
+        "rowActions": {
+          "deleteTooltip": "Excluir"
+        },
+        "toasts": {
+          "deleteFailed": "Falha ao excluir a tarefa",
+          "deleted": "\"{name}\" excluída."
+        }
+      },
+      "newPage": {
+        "description": "Salve um prompt + agendamento. O Craft o executará em um cronograma.",
+        "title": "Nova tarefa agendada"
+      },
+      "preApproval": {
+        "appFallbackName": "App nº {id}",
+        "appsGroupTitle": "Apps",
+        "empty": {
+          "label": "Nenhum app ou servidor MCP disponível no Craft ainda."
+        },
+        "errors": {
+          "loadFailed": "Não foi possível carregar os apps e servidores MCP. Atualize para tentar novamente.",
+          "partialLoadFailed": "Algumas opções de pré-aprovação não puderam ser carregadas. Atualize para tentar novamente."
+        },
+        "loading": {
+          "label": "Carregando apps e servidores MCP…"
+        },
+        "mcpGroupTitle": "Servidores MCP",
+        "mcpServerFallbackName": "Servidor MCP nº {id}",
+        "status": {
+          "connected": "Conectado",
+          "connectionRequired": "Conexão necessária",
+          "unavailable": "Não está mais disponível"
+        },
+        "summary": {
+          "partialLoadFailed": "Alguns detalhes de pré-aprovação não puderam ser carregados. Atualize para tentar novamente.",
+          "title": "Apps e servidores MCP pré-aprovados"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "Duração",
+          "started": "Início",
+          "status": "Status",
+          "summary": "Resumo",
+          "trigger": "Gatilho"
+        },
+        "empty": {
+          "label": "Nenhuma execução ainda. A tarefa criará uma cada vez que disparar, ou use Executar agora acima."
+        },
+        "errors": {
+          "loadFailed": "Falha ao carregar o histórico de execuções.",
+          "tryAgainButton": "Tentar novamente"
+        },
+        "loadMore": {
+          "button": "Carregar mais",
+          "loadingButton": "Carregando..."
+        },
+        "nonClickable": {
+          "noSession": "Esta execução ainda não criou uma sessão.",
+          "queued": "Esta execução ainda não começou, então não há sessão para abrir.",
+          "skipped": "Esta execução foi ignorada porque uma anterior ainda estava em andamento, então nenhuma sessão foi criada."
+        },
+        "status": {
+          "notOpenableAriaLabel": "Não pode ser aberto"
+        },
+        "trigger": {
+          "runNow": "Executar agora",
+          "schedule": "Agendamento"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "Às",
+          "daysLabel": "Nestes dias",
+          "runsEveryDay": "Executa todos os dias",
+          "runsOn": "Executa em {days}"
+        },
+        "interval": {
+          "everyLabel": "A cada"
+        },
+        "intervalUnits": {
+          "days": "dias",
+          "hours": "horas",
+          "minutes": "minutos"
+        },
+        "tabs": {
+          "dailyWeekly": "Diário / Semanal",
+          "interval": "Intervalo"
+        },
+        "weekdays": {
+          "fri": "Sex",
+          "mon": "Seg",
+          "sat": "Sáb",
+          "sun": "Dom",
+          "thu": "Qui",
+          "tue": "Ter",
+          "wed": "Qua"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "Sem tarefas"
+      },
+      "header": {
+        "title": "Tarefas"
+      },
+      "progress": {
+        "label": "{completed}/{total} concluídas"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "Sem saída"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# linha inalterada} other {# linhas inalteradas}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "Mudar para lado a lado",
+          "unifiedTooltip": "Mudar para vista unificada"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "Ainda sem saída..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# chamada} other {# chamadas}}"
+        },
+        "failed": {
+          "tag": "{count} com falha"
+        },
+        "working": {
+          "label": "Trabalhando"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "(arquivo vazio)"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {mais # linha} other {mais # linhas}}"
+        },
+        "showAll": {
+          "button": "Mostrar tudo"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "Nenhuma correspondência"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "Arquivo muito grande ({size}). O máximo é {max}.",
+        "network": "Erro de rede",
+        "notFound": "Recurso não encontrado",
+        "server": "Erro do servidor",
+        "sessionExpired": "A sessão expirou",
+        "tooManyFiles": "Arquivos demais. O máximo é {max} arquivos por sessão.",
+        "totalSizeExceeded": "O tamanho total excede o limite. O máximo é {max} por sessão.",
+        "uploadFailed": "Falha no envio"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "Voltar"
+      },
+      "copyUrl": {
+        "ariaLabel": "Copiar URL: {url}"
+      },
+      "downloadFile": {
+        "tooltip": "Baixar arquivo"
+      },
+      "export": {
+        "button": "Exportar para .docx",
+        "inProgress": "Exportando..."
+      },
+      "forward": {
+        "ariaLabel": "Avançar"
+      },
+      "openInNewTab": {
+        "tooltip": "abrir em uma nova aba"
+      },
+      "refresh": {
+        "ariaLabel": "Atualizar"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "excluir",
+        "button": "Excluir",
+        "entityTypeFile": "arquivo",
+        "entityTypeFolder": "pasta",
+        "fileDetails": "Este arquivo será removido da sua biblioteca.",
+        "folderDetails": "Isso excluirá a pasta e todo o seu conteúdo."
+      },
+      "dropzone": {
+        "formats": "Excel, Word, PowerPoint, PDF ou ZIP",
+        "title": "Arraste arquivos até aqui ou clique para enviar"
+      },
+      "errors": {
+        "createFolderFailed": "Falha ao criar a pasta",
+        "deleteFailed": "Falha ao excluir",
+        "loadFailed": "Falha ao carregar os arquivos",
+        "uploadFailed": "Falha no envio"
+      },
+      "loading": {
+        "label": "Carregando arquivos…"
+      },
+      "modal": {
+        "description": "Arquivos que seu agente pode ler em todas as sessões.",
+        "doneButton": "Concluído",
+        "title": "Biblioteca"
+      },
+      "newFolder": {
+        "cancelButton": "Cancelar",
+        "createButton": "Criar",
+        "label": "Nova pasta",
+        "nameLabel": "Nome da pasta",
+        "namePlaceholder": "Digite o nome da pasta"
+      },
+      "search": {
+        "noResults": "Nenhum arquivo corresponde à sua pesquisa",
+        "placeholder": "Pesquisar arquivos..."
+      },
+      "tree": {
+        "collapseTooltip": "Recolher",
+        "deleteTooltip": "Excluir",
+        "expandTooltip": "Expandir",
+        "toggleAriaLabel": "Alternar {name}",
+        "uploadToFolderTooltip": "Enviar para esta pasta"
+      },
+      "upload": {
+        "button": "Enviar",
+        "dropOverlay": "Solte os arquivos para enviar",
+        "uploadingButton": "Enviando…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "Analise meus dados e crie um painel..."
       }
     }
   },
@@ -8825,6 +12553,13 @@
           "networkError": "Ocorreu um erro ao alterar a senha",
           "updateFailed": "Falha ao alterar a senha",
           "updated": "Senha atualizada com sucesso"
+        },
+        "validation": {
+          "confirmRequired": "Confirme sua nova senha",
+          "currentRequired": "A senha atual é obrigatória",
+          "minLength": "A senha deve ter pelo menos {min} caracteres",
+          "mismatch": "As senhas não coincidem",
+          "newRequired": "A nova senha é obrigatória"
         }
       },
       "title": "Contas"
@@ -8866,6 +12601,7 @@
         "empty": "Nenhum token de acesso criado.",
         "expiresIn": "{count, plural, one {Expira em # dia} other {Expira em # dias}}",
         "loading": "Carregando tokens...",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "Nunca expira",
         "newTokenButton": "Novo token de acesso",
         "noPermissionTooltip": "Você não tem permissão para criar tokens de acesso",
@@ -9012,6 +12748,10 @@
       },
       "description": "Conecte ferramentas externas aos modelos disponíveis para você no Onyx.",
       "guideButton": "Guia",
+      "loadError": {
+        "description": "Atualize a página e tente novamente.",
+        "title": "Não foi possível carregar o LLM Gateway"
+      },
       "models": {
         "description": "{count, plural, one {# modelo está disponível para sua conta. Abra um provedor para copiar um ID.} other {# modelos estão disponíveis para sua conta. Abra um provedor para copiar um ID.}}",
         "title": "Modelos"
@@ -9064,14 +12804,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "Adicionar linha",
+        "maxReached": "Máximo de {count} memórias atingido"
+      },
       "empty": {
-        "description": "Adicione uma nota pessoal ou memória que o Onyx deve lembrar."
+        "description": "Adicione uma nota pessoal ou memória que o Onyx deve lembrar.",
+        "getStarted": "Ainda não há memórias. Clique em \"Adicionar linha\" para começar.",
+        "noMatches": "Nenhuma memória corresponde à sua pesquisa."
+      },
+      "item": {
+        "placeholder": "Digite ou cole uma nota ou memória pessoal"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {Linha} other {Linhas}}"
+      },
+      "modal": {
+        "description": "Permita que o Onyx faça referência a estas notas e memórias armazenadas nos chats.",
+        "searchPlaceholder": "Pesquisar..."
       },
       "referenceStoredMemories": {
         "description": "Permita que o Onyx faça referência a memórias armazenadas nos chats.",
         "title": "Referenciar memórias armazenadas"
       },
+      "removeLineButton": {
+        "label": "Remover linha"
+      },
       "title": "Memória",
+      "toasts": {
+        "saveFailed": "Falha ao salvar as preferências",
+        "saved": "Preferências salvas"
+      },
       "updateMemories": {
         "description": "Permita que o Onyx gere e atualize memórias armazenadas.",
         "title": "Atualizar memórias"
@@ -9491,6 +13254,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "O aplicativo “{appName}” já tem uma habilidade associada chamada “{skillName}”.",
+        "title": "Escolha outro nome para a habilidade"
+      },
+      "confirmUpload": {
+        "importBody": "Este envio inclui SKILL.md. Continuar substituirá o nome, a descrição, as instruções e os arquivos atuais pelo pacote enviado.",
+        "importSubmit": {
+          "label": "Importar habilidade"
+        },
+        "importTitle": "Importar esta habilidade?",
+        "replaceBody": "Este envio deve usar o mesmo nome de habilidade. Continuar substituirá a descrição, as instruções e os arquivos pelo pacote enviado.",
+        "replaceSubmit": {
+          "label": "Substituir conteúdo"
+        },
+        "replaceTitle": "Substituir o conteúdo da habilidade?"
+      },
+      "delete": {
+        "button": {
+          "label": "Excluir habilidade"
+        },
+        "description": "Qualquer pessoa que use esta habilidade perderá o acesso. A exclusão não pode ser desfeita.",
+        "title": "Excluir esta habilidade"
+      },
+      "deleteModal": {
+        "entityType": "habilidade",
+        "label": "Excluir",
+        "pendingLabel": "Excluindo..."
+      },
+      "details": {
+        "description": "Defina quando e como o Craft deve usar esta habilidade.",
+        "descriptionField": {
+          "description": "Descreva quando esta habilidade deve ser usada.",
+          "placeholder": "Com o que esta habilidade ajuda?",
+          "title": "Descrição"
+        },
+        "name": {
+          "createDescription": "Use letras minúsculas, números e hifens simples.",
+          "lockedDescription": "Os nomes das habilidades não podem ser alterados após a criação.",
+          "placeholder": "Dê um nome à sua habilidade",
+          "title": "Nome"
+        },
+        "title": "Detalhes"
+      },
+      "files": {
+        "busyLabel": "Enviando...",
+        "description": "Adicione referências, scripts, recursos ou outros arquivos usados por esta habilidade. Arquivos ZIP são descompactados automaticamente.",
+        "input": {
+          "ariaLabel": "Adicionar arquivos de apoio"
+        },
+        "pendingUpload": {
+          "emptyMessage": "Os arquivos deste envio aparecerão depois que você criar a habilidade."
+        },
+        "title": "Arquivos de apoio"
+      },
+      "filesTooltip": {
+        "noPermission": "Você não tem permissão para atualizar os arquivos desta habilidade.",
+        "saveFirst": "Salve as alterações dos detalhes antes de atualizar os arquivos da habilidade.",
+        "updating": "Atualizando os arquivos da habilidade..."
+      },
+      "header": {
+        "appFallbackName": "Aplicativo externo",
+        "cancel": {
+          "label": "Cancelar"
+        },
+        "createDescription": "Crie uma habilidade pessoal",
+        "createForAppDescription": "Adicione uma habilidade da organização ao aplicativo “{appName}”",
+        "createTitle": "Criar habilidade",
+        "editDescription": "Atualize os detalhes e arquivos da habilidade",
+        "editTitle": "Editar habilidade",
+        "save": {
+          "label": "Salvar",
+          "pendingLabel": "Salvando..."
+        }
+      },
+      "import": {
+        "busyLabel": "Importando...",
+        "button": {
+          "label": "Importar habilidade"
+        },
+        "description": "Importe um SKILL.md, um ZIP ou uma pasta de habilidade para preencher o formulário e incluir seus arquivos.",
+        "input": {
+          "ariaLabel": "Importar habilidade existente"
+        },
+        "prompt": "Escolha um SKILL.md ou ZIP, ou solte uma pasta de habilidade aqui.",
+        "title": "Já tem uma habilidade?"
+      },
+      "instructions": {
+        "description": "Escreva o comportamento e o fluxo de trabalho que esta habilidade adiciona ao Craft.",
+        "emptyFallback": "Ainda não há instruções.",
+        "placeholder": "Escreva as instruções da habilidade.",
+        "title": "Instruções"
+      },
+      "loadError": {
+        "description": "Esta habilidade pode não existir, ser integrada ou não ser editável pela sua conta.",
+        "title": "Habilidade indisponível"
+      },
+      "management": {
+        "description": "Controle quem pode usar esta habilidade.",
+        "externalApp": {
+          "manage": {
+            "label": "Gerenciar nas configurações do aplicativo"
+          },
+          "readyDescription": "Esta habilidade usa o aplicativo “{appName}”.",
+          "title": "Aplicativo externo"
+        },
+        "sharing": {
+          "edit": {
+            "label": "Editar compartilhamento"
+          },
+          "title": "Compartilhamento"
+        },
+        "title": "Gerenciamento"
+      },
+      "saveTooltip": {
+        "missingDescription": "Adicione uma descrição antes de salvar.",
+        "missingInstructions": "Adicione instruções antes de salvar.",
+        "missingName": "Adicione um nome antes de salvar.",
+        "noChanges": "Nenhuma alteração foi feita.",
+        "noPermission": "Você não tem permissão para editar os detalhes desta habilidade.",
+        "savingChanges": "Salvando as alterações...",
+        "savingSkill": "Salvando a habilidade..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "Todos na sua organização podem usar e editar esta habilidade.",
+          "title": "Organização",
+          "viewerDescription": "Todos na sua organização podem usar esta habilidade."
+        },
+        "personal": {
+          "description": "Apenas você pode usar esta habilidade.",
+          "title": "Pessoal"
+        },
+        "shares": {
+          "description": "Apenas usuários e grupos selecionados podem usar esta habilidade.",
+          "title": "{count, plural, one {# compartilhamento} other {# compartilhamentos}}"
+        }
+      },
+      "toasts": {
+        "created": "\"{name}\" criada",
+        "deleteFailed": "Falha ao excluir a habilidade",
+        "deleted": "\"{name}\" excluída",
+        "fileRemoveFailed": "Falha ao remover o arquivo da habilidade",
+        "fileRemoved": "\"{path}\" removido",
+        "filesUpdateFailed": "Falha ao atualizar os arquivos da habilidade",
+        "filesUpdated": "Arquivos de \"{name}\" atualizados",
+        "importMissingSkillMd": "Importe um SKILL.md, um ZIP ou uma pasta contendo SKILL.md.",
+        "inspectFailed": "Falha ao inspecionar o pacote da habilidade",
+        "saveFailed": "Falha ao salvar a habilidade",
+        "saved": "\"{name}\" salva"
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9691,6 +13606,76 @@
         "transferredToast": {
           "message": "Propriedade transferida."
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "Explorar habilidades"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {Habilidade} other {Habilidades}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "Importe uma ou mais habilidades de um repositório.",
+          "title": "Importar do GitHub"
+        },
+        "scratch": {
+          "description": "Escreva as instruções e adicione arquivos de apoio no Onyx.",
+          "title": "Começar do zero"
+        },
+        "trigger": {
+          "label": "Criar habilidade"
+        },
+        "upload": {
+          "description": "Importe um arquivo SKILL.md, um arquivo ZIP ou uma pasta de habilidade.",
+          "title": "Enviar uma habilidade"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "Tente uma pesquisa diferente.",
+          "title": "Nenhuma habilidade correspondente"
+        },
+        "noSkills": {
+          "description": "Nenhuma habilidade personalizada foi compartilhada com você ainda e nenhuma habilidade integrada está configurada.",
+          "title": "Nenhuma habilidade disponível"
+        }
+      },
+      "focusedApp": {
+        "description": "Ative todas as habilidades associadas ao aplicativo “{appName}”. O aplicativo pode não funcionar corretamente sem elas. Se outra habilidade com o mesmo nome estiver ativada, ativar a habilidade associada ao aplicativo desativará a outra habilidade para você.",
+        "showAll": {
+          "label": "Mostrar todas as habilidades"
+        },
+        "title": "Habilidades para o aplicativo “{appName}”"
+      },
+      "header": {
+        "description": "Pacotes de capacidades que seu agente do Craft pode usar. Esta página mostra habilidades integradas, habilidades compartilhadas com você e suas habilidades pessoais.",
+        "title": "Habilidades"
+      },
+      "loadError": {
+        "description": "Verifique o console para mais detalhes e tente atualizar a página.",
+        "title": "Falha ao carregar as habilidades"
+      },
+      "preview": {
+        "unavailableFallback": "Esta habilidade está indisponível no momento."
+      },
+      "search": {
+        "placeholder": "Pesquisar habilidades..."
+      },
+      "switchModal": {
+        "body": "Continuar desativará a habilidade atualmente ativada e ativará esta.",
+        "description": "Apenas uma habilidade chamada “{name}” pode estar ativada por vez.",
+        "submit": {
+          "label": "Trocar habilidade",
+          "pendingLabel": "Trocando..."
+        },
+        "title": "Trocar a habilidade “{name}”?"
+      },
+      "toasts": {
+        "disableFailed": "Falha ao desativar {name}",
+        "enableFailed": "Falha ao ativar {name}",
+        "refreshFailed": "{name} foi atualizada, mas não foi possível atualizar a lista de habilidades."
       }
     },
     "sections": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -5765,6 +5765,27 @@
         "unexpectedError": "Ocorreu um erro inesperado."
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "Cancelado",
+        "completedWithErrors": "Concluído com erros",
+        "deleting": "Excluindo",
+        "error": "Erro",
+        "failed": "Falhou",
+        "inProgress": "Em andamento",
+        "indexed": "Indexado",
+        "indexing": "Indexando",
+        "initialIndexing": "Indexação inicial",
+        "interrupted": "Interrompido",
+        "invalid": "Inválido",
+        "invalidConnectorTooltip": "O conector está em um estado inválido. Atualize as credenciais ou crie um novo conector.",
+        "none": "Nenhum",
+        "notStarted": "Não iniciado",
+        "paused": "Pausado",
+        "scheduled": "Agendado",
+        "succeeded": "Bem-sucedido"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "Versão do backend: "
@@ -7204,6 +7225,70 @@
       },
       "sourcesModal": {
         "title": "Fontes"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "Excluir"
+      },
+      "deleteModal": {
+        "description": "Tem certeza de que deseja excluir este chat? Esta ação não pode ser desfeita.",
+        "submitButton": {
+          "label": "Excluir"
+        },
+        "title": "Excluir chat"
+      },
+      "exportAs": {
+        "label": "Exportar como…"
+      },
+      "exportFailed": {
+        "message": "Falha ao exportar o chat. Tente novamente."
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "Texto simples"
+      },
+      "fullWidth": {
+        "ariaLabel": "Alternar chat de largura total",
+        "fitTooltip": "Ajustar largura",
+        "fullTooltip": "Largura total"
+      },
+      "incognitoExit": {
+        "ariaLabel": "Sair do chat anônimo",
+        "tooltip": "Sair do chat anônimo"
+      },
+      "incognitoPill": {
+        "ariaLabel": "Chat anônimo",
+        "label": "Chat anônimo"
+      },
+      "incognitoStart": {
+        "ariaLabel": "Iniciar chat anônimo",
+        "lockedTooltip": "O modo anônimo só pode ser definido antes do início do chat",
+        "tooltip": "Chat anônimo"
+      },
+      "mode": {
+        "chat": {
+          "description": "Conversa e pesquisa",
+          "label": "Chat"
+        },
+        "search": {
+          "description": "Pesquisa rápida de documentos",
+          "label": "Pesquisa"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "Alterar modo do aplicativo"
+      },
+      "moveToProject": {
+        "label": "Mover para projeto"
+      },
+      "openSidebar": {
+        "ariaLabel": "Abrir barra lateral"
+      },
+      "share": {
+        "label": "Compartilhar"
       }
     },
     "banners": {
@@ -8950,6 +9035,34 @@
         "updateFailed": "Não foi possível atualizar a preferência de idioma"
       }
     },
+    "layout": {
+      "header": {
+        "title": "Configurações"
+      },
+      "sectionSelect": {
+        "placeholder": "Selecione uma seção"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "Contas e acesso"
+        },
+        "chatPreferences": {
+          "label": "Preferências de chat"
+        },
+        "connectors": {
+          "label": "Conectores"
+        },
+        "general": {
+          "label": "Geral"
+        },
+        "llmGateway": {
+          "label": "Gateway LLM"
+        },
+        "usage": {
+          "label": "Uso"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "Adicione uma nota pessoal ou memória que o Onyx deve lembrar."
@@ -9010,6 +9123,47 @@
       "toggle": {
         "description": "Ative os atalhos para inserir rapidamente prompts comuns.",
         "title": "Usar atalhos de prompt"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "Limite de {amount}",
+        "none": "Nenhum orçamento definido",
+        "remaining": "{amount} restante",
+        "resetsOn": "Redefine em {date}",
+        "title": "Orçamento"
+      },
+      "empty": {
+        "description": "O uso e os custos dos seus modelos aparecerão aqui quando você começar a conversar.",
+        "title": "Nenhum uso registrado ainda"
+      },
+      "header": {
+        "title": "Uso"
+      },
+      "loadError": {
+        "description": "Algo deu errado ao buscar seu uso. Tente novamente em instantes.",
+        "title": "Não foi possível carregar o uso"
+      },
+      "modelPrices": {
+        "description": "USD por 1M de tokens (entrada · saída · cache) para cada modelo disponível",
+        "title": "Preços dos modelos",
+        "unavailable": "Preços indisponíveis"
+      },
+      "showFewerModels": {
+        "ariaLabel": "Mostrar menos modelos"
+      },
+      "showLess": {
+        "label": "Mostrar menos"
+      },
+      "showMore": {
+        "label": "Mostrar mais {count}"
+      },
+      "showMoreModels": {
+        "ariaLabel": "Mostrar mais {count} modelos"
+      },
+      "usageThisPeriod": {
+        "description": "{amount} gasto",
+        "title": "Uso neste período"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -60,6 +60,26 @@
         "ariaLabel": "{title} 操作卡片"
       }
     },
+    "actionLineItem": {
+      "addConnectors": {
+        "label": "添加连接器"
+      },
+      "configure": {
+        "tooltip": "配置"
+      },
+      "configureConnectors": {
+        "label": "配置连接器"
+      },
+      "disable": {
+        "label": "禁用"
+      },
+      "enable": {
+        "label": "启用"
+      },
+      "projectSearch": {
+        "label": "项目搜索"
+      }
+    },
     "addMcpModal": {
       "addHeader": {
         "description": "连接 MCP（Model Context Protocol）服务器以添加自定义操作。",
@@ -355,6 +375,53 @@
         "tooltip": "刷新工具"
       }
     },
+    "mcpOauthCallback": {
+      "autoRedirect": {
+        "text": "正在自动返回…"
+      },
+      "backToChatButton": {
+        "label": "返回聊天"
+      },
+      "cancelled": {
+        "description": "授权已被取消或拒绝，因此未建立连接。要重试，请从 MCP 服务器的身份验证设置中重新发起连接。",
+        "title": "授权已取消"
+      },
+      "continueButton": {
+        "label": "继续"
+      },
+      "genericError": {
+        "fallbackDetail": "无法完成授权",
+        "title": "出了点问题"
+      },
+      "invalidLink": {
+        "description": "此链接缺少必需的授权参数。请从 MCP 服务器的身份验证设置中重新发起连接。",
+        "title": "授权链接无效"
+      },
+      "processing": {
+        "description": "正在完成与您的 MCP 服务器的连接。这可能需要片刻…",
+        "title": "正在完成授权"
+      },
+      "serverNotFound": {
+        "description": "此授权所属的 MCP 服务器已不存在或不再配置。请重新创建或重新配置该服务器，然后重新连接。",
+        "title": "未找到 MCP 服务器"
+      },
+      "sessionExpired": {
+        "description": "此授权链接无效、已过期或已被使用。请从 MCP 服务器的身份验证设置中重新发起连接。",
+        "title": "授权会话已过期"
+      },
+      "success": {
+        "description": "授权已成功完成。您现在可以在聊天中使用此服务器的工具。",
+        "title": "已连接到 {serverName}"
+      },
+      "timedOut": {
+        "description": "MCP 服务器未及时确认授权。请重新尝试连接。如果问题持续出现，请检查服务器的 OAuth 配置。",
+        "title": "授权超时"
+      },
+      "tokenExchangeFailed": {
+        "description": "提供方已批准授权，但未能获取有效的访问令牌。请检查服务器的 OAuth 客户端凭据和端点，然后重新尝试连接。",
+        "title": "令牌交换失败"
+      }
+    },
     "mcpPage": {
       "addButton": {
         "label": "添加 MCP 服务器"
@@ -554,6 +621,20 @@
         "label": "拒绝"
       }
     },
+    "switchList": {
+      "back": {
+        "ariaLabel": "返回"
+      },
+      "disableAll": {
+        "label": "全部禁用"
+      },
+      "enableAll": {
+        "label": "全部启用"
+      },
+      "toggle": {
+        "ariaLabel": "切换 {name}"
+      }
+    },
     "toolItem": {
       "unavailable": {
         "label": "工具不可用"
@@ -578,6 +659,81 @@
       "showEnabledButton": {
         "ariaLabel": "仅显示已启用的工具",
         "tooltip": "仅显示已启用"
+      }
+    },
+    "toolsPopover": {
+      "configureLinks": {
+        "codeInterpreter": {
+          "tooltip": "配置代码解释器"
+        },
+        "imageGeneration": {
+          "tooltip": "配置图像生成"
+        },
+        "openapi": {
+          "tooltip": "管理 OpenAPI 操作"
+        },
+        "webSearch": {
+          "tooltip": "配置网络搜索"
+        }
+      },
+      "disableAllSources": {
+        "label": "禁用所有来源"
+      },
+      "disableAllTools": {
+        "label": "禁用所有工具"
+      },
+      "enableAllSources": {
+        "label": "启用所有来源"
+      },
+      "enableAllTools": {
+        "label": "启用所有工具"
+      },
+      "manageActions": {
+        "tooltip": "管理操作"
+      },
+      "mcpTools": {
+        "searchPlaceholder": "搜索 {server} 工具"
+      },
+      "moreActions": {
+        "label": "更多操作"
+      },
+      "reauthenticate": {
+        "label": "重新验证"
+      },
+      "search": {
+        "placeholder": "搜索操作..."
+      },
+      "serverFallback": {
+        "label": "服务器"
+      },
+      "sourceFilters": {
+        "searchPlaceholder": "搜索筛选器"
+      },
+      "tooltips": {
+        "askAdminSuffix": {
+          "text": "请管理员进行配置。"
+        },
+        "codingAgent": {
+          "description": "调查 GitHub 仓库并回答有关其代码的问题。"
+        },
+        "configureSuffix": {
+          "text": "按设置齿轮以启用。"
+        },
+        "default": {
+          "description": "此操作尚未配置。"
+        },
+        "imageGeneration": {
+          "description": "根据提示生成图像。"
+        },
+        "python": {
+          "description": "执行代码进行复杂分析。"
+        },
+        "search": {
+          "description": "搜索已连接的知识以支持回答。"
+        },
+        "webSearch": {
+          "description": "在网络上搜索最新信息。"
+        }
       }
     },
     "toolsSection": {
@@ -631,7 +787,39 @@
         }
       }
     },
+    "agentStats": {
+      "chart": {
+        "description": "所选范围内按天统计",
+        "title": "消息与独立用户"
+      },
+      "empty": {
+        "message": "在所选日期范围内未找到此智能体的数据。"
+      },
+      "fetchFailed": {
+        "message": "获取智能体统计数据失败。"
+      },
+      "permissionDenied": {
+        "message": "您没有权限查看这些统计数据。"
+      },
+      "totalMessages": {
+        "label": "消息总数"
+      },
+      "totalUniqueUsers": {
+        "label": "独立用户总数"
+      },
+      "unknownError": {
+        "message": "发生未知错误"
+      }
+    },
     "agents": {
+      "collapsibleSection": {
+        "collapse": {
+          "ariaLabel": "折叠此部分"
+        },
+        "expand": {
+          "ariaLabel": "展开此部分"
+        }
+      },
       "deleteModal": {
         "confirmation": {
           "description": "确定要删除 <emphasis>{name}</emphasis> 吗？此操作无法撤销。"
@@ -1003,6 +1191,47 @@
         },
         "viewPlans": {
           "title": "查看套餐"
+        }
+      },
+      "info": {
+        "empty": {
+          "message": "没有可用的账单信息。"
+        },
+        "loadError": {
+          "message": "加载账单信息时出错。请稍后重试。"
+        },
+        "loading": {
+          "label": "加载中..."
+        },
+        "manageSubscription": {
+          "description": "查看您的套餐、更新付款方式或更改订阅",
+          "title": "管理订阅"
+        },
+        "page": {
+          "title": "账单信息"
+        },
+        "portalError": {
+          "message": "创建客户门户会话时出错"
+        },
+        "subscriptionDetails": {
+          "title": "订阅详情"
+        },
+        "summary": {
+          "billingEnd": {
+            "label": "账单结束日期"
+          },
+          "billingStart": {
+            "label": "账单开始日期"
+          },
+          "seats": {
+            "label": "席位"
+          },
+          "status": {
+            "label": "订阅状态"
+          }
+        },
+        "updatedToast": {
+          "message": "恭喜!您的订阅已成功更新。"
         }
       },
       "license": {
@@ -1517,6 +1746,25 @@
       }
     },
     "connector": {
+      "accessType": {
+        "autoSyncOption": {
+          "description": "我们将自动从数据源同步权限。只有当执行搜索的用户在数据源中有权访问该文档时，该文档才能在 Onyx 中被搜索到。",
+          "disabledReason": "当前凭据的认证方式不支持自动同步权限。请将凭据的认证方式更改为受支持的方式。",
+          "name": "自动同步权限"
+        },
+        "heading": {
+          "description": "控制谁可以访问此连接器索引的文档。",
+          "title": "文档访问权限"
+        },
+        "privateOption": {
+          "description": "只有（通过用户组页面）被明确授予此连接器访问权限的用户才能访问此连接器导入的文档",
+          "name": "私有"
+        },
+        "publicOption": {
+          "description": "拥有 Onyx 账户的所有人都可以访问此连接器导入的文档",
+          "name": "公开"
+        }
+      },
       "advancedConfig": {
         "duration": {
           "days": "{count, plural, one {# 天} other {# 天}}",
@@ -1546,6 +1794,14 @@
           "label": "收起"
         }
       },
+      "credentialForm": {
+        "errorToast": "错误：{detail}",
+        "successToast": "成功！",
+        "updateButton": {
+          "ariaLabel": "更新凭据",
+          "label": "更新"
+        }
+      },
       "deleteModal": {
         "additionalDetails": "删除此连接器会安排一个删除任务，移除其已索引的文档，并对所有用户删除该连接器。",
         "entityType": "连接器"
@@ -1568,6 +1824,11 @@
         },
         "errorModal": {
           "title": "文档权限同步错误"
+        }
+      },
+      "docsLink": {
+        "checkOutDocs": {
+          "text": "有关配置此连接器的更多信息，请查看<link>我们的文档</link>。"
         }
       },
       "errorsModal": {
@@ -1649,6 +1910,14 @@
           "updateFailed": "更新文件失败"
         }
       },
+      "fileUpload": {
+        "dropzone": {
+          "message": "将{multiple, select, true {文件} other {文件}}拖放到此处，或点击选择{multiple, select, true {文件} other {文件}}"
+        },
+        "selectedFiles": {
+          "heading": "{multiple, select, true {已选择的文件} other {已选择的文件}}"
+        }
+      },
       "groupMembershipTable": {
         "columns": {
           "errorMessage": "错误信息",
@@ -1664,6 +1933,23 @@
         },
         "errorModal": {
           "title": "用户组成员同步错误"
+        }
+      },
+      "groupSelector": {
+        "assignGroupAccess": {
+          "title": "为此连接器分配组访问权限"
+        },
+        "assignToGroup": {
+          "title": "将此连接器分配给一个组"
+        },
+        "scopedManagerGroups": {
+          "description": "选择一个或多个您管理的组以授予对此连接器的访问权限"
+        },
+        "syncGroups": {
+          "description": "以下的组控制谁可以管理此连接器。其文档的访问权限继承自数据源本身的权限。"
+        },
+        "visibleToGroups": {
+          "description": "此连接器将对以下所选的组可见/可访问"
         }
       },
       "indexAttemptsTable": {
@@ -2022,6 +2308,22 @@
         "targetedReindexSubmitted": "已为 {count, plural, one {# 个文档} other {# 个文档}} 提交定向重新索引。文档重新索引完成后，相关错误会从列表中消失。"
       }
     },
+    "connectorTitle": {
+      "metadata": {
+        "channelRegexEnabled": "已启用频道正则表达式",
+        "channels": "频道",
+        "enabledTrue": "是",
+        "excludeChannelRegexEnabled": "已启用排除频道正则表达式",
+        "excludedChannels": "排除的频道",
+        "includeBotMessages": "包含机器人消息",
+        "jiraProjectUrl": "Jira 项目 URL",
+        "multipleRepos": "多个仓库",
+        "pageId": "页面 ID",
+        "realm": "领域",
+        "repo": "仓库",
+        "wikiUrl": "Wiki URL"
+      }
+    },
     "connectorsList": {
       "add": {
         "authorizeButton": {
@@ -2148,6 +2450,7 @@
           "description": "输入拥有目标 Google Drive 的 Google 组织的管理员或所有者邮箱。",
           "invalidEmail": "必须是有效的邮箱地址",
           "label": "主管理员邮箱",
+          "placeholder": "admin@yourcompany.com",
           "required": "必填"
         },
         "section": {
@@ -2205,6 +2508,7 @@
           "description": "输入拥有目标 Gmail 账号的 Google 组织的管理员或所有者邮箱。",
           "invalidEmail": "必须是有效的邮箱地址",
           "label": "主管理员邮箱",
+          "placeholder": "admin@yourcompany.com",
           "required": "必填"
         },
         "section": {
@@ -2590,6 +2894,171 @@
       "unavailable": {
         "description": "Craft 由 Onyx 按部署逐一启用。请联系您的 Onyx 客户代表以获取访问权限。",
         "title": "此部署不提供 Craft"
+      }
+    },
+    "credentials": {
+      "card": {
+        "createdOn": {
+          "label": "创建于 <i>{date}</i>"
+        },
+        "createdOnBy": {
+          "label": "由 <i>{email}</i> 创建于 <i>{date}</i>"
+        },
+        "unnamed": {
+          "label": "凭据 #{id}"
+        }
+      },
+      "create": {
+        "createButton": {
+          "label": "创建"
+        },
+        "created": {
+          "toast": "已创建新凭据!"
+        },
+        "name": {
+          "label": "名称:",
+          "placeholder": "(可选) 凭据名称..."
+        },
+        "submitError": {
+          "toast": "提交凭据时出错"
+        }
+      },
+      "delete": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "confirmBody": {
+          "message": "确定要删除此凭据吗?无法删除与运行中的连接器关联的凭据。"
+        },
+        "confirmButton": {
+          "label": "确认"
+        },
+        "confirmTitle": "确认删除"
+      },
+      "edit": {
+        "name": {
+          "label": "名称(可选):"
+        },
+        "permissions": {
+          "note": "请确保更新为具有适当权限的凭据!"
+        },
+        "resetButton": {
+          "label": "重置更改"
+        },
+        "updateButton": {
+          "label": "更新"
+        },
+        "updateError": {
+          "toast": "更新凭据时出错"
+        }
+      },
+      "modal": {
+        "createTitle": "创建 {source} 凭据",
+        "editTitle": "编辑凭据",
+        "updateTitle": "更新凭据"
+      },
+      "modify": {
+        "createButton": {
+          "label": "创建"
+        },
+        "instructions": {
+          "message": "请根据需要选择凭据!请确保为此连接器选择了具有适当权限的凭据!"
+        },
+        "selectButton": {
+          "label": "选择"
+        }
+      },
+      "oauth": {
+        "connectButton": {
+          "label": "连接"
+        },
+        "connectError": {
+          "title": "无法连接"
+        },
+        "redirectFailed": {
+          "message": "无法重定向到 {source} 登录。请重试。"
+        },
+        "retryButton": {
+          "label": "重试"
+        },
+        "startError": {
+          "message": "无法启动 OAuth"
+        }
+      },
+      "swap": {
+        "error": {
+          "toast": "切换凭据时出现问题:{detail}"
+        },
+        "success": {
+          "toast": "已成功切换凭据!"
+        }
+      },
+      "table": {
+        "actions": {
+          "label": "操作"
+        },
+        "created": {
+          "header": "创建时间"
+        },
+        "edit": {
+          "ariaLabel": "编辑凭据"
+        },
+        "empty": {
+          "message": "此连接器不存在任何凭据!"
+        },
+        "id": {
+          "header": "ID"
+        },
+        "lastUpdated": {
+          "header": "最后更新"
+        },
+        "name": {
+          "header": "名称"
+        },
+        "select": {
+          "label": "选择"
+        },
+        "selected": {
+          "badge": "已选择"
+        },
+        "untitled": {
+          "label": "未命名"
+        }
+      },
+      "update": {
+        "error": {
+          "toast": "更新凭据时出现问题"
+        },
+        "success": {
+          "toast": "已更新凭据"
+        }
+      }
+    },
+    "customAnalytics": {
+      "intro": {
+        "description": "这允许您将自己的分析工具接入 Onyx!将分析提供商的 Web 代码片段复制到下面的输入框中,我们就会开始发送使用事件。"
+      },
+      "notEnabled": {
+        "description": "要设置自定义分析脚本,请与团队中负责部署 Onyx 的人员合作,设置环境变量 <i>CUSTOM_ANALYTICS_SECRET_KEY</i>。",
+        "title": "自定义分析未启用。"
+      },
+      "script": {
+        "description": "指定应在页面加载时运行的 Javascript,用于初始化您的自定义跟踪/分析。",
+        "instructions": "请勿包含 `<script></script>` 标签。如果您在下方上传了脚本但分析平台没有收到任何事件,请尝试删除每行 JavaScript 前多余的空白字符。",
+        "label": "脚本"
+      },
+      "secretKey": {
+        "description": "出于安全考虑,您必须提供密钥才能更新此脚本。该值应为初次设置 Onyx 时配置的环境变量 <i>CUSTOM_ANALYTICS_SECRET_KEY</i> 的值。",
+        "label": "密钥"
+      },
+      "updateButton": {
+        "label": "更新"
+      },
+      "updateFailed": {
+        "message": "更新自定义分析脚本失败:\"{error}\""
+      },
+      "updateSuccess": {
+        "message": "自定义分析脚本更新成功!"
       }
     },
     "discordBot": {
@@ -3047,6 +3516,83 @@
         }
       }
     },
+    "exportLogs": {
+      "button": {
+        "collecting": {
+          "label": "收集中..."
+        },
+        "downloading": {
+          "label": "下载中..."
+        },
+        "export": {
+          "label": "导出日志"
+        },
+        "starting": {
+          "label": "正在启动..."
+        }
+      },
+      "downloadButton": {
+        "label": "下载"
+      },
+      "exportCard": {
+        "description": "将 API 服务器和后台 worker 的日志文件收集到一个 zip 中。收集完成后将自动开始下载。",
+        "title": "导出日志"
+      },
+      "header": {
+        "description": "下载服务器日志文件的 zip 压缩包,以附加到 Onyx 支持工单中。"
+      },
+      "receipt": {
+        "duplicateHost": {
+          "label": "已由同一主机上的其他 worker 处理"
+        },
+        "failed": {
+          "label": "失败"
+        },
+        "failedWithError": {
+          "label": "失败:{error}"
+        },
+        "noLogs": {
+          "label": "未找到日志文件"
+        },
+        "uploaded": {
+          "label": "{count, plural, one {已上传 # 个文件} other {已上传 # 个文件}}"
+        }
+      },
+      "sensitiveWarning": {
+        "description": "日志文件可能包含用户邮箱、文档标题、搜索查询和错误内容。在组织外共享之前请先检查其内容。",
+        "title": "日志可能包含敏感数据"
+      },
+      "status": {
+        "startingCollection": {
+          "label": "正在开始收集..."
+        }
+      },
+      "toasts": {
+        "alreadyRunning": {
+          "message": "日志导出已在进行中。请稍后重试。"
+        },
+        "downloadFailed": {
+          "message": "下载日志导出失败。"
+        },
+        "lostAccess": {
+          "message": "无法访问正在运行的导出。请重新开始一个。"
+        },
+        "startFailed": {
+          "message": "启动日志导出失败。"
+        },
+        "unreachable": {
+          "message": "无法连接服务器以检查导出进度。待服务器恢复后请重新开始导出。"
+        }
+      },
+      "worker": {
+        "collecting": {
+          "label": "收集中..."
+        },
+        "missedDeadline": {
+          "label": "未在截止时间前报告"
+        }
+      }
+    },
     "externalApps": {
       "apps": {
         "empty": {
@@ -3153,9 +3699,137 @@
         "loadFailed": "加载连接器失败：{details}",
         "title": "错误"
       },
+      "form": {
+        "channelInput": {
+          "placeholder": "输入频道名称或正则表达式，然后按 Enter"
+        },
+        "channelsRequired": {
+          "error": "禁用「搜索所有频道」时，至少需要一个频道"
+        },
+        "configSchemaLoadError": {
+          "message": "加载配置架构失败：{error}"
+        },
+        "configTitle": {
+          "text": "联合连接器配置"
+        },
+        "configuration": {
+          "heading": "配置"
+        },
+        "create": {
+          "failed": "创建联合连接器失败",
+          "success": "联合连接器创建成功！"
+        },
+        "credentialField": {
+          "keepCurrentPlaceholder": "••••••••  （留空以保留当前值）"
+        },
+        "credentialValidationFailed": {
+          "message": "凭据验证失败：{message}"
+        },
+        "credentials": {
+          "description": "输入此连接器的凭据。",
+          "heading": "凭据"
+        },
+        "delete": {
+          "failed": "删除联合连接器失败",
+          "success": "联合连接器删除成功！"
+        },
+        "deleteConfirm": {
+          "message": "确定要删除此联合连接器吗？此操作无法撤消。"
+        },
+        "deleteError": {
+          "toast": "删除连接器时出错：{error}"
+        },
+        "deleteItem": {
+          "deleting": "正在删除...",
+          "inProgressTooltip": "正在删除",
+          "label": "删除"
+        },
+        "federatedBadge": {
+          "label": "联合"
+        },
+        "federatedTooltip": {
+          "default": "这是一个联合连接器。与常规连接器相比，它的延迟更高，搜索质量更低。"
+        },
+        "genericError": {
+          "text": "错误：{error}"
+        },
+        "listInput": {
+          "placeholder": "输入内容并按 Enter 添加条目"
+        },
+        "loadingSchema": {
+          "description": "正在获取此连接器类型所需的字段",
+          "title": "正在加载凭据架构..."
+        },
+        "manageButton": {
+          "label": "管理"
+        },
+        "missingFields": {
+          "message": "缺少必填字段：{fields}"
+        },
+        "noConfigSchema": {
+          "message": "此连接器类型没有可用的搜索配置。"
+        },
+        "noCredentialSchema": {
+          "message": "此连接器类型没有可用的凭据架构。"
+        },
+        "schemaLoadError": {
+          "message": "加载凭据架构失败：{error}"
+        },
+        "submitButton": {
+          "create": "创建",
+          "creating": "正在创建...",
+          "update": "更新",
+          "updating": "正在更新..."
+        },
+        "title": {
+          "edit": "编辑 {name}",
+          "setup": "设置 {name}"
+        },
+        "update": {
+          "failed": "更新联合连接器失败",
+          "success": "联合连接器更新成功！"
+        },
+        "validateBeforeEdit": {
+          "message": "请先输入新的凭据值再进行验证。"
+        },
+        "validateButton": {
+          "label": "验证",
+          "validating": "正在验证..."
+        },
+        "validation": {
+          "error": "验证错误：{error}",
+          "failedStatus": "验证失败：{statusText}",
+          "invalid": "凭据无效",
+          "valid": "凭据有效"
+        }
+      },
       "loading": {
         "description": "正在获取连接器详情和凭证结构",
         "title": "正在加载连接器配置..."
+      }
+    },
+    "federatedCallback": {
+      "backButton": {
+        "label": "返回聊天"
+      },
+      "error": {
+        "title": "出了点问题"
+      },
+      "errors": {
+        "clientSecret": "身份验证凭据缺失或无效",
+        "oauth": "OAuth 授权失败",
+        "validation": "配置错误 - 请检查您的连接器设置"
+      },
+      "processing": {
+        "details": "请稍候，我们正在完成设置。",
+        "title": "正在处理..."
+      },
+      "redirecting": {
+        "text": "2 秒后重定向到聊天..."
+      },
+      "success": {
+        "detailsTemplate": "您的 {serviceName} 授权已成功完成。现在可以使用此连接器进行搜索。",
+        "title": "成功！"
       }
     },
     "groups": {
@@ -3418,6 +4092,265 @@
           "header": "Token 上限",
           "placeholder": "Token 上限（千）",
           "unit": "(千)"
+        }
+      }
+    },
+    "hooks": {
+      "card": {
+        "delete": {
+          "ariaLabel": "删除钩子",
+          "tooltip": "删除"
+        },
+        "disconnect": {
+          "ariaLabel": "停用钩子",
+          "tooltip": "断开钩子"
+        },
+        "disconnectedSuffix": {
+          "label": "(已断开)"
+        },
+        "hookPoint": {
+          "description": "钩子点:{name}"
+        },
+        "manage": {
+          "ariaLabel": "配置钩子",
+          "tooltip": "管理"
+        },
+        "reconnectButton": {
+          "label": "重新连接"
+        },
+        "test": {
+          "ariaLabel": "重新验证钩子",
+          "tooltip": "测试连接"
+        }
+      },
+      "connectButton": {
+        "label": "连接"
+      },
+      "deleteModal": {
+        "body": {
+          "description": "钩子 ***{name}*** 将从此钩子点永久移除。外部端点可能仍保留之前发送给它的数据。"
+        },
+        "delete": {
+          "label": "删除"
+        },
+        "header": {
+          "title": "删除 *{name}*"
+        },
+        "permanent": {
+          "description": "删除后无法撤销。"
+        }
+      },
+      "disconnectModal": {
+        "body": {
+          "description": "Onyx 将停止为钩子 ***{name}*** 调用此端点。进行中的请求将继续运行。外部端点可能仍保留之前发送给它的数据。如有需要,您可以稍后重新连接此钩子。"
+        },
+        "deleteNote": {
+          "description": "您也可以删除此钩子。删除后无法撤销。"
+        },
+        "disconnect": {
+          "label": "断开"
+        },
+        "disconnectAndDelete": {
+          "label": "断开并删除"
+        },
+        "header": {
+          "title": "断开 *{name}*"
+        }
+      },
+      "docsLink": {
+        "label": "文档"
+      },
+      "form": {
+        "apiKey": {
+          "description": "Onyx 将使用此密钥向您的 API 端点进行身份验证。",
+          "keepCurrent": {
+            "placeholder": "留空以保留当前密钥"
+          },
+          "title": "API 密钥"
+        },
+        "connectionValid": {
+          "label": "连接有效。"
+        },
+        "createHeader": {
+          "description": "连接外部 API 端点以扩展此钩子点。",
+          "title": "设置钩子扩展"
+        },
+        "editHeader": {
+          "title": "管理钩子扩展"
+        },
+        "endpoint": {
+          "description": "只连接您信任的服务器。您需对通过此连接执行的操作和共享的数据负责。",
+          "title": "外部 API 端点 URL"
+        },
+        "errors": {
+          "connect": "无法连接到端点。",
+          "generic": "出错了。",
+          "invalidApiKey": "API 密钥无效。",
+          "timeout": "连接超时。请尝试增大超时时间。"
+        },
+        "failStrategy": {
+          "default": {
+            "label": "(默认)"
+          },
+          "hard": {
+            "label": "失败时阻止流水线"
+          },
+          "placeholder": "选择策略",
+          "soft": {
+            "label": "记录错误并继续"
+          },
+          "title": "失败策略"
+        },
+        "hookPoint": {
+          "label": "钩子点"
+        },
+        "name": {
+          "placeholder": "为此钩子点上的扩展命名",
+          "title": "显示名称"
+        },
+        "save": {
+          "label": "保存更改"
+        },
+        "softStrategy": {
+          "description": "如果端点返回错误,Onyx 会记录该错误并照常继续流水线,忽略钩子结果。"
+        },
+        "timeout": {
+          "description": "在应用失败策略之前,Onyx 等待端点响应的最长时间。必须大于 0 且最多 {max} 秒。",
+          "revert": {
+            "tooltip": "恢复默认值"
+          },
+          "suffix": "(秒)",
+          "title": "超时"
+        },
+        "toasts": {
+          "created": {
+            "message": "钩子已创建。"
+          },
+          "noHookPoint": {
+            "message": "未指定钩子点。"
+          },
+          "updated": {
+            "message": "钩子已更新。"
+          }
+        },
+        "validation": {
+          "apiKeyRequired": "API 密钥不能为空。",
+          "endpointRequired": "端点 URL 不能为空。",
+          "nameRequired": "显示名称不能为空。",
+          "timeoutRange": "必须大于 0 且最多 {max} 秒。",
+          "timeoutRequired": "必须填写超时时间。"
+        },
+        "verifying": {
+          "label": "正在验证连接…"
+        }
+      },
+      "logs": {
+        "copy": {
+          "tooltip": "复制"
+        },
+        "download": {
+          "tooltip": "下载"
+        },
+        "empty": {
+          "message": "过去 30 天内没有错误。"
+        },
+        "header": {
+          "description": "钩子:{name} • 钩子点:{point}",
+          "title": "最近的错误"
+        },
+        "lineCount": {
+          "label": "{count, plural, one {# 行} other {# 行}}"
+        },
+        "loadFailed": {
+          "message": "加载日志失败。"
+        },
+        "older": {
+          "label": "更早"
+        },
+        "pastHour": {
+          "label": "过去一小时"
+        },
+        "unknownError": {
+          "label": "未知错误"
+        }
+      },
+      "modals": {
+        "cancel": {
+          "label": "取消"
+        }
+      },
+      "page": {
+        "description": "通过在预定义的钩子点将外部 API 端点注册为回调,扩展 Onyx 流水线。",
+        "empty": {
+          "title": "没有可用的钩子点"
+        },
+        "emptySearch": {
+          "description": "请尝试其他搜索词。",
+          "title": "未找到结果"
+        },
+        "enterpriseRequired": {
+          "message": "钩子扩展需要企业版许可证。"
+        },
+        "loadHooksFailed": {
+          "message": "加载钩子失败。请刷新页面。"
+        },
+        "loadSpecsFailed": {
+          "message": "加载钩子规范失败。请刷新页面。"
+        },
+        "notEnabled": {
+          "message": "此部署未启用钩子扩展。"
+        },
+        "search": {
+          "placeholder": "搜索钩子..."
+        }
+      },
+      "status": {
+        "connected": {
+          "label": "已连接"
+        },
+        "connectionLost": {
+          "label": "连接已断开"
+        },
+        "errorCount": {
+          "title": "{count, plural, one {# 个错误} other {# 个错误}}"
+        },
+        "noError": {
+          "title": "无错误"
+        },
+        "pastHour": {
+          "description": "过去一小时内"
+        },
+        "recentErrors": {
+          "title": "最近的错误"
+        },
+        "viewMore": {
+          "label": "查看更多行"
+        },
+        "viewOlder": {
+          "label": "查看更早的错误"
+        }
+      },
+      "toasts": {
+        "deactivateFailed": {
+          "message": "停用钩子失败。"
+        },
+        "deleteFailed": {
+          "message": "删除钩子失败。"
+        },
+        "disconnectFailed": {
+          "message": "断开钩子失败。"
+        },
+        "reconnectFailed": {
+          "message": "重新连接钩子失败。"
+        },
+        "validateFailed": {
+          "message": "验证钩子失败。"
+        },
+        "validateSuccess": {
+          "message": "钩子验证成功。"
+        },
+        "validationFailed": {
+          "message": "验证失败:{status}"
         }
       }
     },
@@ -4297,6 +5230,9 @@
               "label": "添加行"
             },
             "description": "按模型提供商的要求添加额外属性。这些属性会作为[环境变量](https://docs.litellm.ai/docs/set_keys#environment-variables)传递给 LiteLLM 的 `completion()` 调用。更多说明请参见[文档](https://docs.onyx.app/admins/ai_models/custom_inference_provider)。",
+            "keyInput": {
+              "placeholder": "例如 OPENAI_ORGANIZATION"
+            },
             "title": "环境变量"
           },
           "modelRow": {
@@ -4808,6 +5744,132 @@
         "title": "用户"
       }
     },
+    "queryHistory": {
+      "assistant": {
+        "unknown": {
+          "label": "未知"
+        }
+      },
+      "detail": {
+        "ai": {
+          "label": "AI"
+        },
+        "errorTitle": {
+          "title": "出错了 :("
+        },
+        "feedback": {
+          "title": "反馈"
+        },
+        "fetchFailed": {
+          "message": "获取聊天会话失败 - {error}"
+        },
+        "header": {
+          "title": "聊天会话详情"
+        },
+        "referenceDocuments": {
+          "title": "参考文档"
+        },
+        "user": {
+          "label": "用户"
+        }
+      },
+      "export": {
+        "cancel": {
+          "label": "取消"
+        },
+        "downloadFailed": {
+          "message": "下载查询历史失败。"
+        },
+        "generating": {
+          "message": "正在生成 CSV 报告。点击\"{button}\"按钮查看所有任务。"
+        },
+        "kickoff": {
+          "label": "开始导出"
+        }
+      },
+      "exportStatus": {
+        "failure": {
+          "label": "失败"
+        },
+        "pending": {
+          "label": "等待中"
+        },
+        "success": {
+          "label": "成功"
+        }
+      },
+      "exportsModal": {
+        "download": {
+          "header": "下载"
+        },
+        "endRange": {
+          "header": "结束范围"
+        },
+        "generatedAt": {
+          "header": "生成时间"
+        },
+        "header": {
+          "title": "先前的查询历史导出"
+        },
+        "notReady": {
+          "tooltip": "导出尚未就绪"
+        },
+        "startRange": {
+          "header": "起始范围"
+        },
+        "status": {
+          "header": "状态"
+        }
+      },
+      "feedback": {
+        "dislike": {
+          "label": "踩"
+        },
+        "like": {
+          "label": "赞"
+        },
+        "mixed": {
+          "label": "混合"
+        },
+        "na": {
+          "label": "N/A"
+        }
+      },
+      "filters": {
+        "any": {
+          "label": "任意"
+        },
+        "feedbackType": {
+          "label": "反馈类型"
+        }
+      },
+      "previousExports": {
+        "label": "查看导出"
+      },
+      "table": {
+        "date": {
+          "header": "日期"
+        },
+        "feedback": {
+          "header": "反馈"
+        },
+        "fetchError": {
+          "title": "获取查询历史时出错"
+        },
+        "firstAiResponse": {
+          "header": "AI 的第一条回复"
+        },
+        "firstUserMessage": {
+          "header": "用户的第一条消息"
+        },
+        "persona": {
+          "header": "角色"
+        },
+        "user": {
+          "header": "用户"
+        }
+      }
+    },
     "scim": {
       "card": {
         "connected": {
@@ -4862,6 +5924,56 @@
         "generateFailed": "生成 token 失败：{detail}",
         "genericError": "出现问题。请重试。",
         "regenerated": "Token 已重新生成"
+      }
+    },
+    "search": {
+      "errors": {
+        "classificationFailed": {
+          "message": "查询分类失败。将回退到聊天。"
+        },
+        "searchFailed": {
+          "message": "文档搜索失败。请重试。"
+        }
+      },
+      "results": {
+        "count": {
+          "label": "{count, plural, one {# 条结果} other {# 条结果}}"
+        },
+        "empty": {
+          "description": "请检查您的连接器/筛选条件,或尝试其他搜索词。",
+          "title": "未找到结果"
+        },
+        "failed": {
+          "title": "搜索失败"
+        }
+      },
+      "tagFilter": {
+        "count": {
+          "label": "{count, plural, one {# 个标签} other {# 个标签}}"
+        },
+        "empty": {
+          "label": "标签"
+        },
+        "search": {
+          "placeholder": "筛选标签..."
+        }
+      },
+      "timeFilter": {
+        "all": {
+          "label": "全部时间"
+        },
+        "day": {
+          "label": "过去 24 小时"
+        },
+        "month": {
+          "label": "过去一个月"
+        },
+        "week": {
+          "label": "过去一周"
+        },
+        "year": {
+          "label": "过去一年"
+        }
       }
     },
     "security": {
@@ -5753,6 +6865,163 @@
         "unexpectedError": "发生意外错误。"
       }
     },
+    "standardAnswers": {
+      "categoryBubble": {
+        "remove": {
+          "ariaLabel": "移除类别 {name}"
+        },
+        "removeButton": {
+          "ariaLabel": "移除类别"
+        }
+      },
+      "categoryDropdown": {
+        "categories": {
+          "label": "标准回答类别"
+        },
+        "fetchError": {
+          "message": "获取标准回答类别失败 - {message}",
+          "title": "出错了 :("
+        },
+        "search": {
+          "placeholder": "搜索类别..."
+        }
+      },
+      "editPage": {
+        "title": "编辑标准答案"
+      },
+      "errors": {
+        "fetchAnswersFailed": {
+          "message": "获取标准答案失败"
+        },
+        "fetchCategoriesFailed": {
+          "message": "获取标准答案类别失败"
+        },
+        "genericTitle": {
+          "title": "出错了 :("
+        },
+        "loadAnswersFailed": {
+          "title": "加载标准答案时出错"
+        },
+        "loadCategoriesFailed": {
+          "title": "加载标准答案类别时出错"
+        },
+        "notFound": {
+          "message": "未找到 ID 为 {id} 的标准答案"
+        }
+      },
+      "filter": {
+        "allCategories": {
+          "label": "所有类别"
+        }
+      },
+      "form": {
+        "allKeywords": {
+          "label": "所有这些关键词,顺序不限,以空格分隔",
+          "placeholder": "IT 工单"
+        },
+        "answer": {
+          "label": "答案",
+          "placeholder": "使用 Markdown 编写的答案。示例:如需 IT 团队的帮助,请发送邮件至 internalsupport@company.com"
+        },
+        "anyKeywords": {
+          "label": "这些关键词中的任意一个,以空格分隔",
+          "placeholder": "工单 问题 故障"
+        },
+        "categories": {
+          "label": "类别:",
+          "placeholder": "输入类别并按 Enter…"
+        },
+        "createButton": {
+          "label": "创建!"
+        },
+        "keywords": {
+          "tooltip": "问题必须匹配这些关键词才能触发该答案。"
+        },
+        "matchRegex": {
+          "description": "使用正则表达式模式匹配,而不是精确关键词",
+          "label": "匹配正则表达式"
+        },
+        "regexPattern": {
+          "label": "正则表达式模式",
+          "tooltip": "当问题匹配此正则表达式模式时触发(使用 Python 的 `re.search()`)"
+        },
+        "strategy": {
+          "all": {
+            "label": "所有关键词"
+          },
+          "any": {
+            "label": "任意关键词"
+          },
+          "description": "选择用户的问题需要包含上述关键词中的任意一个还是全部,才会显示此答案。",
+          "label": "关键词检测策略"
+        },
+        "toasts": {
+          "categoryCreateFailed": {
+            "message": "创建类别\"{name}\"时出错 - {error}"
+          },
+          "createFailed": {
+            "message": "创建标准答案时出错 - {error}"
+          },
+          "updateFailed": {
+            "message": "更新标准答案时出错 - {error}"
+          }
+        },
+        "updateButton": {
+          "label": "更新!"
+        },
+        "validation": {
+          "answerRequired": "必须填写答案",
+          "categoryRequired": "至少需要一个类别",
+          "keywordRequired": "必须填写关键词或模式"
+        }
+      },
+      "intro": {
+        "addFirst": {
+          "message": "在下方添加您的第一个标准答案!"
+        },
+        "description": "管理预定义问题的标准答案。\n注意:目前只有通过 Slack 提出的问题才能收到标准答案。"
+      },
+      "newStandardAnswer": {
+        "label": "新建标准答案"
+      },
+      "search": {
+        "placeholder": "按关键词/短语查找标准答案..."
+      },
+      "table": {
+        "answer": {
+          "header": "答案"
+        },
+        "categories": {
+          "header": "类别"
+        },
+        "empty": {
+          "message": "未找到匹配的标准答案..."
+        },
+        "keywords": {
+          "header": "关键词/模式"
+        },
+        "matchRegex": {
+          "header": "正则匹配?"
+        },
+        "matchRegexNo": {
+          "label": "否"
+        },
+        "matchRegexYes": {
+          "label": "是"
+        },
+        "slackNote": {
+          "message": "请确保已将该类别添加到相应的 [Slack 机器人](/admin/bots)。"
+        }
+      },
+      "toasts": {
+        "deleteFailed": {
+          "message": "删除标准答案失败 - {error}"
+        },
+        "deleted": {
+          "message": "已删除标准答案 {id}"
+        }
+      }
+    },
     "status": {
       "badges": {
         "canceled": "已取消",
@@ -5783,6 +7052,142 @@
       },
       "webVersion": {
         "label": "Web 版本："
+      }
+    },
+    "theme": {
+      "announcement": {
+        "description": "显示用户可以关闭的持续性系统公告。",
+        "header": {
+          "placeholder": "添加公告"
+        },
+        "label": "系统公告"
+      },
+      "announcementPopup": {
+        "description": "还会在所有用户首次访问时以全屏弹窗形式显示此通知。请谨慎使用。",
+        "label": "首次访问弹窗通知"
+      },
+      "appName": {
+        "description": "此名称将在整个应用中显示,并替换界面中的\"Onyx\"。",
+        "label": "应用显示名称"
+      },
+      "branding": {
+        "description": "移除应用中的\"powered by Onyx\"及其他 Onyx 品牌标识。",
+        "enterpriseTooltip": "隐藏 Onyx 品牌标识是企业版套餐的功能。",
+        "label": "隐藏 Onyx 品牌标识"
+      },
+      "chatFooter": {
+        "description": "添加用于免责声明或附加信息的 markdown 内容。",
+        "label": "聊天页脚文本"
+      },
+      "chatHeader": {
+        "label": "聊天页眉文本"
+      },
+      "consent": {
+        "description": "要求用户在访问应用之前阅读并同意该通知。",
+        "label": "要求同意通知"
+      },
+      "consentPrompt": {
+        "label": "通知同意提示"
+      },
+      "firstVisit": {
+        "description": "在新用户首次访问时显示一次性弹窗。",
+        "label": "显示首次访问通知"
+      },
+      "greeting": {
+        "description": "在主页添加一条简短消息。",
+        "label": "问候语"
+      },
+      "helpLink": {
+        "description": "除 Onyx 文档外,在用户菜单中添加自定义帮助链接。",
+        "enterpriseTooltip": "自定义帮助链接是企业版套餐的功能。",
+        "label": "自定义帮助链接"
+      },
+      "helpLinkLabel": {
+        "label": "自定义帮助链接标签",
+        "placeholder": "链接标签"
+      },
+      "loginSubtitle": {
+        "description": "替换登录页欢迎标题下方的标语。",
+        "label": "登录页副标题"
+      },
+      "logo": {
+        "label": "应用 Logo",
+        "updateButton": {
+          "label": "更新"
+        }
+      },
+      "logoStyle": {
+        "both": {
+          "label": "Logo 和名称",
+          "tooltip": "同时显示您的应用 Logo 和名称。"
+        },
+        "description": "选择侧边栏顶部显示的内容。添加 Logo 或应用名称后,相应选项才可用。",
+        "label": "Logo 显示样式",
+        "logoOnly": {
+          "disabledTooltip": "上传 Logo 以启用此选项。",
+          "label": "仅 Logo",
+          "tooltip": "仅显示您的应用 Logo。"
+        },
+        "nameOnly": {
+          "disabledTooltip": "输入应用名称以启用此选项。",
+          "label": "仅名称",
+          "tooltip": "仅显示您的应用名称。"
+        }
+      },
+      "markdownContent": {
+        "placeholder": "添加 markdown 内容"
+      },
+      "noticeContent": {
+        "label": "通知内容"
+      },
+      "noticeHeader": {
+        "label": "通知标题"
+      },
+      "page": {
+        "announcementClearFailed": {
+          "message": "清除公告失败。"
+        },
+        "announcementSaveFailed": {
+          "message": "保存公告失败。"
+        },
+        "applyButton": {
+          "label": "应用更改"
+        },
+        "applying": {
+          "label": "正在应用..."
+        },
+        "description": "自定义应用在组织内用户面前的显示方式。",
+        "logoUploadFailed": {
+          "message": "上传 Logo 失败。{error}"
+        },
+        "saveSuccess": {
+          "message": "外观设置保存成功!"
+        },
+        "settingsSaveFailed": {
+          "message": "更新设置失败。{error}"
+        },
+        "validation": {
+          "consentPromptRequired": "必须填写通知同意提示",
+          "invalidUrl": "必须是有效的 URL",
+          "maxChars": "最多 {count} 个字符",
+          "noticeContentRequired": "必须填写通知内容",
+          "noticeHeaderRequired": "必须填写通知标题",
+          "urlRequiredWithLabel": "设置标签后必须填写 URL"
+        }
+      },
+      "preview": {
+        "chatFooter": {
+          "placeholder": "聊天页脚内容"
+        },
+        "chatHeader": {
+          "placeholder": "聊天页眉内容"
+        },
+        "greeting": {
+          "placeholder": "欢迎使用 Acme Chat"
+        },
+        "logo": {
+          "alt": "Logo"
+        }
       }
     },
     "tokenRateLimits": {
@@ -6047,6 +7452,9 @@
             "label": "支出"
           }
         }
+      },
+      "page": {
+        "description": "监控工作区支出并按用户查看使用情况。"
       },
       "spendByUser": {
         "columns": {
@@ -6644,6 +8052,204 @@
         "tooltip": "查看智能体统计"
       }
     },
+    "editor": {
+      "actions": {
+        "codeInterpreter": {
+          "description": "生成并运行代码。",
+          "title": "代码解释器"
+        },
+        "codingAgent": {
+          "description": "调查 GitHub 仓库并回答有关其代码的问题。",
+          "title": "编码智能体"
+        },
+        "description": "此智能体可使用的工具和能力。",
+        "imageGeneration": {
+          "description": "使用 AI 驱动的工具生成和处理图像。",
+          "title": "图像生成",
+          "unavailable": {
+            "tooltip": "图像生成需要已配置的模型。如果您有权限，请在设置 > 图像生成中配置一个，或联系管理员。"
+          }
+        },
+        "openUrl": {
+          "description": "从网络 URL 获取并读取内容。",
+          "title": "打开 URL"
+        },
+        "title": "操作",
+        "webSearch": {
+          "description": "在网络上搜索实时信息和最新结果。",
+          "title": "网络搜索"
+        }
+      },
+      "advanced": {
+        "description": "微调智能体的提示词和知识。",
+        "overwritePrompt": {
+          "suffix": "（不推荐）",
+          "title": "覆盖系统提示词"
+        },
+        "reminders": {
+          "description": "在提示消息后附加简短提醒。如果发现智能体在聊天过程中容易忘记某些指令，可用此功能提醒它。提醒应简短，且不干扰用户消息。",
+          "placeholder": "请记住，我希望您始终将回复格式化为编号列表。",
+          "title": "提醒"
+        },
+        "title": "高级选项"
+      },
+      "avatar": {
+        "edit": {
+          "label": "编辑"
+        },
+        "uploadImage": {
+          "label": "上传图片"
+        }
+      },
+      "delete": {
+        "button": {
+          "label": "删除智能体"
+        },
+        "description": "使用此智能体的所有人将无法再访问它。",
+        "title": "删除此智能体"
+      },
+      "deleteModal": {
+        "body": {
+          "confirm": "确定要删除此智能体吗？",
+          "warning": "使用此智能体的所有人将无法再访问它。删除后无法撤销。"
+        },
+        "title": "删除智能体"
+      },
+      "filesModal": {
+        "description": "为此智能体选择的所有文件",
+        "placeholderName": "文件 {id}",
+        "title": "用户文件"
+      },
+      "general": {
+        "avatar": {
+          "title": "智能体头像"
+        },
+        "descriptionField": {
+          "placeholder": "此智能体有什么用途？",
+          "title": "描述"
+        },
+        "name": {
+          "placeholder": "为您的智能体命名",
+          "title": "名称"
+        }
+      },
+      "header": {
+        "cancel": {
+          "label": "取消"
+        },
+        "create": {
+          "label": "创建"
+        },
+        "createTitle": "创建智能体",
+        "editTitle": "编辑智能体",
+        "save": {
+          "label": "保存"
+        }
+      },
+      "mcp": {
+        "noAccess": {
+          "tooltip": "您不再拥有此 MCP 服务器的访问权限。其现有工具将被保留。"
+        },
+        "searchTools": {
+          "placeholder": "搜索工具..."
+        }
+      },
+      "page": {
+        "ariaLabel": "智能体编辑器页面"
+      },
+      "prompts": {
+        "instructions": {
+          "description": "添加说明以定制此智能体的响应。",
+          "placeholder": "对复杂问题逐步思考并展示推理过程。使用具体示例。强调行动项，遇到未知内容时留空供人工填写。使用礼貌热情的语气。",
+          "title": "说明"
+        },
+        "starters": {
+          "description": "帮助用户了解此智能体的功能以及如何与其有效互动的示例消息。",
+          "title": "对话开场白"
+        }
+      },
+      "saveTooltip": {
+        "fixErrors": "保存前请修复表单中的错误。",
+        "noChanges": "尚未进行任何更改。",
+        "saving": "正在保存更改...",
+        "uploading": "请等待文件上传完成。"
+      },
+      "share": {
+        "feature": {
+          "description": "将此智能体显示在探索智能体列表顶部，并为有访问权限的新用户自动固定到侧边栏。",
+          "privateNotice": {
+            "title": "此智能体仅对您私有，只会为您自己精选显示。"
+          },
+          "title": "精选此智能体",
+          "unlistedWarning": {
+            "title": "此智能体已取消展示，不会显示在精选列表中。"
+          }
+        },
+        "labels": {
+          "description": "添加标签和类别，帮助他人更好地发现此智能体。",
+          "placeholder": "添加标签..."
+        },
+        "share": {
+          "button": {
+            "label": "共享"
+          },
+          "description": "与其他用户、群组或组织中的所有人共享。",
+          "title": "共享此智能体"
+        },
+        "title": "共享智能体"
+      },
+      "starters": {
+        "examples": {
+          "engineeringGoals": "整理一份我们本季度的工程目标清单。",
+          "overview": "给我一些文档的概览。",
+          "salesReport": "查找最新的销售报告。",
+          "todayGoals": "总结我今天的目标。"
+        },
+        "placeholder": "输入对话开场白..."
+      },
+      "suffix": {
+        "optional": "可选"
+      },
+      "toasts": {
+        "createFailed": "创建智能体失败 - {detail}",
+        "created": "智能体“{name}”创建成功",
+        "deleteFailed": "删除智能体失败：{error}",
+        "deleted": "智能体删除成功",
+        "genericError": "发生错误：{error}",
+        "noResponse": "未收到响应",
+        "sharingFailed": "智能体已创建，但共享失败：{error}",
+        "toggleListedFailed": "切换可见性失败",
+        "unknownDetail": "未知错误",
+        "unknownError": "未知错误",
+        "updateFailed": "更新智能体失败 - {detail}",
+        "updated": "智能体“{name}”更新成功"
+      },
+      "validation": {
+        "cutoffInFuture": "知识截止日期必须是今天或更早。",
+        "descriptionMax": "描述不得超过 {max} 个字符",
+        "nameRequired": "智能体名称为必填项。",
+        "starterMax": "对话开场白不得超过 {max} 个字符"
+      },
+      "visibility": {
+        "relist": {
+          "button": {
+            "label": "重新展示"
+          },
+          "description": "重新展示的智能体会再次出现在探索智能体列表中。",
+          "title": "重新展示此智能体"
+        },
+        "unlist": {
+          "button": {
+            "label": "取消展示"
+          },
+          "description": "取消展示的智能体不会出现在探索智能体列表中，但仍可访问。",
+          "title": "取消展示此智能体"
+        }
+      },
+      "warnings": {
+        "openUrl": "没有打开 URL 能力的网络搜索可能会导致网络结果明显变差。"
+      }
+    },
     "filters": {
       "actions": {
         "all": {
@@ -6826,6 +8432,47 @@
         }
       }
     },
+    "navigation": {
+      "countSeparator": {
+        "label": "{count, plural, one {智能体} other {智能体}}"
+      },
+      "empty": {
+        "description": "未找到智能体"
+      },
+      "header": {
+        "description": "为您和团队的使用场景定制 AI 的行为和知识。",
+        "title": "智能体"
+      },
+      "newAgent": {
+        "label": "新建智能体",
+        "noPermission": {
+          "tooltip": "您没有创建智能体的权限。请联系管理员申请访问权限。"
+        }
+      },
+      "page": {
+        "ariaLabel": "智能体页面"
+      },
+      "search": {
+        "placeholder": "搜索智能体..."
+      },
+      "sections": {
+        "all": {
+          "title": "全部智能体"
+        },
+        "featured": {
+          "description": "由您的团队精选",
+          "title": "精选智能体"
+        }
+      },
+      "tabs": {
+        "all": {
+          "label": "全部智能体"
+        },
+        "your": {
+          "label": "您的智能体"
+        }
+      }
+    },
     "userVariables": {
       "insert": {
         "tooltip": "插入用户变量"
@@ -6833,6 +8480,12 @@
     }
   },
   "auth": {
+    "anonymous": {
+      "redirecting": {
+        "description": "正在设置您的匿名会话，请稍候。",
+        "title": "正在跳转到聊天页面..."
+      }
+    },
     "createAccount": {
       "createOrgButton": {
         "label": "创建新组织"
@@ -6854,6 +8507,55 @@
       },
       "signInLink": {
         "label": "登录"
+      }
+    },
+    "emailPasswordForm": {
+      "accountExists": {
+        "error": "使用指定电子邮件的账户已存在。"
+      },
+      "continueAsGuest": {
+        "label": "或以访客身份继续"
+      },
+      "email": {
+        "label": "电子邮件地址",
+        "placeholder": "email@yourcompany.com"
+      },
+      "forgotPassword": {
+        "link": "[忘记密码?]({url})"
+      },
+      "invalidCredentials": {
+        "error": "电子邮件或密码无效"
+      },
+      "noPassword": {
+        "error": "创建账户以设置密码"
+      },
+      "password": {
+        "label": "密码",
+        "placeholder": "密码"
+      },
+      "passwordDigit": {
+        "error": "密码必须至少包含一个数字"
+      },
+      "passwordLength": {
+        "error": "密码长度必须为 {min}–{max} 个字符"
+      },
+      "passwordLoginDisabled": {
+        "error": "密码登录已关闭。请使用您的身份提供商登录。"
+      },
+      "passwordLowercase": {
+        "error": "密码必须至少包含一个小写字母"
+      },
+      "passwordRequirements": {
+        "label": "密码要求:"
+      },
+      "passwordSpecialChar": {
+        "error": "密码必须至少包含一个特殊字符"
+      },
+      "passwordUppercase": {
+        "error": "密码必须至少包含一个大写字母"
+      },
+      "tooManyRequests": {
+        "error": "请求过多。请稍后重试。"
       }
     },
     "error": {
@@ -6894,6 +8596,31 @@
         "description": "身份验证系统临时中断"
       }
     },
+    "errorDisplay": {
+      "anonymousDisabled": {
+        "toast": "您的团队未启用匿名访问。"
+      },
+      "generic": {
+        "toast": "发生错误。"
+      }
+    },
+    "flowContainer": {
+      "createAccountLink": {
+        "label": "创建账户"
+      },
+      "logo": {
+        "alt": "徽标"
+      },
+      "signInLink": {
+        "label": "登录"
+      },
+      "signinPrompt": {
+        "text": "已有账户？"
+      },
+      "signupPrompt": {
+        "text": "第一次使用 {appName}？"
+      }
+    },
     "forgotPassword": {
       "backToLoginLink": {
         "label": "[返回登录](/auth/login)"
@@ -6926,7 +8653,8 @@
         "placeholder": "输入 API 密钥"
       },
       "emailField": {
-        "label": "邮箱"
+        "label": "邮箱",
+        "placeholder": "email@yourcompany.com"
       },
       "genericError": {
         "toast": "模拟用户失败"
@@ -6987,6 +8715,23 @@
         "label": "工作邮箱"
       }
     },
+    "passwordRequirements": {
+      "digit": {
+        "label": "包含数字。"
+      },
+      "length": {
+        "label": "{min}–{max} 个字符"
+      },
+      "lowercase": {
+        "label": "包含小写字母。"
+      },
+      "specialChar": {
+        "label": "包含特殊字符。"
+      },
+      "uppercase": {
+        "label": "包含大写字母。"
+      }
+    },
     "resetPassword": {
       "backToLoginLink": {
         "label": "[返回登录](/auth/login)"
@@ -7028,6 +8773,31 @@
       },
       "unexpectedError": {
         "toast": "发生意外错误。请重试。"
+      }
+    },
+    "sessionEnd": {
+      "expired": {
+        "message": "您的会话已过期。请重新登录以继续。"
+      },
+      "loginButton": {
+        "label": "登录"
+      },
+      "modal": {
+        "title": "您已退出登录"
+      },
+      "terminated": {
+        "message": "此会话已退出登录。请重新登录以继续。"
+      },
+      "unrecognized": {
+        "message": "您已意外退出登录。请重新登录以继续。如果此问题持续出现,请联系您的管理员。"
+      }
+    },
+    "signIn": {
+      "captchaTokenError": {
+        "toast": "grecaptcha.execute 未返回令牌"
+      },
+      "google": {
+        "label": "使用 Google 继续"
       }
     },
     "signup": {
@@ -8459,6 +10229,75 @@
         "tooltip": "此模型不支持修改该设置。"
       }
     },
+    "nrf": {
+      "page": {
+        "filesFailed": {
+          "toast": "{count, plural, one {文件处理失败并已移除：{names}} other {文件处理失败并已移除：{names}}}"
+        },
+        "loginModal": {
+          "loginButton": {
+            "label": "登录"
+          },
+          "title": "欢迎使用 Onyx"
+        },
+        "noResubmitMessage": {
+          "toast": "未找到之前发送的消息。"
+        },
+        "settingsButton": {
+          "tooltip": "打开设置"
+        },
+        "setupLlmButton": {
+          "label": "请设置 LLM。"
+        },
+        "turnOffModal": {
+          "cancelButton": {
+            "label": "取消"
+          },
+          "confirmButton": {
+            "label": "关闭"
+          },
+          "description": "您将看到浏览器默认的新标签页。您可以随时在 Onyx 设置中重新开启。",
+          "title": "关闭 Onyx 新标签页？"
+        }
+      },
+      "settingsPanel": {
+        "backgroundNone": {
+          "label": "无"
+        },
+        "backgroundOption": {
+          "ariaLabel": "{label}背景"
+        },
+        "backgroundOptionSelected": {
+          "ariaLabel": "{label}背景（已选择）"
+        },
+        "backgroundSection": {
+          "title": "背景"
+        },
+        "closeButton": {
+          "tooltip": "关闭设置"
+        },
+        "generalSection": {
+          "title": "常规"
+        },
+        "header": {
+          "title": "设置"
+        },
+        "newTabToggle": {
+          "label": "将 Onyx 用作新标签页"
+        },
+        "themeToggle": {
+          "tooltip": "{mode, select, light {切换为浅色主题} other {切换为深色主题}}"
+        }
+      },
+      "sidePanelHeader": {
+        "newChatButton": {
+          "tooltip": "新聊天"
+        },
+        "openInOnyxButton": {
+          "tooltip": "在 Onyx 中打开"
+        }
+      }
+    },
     "popup": {
       "consentCheckbox": {
         "label": "同意复选框"
@@ -8474,6 +10313,128 @@
       },
       "startButton": {
         "label": "开始"
+      }
+    },
+    "projects": {
+      "chatItem": {
+        "lastMessage": {
+          "description": "最后一条消息 {time}"
+        },
+        "projectFallback": {
+          "label": "项目"
+        }
+      },
+      "contextPanel": {
+        "addFilesButton": {
+          "label": "添加文件"
+        },
+        "contextExceeded": {
+          "message": "此项目超出了模型的上下文限制。会话在生成回复前会自动先搜索相关文件。"
+        },
+        "dropFiles": {
+          "message": "将文件拖放到此处以添加到此项目"
+        },
+        "emptyFiles": {
+          "message": "添加文档、文本或图像以在项目中使用。支持拖放。"
+        },
+        "fileCount": {
+          "description": "{count, plural, one {# 个文件} other {# 个文件}}"
+        },
+        "fileCountOverflow": {
+          "description": "100+ 个文件"
+        },
+        "files": {
+          "description": "此项目中的聊天可以访问这些文件。",
+          "title": "文件"
+        },
+        "filesModal": {
+          "description": "此项目中的会话可以访问这里的文件。",
+          "title": "项目文件"
+        },
+        "instructions": {
+          "emptyDescription": "添加指令以定制此项目中的回复。",
+          "title": "指令"
+        },
+        "loadingProject": {
+          "label": "正在加载项目..."
+        },
+        "setInstructionsButton": {
+          "label": "设置指令"
+        },
+        "viewAll": {
+          "label": "查看全部"
+        },
+        "viewFiles": {
+          "label": "查看文件"
+        }
+      },
+      "createModal": {
+        "cancelButton": {
+          "label": "取消"
+        },
+        "createError": {
+          "toast": "创建项目 {name} 失败"
+        },
+        "description": "使用项目将您的文件和聊天集中整理在一处,并为持续进行的工作添加自定义指令。",
+        "name": {
+          "label": "项目名称",
+          "placeholder": "您在做什么?"
+        },
+        "nameRequired": {
+          "error": "项目名称为必填项"
+        },
+        "submitButton": {
+          "label": "创建项目"
+        },
+        "title": "创建新项目"
+      },
+      "foldedPopover": {
+        "empty": {
+          "title": "未找到项目"
+        },
+        "search": {
+          "placeholder": "搜索项目..."
+        }
+      },
+      "folder": {
+        "collapse": {
+          "ariaLabel": "折叠项目"
+        },
+        "delete": {
+          "label": "删除项目"
+        },
+        "deleteModal": {
+          "confirmButton": {
+            "label": "删除"
+          },
+          "message": "确定要删除此项目吗?此操作无法撤销。",
+          "title": "删除项目"
+        },
+        "expand": {
+          "ariaLabel": "展开项目"
+        },
+        "rename": {
+          "label": "重命名项目"
+        }
+      },
+      "sessionList": {
+        "empty": {
+          "message": "暂无聊天。"
+        },
+        "recentChats": {
+          "title": "最近的聊天"
+        }
+      },
+      "uploads": {
+        "failed": {
+          "toast": "上传文件失败"
+        },
+        "oversized": {
+          "toast": "{count, plural, one {已跳过 # 个超大文件} other {已跳过 # 个超大文件}}(>{max} MB):{names}"
+        },
+        "rejected": {
+          "toast": "部分文件未上传。{details}"
+        }
       }
     },
     "sharedChat": {
@@ -8506,6 +10467,1773 @@
       },
       "incognito": {
         "title": "您处于无痕模式"
+      }
+    }
+  },
+  "common": {
+    "adminChrome": {
+      "openSidebar": {
+        "ariaLabel": "打开侧边栏"
+      },
+      "paymentReminder": {
+        "billingButton": {
+          "label": "更新账单信息"
+        },
+        "text": "**警告：**您的试用期将在不到 5 天后结束，且尚未添加付款方式。"
+      }
+    },
+    "agentAvatar": {
+      "image": {
+        "altFallback": "智能体头像"
+      },
+      "logo": {
+        "alt": "徽标"
+      }
+    },
+    "attachment": {
+      "document": {
+        "label": "文档"
+      },
+      "expandButton": {
+        "ariaLabel": "展开文档"
+      }
+    },
+    "backButton": {
+      "label": "返回"
+    },
+    "chatBackgrounds": {
+      "clouds": {
+        "label": "云"
+      },
+      "hills": {
+        "label": "丘陵"
+      },
+      "mountains": {
+        "label": "山脉"
+      },
+      "night": {
+        "label": "夜晚"
+      },
+      "none": {
+        "label": "无"
+      },
+      "plant": {
+        "label": "植物"
+      }
+    },
+    "colorSwatch": {
+      "sample": {
+        "text": "文"
+      }
+    },
+    "comboBox": {
+      "createOption": {
+        "ariaLabel": "{prefix}“{value}”",
+        "defaultPrefix": "创建"
+      },
+      "dropdown": {
+        "closeAriaLabel": "关闭下拉菜单",
+        "openAriaLabel": "打开下拉菜单"
+      },
+      "options": {
+        "empty": "未找到选项"
+      },
+      "separator": {
+        "label": "其他选项"
+      }
+    },
+    "commandMenu": {
+      "closeButton": {
+        "ariaLabel": "关闭菜单"
+      },
+      "dialog": {
+        "title": "命令菜单"
+      },
+      "options": {
+        "ariaLabel": "命令菜单选项"
+      },
+      "search": {
+        "placeholder": "搜索..."
+      }
+    },
+    "connectorMultiSelect": {
+      "allSelected": {
+        "description": "所有可用的连接器均已选择。请在下方移除连接器以添加其他连接器。",
+        "placeholder": "已选择所有连接器"
+      },
+      "documentSetHint": {
+        "description": "所选连接器索引的所有文档都将包含在此文档集中。"
+      },
+      "noMatches": {
+        "text": "未找到匹配的连接器"
+      },
+      "noMoreConnectors": {
+        "text": "没有更多可用的连接器"
+      },
+      "noPrivateConnectors": {
+        "text": "没有可用的私有连接器。请先创建一个私有连接器。"
+      },
+      "noneSelected": {
+        "text": "未选择连接器。请在上方搜索并选择连接器。"
+      },
+      "removeConnector": {
+        "tooltip": "移除连接器"
+      },
+      "search": {
+        "placeholder": "搜索连接器..."
+      }
+    },
+    "datePicker": {
+      "selectDate": {
+        "label": "选择日期"
+      },
+      "todayButton": {
+        "label": "今天"
+      }
+    },
+    "dateRange": {
+      "anyTime": {
+        "text": "任何时间..."
+      },
+      "chooseCustom": {
+        "ariaLabel": "选择自定义范围"
+      },
+      "clearButton": {
+        "ariaLabel": "清除"
+      },
+      "custom": {
+        "label": "自定义"
+      },
+      "customRange": {
+        "ariaLabel": "自定义范围：{from}至{to}"
+      },
+      "date": {
+        "label": "日期"
+      },
+      "group": {
+        "ariaLabel": "日期范围"
+      },
+      "preset": {
+        "oneDay": "1天",
+        "oneMonth": "1个月",
+        "sevenDays": "7天",
+        "threeMonths": "3个月"
+      }
+    },
+    "deleteButton": {
+      "button": {
+        "tooltip": "删除"
+      }
+    },
+    "documentDisplay": {
+      "contextDocs": {
+        "text": "{count, plural, one {# 个上下文文档} other {# 个上下文文档}}"
+      },
+      "openDocument": {
+        "ariaLabel": "打开文档：{title}"
+      },
+      "question": {
+        "title": "问题"
+      },
+      "subqueries": {
+        "text": "{count, plural, one {# 个子查询} other {# 个子查询}}"
+      },
+      "updated": {
+        "text": "更新于 {date}"
+      }
+    },
+    "dropdown": {
+      "default": {
+        "label": "默认"
+      },
+      "selectOption": {
+        "placeholder": "选择一个选项..."
+      }
+    },
+    "editable": {
+      "edit": {
+        "ariaLabel": "编辑"
+      },
+      "rename": {
+        "ariaLabel": "重命名"
+      },
+      "save": {
+        "ariaLabel": "保存"
+      }
+    },
+    "errorPages": {
+      "accessRestricted": {
+        "billingAdminHint": {
+          "text": "如果您是管理员，请访问<billingLink>管理员账单</billingLink>页面以{hadLicense, select, true {续订} other {激活}}您的许可证，通过 Stripe 注册，或联系 <supportLink>support@onyx.app</supportLink> 获取账单帮助。"
+        },
+        "heading": {
+          "title": "访问受限"
+        },
+        "licenseLapse": {
+          "description": "由于许可证失效，您对 Onyx 的访问已被暂时停用。"
+        },
+        "licenseRequired": {
+          "description": "使用 Onyx 需要许可证。您的数据受到保护，许可证激活后即可使用。"
+        },
+        "logoutButton": {
+          "label": "退出登录"
+        },
+        "manageSubscription": {
+          "description": "如果您是管理员，可以点击下方按钮管理您的订阅。其他用户请联系管理员处理此事。"
+        },
+        "obtainLicense": {
+          "description": "要开始使用，请联系系统管理员获取许可证。"
+        },
+        "renewLicense": {
+          "description": "要恢复访问权限并继续使用 Onyx，请联系系统管理员续订许可证。"
+        },
+        "resubscribeButton": {
+          "label": "重新订阅",
+          "loading": "正在加载..."
+        },
+        "resubscribeError": {
+          "text": "打开重新订阅页面时出错。请稍后再试。"
+        },
+        "seatLimit": {
+          "description": "您的组织已超出许可席位数。在减少用户数量或升级许可证之前，访问将受到限制。"
+        },
+        "seatLimitAdminHint": {
+          "text": "如果您是管理员，可以在<userLink>用户管理</userLink>页面管理用户，或在<billingLink>管理员账单</billingLink>页面升级许可证。"
+        },
+        "seatLimitWithCounts": {
+          "description": "您的组织已超出许可席位数（{used} 位用户 / {seats} 个席位）。在减少用户数量或升级许可证之前，访问将受到限制。"
+        },
+        "subscriptionLapse": {
+          "description": "由于订阅失效，您对 Onyx 的访问已被暂时停用。"
+        },
+        "updatePayment": {
+          "description": "要恢复访问权限并继续使用 Onyx 的强大功能，请更新您的付款信息。"
+        }
+      },
+      "configError": {
+        "adminHint": {
+          "text": "如果您是管理员，请查看我们的<docsLink>文档</docsLink>了解正确的配置步骤。如果您是普通用户，请联系管理员寻求帮助。"
+        },
+        "heading": {
+          "description": "加载您的 Onyx 设置时似乎出现了问题。这可能是由于配置问题或安装未完成造成的。",
+          "title": "我们遇到了问题"
+        }
+      },
+      "maintenance": {
+        "apology": {
+          "description": "对由此带来的不便我们深表歉意，感谢您的耐心等待。"
+        },
+        "checkBack": {
+          "description": "Onyx 目前处于维护窗口期。请几分钟后再试。"
+        },
+        "heading": {
+          "title": "维护进行中"
+        }
+      },
+      "needHelp": {
+        "text": "需要帮助？加入我们的 <discordLink>Discord 社区</discordLink>获取支持。"
+      }
+    },
+    "errors": {
+      "unknown": {
+        "message": "未知错误"
+      }
+    },
+    "expandableContent": {
+      "downloadButton": {
+        "tooltip": "下载文件"
+      },
+      "file": {
+        "untitledFallback": "无标题"
+      },
+      "fullScreenButton": {
+        "tooltip": "全屏"
+      },
+      "hideButton": {
+        "tooltip": "隐藏"
+      },
+      "minimizeButton": {
+        "tooltip": "最小化"
+      }
+    },
+    "expandableText": {
+      "copyButton": {
+        "tooltip": "复制"
+      },
+      "downloadButton": {
+        "tooltip": "下载"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {# 行} other {# 行}}"
+      },
+      "size": {
+        "bytes": "{count} 字节",
+        "kilobytes": "{size} KB"
+      },
+      "viewFullButton": {
+        "tooltip": "查看全文"
+      }
+    },
+    "federatedConnectorSelector": {
+      "allSelected": {
+        "placeholder": "已选择所有联合连接器"
+      },
+      "entitiesConfigured": {
+        "tooltip": "已配置实体"
+      },
+      "noMatches": {
+        "text": "未找到匹配的联合连接器"
+      },
+      "noMoreConnectors": {
+        "text": "没有更多可用的联合连接器"
+      },
+      "noneSelected": {
+        "text": "未选择联合连接器。请在上方搜索并选择连接器。"
+      },
+      "realtimeSearchHint": {
+        "description": "查询时将实时搜索所选联合连接器中的文档。"
+      },
+      "removeConnector": {
+        "tooltip": "移除连接器"
+      },
+      "search": {
+        "placeholder": "搜索联合连接器..."
+      }
+    },
+    "field": {
+      "arrayField": {
+        "addButton": "新增"
+      },
+      "booleanField": {
+        "optionalLabel": "{label}（可选）"
+      },
+      "fileValidation": {
+        "noTypeDefinition": "未找到字段的文件类型定义：{name}",
+        "selectionError": "文件选择错误",
+        "unknownError": "未知错误",
+        "validating": "正在验证文件...",
+        "validationError": "验证错误"
+      },
+      "markdown": {
+        "editorLabel": "Markdown",
+        "placeholder": "在此输入 Markdown...",
+        "previewTab": "预览",
+        "writeTab": "编写"
+      },
+      "optionalIndicator": {
+        "text": "（可选）"
+      },
+      "passwordToggle": {
+        "hideAriaLabel": "隐藏密码",
+        "showAriaLabel": "显示密码"
+      },
+      "selector": {
+        "noneOption": "无",
+        "placeholder": "选择..."
+      }
+    },
+    "filePicker": {
+      "allRecentFilesButton": {
+        "title": "所有最近的文件"
+      },
+      "recentFiles": {
+        "title": "最近的文件"
+      },
+      "recentFilesModal": {
+        "description": "上传文件或从最近的文件中选择。"
+      },
+      "toasts": {
+        "associatedAssistants": "无法删除文件。它与以下助手关联：{assistants}",
+        "associatedBoth": "无法删除文件。它与以下项目：{projects} 和助手：{assistants} 关联",
+        "associatedProjects": "无法删除文件。它与以下项目关联：{projects}",
+        "deleteFailed": "删除文件失败。请重试。",
+        "deleteSuccess": "文件删除成功"
+      },
+      "uploadFiles": {
+        "description": "从您的设备上传文件",
+        "title": "上传文件"
+      },
+      "viewFileButton": {
+        "tooltip": "查看文件"
+      }
+    },
+    "fileTile": {
+      "file": {
+        "fallback": "文件"
+      },
+      "open": {
+        "ariaLabel": "打开{title}"
+      },
+      "removeButton": {
+        "label": "移除"
+      }
+    },
+    "filters": {
+      "clearButton": {
+        "ariaLabel": "清除"
+      }
+    },
+    "formField": {
+      "optional": {
+        "label": "（可选）"
+      },
+      "required": {
+        "label": "（必填）"
+      }
+    },
+    "genericMultiSelect": {
+      "loadFailed": {
+        "text": "加载{label}失败。请重试。"
+      },
+      "search": {
+        "placeholder": "搜索..."
+      }
+    },
+    "groupsMultiSelect": {
+      "noGroups": {
+        "emptyMessage": "没有可用的用户组。请先创建一个用户组。"
+      },
+      "userGroups": {
+        "label": "用户组",
+        "subtext": "选择哪些用户组可以访问此资源"
+      }
+    },
+    "icons": {
+      "logo": {
+        "alt": "徽标"
+      }
+    },
+    "initializingLoader": {
+      "initializing": {
+        "text": "正在初始化 {appName}"
+      }
+    },
+    "inputElement": {
+      "removeButton": {
+        "tooltip": "移除"
+      }
+    },
+    "inputFile": {
+      "attachButton": {
+        "ariaLabel": "附加文件"
+      },
+      "clearButton": {
+        "ariaLabel": "清除文件"
+      }
+    },
+    "inputImage": {
+      "dropRejected": {
+        "fallback": "文件被拒绝"
+      },
+      "editButton": {
+        "ariaLabel": "编辑图片"
+      },
+      "editOverlay": {
+        "label": "编辑"
+      },
+      "image": {
+        "altFallback": "图片"
+      },
+      "removeButton": {
+        "ariaLabel": "移除图片"
+      },
+      "uploadButton": {
+        "ariaLabel": "上传图片"
+      }
+    },
+    "inputSelect": {
+      "placeholder": {
+        "fallback": "选择一个选项"
+      }
+    },
+    "isPublicSelector": {
+      "assignGroups": {
+        "label": "为此{objectName}分配组访问权限",
+        "scopedSubtext": "选择一个或多个您管理的组以授予对此{objectName}的访问权限",
+        "visibleSubtext": "此{objectName}将对以下所选的组可见/可访问"
+      },
+      "loading": {
+        "text": "正在加载..."
+      },
+      "makePublic": {
+        "label": "将此{objectName}设为公开？",
+        "subtext": "如果启用，此{objectName}将可供<b>所有{publicToWhom}</b>使用。否则，只有<b>管理员</b>和（例如通过用户组）被明确授予此{objectName}访问权限的<b>{publicToWhom}</b>才能访问。"
+      },
+      "publicDisabled": {
+        "message": "此{objectName}是公开的，所有用户均可使用。"
+      },
+      "usersFallback": {
+        "text": "用户"
+      }
+    },
+    "keyValue": {
+      "addButton": {
+        "ariaLabel": "添加{keyTitle}与{valueTitle}对",
+        "label": "添加行"
+      },
+      "empty": {
+        "title": "尚未添加任何条目。"
+      },
+      "error": {
+        "duplicateKey": "键重复",
+        "duplicateSummary": "{count, plural, one {发现 # 个重复的键} other {发现 # 个重复的键}}",
+        "emptyKey": "键不能为空",
+        "emptySummary": "{count, plural, one {发现 # 个空键} other {发现 # 个空键}}",
+        "validationSummary": "{count, plural, one {发现 # 个验证错误} other {发现 # 个验证错误}}"
+      },
+      "group": {
+        "ariaLabel": "{keyTitle}与{valueTitle}对"
+      },
+      "input": {
+        "ariaLabel": "{label} {index}"
+      },
+      "keyColumn": {
+        "title": "键"
+      },
+      "pair": {
+        "fallbackLabel": "键值"
+      },
+      "removeButton": {
+        "ariaLabel": "移除{label}对 {index}"
+      },
+      "valueColumn": {
+        "title": "值"
+      }
+    },
+    "logo": {
+      "image": {
+        "alt": "徽标"
+      },
+      "poweredBy": {
+        "label": "由 Onyx 提供支持"
+      }
+    },
+    "nonSelectableConnectors": {
+      "unavailable": {
+        "label": "不可用的连接器："
+      }
+    },
+    "oauthCallback": {
+      "authorizationFailed": {
+        "description": "授权已取消或失败。请重试。",
+        "title": "授权失败"
+      },
+      "backButton": {
+        "label": "返回聊天"
+      },
+      "completeFailed": {
+        "message": "无法完成授权"
+      },
+      "genericError": {
+        "description": "OAuth 过程中发生错误。请重试。",
+        "title": "出了点问题"
+      },
+      "invalidRequest": {
+        "description": "授权请求不完整。请重试。",
+        "title": "无效请求"
+      },
+      "loadingHint": {
+        "text": "这可能需要一些时间..."
+      },
+      "processing": {
+        "description": "请稍候，我们正在完成设置。",
+        "title": "正在处理..."
+      },
+      "redirecting": {
+        "text": "将在 {count, plural, one {# 秒} other {# 秒}}后跳转..."
+      },
+      "serviceFallback": {
+        "text": "服务"
+      },
+      "success": {
+        "detailsTemplate": "您的 {serviceName} 授权已成功完成。",
+        "title": "成功！"
+      }
+    },
+    "spreadsheet": {
+      "error": {
+        "description": "电子表格可能已损坏或无法正常加载。",
+        "title": "加载电子表格出错"
+      },
+      "preview": {
+        "truncated": "预览已截断。请下载文件查看所有行。",
+        "unavailable": "无法预览此电子表格。"
+      },
+      "sheet": {
+        "defaultName": "工作表1",
+        "empty": "此工作表为空。",
+        "tooLarge": "此工作表过大，无法预览。请下载文件查看。"
+      }
+    }
+  },
+  "craft": {
+    "agentSwitcher": {
+      "mainAgent": {
+        "label": "主代理"
+      },
+      "subagentFallback": {
+        "label": "子代理"
+      },
+      "switch": {
+        "ariaLabel": "切换代理"
+      }
+    },
+    "approvals": {
+      "approveOnce": {
+        "ariaLabel": "仅批准此操作一次",
+        "button": "批准一次"
+      },
+      "approveSession": {
+        "button": "批准整个会话",
+        "tooltip": "批准此会话中的匹配操作"
+      },
+      "details": {
+        "hideAriaLabel": "隐藏详情",
+        "showAriaLabel": "显示详情"
+      },
+      "header": {
+        "required": "需要批准：{headline}"
+      },
+      "headline": {
+        "multiAction": "{app} 中的 {count, plural, one {# 个操作} other {# 个操作}}",
+        "singleAction": "{app} 中的 {action}"
+      },
+      "payload": {
+        "empty": {
+          "label": "无载荷。"
+        },
+        "showLess": {
+          "button": "收起"
+        },
+        "showMore": {
+          "button": "展开"
+        }
+      },
+      "reject": {
+        "ariaLabel": "拒绝此操作",
+        "button": "拒绝"
+      },
+      "status": {
+        "approved": "已批准",
+        "rejected": "已拒绝"
+      },
+      "submit": {
+        "errorFallback": "提交决定失败"
+      }
+    },
+    "apps": {
+      "addCatalog": {
+        "addButton": "添加",
+        "createButton": "创建",
+        "customApp": {
+          "description": "为您自己的集成提供凭据和网络访问。",
+          "title": "自定义应用"
+        },
+        "mcpHint": {
+          "label": "需要 MCP 服务器？请先在“操作”中连接它，然后在此处为 Craft 启用。",
+          "openActionsButton": "打开操作"
+        },
+        "modal": {
+          "description": "让整个组织都可以使用某个集成。内置提供商附带可教 Craft 智能体使用方法的操作；已配置的提供商不会列出。",
+          "title": "添加应用"
+        }
+      },
+      "associatedSkills": {
+        "associateAriaLabel": "关联 {name}",
+        "associateButton": "关联现有技能",
+        "create": {
+          "github": {
+            "description": "如果您的技能在 GitHub 中，请先在技能页面导入，然后再将其与此应用关联。",
+            "label": "从 GitHub 导入"
+          },
+          "scratch": {
+            "description": "编写说明并添加辅助文件。",
+            "label": "从头开始"
+          },
+          "upload": {
+            "description": "导入 SKILL.md 文件、ZIP 文件或技能文件夹。",
+            "label": "上传技能"
+          }
+        },
+        "createSkillButton": "创建技能",
+        "description": "技能为 Craft 提供使用此应用的说明。技能在整个组织范围内生效；用户可能需要全部启用才能让应用正常工作。",
+        "editButton": "编辑",
+        "empty": {
+          "label": "未找到可编辑的技能。"
+        },
+        "invalidTag": "无效",
+        "loading": {
+          "label": "正在加载技能…"
+        },
+        "noneAssociated": {
+          "label": "尚未关联任何技能。没有技能也可以保存并使用此应用。"
+        },
+        "promote": {
+          "cancelButton": "取消",
+          "confirmButton": "设为组织范围可用",
+          "description": "与应用关联的技能必须对所有人可用。此更改将在保存应用时生效。",
+          "title": "将“{name}”设为组织范围可用？"
+        },
+        "search": {
+          "placeholder": "搜索可编辑的技能..."
+        },
+        "title": "关联的技能",
+        "unavailable": {
+          "duplicateName": "名为“{name}”的技能已关联。",
+          "invalid": "技能无效，请先修复再关联。",
+          "otherApp": "已与应用“{name}”关联。"
+        },
+        "unlink": {
+          "button": "解除关联",
+          "cancelButton": "取消",
+          "confirm": "将“{name}”与此应用解除关联？"
+        },
+        "unlinkAriaLabel": "解除关联 {name}",
+        "viewButton": "查看"
+      },
+      "configureProvider": {
+        "addButton": "添加",
+        "addTitle": "添加 {name}",
+        "editTitle": "编辑 {name}",
+        "emptyPolicies": "此提供商没有可配置的操作。",
+        "fields": {
+          "name": {
+            "description": "此连接的标签。添加同一提供商的多个实例时，请使用不同的名称（例如“{name} — 工程部”）。",
+            "label": "名称"
+          }
+        },
+        "managedDescription": "由 Onyx 提供，请配置智能体可以执行的操作。",
+        "managedNote": "此应用由 Onyx 提供，凭据由系统代管。请在下方选择智能体可以执行的操作。用户可从“应用”页面连接它。",
+        "saveButton": "保存"
+      },
+      "customApp": {
+        "cancelButton": "取消",
+        "createButton": "创建",
+        "createDescription": "配置出站代理如何访问此应用并进行身份验证。技能不是必需的。",
+        "createTitle": "创建自定义应用",
+        "creatingButton": "正在创建…",
+        "disabled": {
+          "nameMissing": "创建此自定义应用前请输入名称。",
+          "patternMissing": "请至少添加一个上游 URL 模式。输入模式后按回车键。",
+          "pristine": "请先进行更改再保存。",
+          "saving": "保存已在进行中。"
+        },
+        "editDescription": "更新网关设置并管理关联的技能。",
+        "editTitle": "编辑 {name}",
+        "errors": {
+          "saveFailedTitle": "无法保存"
+        },
+        "fields": {
+          "headers": {
+            "addButton": "添加标头",
+            "description": "可选。注入到出站请求中的标头。使用 '{placeholder}' 表示由用户（或下方的组织）提供的值，例如 \"Bearer '{api_key}'\"。留空则仅将上游模式加入允许列表而不注入凭据。",
+            "keyTitle": "标头",
+            "label": "标头凭据模式",
+            "valueTitle": "值"
+          },
+          "name": {
+            "label": "名称",
+            "placeholder": "我的自定义应用"
+          },
+          "orgCredentials": {
+            "addButton": "添加凭据",
+            "description": "可选。组织为每个用户预填的值。若每个用户自行提供凭据，请留空。",
+            "keyTitle": "凭据键",
+            "label": "组织凭据",
+            "valueTitle": "值"
+          },
+          "upstreamPatterns": {
+            "description": "代理可注入凭据的出站 URL。使用 * 匹配任意字符（例如 https://api.example.com/* 覆盖该主机上的所有路径）。主机名必须是字面值，第一个斜杠之前不能使用通配符。输入模式后按回车键。",
+            "label": "上游 URL 模式"
+          }
+        },
+        "saveButton": "保存",
+        "savingButton": "正在保存…"
+      },
+      "errors": {
+        "duplicateSkillName": "应用“{appName}”已有名为“{skillName}”的关联技能。请上传其他名称的技能。"
+      },
+      "mcpPolicy": {
+        "description": "配置 Craft 智能体可以使用此 MCP 服务器的工具执行的操作。",
+        "emptyPolicies": "此服务器上没有已启用的工具。请先在 MCP 操作页面启用工具。",
+        "saveButton": "保存",
+        "title": "编辑 {name}"
+      },
+      "oauthCallback": {
+        "backButton": "返回我的应用",
+        "description": "正在完成 OAuth 握手…",
+        "errors": {
+          "cancelled": "OAuth 已被取消或拒绝：{reason}",
+          "failed": "连接失败。",
+          "missingParams": "回调 URL 中缺少 code 或 state。"
+        },
+        "exchanging": {
+          "label": "正在交换授权码…"
+        },
+        "success": {
+          "label": "已连接。正在返回您的应用…"
+        },
+        "title": "正在连接您的应用"
+      },
+      "page": {
+        "connectButton": "连接",
+        "connectingButton": "正在重定向…",
+        "disconnectButton": "断开连接",
+        "empty": {
+          "description": "您的组织尚未配置任何应用或 MCP 服务器。",
+          "title": "暂无可连接的内容"
+        },
+        "errors": {
+          "disconnectFailed": "断开连接失败",
+          "startAuthFailed": "无法启动授权"
+        },
+        "header": {
+          "description": "连接 Onyx Craft 在工作时可用作上下文的工具。",
+          "manageButton": "管理应用",
+          "searchPlaceholder": "搜索应用...",
+          "title": "应用"
+        },
+        "kinds": {
+          "app": {
+            "blurb": "Onyx 直接支持的集成。每个都附带教 Craft 如何使用它的技能，从这里开始。",
+            "empty": "您的组织尚未配置任何应用。",
+            "emptyTitle": "暂无应用",
+            "tabLabel": "应用 · {count}"
+          },
+          "mcp": {
+            "blurb": "管理员向 Craft 开放的服务器。当您需要的应用未在“应用”中列出，或您特别需要某个服务器自己的 MCP 工具时使用。",
+            "empty": "尚未向 Craft 开放任何 MCP 服务器。",
+            "emptyTitle": "暂无 MCP 服务器",
+            "tabLabel": "MCP 服务器 · {count}"
+          }
+        },
+        "loading": {
+          "label": "正在加载…"
+        },
+        "reviewSkillsButton": "查看技能",
+        "search": {
+          "noMatchesDescription": "这里没有与您的搜索匹配的内容。",
+          "noMatchesTitle": "无匹配项"
+        },
+        "status": {
+          "connected": "已连接",
+          "connectedNeedsSkills": "已连接 · 并非所有关联技能都已启用",
+          "notAvailable": "您的账户不可用，请咨询管理员",
+          "skillWarningAriaLabel": "需要设置技能",
+          "skillWarningTooltip": "并非所有关联技能都已启用。此应用可能无法正常工作。"
+        }
+      },
+      "policyEditor": {
+        "advanced": {
+          "description": "为每个操作单独设置策略。",
+          "title": "高级"
+        },
+        "cancelButton": "取消",
+        "loading": {
+          "label": "正在加载…"
+        },
+        "permissions": {
+          "askOption": "询问",
+          "autoApproveOption": "自动批准",
+          "customOption": "自定义",
+          "description": "选择智能体可以执行的操作。“询问”会在每个操作运行前在聊天中提示您；“自动批准”则无需提示即可运行。使用“高级”为每个操作单独设置策略。",
+          "title": "权限"
+        },
+        "savingButton": "正在保存…"
+      },
+      "skillsStep": {
+        "description": "可选。关联现有技能或为此应用创建一个技能。",
+        "errors": {
+          "saveFailedTitle": "无法保存"
+        },
+        "saveButton": "保存技能",
+        "savingButton": "正在保存…",
+        "skipButton": "暂时跳过",
+        "title": "为 {name} 添加技能"
+      },
+      "userCredentials": {
+        "cancelButton": "取消",
+        "connectButton": "连接",
+        "connectingButton": "正在连接…",
+        "description": "输入您的凭据，为您的账户授权此应用。",
+        "errors": {
+          "connectFailedTitle": "无法连接"
+        },
+        "title": "连接 {name}"
+      }
+    },
+    "artifactsTab": {
+      "download": {
+        "button": "下载"
+      },
+      "empty": {
+        "description": "输出文件和 Web 应用将显示在这里",
+        "title": "暂无产物"
+      },
+      "nextjsApp": {
+        "label": "Next.js 应用"
+      },
+      "openItem": {
+        "ariaLabel": "打开 {name}"
+      },
+      "toggleItem": {
+        "ariaLabel": "展开或折叠 {name}"
+      }
+    },
+    "chatPanel": {
+      "input": {
+        "continuePlaceholder": "继续对话...",
+        "scheduledRunPlaceholder": "计划运行进行中...",
+        "subagentPlaceholder": "切换到主代理以发送消息"
+      },
+      "openSidebar": {
+        "ariaLabel": "打开侧边栏"
+      },
+      "outputPanel": {
+        "closeTooltip": "关闭输出面板",
+        "openTooltip": "打开输出面板"
+      },
+      "responseStopped": {
+        "label": "响应已停止"
+      },
+      "scrollToBottom": {
+        "label": "滚动到底部"
+      },
+      "toast": {
+        "operationWait": "请等待当前操作完成。",
+        "sandboxWait": "请等待沙箱初始化",
+        "scheduledRunWait": "请等待计划运行结束。"
+      }
+    },
+    "compaction": {
+      "marker": {
+        "label": "已压缩上下文以释放空间"
+      }
+    },
+    "connectDataBanner": {
+      "cta": {
+        "label": "连接您的数据"
+      }
+    },
+    "craftingLoader": {
+      "messages": {
+        "craftingWorkspace": "正在打造您的工作区...",
+        "enchanting": "正在施加魔法附魔...",
+        "gamemode": "/gamemode 1",
+        "gatheringResources": "正在收集资源...",
+        "miningDependencies": "正在挖掘依赖项...",
+        "placingBlocks": "正在放置方块...",
+        "punchingWood": "正在撸树...",
+        "smeltingCode": "正在熔炼代码...",
+        "worldGenerated": "世界生成完成..."
+      },
+      "tagline": {
+        "label": "正在打造您的下一个好点子..."
+      }
+    },
+    "debugLogs": {
+      "clear": {
+        "tooltip": "清空"
+      },
+      "copy": {
+        "doneTooltip": "已复制",
+        "tooltip": "复制可见内容"
+      },
+      "empty": {
+        "noLines": "暂无日志行。",
+        "noMatch": "没有与 \"{filter}\" 匹配的行",
+        "waiting": "正在等待第一条日志…"
+      },
+      "error": {
+        "endpointDisabled": "调试端点已禁用 (ENABLE_OPENCODE_DEBUGGING=false)",
+        "http": "HTTP {status}",
+        "noSandbox": "没有正在运行的沙箱可读取日志"
+      },
+      "filter": {
+        "placeholder": "筛选…"
+      },
+      "lines": {
+        "count": "{count, plural, one {# 行} other {# 行}}",
+        "filteredCount": "{visible, number} / {total, number} 行"
+      },
+      "modal": {
+        "description": "沙箱容器的实时日志 — 仅限开发/调试。",
+        "title": "Opencode Pod 日志"
+      },
+      "newSincePaused": {
+        "button": "+{count, number} 条新日志 · 跳转"
+      },
+      "open": {
+        "button": "Pod 日志"
+      },
+      "status": {
+        "closed": "已关闭",
+        "connecting": "连接中",
+        "error": "错误",
+        "paused": "已暂停",
+        "streaming": "流式传输中"
+      }
+    },
+    "entryMenu": {
+      "addFiles": {
+        "label": "添加文件或照片"
+      },
+      "apps": {
+        "label": "应用"
+      },
+      "browseSkills": {
+        "label": "浏览技能"
+      },
+      "connect": {
+        "hint": "连接"
+      },
+      "connectApp": {
+        "label": "连接应用"
+      },
+      "library": {
+        "label": "库"
+      },
+      "manageLibrary": {
+        "label": "管理库…"
+      },
+      "mcpServer": {
+        "description": "MCP 服务器"
+      },
+      "skills": {
+        "label": "技能"
+      }
+    },
+    "filePreview": {
+      "cannotPreview": {
+        "title": "无法预览文件"
+      },
+      "error": {
+        "inline": "错误：{message}",
+        "title": "加载文件出错"
+      },
+      "loading": {
+        "label": "正在加载文件..."
+      },
+      "noContent": {
+        "label": "无内容"
+      }
+    },
+    "filesTab": {
+      "empty": {
+        "description": "构建过程中创建的文件将显示在这里",
+        "title": "暂无文件"
+      },
+      "emptyDirectory": {
+        "label": "此目录中没有文件"
+      },
+      "error": {
+        "title": "加载文件出错"
+      },
+      "loading": {
+        "label": "正在加载文件..."
+      },
+      "loadingChildren": {
+        "label": "加载中..."
+      },
+      "preparing": {
+        "description": "正在设置您的开发环境",
+        "title": "正在准备沙箱..."
+      }
+    },
+    "imagePreview": {
+      "error": {
+        "description": "无法显示该图片",
+        "title": "图片加载失败"
+      },
+      "loading": {
+        "label": "正在加载图片..."
+      },
+      "preview": {
+        "ariaLabel": "{name} 的预览"
+      }
+    },
+    "inputBar": {
+      "entryInfo": {
+        "connected": "已连接",
+        "connectionRequired": "需要连接"
+      },
+      "plusMenu": {
+        "tooltip": "添加文件或技能"
+      }
+    },
+    "interruptHint": {
+      "stopping": {
+        "label": "正在停止…"
+      },
+      "toInterrupt": {
+        "label": "以中断"
+      }
+    },
+    "intro": {
+      "beta": {
+        "badge": "BETA"
+      },
+      "returnHome": {
+        "button": "返回首页"
+      },
+      "startCrafting": {
+        "button": "开始创作"
+      },
+      "wordmark": {
+        "label": "Craft"
+      }
+    },
+    "llmPopover": {
+      "noModels": {
+        "label": "未找到模型"
+      },
+      "recommended": {
+        "label": "推荐"
+      },
+      "recommendedOnly": {
+        "label": "仅显示推荐模型"
+      }
+    },
+    "onboarding": {
+      "livingMap": {
+        "examplePrompts": {
+          "flakyRetryTest": "“修复不稳定的重试测试并提交 PR。”",
+          "launchDeck": "“根据 Drive 中的简报制作春季发布演示文稿。”",
+          "rfpSecurity": "“用我们的安全信息填写我邮件里的 RFP。”",
+          "slackToLinear": "“把我们的 Slack 讨论整理成 Linear 工单。”",
+          "vendorSpend": "“把我们第二季度的供应商支出总结成 Drive 中的文档。”"
+        },
+        "modal": {
+          "backButton": "返回",
+          "ctaButton": "让 Craft 开始工作",
+          "nextButton": "下一步",
+          "title": "认识 Craft"
+        },
+        "outputs": {
+          "ariaLabel": "产出：{name}",
+          "githubPr": {
+            "caption": "待审核",
+            "label": "GitHub PR"
+          },
+          "googleDoc": {
+            "caption": "已写入您的 Drive",
+            "label": "Google 文档"
+          },
+          "liveApp": {
+            "caption": "已托管，可通过链接分享",
+            "label": "在线应用"
+          }
+        },
+        "prompt": {
+          "label": "您的提示词"
+        },
+        "schedule": {
+          "ariaLabel": "计划任务：按定时器重新运行此提示词",
+          "caption": "在您离开时运行",
+          "label": "每周一 8:00"
+        },
+        "sources": {
+          "connectedAriaLabel": "已连接的来源：{name}",
+          "yourFiles": {
+            "ariaLabel": "您上传的文件",
+            "label": "您的文件"
+          }
+        },
+        "stages": {
+          "constellation": {
+            "caption": "点击地图的任意部分即可重新查看。",
+            "title": "这就是 Craft。轮到您了。"
+          },
+          "machine": {
+            "caption": "只读取您可见的内容，绝不读取您的机密。",
+            "title": "它在自己的机器上工作。"
+          },
+          "output": {
+            "caption": "既可按需运行，也可在您离开时按计划运行。",
+            "title": "产出的是完成的工作成果。"
+          },
+          "prompt": {
+            "caption": "描述您想要的结果，其余交给 Craft。",
+            "title": "把真正的工作交给 Craft。"
+          }
+        },
+        "team": {
+          "ariaLabel": "您的团队：一个链接即可分享 Craft 的工作成果",
+          "caption": "一个链接即可分享",
+          "label": "您的团队"
+        },
+        "workspace": {
+          "approvalPill": "等待您的批准",
+          "label": "Craft 的工作区",
+          "sandboxBadge": "隔离沙箱"
+        }
+      },
+      "llmLocked": {
+        "backToChatButton": "返回聊天",
+        "description": "Onyx Craft 需要模型提供商，且只有管理员可以设置。请让您的管理员连接 Anthropic、OpenAI 或 OpenRouter。",
+        "title": "需要 LLM 提供商"
+      },
+      "llmSetup": {
+        "description": "Craft 智能体需要模型提供商才能构建。",
+        "title": "连接模型提供商"
+      },
+      "welcomeMock": {
+        "input": {
+          "placeholder": "分析我的数据并创建仪表板..."
+        },
+        "modelPill": {
+          "label": "Claude Opus 4.8"
+        },
+        "promptPills": {
+          "engineering": "工程",
+          "marketing": "市场营销",
+          "product": "产品",
+          "sales": "销售"
+        }
+      }
+    },
+    "outputPanel": {
+      "artifactsEmpty": {
+        "tooltip": "开始构建内容即可查看产物！"
+      },
+      "devServerStarting": {
+        "tooltip": "正在启动开发服务器..."
+      },
+      "noWebapp": {
+        "label": "此会话中还没有 Web 应用"
+      }
+    },
+    "pdfPreview": {
+      "error": {
+        "description": "无法加载该 PDF 文件。",
+        "title": "无法预览 PDF"
+      },
+      "frame": {
+        "title": "PDF 预览"
+      },
+      "loading": {
+        "label": "正在加载 PDF..."
+      }
+    },
+    "pptxPreview": {
+      "converting": {
+        "label": "正在转换演示文稿..."
+      },
+      "empty": {
+        "label": "此演示文稿中没有幻灯片"
+      },
+      "error": {
+        "title": "无法预览演示文稿"
+      },
+      "loadingSlide": {
+        "label": "正在加载幻灯片..."
+      },
+      "slide": {
+        "counter": "幻灯片 {current} / {total}"
+      }
+    },
+    "previewTab": {
+      "empty": {
+        "description": "Web 应用运行后，实时预览将显示在这里。"
+      },
+      "frame": {
+        "title": "Web 应用预览"
+      },
+      "starting": {
+        "description": "正在安装依赖并启动。",
+        "title": "正在启动开发服务器..."
+      }
+    },
+    "redirect": {
+      "redirecting": {
+        "label": "正在重定向..."
+      }
+    },
+    "sandboxAsleep": {
+      "dismiss": {
+        "button": "关闭"
+      },
+      "modal": {
+        "description": "由于一段时间未活动，沙箱已休眠。您的工作已保存。唤醒它即可继续。",
+        "title": "您的沙箱已休眠"
+      },
+      "wake": {
+        "button": "唤醒沙箱"
+      }
+    },
+    "scheduledRun": {
+      "badge": {
+        "label": "已计划"
+      },
+      "startedAt": {
+        "label": "开始于 {time}"
+      },
+      "status": {
+        "awaitingApproval": "此计划运行正在等待批准。恢复并结束后即可发送后续消息。",
+        "running": "此计划运行仍在进行中。运行结束后即可发送后续消息。",
+        "startedBy": "此会话由计划任务 {task} 于 {time} 启动。"
+      },
+      "viewTask": {
+        "ariaLabel": "查看计划任务 {task}。{status}",
+        "label": "查看任务"
+      }
+    },
+    "setupCard": {
+      "appFallback": {
+        "label": "外部应用 {id}"
+      },
+      "connect": {
+        "title": "连接 {app}"
+      },
+      "connected": {
+        "title": "已连接 {app}。"
+      },
+      "error": {
+        "generic": "出了点问题。请重试。",
+        "notConfigurable": "无法从此处设置该应用。",
+        "popupBlocked": "无法打开设置窗口。请允许弹出窗口后重试。",
+        "startFailed": "无法开始设置"
+      },
+      "loading": {
+        "button": "加载中…"
+      },
+      "notNow": {
+        "button": "暂不"
+      },
+      "reason": {
+        "fallback": "代理需要 {app} 才能继续此任务。"
+      },
+      "skipped": {
+        "title": "已跳过连接 {app}。"
+      },
+      "waiting": {
+        "button": "等待中…"
+      }
+    },
+    "share": {
+      "copyLink": {
+        "ariaLabel": "复制链接"
+      },
+      "organization": {
+        "description": "登录您的 Onyx 的任何人都可以查看此应用。",
+        "label": "组织"
+      },
+      "private": {
+        "description": "只有您可以查看此应用。",
+        "label": "私密"
+      },
+      "share": {
+        "label": "分享"
+      },
+      "shared": {
+        "label": "已分享"
+      },
+      "trigger": {
+        "ariaLabel": "分享 Web 应用"
+      }
+    },
+    "sideBar": {
+      "apps": {
+        "label": "应用"
+      },
+      "backToChat": {
+        "label": "返回聊天"
+      },
+      "delete": {
+        "label": "删除"
+      },
+      "deleteModal": {
+        "body": "这将永久删除该 Craft 会话及其所有数据。此操作无法撤销。",
+        "confirm": "删除",
+        "deleting": "正在删除...",
+        "title": "删除\"{title}\"？"
+      },
+      "newSession": {
+        "label": "开始创作"
+      },
+      "rename": {
+        "label": "重命名"
+      },
+      "scheduledTasks": {
+        "label": "计划任务"
+      },
+      "sessions": {
+        "empty": "开始构建吧！会话历史将显示在这里。",
+        "title": "会话"
+      },
+      "skills": {
+        "label": "技能"
+      },
+      "toast": {
+        "deleteFailed": "删除会话失败",
+        "deleted": "已删除\"{title}\"。"
+      }
+    },
+    "skillsStale": {
+      "notice": {
+        "description": "重新加载此会话以应用最新的技能和应用访问权限。",
+        "title": "您的代理能力已发生变化"
+      },
+      "reload": {
+        "button": "重新加载",
+        "inProgress": "正在重新加载…"
+      },
+      "toast": {
+        "reloadFailed": "重新加载会话失败"
+      }
+    },
+    "subagentView": {
+      "notFound": {
+        "label": "未找到子代理。"
+      }
+    },
+    "suggestedPrompts": {
+      "close": {
+        "ariaLabel": "关闭建议"
+      }
+    },
+    "tasks": {
+      "detailPage": {
+        "confirmDelete": {
+          "deleteButton": "删除",
+          "deletingButton": "正在删除...",
+          "description": "这将停止未来的运行并删除该任务。过去的运行历史（及底层会话）将保留以供审计。",
+          "title": "删除“{name}”？"
+        },
+        "deleteButton": "删除",
+        "editButton": "编辑",
+        "fallbackTitle": "计划任务",
+        "loadFailed": "无法加载计划任务。",
+        "missingTaskId": "缺少任务 ID。",
+        "pauseButton": "暂停",
+        "resumeButton": "恢复",
+        "runNowButton": "立即运行",
+        "toasts": {
+          "deleteFailed": "删除任务失败",
+          "deleted": "已删除“{name}”。",
+          "paused": "任务已暂停。",
+          "resumed": "任务已恢复。",
+          "runQueued": "已将“{name}”的运行加入队列。",
+          "runStartFailed": "启动运行失败",
+          "statusUpdateFailed": "更新状态失败"
+        }
+      },
+      "editPage": {
+        "fallbackTitle": "编辑计划任务",
+        "loadFailed": "无法加载计划任务。",
+        "missingTaskId": "缺少任务 ID。",
+        "title": "编辑“{name}”"
+      },
+      "form": {
+        "cancelButton": "取消",
+        "errors": {
+          "nameRequired": "名称为必填项。",
+          "promptRequired": "提示词为必填项。"
+        },
+        "fields": {
+          "name": {
+            "label": "名称",
+            "placeholder": "例如：每周客户升级问题摘要"
+          },
+          "preApproval": {
+            "description": "当此任务在无人值守时运行，Craft 可以直接使用选定的应用和 MCP 服务器而不暂停。其他审批请求会暂停运行并可能导致失败。",
+            "label": "预批准的应用和 MCP 服务器"
+          },
+          "prompt": {
+            "description": "每次任务触发时，此消息都会发送给 Craft。",
+            "label": "提示词",
+            "placeholder": "描述 Craft 每次运行时应执行的操作..."
+          },
+          "schedule": {
+            "label": "计划"
+          }
+        },
+        "saveAndRunNowButton": "保存并立即运行",
+        "saveButton": "保存",
+        "saveChangesButton": "保存更改",
+        "savingLabel": "正在保存...",
+        "toasts": {
+          "created": "计划任务已创建。",
+          "createdAndQueued": "计划任务已创建并加入队列。",
+          "saveFailed": "保存计划任务失败",
+          "updated": "计划任务已更新。"
+        }
+      },
+      "listPage": {
+        "columns": {
+          "lastRun": "上次运行",
+          "name": "名称",
+          "nextRun": "下次运行",
+          "schedule": "计划",
+          "status": "状态"
+        },
+        "confirmDelete": {
+          "deleteButton": "删除",
+          "deletingButton": "正在删除...",
+          "description": "这将停止未来的运行并删除该任务。过去的运行历史（及底层会话）将保留以供审计。",
+          "title": "删除“{name}”？"
+        },
+        "empty": {
+          "description": "尚未创建任何计划任务。",
+          "title": "未找到计划任务"
+        },
+        "errors": {
+          "loadFailed": "无法加载计划任务。",
+          "tryAgainButton": "重试"
+        },
+        "header": {
+          "description": "按定时器运行 Craft 提示词。每次触发都会创建一个在后台运行的新会话。",
+          "title": "计划任务"
+        },
+        "newTaskButton": "新建计划任务",
+        "rowActions": {
+          "deleteTooltip": "删除"
+        },
+        "toasts": {
+          "deleteFailed": "删除任务失败",
+          "deleted": "已删除“{name}”。"
+        }
+      },
+      "newPage": {
+        "description": "保存提示词和计划。Craft 会按定时器运行它。",
+        "title": "新建计划任务"
+      },
+      "preApproval": {
+        "appFallbackName": "应用 #{id}",
+        "appsGroupTitle": "应用",
+        "empty": {
+          "label": "Craft 中尚无可用的应用或 MCP 服务器。"
+        },
+        "errors": {
+          "loadFailed": "无法加载应用和 MCP 服务器。请刷新重试。",
+          "partialLoadFailed": "部分预批准选项无法加载。请刷新重试。"
+        },
+        "loading": {
+          "label": "正在加载应用和 MCP 服务器…"
+        },
+        "mcpGroupTitle": "MCP 服务器",
+        "mcpServerFallbackName": "MCP 服务器 #{id}",
+        "status": {
+          "connected": "已连接",
+          "connectionRequired": "需要连接",
+          "unavailable": "已不可用"
+        },
+        "summary": {
+          "partialLoadFailed": "部分预批准详情无法加载。请刷新重试。",
+          "title": "预批准的应用和 MCP 服务器"
+        }
+      },
+      "runHistory": {
+        "columns": {
+          "duration": "时长",
+          "started": "开始时间",
+          "status": "状态",
+          "summary": "摘要",
+          "trigger": "触发方式"
+        },
+        "empty": {
+          "label": "尚无运行记录。任务每次触发都会创建一条，也可以使用上方的“立即运行”。"
+        },
+        "errors": {
+          "loadFailed": "无法加载运行历史。",
+          "tryAgainButton": "重试"
+        },
+        "loadMore": {
+          "button": "加载更多",
+          "loadingButton": "正在加载..."
+        },
+        "nonClickable": {
+          "noSession": "此运行尚未创建会话。",
+          "queued": "此运行尚未开始，因此没有可打开的会话。",
+          "skipped": "由于先前的运行仍在进行中，此运行被跳过，因此未创建会话。"
+        },
+        "status": {
+          "notOpenableAriaLabel": "无法打开"
+        },
+        "trigger": {
+          "runNow": "立即运行",
+          "schedule": "计划"
+        }
+      },
+      "scheduleEditor": {
+        "dailyWeekly": {
+          "atLabel": "时间",
+          "daysLabel": "在这些日子",
+          "runsEveryDay": "每天运行",
+          "runsOn": "在{days}运行"
+        },
+        "interval": {
+          "everyLabel": "每"
+        },
+        "intervalUnits": {
+          "days": "天",
+          "hours": "小时",
+          "minutes": "分钟"
+        },
+        "tabs": {
+          "dailyWeekly": "每日 / 每周",
+          "interval": "间隔"
+        },
+        "weekdays": {
+          "fri": "周五",
+          "mon": "周一",
+          "sat": "周六",
+          "sun": "周日",
+          "thu": "周四",
+          "tue": "周二",
+          "wed": "周三"
+        }
+      }
+    },
+    "todoList": {
+      "empty": {
+        "label": "无任务"
+      },
+      "header": {
+        "title": "任务"
+      },
+      "progress": {
+        "label": "已完成 {completed}/{total}"
+      }
+    },
+    "toolCards": {
+      "bash": {
+        "noOutput": {
+          "label": "无输出"
+        }
+      },
+      "diff": {
+        "unchangedLines": {
+          "label": "{count, plural, one {# 行未更改} other {# 行未更改}}"
+        },
+        "viewToggle": {
+          "sideBySideTooltip": "切换为并排视图",
+          "unifiedTooltip": "切换为统一视图"
+        }
+      },
+      "generic": {
+        "noOutput": {
+          "label": "暂无输出..."
+        }
+      },
+      "group": {
+        "calls": {
+          "tag": "{count, plural, one {# 次调用} other {# 次调用}}"
+        },
+        "failed": {
+          "tag": "{count} 个失败"
+        },
+        "working": {
+          "label": "处理中"
+        }
+      },
+      "read": {
+        "emptyFile": {
+          "label": "（空文件）"
+        },
+        "moreLines": {
+          "label": "{count, plural, one {还有 # 行} other {还有 # 行}}"
+        },
+        "showAll": {
+          "button": "显示全部"
+        }
+      },
+      "search": {
+        "noMatches": {
+          "label": "无匹配项"
+        }
+      }
+    },
+    "uploadFiles": {
+      "errors": {
+        "fileTooLarge": "文件过大（{size}）。上限为 {max}。",
+        "network": "网络错误",
+        "notFound": "未找到资源",
+        "server": "服务器错误",
+        "sessionExpired": "会话已过期",
+        "tooManyFiles": "文件过多。每个会话最多 {max} 个文件。",
+        "totalSizeExceeded": "总大小超出限制。每个会话最多 {max}。",
+        "uploadFailed": "上传失败"
+      }
+    },
+    "urlBar": {
+      "back": {
+        "ariaLabel": "后退"
+      },
+      "copyUrl": {
+        "ariaLabel": "复制 URL：{url}"
+      },
+      "downloadFile": {
+        "tooltip": "下载文件"
+      },
+      "export": {
+        "button": "导出为 .docx",
+        "inProgress": "正在导出..."
+      },
+      "forward": {
+        "ariaLabel": "前进"
+      },
+      "openInNewTab": {
+        "tooltip": "在新标签页中打开"
+      },
+      "refresh": {
+        "ariaLabel": "刷新"
+      }
+    },
+    "userLibrary": {
+      "delete": {
+        "action": "删除",
+        "button": "删除",
+        "entityTypeFile": "文件",
+        "entityTypeFolder": "文件夹",
+        "fileDetails": "此文件将从您的资料库中移除。",
+        "folderDetails": "这将删除该文件夹及其所有内容。"
+      },
+      "dropzone": {
+        "formats": "Excel、Word、PowerPoint、PDF 或 ZIP",
+        "title": "将文件拖到此处或点击上传"
+      },
+      "errors": {
+        "createFolderFailed": "创建文件夹失败",
+        "deleteFailed": "删除失败",
+        "loadFailed": "加载文件失败",
+        "uploadFailed": "上传失败"
+      },
+      "loading": {
+        "label": "正在加载文件…"
+      },
+      "modal": {
+        "description": "您的智能体在每个会话中都可以读取的文件。",
+        "doneButton": "完成",
+        "title": "资料库"
+      },
+      "newFolder": {
+        "cancelButton": "取消",
+        "createButton": "创建",
+        "label": "新建文件夹",
+        "nameLabel": "文件夹名称",
+        "namePlaceholder": "输入文件夹名称"
+      },
+      "search": {
+        "noResults": "没有与搜索匹配的文件",
+        "placeholder": "搜索文件..."
+      },
+      "tree": {
+        "collapseTooltip": "折叠",
+        "deleteTooltip": "删除",
+        "expandTooltip": "展开",
+        "toggleAriaLabel": "切换 {name}",
+        "uploadToFolderTooltip": "上传到此文件夹"
+      },
+      "upload": {
+        "button": "上传",
+        "dropOverlay": "拖放文件以上传",
+        "uploadingButton": "正在上传…"
+      }
+    },
+    "welcome": {
+      "input": {
+        "placeholder": "分析我的数据并创建仪表板..."
       }
     }
   },
@@ -8813,6 +12541,13 @@
           "networkError": "修改密码时发生错误",
           "updateFailed": "修改密码失败",
           "updated": "密码更新成功"
+        },
+        "validation": {
+          "confirmRequired": "请确认您的新密码",
+          "currentRequired": "当前密码为必填项",
+          "minLength": "密码必须至少包含 {min} 个字符",
+          "mismatch": "两次输入的密码不一致",
+          "newRequired": "新密码为必填项"
         }
       },
       "title": "账户"
@@ -8854,6 +12589,7 @@
         "empty": "尚未创建访问 token。",
         "expiresIn": "{count, plural, one {# 天后过期} other {# 天后过期}}",
         "loading": "正在加载 token…",
+        "middleText": "{created} - {expiry} - {scope}",
         "neverExpires": "永不过期",
         "newTokenButton": "新建访问 token",
         "noPermissionTooltip": "您没有创建访问 token 的权限",
@@ -9000,6 +12736,10 @@
       },
       "description": "将外部工具连接到您在 Onyx 中可用的模型。",
       "guideButton": "指南",
+      "loadError": {
+        "description": "请刷新页面后重试。",
+        "title": "无法加载 LLM 网关"
+      },
       "models": {
         "description": "{count, plural, one {您的账户可使用 # 个模型。打开某个提供商即可复制 ID。} other {您的账户可使用 # 个模型。打开某个提供商即可复制 ID。}}",
         "title": "模型"
@@ -9052,14 +12792,37 @@
       }
     },
     "memory": {
+      "addLineButton": {
+        "label": "添加行",
+        "maxReached": "已达到 {count} 条记忆的上限"
+      },
       "empty": {
-        "description": "添加希望 Onyx 记住的个人笔记或记忆。"
+        "description": "添加希望 Onyx 记住的个人笔记或记忆。",
+        "getStarted": "还没有记忆。点击“添加行”开始。",
+        "noMatches": "没有与搜索匹配的记忆。"
+      },
+      "item": {
+        "placeholder": "输入或粘贴个人笔记或记忆"
+      },
+      "lineCount": {
+        "label": "{count, plural, one {行} other {行}}"
+      },
+      "modal": {
+        "description": "让 Onyx 在聊天中引用这些存储的笔记和记忆。",
+        "searchPlaceholder": "搜索..."
       },
       "referenceStoredMemories": {
         "description": "允许 Onyx 在对话中引用已存储的记忆。",
         "title": "引用已存储的记忆"
       },
+      "removeLineButton": {
+        "label": "移除行"
+      },
       "title": "记忆",
+      "toasts": {
+        "saveFailed": "保存偏好设置失败",
+        "saved": "偏好设置已保存"
+      },
       "updateMemories": {
         "description": "允许 Onyx 生成并更新已存储的记忆。",
         "title": "更新记忆"
@@ -9479,6 +13242,158 @@
     }
   },
   "skills": {
+    "editor": {
+      "appConflict": {
+        "description": "应用“{appName}”已有名为“{skillName}”的关联技能。",
+        "title": "请选择其他技能名称"
+      },
+      "confirmUpload": {
+        "importBody": "此上传包含 SKILL.md。继续操作会用上传的包替换当前的名称、描述、说明和文件。",
+        "importSubmit": {
+          "label": "导入技能"
+        },
+        "importTitle": "导入此技能？",
+        "replaceBody": "此上传必须使用相同的技能名称。继续操作会用上传的包替换描述、说明和文件。",
+        "replaceSubmit": {
+          "label": "替换内容"
+        },
+        "replaceTitle": "替换技能内容？"
+      },
+      "delete": {
+        "button": {
+          "label": "删除技能"
+        },
+        "description": "使用此技能的所有人将失去访问权限。删除后无法撤销。",
+        "title": "删除此技能"
+      },
+      "deleteModal": {
+        "entityType": "技能",
+        "label": "删除",
+        "pendingLabel": "正在删除..."
+      },
+      "details": {
+        "description": "定义 Craft 应在何时以及如何使用此技能。",
+        "descriptionField": {
+          "description": "描述何时应使用此技能。",
+          "placeholder": "此技能有什么用途？",
+          "title": "描述"
+        },
+        "name": {
+          "createDescription": "使用小写字母、数字和单个连字符。",
+          "lockedDescription": "技能名称创建后无法更改。",
+          "placeholder": "为您的技能命名",
+          "title": "名称"
+        },
+        "title": "详情"
+      },
+      "files": {
+        "busyLabel": "正在上传...",
+        "description": "添加此技能使用的参考资料、脚本、资源或其他文件。ZIP 文件会自动解压。",
+        "input": {
+          "ariaLabel": "添加支持文件"
+        },
+        "pendingUpload": {
+          "emptyMessage": "此上传的文件将在您创建技能后显示。"
+        },
+        "title": "支持文件"
+      },
+      "filesTooltip": {
+        "noPermission": "您没有更新此技能文件的权限。",
+        "saveFirst": "更新技能文件前请先保存详情更改。",
+        "updating": "正在更新技能文件..."
+      },
+      "header": {
+        "appFallbackName": "外部应用",
+        "cancel": {
+          "label": "取消"
+        },
+        "createDescription": "构建个人技能",
+        "createForAppDescription": "为应用“{appName}”添加组织技能",
+        "createTitle": "创建技能",
+        "editDescription": "更新技能详情和文件",
+        "editTitle": "编辑技能",
+        "save": {
+          "label": "保存",
+          "pendingLabel": "正在保存..."
+        }
+      },
+      "import": {
+        "busyLabel": "正在导入...",
+        "button": {
+          "label": "导入技能"
+        },
+        "description": "导入 SKILL.md、ZIP 或技能文件夹以预填表单并包含其文件。",
+        "input": {
+          "ariaLabel": "导入现有技能"
+        },
+        "prompt": "选择 SKILL.md 或 ZIP，或将技能文件夹拖放到此处。",
+        "title": "已有技能？"
+      },
+      "instructions": {
+        "description": "编写此技能为 Craft 添加的行为和工作流程。",
+        "emptyFallback": "暂无说明。",
+        "placeholder": "编写技能说明。",
+        "title": "说明"
+      },
+      "loadError": {
+        "description": "此技能可能不存在、是内置技能，或您的账户无法编辑。",
+        "title": "技能不可用"
+      },
+      "management": {
+        "description": "控制谁可以使用此技能。",
+        "externalApp": {
+          "manage": {
+            "label": "在应用设置中管理"
+          },
+          "readyDescription": "此技能使用应用“{appName}”。",
+          "title": "外部应用"
+        },
+        "sharing": {
+          "edit": {
+            "label": "编辑共享"
+          },
+          "title": "共享"
+        },
+        "title": "管理"
+      },
+      "saveTooltip": {
+        "missingDescription": "保存前请添加描述。",
+        "missingInstructions": "保存前请添加说明。",
+        "missingName": "保存前请添加名称。",
+        "noChanges": "尚未进行任何更改。",
+        "noPermission": "您没有编辑此技能详情的权限。",
+        "savingChanges": "正在保存更改...",
+        "savingSkill": "正在保存技能..."
+      },
+      "sharing": {
+        "organization": {
+          "editorDescription": "组织中的所有人都可以使用和编辑此技能。",
+          "title": "组织",
+          "viewerDescription": "组织中的所有人都可以使用此技能。"
+        },
+        "personal": {
+          "description": "只有您可以使用此技能。",
+          "title": "个人"
+        },
+        "shares": {
+          "description": "只有选定的用户和群组可以使用此技能。",
+          "title": "{count, plural, one {# 个共享} other {# 个共享}}"
+        }
+      },
+      "toasts": {
+        "created": "已创建“{name}”",
+        "deleteFailed": "删除技能失败",
+        "deleted": "已删除“{name}”",
+        "fileRemoveFailed": "移除技能文件失败",
+        "fileRemoved": "已移除“{path}”",
+        "filesUpdateFailed": "更新技能文件失败",
+        "filesUpdated": "已更新“{name}”的文件",
+        "importMissingSkillMd": "请导入 SKILL.md、ZIP 或包含 SKILL.md 的文件夹。",
+        "inspectFailed": "检查技能包失败",
+        "saveFailed": "保存技能失败",
+        "saved": "已保存“{name}”"
+      }
+    },
     "modals": {
       "addInstruction": {
         "cancelButton": {
@@ -9679,6 +13594,76 @@
         "transferredToast": {
           "message": "所有权已转移。"
         }
+      }
+    },
+    "page": {
+      "browse": {
+        "title": "浏览技能"
+      },
+      "countSeparator": {
+        "label": "{count, plural, one {技能} other {技能}}"
+      },
+      "createMenu": {
+        "github": {
+          "description": "从仓库导入一个或多个技能。",
+          "title": "从 GitHub 导入"
+        },
+        "scratch": {
+          "description": "在 Onyx 中编写说明并添加支持文件。",
+          "title": "从头开始"
+        },
+        "trigger": {
+          "label": "创建技能"
+        },
+        "upload": {
+          "description": "导入 SKILL.md 文件、ZIP 文件或技能文件夹。",
+          "title": "上传技能"
+        }
+      },
+      "empty": {
+        "noMatches": {
+          "description": "请尝试其他搜索。",
+          "title": "没有匹配的技能"
+        },
+        "noSkills": {
+          "description": "尚无自定义技能与您共享，也未配置内置技能。",
+          "title": "没有可用的技能"
+        }
+      },
+      "focusedApp": {
+        "description": "启用与应用“{appName}”关联的所有技能。缺少这些技能时应用可能无法正常工作。如果已启用同名的其他技能，启用应用关联技能会为您停用另一个技能。",
+        "showAll": {
+          "label": "显示全部技能"
+        },
+        "title": "应用“{appName}”的技能"
+      },
+      "header": {
+        "description": "您的 Craft 智能体可调用的能力包。此页面显示内置技能、与您共享的技能以及您的个人技能。",
+        "title": "技能"
+      },
+      "loadError": {
+        "description": "请查看控制台了解详情，并尝试刷新页面。",
+        "title": "加载技能失败"
+      },
+      "preview": {
+        "unavailableFallback": "此技能当前不可用。"
+      },
+      "search": {
+        "placeholder": "搜索技能..."
+      },
+      "switchModal": {
+        "body": "继续操作将停用当前启用的技能并启用此技能。",
+        "description": "同名技能“{name}”一次只能启用一个。",
+        "submit": {
+          "label": "切换技能",
+          "pendingLabel": "正在切换..."
+        },
+        "title": "切换技能“{name}”？"
+      },
+      "toasts": {
+        "disableFailed": "停用 {name} 失败",
+        "enableFailed": "启用 {name} 失败",
+        "refreshFailed": "{name} 已更新，但技能列表无法刷新。"
       }
     },
     "sections": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -2820,25 +2820,37 @@
       }
     },
     "craftPreferences": {
-      "defaultModel": {
-        "clearButton": { "label": "清除" },
-        "help": {
-          "description": "Craft 将此模型用于新会话和计划任务。未设置时，Craft 将使用工作区默认聊天模型。"
-        },
-        "inheritedTag": { "label": "工作区默认值" },
-        "label": "默认模型",
-        "placeholder": "选择模型",
-        "resetError": { "message": "清除默认模型失败" },
-        "resetSuccess": { "message": "已清除 Craft 默认模型" },
-        "saveError": { "message": "保存默认模型失败" },
-        "saveSuccess": { "message": "已保存 Craft 默认模型" }
-      },
       "baseInstructions": {
         "description": "您的指令会追加到这段内置提示词之后。动态部分会在每个会话中分别填充。",
         "loadError": {
           "description": "加载基础指令失败。"
         },
         "title": "查看基础指令"
+      },
+      "defaultModel": {
+        "clearButton": {
+          "label": "清除"
+        },
+        "help": {
+          "description": "Craft 将此模型用于新会话和计划任务。未设置时，Craft 将使用工作区默认聊天模型。"
+        },
+        "inheritedTag": {
+          "label": "工作区默认值"
+        },
+        "label": "默认模型",
+        "placeholder": "选择模型",
+        "resetError": {
+          "message": "清除默认模型失败"
+        },
+        "resetSuccess": {
+          "message": "已清除 Craft 默认模型"
+        },
+        "saveError": {
+          "message": "保存默认模型失败"
+        },
+        "saveSuccess": {
+          "message": "已保存 Craft 默认模型"
+        }
       },
       "header": {
         "description": "在 Craft 内置行为之上，每个 Craft 智能体都会遵循的默认模型和工作区级指令。",
@@ -12890,9 +12902,29 @@
         "title": "无法加载使用情况"
       },
       "modelPrices": {
+        "defaultTag": {
+          "label": "{model} · 默认"
+        },
         "description": "每个可用模型每百万 token 的美元价格（输入 · 输出 · 缓存）",
+        "otherProvider": {
+          "label": "其他"
+        },
         "title": "模型价格",
         "unavailable": "价格不可用"
+      },
+      "modelUsage": {
+        "cacheReads": {
+          "label": "缓存读取 {count}"
+        },
+        "cacheWrites": {
+          "label": "缓存写入 {count}"
+        },
+        "tokensIn": {
+          "label": "输入 {count}"
+        },
+        "tokensOut": {
+          "label": "输出 {count}"
+        }
       },
       "showFewerModels": {
         "ariaLabel": "显示更少模型"

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -5753,6 +5753,27 @@
         "unexpectedError": "发生意外错误。"
       }
     },
+    "status": {
+      "badges": {
+        "canceled": "已取消",
+        "completedWithErrors": "已完成但有错误",
+        "deleting": "正在删除",
+        "error": "错误",
+        "failed": "失败",
+        "inProgress": "进行中",
+        "indexed": "已索引",
+        "indexing": "正在索引",
+        "initialIndexing": "初始索引",
+        "interrupted": "已中断",
+        "invalid": "无效",
+        "invalidConnectorTooltip": "连接器处于无效状态。请更新凭据或创建新的连接器。",
+        "none": "无",
+        "notStarted": "未开始",
+        "paused": "已暂停",
+        "scheduled": "已计划",
+        "succeeded": "成功"
+      }
+    },
     "systemInfo": {
       "backendVersion": {
         "label": "后端版本："
@@ -7192,6 +7213,70 @@
       },
       "sourcesModal": {
         "title": "来源"
+      }
+    },
+    "appChrome": {
+      "delete": {
+        "label": "删除"
+      },
+      "deleteModal": {
+        "description": "确定要删除此聊天吗？此操作无法撤销。",
+        "submitButton": {
+          "label": "删除"
+        },
+        "title": "删除聊天"
+      },
+      "exportAs": {
+        "label": "导出为…"
+      },
+      "exportFailed": {
+        "message": "导出聊天失败。请重试。"
+      },
+      "exportMarkdown": {
+        "label": "Markdown"
+      },
+      "exportPlaintext": {
+        "label": "纯文本"
+      },
+      "fullWidth": {
+        "ariaLabel": "切换全宽聊天",
+        "fitTooltip": "适应宽度",
+        "fullTooltip": "全宽"
+      },
+      "incognitoExit": {
+        "ariaLabel": "退出无痕聊天",
+        "tooltip": "退出无痕聊天"
+      },
+      "incognitoPill": {
+        "ariaLabel": "无痕聊天",
+        "label": "无痕聊天"
+      },
+      "incognitoStart": {
+        "ariaLabel": "开始无痕聊天",
+        "lockedTooltip": "只能在聊天开始前设置无痕模式",
+        "tooltip": "无痕聊天"
+      },
+      "mode": {
+        "chat": {
+          "description": "对话与研究",
+          "label": "聊天"
+        },
+        "search": {
+          "description": "快速搜索文档",
+          "label": "搜索"
+        }
+      },
+      "modeButton": {
+        "ariaLabel": "更改应用模式"
+      },
+      "moveToProject": {
+        "label": "移动到项目"
+      },
+      "openSidebar": {
+        "ariaLabel": "打开侧边栏"
+      },
+      "share": {
+        "label": "分享"
       }
     },
     "banners": {
@@ -8938,6 +9023,34 @@
         "updateFailed": "更新语言偏好设置失败"
       }
     },
+    "layout": {
+      "header": {
+        "title": "设置"
+      },
+      "sectionSelect": {
+        "placeholder": "选择一个部分"
+      },
+      "tabs": {
+        "accountsAccess": {
+          "label": "账户与访问"
+        },
+        "chatPreferences": {
+          "label": "聊天偏好设置"
+        },
+        "connectors": {
+          "label": "连接器"
+        },
+        "general": {
+          "label": "常规"
+        },
+        "llmGateway": {
+          "label": "LLM 网关"
+        },
+        "usage": {
+          "label": "使用情况"
+        }
+      }
+    },
     "memory": {
       "empty": {
         "description": "添加希望 Onyx 记住的个人笔记或记忆。"
@@ -8998,6 +9111,47 @@
       "toggle": {
         "description": "启用快捷方式以快速插入常用提示词。",
         "title": "使用提示词快捷方式"
+      }
+    },
+    "usage": {
+      "budget": {
+        "limit": "上限 {amount}",
+        "none": "未设置预算",
+        "remaining": "剩余 {amount}",
+        "resetsOn": "{date} 重置",
+        "title": "预算"
+      },
+      "empty": {
+        "description": "开始聊天后，您的模型使用情况和费用将显示在此处。",
+        "title": "尚未记录使用情况"
+      },
+      "header": {
+        "title": "使用情况"
+      },
+      "loadError": {
+        "description": "获取使用情况时出错。请稍后重试。",
+        "title": "无法加载使用情况"
+      },
+      "modelPrices": {
+        "description": "每个可用模型每百万 token 的美元价格（输入 · 输出 · 缓存）",
+        "title": "模型价格",
+        "unavailable": "价格不可用"
+      },
+      "showFewerModels": {
+        "ariaLabel": "显示更少模型"
+      },
+      "showLess": {
+        "label": "收起"
+      },
+      "showMore": {
+        "label": "再显示 {count} 个"
+      },
+      "showMoreModels": {
+        "ariaLabel": "再显示 {count} 个模型"
+      },
+      "usageThisPeriod": {
+        "description": "已花费 {amount}",
+        "title": "本期使用情况"
       }
     },
     "voice": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -625,12 +625,6 @@
       "back": {
         "ariaLabel": "返回"
       },
-      "disableAll": {
-        "label": "全部禁用"
-      },
-      "enableAll": {
-        "label": "全部启用"
-      },
       "toggle": {
         "ariaLabel": "切换 {name}"
       }
@@ -12935,6 +12929,23 @@
   },
   "sidebar": {
     "adminNav": {
+      "hiddenRoutes": {
+        "documentExplorer": {
+          "title": "文档浏览器"
+        },
+        "documentFeedback": {
+          "title": "文档反馈"
+        },
+        "documentProcessing": {
+          "title": "文档处理"
+        },
+        "oauthTest": {
+          "title": "OAuth 测试"
+        },
+        "standardAnswers": {
+          "title": "标准回答"
+        }
+      },
       "items": {
         "addConnector": {
           "label": "添加连接器"

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -23,6 +23,7 @@ import {
   hasPermission,
 } from "@/lib/permissions";
 import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
+import { useTranslations } from "next-intl";
 
 export interface AdminChromeProps {
   children: React.ReactNode;
@@ -54,6 +55,7 @@ export default function AdminChrome({
   children,
   initialAdminCapabilities,
 }: AdminChromeProps) {
+  const t = useTranslations("common");
   const { setFolded } = useSidebarState();
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
@@ -116,13 +118,11 @@ export default function AdminChrome({
         {application_status === ApplicationStatus.PAYMENT_REMINDER && (
           <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-status-warning-01 p-4 rounded-lg shadow-lg z-50 max-w-md text-center">
             <Text font="main-ui-body" color="text-05">
-              {markdown(
-                "**Warning:** Your trial ends in less than 5 days and no payment method has been added."
-              )}
+              {markdown(t("adminChrome.paymentReminder.text"))}
             </Text>
             <div className="mt-2">
               <Button width="full" href="/admin/billing">
-                Update Billing Information
+                {t("adminChrome.paymentReminder.billingButton.label")}
               </Button>
             </div>
           </div>
@@ -145,7 +145,7 @@ export default function AdminChrome({
                 <Button
                   prominence="internal"
                   icon={SvgSidebar}
-                  aria-label="Open Sidebar"
+                  aria-label={t("adminChrome.openSidebar.ariaLabel")}
                   onClick={() => setFolded(false)}
                 />
               </div>

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   useCallback,
   useEffect,
@@ -77,6 +78,7 @@ import { useIncognito } from "@/providers/IncognitoProvider";
 // ---------------------------------------------------------------------------
 
 function Header() {
+  const t = useTranslations("chat.appChrome");
   const appPosition = useAppPosition();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
   const { state, setAppMode } = useQueryController();
@@ -264,7 +266,7 @@ function Header() {
         );
       } catch (error) {
         console.error("Failed to export chat:", error);
-        showErrorNotification("Failed to export chat. Please try again.");
+        showErrorNotification(t("exportFailed.message"));
       }
     },
     [currentChatSession]
@@ -297,7 +299,7 @@ function Header() {
           sizePreset="main-ui"
           rounding={2}
           icon={SvgChevronLeft}
-          title="Export As…"
+          title={t("exportAs.label")}
           onClick={noProp(() => setShowExportOptions(false))}
         />,
         <Popover.Close asChild key="export-plaintext">
@@ -305,7 +307,7 @@ function Header() {
             sizePreset="main-ui"
             rounding={2}
             icon={SvgFileText}
-            title="Plaintext"
+            title={t("exportPlaintext.label")}
             onClick={noProp(() => handleExport("text"))}
           />
         </Popover.Close>,
@@ -314,7 +316,7 @@ function Header() {
             sizePreset="main-ui"
             rounding={2}
             icon={SvgHash}
-            title="Markdown"
+            title={t("exportMarkdown.label")}
             onClick={noProp(() => handleExport("markdown"))}
           />
         </Popover.Close>,
@@ -326,7 +328,7 @@ function Header() {
           sizePreset="main-ui"
           rounding={2}
           icon={SvgFolderIn}
-          title="Move to Project"
+          title={t("moveToProject.label")}
           onClick={noProp(() => setShowMoveOptions(true))}
         />,
         <LineItemButton
@@ -334,7 +336,7 @@ function Header() {
           sizePreset="main-ui"
           rounding={2}
           icon={SvgDownload}
-          title="Export As…"
+          title={t("exportAs.label")}
           onClick={noProp(() => setShowExportOptions(true))}
         />,
         null,
@@ -344,7 +346,7 @@ function Header() {
           rounding={2}
           color="danger"
           icon={SvgTrash}
-          title="Delete"
+          title={t("delete.label")}
           onClick={noProp(() => setDeleteConfirmationModalOpen(true))}
         />,
       ];
@@ -389,17 +391,16 @@ function Header() {
 
       {deleteModalOpen && (
         <ConfirmationModalLayout
-          title="Delete Chat"
+          title={t("deleteModal.title")}
           icon={SvgTrash}
           onClose={() => setDeleteModalOpen(false)}
           submit={
             <Button variant="danger" onClick={handleDeleteChat}>
-              Delete
+              {t("deleteModal.submitButton.label")}
             </Button>
           }
         >
-          Are you sure you want to delete this chat? This action cannot be
-          undone.
+          {t("deleteModal.description")}
         </ConfirmationModalLayout>
       )}
 
@@ -421,7 +422,7 @@ function Header() {
                   <Button
                     prominence="internal"
                     icon={SvgSidebar}
-                    aria-label="Open Sidebar"
+                    aria-label={t("openSidebar.ariaLabel")}
                     onClick={() => setFolded(false)}
                   />
                 )}
@@ -430,10 +431,10 @@ function Header() {
                     <OpenButton
                       disabled
                       icon={SvgEyeOff}
-                      aria-label="Incognito chat"
+                      aria-label={t("incognitoPill.ariaLabel")}
                       data-testid="incognito-chat-pill"
                     >
-                      Incognito Chat
+                      {t("incognitoPill.label")}
                     </OpenButton>
                   )}
                 {businessTier &&
@@ -447,14 +448,16 @@ function Header() {
                     >
                       <Popover.Trigger asChild>
                         <OpenButton
-                          aria-label="Change app mode"
+                          aria-label={t("modeButton.ariaLabel")}
                           icon={
                             effectiveMode === "search"
                               ? SvgSearchMenu
                               : SvgBubbleText
                           }
                         >
-                          {effectiveMode === "search" ? "Search" : "Chat"}
+                          {effectiveMode === "search"
+                            ? t("mode.search.label")
+                            : t("mode.chat.label")}
                         </OpenButton>
                       </Popover.Trigger>
                       <Popover.Content align="start" width="lg">
@@ -466,8 +469,8 @@ function Header() {
                             state={
                               effectiveMode === "search" ? "selected" : "empty"
                             }
-                            title="Search"
-                            description="Quick search for documents"
+                            title={t("mode.search.label")}
+                            description={t("mode.search.description")}
                             onClick={noProp(() => {
                               setAppMode("search");
                               setModePopoverOpen(false);
@@ -480,8 +483,8 @@ function Header() {
                             state={
                               effectiveMode === "chat" ? "selected" : "empty"
                             }
-                            title="Chat"
-                            description="Conversation and research"
+                            title={t("mode.chat.label")}
+                            description={t("mode.chat.description")}
                             onClick={noProp(() => {
                               setAppMode("chat");
                               setModePopoverOpen(false);
@@ -527,11 +530,11 @@ function Header() {
                         prominence="tertiary"
                         onClick={toggleIncognito}
                         disabled={incognitoLocked}
-                        aria-label="Start incognito chat"
+                        aria-label={t("incognitoStart.ariaLabel")}
                         tooltip={
                           incognitoLocked
-                            ? "Incognito can only be set before the chat starts"
-                            : "Incognito Chat"
+                            ? t("incognitoStart.lockedTooltip")
+                            : t("incognitoStart.tooltip")
                         }
                       />
                     )}
@@ -542,8 +545,12 @@ function Header() {
                         icon={fullWidthChat ? SvgFitWidth : SvgFullWidth}
                         prominence="tertiary"
                         onClick={toggleFullWidthChat}
-                        tooltip={fullWidthChat ? "Fit width" : "Full width"}
-                        aria-label="Toggle full width chat"
+                        tooltip={
+                          fullWidthChat
+                            ? t("fullWidth.fitTooltip")
+                            : t("fullWidth.fullTooltip")
+                        }
+                        aria-label={t("fullWidth.ariaLabel")}
                         aria-pressed={fullWidthChat}
                       />
                     )}
@@ -552,8 +559,8 @@ function Header() {
                         icon={SvgX}
                         prominence="tertiary"
                         onClick={() => void handleExitIncognito()}
-                        aria-label="Exit incognito chat"
-                        tooltip="Exit Incognito Chat"
+                        aria-label={t("incognitoExit.ariaLabel")}
+                        tooltip={t("incognitoExit.tooltip")}
                       />
                     )}
                   </FrostedDiv>
@@ -570,7 +577,7 @@ function Header() {
                         onClick={() => setShowShareModal(true)}
                         aria-label="share-chat-button"
                       >
-                        Share
+                        {t("share.label")}
                       </Button>
                       <SimplePopover
                         trigger={

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -269,7 +269,7 @@ function Header() {
         showErrorNotification(t("exportFailed.message"));
       }
     },
-    [currentChatSession]
+    [currentChatSession, t]
   );
 
   useEffect(() => {

--- a/web/src/lib/admin-sidebar-utils.ts
+++ b/web/src/lib/admin-sidebar-utils.ts
@@ -115,6 +115,48 @@ export const NAV_ITEM_IDS: Record<
   PERFORMANCE: null,
 };
 
+/** Title id under `sidebar.adminNav.hiddenRoutes` for pages off the sidebar. */
+export type AdminHiddenRouteId =
+  | "documentExplorer"
+  | "documentFeedback"
+  | "documentProcessing"
+  | "oauthTest"
+  | "standardAnswers";
+
+const HIDDEN_ROUTE_IDS: Partial<
+  Record<keyof typeof ADMIN_ROUTES, AdminHiddenRouteId>
+> = {
+  DOCUMENT_EXPLORER: "documentExplorer",
+  DOCUMENT_FEEDBACK: "documentFeedback",
+  DOCUMENT_PROCESSING: "documentProcessing",
+  OAUTH_TEST: "oauthTest",
+  STANDARD_ANSWERS: "standardAnswers",
+};
+
+const ROUTE_KEYS = Object.keys(ADMIN_ROUTES) as (keyof typeof ADMIN_ROUTES)[];
+
+const NAV_ID_BY_PATH: Record<string, AdminNavItemId | null> =
+  Object.fromEntries(
+    ROUTE_KEYS.map((key) => [ADMIN_ROUTES[key].path, NAV_ITEM_IDS[key]])
+  );
+
+const HIDDEN_ID_BY_PATH: Record<string, AdminHiddenRouteId | undefined> =
+  Object.fromEntries(
+    ROUTE_KEYS.map((key) => [ADMIN_ROUTES[key].path, HIDDEN_ROUTE_IDS[key]])
+  );
+
+/** Nav id for a route, for server components that resolve labels themselves. */
+export function getAdminNavId(route: AdminRouteEntry): AdminNavItemId | null {
+  return NAV_ID_BY_PATH[route.path] ?? null;
+}
+
+/** Hidden-route title id for a route outside the sidebar, if it has one. */
+export function getAdminHiddenRouteId(
+  route: AdminRouteEntry
+): AdminHiddenRouteId | null {
+  return HIDDEN_ID_BY_PATH[route.path] ?? null;
+}
+
 /** Section heading id per `AdminRouteEntry.section` value. */
 const NAV_SECTION_IDS: readonly (readonly [
   section: string,

--- a/web/src/lib/admin-sidebar-utils.ts
+++ b/web/src/lib/admin-sidebar-utils.ts
@@ -69,7 +69,10 @@ export type AdminNavSectionId =
  * Sidebar id per admin route. `null` marks a route that never renders in the
  * sidebar, so a new route cannot silently arrive without a label.
  */
-const NAV_ITEM_IDS: Record<keyof typeof ADMIN_ROUTES, AdminNavItemId | null> = {
+export const NAV_ITEM_IDS: Record<
+  keyof typeof ADMIN_ROUTES,
+  AdminNavItemId | null
+> = {
   LLM_MODELS: "languageModels",
   WEB_SEARCH: "webSearch",
   IMAGE_GENERATION: "imageGeneration",

--- a/web/src/lib/adminNavLabels.tsx
+++ b/web/src/lib/adminNavLabels.tsx
@@ -23,7 +23,7 @@ export function useAdminNavLabels(): Record<AdminNavItemId, string> {
       chatPreferences: t("adminNav.items.chatPreferences.label"),
       craftAccess: t("adminNav.items.craftAccess.label"),
       craftApps: t("adminNav.items.craftApps.label"),
-      craftInstructions: t("adminNav.items.craftInstructions.label"),
+      craftPreferences: t("adminNav.items.craftPreferences.label"),
       customAnalytics: t("adminNav.items.customAnalytics.label"),
       agents: t("adminNav.items.agents.label"),
       mcpActions: t("adminNav.items.mcpActions.label"),

--- a/web/src/lib/adminNavLabels.tsx
+++ b/web/src/lib/adminNavLabels.tsx
@@ -2,8 +2,13 @@
 
 import { useCallback, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { ADMIN_ROUTES, type AdminRouteEntry } from "@/lib/admin-routes";
-import { NAV_ITEM_IDS, type AdminNavItemId } from "@/lib/admin-sidebar-utils";
+import type { AdminRouteEntry } from "@/lib/admin-routes";
+import {
+  getAdminHiddenRouteId,
+  getAdminNavId,
+  type AdminHiddenRouteId,
+  type AdminNavItemId,
+} from "@/lib/admin-sidebar-utils";
 
 // Built with literal keys so the message ids stay statically checkable.
 export function useAdminNavLabels(): Record<AdminNavItemId, string> {
@@ -49,28 +54,33 @@ export function useAdminNavLabels(): Record<AdminNavItemId, string> {
   );
 }
 
-const NAV_ID_BY_PATH: Record<string, AdminNavItemId | null> =
-  Object.fromEntries(
-    (Object.keys(ADMIN_ROUTES) as (keyof typeof ADMIN_ROUTES)[]).map((key) => [
-      ADMIN_ROUTES[key].path,
-      NAV_ITEM_IDS[key],
-    ])
+function useAdminHiddenRouteTitles(): Record<AdminHiddenRouteId, string> {
+  const t = useTranslations("sidebar");
+  return useMemo<Record<AdminHiddenRouteId, string>>(
+    () => ({
+      documentExplorer: t("adminNav.hiddenRoutes.documentExplorer.title"),
+      documentFeedback: t("adminNav.hiddenRoutes.documentFeedback.title"),
+      documentProcessing: t("adminNav.hiddenRoutes.documentProcessing.title"),
+      oauthTest: t("adminNav.hiddenRoutes.oauthTest.title"),
+      standardAnswers: t("adminNav.hiddenRoutes.standardAnswers.title"),
+    }),
+    [t]
   );
-
-/** Nav id for a route, for server components that resolve labels themselves. */
-export function getAdminNavId(route: AdminRouteEntry): AdminNavItemId | null {
-  return NAV_ID_BY_PATH[route.path] ?? null;
 }
 
 // Page headers reuse the sidebar's translated labels so both stay in sync
-// across locales. Routes without a nav entry fall back to their raw title.
+// across locales. Pages outside the sidebar carry their own title keys.
+// Section stubs without a title of their own fall back to the raw title.
 export function useAdminRouteTitle(): (route: AdminRouteEntry) => string {
   const labels = useAdminNavLabels();
+  const hiddenTitles = useAdminHiddenRouteTitles();
   return useCallback(
     (route: AdminRouteEntry) => {
-      const navId = NAV_ID_BY_PATH[route.path];
-      return navId ? labels[navId] : route.title;
+      const navId = getAdminNavId(route);
+      if (navId) return labels[navId];
+      const hiddenId = getAdminHiddenRouteId(route);
+      return hiddenId ? hiddenTitles[hiddenId] : route.title;
     },
-    [labels]
+    [labels, hiddenTitles]
   );
 }

--- a/web/src/lib/adminNavLabels.tsx
+++ b/web/src/lib/adminNavLabels.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { ADMIN_ROUTES, type AdminRouteEntry } from "@/lib/admin-routes";
+import { NAV_ITEM_IDS, type AdminNavItemId } from "@/lib/admin-sidebar-utils";
+
+// Built with literal keys so the message ids stay statically checkable.
+export function useAdminNavLabels(): Record<AdminNavItemId, string> {
+  const t = useTranslations("sidebar");
+  return useMemo<Record<AdminNavItemId, string>>(
+    () => ({
+      languageModels: t("adminNav.items.languageModels.label"),
+      webSearch: t("adminNav.items.webSearch.label"),
+      imageGeneration: t("adminNav.items.imageGeneration.label"),
+      voice: t("adminNav.items.voice.label"),
+      codeInterpreter: t("adminNav.items.codeInterpreter.label"),
+      chatPreferences: t("adminNav.items.chatPreferences.label"),
+      craftAccess: t("adminNav.items.craftAccess.label"),
+      craftApps: t("adminNav.items.craftApps.label"),
+      craftInstructions: t("adminNav.items.craftInstructions.label"),
+      customAnalytics: t("adminNav.items.customAnalytics.label"),
+      agents: t("adminNav.items.agents.label"),
+      mcpActions: t("adminNav.items.mcpActions.label"),
+      openapiActions: t("adminNav.items.openapiActions.label"),
+      existingConnectors: t("adminNav.items.existingConnectors.label"),
+      addConnector: t("adminNav.items.addConnector.label"),
+      documentSets: t("adminNav.items.documentSets.label"),
+      indexSettings: t("adminNav.items.indexSettings.label"),
+      serviceAccounts: t("adminNav.items.serviceAccounts.label"),
+      slackIntegration: t("adminNav.items.slackIntegration.label"),
+      discordIntegration: t("adminNav.items.discordIntegration.label"),
+      hookExtensions: t("adminNav.items.hookExtensions.label"),
+      users: t("adminNav.items.users.label"),
+      groups: t("adminNav.items.groups.label"),
+      scim: t("adminNav.items.scim.label"),
+      plansAndBilling: t("adminNav.items.plansAndBilling.label"),
+      appearanceAndTheming: t("adminNav.items.appearanceAndTheming.label"),
+      securityAndHardening: t("adminNav.items.securityAndHardening.label"),
+      ssoProviders: t("adminNav.items.ssoProviders.label"),
+      usage: t("adminNav.items.usage.label"),
+      analytics: t("adminNav.items.analytics.label"),
+      queryHistory: t("adminNav.items.queryHistory.label"),
+      tracing: t("adminNav.items.tracing.label"),
+      exportLogs: t("adminNav.items.exportLogs.label"),
+      upgradePlan: t("adminNav.items.upgradePlan.label"),
+    }),
+    [t]
+  );
+}
+
+const NAV_ID_BY_PATH: Record<string, AdminNavItemId | null> =
+  Object.fromEntries(
+    (Object.keys(ADMIN_ROUTES) as (keyof typeof ADMIN_ROUTES)[]).map((key) => [
+      ADMIN_ROUTES[key].path,
+      NAV_ITEM_IDS[key],
+    ])
+  );
+
+/** Nav id for a route, for server components that resolve labels themselves. */
+export function getAdminNavId(route: AdminRouteEntry): AdminNavItemId | null {
+  return NAV_ID_BY_PATH[route.path] ?? null;
+}
+
+// Page headers reuse the sidebar's translated labels so both stay in sync
+// across locales. Routes without a nav entry fall back to their raw title.
+export function useAdminRouteTitle(): (route: AdminRouteEntry) => string {
+  const labels = useAdminNavLabels();
+  return useCallback(
+    (route: AdminRouteEntry) => {
+      const navId = NAV_ID_BY_PATH[route.path];
+      return navId ? labels[navId] : route.title;
+    },
+    [labels]
+  );
+}

--- a/web/src/lib/app/components.tsx
+++ b/web/src/lib/app/components.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useSettings } from "@/lib/settings/hooks";
 import {
   DEFAULT_LOGO_SIZE_PX,
@@ -20,6 +21,7 @@ export interface LogoProps {
 }
 
 export function Logo({ folded, size, className, onyxBranded }: LogoProps) {
+  const t = useTranslations("common");
   const resolvedSize = size ?? DEFAULT_LOGO_SIZE_PX;
   const { enterprise, logoUrl } = useSettings();
   const logoDisplayStyle = enterprise?.logo_display_style;
@@ -43,7 +45,7 @@ export function Logo({ folded, size, className, onyxBranded }: LogoProps) {
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        alt="Logo"
+        alt={t("logo.image.alt")}
         src={logoUrl}
         className="object-cover object-center w-full h-full"
       />
@@ -73,7 +75,7 @@ export function Logo({ folded, size, className, onyxBranded }: LogoProps) {
                   className={"line-clamp-1 truncate"}
                   nowrap
                 >
-                  Powered by Onyx
+                  {t("logo.poweredBy.label")}
                 </Text>
               )}
           </div>

--- a/web/src/lib/auth/components.tsx
+++ b/web/src/lib/auth/components.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { useSessionWatcher } from "@/lib/auth/hooks";
@@ -42,19 +43,14 @@ interface AuthenticationShellProps {
   children: React.ReactNode;
 }
 
-const SESSION_END_GENERIC_COPY =
-  "Your session has expired. Please log in again to continue.";
-
-const SESSION_END_COPY: Record<SessionEndReason, string> = {
-  [SessionEndReason.EXPIRED]: SESSION_END_GENERIC_COPY,
-  [SessionEndReason.TERMINATED]:
-    "This session was signed out. Please log in again to continue.",
-  [SessionEndReason.UNRECOGNIZED]:
-    "You were signed out unexpectedly. Please log in again to continue. " +
-    "If this keeps happening, contact your administrator.",
-};
+const SESSION_END_MESSAGE_KEYS = {
+  [SessionEndReason.EXPIRED]: "sessionEnd.expired.message",
+  [SessionEndReason.TERMINATED]: "sessionEnd.terminated.message",
+  [SessionEndReason.UNRECOGNIZED]: "sessionEnd.unrecognized.message",
+} as const;
 
 export function AuthenticationShell({ children }: AuthenticationShellProps) {
+  const t = useTranslations("auth");
   const router = useRouter();
   const { sessionEnded, sessionEndReason } = useSessionWatcher();
 
@@ -90,16 +86,23 @@ export function AuthenticationShell({ children }: AuthenticationShellProps) {
       {sessionEnded && (
         <Modal open>
           <Modal.Content width="sm" height="sm">
-            <Modal.Header icon={SvgLogOut} title="You Have Been Logged Out" />
+            <Modal.Header
+              icon={SvgLogOut}
+              title={t("sessionEnd.modal.title")}
+            />
             <Modal.Body>
               <Text font="main-ui-body" color="text-03">
-                {sessionEndReason
-                  ? SESSION_END_COPY[sessionEndReason]
-                  : SESSION_END_GENERIC_COPY}
+                {t(
+                  sessionEndReason
+                    ? SESSION_END_MESSAGE_KEYS[sessionEndReason]
+                    : SESSION_END_MESSAGE_KEYS[SessionEndReason.EXPIRED]
+                )}
               </Text>
             </Modal.Body>
             <Modal.Footer>
-              <Button onClick={handleLogin}>Log In</Button>
+              <Button onClick={handleLogin}>
+                {t("sessionEnd.loginButton.label")}
+              </Button>
             </Modal.Footer>
           </Modal.Content>
         </Modal>
@@ -141,6 +144,7 @@ interface SignInButtonProps {
 }
 
 export function SignInButton({ authorizeUrl }: SignInButtonProps) {
+  const t = useTranslations("auth");
   const { getCaptchaToken, isCaptchaEnabled } = useCaptcha();
   const [isVerifying, setIsVerifying] = useState(false);
 
@@ -155,7 +159,7 @@ export function SignInButton({ authorizeUrl }: SignInButtonProps) {
     try {
       const token = await getCaptchaToken("oauth");
       if (!token) {
-        toast.error("grecaptcha.execute returned no token");
+        toast.error(t("signIn.captchaTokenError.toast"));
         return;
       }
       await verifyCaptchaForOAuth(token);
@@ -181,7 +185,7 @@ export function SignInButton({ authorizeUrl }: SignInButtonProps) {
       onClick={intercepted ? handleClick : undefined}
       disabled={isVerifying}
     >
-      Continue with Google
+      {t("signIn.google.label")}
     </Button>
   );
 }
@@ -195,6 +199,7 @@ interface PasswordRequirementsProps {
 }
 
 export function PasswordRequirements({ password }: PasswordRequirementsProps) {
+  const t = useTranslations("auth");
   const { authTypeMetadata } = useUser();
 
   if (!authTypeMetadata) return null;
@@ -211,7 +216,10 @@ export function PasswordRequirements({ password }: PasswordRequirementsProps) {
   const rules = (
     [
       {
-        label: `${passwordMinLength}–${passwordMaxLength} characters`,
+        label: t("passwordRequirements.length.label", {
+          min: passwordMinLength,
+          max: passwordMaxLength,
+        }),
         met: passwordMeetsLengthRequirements(
           password,
           passwordMinLength,
@@ -219,19 +227,19 @@ export function PasswordRequirements({ password }: PasswordRequirementsProps) {
         ),
       },
       passwordRequireUppercase && {
-        label: "Contains uppercase letter.",
+        label: t("passwordRequirements.uppercase.label"),
         met: passwordHasUppercase(password),
       },
       passwordRequireLowercase && {
-        label: "Contains lowercase letter.",
+        label: t("passwordRequirements.lowercase.label"),
         met: passwordHasLowercase(password),
       },
       passwordRequireDigit && {
-        label: "Contains number.",
+        label: t("passwordRequirements.digit.label"),
         met: passwordHasDigit(password),
       },
       passwordRequireSpecialChar && {
-        label: "Contains special character.",
+        label: t("passwordRequirements.specialChar.label"),
         met: passwordHasSpecialChar(password),
       },
     ] as const
@@ -277,6 +285,8 @@ export function EmailPasswordForm({
   defaultEmail,
   label,
 }: EmailPasswordFormProps) {
+  const t = useTranslations("auth");
+  const tCommon = useTranslations("common");
   const isSignup = label !== "submit";
   const isJoin = label === "join";
 
@@ -292,32 +302,35 @@ export function EmailPasswordForm({
 
       passwordSchema = passwordSchema.test(
         "length",
-        `Password must be between ${minLength}–${maxLength} characters`,
+        t("emailPasswordForm.passwordLength.error", {
+          min: minLength,
+          max: maxLength,
+        }),
         (v) => passwordMeetsLengthRequirements(v ?? "", minLength, maxLength)
       );
 
       if (authTypeMetadata?.passwordRequireUppercase)
         passwordSchema = passwordSchema.test(
           "uppercase",
-          "Password must contain at least one uppercase letter",
+          t("emailPasswordForm.passwordUppercase.error"),
           (v) => passwordHasUppercase(v ?? "")
         );
       if (authTypeMetadata?.passwordRequireLowercase)
         passwordSchema = passwordSchema.test(
           "lowercase",
-          "Password must contain at least one lowercase letter",
+          t("emailPasswordForm.passwordLowercase.error"),
           (v) => passwordHasLowercase(v ?? "")
         );
       if (authTypeMetadata?.passwordRequireDigit)
         passwordSchema = passwordSchema.test(
           "digit",
-          "Password must contain at least one number",
+          t("emailPasswordForm.passwordDigit.error"),
           (v) => passwordHasDigit(v ?? "")
         );
       if (authTypeMetadata?.passwordRequireSpecialChar)
         passwordSchema = passwordSchema.test(
           "special-char",
-          "Password must contain at least one special character",
+          t("emailPasswordForm.passwordSpecialChar.error"),
           (v) => passwordHasSpecialChar(v ?? "")
         );
     }
@@ -329,7 +342,7 @@ export function EmailPasswordForm({
         .transform((value: string) => value.toLowerCase()),
       password: passwordSchema.required(),
     });
-  }, [isSignup, authTypeMetadata]);
+  }, [isSignup, authTypeMetadata, t]);
 
   const initialValues: FormValues = {
     email: defaultEmail?.toLowerCase() ?? "",
@@ -351,11 +364,11 @@ export function EmailPasswordForm({
       if (!response.ok) {
         const errorBody: any = await response.json().catch(() => ({}));
         const errorDetail = errorBody.detail;
-        let errorMsg = "Unknown error";
+        let errorMsg = tCommon("errors.unknown.message");
         if (response.status === 429) {
-          errorMsg = "Too many requests. Please try again later.";
+          errorMsg = t("emailPasswordForm.tooManyRequests.error");
         } else if (errorDetail === "REGISTER_USER_ALREADY_EXISTS") {
-          errorMsg = "An account already exists with the specified email.";
+          errorMsg = t("emailPasswordForm.accountExists.error");
         } else if (typeof errorDetail === "string" && errorDetail) {
           errorMsg = errorDetail;
         }
@@ -393,16 +406,15 @@ export function EmailPasswordForm({
     } else {
       const errorBody: any = await loginResponse.json().catch(() => ({}));
       const errorDetail = errorBody.detail;
-      let errorMsg = "Unknown error";
+      let errorMsg = tCommon("errors.unknown.message");
       if (loginResponse.status === 429) {
-        errorMsg = "Too many requests. Please try again later.";
+        errorMsg = t("emailPasswordForm.tooManyRequests.error");
       } else if (errorDetail === "LOGIN_BAD_CREDENTIALS") {
-        errorMsg = "Invalid email or password";
+        errorMsg = t("emailPasswordForm.invalidCredentials.error");
       } else if (errorDetail === "NO_WEB_LOGIN_AND_HAS_NO_PASSWORD") {
-        errorMsg = "Create an account to set a password";
+        errorMsg = t("emailPasswordForm.noPassword.error");
       } else if (errorDetail === "PASSWORD_LOGIN_DISABLED") {
-        errorMsg =
-          "Password login is turned off. Sign in with your identity provider.";
+        errorMsg = t("emailPasswordForm.passwordLoginDisabled.error");
       } else if (typeof errorDetail === "string") {
         errorMsg = errorDetail;
       }
@@ -423,10 +435,13 @@ export function EmailPasswordForm({
         return (
           <AuthLayouts.FormBody>
             <AuthLayouts.Fields>
-              <InputVertical title="Email Address" withLabel="email">
+              <InputVertical
+                title={t("emailPasswordForm.email.label")}
+                withLabel="email"
+              >
                 <InputTypeInField
                   name="email"
-                  placeholder="email@yourcompany.com"
+                  placeholder={t("emailPasswordForm.email.placeholder")}
                   data-testid="email"
                   autoComplete="username"
                 />
@@ -434,7 +449,7 @@ export function EmailPasswordForm({
 
               <div className="flex flex-col gap-1">
                 <InputVertical
-                  title="Password"
+                  title={t("emailPasswordForm.password.label")}
                   withLabel="password"
                   topRight={
                     NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED &&
@@ -442,17 +457,21 @@ export function EmailPasswordForm({
                     !errors.email &&
                     !!values.email
                       ? markdown(
-                          `[Forgot password?](/auth/forgot-password?email=${encodeURIComponent(values.email)})`
+                          t("emailPasswordForm.forgotPassword.link", {
+                            url: `/auth/forgot-password?email=${encodeURIComponent(values.email)}`,
+                          })
                         )
                       : undefined
                   }
                   subDescription={
-                    isSignup ? "Password requirements:" : undefined
+                    isSignup
+                      ? t("emailPasswordForm.passwordRequirements.label")
+                      : undefined
                   }
                 >
                   <PasswordInputTypeInField
                     name="password"
-                    placeholder="Password"
+                    placeholder={t("emailPasswordForm.password.placeholder")}
                     mask="native"
                     data-testid="password"
                     autoComplete={
@@ -479,7 +498,7 @@ export function EmailPasswordForm({
                 className="text-xs text-action-selection-05 cursor-pointer text-center w-full font-medium mx-auto"
               >
                 <span className="hover:border-b hover:border-dotted hover:border-action-selection-05">
-                  or continue as guest
+                  {t("emailPasswordForm.continueAsGuest.label")}
                 </span>
               </Link>
             )}

--- a/web/src/lib/credentials/components/CreateCredential.tsx
+++ b/web/src/lib/credentials/components/CreateCredential.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Button as OpalButton } from "@opal/components";
 import { ValidSources, AccessType } from "@/lib/types";
 import { submitCredential } from "@/components/admin/connectors/CredentialForm";
@@ -45,15 +46,18 @@ const CreateButton = ({
   // it of them and of nobody else.
   requiresGroup: boolean;
   groups: number[];
-}) => (
-  <OpalButton
-    disabled={isSubmitting || (requiresGroup && groups.length === 0)}
-    onClick={onClick}
-    icon={SvgPlusCircle}
-  >
-    Create
-  </OpalButton>
-);
+}) => {
+  const t = useTranslations("admin");
+  return (
+    <OpalButton
+      disabled={isSubmitting || (requiresGroup && groups.length === 0)}
+      onClick={onClick}
+      icon={SvgPlusCircle}
+    >
+      {t("credentials.create.createButton.label")}
+    </OpalButton>
+  );
+};
 
 type CreateCredentialFormValues = IsPublicGroupSelectorFormType & {
   name: string;
@@ -96,6 +100,7 @@ export default function CreateCredential({
   // Mutating parent state
   refresh?: () => void;
 }) {
+  const t = useTranslations("admin");
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [authMethod, setAuthMethod] = useState<string>();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
@@ -154,7 +159,7 @@ export default function CreateCredential({
         if (action === "createAndSwap") {
           onSwap(credential, swapConnector.id, accessType);
         } else {
-          toast.success("Created new credential!");
+          toast.success(t("credentials.create.created.toast"));
         }
         onClose();
       } else {
@@ -175,7 +180,7 @@ export default function CreateCredential({
       }
     } catch (error) {
       console.error("Error submitting credential:", error);
-      toast.error("Error submitting credential");
+      toast.error(t("credentials.create.submitError.toast"));
     } finally {
       formikHelpers.setSubmitting(false);
     }
@@ -229,8 +234,8 @@ export default function CreateCredential({
             <CardSection className="w-full items-start dark:bg-neutral-900 mt-4 flex flex-col gap-y-6">
               <TextFormField
                 name="name"
-                placeholder="(Optional) credential name.."
-                label="Name:"
+                placeholder={t("credentials.create.name.placeholder")}
+                label={t("credentials.create.name.label")}
               />
 
               <CredentialFieldsRenderer

--- a/web/src/lib/credentials/components/CreateStdOAuthCredential.tsx
+++ b/web/src/lib/credentials/components/CreateStdOAuthCredential.tsx
@@ -4,6 +4,7 @@ import { Button, InputTypeIn, MessageCard } from "@opal/components";
 import { InputVertical, Section } from "@opal/layouts";
 import { Form, Formik, FormikHelpers } from "formik";
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 
 import { OAuthAdditionalKwargDescription } from "@/lib/connectors/credentials";
 import { getConnectorOauthRedirectUrl } from "@/lib/connectors/oauth";
@@ -11,8 +12,6 @@ import { ValidSources } from "@/lib/types";
 import { FormikField } from "@/refresh-components/form/FormikField";
 
 type OAuthFormValues = Record<string, string>;
-
-const OAUTH_REDIRECT_ERROR = "Unable to start OAuth";
 
 interface CreateStdOAuthCredentialProps {
   sourceType: ValidSources;
@@ -23,6 +22,7 @@ export function CreateStdOAuthCredential({
   sourceType,
   additionalFields,
 }: CreateStdOAuthCredentialProps) {
+  const t = useTranslations("admin");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   async function handleSubmit(
@@ -45,7 +45,9 @@ export function CreateStdOAuthCredential({
       window.location.href = redirectUrl;
     } catch (error) {
       setErrorMessage(
-        error instanceof Error ? error.message : OAUTH_REDIRECT_ERROR
+        error instanceof Error
+          ? error.message
+          : t("credentials.oauth.startError.message")
       );
       formikHelpers.setSubmitting(false);
     }
@@ -87,13 +89,13 @@ export function CreateStdOAuthCredential({
             {errorMessage && (
               <MessageCard
                 variant="error"
-                title="Could not connect"
+                title={t("credentials.oauth.connectError.title")}
                 description={errorMessage}
               />
             )}
             <Section flexDirection="row" justifyContent="start">
               <Button disabled={isSubmitting} type="submit">
-                Connect
+                {t("credentials.oauth.connectButton.label")}
               </Button>
             </Section>
           </Section>

--- a/web/src/lib/credentials/components/CredentialSection.tsx
+++ b/web/src/lib/credentials/components/CredentialSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AccessType, ValidSources } from "@/lib/types";
+import { useTranslations } from "next-intl";
 import useSWR, { mutate } from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { useState } from "react";
@@ -40,8 +41,6 @@ import {
 import EditCredential from "@/lib/credentials/components/EditCredential";
 import ModifyCredential from "@/lib/credentials/components/ModifyCredential";
 
-const OAUTH_REDIRECT_ERROR = "Unable to start OAuth";
-
 export interface CredentialSectionProps {
   ccPair: CCPairFullInfo;
   sourceType: ValidSources;
@@ -53,6 +52,8 @@ export default function CredentialSection({
   sourceType,
   refresh,
 }: CredentialSectionProps) {
+  const t = useTranslations("admin");
+  const tCommon = useTranslations("common");
   const { data: credentials } = useSWR<Credential<ConfluenceCredentialJson>[]>(
     buildSimilarCredentialInfoURL(sourceType),
     errorHandlingFetcher,
@@ -82,7 +83,9 @@ export default function CredentialSection({
         window.location.href = redirectUrl;
       } catch (error) {
         toast.error(
-          error instanceof Error ? error.message : OAUTH_REDIRECT_ERROR
+          error instanceof Error
+            ? error.message
+            : t("credentials.oauth.startError.message")
         );
       }
       return;
@@ -128,13 +131,16 @@ export default function CredentialSection({
       mutate(buildSimilarCredentialInfoURL(sourceType));
       refresh();
 
-      toast.success("Swapped credential successfully!");
+      toast.success(t("credentials.swap.success.toast"));
     } else {
       const errorData = await response.json();
       toast.error(
-        `Issue swapping credential: ${
-          errorData.detail || errorData.message || "Unknown error"
-        }`
+        t("credentials.swap.error.toast", {
+          detail:
+            errorData.detail ||
+            errorData.message ||
+            tCommon("errors.unknown.message"),
+        })
       );
     }
   };
@@ -162,10 +168,10 @@ export default function CredentialSection({
       response = await updateCredential(selectedCredential.id, details);
     }
     if (response.ok) {
-      toast.success("Updated credential");
+      toast.success(t("credentials.update.success.toast"));
       onSucces();
     } else {
-      toast.error("Issue updating credential");
+      toast.error(t("credentials.update.error.toast"));
     }
   };
 
@@ -231,10 +237,12 @@ export default function CredentialSection({
   const showCredentialModal =
     showModifyCredential || editingCredential != null || showCreateCredential;
   const credentialModalTitle = showCreateCredential
-    ? `Create ${getSourceDisplayName(sourceType)} Credential`
+    ? t("credentials.modal.createTitle", {
+        source: getSourceDisplayName(sourceType) ?? sourceType,
+      })
     : editingCredential
-      ? "Edit Credential"
-      : "Update Credentials";
+      ? t("credentials.modal.editTitle")
+      : t("credentials.modal.updateTitle");
   const closeCurrentCredentialView = showCreateCredential
     ? closeCreateCredential
     : editingCredential
@@ -262,24 +270,26 @@ export default function CredentialSection({
               <div>
                 <Text as="p">
                   {ccPair.credential.name ||
-                    `Credential #${ccPair.credential.id}`}
+                    t("credentials.card.unnamed.label", {
+                      id: ccPair.credential.id,
+                    })}
                 </Text>
                 <div className="text-xs text-muted-foreground/70">
-                  Created{" "}
-                  <i>
-                    {new Date(
-                      ccPair.credential.time_created
-                    ).toLocaleDateString(undefined, {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                    })}
-                  </i>
-                  {ccPair.credential.user_email && (
-                    <>
-                      {" "}
-                      by <i>{ccPair.credential.user_email}</i>
-                    </>
+                  {t.rich(
+                    ccPair.credential.user_email
+                      ? "credentials.card.createdOnBy.label"
+                      : "credentials.card.createdOn.label",
+                    {
+                      i: (chunks) => <i>{chunks}</i>,
+                      date: new Date(
+                        ccPair.credential.time_created
+                      ).toLocaleDateString(undefined, {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                      }),
+                      email: ccPair.credential.user_email ?? "",
+                    }
                   )}
                 </div>
               </div>
@@ -296,7 +306,9 @@ export default function CredentialSection({
                   transition-colors"
               >
                 <SvgEdit size={16} />
-                <span className="sr-only">Update Credentials</span>
+                <span className="sr-only">
+                  {t("credentials.modal.updateTitle")}
+                </span>
               </button>
             </div>
           </div>
@@ -335,9 +347,10 @@ export default function CredentialSection({
                   shouldRedirectToOAuth(oauthDetails) ? (
                     <Section alignItems="start">
                       <Text as="p" font="main-ui-body" color="text-03">
-                        {`We couldn't redirect you to sign in with ${getSourceDisplayName(
-                          sourceType
-                        )}. Please try again.`}
+                        {t("credentials.oauth.redirectFailed.message", {
+                          source:
+                            getSourceDisplayName(sourceType) ?? sourceType,
+                        })}
                       </Text>
                       <Button
                         onClick={() =>
@@ -346,7 +359,7 @@ export default function CredentialSection({
                           )
                         }
                       >
-                        Retry
+                        {t("credentials.oauth.retryButton.label")}
                       </Button>
                     </Section>
                   ) : (

--- a/web/src/lib/credentials/components/EditCredential.tsx
+++ b/web/src/lib/credentials/components/EditCredential.tsx
@@ -1,4 +1,5 @@
 import { Button, Text } from "@opal/components";
+import { useTranslations } from "next-intl";
 
 import { TextFormField, TypedFileUploadFormField } from "@/components/Field";
 import { Form, Formik, FormikHelpers } from "formik";
@@ -37,6 +38,7 @@ export default function EditCredential({
   onClose,
   onUpdate,
 }: EditCredentialProps) {
+  const t = useTranslations("admin");
   const editableCredentialFields = getEditableCredentialFields(
     credential,
     sourceType
@@ -58,7 +60,7 @@ export default function EditCredential({
       await onUpdate(credential, values, onClose);
     } catch (error) {
       console.error("Error updating credential:", error);
-      toast.error("Error updating credential");
+      toast.error(t("credentials.edit.updateError.toast"));
     } finally {
       formikHelpers.setSubmitting(false);
     }
@@ -66,9 +68,7 @@ export default function EditCredential({
 
   return (
     <div className="flex w-full flex-col gap-y-6">
-      <Text as="p">
-        Ensure that you update to a credential with the proper permissions!
-      </Text>
+      <Text as="p">{t("credentials.edit.permissions.note")}</Text>
 
       <Formik
         initialValues={initialValues}
@@ -81,7 +81,7 @@ export default function EditCredential({
               includeRevert
               name="name"
               placeholder={credential.name || ""}
-              label="Name (optional):"
+              label={t("credentials.edit.name.label")}
             />
 
             {Object.entries(editableCredentialFields).map(([key, value]) =>
@@ -111,14 +111,14 @@ export default function EditCredential({
             )}
             <div className="flex justify-between w-full">
               <Button onClick={() => resetForm()} icon={SvgTrash}>
-                Reset Changes
+                {t("credentials.edit.resetButton.label")}
               </Button>
               <Button
                 disabled={isSubmitting}
                 type="submit"
                 icon={SvgCheckSquare}
               >
-                Update
+                {t("credentials.edit.updateButton.label")}
               </Button>
             </div>
           </Form>

--- a/web/src/lib/credentials/components/ModifyCredential.tsx
+++ b/web/src/lib/credentials/components/ModifyCredential.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Modal } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { Badge } from "@/components/ui/badge";
@@ -34,6 +35,7 @@ function CredentialSelectionTable({
   currentCredentialId,
   onDeleteCredential,
 }: CredentialSelectionTableProps) {
+  const t = useTranslations("admin");
   const [selectedCredentialId, setSelectedCredentialId] = useState<
     number | null
   >(null);
@@ -67,22 +69,26 @@ function CredentialSelectionTable({
         <thead className="sticky top-0 w-full">
           <tr className="bg-neutral-100 dark:bg-neutral-900">
             <th className="p-2 text-start font-medium text-neutral-600 dark:text-neutral-400">
-              <span className="sr-only">Select</span>
+              <span className="sr-only">
+                {t("credentials.table.select.label")}
+              </span>
             </th>
             <th className="p-2 text-start font-medium text-neutral-600 dark:text-neutral-400">
-              ID
+              {t("credentials.table.id.header")}
             </th>
             <th className="p-2 text-start font-medium text-neutral-600 dark:text-neutral-400">
-              Name
+              {t("credentials.table.name.header")}
             </th>
             <th className="p-2 text-start font-medium text-neutral-600 dark:text-neutral-400">
-              Created
+              {t("credentials.table.created.header")}
             </th>
             <th className="p-2 text-start font-medium text-neutral-600 dark:text-neutral-400">
-              Last Updated
+              {t("credentials.table.lastUpdated.header")}
             </th>
             <th>
-              <span className="sr-only">Actions</span>
+              <span className="sr-only">
+                {t("credentials.table.actions.label")}
+              </span>
             </th>
           </tr>
         </thead>
@@ -112,12 +118,14 @@ function CredentialSelectionTable({
                         className="form-radio ms-4 h-4 w-4 text-blue-600 transition duration-150 ease-in-out"
                       />
                     ) : (
-                      <Badge>selected</Badge>
+                      <Badge>{t("credentials.table.selected.badge")}</Badge>
                     )}
                   </td>
                   <td className="p-2">{credential.id}</td>
                   <td className="p-2">
-                    <p>{credential.name ?? "Untitled"}</p>
+                    <p>
+                      {credential.name ?? t("credentials.table.untitled.label")}
+                    </p>
                   </td>
                   <td className="p-2">
                     {new Date(credential.time_created).toLocaleString()}
@@ -137,7 +145,7 @@ function CredentialSelectionTable({
                       <button
                         onClick={() => onEditCredential(credential)}
                         className="cursor-pointer my-auto"
-                        aria-label="Edit credential"
+                        aria-label={t("credentials.table.edit.ariaLabel")}
                       >
                         <SvgEdit size={16} />
                       </button>
@@ -151,7 +159,7 @@ function CredentialSelectionTable({
       </table>
 
       {allCredentials.length == 0 && (
-        <p className="mt-4"> No credentials exist for this connector!</p>
+        <p className="mt-4">{t("credentials.table.empty.message")}</p>
       )}
     </div>
   );
@@ -190,6 +198,7 @@ export default function ModifyCredential({
   onDeleteCredential,
   onCreateNew,
 }: ModifyCredentialProps) {
+  const t = useTranslations("admin");
   const [selectedCredential, setSelectedCredential] =
     useState<Credential<any> | null>(null);
   const [confirmDeletionCredential, setConfirmDeletionCredential] =
@@ -204,14 +213,11 @@ export default function ModifyCredential({
           <Modal.Content width="sm" height="sm">
             <Modal.Header
               icon={SvgAlertTriangle}
-              title="Confirm Deletion"
+              title={t("credentials.delete.confirmTitle")}
               onClose={() => setConfirmDeletionCredential(null)}
             />
             <Modal.Body>
-              <Text as="p">
-                Are you sure you want to delete this credential? You cannot
-                delete credentials that are linked to live connectors.
-              </Text>
+              <Text as="p">{t("credentials.delete.confirmBody.message")}</Text>
             </Modal.Body>
             <Modal.Footer>
               <Button
@@ -220,13 +226,13 @@ export default function ModifyCredential({
                   setConfirmDeletionCredential(null);
                 }}
               >
-                Confirm
+                {t("credentials.delete.confirmButton.label")}
               </Button>
               <Button
                 prominence="secondary"
                 onClick={() => setConfirmDeletionCredential(null)}
               >
-                Cancel
+                {t("credentials.delete.cancelButton.label")}
               </Button>
             </Modal.Footer>
           </Modal.Content>
@@ -235,8 +241,7 @@ export default function ModifyCredential({
 
       <div className="mb-0 w-full">
         <Text as="p" className="mb-4">
-          Select a credential as needed! Ensure that you have selected a
-          credential with the proper permissions for this connector!
+          {t("credentials.modify.instructions.message")}
         </Text>
 
         <CredentialSelectionTable
@@ -267,7 +272,7 @@ export default function ModifyCredential({
           <div className="flex mt-8 justify-between">
             {onCreateNew ? (
               <Button onClick={onCreateNew} icon={SvgBubbleText}>
-                Create
+                {t("credentials.modify.createButton.label")}
               </Button>
             ) : (
               <div />
@@ -288,7 +293,7 @@ export default function ModifyCredential({
               }}
               icon={SvgArrowExchange}
             >
-              Select
+              {t("credentials.modify.selectButton.label")}
             </Button>
           </div>
         )}

--- a/web/src/lib/projects/components/CreateProjectModal.tsx
+++ b/web/src/lib/projects/components/CreateProjectModal.tsx
@@ -2,6 +2,8 @@
 
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { useProjectsContext } from "@/lib/projects/providers";
 import { InputVertical, toast } from "@opal/layouts";
@@ -11,10 +13,6 @@ import { SvgFolderPlus } from "@opal/icons";
 import { Modal } from "@opal/components";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 
-const validationSchema = Yup.object({
-  projectName: Yup.string().trim().required("Project name is required"),
-});
-
 interface CreateProjectModalProps {
   initialProjectName?: string;
 }
@@ -22,17 +20,27 @@ interface CreateProjectModalProps {
 export default function CreateProjectModal({
   initialProjectName,
 }: CreateProjectModalProps) {
+  const t = useTranslations("chat");
   const { createProject } = useProjectsContext();
   const appPosition = useAppPosition();
   const modal = useModal();
+  const validationSchema = useMemo(
+    () =>
+      Yup.object({
+        projectName: Yup.string()
+          .trim()
+          .required(t("projects.createModal.nameRequired.error")),
+      }),
+    [t]
+  );
 
   return (
     <Modal open={modal.isOpen} onOpenChange={modal.toggle}>
       <Modal.Content width="sm">
         <Modal.Header
           icon={SvgFolderPlus}
-          title="Create New Project"
-          description="Use projects to organize your files and chats in one place, and add custom instructions for ongoing work."
+          title={t("projects.createModal.title")}
+          description={t("projects.createModal.description")}
           onClose={() => modal.toggle(false)}
         />
         <Formik
@@ -47,7 +55,9 @@ export default function CreateProjectModal({
               appPosition.openProject(newProject.id);
               modal.toggle(false);
             } catch {
-              toast.error(`Failed to create the project ${name}`);
+              toast.error(
+                t("projects.createModal.createError.toast", { name })
+              );
             } finally {
               setSubmitting(false);
             }
@@ -56,10 +66,13 @@ export default function CreateProjectModal({
           {({ isSubmitting, isValid }) => (
             <Form>
               <Modal.Body>
-                <InputVertical title="Project Name" withLabel="projectName">
+                <InputVertical
+                  title={t("projects.createModal.name.label")}
+                  withLabel="projectName"
+                >
                   <InputTypeInField
                     name="projectName"
-                    placeholder="What are you working on?"
+                    placeholder={t("projects.createModal.name.placeholder")}
                     clearButton
                   />
                 </InputVertical>
@@ -70,10 +83,10 @@ export default function CreateProjectModal({
                   type="button"
                   onClick={() => modal.toggle(false)}
                 >
-                  Cancel
+                  {t("projects.createModal.cancelButton.label")}
                 </Button>
                 <Button type="submit" disabled={isSubmitting || !isValid}>
-                  Create Project
+                  {t("projects.createModal.submitButton.label")}
                 </Button>
               </Modal.Footer>
             </Form>

--- a/web/src/lib/projects/components/FoldedProjectsPopover.tsx
+++ b/web/src/lib/projects/components/FoldedProjectsPopover.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/projects/components/ProjectFolderButton";
 import CreateProjectModal from "@/lib/projects/components/CreateProjectModal";
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   EmptyMessageCard,
@@ -117,6 +118,8 @@ function FoldedProjectsPopoverContent({
   onNavigate,
   onNewProject,
 }: FoldedProjectsPopoverContentProps) {
+  const t = useTranslations("chat");
+  const tSidebar = useTranslations("sidebar");
   const [query, setQuery] = useState("");
   const matches = useProjectSearch(query);
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
@@ -130,7 +133,7 @@ function FoldedProjectsPopoverContent({
           clearButton
           ref={focusOnMount}
           variant="internal"
-          placeholder="Search projects..."
+          placeholder={t("projects.foldedPopover.search.placeholder")}
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           rightChildren={
@@ -139,7 +142,7 @@ function FoldedProjectsPopoverContent({
               icon={SvgFolderPlus}
               prominence="internal"
               size="sm"
-              tooltip="New Project"
+              tooltip={tSidebar("appSidebar.newProject.tooltip")}
               onClick={noProp(onNewProject)}
             />
           }
@@ -151,7 +154,7 @@ function FoldedProjectsPopoverContent({
           ? [
               <EmptyMessageCard
                 key="empty"
-                title="No projects found"
+                title={t("projects.foldedPopover.empty.title")}
                 padding={2}
               />,
             ]
@@ -179,6 +182,7 @@ function FoldedProjectsPopoverContent({
  * search term inside it works the same way, one level down.
  */
 export function FoldedProjectsPopover() {
+  const tSidebar = useTranslations("sidebar");
   const appPosition = useAppPosition();
   const createProjectModal = useCreateModal();
   const [open, setOpen] = useState(false);
@@ -210,7 +214,7 @@ export function FoldedProjectsPopover() {
               folded
               selected={open || appPosition.isProject()}
             >
-              Projects
+              {tSidebar("appSidebar.projects.title")}
             </SidebarTab>
           </div>
         </Popover.Trigger>

--- a/web/src/lib/projects/components/ProjectChatSessionList.tsx
+++ b/web/src/lib/projects/components/ProjectChatSessionList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { deleteChatSession } from "@/app/app/services/lib";
 import {
   moveChatSession as moveChatSessionService,
@@ -51,6 +52,8 @@ function ProjectChatItem({
   icon,
   afterRefresh,
 }: ProjectChatItemProps) {
+  const t = useTranslations("chat");
+  const tSidebar = useTranslations("sidebar");
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [pendingMoveProjectId, setPendingMoveProjectId] = useState<
@@ -134,7 +137,7 @@ function ProjectChatItem({
           sizePreset="main-ui"
           rounding={2}
           icon={SvgFolderIn}
-          title="Move to Project"
+          title={tSidebar("chatButton.moveToProject.label")}
           onClick={noProp(() => setShowMoveOptions(true))}
         />,
         <LineItemButton
@@ -142,7 +145,11 @@ function ProjectChatItem({
           sizePreset="main-ui"
           rounding={2}
           icon={SvgFolder}
-          title={`Remove from ${projects.find((p) => p.id === projectId)?.name ?? "Project"}`}
+          title={tSidebar("chatButton.removeFromProject.label", {
+            projectName:
+              projects.find((p) => p.id === projectId)?.name ??
+              t("projects.chatItem.projectFallback.label"),
+          })}
           onClick={noProp(handleRemoveFromProject)}
         />,
         null,
@@ -152,7 +159,7 @@ function ProjectChatItem({
           rounding={2}
           color="danger"
           icon={SvgTrash}
-          title="Delete"
+          title={tSidebar("chatButton.delete.label")}
           onClick={noProp(() => setIsDeleteModalOpen(true))}
         />,
       ];
@@ -185,23 +192,24 @@ function ProjectChatItem({
     filteredProjects,
     handleMoveChatSession,
     handleRemoveFromProject,
+    t,
+    tSidebar,
   ]);
 
   return (
     <>
       {isDeleteModalOpen && (
         <ConfirmationModalLayout
-          title="Delete Chat"
+          title={tSidebar("chatButton.deleteConfirmation.title")}
           icon={SvgTrash}
           onClose={() => setIsDeleteModalOpen(false)}
           submit={
             <Button variant="danger" onClick={handleConfirmDelete}>
-              Delete
+              {tSidebar("chatButton.deleteConfirmation.confirmButton.label")}
             </Button>
           }
         >
-          Are you sure you want to delete this chat? This action cannot be
-          undone.
+          {tSidebar("chatButton.deleteConfirmation.description")}
         </ConfirmationModalLayout>
       )}
 
@@ -233,7 +241,11 @@ function ProjectChatItem({
           icon={icon}
           title={chat.name || UNNAMED_CHAT}
           description={
-            lastUpdateTime ? `Last message ${lastUpdateTime}` : undefined
+            lastUpdateTime
+              ? t("projects.chatItem.lastMessage.description", {
+                  time: lastUpdateTime,
+                })
+              : undefined
           }
           sizePreset="main-ui"
           interaction={popoverOpen ? "active" : undefined}
@@ -272,6 +284,7 @@ function ProjectChatItem({
 }
 
 export default function ProjectChatSessionList() {
+  const t = useTranslations("chat");
   const {
     currentProjectDetails,
     currentProjectId,
@@ -295,7 +308,7 @@ export default function ProjectChatSessionList() {
       <div>
         <div className="px-3 py-2">
           <Text as="p" font="secondary-body" color="text-02">
-            Recent Chats
+            {t("projects.sessionList.recentChats.title")}
           </Text>
         </div>
 
@@ -305,7 +318,7 @@ export default function ProjectChatSessionList() {
           <Card rounding={3} border="dashed" background="none" padding={2}>
             <div className="p-1">
               <Text as="p" font="secondary-body" color="text-02">
-                No chats yet.
+                {t("projects.sessionList.empty.message")}
               </Text>
             </div>
           </Card>

--- a/web/src/lib/projects/components/ProjectContextPanel.tsx
+++ b/web/src/lib/projects/components/ProjectContextPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useDropzone } from "react-dropzone";
 import { useProjectsContext } from "@/lib/projects/providers";
 import FilePickerPopover from "@/refresh-components/popovers/FilePickerPopover";
@@ -33,6 +34,7 @@ export default function ProjectContextPanel({
   availableContextTokens = 128_000,
   setPresentingDocument,
 }: ProjectContextPanelProps) {
+  const t = useTranslations("chat");
   const addInstructionModal = useCreateModal();
   const projectFilesModal = useCreateModal();
   // Convert ProjectFile to MinimalOnyxDocument format for viewing
@@ -69,7 +71,12 @@ export default function ProjectContextPanel({
   );
 
   const totalFiles = allCurrentProjectFiles.length;
-  const displayFileCount = totalFiles > 100 ? "100+" : String(totalFiles);
+  const fileCountLabel =
+    totalFiles > 100
+      ? t("projects.contextPanel.fileCountOverflow.description")
+      : t("projects.contextPanel.fileCount.description", {
+          count: totalFiles,
+        });
 
   const handleUploadChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -93,7 +100,8 @@ export default function ProjectContextPanel({
   });
 
   const currentProject = projects.find((p) => p.id === currentProjectId);
-  const projectName = currentProject?.name || "Loading project...";
+  const projectName =
+    currentProject?.name || t("projects.contextPanel.loadingProject.label");
 
   if (!currentProjectId) return null; // no selection yet
 
@@ -110,8 +118,8 @@ export default function ProjectContextPanel({
 
       <projectFilesModal.Provider>
         <UserFilesModal
-          title="Project Files"
-          description="Sessions in this project can access the files here."
+          title={t("projects.contextPanel.filesModal.title")}
+          description={t("projects.contextPanel.filesModal.description")}
           recentFiles={[...allCurrentProjectFiles]}
           onView={handleOnView}
           handleUploadChange={handleUploadChange}
@@ -139,12 +147,12 @@ export default function ProjectContextPanel({
         <ContentAction
           sizePreset="main-ui"
           variant="section"
-          title="Instructions"
+          title={t("projects.contextPanel.instructions.title")}
           description={
             isLoadingProjectDetails && !currentProjectDetails
               ? undefined
               : currentProjectDetails?.project?.instructions ||
-                "Add instructions to tailor the response in this project."
+                t("projects.contextPanel.instructions.emptyDescription")
           }
           descriptionMaxLines={2}
           padding={0}
@@ -156,7 +164,7 @@ export default function ProjectContextPanel({
               onClick={() => addInstructionModal.toggle(true)}
               interaction={addInstructionModal.isOpen ? "active" : undefined}
             >
-              Set Instructions
+              {t("projects.contextPanel.setInstructionsButton.label")}
             </Button>
           }
         />
@@ -168,8 +176,8 @@ export default function ProjectContextPanel({
           <ContentAction
             sizePreset="main-ui"
             variant="section"
-            title="Files"
-            description="Chats in this project can access these files."
+            title={t("projects.contextPanel.files.title")}
+            description={t("projects.contextPanel.files.description")}
             padding={0}
             center
             rightChildren={
@@ -180,7 +188,7 @@ export default function ProjectContextPanel({
                     prominence="tertiary"
                     interaction={open ? "active" : undefined}
                   >
-                    Add Files
+                    {t("projects.contextPanel.addFilesButton.label")}
                   </Button>
                 )}
                 onFileClick={handleOnView}
@@ -215,8 +223,8 @@ export default function ProjectContextPanel({
                 <LineItemButton
                   sizePreset="main-ui"
                   variant="section"
-                  title="View files"
-                  description={`${displayFileCount} files`}
+                  title={t("projects.contextPanel.viewFiles.label")}
+                  description={fileCountLabel}
                   icon={SvgFiles}
                   width="full"
                   onClick={() => projectFilesModal.toggle(true)}
@@ -242,8 +250,8 @@ export default function ProjectContextPanel({
                   <LineItemButton
                     sizePreset="main-ui"
                     variant="section"
-                    title="View All"
-                    description={`${displayFileCount} files`}
+                    title={t("projects.contextPanel.viewAll.label")}
+                    description={fileCountLabel}
                     rightChildren={
                       <SvgFiles className="h-5 w-5 stroke-text-02" />
                     }
@@ -257,9 +265,7 @@ export default function ProjectContextPanel({
 
               {projectTokenCount > availableContextTokens && (
                 <Text as="p" font="secondary-body" color="text-02">
-                  This project exceeds the model&apos;s context limits. Sessions
-                  will automatically search for relevant files first before
-                  generating response.
+                  {t("projects.contextPanel.contextExceeded.message")}
                 </Text>
               )}
             </>
@@ -274,8 +280,8 @@ export default function ProjectContextPanel({
             >
               <Text as="p" font="secondary-body" color="inherit">
                 {isDragActive
-                  ? "Drop files here to add to this project"
-                  : "Add documents, texts, or images to use in the project. Drag & drop supported."}
+                  ? t("projects.contextPanel.dropFiles.message")
+                  : t("projects.contextPanel.emptyFiles.message")}
               </Text>
             </div>
           )}

--- a/web/src/lib/projects/components/ProjectFolderButton.tsx
+++ b/web/src/lib/projects/components/ProjectFolderButton.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { useTranslations } from "next-intl";
 import { useDroppable } from "@dnd-kit/core";
 import {
   Button,
@@ -62,6 +63,7 @@ const FolderIconContext = createContext<FolderIconState | null>(null);
  * without changing type, and the fold state comes through the context.
  */
 export function FolderIcon() {
+  const t = useTranslations("chat");
   const state = useContext(FolderIconContext);
   const [hovering, setHovering] = useState(false);
   const [previewEnabled, setPreviewEnabled] = useState(true);
@@ -85,7 +87,11 @@ export function FolderIcon() {
       type="button"
       data-testid="ProjectFolderIcon"
       // The glyph carries no text, so the control needs its own name and state.
-      aria-label={open ? "Collapse project" : "Expand project"}
+      aria-label={
+        open
+          ? t("projects.folder.collapse.ariaLabel")
+          : t("projects.folder.expand.ariaLabel")
+      }
       aria-expanded={open}
       /* Above the tab's click overlay. `SidebarTab` lays an absolute
          `z-99` control over the whole row whenever it has an `onClick`, and a
@@ -136,6 +142,7 @@ export interface ProjectFolderButtonProps {
   project: Project;
 }
 export function ProjectFolderButton({ project }: ProjectFolderButtonProps) {
+  const t = useTranslations("chat");
   const appPosition = useAppPosition();
   const activeSidebar = useAppPosition();
   const activeProject = useActiveProject();
@@ -178,7 +185,7 @@ export function ProjectFolderButton({ project }: ProjectFolderButtonProps) {
       sizePreset="main-ui"
       rounding={2}
       icon={SvgEdit}
-      title="Rename Project"
+      title={t("projects.folder.rename.label")}
       onClick={noProp(() => setIsEditing(true))}
     />,
     null,
@@ -188,7 +195,7 @@ export function ProjectFolderButton({ project }: ProjectFolderButtonProps) {
       rounding={2}
       color="danger"
       icon={SvgTrash}
-      title="Delete Project"
+      title={t("projects.folder.delete.label")}
       onClick={noProp(() => setDeleteConfirmationModalOpen(true))}
     />,
   ];
@@ -204,7 +211,7 @@ export function ProjectFolderButton({ project }: ProjectFolderButtonProps) {
       {/* Confirmation Modal (only for deletion) */}
       {deleteConfirmationModalOpen && (
         <ConfirmationModalLayout
-          title="Delete Project"
+          title={t("projects.folder.deleteModal.title")}
           icon={SvgTrash}
           onClose={() => setDeleteConfirmationModalOpen(false)}
           submit={
@@ -215,12 +222,11 @@ export function ProjectFolderButton({ project }: ProjectFolderButtonProps) {
                 deleteProject(project.id);
               }}
             >
-              Delete
+              {t("projects.folder.deleteModal.confirmButton.label")}
             </Button>
           }
         >
-          Are you sure you want to delete this project? This action cannot be
-          undone.
+          {t("projects.folder.deleteModal.message")}
         </ConfirmationModalLayout>
       )}
 

--- a/web/src/lib/projects/providers.test.tsx
+++ b/web/src/lib/projects/providers.test.tsx
@@ -1,5 +1,7 @@
 import React, { PropsWithChildren } from "react";
 import { act, renderHook } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import englishMessages from "@/i18n/messages/en.json";
 import { ProjectsProvider, useProjectsContext } from "@/lib/projects/providers";
 import type { ProjectFile } from "@/lib/projects/types";
 
@@ -66,7 +68,9 @@ jest.mock("@/lib/projects/svc", () => {
 });
 
 const wrapper = ({ children }: PropsWithChildren) => (
-  <ProjectsProvider>{children}</ProjectsProvider>
+  <NextIntlClientProvider locale="en" messages={englishMessages}>
+    <ProjectsProvider>{children}</ProjectsProvider>
+  </NextIntlClientProvider>
 );
 
 describe("ProjectsContext beginUpload size precheck", () => {

--- a/web/src/lib/projects/providers.tsx
+++ b/web/src/lib/projects/providers.tsx
@@ -12,6 +12,7 @@ import {
   Dispatch,
   SetStateAction,
 } from "react";
+import { useTranslations } from "next-intl";
 import useSWR from "swr";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import {
@@ -133,6 +134,7 @@ interface ProjectsProviderProps {
 }
 
 export function ProjectsProvider({ children }: ProjectsProviderProps) {
+  const t = useTranslations("chat");
   // Use SWR hook for projects list - no more SSR initial data
   const { projects, refreshProjects } = useProjects();
   // Uploads made in an incognito chat are tied to its session so the server
@@ -375,7 +377,11 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       if (oversizedFiles.length > 0) {
         const skippedNames = oversizedFiles.map((file) => file.name).join(", ");
         toast.warning(
-          `Skipped ${oversizedFiles.length} oversized file(s) (>${rawMax} MB): ${skippedNames}`
+          t("projects.uploads.oversized.toast", {
+            count: oversizedFiles.length,
+            max: rawMax ?? 0,
+            names: skippedNames,
+          })
         );
       }
 
@@ -441,7 +447,9 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
             const detailsParts = Array.from(uniqueReasons);
 
             toast.warning(
-              `Some files were not uploaded. ${detailsParts.join(" | ")}`
+              t("projects.uploads.rejected.toast", {
+                details: detailsParts.join(" | "),
+              })
             );
 
             const failedNameSet = new Set<string>(
@@ -478,7 +486,7 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
 
           removeOptimisticFilesByTempIds(optimisticTempIds, projectId);
 
-          toast.error("Failed to upload files");
+          toast.error(t("projects.uploads.failed.toast"));
 
           onFailure?.(Array.from(optimisticTempIds));
         })
@@ -498,6 +506,7 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
       userFileMaxUploadSizeMb,
       incognitoUploadsEnabled,
       incognitoUploadsEnabled,
+      t,
     ]
   );
 

--- a/web/src/lib/tools/components/ActionLineItem.tsx
+++ b/web/src/lib/tools/components/ActionLineItem.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import { SEARCH_TOOL_ID } from "@/lib/tools/constants";
 import { ToolSnapshot } from "@/lib/tools/types";
 import { getIconForAction } from "@/app/app/services/actionUtils";
@@ -51,7 +52,7 @@ export default function ActionLineItem({
   tooltip,
   showAdminConfigure = false,
   adminConfigureHref,
-  adminConfigureTooltip = "Configure",
+  adminConfigureTooltip,
   onToggle,
   onForceToggle,
   onSourceManagementOpen,
@@ -61,6 +62,7 @@ export default function ActionLineItem({
   onClose,
   sourceCounts,
 }: ActionItemProps) {
+  const t = useTranslations("actions");
   const router = useRouter();
   const { currentProjectId } = useProjectsContext();
 
@@ -69,7 +71,7 @@ export default function ActionLineItem({
 
   let label = tool ? tool.display_name || tool.name : providedLabel!;
   if (!!currentProjectId && tool?.in_code_tool_id === SEARCH_TOOL_ID) {
-    label = "Project Search";
+    label = t("actionLineItem.projectSearch.label");
   }
 
   const isSearchToolWithNoConnectors =
@@ -93,14 +95,17 @@ export default function ActionLineItem({
 
   // Declared once because it renders both bare and hover-revealed, depending
   // on whether the action is already disabled.
+  const toggleLabel = disabled
+    ? t("actionLineItem.enable.label")
+    : t("actionLineItem.disable.label");
   const toggleButton = (
     <Button
       icon={SvgSlash}
       onClick={noProp(onToggle)}
       prominence="internal"
       size="sm"
-      aria-label={disabled ? "Enable" : "Disable"}
-      tooltip={disabled ? "Enable" : "Disable"}
+      aria-label={toggleLabel}
+      tooltip={toggleLabel}
     />
   );
 
@@ -167,7 +172,10 @@ export default function ActionLineItem({
                   })}
                   prominence="tertiary"
                   size="sm"
-                  tooltip={adminConfigureTooltip}
+                  tooltip={
+                    adminConfigureTooltip ??
+                    t("actionLineItem.configure.tooltip")
+                  }
                 />
               )}
 
@@ -187,7 +195,7 @@ export default function ActionLineItem({
                       onClick={noProp(onToggle)}
                       prominence="tertiary"
                       size="sm"
-                      tooltip={disabled ? "Enable" : "Disable"}
+                      tooltip={toggleLabel}
                     />
                   </span>
                 </span>
@@ -197,8 +205,8 @@ export default function ActionLineItem({
                 <Button
                   aria-label={
                     isSearchToolWithNoConnectors
-                      ? "Add Connectors"
-                      : "Configure Connectors"
+                      ? t("actionLineItem.addConnectors.label")
+                      : t("actionLineItem.configureConnectors.label")
                   }
                   icon={
                     isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
@@ -212,8 +220,8 @@ export default function ActionLineItem({
                   size="sm"
                   tooltip={
                     isSearchToolWithNoConnectors
-                      ? "Add Connectors"
-                      : "Configure Connectors"
+                      ? t("actionLineItem.addConnectors.label")
+                      : t("actionLineItem.configureConnectors.label")
                   }
                 />
               )}

--- a/web/src/lib/tools/components/SwitchList.tsx
+++ b/web/src/lib/tools/components/SwitchList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useFocusOnMount } from "@opal/hooks";
 import {
   Button,
@@ -46,6 +47,7 @@ export default function SwitchList({
   onBack,
   footer,
 }: SwitchListProps) {
+  const t = useTranslations("actions");
   const [searchTerm, setSearchTerm] = useState("");
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
   const filteredItems = useMemo(() => {
@@ -68,7 +70,7 @@ export default function SwitchList({
             icon={SvgChevronLeft}
             prominence="tertiary"
             size="sm"
-            aria-label="Back"
+            aria-label={t("switchList.back.ariaLabel")}
             onClick={() => {
               setSearchTerm("");
               onBack();
@@ -89,7 +91,11 @@ export default function SwitchList({
           key="enable-disable-all"
           icon={allDisabled ? SvgPlug : SvgUnplug}
           onClick={allDisabled ? onEnableAll : onDisableAll}
-          title={allDisabled ? "Enable All" : "Disable All"}
+          title={
+            allDisabled
+              ? t("switchList.enableAll.label")
+              : t("switchList.disableAll.label")
+          }
         />,
 
         ...filteredItems.map((item) => {
@@ -125,7 +131,9 @@ export default function SwitchList({
                     <Switch
                       checked={item.isEnabled}
                       onCheckedChange={item.onToggle}
-                      aria-label={`Toggle ${item.label}`}
+                      aria-label={t("switchList.toggle.ariaLabel", {
+                        name: item.label,
+                      })}
                       disabled={item.disabled}
                     />
                   }

--- a/web/src/lib/tools/components/SwitchList.tsx
+++ b/web/src/lib/tools/components/SwitchList.tsx
@@ -44,6 +44,8 @@ export default function SwitchList({
   allDisabled,
   onDisableAll,
   onEnableAll,
+  disableAllLabel,
+  enableAllLabel,
   onBack,
   footer,
 }: SwitchListProps) {
@@ -91,11 +93,7 @@ export default function SwitchList({
           key="enable-disable-all"
           icon={allDisabled ? SvgPlug : SvgUnplug}
           onClick={allDisabled ? onEnableAll : onDisableAll}
-          title={
-            allDisabled
-              ? t("switchList.enableAll.label")
-              : t("switchList.disableAll.label")
-          }
+          title={allDisabled ? enableAllLabel : disableAllLabel}
         />,
 
         ...filteredItems.map((item) => {

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { FILE_READER_TOOL_ID, SEARCH_TOOL_ID } from "@/lib/tools/constants";
+import {
+  CODING_AGENT_TOOL_ID,
+  FILE_READER_TOOL_ID,
+  IMAGE_GENERATION_TOOL_ID,
+  PYTHON_TOOL_ID,
+  SEARCH_TOOL_ID,
+  WEB_SEARCH_TOOL_ID,
+} from "@/lib/tools/constants";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { useFocusOnMount } from "@opal/hooks";
 import { InputTypeIn, Button, Popover, PopoverMenu } from "@opal/components";
 import { SvgActions, SvgKey, SvgSliders, SvgSimpleLoader } from "@opal/icons";
@@ -67,6 +75,39 @@ export default function ToolsPopover({
   toolConfiguration,
   disabled = false,
 }: ToolsPopoverProps) {
+  const t = useTranslations("actions");
+  const tooltipMessages = useMemo(
+    () => ({
+      descriptions: {
+        [SEARCH_TOOL_ID]: t("toolsPopover.tooltips.search.description"),
+        [IMAGE_GENERATION_TOOL_ID]: t(
+          "toolsPopover.tooltips.imageGeneration.description"
+        ),
+        [WEB_SEARCH_TOOL_ID]: t("toolsPopover.tooltips.webSearch.description"),
+        [PYTHON_TOOL_ID]: t("toolsPopover.tooltips.python.description"),
+        [CODING_AGENT_TOOL_ID]: t(
+          "toolsPopover.tooltips.codingAgent.description"
+        ),
+      },
+      defaultDescription: t("toolsPopover.tooltips.default.description"),
+      configure: t("toolsPopover.tooltips.configureSuffix.text"),
+      askAdmin: t("toolsPopover.tooltips.askAdminSuffix.text"),
+    }),
+    [t]
+  );
+  const configureTooltips = useMemo(
+    () => ({
+      [IMAGE_GENERATION_TOOL_ID]: t(
+        "toolsPopover.configureLinks.imageGeneration.tooltip"
+      ),
+      [WEB_SEARCH_TOOL_ID]: t("toolsPopover.configureLinks.webSearch.tooltip"),
+      [PYTHON_TOOL_ID]: t(
+        "toolsPopover.configureLinks.codeInterpreter.tooltip"
+      ),
+      openapi: t("toolsPopover.configureLinks.openapi.tooltip"),
+    }),
+    [t]
+  );
   const { availableSources } = useAvailableSources();
   const [open, setOpen] = useState(false);
   const [secondaryView, setSecondaryView] = useState<SecondaryViewState | null>(
@@ -540,7 +581,7 @@ export default function ToolsPopover({
       onClick={handleFooterReauthClick}
       icon={selectedMcpServerData?.isLoading ? SvgSimpleLoader : SvgKey}
     >
-      Re-authenticate
+      {t("toolsPopover.reauthenticate.label")}
     </LineItem>
   ) : undefined;
 
@@ -639,7 +680,7 @@ export default function ToolsPopover({
       {[
         <InputTypeIn
           key="search"
-          placeholder="Search actions..."
+          placeholder={t("toolsPopover.search.placeholder")}
           searchIcon
           value={searchTerm}
           onChange={(event) => setSearchTerm(event.target.value)}
@@ -659,7 +700,7 @@ export default function ToolsPopover({
             );
             const adminConfigureInfo =
               isUnavailable && canAdminConfigure
-                ? getAdminConfigureInfo(tool)
+                ? getAdminConfigureInfo(tool, configureTooltips)
                 : null;
             return (
               <ActionLineItem
@@ -671,7 +712,8 @@ export default function ToolsPopover({
                 tooltip={getToolTooltip(
                   tool,
                   isToolAvailable,
-                  canAdminConfigure
+                  canAdminConfigure,
+                  tooltipMessages
                 )}
                 showAdminConfigure={!!adminConfigureInfo}
                 adminConfigureHref={adminConfigureInfo?.href}
@@ -742,7 +784,7 @@ export default function ToolsPopover({
             icon={SvgActions}
             key="more-actions"
           >
-            More Actions
+            {t("toolsPopover.moreActions.label")}
           </LineItem>
         ),
       ]}
@@ -752,12 +794,12 @@ export default function ToolsPopover({
   const toolsView = (
     <SwitchList
       items={sourceToggleItems}
-      searchPlaceholder="Search Filters"
+      searchPlaceholder={t("toolsPopover.sourceFilters.searchPlaceholder")}
       allDisabled={allSourcesDisabled}
       onDisableAll={handleDisableAllSources}
       onEnableAll={handleEnableAllSources}
-      disableAllLabel="Disable All Sources"
-      enableAllLabel="Enable All Sources"
+      disableAllLabel={t("toolsPopover.disableAllSources.label")}
+      enableAllLabel={t("toolsPopover.enableAllSources.label")}
       onBack={() => setSecondaryView(null)}
     />
   );
@@ -765,12 +807,15 @@ export default function ToolsPopover({
   const mcpView = (
     <SwitchList
       items={mcpToggleItems}
-      searchPlaceholder={`Search ${selectedMcpServer?.name ?? "server"} tools`}
+      searchPlaceholder={t("toolsPopover.mcpTools.searchPlaceholder", {
+        server:
+          selectedMcpServer?.name ?? t("toolsPopover.serverFallback.label"),
+      })}
       allDisabled={mcpAllDisabled}
       onDisableAll={() => setSelectedServerToolsDisabled(true)}
       onEnableAll={() => setSelectedServerToolsDisabled(false)}
-      disableAllLabel="Disable All Tools"
-      enableAllLabel="Enable All Tools"
+      disableAllLabel={t("toolsPopover.disableAllTools.label")}
+      enableAllLabel={t("toolsPopover.enableAllTools.label")}
       onBack={() => setSecondaryView(null)}
       footer={mcpFooter}
     />
@@ -789,7 +834,7 @@ export default function ToolsPopover({
               icon={SvgSliders}
               interaction={open ? "hover" : "rest"}
               prominence="tertiary"
-              tooltip="Manage Actions"
+              tooltip={t("toolsPopover.manageActions.tooltip")}
             />
           </div>
         </Popover.Trigger>

--- a/web/src/lib/tools/constants.ts
+++ b/web/src/lib/tools/constants.ts
@@ -39,25 +39,6 @@ export const SYSTEM_TOOL_ICONS: Record<
 
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
-/** What each built-in tool does, shown as the row's tooltip. */
-export const TOOL_DESCRIPTIONS: Record<string, string> = {
-  [SEARCH_TOOL_ID]: "Search through connected knowledge to inform the answer.",
-  [IMAGE_GENERATION_TOOL_ID]: "Generate images based on a prompt.",
-  [WEB_SEARCH_TOOL_ID]: "Search the web for up-to-date information.",
-  [PYTHON_TOOL_ID]: "Execute code for complex analysis.",
-  [CODING_AGENT_TOOL_ID]:
-    "Investigate a GitHub repository and answer questions about its code.",
-};
-
-/** Shown for a tool with no description of its own. */
-export const DEFAULT_TOOL_DESCRIPTION = "This action is not configured yet.";
-
-/** Appended to the tooltip when the reader can configure the tool themselves. */
-export const CONFIGURE_MESSAGE = "Press the settings cog to enable.";
-
-/** Appended instead when they cannot. */
-export const USER_NOT_ADMIN_MESSAGE = "Ask an admin to configure.";
-
 /**
  * Where an admin goes to configure a built-in tool.
  */

--- a/web/src/lib/tools/utils.ts
+++ b/web/src/lib/tools/utils.ts
@@ -109,39 +109,62 @@ export function extractMethodSpecsFromDefinition(
  * The tooltip for an action row: what the tool does, plus how to turn it on
  * when it is not configured yet.
  */
+export interface ToolTooltipMessages {
+  descriptions: Record<string, string>;
+  defaultDescription: string;
+  configure: string;
+  askAdmin: string;
+}
+
 export function buildTooltipMessage(
   actionDescription: string,
   isConfigured: boolean,
-  canManageAction: boolean
+  canManageAction: boolean,
+  messages: Pick<ToolTooltipMessages, "configure" | "askAdmin">
 ): string {
   if (isConfigured) return actionDescription;
   return canManageAction
-    ? `${actionDescription} ${CONFIGURE_MESSAGE}`
-    : `${actionDescription} ${USER_NOT_ADMIN_MESSAGE}`;
+    ? `${actionDescription} ${messages.configure}`
+    : `${actionDescription} ${messages.askAdmin}`;
 }
 
 /** {@link buildTooltipMessage}, with the description resolved from the tool. */
 export function getToolTooltip(
   tool: ToolSnapshot,
   isConfigured: boolean,
-  canManageAction: boolean
+  canManageAction: boolean,
+  messages: ToolTooltipMessages
 ): string {
   const description =
-    (tool.in_code_tool_id && TOOL_DESCRIPTIONS[tool.in_code_tool_id]) ||
+    (tool.in_code_tool_id && messages.descriptions[tool.in_code_tool_id]) ||
     tool.description ||
-    DEFAULT_TOOL_DESCRIPTION;
-  return buildTooltipMessage(description, isConfigured, canManageAction);
+    messages.defaultDescription;
+  return buildTooltipMessage(
+    description,
+    isConfigured,
+    canManageAction,
+    messages
+  );
 }
 
 /** Where an admin configures this tool, or null when there is nowhere to go. */
 export function getAdminConfigureInfo(
-  tool: ToolSnapshot
+  tool: ToolSnapshot,
+  configureTooltips: Record<string, string>
 ): { href: string; tooltip: string } | null {
   if (tool.in_code_tool_id && ADMIN_CONFIG_LINKS[tool.in_code_tool_id]) {
-    return ADMIN_CONFIG_LINKS[tool.in_code_tool_id] ?? null;
+    const link = ADMIN_CONFIG_LINKS[tool.in_code_tool_id];
+    if (!link) return null;
+    return {
+      href: link.href,
+      tooltip: configureTooltips[tool.in_code_tool_id] ?? link.tooltip,
+    };
   }
   if (!tool.in_code_tool_id && !tool.mcp_server_id) {
-    return OPENAPI_ADMIN_CONFIG;
+    return {
+      href: OPENAPI_ADMIN_CONFIG.href,
+      tooltip: configureTooltips.openapi ?? OPENAPI_ADMIN_CONFIG.tooltip,
+    };
   }
   return null;
 }

--- a/web/src/lib/tools/utils.ts
+++ b/web/src/lib/tools/utils.ts
@@ -2,11 +2,7 @@ import { SOURCE_METADATA_MAP } from "@/lib/sources";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/types";
 import {
   ADMIN_CONFIG_LINKS,
-  CONFIGURE_MESSAGE,
-  DEFAULT_TOOL_DESCRIPTION,
   OPENAPI_ADMIN_CONFIG,
-  TOOL_DESCRIPTIONS,
-  USER_NOT_ADMIN_MESSAGE,
 } from "@/lib/tools/constants";
 import type { IconProps } from "@opal/types";
 import { SvgFileText, SvgServer } from "@opal/icons";

--- a/web/src/refresh-components/Attachment.tsx
+++ b/web/src/refresh-components/Attachment.tsx
@@ -1,12 +1,14 @@
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { SvgFileText, SvgMaximize2 } from "@opal/icons";
+import { useTranslations } from "next-intl";
 export interface AttachmentsProps {
   fileName: string;
   open?: () => void;
 }
 
 export default function Attachments({ fileName, open }: AttachmentsProps) {
+  const t = useTranslations("common.attachment");
   return (
     <div className="flex items-center border bg-background-tint-00 rounded-12 p-1 gap-1">
       <div className="p-2 bg-background-tint-01 rounded-08">
@@ -17,13 +19,13 @@ export default function Attachments({ fileName, open }: AttachmentsProps) {
           {fileName}
         </Text>
         <Text as="p" secondaryBody text03>
-          Document
+          {t("document.label")}
         </Text>
       </div>
 
       {open && (
         <Button
-          aria-label="Expand document"
+          aria-label={t("expandButton.ariaLabel")}
           onClick={open}
           icon={SvgMaximize2}
           prominence="tertiary"

--- a/web/src/refresh-components/ColorSwatch.tsx
+++ b/web/src/refresh-components/ColorSwatch.tsx
@@ -1,5 +1,7 @@
 import "@/app/css/color-swatch.css";
 
+import { useTranslations } from "next-intl";
+
 /**
  * A small color swatch chip component that displays a visual preview of light or dark color modes.
  * Shows "Aa" text sample with appropriate background and text colors.
@@ -19,12 +21,13 @@ export interface ColorSwatchProps {
 }
 
 export default function ColorSwatch({ light, dark }: ColorSwatchProps) {
+  const t = useTranslations("common.colorSwatch");
   const mode = light ? "light" : dark ? "dark" : "light";
 
   return (
     <div className="color-swatch" data-state={mode}>
       <div className="rounded-full h-[0.3rem] w-[0.3rem] bg-action-selection-05" />
-      <span className="color-swatch__text">Aa</span>
+      <span className="color-swatch__text">{t("sample.text")}</span>
     </div>
   );
 }

--- a/web/src/refresh-components/DateRangePicker.test.tsx
+++ b/web/src/refresh-components/DateRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@tests/setup/test-utils";
 import userEvent from "@testing-library/user-event";
 import { DateRangePicker } from "@/refresh-components/DateRangePicker";
 

--- a/web/src/refresh-components/DateRangePicker.tsx
+++ b/web/src/refresh-components/DateRangePicker.tsx
@@ -1,4 +1,5 @@
 import { memo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { endOfDay, format, isSameDay, startOfDay, subDays } from "date-fns";
 import { Calendar, Popover, SelectButton } from "@opal/components";
 import { SvgCalendar } from "@opal/icons";
@@ -65,6 +66,30 @@ function rangesMatch(left: DateRange, right: DateRange): boolean {
 
 type SelectorSize = "md" | "sm";
 
+type DateRangeTranslator = ReturnType<
+  typeof useTranslations<"common.dateRange">
+>;
+
+// Display labels are looked up per preset so the stable `label` ids used for
+// range matching stay untranslated.
+function presetDisplayLabel(
+  t: DateRangeTranslator,
+  preset: DatePreset
+): string {
+  switch (preset.inclusiveDays) {
+    case 1:
+      return t("preset.oneDay");
+    case 7:
+      return t("preset.sevenDays");
+    case 30:
+      return t("preset.oneMonth");
+    case 90:
+      return t("preset.threeMonths");
+    default:
+      return preset.label;
+  }
+}
+
 export const DateRangePicker = memo(function DateRangePicker({
   value,
   onValueChange,
@@ -74,6 +99,7 @@ export const DateRangePicker = memo(function DateRangePicker({
   onValueChange: (value: DateRange) => void;
   size?: SelectorSize;
 }) {
+  const t = useTranslations("common.dateRange");
   const buttonSize = size === "sm" ? "sm" : "md";
   const [isOpen, setIsOpen] = useState(false);
   const [draftRange, setDraftRange] = useState<DraftDateRange>(value);
@@ -84,10 +110,11 @@ export const DateRangePicker = memo(function DateRangePicker({
     rangesMatch(value, rangeForPreset(preset))
   );
   const customActive = !activePreset;
+  const hasCustomRange = customActive && !!value;
   const customLabel =
     customActive && value
       ? `${format(value.from, value.from.getFullYear() === value.to.getFullYear() ? "MMM d" : "MMM d, y")} – ${format(value.to, value.from.getFullYear() === value.to.getFullYear() ? "MMM d" : "MMM d, y")}`
-      : "Custom";
+      : t("custom.label");
 
   function selectPreset(preset: DatePreset) {
     const range = rangeForPreset(preset);
@@ -102,7 +129,7 @@ export const DateRangePicker = memo(function DateRangePicker({
     <div
       className="inline-flex max-w-full shrink-0 items-center overflow-x-auto rounded-12 border border-border-02 bg-background-tint-03 p-0.5"
       role="group"
-      aria-label="Date range"
+      aria-label={t("group.ariaLabel")}
       data-testid="admin-date-range-selector"
     >
       {PRESETS.map((preset) => {
@@ -116,7 +143,7 @@ export const DateRangePicker = memo(function DateRangePicker({
             aria-pressed={active}
             onClick={() => selectPreset(preset)}
           >
-            {preset.label}
+            {presetDisplayLabel(t, preset)}
           </SelectButton>
         );
       })}
@@ -134,11 +161,14 @@ export const DateRangePicker = memo(function DateRangePicker({
           <SelectButton
             size={buttonSize}
             state={customActive || isOpen ? "selected" : "empty"}
-            rightIcon={customLabel === "Custom" ? SvgCalendar : undefined}
+            rightIcon={hasCustomRange ? undefined : SvgCalendar}
             aria-label={
               value
-                ? `Custom range: ${format(value.from, "MMM d, y")} to ${format(value.to, "MMM d, y")}`
-                : "Choose a custom range"
+                ? t("customRange.ariaLabel", {
+                    from: format(value.from, "MMM d, y"),
+                    to: format(value.to, "MMM d, y"),
+                  })
+                : t("chooseCustom.ariaLabel")
             }
             aria-pressed={customActive}
             aria-haspopup="dialog"

--- a/web/src/refresh-components/avatars/AgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/AgentAvatar.tsx
@@ -7,6 +7,7 @@ import { useSettings } from "@/lib/settings/hooks";
 import { DEFAULT_AVATAR_SIZE_PX, DEFAULT_AGENT_ID } from "@/lib/constants";
 import CustomAgentAvatar from "@/refresh-components/avatars/CustomAgentAvatar";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 
 export interface AgentAvatarProps {
   agent: MinimalAgent;
@@ -18,6 +19,7 @@ export default function AgentAvatar({
   size = DEFAULT_AVATAR_SIZE_PX,
   ...props
 }: AgentAvatarProps) {
+  const t = useTranslations("common.agentAvatar");
   const { enterprise: enterpriseSettings } = useSettings();
 
   if (agent.id === DEFAULT_AGENT_ID) {
@@ -27,7 +29,7 @@ export default function AgentAvatar({
         style={{ height: size, width: size }}
       >
         <Image
-          alt="Logo"
+          alt={t("logo.alt")}
           src="/api/enterprise-settings/logo"
           fill
           className="object-cover object-center"

--- a/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
@@ -4,6 +4,7 @@ import { cn } from "@opal/utils";
 import type { IconProps } from "@opal/types";
 import Text from "@/refresh-components/texts/Text";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import { DEFAULT_AVATAR_SIZE_PX } from "@/lib/constants";
 import {
   SvgActivitySmall,
@@ -98,6 +99,7 @@ export default function CustomAgentAvatar({
 
   size = DEFAULT_AVATAR_SIZE_PX,
 }: CustomAgentAvatarProps) {
+  const t = useTranslations("common.agentAvatar");
   if (src) {
     return (
       <div
@@ -105,7 +107,7 @@ export default function CustomAgentAvatar({
         style={{ height: size, width: size }}
       >
         <Image
-          alt={name || "Agent avatar"}
+          alt={name || t("image.altFallback")}
           src={src}
           fill
           className="object-cover object-center"

--- a/web/src/refresh-components/buttons/BackButton.tsx
+++ b/web/src/refresh-components/buttons/BackButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import type { Route } from "next";
 import { Button } from "@opal/components";
 import { SvgArrowLeft } from "@opal/icons";
@@ -14,6 +15,7 @@ export default function BackButton({
   behaviorOverride,
   routerOverride,
 }: BackButtonProps) {
+  const t = useTranslations("common.backButton");
   const router = useRouter();
 
   return (
@@ -30,7 +32,7 @@ export default function BackButton({
         }
       }}
     >
-      Back
+      {t("label")}
     </Button>
   );
 }

--- a/web/src/refresh-components/commandmenu/CommandMenu.test.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@tests/setup/test-utils";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import CommandMenu, {

--- a/web/src/refresh-components/commandmenu/CommandMenu.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.tsx
@@ -9,6 +9,7 @@ import React, {
   useMemo,
 } from "react";
 import { useFocusOnMount } from "@opal/hooks";
+import { useTranslations } from "next-intl";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import useContainerCenter from "@/hooks/useContainerCenter";
@@ -367,6 +368,7 @@ const CommandMenuContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
   CommandMenuContentProps
 >(({ children }, ref) => {
+  const t = useTranslations("common.commandMenu");
   const { handleKeyDown } = useCommandMenuContext();
   const { centerX, hasContainerCenter } = useContainerCenter();
 
@@ -412,7 +414,7 @@ const CommandMenuContent = React.forwardRef<
         )}
       >
         <VisuallyHidden.Root asChild>
-          <DialogPrimitive.Title>Command Menu</DialogPrimitive.Title>
+          <DialogPrimitive.Title>{t("dialog.title")}</DialogPrimitive.Title>
         </VisuallyHidden.Root>
         {children}
       </DialogPrimitive.Content>
@@ -432,7 +434,7 @@ CommandMenuContent.displayName = "CommandMenuContent";
  * Arrow keys preventDefault at input level (to stop cursor movement) then bubble to Content.
  */
 function CommandMenuHeader({
-  placeholder = "Search...",
+  placeholder,
   filters = [],
   value = "",
   onValueChange,
@@ -440,6 +442,7 @@ function CommandMenuHeader({
   onClose,
   onEmptyBackspace,
 }: CommandMenuHeaderProps) {
+  const t = useTranslations("common.commandMenu");
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
 
   // Prevent default for arrow/enter keys so they don't move cursor or submit forms
@@ -483,7 +486,7 @@ function CommandMenuHeader({
               prominence="tertiary"
               size="sm"
               onClick={onClose}
-              aria-label="Close menu"
+              aria-label={t("closeButton.ariaLabel")}
             />
           </DialogPrimitive.Close>
         )}
@@ -492,7 +495,7 @@ function CommandMenuHeader({
       <div className="px-2 pb-2 pt-0.5">
         <InputTypeIn
           variant="internal"
-          placeholder={placeholder}
+          placeholder={placeholder ?? t("search.placeholder")}
           value={value}
           onChange={(e) => onValueChange?.(e.target.value)}
           onKeyDown={handleInputKeyDown}
@@ -514,6 +517,7 @@ function CommandMenuHeader({
  * Uses ScrollIndicatorDiv for automatic scroll shadows.
  */
 function CommandMenuList({ children, emptyMessage }: CommandMenuListProps) {
+  const t = useTranslations("common.commandMenu");
   const { isKeyboardNav, onListMouseLeave } = useCommandMenuContext();
   const childCount = React.Children.count(children);
 
@@ -535,7 +539,7 @@ function CommandMenuList({ children, emptyMessage }: CommandMenuListProps) {
     <ScrollIndicatorDiv
       role="listbox"
       tabIndex={-1}
-      aria-label="Command menu options"
+      aria-label={t("options.ariaLabel")}
       className="p-1 gap-1 max-h-[60vh] bg-background-tint-01"
       backgroundColor="var(--background-tint-01)"
       data-command-menu-list

--- a/web/src/refresh-components/form/FormField.tsx
+++ b/web/src/refresh-components/form/FormField.tsx
@@ -12,6 +12,7 @@ import {
   APIMessageProps,
 } from "./types";
 import React, { useId, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useFieldContext } from "./FieldContext";
 import { Slot } from "@radix-ui/react-slot";
 import Text from "../texts/Text";
@@ -64,6 +65,7 @@ export const FormFieldLabel: React.FC<LabelProps> = ({
   children,
   ...props
 }) => {
+  const t = useTranslations("common.formField");
   const { baseId } = useFieldContext();
   return (
     <label
@@ -79,11 +81,11 @@ export const FormFieldLabel: React.FC<LabelProps> = ({
       {children}
       {required ? (
         <Text as="p" text03 mainUiMuted className="mx-0.5">
-          {"(Required)"}
+          {t("required.label")}
         </Text>
       ) : optional ? (
         <Text as="p" text03 mainUiMuted className="mx-0.5">
-          {"(Optional)"}
+          {t("optional.label")}
         </Text>
       ) : null}
       {rightIcon && <span className="flex items-center">{rightIcon}</span>}

--- a/web/src/refresh-components/form/InputTypeInElementField.tsx
+++ b/web/src/refresh-components/form/InputTypeInElementField.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useField } from "formik";
+import { useTranslations } from "next-intl";
 import { InputTypeIn, type InputTypeInProps } from "@opal/components";
 import { Button } from "@opal/components";
 import { SvgMinusCircle } from "@opal/icons";
@@ -23,6 +24,7 @@ export default function InputTypeInElementField({
   onBlur: onBlurProp,
   ...inputProps
 }: InputTypeInElementFieldProps) {
+  const t = useTranslations("common.inputElement");
   const [field, meta] = useField(name);
   const onChange = useOnChangeEvent(name, onChangeProp);
   const onBlur = useOnBlurEvent(name, onBlurProp);
@@ -54,7 +56,7 @@ export default function InputTypeInElementField({
         icon={SvgMinusCircle}
         prominence="tertiary"
         onClick={onRemove}
-        tooltip="Remove"
+        tooltip={t("removeButton.tooltip")}
       />
     </Section>
   );

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@tests/setup/test-utils";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import InputComboBox from "./InputComboBox";

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.tsx
@@ -91,6 +91,7 @@ import {
   shift,
   size,
 } from "@floating-ui/react-dom";
+import { useTranslations } from "next-intl";
 import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { InputTypeIn } from "@opal/components";
@@ -129,12 +130,13 @@ const InputComboBox = ({
   name,
   searchIcon = false,
   rightChildren,
-  separatorLabel = "Other options",
+  separatorLabel,
   createPrefix,
   showOtherOptions = false,
   dropdownMaxHeight,
   ...rest
 }: WithoutStyles<InputComboBoxProps>) => {
+  const t = useTranslations("common.comboBox");
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const fieldContext = useContext(FieldContext);
@@ -410,7 +412,11 @@ const InputComboBox = ({
                   size="sm"
                   onClick={noProp(toggleDropdown)}
                   icon={isOpen ? SvgChevronUp : SvgChevronDown}
-                  aria-label={isOpen ? "Close dropdown" : "Open dropdown"}
+                  aria-label={
+                    isOpen
+                      ? t("dropdown.closeAriaLabel")
+                      : t("dropdown.openAriaLabel")
+                  }
                   tabIndex={-1}
                   type="button"
                 />
@@ -433,7 +439,7 @@ const InputComboBox = ({
           matchedOptions={matchedOptions}
           unmatchedOptions={visibleUnmatchedOptions}
           hasSearchTerm={hasSearchTerm}
-          separatorLabel={separatorLabel}
+          separatorLabel={separatorLabel ?? t("separator.label")}
           value={value}
           highlightedIndex={highlightedIndex}
           onSelect={handleOptionSelect}

--- a/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslations } from "next-intl";
 import Text from "@/refresh-components/texts/Text";
 import { OptionItem } from "./OptionItem";
 import { ComboBoxOption } from "../types";
@@ -49,6 +50,7 @@ export const OptionsList: React.FC<OptionsListProps> = ({
   showCreateOption,
   createPrefix,
 }) => {
+  const t = useTranslations("common.comboBox");
   // Index offset for other options when create option is shown
   const indexOffset = showCreateOption ? 1 : 0;
 
@@ -59,7 +61,7 @@ export const OptionsList: React.FC<OptionsListProps> = ({
   ) {
     return (
       <div className="px-3 py-2 text-text-02 font-secondary-body">
-        No options found
+        {t("options.empty")}
       </div>
     );
   }
@@ -74,7 +76,10 @@ export const OptionsList: React.FC<OptionsListProps> = ({
           role="option"
           tabIndex={-1}
           aria-selected={false}
-          aria-label={`${createPrefix ?? "Create"} "${inputValue}"`}
+          aria-label={t("createOption.ariaLabel", {
+            prefix: createPrefix ?? t("createOption.defaultPrefix"),
+            value: inputValue,
+          })}
           onClick={(e) => {
             e.stopPropagation();
             onSelect({ value: inputValue, label: inputValue });

--- a/web/src/refresh-components/inputs/InputDatePicker.tsx
+++ b/web/src/refresh-components/inputs/InputDatePicker.tsx
@@ -6,6 +6,7 @@ import Calendar from "@/refresh-components/Calendar";
 import { Popover } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { SvgCalendar } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 
@@ -38,6 +39,7 @@ export default function InputDatePicker({
   disabled = false,
   maxDate,
 }: InputDatePickerProps) {
+  const t = useTranslations("common.datePicker");
   const validStartYear = Math.max(startYear, 1970);
   const normalizedMaxDate = useMemo(
     () => (maxDate ? normalizeDate(maxDate) : undefined),
@@ -72,7 +74,9 @@ export default function InputDatePicker({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild id={name} name={name}>
         <Button disabled={disabled} prominence="secondary" icon={SvgCalendar}>
-          {selectedDate ? selectedDate.toLocaleDateString() : "Select Date"}
+          {selectedDate
+            ? selectedDate.toLocaleDateString()
+            : t("selectDate.label")}
         </Button>
       </Popover.Trigger>
       <Popover.Content>
@@ -102,7 +106,7 @@ export default function InputDatePicker({
                 setOpen(false);
               }}
             >
-              Today
+              {t("todayButton.label")}
             </Button>
           </Section>
           <Calendar

--- a/web/src/refresh-components/inputs/InputFile.tsx
+++ b/web/src/refresh-components/inputs/InputFile.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { InputTypeIn, type InputTypeInProps } from "@opal/components";
 import { Button } from "@opal/components";
 import { noProp } from "@/lib/utils";
@@ -42,6 +43,7 @@ export default function InputFile({
   placeholder,
   ...rest
 }: InputFileProps) {
+  const t = useTranslations("common.inputFile");
   const [displayValue, setDisplayValue] = useState<string>("");
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
   const [isFileMode, setIsFileMode] = useState<boolean>(false);
@@ -129,7 +131,7 @@ export default function InputFile({
       type="button"
       prominence="tertiary"
       size="sm"
-      aria-label="Clear file"
+      aria-label={t("clearButton.ariaLabel")}
     />
   ) : (
     <Button
@@ -139,7 +141,7 @@ export default function InputFile({
       type="button"
       prominence="tertiary"
       size="sm"
-      aria-label="Attach file"
+      aria-label={t("attachButton.ariaLabel")}
     />
   );
 

--- a/web/src/refresh-components/inputs/InputImage.tsx
+++ b/web/src/refresh-components/inputs/InputImage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { SvgPlus, SvgX } from "@opal/icons";
@@ -125,7 +126,7 @@ export interface InputImageProps {
 export default function InputImage({
   disabled = false,
   src,
-  alt = "Image",
+  alt,
   onEdit,
   onRemove,
   onDrop,
@@ -134,6 +135,7 @@ export default function InputImage({
   size = 120,
   className,
 }: InputImageProps) {
+  const t = useTranslations("common.inputImage");
   const isInteractive = !disabled && (onEdit || onDrop);
   const hasImage = !!src;
 
@@ -144,7 +146,8 @@ export default function InputImage({
       },
       onImageRejected: (rejections) => {
         const firstRejection = rejections[0];
-        const reason = firstRejection?.errors[0]?.message || "File rejected";
+        const reason =
+          firstRejection?.errors[0]?.message || t("dropRejected.fallback");
         onDropRejected?.(reason);
       },
       disabled: disabled || !onDrop,
@@ -197,8 +200,8 @@ export default function InputImage({
           aria-label={
             isInteractive
               ? hasImage
-                ? "Edit image"
-                : "Upload image"
+                ? t("editButton.ariaLabel")
+                : t("uploadButton.ariaLabel")
               : undefined
           }
         >
@@ -206,7 +209,7 @@ export default function InputImage({
           {hasImage ? (
             <img
               src={src}
-              alt={alt}
+              alt={alt ?? t("image.altFallback")}
               className="absolute inset-0 w-full h-full object-cover pointer-events-none"
             />
           ) : (
@@ -235,7 +238,7 @@ export default function InputImage({
                   )}
                 >
                   <div className="pointer-events-auto">
-                    <Tooltip tooltip="Edit" side="top">
+                    <Tooltip tooltip={t("editOverlay.label")} side="top">
                       <div
                         className={cn(
                           "flex items-center justify-center",
@@ -246,7 +249,7 @@ export default function InputImage({
                           className="text-text-03 font-secondary-action"
                           style={{ fontSize: "12px", lineHeight: "16px" }}
                         >
-                          Edit
+                          {t("editOverlay.label")}
                         </Text>
                       </div>
                     </Tooltip>
@@ -268,7 +271,7 @@ export default function InputImage({
                 type="button"
                 primary
                 className="w-5! h-5! p-0.5! rounded-04!"
-                aria-label="Remove image"
+                aria-label={t("removeButton.ariaLabel")}
               />
             </Hoverable.Item>
           </div>

--- a/web/src/refresh-components/inputs/InputKeyValue.tsx
+++ b/web/src/refresh-components/inputs/InputKeyValue.tsx
@@ -69,6 +69,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@opal/utils";
 import { InputTypeIn } from "@opal/components";
 import { Button, EmptyMessageCard } from "@opal/components";
@@ -117,6 +118,7 @@ function KeyValueInputItem({
   canRemove,
   index,
 }: KeyValueInputItemProps) {
+  const t = useTranslations("common.keyValue");
   return (
     <>
       <div className="flex flex-col gap-y-0.5">
@@ -124,7 +126,10 @@ function KeyValueInputItem({
           placeholder={keyPlaceholder}
           value={item.key}
           onChange={(e) => onChange({ ...item, key: e.target.value })}
-          aria-label={`${keyPlaceholder || "Key"} ${index + 1}`}
+          aria-label={t("input.ariaLabel", {
+            label: keyPlaceholder || t("keyColumn.title"),
+            index: index + 1,
+          })}
           aria-invalid={!!error?.key}
         />
         {error?.key && <InputErrorText>{error.key}</InputErrorText>}
@@ -134,7 +139,10 @@ function KeyValueInputItem({
           placeholder={valuePlaceholder}
           value={item.value}
           onChange={(e) => onChange({ ...item, value: e.target.value })}
-          aria-label={`${valuePlaceholder || "Value"} ${index + 1}`}
+          aria-label={t("input.ariaLabel", {
+            label: valuePlaceholder || t("valueColumn.title"),
+            index: index + 1,
+          })}
           aria-invalid={!!error?.value}
         />
         {error?.value && <InputErrorText>{error.value}</InputErrorText>}
@@ -144,7 +152,10 @@ function KeyValueInputItem({
         prominence="tertiary"
         icon={SvgMinusCircle}
         onClick={onRemove}
-        aria-label={`Remove ${keyPlaceholder || "key-value"} pair ${index + 1}`}
+        aria-label={t("removeButton.ariaLabel", {
+          label: keyPlaceholder || t("pair.fallbackLabel"),
+          index: index + 1,
+        })}
       />
     </>
   );
@@ -185,8 +196,8 @@ export interface KeyValueInputProps extends WithoutStyles<
 }
 
 export default function KeyValueInput({
-  keyTitle = "Key",
-  valueTitle = "Value",
+  keyTitle: keyTitleProp,
+  valueTitle: valueTitleProp,
   keyPlaceholder,
   valuePlaceholder,
   items = [],
@@ -194,9 +205,18 @@ export default function KeyValueInput({
   mode = "line",
   layout = "equal",
   onValidationError,
-  addButtonLabel = "Add Line",
+  addButtonLabel: addButtonLabelProp,
   ...rest
 }: KeyValueInputProps) {
+  const t = useTranslations("common.keyValue");
+  const keyTitle = keyTitleProp ?? t("keyColumn.title");
+  const valueTitle = valueTitleProp ?? t("valueColumn.title");
+  const addButtonLabel = addButtonLabelProp ?? t("addButton.label");
+  // Row errors and the summary both compare against these translated
+  // messages, so the strings stay consistent within a render.
+  const emptyKeyMessage = t("error.emptyKey");
+  const duplicateKeyMessage = t("error.duplicateKey");
+
   // Validation logic
   const errors = useMemo((): KeyValueError[] => {
     if (!items || items.length === 0) return [];
@@ -209,7 +229,7 @@ export default function KeyValueInput({
       if (item.key.trim() === "" && item.value.trim() !== "") {
         const error = errorsList[index];
         if (error) {
-          error.key = "Key cannot be empty";
+          error.key = emptyKeyMessage;
         }
       }
 
@@ -227,14 +247,14 @@ export default function KeyValueInput({
         indices.forEach((index) => {
           const error = errorsList[index];
           if (error) {
-            error.key = "Duplicate key";
+            error.key = duplicateKeyMessage;
           }
         });
       }
     });
 
     return errorsList;
-  }, [items]);
+  }, [items, emptyKeyMessage, duplicateKeyMessage]);
 
   const hasAnyError = useMemo(() => {
     return errors.some((error) => error.key || error.value);
@@ -246,23 +266,17 @@ export default function KeyValueInput({
 
     const errorCount = errors.filter((e) => e.key || e.value).length;
     const duplicateCount = errors.filter(
-      (e) => e.key === "Duplicate key"
+      (e) => e.key === duplicateKeyMessage
     ).length;
-    const emptyCount = errors.filter(
-      (e) => e.key === "Key cannot be empty"
-    ).length;
+    const emptyCount = errors.filter((e) => e.key === emptyKeyMessage).length;
 
     if (duplicateCount > 0) {
-      return `${duplicateCount} duplicate ${
-        duplicateCount === 1 ? "key" : "keys"
-      } found`;
+      return t("error.duplicateSummary", { count: duplicateCount });
     } else if (emptyCount > 0) {
-      return `${emptyCount} empty ${emptyCount === 1 ? "key" : "keys"} found`;
+      return t("error.emptySummary", { count: emptyCount });
     }
-    return `${errorCount} validation ${
-      errorCount === 1 ? "error" : "errors"
-    } found`;
-  }, [hasAnyError, errors]);
+    return t("error.validationSummary", { count: errorCount });
+  }, [hasAnyError, errors, duplicateKeyMessage, emptyKeyMessage, t]);
 
   // Notify parent of validation changes
   const onValidationErrorRef = useRef(onValidationError);
@@ -314,7 +328,7 @@ export default function KeyValueInput({
     <div
       className="w-full flex flex-col gap-y-2"
       role="group"
-      aria-label={`${keyTitle} and ${valueTitle} pairs`}
+      aria-label={t("group.ariaLabel", { keyTitle, valueTitle })}
       {...rest}
     >
       {items && items.length > 0 ? (
@@ -346,7 +360,7 @@ export default function KeyValueInput({
         </div>
       ) : (
         <EmptyMessageCard
-          title="No items added yet."
+          title={t("empty.title")}
           padding={2}
           sizePreset="secondary"
         />
@@ -356,7 +370,7 @@ export default function KeyValueInput({
         prominence="secondary"
         onClick={handleAdd}
         icon={SvgPlusCircle}
-        aria-label={`Add ${keyTitle} and ${valueTitle} pair`}
+        aria-label={t("addButton.ariaLabel", { keyTitle, valueTitle })}
         type="button"
       >
         {addButtonLabel}

--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useTranslations } from "next-intl";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { cn } from "@opal/utils";
 import LineItem, { LineItemProps } from "@/refresh-components/buttons/LineItem";
@@ -200,6 +201,7 @@ function InputSelectTrigger({
   ref,
   ...props
 }: InputSelectTriggerProps) {
+  const t = useTranslations("common.inputSelect");
   const { variant, selectedItemDisplay } = useInputSelectContext();
 
   let displayContent: React.ReactNode;
@@ -215,7 +217,7 @@ function InputSelectTrigger({
       )
     ) : (
       <Text as="p" text03>
-        Select an option
+        {t("placeholder.fallback")}
       </Text>
     );
   } else {

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useState, useRef, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Modal } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { InputTextArea, InputTypeIn } from "@opal/components";
@@ -45,6 +46,7 @@ function MemoryItem({
   shouldHighlight,
   onHighlighted,
 }: MemoryItemProps) {
+  const t = useTranslations("settings.memory");
   const [isFocused, setIsFocused] = useState(false);
   const [isHighlighting, setIsHighlighting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -90,7 +92,7 @@ function MemoryItem({
         <Section flexDirection="row" alignItems="start" gap={2}>
           <InputTextArea
             ref={textareaRef}
-            placeholder="Type or paste in a personal note or memory"
+            placeholder={t("item.placeholder")}
             value={memory.content}
             onChange={(e) => onUpdate(originalIndex, e.target.value)}
             onFocus={() => setIsFocused(true)}
@@ -119,8 +121,8 @@ function MemoryItem({
             prominence="tertiary"
             icon={SvgMinusCircle}
             onClick={() => void onRemove(originalIndex)}
-            aria-label="Remove Line"
-            tooltip="Remove Line"
+            aria-label={t("removeLineButton.label")}
+            tooltip={t("removeLineButton.label")}
           />
         </Section>
         <div
@@ -168,6 +170,7 @@ export default function MemoriesModal({
   highlightOnOpen = false,
   focusNewLine = false,
 }: MemoriesModalProps) {
+  const t = useTranslations("settings.memory");
   const close = useModalClose(onClose);
   const [focusMemoryId, setFocusMemoryId] = useState<number | null>(null);
 
@@ -177,8 +180,8 @@ export default function MemoriesModal({
     user,
     updateUserPersonalization,
     {
-      onSuccess: () => toast.success("Preferences saved"),
-      onError: () => toast.error("Failed to save preferences"),
+      onSuccess: () => toast.success(t("toasts.saved")),
+      onError: () => toast.error(t("toasts.saveFailed")),
     }
   );
 
@@ -265,13 +268,13 @@ export default function MemoriesModal({
       <Modal.Content width="sm" height="lg" position="top">
         <Modal.Header
           icon={SvgAddLines}
-          title="Memory"
-          description="Let Onyx reference these stored notes and memories in chats."
+          title={t("title")}
+          description={t("modal.description")}
           onClose={close}
         >
           <Section flexDirection="row" gap={2}>
             <InputTypeIn
-              placeholder="Search..."
+              placeholder={t("modal.searchPlaceholder")}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               searchIcon
@@ -283,11 +286,11 @@ export default function MemoriesModal({
               rightIcon={SvgPlusCircle}
               title={
                 !canAddMemory
-                  ? `Maximum of ${MAX_MEMORY_COUNT} memories reached`
+                  ? t("addLineButton.maxReached", { count: MAX_MEMORY_COUNT })
                   : undefined
               }
             >
-              Add Line
+              {t("addLineButton.label")}
             </Button>
           </Section>
         </Modal.Header>
@@ -297,8 +300,8 @@ export default function MemoriesModal({
             <Section alignItems="center" padding={8}>
               <Text secondaryBody text03>
                 {searchQuery.trim()
-                  ? "No memories match your search."
-                  : 'No memories yet. Click "Add Line" to get started.'}
+                  ? t("empty.noMatches")
+                  : t("empty.getStarted")}
               </Text>
             </Section>
           ) : (
@@ -327,7 +330,7 @@ export default function MemoriesModal({
           )}
           <TextSeparator
             count={totalLineCount}
-            text={totalLineCount === 1 ? "Line" : "Lines"}
+            text={t("lineCount.label", { count: totalLineCount })}
           />
         </Modal.Body>
       </Modal.Content>

--- a/web/src/refresh-components/popovers/FilePickerPopover.tsx
+++ b/web/src/refresh-components/popovers/FilePickerPopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   LineItemButton,
@@ -45,6 +46,7 @@ function FileLineItem({
   onPickRecent,
   onFileClick,
 }: FileLineItemProps) {
+  const t = useTranslations("common.filePicker");
   const showLoader = useMemo(
     () =>
       String(projectFile.status) === UserFileStatus.PROCESSING ||
@@ -90,7 +92,7 @@ function FileLineItem({
               <Button
                 icon={SvgExternalLink}
                 onClick={noProp(() => onFileClick(projectFile))}
-                tooltip="View File"
+                tooltip={t("viewFileButton.tooltip")}
                 disabled={disableActionButton}
                 prominence="internal"
                 size="sm"
@@ -119,6 +121,7 @@ function FilePickerPopoverContents({
   triggerUploadPicker,
   openRecentFilesModal,
 }: FilePickerPopoverContentsProps) {
+  const t = useTranslations("common.filePicker");
   // These are the "quick" files that we show. Essentially "speed dial", but for files.
   // The rest of the files will be hidden behind the "All Recent Files" button, should there be more files left to show!
   const hasFiles = recentFiles.length > 0;
@@ -134,9 +137,9 @@ function FilePickerPopoverContents({
           rounding={2}
           key="upload-files"
           icon={SvgUploadSquare}
-          description="Upload a file from your device"
+          description={t("uploadFiles.description")}
           onClick={triggerUploadPicker}
-          title="Upload Files"
+          title={t("uploadFiles.title")}
         />,
 
         // Separator
@@ -146,7 +149,7 @@ function FilePickerPopoverContents({
         hasFiles && (
           <div key="recent-files" className="pt-1">
             <Text as="p" text02 secondaryBody className="py-1 px-3">
-              Recent Files
+              {t("recentFiles.title")}
             </Text>
           </div>
         ),
@@ -169,7 +172,7 @@ function FilePickerPopoverContents({
             key="more-files"
             icon={SvgMoreHorizontal}
             onClick={openRecentFilesModal}
-            title="All Recent Files"
+            title={t("allRecentFilesButton.title")}
           />
         ),
       ]}
@@ -194,6 +197,7 @@ export default function FilePickerPopover({
   trigger,
   selectedFileIds,
 }: FilePickerPopoverProps) {
+  const t = useTranslations("common.filePicker");
   const { allRecentFiles } = useProjectsContext();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const recentFilesModal = useCreateModal();
@@ -223,7 +227,7 @@ export default function FilePickerPopover({
     deleteUserFile(file.id)
       .then((result) => {
         if (!result.has_associations) {
-          toast.success("File deleted successfully");
+          toast.success(t("toasts.deleteSuccess"));
           setCurrentMessageFiles((prev) =>
             prev.filter((f) => f.id !== file.id)
           );
@@ -235,18 +239,14 @@ export default function FilePickerPopover({
               f.id === file.id ? { ...f, status: lastStatus } : f
             )
           );
-          let projects = result.project_names.join(", ");
-          let assistants = result.assistant_names.join(", ");
-          let message = "Cannot delete file. It is associated with";
-          if (projects) {
-            message += ` projects: ${projects}`;
-          }
-          if (projects && assistants) {
-            message += " and ";
-          }
-          if (assistants) {
-            message += `assistants: ${assistants}`;
-          }
+          const projects = result.project_names.join(", ");
+          const assistants = result.assistant_names.join(", ");
+          const message =
+            projects && assistants
+              ? t("toasts.associatedBoth", { projects, assistants })
+              : projects
+                ? t("toasts.associatedProjects", { projects })
+                : t("toasts.associatedAssistants", { assistants });
 
           toast.error(message);
         }
@@ -256,7 +256,7 @@ export default function FilePickerPopover({
         setRecentFilesSnapshot((prev) =>
           prev.map((f) => (f.id === file.id ? { ...f, status: lastStatus } : f))
         );
-        toast.error("Failed to delete file. Please try again.");
+        toast.error(t("toasts.deleteFailed"));
         // Useful for debugging; safe in client components
         console.error("Failed to delete file", error);
       });
@@ -275,8 +275,8 @@ export default function FilePickerPopover({
 
       <recentFilesModal.Provider>
         <UserFilesModal
-          title="Recent Files"
-          description="Upload files or pick from your recent files."
+          title={t("recentFiles.title")}
+          description={t("recentFilesModal.description")}
           recentFiles={recentFilesSnapshot}
           onPickRecent={(file) => {
             onPickRecent?.(file);

--- a/web/src/refresh-components/texts/ExpandableTextDisplay.tsx
+++ b/web/src/refresh-components/texts/ExpandableTextDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import { useTranslations } from "next-intl";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Modal } from "@opal/components";
 import { CopyButton } from "@opal/components";
@@ -31,11 +32,15 @@ export interface ExpandableTextDisplayProps {
   isStreaming?: boolean;
 }
 
+type ExpandableTextTranslator = ReturnType<
+  typeof useTranslations<"common.expandableText">
+>;
+
 /** Calculate content size in human-readable format */
-function getContentSize(text: string): string {
+function getContentSize(text: string, t: ExpandableTextTranslator): string {
   const bytes = new Blob([text]).size;
-  if (bytes < 1024) return `${bytes} Bytes`;
-  return `${(bytes / 1024).toFixed(2)} KB`;
+  if (bytes < 1024) return t("size.bytes", { count: bytes });
+  return t("size.kilobytes", { size: (bytes / 1024).toFixed(2) });
 }
 
 /** Count lines in text */
@@ -119,13 +124,14 @@ export default function ExpandableTextDisplay({
   renderContent,
   isStreaming = false,
 }: ExpandableTextDisplayProps) {
+  const t = useTranslations("common.expandableText");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isTruncated, setIsTruncated] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentInnerRef = useRef<HTMLDivElement>(null);
 
   const lineCount = useMemo(() => getLineCount(content), [content]);
-  const contentSize = useMemo(() => getContentSize(content), [content]);
+  const contentSize = useMemo(() => getContentSize(content, t), [content, t]);
   const displaySubtitle = subtitle ?? contentSize;
 
   // Truncation detection (read-only, doesn't need to block paint)
@@ -312,7 +318,7 @@ export default function ExpandableTextDisplay({
               prominence="tertiary"
               size="sm"
               icon={SvgMaximize2}
-              tooltip="View Full Text"
+              tooltip={t("viewFullButton.tooltip")}
               onClick={() => setIsModalOpen(true)}
             />
           )}
@@ -361,7 +367,7 @@ export default function ExpandableTextDisplay({
           <div className="flex items-center justify-between p-2 bg-background-tint-01">
             <div className="px-2">
               <Text as="span" mainUiMuted text03>
-                {lineCount} {lineCount === 1 ? "line" : "lines"}
+                {t("lineCount.label", { count: lineCount })}
               </Text>
             </div>
             <div className="flex items-center gap-1 bg-background-tint-00 p-1 rounded-12">
@@ -369,13 +375,13 @@ export default function ExpandableTextDisplay({
                 prominence="tertiary"
                 size="sm"
                 getCopyText={() => content}
-                tooltip="Copy"
+                tooltip={t("copyButton.tooltip")}
               />
               <Button
                 prominence="tertiary"
                 size="sm"
                 icon={SvgDownload}
-                tooltip="Download"
+                tooltip={t("downloadButton.tooltip")}
                 onClick={handleDownload}
               />
             </div>

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -1,4 +1,5 @@
 import type { FunctionComponent } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@opal/components";
 import { cn, clickOnKeyDown } from "@opal/utils";
 import { SvgMaximize2, SvgTextLines, SvgX } from "@opal/icons";
@@ -32,6 +33,7 @@ interface RemoveButtonProps {
 }
 
 function RemoveButton({ onRemove }: RemoveButtonProps) {
+  const t = useTranslations("common.fileTile");
   return (
     <div
       className={cn(
@@ -46,8 +48,8 @@ function RemoveButton({ onRemove }: RemoveButtonProps) {
             e.stopPropagation();
             onRemove();
           }}
-          title="Remove"
-          aria-label="Remove"
+          title={t("removeButton.label")}
+          aria-label={t("removeButton.label")}
           className={cn(
             "h-4 w-4",
             "flex items-center justify-center",
@@ -74,6 +76,7 @@ export default function FileTile({
   onOpen,
   state = "default",
 }: FileTileProps) {
+  const t = useTranslations("common.fileTile");
   const Icon = icon ?? SvgTextLines;
   const isMuted = state === "processing" || state === "disabled";
   const canOpen = !!onOpen && state !== "disabled";
@@ -177,7 +180,9 @@ export default function FileTile({
         <div
           role="button"
           tabIndex={0}
-          aria-label={`Open ${title ?? "file"}`}
+          aria-label={t("open.ariaLabel", {
+            title: title ?? t("file.fallback"),
+          })}
           onKeyDown={clickOnKeyDown(onOpen)}
           onClick={() => onOpen()}
           className={tileClassName}

--- a/web/src/sections/modals/languageModels/CustomModal.tsx
+++ b/web/src/sections/modals/languageModels/CustomModal.tsx
@@ -214,7 +214,7 @@ function CustomConfigKeyValue() {
   return (
     <KeyValueInput
       items={formikProps.values.custom_config_list}
-      keyPlaceholder="e.g. OPENAI_ORGANIZATION"
+      keyPlaceholder={t("custom.envVars.keyInput.placeholder")}
       onChange={(items) =>
         formikProps.setFieldValue("custom_config_list", items)
       }

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useAdminNavLabels } from "@/lib/adminNavLabels";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useSettings } from "@/lib/settings/hooks";
@@ -85,45 +86,7 @@ export default function AdminSidebar() {
   const allItems = buildItems(adminCapabilities, flags, settings);
 
   // Built with literal keys so the message ids stay statically checkable.
-  const navLabels = useMemo<Record<AdminNavItemId, string>>(
-    () => ({
-      languageModels: t("adminNav.items.languageModels.label"),
-      webSearch: t("adminNav.items.webSearch.label"),
-      imageGeneration: t("adminNav.items.imageGeneration.label"),
-      voice: t("adminNav.items.voice.label"),
-      codeInterpreter: t("adminNav.items.codeInterpreter.label"),
-      chatPreferences: t("adminNav.items.chatPreferences.label"),
-      craftAccess: t("adminNav.items.craftAccess.label"),
-      craftApps: t("adminNav.items.craftApps.label"),
-      craftPreferences: t("adminNav.items.craftPreferences.label"),
-      customAnalytics: t("adminNav.items.customAnalytics.label"),
-      agents: t("adminNav.items.agents.label"),
-      mcpActions: t("adminNav.items.mcpActions.label"),
-      openapiActions: t("adminNav.items.openapiActions.label"),
-      existingConnectors: t("adminNav.items.existingConnectors.label"),
-      addConnector: t("adminNav.items.addConnector.label"),
-      documentSets: t("adminNav.items.documentSets.label"),
-      indexSettings: t("adminNav.items.indexSettings.label"),
-      serviceAccounts: t("adminNav.items.serviceAccounts.label"),
-      slackIntegration: t("adminNav.items.slackIntegration.label"),
-      discordIntegration: t("adminNav.items.discordIntegration.label"),
-      hookExtensions: t("adminNav.items.hookExtensions.label"),
-      users: t("adminNav.items.users.label"),
-      groups: t("adminNav.items.groups.label"),
-      scim: t("adminNav.items.scim.label"),
-      plansAndBilling: t("adminNav.items.plansAndBilling.label"),
-      appearanceAndTheming: t("adminNav.items.appearanceAndTheming.label"),
-      securityAndHardening: t("adminNav.items.securityAndHardening.label"),
-      ssoProviders: t("adminNav.items.ssoProviders.label"),
-      usage: t("adminNav.items.usage.label"),
-      analytics: t("adminNav.items.analytics.label"),
-      queryHistory: t("adminNav.items.queryHistory.label"),
-      tracing: t("adminNav.items.tracing.label"),
-      exportLogs: t("adminNav.items.exportLogs.label"),
-      upgradePlan: t("adminNav.items.upgradePlan.label"),
-    }),
-    [t]
-  );
+  const navLabels = useAdminNavLabels();
 
   const sectionLabels = useMemo<Record<AdminNavSectionId, string>>(
     () => ({

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -29,7 +29,6 @@ import { markdown } from "@opal/utils";
 import {
   buildItems,
   groupBySection,
-  type AdminNavItemId,
   type AdminNavSectionId,
   type FeatureFlags,
   type SidebarItemEntry,

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
@@ -36,7 +37,6 @@ import {
 import { useFormikContext } from "formik";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
 import {
-  STARTER_MESSAGES_EXAMPLES,
   MAX_CHARACTERS_STARTER_MESSAGE,
   MAX_CHARACTERS_AGENT_DESCRIPTION,
 } from "@/lib/constants";
@@ -108,11 +108,15 @@ import { hasPermission } from "@/lib/permissions";
 import { can } from "@/lib/permissions/resource-actions";
 import { useDraft, draftKey } from "@/hooks/useDraft";
 
+// Length of starterExamples in the editor body, used where hooks are out of reach.
+const STARTER_MESSAGES_COUNT = 4;
+
 interface AgentIconEditorProps {
   existingAgent?: FullAgent | null;
 }
 
 function FormWarningsEffect() {
+  const t = useTranslations("agents");
   const { values, setStatus } = useFormikContext<{
     web_search: boolean;
     open_url: boolean;
@@ -121,16 +125,16 @@ function FormWarningsEffect() {
   useEffect(() => {
     const warnings: Record<string, string> = {};
     if (values.web_search && !values.open_url) {
-      warnings.open_url =
-        "Web Search without the ability to open URLs can lead to significantly worse web based results.";
+      warnings.open_url = t("editor.warnings.openUrl");
     }
     setStatus({ warnings });
-  }, [values.web_search, values.open_url, setStatus]);
+  }, [values.web_search, values.open_url, setStatus, t]);
 
   return null;
 }
 
 function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
+  const t = useTranslations("agents");
   const { values, setFieldValue } = useFormikContext<{
     name: string;
     icon_name: string | null;
@@ -235,7 +239,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
               <div className="absolute bottom-0 left-1/2 -translate-x-1/2 mb-2">
                 <Hoverable.Item group="inputAvatar" variant="appear-on-hover">
                   <Button prominence="secondary" size="md">
-                    Edit
+                    {t("editor.avatar.edit.label")}
                   </Button>
                 </Hoverable.Item>
               </div>
@@ -252,7 +256,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
                 icon={SvgImage}
                 onClick={() => fileInputRef.current?.click()}
                 selectVariant="select-heavy"
-                title="Upload Image"
+                title={t("editor.avatar.uploadImage.label")}
               />,
               null,
               <div key="icon-grid" className="grid grid-cols-4 gap-1">
@@ -315,6 +319,7 @@ function MCPServerCard({
   tools: enabledTools,
   isLoading,
 }: MCPServerCardProps) {
+  const t = useTranslations("agents");
   const [isFolded, setIsFolded] = useState(false);
   const { values, setFieldValue, getFieldMeta } = useFormikContext<any>();
   const serverFieldName = `mcp_server_${server.id}`;
@@ -377,7 +382,7 @@ function MCPServerCard({
   return (
     <Disabled
       disabled={!server.can_attach}
-      tooltip="You no longer have access to this MCP server. Its existing tools will be preserved."
+      tooltip={t("editor.mcp.noAccess.tooltip")}
     >
       <Card
         expandable
@@ -391,7 +396,7 @@ function MCPServerCard({
           bottomChildren={
             <GeneralLayouts.Section flexDirection="row" gap={2}>
               <InputTypeIn
-                placeholder="Search tools..."
+                placeholder={t("editor.mcp.searchTools.placeholder")}
                 variant="internal"
                 searchIcon
                 value={query}
@@ -403,7 +408,9 @@ function MCPServerCard({
                   rightIcon={isFolded ? SvgExpand : SvgFold}
                   onClick={() => setIsFolded((prev) => !prev)}
                 >
-                  {isFolded ? "Expand" : "Fold"}
+                  {isFolded
+                    ? t("modals.viewer.mcpCard.expand.label")
+                    : t("modals.viewer.mcpCard.fold.label")}
                 </Button>
               )}
             </GeneralLayouts.Section>
@@ -451,7 +458,14 @@ function MCPServerCard({
 }
 
 function AgentStarterMessages() {
-  const max_starters = STARTER_MESSAGES_EXAMPLES.length;
+  const t = useTranslations("agents");
+  const starterExamples = [
+    t("editor.starters.examples.overview"),
+    t("editor.starters.examples.salesReport"),
+    t("editor.starters.examples.engineeringGoals"),
+    t("editor.starters.examples.todayGoals"),
+  ];
+  const max_starters = starterExamples.length;
 
   const { values } = useFormikContext<{
     starter_messages: string[];
@@ -481,8 +495,7 @@ function AgentStarterMessages() {
               key={`starter_messages.${i}`}
               name={`starter_messages.${i}`}
               placeholder={
-                STARTER_MESSAGES_EXAMPLES[i] ||
-                "Enter a conversation starter..."
+                starterExamples[i] || t("editor.starters.placeholder")
               }
               onRemove={() => arrayHelpers.remove(i)}
             />
@@ -551,6 +564,7 @@ export default function AgentEditorPage({
   agent: existingAgent,
   refreshAgent,
 }: AgentEditorPageProps) {
+  const t = useTranslations("agents");
   const appPosition = useAppPosition();
   const router = useRouter();
   const { refresh: refreshAgents } = useAgents();
@@ -612,12 +626,14 @@ export default function AgentEditorPage({
       await refreshAgents();
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to toggle visibility"
+        error instanceof Error
+          ? error.message
+          : t("editor.toasts.toggleListedFailed")
       );
     } finally {
       setIsTogglingListed(false);
     }
-  }, [existingAgent, refreshAgent, refreshAgents]);
+  }, [existingAgent, refreshAgent, refreshAgents, t]);
 
   // Hooks for Knowledge section
   const { allRecentFiles, beginUpload } = useProjectsContext();
@@ -664,7 +680,7 @@ export default function AgentEditorPage({
   const isImageGenerationAvailable = !!imageGenTool;
   const imageGenerationDisabledTooltip = isImageGenerationAvailable
     ? undefined
-    : "Image generation requires a configured model. If you have access, set one up under Settings > Image Generation, or ask an admin.";
+    : t("editor.actions.imageGeneration.unavailable.tooltip");
 
   // Include inaccessible attached tools so edits preserve them.
   const mcpServersWithTools = mcpServers.map((server) => {
@@ -702,7 +718,7 @@ export default function AgentEditorPage({
     // Prompts
     instructions: existingAgent?.system_prompt ?? "",
     starter_messages: Array.from(
-      { length: STARTER_MESSAGES_EXAMPLES.length },
+      { length: STARTER_MESSAGES_COUNT },
       (_, i) => existingAgent?.starter_messages?.[i]?.message ?? ""
     ),
 
@@ -821,11 +837,13 @@ export default function AgentEditorPage({
     icon_name: Yup.string().nullable(),
     remove_image: Yup.boolean().optional(),
     uploaded_image_id: Yup.string().nullable(),
-    name: Yup.string().required("Agent name is required."),
+    name: Yup.string().required(t("editor.validation.nameRequired")),
     description: Yup.string()
       .max(
         MAX_CHARACTERS_AGENT_DESCRIPTION,
-        `Description must be ${MAX_CHARACTERS_AGENT_DESCRIPTION} characters or less`
+        t("editor.validation.descriptionMax", {
+          max: MAX_CHARACTERS_AGENT_DESCRIPTION,
+        })
       )
       .optional(),
 
@@ -834,7 +852,9 @@ export default function AgentEditorPage({
     starter_messages: Yup.array().of(
       Yup.string().max(
         MAX_CHARACTERS_STARTER_MESSAGE,
-        `Conversation starter must be ${MAX_CHARACTERS_STARTER_MESSAGE} characters or less`
+        t("editor.validation.starterMax", {
+          max: MAX_CHARACTERS_STARTER_MESSAGE,
+        })
       )
     ),
 
@@ -853,7 +873,7 @@ export default function AgentEditorPage({
       .optional()
       .test(
         "knowledge-cutoff-date-not-in-future",
-        "Knowledge cutoff date must be today or earlier.",
+        t("editor.validation.cutoffInFuture"),
         (value) => !value || !isDateInFuture(value)
       ),
     replace_base_system_prompt: Yup.boolean(),
@@ -997,11 +1017,20 @@ export default function AgentEditorPage({
 
       // Handle response
       if (!personaResponse || !personaResponse.ok) {
-        const prefix = `Failed to ${existingAgent ? "update" : "create"} agent`;
         const detail = personaResponse
-          ? await parseErrorDetail(personaResponse, "unknown error")
-          : "no response received";
-        toast.error(`${prefix} - ${detail}`);
+          ? await parseErrorDetail(
+              personaResponse,
+              t("editor.toasts.unknownDetail")
+            )
+          : t("editor.toasts.noResponse");
+        toast.error(
+          t(
+            existingAgent
+              ? "editor.toasts.updateFailed"
+              : "editor.toasts.createFailed",
+            { detail }
+          )
+        );
         return;
       }
 
@@ -1032,13 +1061,13 @@ export default function AgentEditorPage({
           businessTier
         );
         if (shareError) {
-          toast.error(`Agent created, but sharing failed: ${shareError}`);
+          toast.error(t("editor.toasts.sharingFailed", { error: shareError }));
         }
       }
       toast.success(
-        `Agent "${agent.name}" ${
-          existingAgent ? "updated" : "created"
-        } successfully`
+        t(existingAgent ? "editor.toasts.updated" : "editor.toasts.created", {
+          name: agent.name,
+        })
       );
 
       // Refresh agents list and the specific agent
@@ -1051,7 +1080,7 @@ export default function AgentEditorPage({
       appPosition.openAgent(agent.id);
     } catch (error) {
       console.error("Submit error:", error);
-      toast.error(`An error occurred: ${error}`);
+      toast.error(t("editor.toasts.genericError", { error: String(error) }));
     }
   }
 
@@ -1061,16 +1090,17 @@ export default function AgentEditorPage({
 
     try {
       await deleteAgent(existingAgent.id);
-      toast.success("Agent deleted successfully");
+      toast.success(t("editor.toasts.deleted"));
       deleteAgentModal.toggle(false);
       await refreshAgents();
       router.push("/app/agents");
     } catch (e) {
       console.error("Delete agent error:", e);
       toast.error(
-        `Failed to delete agent: ${
-          e instanceof Error ? e.message : "Unknown error"
-        }`
+        t("editor.toasts.deleteFailed", {
+          error:
+            e instanceof Error ? e.message : t("editor.toasts.unknownError"),
+        })
       );
     }
   }
@@ -1167,7 +1197,7 @@ export default function AgentEditorPage({
     <>
       <div
         data-testid="AgentsEditorPage/container"
-        aria-label="Agents Editor Page"
+        aria-label={t("editor.page.ariaLabel")}
         className="h-full w-full"
       >
         <Formik
@@ -1236,8 +1266,8 @@ export default function AgentEditorPage({
 
                 <userFilesModal.Provider>
                   <UserFilesModal
-                    title="User Files"
-                    description="All files selected for this agent"
+                    title={t("editor.filesModal.title")}
+                    description={t("editor.filesModal.description")}
                     recentFiles={values.user_file_ids.map(
                       (userFileId: string) => {
                         const rf = allRecentFiles.find(
@@ -1249,7 +1279,9 @@ export default function AgentEditorPage({
                         // placeholder built in `ProjectsContext`.
                         const placeholder: ProjectFile = {
                           id: userFileId,
-                          name: `File ${userFileId.slice(0, 8)}`,
+                          name: t("editor.filesModal.placeholderName", {
+                            id: userFileId.slice(0, 8),
+                          }),
                           status: UserFileStatus.COMPLETED,
                           file_id: userFileId,
                           created_at: new Date().toISOString(),
@@ -1314,20 +1346,17 @@ export default function AgentEditorPage({
                   {deleteAgentModal.isOpen && (
                     <ConfirmationModalLayout
                       icon={SvgTrash}
-                      title="Delete Agent"
+                      title={t("editor.deleteModal.title")}
                       submit={
                         <Button variant="danger" onClick={handleDeleteAgent}>
-                          Delete Agent
+                          {t("editor.delete.button.label")}
                         </Button>
                       }
                       onClose={() => deleteAgentModal.toggle(false)}
                     >
                       <GeneralLayouts.Section alignItems="start" gap={2}>
-                        <Text>
-                          Anyone using this agent will no longer be able to
-                          access it. Deletion cannot be undone.
-                        </Text>
-                        <Text>Are you sure you want to delete this agent?</Text>
+                        <Text>{t("editor.deleteModal.body.warning")}</Text>
+                        <Text>{t("editor.deleteModal.body.confirm")}</Text>
                       </GeneralLayouts.Section>
                     </ConfirmationModalLayout>
                   )}
@@ -1337,7 +1366,11 @@ export default function AgentEditorPage({
                   <SettingsLayouts.Root>
                     <SettingsLayouts.Header
                       icon={SvgOnyxOctagon}
-                      title={existingAgent ? "Edit Agent" : "Create Agent"}
+                      title={
+                        existingAgent
+                          ? t("editor.header.editTitle")
+                          : t("editor.header.createTitle")
+                      }
                       rightChildren={
                         <div className="flex gap-2">
                           <Button
@@ -1345,18 +1378,18 @@ export default function AgentEditorPage({
                             type="button"
                             onClick={() => router.back()}
                           >
-                            Cancel
+                            {t("editor.header.cancel.label")}
                           </Button>
                           <Tooltip
                             tooltip={
                               isSubmitting
-                                ? "Saving changes..."
+                                ? t("editor.saveTooltip.saving")
                                 : !isValid
-                                  ? "Please fix the errors in the form before saving."
+                                  ? t("editor.saveTooltip.fixErrors")
                                   : !dirty
-                                    ? "No changes have been made."
+                                    ? t("editor.saveTooltip.noChanges")
                                     : hasUploadingFiles
-                                      ? "Please wait for files to finish uploading."
+                                      ? t("editor.saveTooltip.uploading")
                                       : undefined
                             }
                             side="bottom"
@@ -1370,7 +1403,9 @@ export default function AgentEditorPage({
                               }
                               type="submit"
                             >
-                              {existingAgent ? "Save" : "Create"}
+                              {existingAgent
+                                ? t("editor.header.save.label")
+                                : t("editor.header.create.label")}
                             </Button>
                           </Tooltip>
                         </div>
@@ -1395,21 +1430,26 @@ export default function AgentEditorPage({
                         alignItems="start"
                       >
                         <GeneralLayouts.Section>
-                          <InputVertical withLabel="name" title="Name">
+                          <InputVertical
+                            withLabel="name"
+                            title={t("editor.general.name.title")}
+                          >
                             <InputTypeInField
                               name="name"
-                              placeholder="Name your agent"
+                              placeholder={t("editor.general.name.placeholder")}
                             />
                           </InputVertical>
 
                           <InputVertical
                             withLabel="description"
-                            title="Description"
-                            suffix="optional"
+                            title={t("editor.general.descriptionField.title")}
+                            suffix={t("editor.suffix.optional")}
                           >
                             <InputTextAreaField
                               name="description"
-                              placeholder="What does this agent do?"
+                              placeholder={t(
+                                "editor.general.descriptionField.placeholder"
+                              )}
                             />
                           </InputVertical>
                         </GeneralLayouts.Section>
@@ -1417,7 +1457,7 @@ export default function AgentEditorPage({
                         <GeneralLayouts.Section width="fit">
                           <InputVertical
                             withLabel="agent_avatar"
-                            title="Agent Avatar"
+                            title={t("editor.general.avatar.title")}
                           >
                             <AgentIconEditor existingAgent={existingAgent} />
                           </InputVertical>
@@ -1429,13 +1469,17 @@ export default function AgentEditorPage({
                       <GeneralLayouts.Section>
                         <InputVertical
                           withLabel="instructions"
-                          title="Instructions"
-                          suffix="optional"
-                          description="Add instructions to tailor the response for this agent."
+                          title={t("editor.prompts.instructions.title")}
+                          suffix={t("editor.suffix.optional")}
+                          description={t(
+                            "editor.prompts.instructions.description"
+                          )}
                         >
                           <InputTextAreaField
                             name="instructions"
-                            placeholder="Think step by step and show reasoning for complex problems. Use specific examples. Emphasize action items, and leave blanks for the human to fill in when you have unknown. Use a polite enthusiastic tone."
+                            placeholder={t(
+                              "editor.prompts.instructions.placeholder"
+                            )}
                             rightSection={
                               <InsertUserVariableMenu fieldName="instructions" />
                             }
@@ -1444,9 +1488,9 @@ export default function AgentEditorPage({
 
                         <InputVertical
                           withLabel="starter_messages"
-                          title="Conversation Starters"
-                          description="Example messages that help users understand what this agent can do and how to interact with it effectively."
-                          suffix="optional"
+                          title={t("editor.prompts.starters.title")}
+                          description={t("editor.prompts.starters.description")}
+                          suffix={t("editor.suffix.optional")}
                         >
                           <AgentStarterMessages />
                         </InputVertical>
@@ -1505,7 +1549,7 @@ export default function AgentEditorPage({
                         height="auto"
                       >
                         <Content
-                          title="Share Agent"
+                          title={t("editor.share.title")}
                           sizePreset="main-content"
                           variant="section"
                         />
@@ -1513,8 +1557,10 @@ export default function AgentEditorPage({
                           <GeneralLayouts.Section>
                             {canShare && (
                               <InputHorizontal
-                                title="Share This Agent"
-                                description="with other users, groups, or everyone in your organization."
+                                title={t("editor.share.share.title")}
+                                description={t(
+                                  "editor.share.share.description"
+                                )}
                                 center
                               >
                                 <Button
@@ -1522,7 +1568,7 @@ export default function AgentEditorPage({
                                   icon={shareStatusIcon}
                                   onClick={() => shareAgentModal.toggle(true)}
                                 >
-                                  Share
+                                  {t("editor.share.share.button.label")}
                                 </Button>
                               </InputHorizontal>
                             )}
@@ -1530,21 +1576,29 @@ export default function AgentEditorPage({
                               <>
                                 <InputHorizontal
                                   withLabel="is_featured"
-                                  title="Feature This Agent"
-                                  description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
+                                  title={t("editor.share.feature.title")}
+                                  description={t(
+                                    "editor.share.feature.description"
+                                  )}
                                 >
                                   <SwitchField name="is_featured" />
                                 </InputHorizontal>
                                 {values.is_featured &&
                                   sharingStatus === "PRIVATE" && (
-                                    <MessageCard title="This agent is private to you and will only be featured for yourself." />
+                                    <MessageCard
+                                      title={t(
+                                        "editor.share.feature.privateNotice.title"
+                                      )}
+                                    />
                                   )}
                                 {values.is_featured &&
                                   existingAgent &&
                                   !existingAgent.is_listed && (
                                     <MessageCard
                                       variant="warning"
-                                      title="This agent is unlisted and won't be shown in the featured list."
+                                      title={t(
+                                        "editor.share.feature.unlistedWarning.title"
+                                      )}
                                     />
                                   )}
                               </>
@@ -1579,12 +1633,13 @@ export default function AgentEditorPage({
                                 }
                                 value={labelInputValue}
                                 onChange={setLabelInputValue}
-                                placeholder="Add labels..."
+                                placeholder={t(
+                                  "editor.share.labels.placeholder"
+                                )}
                                 icon={SvgTag}
                               />
                               <Text text03 secondaryBody>
-                                Add labels and categories to help people better
-                                discover this agent.
+                                {t("editor.share.labels.description")}
                               </Text>
                             </GeneralLayouts.Section>
                           </GeneralLayouts.Section>
@@ -1595,8 +1650,8 @@ export default function AgentEditorPage({
 
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
-                          title="Actions"
-                          description="Tools and capabilities available for this agent to use."
+                          title={t("editor.actions.title")}
+                          description={t("editor.actions.description")}
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section gap={2} alignItems="stretch">
@@ -1607,8 +1662,12 @@ export default function AgentEditorPage({
                               <Card border="solid" rounding={4}>
                                 <InputHorizontal
                                   withLabel="image_generation"
-                                  title="Image Generation"
-                                  description="Generate and manipulate images using AI-powered tools."
+                                  title={t(
+                                    "editor.actions.imageGeneration.title"
+                                  )}
+                                  description={t(
+                                    "editor.actions.imageGeneration.description"
+                                  )}
                                   disabled={!isImageGenerationAvailable}
                                 >
                                   <SwitchField
@@ -1623,8 +1682,10 @@ export default function AgentEditorPage({
                               <Card border="solid" rounding={4}>
                                 <InputHorizontal
                                   withLabel="web_search"
-                                  title="Web Search"
-                                  description="Search the web for real-time information and up-to-date results."
+                                  title={t("editor.actions.webSearch.title")}
+                                  description={t(
+                                    "editor.actions.webSearch.description"
+                                  )}
                                   disabled={!webSearchTool}
                                 >
                                   <SwitchField
@@ -1639,8 +1700,10 @@ export default function AgentEditorPage({
                               <Card border="solid" rounding={4}>
                                 <InputHorizontal
                                   withLabel="open_url"
-                                  title="Open URL"
-                                  description="Fetch and read content from web URLs."
+                                  title={t("editor.actions.openUrl.title")}
+                                  description={t(
+                                    "editor.actions.openUrl.description"
+                                  )}
                                   disabled={!openURLTool}
                                 >
                                   <SwitchField
@@ -1655,8 +1718,12 @@ export default function AgentEditorPage({
                               <Card border="solid" rounding={4}>
                                 <InputHorizontal
                                   withLabel="code_interpreter"
-                                  title="Code Interpreter"
-                                  description="Generate and run code."
+                                  title={t(
+                                    "editor.actions.codeInterpreter.title"
+                                  )}
+                                  description={t(
+                                    "editor.actions.codeInterpreter.description"
+                                  )}
                                   disabled={!codeInterpreterTool}
                                 >
                                   <SwitchField
@@ -1671,8 +1738,10 @@ export default function AgentEditorPage({
                               <Card border="solid" rounding={4}>
                                 <InputHorizontal
                                   withLabel="coding_agent"
-                                  title="Coding Agent"
-                                  description="Investigate a GitHub repository and answer questions about its code."
+                                  title={t("editor.actions.codingAgent.title")}
+                                  description={t(
+                                    "editor.actions.codingAgent.description"
+                                  )}
                                   disabled={!codingAgentTool}
                                 >
                                   <SwitchField
@@ -1733,8 +1802,8 @@ export default function AgentEditorPage({
 
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
-                          title="Advanced Options"
-                          description="Fine-tune agent prompts and knowledge."
+                          title={t("editor.advanced.title")}
+                          description={t("editor.advanced.description")}
                         />
                         <SimpleCollapsible.Content>
                           <GeneralLayouts.Section>
@@ -1742,8 +1811,10 @@ export default function AgentEditorPage({
                               <GeneralLayouts.Section>
                                 <InputHorizontal
                                   withLabel="llm_model"
-                                  title="Default Model"
-                                  description="This model will be used by Onyx by default in your chats."
+                                  title={t("modals.viewer.defaultModel.title")}
+                                  description={t(
+                                    "modals.viewer.defaultModel.description"
+                                  )}
                                 >
                                   <ModelSelector
                                     value={
@@ -1762,9 +1833,13 @@ export default function AgentEditorPage({
                                 </InputHorizontal>
                                 <InputHorizontal
                                   withLabel="knowledge_cutoff_date"
-                                  title="Knowledge Cutoff Date"
-                                  suffix="optional"
-                                  description="Documents with a last-updated date prior to this will be ignored."
+                                  title={t(
+                                    "modals.viewer.knowledgeCutoff.title"
+                                  )}
+                                  suffix={t("editor.suffix.optional")}
+                                  description={t(
+                                    "modals.viewer.knowledgeCutoff.description"
+                                  )}
                                 >
                                   <InputDatePickerField
                                     name="knowledge_cutoff_date"
@@ -1773,9 +1848,15 @@ export default function AgentEditorPage({
                                 </InputHorizontal>
                                 <InputHorizontal
                                   withLabel="replace_base_system_prompt"
-                                  title="Overwrite System Prompt"
-                                  suffix="(Not Recommended)"
-                                  description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
+                                  title={t(
+                                    "editor.advanced.overwritePrompt.title"
+                                  )}
+                                  suffix={t(
+                                    "editor.advanced.overwritePrompt.suffix"
+                                  )}
+                                  description={t(
+                                    "modals.viewer.overwritePrompts.description"
+                                  )}
                                 >
                                   <SwitchField name="replace_base_system_prompt" />
                                 </InputHorizontal>
@@ -1785,23 +1866,21 @@ export default function AgentEditorPage({
                             <GeneralLayouts.Section gap={1}>
                               <InputVertical
                                 withLabel="reminders"
-                                title="Reminders"
-                                suffix="optional"
+                                title={t("editor.advanced.reminders.title")}
+                                suffix={t("editor.suffix.optional")}
                               >
                                 <InputTextAreaField
                                   name="reminders"
-                                  placeholder="Remember, I want you to always format your response as a numbered list."
+                                  placeholder={t(
+                                    "editor.advanced.reminders.placeholder"
+                                  )}
                                   rightSection={
                                     <InsertUserVariableMenu fieldName="reminders" />
                                   }
                                 />
                               </InputVertical>
                               <Text text03 secondaryBody>
-                                Append a brief reminder to the prompt messages.
-                                Use this to remind the agent if you find that it
-                                tends to forget certain instructions as the chat
-                                progresses. This should be brief and not
-                                interfere with the user messages.
+                                {t("editor.advanced.reminders.description")}
                               </Text>
                             </GeneralLayouts.Section>
                           </GeneralLayouts.Section>
@@ -1821,13 +1900,17 @@ export default function AgentEditorPage({
                                 <InputHorizontal
                                   title={
                                     existingAgent.is_listed
-                                      ? "Unlist This Agent"
-                                      : "Relist This Agent"
+                                      ? t("editor.visibility.unlist.title")
+                                      : t("editor.visibility.relist.title")
                                   }
                                   description={
                                     existingAgent.is_listed
-                                      ? "Unlisted agents don't appear in the explore agents list but remain accessible."
-                                      : "Relisted agents appear in the explore agents list again."
+                                      ? t(
+                                          "editor.visibility.unlist.description"
+                                        )
+                                      : t(
+                                          "editor.visibility.relist.description"
+                                        )
                                   }
                                   center
                                 >
@@ -1842,14 +1925,18 @@ export default function AgentEditorPage({
                                     onClick={handleToggleListed}
                                   >
                                     {existingAgent.is_listed
-                                      ? "Unlist Agent"
-                                      : "Relist Agent"}
+                                      ? t(
+                                          "editor.visibility.unlist.button.label"
+                                        )
+                                      : t(
+                                          "editor.visibility.relist.button.label"
+                                        )}
                                   </Button>
                                 </InputHorizontal>
                               )}
                               <InputHorizontal
-                                title="Delete This Agent"
-                                description="Anyone using this agent will no longer be able to access it."
+                                title={t("editor.delete.title")}
+                                description={t("editor.delete.description")}
                                 center
                               >
                                 <Button
@@ -1857,7 +1944,7 @@ export default function AgentEditorPage({
                                   prominence="secondary"
                                   onClick={() => deleteAgentModal.toggle(true)}
                                 >
-                                  Delete Agent
+                                  {t("editor.delete.button.label")}
                                 </Button>
                               </InputHorizontal>
                             </GeneralLayouts.Section>

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -108,7 +108,8 @@ import { hasPermission } from "@/lib/permissions";
 import { can } from "@/lib/permissions/resource-actions";
 import { useDraft, draftKey } from "@/hooks/useDraft";
 
-// Length of starterExamples in the editor body, used where hooks are out of reach.
+// Length of the translated starterExamples array, which is local to
+// AgentStarterMessages, shared here so the editor can size against it.
 const STARTER_MESSAGES_COUNT = 4;
 
 interface AgentIconEditorProps {

--- a/web/src/views/AgentsNavigationPage.tsx
+++ b/web/src/views/AgentsNavigationPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useRef } from "react";
+import { useTranslations } from "next-intl";
 import AgentCard from "@/sections/agents/AgentCard";
 import { AgentViewer } from "@/lib/agents/components";
 import { useUser } from "@/providers/UserProvider";
@@ -57,7 +58,11 @@ function AgentsSection({
   );
 }
 
+// e2e locator, not user copy.
+const NEW_AGENT_BUTTON_ARIA_LABEL = "AgentsPage/new-agent-button";
+
 export default function AgentsNavigationPage() {
+  const t = useTranslations("agents");
   const { agents } = useAgents();
   const { user, permissions } = useUser();
   const canCreateAgent = hasPermission(permissions, Permission.ADD_AGENTS);
@@ -108,7 +113,7 @@ export default function AgentsNavigationPage() {
   return (
     <SettingsLayouts.Root
       data-testid="AgentsPage/container"
-      aria-label="Agents Page"
+      aria-label={t("navigation.page.ariaLabel")}
     >
       <AgentViewer
         agentId={viewedAgentId}
@@ -116,21 +121,21 @@ export default function AgentsNavigationPage() {
       />
       <SettingsLayouts.Header
         icon={SvgOnyxOctagon}
-        title="Agents"
-        description="Customize AI behavior and knowledge for you and your team's use cases."
+        title={t("navigation.header.title")}
+        description={t("navigation.header.description")}
         rightChildren={
           <Button
             href={canCreateAgent ? "/app/agents/create" : undefined}
             icon={SvgPlus}
-            aria-label="AgentsPage/new-agent-button"
+            aria-label={NEW_AGENT_BUTTON_ARIA_LABEL}
             disabled={!canCreateAgent}
             tooltip={
               !canCreateAgent
-                ? "You don't have permission to create agents. Contact your admin to request access."
+                ? t("navigation.newAgent.noPermission.tooltip")
                 : undefined
             }
           >
-            New Agent
+            {t("navigation.newAgent.label")}
           </Button>
         }
       >
@@ -139,7 +144,7 @@ export default function AgentsNavigationPage() {
             <div className="flex-2">
               <InputTypeIn
                 ref={searchInputRef}
-                placeholder="Search agents..."
+                placeholder={t("navigation.search.placeholder")}
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
                 searchIcon
@@ -151,8 +156,12 @@ export default function AgentsNavigationPage() {
                 onValueChange={(value) => setActiveTab(value as "all" | "your")}
               >
                 <Tabs.List>
-                  <Tabs.Trigger value="all">All Agents</Tabs.Trigger>
-                  <Tabs.Trigger value="your">Your Agents</Tabs.Trigger>
+                  <Tabs.Trigger value="all">
+                    {t("navigation.tabs.all.label")}
+                  </Tabs.Trigger>
+                  <Tabs.Trigger value="your">
+                    {t("navigation.tabs.your.label")}
+                  </Tabs.Trigger>
                 </Tabs.List>
               </Tabs>
             </div>
@@ -169,24 +178,26 @@ export default function AgentsNavigationPage() {
             className="w-full h-full flex flex-col items-center justify-center py-12"
             text03
           >
-            No Agents found
+            {t("navigation.empty.description")}
           </Text>
         ) : (
           <>
             <AgentsSection
-              title="Featured Agents"
-              description="Curated by your team"
+              title={t("navigation.sections.featured.title")}
+              description={t("navigation.sections.featured.description")}
               agents={featuredAgents}
               onView={setViewedAgentId}
             />
             <AgentsSection
-              title="All Agents"
+              title={t("navigation.sections.all.title")}
               agents={allAgents}
               onView={setViewedAgentId}
             />
             <TextSeparator
               count={agentCount}
-              text={agentCount === 1 ? "Agent" : "Agents"}
+              text={t("navigation.countSeparator.label", {
+                count: agentCount,
+              })}
             />
           </>
         )}

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -533,6 +533,15 @@ function GeneralSettings() {
   const { theme, setTheme, systemTheme } = useTheme();
   const currentLanguage = user?.preferences?.language ?? DEFAULT_LOCALE;
 
+  const tBg = useTranslations("common.chatBackgrounds");
+  const bgLabels: Record<string, string> = {
+    none: tBg("none.label"),
+    clouds: tBg("clouds.label"),
+    hills: tBg("hills.label"),
+    plant: tBg("plant.label"),
+    mountains: tBg("mountains.label"),
+    night: tBg("night.label"),
+  };
   const applyBackground = useCallback(
     async (bg: (typeof CHAT_BACKGROUND_OPTIONS)[number]) => {
       try {
@@ -764,11 +773,11 @@ function GeneralSettings() {
                         key={bg.id}
                         onClick={() => applyBackground(bg)}
                         className="relative overflow-hidden rounded-lg transition-all w-[90px] h-[68px] cursor-pointer border-none p-0 bg-transparent group"
-                        title={bg.label}
+                        title={bgLabels[bg.id] ?? bg.label}
                         aria-label={t(
                           "appearance.chatBackground.optionAriaLabel",
                           {
-                            label: bg.label,
+                            label: bgLabels[bg.id] ?? bg.label,
                             selected: isSelected ? "true" : "false",
                           }
                         )}
@@ -1246,12 +1255,12 @@ function ChatPreferencesSettings() {
     async (value: number): Promise<void> => {
       try {
         await updateUserTemperatureDefault(value);
-        toast.success("Preferences saved");
+        toast.success(t("chats.toasts.saved"));
       } catch {
-        toast.error("Failed to save preferences");
+        toast.error(t("chats.toasts.saveFailed"));
       }
     },
-    [updateUserTemperatureDefault]
+    [updateUserTemperatureDefault, t]
   );
 
   const saveEffortDefault = useCallback(
@@ -1260,12 +1269,12 @@ function ChatPreferencesSettings() {
         await updateUserReasoningEffortDefault(
           ALL_REASONING_STOPS[effortStop] ?? null
         );
-        toast.success("Preferences saved");
+        toast.success(t("chats.toasts.saved"));
       } catch {
-        toast.error("Failed to save preferences");
+        toast.error(t("chats.toasts.saveFailed"));
       }
     },
-    [updateUserReasoningEffortDefault]
+    [updateUserReasoningEffortDefault, t]
   );
 
   const commitVoicePlaybackSpeed = useCallback(() => {
@@ -1919,16 +1928,23 @@ function AccountsAccessSettings() {
   // constraints (max length, uppercase, lowercase, digit, special char) will be
   // wired up when this form is refreshed as part of auth-refresh.
   const passwordValidationSchema = Yup.object().shape({
-    currentPassword: Yup.string().required("Current password is required"),
+    currentPassword: Yup.string().required(
+      t("accounts.passwordModal.validation.currentRequired")
+    ),
     newPassword: Yup.string()
       .min(
         authTypeMetadata?.passwordMinLength ?? 0,
-        `Password must be at least ${authTypeMetadata?.passwordMinLength ?? 0} characters`
+        t("accounts.passwordModal.validation.minLength", {
+          min: authTypeMetadata?.passwordMinLength ?? 0,
+        })
       )
-      .required("New password is required"),
+      .required(t("accounts.passwordModal.validation.newRequired")),
     confirmPassword: Yup.string()
-      .oneOf([Yup.ref("newPassword")], "Passwords do not match")
-      .required("Please confirm your new password"),
+      .oneOf(
+        [Yup.ref("newPassword")],
+        t("accounts.passwordModal.validation.mismatch")
+      )
+      .required(t("accounts.passwordModal.validation.confirmRequired")),
   });
 
   const [tokenToDelete, setTokenToDelete] = useState<PAT | null>(null);
@@ -2353,7 +2369,11 @@ function AccountsAccessSettings() {
                                 count: daysSinceCreation,
                               });
 
-                        const middleText = `${createdText} - ${expiryText} - ${scopeText}`;
+                        const middleText = t("apiKeys.list.middleText", {
+                          created: createdText,
+                          expiry: expiryText,
+                          scope: scopeText,
+                        });
 
                         return (
                           <Interactive.Container

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type FormEvent,
 } from "react";
+import { useTranslations } from "next-intl";
 import useSWR, { useSWRConfig } from "swr";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
@@ -74,25 +75,32 @@ interface SkillEditorPageProps {
   externalAppName?: string;
 }
 
-function getSharingStatus(skill: SkillEditableDetail): {
+type SkillsTranslate = ReturnType<typeof useTranslations<"skills">>;
+
+function getSharingStatus(
+  skill: SkillEditableDetail,
+  t: SkillsTranslate
+): {
   title: string;
   description: string;
   color: "blue" | "gray" | "purple";
 } {
   if (skill.external_app) {
     return {
-      title: "Organization",
-      description: `Organization-wide viewer access is required while this skill is associated with app “${skill.external_app.name}”.`,
+      title: t("editor.sharing.organization.title"),
+      description: t("modals.share.externalAppNotice", {
+        appName: skill.external_app.name,
+      }),
       color: "blue",
     };
   }
   if (skill.public_permission !== null) {
     return {
-      title: "Organization",
+      title: t("editor.sharing.organization.title"),
       description:
         skill.public_permission === "EDITOR"
-          ? "Everyone in your organization can use and edit this skill."
-          : "Everyone in your organization can use this skill.",
+          ? t("editor.sharing.organization.editorDescription")
+          : t("editor.sharing.organization.viewerDescription"),
       color: "blue",
     };
   }
@@ -102,15 +110,15 @@ function getSharingStatus(skill: SkillEditableDetail): {
   const shareCount = userCount + groupCount;
   if (shareCount > 0) {
     return {
-      title: `${shareCount} ${shareCount === 1 ? "share" : "shares"}`,
-      description: "Only selected users and groups can use this skill.",
+      title: t("editor.sharing.shares.title", { count: shareCount }),
+      description: t("editor.sharing.shares.description"),
       color: "gray",
     };
   }
 
   return {
-    title: "Personal",
-    description: "Only you can use this skill.",
+    title: t("editor.sharing.personal.title"),
+    description: t("editor.sharing.personal.description"),
     color: "purple",
   };
 }
@@ -121,6 +129,7 @@ export default function SkillEditorPage({
   externalAppId,
   externalAppName,
 }: SkillEditorPageProps) {
+  const t = useTranslations("skills");
   const isCreating = skillId === undefined;
   const hasAppContext = externalAppId !== undefined;
   const isCreatingForApp = isCreating && hasAppContext;
@@ -284,7 +293,7 @@ export default function SkillEditorPage({
         void mutate(SWR_KEYS.userSkills).catch((error: unknown) => {
           console.error("Failed to refresh skill data after creation", error);
         });
-        toast.success(`Created "${created.name}"`);
+        toast.success(t("editor.toasts.created", { name: created.name }));
         router.replace(
           isCreatingForApp
             ? externalAppAdminUrl(externalAppId)
@@ -306,7 +315,7 @@ export default function SkillEditorPage({
       await refreshSkill(nextSkill, { revalidate: false });
       syncEditableFields(nextSkill);
       await refreshSkillList();
-      toast.success(`Saved "${updated.name}"`);
+      toast.success(t("editor.toasts.saved", { name: updated.name }));
     } catch (err) {
       if (isCreatingForApp && isSkillNameConflict(err)) {
         setAppConflictingSkillName(name.trim());
@@ -322,7 +331,9 @@ export default function SkillEditorPage({
         return;
       }
       console.error("Failed to save skill", err);
-      toast.error(err instanceof Error ? err.message : "Failed to save skill");
+      toast.error(
+        err instanceof Error ? err.message : t("editor.toasts.saveFailed")
+      );
     } finally {
       setIsSaving(false);
     }
@@ -353,7 +364,7 @@ export default function SkillEditorPage({
       } catch (err) {
         console.error("Failed to inspect skill bundle", err);
         toast.error(
-          err instanceof Error ? err.message : "Failed to inspect skill bundle"
+          err instanceof Error ? err.message : t("editor.toasts.inspectFailed")
         );
       } finally {
         setIsUploadingFiles(false);
@@ -368,11 +379,13 @@ export default function SkillEditorPage({
       await refreshSkill(updated, { revalidate: false });
       syncEditableFields(updated);
       await refreshSkillList();
-      toast.success(`Updated files for "${updated.name}"`);
+      toast.success(t("editor.toasts.filesUpdated", { name: updated.name }));
     } catch (err) {
       console.error("Failed to update skill files", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to update skill files"
+        err instanceof Error
+          ? err.message
+          : t("editor.toasts.filesUpdateFailed")
       );
     } finally {
       setIsUploadingFiles(false);
@@ -393,7 +406,7 @@ export default function SkillEditorPage({
 
   function handleImportSelected(upload: PreparedSkillFilesUpload) {
     if (!upload.containsSkillMd) {
-      toast.error("Import a SKILL.md, ZIP, or folder containing SKILL.md.");
+      toast.error(t("editor.toasts.importMissingSkillMd"));
       return;
     }
     handleFilesSelected(upload);
@@ -406,11 +419,11 @@ export default function SkillEditorPage({
       const updated = await removeUserSkillFile(skill.id, path);
       await refreshSkill(updated, { revalidate: false });
       await refreshSkillList();
-      toast.success(`Removed "${path}"`);
+      toast.success(t("editor.toasts.fileRemoved", { path }));
     } catch (err) {
       console.error("Failed to remove skill file", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to remove skill file"
+        err instanceof Error ? err.message : t("editor.toasts.fileRemoveFailed")
       );
     } finally {
       setRemovingFilePath(null);
@@ -436,12 +449,12 @@ export default function SkillEditorPage({
       // The skill is gone — a transient list-refresh failure must not mask
       // the successful delete or block navigation off the dead editor page.
       void refreshSkillList();
-      toast.success(`Deleted "${skill.name}"`);
+      toast.success(t("editor.toasts.deleted", { name: skill.name }));
       leaveEditor();
     } catch (err) {
       console.error("Failed to delete skill", err);
       toast.error(
-        err instanceof Error ? err.message : "Failed to delete skill"
+        err instanceof Error ? err.message : t("editor.toasts.deleteFailed")
       );
     } finally {
       setIsDeleting(false);
@@ -450,23 +463,23 @@ export default function SkillEditorPage({
 
   const saveTooltip = isSaving
     ? isCreating
-      ? "Saving skill..."
-      : "Saving changes..."
+      ? t("editor.saveTooltip.savingSkill")
+      : t("editor.saveTooltip.savingChanges")
     : !isCreating && !skill
       ? undefined
       : !canManageSkill
-        ? "You don't have permission to edit this skill's details."
+        ? t("editor.saveTooltip.noPermission")
         : !name.trim()
-          ? "Add a name before saving."
+          ? t("editor.saveTooltip.missingName")
           : !description.trim()
-            ? "Add a description before saving."
+            ? t("editor.saveTooltip.missingDescription")
             : !instructionsMarkdown.trim()
-              ? "Add instructions before saving."
+              ? t("editor.saveTooltip.missingInstructions")
               : !isDirty
-                ? "No changes have been made."
+                ? t("editor.saveTooltip.noChanges")
                 : undefined;
 
-  const sharingStatus = skill ? getSharingStatus(skill) : null;
+  const sharingStatus = skill ? getSharingStatus(skill, t) : null;
   const filesUploadDisabled =
     !canManageSkill ||
     isPreparingFiles ||
@@ -475,11 +488,11 @@ export default function SkillEditorPage({
     (!isCreating && isDirty);
   const filesUploadTooltip =
     !isCreating && isDirty
-      ? "Save detail changes before updating skill files."
+      ? t("editor.filesTooltip.saveFirst")
       : isUploadingFiles
-        ? "Updating skill files..."
+        ? t("editor.filesTooltip.updating")
         : !canManageSkill
-          ? "You don't have permission to update this skill's files."
+          ? t("editor.filesTooltip.noPermission")
           : undefined;
   const displayedFiles = isCreating
     ? (pendingFilesUpload?.entries ?? [])
@@ -494,13 +507,20 @@ export default function SkillEditorPage({
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
           icon={SvgBlocks}
-          title={isCreating ? "Create skill" : "Edit skill"}
+          title={
+            isCreating
+              ? t("editor.header.createTitle")
+              : t("editor.header.editTitle")
+          }
           description={
             isCreating
               ? isCreatingForApp
-                ? `Add an organization skill to app “${externalAppName ?? "External app"}”`
-                : "Build a personal skill"
-              : "Update skill details and files"
+                ? t("editor.header.createForAppDescription", {
+                    appName:
+                      externalAppName ?? t("editor.header.appFallbackName"),
+                  })
+                : t("editor.header.createDescription")
+              : t("editor.header.editDescription")
           }
           rightChildren={
             <div className="flex items-center gap-2">
@@ -510,11 +530,13 @@ export default function SkillEditorPage({
                 disabled={isSaving || isPreparingFiles || isUploadingFiles}
                 onClick={handleCancel}
               >
-                Cancel
+                {t("editor.header.cancel.label")}
               </Button>
               <Tooltip tooltip={saveTooltip} side="bottom">
                 <Button disabled={!canSave} type="submit">
-                  {isSaving ? "Saving..." : "Save"}
+                  {isSaving
+                    ? t("editor.header.save.pendingLabel")
+                    : t("editor.header.save.label")}
                 </Button>
               </Tooltip>
             </div>
@@ -533,8 +555,8 @@ export default function SkillEditorPage({
           {!isCreating && error && !isLoading && (
             <MessageCard
               variant="error"
-              title="Skill unavailable"
-              description="This skill may not exist, may be built-in, or may not be editable by your account."
+              title={t("editor.loadError.title")}
+              description={t("editor.loadError.description")}
             />
           )}
 
@@ -543,8 +565,12 @@ export default function SkillEditorPage({
               {appConflictingSkillName && (
                 <MessageCard
                   variant="error"
-                  title="Choose a different skill name"
-                  description={`App “${externalAppName ?? "External app"}” already has an associated skill named “${appConflictingSkillName}”.`}
+                  title={t("editor.appConflict.title")}
+                  description={t("editor.appConflict.description", {
+                    appName:
+                      externalAppName ?? t("editor.header.appFallbackName"),
+                    skillName: appConflictingSkillName,
+                  })}
                 />
               )}
 
@@ -554,19 +580,21 @@ export default function SkillEditorPage({
                     <Card border="solid" rounding={4} padding={2}>
                       <Section gap={2} alignItems="stretch" height="auto">
                         <Content
-                          title="Have an existing skill?"
-                          description="Import a SKILL.md, ZIP, or skill folder to prefill the form and include its files."
+                          title={t("editor.import.title")}
+                          description={t("editor.import.description")}
                           sizePreset="main-content"
                           variant="section"
                         />
                         <SkillFilesPicker
                           disabled={filesUploadDisabled}
                           busyLabel={
-                            isUploadingFiles ? "Importing..." : undefined
+                            isUploadingFiles
+                              ? t("editor.import.busyLabel")
+                              : undefined
                           }
-                          buttonLabel="Import skill"
-                          inputLabel="Import existing skill"
-                          prompt="Choose a SKILL.md or ZIP, or drop a skill folder here."
+                          buttonLabel={t("editor.import.button.label")}
+                          inputLabel={t("editor.import.input.ariaLabel")}
+                          prompt={t("editor.import.prompt")}
                           onChange={handleImportSelected}
                           onError={(message) => toast.error(message)}
                           onPreparingChange={setIsPreparingFiles}
@@ -581,26 +609,26 @@ export default function SkillEditorPage({
 
               <Section alignItems="stretch">
                 <Content
-                  title="Details"
-                  description="Define when and how Craft should use this skill."
+                  title={t("editor.details.title")}
+                  description={t("editor.details.description")}
                   sizePreset="main-content"
                   variant="section"
                 />
                 <InputVertical
                   withLabel="name"
-                  title="Name"
+                  title={t("editor.details.name.title")}
                   disabled={fieldsLocked || !isCreating}
                   description={
                     isCreating
-                      ? "Use lowercase letters, numbers, and single hyphens."
-                      : "Skill names cannot be changed after creation."
+                      ? t("editor.details.name.createDescription")
+                      : t("editor.details.name.lockedDescription")
                   }
                 >
                   <Tooltip
                     tooltip={
                       isCreating
                         ? undefined
-                        : "Skill names cannot be changed after creation."
+                        : t("editor.details.name.lockedDescription")
                     }
                     side="top"
                   >
@@ -613,7 +641,7 @@ export default function SkillEditorPage({
                           setName(event.target.value);
                           setAppConflictingSkillName(null);
                         }}
-                        placeholder="Name your skill"
+                        placeholder={t("editor.details.name.placeholder")}
                         variant={
                           fieldsLocked || !isCreating ? "disabled" : "primary"
                         }
@@ -624,8 +652,8 @@ export default function SkillEditorPage({
 
                 <InputVertical
                   withLabel="description"
-                  title="Description"
-                  description="Describe when this skill should be used."
+                  title={t("editor.details.descriptionField.title")}
+                  description={t("editor.details.descriptionField.description")}
                 >
                   <InputTextArea
                     id="description"
@@ -633,7 +661,9 @@ export default function SkillEditorPage({
                     rows={2}
                     value={description}
                     onChange={(event) => setDescription(event.target.value)}
-                    placeholder="What does this skill help with?"
+                    placeholder={t(
+                      "editor.details.descriptionField.placeholder"
+                    )}
                     autoResize
                     maxRows={8}
                     variant={fieldsLocked ? "disabled" : "primary"}
@@ -646,8 +676,8 @@ export default function SkillEditorPage({
               <Section alignItems="stretch">
                 <div className="flex w-full items-start justify-between gap-2">
                   <Content
-                    title="Instructions"
-                    description="Write the behavior and workflow this skill adds to Craft."
+                    title={t("editor.instructions.title")}
+                    description={t("editor.instructions.description")}
                     sizePreset="main-content"
                     variant="section"
                   />
@@ -667,13 +697,14 @@ export default function SkillEditorPage({
                       onChange={(event) =>
                         setInstructionsMarkdown(event.target.value)
                       }
-                      placeholder="Write the skill instructions."
+                      placeholder={t("editor.instructions.placeholder")}
                       variant={fieldsLocked ? "disabled" : "internal"}
                     />
                   ) : (
                     <div className="min-h-[34rem] max-h-[70dvh] overflow-y-auto overflow-x-hidden rounded-08 bg-background-neutral-00 p-2">
                       <CompactMarkdown>
-                        {instructionsMarkdown || "No instructions yet."}
+                        {instructionsMarkdown ||
+                          t("editor.instructions.emptyFallback")}
                       </CompactMarkdown>
                     </div>
                   )}
@@ -684,8 +715,8 @@ export default function SkillEditorPage({
 
               <Section gap={2} alignItems="stretch" height="auto">
                 <Content
-                  title="Supporting files"
-                  description="Add references, scripts, assets, or other files used by this skill. ZIP files are unpacked automatically."
+                  title={t("editor.files.title")}
+                  description={t("editor.files.description")}
                   sizePreset="main-content"
                   variant="section"
                 />
@@ -699,7 +730,7 @@ export default function SkillEditorPage({
                     removeDisabled={filesUploadDisabled}
                     emptyMessage={
                       pendingFilesUpload?.entries === null
-                        ? "Files from this upload will appear after you create the skill."
+                        ? t("editor.files.pendingUpload.emptyMessage")
                         : undefined
                     }
                   />
@@ -710,9 +741,11 @@ export default function SkillEditorPage({
                           <SkillFilesPicker
                             value={pendingFilesUpload}
                             disabled={filesUploadDisabled}
-                            inputLabel="Add supporting files"
+                            inputLabel={t("editor.files.input.ariaLabel")}
                             busyLabel={
-                              isUploadingFiles ? "Uploading..." : undefined
+                              isUploadingFiles
+                                ? t("editor.files.busyLabel")
+                                : undefined
                             }
                             onChange={handleFilesSelected}
                             onError={(message) => toast.error(message)}
@@ -731,8 +764,8 @@ export default function SkillEditorPage({
 
                   <Section gap={2} alignItems="stretch" height="auto">
                     <Content
-                      title="Management"
-                      description="Control who can use this skill."
+                      title={t("editor.management.title")}
+                      description={t("editor.management.description")}
                       sizePreset="main-content"
                       variant="section"
                     />
@@ -740,13 +773,24 @@ export default function SkillEditorPage({
                       <Section>
                         {skill.external_app && (
                           <InputHorizontal
-                            title="External app"
+                            title={t("editor.management.externalApp.title")}
                             description={
                               skill.external_app.ready
-                                ? `This skill uses app “${skill.external_app.name}”.`
+                                ? t(
+                                    "editor.management.externalApp.readyDescription",
+                                    { appName: skill.external_app.name }
+                                  )
                                 : skill.external_app.enabled
-                                  ? `Connect app “${skill.external_app.name}” from the Apps page to use this skill.`
-                                  : `App “${skill.external_app.name}” is disabled by an administrator.`
+                                  ? t(
+                                      "modals.preview.unavailable.appNotConnected",
+                                      { appName: skill.external_app.name }
+                                    )
+                                  : t(
+                                      "modals.preview.unavailable.appDisabled",
+                                      {
+                                        appName: skill.external_app.name,
+                                      }
+                                    )
                             }
                             center
                           >
@@ -765,7 +809,9 @@ export default function SkillEditorPage({
                                     skill.external_app.external_app_id
                                   )}
                                 >
-                                  Manage in app settings
+                                  {t(
+                                    "editor.management.externalApp.manage.label"
+                                  )}
                                 </Button>
                               )}
                             </div>
@@ -773,7 +819,7 @@ export default function SkillEditorPage({
                         )}
                         {sharingStatus && (
                           <InputHorizontal
-                            title="Sharing"
+                            title={t("editor.management.sharing.title")}
                             description={sharingStatus.description}
                             center
                           >
@@ -789,7 +835,7 @@ export default function SkillEditorPage({
                                   icon={SvgShare}
                                   onClick={() => setShareOpen(true)}
                                 >
-                                  Edit sharing
+                                  {t("editor.management.sharing.edit.label")}
                                 </Button>
                               )}
                             </div>
@@ -806,8 +852,8 @@ export default function SkillEditorPage({
                       <Card border="solid" rounding={4}>
                         <Section>
                           <InputHorizontal
-                            title="Delete this skill"
-                            description="Anyone using this skill will lose access. Deletion cannot be undone."
+                            title={t("editor.delete.title")}
+                            description={t("editor.delete.description")}
                             center
                           >
                             <Button
@@ -818,7 +864,7 @@ export default function SkillEditorPage({
                               disabled={isDeleting}
                               onClick={() => setDeleteOpen(true)}
                             >
-                              Delete skill
+                              {t("editor.delete.button.label")}
                             </Button>
                           </InputHorizontal>
                         </Section>
@@ -842,7 +888,11 @@ export default function SkillEditorPage({
       {filesUploadToConfirm && (
         <ConfirmationModalLayout
           icon={SvgAlertTriangle}
-          title={isCreating ? "Import this skill?" : "Replace skill content?"}
+          title={
+            isCreating
+              ? t("editor.confirmUpload.importTitle")
+              : t("editor.confirmUpload.replaceTitle")
+          }
           onClose={() => setFilesUploadToConfirm(null)}
           submit={
             <Button
@@ -853,13 +903,15 @@ export default function SkillEditorPage({
                 void applyFilesUpload(upload);
               }}
             >
-              {isCreating ? "Import skill" : "Replace content"}
+              {isCreating
+                ? t("editor.confirmUpload.importSubmit.label")
+                : t("editor.confirmUpload.replaceSubmit.label")}
             </Button>
           }
         >
           {isCreating
-            ? "This upload includes SKILL.md. Continuing will replace the current name, description, instructions, and files with the uploaded bundle."
-            : "This upload must use the same skill name. Continuing will replace the description, instructions, and files with the uploaded bundle."}
+            ? t("editor.confirmUpload.importBody")
+            : t("editor.confirmUpload.replaceBody")}
         </ConfirmationModalLayout>
       )}
 
@@ -881,9 +933,13 @@ export default function SkillEditorPage({
       {skill && deleteOpen && (
         <ConfirmEntityModal
           danger
-          entityType="skill"
+          entityType={t("editor.deleteModal.entityType")}
           entityName={skill.name}
-          actionButtonText={isDeleting ? "Deleting..." : "Delete"}
+          actionButtonText={
+            isDeleting
+              ? t("editor.deleteModal.pendingLabel")
+              : t("editor.deleteModal.label")
+          }
           onClose={() => setDeleteOpen(false)}
           onSubmit={handleDeleteConfirmed}
         />

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { Route } from "next";
 import {
@@ -46,6 +47,7 @@ import { isSkillNameConflict, setSkillEnabled } from "@/lib/skills/api";
 // ---------------------------------------------------------------------------
 
 export default function SkillsPage() {
+  const t = useTranslations("skills");
   const router = useRouter();
   const externalAppIdParam = useSearchParams().get("externalAppId");
   const focusedExternalAppId =
@@ -163,9 +165,7 @@ export default function SkillsPage() {
         { revalidate: false }
       );
       void refresh().catch(() => {
-        toast.error(
-          `${item.name} was updated, but the skill list could not be refreshed.`
-        );
+        toast.error(t("page.toasts.refreshFailed", { name: item.name }));
       });
     } catch (error) {
       if (enabled && !replaceConflict && isSkillNameConflict(error)) {
@@ -175,7 +175,12 @@ export default function SkillsPage() {
       toast.error(
         error instanceof Error
           ? error.message
-          : `Failed to ${enabled ? "enable" : "disable"} ${item.name}`
+          : t(
+              enabled
+                ? "page.toasts.enableFailed"
+                : "page.toasts.disableFailed",
+              { name: item.name }
+            )
       );
     } finally {
       setOptimisticEnabledById((current) => {
@@ -276,19 +281,21 @@ export default function SkillsPage() {
   const previewUnavailableReason =
     previewTarget?.source === "builtin" && !previewTarget.is_available
       ? (previewTarget.unavailable_reason ??
-        "This skill is currently unavailable.")
+        t("page.preview.unavailableFallback"))
       : null;
 
   return (
     <SettingsLayouts.Root data-testid="SkillsPage/container">
       <SettingsLayouts.Header
         icon={SvgBlocks}
-        title="Skills"
-        description="Capability bundles your Craft agent can reach for. This page shows built-in skills, skills shared with you, and your own personal skills."
+        title={t("page.header.title")}
+        description={t("page.header.description")}
         rightChildren={
           <Popover open={createMenuOpen} onOpenChange={setCreateMenuOpen}>
             <Popover.Trigger asChild>
-              <Button icon={SvgPlus}>Create skill</Button>
+              <Button icon={SvgPlus}>
+                {t("page.createMenu.trigger.label")}
+              </Button>
             </Popover.Trigger>
             <Popover.Content align="end" sideOffset={4} width="xl">
               <Popover.Menu>
@@ -296,34 +303,34 @@ export default function SkillsPage() {
                   sizePreset="main-ui"
                   rounding={2}
                   icon={SvgEdit}
-                  description="Write the instructions and add supporting files in Onyx."
+                  description={t("page.createMenu.scratch.description")}
                   onClick={() => {
                     setCreateMenuOpen(false);
                     router.push("/craft/v1/skills/new" as Route);
                   }}
-                  title="Start from scratch"
+                  title={t("page.createMenu.scratch.title")}
                 />
                 <LineItemButton
                   sizePreset="main-ui"
                   rounding={2}
                   icon={SvgUploadCloud}
-                  description="Import a SKILL.md file, ZIP file, or skill folder."
+                  description={t("page.createMenu.upload.description")}
                   onClick={() => {
                     setCreateMenuOpen(false);
                     setCreateOpen(true);
                   }}
-                  title="Upload a skill"
+                  title={t("page.createMenu.upload.title")}
                 />
                 <LineItemButton
                   sizePreset="main-ui"
                   rounding={2}
                   icon={SvgGithub}
-                  description="Import one or more skills from a repository."
+                  description={t("page.createMenu.github.description")}
                   onClick={() => {
                     setCreateMenuOpen(false);
                     setGitHubImportOpen(true);
                   }}
-                  title="Import from GitHub"
+                  title={t("page.createMenu.github.title")}
                 />
               </Popover.Menu>
             </Popover.Content>
@@ -332,7 +339,7 @@ export default function SkillsPage() {
       >
         <InputTypeIn
           ref={searchInputRef}
-          placeholder="Search skills..."
+          placeholder={t("page.search.placeholder")}
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
           searchIcon
@@ -343,11 +350,13 @@ export default function SkillsPage() {
         {focusedAppName && (
           <MessageCard
             variant="info"
-            title={`Skills for app “${focusedAppName}”`}
-            description={`Enable every skill associated with app “${focusedAppName}”. The app may not work correctly without them. If another skill with the same name is enabled, enabling the app-associated skill disables the other skill for you.`}
+            title={t("page.focusedApp.title", { appName: focusedAppName })}
+            description={t("page.focusedApp.description", {
+              appName: focusedAppName,
+            })}
             rightChildren={
               <Button prominence="secondary" href="/craft/v1/skills">
-                Show all skills
+                {t("page.focusedApp.showAll.label")}
               </Button>
             }
           />
@@ -358,8 +367,8 @@ export default function SkillsPage() {
         {error && !isLoading && (
           <MessageCard
             variant="error"
-            title="Failed to load skills"
-            description="Check the console for details and try refreshing the page."
+            title={t("page.loadError.title")}
+            description={t("page.loadError.description")}
           />
         )}
 
@@ -370,20 +379,20 @@ export default function SkillsPage() {
                 illustration={SvgNoResult}
                 title={
                   items.length === 0
-                    ? "No skills available"
-                    : "No matching skills"
+                    ? t("page.empty.noSkills.title")
+                    : t("page.empty.noMatches.title")
                 }
                 description={
                   items.length === 0
-                    ? "No custom skills have been shared with you yet, and no built-ins are configured."
-                    : "Try a different search."
+                    ? t("page.empty.noSkills.description")
+                    : t("page.empty.noMatches.description")
                 }
               />
             ) : (
               <>
                 <section className="flex flex-col gap-2">
                   <Text font="secondary-body" color="text-03">
-                    Browse skills
+                    {t("page.browse.title")}
                   </Text>
                   <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-2">
                     {visibleItems.map((item) => (
@@ -405,7 +414,9 @@ export default function SkillsPage() {
                 </section>
                 <TextSeparator
                   count={visibleItems.length}
-                  text={visibleItems.length === 1 ? "Skill" : "Skills"}
+                  text={t("page.countSeparator.label", {
+                    count: visibleItems.length,
+                  })}
                 />
               </>
             )}
@@ -449,8 +460,12 @@ export default function SkillsPage() {
       {pendingSwitchTarget && (
         <ConfirmationModalLayout
           icon={SvgAlertTriangle}
-          title={`Switch “${pendingSwitchTarget.name}” skill?`}
-          description={`Only one skill named “${pendingSwitchTarget.name}” can be enabled at a time.`}
+          title={t("page.switchModal.title", {
+            name: pendingSwitchTarget.name,
+          })}
+          description={t("page.switchModal.description", {
+            name: pendingSwitchTarget.name,
+          })}
           onClose={
             switchPending ? undefined : () => setPendingSwitchTarget(null)
           }
@@ -462,12 +477,13 @@ export default function SkillsPage() {
                 void updateSkillEnabled(target, true, true);
               }}
             >
-              {switchPending ? "Switching..." : "Switch skill"}
+              {switchPending
+                ? t("page.switchModal.submit.pendingLabel")
+                : t("page.switchModal.submit.label")}
             </Button>
           }
         >
-          Continuing will disable the currently enabled skill and enable this
-          one.
+          {t("page.switchModal.body")}
         </ConfirmationModalLayout>
       )}
     </SettingsLayouts.Root>

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { markdown } from "@opal/utils";
 import React, {
   useCallback,
@@ -665,6 +666,7 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
 
 export default function ChatPreferencesPage() {
   const t = useTranslations("admin.chatPreferences");
+  const adminRouteTitle = useAdminRouteTitle();
   const router = useRouter();
   const settings = useSettings();
   const s = settings;
@@ -929,7 +931,7 @@ export default function ChatPreferencesPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
           icon={route.icon}
-          title={route.title}
+          title={adminRouteTitle(route)}
           description={t("header.description")}
           divider
         />

--- a/web/src/views/admin/ExternalAppsPage/index.tsx
+++ b/web/src/views/admin/ExternalAppsPage/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -58,13 +59,14 @@ interface KindCopy {
 // for granting more.
 export default function ExternalAppsPage() {
   const t = useTranslations("admin.externalApps");
+  const adminRouteTitle = useAdminRouteTitle();
   const [catalogOpen, setCatalogOpen] = useState(false);
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={ADMIN_ROUTES.CRAFT_APPS.icon}
-        title={ADMIN_ROUTES.CRAFT_APPS.title}
+        title={adminRouteTitle(ADMIN_ROUTES.CRAFT_APPS)}
         description={t("page.description")}
         rightChildren={
           <div className="flex items-center gap-2">

--- a/web/src/views/admin/GroupsPage/shared.tsx
+++ b/web/src/views/admin/GroupsPage/shared.tsx
@@ -1,10 +1,11 @@
+import { useTranslations } from "next-intl";
 import { createTableColumns } from "@opal/components";
 import { Content } from "@opal/layouts";
 import { SvgUser, SvgUserManage, SvgGlobe } from "@opal/icons";
 import { SvgSlack } from "@opal/logos";
 import type { IconFunctionComponent } from "@opal/types";
 import Text from "@/refresh-components/texts/Text";
-import { AccountType, ACCOUNT_TYPE_LABELS, UserStatus } from "@/lib/types";
+import { AccountType, UserStatus } from "@/lib/types";
 import type { ApiKeyDescriptor, MemberRow } from "./interfaces";
 
 // ---------------------------------------------------------------------------
@@ -17,17 +18,27 @@ export const PAGE_SIZE = 10;
 // Helpers
 // ---------------------------------------------------------------------------
 
-export function apiKeyToMemberRow(key: ApiKeyDescriptor): MemberRow {
+// Translated copy threaded in by the calling component, matching
+// MemberColumnLabels below.
+export interface ApiKeyMemberRowLabels {
+  serviceAccountEmail: string;
+  unnamedKey: string;
+}
+
+export function apiKeyToMemberRow(
+  key: ApiKeyDescriptor,
+  labels: ApiKeyMemberRowLabels
+): MemberRow {
   return {
     id: key.user_id,
-    email: "Service Account",
+    email: labels.serviceAccountEmail,
     account_type: AccountType.SERVICE_ACCOUNT,
     is_admin: false,
     status: UserStatus.ACTIVE,
     is_active: true,
     is_scim_synced: false,
     craft_enabled: null,
-    personal_name: key.api_key_name ?? "Unnamed Key",
+    personal_name: key.api_key_name ?? labels.unnamedKey,
     created_at: null,
     updated_at: null,
     groups: [],
@@ -51,7 +62,15 @@ const ACCOUNT_TYPE_ICONS: Partial<Record<AccountType, IconFunctionComponent>> =
 // Column renderers
 // ---------------------------------------------------------------------------
 
-function renderAccountTypeColumn(_value: unknown, row: MemberRow) {
+function AccountTypeCell({ row }: { row: MemberRow }) {
+  const t = useTranslations("admin.users.accountType");
+  const labels: Record<AccountType, string> = {
+    [AccountType.STANDARD]: t("standard.label"),
+    [AccountType.BOT]: t("bot.label"),
+    [AccountType.EXT_PERM_USER]: t("extPermUser.label"),
+    [AccountType.SERVICE_ACCOUNT]: t("serviceAccount.label"),
+    [AccountType.ANONYMOUS]: t("anonymous.label"),
+  };
   const Icon =
     (row.account_type && ACCOUNT_TYPE_ICONS[row.account_type]) || SvgUser;
   return (
@@ -59,11 +78,15 @@ function renderAccountTypeColumn(_value: unknown, row: MemberRow) {
       <Icon className="w-4 h-4 text-text-03" />
       <Text as="span" mainUiBody text03>
         {row.account_type
-          ? (ACCOUNT_TYPE_LABELS[row.account_type] ?? row.account_type)
+          ? (labels[row.account_type] ?? row.account_type)
           : "\u2014"}
       </Text>
     </div>
   );
+}
+
+function renderAccountTypeColumn(_value: unknown, row: MemberRow) {
+  return <AccountTypeCell row={row} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Formik } from "formik";
 import { markdown } from "@opal/utils";
@@ -506,6 +507,7 @@ function EmbeddingModelCard({
   onSelect,
 }: EmbeddingModelCardProps) {
   const t = useTranslations("admin.indexSettings");
+  const adminRouteTitle = useAdminRouteTitle();
   const topRightButton = (() => {
     switch (modelState) {
       case "unconnected":
@@ -618,6 +620,7 @@ function isContextualModelOnlyChange(
 
 export default function IndexSettingsPage() {
   const t = useTranslations("admin.indexSettings");
+  const adminRouteTitle = useAdminRouteTitle();
   const router = useRouter();
   const settings = useSettings();
   const editModal = useCreateModal();
@@ -927,7 +930,11 @@ export default function IndexSettingsPage() {
   ) {
     return (
       <SettingsLayouts.Root>
-        <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+        <SettingsLayouts.Header
+          icon={route.icon}
+          title={adminRouteTitle(route)}
+          divider
+        />
         <SettingsLayouts.Body>
           <PageLoader />
         </SettingsLayouts.Body>
@@ -972,7 +979,7 @@ export default function IndexSettingsPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
           icon={route.icon}
-          title={route.title}
+          title={adminRouteTitle(route)}
           description={t("header.description")}
           divider
         />

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -507,7 +507,6 @@ function EmbeddingModelCard({
   onSelect,
 }: EmbeddingModelCardProps) {
   const t = useTranslations("admin.indexSettings");
-  const adminRouteTitle = useAdminRouteTitle();
   const topRightButton = (() => {
     switch (modelState) {
       case "unconnected":

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -76,7 +76,6 @@ function ExistingProviderCard({
   isLastProvider,
 }: ExistingProviderCardProps) {
   const t = useTranslations("admin.languageModels");
-  const adminRouteTitle = useAdminRouteTitle();
   const { mutate } = useSWRConfig();
   const [isOpen, setIsOpen] = useState(false);
   const deleteModal = useCreateModal();
@@ -221,7 +220,6 @@ function NewProviderCard({
   isFirstProvider,
 }: NewProviderCardProps) {
   const t = useTranslations("admin.languageModels");
-  const adminRouteTitle = useAdminRouteTitle();
   const [isOpen, setIsOpen] = useState(false);
   const { icon, productName, companyName, Modal } = getProvider(providerName);
 
@@ -278,7 +276,6 @@ function NewCustomProviderCard({
   isFirstProvider,
 }: NewCustomProviderCardProps) {
   const t = useTranslations("admin.languageModels");
-  const adminRouteTitle = useAdminRouteTitle();
   const [isOpen, setIsOpen] = useState(false);
   const { icon, productName, companyName, Modal } = getProvider("custom");
 

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { useSWRConfig } from "swr";
@@ -75,6 +76,7 @@ function ExistingProviderCard({
   isLastProvider,
 }: ExistingProviderCardProps) {
   const t = useTranslations("admin.languageModels");
+  const adminRouteTitle = useAdminRouteTitle();
   const { mutate } = useSWRConfig();
   const [isOpen, setIsOpen] = useState(false);
   const deleteModal = useCreateModal();
@@ -219,6 +221,7 @@ function NewProviderCard({
   isFirstProvider,
 }: NewProviderCardProps) {
   const t = useTranslations("admin.languageModels");
+  const adminRouteTitle = useAdminRouteTitle();
   const [isOpen, setIsOpen] = useState(false);
   const { icon, productName, companyName, Modal } = getProvider(providerName);
 
@@ -275,6 +278,7 @@ function NewCustomProviderCard({
   isFirstProvider,
 }: NewCustomProviderCardProps) {
   const t = useTranslations("admin.languageModels");
+  const adminRouteTitle = useAdminRouteTitle();
   const [isOpen, setIsOpen] = useState(false);
   const { icon, productName, companyName, Modal } = getProvider("custom");
 
@@ -321,6 +325,7 @@ function NewCustomProviderCard({
 
 export default function LanguageModelsPage() {
   const t = useTranslations("admin.languageModels");
+  const adminRouteTitle = useAdminRouteTitle();
   const { mutate } = useSWRConfig();
   const { llmProviders: existingLlmProviders, defaultText } =
     useAdminLLMProviders();
@@ -419,7 +424,11 @@ export default function LanguageModelsPage() {
 
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={adminRouteTitle(route)}
+        divider
+      />
 
       <SettingsLayouts.Body>
         {hasProviders ? (

--- a/web/src/views/admin/SSOProvidersPage.tsx
+++ b/web/src/views/admin/SSOProvidersPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import useSWR from "swr";
@@ -36,12 +37,13 @@ interface ShellProps {
 
 function Shell({ children, onAddProvider, addGated }: ShellProps) {
   const t = useTranslations("admin.ssoProviders");
+  const adminRouteTitle = useAdminRouteTitle();
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("page.description")}
         divider
         rightChildren={

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import useSWR, { mutate } from "swr";
@@ -91,6 +92,7 @@ function JwtTextRow({
   onCommit,
 }: JwtTextRowProps) {
   const t = useTranslations("admin.security");
+  const adminRouteTitle = useAdminRouteTitle();
   const [text, setText] = useState(value);
   // The revision bump resyncs after a commit settles even when `value` did not
   // move, e.g. a failed clear where the optimistic patch drops nulls. A focused
@@ -150,6 +152,7 @@ function JwtTextRow({
 
 export default function SecurityHardeningPage() {
   const t = useTranslations("admin.security");
+  const adminRouteTitle = useAdminRouteTitle();
   const isMultiTenant = NEXT_PUBLIC_CLOUD_ENABLED;
   const { authTypeMetadata, isLoading: authTypeLoading } =
     useAuthTypeMetadata();
@@ -308,7 +311,11 @@ export default function SecurityHardeningPage() {
   if (settingsLoading || !draft) {
     return (
       <SettingsLayouts.Root>
-        <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+        <SettingsLayouts.Header
+          icon={route.icon}
+          title={adminRouteTitle(route)}
+          divider
+        />
         <SettingsLayouts.Body />
       </SettingsLayouts.Root>
     );
@@ -346,7 +353,7 @@ export default function SecurityHardeningPage() {
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("page.description")}
         divider
       />

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -92,7 +92,6 @@ function JwtTextRow({
   onCommit,
 }: JwtTextRowProps) {
   const t = useTranslations("admin.security");
-  const adminRouteTitle = useAdminRouteTitle();
   const [text, setText] = useState(value);
   // The revision bump resyncs after a commit settles even when `value` did not
   // move, e.g. a failed clear where the optimistic patch drops nulls. A focused

--- a/web/src/views/admin/ServiceAccountsPage/index.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import useSWR, { mutate } from "swr";
@@ -62,6 +63,7 @@ const tc = createTableColumns<APIKey>();
 
 export default function ServiceAccountsPage() {
   const t = useTranslations("admin.serviceAccounts");
+  const adminRouteTitle = useAdminRouteTitle();
   const {
     data: apiKeys,
     isLoading,
@@ -244,7 +246,7 @@ export default function ServiceAccountsPage() {
     return (
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
-          title={route.title}
+          title={adminRouteTitle(route)}
           icon={route.icon}
           description={t("page.description")}
           divider
@@ -264,7 +266,7 @@ export default function ServiceAccountsPage() {
     return (
       <SettingsLayouts.Root>
         <SettingsLayouts.Header
-          title={route.title}
+          title={adminRouteTitle(route)}
           icon={route.icon}
           description={t("page.description")}
           divider
@@ -281,7 +283,7 @@ export default function ServiceAccountsPage() {
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
-        title={route.title}
+        title={adminRouteTitle(route)}
         icon={route.icon}
         description={t("page.description")}
         divider

--- a/web/src/views/admin/TracingPage/index.tsx
+++ b/web/src/views/admin/TracingPage/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { SettingsLayouts } from "@opal/layouts";
@@ -29,12 +30,13 @@ interface ShellProps {
 
 function Shell({ children }: ShellProps) {
   const t = useTranslations("admin.tracing");
+  const adminRouteTitle = useAdminRouteTitle();
 
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("page.description")}
         divider
       />

--- a/web/src/views/admin/WorkspaceAnalyticsPage/index.tsx
+++ b/web/src/views/admin/WorkspaceAnalyticsPage/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useTranslations } from "next-intl";
 import { DateRangePicker } from "@/refresh-components/DateRangePicker";
 import { useTimeRange } from "@/lib/usage/hooks";
@@ -18,13 +19,14 @@ const route = ADMIN_ROUTES.WORKSPACE_ANALYTICS;
 
 export default function WorkspaceAnalyticsPage() {
   const t = useTranslations("admin.analytics");
+  const adminRouteTitle = useAdminRouteTitle();
   const [timeRange, setTimeRange] = useTimeRange();
 
   return (
     <SettingsLayouts.Root width="lg">
       <SettingsLayouts.Header
         icon={route.icon}
-        title={route.title}
+        title={adminRouteTitle(route)}
         description={t("page.description")}
         divider
         rightChildren={


### PR DESCRIPTION
## Description

**Why:** Large parts of the product still hardcode English strings, so any non-English locale shows a mixed-language UI.

**What:** Extracts the remaining user-facing strings across the web app into next-intl, adding the keys to all nine locale catalogs. Widens the `i18n/no-raw-jsx-text` oxlint ratchet to `src/**` so raw strings cannot come back. Admin route titles translate everywhere, including the five pages that live outside the sidebar, and nav-id resolution moves into the server-safe sidebar utils module so server pages can use it. Cleans up along the way: dead route-title hook calls, dead tool-description constants, and unreachable SwitchList label keys.

## How Has This Been Tested?

- oxlint `i18n/no-raw-jsx-text` reports zero violations across `src/**`.
- Compile-time checks pass: message key augmentation and `keyParity.ts` (tsc via pre-commit).
- jest: i18n catalog suites 10/10, touched suites pass (23/23 on the combined stack).
- Live spot-checks in Chrome in Arabic: sidebar, settings, and admin surfaces render translated.

| Before (English) | After (Arabic, extracted surfaces) |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/rtl-ui-screenshots/settings-english-before.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/rtl-ui-screenshots/settings-arabic-after.jpg) |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
