### PR TITLE
fix(slackbot): treat a blank respond_member_group_list as no allowlist

### DIFF
--- a/backend/onyx/onyxbot/slack/config.py
+++ b/backend/onyx/onyxbot/slack/config.py
@@ -31,6 +31,22 @@ def get_slack_channel_config_for_bot_and_channel(
     return slack_bot_config
 
 
+def clean_respond_member_group_list(
+    respond_member_group_list: list[str] | None,
+) -> list[str]:
+    """Drop blank entries from a `respond_member_group_list`.
+
+    The admin UI submits a single empty string when the members field is left
+    blank, which is indistinguishable in intent from "no allowlist". Keeping the
+    blank entry would enforce an allowlist that resolves to nobody, silencing
+    OnyxBot for every sender in the channel.
+    """
+    if not respond_member_group_list:
+        return []
+
+    return [entry.strip() for entry in respond_member_group_list if entry.strip()]
+
+
 def validate_channel_name(
     db_session: Session,
     current_slack_bot_id: int,

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -17,6 +17,7 @@ from onyx.db.users import add_slack_user_if_not_exists, get_user_by_email
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.onyxbot.slack.blocks import get_feedback_reminder_blocks
+from onyx.onyxbot.slack.config import clean_respond_member_group_list
 from onyx.onyxbot.slack.handlers.handle_regular_answer import handle_regular_answer
 from onyx.onyxbot.slack.handlers.handle_standard_answers import handle_standard_answers
 from onyx.onyxbot.slack.models import SlackMessageInfo
@@ -134,7 +135,12 @@ def _resolve_allowlist_user_ids(
     when no allowlist is configured, meaning the bot has no invocation gate or
     response-visibility scope for the channel.
     """
-    allowlist = (channel_conf or {}).get("respond_member_group_list") or None
+    # Blank entries are stripped here too, so configs already persisted with a
+    # blank member (e.g. saved before this was normalized on write) don't enforce
+    # an allowlist that resolves to nobody.
+    allowlist = clean_respond_member_group_list(
+        (channel_conf or {}).get("respond_member_group_list")
+    )
     if not allowlist:
         return None, []
 

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -23,7 +23,10 @@ from onyx.db.slack_channel_config import (
     remove_slack_channel_config,
     update_slack_channel_config,
 )
-from onyx.onyxbot.slack.config import validate_channel_name
+from onyx.onyxbot.slack.config import (
+    clean_respond_member_group_list,
+    validate_channel_name,
+)
 from onyx.server.manage.models import (
     SlackBot,
     SlackBotCreationRequest,
@@ -55,7 +58,7 @@ def _form_channel_config(
 ) -> ChannelConfig:
     raw_channel_name = slack_channel_config_creation_request.channel_name
     respond_tag_only = slack_channel_config_creation_request.respond_tag_only
-    respond_member_group_list = (
+    respond_member_group_list = clean_respond_member_group_list(
         slack_channel_config_creation_request.respond_member_group_list
     )
     answer_filters = slack_channel_config_creation_request.answer_filters
@@ -74,10 +77,7 @@ def _form_channel_config(
             detail=str(e),
         )
 
-    if (
-        slack_channel_config_creation_request.is_ephemeral
-        and slack_channel_config_creation_request.respond_member_group_list
-    ):
+    if slack_channel_config_creation_request.is_ephemeral and respond_member_group_list:
         raise ValueError(
             "Cannot set OnyxBot to respond to users in a private (ephemeral) message "
             "and also respond to a selected list of users."

--- a/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
@@ -9,6 +9,10 @@ import pytest
 from onyx.db.enums import AccountType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.models import (
+    SlackBotResponseType,
+    SlackChannelConfigCreationRequest,
+)
 from onyx.server.settings.models import ApplicationStatus
 
 # ---------------------------------------------------------------------------
@@ -615,6 +619,36 @@ class TestHandleMessageInvocationAllowlist:
         mock_usage_report.assert_called_once()
 
     @pytest.mark.usefixtures("db_session")
+    @pytest.mark.parametrize(
+        "allowlist",
+        [[""], ["   "], ["", "  "]],
+        ids=["single_blank", "whitespace_only", "all_blank"],
+    )
+    @patch(f"{_HANDLE_MSG}.fetch_user_ids_from_groups")
+    @patch(f"{_HANDLE_MSG}.fetch_slack_user_ids_from_emails")
+    @patch(f"{_HANDLE_MSG}.slack_usage_report")
+    def test_all_blank_allowlist_is_not_a_gate(
+        self,
+        mock_usage_report: MagicMock,
+        mock_fetch_emails: MagicMock,
+        mock_fetch_groups: MagicMock,
+        allowlist: list[str],
+    ) -> None:
+        """An allowlist of only blank entries means "no allowlist", not "nobody".
+
+        A stored `[""]` used to resolve to zero user IDs while still counting as
+        configured, which silenced the bot for every sender in the channel.
+        """
+        _call_handle_message(
+            slack_channel_config=self._make_config(allowlist=allowlist)
+        )
+
+        mock_usage_report.assert_called_once()
+        # No lookup should be attempted for a blank entry
+        mock_fetch_emails.assert_not_called()
+        mock_fetch_groups.assert_not_called()
+
+    @pytest.mark.usefixtures("db_session")
     @patch(f"{_HANDLE_MSG}.fetch_user_ids_from_groups", return_value=([], []))
     @patch(f"{_HANDLE_MSG}.fetch_slack_user_ids_from_emails")
     @patch(f"{_HANDLE_MSG}.slack_usage_report")
@@ -727,3 +761,93 @@ class TestHandleMessageInvocationAllowlist:
         assert result is False
         mock_usage_report.assert_not_called()
         mock_add_user.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# respond_member_group_list normalization (write path)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanRespondMemberGroupList:
+    """Blank `respond_member_group_list` entries are dropped before persisting."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, []),
+            ([], []),
+            ([""], []),
+            (["   "], []),
+            (["", "  "], []),
+            (["user@test.com"], ["user@test.com"]),
+            ([" user@test.com "], ["user@test.com"]),
+            (["", "user@test.com"], ["user@test.com"]),
+        ],
+    )
+    def test_drops_blank_entries(
+        self, raw: list[str] | None, expected: list[str]
+    ) -> None:
+        from onyx.onyxbot.slack.config import clean_respond_member_group_list
+
+        assert clean_respond_member_group_list(raw) == expected
+
+
+class TestFormChannelConfigAllowlist:
+    """`_form_channel_config` must not persist a blank-only allowlist."""
+
+    @staticmethod
+    def _make_request(**overrides: Any) -> SlackChannelConfigCreationRequest:
+        return SlackChannelConfigCreationRequest(
+            slack_bot_id=1,
+            channel_name="general",
+            response_type=SlackBotResponseType.CITATIONS,
+            **overrides,
+        )
+
+    @patch("onyx.server.manage.slack_bot.validate_channel_name", return_value="general")
+    def test_blank_allowlist_is_not_persisted(self, _mock_validate: MagicMock) -> None:
+        from onyx.server.manage.slack_bot import _form_channel_config
+
+        channel_config = _form_channel_config(
+            db_session=MagicMock(),
+            slack_channel_config_creation_request=self._make_request(
+                respond_member_group_list=[""]
+            ),
+            current_slack_channel_config_id=None,
+        )
+
+        assert "respond_member_group_list" not in channel_config
+
+    @patch("onyx.server.manage.slack_bot.validate_channel_name", return_value="general")
+    def test_real_allowlist_is_persisted_trimmed(
+        self, _mock_validate: MagicMock
+    ) -> None:
+        from onyx.server.manage.slack_bot import _form_channel_config
+
+        channel_config = _form_channel_config(
+            db_session=MagicMock(),
+            slack_channel_config_creation_request=self._make_request(
+                respond_member_group_list=["", " user@test.com "]
+            ),
+            current_slack_channel_config_id=None,
+        )
+
+        assert channel_config["respond_member_group_list"] == ["user@test.com"]
+
+    @patch("onyx.server.manage.slack_bot.validate_channel_name", return_value="general")
+    def test_ephemeral_with_blank_allowlist_is_allowed(
+        self, _mock_validate: MagicMock
+    ) -> None:
+        """A blank members field must not trip the ephemeral/allowlist conflict."""
+        from onyx.server.manage.slack_bot import _form_channel_config
+
+        channel_config = _form_channel_config(
+            db_session=MagicMock(),
+            slack_channel_config_creation_request=self._make_request(
+                is_ephemeral=True, respond_member_group_list=[""]
+            ),
+            current_slack_channel_config_id=None,
+        )
+
+        assert channel_config["is_ephemeral"] is True
+        assert "respond_member_group_list" not in channel_config


### PR DESCRIPTION
Fixes #14458

## What changed

A `respond_member_group_list` holding only blank entries now means "no allowlist" instead of "an allowlist nobody is in".

New helper `clean_respond_member_group_list` in `onyxbot/slack/config.py` drops blank and whitespace-only entries. It is applied on both ends:

- `_form_channel_config` normalizes before persisting, so a blank members field is stored as no allowlist. The cleaned list also feeds the ephemeral/allowlist conflict check, which previously rejected an ephemeral config whose members field was merely left blank.
- `_resolve_allowlist_user_ids` normalizes on read, so configs already saved with a blank entry stop gating without a data migration.

## Why

`[""]` is truthy, so both the write and the read path treated it as a configured allowlist. It was persisted, then enforced, then resolved to zero Slack user IDs — and the invocation gate from #10992 dropped every sender, including DMs and direct @-mentions. The bot looked healthy in Slack and in the admin UI; the only evidence was in the `background` container's `/var/log/slack_bot.log`:

```
ERROR utils.py 452: Was not able to find slack user by email: 
WARNING handle_message.py 175: Failed to find these users/groups in respond_member_group_list: ['']
ERROR handle_message.py 183: respond_member_group_list is configured but no entries resolved; OnyxBot will be silent in this channel until lookups recover
INFO handle_message.py 195: Skipping message: sender U692XA0AG is not in respond_member_group_list
```

Stored config on the affected channel (v4.4.8):

```json
{"disabled": false, "channel_name": "", "respond_tag_only": true, "respond_member_group_list": [""]}
```

Fixing only the write path would leave every already-saved config silent, which is why the read path is normalized too.

## How it was verified

`ruff check` and `ruff format --check` (0.16.0, the pinned version) pass on all four changed files.

Tests added to `backend/tests/unit/onyx/onyxbot/test_slack_gating.py`:

- `test_all_blank_allowlist_is_not_a_gate` — parametrized over `[""]`, `["   "]`, `["", "  "]`; asserts the message is processed and that no email or group lookup is attempted.
- `TestCleanRespondMemberGroupList::test_drops_blank_entries` — 8 cases covering `None`, `[]`, blank-only, and mixed blank/real entries.
- `TestFormChannelConfigAllowlist` — a blank list is not persisted, a mixed list is persisted trimmed, and an ephemeral config with a blank list no longer raises.

I could not run the backend suite locally (the full dep install was not available in my environment), so those tests are unexecuted and I would appreciate CI confirming them. I did verify the changed logic directly: I executed the real `clean_respond_member_group_list` source in isolation across all 8 cases, and replayed both call sites' branch conditions with it. A stored `[""]` yields no gate; `["a@b.com"]` still gates.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #14458. A `respond_member_group_list` containing only blank entries was treated as a real allowlist, resolved to zero Slack user IDs, and made OnyxBot drop every message in the channel, including DMs and direct @-mentions. It is now treated as no allowlist when saving and when resolving allowlist users, so both newly saved and already-saved configs recover without a data migration.

**Bug Fixes**
- Adds `clean_respond_member_group_list` to drop blank and whitespace-only entries.
- Normalizes the list before persisting, so blank lists are not stored and no longer trip the ephemeral/allowlist conflict check.
- Normalizes the list on read, so existing blank allowlists stop gating immediately.
- Adds tests for blank-only and mixed allowlists on both paths.

<sup>Written for commit 3ba1ae48fd46729d1c6aea99d0c73724f8ea6107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

