### PR TITLE
feat: add voice provider API secret admin support

### DIFF
--- a/backend/onyx/db/voice.py
+++ b/backend/onyx/db/voice.py
@@ -59,6 +59,8 @@ def upsert_voice_provider(
     provider_type: str,
     api_key: str | None,
     api_key_changed: bool,
+    api_secret: str | None = None,
+    api_secret_changed: bool = False,
     api_base: str | None = None,
     custom_config: dict[str, Any] | None = None,
     stt_model: str | None = None,
@@ -96,6 +98,9 @@ def upsert_voice_provider(
     # Only update API key if explicitly changed or if provider has no key
     if api_key_changed or provider.api_key is None:
         provider.api_key = api_key  # ty: ignore[invalid-assignment]
+
+    if api_secret_changed or provider.api_secret is None:
+        provider.api_secret = api_secret  # ty: ignore[invalid-assignment]
 
     db_session.flush()
 

--- a/backend/onyx/server/manage/voice/api.py
+++ b/backend/onyx/server/manage/voice/api.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 from fastapi import APIRouter, Depends, Response
 from sqlalchemy.orm import Session
 
@@ -36,8 +38,57 @@ logger = setup_logger()
 admin_router = APIRouter(prefix="/admin/voice")
 
 VOICE_PROVIDER_VALIDATION_FAILURE_MESSAGE = (
-    "Connection test failed. Please verify your API key and settings."
+    "Connection test failed. Please verify your credentials and settings."
 )
+STORED_API_SECRET_PLACEHOLDER = "********"
+_CUSTOM_CONFIG_CREDENTIAL_KEYS = {"api_key", "api_secret"}
+
+
+def _contains_custom_config_credential_key(value: object) -> bool:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            if isinstance(key, str) and key.lower() in _CUSTOM_CONFIG_CREDENTIAL_KEYS:
+                return True
+            if _contains_custom_config_credential_key(nested_value):
+                return True
+    if isinstance(value, list):
+        return any(_contains_custom_config_credential_key(item) for item in value)
+    return False
+
+
+def _reject_custom_config_credentials(
+    custom_config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if custom_config is not None and _contains_custom_config_credential_key(
+        custom_config
+    ):
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Voice provider custom_config cannot contain API credentials.",
+        )
+    return custom_config
+
+
+def _sanitize_custom_config_for_response(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_custom_config_for_response(nested_value)
+            for key, nested_value in value.items()
+            if not (
+                isinstance(key, str) and key.lower() in _CUSTOM_CONFIG_CREDENTIAL_KEYS
+            )
+        }
+    if isinstance(value, list):
+        return [_sanitize_custom_config_for_response(item) for item in value]
+    return value
+
+
+def _custom_config_to_view(
+    custom_config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if custom_config is None:
+        return None
+    return cast(dict[str, Any], _sanitize_custom_config_for_response(custom_config))
 
 
 def _validate_voice_api_base(provider_type: str, api_base: str | None) -> str | None:
@@ -70,8 +121,9 @@ def _provider_to_view(provider: VoiceProvider) -> VoiceProviderView:
         tts_model=provider.tts_model,
         default_voice=provider.default_voice,
         api_key=mask_string(raw_key) if raw_key else None,
+        api_secret=STORED_API_SECRET_PLACEHOLDER if provider.api_secret else None,
         target_uri=provider.api_base,  # api_base stores the target URI for Azure
-        custom_config=provider.custom_config,
+        custom_config=_custom_config_to_view(provider.custom_config),
     )
 
 
@@ -94,6 +146,8 @@ async def upsert_voice_provider_endpoint(
     """Create or update a voice provider."""
     api_key = request.api_key
     api_key_changed = request.api_key_changed
+    api_secret = request.api_secret
+    api_secret_changed = request.api_secret_changed
 
     # If llm_provider_id is specified, copy the API key from that LLM provider
     if request.llm_provider_id is not None:
@@ -115,6 +169,7 @@ async def upsert_voice_provider_endpoint(
     api_base = _validate_voice_api_base(
         request.provider_type, request.target_uri or request.api_base
     )
+    custom_config = _reject_custom_config_credentials(request.custom_config)
 
     provider = upsert_voice_provider(
         db_session=db_session,
@@ -123,8 +178,10 @@ async def upsert_voice_provider_endpoint(
         provider_type=request.provider_type,
         api_key=api_key,
         api_key_changed=api_key_changed,
+        api_secret=api_secret,
+        api_secret_changed=api_secret_changed,
         api_base=api_base,
-        custom_config=request.custom_config,
+        custom_config=custom_config,
         stt_model=request.stt_model,
         tts_model=request.tts_model,
         default_voice=request.default_voice,
@@ -229,6 +286,8 @@ async def test_voice_provider(
 ) -> VoiceProviderUpdateSuccess:
     """Test a voice provider connection by making a real API call."""
     api_key = request.api_key
+    api_secret = request.api_secret
+    existing_provider: VoiceProvider | None = None
 
     if request.use_stored_key:
         existing_provider = fetch_voice_provider_by_type(
@@ -240,6 +299,18 @@ async def test_voice_provider(
                 "No stored API key found for this provider type.",
             )
         api_key = existing_provider.api_key.get_value(apply_mask=False)
+
+    if request.use_stored_secret:
+        if existing_provider is None:
+            existing_provider = fetch_voice_provider_by_type(
+                db_session, request.provider_type
+            )
+        if existing_provider is None or not existing_provider.api_secret:
+            raise OnyxError(
+                OnyxErrorCode.VALIDATION_ERROR,
+                "No stored API secret found for this provider type.",
+            )
+        api_secret = existing_provider.api_secret.get_value(apply_mask=False)
 
     if not api_key:
         raise OnyxError(
@@ -260,6 +331,7 @@ async def test_voice_provider(
         custom_config=request.custom_config or {},
     )
     temp_provider.api_key = api_key  # ty: ignore[invalid-assignment]
+    temp_provider.api_secret = api_secret  # ty: ignore[invalid-assignment]
 
     try:
         provider = get_voice_provider(temp_provider)

--- a/backend/onyx/server/manage/voice/api.py
+++ b/backend/onyx/server/manage/voice/api.py
@@ -108,6 +108,30 @@ def _validate_voice_api_base(provider_type: str, api_base: str | None) -> str | 
         ) from e
 
 
+def _fetch_provider_for_stored_secret(
+    db_session: Session,
+    provider_id: int | None,
+    provider_type: str,
+) -> VoiceProvider:
+    if provider_id is None:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Provider id is required to use a stored API secret.",
+        )
+
+    provider = fetch_voice_provider_by_id(db_session, provider_id)
+    if provider is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Voice provider not found.")
+
+    if provider.provider_type != provider_type:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Stored API secret provider does not match the requested provider type.",
+        )
+
+    return provider
+
+
 def _provider_to_view(provider: VoiceProvider) -> VoiceProviderView:
     """Convert a VoiceProvider model to a VoiceProviderView."""
     raw_key = provider.api_key.get_value(apply_mask=False) if provider.api_key else None
@@ -289,10 +313,16 @@ async def test_voice_provider(
     api_secret = request.api_secret
     existing_provider: VoiceProvider | None = None
 
-    if request.use_stored_key:
+    if request.use_stored_secret:
+        existing_provider = _fetch_provider_for_stored_secret(
+            db_session, request.id, request.provider_type
+        )
+    elif request.use_stored_key:
         existing_provider = fetch_voice_provider_by_type(
             db_session, request.provider_type
         )
+
+    if request.use_stored_key:
         if existing_provider is None or not existing_provider.api_key:
             raise OnyxError(
                 OnyxErrorCode.VALIDATION_ERROR,
@@ -301,10 +331,6 @@ async def test_voice_provider(
         api_key = existing_provider.api_key.get_value(apply_mask=False)
 
     if request.use_stored_secret:
-        if existing_provider is None:
-            existing_provider = fetch_voice_provider_by_type(
-                db_session, request.provider_type
-            )
         if existing_provider is None or not existing_provider.api_secret:
             raise OnyxError(
                 OnyxErrorCode.VALIDATION_ERROR,

--- a/backend/onyx/server/manage/voice/models.py
+++ b/backend/onyx/server/manage/voice/models.py
@@ -97,6 +97,10 @@ class VoiceProviderUpsertRequest(BaseModel):
 class VoiceProviderTestRequest(BaseModel):
     """Request model for testing a voice provider connection."""
 
+    id: int | None = Field(
+        default=None,
+        description="Existing provider ID to use when testing stored credentials.",
+    )
     provider_type: str
     api_key: str | None = Field(
         default=None,

--- a/backend/onyx/server/manage/voice/models.py
+++ b/backend/onyx/server/manage/voice/models.py
@@ -18,6 +18,10 @@ class VoiceProviderView(BaseModel):
         default=None,
         description="Masked API key for display (e.g. 'sk-a...b1c2'). Non-null means a key is stored.",
     )
+    api_secret: str | None = Field(
+        default=None,
+        description="Fixed placeholder for display. Non-null means a secret is stored.",
+    )
     target_uri: str | None = Field(
         default=None,
         description="Target URI for Azure Speech Services.",
@@ -54,6 +58,14 @@ class VoiceProviderUpsertRequest(BaseModel):
     api_key_changed: bool = Field(
         default=False,
         description="Set to true when providing a new API key for an existing provider.",
+    )
+    api_secret: str | None = Field(
+        default=None,
+        description="API secret for providers that require one.",
+    )
+    api_secret_changed: bool = Field(
+        default=False,
+        description="Set to true when providing a new API secret for an existing provider.",
     )
     llm_provider_id: int | None = Field(
         default=None,
@@ -93,6 +105,14 @@ class VoiceProviderTestRequest(BaseModel):
     use_stored_key: bool = Field(
         default=False,
         description="If true, use the stored API key for this provider type.",
+    )
+    api_secret: str | None = Field(
+        default=None,
+        description="API secret for testing providers that require one.",
+    )
+    use_stored_secret: bool = Field(
+        default=False,
+        description="If true, use the stored API secret for this provider type.",
     )
     api_base: str | None = None
     target_uri: str | None = Field(

--- a/backend/tests/unit/onyx/db/test_voice.py
+++ b/backend/tests/unit/onyx/db/test_voice.py
@@ -40,6 +40,7 @@ def _make_voice_provider(
     provider.is_default_stt = is_default_stt
     provider.is_default_tts = is_default_tts
     provider.api_key = None
+    provider.api_secret = None
     provider.api_base = None
     provider.custom_config = None
     provider.stt_model = None
@@ -231,6 +232,72 @@ class TestUpsertVoiceProvider:
 
         # api_key should remain unchanged (same object reference)
         assert existing_provider.api_key is original_api_key
+
+    def test_updates_api_secret_when_changed(self, mock_db_session: MagicMock) -> None:
+        existing_provider = _make_voice_provider(id=1)
+        existing_provider.api_secret = "original-secret"  # ty: ignore[invalid-assignment]
+        mock_db_session.scalar.return_value = existing_provider
+        mock_db_session.flush.return_value = None
+        mock_db_session.refresh.return_value = None
+
+        upsert_voice_provider(
+            db_session=mock_db_session,
+            provider_id=1,
+            name="Test",
+            provider_type="openai",
+            api_key=None,
+            api_key_changed=False,
+            api_secret="new-secret",
+            api_secret_changed=True,
+        )
+
+        assert existing_provider.api_secret is not None
+        assert existing_provider.api_secret.get_value(apply_mask=False) == "new-secret"
+
+    def test_preserves_api_secret_when_not_changed(
+        self, mock_db_session: MagicMock
+    ) -> None:
+        existing_provider = _make_voice_provider(id=1)
+        existing_provider.api_secret = "original-secret"  # ty: ignore[invalid-assignment]
+        original_api_secret = existing_provider.api_secret
+        mock_db_session.scalar.return_value = existing_provider
+        mock_db_session.flush.return_value = None
+        mock_db_session.refresh.return_value = None
+
+        upsert_voice_provider(
+            db_session=mock_db_session,
+            provider_id=1,
+            name="Test",
+            provider_type="openai",
+            api_key=None,
+            api_key_changed=False,
+            api_secret="new-secret",
+            api_secret_changed=False,
+        )
+
+        assert existing_provider.api_secret is original_api_secret
+
+    def test_sets_api_secret_when_missing_even_if_not_changed(
+        self, mock_db_session: MagicMock
+    ) -> None:
+        existing_provider = _make_voice_provider(id=1)
+        mock_db_session.scalar.return_value = existing_provider
+        mock_db_session.flush.return_value = None
+        mock_db_session.refresh.return_value = None
+
+        upsert_voice_provider(
+            db_session=mock_db_session,
+            provider_id=1,
+            name="Test",
+            provider_type="openai",
+            api_key=None,
+            api_key_changed=False,
+            api_secret="new-secret",
+            api_secret_changed=False,
+        )
+
+        assert existing_provider.api_secret is not None
+        assert existing_provider.api_secret.get_value(apply_mask=False) == "new-secret"
 
     def test_preserves_custom_config_when_omitted(
         self, mock_db_session: MagicMock

--- a/backend/tests/unit/onyx/server/manage/voice/test_voice_api_secrets.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_voice_api_secrets.py
@@ -153,6 +153,7 @@ async def test_voice_provider_test_uses_stored_secret_independently(
 
     await voice_provider_test_endpoint(
         VoiceProviderTestRequest(
+            id=1,
             provider_type="openai",
             api_key="provided-key",
             use_stored_secret=True,
@@ -166,3 +167,39 @@ async def test_voice_provider_test_uses_stored_secret_independently(
     assert captured_provider.api_secret is not None
     assert captured_provider.api_key.get_value(apply_mask=False) == "provided-key"
     assert captured_provider.api_secret.get_value(apply_mask=False) == "stored-secret"
+
+
+@pytest.mark.asyncio
+async def test_voice_provider_test_requires_id_for_stored_secret() -> None:
+    with pytest.raises(OnyxError, match="Provider id is required"):
+        await voice_provider_test_endpoint(
+            VoiceProviderTestRequest(
+                provider_type="openai",
+                api_key="provided-key",
+                use_stored_secret=True,
+            ),
+            MagicMock(),
+            MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_voice_provider_test_rejects_stored_secret_type_mismatch() -> None:
+    stored_provider = _make_provider()
+    stored_provider.provider_type = "azure"
+    stored_provider.api_secret = "stored-secret"  # ty: ignore[invalid-assignment]
+
+    db_session = MagicMock()
+    db_session.scalar.return_value = stored_provider
+
+    with pytest.raises(OnyxError, match="does not match"):
+        await voice_provider_test_endpoint(
+            VoiceProviderTestRequest(
+                id=1,
+                provider_type="openai",
+                api_key="provided-key",
+                use_stored_secret=True,
+            ),
+            MagicMock(),
+            db_session,
+        )

--- a/backend/tests/unit/onyx/server/manage/voice/test_voice_api_secrets.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_voice_api_secrets.py
@@ -1,0 +1,168 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.db.models import VoiceProvider
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.voice.api import (
+    STORED_API_SECRET_PLACEHOLDER,
+    _provider_to_view,
+    upsert_voice_provider_endpoint,
+)
+from onyx.server.manage.voice.api import (
+    test_voice_provider as voice_provider_test_endpoint,
+)
+from onyx.server.manage.voice.models import (
+    VoiceProviderTestRequest,
+    VoiceProviderUpsertRequest,
+)
+
+
+def _make_provider() -> VoiceProvider:
+    provider = VoiceProvider()
+    provider.id = 1
+    provider.name = "Test"
+    provider.provider_type = "openai"
+    provider.is_default_stt = False
+    provider.is_default_tts = False
+    provider.stt_model = None
+    provider.tts_model = None
+    provider.default_voice = None
+    provider.api_base = None
+    provider.custom_config = {}
+    provider.api_key = None
+    provider.api_secret = None
+    return provider
+
+
+class MockVoiceProvider:
+    async def validate_credentials(self) -> None:
+        return None
+
+
+def test_provider_to_view_returns_fixed_secret_placeholder() -> None:
+    provider = _make_provider()
+    provider.api_key = "provider-key"  # ty: ignore[invalid-assignment]
+    provider.api_secret = "actual-secret-value"  # ty: ignore[invalid-assignment]
+
+    view = _provider_to_view(provider)
+
+    assert view.api_key is not None
+    assert view.api_key != "provider-key"
+    assert view.api_secret == STORED_API_SECRET_PLACEHOLDER
+    assert "actual" not in view.api_secret
+
+
+def test_provider_to_view_strips_legacy_custom_config_credentials() -> None:
+    provider = _make_provider()
+    provider.custom_config = {
+        "speech_region": "us-east",
+        "nested": {
+            "API_SECRET": "legacy-secret",
+            "allowed": [{"api_key": "legacy-key"}, {"voice": "alloy"}],
+        },
+    }
+
+    view = _provider_to_view(provider)
+
+    assert view.custom_config == {
+        "speech_region": "us-east",
+        "nested": {
+            "allowed": [{}, {"voice": "alloy"}],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_custom_config_credentials() -> None:
+    with pytest.raises(OnyxError, match="custom_config cannot contain"):
+        await upsert_voice_provider_endpoint(
+            VoiceProviderUpsertRequest(
+                name="Test",
+                provider_type="openai",
+                api_key="key",
+                api_key_changed=True,
+                custom_config={"nested": [{"api_secret": "secret"}]},
+            ),
+            MagicMock(),
+            MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_forwards_api_secret_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+    provider = _make_provider()
+    provider.api_key = "key"  # ty: ignore[invalid-assignment]
+    provider.api_secret = "secret"  # ty: ignore[invalid-assignment]
+
+    def mock_upsert_voice_provider(**kwargs: Any) -> VoiceProvider:
+        captured_kwargs.update(kwargs)
+        return provider
+
+    monkeypatch.setattr(
+        "onyx.server.manage.voice.api.upsert_voice_provider",
+        mock_upsert_voice_provider,
+    )
+    monkeypatch.setattr(
+        "onyx.server.manage.voice.api.get_voice_provider",
+        lambda _: MockVoiceProvider(),
+    )
+    db_session = MagicMock()
+
+    await upsert_voice_provider_endpoint(
+        VoiceProviderUpsertRequest(
+            name="Test",
+            provider_type="openai",
+            api_key="key",
+            api_key_changed=True,
+            api_secret="secret",
+            api_secret_changed=True,
+        ),
+        MagicMock(),
+        db_session,
+    )
+
+    assert captured_kwargs["api_secret"] == "secret"
+    assert captured_kwargs["api_secret_changed"] is True
+    db_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_voice_provider_test_uses_stored_secret_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_provider = _make_provider()
+    stored_provider.api_secret = "stored-secret"  # ty: ignore[invalid-assignment]
+
+    db_session = MagicMock()
+    db_session.scalar.return_value = stored_provider
+    captured_provider: VoiceProvider | None = None
+
+    def mock_get_voice_provider(provider: VoiceProvider) -> MockVoiceProvider:
+        nonlocal captured_provider
+        captured_provider = provider
+        return MockVoiceProvider()
+
+    monkeypatch.setattr(
+        "onyx.server.manage.voice.api.get_voice_provider", mock_get_voice_provider
+    )
+
+    await voice_provider_test_endpoint(
+        VoiceProviderTestRequest(
+            provider_type="openai",
+            api_key="provided-key",
+            use_stored_secret=True,
+        ),
+        MagicMock(),
+        db_session,
+    )
+
+    assert captured_provider is not None
+    assert captured_provider.api_key is not None
+    assert captured_provider.api_secret is not None
+    assert captured_provider.api_key.get_value(apply_mask=False) == "provided-key"
+    assert captured_provider.api_secret.get_value(apply_mask=False) == "stored-secret"


### PR DESCRIPTION
## Description

Builds on #14421 to let the admin voice API handle providers with a second credential.

- Persists optional `api_secret` through the generic voice provider upsert path.
- Returns only a fixed placeholder when a secret is stored.
- Lets the test endpoint combine a supplied API key with the stored secret.
- Requires a provider id before reusing a stored secret, so duplicate provider types cannot pair the wrong credentials.
- Rejects `api_key` and `api_secret` inside `custom_config` because that JSON can be returned to clients.

Provider-specific runtime behavior stays out of this PR.

## Stack

- Depends on #14421.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/db/test_voice.py backend/tests/unit/onyx/server/manage/voice/test_voice_api_secrets.py` -> 49 passed.
- `uv run pre-commit run --files backend/onyx/db/voice.py backend/onyx/server/manage/voice/api.py backend/onyx/server/manage/voice/models.py backend/tests/unit/onyx/db/test_voice.py backend/tests/unit/onyx/server/manage/voice/test_voice_api_secrets.py`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check