### PR TITLE
fix(tools): i18n fixes for builtin-tools

### DIFF
--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -658,6 +658,35 @@
         "tooltip": "عرض المفعّلة فقط"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "البحث الداخلي"
+      },
+      "imageGeneration": {
+        "label": "توليد الصور"
+      },
+      "webSearch": {
+        "label": "البحث في الويب"
+      },
+      "knowledgeGraph": {
+        "label": "البحث في مخطط المعرفة"
+      },
+      "openUrl": {
+        "label": "فتح رابط"
+      },
+      "codeInterpreter": {
+        "label": "مفسر الأكواد"
+      },
+      "fileReader": {
+        "label": "قارئ الملفات"
+      },
+      "addMemory": {
+        "label": "إضافة إلى الذاكرة"
+      },
+      "codingAgent": {
+        "label": "وكيل البرمجة"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -658,6 +658,35 @@
         "tooltip": "Nur aktivierte anzeigen"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "Interne Suche"
+      },
+      "imageGeneration": {
+        "label": "Bilderzeugung"
+      },
+      "webSearch": {
+        "label": "Websuche"
+      },
+      "knowledgeGraph": {
+        "label": "Wissensgraph-Suche"
+      },
+      "openUrl": {
+        "label": "URL öffnen"
+      },
+      "codeInterpreter": {
+        "label": "Code-Interpreter"
+      },
+      "fileReader": {
+        "label": "Dateileser"
+      },
+      "addMemory": {
+        "label": "Erinnerung hinzufügen"
+      },
+      "codingAgent": {
+        "label": "Coding-Agent"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -658,6 +658,35 @@
         "tooltip": "Show only enabled"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "Internal Search"
+      },
+      "imageGeneration": {
+        "label": "Image Generation"
+      },
+      "webSearch": {
+        "label": "Web Search"
+      },
+      "knowledgeGraph": {
+        "label": "Knowledge Graph Search"
+      },
+      "openUrl": {
+        "label": "Open URL"
+      },
+      "codeInterpreter": {
+        "label": "Code Interpreter"
+      },
+      "fileReader": {
+        "label": "File Reader"
+      },
+      "addMemory": {
+        "label": "Add Memory"
+      },
+      "codingAgent": {
+        "label": "Coding Agent"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -658,6 +658,35 @@
         "tooltip": "Mostrar solo las activadas"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "Búsqueda interna"
+      },
+      "imageGeneration": {
+        "label": "Generación de imágenes"
+      },
+      "webSearch": {
+        "label": "Búsqueda web"
+      },
+      "knowledgeGraph": {
+        "label": "Búsqueda en el grafo de conocimiento"
+      },
+      "openUrl": {
+        "label": "Abrir URL"
+      },
+      "codeInterpreter": {
+        "label": "Intérprete de código"
+      },
+      "fileReader": {
+        "label": "Lector de archivos"
+      },
+      "addMemory": {
+        "label": "Añadir a la memoria"
+      },
+      "codingAgent": {
+        "label": "Agente de código"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -658,6 +658,35 @@
         "tooltip": "Afficher uniquement les activés"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "Recherche interne"
+      },
+      "imageGeneration": {
+        "label": "Génération d'images"
+      },
+      "webSearch": {
+        "label": "Recherche web"
+      },
+      "knowledgeGraph": {
+        "label": "Recherche dans le graphe de connaissances"
+      },
+      "openUrl": {
+        "label": "Ouvrir l'URL"
+      },
+      "codeInterpreter": {
+        "label": "Interpréteur de code"
+      },
+      "fileReader": {
+        "label": "Lecteur de fichiers"
+      },
+      "addMemory": {
+        "label": "Ajouter à la mémoire"
+      },
+      "codingAgent": {
+        "label": "Agent de code"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -658,6 +658,35 @@
         "tooltip": "有効なもののみ表示"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "内部検索"
+      },
+      "imageGeneration": {
+        "label": "画像生成"
+      },
+      "webSearch": {
+        "label": "ウェブ検索"
+      },
+      "knowledgeGraph": {
+        "label": "ナレッジグラフ検索"
+      },
+      "openUrl": {
+        "label": "URLを開く"
+      },
+      "codeInterpreter": {
+        "label": "コードインタープリター"
+      },
+      "fileReader": {
+        "label": "ファイルリーダー"
+      },
+      "addMemory": {
+        "label": "メモリに追加"
+      },
+      "codingAgent": {
+        "label": "コーディングエージェント"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -658,6 +658,35 @@
         "tooltip": "활성화된 항목만 표시"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "내부 검색"
+      },
+      "imageGeneration": {
+        "label": "이미지 생성"
+      },
+      "webSearch": {
+        "label": "웹 검색"
+      },
+      "knowledgeGraph": {
+        "label": "지식 그래프 검색"
+      },
+      "openUrl": {
+        "label": "URL 열기"
+      },
+      "codeInterpreter": {
+        "label": "코드 인터프리터"
+      },
+      "fileReader": {
+        "label": "파일 리더"
+      },
+      "addMemory": {
+        "label": "메모리에 추가"
+      },
+      "codingAgent": {
+        "label": "코딩 에이전트"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -658,6 +658,35 @@
         "tooltip": "Mostrar apenas as ativadas"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "Pesquisa interna"
+      },
+      "imageGeneration": {
+        "label": "Geração de imagens"
+      },
+      "webSearch": {
+        "label": "Pesquisa na web"
+      },
+      "knowledgeGraph": {
+        "label": "Pesquisa no grafo de conhecimento"
+      },
+      "openUrl": {
+        "label": "Abrir URL"
+      },
+      "codeInterpreter": {
+        "label": "Interpretador de código"
+      },
+      "fileReader": {
+        "label": "Leitor de arquivos"
+      },
+      "addMemory": {
+        "label": "Adicionar à memória"
+      },
+      "codingAgent": {
+        "label": "Agente de código"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -658,6 +658,35 @@
         "tooltip": "仅显示已启用"
       }
     },
+    "toolNames": {
+      "internalSearch": {
+        "label": "内部搜索"
+      },
+      "imageGeneration": {
+        "label": "图像生成"
+      },
+      "webSearch": {
+        "label": "网络搜索"
+      },
+      "knowledgeGraph": {
+        "label": "知识图谱搜索"
+      },
+      "openUrl": {
+        "label": "打开 URL"
+      },
+      "codeInterpreter": {
+        "label": "代码解释器"
+      },
+      "fileReader": {
+        "label": "文件读取器"
+      },
+      "addMemory": {
+        "label": "添加到记忆"
+      },
+      "codingAgent": {
+        "label": "编码智能体"
+      }
+    },
     "toolsPopover": {
       "configureLinks": {
         "codeInterpreter": {

--- a/web/src/lib/tools/components/ToolLineItem.tsx
+++ b/web/src/lib/tools/components/ToolLineItem.tsx
@@ -24,7 +24,7 @@ import {
   SEARCH_TOOL_ID,
   WEB_SEARCH_TOOL_ID,
 } from "@/lib/tools/constants";
-import { useAvailableTools } from "@/lib/tools/hooks";
+import { useAvailableTools, useBuiltInToolNames } from "@/lib/tools/hooks";
 import { useToolsPopover } from "@/lib/tools/providers";
 import { ToolSnapshot } from "@/lib/tools/types";
 import { getAdminConfigureInfo, getToolTooltip } from "@/lib/tools/utils";
@@ -70,6 +70,7 @@ export default function ToolLineItem({ tool }: ToolLineItemProps) {
   const { permissions } = useUser();
   const { vectorDbEnabled } = useSettings();
   const { tools: availableTools } = useAvailableTools();
+  const builtInToolNames = useBuiltInToolNames();
   const { ccPairs } = useCCPairs(vectorDbEnabled);
   const { currentProjectId } = useProjectsContext();
   const { getToolAuthStatus, authenticateTool } = useToolOAuthStatus(agent.id);
@@ -132,10 +133,14 @@ export default function ToolLineItem({ tool }: ToolLineItemProps) {
       ? getAdminConfigureInfo(tool, configureTooltips)
       : null;
 
+  // A tool defined through the UI or served by MCP is named by whoever
+  // created it, so its own name is all there is to show.
   const label =
     inProject && isSearchTool
       ? t("actionLineItem.projectSearch.label")
-      : tool.display_name || tool.name;
+      : (builtInToolNames[tool.in_code_tool_id ?? ""] ??
+        tool.display_name ??
+        tool.name);
 
   // Only worth saying when the pin is narrowed to some of the sources.
   const sourcesNarrowed =

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -21,7 +21,10 @@ import { hasPermission } from "@/lib/permissions";
 import { useProjectsContext } from "@/lib/projects/providers";
 import { useSettings } from "@/lib/settings/hooks";
 import { FILE_READER_TOOL_ID, SEARCH_TOOL_ID } from "@/lib/tools/constants";
-import type { ToolConfigurationHandle } from "@/lib/tools/hooks";
+import {
+  useBuiltInToolNames,
+  type ToolConfigurationHandle,
+} from "@/lib/tools/hooks";
 import { ToolsPopoverProvider } from "@/lib/tools/providers";
 import MCPLineItem, { MCPServer } from "@/lib/tools/components/MCPLineItem";
 import SourcesView from "@/lib/tools/components/SourcesView";
@@ -67,6 +70,7 @@ export default function ToolsPopover({
   disabled = false,
 }: ToolsPopoverProps) {
   const t = useTranslations("actions");
+  const builtInToolNames = useBuiltInToolNames();
   const [open, setOpen] = useState(false);
   const [secondaryView, setSecondaryView] = useState<SecondaryViewState | null>(
     null
@@ -310,7 +314,12 @@ export default function ToolsPopover({
   const filteredTools = displayTools.filter((tool) => {
     if (!searchTerm) return true;
     const searchLower = searchTerm.toLowerCase();
+    // Match the name the row shows, so typing in the current locale finds
+    // the tool. The raw names stay searchable for anyone who knows them.
+    const shownName =
+      builtInToolNames[tool.in_code_tool_id ?? ""] ?? tool.display_name;
     return (
+      shownName?.toLowerCase().includes(searchLower) ||
       tool.display_name?.toLowerCase().includes(searchLower) ||
       tool.name.toLowerCase().includes(searchLower) ||
       tool.description?.toLowerCase().includes(searchLower)

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -314,10 +314,13 @@ export default function ToolsPopover({
   const filteredTools = displayTools.filter((tool) => {
     if (!searchTerm) return true;
     const searchLower = searchTerm.toLowerCase();
-    // Match the name the row shows, so typing in the current locale finds
-    // the tool. The raw names stay searchable for anyone who knows them.
+    // Match the name the row actually shows, including the rename search
+    // takes on inside a project, so typing what is on screen finds it. The
+    // raw names stay searchable below for anyone who knows them.
     const shownName =
-      builtInToolNames[tool.in_code_tool_id ?? ""] ?? tool.display_name;
+      currentProjectId != null && tool.in_code_tool_id === SEARCH_TOOL_ID
+        ? t("actionLineItem.projectSearch.label")
+        : (builtInToolNames[tool.in_code_tool_id ?? ""] ?? tool.display_name);
     return (
       shownName?.toLowerCase().includes(searchLower) ||
       tool.display_name?.toLowerCase().includes(searchLower) ||

--- a/web/src/lib/tools/constants.ts
+++ b/web/src/lib/tools/constants.ts
@@ -23,6 +23,8 @@ export const PYTHON_TOOL_ID = "PythonTool";
 export const OPEN_URL_TOOL_ID = "OpenURLTool";
 export const FILE_READER_TOOL_ID = "FileReaderTool";
 export const CODING_AGENT_TOOL_ID = "CodingAgentTool";
+export const KNOWLEDGE_GRAPH_TOOL_ID = "KnowledgeGraphTool";
+export const MEMORY_TOOL_ID = "MemoryTool";
 
 // Icon mappings for system tools
 export const SYSTEM_TOOL_ICONS: Record<

--- a/web/src/lib/tools/hooks.ts
+++ b/web/src/lib/tools/hooks.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import useSWR, { mutate } from "swr";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -12,6 +13,17 @@ import type {
 } from "@/lib/tools/types";
 import { useAppPosition } from "@/lib/position/hooks";
 import { useActiveAgent } from "@/lib/agents/hooks";
+import {
+  CODING_AGENT_TOOL_ID,
+  FILE_READER_TOOL_ID,
+  IMAGE_GENERATION_TOOL_ID,
+  KNOWLEDGE_GRAPH_TOOL_ID,
+  MEMORY_TOOL_ID,
+  OPEN_URL_TOOL_ID,
+  PYTHON_TOOL_ID,
+  SEARCH_TOOL_ID,
+  WEB_SEARCH_TOOL_ID,
+} from "@/lib/tools/constants";
 
 /**
  * Every MCP server the current user can reach.
@@ -488,4 +500,33 @@ export function useToolConfiguration(
       handOffToNewChatWith,
     };
   }, [configuration, setToolState, handOffTo, handOffToNewChatWith]);
+}
+
+/**
+ * Display names for the built-in tools, keyed by `in_code_tool_id`.
+ *
+ * The backend names these in English, which is right for the model but not for
+ * the UI, so a row reads its name from here instead. Spelled out rather than
+ * looked up dynamically because next-intl types its keys, and a lookup by
+ * variable would give up that checking.
+ *
+ * Only in-code tools appear. A tool defined through the UI or served by an MCP
+ * server is named by whoever created it, and there is nothing to translate.
+ */
+export function useBuiltInToolNames(): Record<string, string> {
+  const t = useTranslations("actions");
+  return useMemo(
+    () => ({
+      [SEARCH_TOOL_ID]: t("toolNames.internalSearch.label"),
+      [IMAGE_GENERATION_TOOL_ID]: t("toolNames.imageGeneration.label"),
+      [WEB_SEARCH_TOOL_ID]: t("toolNames.webSearch.label"),
+      [KNOWLEDGE_GRAPH_TOOL_ID]: t("toolNames.knowledgeGraph.label"),
+      [OPEN_URL_TOOL_ID]: t("toolNames.openUrl.label"),
+      [PYTHON_TOOL_ID]: t("toolNames.codeInterpreter.label"),
+      [FILE_READER_TOOL_ID]: t("toolNames.fileReader.label"),
+      [MEMORY_TOOL_ID]: t("toolNames.addMemory.label"),
+      [CODING_AGENT_TOOL_ID]: t("toolNames.codingAgent.label"),
+    }),
+    [t]
+  );
 }


### PR DESCRIPTION
## Description

A tool row took its title from the backend's `display_name`, which is English whatever locale the reader is in. A Mandarin session still read "Internal Search". The backend names these tools for the model, and the UI needs its own name for them.

The nine in-code tools now carry a catalog key each, resolved through `useBuiltInToolNames`. English matches the backend's own `DISPLAY_NAME` constants, so nothing is reworded: Internal Search, Image Generation, Web Search, Knowledge Graph Search, Open URL, Code Interpreter, File Reader, Add Memory, Coding Agent.

Two choices worth flagging:

- **Keys are spelled out, not looked up by variable.** next-intl types its keys against `en.json`, so `t(someString)` would compile away that checking. The hook lists all nine literally, which mirrors how `tooltipMessages` is already built in the same component.
- **Only in-code tools are translated.** A tool defined through the UI, or served by an MCP server, is named by whoever created it. There is no key to translate and never can be, so those still show `display_name`.

Search now matches the translated name as well as the raw one. Without that, this change would have made search worse in every non-English locale: the row would read one way and only answer to another.

Translations reuse what the catalogs already established where possible — `configureLinks` already carried renderings of Code Interpreter, Image Generation and Web Search in all eight locales, so those are taken verbatim rather than guessed again. The remaining six follow the same register.

## Screenshots + Videos

### Before

Builtin tools were not properly translated.

<img width="807" height="593" alt="image" src="https://github.com/user-attachments/assets/2f739c8f-e5de-49a2-9ab3-503e990612e8" />

### After

Builtin tools are now properly translated.

<img width="791" height="571" alt="image" src="https://github.com/user-attachments/assets/bf714901-7e82-4a9a-b6b6-dd663d42cc0c" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the built-in tool names in the tool list and popover search so non-English readers see and can search for tools in their own language.

- Adds a `toolNames` catalog key with nine entries, resolved via a new `useBuiltInToolNames` hook in `web/src/lib/tools/hooks.ts`.
- English labels match the backend `DISPLAY_NAME` constants, so nothing is reworded.
- Tools defined through the UI or served by MCP still show their original `display_name`, since there is nothing to translate.
- Popover search now matches the translated name, the raw name, and the project-scoped "Project Search" rename, so typing any of them finds the tool.

**Migration**
- New catalog keys must be added to all nine locale files; `bun run types:check` enforces parity.

<sup>Written for commit 8dff6f5726789e1580d3915ee5653f8a8f9fdf76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

