### PR TITLE
feat: add voice provider API secret migration

### DIFF
--- a/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
+++ b/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
@@ -1,7 +1,7 @@
 """add voice provider api secret
 
 Revision ID: 287021f3b46c
-Revises: 77962d18fd41
+Revises: 947b94d2ebf1
 Create Date: 2026-08-27 10:38:32.439483
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "287021f3b46c"
-down_revision = "77962d18fd41"
+down_revision = "947b94d2ebf1"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
+++ b/backend/alembic/versions/287021f3b46c_add_voice_provider_api_secret.py
@@ -1,0 +1,28 @@
+"""add voice provider api secret
+
+Revision ID: 287021f3b46c
+Revises: 77962d18fd41
+Create Date: 2026-08-27 10:38:32.439483
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "287021f3b46c"
+down_revision = "77962d18fd41"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "voice_provider",
+        sa.Column("api_secret", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("voice_provider", "api_secret")


### PR DESCRIPTION
## Description

Adds the nullable `voice_provider.api_secret` column for providers that need a second credential.

This PR is intentionally migration-only. The ORM and admin API changes are stacked in #14424, and provider-specific behavior remains in #14338.

## How Has This Been Tested?

- `uv run alembic heads` reports one head at `287021f3b46c`.
- Pre-commit hooks passed for the migration.

## Not Tested

- Full upgrade and downgrade against a live database. CI owns that coverage.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check