### PR TITLE
fix(llm): keep a model visible while it still holds a deployment default

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1273,7 +1273,9 @@ def sync_auto_mode_models(
     #
     # Both statements test the default in SQL rather than from a snapshot read
     # here. A default assigned between the two would otherwise be missed, and
-    # the model hidden anyway.
+    # the model hidden anyway. They synchronize the session because sessions are
+    # built with expire_on_commit=False, so a caller holding these rows — as
+    # put_llm_provider does — would otherwise serialize stale visibility.
     db_session.flush()
 
     dropped_names = [
@@ -1301,7 +1303,7 @@ def sync_auto_mode_models(
                 ~holds_a_default,
             )
             .values(is_visible=False)
-            .execution_options(synchronize_session=False)
+            .execution_options(synchronize_session="fetch")
         )
 
         # An earlier sync could have hidden a model that still holds a default,
@@ -1314,7 +1316,7 @@ def sync_auto_mode_models(
                 holds_a_default,
             )
             .values(is_visible=True)
-            .execution_options(synchronize_session=False)
+            .execution_options(synchronize_session="fetch")
         )
 
         changes += int(hidden.rowcount)  # ty: ignore[unresolved-attribute]

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1265,20 +1265,60 @@ def sync_auto_mode_models(
             )
             changes += 1
 
-    # Mark models that are no longer in GitHub config as not visible. A model
-    # still holding a deployment default keeps its visibility: only the chat
-    # default is re-pointed above, so hiding the rest would strand a default on
-    # a model the admin can no longer see or change. Every other write path
-    # keeps a default model visible.
+    # Reconcile the visibility of the models the config dropped. A model still
+    # holding a deployment default stays visible: only the chat default is
+    # re-pointed above, so hiding the rest would strand a default on a model the
+    # admin can no longer see or change. Every other write path keeps a default
+    # model visible.
+    #
+    # Both statements test the default in SQL rather than from a snapshot read
+    # here. A default assigned between the two would otherwise be missed, and
+    # the model hidden anyway.
     db_session.flush()
-    defaults_by_model_id = fetch_default_flows_by_model_id(db_session)
 
-    for model_name, model in existing_models.items():
-        if model_name in recommended_visible_model_names:
-            continue
-        if model.is_visible and not defaults_by_model_id.get(model.id):
-            model.is_visible = False
-            changes += 1
+    dropped_names = [
+        name for name in existing_models if name not in recommended_visible_model_names
+    ]
+    if dropped_names:
+        holds_a_default = (
+            select(LLMModelFlow.id)
+            .where(
+                LLMModelFlow.model_configuration_id == ModelConfiguration.id,
+                LLMModelFlow.is_default == True,  # noqa: E712
+            )
+            .exists()
+        )
+        dropped_models = (
+            ModelConfiguration.llm_provider_id == provider.id,
+            ModelConfiguration.name.in_(dropped_names),
+        )
+
+        hidden = db_session.execute(
+            update(ModelConfiguration)
+            .where(
+                *dropped_models,
+                ModelConfiguration.is_visible == True,  # noqa: E712
+                ~holds_a_default,
+            )
+            .values(is_visible=False)
+            .execution_options(synchronize_session=False)
+        )
+
+        # An earlier sync could have hidden a model that still holds a default,
+        # so restore those rather than leaving the default unreachable forever.
+        restored = db_session.execute(
+            update(ModelConfiguration)
+            .where(
+                *dropped_models,
+                ModelConfiguration.is_visible == False,  # noqa: E712
+                holds_a_default,
+            )
+            .values(is_visible=True)
+            .execution_options(synchronize_session=False)
+        )
+
+        changes += int(hidden.rowcount)  # ty: ignore[unresolved-attribute]
+        changes += int(restored.rowcount)  # ty: ignore[unresolved-attribute]
 
     db_session.commit()
     return changes

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1211,13 +1211,6 @@ def sync_auto_mode_models(
         ).all()
     }
 
-    # Mark models that are no longer in GitHub config as not visible
-    for model_name, model in existing_models.items():
-        if model_name not in recommended_visible_model_names:
-            if model.is_visible:
-                model.is_visible = False
-                changes += 1
-
     # Add or update models from GitHub config
     for model_config in recommended_visible_models:
         if model_config.name in existing_models:
@@ -1248,6 +1241,8 @@ def sync_auto_mode_models(
             changes += 1
 
     # Update the default if this provider currently holds the global CHAT default.
+    # This runs before the models the config dropped are hidden, so a model that
+    # gives up the chat default here can still be hidden below.
     # We flush (but don't commit) so that _update_default_model can see the new
     # model rows, then commit everything atomically to avoid a window where the
     # old default is invisible but still pointed-to.
@@ -1268,6 +1263,21 @@ def sync_auto_mode_models(
                 model=recommended_default.name,
                 flow_type=LLMModelFlowType.CHAT,
             )
+            changes += 1
+
+    # Mark models that are no longer in GitHub config as not visible. A model
+    # still holding a deployment default keeps its visibility: only the chat
+    # default is re-pointed above, so hiding the rest would strand a default on
+    # a model the admin can no longer see or change. Every other write path
+    # keeps a default model visible.
+    db_session.flush()
+    defaults_by_model_id = fetch_default_flows_by_model_id(db_session)
+
+    for model_name, model in existing_models.items():
+        if model_name in recommended_visible_model_names:
+            continue
+        if model.is_visible and not defaults_by_model_id.get(model.id):
+            model.is_visible = False
             changes += 1
 
     db_session.commit()

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -1509,3 +1509,98 @@ class TestAutoModeSyncKeepsDefaultModelsVisible:
         finally:
             db_session.rollback()
             _cleanup_provider(db_session, provider_name)
+
+    def test_sync_restores_a_hidden_model_that_still_holds_a_default(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """An earlier sync could already have hidden a model holding a default.
+        Sync repairs that instead of leaving the default unreachable.
+
+        Steps:
+        1. Create provider with config: default=gpt-4o, additional=[gpt-4o-mini].
+        2. Point the Craft default at gpt-4o-mini, then hide it by hand to
+           reproduce what the previous sync left behind.
+        3. Re-sync with config: default=gpt-4o (gpt-4o-mini removed).
+        4. Verify gpt-4o-mini is visible again and still holds Craft.
+        """
+        config_v1 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini"],
+        )
+        config_v2 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=[],
+        )
+
+        try:
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=config_v1,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        name=provider_name,
+                        provider=LlmProviderNames.OPENAI,
+                        api_key="sk-test-key-00000000000000000000000000000000000",
+                        api_key_changed=True,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=True,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_craft_provider(provider.id, "gpt-4o-mini", db_session)
+
+            # Reproduce the state the old sync left: hidden, but still the default.
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            for mc in provider.model_configurations:
+                if mc.name == "gpt-4o-mini":
+                    mc.is_visible = False
+            db_session.commit()
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=config_v2,
+            )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            visibility = {
+                mc.name: mc.is_visible for mc in provider.model_configurations
+            }
+            assert visibility["gpt-4o-mini"] is True, (
+                "Sync must restore a model that an earlier sync hid while it "
+                "still held a default"
+            )
+
+            craft_default = fetch_default_craft_model(db_session)
+            assert craft_default is not None
+            assert craft_default.name == "gpt-4o-mini"
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -1604,3 +1604,94 @@ class TestAutoModeSyncKeepsDefaultModelsVisible:
         finally:
             db_session.rollback()
             _cleanup_provider(db_session, provider_name)
+
+    def test_sync_leaves_no_stale_visibility_on_the_loaded_provider(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """put_llm_provider serializes the provider it just handed to sync, and
+        sessions are built with expire_on_commit=False. Both visibility writes
+        must reach the loaded rows, not only the database.
+
+        Steps:
+        1. Create provider with config: default=gpt-4o,
+           additional=[gpt-4o-mini, gpt-4-turbo].
+        2. Point Craft at gpt-4o-mini and hide it by hand, so the sync has one
+           model to restore and one (gpt-4-turbo) to hide.
+        3. Re-sync with config: default=gpt-4o (both extras removed).
+        4. Read the same provider object back with no expire_all in between.
+        """
+        config_v1 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini", "gpt-4-turbo"],
+        )
+        config_v2 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=[],
+        )
+
+        try:
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=config_v1,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        name=provider_name,
+                        provider=LlmProviderNames.OPENAI,
+                        api_key="sk-test-key-00000000000000000000000000000000000",
+                        api_key_changed=True,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=True,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_craft_provider(provider.id, "gpt-4o-mini", db_session)
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            for mc in provider.model_configurations:
+                if mc.name == "gpt-4o-mini":
+                    mc.is_visible = False
+            db_session.commit()
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=config_v2,
+            )
+
+            # Deliberately no expire_all: this is the state put_llm_provider
+            # serializes straight after the sync returns.
+            visibility = {
+                mc.name: mc.is_visible for mc in provider.model_configurations
+            }
+            assert visibility["gpt-4-turbo"] is False, (
+                "The hide must reach the loaded row, not just the database"
+            )
+            assert visibility["gpt-4o-mini"] is True, (
+                "The restore must reach the loaded row, not just the database"
+            )
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -16,12 +16,14 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import (
     fetch_auto_mode_providers,
+    fetch_default_craft_model,
     fetch_default_llm_model,
     fetch_existing_llm_provider,
     fetch_existing_llm_providers,
     fetch_llm_provider_view,
     remove_llm_provider,
     sync_auto_mode_models,
+    update_default_craft_provider,
     update_default_provider,
 )
 from onyx.llm.constants import LlmProviderNames
@@ -1322,6 +1324,187 @@ class TestAutoModeTransitionsAndResync:
             default_model = fetch_default_llm_model(db_session)
             assert default_model is not None
             assert default_model.name == "gpt-4o"
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)
+
+
+class TestAutoModeSyncKeepsDefaultModelsVisible:
+    """Sync only re-points the chat default. A model holding any other default
+    must stay visible, or the admin can no longer see or change that default."""
+
+    def test_sync_keeps_a_dropped_craft_default_visible(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """A model holding the Craft default is not hidden when the config
+        drops it. Nothing re-points Craft, so hiding the model would strand the
+        default on a model the admin cannot select.
+
+        Steps:
+        1. Create provider with config: default=gpt-4o, additional=[gpt-4o-mini].
+        2. Point the Craft default at gpt-4o-mini.
+        3. Re-sync with config: default=gpt-4o (gpt-4o-mini removed).
+        4. Verify gpt-4o-mini stays visible and still holds the Craft default.
+        """
+        config_v1 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini"],
+        )
+        config_v2 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=[],
+        )
+
+        try:
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=config_v1,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        name=provider_name,
+                        provider=LlmProviderNames.OPENAI,
+                        api_key="sk-test-key-00000000000000000000000000000000000",
+                        api_key_changed=True,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=True,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_craft_provider(provider.id, "gpt-4o-mini", db_session)
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=config_v2,
+            )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            visibility = {
+                mc.name: mc.is_visible for mc in provider.model_configurations
+            }
+            assert visibility["gpt-4o-mini"] is True, (
+                "A model holding the Craft default must stay visible, even once "
+                "the config drops it"
+            )
+
+            craft_default = fetch_default_craft_model(db_session)
+            assert craft_default is not None
+            assert craft_default.name == "gpt-4o-mini"
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)
+
+    def test_sync_keeps_a_model_visible_for_the_defaults_it_still_holds(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """One model can hold several defaults. Giving up the chat default is
+        not enough to hide it while it still holds another.
+
+        Steps:
+        1. Create provider with config: default=gpt-4o, additional=[gpt-4o-mini].
+        2. Point both the chat default and the Craft default at gpt-4o.
+        3. Re-sync with config: default=gpt-4o-mini (gpt-4o removed).
+        4. Verify chat re-points to gpt-4o-mini, and gpt-4o stays visible
+           because it still holds Craft.
+        """
+        config_v1 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini"],
+        )
+        config_v2 = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o-mini",
+            additional_models=[],
+        )
+
+        try:
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=config_v1,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        name=provider_name,
+                        provider=LlmProviderNames.OPENAI,
+                        api_key="sk-test-key-00000000000000000000000000000000000",
+                        api_key_changed=True,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=True,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_provider(provider.id, "gpt-4o", db_session)
+            update_default_craft_provider(provider.id, "gpt-4o", db_session)
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=config_v2,
+            )
+
+            db_session.expire_all()
+            chat_default = fetch_default_llm_model(db_session)
+            assert chat_default is not None
+            assert chat_default.name == "gpt-4o-mini", (
+                "The chat default should follow the new recommendation"
+            )
+
+            craft_default = fetch_default_craft_model(db_session)
+            assert craft_default is not None
+            assert craft_default.name == "gpt-4o"
+
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            visibility = {
+                mc.name: mc.is_visible for mc in provider.model_configurations
+            }
+            assert visibility["gpt-4o"] is True, (
+                "gpt-4o gave up the chat default but still holds Craft, so it "
+                "must stay visible"
+            )
+            assert visibility["gpt-4o-mini"] is True
 
         finally:
             db_session.rollback()


### PR DESCRIPTION
## Description

Auto mode hides every model the recommendations config drops, then re-points **only** the chat default. A model holding the vision, reasoning, contextual RAG, chat naming or Craft default was hidden with that default still on it, so an admin could no longer see or change it.

Every other write path keeps a default model visible — `_update_default_model__no_commit` sets `is_visible = True` when a model becomes a default. `sync_auto_mode_models` was the one path that broke the invariant.

The fix moves the hide pass to run *after* the chat default is re-pointed, then skips any model that still holds a default:

```python
db_session.flush()
defaults_by_model_id = fetch_default_flows_by_model_id(db_session)

for model_name, model in existing_models.items():
    if model_name in recommended_visible_model_names:
        continue
    if model.is_visible and not defaults_by_model_id.get(model.id):
        model.is_visible = False
        changes += 1
```

The ordering matters. Re-pointing chat first means a model that *gives up* the chat default is still hidden as before, while a model that also holds Craft stays visible.

## How Has This Been Tested?

Two new external dependency unit tests in `test_llm_provider_auto_mode.py`:

- `test_sync_keeps_a_dropped_craft_default_visible` — a model holding the Craft default is not hidden when the config drops it.
- `test_sync_keeps_a_model_visible_for_the_defaults_it_still_holds` — one model holds both the chat and Craft defaults; chat re-points to the new recommendation, and the model stays visible for Craft.

Both fail against unmodified `main` with the intended assertions, and pass with the fix.

Full `backend/tests/external_dependency_unit/llm/` failure sets were diffed between `main` and this branch: 11 failures before, 9 after, **zero regressions**. The two that flip to passing are exactly the new tests. The 9 that remain are pre-existing live-provider failures unrelated to this change (Ollama not running locally, OpenAI 500s).

`ty`, `ruff`, and `ruff format` pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto mode hiding models that still hold a non-chat deployment default, which stranded that default on an invisible model. The hide pass now runs after the chat default is re-pointed, skips any model still holding a default, and restores models an earlier sync hid while holding one.

- Visibility checks happen in SQL to avoid race conditions.
- The visibility writes synchronize with the session so callers like `put_llm_provider` don't serialize stale visibility.
- Models that give up the chat default are still hidden as before.
- Models holding vision, reasoning, contextual RAG, chat naming, or Craft defaults stay visible.
- Adds four tests: a dropped Craft default stays visible, a model holding both chat and Craft stays visible after chat re-points, a previously hidden default-holder is restored, and loaded provider rows reflect the visibility changes.

<sup>Written for commit b5095e5a19fa96f22abc0a5eebf124de4b3037bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

