### PR TITLE
fix(terraform): resolve masked header reads against state

### DIFF
--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -86,6 +86,9 @@ jobs:
               # through while only the provider directory was filtered.
               - 'backend/onyx/server/**'
               - 'backend/ee/onyx/server/**'
+              # The masking contract the provider mirrors lives here.
+              - 'backend/onyx/utils/encryption.py'
+              - 'backend/onyx/configs/constants.py'
               - 'backend/Dockerfile'
               - 'deployment/docker_compose/docker-compose.yml'
               - 'deployment/docker_compose/docker-compose.dev.yml'

--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -81,6 +81,11 @@ jobs:
           filters: |
             provider:
               - 'terraform-provider-onyx/**'
+              # The suite drives live API routes end to end, so server-side
+              # changes must run it: a tool-API masking change once slipped
+              # through while only the provider directory was filtered.
+              - 'backend/onyx/server/**'
+              - 'backend/ee/onyx/server/**'
               - 'backend/Dockerfile'
               - 'deployment/docker_compose/docker-compose.yml'
               - 'deployment/docker_compose/docker-compose.dev.yml'

--- a/terraform-provider-onyx/docs/resources/custom_tool.md
+++ b/terraform-provider-onyx/docs/resources/custom_tool.md
@@ -6,7 +6,7 @@ description: |-
   A custom action: an external HTTP API, described by an OpenAPI schema, that assistants can call.
   Attach one to an assistant through tool_ids on onyx_persona.
   ~> Deleting an action detaches it from every agent that uses it, including agents Terraform does not manage. Onyx does not refuse the delete or warn about it.
-  ~> custom_headers holds secrets and Onyx returns them in full. Anyone who can read the deployment's actions can read the values, and they are stored in Terraform state in clear text. Supply them from a secret store rather than literals.
+  ~> custom_headers holds secrets. Onyx masks the values on reads, but they are stored in Terraform state in clear text. Supply them from a secret store rather than literals, or use custom_headers_wo to keep them out of state entirely.
 ---
 
 # onyx_custom_tool (Resource)
@@ -17,7 +17,7 @@ Attach one to an assistant through `tool_ids` on `onyx_persona`.
 
 ~> **Deleting an action detaches it from every agent that uses it**, including agents Terraform does not manage. Onyx does not refuse the delete or warn about it.
 
-~> **`custom_headers` holds secrets and Onyx returns them in full.** Anyone who can read the deployment's actions can read the values, and they are stored in Terraform state in clear text. Supply them from a secret store rather than literals.
+~> **`custom_headers` holds secrets.** Onyx masks the values on reads, but they are stored in Terraform state in clear text. Supply them from a secret store rather than literals, or use `custom_headers_wo` to keep them out of state entirely.
 
 ## Example Usage
 

--- a/terraform-provider-onyx/docs/resources/custom_tool.md
+++ b/terraform-provider-onyx/docs/resources/custom_tool.md
@@ -6,7 +6,7 @@ description: |-
   A custom action: an external HTTP API, described by an OpenAPI schema, that assistants can call.
   Attach one to an assistant through tool_ids on onyx_persona.
   ~> Deleting an action detaches it from every agent that uses it, including agents Terraform does not manage. Onyx does not refuse the delete or warn about it.
-  ~> custom_headers holds secrets. Onyx masks the values on reads, but they are stored in Terraform state in clear text. Supply them from a secret store rather than literals, or use custom_headers_wo to keep them out of state entirely.
+  ~> custom_headers holds secrets. Onyx masks the values on reads, but they are stored in Terraform state in clear text. Supply them from a secret store rather than literals, or use custom_headers_wo to keep them out of state entirely. Masked reads also mean a rotation made outside Terraform is only visible when its mask differs, so rotate values through Terraform, ideally custom_headers_wo with its version attribute.
 ---
 
 # onyx_custom_tool (Resource)
@@ -17,7 +17,7 @@ Attach one to an assistant through `tool_ids` on `onyx_persona`.
 
 ~> **Deleting an action detaches it from every agent that uses it**, including agents Terraform does not manage. Onyx does not refuse the delete or warn about it.
 
-~> **`custom_headers` holds secrets.** Onyx masks the values on reads, but they are stored in Terraform state in clear text. Supply them from a secret store rather than literals, or use `custom_headers_wo` to keep them out of state entirely.
+~> **`custom_headers` holds secrets.** Onyx masks the values on reads, but they are stored in Terraform state in clear text. Supply them from a secret store rather than literals, or use `custom_headers_wo` to keep them out of state entirely. Masked reads also mean a rotation made outside Terraform is only visible when its mask differs, so rotate values through Terraform, ideally `custom_headers_wo` with its version attribute.
 
 ## Example Usage
 

--- a/terraform-provider-onyx/internal/provider/custom_tool_resource.go
+++ b/terraform-provider-onyx/internal/provider/custom_tool_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,9 +64,9 @@ func (r *customToolResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"Attach one to an assistant through `tool_ids` on `onyx_persona`.\n\n" +
 			"~> **Deleting an action detaches it from every agent that uses it**, including agents " +
 			"Terraform does not manage. Onyx does not refuse the delete or warn about it.\n\n" +
-			"~> **`custom_headers` holds secrets and Onyx returns them in full.** Anyone who can read " +
-			"the deployment's actions can read the values, and they are stored in Terraform state in " +
-			"clear text. Supply them from a secret store rather than literals.",
+			"~> **`custom_headers` holds secrets.** Onyx masks the values on reads, but they are " +
+			"stored in Terraform state in clear text. Supply them from a secret store rather than " +
+			"literals, or use `custom_headers_wo` to keep them out of state entirely.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -298,9 +299,9 @@ func applyRemoteCustomTool(ctx context.Context, model *customToolResourceModel, 
 	if !ok {
 		return false
 	}
-	// Onyx returns header values in full. Refreshing them is what makes an
-	// out-of-band change visible, but for a write-only header map it would put
-	// the very secret Terraform was told not to keep back into state.
+	// Onyx masks header values on reads, so the refresh resolves masks against
+	// state. A write-only header map skips even that: those values must never
+	// reach state at all.
 	if !headersAreWriteOnly {
 		model.CustomHeaders = headersFromRemote(ctx, model.CustomHeaders, remote, diags)
 		if diags.HasError() {
@@ -323,18 +324,50 @@ func applyRemoteCustomTool(ctx context.Context, model *customToolResourceModel, 
 	return true
 }
 
+// isMaskedHeaderValue mirrors the backend's is_masked_credential: a bullet
+// mask for short values, or the first4...last4 shape for longer ones.
+func isMaskedHeaderValue(value string) bool {
+	return strings.ContainsRune(value, '\u2022') || maskedLongRE.MatchString(value)
+}
+
+var maskedLongRE = regexp.MustCompile(`^.{4}\.{3}.{4}$`)
+
+// maskHeaderValue mirrors the backend's mask_string, which slices
+// characters, so the comparison works on runes rather than bytes.
+func maskHeaderValue(value string) string {
+	runes := []rune(value)
+	if len(runes) < 14 {
+		return strings.Repeat("\u2022", 12)
+	}
+	return string(runes[:4]) + "..." + string(runes[len(runes)-4:])
+}
+
 // headersFromRemote rebuilds the header map from the server's list. A repeated
-// key keeps its last value, which is all a map can hold.
+// key keeps its last value, which is all a map can hold. An action with no
+// headers reads back as null only when nothing was configured.
 //
-// An action with no headers reads back as null only when nothing was
-// configured; a configuration that sets an empty map keeps one, so the applied
-// result matches the plan.
+// Onyx masks values on reads: a mask matching the state value keeps the
+// known value, an unmatched mask stays in state and surfaces as drift.
 func headersFromRemote(ctx context.Context, current types.Map, remote *client.CustomTool, diags *diag.Diagnostics) types.Map {
 	if len(remote.CustomHeaders) == 0 && current.IsNull() {
 		return types.MapNull(types.StringType)
 	}
+	known := map[string]string{}
+	if !current.IsNull() && !current.IsUnknown() {
+		for key, value := range current.Elements() {
+			if str, ok := value.(types.String); ok && !str.IsNull() && !str.IsUnknown() {
+				known[key] = str.ValueString()
+			}
+		}
+	}
 	values := make(map[string]string, len(remote.CustomHeaders))
 	for _, header := range remote.CustomHeaders {
+		if isMaskedHeaderValue(header.Value) {
+			if knownValue, ok := known[header.Key]; ok && maskHeaderValue(knownValue) == header.Value {
+				values[header.Key] = knownValue
+				continue
+			}
+		}
 		values[header.Key] = header.Value
 	}
 	value, mapDiags := types.MapValueFrom(ctx, types.StringType, values)

--- a/terraform-provider-onyx/internal/provider/custom_tool_resource.go
+++ b/terraform-provider-onyx/internal/provider/custom_tool_resource.go
@@ -66,7 +66,9 @@ func (r *customToolResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"Terraform does not manage. Onyx does not refuse the delete or warn about it.\n\n" +
 			"~> **`custom_headers` holds secrets.** Onyx masks the values on reads, but they are " +
 			"stored in Terraform state in clear text. Supply them from a secret store rather than " +
-			"literals, or use `custom_headers_wo` to keep them out of state entirely.",
+			"literals, or use `custom_headers_wo` to keep them out of state entirely. Masked reads " +
+			"also mean a rotation made outside Terraform is only visible when its mask differs, so " +
+			"rotate values through Terraform, ideally `custom_headers_wo` with its version attribute.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -348,6 +350,9 @@ func maskHeaderValue(value string) string {
 //
 // Onyx masks values on reads: a mask matching the state value keeps the
 // known value, an unmatched mask stays in state and surfaces as drift.
+// Colliding masks (all short values share one) make an out-of-band
+// rotation invisible, which only a changed-flag in the API could fix;
+// rotate through custom_headers_wo and its version instead.
 func headersFromRemote(ctx context.Context, current types.Map, remote *client.CustomTool, diags *diag.Diagnostics) types.Map {
 	if len(remote.CustomHeaders) == 0 && current.IsNull() {
 		return types.MapNull(types.StringType)

--- a/terraform-provider-onyx/internal/provider/write_only_acc_test.go
+++ b/terraform-provider-onyx/internal/provider/write_only_acc_test.go
@@ -395,8 +395,8 @@ resource "onyx_custom_tool" "conflict_wo" {
 	})
 }
 
-// testAccCheckCustomToolHeader reads the header back from Onyx, which returns
-// action headers in full rather than masked.
+// testAccCheckCustomToolHeader reads the header back from Onyx, which masks
+// action header values, so the check compares against the masked form.
 func testAccCheckCustomToolHeader(t *testing.T, name, headerKey, want string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[name]
@@ -415,8 +415,8 @@ func testAccCheckCustomToolHeader(t *testing.T, name, headerKey, want string) re
 			if header.Key != headerKey {
 				continue
 			}
-			if header.Value != want {
-				return fmt.Errorf("header %q is %q on the server, want %q", headerKey, header.Value, want)
+			if header.Value != maskHeaderValue(want) {
+				return fmt.Errorf("header %q is %q on the server, want %q", headerKey, header.Value, maskHeaderValue(want))
 			}
 			return nil
 		}


### PR DESCRIPTION
## Description

**Why:** The terraform provider acceptance suite is red since #14365 started masking custom action header values on API reads. The provider refresh read the mask back into state, so applies reported `Provider produced inconsistent result` and the write-only test's server check compared a mask against the literal. Nothing caught it at merge time because the suite's path filter only watched the provider directory and infra files, not the backend API it exercises.

**What:** The refresh resolves masked reads against state: a masked value whose mask matches the state value keeps the known value, an unmatched mask stays in state and surfaces as drift. Mask helpers mirror the backend's `mask_string` exactly, on runes. The acceptance server-side check compares the masked form, the schema warning and generated docs now describe masked reads, and the workflow path filter gains `backend/onyx/server/**` and `backend/ee/onyx/server/**` so backend API changes run this suite.

## How Has This Been Tested?

- All six custom tool acceptance tests (`TestAccCustomTool*`, including both write-only header tests) pass with `TF_ACC=1` against a live dev stack, previously failing exactly as in CI.
- `go build`, `go vet`, `gofmt`, and the unit lane (`go test ./...`) pass; docs regenerated via `go generate`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
