### PR TITLE
perf(search): double the section-selection token budget

### DIFF
--- a/backend/onyx/tools/tool_implementations/search/constants.py
+++ b/backend/onyx/tools/tool_implementations/search/constants.py
@@ -19,6 +19,13 @@ KEYWORD_QUERY_HYBRID_ALPHA = 0.2
 # Reciprocal Rank Fusion
 RRF_K_VALUE = 50
 
+# Token budget multiplier for the LLM section-selection step. RRF ranks by
+# fused rank votes without reading content, so relevant documents regularly
+# land at fused ranks 26-50; a 2x budget lets the selection LLM see and
+# rescue them. +1.6 to +6.2 combined score on EnterpriseRAG-Bench across
+# 8 paired 500-question runs (3 models/efforts), latency neutral.
+SELECTION_TOKEN_BUDGET_MULTIPLIER = 2
+
 # Context Expansion
 FULL_DOC_NUM_CHUNKS_AROUND = 5
 

--- a/backend/onyx/tools/tool_implementations/search/constants.py
+++ b/backend/onyx/tools/tool_implementations/search/constants.py
@@ -19,11 +19,8 @@ KEYWORD_QUERY_HYBRID_ALPHA = 0.2
 # Reciprocal Rank Fusion
 RRF_K_VALUE = 50
 
-# Token budget multiplier for the LLM section-selection step. RRF ranks by
-# fused rank votes without reading content, so relevant documents regularly
-# land at fused ranks 26-50; a 2x budget lets the selection LLM see and
-# rescue them. +1.6 to +6.2 combined score on EnterpriseRAG-Bench across
-# 8 paired 500-question runs (3 models/efforts), latency neutral.
+# RRF ranks without reading content, so relevant documents often land just
+# below the selection cut; a wider budget lets the selection LLM rescue them.
 SELECTION_TOKEN_BUDGET_MULTIPLIER = 2
 
 # Context Expansion

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -120,6 +120,7 @@ from onyx.tools.tool_implementations.search.constants import (
     LLM_SEMANTIC_QUERY_WEIGHT,
     MAX_CHUNKS_FOR_RELEVANCE,
     ORIGINAL_QUERY_WEIGHT,
+    SELECTION_TOKEN_BUDGET_MULTIPLIER,
 )
 from onyx.tools.tool_implementations.search.search_utils import (
     expand_section_with_context,
@@ -1086,8 +1087,10 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         # Only consider MAX_CHUNKS_FOR_RELEVANCE chunks per section to avoid flooding from
         # documents with many matching sections
         max_tokens_for_selection = (
-            override_kwargs.max_llm_chunks or MAX_CHUNKS_FED_TO_CHAT
-        ) * DOC_EMBEDDING_CONTEXT_SIZE
+            (override_kwargs.max_llm_chunks or MAX_CHUNKS_FED_TO_CHAT)
+            * DOC_EMBEDDING_CONTEXT_SIZE
+            * SELECTION_TOKEN_BUDGET_MULTIPLIER
+        )
 
         # This is approximate since it doesn't build the exact string of the call below
         # Some things are estimated and may be under (like the metadata tokens)


### PR DESCRIPTION
## Description

Doubles the token budget for the SearchTool's LLM section-selection step (12.8k → 25.6k tokens) via a new `SELECTION_TOKEN_BUDGET_MULTIPLIER` constant. RRF fuses probe rankings by rank votes without reading content, so relevant documents regularly land at fused ranks 26–50 — below the old cut. With the doubled budget, the content-aware selection LLM sees the full fused pool and rescues them. The answer context fed to the chat model is unchanged (still capped by `max_llm_chunks` at the final render); only the selection call's input grows.

## How Has This Been Tested?

Validated on EnterpriseRAG-Bench (500-question runs, treatment and control run simultaneously against the same index):

| Pair (500q) | Combined 1× → 2× | Correctness | Completeness | Cited recall | Latency (mean) |
|---|---|---|---|---|---|
| gpt-5.6-luna medium | 71.5 → 73.9 | +1.6 | +1.9 | +4.2 | 25.6s → 25.4s |
| gpt-5.6-sol medium | 73.5 → 75.1 | +1.4 | +1.7 | +3.5 | 25.0s → 23.5s |
| gpt-5.6-luna xhigh | 73.3 → 75.8 | +2.8 | +1.5 | +3.5 | 35.6s → 34.3s |

8 of 8 paired tests to date positive (+1.6 to +6.2 combined); every sub-metric improved in every pair; latency neutral-to-faster. Cost: ~+45% input tokens on the selection call only. Full experiment log: agent-wiki, "Benchmark Speed Cost and Quality".

Related work: matches the `SELECTION_TOKEN_BUDGET_MULTIPLIER` in the `search-update` branch — isolated here because ablations showed this change carries most of that branch's gain on its own.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doubles the token budget for the LLM section-selection step in the search tool, so relevant documents that RRF ranked 26–50 are no longer cut off before the selection LLM can judge them. The budget grows from ~12.8k to ~25.6k tokens; the final answer context fed to the chat model is unchanged.

**Benchmark results**
- +1.6 to +6.2 combined score across 8 paired 500-question EnterpriseRAG-Bench runs; correctness, completeness, and cited recall improved in every pair.
- Latency is neutral-to-faster; input tokens on the selection call increase ~45%.

<sup>Written for commit e7daef8056dd14d80cf35db8db4c5213f8200bc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

