### PR TITLE
chore(docker): refresh the DHI base image digests for openssl 3.5.7

### DIFF
--- a/.github/actions/dhi-base-images/action.yml
+++ b/.github/actions/dhi-base-images/action.yml
@@ -46,11 +46,11 @@ runs:
       run: |
         {
           echo "DHI_NODE_BUILD_ARGS<<EOF"
-          echo "NODE_BUILDER_IMAGE=dhi.io/node:24-debian13-dev@sha256:25a83f18150669e9ce3c9437327add4d75ae4ea26cbdb5e8747b66d3b74a567a"
-          echo "NODE_RUNTIME_IMAGE=dhi.io/node:24-debian13@sha256:805278f24c1146c6d3c96577b6256f8f97c43196fff88315fe3291a1ce118ddd"
+          echo "NODE_BUILDER_IMAGE=dhi.io/node:24-debian13-dev@sha256:35dae551ffb9790b9e0416c5359c80b1b45c345b950b0670615a307451f0005f"
+          echo "NODE_RUNTIME_IMAGE=dhi.io/node:24-debian13@sha256:d6ae37f15884f5c9a3b945beba1dd5781b7107ecbcb72b64db9bbb7a74d7d870"
           echo "EOF"
           echo "DHI_PYTHON_BUILD_ARGS<<EOF"
-          echo "PYTHON_BUILDER_IMAGE=dhi.io/python:3.13-debian13-dev@sha256:7933d16e50454c39bca6e935027166d5e5b05c6c03383dc2f58e8fe6e2440b7d"
-          echo "PYTHON_RUNTIME_IMAGE=dhi.io/python:3.13-debian13@sha256:05827957dafc7b83633d56f24d9281525d3546a1d600eef90385c7212d3def5e"
+          echo "PYTHON_BUILDER_IMAGE=dhi.io/python:3.13-debian13-dev@sha256:e80760f68bff8d37c82b9f407951cb6286c90be39b1120e7798cb4621cee8bd6"
+          echo "PYTHON_RUNTIME_IMAGE=dhi.io/python:3.13-debian13@sha256:fec8992879e8a634f0af282f67bf09a837212d0a386eb810427d3e72a1dd8fde"
           echo "EOF"
         } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Description

**Why:** The `edge` image build fails the vulnerability audit on `DEBIAN-CVE-2026-63073` (openssl 3.5.6) for the model-server and web images. #14407 refreshed the `python:3.13-slim` digest, but those two images are built on Docker Hardened Images: `.github/actions/dhi-base-images` passes the `PYTHON_*_IMAGE` and `NODE_*_IMAGE` build args, which override the Dockerfile defaults, and the pinned DHI digests still shipped openssl 3.5.6. The backend image builds on the slim digest and its audit already passes.

**What:** Refresh the four DHI digests (python runtime and dev, node runtime and dev) to the current dhi.io builds.

## How Has This Been Tested?

Digests read with `docker buildx imagetools inspect` against dhi.io. Each new image was pulled and `/var/lib/dpkg/status` checked: all four ship `libssl3t64 3.5.7-1~deb13u2+dhi0`, the Debian fix for the blocking CVE. The image-audit jobs on the next `edge` build are the real check.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
