### PR TITLE
fix(web): Unpin the first column in chat markdown tables

### DIFF
--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -320,7 +320,7 @@ pre[class*="language-"] {
 }
 
 /* Fade the scroll-end edge via an ::after overlay on the non-scrolling
-   card. Stays pinned while table scrolls; not on the sticky column. */
+   card. Stays pinned while the table scrolls. */
 .markdown-table-card::after {
   content: "";
   position: absolute;
@@ -351,45 +351,12 @@ pre[class*="language-"] {
   opacity: 1;
 }
 
-/* Sticky first column — inherits the container's background so it
-   matches regardless of theme or custom wallpaper. */
+/* Edge padding on the outer columns. */
 .markdown-table-breakout th:first-child,
 .markdown-table-breakout td:first-child {
-  position: sticky;
-  inset-inline-start: 0;
-  z-index: 1;
   padding-inline-start: 0.75rem;
-  background: var(--background-neutral-01);
 }
 .markdown-table-breakout th:last-child,
 .markdown-table-breakout td:last-child {
   padding-inline-end: 0.75rem;
-}
-
-/* Shadow on sticky column when scrolled. Uses an ::after pseudo-element
-   so it isn't clipped by the overflow container or the mask-image fade. */
-.markdown-table-breakout th:first-child::after,
-.markdown-table-breakout td:first-child::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  inset-inline-end: -6px;
-  bottom: 0;
-  width: 6px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s;
-  box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-25);
-}
-.markdown-table-breakout:dir(rtl) th:first-child::after,
-.markdown-table-breakout:dir(rtl) td:first-child::after {
-  box-shadow: inset -6px 0 8px -4px var(--alpha-grey-100-25);
-}
-.dark .markdown-table-breakout th:first-child::after,
-.dark .markdown-table-breakout td:first-child::after {
-  box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-60);
-}
-.markdown-table-breakout[data-scrolled="true"] th:first-child::after,
-.markdown-table-breakout[data-scrolled="true"] td:first-child::after {
-  opacity: 1;
 }

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -58,7 +58,6 @@ export function ScrollableTable({
           : el.scrollLeft;
       const atEnd = fromStart >= maxScroll - 2;
       wrap.dataset.overflows = overflows && !atEnd ? "true" : "false";
-      el.dataset.scrolled = fromStart > 0 ? "true" : "false";
     };
 
     check();


### PR DESCRIPTION
## Description

The first column of a chat markdown table was pinned with `position: sticky`. When that column is wide it eats the visible width and cannot be scrolled away, which makes the remaining columns hard to reach. The table now scrolls as a single unit.

The pin lived entirely in CSS, in `web/src/app/app/message/custom-code-styles.css`:

- Dropped `position: sticky`, `inset-inline-start`, `z-index` and the background from `th/td:first-child`.
- Dropped the `::after` edge shadow that shaded the pinned column (4 rules, including the RTL and `.dark` variants).
- Dropped the now-dead `el.dataset.scrolled` write in `ScrollableTable`, which had no other consumer once that shadow was gone.

Kept on purpose: `padding-inline-start` on the first column, which is edge padding rather than pinning and pairs with the matching `padding-inline-end` on the last column. The scroll-end fade also stays — it lives on the non-scrolling card and is driven by `data-overflows`, independent of the pin. Removing the first column's `background` is a visual no-op, since the card behind it uses the same `--background-neutral-01`.

`overflow-x: auto` on `.markdown-table-breakout` was already present, and is what now scrolls the whole table.

## Screenshots + Videos

### Before

Notice how the first column gets pinned. For the first table, it's fine since the first column is narrow. But for the *second* table, the first column is so large that is completely overtakes the entire table.

https://github.com/user-attachments/assets/4f9b13bd-f8b2-48ef-ab35-efd64cbe2947

### After

The first column is not fixed anymore.

https://github.com/user-attachments/assets/6bd59e68-a320-45e4-b934-d54da380e055

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unpins the first column in chat markdown tables so a wide first column no longer eats the visible width and can't be scrolled away; the table now scrolls as a single unit.

- Drops the sticky CSS and the `::after` edge shadow from the first column, including RTL and dark variants; removing the background is a visual no-op since the card behind it uses the same color.
- Removes the now-dead `data-scrolled` write in `ScrollableTable`.
- Keeps the first-column padding and the scroll-end fade, which are independent of the pin.

<sup>Written for commit 0a8e84f3b7088f586573f302deccab5056bd9105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->