### PR TITLE
fix(hubspot): pass a request timeout to every HubSpot SDK call

### DIFF
--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -131,6 +131,8 @@ class HubSpotConnector(LoadConnector, PollConnector):
         self._portal_id = value
 
     def _call_hubspot(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        # The SDK sends requests with no timeout unless one is passed per call.
+        kwargs.setdefault("_request_timeout", REQUEST_TIMEOUT_SECONDS)
         return self._rate_limiter.call(func, *args, **kwargs)
 
     def _batch_read(

--- a/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_request_timeout.py
+++ b/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_request_timeout.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
+from onyx.connectors.hubspot.connector import HubSpotConnector
+
+
+def _make_connector() -> HubSpotConnector:
+    connector = HubSpotConnector()
+    connector._access_token = "token"
+    connector._portal_id = "portal"
+    return connector
+
+
+class TestCallHubspotRequestTimeout:
+    def test_default_timeout_is_passed_to_sdk(self) -> None:
+        connector = _make_connector()
+        sdk_fn = MagicMock(return_value="ok")
+
+        result = connector._call_hubspot(sdk_fn, "arg", key="value")
+
+        assert result == "ok"
+        sdk_fn.assert_called_once_with(
+            "arg", key="value", _request_timeout=REQUEST_TIMEOUT_SECONDS
+        )
+
+    def test_explicit_timeout_is_preserved(self) -> None:
+        connector = _make_connector()
+        sdk_fn = MagicMock(return_value="ok")
+
+        connector._call_hubspot(sdk_fn, _request_timeout=5)
+
+        sdk_fn.assert_called_once_with(_request_timeout=5)
+
+    def test_search_path_passes_timeout_to_sdk(self) -> None:
+        connector = _make_connector()
+        page = MagicMock()
+        page.results = []
+        page.paging = None
+        search_fn = MagicMock(return_value=page)
+        filter_group = connector._build_time_filter_group(
+            None, None, "hs_lastmodifieddate"
+        )
+
+        list(connector._search_paginated_results(search_fn, ["prop"], filter_group))
+
+        search_fn.assert_called_once()
+        assert search_fn.call_args.kwargs["_request_timeout"] == REQUEST_TIMEOUT_SECONDS


### PR DESCRIPTION
## Description

The HubSpot connector never passes `_request_timeout` to the HubSpot SDK, so the SDK sends every request with no urllib3 timeout. When the network silently drops a connection to `api.hubapi.com`, the docfetching worker blocks until the kernel TCP retransmit timeout, which is 15 to 30 minutes by default. The error surfaces as `ReadTimeoutError ... (read timeout=None)` caused by `TimeoutError: [Errno 110] Connection timed out`.

#10693 added a timeout to the raw `requests.get` used for the portal ID lookup but not to the SDK calls. The SDK has no global timeout setting. The only option is the per-call `_request_timeout` argument.

This change defaults `_request_timeout` to `REQUEST_TIMEOUT_SECONDS` (60s) in `_call_hubspot`, which wraps every SDK call: search, page, batch read, and associations. A dropped connection now fails within 60 seconds with a clear timeout error instead of pinning a worker for 20+ minutes.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/connectors/hubspot/test_hubspot_request_timeout.py` verify the default timeout reaches the SDK function, an explicit timeout is preserved, and the search pagination path passes it through.
- `backend/tests/daily/connectors/hubspot` against the real HubSpot API: 20 passed, covering load, poll, batch read, and association calls with the timeout in place.
- `pre-commit run --files` on the touched files passes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
HubSpot SDK calls previously ran without a request timeout, so dropped connections could block docfetching workers for 15–30 minutes. They now default to `REQUEST_TIMEOUT_SECONDS` (60 seconds), while explicit per-call timeouts remain unchanged, so failures surface promptly. Unit tests cover default, explicit, and paginated search timeout handling.

<sup>Written for commit a408c036022cac4be463d275aa5c0f529cf17b80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

