### PR TITLE
fix(web): Unpin the first column in chat markdown tables (#14425) to release v4.7

### DIFF
--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -319,8 +319,8 @@ pre[class*="language-"] {
   background: var(--border-03);
 }
 
-/* Fade the right edge via an ::after overlay on the non-scrolling card.
-   Stays pinned while table scrolls; doesn't affect the sticky column. */
+/* Fade the scroll-end edge via an ::after overlay on the non-scrolling
+   card. Stays pinned while the table scrolls. */
 .markdown-table-card::after {
   content: "";
   position: absolute;
@@ -343,41 +343,12 @@ pre[class*="language-"] {
   opacity: 1;
 }
 
-/* Sticky first column — inherits the container's background so it
-   matches regardless of theme or custom wallpaper. */
+/* Edge padding on the outer columns. */
 .markdown-table-breakout th:first-child,
 .markdown-table-breakout td:first-child {
-  position: sticky;
-  left: 0;
-  z-index: 1;
-  padding-left: 0.75rem;
-  background: var(--background-neutral-01);
+  padding-inline-start: 0.75rem;
 }
 .markdown-table-breakout th:last-child,
 .markdown-table-breakout td:last-child {
   padding-right: 0.75rem;
-}
-
-/* Shadow on sticky column when scrolled. Uses an ::after pseudo-element
-   so it isn't clipped by the overflow container or the mask-image fade. */
-.markdown-table-breakout th:first-child::after,
-.markdown-table-breakout td:first-child::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: -6px;
-  bottom: 0;
-  width: 6px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s;
-  box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-25);
-}
-.dark .markdown-table-breakout th:first-child::after,
-.dark .markdown-table-breakout td:first-child::after {
-  box-shadow: inset 6px 0 8px -4px var(--alpha-grey-100-60);
-}
-.markdown-table-breakout[data-scrolled="true"] th:first-child::after,
-.markdown-table-breakout[data-scrolled="true"] td:first-child::after {
-  opacity: 1;
 }

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -350,5 +350,5 @@ pre[class*="language-"] {
 }
 .markdown-table-breakout th:last-child,
 .markdown-table-breakout td:last-child {
-  padding-right: 0.75rem;
+  padding-inline-end: 0.75rem;
 }

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -49,7 +49,6 @@ export function ScrollableTable({
       const overflows = el.scrollWidth > el.clientWidth;
       const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 2;
       wrap.dataset.overflows = overflows && !atEnd ? "true" : "false";
-      el.dataset.scrolled = el.scrollLeft > 0 ? "true" : "false";
     };
 
     check();


### PR DESCRIPTION
Cherry-pick of commit cb9ac29fba80373312cfe25d7daccc6a3be7a4b7 to release/v4.7 branch.

Original PR: #14425

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the sticky first column in chat markdown tables so the table scrolls freely. Also drops the shadow that appeared on the pinned column while scrolling and the `data-scrolled` tracking in `markdownUtils.tsx`.

<sup>Written for commit 138e887978e20ba2f75af61eb397246c8901760e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

