### PR TITLE
fix(web): persist a reasoning level chosen before the first message

### DIFF
--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -1490,6 +1490,7 @@ export default function useChatController({
       llmManager.currentLlm,
       llmManager.temperature,
       llmManager.hasTemperatureOverride,
+      llmManager.persistOverrides,
       // Others that affect logic
       activeAgent,
       availableAgents,

--- a/web/src/lib/hooks.llmManager.test.tsx
+++ b/web/src/lib/hooks.llmManager.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@tests/setup/test-utils";
+import { useLlmManager } from "@/lib/hooks";
+import { ChatSession, ChatSessionSharedStatus } from "@/app/app/interfaces";
+import { ReasoningEffortOverride } from "@/lib/languageModels/types";
+import {
+  updateReasoningEffortForChatSession,
+  updateTemperatureOverrideForChatSession,
+} from "@/app/app/services/lib";
+
+jest.mock("@/providers/UserProvider", () => ({
+  useUser: () => ({ user: null }),
+}));
+jest.mock("@/lib/languageModels/hooks", () => ({
+  useLLMProviders: () => ({
+    llmProviders: [],
+    defaultText: undefined,
+    isLoading: false,
+  }),
+}));
+jest.mock("@/app/app/services/lib", () => ({
+  updateReasoningEffortForChatSession: jest.fn(),
+  updateTemperatureOverrideForChatSession: jest.fn(),
+}));
+
+function makeSession(
+  id: string,
+  reasoningEffort: ReasoningEffortOverride | null
+): ChatSession {
+  return {
+    id,
+    name: "",
+    persona_id: 0,
+    time_created: "",
+    time_updated: "",
+    shared_status: ChatSessionSharedStatus.Private,
+    project_id: null,
+    current_alternate_model: "",
+    current_temperature_override: null,
+    current_reasoning_effort_override: reasoningEffort,
+  };
+}
+
+interface HookProps {
+  session?: ChatSession;
+}
+
+describe("useLlmManager override persistence", () => {
+  beforeEach(() => {
+    const ok = { ok: true, status: 200 } as Response;
+    jest.mocked(updateReasoningEffortForChatSession).mockResolvedValue(ok);
+    jest.mocked(updateTemperatureOverrideForChatSession).mockResolvedValue(ok);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("a persistOverrides reference taken before the selection writes the current choice", async () => {
+    const { result } = renderHook(() => useLlmManager());
+    // The send path can hold a reference from an earlier render.
+    const persistOverrides = result.current.persistOverrides;
+
+    act(() => result.current.updateReasoningEffort("high"));
+    await act(async () => {
+      await persistOverrides("session-1");
+    });
+
+    expect(updateReasoningEffortForChatSession).toHaveBeenCalledWith(
+      "session-1",
+      "high"
+    );
+  });
+
+  test("a session persisted while unbound keeps the selection once it is adopted", async () => {
+    const { result, rerender } = renderHook(
+      (props: HookProps) => useLlmManager(props.session),
+      { initialProps: {} }
+    );
+
+    act(() => result.current.updateReasoningEffort("high"));
+    await act(async () => {
+      await result.current.persistOverrides("session-1");
+    });
+
+    // The placeholder for the new session carries no override yet.
+    rerender({ session: makeSession("session-1", null) });
+    expect(result.current.reasoningEffort).toBe("high");
+
+    // Another session still reads its own row.
+    rerender({ session: makeSession("session-2", "low") });
+    expect(result.current.reasoningEffort).toBe("low");
+
+    // Coming back reads the row too, not the old local choice.
+    rerender({ session: makeSession("session-1", null) });
+    expect(result.current.reasoningEffort).toBeNull();
+  });
+});

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -254,7 +254,9 @@ export interface LlmManager {
   hasBoundSession: boolean;
   /** Ensure the session row reflects the local override selections. No-op
    * when the session is bound and every selection is confirmed persisted.
-   * Throws when a write fails, leaving the overrides unconfirmed for retry. */
+   * Safe to call through a stale reference: reads the selections as last
+   * rendered. Throws when a write fails, leaving the overrides unconfirmed
+   * for retry. */
   persistOverrides: (sessionId: string) => Promise<void>;
   updateModelOverrideBasedOnChatSession: (chatSession?: ChatSession) => void;
   imageFilesPresent: boolean;
@@ -671,13 +673,18 @@ export function useLlmManager(
   // Serializes every override PUT so an older selection can never land on
   // the server after a newer one. persistOverrides joins the same chain.
   const overrideWriteChainRef = useRef<Promise<unknown>>(Promise.resolve());
-  const enqueueOverrideWrite = (
-    write: () => Promise<Response>
-  ): Promise<Response> => {
-    const next = overrideWriteChainRef.current.then(write, write);
-    overrideWriteChainRef.current = next.catch(() => undefined);
-    return next;
-  };
+  const enqueueOverrideWrite = useCallback(
+    (write: () => Promise<Response>): Promise<Response> => {
+      const next = overrideWriteChainRef.current.then(write, write);
+      overrideWriteChainRef.current = next.catch(() => undefined);
+      return next;
+    },
+    []
+  );
+
+  // Session persisted while unbound. Its placeholder snapshot has no
+  // overrides, so adopting it would wipe the selections just written to it.
+  const handedOffSessionIdRef = useRef<string | null>(null);
 
   // Adopt the stored reasoning override (and reset the explicit-temperature
   // flag) only when session identity changes. Keying on identity, not the
@@ -689,6 +696,11 @@ export function useLlmManager(
     const sessionId = currentChatSession?.id ?? null;
     if (prevSessionIdRef.current === sessionId) return;
     prevSessionIdRef.current = sessionId;
+    if (sessionId !== null && sessionId === handedOffSessionIdRef.current) {
+      // Consumed once: coming back to this session later reads its row.
+      handedOffSessionIdRef.current = null;
+      return;
+    }
     setTemperatureExplicitlySet(false);
     persistedGenRef.current = selectionGen;
     setReasoningEffort(
@@ -789,37 +801,69 @@ export function useLlmManager(
     }
   };
 
-  const persistOverrides = async (sessionId: string): Promise<void> => {
-    // selectionGen is render-captured with the values below, so this persist
-    // confirms exactly the generation whose values it writes.
-    if (chatSession != null && persistedGenRef.current >= selectionGen) {
-      return;
-    }
-    const writes: Promise<Response>[] = [];
-    if (reasoningEffort) {
-      writes.push(
-        enqueueOverrideWrite(() =>
-          updateReasoningEffortForChatSession(sessionId, reasoningEffort)
-        )
-      );
-    }
-    if (temperatureExplicitlySet) {
-      writes.push(
-        enqueueOverrideWrite(() =>
-          updateTemperatureOverrideForChatSession(sessionId, temperature)
-        )
-      );
-    }
-    if (writes.length === 0) return;
-    const responses = await Promise.all(writes);
-    const failed = responses.find((response) => !response.ok);
-    if (failed) {
-      throw new Error(
-        `Failed to persist chat session overrides: ${failed.status}`
-      );
-    }
-    persistedGenRef.current = Math.max(persistedGenRef.current, selectionGen);
+  // persistOverrides is identity-stable, so it reads selections through this
+  // ref instead of its closure.
+  const latestSelection = {
+    reasoningEffort,
+    temperature,
+    temperatureExplicitlySet,
+    selectionGen,
+    chatSessionId: chatSession?.id ?? null,
   };
+  const latestSelectionRef = useRef(latestSelection);
+  useLayoutEffect(() => {
+    latestSelectionRef.current = latestSelection;
+  });
+
+  const persistOverrides = useCallback(
+    async (sessionId: string): Promise<void> => {
+      // One snapshot: this persist confirms exactly the generation it writes.
+      const selection = latestSelectionRef.current;
+      if (
+        selection.chatSessionId != null &&
+        persistedGenRef.current >= selection.selectionGen
+      ) {
+        return;
+      }
+      const writes: Promise<Response>[] = [];
+      if (selection.reasoningEffort) {
+        writes.push(
+          enqueueOverrideWrite(() =>
+            updateReasoningEffortForChatSession(
+              sessionId,
+              selection.reasoningEffort
+            )
+          )
+        );
+      }
+      if (selection.temperatureExplicitlySet) {
+        writes.push(
+          enqueueOverrideWrite(() =>
+            updateTemperatureOverrideForChatSession(
+              sessionId,
+              selection.temperature
+            )
+          )
+        );
+      }
+      if (writes.length === 0) return;
+      if (selection.chatSessionId == null) {
+        handedOffSessionIdRef.current = sessionId;
+      }
+      const responses = await Promise.all(writes);
+      const failed = responses.find((response) => !response.ok);
+      if (failed) {
+        throw new Error(
+          `Failed to persist chat session overrides: ${failed.status}`
+        );
+      }
+      persistedGenRef.current = Math.max(
+        persistedGenRef.current,
+        selection.selectionGen
+      );
+    },
+    [enqueueOverrideWrite]
+  );
 
   // Track if any provider exists for the current persona context.
   // Uses the persona-aware list so chat input reflects actual access,

--- a/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
+++ b/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
@@ -1,6 +1,6 @@
 import { SourceIcon } from "@/components/SourceIcon";
 import { MinimalOnyxDocument, OnyxDocument } from "@/lib/search/interfaces";
-import { FiTag } from "react-icons/fi";
+import { SvgTag } from "@opal/icons";
 import { buildDocumentSummaryDisplay } from "@/components/search/DocumentDisplay";
 import { DocumentUpdatedAtBadge } from "@/components/search/DocumentUpdatedAtBadge";
 import { MetadataBadge } from "@/components/MetadataBadge";
@@ -38,7 +38,7 @@ function DocumentMetadataBlock({
               .map(([key, value], index) => (
                 <MetadataBadge
                   key={index}
-                  icon={FiTag}
+                  icon={SvgTag}
                   value={`${key}=${value}`}
                 />
               ))}


### PR DESCRIPTION
## Description

**Bug:** a reasoning level chosen before the first message of a new chat is not applied to that message, and the pane shows Medium again once the session exists.

**Why:** `onSubmit` in `useChatController` narrows its deps to a few `llmManager` fields, so it keeps the manager snapshot from before the slider change. `persistOverrides` then sees no selection and writes nothing before the send. The session-bind effect writes it only after the send, and the identity effect adopts the placeholder's null.

**Fix:**
- `persistOverrides` reads the current selections through a ref, is stable, and is listed in the deps.
- The session a send creates keeps the selection made before it existed.
- Jest test for both, fails on the old code.

Also: main's type check broke with the react-icons 5 bump (#14441). `ChatDocumentDisplay` now uses the Opal tag icon.

## How Has This Been Tested?

Set the level to High in a new chat, send the first message, reopen the pane. Before: the row and the first message's `request_params` say medium. After: both say high.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/d30e42b9-d075-42e4-9b1d-33c2b750bf9b) | ![after](https://github.com/user-attachments/assets/5616b2cf-508d-4fc3-8167-dcea0cbf9f3c) |

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_013uc2y7QHPuoKPW1nHmoqRz
