### PR TITLE
fix(slackbot): honor send_as_ephemeral when choosing a delivery mode

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -255,6 +255,9 @@ def handle_message(
         return False
 
     # Reuses the resolved allowlist as the ephemeral response-visibility scope.
+    # Whether the answer is actually delivered ephemerally is the caller's call
+    # via `send_as_ephemeral` -- an allowlist alone no longer forces it, so a
+    # bot DM and a non-ephemeral channel still get a normal post.
     send_to: list[str] | None = allowed_user_ids
 
     # If configured to respond to team members only, then cannot be used with a /OnyxBot command

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -252,13 +252,18 @@ def respond_in_thread_or_channel(
     receiver_ids: list[str] | None = None,
     metadata: Metadata | None = None,
     unfurl: bool = True,
-    send_as_ephemeral: bool | None = True,  # noqa: ARG001
+    send_as_ephemeral: bool | None = True,
 ) -> list[str]:
     if not text and not blocks:
         raise ValueError("One of `text` or `blocks` must be provided")
 
     message_ids: list[str] = []
-    if not receiver_ids:
+    # Ephemeral delivery needs a target audience *and* the caller's consent.
+    # `receiver_ids` alone used to decide it, which silently overrode any caller
+    # that had explicitly asked for a public post -- notably the bot-DM carve-out
+    # in `handle_regular_answer`, which sets `send_as_ephemeral=False` and still
+    # passes the channel allowlist as `receiver_ids`.
+    if not receiver_ids or not send_as_ephemeral:
         try:
             response = client.chat_postMessage(
                 channel=channel,

--- a/backend/tests/unit/onyx/onyxbot/test_slack_respond_delivery.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_respond_delivery.py
@@ -1,0 +1,89 @@
+"""Tests for how `respond_in_thread_or_channel` picks a delivery mode."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.onyxbot.slack.utils import respond_in_thread_or_channel
+
+
+def _make_client() -> MagicMock:
+    client = MagicMock()
+    client.chat_postMessage.return_value = {"message_ts": "1700000000.000100"}
+    client.chat_postEphemeral.return_value = {"message_ts": "1700000000.000200"}
+    return client
+
+
+def test_no_receivers_posts_publicly() -> None:
+    client = _make_client()
+
+    respond_in_thread_or_channel(
+        client=client,
+        channel="C123",
+        thread_ts=None,
+        text="hello",
+        receiver_ids=None,
+    )
+
+    client.chat_postMessage.assert_called_once()
+    client.chat_postEphemeral.assert_not_called()
+
+
+def test_receivers_with_ephemeral_consent_posts_ephemerally() -> None:
+    client = _make_client()
+
+    message_ids = respond_in_thread_or_channel(
+        client=client,
+        channel="C123",
+        thread_ts=None,
+        text="hello",
+        receiver_ids=["U1", "U2"],
+        send_as_ephemeral=True,
+    )
+
+    assert client.chat_postEphemeral.call_count == 2
+    client.chat_postMessage.assert_not_called()
+    assert len(message_ids) == 2
+
+
+def test_omitting_send_as_ephemeral_keeps_receiver_driven_delivery() -> None:
+    """Callers that don't pass the flag keep the historical behavior."""
+    client = _make_client()
+
+    respond_in_thread_or_channel(
+        client=client,
+        channel="C123",
+        thread_ts=None,
+        text="hello",
+        receiver_ids=["U1"],
+    )
+
+    client.chat_postEphemeral.assert_called_once()
+    client.chat_postMessage.assert_not_called()
+
+
+@pytest.mark.parametrize("send_as_ephemeral", [False, None], ids=["false", "none"])
+def test_receivers_without_ephemeral_consent_posts_publicly(
+    send_as_ephemeral: bool | None,
+) -> None:
+    """A caller asking for a public post gets one even when receivers are set.
+
+    `receiver_ids` alone used to force ephemeral delivery, so a caller that
+    explicitly passed `send_as_ephemeral=False` was silently overridden. That
+    made the bot-DM carve-out in `handle_regular_answer` dead code, because it
+    sets the flag to False and still forwards the channel allowlist as
+    `receiver_ids`.
+    """
+    client = _make_client()
+
+    respond_in_thread_or_channel(
+        client=client,
+        channel="C123",
+        thread_ts="1700000000.000001",
+        text="hello",
+        receiver_ids=["U1", "U2"],
+        send_as_ephemeral=send_as_ephemeral,
+    )
+
+    client.chat_postMessage.assert_called_once()
+    client.chat_postEphemeral.assert_not_called()


### PR DESCRIPTION
Fixes #14460

## What changed

`respond_in_thread_or_channel` now reads `send_as_ephemeral` instead of ignoring it. Ephemeral delivery requires both a target audience and the caller's consent:

```python
if not receiver_ids or not send_as_ephemeral:
```

The `# noqa: ARG001` is gone, and a stale comment in `handle_message.py` is corrected.

## Why

The parameter was accepted and never read, so delivery was chosen solely by whether `receiver_ids` was non-empty. A caller that explicitly asked for a public post was silently overridden whenever it also passed receivers.

That made the bot-DM carve-out in `handle_regular_answer` dead code. It computes `send_as_ephemeral = (is_ephemeral or is_slash_command) and not is_bot_dm`, with a comment saying a DM should still get a non-ephemeral reply, then falls through to `target_receiver_ids = receiver_ids` — the channel allowlist from `handle_message.py`. With a `respond_member_group_list` set, every answer became ephemeral in DMs and non-ephemeral channels alike.

The ephemeral also went to the *allowlisted* users rather than the asker, so the person who asked saw nothing at all. Reported symptom: the bot adds its :eyes: reaction, removes it, and posts nothing.

The two `handle_buttons.py` call sites show the intended meaning — `send_as_ephemeral=False` with `receiver_ids=None` is commented "Post in thread as non-ephemeral message", and `send_as_ephemeral=True` with `receiver_ids=[sender]` is the ephemeral case — so this restores the design rather than inventing one.

## Blast radius

Callers that omit the flag keep the default `True` and the previous receiver-driven behavior. Of the six call sites that pass it explicitly, four are already self-consistent. The only behavior change is where a caller passes `send_as_ephemeral=False` alongside a non-empty `receiver_ids`, which today only happens via the allowlist:

| scenario | before | after |
|---|---|---|
| plain channel, no allowlist | public | public |
| plain channel, with allowlist | ephemeral to allowlist | **public** |
| bot DM, with allowlist | ephemeral to allowlist | **public** |
| ephemeral channel, with allowlist | ephemeral to sender | ephemeral to sender |
| slash command, with allowlist | ephemeral to sender | ephemeral to sender |

## The design call I'd like your read on

`handle_message.py` comments that the allowlist is "the ephemeral response-visibility scope". This PR treats that as the source of the bug: `is_ephemeral` is already the dedicated per-channel visibility setting, so an allowlist should gate *invocation* while `is_ephemeral` controls *visibility*.

If you would rather keep allowlist-driven visibility scoping, the alternative is to leave the util alone and fix only the DM carve-out, sending to the sender rather than to the allowlist. Say which you prefer and I'll rework it.

## How it was verified

`ruff check` and `ruff format --check` (0.16.0, the pinned version) pass on all three changed files.

New `backend/tests/unit/onyx/onyxbot/test_slack_respond_delivery.py` covers the delivery matrix: no receivers posts publicly; receivers plus consent posts ephemerally per receiver; receivers with `send_as_ephemeral` False or None posts publicly; and omitting the flag preserves the historical receiver-driven path.

I could not run the backend suite locally (the full dep install was unavailable in my environment), so those tests are unexecuted and I would appreciate CI confirming them. I did verify the changed branch condition directly by replaying the full `receiver_ids` × `send_as_ephemeral` matrix and the five `handle_regular_answer` scenarios above against the real condition; only the two rows marked in bold change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #14460 by making `respond_in_thread_or_channel` honor `send_as_ephemeral` when choosing delivery mode. Previously the flag was accepted but ignored, so an allowlist alone forced ephemeral replies even when the caller explicitly asked for a public post; ephemeral delivery now requires both a target audience and the caller's consent.

**Bug Fixes**
- Removes the `# noqa: ARG001` and corrects the stale comment in `handle_message.py`.
- Restores the bot-DM carve-out in `handle_regular_answer`, which was dead code because it passed `send_as_ephemeral=False` and still forwarded the allowlist as `receiver_ids`.
- Only callers that pass `send_as_ephemeral=False` with non-empty `receiver_ids` see a change; callers that omit the flag keep the previous receiver-driven behavior.
- Adds `backend/tests/unit/onyx/onyxbot/test_slack_respond_delivery.py` to cover the delivery matrix.

<sup>Written for commit ed339a300d2e7e4e4713137d076577051fa9c632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

