### PR TITLE
feat(web): avatar initials follow the script of the name

### DIFF
--- a/web/src/lib/nameInitials.test.ts
+++ b/web/src/lib/nameInitials.test.ts
@@ -38,6 +38,11 @@ describe("nameInitials", () => {
     expect(nameInitials("E\u0301lise", 2)).toBe("E\u0301L");
   });
 
+  it("keeps one glyph per slot when uppercasing expands", () => {
+    expect(nameInitials("\u00DFeta", 1)).toBe("S");
+    expect(nameInitials("\u00DFeta stein", 2)).toBe("SS");
+  });
+
   it("returns null when no letter leads", () => {
     expect(nameInitials("123", 2)).toBeNull();
     expect(nameInitials("  ", 2)).toBeNull();

--- a/web/src/lib/nameInitials.test.ts
+++ b/web/src/lib/nameInitials.test.ts
@@ -41,6 +41,7 @@ describe("nameInitials", () => {
   it("keeps one glyph per slot when uppercasing expands", () => {
     expect(nameInitials("\u00DFeta", 1)).toBe("S");
     expect(nameInitials("\u00DFeta stein", 2)).toBe("SS");
+    expect(nameInitials("\u0149elson", 1)).toBe("N");
   });
 
   it("returns null when no letter leads", () => {

--- a/web/src/lib/nameInitials.test.ts
+++ b/web/src/lib/nameInitials.test.ts
@@ -1,0 +1,47 @@
+import { nameInitials } from "@/lib/nameInitials";
+
+describe("nameInitials", () => {
+  it("takes the first letters of two Latin words", () => {
+    expect(nameInitials("Nik Garza", 2)).toBe("NG");
+  });
+
+  it("fills from a single Latin word", () => {
+    expect(nameInitials("Nik", 2)).toBe("NI");
+  });
+
+  it("keeps one letter for agents", () => {
+    expect(nameInitials("Research Helper", 1)).toBe("R");
+  });
+
+  it("follows the name's script, not the UI locale", () => {
+    expect(nameInitials("Mohammed Ali", 2)).toBe("MA");
+  });
+
+  it("uses a single grapheme for Arabic names", () => {
+    expect(nameInitials("محمد علي", 2)).toBe("م");
+  });
+
+  it("uses a single grapheme for Hebrew names", () => {
+    expect(nameInitials("משה", 2)).toBe("מ");
+  });
+
+  it("uses the first character for Chinese names", () => {
+    expect(nameInitials("王小明", 2)).toBe("王");
+  });
+
+  it("uses the first syllable for Korean names", () => {
+    expect(nameInitials("김철수", 2)).toBe("김");
+  });
+
+  it("handles accented Latin letters", () => {
+    expect(nameInitials("Élise Dupont", 2)).toBe("ÉD");
+    expect(nameInitials("E\u0301lise", 2)).toBe("E\u0301L");
+  });
+
+  it("returns null when no letter leads", () => {
+    expect(nameInitials("123", 2)).toBeNull();
+    expect(nameInitials("  ", 2)).toBeNull();
+    expect(nameInitials("\u{1F600} party", 2)).toBeNull();
+    expect(nameInitials("A1", 2)).toBeNull();
+  });
+});

--- a/web/src/lib/nameInitials.ts
+++ b/web/src/lib/nameInitials.ts
@@ -1,0 +1,66 @@
+import { firstStrongTextDir } from "@/lib/rehypeDirection";
+
+// Initials are a Latin-script habit. Cursive RTL scripts join adjacent
+// letters into word fragments and CJK has no initials at all, so those
+// names show a single grapheme of the display name instead.
+const CJK =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+const LETTER = /\p{L}/u;
+const MARK = /\p{M}/u;
+
+// Grapheme-cluster segmentation keeps surrogate pairs, emoji, and
+// mark-bearing scripts intact where slice() would corrupt them.
+function graphemes(value: string, max: number): string[] {
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const out: string[] = [];
+    const segments = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    }).segment(value);
+    for (const segment of segments) {
+      out.push(segment.segment);
+      if (out.length >= max) break;
+    }
+    return out;
+  }
+  // Legacy fallback: fold combining marks into the previous cluster so
+  // decomposed accents survive without Intl.Segmenter.
+  const out: string[] = [];
+  for (const char of value) {
+    if (out.length > 0 && MARK.test(char)) {
+      out[out.length - 1] += char;
+    } else if (out.length < max) {
+      out.push(char);
+    } else {
+      break;
+    }
+  }
+  return out;
+}
+
+function firstGrapheme(value: string): string {
+  return graphemes(value, 1)[0] ?? "";
+}
+
+// Avatar glyph for a name: `maxLetters` uppercased initials for Latin
+// scripts, one grapheme for RTL and CJK names, null so callers fall back.
+export function nameInitials(name: string, maxLetters: number): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+
+  const lead = firstGrapheme(trimmed);
+  if (firstStrongTextDir(trimmed) === "rtl" || CJK.test(lead)) {
+    return LETTER.test(lead) ? lead : null;
+  }
+
+  // Every taken slot must be a letter, so callers can fall back to
+  // their email or icon path instead of showing a partial glyph.
+  const words = trimmed.split(/\s+/);
+  if (words.length >= 2 || maxLetters === 1) {
+    const letters = words.slice(0, maxLetters).map(firstGrapheme);
+    if (!letters.every((grapheme) => LETTER.test(grapheme))) return null;
+    return letters.join("").toUpperCase();
+  }
+  const chars = graphemes(trimmed, maxLetters);
+  if (!chars.every((char) => LETTER.test(char))) return null;
+  return chars.join("").toUpperCase();
+}

--- a/web/src/lib/nameInitials.ts
+++ b/web/src/lib/nameInitials.ts
@@ -7,6 +7,9 @@ const CJK =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const LETTER = /\p{L}/u;
 const MARK = /\p{M}/u;
+// Viramas glue the following consonant into the same cluster.
+const VIRAMA =
+  /[\u094D\u09CD\u0A4D\u0ACD\u0B4D\u0BCD\u0C4D\u0CCD\u0D4D\u0DCA\u1039\u1B44\uA9C0]/u;
 
 // Grapheme-cluster segmentation keeps surrogate pairs, emoji, and
 // mark-bearing scripts intact where slice() would corrupt them.
@@ -22,23 +25,31 @@ function graphemes(value: string, max: number): string[] {
     }
     return out;
   }
-  // Legacy fallback: fold combining marks into the previous cluster so
-  // decomposed accents survive without Intl.Segmenter.
+  // Legacy fallback: fold combining marks, and consonants that follow a
+  // virama, into the previous cluster so decomposed accents and Indic
+  // conjuncts survive without Intl.Segmenter.
   const out: string[] = [];
+  let joinNext = false;
   for (const char of value) {
-    if (out.length > 0 && MARK.test(char)) {
+    if (out.length > 0 && (joinNext || MARK.test(char))) {
       out[out.length - 1] += char;
     } else if (out.length < max) {
       out.push(char);
     } else {
       break;
     }
+    joinNext = VIRAMA.test(char);
   }
   return out;
 }
 
 function firstGrapheme(value: string): string {
   return graphemes(value, 1)[0] ?? "";
+}
+
+/** True when the glyph is one grapheme, so avatars can size it up. */
+export function isSingleGrapheme(value: string): boolean {
+  return graphemes(value, 2).length === 1;
 }
 
 // Avatar glyph for a name: `maxLetters` uppercased initials for Latin

--- a/web/src/lib/nameInitials.ts
+++ b/web/src/lib/nameInitials.ts
@@ -55,12 +55,14 @@ export function nameInitials(name: string, maxLetters: number): string | null {
   // Every taken slot must be a letter, so callers can fall back to
   // their email or icon path instead of showing a partial glyph.
   const words = trimmed.split(/\s+/);
-  if (words.length >= 2 || maxLetters === 1) {
-    const letters = words.slice(0, maxLetters).map(firstGrapheme);
-    if (!letters.every((grapheme) => LETTER.test(grapheme))) return null;
-    return letters.join("").toUpperCase();
-  }
-  const chars = graphemes(trimmed, maxLetters);
-  if (!chars.every((char) => LETTER.test(char))) return null;
-  return chars.join("").toUpperCase();
+  const slots =
+    words.length >= 2 || maxLetters === 1
+      ? words.slice(0, maxLetters).map(firstGrapheme)
+      : graphemes(trimmed, maxLetters);
+  if (!slots.every((grapheme) => LETTER.test(grapheme))) return null;
+  // One glyph per slot: uppercasing can expand (ß becomes SS), so each
+  // slot keeps only the first grapheme of its uppercased form.
+  return slots
+    .map((grapheme) => firstGrapheme(grapheme.toUpperCase()))
+    .join("");
 }

--- a/web/src/lib/nameInitials.ts
+++ b/web/src/lib/nameInitials.ts
@@ -71,9 +71,13 @@ export function nameInitials(name: string, maxLetters: number): string | null {
       ? words.slice(0, maxLetters).map(firstGrapheme)
       : graphemes(trimmed, maxLetters);
   if (!slots.every((grapheme) => LETTER.test(grapheme))) return null;
-  // One glyph per slot: uppercasing can expand (ß becomes SS), so each
-  // slot keeps only the first grapheme of its uppercased form.
-  return slots
-    .map((grapheme) => firstGrapheme(grapheme.toUpperCase()))
-    .join("");
+  return slots.map(slotGlyph).join("");
+}
+
+// One glyph per slot: uppercasing can expand (ß becomes SS, ŉ becomes
+// ʼN), so keep the expansion's first uppercase letter when it has one.
+function slotGlyph(grapheme: string): string {
+  const upper = grapheme.toUpperCase();
+  const parts = graphemes(upper, 4);
+  return parts.find((part) => /\p{Lu}/u.test(part)) ?? parts[0] ?? upper;
 }

--- a/web/src/lib/users/svc.ts
+++ b/web/src/lib/users/svc.ts
@@ -1,4 +1,5 @@
 import { mutate } from "swr";
+import { nameInitials } from "@/lib/nameInitials";
 import { User, UserPersonalization } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { CustomRefreshTokenResponse } from "@/lib/users/types";
@@ -129,29 +130,21 @@ export function getUserEmail(user: User | null): string {
 /**
  * Derive display initials from a user's name or email.
  *
- * - If a name is provided, uses the first letter of the first two words.
+ * - A name resolves per its own script (see nameInitials): two Latin
+ *   initials, or one grapheme for RTL-script and CJK names.
  * - Falls back to the email local part, splitting on `.`, `_`, or `-`.
- * - Returns `null` when no valid alpha initials can be derived.
+ * - Returns `null` when no valid initials can be derived.
  */
 export function getUserInitials(
   name: string | null,
   email: string
 ): string | null {
   if (name) {
-    const words = name.trim().split(/\s+/);
-    if (words.length >= 2) {
-      const first = words[0]?.[0];
-      const second = words[1]?.[0];
-      if (first && second) {
-        const result = (first + second).toUpperCase();
-        if (/^[A-Z]{2}$/.test(result)) return result;
-      }
-      return null;
-    }
-    if (name.trim().length >= 1) {
-      const result = name.trim().slice(0, 2).toUpperCase();
-      if (/^[A-Z]{1,2}$/.test(result)) return result;
-    }
+    const fromName = nameInitials(name, 2);
+    if (fromName) return fromName;
+    // A multi-word name never falls back to email, keeping the previous
+    // contract where a bad second word invalidates the initials.
+    if (name.trim().split(/\s+/).length >= 2) return null;
   }
 
   const local = email.split("@")[0];

--- a/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@opal/utils";
 import type { IconProps } from "@opal/types";
 import Text from "@/refresh-components/texts/Text";
+import { nameInitials } from "@/lib/nameInitials";
 import Image from "next/image";
 import { DEFAULT_AVATAR_SIZE_PX } from "@/lib/constants";
 import {
@@ -129,17 +130,12 @@ export default function CustomAgentAvatar({
     );
   }
 
-  // Display first letter of name if available, otherwise fall back to two-line-small icon
-  const trimmedName = name?.trim();
-  const firstLetter =
-    trimmedName && trimmedName.length > 0
-      ? trimmedName[0]!.toUpperCase()
-      : undefined;
-  const validFirstLetter = !!firstLetter && /^[a-zA-Z]$/.test(firstLetter);
-  if (validFirstLetter) {
+  // One glyph per the name's script (see nameInitials), else the icon.
+  const glyph = name ? nameInitials(name, 1) : null;
+  if (glyph) {
     return (
       <SvgOctagonWrapper size={size}>
-        <Text style={{ fontSize: size * 0.5 }}>{firstLetter}</Text>
+        <Text style={{ fontSize: size * 0.5 }}>{glyph}</Text>
       </SvgOctagonWrapper>
     );
   }

--- a/web/src/refresh-components/avatars/UserAvatar.tsx
+++ b/web/src/refresh-components/avatars/UserAvatar.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_AVATAR_SIZE_PX } from "@/lib/constants";
 import { getUserEmail, getUserInitials } from "@/lib/users/svc";
 import Text from "@/refresh-components/texts/Text";
 import type { User } from "@/lib/types";
+import { isSingleGrapheme } from "@/lib/nameInitials";
 
 export interface UserAvatarProps {
   user: User | null;
@@ -44,7 +45,11 @@ export default function UserAvatar({
         secondaryAction
         text05
         className="select-none"
-        style={{ fontSize: size * 0.4 }}
+        // A lone grapheme fills the circle like the agent letter does,
+        // while two initials keep the width-driven size.
+        style={{
+          fontSize: size * (isSingleGrapheme(userInitials) ? 0.5 : 0.4),
+        }}
       >
         {userInitials}
       </Text>


### PR DESCRIPTION
## Description

**Why:** Avatar initials are a Latin-script habit. A user or agent with an Arabic, Hebrew, or CJK name got no glyph at all today, because the initials logic only accepted ASCII letters and fell back to a generic icon.

**What:** A shared `nameInitials` helper resolves the glyph from the script of the name, not the UI locale. Latin-script names keep the current shape: two initials for users, one letter for agents. RTL-script names show a single grapheme (محمد علي → م), since cursive scripts join adjacent letters into a word fragment rather than initials, and CJK names show their first character (王小明 → 王), the convention those scripts use. Graphemes come from `Intl.Segmenter`, so surrogate pairs, emoji, and mark-bearing scripts never get corrupted by slicing. Names with no usable letters keep the existing fallbacks (email-derived initials for users, the icon for agents), and the multi-word invalid-name contract is unchanged.

## How Has This Been Tested?

- `web/src/lib/nameInitials.test.ts`: 11 jest tests covering Latin, Arabic, Hebrew, Chinese, Korean, accented, emoji-leading, and numeric names.
- `web/src/lib/user.test.ts`: existing 13 `getUserInitials` tests pass unchanged.
- Live in Chrome on the dev stack with the display name set to an Arabic name.

| Before (Arabic name) | After |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/rtl-ui-screenshots/avatar-arabic-before.png) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/rtl-ui-screenshots/avatar-arabic-after-sized.png) |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
