### PR TITLE
fix: prevent document set deletion FK violations

### DIFF
--- a/backend/alembic/versions/947b94d2ebf1_cascade_document_set_group_deletion.py
+++ b/backend/alembic/versions/947b94d2ebf1_cascade_document_set_group_deletion.py
@@ -1,0 +1,43 @@
+"""cascade document set group deletion
+
+Revision ID: 947b94d2ebf1
+Revises: 34fe28843029
+Create Date: 2026-09-01 16:51:10.561206
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "947b94d2ebf1"
+down_revision = "34fe28843029"
+branch_labels = None
+depends_on = None
+
+FK_NAME = "document_set__user_group_document_set_id_fkey"
+TABLE_NAME = "document_set__user_group"
+PARENT_TABLE_NAME = "document_set"
+
+
+def upgrade() -> None:
+    op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        TABLE_NAME,
+        PARENT_TABLE_NAME,
+        ["document_set_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        TABLE_NAME,
+        PARENT_TABLE_NAME,
+        ["document_set_id"],
+        ["id"],
+    )

--- a/backend/alembic/versions/947b94d2ebf1_cascade_document_set_group_deletion.py
+++ b/backend/alembic/versions/947b94d2ebf1_cascade_document_set_group_deletion.py
@@ -1,7 +1,7 @@
 """cascade document set group deletion
 
 Revision ID: 947b94d2ebf1
-Revises: 34fe28843029
+Revises: 77962d18fd41
 Create Date: 2026-09-01 16:51:10.561206
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "947b94d2ebf1"
-down_revision = "34fe28843029"
+down_revision = "77962d18fd41"
 branch_labels = None
 depends_on = None
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5162,7 +5162,7 @@ class DocumentSet__UserGroup(Base):
     __tablename__ = "document_set__user_group"
 
     document_set_id: Mapped[int] = mapped_column(
-        ForeignKey("document_set.id"), primary_key=True
+        ForeignKey("document_set.id", ondelete="CASCADE"), primary_key=True
     )
     user_group_id: Mapped[int] = mapped_column(
         ForeignKey("user_group.id"), primary_key=True

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -187,7 +187,8 @@ def delete_document_set(
     db_session: Session = Depends(get_session),
     tenant_id: str = Depends(get_current_tenant_id),
 ) -> None:
-    document_set = get_document_set_by_id(db_session, document_set_id)
+    # Serialize the delete marker with document-set and group-share updates.
+    document_set = get_document_set_by_id(db_session, document_set_id, for_update=True)
     if document_set is None:
         raise OnyxError(
             OnyxErrorCode.DOCUMENT_SET_NOT_FOUND,

--- a/backend/tests/external_dependency_unit/db/test_document_set_delete_cascade.py
+++ b/backend/tests/external_dependency_unit/db/test_document_set_delete_cascade.py
@@ -1,0 +1,71 @@
+"""Verify document-set deletion locks mutations and removes group-share rows."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.document_set import delete_document_set
+from onyx.db.enums import PermissionAuthority
+from onyx.db.models import DocumentSet, DocumentSet__UserGroup, User, UserGroup
+from onyx.server.features.document_set import api
+
+DOCUMENT_SET_ID = 42
+TENANT_ID = "test-tenant"
+
+
+def test_delete_endpoint_locks_document_set() -> None:
+    document_set = DocumentSet(id=DOCUMENT_SET_ID, name="locked-document-set")
+    user = MagicMock(spec=User)
+    db_session = MagicMock(spec=Session)
+
+    with (
+        patch.object(api, "get_document_set_by_id", return_value=document_set) as get,
+        patch.object(
+            api,
+            "has_permission",
+            return_value=PermissionAuthority.GLOBAL,
+        ),
+        patch.object(api, "mark_document_set_as_to_be_deleted"),
+        patch.object(api.client_app, "send_task"),
+        patch.object(api, "DISABLE_VECTOR_DB", False),
+    ):
+        api.delete_document_set(
+            document_set_id=DOCUMENT_SET_ID,
+            user=user,
+            db_session=db_session,
+            tenant_id=TENANT_ID,
+        )
+
+    get.assert_called_once_with(db_session, DOCUMENT_SET_ID, for_update=True)
+
+
+def test_delete_document_set_cascades_user_group_link(
+    db_session: Session,
+) -> None:
+    user_group = UserGroup(name=f"doc-set-delete-{uuid4().hex[:12]}")
+    document_set = DocumentSet(name=f"doc-set-delete-{uuid4().hex[:12]}")
+    db_session.add_all([user_group, document_set])
+    db_session.flush()
+
+    document_set_id = document_set.id
+    db_session.add(
+        DocumentSet__UserGroup(
+            document_set_id=document_set_id,
+            user_group_id=user_group.id,
+        )
+    )
+    db_session.commit()
+
+    delete_document_set(document_set, db_session)
+
+    link = db_session.scalar(
+        select(DocumentSet__UserGroup).where(
+            DocumentSet__UserGroup.document_set_id == document_set_id
+        )
+    )
+    assert link is None
+
+    db_session.delete(user_group)
+    db_session.commit()


### PR DESCRIPTION
## Description

- Cascade document-set deletion through user-group sharing rows.
- Lock document sets while deletion starts to serialize concurrent sharing updates.
- Add regression coverage for the lock and database cascade.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/external_dependency_unit/db/test_document_set_delete_cascade.py backend/tests/external_dependency_unit/db/test_document_set_get_by_id.py`
- `uv run pre-commit run --files backend/onyx/db/models.py backend/onyx/server/features/document_set/api.py backend/alembic/versions/947b94d2ebf1_cascade_document_set_group_deletion.py backend/tests/external_dependency_unit/db/test_document_set_delete_cascade.py`

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes document set deletion failing with foreign key violations when the document set is shared with user groups. Deleting a document set now cascades through `document_set__user_group` rows, and the delete endpoint locks the document set row so concurrent sharing updates can't race with deletion.

- Adds an Alembic migration that sets `ON DELETE CASCADE` on the `document_set__user_group` foreign key.
- The delete endpoint now fetches the document set with `for_update=True` to serialize concurrent updates.
- Adds regression tests covering the lock and the database cascade.

<sup>Written for commit 304264748a131a2a84df35c62bda4e922f3ae22f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

