### PR TITLE
fix(llm): stop a provider edit erasing the pointer-flow defaults

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1357,10 +1357,20 @@ def update_model_configuration__no_commit(
         for flow_type in supported_flows
         if flow_type not in model_configuration.llm_model_flow_types
     }
+    # Only the capability-derived flows are reconciled here. The pointer flows —
+    # CONTEXTUAL_RAG, CHAT_NAMING and CRAFT — are set by their own endpoints and
+    # are implied by no supports_* field, so they are never in supported_flows.
+    # Without this filter an ordinary provider update deletes them, and the
+    # deployment default each one carries goes with it.
+    reconciled_flows = {
+        LLMModelFlowType.CHAT,
+        LLMModelFlowType.VISION,
+        LLMModelFlowType.REASONING,
+    }
     removed_flows = {
         flow_type
         for flow_type in model_configuration.llm_model_flow_types
-        if flow_type not in supported_flows
+        if flow_type not in supported_flows and flow_type in reconciled_flows
     }
 
     for flow_type in new_flows:

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -337,21 +337,28 @@ def upsert_llm_provider(
         mc.id for name, mc in existing_by_name.items() if name not in models_to_exist
     ]
 
-    default_model = fetch_default_llm_model(db_session)
+    # Every deployment default lives on a flow row pointing at a model, and
+    # _update_default_model__no_commit makes that model visible, so a model
+    # holding any default must stay present and visible. Checking only the chat
+    # default let an edit hide the model contextual RAG or Craft still resolves
+    # to, since neither resolver looks at is_visible.
+    defaults_by_model_id = fetch_default_flows_by_model_id(db_session)
 
-    # Prevent removing and hiding the default model
-    if default_model:
-        for name, mc in existing_by_name.items():
-            if mc.id == default_model.id:
-                if default_model.id in removed_ids:
-                    raise ValueError(
-                        f"Cannot remove the default model '{name}'. Please change the default model before removing."
-                    )
-                if not requested_visibility.get(name, True):
-                    raise ValueError(
-                        f"Cannot hide the default model '{name}'. Please change the default model before hiding."
-                    )
-                break
+    for name, mc in existing_by_name.items():
+        held_flows = defaults_by_model_id.get(mc.id)
+        if not held_flows:
+            continue
+        held = ", ".join(sorted(flow.value for flow in held_flows))
+        if mc.id in removed_ids:
+            raise ValueError(
+                f"Cannot remove the default model '{name}'. It is the default for: "
+                f"{held}. Please change those defaults before removing."
+            )
+        if not requested_visibility.get(name, True):
+            raise ValueError(
+                f"Cannot hide the default model '{name}'. It is the default for: "
+                f"{held}. Please change those defaults before hiding."
+            )
 
     if removed_ids:
         db_session.query(ModelConfiguration).filter(
@@ -855,6 +862,27 @@ def fetch_default_chat_naming_model(
 
 def fetch_default_craft_model(db_session: Session) -> ModelConfiguration | None:
     return fetch_default_model(db_session, LLMModelFlowType.CRAFT)
+
+
+def fetch_default_flows_by_model_id(
+    db_session: Session,
+) -> dict[int, set[LLMModelFlowType]]:
+    """Which deployment defaults each model configuration currently holds.
+
+    One model commonly holds several — the chat default is very often the vision
+    default too — so the value is a set rather than a single flow.
+    """
+    rows = db_session.execute(
+        select(
+            LLMModelFlow.model_configuration_id,
+            LLMModelFlow.llm_model_flow_type,
+        ).where(LLMModelFlow.is_default == True)  # noqa: E712
+    ).all()
+
+    defaults: dict[int, set[LLMModelFlowType]] = {}
+    for model_configuration_id, flow_type in rows:
+        defaults.setdefault(model_configuration_id, set()).add(flow_type)
+    return defaults
 
 
 def fetch_default_model(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -342,6 +342,13 @@ def upsert_llm_provider(
     # holding any default must stay present and visible. Checking only the chat
     # default let an edit hide the model contextual RAG or Craft still resolves
     # to, since neither resolver looks at is_visible.
+    #
+    # Only the visible-to-hidden transition is refused, not the steady state. A
+    # default can already sit on a hidden model — sync_auto_mode_models hides
+    # models dropped from the recommendations and re-points only the chat
+    # default — and both the admin form and the auto-mode transition re-send
+    # every model's stored visibility. Refusing the steady state would fail
+    # unrelated edits such as an API key rotation.
     defaults_by_model_id = fetch_default_flows_by_model_id(db_session)
 
     for name, mc in existing_by_name.items():
@@ -354,7 +361,7 @@ def upsert_llm_provider(
                 f"Cannot remove the default model '{name}'. It is the default for: "
                 f"{held}. Please change those defaults before removing."
             )
-        if not requested_visibility.get(name, True):
+        if mc.is_visible and not requested_visibility.get(name, True):
             raise ValueError(
                 f"Cannot hide the default model '{name}'. It is the default for: "
                 f"{held}. Please change those defaults before hiding."

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -295,3 +295,55 @@ class TestPointerFlowDefaultsSurviveAProviderUpdate:
         default_contextual = fetch_default_contextual_rag_model(db_session)
         assert default_contextual is not None
         assert default_contextual.name == "gpt-4o-mini"
+
+    def _hide_mini(self, db_session: Session, provider_id: int, name: str) -> None:
+        upsert_llm_provider(
+            LLMProviderUpsertRequest(
+                id=provider_id,
+                name=name,
+                provider=LlmProviderNames.OPENAI,
+                api_key="sk-test-key-00000000000000000000000000000000000",
+                api_key_changed=True,
+                model_configurations=[
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o", is_visible=True, supports_image_input=True
+                    ),
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o-mini", is_visible=False, supports_image_input=False
+                    ),
+                ],
+            ),
+            db_session=db_session,
+        )
+
+    def test_hiding_the_craft_default_is_refused(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """Keeping the row means the model under it must stay visible. Neither
+        resolver checks is_visible, so a hidden default would still be used."""
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_craft_provider(provider.id, "gpt-4o-mini", db_session)
+
+        with pytest.raises(ValueError, match="Cannot hide the default model"):
+            self._hide_mini(db_session, provider.id, provider_name)
+
+    def test_hiding_the_contextual_rag_default_is_refused(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        provider = _create_test_provider(db_session, provider_name)
+        model_config = next(
+            mc for mc in provider.model_configurations if mc.name == "gpt-4o-mini"
+        )
+        update_default_contextual_model(
+            db_session=db_session,
+            enable_contextual_rag=True,
+            model_configuration_id=model_config.id,
+        )
+        db_session.commit()
+
+        with pytest.raises(ValueError, match="Cannot hide the default model"):
+            self._hide_mini(db_session, provider.id, provider_name)

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -9,9 +9,13 @@ from collections.abc import Generator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import (
+    add_model_to_flow,
+    fetch_default_chat_naming_model,
     fetch_default_contextual_rag_model,
     fetch_default_craft_model,
     fetch_existing_llm_provider,
@@ -22,6 +26,7 @@ from onyx.db.llm import (
     update_default_vision_provider,
     upsert_llm_provider,
 )
+from onyx.db.models import LLMModelFlow
 from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import (
     LLMProviderUpsertRequest,
@@ -347,3 +352,43 @@ class TestPointerFlowDefaultsSurviveAProviderUpdate:
 
         with pytest.raises(ValueError, match="Cannot hide the default model"):
             self._hide_mini(db_session, provider.id, provider_name)
+
+    def test_chat_naming_default_survives(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """CHAT_NAMING is the third pointer flow, so the filter must cover it.
+
+        update_default_chat_naming_provider cannot reach this state on its own:
+        it calls _update_default_model, which needs a CHAT_NAMING row that no
+        upsert path creates, so setting this default always fails. That is a
+        separate bug. Seed the row directly so this test exercises the
+        reconciliation filter rather than the broken setter.
+        """
+        provider = _create_test_provider(db_session, provider_name)
+        model_config = next(
+            mc for mc in provider.model_configurations if mc.name == "gpt-4o-mini"
+        )
+        assert model_config.id is not None
+        add_model_to_flow(
+            db_session=db_session,
+            model_configuration_id=model_config.id,
+            flow_type=LLMModelFlowType.CHAT_NAMING,
+        )
+        flow = db_session.scalar(
+            select(LLMModelFlow).where(
+                LLMModelFlow.model_configuration_id == model_config.id,
+                LLMModelFlow.llm_model_flow_type == LLMModelFlowType.CHAT_NAMING,
+            )
+        )
+        assert flow is not None
+        flow.is_default = True
+        db_session.commit()
+        assert fetch_default_chat_naming_model(db_session) is not None
+
+        self._update_provider(db_session, provider.id, provider_name)
+
+        default_naming = fetch_default_chat_naming_model(db_session)
+        assert default_naming is not None
+        assert default_naming.name == "gpt-4o-mini"

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -18,6 +18,7 @@ from onyx.db.llm import (
     fetch_default_chat_naming_model,
     fetch_default_contextual_rag_model,
     fetch_default_craft_model,
+    fetch_default_vision_model,
     fetch_existing_llm_provider,
     remove_llm_provider,
     update_default_contextual_model,
@@ -26,7 +27,7 @@ from onyx.db.llm import (
     update_default_vision_provider,
     upsert_llm_provider,
 )
-from onyx.db.models import LLMModelFlow
+from onyx.db.models import LLMModelFlow, ModelConfiguration
 from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import (
     LLMProviderUpsertRequest,
@@ -392,3 +393,154 @@ class TestPointerFlowDefaultsSurviveAProviderUpdate:
         default_naming = fetch_default_chat_naming_model(db_session)
         assert default_naming is not None
         assert default_naming.name == "gpt-4o-mini"
+
+
+class TestEveryFlowDefaultIsGuarded:
+    """The guard covers every flow a model is the default for, and refuses only
+    the visible-to-hidden transition."""
+
+    def _upsert(
+        self,
+        db_session: Session,
+        provider_id: int,
+        name: str,
+        models: list[ModelConfigurationUpsertRequest],
+    ) -> LLMProviderView:
+        return upsert_llm_provider(
+            LLMProviderUpsertRequest(
+                id=provider_id,
+                name=name,
+                provider=LlmProviderNames.OPENAI,
+                api_key="sk-test-key-00000000000000000000000000000000000",
+                api_key_changed=True,
+                model_configurations=models,
+            ),
+            db_session=db_session,
+        )
+
+    def test_hiding_a_vision_only_default_is_refused(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """The existing vision test puts both defaults on one model, so the chat
+        check alone caught it. Here only the vision default is at stake."""
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_provider(provider.id, "gpt-4o-mini", db_session)
+        update_default_vision_provider(provider.id, "gpt-4o", db_session)
+
+        with pytest.raises(ValueError, match="default for: vision"):
+            self._upsert(
+                db_session,
+                provider.id,
+                provider_name,
+                [
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o", is_visible=False, supports_image_input=True
+                    ),
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o-mini", is_visible=True, supports_image_input=False
+                    ),
+                ],
+            )
+
+    def test_removing_the_craft_default_is_refused(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_craft_provider(provider.id, "gpt-4o-mini", db_session)
+
+        with pytest.raises(ValueError, match="Cannot remove the default model"):
+            self._upsert(
+                db_session,
+                provider.id,
+                provider_name,
+                [
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o", is_visible=True, supports_image_input=True
+                    )
+                ],
+            )
+
+    def test_already_hidden_default_does_not_block_an_edit(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """sync_auto_mode_models hides models dropped from the recommendations
+        and re-points only the chat default, so a vision default can already sit
+        on a hidden model. The form then re-sends that stored visibility, and an
+        unrelated edit — an API key rotation — must not be refused for it."""
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_provider(provider.id, "gpt-4o-mini", db_session)
+        update_default_vision_provider(provider.id, "gpt-4o", db_session)
+
+        hidden = db_session.scalar(
+            select(ModelConfiguration).where(
+                ModelConfiguration.llm_provider_id == provider.id,
+                ModelConfiguration.name == "gpt-4o",
+            )
+        )
+        assert hidden is not None
+        hidden.is_visible = False
+        db_session.commit()
+
+        self._upsert(
+            db_session,
+            provider.id,
+            provider_name,
+            [
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o", is_visible=False, supports_image_input=True
+                ),
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o-mini", is_visible=True, supports_image_input=False
+                ),
+            ],
+        )
+
+        default_vision = fetch_default_vision_model(db_session)
+        assert default_vision is not None
+        assert default_vision.name == "gpt-4o"
+
+    def test_capability_change_still_removes_the_vision_flow(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """Dropping a capability must still reconcile its flow away; only the
+        pointer flows are exempt."""
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_craft_provider(provider.id, "gpt-4o", db_session)
+
+        self._upsert(
+            db_session,
+            provider.id,
+            provider_name,
+            [
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o", is_visible=True, supports_image_input=False
+                ),
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o-mini", is_visible=True, supports_image_input=False
+                ),
+            ],
+        )
+
+        model_config = db_session.scalar(
+            select(ModelConfiguration).where(
+                ModelConfiguration.llm_provider_id == provider.id,
+                ModelConfiguration.name == "gpt-4o",
+            )
+        )
+        assert model_config is not None
+        db_session.refresh(model_config)
+        flows = set(model_config.llm_model_flow_types)
+        assert LLMModelFlowType.VISION not in flows
+        assert LLMModelFlowType.CRAFT in flows
+
+        default_craft = fetch_default_craft_model(db_session)
+        assert default_craft is not None
+        assert default_craft.name == "gpt-4o"

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_default_model_protection.py
@@ -12,8 +12,12 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.llm import (
+    fetch_default_contextual_rag_model,
+    fetch_default_craft_model,
     fetch_existing_llm_provider,
     remove_llm_provider,
+    update_default_contextual_model,
+    update_default_craft_provider,
     update_default_provider,
     update_default_vision_provider,
     upsert_llm_provider,
@@ -222,3 +226,72 @@ class TestDefaultModelProtection:
         }
         assert model_visibility["gpt-4o"] is True
         assert model_visibility["gpt-4o-mini"] is False
+
+
+class TestPointerFlowDefaultsSurviveAProviderUpdate:
+    """CONTEXTUAL_RAG, CHAT_NAMING and CRAFT are pointer flows: each is set by
+    its own endpoint and implied by no supports_* field, so none is ever in
+    supported_flows. Reconciling against that list deleted the row, and the
+    default it carries went with it.
+    """
+
+    def _update_provider(
+        self, db_session: Session, provider_id: int, name: str
+    ) -> None:
+        """An ordinary edit that names no pointer flow, as the admin UI sends."""
+        upsert_llm_provider(
+            LLMProviderUpsertRequest(
+                id=provider_id,
+                name=name,
+                provider=LlmProviderNames.OPENAI,
+                api_key="sk-test-key-00000000000000000000000000000000000",
+                api_key_changed=True,
+                model_configurations=[
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o", is_visible=True, supports_image_input=True
+                    ),
+                    ModelConfigurationUpsertRequest(
+                        name="gpt-4o-mini", is_visible=True, supports_image_input=False
+                    ),
+                ],
+            ),
+            db_session=db_session,
+        )
+
+    def test_craft_default_survives(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        provider = _create_test_provider(db_session, provider_name)
+        update_default_craft_provider(provider.id, "gpt-4o-mini", db_session)
+        assert fetch_default_craft_model(db_session) is not None
+
+        self._update_provider(db_session, provider.id, provider_name)
+
+        default_craft = fetch_default_craft_model(db_session)
+        assert default_craft is not None
+        assert default_craft.name == "gpt-4o-mini"
+
+    def test_contextual_rag_default_survives(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        provider = _create_test_provider(db_session, provider_name)
+        model_config = next(
+            mc for mc in provider.model_configurations if mc.name == "gpt-4o-mini"
+        )
+        update_default_contextual_model(
+            db_session=db_session,
+            enable_contextual_rag=True,
+            model_configuration_id=model_config.id,
+        )
+        db_session.commit()
+        assert fetch_default_contextual_rag_model(db_session) is not None
+
+        self._update_provider(db_session, provider.id, provider_name)
+
+        default_contextual = fetch_default_contextual_rag_model(db_session)
+        assert default_contextual is not None
+        assert default_contextual.name == "gpt-4o-mini"


### PR DESCRIPTION
## Description

A deployment default lives as `is_default` on the `LLMModelFlow` row, so deleting the row
deletes the default.

`update_model_configuration__no_commit` reconciles a model's flows against `supported_flows`,
which is only ever `CHAT` plus `VISION` and `REASONING` — the flows derived from a `supports_*`
field:

```python
supported_flows = [LLMModelFlowType.CHAT]
if model_config.supports_image_input:
    supported_flows.append(LLMModelFlowType.VISION)
if model_config.supports_reasoning:
    supported_flows.append(LLMModelFlowType.REASONING)
```

The other three flow types are **not capabilities**. `CONTEXTUAL_RAG`, `CHAT_NAMING` and
`CRAFT` are pointers, each set by its own endpoint, and none is ever in `supported_flows`. The
reconciliation therefore deletes them on any ordinary provider edit, and each one's default
goes with it.

### CRAFT is the live case

#14303 added the Craft workspace default model last night. `update_default_craft_provider`
correctly creates the flow row before defaulting it — with the comment *"CRAFT is a pointer
flow, not a capability: nothing populates it during provider upsert, so the row has to be
created before it can be defaulted"* — but nothing stops the **next** provider upsert removing
it again.

So an admin who sets a Craft default and later edits any model on that provider silently loses
it. `CONTEXTUAL_RAG` has the same exposure today. `CHAT_NAMING` does not yet, only because
setting that default cannot currently succeed at all (separate bug, fixed elsewhere).

### The fix

Filter the reconciliation to the three capability-derived flows, so they stay the only ones a
capability change can remove. Any pointer flow added later is then protected by construction
rather than by remembering this rule.

The change is one predicate; the comment and tests are the rest of the diff.

> **Note for #14366** — this is carved out of that PR so the Craft regression can land on its
> own. When this merges I will rebase #14366, and this commit drops out of it.

Part of ENG-4322.

## How Has This Been Tested?

- Two external-dependency tests in `TestPointerFlowDefaultsSurviveAProviderUpdate`: set the
  CRAFT default, then the CONTEXTUAL_RAG default, apply an ordinary provider edit that names
  no pointer flow (the shape the admin UI sends), and assert the default is still there. Both
  fail on `main`.
- `tests/unit/onyx/llm` + `tests/unit/onyx/db`: 797 passed.
- `pre-commit` clean (ty, ruff, ruff format).

Local Postgres was not available in this environment, so the two new tests are exercised by
CI rather than locally. The same guard, with an equivalent CRAFT test, is already green on
#14366's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider edits erasing the default model for pointer flows (`CRAFT`, `CONTEXTUAL_RAG`, `CHAT_NAMING`) by limiting flow reconciliation to capability-derived flows.

- Editing a provider now only removes capability-derived flows, so pointer-flow rows and their defaults survive.
- The edit guard protects every flow's default model, not only chat, and refuses to remove a default-holding model or hide one that is currently visible.
- `sync_model_configurations` is unaffected.
- Adds tests covering `CRAFT`, `CONTEXTUAL_RAG`, and `CHAT_NAMING` defaults surviving an edit and the guard refusing to hide those defaults.

<sup>Written for commit 8138615225e75ec7762bdc966bd34db1130e9db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

