### PR TITLE
docs(greptile): codify that the backend API has non-web consumers

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -37,6 +37,21 @@ Routes not starting with `/api` are not caught by the existing `^/(api|openapi\.
 
 The route must ALSO be covered in Helm ingress mode (`ingress.enabled=true`), which does not use the bundled nginx. Add a dedicated ingress template for the route (see `deployment/helm/charts/onyx/templates/ingress-scim.yaml`). `ingress-api.yaml` cannot host it, since that resource only routes `/api` and its resource-wide rewrite annotation strips other prefixes. If the web app owns a sub-path of the route (for example an IdP callback page), carve that sub-path back out to the webserver with `pathType: Exact`, following `ingress-mcp-oauth-callback.yaml`.
 
+## Backend API Consumers Beyond the Web App
+
+The backend HTTP API is not consumed only by `web/`. Changing a route path, its request or response model, or its auth requirements is a breaking change for consumers that no frontend build or type check will catch:
+
+- `backend/onyx/mcp_server/` — MCP tools and resources call the API over HTTP, forwarding the caller's bearer token, and parse responses with the backend's own Pydantic models. A renamed or removed field breaks them at runtime, not at build time.
+- `terraform-provider-onyx/internal/client/` — a Go client with hand-written request and response structs. It depends heavily on **admin** routes (`/admin/api-key`, `/admin/persona`, `/manage/admin/connector`, `/manage/admin/cc-pair`, `/manage/admin/document-set`, `/manage/admin/user-group`) as well as non-admin ones like `/persona`. "This is only an admin endpoint" is not a reason to treat a change as safe.
+- `mobile/` and `desktop/`.
+- External customers calling the API directly with a Personal Access Token or API key.
+
+When a change touches a route or a model it returns, check whether these consumers reference the path before treating the change as web-only. Prefer additive changes: adding an optional field is safe, renaming or removing one is not.
+
+Routes tagged `PUBLIC_API_TAGS` are a published contract. `backend/scripts/transform_openapi_for_docs.py` filters on the `public` tag to build the customer-facing API documentation, so those paths, parameters and response fields are visible to customers and should only change additively.
+
+Any route intended to be reachable programmatically must declare an auth marker: either `Depends(require_permission(...))` or `dependencies=[Depends(scope_exempt)]`. `_scoped_pat_permitted_on_route` in `backend/onyx/auth/users.py` fails closed — a route whose auth dependency carries neither marker rejects scoped Personal Access Tokens with `INSUFFICIENT_PERMISSIONS`, while still working with a session cookie or an unscoped token. This is easy to miss, because the web app only ever authenticates with a session.
+
 ## Full vs Lite Deployments
 
 Code changes must consider both regular Onyx deployments and Onyx lite deployments. Lite deployments disable the vector DB, Redis, model servers, and background workers by default, use PostgreSQL-backed cache/auth/file storage, and rely on the API server to handle background work. Do not assume those services are available unless the code path is explicitly limited to full deployments.


### PR DESCRIPTION
## Description

Adds one section to `.greptile/rules.md`: **Backend API Consumers Beyond the Web App**.

The backend HTTP API is no longer consumed only by `web/`. The MCP server, the Terraform provider, mobile and desktop, and external callers using a PAT or API key all depend on it. None of them break the web build, so a route or model change that breaks them passes CI and review unnoticed. This gives the reviewer that context.

It records three things that cannot be inferred from a diff:

- **Who the consumers are, and which routes they depend on.** Worth calling out that `terraform-provider-onyx/internal/client/` leans heavily on *admin* routes (`/admin/api-key`, `/admin/persona`, `/manage/admin/connector`, `/manage/admin/cc-pair`, `/manage/admin/document-set`, `/manage/admin/user-group`) as well as `/persona` — so "this is only an admin endpoint" is not a safety argument. The MCP server parses responses with the backend's own Pydantic models, so a renamed field breaks it at runtime rather than at build time.
- **`PUBLIC_API_TAGS` marks a published contract.** `backend/scripts/transform_openapi_for_docs.py` filters on the `public` tag to build the customer-facing API docs, so those paths and response fields are customer-visible and should change only additively.
- **The scoped-PAT auth marker.** `_scoped_pat_permitted_on_route` in `backend/onyx/auth/users.py` fails closed: a route whose auth dependency carries neither `require_permission(...)` nor `Depends(scope_exempt)` rejects scoped Personal Access Tokens with `INSUFFICIENT_PERMISSIONS` while still working from the web app. This one is genuinely easy to miss, since the web app only ever authenticates with a session — it was hit for real on `GET /persona` in #14465.

Docs only. No code or behaviour changes.

## How Has This Been Tested?

Not applicable — this changes reviewer instructions, not code. Every claim was verified against the tree before writing:

- Terraform route paths read from `terraform-provider-onyx/internal/client/*.go`.
- The `public` tag filter confirmed in `backend/scripts/transform_openapi_for_docs.py`, and `PUBLIC_API_TAGS` in `backend/onyx/configs/constants.py`.
- The fail-closed scoped-PAT behaviour confirmed by evaluating `_scoped_pat_permitted_on_route` against the live route table.

pre-commit clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a section to `.greptile/rules.md` codifying that the backend HTTP API is used by more than `web/` — the MCP server, Terraform provider, mobile/desktop, and external callers with PATs/API keys — so reviewers can catch breaking changes that no frontend build would catch.

- Records which consumers depend on which routes, including the Terraform provider's heavy reliance on admin routes.
- Notes that `PUBLIC_API_TAGS` marks a published contract because the docs pipeline filters on that tag.
- Documents the fail-closed scoped-PAT auth marker that silently rejects scoped PATs while still working from the web app.

Docs only; no code or behavior changes.

<sup>Written for commit 39c93f38132c55b274636527b93572b95e30c639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

