### PR TITLE
feat: expose system LLM usage in reports

### DIFF
--- a/backend/alembic/versions/ad99acb9be41_add_system_llm_usage.py
+++ b/backend/alembic/versions/ad99acb9be41_add_system_llm_usage.py
@@ -1,0 +1,65 @@
+"""add system llm usage
+
+Revision ID: ad99acb9be41
+Revises: 947b94d2ebf1
+Create Date: 2026-09-02 16:59:23.117473
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ad99acb9be41"
+down_revision = "947b94d2ebf1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_usage",
+        sa.Column("actor_kind", sa.String(), server_default="USER", nullable=False),
+    )
+    op.add_column(
+        "user_usage",
+        sa.Column("system_attribution", sa.String(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_user_usage_actor",
+        "user_usage",
+        "(actor_kind = 'USER' AND system_attribution IS NULL) OR "
+        "(actor_kind = 'SYSTEM' AND user_id IS NULL "
+        "AND system_attribution IS NOT NULL AND incognito = false)",
+    )
+    op.drop_index("uq_user_usage_dims", table_name="user_usage")
+    op.create_index(
+        "uq_user_usage_dims",
+        "user_usage",
+        ["user_id", "window_start", "model", "flow", "provider", "incognito"],
+        unique=True,
+        postgresql_where=sa.text("actor_kind = 'USER'"),
+    )
+    op.create_index(
+        "uq_system_usage_dims",
+        "user_usage",
+        ["system_attribution", "window_start", "model", "flow", "provider"],
+        unique=True,
+        postgresql_where=sa.text("actor_kind = 'SYSTEM'"),
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM user_usage WHERE actor_kind = 'SYSTEM'")
+    op.drop_index("uq_system_usage_dims", table_name="user_usage")
+    op.drop_index("uq_user_usage_dims", table_name="user_usage")
+    op.create_index(
+        "uq_user_usage_dims",
+        "user_usage",
+        ["user_id", "window_start", "model", "flow", "provider", "incognito"],
+        unique=True,
+    )
+    op.drop_constraint("ck_user_usage_actor", "user_usage", type_="check")
+    op.drop_column("user_usage", "system_attribution")
+    op.drop_column("user_usage", "actor_kind")

--- a/backend/alembic/versions/ad99acb9be41_add_system_llm_usage.py
+++ b/backend/alembic/versions/ad99acb9be41_add_system_llm_usage.py
@@ -1,7 +1,7 @@
 """add system llm usage
 
 Revision ID: ad99acb9be41
-Revises: 947b94d2ebf1
+Revises: 287021f3b46c
 Create Date: 2026-09-02 16:59:23.117473
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "ad99acb9be41"
-down_revision = "947b94d2ebf1"
+down_revision = "287021f3b46c"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/ad99acb9be41_add_system_llm_usage.py
+++ b/backend/alembic/versions/ad99acb9be41_add_system_llm_usage.py
@@ -31,7 +31,8 @@ def upgrade() -> None:
         "user_usage",
         "(actor_kind = 'USER' AND system_attribution IS NULL) OR "
         "(actor_kind = 'SYSTEM' AND user_id IS NULL "
-        "AND system_attribution IS NOT NULL AND incognito = false)",
+        "AND system_attribution IN ('ATTRIBUTED', 'UNATTRIBUTED') "
+        "AND incognito = false)",
     )
     op.drop_index("uq_user_usage_dims", table_name="user_usage")
     op.create_index(

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -25,6 +25,7 @@ from ee.onyx.server.reporting.usage_report_data import build_usage_report_data
 from ee.onyx.server.reporting.usage_report_pdf import render_usage_report_pdf
 from onyx.configs.constants import FileOrigin
 from onyx.db.models import User
+from onyx.db.system_usage import SystemUsageExportRow, iter_system_usage_export
 from onyx.db.user_usage import UsageExportRow, iter_usage_export
 from onyx.db.users import get_all_users
 from onyx.file_store.constants import MAX_IN_MEMORY_SIZE
@@ -192,12 +193,63 @@ def generate_usage_breakdown_report(
     return file_id
 
 
+def generate_system_usage_report(
+    file_store: FileStore,
+    report_id: str,
+    rows: Iterable[SystemUsageExportRow],
+) -> str:
+    file_name = f"{report_id}_usage_by_system"
+
+    with tempfile.SpooledTemporaryFile(
+        max_size=MAX_IN_MEMORY_SIZE, mode="w+"
+    ) as temp_file:
+        csvwriter = csv.writer(temp_file, delimiter=",")
+        csvwriter.writerow(
+            [
+                "attribution",
+                "day",
+                "model",
+                "flow",
+                "provider",
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "cache_creation_tokens",
+                "cost_cents",
+            ]
+        )
+        for row in rows:
+            csvwriter.writerow(
+                [
+                    row.attribution.value,
+                    row.day,
+                    sanitize_csv_cell_or_none(row.model),
+                    sanitize_csv_cell_or_none(row.flow),
+                    sanitize_csv_cell_or_none(row.provider),
+                    row.input_tokens,
+                    row.output_tokens,
+                    row.cache_read_tokens,
+                    row.cache_creation_tokens,
+                    row.cost_cents,
+                ]
+            )
+
+        temp_file.seek(0)
+        return file_store.save_file(
+            content=temp_file,
+            display_name=file_name,
+            file_origin=FileOrigin.GENERATED_REPORT,
+            file_type="text/csv",
+        )
+
+
 def generate_usage_report_pdf(
     db_session: Session,
     file_store: FileStore,
     report_id: str,
     period: tuple[datetime, datetime] | None,
     rows: list[UsageExportRow],
+    system_rows: list[SystemUsageExportRow],
 ) -> str:
     """Render the review pack PDF and store it. Returns the file id."""
     file_name = f"{report_id}_review_pack"
@@ -205,7 +257,9 @@ def generate_usage_report_pdf(
     # The queried bounds are half-open; only a given period gets the extra day.
     display_start, display_end = period if period else _normalize_period(None)
 
-    data = build_usage_report_data(db_session, rows, display_start, display_end)
+    data = build_usage_report_data(
+        db_session, rows, display_start, display_end, system_rows
+    )
     branding = load_report_branding(file_store)
     pdf_bytes = render_usage_report_pdf(data, branding)
 
@@ -239,16 +293,28 @@ def create_new_usage_report(
         query_start, query_end = normalized_period
         # The CSV and PDF must use the same rows so their totals reconcile.
         usage_rows = list(iter_usage_export(db_session, query_start, query_end))
+        system_usage_rows = list(
+            iter_system_usage_export(db_session, query_start, query_end)
+        )
         usage_breakdown_file_id = generate_usage_breakdown_report(
             file_store, report_id, usage_rows
         )
         intermediate_file_ids.append(usage_breakdown_file_id)
+        system_usage_file_id = generate_system_usage_report(
+            file_store, report_id, system_usage_rows
+        )
+        intermediate_file_ids.append(system_usage_file_id)
 
         # A render failure must not cost the admin their CSV export.
         pdf_file_id: str | None = None
         try:
             pdf_file_id = generate_usage_report_pdf(
-                db_session, file_store, report_id, period, usage_rows
+                db_session,
+                file_store,
+                report_id,
+                period,
+                usage_rows,
+                system_usage_rows,
             )
         except Exception:
             logger.exception("Failed to render usage report PDF; continuing without it")
@@ -283,6 +349,11 @@ def create_new_usage_report(
                     usage_breakdown_file_id, mode="b", use_tempfile=True
                 )
                 zip_file.writestr("usage_by_user.csv", usage_breakdown_tmpfile.read())
+
+                system_usage_tmpfile = file_store.read_file(
+                    system_usage_file_id, mode="b", use_tempfile=True
+                )
+                zip_file.writestr("usage_by_system.csv", system_usage_tmpfile.read())
 
                 if pdf_file_id is not None:
                     pdf_tmpfile = file_store.read_file(

--- a/backend/ee/onyx/server/reporting/usage_report_data.py
+++ b/backend/ee/onyx/server/reporting/usage_report_data.py
@@ -1,6 +1,7 @@
 """Aggregates behind the usage report review pack."""
 
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -8,6 +9,11 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.db.license import user_counts_toward_seats
 from onyx.db.api_key import is_api_key_email_address
+from onyx.db.enums import SystemUsageAttribution
+from onyx.db.system_usage import (
+    UNATTRIBUTED_SYSTEM_USAGE_CATEGORY,
+    SystemUsageExportRow,
+)
 from onyx.db.user_usage import DELETED_USER_EXPORT_EMAIL, UsageExportRow
 from onyx.db.users import get_all_users
 
@@ -54,6 +60,10 @@ class UsageReportData(BaseModel):
     top_users: list[NamedSpend]
     by_model: list[NamedSpend]
     by_flow: list[NamedSpend]
+    system_cost_cents: float
+    system_input_tokens: int
+    system_output_tokens: int
+    system_by_flow: list[NamedSpend]
     daily: list[DailySpend]
 
     @property
@@ -95,12 +105,13 @@ def build_usage_report_data(
     rows: list[UsageExportRow],
     period_start: datetime,
     period_end: datetime,
+    system_rows: Sequence[SystemUsageExportRow] = (),
 ) -> UsageReportData:
-    """`rows` is the list written to usage_by_user.csv, so the two cannot
-    diverge. The period is the admin's requested bounds, for display."""
+    """Build totals from the same rows written to both usage CSV files."""
     by_user: dict[str, NamedSpend] = {}
     by_model: dict[str, NamedSpend] = {}
     by_flow: dict[str, NamedSpend] = {}
+    system_by_flow: dict[str, NamedSpend] = {}
     daily_cost: dict[str, float] = defaultdict(float)
     daily_users: dict[str, set[str]] = defaultdict(set)
 
@@ -110,6 +121,9 @@ def build_usage_report_data(
     total_cache_read = 0
     total_cache_creation = 0
     active_emails: set[str] = set()
+    system_cost = 0.0
+    system_input = 0
+    system_output = 0
 
     for row in rows:
         for bucket, key in (
@@ -142,6 +156,37 @@ def build_usage_report_data(
             active_emails.add(row.email)
             daily_users[row.day].add(row.email)
 
+    for row in system_rows:
+        flow = (
+            UNATTRIBUTED_SYSTEM_USAGE_CATEGORY
+            if row.attribution == SystemUsageAttribution.UNATTRIBUTED
+            else row.flow or UNLABELED_FLOW
+        )
+        for bucket, key in (
+            (by_model, row.model),
+            (by_flow, flow),
+            (system_by_flow, flow),
+        ):
+            entry = bucket.get(key)
+            if entry is None:
+                entry = NamedSpend(
+                    name=key, cost_cents=0.0, input_tokens=0, output_tokens=0
+                )
+                bucket[key] = entry
+            entry.cost_cents += row.cost_cents
+            entry.input_tokens += row.input_tokens
+            entry.output_tokens += row.output_tokens
+
+        total_cost += row.cost_cents
+        total_input += row.input_tokens
+        total_output += row.output_tokens
+        total_cache_read += row.cache_read_tokens
+        total_cache_creation += row.cache_creation_tokens
+        system_cost += row.cost_cents
+        system_input += row.input_tokens
+        system_output += row.output_tokens
+        daily_cost[row.day] += row.cost_cents
+
     # Must match license enforcement, or this disagrees with what is billed.
     users = get_all_users(db_session, include_api_key_users=False)
     seat_emails = {user.email for user in users if user_counts_toward_seats(user)}
@@ -171,5 +216,9 @@ def build_usage_report_data(
         top_users=_top_n(by_user, TOP_USER_LIMIT),
         by_model=_top_n(by_model, TOP_ENTRY_LIMIT),
         by_flow=_top_n(by_flow, TOP_ENTRY_LIMIT),
+        system_cost_cents=system_cost,
+        system_input_tokens=system_input,
+        system_output_tokens=system_output,
+        system_by_flow=_top_n(system_by_flow, TOP_ENTRY_LIMIT),
         daily=daily,
     )

--- a/backend/ee/onyx/server/reporting/usage_report_pdf.py
+++ b/backend/ee/onyx/server/reporting/usage_report_pdf.py
@@ -589,6 +589,14 @@ def render_usage_report_pdf(data: UsageReportData, branding: ReportBranding) -> 
     story += _section("Spend by surface", "Where the work happens.", styles)
     story += [_spend_table("Flow", data.by_flow)]
 
+    if data.system_by_flow:
+        story += _section(
+            "System spend by flow",
+            "Background text generation without a user principal.",
+            styles,
+        )
+        story += [_spend_table("Flow", data.system_by_flow)]
+
     story += _section(
         "Seats not in use",
         "Licensed people who sent nothing this period. Reclaim, retrain, or "
@@ -617,9 +625,8 @@ def render_usage_report_pdf(data: UsageReportData, branding: ReportBranding) -> 
         _Rule(_CONTENT_WIDTH),
         Spacer(1, 8),
         Paragraph(
-            "Spend from deleted users and API keys is included in every total "
-            "and attributed separately. Neither counts as a person or a seat. "
-            "Days are UTC.",
+            "System, deleted-user, and API-key spend is included in every total. "
+            "None counts as a person or a seat. Days are UTC.",
             styles["note"],
         ),
     ]

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -779,6 +779,16 @@ class SSOProviderType(str, PyEnum):
     SAML = "SAML"
 
 
+class SystemUsageAttribution(str, PyEnum):
+    ATTRIBUTED = "ATTRIBUTED"
+    UNATTRIBUTED = "UNATTRIBUTED"
+
+
+class UsageActorKind(str, PyEnum):
+    USER = "USER"
+    SYSTEM = "SYSTEM"
+
+
 class IncognitoRecordMode(str, PyEnum):
     """What a workspace retains from an incognito chat.
 

--- a/backend/onyx/db/llm_usage.py
+++ b/backend/onyx/db/llm_usage.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class LLMUsageRecord(BaseModel):
+    model: str
+    flow: str
+    provider: str | None
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int = 0
+    cost_cents: float
+    window_start: datetime

--- a/backend/onyx/db/llm_usage.py
+++ b/backend/onyx/db/llm_usage.py
@@ -1,6 +1,11 @@
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel
+from sqlalchemy.dialects.postgresql.dml import Insert
+from sqlalchemy.sql.elements import ColumnElement
+
+from onyx.db.models import UserUsage
 
 
 class LLMUsageRecord(BaseModel):
@@ -13,3 +18,19 @@ class LLMUsageRecord(BaseModel):
     cache_creation_tokens: int = 0
     cost_cents: float
     window_start: datetime
+
+
+def build_usage_upsert_values(
+    statement: Insert,
+) -> dict[str, ColumnElement[Any]]:
+    return {
+        "input_tokens": UserUsage.input_tokens + statement.excluded.input_tokens,
+        "output_tokens": UserUsage.output_tokens + statement.excluded.output_tokens,
+        "cache_read_tokens": (
+            UserUsage.cache_read_tokens + statement.excluded.cache_read_tokens
+        ),
+        "cache_creation_tokens": (
+            UserUsage.cache_creation_tokens + statement.excluded.cache_creation_tokens
+        ),
+        "cost_cents": UserUsage.cost_cents + statement.excluded.cost_cents,
+    }

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -117,8 +117,10 @@ from onyx.db.enums import (
     SwitchoverType,
     SyncStatus,
     SyncType,
+    SystemUsageAttribution,
     TaskStatus,
     ThemePreference,
+    UsageActorKind,
     UserFileStatus,
 )
 from onyx.db.index_attempt_metrics_models import IndexAttemptStage
@@ -6186,11 +6188,9 @@ class TenantUsage(Base):
 
 
 class UserUsage(Base):
-    """
-    Daily per-user LLM usage rollup for cost/token attribution and budget checks.
-
-    One accumulating row per (user, window, model, flow, provider, incognito),
-    not per call.
+    """Daily user and system LLM usage rollup. ``user_usage`` is a legacy
+    physical name retained for deployment compatibility; partial indexes
+    provide each actor kind's accumulation key.
     """
 
     __tablename__ = "user_usage"
@@ -6200,6 +6200,15 @@ class UserUsage(Base):
     # No index=True: uq_user_usage_dims (user_id-first) covers user-only lookups.
     user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    actor_kind: Mapped[UsageActorKind] = mapped_column(
+        Enum(UsageActorKind, native_enum=False),
+        nullable=False,
+        default=UsageActorKind.USER,
+        server_default=UsageActorKind.USER.value,
+    )
+    system_attribution: Mapped[SystemUsageAttribution | None] = mapped_column(
+        Enum(SystemUsageAttribution, native_enum=False), nullable=True
     )
 
     window_start: Mapped[datetime.datetime] = mapped_column(
@@ -6241,9 +6250,12 @@ class UserUsage(Base):
     )
 
     __table_args__ = (
-        # Upsert key: accumulate into one row per dimension tuple per window.
-        # provider is non-null ('' when absent), so a plain unique index dedups
-        # correctly on every Postgres version (no NULLS NOT DISTINCT needed).
+        CheckConstraint(
+            "(actor_kind = 'USER' AND system_attribution IS NULL) OR "
+            "(actor_kind = 'SYSTEM' AND user_id IS NULL "
+            "AND system_attribution IS NOT NULL AND incognito = false)",
+            name="ck_user_usage_actor",
+        ),
         Index(
             "uq_user_usage_dims",
             "user_id",
@@ -6253,6 +6265,17 @@ class UserUsage(Base):
             "provider",
             "incognito",
             unique=True,
+            postgresql_where=text("actor_kind = 'USER'"),
+        ),
+        Index(
+            "uq_system_usage_dims",
+            "system_attribution",
+            "window_start",
+            "model",
+            "flow",
+            "provider",
+            unique=True,
+            postgresql_where=text("actor_kind = 'SYSTEM'"),
         ),
     )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6253,7 +6253,9 @@ class UserUsage(Base):
         CheckConstraint(
             "(actor_kind = 'USER' AND system_attribution IS NULL) OR "
             "(actor_kind = 'SYSTEM' AND user_id IS NULL "
-            "AND system_attribution IS NOT NULL AND incognito = false)",
+            f"AND system_attribution IN ('{SystemUsageAttribution.ATTRIBUTED.value}', "
+            f"'{SystemUsageAttribution.UNATTRIBUTED.value}') "
+            "AND incognito = false)",
             name="ck_user_usage_actor",
         ),
         Index(

--- a/backend/onyx/db/system_usage.py
+++ b/backend/onyx/db/system_usage.py
@@ -1,0 +1,118 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SystemUsageAttribution, UsageActorKind
+from onyx.db.llm_usage import LLMUsageRecord
+from onyx.db.models import UserUsage
+from onyx.utils.datetime import datetime_to_utc
+
+_CONFLICT_COLUMNS = [
+    "system_attribution",
+    "window_start",
+    "model",
+    "flow",
+    "provider",
+]
+_SYSTEM_ACTOR_INDEX_PREDICATE = text("actor_kind = 'SYSTEM'")
+
+
+class SystemTokenUsageBucket(BaseModel):
+    window_start: datetime
+    tokens: int
+
+
+def record_system_usage(
+    db_session: Session,
+    attribution: SystemUsageAttribution,
+    usage: LLMUsageRecord,
+) -> None:
+    """Accumulate one non-user generation into its daily rollup."""
+    statement = pg_insert(UserUsage).values(
+        user_id=None,
+        actor_kind=UsageActorKind.SYSTEM,
+        system_attribution=attribution,
+        window_start=usage.window_start,
+        model=usage.model,
+        flow=usage.flow,
+        provider=usage.provider or "",
+        incognito=False,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_creation_tokens=usage.cache_creation_tokens,
+        cost_cents=usage.cost_cents,
+    )
+    statement = statement.on_conflict_do_update(
+        index_elements=_CONFLICT_COLUMNS,
+        index_where=_SYSTEM_ACTOR_INDEX_PREDICATE,
+        set_={
+            "input_tokens": UserUsage.input_tokens + statement.excluded.input_tokens,
+            "output_tokens": (
+                UserUsage.output_tokens + statement.excluded.output_tokens
+            ),
+            "cache_read_tokens": (
+                UserUsage.cache_read_tokens + statement.excluded.cache_read_tokens
+            ),
+            "cache_creation_tokens": (
+                UserUsage.cache_creation_tokens
+                + statement.excluded.cache_creation_tokens
+            ),
+            "cost_cents": UserUsage.cost_cents + statement.excluded.cost_cents,
+        },
+    )
+    db_session.execute(statement)
+    db_session.flush()
+
+
+def get_system_cost_cents_since(db_session: Session, cutoff: datetime) -> float:
+    total = db_session.scalar(
+        select(func.coalesce(func.sum(UserUsage.cost_cents), 0.0)).where(
+            UserUsage.actor_kind == UsageActorKind.SYSTEM,
+            UserUsage.window_start >= cutoff,
+        )
+    )
+    return float(total or 0.0)
+
+
+def get_system_cost_cents_buckets_since(
+    db_session: Session, cutoff: datetime
+) -> list[tuple[datetime, float]]:
+    rows = db_session.execute(
+        select(
+            UserUsage.window_start,
+            func.coalesce(func.sum(UserUsage.cost_cents), 0.0),
+        )
+        .where(
+            UserUsage.actor_kind == UsageActorKind.SYSTEM,
+            UserUsage.window_start >= cutoff,
+        )
+        .group_by(UserUsage.window_start)
+    ).all()
+    return [(datetime_to_utc(window_start), float(cost)) for window_start, cost in rows]
+
+
+def get_system_token_buckets_since(
+    db_session: Session, cutoff: datetime
+) -> list[SystemTokenUsageBucket]:
+    rows = db_session.execute(
+        select(
+            UserUsage.window_start,
+            func.sum(UserUsage.input_tokens + UserUsage.output_tokens),
+        )
+        .where(
+            UserUsage.actor_kind == UsageActorKind.SYSTEM,
+            UserUsage.window_start >= cutoff,
+        )
+        .group_by(UserUsage.window_start)
+        .order_by(UserUsage.window_start)
+    ).all()
+    return [
+        SystemTokenUsageBucket(
+            window_start=datetime_to_utc(window_start), tokens=int(tokens)
+        )
+        for window_start, tokens in rows
+    ]

--- a/backend/onyx/db/system_usage.py
+++ b/backend/onyx/db/system_usage.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -18,11 +19,26 @@ _CONFLICT_COLUMNS = [
     "provider",
 ]
 _SYSTEM_ACTOR_INDEX_PREDICATE = text("actor_kind = 'SYSTEM'")
+UNATTRIBUTED_SYSTEM_USAGE_CATEGORY = "unattributed"
+OTHER_SYSTEM_USAGE_CATEGORY = "other"
 
 
 class SystemTokenUsageBucket(BaseModel):
     window_start: datetime
     tokens: int
+
+
+class SystemUsageExportRow(BaseModel):
+    attribution: SystemUsageAttribution
+    model: str
+    flow: str
+    provider: str
+    day: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    cost_cents: float
 
 
 def record_system_usage(
@@ -103,3 +119,73 @@ def get_system_token_buckets_since(
         )
         for window_start, tokens in rows
     ]
+
+
+def iter_system_usage_export(
+    db_session: Session,
+    start: datetime,
+    end: datetime,
+    model: str | None = None,
+) -> Iterator[SystemUsageExportRow]:
+    utc_day = func.date(func.timezone("UTC", UserUsage.window_start))
+    query = (
+        select(
+            UserUsage.system_attribution,
+            UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
+            utc_day.label("day"),
+            func.sum(UserUsage.input_tokens),
+            func.sum(UserUsage.output_tokens),
+            func.sum(UserUsage.cache_read_tokens),
+            func.sum(UserUsage.cache_creation_tokens),
+            func.sum(UserUsage.cost_cents),
+        )
+        .where(
+            UserUsage.actor_kind == UsageActorKind.SYSTEM,
+            UserUsage.window_start >= start,
+            UserUsage.window_start < end,
+        )
+        .group_by(
+            UserUsage.system_attribution,
+            UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
+            utc_day,
+        )
+        .order_by(
+            UserUsage.system_attribution,
+            utc_day,
+            UserUsage.model,
+            UserUsage.flow,
+            UserUsage.provider,
+        )
+    )
+    if model is not None:
+        query = query.where(UserUsage.model == model)
+
+    result = db_session.execute(query.execution_options(stream_results=True)).yield_per(
+        1000
+    )
+    for row in result:
+        yield SystemUsageExportRow(
+            attribution=row[0],
+            model=row[1],
+            flow=row[2],
+            provider=row[3],
+            day=str(row[4]),
+            input_tokens=int(row[5] or 0),
+            output_tokens=int(row[6] or 0),
+            cache_read_tokens=int(row[7] or 0),
+            cache_creation_tokens=int(row[8] or 0),
+            cost_cents=float(row[9] or 0.0),
+        )
+
+
+def get_system_usage_export(
+    db_session: Session,
+    start: datetime,
+    end: datetime,
+    model: str | None = None,
+) -> list[SystemUsageExportRow]:
+    return list(iter_system_usage_export(db_session, start, end, model))

--- a/backend/onyx/db/system_usage.py
+++ b/backend/onyx/db/system_usage.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import SystemUsageAttribution, UsageActorKind
-from onyx.db.llm_usage import LLMUsageRecord
+from onyx.db.llm_usage import LLMUsageRecord, build_usage_upsert_values
 from onyx.db.models import UserUsage
 from onyx.utils.datetime import datetime_to_utc
 
@@ -49,20 +49,7 @@ def record_system_usage(
     statement = statement.on_conflict_do_update(
         index_elements=_CONFLICT_COLUMNS,
         index_where=_SYSTEM_ACTOR_INDEX_PREDICATE,
-        set_={
-            "input_tokens": UserUsage.input_tokens + statement.excluded.input_tokens,
-            "output_tokens": (
-                UserUsage.output_tokens + statement.excluded.output_tokens
-            ),
-            "cache_read_tokens": (
-                UserUsage.cache_read_tokens + statement.excluded.cache_read_tokens
-            ),
-            "cache_creation_tokens": (
-                UserUsage.cache_creation_tokens
-                + statement.excluded.cache_creation_tokens
-            ),
-            "cost_cents": UserUsage.cost_cents + statement.excluded.cost_cents,
-        },
+        set_=build_usage_upsert_values(statement),
     )
     db_session.execute(statement)
     db_session.flush()

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -12,11 +12,13 @@ from typing import Any, cast
 
 from cachetools import TTLCache
 from pydantic import BaseModel
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import UsageActorKind
+from onyx.db.llm_usage import LLMUsageRecord
 from onyx.db.models import TokenRateLimit, User, User__UserGroup, UserUsage
 from onyx.utils.datetime import datetime_to_utc, get_window_start
 from onyx.utils.logger import setup_logger
@@ -39,6 +41,7 @@ _invalid_cost_budget_warning_cache: TTLCache[tuple[str | None, int, int], None] 
 # Not email-shaped on purpose: it can never collide with a real address.
 DELETED_USER_EXPORT_EMAIL = "(deleted user)"
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider", "incognito"]
+_USER_ACTOR_INDEX_PREDICATE = text("actor_kind = 'USER'")
 
 
 class TokenUsageBucket(BaseModel):
@@ -189,37 +192,30 @@ class UsageExportRow(BaseModel):
 def record_user_usage(
     db_session: Session,
     user_id: str,
-    model: str,
-    flow: str,
-    provider: str | None,
-    input_tokens: int,
-    output_tokens: int,
-    cache_read_tokens: int,
-    cost_cents: float,
-    window_start: datetime,
+    usage: LLMUsageRecord,
     incognito: bool = False,
-    *,
-    cache_creation_tokens: int = 0,
 ) -> None:
     """Atomically accumulate into the ledger (Postgres upsert). Caller commits."""
     # Store "" rather than NULL for a missing provider so the dedup unique index
     # collapses these rows on every Postgres version (no NULLS NOT DISTINCT).
-    provider = provider or ""
+    provider = usage.provider or ""
     stmt = pg_insert(UserUsage).values(
         user_id=user_id,
-        window_start=window_start,
-        model=model,
-        flow=flow,
+        actor_kind=UsageActorKind.USER,
+        window_start=usage.window_start,
+        model=usage.model,
+        flow=usage.flow,
         provider=provider,
         incognito=incognito,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_read_tokens=cache_read_tokens,
-        cache_creation_tokens=cache_creation_tokens,
-        cost_cents=cost_cents,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_creation_tokens=usage.cache_creation_tokens,
+        cost_cents=usage.cost_cents,
     )
     stmt = stmt.on_conflict_do_update(
         index_elements=_CONFLICT_COLS,
+        index_where=_USER_ACTOR_INDEX_PREDICATE,
         set_={
             "input_tokens": UserUsage.input_tokens + stmt.excluded.input_tokens,
             "output_tokens": UserUsage.output_tokens + stmt.excluded.output_tokens,
@@ -311,6 +307,7 @@ def _get_usage_export_query(
         # base, which ty resolves as a plain value rather than a column.
         .outerjoin(User, UserUsage.user_id == User.id)
         .where(
+            UserUsage.actor_kind == UsageActorKind.USER,
             UserUsage.window_start >= start,
             UserUsage.window_start < end,
         )

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -18,7 +18,7 @@ from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import UsageActorKind
-from onyx.db.llm_usage import LLMUsageRecord
+from onyx.db.llm_usage import LLMUsageRecord, build_usage_upsert_values
 from onyx.db.models import TokenRateLimit, User, User__UserGroup, UserUsage
 from onyx.utils.datetime import datetime_to_utc, get_window_start
 from onyx.utils.logger import setup_logger
@@ -216,15 +216,7 @@ def record_user_usage(
     stmt = stmt.on_conflict_do_update(
         index_elements=_CONFLICT_COLS,
         index_where=_USER_ACTOR_INDEX_PREDICATE,
-        set_={
-            "input_tokens": UserUsage.input_tokens + stmt.excluded.input_tokens,
-            "output_tokens": UserUsage.output_tokens + stmt.excluded.output_tokens,
-            "cache_read_tokens": UserUsage.cache_read_tokens
-            + stmt.excluded.cache_read_tokens,
-            "cache_creation_tokens": UserUsage.cache_creation_tokens
-            + stmt.excluded.cache_creation_tokens,
-            "cost_cents": UserUsage.cost_cents + stmt.excluded.cost_cents,
-        },
+        set_=build_usage_upsert_values(stmt),
     )
     db_session.execute(stmt)
     db_session.flush()

--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -21,6 +21,7 @@ from onyx.llm.models import (
 from onyx.llm.utils import llm_response_to_string
 from onyx.server.metrics.image_processing import track_image_summarization
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
@@ -136,8 +137,8 @@ def _summarize_image(
             llm=llm,
             flow=LLMFlow.IMAGE_SUMMARIZATION,
             input_messages=[{"type": "image_summarization_request"}],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
-            # Note: We don't include the actual image in the span input to avoid bloating traces
             response = llm.invoke(
                 messages, total_timeout_override=IMAGE_SUMMARIZATION_TIMEOUT
             )

--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -136,7 +136,6 @@ def _summarize_image(
         with llm_generation_span(
             llm=llm,
             flow=LLMFlow.IMAGE_SUMMARIZATION,
-            input_messages=[{"type": "image_summarization_request"}],
             content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -59,6 +59,8 @@ from onyx.document_index.interfaces_new import (
     DocumentInsertionRecord,
     IndexingMetadata,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.image_summarization import summarize_image_with_error_handling
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.staging import promote_staged_file
@@ -103,6 +105,7 @@ from onyx.prompts.contextual_retrieval import (
     CONTEXTUAL_RAG_PROMPT2,
     DOCUMENT_SUMMARY_PROMPT,
 )
+from onyx.server.query_and_chat.token_limit import check_global_token_rate_limits
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import ensure_trace
 from onyx.tracing.framework.traces import TraceContentMode
@@ -118,6 +121,12 @@ logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
+CONTEXTUAL_RAG_ENRICHMENT_NAME = "contextual RAG"
+IMAGE_SUMMARIZATION_ENRICHMENT_NAME = "image summarization"
+LLM_ENRICHMENT_SPEND_LIMIT_FAILURE_MESSAGE = (
+    "Document requires {enrichments}, but the workspace global LLM usage limit "
+    "has been reached. Adjust the limit or wait for it to reset, then retry."
+)
 INDEXING_PIPELINE_TRACE_NAME = "indexing_pipeline"
 
 # Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
@@ -147,6 +156,11 @@ class DocumentBatchPrepareContext(BaseModel):
     indexable_docs: list[IndexingDocument] = []
     doc_id_to_content_hash: dict[str, str] = {}
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _LLMEnrichmentPartition(BaseModel):
+    documents: list[Document]
+    failures: list[ConnectorFailure]
 
 
 class IndexingPipelineResult(BaseModel):
@@ -424,6 +438,7 @@ def index_doc_batch_with_handler(
     index_to_secondary: bool = False,
     from_beginning: bool = False,
     enable_contextual_rag: bool = False,
+    llm_enrichment_allowed: bool = True,
     llm: LLM | None = None,
 ) -> IndexingPipelineResult:
     try:
@@ -439,6 +454,7 @@ def index_doc_batch_with_handler(
             index_to_secondary=index_to_secondary,
             from_beginning=from_beginning,
             enable_contextual_rag=enable_contextual_rag,
+            llm_enrichment_allowed=llm_enrichment_allowed,
             llm=llm,
         )
 
@@ -724,6 +740,90 @@ def filter_documents(
     return documents, failures
 
 
+def _convert_documents_without_image_summaries(
+    documents: list[Document],
+) -> list[IndexingDocument]:
+    return [
+        IndexingDocument(
+            **document.model_dump(),
+            processed_sections=[
+                (
+                    Section(
+                        type=section.type,
+                        text="",
+                        link=section.link,
+                        image_file_id=section.image_file_id,
+                        heading=section.heading,
+                    )
+                    if isinstance(section, ImageSection)
+                    else section.model_copy()
+                )
+                for section in document.sections
+            ],
+        )
+        for document in documents
+    ]
+
+
+def _system_llm_enrichment_is_allowed() -> bool:
+    try:
+        check_global_token_rate_limits()
+    except OnyxError as error:
+        if error.error_code != OnyxErrorCode.RATE_LIMITED:
+            raise
+        logger.warning(
+            "Blocking indexing LLM enrichment at the global usage limit: %s",
+            error.detail,
+        )
+        return False
+    return True
+
+
+def _partition_documents_blocked_by_llm_spend_limit(
+    documents: list[Document],
+    *,
+    enable_contextual_rag: bool,
+    enable_image_summarization: bool,
+    llm_enrichment_allowed: bool,
+) -> _LLMEnrichmentPartition:
+    if llm_enrichment_allowed:
+        return _LLMEnrichmentPartition(documents=documents, failures=[])
+
+    allowed_documents: list[Document] = []
+    failures: list[ConnectorFailure] = []
+    for document in documents:
+        blocked_enrichments: list[str] = []
+        if enable_contextual_rag:
+            blocked_enrichments.append(CONTEXTUAL_RAG_ENRICHMENT_NAME)
+        if enable_image_summarization and any(
+            section.type == SectionType.IMAGE for section in document.sections
+        ):
+            blocked_enrichments.append(IMAGE_SUMMARIZATION_ENRICHMENT_NAME)
+        if not blocked_enrichments:
+            allowed_documents.append(document)
+            continue
+
+        failures.append(
+            ConnectorFailure(
+                failed_document=DocumentFailure(
+                    document_id=document.id,
+                    document_link=next(
+                        (section.link for section in document.sections if section.link),
+                        None,
+                    ),
+                ),
+                failure_message=LLM_ENRICHMENT_SPEND_LIMIT_FAILURE_MESSAGE.format(
+                    enrichments=" and ".join(blocked_enrichments)
+                ),
+            )
+        )
+
+    return _LLMEnrichmentPartition(
+        documents=allowed_documents,
+        failures=failures,
+    )
+
+
 def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
     """
     Process all sections in documents by:
@@ -758,27 +858,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                 "available — images will not be summarized. Configure a "
                 "vision model in the admin LLM settings."
             )
-        # Even without LLM, we still convert to IndexingDocument with base Sections
-        return [
-            IndexingDocument(
-                **document.model_dump(),
-                processed_sections=[
-                    (
-                        Section(
-                            type=section.type,
-                            text="",
-                            link=section.link,
-                            image_file_id=section.image_file_id,
-                            heading=section.heading,
-                        )
-                        if isinstance(section, ImageSection)
-                        else section.model_copy()
-                    )
-                    for section in document.sections
-                ],
-            )
-            for document in documents
-        ]
+        return _convert_documents_without_image_summaries(documents)
 
     indexed_documents: list[IndexingDocument] = []
     # Sections that need LLM summarization, paired with their image data.
@@ -1284,6 +1364,7 @@ def index_doc_batch(
     tenant_id: str,
     adapter: IndexingBatchAdapter,
     enable_contextual_rag: bool = False,
+    llm_enrichment_allowed: bool = True,
     llm: LLM | None = None,
     ignore_time_skip: bool = False,
     index_to_secondary: bool = False,
@@ -1334,6 +1415,22 @@ def index_doc_batch(
         result.failures.extend(filter_failures)
         return result
 
+    enrichment_partition = _partition_documents_blocked_by_llm_spend_limit(
+        context.updatable_docs,
+        enable_contextual_rag=enable_contextual_rag,
+        enable_image_summarization=get_image_extraction_and_analysis_enabled(),
+        llm_enrichment_allowed=llm_enrichment_allowed,
+    )
+    enrichment_failed_doc_ids = _get_failed_doc_ids(enrichment_partition.failures)
+    context.updatable_docs = enrichment_partition.documents
+    if not context.updatable_docs:
+        return IndexingPipelineResult(
+            new_docs=0,
+            total_docs=len(filtered_documents),
+            total_chunks=0,
+            failures=filter_failures + enrichment_partition.failures,
+        )
+
     # Convert documents to IndexingDocument objects with processed section.
     # Only record IMAGE_PROCESSING when there's actually image work to do --
     # otherwise the average/stddev gets polluted with no-op zero events.
@@ -1365,7 +1462,7 @@ def index_doc_batch(
     llm_tokenizer: BaseTokenizer | None = None
 
     # contextual RAG
-    if enable_contextual_rag:
+    if enable_contextual_rag and llm_enrichment_allowed:
         assert llm is not None, "must provide an LLM for contextual RAG"
         llm_tokenizer = get_tokenizer(
             model_name=llm.config.model_name,
@@ -1490,7 +1587,11 @@ def index_doc_batch(
                 adapter.post_index(
                     context=context,
                     updatable_chunk_data=updatable_chunk_data,
-                    filtered_documents=filtered_documents,
+                    filtered_documents=[
+                        document
+                        for document in filtered_documents
+                        if document.id not in enrichment_failed_doc_ids
+                    ],
                     enrichment=enricher,
                     db_session=db_session,
                     index_to_secondary=index_to_secondary,
@@ -1533,6 +1634,7 @@ def index_doc_batch(
         total_chunks=len(embedding_result.successful_chunk_ids),
         failures=primary_doc_idx_vector_db_write_failures
         + embedding_result.connector_failures
+        + enrichment_partition.failures
         + filter_failures,
     )
 
@@ -1571,21 +1673,25 @@ def run_indexing_pipeline(
 
     multipass_config = get_multipass_config(search_settings)
 
-    enable_contextual_rag = (
+    contextual_rag_configured = (
         search_settings.enable_contextual_rag or ENABLE_CONTEXTUAL_RAG
     )
+    image_summarization_configured = get_image_extraction_and_analysis_enabled()
     llm_enrichment_configured = (
-        enable_contextual_rag or get_image_extraction_and_analysis_enabled()
+        contextual_rag_configured or image_summarization_configured
+    )
+    llm_enrichment_allowed = (
+        not llm_enrichment_configured or _system_llm_enrichment_is_allowed()
     )
     llm = None
-    if enable_contextual_rag:
+    if contextual_rag_configured and llm_enrichment_allowed:
         llm = get_contextual_rag_llm_for_search_settings(search_settings)
 
     chunker = chunker or Chunker(
         tokenizer=embedder.embedding_model.tokenizer,
         enable_multipass=multipass_config.multipass_indexing,
         enable_large_chunks=multipass_config.enable_large_chunks,
-        enable_contextual_rag=enable_contextual_rag,
+        enable_contextual_rag=contextual_rag_configured and llm_enrichment_allowed,
         # after every doc, update status in case there are a bunch of really long docs
     )
 
@@ -1606,7 +1712,8 @@ def run_indexing_pipeline(
             request_id=request_id,
             tenant_id=tenant_id,
             adapter=adapter,
-            enable_contextual_rag=enable_contextual_rag,
+            enable_contextual_rag=contextual_rag_configured,
+            llm_enrichment_allowed=llm_enrichment_allowed,
             llm=llm,
             ignore_time_skip=ignore_time_skip,
             index_to_secondary=index_to_secondary,

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1,7 +1,7 @@
 import time
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import NamedTuple, Protocol
 
 import sentry_sdk
@@ -104,6 +104,8 @@ from onyx.prompts.contextual_retrieval import (
     DOCUMENT_SUMMARY_PROMPT,
 )
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
@@ -116,6 +118,7 @@ logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
+INDEXING_PIPELINE_TRACE_NAME = "indexing_pipeline"
 
 # Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
 # model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the
@@ -884,6 +887,7 @@ def add_document_summaries(
         llm=llm,
         flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
         input_messages=[prompt_msg],
+        content_mode=TraceContentMode.METADATA_ONLY,
     ) as span_generation:
         response = llm.invoke(
             prompt_msg,
@@ -938,6 +942,7 @@ def add_chunk_summaries(
             llm=llm,
             flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
             input_messages=[fallback_prompt],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(
                 fallback_prompt,
@@ -968,6 +973,7 @@ def add_chunk_summaries(
                 llm=llm,
                 flow=LLMFlow.CONTEXTUAL_RAG_CHUNK_CONTEXT,
                 input_messages=[processed_prompt],
+                content_mode=TraceContentMode.METADATA_ONLY,
             ) as span_generation:
                 response = llm.invoke(
                     processed_prompt,
@@ -1568,6 +1574,9 @@ def run_indexing_pipeline(
     enable_contextual_rag = (
         search_settings.enable_contextual_rag or ENABLE_CONTEXTUAL_RAG
     )
+    llm_enrichment_configured = (
+        enable_contextual_rag or get_image_extraction_and_analysis_enabled()
+    )
     llm = None
     if enable_contextual_rag:
         llm = get_contextual_rag_llm_for_search_settings(search_settings)
@@ -1580,17 +1589,26 @@ def run_indexing_pipeline(
         # after every doc, update status in case there are a bunch of really long docs
     )
 
-    return index_doc_batch_with_handler(
-        chunker=chunker,
-        embedder=embedder,
-        document_indices=document_indices,
-        document_batch=document_batch,
-        request_id=request_id,
-        tenant_id=tenant_id,
-        adapter=adapter,
-        enable_contextual_rag=enable_contextual_rag,
-        llm=llm,
-        ignore_time_skip=ignore_time_skip,
-        index_to_secondary=index_to_secondary,
-        from_beginning=from_beginning,
+    trace_context = (
+        ensure_trace(
+            INDEXING_PIPELINE_TRACE_NAME,
+            content_mode=TraceContentMode.METADATA_ONLY,
+        )
+        if llm_enrichment_configured
+        else nullcontext()
     )
+    with trace_context:
+        return index_doc_batch_with_handler(
+            chunker=chunker,
+            embedder=embedder,
+            document_indices=document_indices,
+            document_batch=document_batch,
+            request_id=request_id,
+            tenant_id=tenant_id,
+            adapter=adapter,
+            enable_contextual_rag=enable_contextual_rag,
+            llm=llm,
+            ignore_time_skip=ignore_time_skip,
+            index_to_secondary=index_to_secondary,
+            from_beginning=from_beginning,
+        )

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -439,6 +439,7 @@ def index_doc_batch_with_handler(
     from_beginning: bool = False,
     enable_contextual_rag: bool = False,
     llm_enrichment_allowed: bool = True,
+    image_summarization_llm: LLM | None = None,
     llm: LLM | None = None,
 ) -> IndexingPipelineResult:
     try:
@@ -455,6 +456,7 @@ def index_doc_batch_with_handler(
             from_beginning=from_beginning,
             enable_contextual_rag=enable_contextual_rag,
             llm_enrichment_allowed=llm_enrichment_allowed,
+            image_summarization_llm=image_summarization_llm,
             llm=llm,
         )
 
@@ -824,40 +826,31 @@ def _partition_documents_blocked_by_llm_spend_limit(
     )
 
 
-def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
-    """
-    Process all sections in documents by:
-    1. Converting both TextSection and ImageSection objects to base Section objects
-    2. Processing ImageSections to generate text summaries using a vision-capable LLM
-    3. Returning IndexingDocument objects with both original and processed sections
-
-    Args:
-        documents: List of documents with TextSection | ImageSection objects
-
-    Returns:
-        List of IndexingDocument objects with processed_sections as list[Section]
-    """
-    # Check if image extraction and analysis is enabled before trying to get a vision LLM.
-    # Use section.type rather than isinstance because sections can round-trip
-    # through pydantic as base Section instances (not the concrete subclass).
+def _get_image_summarization_llm(
+    documents: list[Document], enabled: bool
+) -> LLM | None:
     has_image_section = any(
         section.type == SectionType.IMAGE
         for document in documents
         for section in document.sections
     )
-    if not get_image_extraction_and_analysis_enabled() or not has_image_section:
-        llm = None
-    else:
-        # Only get the vision LLM if image processing is enabled
-        llm = get_default_llm_with_vision()
+    if not enabled or not has_image_section:
+        return None
 
-    if not llm:
-        if get_image_extraction_and_analysis_enabled():
-            logger.warning(
-                "Image analysis is enabled but no vision-capable LLM is "
-                "available — images will not be summarized. Configure a "
-                "vision model in the admin LLM settings."
-            )
+    llm = get_default_llm_with_vision()
+    if llm is None:
+        logger.warning(
+            "Image analysis is enabled but no vision-capable LLM is "
+            "available — images will not be summarized. Configure a "
+            "vision model in the admin LLM settings."
+        )
+    return llm
+
+
+def _process_image_sections(
+    documents: list[Document], llm: LLM | None
+) -> list[IndexingDocument]:
+    if llm is None:
         return _convert_documents_without_image_summaries(documents)
 
     indexed_documents: list[IndexingDocument] = []
@@ -934,6 +927,14 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             p.section.text = result or "[Error processing image]"
 
     return indexed_documents
+
+
+def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
+    """Convert document sections and summarize images when a vision LLM is available."""
+    llm = _get_image_summarization_llm(
+        documents, get_image_extraction_and_analysis_enabled()
+    )
+    return _process_image_sections(documents, llm)
 
 
 def add_document_summaries(
@@ -1365,6 +1366,7 @@ def index_doc_batch(
     adapter: IndexingBatchAdapter,
     enable_contextual_rag: bool = False,
     llm_enrichment_allowed: bool = True,
+    image_summarization_llm: LLM | None = None,
     llm: LLM | None = None,
     ignore_time_skip: bool = False,
     index_to_secondary: bool = False,
@@ -1418,7 +1420,7 @@ def index_doc_batch(
     enrichment_partition = _partition_documents_blocked_by_llm_spend_limit(
         context.updatable_docs,
         enable_contextual_rag=enable_contextual_rag,
-        enable_image_summarization=get_image_extraction_and_analysis_enabled(),
+        enable_image_summarization=image_summarization_llm is not None,
         llm_enrichment_allowed=llm_enrichment_allowed,
     )
     enrichment_failed_doc_ids = _get_failed_doc_ids(enrichment_partition.failures)
@@ -1441,9 +1443,13 @@ def index_doc_batch(
     )
     if has_image_section:
         with time_stage_if_set(IndexAttemptStage.IMAGE_PROCESSING, attempt_id):
-            context.indexable_docs = process_image_sections(context.updatable_docs)
+            context.indexable_docs = _process_image_sections(
+                context.updatable_docs, image_summarization_llm
+            )
     else:
-        context.indexable_docs = process_image_sections(context.updatable_docs)
+        context.indexable_docs = _process_image_sections(
+            context.updatable_docs, image_summarization_llm
+        )
 
     doc_descriptors = [
         {
@@ -1676,7 +1682,10 @@ def run_indexing_pipeline(
     contextual_rag_configured = (
         search_settings.enable_contextual_rag or ENABLE_CONTEXTUAL_RAG
     )
-    image_summarization_configured = get_image_extraction_and_analysis_enabled()
+    image_summarization_llm = _get_image_summarization_llm(
+        document_batch, get_image_extraction_and_analysis_enabled()
+    )
+    image_summarization_configured = image_summarization_llm is not None
     llm_enrichment_configured = (
         contextual_rag_configured or image_summarization_configured
     )
@@ -1714,6 +1723,7 @@ def run_indexing_pipeline(
             adapter=adapter,
             enable_contextual_rag=contextual_rag_configured,
             llm_enrichment_allowed=llm_enrichment_allowed,
+            image_summarization_llm=image_summarization_llm,
             llm=llm,
             ignore_time_skip=ignore_time_skip,
             index_to_secondary=index_to_secondary,

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -59,10 +59,15 @@ from onyx.indexing.chunker import (
 )
 from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import DocAwareChunk, IndexChunk
+from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.traces import TraceContentMode
 
 if TYPE_CHECKING:
     from onyx.llm.interfaces import LLM
     from onyx.natural_language_processing.utils import BaseTokenizer
+
+
+CONTEXTUAL_RAG_REEMBED_TRACE_NAME = "contextual_rag_reembed"
 
 
 class ReembedStrategy(enum.Enum):
@@ -430,12 +435,16 @@ def _augmentation_reembed(
         from onyx.indexing.indexing_pipeline import add_contextual_summaries
 
         # Groups by source_document.id internally, so the mixed-doc input is fine.
-        add_contextual_summaries(
-            chunks=doc_aware_chunks,
-            llm=ctx.llm,
-            tokenizer=ctx.tokenizer,
-            chunk_token_limit=ctx.chunk_token_limit,
-        )
+        with ensure_trace(
+            CONTEXTUAL_RAG_REEMBED_TRACE_NAME,
+            content_mode=TraceContentMode.METADATA_ONLY,
+        ):
+            add_contextual_summaries(
+                chunks=doc_aware_chunks,
+                llm=ctx.llm,
+                tokenizer=ctx.tokenizer,
+                chunk_token_limit=ctx.chunk_token_limit,
+            )
 
     embedded = embedder.embed_chunks(doc_aware_chunks)
     # Pair each stored chunk with its OWN vector by identity, not list position.

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -39,10 +39,14 @@ from onyx.prompts.kg_prompts import (
     MASTER_EXTRACTION_PROMPT,
 )
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+KG_DOCUMENT_PROCESSING_TRACE_NAME = "kg_document_processing"
 
 
 def get_entity_types_str(active: bool | None = None) -> str:
@@ -335,9 +339,29 @@ def kg_deep_extraction(
     index_name: str,
     kg_config_settings: KGConfigSettings,
 ) -> KGDocumentDeepExtractionResults:
-    """
-    Perform deep extraction and classification on the document.
-    """
+    """Perform one document's deep extraction and classification workflow."""
+    with ensure_trace(
+        KG_DOCUMENT_PROCESSING_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
+    ):
+        return _kg_deep_extraction(
+            document_id=document_id,
+            metadata=metadata,
+            implied_extraction=implied_extraction,
+            tenant_id=tenant_id,
+            index_name=index_name,
+            kg_config_settings=kg_config_settings,
+        )
+
+
+def _kg_deep_extraction(
+    document_id: str,
+    metadata: KGEnhancedDocumentMetadata,
+    implied_extraction: KGImpliedExtractionResults,
+    tenant_id: str,
+    index_name: str,
+    kg_config_settings: KGConfigSettings,
+) -> KGDocumentDeepExtractionResults:
     result = KGDocumentDeepExtractionResults(
         classification_result=None,
         deep_extracted_entities=set(),
@@ -427,6 +451,7 @@ def kg_classify_document(
             llm=llm,
             flow=LLMFlow.KG_DOCUMENT_CLASSIFICATION,
             input_messages=[prompt_msg],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, response)
@@ -499,7 +524,10 @@ def kg_deep_extract_chunks(
     try:
         prompt_msg = UserMessage(content=prompt)
         with llm_generation_span(
-            llm=llm, flow=LLMFlow.KG_DEEP_EXTRACTION, input_messages=[prompt_msg]
+            llm=llm,
+            flow=LLMFlow.KG_DEEP_EXTRACTION,
+            input_messages=[prompt_msg],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, response)

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -13,12 +13,17 @@ from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_user
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import Permission
+from onyx.db.enums import Permission, SystemUsageAttribution
 from onyx.db.llm import (
     fetch_all_llm_providers_accessible_in_any_context,
     fetch_default_llm_model,
 )
 from onyx.db.models import TokenRateLimit, User
+from onyx.db.system_usage import (
+    OTHER_SYSTEM_USAGE_CATEGORY,
+    UNATTRIBUTED_SYSTEM_USAGE_CATEGORY,
+    get_system_usage_export,
+)
 from onyx.db.token_limit import (
     fetch_all_global_token_rate_limits,
     fetch_all_user_token_rate_limits,
@@ -54,6 +59,9 @@ from onyx.server.features.usage.models import (
     EffectiveCostBudget,
     ResetUsageRequest,
     ResetUsageResponse,
+    SystemUsageCategory,
+    SystemUsageRecord,
+    SystemUsageResponse,
     UsageExportRecord,
     UsageExportResponse,
     UsageExportTotals,
@@ -338,6 +346,54 @@ def export_usage(
         start=start_date.isoformat(),
         end=end_date.isoformat(),
         users=users,
+    )
+
+
+@admin_usage_router.get("/system")
+def get_system_usage(
+    start: date | None = None,
+    end: date | None = None,
+    model: str | None = None,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SystemUsageResponse:
+    end_date = end or datetime.now(timezone.utc).date()
+    start_date = start or _start_for_inclusive_range(
+        end_date, _DEFAULT_USAGE_RANGE_INCLUSIVE_DAYS
+    )
+    start_dt, end_dt = _date_range_to_utc_bounds(start_date, end_date)
+
+    records_by_category: dict[str, list[SystemUsageRecord]] = defaultdict(list)
+    for row in get_system_usage_export(db_session, start_dt, end_dt, model):
+        category = (
+            UNATTRIBUTED_SYSTEM_USAGE_CATEGORY
+            if row.attribution == SystemUsageAttribution.UNATTRIBUTED
+            else row.flow or OTHER_SYSTEM_USAGE_CATEGORY
+        )
+        records_by_category[category].append(
+            SystemUsageRecord.model_validate(row.model_dump())
+        )
+
+    categories = [
+        SystemUsageCategory(
+            category=category,
+            totals=UsageExportTotals(
+                input_tokens=sum(record.input_tokens for record in records),
+                output_tokens=sum(record.output_tokens for record in records),
+                cache_read_tokens=sum(record.cache_read_tokens for record in records),
+                cache_creation_tokens=sum(
+                    record.cache_creation_tokens for record in records
+                ),
+                cost_cents=sum(record.cost_cents for record in records),
+            ),
+            records=records,
+        )
+        for category, records in sorted(records_by_category.items())
+    ]
+    return SystemUsageResponse(
+        start=start_date.isoformat(),
+        end=end_date.isoformat(),
+        categories=categories,
     )
 
 

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from onyx.db.enums import SystemUsageAttribution
 from onyx.db.models import ModelCostOverride
 from onyx.db.user_usage import UserUsageByDay as UsageDayModel
 from onyx.llm.cost import ModelPrice
@@ -72,6 +73,31 @@ class UsageExportResponse(BaseModel):
     start: str
     end: str
     users: list[UsageExportUser]
+
+
+class SystemUsageRecord(BaseModel):
+    attribution: SystemUsageAttribution
+    model: str
+    flow: str
+    provider: str
+    day: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    cost_cents: float
+
+
+class SystemUsageCategory(BaseModel):
+    category: str
+    totals: UsageExportTotals
+    records: list[SystemUsageRecord]
+
+
+class SystemUsageResponse(BaseModel):
+    start: str
+    end: str
+    categories: list[SystemUsageCategory]
 
 
 class ResetUsageRequest(BaseModel):

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -56,6 +56,12 @@ def _check_token_rate_limits(_: User) -> None:
     _user_is_rate_limited_by_global()
 
 
+def check_global_token_rate_limits() -> None:
+    """Enforce tenant-wide budgets without requiring a user principal."""
+    if any_rate_limit_exists():
+        _user_is_rate_limited_by_global()
+
+
 """
 Global rate limits
 """

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -72,3 +72,13 @@ class LLMFlow(StrEnum):
 IMAGE_FLOWS: frozenset[LLMFlow] = frozenset(
     {LLMFlow.IMAGE_GENERATION, LLMFlow.IMAGE_EDIT}
 )
+
+SYSTEM_TEXT_GENERATION_FLOWS: frozenset[LLMFlow] = frozenset(
+    {
+        LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
+        LLMFlow.CONTEXTUAL_RAG_CHUNK_CONTEXT,
+        LLMFlow.IMAGE_SUMMARIZATION,
+        LLMFlow.KG_DOCUMENT_CLASSIFICATION,
+        LLMFlow.KG_DEEP_EXTRACTION,
+    }
+)

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -12,7 +12,7 @@ from shared_configs.contextvars import get_current_tenant_id
 from .setup import get_trace_provider
 from .span_data import AgentSpanData, FunctionSpanData, GenerationSpanData
 from .spans import Span
-from .traces import Trace
+from .traces import Trace, TraceContentMode
 
 if TYPE_CHECKING:
     pass
@@ -31,6 +31,7 @@ def trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
 ) -> Trace:
     """
@@ -67,6 +68,7 @@ def trace(
         trace_id=trace_id,
         group_id=group_id,
         metadata=metadata,
+        content_mode=content_mode,
         disabled=disabled,
     )
 
@@ -77,6 +79,7 @@ def ensure_trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
 ) -> Iterator[Trace | None]:
     """
@@ -93,6 +96,7 @@ def ensure_trace(
         trace_id=trace_id,
         group_id=group_id,
         metadata=metadata,
+        content_mode=content_mode,
         disabled=disabled,
     ) as created_trace:
         yield created_trace
@@ -190,6 +194,7 @@ def generation_span(
     tools: Sequence[Mapping[str, Any]] | None = None,
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
+    content_mode: TraceContentMode | None = None,
     disabled: bool = False,
 ) -> Span[GenerationSpanData]:
     """Create a new generation span. The span will not be started automatically, you should either
@@ -234,5 +239,6 @@ def generation_span(
         ),
         span_id=span_id,
         parent=parent,
+        content_mode=content_mode,
         disabled=disabled,
     )

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -31,8 +31,8 @@ def trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
-    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
 ) -> Trace:
     """
     Create a new trace. The trace will not be started automatically; you should either use
@@ -79,8 +79,8 @@ def ensure_trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
-    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
 ) -> Iterator[Trace | None]:
     """
     Ensure a trace exists. If a trace is already active, reuse it.
@@ -194,8 +194,8 @@ def generation_span(
     tools: Sequence[Mapping[str, Any]] | None = None,
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
-    content_mode: TraceContentMode | None = None,
     disabled: bool = False,
+    content_mode: TraceContentMode | None = None,
 ) -> Span[GenerationSpanData]:
     """Create a new generation span. The span will not be started automatically, you should either
     do `with generation_span() ...` or call `span.start()` + `span.finish()` manually.

--- a/backend/onyx/tracing/framework/processor_interface.py
+++ b/backend/onyx/tracing/framework/processor_interface.py
@@ -68,7 +68,7 @@ class TracingProcessor(abc.ABC):
         """Called when a trace completes execution.
 
         Args:
-            trace: The completed trace containing all spans and results.
+            trace: The completed workflow correlation root.
 
         Notes:
             - Called synchronously when trace finishes

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -10,8 +10,9 @@ from onyx.utils.logger import setup_logger
 
 from .processor_interface import TracingProcessor
 from .scope import Scope
+from .span_data import GenerationSpanData
 from .spans import NoOpSpan, Span, SpanImpl, TSpanData
-from .traces import NoOpTrace, Trace, TraceImpl
+from .traces import NoOpTrace, Trace, TraceContentMode, TraceImpl
 
 logger = setup_logger(__name__)
 
@@ -39,6 +40,9 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
         """
         with self._lock:
             self._processors = tuple(processors)
+
+    def has_processors(self) -> bool:
+        return bool(self._processors)
 
     def on_trace_start(self, trace: Trace) -> None:
         """
@@ -154,6 +158,7 @@ class TraceProvider(ABC):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
     ) -> Trace:
         """Create a new trace."""
@@ -164,6 +169,7 @@ class TraceProvider(ABC):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
+        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
     ) -> Span[TSpanData]:
         """Create a new span."""
@@ -223,6 +229,7 @@ class DefaultTraceProvider(TraceProvider):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
     ) -> Trace:
         """
@@ -230,7 +237,7 @@ class DefaultTraceProvider(TraceProvider):
         """
         if disabled:
             logger.debug("Tracing is disabled. Not creating trace %s", name)
-            return NoOpTrace()
+            return NoOpTrace(content_mode)
 
         trace_id = trace_id or self.gen_trace_id()
 
@@ -242,6 +249,7 @@ class DefaultTraceProvider(TraceProvider):
             group_id=group_id,
             metadata=metadata,
             processor=self._multi_processor,
+            content_mode=content_mode,
         )
 
     def create_span(
@@ -249,6 +257,7 @@ class DefaultTraceProvider(TraceProvider):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
+        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
     ) -> Span[TSpanData]:
         """
@@ -265,10 +274,6 @@ class DefaultTraceProvider(TraceProvider):
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
             if current_trace is None:
-                # Expected when tracing is disabled or a caller creates a span
-                # outside an active trace context (e.g. celery tasks with
-                # SENTRY_CELERY_TRACES_SAMPLE_RATE=0). Fall through to NoOpSpan
-                # silently — matches the other no-op branches below.
                 logger.debug("No active trace; returning NoOpSpan for %s", span_data)
                 return NoOpSpan(span_data)
             elif isinstance(current_trace, NoOpTrace) or isinstance(
@@ -283,6 +288,11 @@ class DefaultTraceProvider(TraceProvider):
 
             parent_id = current_span.span_id if current_span else None
             trace_id = current_trace.trace_id
+            inherited_content_mode = (
+                current_span.content_mode
+                if current_span
+                else current_trace.content_mode
+            )
 
         elif isinstance(parent, Trace):
             if isinstance(parent, NoOpTrace):
@@ -290,15 +300,23 @@ class DefaultTraceProvider(TraceProvider):
                 return NoOpSpan(span_data)
             trace_id = parent.trace_id
             parent_id = None
+            inherited_content_mode = parent.content_mode
         elif isinstance(parent, Span):
             if isinstance(parent, NoOpSpan):
                 logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
                 return NoOpSpan(span_data)
             parent_id = parent.span_id
             trace_id = parent.trace_id
+            inherited_content_mode = parent.content_mode
         else:
             # This should never happen, but type-checking needs it
             raise ValueError(f"Invalid parent type: {type(parent)}")
+
+        resolved_content_mode = content_mode or inherited_content_mode
+        if resolved_content_mode == TraceContentMode.METADATA_ONLY and isinstance(
+            span_data, GenerationSpanData
+        ):
+            span_data.disable_content_capture()
 
         return SpanImpl(
             trace_id=trace_id,
@@ -306,6 +324,7 @@ class DefaultTraceProvider(TraceProvider):
             parent_id=parent_id,
             processor=self._multi_processor,
             span_data=span_data,
+            content_mode=resolved_content_mode,
         )
 
     def shutdown(self) -> None:

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -10,7 +10,7 @@ from onyx.utils.logger import setup_logger
 
 from .processor_interface import TracingProcessor
 from .scope import Scope
-from .span_data import GenerationSpanData
+from .span_data import GenerationSpanData, SpanData
 from .spans import NoOpSpan, Span, SpanImpl, TSpanData
 from .traces import NoOpTrace, Trace, TraceContentMode, TraceImpl
 
@@ -40,9 +40,6 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
         """
         with self._lock:
             self._processors = tuple(processors)
-
-    def has_processors(self) -> bool:
-        return bool(self._processors)
 
     def on_trace_start(self, trace: Trace) -> None:
         """
@@ -263,10 +260,6 @@ class DefaultTraceProvider(TraceProvider):
         """
         Create a new span.
         """
-        if disabled:
-            logger.debug("Tracing is disabled. Not creating span %s", span_data)
-            return NoOpSpan(span_data)
-
         trace_id: str
         parent_id: str | None
 
@@ -275,7 +268,12 @@ class DefaultTraceProvider(TraceProvider):
             current_trace = Scope.get_current_trace()
             if current_trace is None:
                 logger.debug("No active trace; returning NoOpSpan for %s", span_data)
-                return NoOpSpan(span_data)
+                inherited_content_mode = (
+                    current_span.content_mode if current_span else TraceContentMode.FULL
+                )
+                return self._create_noop_span(
+                    span_data, content_mode or inherited_content_mode
+                )
             elif isinstance(current_trace, NoOpTrace) or isinstance(
                 current_span, NoOpSpan
             ):
@@ -284,7 +282,14 @@ class DefaultTraceProvider(TraceProvider):
                     current_span,
                     current_trace,
                 )
-                return NoOpSpan(span_data)
+                inherited_content_mode = (
+                    current_span.content_mode
+                    if current_span
+                    else current_trace.content_mode
+                )
+                return self._create_noop_span(
+                    span_data, content_mode or inherited_content_mode
+                )
 
             parent_id = current_span.span_id if current_span else None
             trace_id = current_trace.trace_id
@@ -297,14 +302,18 @@ class DefaultTraceProvider(TraceProvider):
         elif isinstance(parent, Trace):
             if isinstance(parent, NoOpTrace):
                 logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
-                return NoOpSpan(span_data)
+                return self._create_noop_span(
+                    span_data, content_mode or parent.content_mode
+                )
             trace_id = parent.trace_id
             parent_id = None
             inherited_content_mode = parent.content_mode
         elif isinstance(parent, Span):
             if isinstance(parent, NoOpSpan):
                 logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
-                return NoOpSpan(span_data)
+                return self._create_noop_span(
+                    span_data, content_mode or parent.content_mode
+                )
             parent_id = parent.span_id
             trace_id = parent.trace_id
             inherited_content_mode = parent.content_mode
@@ -313,10 +322,11 @@ class DefaultTraceProvider(TraceProvider):
             raise ValueError(f"Invalid parent type: {type(parent)}")
 
         resolved_content_mode = content_mode or inherited_content_mode
-        if resolved_content_mode == TraceContentMode.METADATA_ONLY and isinstance(
-            span_data, GenerationSpanData
-        ):
-            span_data.disable_content_capture()
+        if disabled:
+            logger.debug("Tracing is disabled. Not creating span %s", span_data)
+            return self._create_noop_span(span_data, resolved_content_mode)
+
+        self._disable_generation_content(span_data, resolved_content_mode)
 
         return SpanImpl(
             trace_id=trace_id,
@@ -326,6 +336,22 @@ class DefaultTraceProvider(TraceProvider):
             span_data=span_data,
             content_mode=resolved_content_mode,
         )
+
+    @staticmethod
+    def _disable_generation_content(
+        span_data: SpanData, content_mode: TraceContentMode
+    ) -> None:
+        if content_mode == TraceContentMode.METADATA_ONLY and isinstance(
+            span_data, GenerationSpanData
+        ):
+            span_data.disable_content_capture()
+
+    @classmethod
+    def _create_noop_span(
+        cls, span_data: TSpanData, content_mode: TraceContentMode
+    ) -> NoOpSpan[TSpanData]:
+        cls._disable_generation_content(span_data, content_mode)
+        return NoOpSpan(span_data, content_mode)
 
     def shutdown(self) -> None:
         try:

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -155,8 +155,8 @@ class TraceProvider(ABC):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
-        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ) -> Trace:
         """Create a new trace."""
 
@@ -166,8 +166,8 @@ class TraceProvider(ABC):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
-        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
+        content_mode: TraceContentMode | None = None,
     ) -> Span[TSpanData]:
         """Create a new span."""
 
@@ -226,8 +226,8 @@ class DefaultTraceProvider(TraceProvider):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
-        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ) -> Trace:
         """
         Create a new trace.
@@ -254,8 +254,8 @@ class DefaultTraceProvider(TraceProvider):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
-        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
+        content_mode: TraceContentMode | None = None,
     ) -> Span[TSpanData]:
         """
         Create a new span.

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -266,6 +266,12 @@ class DefaultTraceProvider(TraceProvider):
         if not parent:
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
+            if (
+                current_span
+                and current_trace
+                and current_span.trace_id != current_trace.trace_id
+            ):
+                current_span = None
             if current_trace is None:
                 logger.debug("No active trace; returning NoOpSpan for %s", span_data)
                 inherited_content_mode = (

--- a/backend/onyx/tracing/framework/span_data.py
+++ b/backend/onyx/tracing/framework/span_data.py
@@ -93,16 +93,17 @@ class GenerationSpanData(SpanData):
     """
 
     __slots__ = (
-        "input",
-        "output",
-        "reasoning",
+        "_capture_content",
+        "_input",
+        "_output",
+        "_reasoning",
+        "_tools",
+        "_request_params",
         "model",
         "model_config",
         "image_count",
         "usage",
         "time_to_first_action_seconds",
-        "tools",
-        "request_params",
     )
 
     def __init__(
@@ -120,6 +121,7 @@ class GenerationSpanData(SpanData):
     ):
         if image_count is not None and image_count < 1:
             raise ValueError("image_count must be positive")
+        self._capture_content = True
         self.input = input
         self.output = output
         self.reasoning = reasoning
@@ -149,3 +151,52 @@ class GenerationSpanData(SpanData):
             "tools": self.tools,
             "request_params": self.request_params,
         }
+
+    @property
+    def input(self) -> Sequence[Mapping[str, Any]] | None:
+        return self._input
+
+    @input.setter
+    def input(self, value: Sequence[Mapping[str, Any]] | None) -> None:
+        self._input = value if self._capture_content else None
+
+    @property
+    def output(self) -> Sequence[Mapping[str, Any]] | None:
+        return self._output
+
+    @output.setter
+    def output(self, value: Sequence[Mapping[str, Any]] | None) -> None:
+        self._output = value if self._capture_content else None
+
+    @property
+    def reasoning(self) -> str | None:
+        return self._reasoning
+
+    @reasoning.setter
+    def reasoning(self, value: str | None) -> None:
+        self._reasoning = value if self._capture_content else None
+
+    @property
+    def tools(self) -> Sequence[Mapping[str, Any]] | None:
+        return self._tools
+
+    @tools.setter
+    def tools(self, value: Sequence[Mapping[str, Any]] | None) -> None:
+        self._tools = value if self._capture_content else None
+
+    @property
+    def request_params(self) -> Mapping[str, Any] | None:
+        return self._request_params
+
+    @request_params.setter
+    def request_params(self, value: Mapping[str, Any] | None) -> None:
+        self._request_params = value if self._capture_content else None
+
+    def disable_content_capture(self) -> None:
+        """Retain generation metadata but reject all operation content."""
+        self._capture_content = False
+        self._input = None
+        self._output = None
+        self._reasoning = None
+        self._tools = None
+        self._request_params = None

--- a/backend/onyx/tracing/framework/spans.py
+++ b/backend/onyx/tracing/framework/spans.py
@@ -11,6 +11,7 @@ from . import util
 from .processor_interface import TracingProcessor
 from .scope import Scope
 from .span_data import SpanData
+from .traces import TraceContentMode
 
 TSpanData = TypeVar("TSpanData", bound=SpanData)
 
@@ -92,6 +93,11 @@ class Span(abc.ABC, Generic[TSpanData]):
         Returns:
             TSpanData: Data specific to this type of span (e.g., LLM generation data).
         """
+
+    @property
+    @abc.abstractmethod
+    def content_mode(self) -> TraceContentMode:
+        """Control whether processors can include operation content."""
 
     @abc.abstractmethod
     def start(self, mark_as_current: bool = False) -> None:
@@ -178,9 +184,14 @@ class NoOpSpan(Span[TSpanData]):
         span_data: The operation-specific data for this span.
     """
 
-    __slots__ = ("_span_data", "_prev_span_token")
+    __slots__ = ("_content_mode", "_span_data", "_prev_span_token")
 
-    def __init__(self, span_data: TSpanData):
+    def __init__(
+        self,
+        span_data: TSpanData,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
+    ):
+        self._content_mode = content_mode
         self._span_data = span_data
         self._prev_span_token: contextvars.Token[Span[TSpanData] | None] | None = None
 
@@ -195,6 +206,10 @@ class NoOpSpan(Span[TSpanData]):
     @property
     def span_data(self) -> TSpanData:
         return self._span_data
+
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
 
     @property
     def parent_id(self) -> str | None:
@@ -249,6 +264,7 @@ class SpanImpl(Span[TSpanData]):
         "_trace_id",
         "_span_id",
         "_parent_id",
+        "_content_mode",
         "_started_at",
         "_ended_at",
         "_error",
@@ -264,10 +280,12 @@ class SpanImpl(Span[TSpanData]):
         parent_id: str | None,
         processor: TracingProcessor,
         span_data: TSpanData,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ):
         self._trace_id = trace_id
         self._span_id = span_id or util.gen_span_id()
         self._parent_id = parent_id
+        self._content_mode = content_mode
         self._started_at: str | None = None
         self._ended_at: str | None = None
         self._processor = processor
@@ -286,6 +304,10 @@ class SpanImpl(Span[TSpanData]):
     @property
     def span_data(self) -> TSpanData:
         return self._span_data
+
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
 
     @property
     def parent_id(self) -> str | None:

--- a/backend/onyx/tracing/framework/spans.py
+++ b/backend/onyx/tracing/framework/spans.py
@@ -97,7 +97,7 @@ class Span(abc.ABC, Generic[TSpanData]):
     @property
     @abc.abstractmethod
     def content_mode(self) -> TraceContentMode:
-        """Control whether processors can include operation content."""
+        """Control whether a generation span can capture model content."""
 
     @abc.abstractmethod
     def start(self, mark_as_current: bool = False) -> None:

--- a/backend/onyx/tracing/framework/traces.py
+++ b/backend/onyx/tracing/framework/traces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import contextvars
+from enum import StrEnum
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -12,12 +13,13 @@ if TYPE_CHECKING:
     from .processor_interface import TracingProcessor
 
 
-class Trace(abc.ABC):
-    """A complete end-to-end workflow containing related spans and metadata.
+class TraceContentMode(StrEnum):
+    FULL = "full"
+    METADATA_ONLY = "metadata_only"
 
-    A trace represents a logical workflow or operation (e.g., "Customer Service Query"
-    or "Code Generation") and contains all the spans (individual operations) that occur
-    during that workflow.
+
+class Trace(abc.ABC):
+    """A workflow lifecycle and correlation root for independently processed spans.
 
     Example:
         ```python
@@ -81,7 +83,6 @@ class Trace(abc.ABC):
 
         Notes:
             - Must be called to complete the trace
-            - Finalizes all open spans
             - Thread-safe when using reset_current
         """
 
@@ -113,6 +114,11 @@ class Trace(abc.ABC):
             - Helps identify the purpose of the trace
         """
 
+    @property
+    @abc.abstractmethod
+    def content_mode(self) -> TraceContentMode:
+        """Control whether child spans can capture operation content."""
+
     @abc.abstractmethod
     def export(self) -> dict[str, Any] | None:
         """Export the trace data as a serializable dictionary.
@@ -121,7 +127,6 @@ class Trace(abc.ABC):
             dict | None: Dictionary containing trace data, or None if tracing is disabled.
 
         Notes:
-            - Includes all spans and their data
             - Used for sending traces to backends
             - May include metadata and group ID
         """
@@ -142,8 +147,9 @@ class NoOpTrace(Trace):
         ```
     """
 
-    def __init__(self) -> None:
+    def __init__(self, content_mode: TraceContentMode = TraceContentMode.FULL) -> None:
         self._started = False
+        self._content_mode = content_mode
         self._prev_context_token: contextvars.Token[Trace | None] | None = None
 
     def __enter__(self) -> Trace:
@@ -190,6 +196,10 @@ class NoOpTrace(Trace):
         """
         return "no-op"
 
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
+
     def export(self) -> dict[str, Any] | None:
         """Export the trace data as a dictionary.
 
@@ -210,6 +220,7 @@ class TraceImpl(Trace):
     __slots__ = (
         "_name",
         "_trace_id",
+        "_content_mode",
         "group_id",
         "metadata",
         "_prev_context_token",
@@ -224,9 +235,11 @@ class TraceImpl(Trace):
         group_id: str | None,
         metadata: dict[str, Any] | None,
         processor: TracingProcessor,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ):
         self._name = name
         self._trace_id = trace_id or util.gen_trace_id()
+        self._content_mode = content_mode
         self.group_id = group_id
         self.metadata = metadata
         self._prev_context_token: contextvars.Token[Trace | None] | None = None
@@ -240,6 +253,10 @@ class TraceImpl(Trace):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
 
     def start(self, mark_as_current: bool = False) -> None:
         if self._started:

--- a/backend/onyx/tracing/framework/traces.py
+++ b/backend/onyx/tracing/framework/traces.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 
 class TraceContentMode(StrEnum):
+    """Generation content policy; explicit span modes override trace defaults."""
+
     FULL = "full"
     METADATA_ONLY = "metadata_only"
 
@@ -117,7 +119,7 @@ class Trace(abc.ABC):
     @property
     @abc.abstractmethod
     def content_mode(self) -> TraceContentMode:
-        """Control whether child spans can capture operation content."""
+        """Set the default model-content policy for child generation spans."""
 
     @abc.abstractmethod
     def export(self) -> dict[str, Any] | None:

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -11,6 +11,7 @@ from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span, get_current_span
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
+from onyx.tracing.framework.traces import TraceContentMode
 
 
 def build_llm_model_config(llm: LLM, flow: LLMFlow | None = None) -> dict[str, str]:
@@ -30,14 +31,16 @@ def llm_generation_span(
     input_messages: Sequence[Any] | Any | None = None,
     tools: Sequence[Mapping[str, Any]] | None = None,
     parent: Any | None = None,
+    content_mode: TraceContentMode | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     with generation_span(
         model=llm.config.model_name,
         model_config=build_llm_model_config(llm, flow),
         tools=tools,
         parent=parent,
+        content_mode=content_mode,
     ) as span:
-        if input_messages is not None:
+        if input_messages is not None and span.content_mode == TraceContentMode.FULL:
             if isinstance(input_messages, Sequence) and not isinstance(
                 input_messages, (str, bytes)
             ):
@@ -60,6 +63,7 @@ def traced_llm_call(
     input_messages: Sequence[Any] | Any | None = None,
     tools: Sequence[Mapping[str, Any]] | None = None,
     parent: Any | None = None,
+    content_mode: TraceContentMode | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     """Open a generation span for call sites that don't go through ``LLM``.
 
@@ -80,8 +84,9 @@ def traced_llm_call(
         image_count=image_count,
         tools=tools,
         parent=parent,
+        content_mode=content_mode,
     ) as span:
-        if input_messages is not None:
+        if input_messages is not None and span.content_mode == TraceContentMode.FULL:
             if isinstance(input_messages, Sequence) and not isinstance(
                 input_messages, (str, bytes)
             ):
@@ -101,6 +106,8 @@ def record_llm_request_params(params: Mapping[str, Any]) -> None:
     span = get_current_span()
     if span is None or not isinstance(span.span_data, GenerationSpanData):
         return
+    if span.content_mode == TraceContentMode.METADATA_ONLY:
+        return
     span.span_data.request_params = dict(params)
 
 
@@ -117,22 +124,16 @@ def record_llm_response(
         span: The generation span to record to.
         response: The ModelResponse from the LLM.
     """
-    message = response.choice.message
-
-    # Build output dict matching AssistantMessage format
-    output_dict: dict[str, Any] = {"role": "assistant"}
-
-    if message.content is not None:
-        output_dict["content"] = message.content
-
-    if message.tool_calls:
-        output_dict["tool_calls"] = [tc.model_dump() for tc in message.tool_calls]
-
-    span.span_data.output = [output_dict]
-
-    # Record reasoning (extended thinking from reasoning models)
-    if message.reasoning_content:
-        span.span_data.reasoning = message.reasoning_content
+    if span.content_mode == TraceContentMode.FULL:
+        message = response.choice.message
+        output_dict: dict[str, Any] = {"role": "assistant"}
+        if message.content is not None:
+            output_dict["content"] = message.content
+        if message.tool_calls:
+            output_dict["tool_calls"] = [tc.model_dump() for tc in message.tool_calls]
+        span.span_data.output = [output_dict]
+        if message.reasoning_content:
+            span.span_data.reasoning = message.reasoning_content
 
     # Record usage
     if response.usage:
@@ -160,24 +161,25 @@ def record_llm_span_output(
         reasoning: Optional reasoning/extended thinking content.
         tool_calls: Optional list of tool calls.
     """
-    if output is None:
-        output_dict: dict[str, Any] = {"role": "assistant", "content": None}
-        if tool_calls:
-            output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
-        span.span_data.output = [output_dict]
-    elif isinstance(output, str):
-        output_dict = {"role": "assistant", "content": output}
-        if tool_calls:
-            output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
-        span.span_data.output = [output_dict]
-    else:
-        span.span_data.output = cast(Sequence[Mapping[str, Any]], output)
+    if span.content_mode == TraceContentMode.FULL:
+        if output is None:
+            output_dict: dict[str, Any] = {"role": "assistant", "content": None}
+            if tool_calls:
+                output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+            span.span_data.output = [output_dict]
+        elif isinstance(output, str):
+            output_dict = {"role": "assistant", "content": output}
+            if tool_calls:
+                output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+            span.span_data.output = [output_dict]
+        else:
+            span.span_data.output = cast(Sequence[Mapping[str, Any]], output)
 
     usage_dict = _build_usage_dict(usage)
     if usage_dict:
         span.span_data.usage = usage_dict
 
-    if reasoning:
+    if reasoning and span.content_mode == TraceContentMode.FULL:
         span.span_data.reasoning = reasoning
 
 

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -1,5 +1,4 @@
-"""Universal per-user usage recorder — buffers priced generation spans and
-drains them to the per-user usage rollup off the LLM hot path."""
+"""Buffers priced generation spans and drains them to user or system rollups."""
 
 from __future__ import annotations
 
@@ -13,10 +12,16 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
-from onyx.db.enums import IncognitoRecordMode
+from onyx.db.enums import IncognitoRecordMode, SystemUsageAttribution
+from onyx.db.llm_usage import LLMUsageRecord
+from onyx.db.system_usage import record_system_usage
 from onyx.db.user_usage import USER_USAGE_BUCKET_SECONDS, record_user_usage
 from onyx.llm.cost import compute_cost_cents
-from onyx.tracing.flows import IMAGE_FLOWS
+from onyx.tracing.flows import (
+    IMAGE_FLOWS,
+    SYSTEM_TEXT_GENERATION_FLOWS,
+    LLMFlow,
+)
 from onyx.tracing.framework.processor_interface import TracingProcessor
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
@@ -49,7 +54,8 @@ class _UsageRecord:
     request contextvars are still valid (the drain thread has none)."""
 
     tenant_id: str
-    user_id: str
+    user_id: str | None
+    system_attribution: SystemUsageAttribution | None
     model: str
     flow: str
     provider: str | None
@@ -70,6 +76,16 @@ def _usage_field(usage: dict[str, Any], *names: str) -> int:
         if value is not None:
             return int(value)
     return 0
+
+
+def _system_attribution(flow: str) -> SystemUsageAttribution:
+    try:
+        llm_flow = LLMFlow(flow)
+    except ValueError:
+        return SystemUsageAttribution.UNATTRIBUTED
+    if llm_flow in SYSTEM_TEXT_GENERATION_FLOWS:
+        return SystemUsageAttribution.ATTRIBUTED
+    return SystemUsageAttribution.UNATTRIBUTED
 
 
 class UserUsageTracingProcessor(TracingProcessor):
@@ -118,10 +134,8 @@ class UserUsageTracingProcessor(TracingProcessor):
             return None
 
         user_id = get_current_user_id()
-        if user_id is None:
-            # No user id → skip (undercount, never wrong-user). The
-            # optional_user dependency sets this for any authenticated request,
-            # so it is absent only for work started outside one (e.g. Celery).
+        if user_id is None and not data.usage:
+            # TODO: Meter non-text flows after they expose provider billing units.
             return None
 
         model = data.model
@@ -147,6 +161,7 @@ class UserUsageTracingProcessor(TracingProcessor):
         return _UsageRecord(
             tenant_id=get_current_tenant_id(),
             user_id=user_id,
+            system_attribution=(_system_attribution(flow) if user_id is None else None),
             model=model,
             flow=flow,
             provider=provider,
@@ -209,12 +224,23 @@ class UserUsageTracingProcessor(TracingProcessor):
     @staticmethod
     def _aggregate_batch(batch: list[_UsageRecord]) -> list[_UsageRecord]:
         aggregated: dict[
-            tuple[str, str, str, str, str | None, bool, datetime], _UsageRecord
+            tuple[
+                str,
+                str | None,
+                SystemUsageAttribution | None,
+                str,
+                str,
+                str | None,
+                bool,
+                datetime,
+            ],
+            _UsageRecord,
         ] = {}
         for record in batch:
             key = (
                 record.tenant_id,
                 record.user_id,
+                record.system_attribution,
                 record.model,
                 record.flow,
                 record.provider,
@@ -260,9 +286,7 @@ class UserUsageTracingProcessor(TracingProcessor):
             image_count=record.image_count,
             db_session=db_session,
         )
-        record_user_usage(
-            db_session,
-            user_id=record.user_id,
+        usage = LLMUsageRecord(
             model=record.model,
             flow=record.flow,
             provider=record.provider,
@@ -272,7 +296,22 @@ class UserUsageTracingProcessor(TracingProcessor):
             cache_creation_tokens=record.cache_creation_tokens,
             cost_cents=input_cost + output_cost,
             window_start=record.window_start,
-            incognito=record.incognito,
+        )
+        if record.user_id is not None:
+            record_user_usage(
+                db_session=db_session,
+                user_id=record.user_id,
+                usage=usage,
+                incognito=record.incognito,
+            )
+            return
+
+        if record.system_attribution is None:
+            raise ValueError("Non-user usage requires system attribution")
+        record_system_usage(
+            db_session=db_session,
+            attribution=record.system_attribution,
+            usage=usage,
         )
 
     # --- TracingProcessor interface (non-generation events are no-ops) ---

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -135,7 +135,6 @@ class UserUsageTracingProcessor(TracingProcessor):
 
         user_id = get_current_user_id()
         if user_id is None and not data.usage:
-            # TODO: Meter non-text flows after they expose provider billing units.
             return None
 
         model = data.model

--- a/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 import ee.onyx.server.query_and_chat.token_limit as ee_token_limit
 from onyx.configs.constants import TokenRateLimitScope
+from onyx.db.llm_usage import LLMUsageRecord
 from onyx.db.models import (
     TokenRateLimit,
     TokenRateLimit__UserGroup,
@@ -49,14 +50,16 @@ def _record_cost(db_session: Session, user: User, cost_cents: float) -> None:
     record_user_usage(
         db_session=db_session,
         user_id=str(user.id),
-        model=_TEST_MODEL,
-        flow=LLMFlow.CHAT_RESPONSE.value,
-        provider=None,
-        input_tokens=1,
-        output_tokens=1,
-        cache_read_tokens=0,
-        cost_cents=cost_cents,
-        window_start=window_start,
+        usage=LLMUsageRecord(
+            model=_TEST_MODEL,
+            flow=LLMFlow.CHAT_RESPONSE.value,
+            provider=None,
+            input_tokens=1,
+            output_tokens=1,
+            cache_read_tokens=0,
+            cost_cents=cost_cents,
+            window_start=window_start,
+        ),
     )
     db_session.commit()
 

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -10,6 +10,7 @@ from the raw stored content (here) is equivalent to proving the resulting vector
 differs; the real-embedder path is exercised once the port task is wired.
 """
 
+from contextlib import nullcontext
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -38,6 +39,7 @@ from onyx.indexing.chunker import get_metadata_suffix_for_document_index
 from onyx.indexing.embedder import DefaultIndexingEmbedder, IndexingEmbedder
 from onyx.indexing.models import ChunkEmbedding, DocAwareChunk, IndexChunk
 from onyx.indexing.port_reembed import (
+    CONTEXTUAL_RAG_REEMBED_TRACE_NAME,
     AugmentationReembedContext,
     ReembedStrategy,
     _bare_contents,
@@ -49,6 +51,7 @@ from onyx.indexing.port_reembed import (
     select_reembed_strategy,
 )
 from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.utils.pydantic_util import shallow_model_dump
 from shared_configs.configs import (
     DOC_EMBEDDING_CONTEXT_SIZE,
@@ -431,6 +434,8 @@ def test_augmentation_enrich_on_generates_and_reembeds(
     monkeypatch.setattr(
         "onyx.indexing.indexing_pipeline.add_contextual_summaries", _fake_enrich
     )
+    ensure_trace = MagicMock(return_value=nullcontext())
+    monkeypatch.setattr("onyx.indexing.port_reembed.ensure_trace", ensure_trace)
 
     bare = "the body text"
     metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
@@ -466,6 +471,10 @@ def test_augmentation_enrich_on_generates_and_reembeds(
     assert result.chunk_context == " CONTEXT."
     assert (
         result.content == f"My Title{RETURN_SEPARATOR}SUMMARY. {bare} CONTEXT.{keyword}"
+    )
+    ensure_trace.assert_called_once_with(
+        CONTEXTUAL_RAG_REEMBED_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
     )
 
     # the embedded text carries the new summaries; vector differs from strip-only

--- a/backend/tests/external_dependency_unit/tracing/test_llm_span_recording.py
+++ b/backend/tests/external_dependency_unit/tracing/test_llm_span_recording.py
@@ -15,6 +15,7 @@ from onyx.llm.model_response import (
 from onyx.llm.model_response import FunctionCall as ModelResponseFunctionCall
 from onyx.llm.models import FunctionCall, ToolCall
 from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import record_llm_response, record_llm_span_output
 
 
@@ -22,6 +23,7 @@ from onyx.tracing.llm_utils import record_llm_response, record_llm_span_output
 def mock_span() -> MagicMock:
     """Create a mock span with GenerationSpanData."""
     span = MagicMock()
+    span.content_mode = TraceContentMode.FULL
     span.span_data = GenerationSpanData()
     return span
 

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -290,6 +290,7 @@ class TestUsageExportAPI:
             assert "chat_messages.csv" in file_names
             assert "users.csv" in file_names
             assert "usage_by_user.csv" in file_names
+            assert "usage_by_system.csv" in file_names
             assert "usage_report.pdf" in file_names
 
             with zip_file.open("usage_report.pdf") as pdf_file:
@@ -320,6 +321,21 @@ class TestUsageExportAPI:
                 assert expected_columns == actual_columns, (
                     f"Expected columns {expected_columns}, but got {actual_columns}"
                 )
+
+            with zip_file.open("usage_by_system.csv") as csv_file:
+                csv_reader = csv.DictReader(StringIO(csv_file.read().decode("utf-8")))
+                assert set(csv_reader.fieldnames or []) == {
+                    "attribution",
+                    "day",
+                    "model",
+                    "flow",
+                    "provider",
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_read_tokens",
+                    "cache_creation_tokens",
+                    "cost_cents",
+                }
 
             # Verify chat_messages.csv has the expected columns
             with zip_file.open("chat_messages.csv") as csv_file:

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -10,10 +10,40 @@ import pytest
 
 from ee.onyx.db.usage_export import UsageReportMetadata
 from onyx.configs.constants import DEFAULT_PERSONA_ID
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import SystemUsageAttribution
+from onyx.db.llm_usage import LLMUsageRecord
 from onyx.db.seeding.chat_history_seeding import seed_chat_history
+from onyx.db.system_usage import record_system_usage
+from onyx.tracing.flows import LLMFlow
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
+
+_SYSTEM_USAGE_MODEL = "usage-report-test-model"
+_SYSTEM_USAGE_PROVIDER = "usage-report-test-provider"
+
+
+def _seed_system_usage() -> LLMUsageRecord:
+    usage = LLMUsageRecord(
+        model=_SYSTEM_USAGE_MODEL,
+        flow=LLMFlow.IMAGE_SUMMARIZATION.value,
+        provider=_SYSTEM_USAGE_PROVIDER,
+        input_tokens=120,
+        output_tokens=30,
+        cache_read_tokens=10,
+        cache_creation_tokens=5,
+        cost_cents=2.5,
+        window_start=datetime.now(timezone.utc),
+    )
+    with get_session_with_current_tenant() as db_session:
+        record_system_usage(
+            db_session,
+            attribution=SystemUsageAttribution.ATTRIBUTED,
+            usage=usage,
+        )
+        db_session.commit()
+    return usage
 
 
 @pytest.mark.skipif(
@@ -231,6 +261,7 @@ class TestUsageExportAPI:
             user_id=UUID(admin_user.id),
             persona_id=DEFAULT_PERSONA_ID,
         )
+        system_usage = _seed_system_usage()
 
         # Get initial reports count
         initial_response = client.get(
@@ -336,6 +367,20 @@ class TestUsageExportAPI:
                     "cache_creation_tokens",
                     "cost_cents",
                 }
+                assert list(csv_reader) == [
+                    {
+                        "attribution": SystemUsageAttribution.ATTRIBUTED.value,
+                        "day": system_usage.window_start.date().isoformat(),
+                        "model": _SYSTEM_USAGE_MODEL,
+                        "flow": LLMFlow.IMAGE_SUMMARIZATION.value,
+                        "provider": _SYSTEM_USAGE_PROVIDER,
+                        "input_tokens": "120",
+                        "output_tokens": "30",
+                        "cache_read_tokens": "10",
+                        "cache_creation_tokens": "5",
+                        "cost_cents": "2.5",
+                    }
+                ]
 
             # Verify chat_messages.csv has the expected columns
             with zip_file.open("chat_messages.csv") as csv_file:

--- a/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
+++ b/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
@@ -69,7 +69,7 @@ def _system_row(
     cost: float = 7.0,
 ) -> SystemUsageExportRow:
     return SystemUsageExportRow(
-        attribution=SystemUsageAttribution.SYSTEM,
+        attribution=SystemUsageAttribution.ATTRIBUTED,
         model="claude-sonnet",
         flow=flow,
         provider="anthropic",

--- a/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
+++ b/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
@@ -19,8 +19,9 @@ from ee.onyx.server.reporting.usage_report_pdf import (
     _display_name,
     render_usage_report_pdf,
 )
-from onyx.db.enums import AccountType
+from onyx.db.enums import AccountType, SystemUsageAttribution
 from onyx.db.models import User
+from onyx.db.system_usage import SystemUsageExportRow
 from onyx.db.user_usage import DELETED_USER_EXPORT_EMAIL, UsageExportRow
 
 _BRANDING = ReportBranding(application_name="Acme Intelligence", logo=None)
@@ -63,7 +64,29 @@ def _user(
     return user
 
 
-def _build(rows: list[UsageExportRow], users: list[User]) -> UsageReportData:
+def _system_row(
+    flow: str = "image_summarization",
+    cost: float = 7.0,
+) -> SystemUsageExportRow:
+    return SystemUsageExportRow(
+        attribution=SystemUsageAttribution.SYSTEM,
+        model="claude-sonnet",
+        flow=flow,
+        provider="anthropic",
+        day="2026-07-01",
+        input_tokens=200,
+        output_tokens=40,
+        cache_read_tokens=20,
+        cache_creation_tokens=10,
+        cost_cents=cost,
+    )
+
+
+def _build(
+    rows: list[UsageExportRow],
+    users: list[User],
+    system_rows: list[SystemUsageExportRow] | None = None,
+) -> UsageReportData:
     with patch(
         "ee.onyx.server.reporting.usage_report_data.get_all_users", return_value=users
     ):
@@ -72,6 +95,7 @@ def _build(rows: list[UsageExportRow], users: list[User]) -> UsageReportData:
             rows=rows,
             period_start=PERIOD_START,
             period_end=PERIOD_END,
+            system_rows=system_rows or [],
         )
 
 
@@ -100,6 +124,26 @@ def test_deleted_user_counts_toward_spend_but_is_not_a_person() -> None:
     assert data.active_users == 1
     assert data.daily[0].active_users == 1
     assert data.total_cost_cents == pytest.approx(20.0)
+
+
+def test_system_usage_counts_toward_spend_but_not_people() -> None:
+    data = _build([_row("a@x.com", cost=10.0)], [_user("a@x.com")], [_system_row()])
+
+    assert data.total_cost_cents == pytest.approx(17.0)
+    assert data.system_cost_cents == pytest.approx(7.0)
+    assert data.active_users == 1
+    assert data.system_by_flow[0].name == "image_summarization"
+    assert sum(entry.cost_cents for entry in data.by_model) == pytest.approx(17.0)
+
+
+def test_pdf_includes_system_spend_section() -> None:
+    data = _build([_row("a@x.com")], [_user("a@x.com")], [_system_row()])
+
+    reader = PdfReader(BytesIO(render_usage_report_pdf(data, _BRANDING)))
+    text = "\n".join(page.extract_text() for page in reader.pages)
+
+    assert "System spend by flow" in text
+    assert "image_summarization" in text
 
 
 def test_api_key_usage_is_not_an_active_user() -> None:

--- a/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
+++ b/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
@@ -21,7 +21,10 @@ from ee.onyx.server.reporting.usage_report_pdf import (
 )
 from onyx.db.enums import AccountType, SystemUsageAttribution
 from onyx.db.models import User
-from onyx.db.system_usage import SystemUsageExportRow
+from onyx.db.system_usage import (
+    UNATTRIBUTED_SYSTEM_USAGE_CATEGORY,
+    SystemUsageExportRow,
+)
 from onyx.db.user_usage import DELETED_USER_EXPORT_EMAIL, UsageExportRow
 
 _BRANDING = ReportBranding(application_name="Acme Intelligence", logo=None)
@@ -67,9 +70,10 @@ def _user(
 def _system_row(
     flow: str = "image_summarization",
     cost: float = 7.0,
+    attribution: SystemUsageAttribution = SystemUsageAttribution.ATTRIBUTED,
 ) -> SystemUsageExportRow:
     return SystemUsageExportRow(
-        attribution=SystemUsageAttribution.ATTRIBUTED,
+        attribution=attribution,
         model="claude-sonnet",
         flow=flow,
         provider="anthropic",
@@ -127,13 +131,27 @@ def test_deleted_user_counts_toward_spend_but_is_not_a_person() -> None:
 
 
 def test_system_usage_counts_toward_spend_but_not_people() -> None:
-    data = _build([_row("a@x.com", cost=10.0)], [_user("a@x.com")], [_system_row()])
+    data = _build(
+        [_row("a@x.com", cost=10.0)],
+        [_user("a@x.com")],
+        [
+            _system_row(),
+            _system_row(
+                flow="untagged_invoke",
+                cost=3.0,
+                attribution=SystemUsageAttribution.UNATTRIBUTED,
+            ),
+        ],
+    )
 
-    assert data.total_cost_cents == pytest.approx(17.0)
-    assert data.system_cost_cents == pytest.approx(7.0)
+    assert data.total_cost_cents == pytest.approx(20.0)
+    assert data.system_cost_cents == pytest.approx(10.0)
     assert data.active_users == 1
-    assert data.system_by_flow[0].name == "image_summarization"
-    assert sum(entry.cost_cents for entry in data.by_model) == pytest.approx(17.0)
+    assert {entry.name: entry.cost_cents for entry in data.system_by_flow} == {
+        "image_summarization": 7.0,
+        UNATTRIBUTED_SYSTEM_USAGE_CATEGORY: 3.0,
+    }
+    assert sum(entry.cost_cents for entry in data.by_model) == pytest.approx(20.0)
 
 
 def test_pdf_includes_system_spend_section() -> None:

--- a/backend/tests/unit/onyx/db/test_system_usage.py
+++ b/backend/tests/unit/onyx/db/test_system_usage.py
@@ -1,0 +1,37 @@
+"""System LLM usage rollup writes and reads."""
+
+import datetime
+from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
+
+from onyx.db.enums import SystemUsageAttribution
+from onyx.db.llm_usage import LLMUsageRecord
+from onyx.db.system_usage import record_system_usage
+
+
+def test_record_system_usage_builds_accumulating_upsert() -> None:
+    db_session = MagicMock()
+    window_start = datetime.datetime(2026, 9, 2, tzinfo=datetime.timezone.utc)
+
+    record_system_usage(
+        db_session,
+        attribution=SystemUsageAttribution.ATTRIBUTED,
+        usage=LLMUsageRecord(
+            model="claude-sonnet",
+            flow="image_summarization",
+            provider="anthropic",
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=10,
+            cache_creation_tokens=5,
+            cost_cents=1.5,
+            window_start=window_start,
+        ),
+    )
+
+    statement = db_session.execute.call_args.args[0]
+    compiled = statement.compile(dialect=postgresql.dialect())
+    assert compiled.params["system_attribution"] == SystemUsageAttribution.ATTRIBUTED
+    assert "user_usage.input_tokens + excluded.input_tokens" in str(compiled)
+    db_session.flush.assert_called_once()

--- a/backend/tests/unit/onyx/db/test_system_usage.py
+++ b/backend/tests/unit/onyx/db/test_system_usage.py
@@ -33,5 +33,13 @@ def test_record_system_usage_builds_accumulating_upsert() -> None:
     statement = db_session.execute.call_args.args[0]
     compiled = statement.compile(dialect=postgresql.dialect())
     assert compiled.params["system_attribution"] == SystemUsageAttribution.ATTRIBUTED
-    assert "user_usage.input_tokens + excluded.input_tokens" in str(compiled)
+    sql = str(compiled)
+    for column in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+        "cost_cents",
+    ):
+        assert f"user_usage.{column} + excluded.{column}" in sql
     db_session.flush.assert_called_once()

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -23,6 +23,8 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 
 import onyx.db.user_usage as user_usage_module
+from onyx.db.enums import SystemUsageAttribution, UsageActorKind
+from onyx.db.llm_usage import LLMUsageRecord
 from onyx.db.models import (
     TokenRateLimit,
     TokenRateLimitScope,
@@ -119,6 +121,34 @@ def _seed_usage(
     db_session.flush()
 
 
+def _seed_system_usage(
+    db_session: Session,
+    window_start: datetime.datetime,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cost_cents: float,
+) -> None:
+    db_session.add(
+        UserUsage(
+            user_id=None,
+            actor_kind=UsageActorKind.SYSTEM,
+            system_attribution=SystemUsageAttribution.ATTRIBUTED,
+            window_start=window_start,
+            model="m",
+            flow="image_summarization",
+            provider="anthropic",
+            incognito=False,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            cost_cents=cost_cents,
+        )
+    )
+    db_session.flush()
+
+
 @pytest.fixture
 def db_session() -> Generator[Session, None, None]:
     engine: Engine = create_engine("sqlite://")
@@ -155,15 +185,17 @@ class TestRecordUserUsage:
         record_user_usage(
             mock_session,
             user_id=user_id,
-            model="claude-3",
-            flow="CHAT",
-            provider="anthropic",
-            input_tokens=100,
-            output_tokens=50,
-            cache_read_tokens=10,
-            cache_creation_tokens=25,
-            cost_cents=1.5,
-            window_start=window,
+            usage=LLMUsageRecord(
+                model="claude-3",
+                flow="CHAT",
+                provider="anthropic",
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=10,
+                cache_creation_tokens=25,
+                cost_cents=1.5,
+                window_start=window,
+            ),
         )
 
         mock_session.execute.assert_called_once()
@@ -184,14 +216,16 @@ class TestRecordUserUsage:
         record_user_usage(
             mock_session,
             user_id=str(uuid4()),
-            model="model-a",
-            flow="CHAT",
-            provider=None,
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_tokens=0,
-            cost_cents=0.1,
-            window_start=window,
+            usage=LLMUsageRecord(
+                model="model-a",
+                flow="CHAT",
+                provider=None,
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=0,
+                cost_cents=0.1,
+                window_start=window,
+            ),
         )
 
         stmt = mock_session.execute.call_args[0][0]
@@ -207,14 +241,16 @@ class TestRecordUserUsage:
         record_user_usage(
             mock_session,
             user_id=str(uuid4()),
-            model="model-a",
-            flow="CHAT",
-            provider="openai",
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_tokens=0,
-            cost_cents=0.1,
-            window_start=window,
+            usage=LLMUsageRecord(
+                model="model-a",
+                flow="CHAT",
+                provider="openai",
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=0,
+                cost_cents=0.1,
+                window_start=window,
+            ),
             incognito=True,
         )
 
@@ -258,6 +294,16 @@ class TestRecordUserUsage:
 
 
 class TestUsageExport:
+    def test_system_usage_is_excluded(self, db_session: Session) -> None:
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        _seed_system_usage(
+            db_session, window, input_tokens=20, output_tokens=7, cost_cents=4.0
+        )
+
+        rows = get_usage_export(db_session, window, window + datetime.timedelta(days=1))
+
+        assert rows == []
+
     def test_orphaned_usage_is_exported_and_reconciles_with_total(
         self, db_session: Session
     ) -> None:
@@ -463,6 +509,15 @@ class TestTotalCostSince:
 
         assert get_total_cost_cents_since(db_session, window) == pytest.approx(7.0)
 
+    def test_includes_system_usage(self, db_session: Session) -> None:
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        _seed_usage(db_session, str(uuid4()), "m", "CHAT", None, 1, 1, 0, 3.0, window)
+        _seed_system_usage(
+            db_session, window, input_tokens=5, output_tokens=2, cost_cents=4.0
+        )
+
+        assert get_total_cost_cents_since(db_session, window) == pytest.approx(7.0)
+
     def test_older_window_excluded(self, db_session: Session) -> None:
         u1 = str(uuid4())
         w1 = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
@@ -503,6 +558,16 @@ class TestTotalCostBucketsSince:
         assert buckets[w1] == pytest.approx(7.0)
         assert buckets[w2] == pytest.approx(9.0)
 
+    def test_includes_system_usage(self, db_session: Session) -> None:
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        _seed_system_usage(
+            db_session, window, input_tokens=5, output_tokens=2, cost_cents=4.0
+        )
+
+        assert dict(get_total_cost_cents_buckets_since(db_session, window))[
+            window
+        ] == pytest.approx(4.0)
+
 
 class TestTokenBuckets:
     def test_user_tokens_are_provider_input_plus_output(
@@ -527,6 +592,16 @@ class TestTokenBuckets:
 
         assert get_total_token_buckets_since(db_session, window) == [
             TokenUsageBucket(window_start=window, tokens=180)
+        ]
+
+    def test_total_tokens_include_system_usage(self, db_session: Session) -> None:
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        _seed_system_usage(
+            db_session, window, input_tokens=50, output_tokens=10, cost_cents=1.0
+        )
+
+        assert get_total_token_buckets_since(db_session, window) == [
+            TokenUsageBucket(window_start=window, tokens=60)
         ]
 
 

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -128,12 +129,13 @@ def _seed_system_usage(
     input_tokens: int,
     output_tokens: int,
     cost_cents: float,
+    attribution: SystemUsageAttribution = SystemUsageAttribution.ATTRIBUTED,
 ) -> None:
     db_session.add(
         UserUsage(
             user_id=None,
             actor_kind=UsageActorKind.SYSTEM,
-            system_attribution=SystemUsageAttribution.ATTRIBUTED,
+            system_attribution=attribution,
             window_start=window_start,
             model="m",
             flow="image_summarization",
@@ -172,6 +174,18 @@ def db_session() -> Generator[Session, None, None]:
         yield session
     finally:
         session.close()
+
+
+def test_system_usage_rejects_unknown_attribution(db_session: Session) -> None:
+    with pytest.raises(IntegrityError):
+        _seed_system_usage(
+            db_session,
+            datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
+            input_tokens=1,
+            output_tokens=1,
+            cost_cents=1.0,
+            attribution=cast(SystemUsageAttribution, "UNKNOWN"),
+        )
 
 
 class TestRecordUserUsage:
@@ -515,8 +529,16 @@ class TestTotalCostSince:
         _seed_system_usage(
             db_session, window, input_tokens=5, output_tokens=2, cost_cents=4.0
         )
+        _seed_system_usage(
+            db_session,
+            window,
+            input_tokens=3,
+            output_tokens=1,
+            cost_cents=2.0,
+            attribution=SystemUsageAttribution.UNATTRIBUTED,
+        )
 
-        assert get_total_cost_cents_since(db_session, window) == pytest.approx(7.0)
+        assert get_total_cost_cents_since(db_session, window) == pytest.approx(9.0)
 
     def test_older_window_excluded(self, db_session: Session) -> None:
         u1 = str(uuid4())
@@ -599,9 +621,17 @@ class TestTokenBuckets:
         _seed_system_usage(
             db_session, window, input_tokens=50, output_tokens=10, cost_cents=1.0
         )
+        _seed_system_usage(
+            db_session,
+            window,
+            input_tokens=10,
+            output_tokens=5,
+            cost_cents=1.0,
+            attribution=SystemUsageAttribution.UNATTRIBUTED,
+        )
 
         assert get_total_token_buckets_since(db_session, window) == [
-            TokenUsageBucket(window_start=window, tokens=60)
+            TokenUsageBucket(window_start=window, tokens=75)
         ]
 
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -1,7 +1,9 @@
 import random
 import threading
 import time
+from contextlib import nullcontext
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, List, cast
 from unittest.mock import MagicMock, Mock, patch
 
@@ -22,15 +24,18 @@ from onyx.hooks.points.document_ingestion import (
 from onyx.indexing.chunker import Chunker
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import (
+    INDEXING_PIPELINE_TRACE_NAME,
     _apply_document_ingestion_hook,
     add_contextual_summaries,
     filter_documents,
     get_docs_to_update,
     process_image_sections,
+    run_indexing_pipeline,
 )
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.llm.model_response import Choice, Message, ModelResponse
+from onyx.tracing.framework.traces import TraceContentMode
 
 
 def create_test_document(
@@ -654,6 +659,45 @@ def test_document_ingestion_hook_mixed_batch() -> None:
 # ---------------------------------------------------------------------------
 
 _PATCH_PREFIX = "onyx.indexing.indexing_pipeline"
+
+
+def test_run_pipeline_owns_llm_enrichment_trace() -> None:
+    search_settings = SimpleNamespace(enable_contextual_rag=False)
+    all_search_settings = SimpleNamespace(primary=search_settings, secondary=None)
+    expected_result = MagicMock()
+
+    with (
+        patch(
+            f"{_PATCH_PREFIX}.get_active_search_settings",
+            return_value=all_search_settings,
+        ),
+        patch(f"{_PATCH_PREFIX}.get_multipass_config"),
+        patch(
+            f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
+            return_value=True,
+        ),
+        patch(
+            f"{_PATCH_PREFIX}.index_doc_batch_with_handler",
+            return_value=expected_result,
+        ),
+        patch(f"{_PATCH_PREFIX}.ensure_trace", return_value=nullcontext()) as ensure,
+    ):
+        result = run_indexing_pipeline(
+            document_batch=[],
+            request_id=None,
+            embedder=MagicMock(),
+            document_indices=[],
+            db_session=MagicMock(),
+            tenant_id="tenant",
+            adapter=MagicMock(),
+            chunker=MagicMock(),
+        )
+
+    assert result is expected_result
+    ensure.assert_called_once_with(
+        INDEXING_PIPELINE_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
+    )
 
 
 def _mock_file_store(image_map: dict[str, bytes]) -> MagicMock:

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -16,6 +16,8 @@ from onyx.connectors.models import (
     TabularSection,
     TextSection,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.hooks.executor import HookSkipped, HookSoftFailed
 from onyx.hooks.points.document_ingestion import (
     DocumentIngestionResponse,
@@ -25,10 +27,14 @@ from onyx.indexing.chunker import Chunker
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import (
     INDEXING_PIPELINE_TRACE_NAME,
+    DocumentBatchPrepareContext,
     _apply_document_ingestion_hook,
+    _partition_documents_blocked_by_llm_spend_limit,
+    _system_llm_enrichment_is_allowed,
     add_contextual_summaries,
     filter_documents,
     get_docs_to_update,
+    index_doc_batch,
     process_image_sections,
     run_indexing_pipeline,
 )
@@ -676,6 +682,7 @@ def test_run_pipeline_owns_llm_enrichment_trace() -> None:
             f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
             return_value=True,
         ),
+        patch(f"{_PATCH_PREFIX}._system_llm_enrichment_is_allowed", return_value=True),
         patch(
             f"{_PATCH_PREFIX}.index_doc_batch_with_handler",
             return_value=expected_result,
@@ -698,6 +705,14 @@ def test_run_pipeline_owns_llm_enrichment_trace() -> None:
         INDEXING_PIPELINE_TRACE_NAME,
         content_mode=TraceContentMode.METADATA_ONLY,
     )
+
+
+def test_system_llm_enrichment_stops_at_global_limit() -> None:
+    with patch(
+        f"{_PATCH_PREFIX}.check_global_token_rate_limits",
+        side_effect=OnyxError(OnyxErrorCode.RATE_LIMITED),
+    ):
+        assert not _system_llm_enrichment_is_allowed()
 
 
 def _mock_file_store(image_map: dict[str, bytes]) -> MagicMock:
@@ -733,6 +748,107 @@ def _make_image_doc(
         source=DocumentSource.FILE,
         metadata={},
     )
+
+
+def test_spend_limit_blocks_only_documents_with_images() -> None:
+    image_doc = _make_image_doc(
+        "image-doc",
+        [TextSection(text="text", link="image-link"), ImageSection(image_file_id="1")],
+    )
+    text_doc = _make_image_doc("text-doc", [TextSection(text="text", link="text-link")])
+
+    result = _partition_documents_blocked_by_llm_spend_limit(
+        [image_doc, text_doc],
+        enable_contextual_rag=False,
+        enable_image_summarization=True,
+        llm_enrichment_allowed=False,
+    )
+
+    assert result.documents == [text_doc]
+    assert len(result.failures) == 1
+    failure = result.failures[0]
+    assert failure.failed_document is not None
+    assert failure.failed_document.document_id == "image-doc"
+    assert failure.failed_document.document_link == "image-link"
+    assert "image summarization" in failure.failure_message
+
+
+def test_spend_limit_blocks_all_contextual_rag_documents() -> None:
+    image_doc = _make_image_doc("image-doc", [ImageSection(image_file_id="1")])
+    text_doc = _make_image_doc("text-doc", [TextSection(text="text", link=None)])
+
+    result = _partition_documents_blocked_by_llm_spend_limit(
+        [image_doc, text_doc],
+        enable_contextual_rag=True,
+        enable_image_summarization=True,
+        llm_enrichment_allowed=False,
+    )
+
+    assert result.documents == []
+    assert {
+        failure.failed_document.document_id
+        for failure in result.failures
+        if failure.failed_document is not None
+    } == {"image-doc", "text-doc"}
+    assert (
+        "contextual RAG and image summarization" in result.failures[0].failure_message
+    )
+    assert "contextual RAG" in result.failures[1].failure_message
+
+
+def test_spend_limit_partition_preserves_documents_when_allowed() -> None:
+    document = _make_image_doc("doc", [ImageSection(image_file_id="1")])
+
+    result = _partition_documents_blocked_by_llm_spend_limit(
+        [document],
+        enable_contextual_rag=True,
+        enable_image_summarization=True,
+        llm_enrichment_allowed=True,
+    )
+
+    assert result.documents == [document]
+    assert result.failures == []
+
+
+def test_index_batch_returns_spend_limit_failures_before_contextual_rag() -> None:
+    document = _make_image_doc("doc", [TextSection(text="text", link="link")])
+    adapter = MagicMock()
+    adapter.connector_id = 1
+    adapter.credential_id = 2
+    adapter.index_attempt_metadata = None
+    adapter.prepare.return_value = DocumentBatchPrepareContext(
+        updatable_docs=[document],
+        id_to_boost_map={},
+    )
+    chunker = MagicMock()
+
+    with (
+        patch(
+            f"{_PATCH_PREFIX}._apply_document_ingestion_hook",
+            side_effect=lambda documents: documents,
+        ),
+        patch(
+            f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
+            return_value=False,
+        ),
+    ):
+        result = index_doc_batch(
+            document_batch=[document],
+            chunker=chunker,
+            embedder=MagicMock(),
+            document_indices=[],
+            request_id=None,
+            tenant_id="tenant",
+            adapter=adapter,
+            enable_contextual_rag=True,
+            llm_enrichment_allowed=False,
+        )
+
+    assert result.total_docs == 1
+    assert len(result.failures) == 1
+    assert result.failures[0].failed_document is not None
+    assert result.failures[0].failed_document.document_id == "doc"
+    chunker.chunk.assert_not_called()
 
 
 def _make_tabular_doc(doc_id: str, section: TabularSection) -> Document:

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -671,6 +671,8 @@ def test_run_pipeline_owns_llm_enrichment_trace() -> None:
     search_settings = SimpleNamespace(enable_contextual_rag=False)
     all_search_settings = SimpleNamespace(primary=search_settings, secondary=None)
     expected_result = MagicMock()
+    vision_llm = MagicMock()
+    document = _make_image_doc("image-doc", [ImageSection(image_file_id="1")])
 
     with (
         patch(
@@ -682,15 +684,19 @@ def test_run_pipeline_owns_llm_enrichment_trace() -> None:
             f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
             return_value=True,
         ),
+        patch(
+            f"{_PATCH_PREFIX}.get_default_llm_with_vision",
+            return_value=vision_llm,
+        ),
         patch(f"{_PATCH_PREFIX}._system_llm_enrichment_is_allowed", return_value=True),
         patch(
             f"{_PATCH_PREFIX}.index_doc_batch_with_handler",
             return_value=expected_result,
-        ),
+        ) as index_doc_batch_with_handler,
         patch(f"{_PATCH_PREFIX}.ensure_trace", return_value=nullcontext()) as ensure,
     ):
         result = run_indexing_pipeline(
-            document_batch=[],
+            document_batch=[document],
             request_id=None,
             embedder=MagicMock(),
             document_indices=[],
@@ -704,6 +710,10 @@ def test_run_pipeline_owns_llm_enrichment_trace() -> None:
     ensure.assert_called_once_with(
         INDEXING_PIPELINE_TRACE_NAME,
         content_mode=TraceContentMode.METADATA_ONLY,
+    )
+    assert (
+        index_doc_batch_with_handler.call_args.kwargs["image_summarization_llm"]
+        is vision_llm
     )
 
 
@@ -748,6 +758,52 @@ def _make_image_doc(
         source=DocumentSource.FILE,
         metadata={},
     )
+
+
+def test_unavailable_vision_llm_does_not_enable_spend_gate() -> None:
+    search_settings = SimpleNamespace(enable_contextual_rag=False)
+    all_search_settings = SimpleNamespace(primary=search_settings, secondary=None)
+    expected_result = MagicMock()
+    document = _make_image_doc("image-doc", [ImageSection(image_file_id="1")])
+
+    with (
+        patch(
+            f"{_PATCH_PREFIX}.get_active_search_settings",
+            return_value=all_search_settings,
+        ),
+        patch(f"{_PATCH_PREFIX}.get_multipass_config"),
+        patch(
+            f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
+            return_value=True,
+        ),
+        patch(f"{_PATCH_PREFIX}.get_default_llm_with_vision", return_value=None),
+        patch(
+            f"{_PATCH_PREFIX}._system_llm_enrichment_is_allowed"
+        ) as enrichment_allowed,
+        patch(
+            f"{_PATCH_PREFIX}.index_doc_batch_with_handler",
+            return_value=expected_result,
+        ) as index_doc_batch_with_handler,
+        patch(f"{_PATCH_PREFIX}.ensure_trace") as ensure,
+    ):
+        result = run_indexing_pipeline(
+            document_batch=[document],
+            request_id=None,
+            embedder=MagicMock(),
+            document_indices=[],
+            db_session=MagicMock(),
+            tenant_id="tenant",
+            adapter=MagicMock(),
+            chunker=MagicMock(),
+        )
+
+    assert result is expected_result
+    enrichment_allowed.assert_not_called()
+    ensure.assert_not_called()
+    assert (
+        index_doc_batch_with_handler.call_args.kwargs["image_summarization_llm"] is None
+    )
+    assert index_doc_batch_with_handler.call_args.kwargs["llm_enrichment_allowed"]
 
 
 def test_spend_limit_blocks_only_documents_with_images() -> None:
@@ -826,10 +882,6 @@ def test_index_batch_returns_spend_limit_failures_before_contextual_rag() -> Non
         patch(
             f"{_PATCH_PREFIX}._apply_document_ingestion_hook",
             side_effect=lambda documents: documents,
-        ),
-        patch(
-            f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
-            return_value=False,
         ),
     ):
         result = index_doc_batch(

--- a/backend/tests/unit/onyx/kg/test_kg_extraction_tracing.py
+++ b/backend/tests/unit/onyx/kg/test_kg_extraction_tracing.py
@@ -1,0 +1,37 @@
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from onyx.kg.utils.extraction_utils import (
+    KG_DOCUMENT_PROCESSING_TRACE_NAME,
+    kg_deep_extraction,
+)
+from onyx.tracing.framework.traces import TraceContentMode
+
+_EXTRACTION_UTILS = "onyx.kg.utils.extraction_utils"
+
+
+def test_kg_deep_extraction_owns_document_trace() -> None:
+    expected_result = MagicMock()
+    with (
+        patch(
+            f"{_EXTRACTION_UTILS}._kg_deep_extraction",
+            return_value=expected_result,
+        ),
+        patch(
+            f"{_EXTRACTION_UTILS}.ensure_trace", return_value=nullcontext()
+        ) as ensure,
+    ):
+        result = kg_deep_extraction(
+            document_id="document",
+            metadata=MagicMock(),
+            implied_extraction=MagicMock(),
+            tenant_id="tenant",
+            index_name="index",
+            kg_config_settings=MagicMock(),
+        )
+
+    assert result is expected_result
+    ensure.assert_called_once_with(
+        KG_DOCUMENT_PROCESSING_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
+    )

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -163,7 +163,7 @@ def _seed_system_usage(db_session: Session) -> None:
             UserUsage(
                 user_id=None,
                 actor_kind=UsageActorKind.SYSTEM,
-                system_attribution=SystemUsageAttribution.SYSTEM,
+                system_attribution=SystemUsageAttribution.ATTRIBUTED,
                 window_start=_W1,
                 model="model-a",
                 flow="image_summarization",

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -20,7 +20,12 @@ from sqlalchemy.pool import StaticPool
 
 from onyx.auth.users import current_user
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import AccountType, Permission
+from onyx.db.enums import (
+    AccountType,
+    Permission,
+    SystemUsageAttribution,
+    UsageActorKind,
+)
 from onyx.db.models import UserUsage
 from onyx.db.user_usage import UsageExportRow, get_usage_export
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
@@ -150,6 +155,44 @@ def _seed_two_users(db_session: Session) -> tuple[str, str]:
     _seed_usage(db_session, bob, "model-a", "CHAT", "anthropic", 400, 80, 0, 4.0, _W2)
     db_session.commit()
     return alice, bob
+
+
+def _seed_system_usage(db_session: Session) -> None:
+    db_session.add_all(
+        [
+            UserUsage(
+                user_id=None,
+                actor_kind=UsageActorKind.SYSTEM,
+                system_attribution=SystemUsageAttribution.SYSTEM,
+                window_start=_W1,
+                model="model-a",
+                flow="image_summarization",
+                provider="anthropic",
+                incognito=False,
+                input_tokens=100,
+                output_tokens=20,
+                cache_read_tokens=5,
+                cache_creation_tokens=3,
+                cost_cents=2.0,
+            ),
+            UserUsage(
+                user_id=None,
+                actor_kind=UsageActorKind.SYSTEM,
+                system_attribution=SystemUsageAttribution.UNATTRIBUTED,
+                window_start=_W1,
+                model="model-b",
+                flow="untagged_invoke",
+                provider="openai",
+                incognito=False,
+                input_tokens=50,
+                output_tokens=10,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,
+                cost_cents=1.0,
+            ),
+        ]
+    )
+    db_session.commit()
 
 
 class TestGetUsageExportHelper:
@@ -359,6 +402,32 @@ class TestExportEndpoint:
         )
         assert resp.status_code == 400
         assert resp.json()["error_code"] == "INVALID_INPUT"
+
+
+class TestSystemUsageEndpoint:
+    def test_groups_system_usage_by_flow(self, db_session: Session) -> None:
+        _seed_system_usage(db_session)
+        client = TestClient(_make_app(db_session, _ADMIN))
+
+        response = client.get(
+            "/admin/usage/system",
+            params={"start": "2026-06-01", "end": "2026-06-07"},
+        )
+
+        assert response.status_code == 200
+        categories = {
+            category["category"]: category for category in response.json()["categories"]
+        }
+        assert set(categories) == {"image_summarization", "unattributed"}
+        assert categories["image_summarization"]["totals"]["cost_cents"] == 2.0
+        assert categories["unattributed"]["records"][0]["flow"] == "untagged_invoke"
+
+    def test_rejects_non_admin(self, db_session: Session) -> None:
+        client = TestClient(_make_app(db_session, _NON_ADMIN))
+
+        response = client.get("/admin/usage/system")
+
+        assert response.status_code == 403
 
 
 class TestResetUsageEndpoint:

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -178,6 +178,21 @@ def _seed_system_usage(db_session: Session) -> None:
             UserUsage(
                 user_id=None,
                 actor_kind=UsageActorKind.SYSTEM,
+                system_attribution=SystemUsageAttribution.ATTRIBUTED,
+                window_start=_W1 + datetime.timedelta(hours=1),
+                model="model-a",
+                flow="image_summarization",
+                provider="anthropic",
+                incognito=False,
+                input_tokens=25,
+                output_tokens=5,
+                cache_read_tokens=2,
+                cache_creation_tokens=1,
+                cost_cents=1.5,
+            ),
+            UserUsage(
+                user_id=None,
+                actor_kind=UsageActorKind.SYSTEM,
                 system_attribution=SystemUsageAttribution.UNATTRIBUTED,
                 window_start=_W1,
                 model="model-b",
@@ -419,7 +434,11 @@ class TestSystemUsageEndpoint:
             category["category"]: category for category in response.json()["categories"]
         }
         assert set(categories) == {"image_summarization", "unattributed"}
-        assert categories["image_summarization"]["totals"]["cost_cents"] == 2.0
+        image_summary = categories["image_summarization"]
+        assert len(image_summary["records"]) == 1
+        assert image_summary["totals"]["input_tokens"] == 125
+        assert image_summary["totals"]["output_tokens"] == 25
+        assert image_summary["totals"]["cost_cents"] == 3.5
         assert categories["unattributed"]["records"][0]["flow"] == "untagged_invoke"
 
     def test_rejects_non_admin(self, db_session: Session) -> None:

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session, sessionmaker
 
 import onyx.server.query_and_chat.token_limit as token_limit
+from onyx.db.llm_usage import LLMUsageRecord
 from onyx.db.models import TokenRateLimit, TokenRateLimitScope, UserUsage
 from onyx.db.user_usage import (
     TokenUsageBucket,
@@ -518,14 +519,16 @@ class TestCostEnforcementRealLedgerPath:
         record_user_usage(
             ledger_session,
             str(uuid.uuid4()),
-            "m",
-            "CHAT",
-            None,
-            1,
-            1,
-            0,
-            500.0,
-            ledger_window,
+            LLMUsageRecord(
+                model="m",
+                flow="CHAT",
+                provider=None,
+                input_tokens=1,
+                output_tokens=1,
+                cache_read_tokens=0,
+                cost_cents=500.0,
+                window_start=ledger_window,
+            ),
         )
 
         limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
@@ -552,7 +555,18 @@ class TestCostEnforcementRealLedgerPath:
         current = get_cost_window_start(now, 24)
         prior = current - datetime.timedelta(days=1)
         record_user_usage(
-            ledger_session, str(uuid.uuid4()), "m", "CHAT", None, 1, 1, 0, 9999.0, prior
+            ledger_session,
+            str(uuid.uuid4()),
+            LLMUsageRecord(
+                model="m",
+                flow="CHAT",
+                provider=None,
+                input_tokens=1,
+                output_tokens=1,
+                cache_read_tokens=0,
+                cost_cents=9999.0,
+                window_start=prior,
+            ),
         )
 
         limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -1,0 +1,117 @@
+"""Metadata-only traces retain metering data without capturing model content."""
+
+from typing import Any
+
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.processor_interface import TracingProcessor
+from onyx.tracing.framework.provider import DefaultTraceProvider
+from onyx.tracing.framework.setup import get_trace_provider, set_trace_provider
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import NoOpSpan, Span
+from onyx.tracing.framework.traces import Trace, TraceContentMode
+from onyx.tracing.llm_utils import record_llm_span_output, traced_llm_call
+
+
+class _CaptureProcessor(TracingProcessor):
+    def __init__(self) -> None:
+        self.started_traces: list[Trace] = []
+        self.ended_traces: list[Trace] = []
+        self.ended_spans: list[Span[Any]] = []
+
+    def on_trace_start(self, trace: Trace) -> None:
+        self.started_traces.append(trace)
+
+    def on_trace_end(self, trace: Trace) -> None:
+        self.ended_traces.append(trace)
+
+    def on_span_start(self, span: Span[Any]) -> None:
+        pass
+
+    def on_span_end(self, span: Span[Any]) -> None:
+        self.ended_spans.append(span)
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self) -> None:
+        pass
+
+
+def test_metadata_only_trace_removes_generation_content() -> None:
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+
+    with provider.create_trace(
+        "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+    ) as trace:
+        span = provider.create_span(
+            GenerationSpanData(
+                input=[{"role": "user", "content": "private document"}],
+                output=[{"role": "assistant", "content": "private response"}],
+                reasoning="private reasoning",
+                model="claude-sonnet",
+                tools=[{"name": "private_tool"}],
+                request_params={"private": "parameter"},
+            )
+        )
+        with span:
+            span.span_data.output = [
+                {"role": "assistant", "content": "late private response"}
+            ]
+            span.span_data.usage = {"input_tokens": 5, "output_tokens": 2}
+
+    assert processor.started_traces == [trace]
+    assert processor.ended_traces == [trace]
+    assert processor.ended_spans == [span]
+    assert span.trace_id == trace.trace_id
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+    assert span.span_data.input is None
+    assert span.span_data.output is None
+    assert span.span_data.reasoning is None
+    assert span.span_data.tools is None
+    assert span.span_data.request_params is None
+    assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
+
+
+def test_span_without_trace_remains_noop() -> None:
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+
+    span = provider.create_span(GenerationSpanData(model="claude-sonnet"))
+    with span:
+        span.span_data.usage = {"input_tokens": 5, "output_tokens": 2}
+
+    assert isinstance(span, NoOpSpan)
+    assert processor.ended_spans == []
+
+
+def test_llm_helper_does_not_create_workflow_trace() -> None:
+    original_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+    set_trace_provider(provider)
+
+    try:
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_SUMMARIZATION,
+            model="claude-sonnet",
+            provider="anthropic",
+            input_messages=[{"role": "user", "content": "private document"}],
+        ) as span:
+            record_llm_span_output(
+                span,
+                output="private response",
+                reasoning="private reasoning",
+                usage={"input_tokens": 5, "output_tokens": 2},
+            )
+    finally:
+        set_trace_provider(original_provider)
+
+    assert isinstance(span, NoOpSpan)
+    assert processor.started_traces == []
+    assert processor.ended_traces == []
+    assert processor.ended_spans == []
+    assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -80,6 +80,26 @@ def test_metadata_only_trace_removes_generation_content() -> None:
     assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
 
 
+def test_new_trace_ignores_stale_noop_span() -> None:
+    provider = DefaultTraceProvider()
+    stale_span = NoOpSpan(GenerationSpanData(model="claude-sonnet"))
+    stale_span.start(mark_as_current=True)
+    stale_span.__exit__(GeneratorExit, GeneratorExit(), None)
+
+    try:
+        with provider.create_trace(
+            "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+        ) as trace:
+            span = provider.create_span(GenerationSpanData(model="claude-sonnet"))
+    finally:
+        stale_span.finish(reset_current=True)
+
+    assert not isinstance(span, NoOpSpan)
+    assert span.trace_id == trace.trace_id
+    assert span.parent_id is None
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+
+
 def test_full_span_overrides_metadata_only_trace() -> None:
     provider = DefaultTraceProvider()
 

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -1,15 +1,21 @@
 """Metadata-only traces retain metering data without capturing model content."""
 
 from typing import Any
+from unittest.mock import MagicMock
 
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import ensure_trace
 from onyx.tracing.framework.processor_interface import TracingProcessor
 from onyx.tracing.framework.provider import DefaultTraceProvider
 from onyx.tracing.framework.setup import get_trace_provider, set_trace_provider
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import NoOpSpan, Span
 from onyx.tracing.framework.traces import Trace, TraceContentMode
-from onyx.tracing.llm_utils import record_llm_span_output, traced_llm_call
+from onyx.tracing.llm_utils import (
+    llm_generation_span,
+    record_llm_span_output,
+    traced_llm_call,
+)
 
 
 class _CaptureProcessor(TracingProcessor):
@@ -74,17 +80,92 @@ def test_metadata_only_trace_removes_generation_content() -> None:
     assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
 
 
-def test_span_without_trace_remains_noop() -> None:
+def test_full_span_overrides_metadata_only_trace() -> None:
+    provider = DefaultTraceProvider()
+
+    with provider.create_trace(
+        "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+    ):
+        span = provider.create_span(
+            GenerationSpanData(
+                input=[{"role": "user", "content": "captured document"}],
+                model="claude-sonnet",
+            ),
+            content_mode=TraceContentMode.FULL,
+        )
+
+    assert span.content_mode == TraceContentMode.FULL
+    assert span.span_data.input == [{"role": "user", "content": "captured document"}]
+
+
+def test_metadata_only_span_without_trace_remains_redacted_noop() -> None:
     provider = DefaultTraceProvider()
     processor = _CaptureProcessor()
     provider.register_processor(processor)
 
-    span = provider.create_span(GenerationSpanData(model="claude-sonnet"))
+    span = provider.create_span(
+        GenerationSpanData(
+            input=[{"role": "user", "content": "private document"}],
+            model="claude-sonnet",
+        ),
+        content_mode=TraceContentMode.METADATA_ONLY,
+    )
     with span:
+        span.span_data.output = [{"role": "assistant", "content": "private response"}]
         span.span_data.usage = {"input_tokens": 5, "output_tokens": 2}
 
     assert isinstance(span, NoOpSpan)
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+    assert span.span_data.input is None
+    assert span.span_data.output is None
+    assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
     assert processor.ended_spans == []
+
+
+def test_llm_helper_inherits_metadata_only_trace() -> None:
+    original_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    set_trace_provider(provider)
+    llm = MagicMock()
+    llm.config.model_name = "claude-sonnet"
+    llm.config.model_provider = "anthropic"
+    llm.config.api_base = None
+
+    try:
+        with provider.create_trace(
+            "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+        ):
+            with llm_generation_span(
+                llm=llm,
+                flow=LLMFlow.IMAGE_SUMMARIZATION,
+                input_messages=[{"role": "user", "content": "private document"}],
+            ) as span:
+                pass
+    finally:
+        set_trace_provider(original_provider)
+
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+    assert span.span_data.input is None
+
+
+def test_ensure_trace_reuses_active_trace() -> None:
+    original_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+    set_trace_provider(provider)
+
+    try:
+        with provider.create_trace("existing_trace") as existing_trace:
+            with ensure_trace(
+                "unused_trace", content_mode=TraceContentMode.METADATA_ONLY
+            ) as reused_trace:
+                assert reused_trace is existing_trace
+    finally:
+        set_trace_provider(original_provider)
+
+    assert processor.started_traces == [existing_trace]
+    assert processor.ended_traces == [existing_trace]
 
 
 def test_llm_helper_does_not_create_workflow_trace() -> None:

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -10,7 +10,7 @@ from onyx.tracing.framework.provider import DefaultTraceProvider
 from onyx.tracing.framework.setup import get_trace_provider, set_trace_provider
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import NoOpSpan, Span
-from onyx.tracing.framework.traces import Trace, TraceContentMode
+from onyx.tracing.framework.traces import NoOpTrace, Trace, TraceContentMode
 from onyx.tracing.llm_utils import (
     llm_generation_span,
     record_llm_span_output,
@@ -120,6 +120,21 @@ def test_metadata_only_span_without_trace_remains_redacted_noop() -> None:
     assert span.span_data.output is None
     assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
     assert processor.ended_spans == []
+
+
+def test_provider_preserves_positional_disabled_arguments() -> None:
+    provider = DefaultTraceProvider()
+
+    disabled_trace = provider.create_trace("disabled", None, None, None, True)
+    with provider.create_trace("active"):
+        disabled_span = provider.create_span(
+            GenerationSpanData(model="claude-sonnet"), None, None, True
+        )
+
+    assert isinstance(disabled_trace, NoOpTrace)
+    assert disabled_trace.content_mode == TraceContentMode.FULL
+    assert isinstance(disabled_span, NoOpSpan)
+    assert disabled_span.content_mode == TraceContentMode.FULL
 
 
 def test_llm_helper_inherits_metadata_only_trace() -> None:

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import pytest
 
+from onyx.db.enums import SystemUsageAttribution
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.span_data import (
     FunctionSpanData,
@@ -75,6 +76,7 @@ def processor(
     monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
     monkeypatch.setattr(proc_mod, "compute_cost_cents", lambda *_a, **_k: (1.0, 2.0))
     monkeypatch.setattr(proc_mod, "record_user_usage", _capture_record)
+    monkeypatch.setattr(proc_mod, "record_system_usage", _capture_record)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
     try:
@@ -106,14 +108,15 @@ def test_records_usage_when_user_id_set(
     assert len(recorded_calls) == 1
     call = recorded_calls[0]
     assert call["user_id"] == user_id
-    assert call["input_tokens"] == 100
-    assert call["output_tokens"] == 50
-    assert call["cache_read_tokens"] == 20
-    assert call["model"] == "gpt-4o"
-    assert call["provider"] == "openai"
-    assert call["flow"] == "chat_response"
-    assert call["cost_cents"] == pytest.approx(3.0)  # 1.0 input + 2.0 output
-    window_start = call["window_start"]
+    usage = call["usage"]
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 50
+    assert usage.cache_read_tokens == 20
+    assert usage.model == "gpt-4o"
+    assert usage.provider == "openai"
+    assert usage.flow == "chat_response"
+    assert usage.cost_cents == pytest.approx(3.0)  # 1.0 input + 2.0 output
+    window_start = usage.window_start
     assert (
         window_start.hour
         == window_start.minute
@@ -140,8 +143,9 @@ def test_normalizes_prompt_completion_token_aliases(
     processor.force_flush()
 
     assert len(recorded_calls) == 1
-    assert recorded_calls[0]["input_tokens"] == 7
-    assert recorded_calls[0]["output_tokens"] == 3
+    usage = recorded_calls[0]["usage"]
+    assert usage.input_tokens == 7
+    assert usage.output_tokens == 3
 
 
 def test_batch_aggregates_matching_ledger_dimensions(
@@ -198,10 +202,42 @@ def test_batch_aggregates_cache_creation_tokens(
     assert aggregated[0].cache_creation_tokens == 30
 
 
-def test_no_record_when_user_id_unset(
+def test_records_system_usage_when_user_id_unset(
     processor: UserUsageTracingProcessor, recorded_calls: list[dict[str, Any]]
 ) -> None:
-    processor.on_span_end(_generation_span(usage={"input_tokens": 5}))
+    processor.on_span_end(
+        _generation_span(
+            flow=LLMFlow.IMAGE_SUMMARIZATION.value,
+            usage={"input_tokens": 5, "output_tokens": 2},
+        )
+    )
+    processor.force_flush()
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0]["attribution"] == SystemUsageAttribution.ATTRIBUTED
+    assert recorded_calls[0]["usage"].flow == LLMFlow.IMAGE_SUMMARIZATION.value
+
+
+def test_records_unknown_non_user_flow_as_unattributed(
+    processor: UserUsageTracingProcessor, recorded_calls: list[dict[str, Any]]
+) -> None:
+    processor.on_span_end(_generation_span(flow="unknown", usage={"input_tokens": 5}))
+    processor.force_flush()
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0]["attribution"] == SystemUsageAttribution.UNATTRIBUTED
+
+
+def test_ignores_non_user_generation_without_token_usage(
+    processor: UserUsageTracingProcessor, recorded_calls: list[dict[str, Any]]
+) -> None:
+    processor.on_span_end(
+        _fake_span(
+            GenerationSpanData(
+                model="dall-e-3",
+                model_config={"flow": LLMFlow.IMAGE_GENERATION.value},
+                image_count=1,
+            )
+        )
+    )
     processor.force_flush()
     assert recorded_calls == []
 
@@ -258,8 +294,9 @@ def test_records_image_span_without_token_usage(
 
     processor.force_flush()
     assert len(recorded_calls) == 1
-    assert recorded_calls[0]["input_tokens"] == 0
-    assert recorded_calls[0]["output_tokens"] == 0
+    usage = recorded_calls[0]["usage"]
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
 
 
 def test_on_span_end_never_raises_on_internal_error(
@@ -317,6 +354,7 @@ def test_passes_cache_inclusive_usage_to_shared_pricing(
 
     monkeypatch.setattr(proc_mod, "compute_cost_cents", _capture_cost)
     monkeypatch.setattr(proc_mod, "record_user_usage", _capture_record)
+    monkeypatch.setattr(proc_mod, "record_system_usage", _capture_record)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
     try:
@@ -341,9 +379,10 @@ def test_passes_cache_inclusive_usage_to_shared_pricing(
 
     assert priced == [(3000, 500, 2000, 500)]
     assert len(recorded_calls) == 1
-    assert recorded_calls[0]["input_tokens"] == 3000
-    assert recorded_calls[0]["cache_read_tokens"] == 2000
-    assert recorded_calls[0]["cache_creation_tokens"] == 500
+    usage = recorded_calls[0]["usage"]
+    assert usage.input_tokens == 3000
+    assert usage.cache_read_tokens == 2000
+    assert usage.cache_creation_tokens == 500
 
 
 def test_flush_swallows_record_errors(

--- a/docs/usage/usage-reports.md
+++ b/docs/usage/usage-reports.md
@@ -9,13 +9,14 @@ the number.
 
 ## Where we are today
 
-`create_new_usage_report` builds a zip with three CSVs and a PDF review pack:
+`create_new_usage_report` builds a zip with four CSVs and a PDF review pack:
 
 | File                 | Contents                                                                              |
 | -------------------- | ------------------------------------------------------------------------------------- |
 | `chat_messages.csv`  | One row per message: session, user, flow, time, agent, email, tokens, model            |
 | `users.csv`          | `user_id`, `is_active`                                                                  |
 | `usage_by_user.csv`  | Per user, per day, per model/flow/provider: tokens, cache reads, cost                   |
+| `usage_by_system.csv`| Non-user text generation per day, model, flow, provider, and attribution               |
 | `usage_report.pdf`   | Summary of spend, adoption, seats, and usage attribution                                |
 
 The raw CSV files are still a data dump. They have three problems:


### PR DESCRIPTION
## Description

Add a typed admin endpoint that groups non-user text-generation spend by flow. Generated usage packs now include `usage_by_system.csv`, and their PDF totals and breakdowns include system spend without counting it as user activity.

This PR is stacked on #14452.

## How Has This Been Tested?

- `uv run pytest -q tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py tests/unit/ee/onyx/server/reporting/test_usage_report_data.py tests/unit/onyx/db/test_system_usage.py`
- Targeted Ruff formatting and lint checks
- Targeted `ty check`
- Pre-commit hooks

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes system LLM usage to admins and includes it in usage reports. That spend was previously absent from exports and PDF breakdowns; it now appears in a typed `/admin/usage/system` response, `usage_by_system.csv`, and a PDF "System spend by flow" section without counting toward user or seat activity.

- The endpoint requires full admin access and supports date-range and model filters.
- Groups usage by flow, separates unattributed records, and labels missing flows `other`.
- Adds system spend to model, flow, and daily cost totals while keeping activity counts user-only.
- Updates usage-report documentation and adds unit and integration coverage.

<sup>Written for commit 8f0210c52671dd2af1dbda5eebfe45b91fce0e31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

