### PR TITLE
feat(mcp): resolve search filters on the call and teach on failure

### DIFF
--- a/backend/onyx/mcp_server/README.md
+++ b/backend/onyx/mcp_server/README.md
@@ -95,6 +95,8 @@ Pass `agent` with an agent name to run the search as that Onyx agent. The search
 
 `agent` and `document_set_names` are mutually exclusive. Explicit document sets replace an agent's knowledge scope rather than narrowing it, so passing both is rejected instead of silently returning out-of-scope results.
 
+Filter values resolve on the search call, so clients do not need a lookup call first. `agent`, `source_types` and `document_set_names` are all validated: a value that does not resolve returns an error naming close matches, or the available values when there are few of them, rather than being dropped. A dropped filter would return a wider result set that looks correctly scoped, so these fail instead.
+
 2. `search_web`
 Search the public internet for current events and general knowledge. Returns web search results with titles, URLs, and snippets.
 

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -1,6 +1,8 @@
 """Search tools for MCP server - document and web search."""
 
+import difflib
 import time
+from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
 
@@ -14,6 +16,7 @@ from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import (
     AgentEntry,
     get_accessible_agents,
+    get_accessible_document_sets,
     get_http_client,
     get_indexed_sources,
     require_access_token,
@@ -100,8 +103,12 @@ def _error_payload(error: str) -> dict[str, Any]:
 
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
-# Keeps the unknown-agent error readable when a tenant has many agents.
-_MAX_AGENT_NAMES_IN_ERROR = 50
+# A full inventory duplicates the matching resource and costs tokens on every
+# failed call, so prefer near misses and only list everything when the
+# inventory is small enough to be cheap.
+_MAX_SUGGESTIONS = 5
+_SUGGESTION_CUTOFF = 0.6
+_MAX_NAMES_IN_ERROR = 10
 
 
 def _match_agents(agent: str, agents: list[AgentEntry]) -> list[AgentEntry]:
@@ -113,20 +120,33 @@ def _match_agents(agent: str, agents: list[AgentEntry]) -> list[AgentEntry]:
     return [entry for entry in agents if entry.name.casefold() == folded]
 
 
-def _unknown_agent_error(agent: str, agents: list[AgentEntry]) -> str:
-    """Name the valid agents so the caller can retry without a lookup call.
+def _unknown_value_error(
+    kind: str, supplied: str, available: Iterable[str], discover: str
+) -> str:
+    """Explain an unusable filter value without dumping the whole inventory.
 
-    An unresolvable agent has to fail rather than fall back to an unscoped
-    search — the wrong scope returned as if it were right is worse than an
-    error.
+    Near misses cover the common cause — a human-supplied name that is stale or
+    colloquial. When nothing is close the value has most likely been renamed or
+    removed, so say that instead. Either way the call fails rather than dropping
+    the filter, because a silently widened search reads as if it were scoped.
     """
-    if not agents:
-        return f"Agent '{agent}' not found. No agents are accessible to this user."
+    names = sorted(available)
+    if not names:
+        return f"{kind} '{supplied}' not found. None are accessible to this user."
 
-    names = sorted(entry.name for entry in agents)
-    shown = names[:_MAX_AGENT_NAMES_IN_ERROR]
-    suffix = f" (and {len(names) - len(shown)} more)" if len(names) > len(shown) else ""
-    return f"Agent '{agent}' not found. Available agents: {', '.join(shown)}{suffix}."
+    suggestions = difflib.get_close_matches(
+        supplied, names, n=_MAX_SUGGESTIONS, cutoff=_SUGGESTION_CUTOFF
+    )
+    if suggestions:
+        return f"{kind} '{supplied}' not found. Did you mean: {', '.join(suggestions)}?"
+
+    if len(names) <= _MAX_NAMES_IN_ERROR:
+        return f"{kind} '{supplied}' not found. Available: {', '.join(names)}."
+
+    return (
+        f"{kind} '{supplied}' not found — it may have been renamed or removed. "
+        f"{discover}"
+    )
 
 
 def _record_requested_sources(source_types: list[str] | None) -> None:
@@ -158,11 +178,12 @@ async def search_indexed_documents(
     document selection, context expansion) — the same search quality as the
     Onyx chat interface.
 
-    To find a list of available sources, use the `indexed_sources` resource.
-    `document_set_names` restricts results to documents belonging to the named
-    Document Sets — useful for scoping queries to a curated subset of the
-    knowledge base (e.g. to isolate knowledge between agents). Use the
-    `document_sets` resource to discover accessible set names.
+    `source_types` restricts results to the named connector sources, and
+    `document_set_names` to documents in the named Document Sets — useful for
+    scoping a query to a curated subset of the knowledge base. Pass the values
+    the user gave you; no lookup call is needed first. A value that does not
+    resolve returns an error naming close matches or what is available, so you
+    can retry with a valid one rather than searching unscoped.
     `time_cutoff` accepts an ISO 8601 timestamp; only documents updated on or
     after that moment are returned. Naive (timezone-less) timestamps are
     treated as UTC server-side.
@@ -171,12 +192,10 @@ async def search_indexed_documents(
     expansion).
     `agent` runs the search as a named Onyx agent, applying that agent's
     knowledge scope (its document sets, attached documents and start date) and
-    its configured model. Pass the name the user gave you — no lookup call is
-    needed first. If the name does not resolve, the error names the agents
-    available to this user, so you can retry with a valid one. Use the `agents`
-    resource to browse them. `agent` and `document_set_names` are mutually
-    exclusive: explicit document sets replace an agent's knowledge scope rather
-    than narrowing it, so passing both is rejected.
+    its configured model. It resolves the same way as the filters above.
+    `agent` and `document_set_names` are mutually exclusive: explicit document
+    sets replace an agent's knowledge scope rather than narrowing it, so passing
+    both is rejected.
 
     Returns ``{"results": [{title, url, source_type, content, updated_at},
     ...]}``. Results are ordered by LLM-judged relevance. ``content`` is the
@@ -252,7 +271,14 @@ async def search_indexed_documents(
 
             matches = _match_agents(agent, accessible_agents)
             if not matches:
-                return _error_payload(_unknown_agent_error(agent, accessible_agents))
+                return _error_payload(
+                    _unknown_value_error(
+                        "Agent",
+                        agent,
+                        (entry.name for entry in accessible_agents),
+                        "Read the `agents` resource for the current list.",
+                    )
+                )
             if len(matches) > 1:
                 return _error_payload(
                     f"Agent name '{agent}' is ambiguous: {len(matches)} accessible "
@@ -260,9 +286,12 @@ async def search_indexed_documents(
                 )
             persona_id = matches[0].id
 
-        if agent is None:
+        # Needed for the empty-tenant guard, and to validate a source_types
+        # filter against what this tenant actually has.
+        indexed_sources: list[str] = []
+        if agent is None or source_types is not None:
             try:
-                sources = await get_indexed_sources(access_token)
+                indexed_sources = await get_indexed_sources(access_token)
             except Exception as err:
                 logger.error(
                     "Onyx MCP Server: Error checking indexed sources: %s",
@@ -271,25 +300,55 @@ async def search_indexed_documents(
                 )
                 return _error_payload(f"Failed to check indexed sources: {str(err)}")
 
-            if not sources:
-                logger.info("Onyx MCP Server: No indexed sources available for tenant")
-                outcome = MCPToolCallStatus.SUCCESS
-                result_count = 0
-                return _error_payload(
-                    "No document sources are indexed yet. Add connectors or upload data "
-                    "through Onyx before calling search_indexed_documents."
-                )
+        if agent is None and not indexed_sources:
+            logger.info("Onyx MCP Server: No indexed sources available for tenant")
+            outcome = MCPToolCallStatus.SUCCESS
+            result_count = 0
+            return _error_payload(
+                "No document sources are indexed yet. Add connectors or upload data "
+                "through Onyx before calling search_indexed_documents."
+            )
 
+        # An unusable filter value fails instead of being dropped: a silently
+        # widened search is indistinguishable from a correctly scoped one.
         source_type_enums: list[DocumentSource] | None = None
         if source_types is not None:
+            available_sources = set(indexed_sources)
             source_type_enums = []
             for source_str in source_types:
-                try:
-                    source_type_enums.append(DocumentSource(source_str.lower()))
-                except ValueError:
-                    logger.warning(
-                        "Onyx MCP Server: Invalid source type '%s' - skipping",
-                        source_str,
+                canonical = source_str.lower()
+                if canonical not in available_sources:
+                    return _error_payload(
+                        _unknown_value_error(
+                            "Source type",
+                            source_str,
+                            available_sources,
+                            "Read the `indexed_sources` resource for the current list.",
+                        )
+                    )
+                source_type_enums.append(DocumentSource(canonical))
+
+        if document_set_names is not None:
+            try:
+                accessible_sets = await get_accessible_document_sets(access_token)
+            except Exception as err:
+                logger.error(
+                    "Onyx MCP Server: Error fetching document sets: %s",
+                    err,
+                    exc_info=True,
+                )
+                return _error_payload(f"Failed to look up document sets: {str(err)}")
+
+            available_set_names = {entry.name for entry in accessible_sets}
+            for set_name in document_set_names:
+                if set_name not in available_set_names:
+                    return _error_payload(
+                        _unknown_value_error(
+                            "Document set",
+                            set_name,
+                            available_set_names,
+                            "Read the `document_sets` resource for the current list.",
+                        )
                     )
 
         try:

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -15,6 +15,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import (
     AgentEntry,
+    DocumentSetEntry,
     get_accessible_agents,
     get_accessible_document_sets,
     get_http_client,
@@ -101,6 +102,17 @@ def _error_payload(error: str) -> dict[str, Any]:
     return {"error": error, "results": []}
 
 
+def _is_forbidden(err: Exception) -> bool:
+    """Whether the caller's token may not read an inventory endpoint.
+
+    The inventory endpoints require BASIC_ACCESS, which no PAT scope grants —
+    it is not in SELECTABLE_PAT_SCOPES — so every scoped token is refused.
+    Filter validation is a convenience and must never block a search the token
+    is otherwise allowed to run, so a 403 degrades to skipping validation.
+    """
+    return isinstance(err, httpx.HTTPStatusError) and err.response.status_code == 403
+
+
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
 # A full inventory duplicates the matching resource and costs tokens on every
@@ -147,6 +159,162 @@ def _unknown_value_error(
         f"{kind} '{supplied}' not found — it may have been renamed or removed. "
         f"{discover}"
     )
+
+
+class _FilterError(Exception):
+    """An unusable filter value. The message is returned to the caller."""
+
+
+class _NoIndexedSources(Exception):
+    """Nothing is indexed and no agent supplied knowledge of its own."""
+
+
+async def _resolve_agent(agent: str, access_token: AccessToken) -> int:
+    """Resolve an agent name to its persona id."""
+    try:
+        accessible_agents = await get_accessible_agents(access_token)
+    except Exception as err:
+        logger.error("Onyx MCP Server: Error fetching agents: %s", err, exc_info=True)
+        raise _FilterError(f"Failed to look up agents: {str(err)}") from err
+
+    matches = _match_agents(agent, accessible_agents)
+    if not matches:
+        raise _FilterError(
+            _unknown_value_error(
+                "Agent",
+                agent,
+                (entry.name for entry in accessible_agents),
+                "Read the `agents` resource for the current list.",
+            )
+        )
+    if len(matches) > 1:
+        raise _FilterError(
+            f"Agent name '{agent}' is ambiguous: {len(matches)} accessible "
+            "agents share it. Ask the user which one they mean."
+        )
+    return matches[0].id
+
+
+async def _load_indexed_sources(access_token: AccessToken) -> list[str] | None:
+    """The tenant's filterable sources, or None when the token may not list them."""
+    try:
+        return await get_indexed_sources(access_token)
+    except Exception as err:
+        if not _is_forbidden(err):
+            logger.error(
+                "Onyx MCP Server: Error checking indexed sources: %s",
+                err,
+                exc_info=True,
+            )
+            raise _FilterError(f"Failed to check indexed sources: {str(err)}") from err
+        logger.info(
+            "Onyx MCP Server: token may not list indexed sources; "
+            "searching without the source inventory"
+        )
+        return None
+
+
+def _resolve_source_types(
+    source_types: list[str], available: set[str] | None
+) -> list[DocumentSource]:
+    """Convert supplied source names, rejecting any this tenant cannot filter on."""
+    resolved: list[DocumentSource] = []
+    for source_str in source_types:
+        canonical = source_str.lower()
+        if available is not None and canonical not in available:
+            raise _FilterError(
+                _unknown_value_error(
+                    "Source type",
+                    source_str,
+                    available,
+                    "Read the `indexed_sources` resource for the current list.",
+                )
+            )
+        try:
+            resolved.append(DocumentSource(canonical))
+        except ValueError:
+            # Only reachable when the inventory was unavailable; an unparseable
+            # source would otherwise have been rejected above.
+            logger.warning(
+                "Onyx MCP Server: Invalid source type '%s' - skipping", source_str
+            )
+    return resolved
+
+
+async def _validate_document_sets(
+    document_set_names: list[str], access_token: AccessToken
+) -> None:
+    """Reject names the user cannot filter on, so the scope is never silently wider."""
+    accessible_sets: list[DocumentSetEntry] | None
+    try:
+        accessible_sets = await get_accessible_document_sets(access_token)
+    except Exception as err:
+        if not _is_forbidden(err):
+            logger.error(
+                "Onyx MCP Server: Error fetching document sets: %s", err, exc_info=True
+            )
+            raise _FilterError(f"Failed to look up document sets: {str(err)}") from err
+        logger.info(
+            "Onyx MCP Server: token may not list document sets; "
+            "passing the filter through unvalidated"
+        )
+        return
+
+    available_set_names: set[str] = {entry.name for entry in accessible_sets}
+    for set_name in document_set_names:
+        if set_name not in available_set_names:
+            raise _FilterError(
+                _unknown_value_error(
+                    "Document set",
+                    set_name,
+                    available_set_names,
+                    "Read the `document_sets` resource for the current list.",
+                )
+            )
+
+
+async def _resolve_filters(
+    access_token: AccessToken,
+    source_types: list[str] | None,
+    document_set_names: list[str] | None,
+    agent: str | None,
+) -> tuple[int | None, list[DocumentSource] | None]:
+    """Resolve every filter up front so an unusable value fails before searching.
+
+    A value that cannot be honoured raises rather than being dropped: a silently
+    widened search is indistinguishable from a correctly scoped one.
+    """
+    # _build_index_filters lets explicit document sets *replace* the agent's own
+    # sets rather than narrow them, so honouring both would silently search
+    # outside the agent's knowledge scope.
+    if agent is not None and document_set_names is not None:
+        raise _FilterError(
+            "Pass either `agent` or `document_set_names`, not both. Explicit "
+            "document sets replace an agent's knowledge scope instead of "
+            "narrowing it, so the results would not be scoped to the agent."
+        )
+
+    # Resolve the agent before the indexed-sources guard: a bad name deserves
+    # its own actionable error, and an agent can carry attached documents even
+    # when no connector has indexed anything.
+    persona_id = await _resolve_agent(agent, access_token) if agent else None
+
+    indexed_sources: list[str] | None = None
+    if agent is None or source_types is not None:
+        indexed_sources = await _load_indexed_sources(access_token)
+
+    if agent is None and indexed_sources is not None and not indexed_sources:
+        raise _NoIndexedSources()
+
+    source_type_enums: list[DocumentSource] | None = None
+    if source_types is not None:
+        available = set(indexed_sources) if indexed_sources is not None else None
+        source_type_enums = _resolve_source_types(source_types, available)
+
+    if document_set_names is not None:
+        await _validate_document_sets(document_set_names, access_token)
+
+    return persona_id, source_type_enums
 
 
 def _record_requested_sources(source_types: list[str] | None) -> None:
@@ -246,61 +414,16 @@ async def search_indexed_documents(
     result_count: int | None = None
 
     try:
-        # _build_index_filters lets explicit document sets *replace* the
-        # agent's own sets rather than narrow them, so honouring both would
-        # silently search outside the agent's knowledge scope.
-        if agent is not None and document_set_names is not None:
-            return _error_payload(
-                "Pass either `agent` or `document_set_names`, not both. Explicit "
-                "document sets replace an agent's knowledge scope instead of "
-                "narrowing it, so the results would not be scoped to the agent."
+        try:
+            persona_id, source_type_enums = await _resolve_filters(
+                access_token=access_token,
+                source_types=source_types,
+                document_set_names=document_set_names,
+                agent=agent,
             )
-
-        # Resolve the agent before the indexed-sources guard below: a bad name
-        # deserves its own actionable error, and an agent can carry attached
-        # documents even when no connector has indexed anything.
-        persona_id: int | None = None
-        if agent is not None:
-            try:
-                accessible_agents = await get_accessible_agents(access_token)
-            except Exception as err:
-                logger.error(
-                    "Onyx MCP Server: Error fetching agents: %s", err, exc_info=True
-                )
-                return _error_payload(f"Failed to look up agents: {str(err)}")
-
-            matches = _match_agents(agent, accessible_agents)
-            if not matches:
-                return _error_payload(
-                    _unknown_value_error(
-                        "Agent",
-                        agent,
-                        (entry.name for entry in accessible_agents),
-                        "Read the `agents` resource for the current list.",
-                    )
-                )
-            if len(matches) > 1:
-                return _error_payload(
-                    f"Agent name '{agent}' is ambiguous: {len(matches)} accessible "
-                    "agents share it. Ask the user which one they mean."
-                )
-            persona_id = matches[0].id
-
-        # Needed for the empty-tenant guard, and to validate a source_types
-        # filter against what this tenant actually has.
-        indexed_sources: list[str] = []
-        if agent is None or source_types is not None:
-            try:
-                indexed_sources = await get_indexed_sources(access_token)
-            except Exception as err:
-                logger.error(
-                    "Onyx MCP Server: Error checking indexed sources: %s",
-                    err,
-                    exc_info=True,
-                )
-                return _error_payload(f"Failed to check indexed sources: {str(err)}")
-
-        if agent is None and not indexed_sources:
+        except _FilterError as err:
+            return _error_payload(str(err))
+        except _NoIndexedSources:
             logger.info("Onyx MCP Server: No indexed sources available for tenant")
             outcome = MCPToolCallStatus.SUCCESS
             result_count = 0
@@ -308,48 +431,6 @@ async def search_indexed_documents(
                 "No document sources are indexed yet. Add connectors or upload data "
                 "through Onyx before calling search_indexed_documents."
             )
-
-        # An unusable filter value fails instead of being dropped: a silently
-        # widened search is indistinguishable from a correctly scoped one.
-        source_type_enums: list[DocumentSource] | None = None
-        if source_types is not None:
-            available_sources = set(indexed_sources)
-            source_type_enums = []
-            for source_str in source_types:
-                canonical = source_str.lower()
-                if canonical not in available_sources:
-                    return _error_payload(
-                        _unknown_value_error(
-                            "Source type",
-                            source_str,
-                            available_sources,
-                            "Read the `indexed_sources` resource for the current list.",
-                        )
-                    )
-                source_type_enums.append(DocumentSource(canonical))
-
-        if document_set_names is not None:
-            try:
-                accessible_sets = await get_accessible_document_sets(access_token)
-            except Exception as err:
-                logger.error(
-                    "Onyx MCP Server: Error fetching document sets: %s",
-                    err,
-                    exc_info=True,
-                )
-                return _error_payload(f"Failed to look up document sets: {str(err)}")
-
-            available_set_names = {entry.name for entry in accessible_sets}
-            for set_name in document_set_names:
-                if set_name not in available_set_names:
-                    return _error_payload(
-                        _unknown_value_error(
-                            "Document set",
-                            set_name,
-                            available_set_names,
-                            "Read the `document_sets` resource for the current list.",
-                        )
-                    )
 
         try:
             parsed_cutoff = _TIME_CUTOFF_ADAPTER.validate_python(time_cutoff)

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -232,12 +232,14 @@ def _resolve_source_types(
             )
         try:
             resolved.append(DocumentSource(canonical))
-        except ValueError:
-            # Only reachable when the inventory was unavailable; an unparseable
-            # source would otherwise have been rejected above.
-            logger.warning(
-                "Onyx MCP Server: Invalid source type '%s' - skipping", source_str
-            )
+        except ValueError as err:
+            # Only reachable when the inventory was unavailable. Dropping the
+            # value would leave an empty source list, and the retrieval layer
+            # adds no clause at all for that (`if source_types:`), so the
+            # search would silently widen to every accessible source.
+            raise _FilterError(
+                f"Source type '{source_str}' is not a known Onyx source."
+            ) from err
     return resolved
 
 
@@ -401,9 +403,9 @@ async def search_indexed_documents(
 
     _record_requested_sources(source_types)
 
-    # Normalize empty list inputs to None so downstream filter construction is
-    # consistent — BaseFilters treats [] as "match zero" which differs from
-    # "no filter" (None).
+    # Normalize empty inputs to None so "not supplied" is explicit at the
+    # boundary. Retrieval adds no clause for an empty list, so letting one
+    # through as a filter would read as a scoped search that is not scoped.
     source_types = source_types or None
     document_set_names = document_set_names or None
     agent = (agent or "").strip() or None

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -102,17 +102,6 @@ def _error_payload(error: str) -> dict[str, Any]:
     return {"error": error, "results": []}
 
 
-def _is_forbidden(err: Exception) -> bool:
-    """Whether the caller's token may not read an inventory endpoint.
-
-    The inventory endpoints require BASIC_ACCESS, which no PAT scope grants —
-    it is not in SELECTABLE_PAT_SCOPES — so every scoped token is refused.
-    Filter validation is a convenience and must never block a search the token
-    is otherwise allowed to run, so a 403 degrades to skipping validation.
-    """
-    return isinstance(err, httpx.HTTPStatusError) and err.response.status_code == 403
-
-
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
 # A full inventory duplicates the matching resource and costs tokens on every
@@ -195,33 +184,30 @@ async def _resolve_agent(agent: str, access_token: AccessToken) -> int:
     return matches[0].id
 
 
-async def _load_indexed_sources(access_token: AccessToken) -> list[str] | None:
-    """The tenant's filterable sources, or None when the token may not list them."""
+async def _load_indexed_sources(access_token: AccessToken) -> list[str]:
+    """The tenant's filterable sources.
+
+    Reachable by anything that can reach /search: both reads require
+    READ_SEARCH, so a caller authorized to search is authorized to list what
+    it may filter by.
+    """
     try:
         return await get_indexed_sources(access_token)
     except Exception as err:
-        if not _is_forbidden(err):
-            logger.error(
-                "Onyx MCP Server: Error checking indexed sources: %s",
-                err,
-                exc_info=True,
-            )
-            raise _FilterError(f"Failed to check indexed sources: {str(err)}") from err
-        logger.info(
-            "Onyx MCP Server: token may not list indexed sources; "
-            "searching without the source inventory"
+        logger.error(
+            "Onyx MCP Server: Error checking indexed sources: %s", err, exc_info=True
         )
-        return None
+        raise _FilterError(f"Failed to check indexed sources: {str(err)}") from err
 
 
 def _resolve_source_types(
-    source_types: list[str], available: set[str] | None
+    source_types: list[str], available: set[str]
 ) -> list[DocumentSource]:
     """Convert supplied source names, rejecting any this tenant cannot filter on."""
     resolved: list[DocumentSource] = []
     for source_str in source_types:
         canonical = source_str.lower()
-        if available is not None and canonical not in available:
+        if canonical not in available:
             raise _FilterError(
                 _unknown_value_error(
                     "Source type",
@@ -230,16 +216,8 @@ def _resolve_source_types(
                     "Read the `indexed_sources` resource for the current list.",
                 )
             )
-        try:
-            resolved.append(DocumentSource(canonical))
-        except ValueError as err:
-            # Only reachable when the inventory was unavailable. Dropping the
-            # value would leave an empty source list, and the retrieval layer
-            # adds no clause at all for that (`if source_types:`), so the
-            # search would silently widen to every accessible source.
-            raise _FilterError(
-                f"Source type '{source_str}' is not a known Onyx source."
-            ) from err
+        # Membership in the inventory guarantees this parses.
+        resolved.append(DocumentSource(canonical))
     return resolved
 
 
@@ -247,20 +225,14 @@ async def _validate_document_sets(
     document_set_names: list[str], access_token: AccessToken
 ) -> None:
     """Reject names the user cannot filter on, so the scope is never silently wider."""
-    accessible_sets: list[DocumentSetEntry] | None
+    accessible_sets: list[DocumentSetEntry]
     try:
         accessible_sets = await get_accessible_document_sets(access_token)
     except Exception as err:
-        if not _is_forbidden(err):
-            logger.error(
-                "Onyx MCP Server: Error fetching document sets: %s", err, exc_info=True
-            )
-            raise _FilterError(f"Failed to look up document sets: {str(err)}") from err
-        logger.info(
-            "Onyx MCP Server: token may not list document sets; "
-            "passing the filter through unvalidated"
+        logger.error(
+            "Onyx MCP Server: Error fetching document sets: %s", err, exc_info=True
         )
-        return
+        raise _FilterError(f"Failed to look up document sets: {str(err)}") from err
 
     available_set_names: set[str] = {entry.name for entry in accessible_sets}
     for set_name in document_set_names:
@@ -301,17 +273,16 @@ async def _resolve_filters(
     # when no connector has indexed anything.
     persona_id = await _resolve_agent(agent, access_token) if agent else None
 
-    indexed_sources: list[str] | None = None
+    indexed_sources: list[str] = []
     if agent is None or source_types is not None:
         indexed_sources = await _load_indexed_sources(access_token)
 
-    if agent is None and indexed_sources is not None and not indexed_sources:
+    if agent is None and not indexed_sources:
         raise _NoIndexedSources()
 
     source_type_enums: list[DocumentSource] | None = None
     if source_types is not None:
-        available = set(indexed_sources) if indexed_sources is not None else None
-        source_type_enums = _resolve_source_types(source_types, available)
+        source_type_enums = _resolve_source_types(source_types, set(indexed_sources))
 
     if document_set_names is not None:
         await _validate_document_sets(document_set_names, access_token)

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -1,8 +1,8 @@
 """Search tools for MCP server - document and web search."""
 
-import difflib
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -15,7 +15,6 @@ from onyx.configs.constants import DocumentSource
 from onyx.mcp_server.api import mcp_server
 from onyx.mcp_server.utils import (
     AgentEntry,
-    DocumentSetEntry,
     get_accessible_agents,
     get_accessible_document_sets,
     get_http_client,
@@ -104,11 +103,8 @@ def _error_payload(error: str) -> dict[str, Any]:
 
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
-# A full inventory duplicates the matching resource and costs tokens on every
-# failed call, so prefer near misses and only list everything when the
-# inventory is small enough to be cheap.
-_MAX_SUGGESTIONS = 5
-_SUGGESTION_CUTOFF = 0.6
+# Listing the whole inventory duplicates the matching resource and costs tokens
+# on every failed call, so only name the alternatives while that is cheap.
 _MAX_NAMES_IN_ERROR = 10
 
 
@@ -124,22 +120,14 @@ def _match_agents(agent: str, agents: list[AgentEntry]) -> list[AgentEntry]:
 def _unknown_value_error(
     kind: str, supplied: str, available: Iterable[str], discover: str
 ) -> str:
-    """Explain an unusable filter value without dumping the whole inventory.
+    """Explain an unusable filter value, naming the alternatives while cheap.
 
-    Near misses cover the common cause — a human-supplied name that is stale or
-    colloquial. When nothing is close the value has most likely been renamed or
-    removed, so say that instead. Either way the call fails rather than dropping
-    the filter, because a silently widened search reads as if it were scoped.
+    The call fails rather than dropping the filter, because a silently widened
+    search is indistinguishable from a correctly scoped one.
     """
     names = sorted(available)
     if not names:
         return f"{kind} '{supplied}' not found. None are accessible to this user."
-
-    suggestions = difflib.get_close_matches(
-        supplied, names, n=_MAX_SUGGESTIONS, cutoff=_SUGGESTION_CUTOFF
-    )
-    if suggestions:
-        return f"{kind} '{supplied}' not found. Did you mean: {', '.join(suggestions)}?"
 
     if len(names) <= _MAX_NAMES_IN_ERROR:
         return f"{kind} '{supplied}' not found. Available: {', '.join(names)}."
@@ -151,7 +139,18 @@ def _unknown_value_error(
 
 
 class _FilterError(Exception):
-    """An unusable filter value. The message is returned to the caller."""
+    """A filter value the caller supplied that cannot be honoured.
+
+    Carries a caller-facing message that goes back verbatim. Anything else —
+    a failed lookup, an unexpected error — falls through to the tool's generic
+    handler instead, which is what makes this type worth distinguishing.
+    """
+
+
+@dataclass
+class _ResolvedFilters:
+    persona_id: int | None
+    source_types: list[DocumentSource] | None
 
 
 class _NoIndexedSources(Exception):
@@ -160,12 +159,7 @@ class _NoIndexedSources(Exception):
 
 async def _resolve_agent(agent: str, access_token: AccessToken) -> int:
     """Resolve an agent name to its persona id."""
-    try:
-        accessible_agents = await get_accessible_agents(access_token)
-    except Exception as err:
-        logger.error("Onyx MCP Server: Error fetching agents: %s", err, exc_info=True)
-        raise _FilterError(f"Failed to look up agents: {str(err)}") from err
-
+    accessible_agents = await get_accessible_agents(access_token)
     matches = _match_agents(agent, accessible_agents)
     if not matches:
         raise _FilterError(
@@ -184,67 +178,41 @@ async def _resolve_agent(agent: str, access_token: AccessToken) -> int:
     return matches[0].id
 
 
-async def _load_indexed_sources(access_token: AccessToken) -> list[str]:
-    """The tenant's filterable sources.
-
-    Reachable by anything that can reach /search: both reads require
-    READ_SEARCH, so a caller authorized to search is authorized to list what
-    it may filter by.
-    """
-    try:
-        return await get_indexed_sources(access_token)
-    except Exception as err:
-        logger.error(
-            "Onyx MCP Server: Error checking indexed sources: %s", err, exc_info=True
-        )
-        raise _FilterError(f"Failed to check indexed sources: {str(err)}") from err
-
-
 def _resolve_source_types(
     source_types: list[str], available: set[str]
 ) -> list[DocumentSource]:
     """Convert supplied source names, rejecting any this tenant cannot filter on."""
-    resolved: list[DocumentSource] = []
-    for source_str in source_types:
-        canonical = source_str.lower()
-        if canonical not in available:
-            raise _FilterError(
-                _unknown_value_error(
-                    "Source type",
-                    source_str,
-                    available,
-                    "Read the `indexed_sources` resource for the current list.",
-                )
+    canonical = [source.lower() for source in source_types]
+    unknown = sorted(set(canonical) - available)
+    if unknown:
+        raise _FilterError(
+            _unknown_value_error(
+                "Source type",
+                unknown[0],
+                available,
+                "Read the `indexed_sources` resource for the current list.",
             )
-        # Membership in the inventory guarantees this parses.
-        resolved.append(DocumentSource(canonical))
-    return resolved
+        )
+    # Membership in the inventory guarantees these parse.
+    return [DocumentSource(source) for source in canonical]
 
 
 async def _validate_document_sets(
     document_set_names: list[str], access_token: AccessToken
 ) -> None:
     """Reject names the user cannot filter on, so the scope is never silently wider."""
-    accessible_sets: list[DocumentSetEntry]
-    try:
-        accessible_sets = await get_accessible_document_sets(access_token)
-    except Exception as err:
-        logger.error(
-            "Onyx MCP Server: Error fetching document sets: %s", err, exc_info=True
-        )
-        raise _FilterError(f"Failed to look up document sets: {str(err)}") from err
-
-    available_set_names: set[str] = {entry.name for entry in accessible_sets}
-    for set_name in document_set_names:
-        if set_name not in available_set_names:
-            raise _FilterError(
-                _unknown_value_error(
-                    "Document set",
-                    set_name,
-                    available_set_names,
-                    "Read the `document_sets` resource for the current list.",
-                )
+    accessible_sets = await get_accessible_document_sets(access_token)
+    available: set[str] = {entry.name for entry in accessible_sets}
+    unknown = sorted(set(document_set_names) - available)
+    if unknown:
+        raise _FilterError(
+            _unknown_value_error(
+                "Document set",
+                unknown[0],
+                available,
+                "Read the `document_sets` resource for the current list.",
             )
+        )
 
 
 async def _resolve_filters(
@@ -252,7 +220,7 @@ async def _resolve_filters(
     source_types: list[str] | None,
     document_set_names: list[str] | None,
     agent: str | None,
-) -> tuple[int | None, list[DocumentSource] | None]:
+) -> _ResolvedFilters:
     """Resolve every filter up front so an unusable value fails before searching.
 
     A value that cannot be honoured raises rather than being dropped: a silently
@@ -275,7 +243,7 @@ async def _resolve_filters(
 
     indexed_sources: list[str] = []
     if agent is None or source_types is not None:
-        indexed_sources = await _load_indexed_sources(access_token)
+        indexed_sources = await get_indexed_sources(access_token)
 
     if agent is None and not indexed_sources:
         raise _NoIndexedSources()
@@ -287,7 +255,7 @@ async def _resolve_filters(
     if document_set_names is not None:
         await _validate_document_sets(document_set_names, access_token)
 
-    return persona_id, source_type_enums
+    return _ResolvedFilters(persona_id=persona_id, source_types=source_type_enums)
 
 
 def _record_requested_sources(source_types: list[str] | None) -> None:
@@ -388,7 +356,7 @@ async def search_indexed_documents(
 
     try:
         try:
-            persona_id, source_type_enums = await _resolve_filters(
+            filters = await _resolve_filters(
                 access_token=access_token,
                 source_types=source_types,
                 document_set_names=document_set_names,
@@ -417,11 +385,11 @@ async def search_indexed_documents(
 
         request = SearchRequest(
             query=query,
-            sources=source_type_enums,
+            sources=filters.source_types,
             document_sets=document_set_names,
             time_cutoff=parsed_cutoff,
             skip_query_expansion=skip_query_expansion,
-            persona_id=persona_id,
+            persona_id=filters.persona_id,
         )
         endpoint = f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/search"
         response = await _post_model(endpoint, request, access_token)

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -295,6 +295,18 @@ def test_mcp_search_filters_by_document_set(
     assert any(in_set_content in content for content in filtered_contents)
     assert all(out_of_set_content not in content for content in filtered_contents)
 
+    # A name that does not resolve must fail with a usable hint rather than be
+    # dropped, which would return a wider result set that looks scoped.
+    unknown_payload = _extract_tool_payload(
+        _call_search_tool(
+            headers,
+            shared_phrase,
+            document_set_names=[f"{doc_set.name}-does-not-exist"],
+        )
+    )
+    assert unknown_payload["results"] == []
+    assert doc_set.name in unknown_payload["error"]
+
     # An empty document_set_names should behave like "no filter" (normalized
     # to None), not "match zero sets".
     empty_list_payload = _extract_tool_payload(

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -405,13 +405,14 @@ def test_mcp_search_scopes_to_agent(
     assert "no-such-agent" in unknown_payload["error"]
     assert persona.name in unknown_payload["error"]
 
-    # A scoped PAT must still resolve the agent name: /persona carries no
-    # require_permission marker, so it needs the scope_exempt marker to be
-    # reachable at all.
+    # A scoped PAT must still resolve the agent name and search. READ_SEARCH is
+    # the whole token: BASIC_ACCESS is not in SELECTABLE_PAT_SCOPES and
+    # READ_SEARCH does not imply it, so the inventory endpoints refuse this
+    # token and the tool has to degrade rather than fail the search.
     scoped_pat_headers = _auth_headers(
         admin_user,
         name="mcp-agent-scope-scoped-pat",
-        scopes=[Permission.BASIC_ACCESS, Permission.READ_SEARCH],
+        scopes=[Permission.READ_SEARCH],
     )
     scoped_pat_payload = _extract_tool_payload(
         _call_search_tool(scoped_pat_headers, shared_phrase, agent=persona.name)

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -405,10 +405,9 @@ def test_mcp_search_scopes_to_agent(
     assert "no-such-agent" in unknown_payload["error"]
     assert persona.name in unknown_payload["error"]
 
-    # A scoped PAT must still resolve the agent name and search. READ_SEARCH is
-    # the whole token: BASIC_ACCESS is not in SELECTABLE_PAT_SCOPES and
-    # READ_SEARCH does not imply it, so the inventory endpoints refuse this
-    # token and the tool has to degrade rather than fail the search.
+    # A scoped PAT must resolve the agent name and search. READ_SEARCH is the
+    # whole token: it covers /search, the filter listings the tool validates
+    # against, and /persona via its scope_exempt marker.
     scoped_pat_headers = _auth_headers(
         admin_user,
         name="mcp-agent-scope-scoped-pat",

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -31,6 +31,9 @@ class _Stub:
     agents: list[dict[str, Any]]
     sources: list[str]
     document_sets: list[dict[str, Any]]
+    # Stands in for a scoped PAT, which cannot hold BASIC_ACCESS.
+    forbid_inventory: bool = False
+    inventory_status: int | None = None
 
 
 async def _unreachable_indexed_sources(_access_token: AccessToken) -> list[str]:
@@ -55,6 +58,13 @@ async def stub(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_Stub, None]:
 
     def _handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
+        is_inventory = path.endswith("/manage/indexed-sources") or path.endswith(
+            "/manage/document-set"
+        )
+        if is_inventory and state.inventory_status is not None:
+            return httpx.Response(state.inventory_status, json={"detail": "boom"})
+        if is_inventory and state.forbid_inventory:
+            return httpx.Response(403, json={"detail": "insufficient permissions"})
         if path.endswith("/manage/indexed-sources"):
             return httpx.Response(200, json={"sources": state.sources})
         if path.endswith("/manage/document-set"):
@@ -223,6 +233,43 @@ async def test_unknown_document_set_errors_with_a_suggestion(stub: _Stub) -> Non
     assert payload["results"] == []
     assert "Did you mean" in payload["error"]
     assert "Engineering Wiki" in payload["error"]
+    assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
+async def test_search_survives_a_token_that_cannot_list_inventory(
+    stub: _Stub,
+) -> None:
+    """No PAT scope grants BASIC_ACCESS, so the inventory endpoints 403 for
+    every scoped token. Validation is a convenience and must not block a search
+    the token is allowed to run."""
+    stub.forbid_inventory = True
+
+    payload = await search_module.search_indexed_documents(
+        query="anything",
+        source_types=["github"],
+        document_set_names=["Engineering Wiki"],
+    )
+
+    assert "error" not in payload
+    sent = stub.search_requests[0]
+    assert sent["sources"] == ["github"]
+    assert sent["document_sets"] == ["Engineering Wiki"]
+
+
+@pytest.mark.asyncio
+async def test_inventory_failure_that_is_not_permissions_still_errors(
+    stub: _Stub,
+) -> None:
+    """A 500 is real trouble, not a scope limitation — keep failing loudly."""
+    stub.inventory_status = 500
+
+    payload = await search_module.search_indexed_documents(
+        query="anything", source_types=["github"]
+    )
+
+    assert payload["results"] == []
+    assert "Failed to check indexed sources" in payload["error"]
     assert stub.search_requests == []
 
 

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -1,8 +1,9 @@
-"""Agent scoping in the MCP document-search tool.
+"""Filter resolution in the MCP document-search tool.
 
-`agent` resolves a name to a persona id on the search call itself, so the
-happy path needs no discovery round trip. A name that does not resolve must
-fail rather than fall back to an unscoped search.
+`agent`, `source_types` and `document_set_names` all resolve on the search call
+itself, so the happy path needs no discovery round trip. A value that does not
+resolve must fail rather than be dropped, and the error teaches the caller
+without dumping the whole inventory.
 """
 
 import json
@@ -17,6 +18,7 @@ from fastmcp.server.auth.auth import AccessToken
 
 import onyx.mcp_server.tools.search as search_module
 import onyx.mcp_server.utils as utils_module
+from onyx.mcp_server.tools.search import _MAX_SUGGESTIONS
 
 _TOKEN = AccessToken(token="test-token", client_id="test", scopes=[])
 
@@ -28,6 +30,7 @@ class _Stub:
     search_requests: list[dict[str, Any]]
     agents: list[dict[str, Any]]
     sources: list[str]
+    document_sets: list[dict[str, Any]]
 
 
 async def _unreachable_indexed_sources(_access_token: AccessToken) -> list[str]:
@@ -44,12 +47,18 @@ async def stub(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_Stub, None]:
             {"id": 9, "name": "Engineering Wiki", "description": "Eng docs"},
         ],
         sources=["github"],
+        document_sets=[
+            {"name": "Engineering Wiki", "description": "eng"},
+            {"name": "Sales Playbook", "description": "sales"},
+        ],
     )
 
     def _handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if path.endswith("/manage/indexed-sources"):
             return httpx.Response(200, json={"sources": state.sources})
+        if path.endswith("/manage/document-set"):
+            return httpx.Response(200, json=state.document_sets)
         if path.endswith("/persona"):
             return httpx.Response(200, json=state.agents)
         if path.endswith("/search"):
@@ -90,18 +99,46 @@ async def test_search_without_agent_stays_unscoped(stub: _Stub) -> None:
 
 
 @pytest.mark.asyncio
-async def test_unknown_agent_errors_and_names_the_valid_ones(stub: _Stub) -> None:
+async def test_unknown_agent_errors_without_searching(stub: _Stub) -> None:
     payload = await search_module.search_indexed_documents(
         query="anything", agent="no-such-agent"
     )
 
     assert payload["results"] == []
     assert "no-such-agent" in payload["error"]
-    assert "Support" in payload["error"]
-    assert "Engineering Wiki" in payload["error"]
     # The wrong scope returned as if it were right is worse than an error, so
     # the tool must not fall back to an unscoped search.
     assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("stub")
+async def test_near_miss_agent_name_is_suggested() -> None:
+    """A stale or colloquial name is the common failure, so suggest the fix."""
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="Enginering Wiki"
+    )
+
+    assert "Did you mean" in payload["error"]
+    assert "Engineering Wiki" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_error_stays_small_for_large_tenants(
+    stub: _Stub,
+) -> None:
+    """Listing every agent duplicates the resource and costs tokens per call."""
+    stub.agents = [
+        {"id": i, "name": f"Team {i} Knowledge", "description": "d"} for i in range(40)
+    ]
+
+    payload = await search_module.search_indexed_documents(
+        query="anything", agent="totally-unrelated"
+    )
+
+    assert "renamed or removed" in payload["error"]
+    assert "agents" in payload["error"]
+    assert payload["error"].count(",") <= _MAX_SUGGESTIONS
 
 
 @pytest.mark.asyncio
@@ -147,6 +184,46 @@ async def test_unknown_agent_error_survives_empty_source_list(stub: _Stub) -> No
 
     assert "no-such-agent" in payload["error"]
     assert "Support" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_valid_filters_pass_through(stub: _Stub) -> None:
+    await search_module.search_indexed_documents(
+        query="anything",
+        source_types=["github"],
+        document_set_names=["Engineering Wiki"],
+    )
+
+    sent = stub.search_requests[0]
+    assert sent["sources"] == ["github"]
+    assert sent["document_sets"] == ["Engineering Wiki"]
+
+
+@pytest.mark.asyncio
+async def test_unindexed_source_type_errors_instead_of_being_dropped(
+    stub: _Stub,
+) -> None:
+    """Silently skipping the filter returns a wider result set as if scoped."""
+    payload = await search_module.search_indexed_documents(
+        query="anything", source_types=["confluence"]
+    )
+
+    assert payload["results"] == []
+    assert "confluence" in payload["error"]
+    assert "github" in payload["error"]
+    assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_document_set_errors_with_a_suggestion(stub: _Stub) -> None:
+    payload = await search_module.search_indexed_documents(
+        query="anything", document_set_names=["Enginering Wiki"]
+    )
+
+    assert payload["results"] == []
+    assert "Did you mean" in payload["error"]
+    assert "Engineering Wiki" in payload["error"]
+    assert stub.search_requests == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -258,6 +258,21 @@ async def test_search_survives_a_token_that_cannot_list_inventory(
 
 
 @pytest.mark.asyncio
+async def test_unknown_source_still_errors_without_the_inventory(stub: _Stub) -> None:
+    """Dropping it would leave an empty source list, and retrieval adds no
+    clause for that — the search would widen to every accessible source."""
+    stub.forbid_inventory = True
+
+    payload = await search_module.search_indexed_documents(
+        query="anything", source_types=["not-a-real-source"]
+    )
+
+    assert payload["results"] == []
+    assert "not-a-real-source" in payload["error"]
+    assert stub.search_requests == []
+
+
+@pytest.mark.asyncio
 async def test_inventory_failure_that_is_not_permissions_still_errors(
     stub: _Stub,
 ) -> None:

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -18,7 +18,6 @@ from fastmcp.server.auth.auth import AccessToken
 
 import onyx.mcp_server.tools.search as search_module
 import onyx.mcp_server.utils as utils_module
-from onyx.mcp_server.tools.search import _MAX_SUGGESTIONS
 
 _TOKEN = AccessToken(token="test-token", client_id="test", scopes=[])
 
@@ -118,18 +117,6 @@ async def test_unknown_agent_errors_without_searching(stub: _Stub) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("stub")
-async def test_near_miss_agent_name_is_suggested() -> None:
-    """A stale or colloquial name is the common failure, so suggest the fix."""
-    payload = await search_module.search_indexed_documents(
-        query="anything", agent="Enginering Wiki"
-    )
-
-    assert "Did you mean" in payload["error"]
-    assert "Engineering Wiki" in payload["error"]
-
-
-@pytest.mark.asyncio
 async def test_unknown_agent_error_stays_small_for_large_tenants(
     stub: _Stub,
 ) -> None:
@@ -144,7 +131,8 @@ async def test_unknown_agent_error_stays_small_for_large_tenants(
 
     assert "renamed or removed" in payload["error"]
     assert "agents" in payload["error"]
-    assert payload["error"].count(",") <= _MAX_SUGGESTIONS
+    # The point of the cap: no agent name is enumerated at this size.
+    assert not any(entry["name"] in payload["error"] for entry in stub.agents)
 
 
 @pytest.mark.asyncio
@@ -221,13 +209,15 @@ async def test_unindexed_source_type_errors_instead_of_being_dropped(
 
 
 @pytest.mark.asyncio
-async def test_unknown_document_set_errors_with_a_suggestion(stub: _Stub) -> None:
+async def test_unknown_document_set_errors_and_names_the_valid_ones(
+    stub: _Stub,
+) -> None:
     payload = await search_module.search_indexed_documents(
         query="anything", document_set_names=["Enginering Wiki"]
     )
 
     assert payload["results"] == []
-    assert "Did you mean" in payload["error"]
+    assert "Enginering Wiki" in payload["error"]
     assert "Engineering Wiki" in payload["error"]
     assert stub.search_requests == []
 
@@ -243,7 +233,10 @@ async def test_inventory_failure_errors(stub: _Stub) -> None:
     )
 
     assert payload["results"] == []
-    assert "Failed to check indexed sources" in payload["error"]
+    # Not a _FilterError: the caller supplied nothing wrong, so it surfaces
+    # through the tool's generic handler rather than as filter feedback.
+    assert "Document search failed" in payload["error"]
+    assert "500" in payload["error"]
     assert stub.search_requests == []
 
 

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -31,8 +31,6 @@ class _Stub:
     agents: list[dict[str, Any]]
     sources: list[str]
     document_sets: list[dict[str, Any]]
-    # Stands in for a scoped PAT, which cannot hold BASIC_ACCESS.
-    forbid_inventory: bool = False
     inventory_status: int | None = None
 
 
@@ -63,8 +61,6 @@ async def stub(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_Stub, None]:
         )
         if is_inventory and state.inventory_status is not None:
             return httpx.Response(state.inventory_status, json={"detail": "boom"})
-        if is_inventory and state.forbid_inventory:
-            return httpx.Response(403, json={"detail": "insufficient permissions"})
         if path.endswith("/manage/indexed-sources"):
             return httpx.Response(200, json={"sources": state.sources})
         if path.endswith("/manage/document-set"):
@@ -237,46 +233,9 @@ async def test_unknown_document_set_errors_with_a_suggestion(stub: _Stub) -> Non
 
 
 @pytest.mark.asyncio
-async def test_search_survives_a_token_that_cannot_list_inventory(
-    stub: _Stub,
-) -> None:
-    """No PAT scope grants BASIC_ACCESS, so the inventory endpoints 403 for
-    every scoped token. Validation is a convenience and must not block a search
-    the token is allowed to run."""
-    stub.forbid_inventory = True
-
-    payload = await search_module.search_indexed_documents(
-        query="anything",
-        source_types=["github"],
-        document_set_names=["Engineering Wiki"],
-    )
-
-    assert "error" not in payload
-    sent = stub.search_requests[0]
-    assert sent["sources"] == ["github"]
-    assert sent["document_sets"] == ["Engineering Wiki"]
-
-
-@pytest.mark.asyncio
-async def test_unknown_source_still_errors_without_the_inventory(stub: _Stub) -> None:
-    """Dropping it would leave an empty source list, and retrieval adds no
-    clause for that — the search would widen to every accessible source."""
-    stub.forbid_inventory = True
-
-    payload = await search_module.search_indexed_documents(
-        query="anything", source_types=["not-a-real-source"]
-    )
-
-    assert payload["results"] == []
-    assert "not-a-real-source" in payload["error"]
-    assert stub.search_requests == []
-
-
-@pytest.mark.asyncio
-async def test_inventory_failure_that_is_not_permissions_still_errors(
-    stub: _Stub,
-) -> None:
-    """A 500 is real trouble, not a scope limitation — keep failing loudly."""
+async def test_inventory_failure_errors(stub: _Stub) -> None:
+    """The listings are reachable by anything that can search, so a failure
+    here is real trouble — fail loudly rather than search unvalidated."""
     stub.inventory_status = 500
 
     payload = await search_module.search_indexed_documents(


### PR DESCRIPTION
## Description

Follow-on to #14465. Two related changes to `search_indexed_documents`.

**1. `source_types` and `document_set_names` now resolve on the search call.**

The tool's docstring told the model to read the `indexed_sources` and `document_sets` resources to learn valid filter values. Resources are application-controlled — most MCP clients never expose them to the model at all — so that instruction is unreachable in practice and these filters went unused or guessed. Both are now validated on the call itself, the same way `agent` already was, so no discovery round trip is needed and the docstring no longer points at something the model cannot open.

An unindexed source type or an unknown document set now fails rather than being dropped. A dropped filter returns a wider result set that reads as correctly scoped, which is the same failure class as the document-set/agent issue fixed in #14465.

**Behaviour change worth flagging:** an invalid source type previously logged a warning and was skipped. It is now an error, consistent with the other two filters.

**2. Reworked the unknown-value error, per Wenxi's review comment on #14465.**

The point was fair: listing every agent duplicated the `agents` resource and spent tokens on every failed call. The error now:

- offers **close matches** when there are any — this covers the common cause, a human-supplied name that is stale or colloquial;
- falls back to **listing everything only when the inventory is small** (≤ 10), which keeps small tenants fully self-correcting at negligible cost;
- otherwise reports the value **may have been renamed or removed** and names the resource to consult.

That drops the worst case from 50 names to at most 5 suggestions. One helper now serves all three filters, so the behaviour is defined once rather than per-filter.

## How Has This Been Tested?

- **Unit tests** (`test_agent_scoped_search.py`, now 16 passing): valid filters pass through unchanged; an unindexed source type and an unknown document set each error without issuing a `/search` request; a near-miss name produces a "Did you mean" suggestion; a large tenant gets the short "renamed or removed" form rather than an inventory dump.
- **Integration test**: extended the existing document-set case so an unresolvable set name fails with a usable hint instead of being dropped.
- **Live MCP wire check**: ran the real MCP server over streamable HTTP against a stub API server and confirmed the tool schema, resources, and all agent paths still behave, with the error now reading `Agent 'nope' not found. Available: Engineering Wiki, Support.`
- pre-commit clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves `source_types` and `document_set_names` on the search call so invalid values fail with a helpful error instead of being dropped, matching how `agent` already resolved.

- Invalid source types now error instead of being logged and skipped.
- Unknown values name the alternatives when the inventory is small (≤ 10), otherwise say the value may have been renamed or removed.
- Filter validation is unconditional: the inventory listings now require the same `READ_SEARCH` permission as `/search`, so any lookup failure fails the call.
- Filter resolution is extracted into shared helpers, giving each filter one place to fail.
- The merge-order dependency on #14593 is resolved; it merged and this branch is rebased onto it.

<sup>Written for commit 355cbd37522b0f55ae9c077c73e5037f61563a15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Merge-order dependency — resolved

This depended on #14593, which **merged as ad8ae7b510**. The branch is rebased onto it, so `/manage/indexed-sources` and the document-set listing now require `READ_SEARCH` — the same permission `/search` requires.

That resolves the P1 both reviewers raised against the pre-rebase base: a `READ_SEARCH`-only PAT can now reach both listings, so filter validation no longer blocks a valid scoped search. Cubic's own suggested remedy ("changing the inventory endpoints to accept READ_SEARCH") is what #14593 did. The 403 fallback that previously papered over this is removed here as unreachable.