### PR TITLE
fix(web): align the build tsconfig target with types:check

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Description

**Why:** The web image builds on `edge` fail type check: `next build` checks against `web/tsconfig.json`, which still targeted es5 and rejects `u`-flag Unicode regexes (TS1501) in `src/lib/rehypeDirection.ts` from #14393. Every other check (pre-commit, PR CI) runs `types:check` against `tsconfig.types.json` at ES2017, so nothing caught it before the Docker build.

**What:** Bumps `web/tsconfig.json` target from es5 to ES2017 to match `tsconfig.types.json`. Next transpiles via SWC per browserslist, so the target only governs type checking and lib assumptions.

## How Has This Been Tested?

- `tsc --noEmit --project tsconfig.json` (the failing invocation's config) exits clean with the new target.
- Full local `next build` compiles successfully and generates static pages, exit 0.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
