### PR TITLE
refactor(fe, credentials): remove dead sharing controls from the credential form

### DIFF
--- a/web/src/app/admin/connectors/[connector]/pages/utils/files.ts
+++ b/web/src/app/admin/connectors/[connector]/pages/utils/files.ts
@@ -58,7 +58,6 @@ export const submitFiles = async (
     credential_json: {},
     admin_public: true,
     source: ValidSources.File,
-    curator_public: true,
     groups: groups,
     name,
   });

--- a/web/src/components/admin/connectors/CredentialForm.tsx
+++ b/web/src/components/admin/connectors/CredentialForm.tsx
@@ -89,8 +89,6 @@ export function CredentialForm<T extends Yup.AnyObject>({
             {
               credential_json: values,
               admin_public: true,
-              curator_public: false,
-              groups: [],
               source: source,
             },
             {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -30,7 +30,6 @@ export interface CredentialBase<T> {
   admin_public: boolean;
   source: ValidSources;
   name?: string;
-  curator_public?: boolean;
   groups?: number[];
 }
 

--- a/web/src/lib/credential.ts
+++ b/web/src/lib/credential.ts
@@ -29,10 +29,6 @@ export async function createCredentialWithPrivateKey(
   const formData = new FormData();
   formData.append(CREDENTIAL_JSON, JSON.stringify(credential.credential_json));
   formData.append("admin_public", credential.admin_public.toString());
-  formData.append(
-    "curator_public",
-    credential.curator_public?.toString() || "false"
-  );
   if (credential.groups && credential.groups.length > 0) {
     credential.groups.forEach((group) => {
       formData.append("groups", String(group));

--- a/web/src/lib/credentials/components/CreateCredential.tsx
+++ b/web/src/lib/credentials/components/CreateCredential.tsx
@@ -19,47 +19,27 @@ import type {
   CredentialFieldValues,
 } from "@/lib/credentials/types";
 import { createValidationSchema } from "@/lib/credentials/utils";
-import { useTierAtLeast } from "@/hooks/useTierAtLeast";
-import { Tier } from "@/lib/settings/types";
-import { AdvancedOptionsToggle } from "@/components/AdvancedOptionsToggle";
-import {
-  IsPublicGroupSelectorFormType,
-  IsPublicGroupSelector,
-} from "@/components/IsPublicGroupSelector";
-import { useUser } from "@/providers/UserProvider";
 import CardSection from "@/components/admin/CardSection";
 import { CredentialFieldsRenderer } from "@/lib/credentials/components/CredentialFieldsRenderer";
 import { TypedFile } from "@/lib/connectors/fileTypes";
 import ConnectorDocsLink from "@/components/admin/connectors/ConnectorDocsLink";
-import { usePermissionAuthority } from "@/lib/permissions/hooks";
-import { Permission } from "@/lib/types";
 import { SvgPlusCircle } from "@opal/icons";
 const CreateButton = ({
   onClick,
   isSubmitting,
-  requiresGroup,
-  groups,
 }: {
   onClick: () => void;
   isSubmitting: boolean;
-  // Only a scoped manager must land the credential in a group — GATE 2 requires
-  // it of them and of nobody else.
-  requiresGroup: boolean;
-  groups: number[];
 }) => {
   const t = useTranslations("admin");
   return (
-    <OpalButton
-      disabled={isSubmitting || (requiresGroup && groups.length === 0)}
-      onClick={onClick}
-      icon={SvgPlusCircle}
-    >
+    <OpalButton disabled={isSubmitting} onClick={onClick} icon={SvgPlusCircle}>
       {t("credentials.create.createButton.label")}
     </OpalButton>
   );
 };
 
-type CreateCredentialFormValues = IsPublicGroupSelectorFormType & {
+type CreateCredentialFormValues = {
   name: string;
   [key: string]: unknown;
 };
@@ -101,13 +81,7 @@ export default function CreateCredential({
   refresh?: () => void;
 }) {
   const t = useTranslations("admin");
-  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [authMethod, setAuthMethod] = useState<string>();
-  const businessTier = useTierAtLeast(Tier.BUSINESS);
-
-  const { isGlobalHolder, isScopedManager } = usePermissionAuthority(
-    Permission.MANAGE_CONNECTORS
-  );
 
   const handleSubmit = async (
     values: CreateCredentialFormValues,
@@ -125,7 +99,7 @@ export default function CreateCredential({
     setSubmitting(true);
     formikHelpers.setSubmitting(true);
 
-    const { name, is_public, groups, ...credentialValues } = values;
+    const { name, ...credentialValues } = values;
 
     let privateKey: TypedFile | null = null;
     const filteredCredentialValues = Object.fromEntries(
@@ -142,8 +116,6 @@ export default function CreateCredential({
       const response = await submitCredential({
         credential_json: filteredCredentialValues,
         admin_public: true,
-        curator_public: is_public,
-        groups: groups,
         name: name,
         source: sourceType,
         private_key: privateKey || undefined,
@@ -209,8 +181,6 @@ export default function CreateCredential({
       initialValues={
         {
           name: "",
-          is_public: isGlobalHolder || !businessTier,
-          groups: [],
           ...(initialAuthMethod && {
             authentication_method: initialAuthMethod,
           }),
@@ -244,26 +214,7 @@ export default function CreateCredential({
                 setAuthMethod={setAuthMethod}
               />
 
-              <div className="mt-4 flex w-full flex-col sm:flex-row justify-between items-end">
-                <div className="w-full sm:w-3/4 mb-4 sm:mb-0">
-                  {businessTier && (
-                    <div className="flex flex-col items-start">
-                      {isGlobalHolder && (
-                        <AdvancedOptionsToggle
-                          showAdvancedOptions={showAdvancedOptions}
-                          setShowAdvancedOptions={setShowAdvancedOptions}
-                        />
-                      )}
-                      {(showAdvancedOptions || !isGlobalHolder) && (
-                        <IsPublicGroupSelector
-                          formikProps={formikProps}
-                          objectName="credential"
-                          isGlobalHolder={isGlobalHolder}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
+              <div className="mt-4 flex w-full justify-end">
                 <CreateButton
                   onClick={() =>
                     handleSubmit(
@@ -273,8 +224,6 @@ export default function CreateCredential({
                     )
                   }
                   isSubmitting={formikProps.isSubmitting}
-                  requiresGroup={isScopedManager}
-                  groups={formikProps.values.groups}
                 />
               </div>
             </CardSection>


### PR DESCRIPTION
## Description

- The "Make this credential Public?" checkbox wrote curator_public, a curator-role leftover (#2166). Since the permission rewrite (#10172), no query reads it to grant access; its only effect was the creation-time gate that blocks scoped managers from setting it.
- Removes the checkbox, group picker, and Advanced Options toggle from the credential form, stops sending curator_public everywhere, and drops the field from the CredentialBase interface. The backend defaults it to False, so this PR is FE-only.
- Behavior change: scoped group managers can now create credentials without picking a group. The backend permits ungrouped private credentials, and credential group assignment grants no visibility.
- Unchanged: admin_public stays hardcoded true, files.ts still mirrors connector groups onto its dummy file credential, and IsPublicGroupSelector remains in use by document sets and MCP servers. Dropping the column and API fields is a follow-up.

## How Has This Been Tested?

It wasn't but I'll include screenshots soon.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the credential sharing controls (`curator_public` checkbox, group picker, Advanced Options toggle) from the credential creation form. No query reads `curator_public` to grant access after the permission rewrite, so the controls only blocked scoped managers from creating credentials.

**Behavior change**
- Scoped group managers can now create credentials without selecting a group.
- `admin_public` stays hardcoded true, and `files.ts` still mirrors connector groups onto dummy file credentials.
- Dropping the `curator_public` column and API fields is a follow-up.

<sup>Written for commit 48b37b9965f9bf02ba3ba1b263b59ae77a021421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

