### PR TITLE
feat(mcp): let MCP search run as a named Onyx agent

### DIFF
--- a/backend/onyx/mcp_server/README.md
+++ b/backend/onyx/mcp_server/README.md
@@ -88,6 +88,8 @@ Search the user's private knowledge base indexed in Onyx. Returns ranked documen
 
 Pass `agent` with an agent name to run the search as that Onyx agent. The search then applies the agent's knowledge scope (document sets, attached documents, start date) and its configured model. An unresolvable name returns an error listing the agents available to the user, so no lookup call is needed first.
 
+`agent` and `document_set_names` are mutually exclusive. Explicit document sets replace an agent's knowledge scope rather than narrowing it, so passing both is rejected instead of silently returning out-of-scope results.
+
 2. `search_web`
 Search the public internet for current events and general knowledge. Returns web search results with titles, URLs, and snippets.
 

--- a/backend/onyx/mcp_server/README.md
+++ b/backend/onyx/mcp_server/README.md
@@ -4,8 +4,8 @@
 
 The Onyx MCP server allows LLMs to connect to your Onyx instance and access its knowledge base and search capabilities through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
 
-With the Onyx MCP Server, you can search your knowledgebase,
-give your LLMs web search, and upload and manage documents in Onyx.
+With the Onyx MCP Server, you can search your knowledgebase and
+give your LLMs web search.
 
 All access controls are managed within the main Onyx application.
 
@@ -86,6 +86,8 @@ The server provides three tools for searching and retrieving information:
 1. `search_indexed_documents`
 Search the user's private knowledge base indexed in Onyx. Returns ranked documents with content snippets, scores, and metadata.
 
+Pass `agent` with an agent name to run the search as that Onyx agent. The search then applies the agent's knowledge scope (document sets, attached documents, start date) and its configured model. An unresolvable name returns an error listing the agents available to the user, so no lookup call is needed first.
+
 2. `search_web`
 Search the public internet for current events and general knowledge. Returns web search results with titles, URLs, and snippets.
 
@@ -96,6 +98,12 @@ Retrieve the complete text content from specific web URLs. Useful for fetching f
 
 1. `indexed_sources`
 Lists all document sources currently indexed in the tenant (e.g., `"confluence"`, `"github"`). Use these values to filter results when calling `search_indexed_documents`.
+
+2. `document_sets`
+Lists the Document Sets accessible to the user. Use the returned `name` values with the `document_set_names` filter of `search_indexed_documents`.
+
+3. `agents`
+Lists the Onyx agents accessible to the user (`id`, `name`, `description`). Use a returned `name` with the `agent` filter of `search_indexed_documents`.
 
 ## Local Development
 

--- a/backend/onyx/mcp_server/resources/__init__.py
+++ b/backend/onyx/mcp_server/resources/__init__.py
@@ -2,6 +2,7 @@
 
 # Import resource modules so decorators execute when the package loads.
 from onyx.mcp_server.resources import (
+    agents,  # noqa: F401
     document_sets,  # noqa: F401
     indexed_sources,  # noqa: F401
 )

--- a/backend/onyx/mcp_server/resources/agents.py
+++ b/backend/onyx/mcp_server/resources/agents.py
@@ -1,0 +1,41 @@
+"""Resource exposing the agents available to the current user."""
+
+from __future__ import annotations
+
+import json
+
+from onyx.mcp_server.api import mcp_server
+from onyx.mcp_server.utils import get_accessible_agents, require_access_token
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+@mcp_server.resource(
+    "resource://agents",
+    name="agents",
+    description=(
+        "Enumerate the Onyx agents accessible to the current user. Use a "
+        "returned `name` value with the `agent` filter of the "
+        "`search_indexed_documents` tool to run a search with that agent's "
+        "knowledge scope and model."
+    ),
+    mime_type="application/json",
+)
+async def agents_resource() -> str:
+    """Return the agents the user can scope a search to."""
+
+    access_token = require_access_token()
+
+    agents = sorted(
+        await get_accessible_agents(access_token), key=lambda entry: entry.name
+    )
+
+    logger.info(
+        "Onyx MCP Server: agents resource returning %s entries",
+        len(agents),
+    )
+
+    # FastMCP 3.2+ requires str/bytes/list[ResourceContent] — it no longer
+    # auto-serializes; serialize to JSON ourselves.
+    return json.dumps([entry.model_dump(mode="json") for entry in agents])

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -12,6 +12,8 @@ from onyx.configs.app_configs import MCP_SERVER_API_REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import (
+    AgentEntry,
+    get_accessible_agents,
     get_http_client,
     get_indexed_sources,
     require_access_token,
@@ -98,6 +100,34 @@ def _error_payload(error: str) -> dict[str, Any]:
 
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
+# Keeps the unknown-agent error readable when a tenant has many agents.
+_MAX_AGENT_NAMES_IN_ERROR = 50
+
+
+def _match_agents(agent: str, agents: list[AgentEntry]) -> list[AgentEntry]:
+    """Match an agent by name, preferring an exact hit over a case-fold one."""
+    exact = [entry for entry in agents if entry.name == agent]
+    if exact:
+        return exact
+    folded = agent.casefold()
+    return [entry for entry in agents if entry.name.casefold() == folded]
+
+
+def _unknown_agent_error(agent: str, agents: list[AgentEntry]) -> str:
+    """Name the valid agents so the caller can retry without a lookup call.
+
+    An unresolvable agent has to fail rather than fall back to an unscoped
+    search — the wrong scope returned as if it were right is worse than an
+    error.
+    """
+    if not agents:
+        return f"Agent '{agent}' not found. No agents are accessible to this user."
+
+    names = sorted(entry.name for entry in agents)
+    shown = names[:_MAX_AGENT_NAMES_IN_ERROR]
+    suffix = f" (and {len(names) - len(shown)} more)" if len(names) > len(shown) else ""
+    return f"Agent '{agent}' not found. Available agents: {', '.join(shown)}{suffix}."
+
 
 def _record_requested_sources(source_types: list[str] | None) -> None:
     canonical_sources: set[str] = set()
@@ -117,6 +147,7 @@ async def search_indexed_documents(
     document_set_names: list[str] | None = None,
     time_cutoff: str | None = None,
     skip_query_expansion: bool = False,
+    agent: str | None = None,
 ) -> dict[str, Any]:
     """
     Search the user's knowledge base indexed in Onyx.
@@ -138,6 +169,12 @@ async def search_indexed_documents(
     `skip_query_expansion` bypasses the LLM query-expansion step; useful when
     you already know the exact phrase to search for (faster, no LLM call for
     expansion).
+    `agent` runs the search as a named Onyx agent, applying that agent's
+    knowledge scope (its document sets, attached documents and start date) and
+    its configured model. Pass the name the user gave you — no lookup call is
+    needed first. If the name does not resolve, the error names the agents
+    available to this user, so you can retry with a valid one. Use the `agents`
+    resource to browse them.
 
     Returns ``{"results": [{title, url, source_type, content, updated_at},
     ...]}``. Results are ordered by LLM-judged relevance. ``content`` is the
@@ -152,16 +189,18 @@ async def search_indexed_documents(
         "source_types": ["jira", "google_drive", "github"],
         "document_set_names": ["Engineering Wiki"],
         "time_cutoff": "2025-11-24T00:00:00Z",
+        "agent": "Engineering Support",
     }
     ```
     """
     _start = time.monotonic()
     tool = MCPServerToolName.SEARCH_INDEXED_DOCUMENTS
     logger.info(
-        "Onyx MCP Server: document search: query='%s', sources=%s, document_sets=%s",
+        "Onyx MCP Server: document search: query='%s', sources=%s, document_sets=%s, agent=%s",
         query,
         source_types,
         document_set_names,
+        agent,
     )
 
     _record_requested_sources(source_types)
@@ -171,6 +210,7 @@ async def search_indexed_documents(
     # "no filter" (None).
     source_types = source_types or None
     document_set_names = document_set_names or None
+    agent = (agent or "").strip() or None
 
     # Get authenticated user from FastMCP's access token
     access_token = require_access_token()
@@ -219,12 +259,33 @@ async def search_indexed_documents(
             )
             parsed_cutoff = None
 
+        persona_id: int | None = None
+        if agent is not None:
+            try:
+                accessible_agents = await get_accessible_agents(access_token)
+            except Exception as err:
+                logger.error(
+                    "Onyx MCP Server: Error fetching agents: %s", err, exc_info=True
+                )
+                return _error_payload(f"Failed to look up agents: {str(err)}")
+
+            matches = _match_agents(agent, accessible_agents)
+            if not matches:
+                return _error_payload(_unknown_agent_error(agent, accessible_agents))
+            if len(matches) > 1:
+                return _error_payload(
+                    f"Agent name '{agent}' is ambiguous: {len(matches)} accessible "
+                    "agents share it. Ask the user which one they mean."
+                )
+            persona_id = matches[0].id
+
         request = SearchRequest(
             query=query,
             sources=source_type_enums,
             document_sets=document_set_names,
             time_cutoff=parsed_cutoff,
             skip_query_expansion=skip_query_expansion,
+            persona_id=persona_id,
         )
         endpoint = f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/search"
         response = await _post_model(endpoint, request, access_token)

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -174,7 +174,9 @@ async def search_indexed_documents(
     its configured model. Pass the name the user gave you — no lookup call is
     needed first. If the name does not resolve, the error names the agents
     available to this user, so you can retry with a valid one. Use the `agents`
-    resource to browse them.
+    resource to browse them. `agent` and `document_set_names` are mutually
+    exclusive: explicit document sets replace an agent's knowledge scope rather
+    than narrowing it, so passing both is rejected.
 
     Returns ``{"results": [{title, url, source_type, content, updated_at},
     ...]}``. Results are ordered by LLM-judged relevance. ``content`` is the
@@ -189,6 +191,13 @@ async def search_indexed_documents(
         "source_types": ["jira", "google_drive", "github"],
         "document_set_names": ["Engineering Wiki"],
         "time_cutoff": "2025-11-24T00:00:00Z",
+    }
+    ```
+
+    Scoping the same question to an agent instead:
+    ```
+    {
+        "query": "What is the latest status of PROJ-1234?",
         "agent": "Engineering Support",
     }
     ```
@@ -218,24 +227,58 @@ async def search_indexed_documents(
     result_count: int | None = None
 
     try:
-        try:
-            sources = await get_indexed_sources(access_token)
-        except Exception as err:
-            logger.error(
-                "Onyx MCP Server: Error checking indexed sources: %s",
-                err,
-                exc_info=True,
-            )
-            return _error_payload(f"Failed to check indexed sources: {str(err)}")
-
-        if not sources:
-            logger.info("Onyx MCP Server: No indexed sources available for tenant")
-            outcome = MCPToolCallStatus.SUCCESS
-            result_count = 0
+        # _build_index_filters lets explicit document sets *replace* the
+        # agent's own sets rather than narrow them, so honouring both would
+        # silently search outside the agent's knowledge scope.
+        if agent is not None and document_set_names is not None:
             return _error_payload(
-                "No document sources are indexed yet. Add connectors or upload data "
-                "through Onyx before calling search_indexed_documents."
+                "Pass either `agent` or `document_set_names`, not both. Explicit "
+                "document sets replace an agent's knowledge scope instead of "
+                "narrowing it, so the results would not be scoped to the agent."
             )
+
+        # Resolve the agent before the indexed-sources guard below: a bad name
+        # deserves its own actionable error, and an agent can carry attached
+        # documents even when no connector has indexed anything.
+        persona_id: int | None = None
+        if agent is not None:
+            try:
+                accessible_agents = await get_accessible_agents(access_token)
+            except Exception as err:
+                logger.error(
+                    "Onyx MCP Server: Error fetching agents: %s", err, exc_info=True
+                )
+                return _error_payload(f"Failed to look up agents: {str(err)}")
+
+            matches = _match_agents(agent, accessible_agents)
+            if not matches:
+                return _error_payload(_unknown_agent_error(agent, accessible_agents))
+            if len(matches) > 1:
+                return _error_payload(
+                    f"Agent name '{agent}' is ambiguous: {len(matches)} accessible "
+                    "agents share it. Ask the user which one they mean."
+                )
+            persona_id = matches[0].id
+
+        if agent is None:
+            try:
+                sources = await get_indexed_sources(access_token)
+            except Exception as err:
+                logger.error(
+                    "Onyx MCP Server: Error checking indexed sources: %s",
+                    err,
+                    exc_info=True,
+                )
+                return _error_payload(f"Failed to check indexed sources: {str(err)}")
+
+            if not sources:
+                logger.info("Onyx MCP Server: No indexed sources available for tenant")
+                outcome = MCPToolCallStatus.SUCCESS
+                result_count = 0
+                return _error_payload(
+                    "No document sources are indexed yet. Add connectors or upload data "
+                    "through Onyx before calling search_indexed_documents."
+                )
 
         source_type_enums: list[DocumentSource] | None = None
         if source_types is not None:
@@ -258,26 +301,6 @@ async def search_indexed_documents(
                 err,
             )
             parsed_cutoff = None
-
-        persona_id: int | None = None
-        if agent is not None:
-            try:
-                accessible_agents = await get_accessible_agents(access_token)
-            except Exception as err:
-                logger.error(
-                    "Onyx MCP Server: Error fetching agents: %s", err, exc_info=True
-                )
-                return _error_payload(f"Failed to look up agents: {str(err)}")
-
-            matches = _match_agents(agent, accessible_agents)
-            if not matches:
-                return _error_payload(_unknown_agent_error(agent, accessible_agents))
-            if len(matches) > 1:
-                return _error_payload(
-                    f"Agent name '{agent}' is ambiguous: {len(matches)} accessible "
-                    "agents share it. Ask the user which one they mean."
-                )
-            persona_id = matches[0].id
 
         request = SearchRequest(
             query=query,

--- a/backend/onyx/mcp_server/utils.py
+++ b/backend/onyx/mcp_server/utils.py
@@ -22,6 +22,18 @@ class DocumentSetEntry(BaseModel):
     description: str | None = None
 
 
+class AgentEntry(BaseModel):
+    """Minimal agent (persona) shape surfaced to MCP clients.
+
+    Projected from the backend's MinimalPersonaSnapshot to keep MCP decoupled
+    from chat-UI fields (tools, starter messages, icons, ...).
+    """
+
+    id: int
+    name: str
+    description: str | None = None
+
+
 logger = setup_logger()
 
 # Shared HTTP client reused across requests
@@ -126,3 +138,32 @@ async def get_accessible_document_sets(
             exc_info=True,
         )
         raise RuntimeError(f"Failed to fetch document sets: {exc}") from exc
+
+
+_AGENT_ENTRIES_ADAPTER = TypeAdapter(list[AgentEntry])
+
+
+async def get_accessible_agents(
+    access_token: AccessToken,
+) -> list[AgentEntry]:
+    """Fetch the agents (personas) the current user can search with."""
+    headers = {"Authorization": f"Bearer {access_token.token}"}
+    try:
+        response = await get_http_client().get(
+            f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/persona",
+            headers=headers,
+        )
+        response.raise_for_status()
+        return _AGENT_ENTRIES_ADAPTER.validate_json(response.content)
+    except (httpx.HTTPStatusError, httpx.RequestError, ValueError):
+        logger.error(
+            "Onyx MCP Server: Failed to fetch agents",
+            exc_info=True,
+        )
+        raise
+    except Exception as exc:
+        logger.error(
+            "Onyx MCP Server: Unexpected error fetching agents",
+            exc_info=True,
+        )
+        raise RuntimeError(f"Failed to fetch agents: {exc}") from exc

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -20,7 +20,11 @@ from onyx.auth.permissions import (
     has_permission,
     require_permission,
 )
-from onyx.auth.users import current_chat_accessible_user, current_limited_user
+from onyx.auth.users import (
+    current_chat_accessible_user,
+    current_limited_user,
+    scope_exempt,
+)
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS, FileOrigin, MilestoneRecordType
 from onyx.db.engine.sql_engine import get_session
@@ -596,7 +600,10 @@ def delete_persona(
         ) from e
 
 
-@basic_router.get("")
+# scope_exempt: the auth dependency below carries no require_permission marker,
+# so without this a scoped PAT is rejected fail-closed. MCP clients need this
+# route to resolve an agent name for a scoped search.
+@basic_router.get("", dependencies=[Depends(scope_exempt)])
 def list_personas(
     user: User = Depends(current_chat_accessible_user),
     db_session: Session = Depends(get_session),

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -14,7 +14,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import CallToolResult, TextContent
 from pydantic import AnyUrl
 
-from onyx.db.enums import AccessType
+from onyx.db.enums import AccessType, Permission
 from tests.integration.common_utils.constants import MCP_SERVER_URL
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -22,6 +22,7 @@ from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.pat import PATManager
+from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
@@ -30,6 +31,7 @@ from tests.integration.common_utils.test_models import DATestUser
 MCP_SEARCH_TOOL = "search_indexed_documents"
 INDEXED_SOURCES_RESOURCE_URI = "resource://indexed_sources"
 DOCUMENT_SETS_RESOURCE_URI = "resource://document_sets"
+AGENTS_RESOURCE_URI = "resource://agents"
 STREAMABLE_HTTP_URL = f"{MCP_SERVER_URL.rstrip('/')}/?transportType=streamable-http"
 
 
@@ -71,6 +73,7 @@ def _call_search_tool(
     headers: dict[str, str],
     query: str,
     document_set_names: list[str] | None = None,
+    agent: str | None = None,
 ) -> CallToolResult:
     """Call the search_indexed_documents tool via MCP."""
 
@@ -79,17 +82,24 @@ def _call_search_tool(
         arguments: dict[str, Any] = {"query": query}
         if document_set_names is not None:
             arguments["document_set_names"] = document_set_names
+        if agent is not None:
+            arguments["agent"] = agent
         return await session.call_tool(MCP_SEARCH_TOOL, arguments)
 
     return _run_with_mcp_session(headers, _action)
 
 
-def _auth_headers(user: DATestUser, name: str) -> dict[str, str]:
+def _auth_headers(
+    user: DATestUser,
+    name: str,
+    scopes: list[Permission] | None = None,
+) -> dict[str, str]:
     """Create authorization headers with a PAT token."""
     pat = PATManager.create(
         name=name,
         expiration_days=7,
         user_performing_action=user,
+        scopes=scopes,
     )
     return {"Authorization": f"Bearer {pat.token}"}
 
@@ -299,3 +309,103 @@ def test_mcp_search_filters_by_document_set(
     ]
     assert any(in_set_content in content for content in empty_list_contents)
     assert any(out_of_set_content in content for content in empty_list_contents)
+
+
+def test_mcp_search_scopes_to_agent(
+    admin_user: DATestUser,
+) -> None:
+    """Passing `agent` should apply that agent's knowledge scope to the search."""
+    LLMProviderManager.create(user_performing_action=admin_user)
+
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    cc_pair_in_scope = CCPairManager.create_from_scratch(
+        user_performing_action=admin_user,
+    )
+    cc_pair_out_of_scope = CCPairManager.create_from_scratch(
+        user_performing_action=admin_user,
+    )
+
+    shared_phrase = "agent-scope-shared-phrase"
+    in_scope_content = f"{shared_phrase} inside the agent's knowledge"
+    out_of_scope_content = f"{shared_phrase} outside the agent's knowledge"
+
+    DocumentManager.seed_doc_with_content(cc_pair_in_scope, in_scope_content, api_key)
+    DocumentManager.seed_doc_with_content(
+        cc_pair_out_of_scope, out_of_scope_content, api_key
+    )
+
+    doc_set = DocumentSetManager.create(
+        cc_pair_ids=[cc_pair_in_scope.id],
+        user_performing_action=admin_user,
+    )
+    DocumentSetManager.wait_for_sync(
+        user_performing_action=admin_user,
+        document_sets_to_check=[doc_set],
+    )
+
+    persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        document_set_ids=[doc_set.id],
+    )
+
+    headers = _auth_headers(admin_user, name="mcp-agent-scope")
+
+    # The agents resource should surface the new agent so clients can browse
+    # the names accepted by the `agent` filter.
+    async def _read_agents(session: ClientSession) -> Any:
+        await session.initialize()
+        resources = await session.list_resources()
+        contents = await session.read_resource(AnyUrl(AGENTS_RESOURCE_URI))
+        return resources, contents
+
+    resources_result, agents_contents = _run_with_mcp_session(headers, _read_agents)
+    resource_uris = {str(resource.uri) for resource in resources_result.resources}
+    assert AGENTS_RESOURCE_URI in resource_uris
+    agents_payload = json.loads(agents_contents.contents[0].text)
+    assert persona.name in {entry["name"] for entry in agents_payload}
+
+    # Without the agent both documents are visible.
+    unfiltered_payload = _extract_tool_payload(
+        _call_search_tool(headers, shared_phrase)
+    )
+    unfiltered_contents = [
+        doc.get("content") or "" for doc in unfiltered_payload["results"]
+    ]
+    assert any(in_scope_content in content for content in unfiltered_contents)
+    assert any(out_of_scope_content in content for content in unfiltered_contents)
+
+    # Scoped to the agent, only its document set is searched.
+    scoped_payload = _extract_tool_payload(
+        _call_search_tool(headers, shared_phrase, agent=persona.name)
+    )
+    scoped_contents = [doc.get("content") or "" for doc in scoped_payload["results"]]
+    assert "error" not in scoped_payload, scoped_payload
+    assert len(scoped_payload["results"]) >= 1
+    assert any(in_scope_content in content for content in scoped_contents)
+    assert all(out_of_scope_content not in content for content in scoped_contents)
+
+    # An unresolvable agent must fail loudly and name the valid options, rather
+    # than silently falling back to an unscoped search.
+    unknown_payload = _extract_tool_payload(
+        _call_search_tool(headers, shared_phrase, agent="no-such-agent")
+    )
+    assert unknown_payload["results"] == []
+    assert "no-such-agent" in unknown_payload["error"]
+    assert persona.name in unknown_payload["error"]
+
+    # A scoped PAT must still resolve the agent name: /persona carries no
+    # require_permission marker, so it needs the scope_exempt marker to be
+    # reachable at all.
+    scoped_pat_headers = _auth_headers(
+        admin_user,
+        name="mcp-agent-scope-scoped-pat",
+        scopes=[Permission.BASIC_ACCESS, Permission.READ_SEARCH],
+    )
+    scoped_pat_payload = _extract_tool_payload(
+        _call_search_tool(scoped_pat_headers, shared_phrase, agent=persona.name)
+    )
+    assert "error" not in scoped_pat_payload, scoped_pat_payload
+    assert any(
+        in_scope_content in (doc.get("content") or "")
+        for doc in scoped_pat_payload["results"]
+    )

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -23,10 +23,15 @@ _TOKEN = AccessToken(token="test-token", client_id="test", scopes=[])
 
 @dataclass
 class _Stub:
-    """Bodies the tool sent to /search, and the agents /persona returns."""
+    """Bodies the tool sent to /search, plus what the API server returns."""
 
     search_requests: list[dict[str, Any]]
     agents: list[dict[str, Any]]
+    sources: list[str]
+
+
+async def _unreachable_indexed_sources(_access_token: AccessToken) -> list[str]:
+    raise AssertionError("indexed-sources must not be consulted for an agent search")
 
 
 @pytest_asyncio.fixture
@@ -38,12 +43,13 @@ async def stub(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_Stub, None]:
             {"id": 7, "name": "Support", "description": "Customer support"},
             {"id": 9, "name": "Engineering Wiki", "description": "Eng docs"},
         ],
+        sources=["github"],
     )
 
     def _handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if path.endswith("/manage/indexed-sources"):
-            return httpx.Response(200, json={"sources": ["github"]})
+            return httpx.Response(200, json={"sources": state.sources})
         if path.endswith("/persona"):
             return httpx.Response(200, json=state.agents)
         if path.endswith("/search"):
@@ -96,6 +102,51 @@ async def test_unknown_agent_errors_and_names_the_valid_ones(stub: _Stub) -> Non
     # The wrong scope returned as if it were right is worse than an error, so
     # the tool must not fall back to an unscoped search.
     assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
+async def test_agent_with_document_sets_is_rejected(stub: _Stub) -> None:
+    """Explicit sets replace an agent's scope downstream, so both is refused."""
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="Support", document_set_names=["Engineering Wiki"]
+    )
+
+    assert payload["results"] == []
+    assert "not both" in payload["error"]
+    assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
+async def test_agent_search_runs_without_connector_sources(
+    stub: _Stub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An agent can carry attached documents, so the no-sources guard, which
+    only counts connector sources, must not block an agent-scoped search."""
+    monkeypatch.setattr(
+        search_module,
+        "get_indexed_sources",
+        _unreachable_indexed_sources,
+    )
+
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="Support"
+    )
+
+    assert "error" not in payload
+    assert stub.search_requests[0]["persona_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_error_survives_empty_source_list(stub: _Stub) -> None:
+    """The agent error is more actionable than the generic no-sources message."""
+    stub.sources = []
+
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="no-such-agent"
+    )
+
+    assert "no-such-agent" in payload["error"]
+    assert "Support" in payload["error"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -1,0 +1,111 @@
+"""Agent scoping in the MCP document-search tool.
+
+`agent` resolves a name to a persona id on the search call itself, so the
+happy path needs no discovery round trip. A name that does not resolve must
+fail rather than fall back to an unscoped search.
+"""
+
+import json
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastmcp.server.auth.auth import AccessToken
+
+import onyx.mcp_server.tools.search as search_module
+import onyx.mcp_server.utils as utils_module
+
+_TOKEN = AccessToken(token="test-token", client_id="test", scopes=[])
+
+
+@dataclass
+class _Stub:
+    """Bodies the tool sent to /search, and the agents /persona returns."""
+
+    search_requests: list[dict[str, Any]]
+    agents: list[dict[str, Any]]
+
+
+@pytest_asyncio.fixture
+async def stub(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_Stub, None]:
+    """Stand in for the API server the MCP tools call."""
+    state = _Stub(
+        search_requests=[],
+        agents=[
+            {"id": 7, "name": "Support", "description": "Customer support"},
+            {"id": 9, "name": "Engineering Wiki", "description": "Eng docs"},
+        ],
+    )
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/manage/indexed-sources"):
+            return httpx.Response(200, json={"sources": ["github"]})
+        if path.endswith("/persona"):
+            return httpx.Response(200, json=state.agents)
+        if path.endswith("/search"):
+            state.search_requests.append(json.loads(request.content))
+            return httpx.Response(200, json={"results": []})
+        return httpx.Response(404, json={"detail": f"unexpected path {path}"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    monkeypatch.setattr(utils_module, "_http_client", client)
+    monkeypatch.setattr(search_module, "require_access_token", lambda: _TOKEN)
+    yield state
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_name_resolves_to_persona_id(stub: _Stub) -> None:
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="Support"
+    )
+
+    assert "error" not in payload
+    assert len(stub.search_requests) == 1
+    assert stub.search_requests[0]["persona_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_agent_match_is_case_insensitive(stub: _Stub) -> None:
+    await search_module.search_indexed_documents(query="anything", agent="sUpPoRt")
+
+    assert stub.search_requests[0]["persona_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_search_without_agent_stays_unscoped(stub: _Stub) -> None:
+    await search_module.search_indexed_documents(query="anything")
+
+    assert stub.search_requests[0].get("persona_id") is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_errors_and_names_the_valid_ones(stub: _Stub) -> None:
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="no-such-agent"
+    )
+
+    assert payload["results"] == []
+    assert "no-such-agent" in payload["error"]
+    assert "Support" in payload["error"]
+    assert "Engineering Wiki" in payload["error"]
+    # The wrong scope returned as if it were right is worse than an error, so
+    # the tool must not fall back to an unscoped search.
+    assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_agent_name_errors(stub: _Stub) -> None:
+    stub.agents.append({"id": 11, "name": "support", "description": "same name"})
+
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="SUPPORT"
+    )
+
+    assert payload["results"] == []
+    assert "ambiguous" in payload["error"]
+    assert stub.search_requests == []


### PR DESCRIPTION
## Description

The MCP server's `search_indexed_documents` tool could not target an Onyx agent, even though `POST /search` already accepted `persona_id`. This adds an `agent` parameter taking an agent name, so the search applies that agent's knowledge scope (document sets, attached documents, start date) and its configured model.

The name resolves on the search call itself, so the happy path needs no discovery round trip. A name that does not resolve returns an error listing the agents available to the caller, rather than falling back to an unscoped search — the wrong scope returned as if it were right is worse than an error. This is a deliberate departure from the tool's lenient handling of bad `source_types` and `time_cutoff`.

Also in this PR:

- New `agents` resource (`resource://agents`), mirroring the existing `document_sets` one. It shares a single `get_accessible_agents` helper with the name lookup.
- `GET /persona` marked `scope_exempt`. The route carries no `require_permission` marker, so `_scoped_pat_permitted_on_route` rejected scoped PATs fail-closed and agent resolution would have broken for them. This matches how `/me` is handled.
- README: documents the new parameter and both previously undocumented resources, and drops the claim that the server can upload and manage documents. No tool does that — everything registered is read-only.

## How Has This Been Tested?

- **Integration test** `test_mcp_search_scopes_to_agent`: the `agents` resource lists a newly created agent, an agent-scoped search excludes out-of-scope documents, an unknown agent errors and names the valid agents, and a scoped PAT succeeds (regression guard for the `scope_exempt` change). Added here and exercised by CI; the local dev stack was down, so it was not run locally.
- **Unit tests** `test_agent_scoped_search.py`: 5 tests against a stubbed API server covering name resolution, case-insensitive match, the unscoped default, and both failure modes. Mutation-checked — breaking the `persona_id` wiring fails the wiring tests, and making the unknown-agent path fall back silently fails the guard test.
- **Live MCP wire check**: ran the real MCP server over streamable HTTP against a stub API server (it needs no database) and drove it with an MCP client. Confirmed `agent` in the published tool schema, `resource://agents` advertised and readable, `persona_id` correct in the outgoing `/search` body, no `/search` issued on an unknown agent, and the bearer forwarded verbatim to `/me` and `/persona`.
- **Route table check**: `_scoped_pat_permitted_on_route` returns `True` for `/persona` and `False` for the untouched `/persona/{persona_id}`, confirming the marker is what changed the behaviour.
- **Full backend unit suite**: 8897 passed. The 8 failures in `test_process_isolation.py` are pre-existing and environmental — they fail identically on `main`.
- pre-commit clean on every touched file.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the MCP `search_indexed_documents` tool run as a named Onyx agent, so searches apply the agent's knowledge scope and configured model. The name resolves to the persona id on the search call itself; an unresolvable name errors with the available agents rather than silently falling back to an unscoped search, since the wrong scope returned as if it were right is worse than an error.

**Supporting changes**
- Adds a `resource://agents` resource for browsing accessible agents, sharing a lookup helper with the tool.
- Marks `GET /persona` as `scope_exempt` so scoped PATs can resolve agent names instead of being rejected fail-closed.
- Updates the README to document the new parameter and resources and drops the claim that the server can upload and manage documents.
- Rejects passing both `agent` and `document_set_names`, since explicit sets replace an agent's scope rather than narrow it.
- Resolves the agent before the indexed-sources guard, so agents with only attached documents aren't blocked and unknown names get the actionable error.

<sup>Written for commit 2477de4487099dfcb3c82e5ee34335da91694826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

