### PR TITLE
fix(web): treat enterprise-settings 404 as CE, not a fatal error

### DIFF
--- a/web/src/lib/fetcher.ts
+++ b/web/src/lib/fetcher.ts
@@ -40,6 +40,10 @@ export function isAuthStatusError(error: unknown): boolean {
   );
 }
 
+export function isNotFoundError(error: unknown): boolean {
+  return error instanceof FetchError && error.status === 404;
+}
+
 /**
  * SWR `onErrorRetry` callback that suppresses automatic retries for
  * auth or tier-gated errors (401/402/403). Pass this to any SWR hook whose

--- a/web/src/lib/settings/hooks.test.tsx
+++ b/web/src/lib/settings/hooks.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import useSWR from "swr";
+import { usePathname } from "next/navigation";
+import { FetchError } from "@/lib/fetcher";
+import { useSettings } from "@/lib/settings/hooks";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  ...jest.requireActual("next/navigation"),
+  usePathname: jest.fn(),
+}));
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+function swrResult(overrides: { error?: Error } = {}) {
+  return {
+    data: undefined,
+    error: undefined,
+    mutate: jest.fn(),
+    isValidating: false,
+    isLoading: false,
+    ...overrides,
+  } as unknown as ReturnType<typeof useSWR>;
+}
+
+function stubEnterpriseFetchError(error: Error) {
+  mockUseSWR.mockImplementation((key) =>
+    key === SWR_KEYS.enterpriseSettings ? swrResult({ error }) : swrResult()
+  );
+}
+
+function enterpriseRetryPolicy(): (err: Error) => boolean {
+  const call = mockUseSWR.mock.calls.find(
+    ([key]) => key === SWR_KEYS.enterpriseSettings
+  );
+  expect(call).toBeDefined();
+  const config = call?.[2] as { shouldRetryOnError: (err: Error) => boolean };
+  return config.shouldRetryOnError;
+}
+
+// A CE backend has no enterprise-settings route. The login page probes it
+// anyway, so the 404 must degrade to default branding, not a fatal error.
+describe("useSettings enterprise-settings 404 handling", () => {
+  beforeEach(() => {
+    mockUseSWR.mockReset();
+    mockUsePathname.mockReset();
+    mockUsePathname.mockReturnValue("/auth/login");
+  });
+
+  test("a 404 yields default branding with no error and no retry", () => {
+    const missing = new FetchError("Not Found", 404, {});
+    stubEnterpriseFetchError(missing);
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.enterprise).toBeNull();
+    expect(result.current.appName).toBe("Onyx");
+    expect(result.current.logoUrl).toBeNull();
+    expect(enterpriseRetryPolicy()(missing)).toBe(false);
+  });
+
+  test("a 404 off the auth path is not surfaced either", () => {
+    mockUsePathname.mockReturnValue("/app");
+    stubEnterpriseFetchError(new FetchError("Not Found", 404, {}));
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.enterprise).toBeNull();
+  });
+
+  test("other enterprise-settings failures still surface and retry", () => {
+    const outage = new FetchError("Internal Server Error", 500, {});
+    stubEnterpriseFetchError(outage);
+    const { result } = renderHook(() => useSettings());
+    expect(result.current.error).toBe(outage);
+    expect(enterpriseRetryPolicy()(outage)).toBe(true);
+  });
+});

--- a/web/src/lib/settings/hooks.ts
+++ b/web/src/lib/settings/hooks.ts
@@ -4,7 +4,7 @@ import useSWR from "swr";
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
 import useCCPairs from "@/hooks/useCCPairs";
-import { errorHandlingFetcher } from "@/lib/fetcher";
+import { errorHandlingFetcher, isNotFoundError } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { isAuthPath } from "@/lib/auth/paths";
 import {
@@ -33,6 +33,10 @@ const DEFAULT_SETTINGS: Settings = {
   reasoning_override_enabled: true,
   query_history_type: QueryHistoryType.NORMAL,
 };
+
+// A CE backend never registers the enterprise-settings route, so its 404
+// means no enterprise settings, not an outage: no error and no retry.
+const isEnterpriseSettingsMissing = isNotFoundError;
 
 /**
  * The single settings hook. Returns a fully-derived `AppSettings` object that
@@ -64,7 +68,7 @@ export function useSettings(): AppSettings {
 
   const core = rawSettings ?? DEFAULT_SETTINGS;
   // Auth pages need branding pre-sign-in but standard web images lack the EE
-  // flag, so probe the endpoint. A CE backend 404s once (no retry below).
+  // flag, so probe the endpoint.
   const shouldFetchEnterprise =
     EE_ENABLED ||
     onAuthPath ||
@@ -83,9 +87,7 @@ export function useSettings(): AppSettings {
       revalidateIfStale: false,
       dedupingInterval: 30_000,
       errorRetryInterval: SETTINGS_ERROR_RETRY_INTERVAL,
-      // No retry on auth pages: a CE backend 404s this endpoint and the login
-      // page should settle on default branding instead of re-fetching.
-      shouldRetryOnError: !onAuthPath,
+      shouldRetryOnError: (err) => !isEnterpriseSettingsMissing(err),
       // Referential equality — logo can change without JSON changing, so
       // mutate() must propagate a new reference for cache-busters.
       compare: (a, b) => a === b,
@@ -111,7 +113,11 @@ export function useSettings(): AppSettings {
       !settingsLoading && !settingsError && core.vector_db_enabled !== false,
     isLoading:
       settingsLoading || (shouldFetchEnterprise ? enterpriseLoading : false),
-    error: settingsError ?? enterpriseError,
+    error:
+      settingsError ??
+      (isEnterpriseSettingsMissing(enterpriseError)
+        ? undefined
+        : enterpriseError),
   };
 }
 


### PR DESCRIPTION
## Description

**Why:** Community Edition deployments (`LICENSE_ENFORCEMENT_ENABLED=false`, no paid EE flag) on v4.6.5 get "We encountered an issue" on `/auth/login` (#14384). #14244 made the login page fetch `/api/enterprise-settings` for branding. A CE backend never registers that route, so the 404 landed in `useSettings().error`, and `SettingsProvider` only tolerates 401/403.

**What:** `useSettings` treats a 404 from `/api/enterprise-settings` as "no enterprise settings": `enterprise` stays `null`, no error, no SWR retry, on every route. Other failures still surface and retry. EE deployments are unchanged. The status predicate (`isNotFoundError`) lives in `fetcher.ts` next to `isAuthStatusError`.

Fixes #14384

## How Has This Been Tested?

Live against a CE backend (`LICENSE_ENFORCEMENT_ENABLED=false`, `AUTH_TYPE=basic`) on a copy of a dev database (1466 users, SSO providers configured), first with the published `onyx-backend:v4.6.5` image and then with main, in Chrome through the web dev server:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/ce-login-404/before.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/ce-login-404/after.jpg) |

The test browser runs with an Arabic locale, so the RTL copy is unrelated to this change.

- Before: the 404 produces the error card, with the same request log as the report (`GET /enterprise-settings 404`, `GET /me 403`, `GET /auth/type 200`).
- After: the login form renders with default branding, the 404 happens once and is not retried (no further requests over 10s), and `/api/auth/login` plus `/api/me` work on the same backend.
- New `web/src/lib/settings/hooks.test.tsx`: 404 on `/auth/login`, 404 off the auth path, and a 500 that still surfaces and retries. All 3 fail on the unfixed hook and pass with the fix. `paths.test.tsx` still passes.
- `bun run types:check`, oxfmt, and oxlint are clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
