### PR TITLE
fix(scim): mark promoted shadow users verified on adoption

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -263,13 +263,18 @@ class ScimDAL(DAL):
         email: str | None = None,
         is_active: bool | None = None,
         personal_name: str | None = None,
-        account_type: AccountType | None = None,
+        promote_to_standard: bool = False,
     ) -> None:
         """Update user attributes. Only sets fields that are provided.
 
         A rename runs the same reconciliation a login-driven one does, so the
         replaced address keeps reaching documents whose indexed ACLs still name
         it and every other row keyed by the address moves with it.
+
+        Promotion turns a shadow EXT_PERM_USER into a STANDARD account and sets
+        ``is_verified``: the IdP vouches for the address, and SSO login never
+        touches the flag on a row that is already web-login, so the row would
+        otherwise sit behind REQUIRE_EMAIL_VERIFICATION.
         """
         if email is not None:
             reconcile_user_email__no_commit(user.id, email, self._session)
@@ -277,8 +282,9 @@ class ScimDAL(DAL):
             user.is_active = is_active
         if personal_name is not None:
             user.personal_name = personal_name
-        if account_type is not None:
-            user.account_type = account_type
+        if promote_to_standard:
+            user.account_type = AccountType.STANDARD
+            user.is_verified = True
 
     def deactivate_user(self, user: User) -> None:
         """Mark a user as inactive."""

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -818,7 +818,7 @@ def create_user(
         dal.update_user(
             existing_user,
             is_active=user_resource.active,
-            account_type=AccountType.STANDARD if promote else None,
+            promote_to_standard=promote,
             **({"personal_name": personal_name} if personal_name else {}),
         )
 
@@ -969,7 +969,7 @@ def replace_user(
         email=new_email,
         is_active=user_resource.active,
         personal_name=personal_name,
-        account_type=AccountType.STANDARD if promote else None,
+        promote_to_standard=promote,
     )
     if error:
         return error
@@ -1107,7 +1107,7 @@ def patch_user(
         email=new_email,
         is_active=patched.active if patched.active != user.is_active else None,
         personal_name=personal_name,
-        account_type=AccountType.STANDARD if promote else None,
+        promote_to_standard=promote,
     )
     if error:
         return error

--- a/backend/tests/unit/onyx/db/test_scim_dal.py
+++ b/backend/tests/unit/onyx/db/test_scim_dal.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from ee.onyx.db.scim import ScimDAL
+from onyx.db.enums import AccountType
 from onyx.db.models import ScimGroupMapping, ScimToken, ScimUserMapping, User
 from tests.unit.onyx.db.conftest import model_attrs
 
@@ -233,3 +234,35 @@ class TestScimDALUserRename:
         reconcile.assert_not_called()
         assert user.email == "user@example.com"
         assert user.prior_emails == ["old@e.com"]
+
+
+class TestScimDALPromotion:
+    """Promotion is the one update that writes two fields under one flag."""
+
+    def test_promotion_sets_standard_and_verified(self, scim_dal: ScimDAL) -> None:
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            account_type=AccountType.EXT_PERM_USER,
+            is_verified=False,
+        )
+
+        scim_dal.update_user(user, promote_to_standard=True)
+
+        assert user.account_type == AccountType.STANDARD
+        assert user.is_verified is True
+
+    def test_other_updates_leave_promotion_fields_alone(
+        self, scim_dal: ScimDAL
+    ) -> None:
+        user = User(
+            id=uuid4(),
+            email="user@example.com",
+            account_type=AccountType.EXT_PERM_USER,
+            is_verified=False,
+        )
+
+        scim_dal.update_user(user, is_active=True)
+
+        assert user.account_type == AccountType.EXT_PERM_USER
+        assert user.is_verified is False

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -329,7 +329,7 @@ class TestCreateUser:
         mock_dal.update_user.assert_called_once_with(
             existing,
             is_active=True,
-            account_type=None,
+            promote_to_standard=False,
             personal_name="Test User",
         )
         # Should create a SCIM mapping for the existing user
@@ -377,7 +377,7 @@ class TestCreateUser:
         mock_dal.update_user.assert_called_once_with(
             existing,
             is_active=True,
-            account_type=AccountType.STANDARD,
+            promote_to_standard=True,
             personal_name="Test User",
         )
         # Promoted shadow user must land in the Basic default group
@@ -680,7 +680,7 @@ class TestReplaceUser:
         # Promotion consumes a seat even though the user was already active
         mock_seats.assert_called_once()
         _, kwargs = mock_dal.update_user.call_args
-        assert kwargs["account_type"] == AccountType.STANDARD
+        assert kwargs["promote_to_standard"] is True
         mock_assign.assert_called_once()
 
     @patch("ee.onyx.server.scim.api._check_seat_availability")
@@ -809,7 +809,7 @@ class TestPatchUser:
         parse_scim_user(result)
         mock_seats.assert_called_once()
         _, kwargs = mock_dal.update_user.call_args
-        assert kwargs["account_type"] == AccountType.STANDARD
+        assert kwargs["promote_to_standard"] is True
         mock_assign.assert_called_once()
 
     def test_not_found_returns_404(


### PR DESCRIPTION
## Description

**Why:** On cloud, `REQUIRE_EMAIL_VERIFICATION` is on. Permission sync creates `EXT_PERM_USER` shadow rows with `is_verified=false`. When SCIM adopts one of those rows it promotes it to `STANDARD` but leaves `is_verified` alone. The later SSO login treats the row as an existing web account, links the identity, and never verifies it. The user is bounced to the verify-email page even though the IdP just authenticated them. We have cloud tenants with SCIM-managed users sitting in this state right now.

**What:** SCIM promotion of a shadow user now also sets `is_verified=True`, on all three promote paths (`POST /Users` adoption, `PUT`, `PATCH`). The `account_type` kwarg on `ScimDAL.update_user`, whose only callers were those three sites, becomes a single `promote_to_standard` flag that writes both fields, so the invariant lives in one place. Net-new SCIM users were already created verified, so this brings adopted shadows in line with them. Real password-signup users adopted by SCIM are untouched.

## How Has This Been Tested?

- `backend/tests/unit/onyx/server/scim/test_user_endpoints.py`: the three promote tests (create adopt, PUT, PATCH) now assert `promote_to_standard=True`, and the non-promote adoption test asserts `False`.
- `backend/tests/unit/onyx/db/test_scim_dal.py`: new `TestScimDALPromotion` checks the flag sets `STANDARD` plus `is_verified`, and that other updates leave both alone.
- Fail-first check: with `scim.py` and `api.py` restored to `origin/main`, 9 of these tests fail. With the fix, all 162 pass.
- `ruff format --check` on the changed files and project-wide `ty check` are clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check