### PR TITLE
Make contextual RAG worker count configurable

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1,3 +1,4 @@
+import os
 import time
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterator
@@ -114,8 +115,8 @@ from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
 
-MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
-MAX_IMAGE_WORKERS = 16
+MAX_CONTEXTUAL_RAG_WORKERS = int(os.environ.get("MAX_CONTEXTUAL_RAG_WORKERS") or "128")
+MAX_IMAGE_WORKERS = int(os.environ.get("MAX_IMAGE_WORKERS") or "16")
 
 # Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
 # model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -115,8 +115,8 @@ from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
 
-MAX_CONTEXTUAL_RAG_WORKERS = int(os.environ.get("MAX_CONTEXTUAL_RAG_WORKERS") or "128")
-MAX_IMAGE_WORKERS = int(os.environ.get("MAX_IMAGE_WORKERS") or "16")
+MAX_CONTEXTUAL_RAG_WORKERS: int = max(1, int(os.environ.get("MAX_CONTEXTUAL_RAG_WORKERS") or "128"))
+MAX_IMAGE_WORKERS: int = max(1, int(os.environ.get("MAX_IMAGE_WORKERS") or "16"))
 
 # Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
 # model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the


### PR DESCRIPTION
Makes MAX_CONTEXTUAL_RAG_WORKERS configurable via the environment while preserving 128 as the default. This allows Onyx deployments using single-concurrency Ollama runners to reduce contextual-RAG request concurrency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes contextual RAG and image worker counts configurable via `MAX_CONTEXTUAL_RAG_WORKERS` and `MAX_IMAGE_WORKERS`, keeping 128 and 16 as defaults. Previously both were hardcoded, which forced single-concurrency Ollama runners to handle too many concurrent requests; deployments can now lower these values to reduce concurrency. Values below 1 are clamped to 1.

<sup>Written for commit 0c96bcea8b2d56e3b959501587e1e2488b361e26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

