### PR TITLE
feat: add encrypted voice provider API secret column

### DIFF
--- a/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
+++ b/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
@@ -1,7 +1,7 @@
 """add voice provider api secret
 
 Revision ID: 287021f3b46c
-Revises: 34fe28843029
+Revises: 77962d18fd41
 Create Date: 2026-08-27 10:38:32.439483
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "287021f3b46c"
-down_revision = "34fe28843029"
+down_revision = "77962d18fd41"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
+++ b/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
@@ -1,0 +1,28 @@
+"""add voice provider api secret
+
+Revision ID: 287021f3b46c
+Revises: 34fe28843029
+Create Date: 2026-08-27 10:38:32.439483
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "287021f3b46c"
+down_revision = "34fe28843029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "voice_provider",
+        sa.Column("api_secret", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("voice_provider", "api_secret")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3796,6 +3796,9 @@ class VoiceProvider(Base):
     api_key: Mapped[SensitiveValue[str] | None] = mapped_column(
         EncryptedString(), nullable=True
     )
+    api_secret: Mapped[SensitiveValue[str] | None] = mapped_column(
+        EncryptedString(), nullable=True
+    )
     api_base: Mapped[str | None] = mapped_column(String, nullable=True)
     custom_config: Mapped[dict[str, Any] | None] = mapped_column(
         postgresql.JSONB(), nullable=True


### PR DESCRIPTION
## Summary
Adds a nullable encrypted `voice_provider.api_secret` column and the ORM field for voice providers that need a second credential. Existing providers remain valid because the column is nullable.

## Stack
- This is PR 1 in the stack.
- Follow-up API PR: #14422

## Linear
- [x] Override Linear Check

## Verification
- `cd backend && uv run alembic heads` -> `287021f3b46c (head)`
- `uv run pre-commit run --files backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py backend/onyx/db/models.py`
