### PR TITLE
fix(llm): price models litellm knows under a vendor prefix and refresh its price map on a miss

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1626,6 +1626,13 @@ DEFAULT_LLM_OUTPUT_COST_PER_MTOK = max(
     0.0, float(os.environ.get("DEFAULT_LLM_OUTPUT_COST_PER_MTOK") or 0.0)
 )
 
+# Re-download litellm's price map at most this often when a model is missing
+# from the copy loaded at startup (0 disables), so models released after the
+# process started get priced without a restart.
+LITELLM_MODEL_COST_REFRESH_SECONDS = max(
+    0, int(os.environ.get("LITELLM_MODEL_COST_REFRESH_SECONDS") or 3600)
+)
+
 
 #####
 # Tool Configs

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -1,5 +1,6 @@
 """LLM cost calculation utilities."""
 
+import json
 import threading
 import time
 from collections.abc import Mapping
@@ -67,9 +68,12 @@ def _refresh_litellm_model_cost() -> bool:
         try:
             fetched = _fetch_litellm_model_cost()
         except Exception:
-            logger.debug("litellm model cost map refresh failed", exc_info=True)
+            logger.warning("litellm model cost map refresh failed", exc_info=True)
             return False
         if not fetched:
+            logger.warning(
+                "litellm model cost map refresh skipped: remote map unavailable"
+            )
             return False
         import litellm
 
@@ -81,24 +85,28 @@ def _refresh_litellm_model_cost() -> bool:
         return True
 
 
+def _cost_fields(entry: Mapping[str, Any]) -> str:
+    """Every rate cost_per_token may read (base, cache, tiered), canonicalised
+    so candidates can be compared as a whole."""
+    return json.dumps(
+        {field: value for field, value in entry.items() if "cost" in field},
+        sort_keys=True,
+        default=str,
+    )
+
+
 def _vendor_prefixed_target(model: str) -> _LitellmTarget | None:
     """Provider names litellm doesn't know (e.g. openai_compatible) hide models
     it prices under a vendor prefix such as "xai/grok-4". Accept that key only
-    when unambiguous: a single match, or several that agree on token prices."""
+    when unambiguous: a single match, or several with identical rates."""
     import litellm
 
     suffix = "/" + model
-    candidates = [key for key in litellm.model_cost if key.endswith(suffix)]
-    if not candidates:
-        return None
-    prices = {
-        (
-            litellm.model_cost[key].get("input_cost_per_token"),
-            litellm.model_cost[key].get("output_cost_per_token"),
-        )
-        for key in candidates
-    }
-    if len(prices) != 1:
+    # Under the refresh lock: an in-place map update would break this scan.
+    with _refresh_lock:
+        candidates = [key for key in litellm.model_cost if key.endswith(suffix)]
+        rates = {_cost_fields(litellm.model_cost[key]) for key in candidates}
+    if not candidates or len(rates) != 1:
         return None
     return candidates[0], None
 

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -22,9 +22,9 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 # (model, custom_llm_provider) litellm prices a model under when the pair Onyx
-# passes does not resolve on its own.
+# passes does not resolve on its own, per (model, provider, pricing path).
 _LitellmTarget = tuple[str, str | None]
-_fallback_targets: dict[tuple[str, str | None], _LitellmTarget] = {}
+_fallback_targets: dict[tuple[str, str | None, str], _LitellmTarget] = {}
 _refresh_lock = threading.Lock()
 _last_refresh_attempt = float("-inf")
 
@@ -85,60 +85,66 @@ def _refresh_litellm_model_cost() -> bool:
         return True
 
 
-def _cost_fields(entry: Mapping[str, Any]) -> str:
-    """Every rate cost_per_token may read (base, cache, tiered), canonicalised
-    so candidates can be compared as a whole."""
-    return json.dumps(
-        {field: value for field, value in entry.items() if "cost" in field},
-        sort_keys=True,
-        default=str,
-    )
+def _rate_fields(entry: Mapping[str, Any], path: str) -> str:
+    """The rates one pricing path reads ("token": base, cache and tiered
+    token rates; "image": per-image rates), canonicalised for comparison."""
+    fields = {
+        field: value
+        for field, value in entry.items()
+        if ("cost" in field and path in field) or field == "tiered_pricing"
+    }
+    return json.dumps(fields, sort_keys=True, default=str)
 
 
-def _vendor_prefixed_target(model: str) -> _LitellmTarget | None:
+def _vendor_prefixed_target(model: str, path: str) -> _LitellmTarget | None:
     """Provider names litellm doesn't know (e.g. openai_compatible) hide models
     it prices under a vendor prefix such as "xai/grok-4". Accept that key only
-    when unambiguous: a single match, or several with identical rates."""
+    when unambiguous for this pricing path: a single match, or several whose
+    rates for the path are identical."""
     import litellm
 
     suffix = "/" + model
     # Under the refresh lock: an in-place map update would break this scan.
     with _refresh_lock:
         candidates = [key for key in litellm.model_cost if key.endswith(suffix)]
-        rates = {_cost_fields(litellm.model_cost[key]) for key in candidates}
+        rates = {_rate_fields(litellm.model_cost[key], path) for key in candidates}
     if not candidates or len(rates) != 1:
         return None
     return candidates[0], None
 
 
-def _fallback_target(model: str, provider: str | None) -> _LitellmTarget | None:
+def _fallback_target(
+    model: str, provider: str | None, path: str
+) -> _LitellmTarget | None:
     """Where litellm prices a model whose (model, provider) pair failed to
     resolve, refreshing the price map when nothing matches."""
     import litellm
 
-    key = (model, provider)
+    key = (model, provider, path)
     cached = _fallback_targets.get(key)
     if cached is not None:
         return cached
-    target = _vendor_prefixed_target(model)
+    target = _vendor_prefixed_target(model, path)
     if target is None and _refresh_litellm_model_cost():
         try:
             litellm.get_model_info(model=model, custom_llm_provider=provider)
             target = (model, provider)
         except Exception:
-            target = _vendor_prefixed_target(model)
+            target = _vendor_prefixed_target(model, path)
     if target is not None:
         _fallback_targets[key] = target
     return target
 
 
-def _litellm_model_info(model: str, provider: str | None) -> Mapping[str, Any]:
+def _litellm_model_info(
+    model: str, provider: str | None, path: str = "token"
+) -> Mapping[str, Any]:
     import litellm
 
     try:
         return litellm.get_model_info(model=model, custom_llm_provider=provider)
     except Exception:
-        target = _fallback_target(model, provider)
+        target = _fallback_target(model, provider, path)
         if target is None:
             raise
         return litellm.get_model_info(model=target[0], custom_llm_provider=target[1])
@@ -154,7 +160,7 @@ def _litellm_cost_per_token(
             model=model, custom_llm_provider=provider, **usage
         )
     except Exception:
-        target = _fallback_target(model, provider)
+        target = _fallback_target(model, provider, "token")
         if target is None:
             raise
         return litellm.cost_per_token(
@@ -220,7 +226,7 @@ def _image_cost_cents(model: str, provider: str | None) -> float:
         import litellm
 
         try:
-            entry = _litellm_model_info(model, provider)
+            entry = _litellm_model_info(model, provider, "image")
         except Exception:
             entry = litellm.model_cost.get(model) or {}
         # litellm prices images per-image under either of these keys. Use an

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -91,7 +91,8 @@ def _rate_fields(entry: Mapping[str, Any], path: str) -> str:
     fields = {
         field: value
         for field, value in entry.items()
-        if ("cost" in field and path in field) or field == "tiered_pricing"
+        if ("cost" in field and path in field)
+        or (path == "token" and field == "tiered_pricing")
     }
     return json.dumps(fields, sort_keys=True, default=str)
 

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -1,5 +1,10 @@
 """LLM cost calculation utilities."""
 
+import threading
+import time
+from collections.abc import Mapping
+from typing import Any
+
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -7,12 +12,20 @@ from onyx.configs.app_configs import (
     DEFAULT_IMAGE_COST_CENTS,
     DEFAULT_LLM_INPUT_COST_PER_MTOK,
     DEFAULT_LLM_OUTPUT_COST_PER_MTOK,
+    LITELLM_MODEL_COST_REFRESH_SECONDS,
 )
 from onyx.llm import cost_overrides
 from onyx.tracing.flows import IMAGE_FLOWS, LLMFlow
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# (model, custom_llm_provider) litellm prices a model under when the pair Onyx
+# passes does not resolve on its own.
+_LitellmTarget = tuple[str, str | None]
+_fallback_targets: dict[tuple[str, str | None], _LitellmTarget] = {}
+_refresh_lock = threading.Lock()
+_last_refresh_attempt = float("-inf")
 
 
 class ModelPrice(BaseModel):
@@ -21,6 +34,124 @@ class ModelPrice(BaseModel):
     input_per_mtok: float | None
     output_per_mtok: float | None
     cache_per_mtok: float | None
+
+
+def _fetch_litellm_model_cost() -> dict[str, Any] | None:
+    """litellm's current remote price map; None when only the bundled copy
+    could be loaded (a stale bundle must not overwrite fresher entries)."""
+    import litellm
+    from litellm.litellm_core_utils.get_model_cost_map import (
+        get_model_cost_map,
+        get_model_cost_map_source_info,
+    )
+
+    fetched = get_model_cost_map(url=litellm.model_cost_map_url)
+    if get_model_cost_map_source_info().get("source") != "remote":
+        return None
+    return fetched if isinstance(fetched, dict) else None
+
+
+def _refresh_litellm_model_cost() -> bool:
+    """Re-download litellm's price map, at most once per
+    LITELLM_MODEL_COST_REFRESH_SECONDS. litellm loads the map once at import,
+    so models released after process start would otherwise bill $0 until a
+    restart."""
+    global _last_refresh_attempt
+    if LITELLM_MODEL_COST_REFRESH_SECONDS <= 0:
+        return False
+    with _refresh_lock:
+        now = time.monotonic()
+        if now - _last_refresh_attempt < LITELLM_MODEL_COST_REFRESH_SECONDS:
+            return False
+        _last_refresh_attempt = now
+        try:
+            fetched = _fetch_litellm_model_cost()
+        except Exception:
+            logger.debug("litellm model cost map refresh failed", exc_info=True)
+            return False
+        if not fetched:
+            return False
+        import litellm
+
+        # In place: litellm keeps references to this dict.
+        added = sum(1 for key in fetched if key not in litellm.model_cost)
+        litellm.model_cost.update(fetched)
+        _fallback_targets.clear()
+        logger.info("Refreshed litellm model cost map (%d new models)", added)
+        return True
+
+
+def _vendor_prefixed_target(model: str) -> _LitellmTarget | None:
+    """Provider names litellm doesn't know (e.g. openai_compatible) hide models
+    it prices under a vendor prefix such as "xai/grok-4". Accept that key only
+    when unambiguous: a single match, or several that agree on token prices."""
+    import litellm
+
+    suffix = "/" + model
+    candidates = [key for key in litellm.model_cost if key.endswith(suffix)]
+    if not candidates:
+        return None
+    prices = {
+        (
+            litellm.model_cost[key].get("input_cost_per_token"),
+            litellm.model_cost[key].get("output_cost_per_token"),
+        )
+        for key in candidates
+    }
+    if len(prices) != 1:
+        return None
+    return candidates[0], None
+
+
+def _fallback_target(model: str, provider: str | None) -> _LitellmTarget | None:
+    """Where litellm prices a model whose (model, provider) pair failed to
+    resolve, refreshing the price map when nothing matches."""
+    import litellm
+
+    key = (model, provider)
+    cached = _fallback_targets.get(key)
+    if cached is not None:
+        return cached
+    target = _vendor_prefixed_target(model)
+    if target is None and _refresh_litellm_model_cost():
+        try:
+            litellm.get_model_info(model=model, custom_llm_provider=provider)
+            target = (model, provider)
+        except Exception:
+            target = _vendor_prefixed_target(model)
+    if target is not None:
+        _fallback_targets[key] = target
+    return target
+
+
+def _litellm_model_info(model: str, provider: str | None) -> Mapping[str, Any]:
+    import litellm
+
+    try:
+        return litellm.get_model_info(model=model, custom_llm_provider=provider)
+    except Exception:
+        target = _fallback_target(model, provider)
+        if target is None:
+            raise
+        return litellm.get_model_info(model=target[0], custom_llm_provider=target[1])
+
+
+def _litellm_cost_per_token(
+    model: str, provider: str | None, **usage: int
+) -> tuple[float, float]:
+    import litellm
+
+    try:
+        return litellm.cost_per_token(
+            model=model, custom_llm_provider=provider, **usage
+        )
+    except Exception:
+        target = _fallback_target(model, provider)
+        if target is None:
+            raise
+        return litellm.cost_per_token(
+            model=target[0], custom_llm_provider=target[1], **usage
+        )
 
 
 def get_model_price_per_million(
@@ -45,9 +176,7 @@ def get_model_price_per_million(
             )
 
     try:
-        import litellm
-
-        entry = litellm.get_model_info(model=model, custom_llm_provider=provider)
+        entry = _litellm_model_info(model, provider)
         input_per_tok = entry.get("input_cost_per_token")
         output_per_tok = entry.get("output_cost_per_token")
         cache_per_tok = entry.get("cache_read_input_token_cost")
@@ -83,7 +212,7 @@ def _image_cost_cents(model: str, provider: str | None) -> float:
         import litellm
 
         try:
-            entry = litellm.get_model_info(model=model, custom_llm_provider=provider)
+            entry = _litellm_model_info(model, provider)
         except Exception:
             entry = litellm.model_cost.get(model) or {}
         # litellm prices images per-image under either of these keys. Use an
@@ -172,16 +301,14 @@ def compute_cost_cents(
             )
 
     try:
-        import litellm
-
         # custom_llm_provider is required for non-self-identifying model names
         # (bedrock/vertex/anthropic-plain) — without it litellm raises and we'd
         # record $0 for entire provider classes.
         # litellm re-prices the cache subsets of prompt_tokens at the model's own
         # cache rates (reads discounted, writes at a premium), never as output.
-        prompt_cost_usd, completion_cost_usd = litellm.cost_per_token(
-            model=model,
-            custom_llm_provider=provider,
+        prompt_cost_usd, completion_cost_usd = _litellm_cost_per_token(
+            model,
+            provider,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             cache_read_input_tokens=cache_read_tokens,

--- a/backend/tests/unit/onyx/llm/test_cost.py
+++ b/backend/tests/unit/onyx/llm/test_cost.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Generator
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from sqlalchemy import Table, create_engine
@@ -50,6 +50,16 @@ def _clear_override_cache() -> Generator[None, None, None]:
     yield
     cost_overrides._cache.clear()
     cost_overrides._last_known_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _offline_refresh(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    # Keep unpriced-model paths off the network; refresh tests stub the fetch.
+    monkeypatch.setattr(cost_mod, "_fetch_litellm_model_cost", lambda: None)
+    monkeypatch.setattr(cost_mod, "_last_refresh_attempt", float("-inf"))
+    cost_mod._fallback_targets.clear()
+    yield
+    cost_mod._fallback_targets.clear()
 
 
 class TestComputeCostCents:
@@ -483,3 +493,130 @@ class TestGetOverride:
             output_cost_per_mtok=2.0,
             cache_read_cost_per_mtok=None,
         )
+
+
+def _chat_entry(provider: str, input_usd: float, output_usd: float) -> dict[str, Any]:
+    return {
+        "input_cost_per_token": input_usd,
+        "output_cost_per_token": output_usd,
+        "litellm_provider": provider,
+        "mode": "chat",
+    }
+
+
+class TestLitellmFallback:
+    def test_vendor_prefixed_key_prices_unknown_provider_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+
+        # Onyx's provider name is not a litellm provider, but litellm prices the
+        # model under its vendor prefix.
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "xai/onyx-test-vendor-model",
+            _chat_entry("xai", 1e-6, 2e-6),
+        )
+        in_cents, out_cents = compute_cost_cents(
+            model="onyx-test-vendor-model",
+            provider="openai_compatible",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert in_cents == pytest.approx(0.1)
+        assert out_cents == pytest.approx(0.2)
+
+    def test_price_per_million_uses_vendor_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "xai/onyx-test-vendor-model",
+            _chat_entry("xai", 1e-6, 2e-6),
+        )
+        price = cost_mod.get_model_price_per_million(
+            "onyx-test-vendor-model", "openai_compatible"
+        )
+        assert price.input_per_mtok == pytest.approx(1.0)
+        assert price.output_per_mtok == pytest.approx(2.0)
+
+    def test_conflicting_vendor_keys_stay_unpriced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "vendor-a/onyx-test-dup-model",
+            _chat_entry("xai", 1e-6, 2e-6),
+        )
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "vendor-b/onyx-test-dup-model",
+            _chat_entry("xai", 5e-6, 9e-6),
+        )
+        result = compute_cost_cents(
+            model="onyx-test-dup-model",
+            provider="openai_compatible",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert result == (0.0, 0.0)
+
+    def test_refresh_prices_model_released_after_startup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+
+        fetches = 0
+
+        def _fetch() -> dict[str, Any]:
+            nonlocal fetches
+            fetches += 1
+            return {"gemini/onyx-test-new-model": _chat_entry("gemini", 1e-6, 2e-6)}
+
+        monkeypatch.setattr(cost_mod, "_fetch_litellm_model_cost", _fetch)
+        try:
+            in_cents, out_cents = compute_cost_cents(
+                model="onyx-test-new-model",
+                provider="gemini",
+                prompt_tokens=1000,
+                completion_tokens=1000,
+            )
+            assert in_cents == pytest.approx(0.1)
+            assert out_cents == pytest.approx(0.2)
+            assert fetches == 1
+
+            # A second miss inside the refresh interval must not re-download.
+            compute_cost_cents(
+                model="onyx-test-still-unknown",
+                provider="gemini",
+                prompt_tokens=1000,
+                completion_tokens=1000,
+            )
+            assert fetches == 1
+        finally:
+            litellm.model_cost.pop("gemini/onyx-test-new-model", None)
+
+    def test_refresh_disabled_when_interval_is_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fetches = 0
+
+        def _fetch() -> dict[str, Any]:
+            nonlocal fetches
+            fetches += 1
+            return {}
+
+        monkeypatch.setattr(cost_mod, "_fetch_litellm_model_cost", _fetch)
+        monkeypatch.setattr(cost_mod, "LITELLM_MODEL_COST_REFRESH_SECONDS", 0)
+        result = compute_cost_cents(
+            model="onyx-test-still-unknown",
+            provider="gemini",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert result == (0.0, 0.0)
+        assert fetches == 0

--- a/backend/tests/unit/onyx/llm/test_cost.py
+++ b/backend/tests/unit/onyx/llm/test_cost.py
@@ -578,6 +578,7 @@ class TestLitellmFallback:
             return {"gemini/onyx-test-new-model": _chat_entry("gemini", 1e-6, 2e-6)}
 
         monkeypatch.setattr(cost_mod, "_fetch_litellm_model_cost", _fetch)
+        monkeypatch.setattr(cost_mod, "LITELLM_MODEL_COST_REFRESH_SECONDS", 3600)
         try:
             in_cents, out_cents = compute_cost_cents(
                 model="onyx-test-new-model",

--- a/backend/tests/unit/onyx/llm/test_cost.py
+++ b/backend/tests/unit/onyx/llm/test_cost.py
@@ -565,6 +565,30 @@ class TestLitellmFallback:
         )
         assert result == (0.0, 0.0)
 
+    def test_image_rate_differences_do_not_block_token_pricing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "xai/onyx-test-mixed-model",
+            {**_chat_entry("xai", 1e-6, 2e-6), "output_cost_per_image": 0.01},
+        )
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "deepseek/onyx-test-mixed-model",
+            {**_chat_entry("deepseek", 1e-6, 2e-6), "output_cost_per_image": 0.05},
+        )
+        in_cents, out_cents = compute_cost_cents(
+            model="onyx-test-mixed-model",
+            provider="openai_compatible",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert in_cents == pytest.approx(0.1)
+        assert out_cents == pytest.approx(0.2)
+
     def test_refresh_prices_model_released_after_startup(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -332,6 +332,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # Fallback USD per million tokens when litellm can't price a model (default 0 = free).
 # DEFAULT_LLM_INPUT_COST_PER_MTOK=0
 # DEFAULT_LLM_OUTPUT_COST_PER_MTOK=0
+# Re-download litellm's price map at most this often when a model is missing from
+# the copy loaded at startup, so newly released models get priced without a
+# restart (default 3600; 0 disables).
+# LITELLM_MODEL_COST_REFRESH_SECONDS=3600
 
 ## Query Options
 # DOC_TIME_DECAY=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -332,6 +332,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # Fallback USD per million tokens when litellm can't price a model (default 0 = free).
 # DEFAULT_LLM_INPUT_COST_PER_MTOK=0
 # DEFAULT_LLM_OUTPUT_COST_PER_MTOK=0
+# Re-download litellm's price map at most this often when a model is missing from
+# the copy loaded at startup, so newly released models get priced without a
+# restart (default 3600; 0 disables).
+# LITELLM_MODEL_COST_REFRESH_SECONDS=3600
 
 ## Query Options
 # DOC_TIME_DECAY=

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.20
+version: 0.8.21
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1597,6 +1597,9 @@ configMap:
   # Fallback USD per million tokens when litellm can't price a model (default 0 = free).
   DEFAULT_LLM_INPUT_COST_PER_MTOK: ""
   DEFAULT_LLM_OUTPUT_COST_PER_MTOK: ""
+  # Re-download litellm's price map at most this often when a model is missing
+  # from the copy loaded at startup (default 3600; 0 disables).
+  LITELLM_MODEL_COST_REFRESH_SECONDS: ""
   # Query Options
   DOC_TIME_DECAY: ""
   HYBRID_ALPHA: ""


### PR DESCRIPTION
## Description

Two ways usage accounting silently records $0 for a model litellm can actually price, and a fix for each in `onyx/llm/cost.py`:

1. **Provider names litellm doesn't know.** `compute_cost_cents` passes Onyx's own provider name as `custom_llm_provider`. For `openai_compatible` providers (xAI, DeepSeek, self-hosted OpenAI-style servers, …) litellm raises "This model isn't mapped yet" even when its map prices the model under a vendor prefix (`xai/grok-4.6`, `deepseek/deepseek-v4-pro`), so every model on such a provider bills $0 unless an admin override exists. The cost path now falls back to the vendor-prefixed key when it is unambiguous: exactly one `*/<model>` entry, or several that agree on token prices. Conflicting candidates stay unpriced rather than guessing.

2. **Models released after process start.** litellm downloads its price map once at import and never refreshes, so a model whose price lands in litellm after the last restart bills $0 until the next restart (we saw ~10 hours between a container start and the day-0 price entry landing, then two days of $0 usage). On a pricing miss the map is now re-downloaded at most once per `LITELLM_MODEL_COST_REFRESH_SECONDS` (default 1h, `0` disables) via litellm's own loader, updated in place, and the lookup retried. Only a *remote* map is applied, so a failed download can never regress prices to the bundled copy.

Both apply to `get_model_price_per_million` (Usage tab display) and image pricing as well, since they share the litellm lookup. Admin cost overrides still win over everything.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/llm/test_cost.py` (`TestLitellmFallback`): vendor-prefixed key prices an `openai_compatible` model for both cost and price-per-million; conflicting vendor keys stay at $0; a refresh prices a model added after startup and does not re-download inside the interval; `LITELLM_MODEL_COST_REFRESH_SECONDS=0` disables refresh. The refresh is stubbed so tests stay offline.
- Existing `test_cost.py` suite passes unchanged.
- Verified against litellm 1.93.0 on a running deployment: `cost_per_token(model="xai/grok-4.6")` prices correctly while `custom_llm_provider="openai_compatible"` raises; `get_model_cost_map(url=litellm.model_cost_map_url)` returns a fresh remote map in ~40 ms.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes usage accounting recording $0 for models litellm can price: models on providers litellm doesn't know now fall back to an unambiguous vendor-prefixed key, and a missing model triggers a price-map refresh at most once per `LITELLM_MODEL_COST_REFRESH_SECONDS` (default 1h, `0` disables) so newly released models get priced without a restart. Admin overrides still win, and a failed refresh can't regress prices to the bundled copy.

- Applies to `compute_cost_cents`, price-per-million display, and image pricing.
- Vendor-prefixed candidates are compared per pricing path (tiered rates count only on the token path), so an image-rate difference no longer blocks an unambiguous token price; conflicting candidates stay unpriced.
- Documents the new setting in Docker Compose, Helm, and CLI embedded deployment configs.
- New unit tests cover vendor fallback, per-path conflicts, and refresh throttling.

<sup>Written for commit 534841fb353c556f974277be52bc50803269e73d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

