### PR TITLE
feat(llm): admin toggle to hide provider grouping in the model selector

### DIFF
--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -65,6 +65,8 @@ class Settings(BaseModel):
 
     temperature_override_enabled: bool | None = True
     reasoning_override_enabled: bool | None = True
+    # Model selector shows one flat list instead of per-provider groups.
+    hide_provider_grouping: bool = False
     auto_scroll: bool | None = False
     query_history_type: QueryHistoryType | None = None
 

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -5110,6 +5110,10 @@
           "title": "مستضاف ذاتيًا ومخصص"
         }
       },
+      "hideProviderGrouping": {
+        "description": "اعرض جميع النماذج في قائمة واحدة عند اختيار النماذج في الدردشة. الأفضل مع مجموعة صغيرة من النماذج.",
+        "title": "إخفاء تجميع مزوّدي الخدمة"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "فشل حذف الموفر: {message}",
         "providerDeleted": "تم حذف الموفر بنجاح!",
+        "settingsUpdateFailed": "فشل تحديث الإعدادات",
+        "settingsUpdated": "تم تحديث الإعدادات",
         "unknownError": "خطأ غير معروف"
       }
     },

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -5110,6 +5110,10 @@
           "title": "Selbst gehostet & Benutzerdefiniert"
         }
       },
+      "hideProviderGrouping": {
+        "description": "Zeigen Sie alle Modelle als eine Liste an, wenn Sie im Chat Modelle auswählen. Ideal für eine kleine Modellauswahl.",
+        "title": "Anbietergruppierung ausblenden"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "Der Anbieter konnte nicht gelöscht werden: {message}",
         "providerDeleted": "Anbieter erfolgreich gelöscht!",
+        "settingsUpdateFailed": "Die Einstellungen konnten nicht aktualisiert werden",
+        "settingsUpdated": "Einstellungen aktualisiert",
         "unknownError": "Unbekannter Fehler"
       }
     },

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -5110,6 +5110,10 @@
           "title": "Self-hosted & Custom"
         }
       },
+      "hideProviderGrouping": {
+        "description": "Show all models as one list when choosing models in chat. Best with a small model set.",
+        "title": "Hide Provider Grouping"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "Failed to delete provider: {message}",
         "providerDeleted": "Provider deleted successfully!",
+        "settingsUpdateFailed": "Failed to update settings",
+        "settingsUpdated": "Settings updated",
         "unknownError": "Unknown error"
       }
     },

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -5110,6 +5110,10 @@
           "title": "Autoalojados y personalizados"
         }
       },
+      "hideProviderGrouping": {
+        "description": "Muestra todos los modelos en una sola lista al elegir modelos en el chat. Ideal para un conjunto pequeño de modelos.",
+        "title": "Ocultar agrupación por proveedor"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "No se pudo eliminar el proveedor: {message}",
         "providerDeleted": "¡Proveedor eliminado correctamente!",
+        "settingsUpdateFailed": "No se pudo actualizar la configuración",
+        "settingsUpdated": "Configuración actualizada",
         "unknownError": "Error desconocido"
       }
     },

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -5110,6 +5110,10 @@
           "title": "Auto-hébergés et personnalisés"
         }
       },
+      "hideProviderGrouping": {
+        "description": "Affichez tous les modèles dans une seule liste lors du choix des modèles dans la discussion. Idéal pour un petit ensemble de modèles.",
+        "title": "Masquer le regroupement par fournisseur"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "Échec de la suppression du fournisseur : {message}",
         "providerDeleted": "Fournisseur supprimé avec succès !",
+        "settingsUpdateFailed": "Échec de la mise à jour des paramètres",
+        "settingsUpdated": "Paramètres mis à jour",
         "unknownError": "Erreur inconnue"
       }
     },

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -5110,6 +5110,10 @@
           "title": "セルフホストとカスタム"
         }
       },
+      "hideProviderGrouping": {
+        "description": "チャットでモデルを選ぶときに、すべてのモデルを1つのリストとして表示します。モデル数が少ない場合に最適です。",
+        "title": "プロバイダーのグループ化を非表示"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "プロバイダーを削除できませんでした：{message}",
         "providerDeleted": "プロバイダーを削除しました。",
+        "settingsUpdateFailed": "設定の更新に失敗しました",
+        "settingsUpdated": "設定を更新しました",
         "unknownError": "不明なエラー"
       }
     },

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -5110,6 +5110,10 @@
           "title": "자체 호스팅 및 사용자 지정"
         }
       },
+      "hideProviderGrouping": {
+        "description": "채팅에서 모델을 선택할 때 모든 모델을 하나의 목록으로 표시합니다. 모델 수가 적을 때 적합합니다.",
+        "title": "제공업체 그룹화 숨기기"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "제공자를 삭제하지 못했습니다: {message}",
         "providerDeleted": "제공자를 삭제했습니다!",
+        "settingsUpdateFailed": "설정을 업데이트하지 못했습니다",
+        "settingsUpdated": "설정을 업데이트했습니다",
         "unknownError": "알 수 없는 오류"
       }
     },

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -5110,6 +5110,10 @@
           "title": "Auto-hospedados e personalizados"
         }
       },
+      "hideProviderGrouping": {
+        "description": "Mostre todos os modelos em uma única lista ao escolher modelos no chat. Ideal para um conjunto pequeno de modelos.",
+        "title": "Ocultar agrupamento por provedor"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "Falha ao excluir o provedor: {message}",
         "providerDeleted": "Provedor excluído com sucesso!",
+        "settingsUpdateFailed": "Falha ao atualizar as configurações",
+        "settingsUpdated": "Configurações atualizadas",
         "unknownError": "Erro desconhecido"
       }
     },

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -5110,6 +5110,10 @@
           "title": "自托管和自定义"
         }
       },
+      "hideProviderGrouping": {
+        "description": "在聊天中选择模型时，将所有模型显示为一个列表。适合模型数量较少的情况。",
+        "title": "隐藏提供商分组"
+      },
       "modals": {
         "access": {
           "admin": {
@@ -5571,6 +5575,8 @@
       "toasts": {
         "providerDeleteFailed": "删除提供商失败：{message}",
         "providerDeleted": "提供商已成功删除！",
+        "settingsUpdateFailed": "更新设置失败",
+        "settingsUpdated": "设置已更新",
         "unknownError": "未知错误"
       }
     },

--- a/web/src/lib/settings/svc.ts
+++ b/web/src/lib/settings/svc.ts
@@ -12,7 +12,11 @@ async function parseErrorDetail(
   }
 }
 
-export async function updateAdminSettings(settings: Settings): Promise<void> {
+// The endpoint merges only the fields sent, so a partial patch leaves the
+// rest of the stored settings untouched.
+export async function updateAdminSettings(
+  settings: Partial<Settings>
+): Promise<void> {
   const res = await fetch("/api/admin/settings", {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -33,6 +33,8 @@ export interface Settings {
   auto_scroll: boolean;
   temperature_override_enabled: boolean;
   reasoning_override_enabled?: boolean;
+  // Model selector shows one flat list instead of per-provider groups.
+  hide_provider_grouping?: boolean;
   query_history_type: QueryHistoryType;
 
   // Visibility-only: hides the sidebar page; query-history APIs + recording stay on.

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -409,6 +409,7 @@ export default function ModelSelectorContent({
   onDetailSelect,
 }: ModelSelectorContentProps) {
   const t = useTranslations("chat.modelSelector");
+  const { hide_provider_grouping: hideProviderGrouping } = useSettings();
   const [detailOption, setDetailOption] = useState<LLMOption | null>(null);
   const {
     llmProviders: currentAgentProviderOptions,
@@ -489,6 +490,9 @@ export default function ModelSelectorContent({
   };
 
   const isGroupOpen = (key: string) => isSearching || expandedGroups.has(key);
+
+  // A lone group needs no header, and an admin can drop them workspace-wide.
+  const showFlatList = hideProviderGrouping || groupedOptions.length === 1;
 
   const renderModelItem = (option: LLMOption) => {
     const selected = isSelected(option);
@@ -588,10 +592,12 @@ export default function ModelSelectorContent({
                     {t("list.empty.text")}
                   </Text>,
                 ]
-              : groupedOptions.length === 1
+              : showFlatList
                 ? [
-                    <Section key="single-provider" gap={1} alignItems="stretch">
-                      {groupedOptions[0]!.options.map(renderModelItem)}
+                    <Section key="flat" gap={1} alignItems="stretch">
+                      {groupedOptions
+                        .flatMap((group) => group.options)
+                        .map(renderModelItem)}
                     </Section>,
                   ]
                 : groupedOptions.flatMap((group, groupIndex) => {

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -12,6 +12,7 @@ import {
   Divider,
   MessageCard,
   SelectCard,
+  Switch,
   Text,
   Card,
 } from "@opal/components";
@@ -26,6 +27,10 @@ import {
   setDefaultLlmModelAndRefresh,
 } from "@/lib/languageModels/cache";
 import { deleteLlmProvider } from "@/lib/languageModels/svc";
+import { buildLlmOptions, groupLlmOptions } from "@/lib/languageModels/options";
+import { useSettings } from "@/lib/settings/hooks";
+import { updateAdminSettings } from "@/lib/settings/svc";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { useCreateModal } from "@opal/components";
@@ -324,10 +329,18 @@ export default function LanguageModelsPage() {
   const t = useTranslations("admin.languageModels");
   const adminRouteTitle = useAdminRouteTitle();
   const { mutate } = useSWRConfig();
+  const settings = useSettings();
   const { llmProviders: existingLlmProviders, defaultText } =
     useAdminLLMProviders();
   const isConfigurationDisabled = usePHFeatureFlag(
     PHFeatureFlag.LANGUAGE_MODEL_CONFIGURATION_DISABLED
+  );
+
+  // Hide the toggle unless the selector would group: several providers, or
+  // one aggregator provider whose models span several vendors.
+  const hasProviderGrouping = useMemo(
+    () => groupLlmOptions(buildLlmOptions(existingLlmProviders)).length > 1,
+    [existingLlmProviders]
   );
 
   // Resolve the current default to a model_configuration_id for ModelSelector
@@ -419,6 +432,18 @@ export default function LanguageModelsPage() {
     await setDefaultLlmModelAndRefresh(providerId, modelName, mutate);
   }
 
+  async function handleHideProviderGroupingChange(checked: boolean) {
+    try {
+      await updateAdminSettings({ hide_provider_grouping: checked });
+      await mutate(SWR_KEYS.settings);
+      toast.success(t("toasts.settingsUpdated"));
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : t("toasts.settingsUpdateFailed")
+      );
+    }
+  }
+
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
@@ -430,29 +455,45 @@ export default function LanguageModelsPage() {
       <SettingsLayouts.Body>
         {hasProviders ? (
           <Card border="solid" rounding={4}>
-            <InputHorizontal
-              title={t("defaultModel.title")}
-              description={t("defaultModel.description")}
-              center
-              withLabel
-            >
-              <ModelSelector
-                value={defaultModelConfigId}
-                onChange={(opt) => {
-                  const provider = existingLlmProviders?.find(
-                    (p) =>
-                      p.provider === opt.provider &&
-                      (p.name === opt.name || (!p.name && !opt.name))
-                  );
-                  if (provider) {
-                    void handleDefaultModelChange(
-                      `${provider.id}:${opt.modelName}`
+            <Section alignItems="stretch">
+              <InputHorizontal
+                title={t("defaultModel.title")}
+                description={t("defaultModel.description")}
+                center
+                withLabel
+              >
+                <ModelSelector
+                  value={defaultModelConfigId}
+                  onChange={(opt) => {
+                    const provider = existingLlmProviders?.find(
+                      (p) =>
+                        p.provider === opt.provider &&
+                        (p.name === opt.name || (!p.name && !opt.name))
                     );
-                  }
-                }}
-                side="bottom"
-              />
-            </InputHorizontal>
+                    if (provider) {
+                      void handleDefaultModelChange(
+                        `${provider.id}:${opt.modelName}`
+                      );
+                    }
+                  }}
+                  side="bottom"
+                />
+              </InputHorizontal>
+              {hasProviderGrouping && (
+                <InputHorizontal
+                  title={t("hideProviderGrouping.title")}
+                  description={t("hideProviderGrouping.description")}
+                  withLabel
+                >
+                  <Switch
+                    checked={settings.hide_provider_grouping ?? false}
+                    onCheckedChange={(checked) => {
+                      void handleHideProviderGroupingChange(checked);
+                    }}
+                  />
+                </InputHorizontal>
+              )}
+            </Section>
           </Card>
         ) : (
           <MessageCard variant="info" title={t("noProviders.title")} />

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -330,6 +330,11 @@ export default function LanguageModelsPage() {
   const adminRouteTitle = useAdminRouteTitle();
   const { mutate } = useSWRConfig();
   const settings = useSettings();
+  // Optimistic value while the save is in flight. It also locks the switch so
+  // a second click cannot resubmit the stale stored value.
+  const [pendingHideGrouping, setPendingHideGrouping] = useState<
+    boolean | null
+  >(null);
   const { llmProviders: existingLlmProviders, defaultText } =
     useAdminLLMProviders();
   const isConfigurationDisabled = usePHFeatureFlag(
@@ -433,6 +438,8 @@ export default function LanguageModelsPage() {
   }
 
   async function handleHideProviderGroupingChange(checked: boolean) {
+    if (pendingHideGrouping !== null) return;
+    setPendingHideGrouping(checked);
     try {
       await updateAdminSettings({ hide_provider_grouping: checked });
       await mutate(SWR_KEYS.settings);
@@ -441,6 +448,8 @@ export default function LanguageModelsPage() {
       toast.error(
         e instanceof Error ? e.message : t("toasts.settingsUpdateFailed")
       );
+    } finally {
+      setPendingHideGrouping(null);
     }
   }
 
@@ -486,7 +495,12 @@ export default function LanguageModelsPage() {
                   withLabel
                 >
                   <Switch
-                    checked={settings.hide_provider_grouping ?? false}
+                    checked={
+                      pendingHideGrouping ??
+                      settings.hide_provider_grouping ??
+                      false
+                    }
+                    disabled={pendingHideGrouping !== null}
                     onCheckedChange={(checked) => {
                       void handleHideProviderGroupingChange(checked);
                     }}


### PR DESCRIPTION
## Description

**Why.** Customers that route every model through a gateway see the chat model selector split into collapsible headers like `Bifrost/Azure`, `Bifrost/Vertex`, `Bifrost/Anthropic`. HRT asked to hide that structure from end users: they want one flat model list because the provider is an infrastructure detail their users should not have to navigate ([thread](https://onyx-company.slack.com/archives/C09PCCHRJDS/p1787602830330359), [mock](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=7496-42881)).

**What.** A new `hide_provider_grouping` workspace setting (default off, so nothing changes for existing deployments) and a "Hide Provider Grouping" switch on the admin Language Models page, in the default-model card. The switch only renders when the selector would group at all: several providers, or one gateway spanning several vendors. When it is on, every model selector (chat input, agent editor, admin default model) renders one flat list, the same layout the single-provider case already uses. Search behaves as before.

`updateAdminSettings` now accepts a partial `Settings`, since the PATCH endpoint merges only the fields sent. Strings added to all nine locale catalogs.

## How Has This Been Tested?

Live on a dev stack with seven providers (Anthropic, Bifrost, two Azure, OpenAI, Vertex):

- Toggle renders on the Language Models page, flipping it shows the "Settings updated" toast and `GET /api/settings` returns the new value.
- With it on, the chat selector and the admin default-model selector both show one flat list with no headers. With it off, the grouped view with collapsible headers is back.
- `GET /api/settings` on a workspace that has never set the field returns `false`.
- `bun run types:check` (includes locale key parity) and pre-commit (oxfmt, oxlint, ruff, ty) pass on the changed files, plus project-wide `ty check`.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/hide-provider-grouping/before-grouped.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/hide-provider-grouping/after-flat.jpg) |

Admin toggle:

![admin toggle](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/hide-provider-grouping/admin-toggle.jpg)

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01SttmJRGnrzEcXKxwfmCYVP
