### PR TITLE
feat: show system LLM usage in workspace analytics

### DIFF
--- a/backend/ee/onyx/server/reporting/usage_report_data.py
+++ b/backend/ee/onyx/server/reporting/usage_report_data.py
@@ -60,9 +60,6 @@ class UsageReportData(BaseModel):
     top_users: list[NamedSpend]
     by_model: list[NamedSpend]
     by_flow: list[NamedSpend]
-    system_cost_cents: float
-    system_input_tokens: int
-    system_output_tokens: int
     system_by_flow: list[NamedSpend]
     daily: list[DailySpend]
 
@@ -121,9 +118,6 @@ def build_usage_report_data(
     total_cache_read = 0
     total_cache_creation = 0
     active_emails: set[str] = set()
-    system_cost = 0.0
-    system_input = 0
-    system_output = 0
 
     for row in rows:
         for bucket, key in (
@@ -182,9 +176,6 @@ def build_usage_report_data(
         total_output += row.output_tokens
         total_cache_read += row.cache_read_tokens
         total_cache_creation += row.cache_creation_tokens
-        system_cost += row.cost_cents
-        system_input += row.input_tokens
-        system_output += row.output_tokens
         daily_cost[row.day] += row.cost_cents
 
     # Must match license enforcement, or this disagrees with what is billed.
@@ -216,9 +207,6 @@ def build_usage_report_data(
         top_users=_top_n(by_user, TOP_USER_LIMIT),
         by_model=_top_n(by_model, TOP_ENTRY_LIMIT),
         by_flow=_top_n(by_flow, TOP_ENTRY_LIMIT),
-        system_cost_cents=system_cost,
-        system_input_tokens=system_input,
-        system_output_tokens=system_output,
         system_by_flow=_top_n(system_by_flow, TOP_ENTRY_LIMIT),
         daily=daily,
     )

--- a/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
+++ b/backend/tests/unit/ee/onyx/server/reporting/test_usage_report_data.py
@@ -145,7 +145,6 @@ def test_system_usage_counts_toward_spend_but_not_people() -> None:
     )
 
     assert data.total_cost_cents == pytest.approx(20.0)
-    assert data.system_cost_cents == pytest.approx(10.0)
     assert data.active_users == 1
     assert {entry.name: entry.cost_cents for entry in data.system_by_flow} == {
         "image_summarization": 7.0,

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { DateRangePicker } from "@opal/components";
 import { useTimeRange } from "@/lib/usage/hooks";
 import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
+import SystemUsagePanel from "@/views/admin/SystemUsagePanel";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Divider } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
@@ -27,13 +28,21 @@ export default function UsagePage() {
         rightChildren={
           <DateRangePicker
             value={timeRange}
-            onValueChange={(value) => setTimeRange(value as any)}
+            onValueChange={(value) => {
+              if (!value) return;
+              setTimeRange((previous) => ({
+                ...value,
+                selectValue: previous.selectValue,
+              }));
+            }}
             size="sm"
           />
         }
       />
       <SettingsLayouts.Body>
         <PerUserUsagePanel timeRange={timeRange} />
+        <Divider />
+        <SystemUsagePanel timeRange={timeRange} />
         <Divider />
         <TokenRateLimitsPanel embedded />
       </SettingsLayouts.Body>

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "سياق مقاطع RAG السياقية"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "ملخصات مستندات RAG السياقية"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "تلخيص الصور" },
+        "kgDeepExtraction": { "label": "استخراج الرسم البياني المعرفي" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "تصنيف الرسم البياني المعرفي"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "أخرى" },
+        "unattributed": { "label": "غير منسوب" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "كل النماذج" },
+        "allProviders": { "label": "كل المزوّدين" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · إنشاء نص في الخلفية بدون مستخدم.",
+        "emptyDescription": "تكلفة إنشاء النص في الخلفية للفترة المحددة.",
+        "error": { "title": "تعذر تحميل استخدام النظام لهذه الفترة." },
+        "title": "استخدام النظام"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "إنفاق النظام" },
+        "tokens": { "label": "إجمالي الرموز" },
+        "unattributed": { "label": "إنفاق غير منسوب" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
-          "tokens": { "header": "Tokens" }
+          "category": { "header": "الفئة" },
+          "input": { "header": "الإدخال" },
+          "output": { "header": "الإخراج" },
+          "spend": { "header": "الإنفاق" },
+          "tokens": { "header": "الرموز" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "لا يوجد استخدام للنظام يطابق عوامل التصفية الحالية."
         }
       }
     },

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -5803,6 +5803,49 @@
         "description": "اربط خوادم OpenAPI لإضافة إجراءات وأدوات مخصصة لوكلائك."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · تُحسب التكاليف من استخدام النماذج المسجل.",

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -5803,6 +5803,49 @@
         "description": "Verbinden Sie OpenAPI-Server, um benutzerdefinierte Aktionen und Tools für Ihre Agenten hinzuzufügen."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Die Kosten werden aus der erfassten Modellnutzung berechnet.",

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "Kontext für kontextbezogene RAG-Abschnitte"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "Kontextbezogene RAG-Dokumentzusammenfassungen"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "Bildzusammenfassung" },
+        "kgDeepExtraction": { "label": "Knowledge-Graph-Extraktion" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "Knowledge-Graph-Klassifizierung"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "Sonstige" },
+        "unattributed": { "label": "Nicht zugeordnet" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "Alle Modelle" },
+        "allProviders": { "label": "Alle Anbieter" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · Texterzeugung im Hintergrund ohne Benutzer.",
+        "emptyDescription": "Ausgaben für die Texterzeugung im Hintergrund im ausgewählten Zeitraum.",
+        "error": { "title": "Die Systemnutzung für diesen Zeitraum konnte nicht geladen werden." },
+        "title": "Systemnutzung"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "Systemausgaben" },
+        "tokens": { "label": "Token insgesamt" },
+        "unattributed": { "label": "Nicht zugeordnete Ausgaben" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
-          "tokens": { "header": "Tokens" }
+          "category": { "header": "Kategorie" },
+          "input": { "header": "Eingabe" },
+          "output": { "header": "Ausgabe" },
+          "spend": { "header": "Ausgaben" },
+          "tokens": { "header": "Token" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "Keine Systemnutzung entspricht den aktuellen Filtern."
         }
       }
     },

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -5803,6 +5803,77 @@
         "description": "Connect OpenAPI servers to add custom actions and tools for your agents."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": {
+          "label": "Image summarization"
+        },
+        "kgDeepExtraction": {
+          "label": "Knowledge graph extraction"
+        },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": {
+          "label": "Unattributed"
+        }
+      },
+      "filters": {
+        "allModels": {
+          "label": "All models"
+        },
+        "allProviders": {
+          "label": "All providers"
+        }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": {
+          "title": "Failed to load system usage for this period."
+        },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": {
+          "label": "System spend"
+        },
+        "tokens": {
+          "label": "Total tokens"
+        },
+        "unattributed": {
+          "label": "Unattributed spend"
+        }
+      },
+      "table": {
+        "columns": {
+          "category": {
+            "header": "Category"
+          },
+          "input": {
+            "header": "Input"
+          },
+          "output": {
+            "header": "Output"
+          },
+          "spend": {
+            "header": "Spend"
+          },
+          "tokens": {
+            "header": "Tokens"
+          }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Costs are calculated from recorded model usage.",

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -5820,6 +5820,9 @@
         "kgDocumentClassification": {
           "label": "Knowledge graph classification"
         },
+        "other": {
+          "label": "Other"
+        },
         "unattributed": {
           "label": "Unattributed"
         }

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "Contexto de fragmentos RAG contextuales"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "Resúmenes contextuales de documentos RAG"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "Resumen de imágenes" },
+        "kgDeepExtraction": { "label": "Extracción del grafo de conocimiento" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "Clasificación del grafo de conocimiento"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "Otros" },
+        "unattributed": { "label": "Sin atribuir" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "Todos los modelos" },
+        "allProviders": { "label": "Todos los proveedores" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · Generación de texto en segundo plano sin usuario.",
+        "emptyDescription": "Gasto de generación de texto en segundo plano durante el periodo seleccionado.",
+        "error": { "title": "No se pudo cargar el uso del sistema de este periodo." },
+        "title": "Uso del sistema"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "Gasto del sistema" },
+        "tokens": { "label": "Tokens totales" },
+        "unattributed": { "label": "Gasto sin atribuir" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
+          "category": { "header": "Categoría" },
+          "input": { "header": "Entrada" },
+          "output": { "header": "Salida" },
+          "spend": { "header": "Gasto" },
           "tokens": { "header": "Tokens" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "Ningún uso del sistema coincide con los filtros actuales."
         }
       }
     },

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -5803,6 +5803,49 @@
         "description": "Conecta servidores de OpenAPI para añadir acciones y herramientas personalizadas a tus agentes."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Los costes se calculan a partir del uso registrado de los modelos.",

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -5803,6 +5803,49 @@
         "description": "Connectez des serveurs OpenAPI pour ajouter des actions et des outils personnalisés à vos agents."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Les coûts sont calculés à partir de l'utilisation enregistrée des modèles.",

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "Contexte des fragments RAG contextuels"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "Résumés contextuels des documents RAG"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "Résumé des images" },
+        "kgDeepExtraction": { "label": "Extraction du graphe de connaissances" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "Classification du graphe de connaissances"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "Autres" },
+        "unattributed": { "label": "Non attribué" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "Tous les modèles" },
+        "allProviders": { "label": "Tous les fournisseurs" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · Génération de texte en arrière-plan sans utilisateur.",
+        "emptyDescription": "Dépenses de génération de texte en arrière-plan pour la période sélectionnée.",
+        "error": { "title": "Échec du chargement de l'utilisation système pour cette période." },
+        "title": "Utilisation système"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "Dépenses système" },
+        "tokens": { "label": "Total des jetons" },
+        "unattributed": { "label": "Dépenses non attribuées" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
-          "tokens": { "header": "Tokens" }
+          "category": { "header": "Catégorie" },
+          "input": { "header": "Entrée" },
+          "output": { "header": "Sortie" },
+          "spend": { "header": "Dépenses" },
+          "tokens": { "header": "Jetons" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "Aucune utilisation système ne correspond aux filtres actuels."
         }
       }
     },

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -5803,6 +5803,49 @@
         "description": "OpenAPI サーバーを接続して、エージェント用のカスタムアクションとツールを追加します。"
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · コストは記録されたモデル使用量から算出されます。",

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "コンテキスト RAG チャンクの文脈"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "コンテキスト RAG ドキュメント要約"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "画像要約" },
+        "kgDeepExtraction": { "label": "ナレッジグラフ抽出" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "ナレッジグラフ分類"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "その他" },
+        "unattributed": { "label": "未帰属" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "すべてのモデル" },
+        "allProviders": { "label": "すべてのプロバイダー" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · ユーザーを伴わないバックグラウンドでのテキスト生成。",
+        "emptyDescription": "選択した期間のバックグラウンドテキスト生成費用。",
+        "error": { "title": "この期間のシステム使用状況を読み込めませんでした。" },
+        "title": "システム使用状況"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "システム費用" },
+        "tokens": { "label": "合計トークン" },
+        "unattributed": { "label": "未帰属の費用" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
-          "tokens": { "header": "Tokens" }
+          "category": { "header": "カテゴリー" },
+          "input": { "header": "入力" },
+          "output": { "header": "出力" },
+          "spend": { "header": "費用" },
+          "tokens": { "header": "トークン" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "現在のフィルターに一致するシステム使用状況はありません。"
         }
       }
     },

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -5803,6 +5803,49 @@
         "description": "OpenAPI 서버를 연결해 에이전트용 사용자 지정 작업과 도구를 추가하세요."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · 비용은 기록된 모델 사용량을 기준으로 계산됩니다.",

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "컨텍스트 RAG 청크 문맥"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "컨텍스트 RAG 문서 요약"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "이미지 요약" },
+        "kgDeepExtraction": { "label": "지식 그래프 추출" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "지식 그래프 분류"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "기타" },
+        "unattributed": { "label": "미귀속" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "모든 모델" },
+        "allProviders": { "label": "모든 제공업체" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · 사용자 없이 실행된 백그라운드 텍스트 생성.",
+        "emptyDescription": "선택한 기간의 백그라운드 텍스트 생성 비용입니다.",
+        "error": { "title": "이 기간의 시스템 사용량을 불러오지 못했습니다." },
+        "title": "시스템 사용량"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "시스템 비용" },
+        "tokens": { "label": "총 토큰" },
+        "unattributed": { "label": "미귀속 비용" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
-          "tokens": { "header": "Tokens" }
+          "category": { "header": "카테고리" },
+          "input": { "header": "입력" },
+          "output": { "header": "출력" },
+          "spend": { "header": "비용" },
+          "tokens": { "header": "토큰" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "현재 필터와 일치하는 시스템 사용량이 없습니다."
         }
       }
     },

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "Contexto de trechos RAG contextuais"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "Resumos contextuais de documentos RAG"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "Resumo de imagens" },
+        "kgDeepExtraction": { "label": "Extração do grafo de conhecimento" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "Classificação do grafo de conhecimento"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "Outros" },
+        "unattributed": { "label": "Não atribuído" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "Todos os modelos" },
+        "allProviders": { "label": "Todos os provedores" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · Geração de texto em segundo plano sem usuário.",
+        "emptyDescription": "Gastos de geração de texto em segundo plano no período selecionado.",
+        "error": { "title": "Falha ao carregar o uso do sistema neste período." },
+        "title": "Uso do sistema"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "Gastos do sistema" },
+        "tokens": { "label": "Total de tokens" },
+        "unattributed": { "label": "Gastos não atribuídos" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
+          "category": { "header": "Categoria" },
+          "input": { "header": "Entrada" },
+          "output": { "header": "Saída" },
+          "spend": { "header": "Gastos" },
           "tokens": { "header": "Tokens" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "Nenhum uso do sistema corresponde aos filtros atuais."
         }
       }
     },

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -5803,6 +5803,49 @@
         "description": "Conecte servidores OpenAPI para adicionar ações e ferramentas personalizadas aos seus agentes."
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · Os custos são calculados a partir do uso registrado do modelo.",

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -5803,6 +5803,49 @@
         "description": "连接 OpenAPI 服务器，为您的智能体添加自定义操作和工具。"
       }
     },
+    "systemUsage": {
+      "categories": {
+        "contextualRagChunkContext": {
+          "label": "Contextual RAG chunk context"
+        },
+        "contextualRagDocumentSummary": {
+          "label": "Contextual RAG document summaries"
+        },
+        "imageSummarization": { "label": "Image summarization" },
+        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "kgDocumentClassification": {
+          "label": "Knowledge graph classification"
+        },
+        "unattributed": { "label": "Unattributed" }
+      },
+      "filters": {
+        "allModels": { "label": "All models" },
+        "allProviders": { "label": "All providers" }
+      },
+      "panel": {
+        "description": "{start} – {end} · Background text generation without a user.",
+        "emptyDescription": "Background text-generation spend for the selected period.",
+        "error": { "title": "Failed to load system usage for this period." },
+        "title": "System usage"
+      },
+      "summary": {
+        "spend": { "label": "System spend" },
+        "tokens": { "label": "Total tokens" },
+        "unattributed": { "label": "Unattributed spend" }
+      },
+      "table": {
+        "columns": {
+          "category": { "header": "Category" },
+          "input": { "header": "Input" },
+          "output": { "header": "Output" },
+          "spend": { "header": "Spend" },
+          "tokens": { "header": "Tokens" }
+        },
+        "empty": {
+          "description": "No system usage matches the current filters."
+        }
+      }
+    },
     "perUserUsage": {
       "panel": {
         "description": "{start} – {end} · 费用根据记录的模型用量计算。",

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -5806,43 +5806,44 @@
     "systemUsage": {
       "categories": {
         "contextualRagChunkContext": {
-          "label": "Contextual RAG chunk context"
+          "label": "上下文 RAG 分块上下文"
         },
         "contextualRagDocumentSummary": {
-          "label": "Contextual RAG document summaries"
+          "label": "上下文 RAG 文档摘要"
         },
-        "imageSummarization": { "label": "Image summarization" },
-        "kgDeepExtraction": { "label": "Knowledge graph extraction" },
+        "imageSummarization": { "label": "图像摘要" },
+        "kgDeepExtraction": { "label": "知识图谱提取" },
         "kgDocumentClassification": {
-          "label": "Knowledge graph classification"
+          "label": "知识图谱分类"
         },
-        "unattributed": { "label": "Unattributed" }
+        "other": { "label": "其他" },
+        "unattributed": { "label": "未归属" }
       },
       "filters": {
-        "allModels": { "label": "All models" },
-        "allProviders": { "label": "All providers" }
+        "allModels": { "label": "所有模型" },
+        "allProviders": { "label": "所有提供商" }
       },
       "panel": {
-        "description": "{start} – {end} · Background text generation without a user.",
-        "emptyDescription": "Background text-generation spend for the selected period.",
-        "error": { "title": "Failed to load system usage for this period." },
-        "title": "System usage"
+        "description": "{start} – {end} · 无用户参与的后台文本生成。",
+        "emptyDescription": "所选期间的后台文本生成支出。",
+        "error": { "title": "无法加载此期间的系统用量。" },
+        "title": "系统用量"
       },
       "summary": {
-        "spend": { "label": "System spend" },
-        "tokens": { "label": "Total tokens" },
-        "unattributed": { "label": "Unattributed spend" }
+        "spend": { "label": "系统支出" },
+        "tokens": { "label": "总 Token 数" },
+        "unattributed": { "label": "未归属支出" }
       },
       "table": {
         "columns": {
-          "category": { "header": "Category" },
-          "input": { "header": "Input" },
-          "output": { "header": "Output" },
-          "spend": { "header": "Spend" },
-          "tokens": { "header": "Tokens" }
+          "category": { "header": "类别" },
+          "input": { "header": "输入" },
+          "output": { "header": "输出" },
+          "spend": { "header": "支出" },
+          "tokens": { "header": "Token" }
         },
         "empty": {
-          "description": "No system usage matches the current filters."
+          "description": "没有符合当前筛选条件的系统用量。"
         }
       }
     },

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -54,6 +54,7 @@ export const SWR_KEYS = {
   userUsage: "/api/user/usage",
   costOverrides: "/api/admin/cost-overrides",
   adminUsageExport: "/api/admin/usage/export",
+  adminSystemUsage: "/api/admin/usage/system",
   adminUsageReset: "/api/admin/usage/reset",
 
   // ── Image Generation ──────────────────────────────────────────────────────

--- a/web/src/lib/usage/hooks.ts
+++ b/web/src/lib/usage/hooks.ts
@@ -7,7 +7,9 @@ import { buildApiPath } from "@/lib/urlBuilder";
 import {
   convertDateToEndOfDay,
   convertDateToStartOfDay,
+  formatDateForApiParam,
 } from "@/lib/dateUtils";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   OnyxBotAnalytics,
   PersonaMessageAnalytics,
@@ -15,8 +17,10 @@ import {
   QueryAnalytics,
   UserAnalytics,
 } from "@/lib/usage/interfaces";
+import type { SystemUsageResponse } from "@/lib/usage/systemUsage";
 import {
   THIRTY_DAYS,
+  type DateRange,
   type DateRangePickerValue,
   rangeForInclusiveDays,
 } from "@opal/components";
@@ -26,6 +30,20 @@ export function useTimeRange() {
     ...rangeForInclusiveDays(30),
     selectValue: THIRTY_DAYS,
   });
+}
+
+export function useSystemUsage(range?: DateRange) {
+  const url = buildApiPath(SWR_KEYS.adminSystemUsage, {
+    start: range?.from ? formatDateForApiParam(range.from) : undefined,
+    end: range?.to ? formatDateForApiParam(range.to) : undefined,
+  });
+  const { data, error, isLoading, mutate } = useSWR<SystemUsageResponse>(
+    url,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return { usage: data, isLoading, error, refetch: mutate };
 }
 
 function analyticsRange(timeRange: DateRangePickerValue) {

--- a/web/src/lib/usage/hooks.ts
+++ b/web/src/lib/usage/hooks.ts
@@ -37,7 +37,7 @@ export function useSystemUsage(range?: DateRange) {
     start: range?.from ? formatDateForApiParam(range.from) : undefined,
     end: range?.to ? formatDateForApiParam(range.to) : undefined,
   });
-  const { data, error, isLoading, mutate } = useSWR<SystemUsageResponse>(
+  const { data, error, isLoading, mutate } = useSWR<SystemUsageResponse, Error>(
     url,
     errorHandlingFetcher,
     { revalidateOnFocus: false }

--- a/web/src/lib/usage/systemUsage.ts
+++ b/web/src/lib/usage/systemUsage.ts
@@ -7,7 +7,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { buildApiPath } from "@/lib/urlBuilder";
 import type { UsageExportTotals } from "@/lib/usage/userUsage";
 
-export type SystemUsageAttribution = "SYSTEM" | "UNATTRIBUTED";
+export type SystemUsageAttribution = "ATTRIBUTED" | "UNATTRIBUTED";
 
 export interface SystemUsageRecord {
   attribution: SystemUsageAttribution;

--- a/web/src/lib/usage/systemUsage.ts
+++ b/web/src/lib/usage/systemUsage.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import useSWR from "swr";
+import { formatDateForApiParam } from "@/lib/dateUtils";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { buildApiPath } from "@/lib/urlBuilder";
+import type { UsageExportTotals } from "@/lib/usage/userUsage";
+
+export type SystemUsageAttribution = "SYSTEM" | "UNATTRIBUTED";
+
+export interface SystemUsageRecord {
+  attribution: SystemUsageAttribution;
+  model: string;
+  flow: string;
+  provider: string;
+  day: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  cost_cents: number;
+}
+
+export interface SystemUsageCategory {
+  category: string;
+  totals: UsageExportTotals;
+  records: SystemUsageRecord[];
+}
+
+export interface SystemUsageResponse {
+  start: string;
+  end: string;
+  categories: SystemUsageCategory[];
+}
+
+export function useSystemUsage(range?: { from: Date; to: Date }) {
+  const url = buildApiPath(SWR_KEYS.adminSystemUsage, {
+    start: range?.from ? formatDateForApiParam(range.from) : undefined,
+    end: range?.to ? formatDateForApiParam(range.to) : undefined,
+  });
+  const { data, error, isLoading, mutate } = useSWR<SystemUsageResponse>(
+    url,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return { usage: data, isLoading, error, refetch: mutate };
+}

--- a/web/src/lib/usage/systemUsage.ts
+++ b/web/src/lib/usage/systemUsage.ts
@@ -1,10 +1,3 @@
-"use client";
-
-import useSWR from "swr";
-import { formatDateForApiParam } from "@/lib/dateUtils";
-import { errorHandlingFetcher } from "@/lib/fetcher";
-import { SWR_KEYS } from "@/lib/swr-keys";
-import { buildApiPath } from "@/lib/urlBuilder";
 import type { UsageExportTotals } from "@/lib/usage/userUsage";
 
 export type SystemUsageAttribution = "ATTRIBUTED" | "UNATTRIBUTED";
@@ -32,18 +25,4 @@ export interface SystemUsageResponse {
   start: string;
   end: string;
   categories: SystemUsageCategory[];
-}
-
-export function useSystemUsage(range?: { from: Date; to: Date }) {
-  const url = buildApiPath(SWR_KEYS.adminSystemUsage, {
-    start: range?.from ? formatDateForApiParam(range.from) : undefined,
-    end: range?.to ? formatDateForApiParam(range.to) : undefined,
-  });
-  const { data, error, isLoading, mutate } = useSWR<SystemUsageResponse>(
-    url,
-    errorHandlingFetcher,
-    { revalidateOnFocus: false }
-  );
-
-  return { usage: data, isLoading, error, refetch: mutate };
 }

--- a/web/src/views/admin/SystemUsagePanel.test.tsx
+++ b/web/src/views/admin/SystemUsagePanel.test.tsx
@@ -27,7 +27,7 @@ test("shows system and unattributed spend by category", () => {
           },
           records: [
             {
-              attribution: "SYSTEM",
+              attribution: "ATTRIBUTED",
               model: "claude-sonnet",
               flow: "image_summarization",
               provider: "anthropic",

--- a/web/src/views/admin/SystemUsagePanel.test.tsx
+++ b/web/src/views/admin/SystemUsagePanel.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@tests/setup/test-utils";
+import SystemUsagePanel from "@/views/admin/SystemUsagePanel";
+import { useSystemUsage } from "@/lib/usage/systemUsage";
+
+jest.mock("@/lib/usage/systemUsage", () => ({
+  useSystemUsage: jest.fn(),
+}));
+
+const mockUseSystemUsage = useSystemUsage as jest.MockedFunction<
+  typeof useSystemUsage
+>;
+
+test("shows system and unattributed spend by category", () => {
+  mockUseSystemUsage.mockReturnValue({
+    usage: {
+      start: "2026-09-01",
+      end: "2026-09-02",
+      categories: [
+        {
+          category: "image_summarization",
+          totals: {
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            cost_cents: 200,
+          },
+          records: [
+            {
+              attribution: "SYSTEM",
+              model: "claude-sonnet",
+              flow: "image_summarization",
+              provider: "anthropic",
+              day: "2026-09-01",
+              input_tokens: 100,
+              output_tokens: 20,
+              cache_read_tokens: 0,
+              cache_creation_tokens: 0,
+              cost_cents: 200,
+            },
+          ],
+        },
+        {
+          category: "unattributed",
+          totals: {
+            input_tokens: 50,
+            output_tokens: 10,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            cost_cents: 100,
+          },
+          records: [
+            {
+              attribution: "UNATTRIBUTED",
+              model: "gpt-5",
+              flow: "untagged_invoke",
+              provider: "openai",
+              day: "2026-09-01",
+              input_tokens: 50,
+              output_tokens: 10,
+              cache_read_tokens: 0,
+              cache_creation_tokens: 0,
+              cost_cents: 100,
+            },
+          ],
+        },
+      ],
+    },
+    isLoading: false,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+
+  render(<SystemUsagePanel />);
+
+  expect(screen.getByText("System usage")).toBeInTheDocument();
+  expect(screen.getByText("Image summarization")).toBeInTheDocument();
+  expect(screen.getAllByText("Unattributed").length).toBeGreaterThan(0);
+  expect(
+    screen.getByRole("columnheader", { name: "Spend" })
+  ).toBeInTheDocument();
+  expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+});

--- a/web/src/views/admin/SystemUsagePanel.test.tsx
+++ b/web/src/views/admin/SystemUsagePanel.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from "@tests/setup/test-utils";
+import { render, screen, setupUser } from "@tests/setup/test-utils";
+import { useSystemUsage } from "@/lib/usage/hooks";
+import type { SystemUsageResponse } from "@/lib/usage/systemUsage";
 import SystemUsagePanel from "@/views/admin/SystemUsagePanel";
-import { useSystemUsage } from "@/lib/usage/systemUsage";
 
-jest.mock("@/lib/usage/systemUsage", () => ({
+jest.mock("@/lib/usage/hooks", () => ({
   useSystemUsage: jest.fn(),
 }));
 
@@ -10,66 +11,79 @@ const mockUseSystemUsage = useSystemUsage as jest.MockedFunction<
   typeof useSystemUsage
 >;
 
-test("shows system and unattributed spend by category", () => {
-  mockUseSystemUsage.mockReturnValue({
-    usage: {
-      start: "2026-09-01",
-      end: "2026-09-02",
-      categories: [
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+  Element.prototype.hasPointerCapture = jest.fn();
+  Element.prototype.setPointerCapture = jest.fn();
+  Element.prototype.releasePointerCapture = jest.fn();
+});
+
+const SYSTEM_USAGE_RESPONSE = {
+  start: "2026-09-01",
+  end: "2026-09-02",
+  categories: [
+    {
+      category: "image_summarization",
+      totals: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        cost_cents: 200,
+      },
+      records: [
         {
-          category: "image_summarization",
-          totals: {
-            input_tokens: 100,
-            output_tokens: 20,
-            cache_read_tokens: 0,
-            cache_creation_tokens: 0,
-            cost_cents: 200,
-          },
-          records: [
-            {
-              attribution: "ATTRIBUTED",
-              model: "claude-sonnet",
-              flow: "image_summarization",
-              provider: "anthropic",
-              day: "2026-09-01",
-              input_tokens: 100,
-              output_tokens: 20,
-              cache_read_tokens: 0,
-              cache_creation_tokens: 0,
-              cost_cents: 200,
-            },
-          ],
-        },
-        {
-          category: "unattributed",
-          totals: {
-            input_tokens: 50,
-            output_tokens: 10,
-            cache_read_tokens: 0,
-            cache_creation_tokens: 0,
-            cost_cents: 100,
-          },
-          records: [
-            {
-              attribution: "UNATTRIBUTED",
-              model: "gpt-5",
-              flow: "untagged_invoke",
-              provider: "openai",
-              day: "2026-09-01",
-              input_tokens: 50,
-              output_tokens: 10,
-              cache_read_tokens: 0,
-              cache_creation_tokens: 0,
-              cost_cents: 100,
-            },
-          ],
+          attribution: "ATTRIBUTED",
+          model: "claude-sonnet",
+          flow: "image_summarization",
+          provider: "anthropic",
+          day: "2026-09-01",
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          cost_cents: 200,
         },
       ],
     },
+    {
+      category: "unattributed",
+      totals: {
+        input_tokens: 50,
+        output_tokens: 10,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        cost_cents: 100,
+      },
+      records: [
+        {
+          attribution: "UNATTRIBUTED",
+          model: "gpt-5",
+          flow: "untagged_invoke",
+          provider: "openai",
+          day: "2026-09-01",
+          input_tokens: 50,
+          output_tokens: 10,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          cost_cents: 100,
+        },
+      ],
+    },
+  ],
+} satisfies SystemUsageResponse;
+
+function mockLoadedUsage(): void {
+  mockUseSystemUsage.mockReturnValue({
+    usage: SYSTEM_USAGE_RESPONSE,
     isLoading: false,
     error: undefined,
     refetch: jest.fn(),
   });
+}
+
+test("shows system and unattributed spend by category", () => {
+  mockLoadedUsage();
 
   render(<SystemUsagePanel />);
 
@@ -80,4 +94,32 @@ test("shows system and unattributed spend by category", () => {
     screen.getByRole("columnheader", { name: "Spend" })
   ).toBeInTheDocument();
   expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+});
+
+test("preserves filters while a new date range loads", async () => {
+  const user = setupUser();
+  mockLoadedUsage();
+  const { rerender } = render(<SystemUsagePanel />);
+
+  const modelSelect = screen.getAllByRole("combobox")[0]!;
+  await user.click(modelSelect);
+  const modelOption = await screen.findByRole("option", {
+    name: "claude-sonnet",
+  });
+  await user.click(modelOption);
+  expect(modelSelect).toHaveTextContent("claude-sonnet");
+  expect(screen.queryByText("$3.00")).not.toBeInTheDocument();
+
+  mockUseSystemUsage.mockReturnValue({
+    usage: undefined,
+    isLoading: true,
+    error: undefined,
+    refetch: jest.fn(),
+  });
+  rerender(<SystemUsagePanel />);
+
+  mockLoadedUsage();
+  rerender(<SystemUsagePanel />);
+
+  expect(screen.queryByText("$3.00")).not.toBeInTheDocument();
 });

--- a/web/src/views/admin/SystemUsagePanel.tsx
+++ b/web/src/views/admin/SystemUsagePanel.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import {
+  Card,
+  InputSelect,
+  MessageCard,
+  Table,
+  Text,
+  createTableColumns,
+} from "@opal/components";
+import { SvgCpu, SvgX } from "@opal/icons";
+import { PageLoader, Section } from "@opal/layouts";
+import { formatCalendarDay } from "@/lib/dateUtils";
+import type { DateRange } from "@/refresh-components/DateRangePicker";
+import {
+  type SystemUsageCategory,
+  useSystemUsage,
+} from "@/lib/usage/systemUsage";
+import type { UsageExportTotals } from "@/lib/usage/userUsage";
+import { formatCost, formatTokens } from "@/lib/utils";
+
+const ALL_FILTER = "__all__";
+const UNATTRIBUTED_CATEGORY = "unattributed";
+const IMAGE_SUMMARIZATION_FLOW = "image_summarization";
+const CONTEXTUAL_RAG_DOC_SUMMARY_FLOW = "contextual_rag_doc_summary";
+const CONTEXTUAL_RAG_CHUNK_CONTEXT_FLOW = "contextual_rag_chunk_context";
+const KG_DOCUMENT_CLASSIFICATION_FLOW = "kg_document_classification";
+const KG_DEEP_EXTRACTION_FLOW = "kg_deep_extraction";
+
+interface SystemUsageRow extends UsageExportTotals {
+  category: string;
+  total_tokens: number;
+}
+
+type SystemUsageTranslate = ReturnType<
+  typeof useTranslations<"admin.systemUsage">
+>;
+
+function emptyTotals(): UsageExportTotals {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+    cost_cents: 0,
+  };
+}
+
+function categoryLabel(category: string, t: SystemUsageTranslate): string {
+  switch (category) {
+    case IMAGE_SUMMARIZATION_FLOW:
+      return t("categories.imageSummarization.label");
+    case CONTEXTUAL_RAG_DOC_SUMMARY_FLOW:
+      return t("categories.contextualRagDocumentSummary.label");
+    case CONTEXTUAL_RAG_CHUNK_CONTEXT_FLOW:
+      return t("categories.contextualRagChunkContext.label");
+    case KG_DOCUMENT_CLASSIFICATION_FLOW:
+      return t("categories.kgDocumentClassification.label");
+    case KG_DEEP_EXTRACTION_FLOW:
+      return t("categories.kgDeepExtraction.label");
+    case UNATTRIBUTED_CATEGORY:
+      return t("categories.unattributed.label");
+    default:
+      return category;
+  }
+}
+
+function filterCategory(
+  category: SystemUsageCategory,
+  model: string,
+  provider: string
+): SystemUsageRow | null {
+  const records = category.records.filter(
+    (record) =>
+      (model === ALL_FILTER || record.model === model) &&
+      (provider === ALL_FILTER || record.provider === provider)
+  );
+  if (records.length === 0) return null;
+
+  const totals = records.reduce(
+    (sum, record) => ({
+      input_tokens: sum.input_tokens + record.input_tokens,
+      output_tokens: sum.output_tokens + record.output_tokens,
+      cache_read_tokens: sum.cache_read_tokens + record.cache_read_tokens,
+      cache_creation_tokens:
+        sum.cache_creation_tokens + record.cache_creation_tokens,
+      cost_cents: sum.cost_cents + record.cost_cents,
+    }),
+    emptyTotals()
+  );
+  return {
+    category: category.category,
+    ...totals,
+    total_tokens: totals.input_tokens + totals.output_tokens,
+  };
+}
+
+const tc = createTableColumns<SystemUsageRow>();
+
+function buildColumns(t: SystemUsageTranslate) {
+  return [
+    tc.qualifier({ content: "icon", getContent: () => SvgCpu }),
+    tc.column("category", {
+      header: t("table.columns.category.header"),
+      weight: 40,
+      cell: (value) => (
+        <Text font="main-ui-body" color="text-05">
+          {categoryLabel(value, t)}
+        </Text>
+      ),
+    }),
+    tc.column("cost_cents", {
+      header: t("table.columns.spend.header"),
+      weight: 18,
+      alignment: "right",
+      cell: (value) => (
+        <Text font="main-ui-action" color="text-05">
+          {formatCost(value)}
+        </Text>
+      ),
+    }),
+    tc.column("total_tokens", {
+      header: t("table.columns.tokens.header"),
+      weight: 18,
+      alignment: "right",
+      cell: (value) => (
+        <Text font="main-ui-action" color="text-05">
+          {formatTokens(value)}
+        </Text>
+      ),
+    }),
+    tc.column("input_tokens", {
+      header: t("table.columns.input.header"),
+      weight: 12,
+      alignment: "right",
+      cell: (value) => (
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(value)}
+        </Text>
+      ),
+    }),
+    tc.column("output_tokens", {
+      header: t("table.columns.output.header"),
+      weight: 12,
+      alignment: "right",
+      cell: (value) => (
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(value)}
+        </Text>
+      ),
+    }),
+  ];
+}
+
+interface SystemUsagePanelProps {
+  timeRange?: DateRange;
+}
+
+export default function SystemUsagePanel({ timeRange }: SystemUsagePanelProps) {
+  const t = useTranslations("admin.systemUsage");
+  const locale = useLocale();
+  const { usage, isLoading, error } = useSystemUsage(timeRange);
+  const [model, setModel] = useState(ALL_FILTER);
+  const [provider, setProvider] = useState(ALL_FILTER);
+  const columns = useMemo(() => buildColumns(t), [t]);
+  const records = useMemo(
+    () => usage?.categories.flatMap((category) => category.records) ?? [],
+    [usage]
+  );
+  const models = useMemo(
+    () => Array.from(new Set(records.map((record) => record.model))).sort(),
+    [records]
+  );
+  const providers = useMemo(
+    () =>
+      Array.from(
+        new Set(records.map((record) => record.provider).filter(Boolean))
+      ).sort(),
+    [records]
+  );
+  useEffect(() => {
+    if (model !== ALL_FILTER && !models.includes(model)) setModel(ALL_FILTER);
+  }, [model, models]);
+  useEffect(() => {
+    if (provider !== ALL_FILTER && !providers.includes(provider)) {
+      setProvider(ALL_FILTER);
+    }
+  }, [provider, providers]);
+  const rows = useMemo(
+    () =>
+      (usage?.categories ?? []).flatMap((category) => {
+        const row = filterCategory(category, model, provider);
+        return row ? [row] : [];
+      }),
+    [usage, model, provider]
+  );
+  const totalCostCents = rows.reduce((sum, row) => sum + row.cost_cents, 0);
+  const totalTokens = rows.reduce((sum, row) => sum + row.total_tokens, 0);
+  const unattributedCostCents =
+    rows.find((row) => row.category === UNATTRIBUTED_CATEGORY)?.cost_cents ?? 0;
+
+  const header = (
+    <Section alignItems="stretch" gap={0.125} height="fit">
+      <Text font="heading-h3">{t("panel.title")}</Text>
+      <Text font="secondary-body" color="text-03">
+        {usage
+          ? t("panel.description", {
+              start: formatCalendarDay(usage.start, { withYear: true }),
+              end: formatCalendarDay(usage.end, { withYear: true }),
+            })
+          : t("panel.emptyDescription")}
+      </Text>
+    </Section>
+  );
+
+  if (isLoading) {
+    return (
+      <Section alignItems="stretch" gap={1} height="fit">
+        {header}
+        <PageLoader />
+      </Section>
+    );
+  }
+  if (error) {
+    return (
+      <Section alignItems="stretch" gap={1} height="fit">
+        {header}
+        <MessageCard
+          variant="error"
+          icon={SvgX}
+          title={t("panel.error.title")}
+        />
+      </Section>
+    );
+  }
+
+  return (
+    <Section alignItems="stretch" gap={1} height="fit">
+      {header}
+      <Card border="solid" rounding={4} padding={3}>
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="start"
+          wrap
+          gap={2}
+          height="fit"
+        >
+          <Section alignItems="start" gap={0.125} width="fit" height="fit">
+            <Text font="secondary-body" color="text-03">
+              {t("summary.spend.label")}
+            </Text>
+            <Text font="heading-h3">{formatCost(totalCostCents, locale)}</Text>
+          </Section>
+          <Section alignItems="start" gap={0.125} width="fit" height="fit">
+            <Text font="secondary-body" color="text-03">
+              {t("summary.tokens.label")}
+            </Text>
+            <Text font="heading-h3">{formatTokens(totalTokens, locale)}</Text>
+          </Section>
+          <Section alignItems="start" gap={0.125} width="fit" height="fit">
+            <Text font="secondary-body" color="text-03">
+              {t("summary.unattributed.label")}
+            </Text>
+            <Text font="heading-h3">
+              {formatCost(unattributedCostCents, locale)}
+            </Text>
+          </Section>
+        </Section>
+      </Card>
+
+      <Section
+        flexDirection="row"
+        justifyContent="end"
+        alignItems="center"
+        wrap
+        gap={0.5}
+        height="fit"
+      >
+        {models.length > 0 && (
+          <Section width={12} height="fit">
+            <InputSelect value={model} onValueChange={setModel}>
+              <InputSelect.Trigger placeholder={t("filters.allModels.label")} />
+              <InputSelect.Content>
+                <InputSelect.Item value={ALL_FILTER}>
+                  {t("filters.allModels.label")}
+                </InputSelect.Item>
+                {models.map((option) => (
+                  <InputSelect.Item key={option} value={option}>
+                    {option}
+                  </InputSelect.Item>
+                ))}
+              </InputSelect.Content>
+            </InputSelect>
+          </Section>
+        )}
+        {providers.length > 0 && (
+          <Section width={12} height="fit">
+            <InputSelect value={provider} onValueChange={setProvider}>
+              <InputSelect.Trigger
+                placeholder={t("filters.allProviders.label")}
+              />
+              <InputSelect.Content>
+                <InputSelect.Item value={ALL_FILTER}>
+                  {t("filters.allProviders.label")}
+                </InputSelect.Item>
+                {providers.map((option) => (
+                  <InputSelect.Item key={option} value={option}>
+                    {option}
+                  </InputSelect.Item>
+                ))}
+              </InputSelect.Content>
+            </InputSelect>
+          </Section>
+        )}
+      </Section>
+
+      <Table
+        key={`${model}-${provider}`}
+        data={rows}
+        columns={columns}
+        getRowId={(row) => row.category}
+        initialSorting={[{ id: "cost_cents", desc: true }]}
+        emptyState={
+          <Text font="main-ui-body" color="text-03">
+            {t("table.empty.description")}
+          </Text>
+        }
+      />
+    </Section>
+  );
+}

--- a/web/src/views/admin/SystemUsagePanel.tsx
+++ b/web/src/views/admin/SystemUsagePanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import {
   Card,
+  type DateRange,
   InputSelect,
   MessageCard,
   Table,
@@ -13,16 +14,14 @@ import {
 import { SvgCpu, SvgX } from "@opal/icons";
 import { PageLoader, Section } from "@opal/layouts";
 import { formatCalendarDay } from "@/lib/dateUtils";
-import type { DateRange } from "@/refresh-components/DateRangePicker";
-import {
-  type SystemUsageCategory,
-  useSystemUsage,
-} from "@/lib/usage/systemUsage";
+import { useSystemUsage } from "@/lib/usage/hooks";
+import type { SystemUsageCategory } from "@/lib/usage/systemUsage";
 import type { UsageExportTotals } from "@/lib/usage/userUsage";
 import { formatCost, formatTokens } from "@/lib/utils";
 
 const ALL_FILTER = "__all__";
 const UNATTRIBUTED_CATEGORY = "unattributed";
+const OTHER_CATEGORY = "other";
 const IMAGE_SUMMARIZATION_FLOW = "image_summarization";
 const CONTEXTUAL_RAG_DOC_SUMMARY_FLOW = "contextual_rag_doc_summary";
 const CONTEXTUAL_RAG_CHUNK_CONTEXT_FLOW = "contextual_rag_chunk_context";
@@ -62,6 +61,8 @@ function categoryLabel(category: string, t: SystemUsageTranslate): string {
       return t("categories.kgDeepExtraction.label");
     case UNATTRIBUTED_CATEGORY:
       return t("categories.unattributed.label");
+    case OTHER_CATEGORY:
+      return t("categories.other.label");
     default:
       return category;
   }
@@ -181,13 +182,15 @@ export default function SystemUsagePanel({ timeRange }: SystemUsagePanelProps) {
     [records]
   );
   useEffect(() => {
-    if (model !== ALL_FILTER && !models.includes(model)) setModel(ALL_FILTER);
-  }, [model, models]);
+    if (usage && model !== ALL_FILTER && !models.includes(model)) {
+      setModel(ALL_FILTER);
+    }
+  }, [usage, model, models]);
   useEffect(() => {
-    if (provider !== ALL_FILTER && !providers.includes(provider)) {
+    if (usage && provider !== ALL_FILTER && !providers.includes(provider)) {
       setProvider(ALL_FILTER);
     }
-  }, [provider, providers]);
+  }, [usage, provider, providers]);
   const rows = useMemo(
     () =>
       (usage?.categories ?? []).flatMap((category) => {
@@ -207,8 +210,8 @@ export default function SystemUsagePanel({ timeRange }: SystemUsagePanelProps) {
       <Text font="secondary-body" color="text-03">
         {usage
           ? t("panel.description", {
-              start: formatCalendarDay(usage.start, { withYear: true }),
-              end: formatCalendarDay(usage.end, { withYear: true }),
+              start: formatCalendarDay(usage.start, locale, { withYear: true }),
+              end: formatCalendarDay(usage.end, locale, { withYear: true }),
             })
           : t("panel.emptyDescription")}
       </Text>


### PR DESCRIPTION
## Description

Add a separate System usage section to the admin usage page. It shows spend, tokens, unattributed cost, category totals, and model/provider filters without changing the per-user view.

This PR is stacked on #14454, which is stacked on #14452.

<img width="1920" height="766" alt="usage_panel2" src="https://github.com/user-attachments/assets/24546136-d8ae-4db6-995f-bed6f072e6cc" />
<img width="1920" height="766" alt="System_usage_panel" src="https://github.com/user-attachments/assets/3c9a775c-9f29-42b0-a5cb-d7a9c9a0ca8b" />


## How Has This Been Tested?

- `bun run types:check`
- `bun run test --runInBand src/views/admin/SystemUsagePanel.test.tsx src/i18n/__tests__/catalog.test.ts`
- Targeted Oxlint checks
- `bun run format:check`
- Pre-commit hooks

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a separate System usage section to the admin usage page so background LLM spend is no longer mixed into per-user totals, and preserves the selected date range preset when the range changes.

- Shows system spend, total tokens, unattributed spend, and per-category input/output totals with model and provider filters.
- Adds the `useSystemUsage` hook, a new SWR key for the admin system usage endpoint, and consistent attributed/unattributed states in the client.
- Removes the now-redundant system cost/token fields from the backend usage report.

<sup>Written for commit 6a4e63706bd94bdfa34e844ee9a1c35d9c2d484c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



