### PR TITLE
fix(search): tag the search endpoints for the public OpenAPI spec

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/search_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/search_backend.py
@@ -34,6 +34,7 @@ from ee.onyx.server.query_and_chat.models import (
 from ee.onyx.server.query_and_chat.streaming_models import SearchErrorPacket
 from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import ONYX_SEARCH_UI_USES_OPENSEARCH_KEYWORD_SEARCH
+from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
 from onyx.db.enums import Permission
 from onyx.db.models import User
@@ -49,12 +50,19 @@ logger = setup_logger()
 router = APIRouter(prefix="/search")
 
 
-@router.post("/search-flow-classification")
+@router.post("/search-flow-classification", tags=PUBLIC_API_TAGS)
 def search_flow_classification(
     request: SearchFlowClassificationRequest,
     _: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> SearchFlowClassificationResponse:
+    """
+    Classify whether a query should be answered by search or by chat.
+
+    Queries longer than 200 characters are classified as a chat flow without an
+    LLM call. A failed classification falls back to ``is_search_flow: false``
+    rather than raising.
+    """
     query = request.user_query
     # This is a heuristic that if the user is typing a lot of text, it's unlikely they're looking for some specific document
     # Most likely something needs to be done with the text included so we'll just classify it as a chat flow
@@ -87,8 +95,29 @@ def search_flow_classification(
 # compatible across versions.
 @router.post(
     "/send-search-message",
-    response_model=None,
+    response_model=SearchFullResponse,
     dependencies=[Depends(require_vector_db)],
+    tags=PUBLIC_API_TAGS,
+    responses={
+        200: {
+            "description": (
+                "If `stream=true`, returns `text/event-stream`.\n"
+                "If `stream=false` (the default), returns `application/json` "
+                "(SearchFullResponse)."
+            ),
+            "content": {
+                "text/event-stream": {
+                    "schema": {"type": "string"},
+                    "examples": {
+                        "stream": {
+                            "summary": "Stream of NDJSON search packets",
+                            "value": "string",
+                        }
+                    },
+                },
+            },
+        }
+    },
 )
 def handle_send_search_message(
     request: SendSearchQueryRequest,
@@ -138,7 +167,7 @@ def handle_send_search_message(
     return StreamingResponse(stream_generator(), media_type="text/event-stream")
 
 
-@router.get("/search-history")
+@router.get("/search-history", tags=PUBLIC_API_TAGS)
 def get_search_history(
     limit: int = 100,
     filter_days: int | None = None,

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import has_global_permission, require_permission
 from onyx.chat.emitter import NullEmitter
-from onyx.configs.constants import MessageType
+from onyx.configs.constants import PUBLIC_API_TAGS, MessageType
 from onyx.context.search.models import BaseFilters, PersonaSearchInfo, TimeRange
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
@@ -53,12 +53,21 @@ from shared_configs.contextvars import get_current_tenant_id
 router = APIRouter(prefix="/search")
 
 
-@router.post("", dependencies=[Depends(require_vector_db)])
+@router.post("", dependencies=[Depends(require_vector_db)], tags=PUBLIC_API_TAGS)
 def search(
     request: SearchRequest,
     user: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> SearchResponse:
+    """
+    Search the Onyx index and get back ranked document sections.
+
+    Runs the same multi-stage retrieval as the Search action in chat — query
+    expansion, hybrid retrieval, reranking and section merging — and returns the
+    ranked sections without generating an answer. Results are ordered most
+    relevant first and are always filtered by the calling user's document
+    permissions.
+    """
     # 1. Load persona
     persona = None
     if request.persona_id is not None:


### PR DESCRIPTION
## Description

The four search endpoints never reach the published API reference, because none of them carry `PUBLIC_API_TAGS` and `scripts/transform_openapi_for_docs.py` keeps only tagged routes:

```python
PUBLIC_TAG = "public"
...
if PUBLIC_TAG in method_data.get("tags", []):
```

So `POST /search` — the one `onyx/server/features/search/api.py` describes as "intended for programmatic consumers (onyx-cli, Craft sandbox, integrations)" — is undocumented, along with the three Search UI routes. This tags all four.

`send-search-message` has a second problem. It declares `response_model=None`, which is understandable given it returns `StreamingResponse | SearchFullResponse`, but the cost is that FastAPI never walks into `SearchFullResponse`: neither it nor `SearchDocWithContent` is registered as a component schema anywhere in the spec, and the 200 comes out as `"schema": {}`. This declares the response model and describes both branches of the union with `responses=`, which is what `handle_send_chat_message` already does for the same union. Returning a `Response` object bypasses `response_model` serialization, so the streaming path is unchanged.

The two endpoints that had no docstring get one, since the docstring is what becomes the endpoint `description` in the spec.

Nothing reads route tags at runtime — I checked every `PUBLIC_API_TAGS` reference and there is no middleware or auth path keyed off them — so this only changes what the docs transform keeps. No behavior change, no permission change: all four still require `Permission.READ_SEARCH`.

## How Has This Been Tested?

Ran the real pipeline before and after.

Before — the four routes are absent from the transform's output:

```
$ python scripts/onyx_openapi_schema.py --tagged-for-docs tagged.json ...
$ python scripts/transform_openapi_for_docs.py -i tagged.json -o docs.json
Wrote docs.json: 150 endpoints, 253 schemas
search endpoints in the public spec: []
```

After:

```
Wrote docs.json: 154 endpoints, 264 schemas
search endpoints in the public spec:
  ['/search', '/search/search-flow-classification',
   '/search/send-search-message', '/search/search-history']
SearchFullResponse: registered
SearchDocWithContent: registered
```

and the 200 on `send-search-message` now carries both content types:

```json
{
  "description": "If `stream=true`, returns `text/event-stream`.\nIf `stream=false` (the default), returns `application/json` (SearchFullResponse).",
  "content": {
    "application/json": { "schema": { "$ref": "#/components/schemas/SearchFullResponse" } },
    "text/event-stream": { "schema": { "type": "string" }, "examples": { ... } }
  }
}
```

Also checked that the generated entries match the ones written by hand in the companion docs PR: all four paths and all ten search schemas are structurally identical, differing only in prose descriptions.

`pre-commit` passes on the touched files (ty, ruff, ruff format, check-getattr, check-lazy-imports).

## Companion PR

onyx-dot-app/documentation#448 adds the reference pages and a guide for these endpoints. It carries hand-merged spec entries because of this gap; once this lands, a regeneration produces them instead of deleting them. That PR's field-level descriptions are still hand-written and would be lost by a blind regeneration — moving them into `Field(description=...)` on the request models would fix that too, but it touches `SendMessageRequest`-adjacent models and felt out of scope here.

## Note for reviewers

`search-flow-classification` is a UI helper rather than an integration surface, so if you'd rather not commit to it as public API, drop that one tag and I'll unpublish the corresponding docs page.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHgZVvyM5degeZWXedbSn


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the four search endpoints in the public OpenAPI spec by tagging them with `PUBLIC_API_TAGS`, and fixes the `send-search-message` response schema so the docs show a real `SearchFullResponse` instead of an empty object.

- Tags `POST /search`, `/search/send-search-message`, `/search/search-history`, and `/search/search-flow-classification` so the docs transform keeps them.
- Declares `response_model=SearchFullResponse` on `send-search-message` and describes both streaming and JSON branches in `responses=`; streaming output is unchanged.
- Adds docstrings to the two endpoints that lacked them; the docstring becomes the endpoint description in the spec.

No runtime behavior change: route tags are only read by the docs transform, and all four endpoints still require `Permission.READ_SEARCH`.

<sup>Written for commit 171b28c630745f3620a9852561c9e279f1854a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

