### PR TITLE
feat(zoom): add Zoom API client and transcript parsing

### DIFF
--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -10,6 +10,7 @@ from urllib3.util import Retry
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.connectors.exceptions import (
     CredentialExpiredError,
+    CredentialInvalidError,
     InsufficientPermissionsError,
 )
 from onyx.connectors.zoom.models import (
@@ -108,9 +109,16 @@ class ZoomClient:
             auth=(self.client_id, self.client_secret),
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
+        # A Server-to-Server client secret never expires, so this 401 is invalid,
+        # not expired. The 401 in _send_authorized is a real token expiry.
         if response.status_code == 401:
-            raise CredentialExpiredError(
+            raise CredentialInvalidError(
                 "Zoom rejected the Server-to-Server OAuth client credentials"
+            )
+        if response.status_code == 403:
+            raise InsufficientPermissionsError(
+                "Zoom refused to issue a token for this app — check that it is "
+                "activated and its scopes are granted"
             )
         _raise_for_zoom_error(response, "the OAuth token request")
 

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import quote
 
@@ -23,8 +24,8 @@ logger = setup_logger()
 _OAUTH_TOKEN_URL = "https://zoom.us/oauth/token"
 _API_BASE_URL = "https://api.zoom.us/v2"
 
-# Zoom access tokens last about an hour. Refresh this many seconds early so a
-# request never goes out holding a token that expires mid-flight.
+# Zoom access tokens last about an hour, so refresh early rather than letting
+# one lapse mid-request.
 _TOKEN_REFRESH_MARGIN_SECONDS = 60
 
 
@@ -87,23 +88,44 @@ class ZoomClient:
         assert self._access_token is not None
         return self._access_token
 
+    def _send_authorized(
+        self, description: str, send: Callable[[str], requests.Response]
+    ) -> requests.Response:
+        """Zoom can reject a token before the expiry it gave us, so try a
+        fresh one before reporting a 401. CredentialExpiredError cancels the
+        indexing attempt, and five of them in a row mark the connector
+        invalid and email the admins. Retrying is safe because a 401 is
+        refused before the request does anything.
+        """
+        response = send(self._get_access_token())
+        if response.status_code == 401:
+            self._access_token = None
+            response = send(self._get_access_token())
+
+        if response.status_code == 401:
+            raise CredentialExpiredError(
+                f"Zoom rejected {description} as unauthorized, even with a fresh token"
+            )
+        if response.status_code == 403:
+            raise InsufficientPermissionsError(
+                f"Zoom denied access to {description} — check the app's granted scopes"
+            )
+        return response
+
     def _request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
         url = f"{_API_BASE_URL}{endpoint}"
         headers = kwargs.pop("headers", {})
-        headers["Authorization"] = f"Bearer {self._get_access_token()}"
 
-        response = self._session.request(
-            method, url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS, **kwargs
-        )
-
-        if response.status_code == 401:
-            raise CredentialExpiredError("Zoom rejected the request as unauthorized")
-        if response.status_code == 403:
-            raise InsufficientPermissionsError(
-                f"Zoom denied access to {endpoint} — check the app's granted scopes"
+        def send(token: str) -> requests.Response:
+            return self._session.request(
+                method,
+                url,
+                headers={**headers, "Authorization": f"Bearer {token}"},
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                **kwargs,
             )
 
-        return response
+        return self._send_authorized(endpoint, send)
 
     def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript | None:
         """This endpoint takes a meeting ID, a webinar ID, or a single
@@ -146,10 +168,13 @@ class ZoomClient:
         return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]
 
     def download_transcript_vtt(self, download_url: str) -> str:
-        response = requests.get(
-            download_url,
-            headers={"Authorization": f"Bearer {self._get_access_token()}"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
+        def send(token: str) -> requests.Response:
+            return requests.get(
+                download_url,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+
+        response = self._send_authorized("the transcript download", send)
         response.raise_for_status()
         return response.text

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -1,7 +1,7 @@
 import time
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -17,7 +17,11 @@ from onyx.connectors.zoom.models import (
     ZoomPastMeetingDetails,
     ZoomTranscript,
 )
-from onyx.utils.url import SSRFException, validate_outbound_http_url
+from onyx.utils.url import (
+    SSRFException,
+    ssrf_safe_get,
+    validate_outbound_http_url,
+)
 
 _OAUTH_TOKEN_URL = "https://zoom.us/oauth/token"
 _API_BASE_URL = "https://api.zoom.us/v2"
@@ -208,6 +212,12 @@ class ZoomClient:
         return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]
 
     def download_transcript_vtt(self, download_url: str) -> str:
+        """The download redirects to a storage host, so every hop is checked
+        before it is followed — an open redirect on a Zoom host would otherwise
+        make this connector fetch private addresses. The token goes only to the
+        Zoom host checked up front, since the storage host authenticates from
+        the signed URL.
+        """
         _reject_non_zoom_download_url(download_url)
 
         def send(token: str) -> requests.Response:
@@ -215,8 +225,22 @@ class ZoomClient:
                 download_url,
                 headers={"Authorization": f"Bearer {token}"},
                 timeout=REQUEST_TIMEOUT_SECONDS,
+                allow_redirects=False,
             )
 
         response = self._send_authorized("the transcript download", send)
+        if response.is_redirect:
+            location = urljoin(download_url, response.headers["Location"])
+            try:
+                response = ssrf_safe_get(
+                    location,
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                    https_only=True,
+                )
+            except SSRFException as e:
+                raise ValueError(
+                    f"Zoom redirected the transcript download somewhere unsafe: {e}"
+                ) from e
+
         _raise_for_zoom_error(response, "the transcript download")
         return response.text

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -1,0 +1,155 @@
+import time
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
+from onyx.connectors.exceptions import (
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+)
+from onyx.connectors.zoom.models import (
+    ZoomMeetingOccurrence,
+    ZoomPastMeetingDetails,
+    ZoomTranscript,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_OAUTH_TOKEN_URL = "https://zoom.us/oauth/token"
+_API_BASE_URL = "https://api.zoom.us/v2"
+
+# Zoom access tokens last about an hour. Refresh this many seconds early so a
+# request never goes out holding a token that expires mid-flight.
+_TOKEN_REFRESH_MARGIN_SECONDS = 60
+
+
+def _encode_meeting_identifier(identifier: str) -> str:
+    """Zoom's docs require encoding a UUID twice when it starts with "/" or
+    contains "//", because something in front of their API decodes one layer
+    before the request arrives."""
+    encoded = quote(identifier, safe="")
+    if identifier.startswith("/") or "//" in identifier:
+        encoded = quote(encoded, safe="")
+    return encoded
+
+
+class ZoomClient:
+    def __init__(self, account_id: str, client_id: str, client_secret: str) -> None:
+        self.account_id = account_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+        self._access_token: str | None = None
+        self._token_expires_at: float = 0.0
+
+        self._session = requests.Session()
+        retry_strategy = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET", "POST"],
+        )
+        self._session.mount(_API_BASE_URL, HTTPAdapter(max_retries=retry_strategy))
+
+    def _fetch_access_token(self) -> None:
+        response = requests.post(
+            _OAUTH_TOKEN_URL,
+            params={
+                "grant_type": "account_credentials",
+                "account_id": self.account_id,
+            },
+            auth=(self.client_id, self.client_secret),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 401:
+            raise CredentialExpiredError(
+                "Zoom rejected the Server-to-Server OAuth client credentials"
+            )
+        response.raise_for_status()
+
+        token_data = response.json()
+        self._access_token = token_data["access_token"]
+        expires_in = token_data.get("expires_in", 3600)
+        self._token_expires_at = time.monotonic() + expires_in
+
+    def _get_access_token(self) -> str:
+        if (
+            self._access_token is None
+            or time.monotonic()
+            >= self._token_expires_at - _TOKEN_REFRESH_MARGIN_SECONDS
+        ):
+            self._fetch_access_token()
+        assert self._access_token is not None
+        return self._access_token
+
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> requests.Response:
+        url = f"{_API_BASE_URL}{endpoint}"
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {self._get_access_token()}"
+
+        response = self._session.request(
+            method, url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS, **kwargs
+        )
+
+        if response.status_code == 401:
+            raise CredentialExpiredError("Zoom rejected the request as unauthorized")
+        if response.status_code == 403:
+            raise InsufficientPermissionsError(
+                f"Zoom denied access to {endpoint} — check the app's granted scopes"
+            )
+
+        return response
+
+    def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript | None:
+        """This endpoint takes a meeting ID, a webinar ID, or a single
+        occurrence's UUID. None means Zoom has no recording for it, so the
+        caller should skip it rather than treat it as an error."""
+        response = self._request(
+            "GET",
+            f"/meetings/{_encode_meeting_identifier(meeting_identifier)}/transcript",
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return ZoomTranscript.model_validate(response.json())
+
+    def get_past_meeting_details(
+        self, meeting_identifier: str
+    ) -> ZoomPastMeetingDetails | None:
+        response = self._request(
+            "GET", f"/past_meetings/{_encode_meeting_identifier(meeting_identifier)}"
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return ZoomPastMeetingDetails.model_validate(response.json())
+
+    def list_past_meeting_occurrences(
+        self, meeting_id: str
+    ) -> list[ZoomMeetingOccurrence]:
+        """A recurring meeting records each run separately, and passing the
+        bare meeting_id to the transcript endpoint only ever reaches the
+        latest one. Call this first to get every past occurrence's UUID."""
+        response = self._request(
+            "GET",
+            f"/past_meetings/{_encode_meeting_identifier(meeting_id)}/instances",
+        )
+        if response.status_code == 404:
+            return []
+        response.raise_for_status()
+        occurrences = response.json().get("meetings", [])
+        return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]
+
+    def download_transcript_vtt(self, download_url: str) -> str:
+        response = requests.get(
+            download_url,
+            headers={"Authorization": f"Bearer {self._get_access_token()}"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        return response.text

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -1,7 +1,7 @@
 import time
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -18,15 +18,16 @@ from onyx.connectors.zoom.models import (
     ZoomTranscript,
 )
 from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException, validate_outbound_http_url
 
 logger = setup_logger()
 
 _OAUTH_TOKEN_URL = "https://zoom.us/oauth/token"
 _API_BASE_URL = "https://api.zoom.us/v2"
 
-# Zoom access tokens last about an hour, so refresh early rather than letting
-# one lapse mid-request.
-_TOKEN_REFRESH_MARGIN_SECONDS = 60
+_ZOOM_HOST = "zoom.us"
+
+_TOKEN_REFRESH_MARGIN_SECONDS = 60  # Zoom's own tokens last about an hour.
 
 
 def _encode_meeting_identifier(identifier: str) -> str:
@@ -37,6 +38,24 @@ def _encode_meeting_identifier(identifier: str) -> str:
     if identifier.startswith("/") or "//" in identifier:
         encoded = quote(encoded, safe="")
     return encoded
+
+
+def _reject_non_zoom_download_url(download_url: str) -> None:
+    """Zoom supplies this URL, but the download carries the account-wide bearer
+    token, so a wrong or tampered one would hand that credential to whatever
+    host it names. requests drops the header on a cross-host redirect, so only
+    the first host needs checking.
+    """
+    host = (urlparse(download_url).hostname or "").rstrip(".").lower()
+    if host != _ZOOM_HOST and not host.endswith(f".{_ZOOM_HOST}"):
+        raise ValueError(
+            f"Refusing to send Zoom credentials to a non-Zoom host: {host or download_url!r}"
+        )
+
+    try:
+        validate_outbound_http_url(download_url, https_only=True)
+    except (SSRFException, ValueError) as e:
+        raise ValueError(f"Unsafe Zoom transcript download URL: {e}") from e
 
 
 class ZoomClient:
@@ -129,8 +148,8 @@ class ZoomClient:
 
     def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript | None:
         """This endpoint takes a meeting ID, a webinar ID, or a single
-        occurrence's UUID. None means Zoom has no recording for it, so the
-        caller should skip it rather than treat it as an error."""
+        occurrence's UUID. A meeting with no recording is a normal skip, not a
+        failure, so that comes back as None rather than raising."""
         response = self._request(
             "GET",
             f"/meetings/{_encode_meeting_identifier(meeting_identifier)}/transcript",
@@ -168,6 +187,8 @@ class ZoomClient:
         return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]
 
     def download_transcript_vtt(self, download_url: str) -> str:
+        _reject_non_zoom_download_url(download_url)
+
         def send(token: str) -> requests.Response:
             return requests.get(
                 download_url,

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -17,23 +17,19 @@ from onyx.connectors.zoom.models import (
     ZoomPastMeetingDetails,
     ZoomTranscript,
 )
-from onyx.utils.logger import setup_logger
 from onyx.utils.url import SSRFException, validate_outbound_http_url
-
-logger = setup_logger()
 
 _OAUTH_TOKEN_URL = "https://zoom.us/oauth/token"
 _API_BASE_URL = "https://api.zoom.us/v2"
 
 _ZOOM_HOST = "zoom.us"
 
-_TOKEN_REFRESH_MARGIN_SECONDS = 60  # Zoom's own tokens last about an hour.
+_TOKEN_REFRESH_MARGIN_SECONDS = 60
 
 
 def _encode_meeting_identifier(identifier: str) -> str:
-    """Zoom's docs require encoding a UUID twice when it starts with "/" or
-    contains "//", because something in front of their API decodes one layer
-    before the request arrives."""
+    """Zoom requires a UUID to be encoded twice when it starts with "/" or
+    contains "//"."""
     encoded = quote(identifier, safe="")
     if identifier.startswith("/") or "//" in identifier:
         encoded = quote(encoded, safe="")
@@ -41,10 +37,9 @@ def _encode_meeting_identifier(identifier: str) -> str:
 
 
 def _reject_non_zoom_download_url(download_url: str) -> None:
-    """Zoom supplies this URL, but the download carries the account-wide bearer
-    token, so a wrong or tampered one would hand that credential to whatever
-    host it names. requests drops the header on a cross-host redirect, so only
-    the first host needs checking.
+    """The download sends the account-wide bearer token, so a tampered URL would
+    hand that credential to whatever host it names. Only the first host needs
+    checking, because requests drops the header on a cross-host redirect.
     """
     host = (urlparse(download_url).hostname or "").rstrip(".").lower()
     if host != _ZOOM_HOST and not host.endswith(f".{_ZOOM_HOST}"):
@@ -56,6 +51,27 @@ def _reject_non_zoom_download_url(download_url: str) -> None:
         validate_outbound_http_url(download_url, https_only=True)
     except (SSRFException, ValueError) as e:
         raise ValueError(f"Unsafe Zoom transcript download URL: {e}") from e
+
+
+def _raise_for_zoom_error(response: requests.Response, description: str) -> None:
+    """requests' own message stops at "400 Client Error" and drops Zoom's
+    explanation, which is where codes like 12702 (meeting over a year old) live.
+    """
+    if response.ok:
+        return
+
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+
+    detail = ""
+    if isinstance(body, dict) and body.get("message"):
+        detail = f": {body['message']} (Zoom code {body.get('code')})"
+
+    raise requests.HTTPError(
+        f"{response.status_code} from {description}{detail}", response=response
+    )
 
 
 class ZoomClient:
@@ -74,10 +90,12 @@ class ZoomClient:
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["GET", "POST"],
         )
-        self._session.mount(_API_BASE_URL, HTTPAdapter(max_retries=retry_strategy))
+        # Mount on the scheme, not per URL: the API, token endpoint and download
+        # are three different Zoom hosts, and a missed one silently gets no retries.
+        self._session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
 
     def _fetch_access_token(self) -> None:
-        response = requests.post(
+        response = self._session.post(
             _OAUTH_TOKEN_URL,
             params={
                 "grant_type": "account_credentials",
@@ -90,7 +108,7 @@ class ZoomClient:
             raise CredentialExpiredError(
                 "Zoom rejected the Server-to-Server OAuth client credentials"
             )
-        response.raise_for_status()
+        _raise_for_zoom_error(response, "the OAuth token request")
 
         token_data = response.json()
         self._access_token = token_data["access_token"]
@@ -110,11 +128,10 @@ class ZoomClient:
     def _send_authorized(
         self, description: str, send: Callable[[str], requests.Response]
     ) -> requests.Response:
-        """Zoom can reject a token before the expiry it gave us, so try a
-        fresh one before reporting a 401. CredentialExpiredError cancels the
-        indexing attempt, and five of them in a row mark the connector
-        invalid and email the admins. Retrying is safe because a 401 is
-        refused before the request does anything.
+        """Zoom sometimes rejects a token before the expiry it gave us, so retry
+        once with a fresh one. Reporting the 401 instead raises
+        CredentialExpiredError, and five of those in a row mark the connector
+        invalid and email the admins.
         """
         response = send(self._get_access_token())
         if response.status_code == 401:
@@ -147,16 +164,17 @@ class ZoomClient:
         return self._send_authorized(endpoint, send)
 
     def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript | None:
-        """This endpoint takes a meeting ID, a webinar ID, or a single
-        occurrence's UUID. A meeting with no recording is a normal skip, not a
-        failure, so that comes back as None rather than raising."""
+        """Takes a meeting ID, a webinar ID, or one occurrence's UUID. Zoom has
+        no webinar transcript endpoint, so webinars come through here too.
+        Returns None when the session was never recorded, which is a normal skip.
+        """
         response = self._request(
             "GET",
             f"/meetings/{_encode_meeting_identifier(meeting_identifier)}/transcript",
         )
         if response.status_code == 404:
             return None
-        response.raise_for_status()
+        _raise_for_zoom_error(response, f"the transcript for {meeting_identifier}")
         return ZoomTranscript.model_validate(response.json())
 
     def get_past_meeting_details(
@@ -167,22 +185,25 @@ class ZoomClient:
         )
         if response.status_code == 404:
             return None
-        response.raise_for_status()
+        _raise_for_zoom_error(response, f"the details for {meeting_identifier}")
         return ZoomPastMeetingDetails.model_validate(response.json())
 
     def list_past_meeting_occurrences(
         self, meeting_id: str
     ) -> list[ZoomMeetingOccurrence]:
-        """A recurring meeting records each run separately, and passing the
-        bare meeting_id to the transcript endpoint only ever reaches the
-        latest one. Call this first to get every past occurrence's UUID."""
+        """A recurring meeting records each run separately, and the bare
+        meeting_id only ever reaches the latest one, so call this first for every
+        occurrence's UUID. This endpoint is not paginated. Zoom returns nothing
+        for meetings older than 15 months, silently and with no way to detect it,
+        so scope by host or group to reach further back.
+        """
         response = self._request(
             "GET",
             f"/past_meetings/{_encode_meeting_identifier(meeting_id)}/instances",
         )
         if response.status_code == 404:
             return []
-        response.raise_for_status()
+        _raise_for_zoom_error(response, f"the occurrences for {meeting_id}")
         occurrences = response.json().get("meetings", [])
         return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]
 
@@ -190,12 +211,12 @@ class ZoomClient:
         _reject_non_zoom_download_url(download_url)
 
         def send(token: str) -> requests.Response:
-            return requests.get(
+            return self._session.get(
                 download_url,
                 headers={"Authorization": f"Bearer {token}"},
                 timeout=REQUEST_TIMEOUT_SECONDS,
             )
 
         response = self._send_authorized("the transcript download", send)
-        response.raise_for_status()
+        _raise_for_zoom_error(response, "the transcript download")
         return response.text

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -14,6 +14,7 @@ from onyx.connectors.exceptions import (
     InsufficientPermissionsError,
 )
 from onyx.connectors.zoom.models import (
+    ZoomAccessToken,
     ZoomMeetingOccurrence,
     ZoomPastMeetingDetails,
     ZoomTranscript,
@@ -122,10 +123,9 @@ class ZoomClient:
             )
         _raise_for_zoom_error(response, "the OAuth token request")
 
-        token_data = response.json()
-        self._access_token = token_data["access_token"]
-        expires_in = token_data.get("expires_in", 3600)
-        self._token_expires_at = time.monotonic() + expires_in
+        token = ZoomAccessToken.model_validate(response.json())
+        self._access_token = token.access_token
+        self._token_expires_at = time.monotonic() + token.expires_in
 
     def _get_access_token(self) -> str:
         if (

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -175,28 +175,26 @@ class ZoomClient:
 
         return self._send_authorized(endpoint, send)
 
-    def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript | None:
+    def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript:
         """Takes a meeting ID, a webinar ID, or one occurrence's UUID. Zoom has
         no webinar transcript endpoint, so webinars come through here too.
-        Returns None when the session was never recorded, which is a normal skip.
+
+        A session that was never recorded answers 404, which raises here. Whether
+        that is a skip or a failure is the caller's call, not this client's.
         """
         response = self._request(
             "GET",
             f"/meetings/{_encode_meeting_identifier(meeting_identifier)}/transcript",
         )
-        if response.status_code == 404:
-            return None
         _raise_for_zoom_error(response, f"the transcript for {meeting_identifier}")
         return ZoomTranscript.model_validate(response.json())
 
     def get_past_meeting_details(
         self, meeting_identifier: str
-    ) -> ZoomPastMeetingDetails | None:
+    ) -> ZoomPastMeetingDetails:
         response = self._request(
             "GET", f"/past_meetings/{_encode_meeting_identifier(meeting_identifier)}"
         )
-        if response.status_code == 404:
-            return None
         _raise_for_zoom_error(response, f"the details for {meeting_identifier}")
         return ZoomPastMeetingDetails.model_validate(response.json())
 
@@ -213,8 +211,6 @@ class ZoomClient:
             "GET",
             f"/past_meetings/{_encode_meeting_identifier(meeting_id)}/instances",
         )
-        if response.status_code == 404:
-            return []
         _raise_for_zoom_error(response, f"the occurrences for {meeting_id}")
         occurrences = response.json().get("meetings", [])
         return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -100,7 +100,7 @@ class ZoomClient:
         # are three different Zoom hosts, and a missed one silently gets no retries.
         self._session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
 
-    def _fetch_access_token(self) -> None:
+    def _fetch_access_token(self) -> str:
         response = self._session.post(
             _OAUTH_TOKEN_URL,
             params={
@@ -126,6 +126,7 @@ class ZoomClient:
         token = ZoomAccessToken.model_validate(response.json())
         self._access_token = token.access_token
         self._token_expires_at = time.monotonic() + token.expires_in
+        return token.access_token
 
     def _get_access_token(self) -> str:
         if (
@@ -133,8 +134,7 @@ class ZoomClient:
             or time.monotonic()
             >= self._token_expires_at - _TOKEN_REFRESH_MARGIN_SECONDS
         ):
-            self._fetch_access_token()
-        assert self._access_token is not None
+            return self._fetch_access_token()
         return self._access_token
 
     def _send_authorized(

--- a/backend/onyx/connectors/zoom/models.py
+++ b/backend/onyx/connectors/zoom/models.py
@@ -4,11 +4,26 @@ from pydantic import BaseModel
 class ZoomTranscript(BaseModel):
     """Response shape of `GET /meetings/{meetingId}/transcript`."""
 
+    meeting_id: str | None = None
+    meeting_topic: str | None = None
+    host_id: str | None = None
+    can_download: bool | None = None
     download_url: str | None = None
     download_restriction_reason: str | None = None
     transcript_created_time: str | None = None
     auto_delete: bool | None = None
     auto_delete_date: str | None = None
+
+    @property
+    def is_downloadable(self) -> bool:
+        """Zoom documents these three fields as mutually exclusive, then their
+        own example returns all three together, so no one of them can be trusted.
+        """
+        return (
+            self.can_download is not False
+            and self.download_restriction_reason is None
+            and bool(self.download_url)
+        )
 
 
 class ZoomPastMeetingDetails(BaseModel):

--- a/backend/onyx/connectors/zoom/models.py
+++ b/backend/onyx/connectors/zoom/models.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+
+
+class ZoomTranscript(BaseModel):
+    """Response shape of `GET /meetings/{meetingId}/transcript`."""
+
+    download_url: str | None = None
+    download_restriction_reason: str | None = None
+    transcript_created_time: str | None = None
+    auto_delete: bool | None = None
+    auto_delete_date: str | None = None
+
+
+class ZoomPastMeetingDetails(BaseModel):
+    """Response shape of `GET /past_meetings/{meetingId}`."""
+
+    uuid: str | None = None
+    topic: str | None = None
+    start_time: str | None = None
+    duration: int | None = None
+
+
+class ZoomMeetingOccurrence(BaseModel):
+    """One entry from `GET /past_meetings/{meetingId}/instances`."""
+
+    uuid: str
+    start_time: str | None = None

--- a/backend/onyx/connectors/zoom/models.py
+++ b/backend/onyx/connectors/zoom/models.py
@@ -8,6 +8,20 @@ Zoom's own text says the field is conditional.
 from pydantic import BaseModel
 
 
+class ZoomAccessToken(BaseModel):
+    """Response shape of `POST https://zoom.us/oauth/token`.
+
+    Zoom's API export does not document this endpoint, so these types come from
+    Zoom's OAuth docs and not from the export every other model here follows.
+    """
+
+    access_token: str
+    expires_in: int
+    token_type: str | None = None
+    scope: str | None = None
+    api_url: str | None = None
+
+
 class ZoomTranscript(BaseModel):
     """Response shape of `GET /meetings/{meetingId}/transcript`."""
 

--- a/backend/onyx/connectors/zoom/models.py
+++ b/backend/onyx/connectors/zoom/models.py
@@ -1,26 +1,35 @@
+"""Response models for the Zoom endpoints this connector calls.
+
+These mirror Zoom's documented responses and nothing else. A field is `| None`
+only where Zoom types it `string | null`, and it has a default only where
+Zoom's own text says the field is conditional.
+"""
+
 from pydantic import BaseModel
 
 
 class ZoomTranscript(BaseModel):
     """Response shape of `GET /meetings/{meetingId}/transcript`."""
 
-    meeting_id: str | None = None
-    meeting_topic: str | None = None
-    host_id: str | None = None
-    can_download: bool | None = None
-    download_url: str | None = None
-    download_restriction_reason: str | None = None
-    transcript_created_time: str | None = None
+    meeting_id: str
+    account_id: str
+    meeting_topic: str
+    host_id: str
+    can_download: bool
+    transcript_created_time: str
+
     auto_delete: bool | None = None
     auto_delete_date: str | None = None
+    download_url: str | None = None
+    download_restriction_reason: str | None = None
 
     @property
     def is_downloadable(self) -> bool:
-        """Zoom documents these three fields as mutually exclusive, then their
-        own example returns all three together, so no one of them can be trusted.
+        """Zoom documents these three fields as mutually exclusive, then returns
+        all three together in its own example, so all three must agree here.
         """
         return (
-            self.can_download is not False
+            self.can_download
             and self.download_restriction_reason is None
             and bool(self.download_url)
         )
@@ -29,14 +38,25 @@ class ZoomTranscript(BaseModel):
 class ZoomPastMeetingDetails(BaseModel):
     """Response shape of `GET /past_meetings/{meetingId}`."""
 
-    uuid: str | None = None
-    topic: str | None = None
-    start_time: str | None = None
-    duration: int | None = None
+    uuid: str
+    id: int
+    topic: str
+    start_time: str
+    end_time: str
+    duration: int
+    host_id: str
+    dept: str
+    participants_count: int
+    total_minutes: int
+    has_meeting_summary: bool
+    source: str
+    type: int
+    user_email: str
+    user_name: str
 
 
 class ZoomMeetingOccurrence(BaseModel):
     """One entry from `GET /past_meetings/{meetingId}/instances`."""
 
     uuid: str
-    start_time: str | None = None
+    start_time: str

--- a/backend/onyx/connectors/zoom/recordings/vtt.py
+++ b/backend/onyx/connectors/zoom/recordings/vtt.py
@@ -1,0 +1,43 @@
+import re
+
+# Anchored and shaped like a real timestamp, so a speaker saying something
+# like "the flow goes A --> B" isn't mistaken for a timing line and dropped.
+_TIMING_LINE_RE = re.compile(r"^(?:\d+:)?\d{1,2}:\d{2}[.,]\d{1,3}\s*-->")
+
+_NON_CUE_BLOCK_RE = re.compile(r"^(WEBVTT|NOTE|STYLE|REGION)\b", re.IGNORECASE)
+
+_CUE_TAG_RE = re.compile(r"<[^>]*>")
+
+
+def parse_vtt_transcript(vtt_content: str) -> str:
+    """Follows the W3C WebVTT spec, which is as far as Zoom commits: their docs
+    name the file type and say it holds timestamped sections, but never define
+    the layout inside it. Real Zoom files put the speaker inline in the cue
+    text ("Jane Doe: hello"), which is undocumented — if that ever changed to
+    <v> tags the speech would survive but the names would be lost.
+    """
+    normalized = vtt_content.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
+
+    paragraphs: list[str] = []
+    for block in normalized.split("\n\n"):
+        lines = [line.strip() for line in block.splitlines() if line.strip()]
+        if not lines or _NON_CUE_BLOCK_RE.match(lines[0]):
+            continue
+
+        # Take the speech by position rather than by what it looks like, so a
+        # cue that is only a number survives instead of reading as a cue index.
+        timing_index = next(
+            (i for i, line in enumerate(lines) if _TIMING_LINE_RE.match(line)), None
+        )
+        if timing_index is None:
+            continue
+
+        spoken = [
+            stripped
+            for line in lines[timing_index + 1 :]
+            if (stripped := _CUE_TAG_RE.sub("", line).strip())
+        ]
+        if spoken:
+            paragraphs.append(" ".join(spoken))
+
+    return "\n\n".join(paragraphs)

--- a/backend/onyx/connectors/zoom/recordings/vtt.py
+++ b/backend/onyx/connectors/zoom/recordings/vtt.py
@@ -1,10 +1,9 @@
 """Turns a Zoom transcript's WebVTT into indexable text.
 
-Zoom names the file type but never defines the layout inside, so this follows
-the W3C spec; real files put the speaker inline ("Jane Doe: hello"), which is
-undocumented. Cue text is found by position, never by shape — a speaker can
-say "A --> B" and a cue can be nothing but a number, and matching either as
-markup deletes real speech.
+Zoom never documents the layout inside the file, so this follows the W3C spec.
+Cue text is found by position, never by shape: a speaker can say "A --> B" and
+a cue can be nothing but a number, so matching either as markup deletes real
+speech.
 """
 
 import html
@@ -12,16 +11,19 @@ import re
 
 _TIMING_LINE_RE = re.compile(r"^(?:\d+:)?\d{1,2}:\d{2}[.,]\d{1,3}\s*-->")
 
-_NON_CUE_BLOCK_RE = re.compile(r"^(WEBVTT|NOTE|STYLE|REGION)\b", re.IGNORECASE)
+# Matching loosely here eats a cue whose identifier merely starts with one of
+# these words, taking the speech under it. Only NOTE and WEBVTT may carry
+# trailing text.
+_NON_CUE_BLOCK_RE = re.compile(r"^(?:(?:WEBVTT|NOTE)(?:[ \t].*)?|STYLE|REGION)$")
 
 _CUE_TAG_RE = re.compile(r"<[^>]*>")
 
 
 def _clean_cue_line(line: str) -> str:
-    """WebVTT forbids a literal "&", so someone saying "R&D" arrives as
-    "R&amp;D". Decode only after stripping markup, or an escaped
-    "&lt;v Jane&gt;" turns into a tag and gets deleted. The decoded
-    non-breaking space goes too, since it will not match a typed space.
+    """WebVTT forbids a literal "&", so "R&D" arrives as "R&amp;D". Strip markup
+    before decoding, or an escaped "&lt;v Jane&gt;" becomes a tag and gets
+    deleted. The decoded non-breaking space goes too, since it will not match a
+    typed space in search.
     """
     decoded = html.unescape(_CUE_TAG_RE.sub("", line))
     return decoded.replace("\xa0", " ").strip()

--- a/backend/onyx/connectors/zoom/recordings/vtt.py
+++ b/backend/onyx/connectors/zoom/recordings/vtt.py
@@ -10,11 +10,9 @@ _CUE_TAG_RE = re.compile(r"<[^>]*>")
 
 
 def parse_vtt_transcript(vtt_content: str) -> str:
-    """Follows the W3C WebVTT spec, which is as far as Zoom commits: their docs
-    name the file type and say it holds timestamped sections, but never define
-    the layout inside it. Real Zoom files put the speaker inline in the cue
-    text ("Jane Doe: hello"), which is undocumented — if that ever changed to
-    <v> tags the speech would survive but the names would be lost.
+    """Follows the W3C WebVTT spec, because Zoom names the file type but never
+    defines the layout inside it. Real Zoom files put the speaker inline in
+    the cue text ("Jane Doe: hello"), which is undocumented and could change.
     """
     normalized = vtt_content.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
 

--- a/backend/onyx/connectors/zoom/recordings/vtt.py
+++ b/backend/onyx/connectors/zoom/recordings/vtt.py
@@ -1,7 +1,15 @@
+"""Turns a Zoom transcript's WebVTT into indexable text.
+
+Zoom names the file type but never defines the layout inside, so this follows
+the W3C spec; real files put the speaker inline ("Jane Doe: hello"), which is
+undocumented. Cue text is found by position, never by shape — a speaker can
+say "A --> B" and a cue can be nothing but a number, and matching either as
+markup deletes real speech.
+"""
+
+import html
 import re
 
-# Anchored and shaped like a real timestamp, so a speaker saying something
-# like "the flow goes A --> B" isn't mistaken for a timing line and dropped.
 _TIMING_LINE_RE = re.compile(r"^(?:\d+:)?\d{1,2}:\d{2}[.,]\d{1,3}\s*-->")
 
 _NON_CUE_BLOCK_RE = re.compile(r"^(WEBVTT|NOTE|STYLE|REGION)\b", re.IGNORECASE)
@@ -9,11 +17,17 @@ _NON_CUE_BLOCK_RE = re.compile(r"^(WEBVTT|NOTE|STYLE|REGION)\b", re.IGNORECASE)
 _CUE_TAG_RE = re.compile(r"<[^>]*>")
 
 
-def parse_vtt_transcript(vtt_content: str) -> str:
-    """Follows the W3C WebVTT spec, because Zoom names the file type but never
-    defines the layout inside it. Real Zoom files put the speaker inline in
-    the cue text ("Jane Doe: hello"), which is undocumented and could change.
+def _clean_cue_line(line: str) -> str:
+    """WebVTT forbids a literal "&", so someone saying "R&D" arrives as
+    "R&amp;D". Decode only after stripping markup, or an escaped
+    "&lt;v Jane&gt;" turns into a tag and gets deleted. The decoded
+    non-breaking space goes too, since it will not match a typed space.
     """
+    decoded = html.unescape(_CUE_TAG_RE.sub("", line))
+    return decoded.replace("\xa0", " ").strip()
+
+
+def parse_vtt_transcript(vtt_content: str) -> str:
     normalized = vtt_content.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
 
     paragraphs: list[str] = []
@@ -22,8 +36,6 @@ def parse_vtt_transcript(vtt_content: str) -> str:
         if not lines or _NON_CUE_BLOCK_RE.match(lines[0]):
             continue
 
-        # Take the speech by position rather than by what it looks like, so a
-        # cue that is only a number survives instead of reading as a cue index.
         timing_index = next(
             (i for i, line in enumerate(lines) if _TIMING_LINE_RE.match(line)), None
         )
@@ -31,9 +43,9 @@ def parse_vtt_transcript(vtt_content: str) -> str:
             continue
 
         spoken = [
-            stripped
+            cleaned
             for line in lines[timing_index + 1 :]
-            if (stripped := _CUE_TAG_RE.sub("", line).strip())
+            if (cleaned := _clean_cue_line(line))
         ]
         if spoken:
             paragraphs.append(" ".join(spoken))

--- a/backend/onyx/connectors/zoom/recordings/vtt.py
+++ b/backend/onyx/connectors/zoom/recordings/vtt.py
@@ -6,8 +6,8 @@ a cue can be nothing but a number, so matching either as markup deletes real
 speech.
 """
 
-import html
 import re
+from html import unescape
 
 _TIMING_LINE_RE = re.compile(r"^(?:\d+:)?\d{1,2}:\d{2}[.,]\d{1,3}\s*-->")
 
@@ -25,7 +25,7 @@ def _clean_cue_line(line: str) -> str:
     deleted. The decoded non-breaking space goes too, since it will not match a
     typed space in search.
     """
-    decoded = html.unescape(_CUE_TAG_RE.sub("", line))
+    decoded = unescape(_CUE_TAG_RE.sub("", line))
     return decoded.replace("\xa0", " ").strip()
 
 

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -1,0 +1,227 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.connectors.exceptions import (
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+)
+from onyx.connectors.zoom.client import ZoomClient, _encode_meeting_identifier
+
+
+def _response(status: int, payload: Any = None, text: str = "") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.json.return_value = payload if payload is not None else {}
+    response.text = text
+    response.raise_for_status.side_effect = None
+    return response
+
+
+def _client() -> ZoomClient:
+    client = ZoomClient(account_id="acct", client_id="cid", client_secret="secret")
+    # Skip the OAuth round trip; token handling has its own tests below.
+    client._access_token = "tok"
+    client._token_expires_at = float("inf")
+    return client
+
+
+class TestEncodeMeetingIdentifier:
+    """Zoom's docs require encoding a uuid twice when it starts with "/" or
+    contains "//", because something in front of their API decodes one layer
+    before the request arrives."""
+
+    def test_plain_numeric_id_is_untouched(self) -> None:
+        assert _encode_meeting_identifier("81234567890") == "81234567890"
+
+    def test_slash_is_escaped_so_it_cannot_split_the_url_path(self) -> None:
+        assert "/" not in _encode_meeting_identifier("abc/def==")
+
+    def test_uuid_starting_with_a_slash_is_encoded_twice(self) -> None:
+        once = "%2FabcXYZ%3D%3D"
+        assert _encode_meeting_identifier("/abcXYZ==") == "%252FabcXYZ%253D%253D"
+        assert _encode_meeting_identifier("/abcXYZ==") != once
+
+    def test_uuid_containing_a_double_slash_is_encoded_twice(self) -> None:
+        assert _encode_meeting_identifier("ab//cd==") == "ab%252F%252Fcd%253D%253D"
+
+    def test_single_interior_slash_is_encoded_once(self) -> None:
+        assert _encode_meeting_identifier("ab/cd==") == "ab%2Fcd%3D%3D"
+
+
+class TestAccessToken:
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_token_is_fetched_once_and_reused(self, post: MagicMock) -> None:
+        post.return_value = _response(200, {"access_token": "t1", "expires_in": 3600})
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+
+        assert client._get_access_token() == "t1"
+        assert client._get_access_token() == "t1"
+
+        assert post.call_count == 1
+        assert post.call_args.kwargs["params"] == {
+            "grant_type": "account_credentials",
+            "account_id": "a",
+        }
+        assert post.call_args.kwargs["auth"] == ("c", "s")
+
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_token_is_refreshed_before_it_expires(self, post: MagicMock) -> None:
+        post.side_effect = [
+            _response(200, {"access_token": "t1", "expires_in": 3600}),
+            _response(200, {"access_token": "t2", "expires_in": 3600}),
+        ]
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+        assert client._get_access_token() == "t1"
+
+        # Inside the refresh margin: a request must not go out holding a token
+        # that lapses mid-flight.
+        client._token_expires_at = 0.0
+
+        assert client._get_access_token() == "t2"
+        assert post.call_count == 2
+
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_rejected_credentials_raise_a_typed_error(self, post: MagicMock) -> None:
+        post.return_value = _response(401)
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+
+        with pytest.raises(CredentialExpiredError):
+            client._get_access_token()
+
+
+class TestRequestErrorMapping:
+    def test_unauthorized_raises_credential_expired(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(401)
+
+        with pytest.raises(CredentialExpiredError):
+            client._request("GET", "/anything")
+
+    def test_forbidden_raises_insufficient_permissions(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(403)
+
+        with pytest.raises(InsufficientPermissionsError) as exc:
+            client._request("GET", "/meetings/1/transcript")
+
+        # The message has to name the endpoint, since the fix is a scope change.
+        assert "/meetings/1/transcript" in str(exc.value)
+
+    def test_bearer_token_is_attached(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200)
+
+        client._request("GET", "/anything")
+
+        headers = client._session.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok"
+
+
+class TestGetMeetingTranscript:
+    def test_parses_the_response(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            200,
+            {
+                "download_url": "https://zoom.example/t.vtt",
+                "download_restriction_reason": "NOT_READY",
+            },
+        )
+
+        transcript = client.get_meeting_transcript("111")
+
+        assert transcript is not None
+        assert transcript.download_url == "https://zoom.example/t.vtt"
+        assert transcript.download_restriction_reason == "NOT_READY"
+
+    def test_404_means_never_recorded_not_an_error(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(404)
+
+        assert client.get_meeting_transcript("111") is None
+
+    def test_identifier_is_encoded_into_the_path(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, {})
+
+        client.get_meeting_transcript("ab/cd==")
+
+        url = client._session.request.call_args.args[1]
+        assert "ab%2Fcd%3D%3D" in url
+        assert "ab/cd==" not in url
+
+
+class TestGetPastMeetingDetails:
+    def test_parses_the_response(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            200, {"topic": "Weekly Sync", "start_time": "2026-01-15T10:00:00Z"}
+        )
+
+        details = client.get_past_meeting_details("111")
+
+        assert details is not None
+        assert details.topic == "Weekly Sync"
+        assert details.start_time == "2026-01-15T10:00:00Z"
+
+    def test_404_returns_none(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(404)
+
+        assert client.get_past_meeting_details("111") is None
+
+
+class TestListPastMeetingOccurrences:
+    def test_reads_the_meetings_key(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            200,
+            {
+                "meetings": [
+                    {"uuid": "u1", "start_time": "2026-01-01T10:00:00Z"},
+                    {"uuid": "u2", "start_time": "2026-01-08T10:00:00Z"},
+                ]
+            },
+        )
+
+        occurrences = client.list_past_meeting_occurrences("111")
+
+        assert [o.uuid for o in occurrences] == ["u1", "u2"]
+        assert occurrences[0].start_time == "2026-01-01T10:00:00Z"
+
+    def test_404_yields_an_empty_list(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(404)
+
+        assert client.list_past_meeting_occurrences("111") == []
+
+    def test_missing_meetings_key_yields_an_empty_list(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, {})
+
+        assert client.list_past_meeting_occurrences("111") == []
+
+
+class TestDownloadTranscriptVtt:
+    @patch("onyx.connectors.zoom.client.requests.get")
+    def test_returns_body_and_authenticates(self, get: MagicMock) -> None:
+        get.return_value = _response(200, text="WEBVTT\n")
+        client = _client()
+
+        body = client.download_transcript_vtt("https://zoom.example/t.vtt")
+
+        assert body == "WEBVTT\n"
+        assert get.call_args.kwargs["headers"]["Authorization"] == "Bearer tok"

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -8,6 +8,7 @@ from requests.adapters import HTTPAdapter
 
 from onyx.connectors.exceptions import (
     CredentialExpiredError,
+    CredentialInvalidError,
     InsufficientPermissionsError,
 )
 from onyx.connectors.zoom.client import (
@@ -109,12 +110,20 @@ class TestAccessToken:
         assert client._get_access_token() == "t2"
         assert post.call_count == 2
 
-    def test_rejected_credentials_raise_a_typed_error(self) -> None:
+    @pytest.mark.parametrize(
+        "status, expected",
+        [(401, CredentialInvalidError), (403, InsufficientPermissionsError)],
+    )
+    def test_a_refused_token_raises_a_typed_error(
+        self, status: int, expected: type[Exception]
+    ) -> None:
+        # An untyped error here is retried forever instead of telling the admin
+        # the credentials are wrong.
         client = ZoomClient(account_id="a", client_id="c", client_secret="s")
         client._session = MagicMock()
-        client._session.post.return_value = _response(401)
+        client._session.post.return_value = _response(status)
 
-        with pytest.raises(CredentialExpiredError):
+        with pytest.raises(expected):
             client._get_access_token()
 
 

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
 import pytest
+import requests
+from requests.adapters import HTTPAdapter
 
 from onyx.connectors.exceptions import (
     CredentialExpiredError,
@@ -10,27 +12,40 @@ from onyx.connectors.exceptions import (
 )
 from onyx.connectors.zoom.client import (
     _API_BASE_URL,
+    _OAUTH_TOKEN_URL,
     _ZOOM_HOST,
     ZoomClient,
     _encode_meeting_identifier,
     _reject_non_zoom_download_url,
 )
+from onyx.connectors.zoom.models import ZoomTranscript
 
 _ZOOM_DOWNLOAD_URL = "https://zoom.us/rec/download/abc.vtt"
+
+# Zoom's own documented example, which returns all three readiness fields at
+# once even though their field docs say that cannot happen.
+_DOCUMENTED_TRANSCRIPT = {
+    "meeting_id": "uaFkQyFCSwya8iNYtkAw3A==",
+    "meeting_topic": "My Personal Meeting",
+    "host_id": "_0ctZtY0REqWalTmwvrdIw",
+    "transcript_created_time": "2025-06-27T13:48:24Z",
+    "can_download": True,
+    "download_url": "https://zoom.example/t.vtt",
+    "download_restriction_reason": "NOT_READY",
+}
 
 
 def _response(status: int, payload: Any = None, text: str = "") -> MagicMock:
     response = MagicMock()
     response.status_code = status
+    response.ok = status < 400
     response.json.return_value = payload if payload is not None else {}
     response.text = text
-    response.raise_for_status.side_effect = None
     return response
 
 
 def _client() -> ZoomClient:
     client = ZoomClient(account_id="acct", client_id="cid", client_secret="secret")
-    # Token handling has its own tests, so skip the OAuth round trip here.
     client._access_token = "tok"
     client._token_expires_at = float("inf")
     return client
@@ -56,10 +71,11 @@ class TestEncodeMeetingIdentifier:
 
 
 class TestAccessToken:
-    @patch("onyx.connectors.zoom.client.requests.post")
-    def test_token_is_fetched_once_and_reused(self, post: MagicMock) -> None:
-        post.return_value = _response(200, {"access_token": "t1", "expires_in": 3600})
+    def test_token_is_fetched_once_and_reused(self) -> None:
         client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+        client._session = MagicMock()
+        post = client._session.post
+        post.return_value = _response(200, {"access_token": "t1", "expires_in": 3600})
 
         assert client._get_access_token() == "t1"
         assert client._get_access_token() == "t1"
@@ -71,13 +87,14 @@ class TestAccessToken:
         }
         assert post.call_args.kwargs["auth"] == ("c", "s")
 
-    @patch("onyx.connectors.zoom.client.requests.post")
-    def test_token_is_refreshed_before_it_expires(self, post: MagicMock) -> None:
+    def test_token_is_refreshed_before_it_expires(self) -> None:
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+        client._session = MagicMock()
+        post = client._session.post
         post.side_effect = [
             _response(200, {"access_token": "t1", "expires_in": 3600}),
             _response(200, {"access_token": "t2", "expires_in": 3600}),
         ]
-        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
         assert client._get_access_token() == "t1"
 
         client._token_expires_at = 0.0
@@ -85,10 +102,10 @@ class TestAccessToken:
         assert client._get_access_token() == "t2"
         assert post.call_count == 2
 
-    @patch("onyx.connectors.zoom.client.requests.post")
-    def test_rejected_credentials_raise_a_typed_error(self, post: MagicMock) -> None:
-        post.return_value = _response(401)
+    def test_rejected_credentials_raise_a_typed_error(self) -> None:
         client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+        client._session = MagicMock()
+        client._session.post.return_value = _response(401)
 
         with pytest.raises(CredentialExpiredError):
             client._get_access_token()
@@ -98,15 +115,12 @@ class TestStaleTokenIsRetried:
     """Delete the retry and a stale token starts reporting itself as a bad
     credential, which eventually marks the connector invalid."""
 
-    @patch("onyx.connectors.zoom.client.requests.post")
-    def test_stale_token_is_refreshed_and_the_request_succeeds(
-        self, post: MagicMock
-    ) -> None:
-        post.return_value = _response(
-            200, {"access_token": "fresh", "expires_in": 3600}
-        )
+    def test_stale_token_is_refreshed_and_the_request_succeeds(self) -> None:
         client = _client()
         client._session = MagicMock()
+        client._session.post.return_value = _response(
+            200, {"access_token": "fresh", "expires_in": 3600}
+        )
         client._session.request.side_effect = [_response(401), _response(200, {})]
 
         response = client._request("GET", "/anything")
@@ -119,13 +133,12 @@ class TestStaleTokenIsRetried:
             == "Bearer fresh"
         )
 
-    @patch("onyx.connectors.zoom.client.requests.post")
-    def test_a_second_rejection_is_reported_as_expired(self, post: MagicMock) -> None:
-        post.return_value = _response(
-            200, {"access_token": "fresh", "expires_in": 3600}
-        )
+    def test_a_second_rejection_is_reported_as_expired(self) -> None:
         client = _client()
         client._session = MagicMock()
+        client._session.post.return_value = _response(
+            200, {"access_token": "fresh", "expires_in": 3600}
+        )
         client._session.request.return_value = _response(401)
 
         with pytest.raises(CredentialExpiredError):
@@ -134,40 +147,53 @@ class TestStaleTokenIsRetried:
         assert client._session.request.call_count == 2
 
     @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
-    @patch("onyx.connectors.zoom.client.requests.get")
-    @patch("onyx.connectors.zoom.client.requests.post")
     def test_transcript_download_also_retries(
         self,
-        post: MagicMock,
-        get: MagicMock,
         ssrf: MagicMock,  # noqa: ARG002
     ) -> None:
-        post.return_value = _response(
+        client = _client()
+        client._session = MagicMock()
+        client._session.get.side_effect = [
+            _response(401),
+            _response(200, text="WEBVTT\n"),
+        ]
+        client._session.post.return_value = _response(
             200, {"access_token": "fresh", "expires_in": 3600}
         )
-        get.side_effect = [_response(401), _response(200, text="WEBVTT\n")]
-        client = _client()
 
         assert client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL) == "WEBVTT\n"
-        assert get.call_count == 2
+        assert client._session.get.call_count == 2
 
     @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
-    @patch("onyx.connectors.zoom.client.requests.get")
-    @patch("onyx.connectors.zoom.client.requests.post")
     def test_transcript_download_reports_a_typed_error(
         self,
-        post: MagicMock,
-        get: MagicMock,
         ssrf: MagicMock,  # noqa: ARG002
     ) -> None:
-        post.return_value = _response(
+        client = _client()
+        client._session = MagicMock()
+        client._session.get.return_value = _response(403)
+        client._session.post.return_value = _response(
             200, {"access_token": "fresh", "expires_in": 3600}
         )
-        get.return_value = _response(403)
-        client = _client()
 
         with pytest.raises(InsufficientPermissionsError):
             client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL)
+
+
+class TestRetryPolicy:
+    @pytest.mark.parametrize(
+        "url",
+        [_API_BASE_URL, _OAUTH_TOKEN_URL, _ZOOM_DOWNLOAD_URL],
+        ids=["api", "token", "download"],
+    )
+    def test_every_zoom_host_retries(self, url: str) -> None:
+        # Mounting per URL left the download host on the no-retry default.
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+
+        adapter = client._session.get_adapter(url)
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries.total == 5
+        assert 429 in adapter.max_retries.status_forcelist
 
 
 class TestRequestErrorMapping:
@@ -197,19 +223,27 @@ class TestGetMeetingTranscript:
     def test_parses_the_response(self) -> None:
         client = _client()
         client._session = MagicMock()
-        client._session.request.return_value = _response(
-            200,
-            {
-                "download_url": "https://zoom.example/t.vtt",
-                "download_restriction_reason": "NOT_READY",
-            },
-        )
+        client._session.request.return_value = _response(200, _DOCUMENTED_TRANSCRIPT)
 
         transcript = client.get_meeting_transcript("111")
 
         assert transcript is not None
         assert transcript.download_url == "https://zoom.example/t.vtt"
         assert transcript.download_restriction_reason == "NOT_READY"
+
+    def test_keeps_the_fields_that_save_a_second_api_call(self) -> None:
+        # The topic is the only reason to call /past_meetings, and that call is
+        # the one subject to Zoom's one-year limit.
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, _DOCUMENTED_TRANSCRIPT)
+
+        transcript = client.get_meeting_transcript("111")
+
+        assert transcript is not None
+        assert transcript.meeting_topic == "My Personal Meeting"
+        assert transcript.host_id == "_0ctZtY0REqWalTmwvrdIw"
+        assert transcript.transcript_created_time == "2025-06-27T13:48:24Z"
 
     def test_404_means_never_recorded_not_an_error(self) -> None:
         client = _client()
@@ -288,19 +322,19 @@ class TestListPastMeetingOccurrences:
 
 class TestDownloadTranscriptVtt:
     @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
-    @patch("onyx.connectors.zoom.client.requests.get")
     def test_returns_body_and_authenticates(
         self,
-        get: MagicMock,
         ssrf: MagicMock,  # noqa: ARG002
     ) -> None:
-        get.return_value = _response(200, text="WEBVTT\n")
         client = _client()
+        client._session = MagicMock()
+        client._session.get.return_value = _response(200, text="WEBVTT\n")
 
         body = client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL)
 
         assert body == "WEBVTT\n"
-        assert get.call_args.kwargs["headers"]["Authorization"] == "Bearer tok"
+        headers = client._session.get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok"
 
 
 class TestDownloadUrlGuard:
@@ -340,16 +374,80 @@ class TestDownloadUrlGuard:
         _reject_non_zoom_download_url(url)
 
     def test_the_allowlist_tracks_whichever_zoom_the_client_talks_to(self) -> None:
-        # Point the client at Zoom for Government (api.zoomgov.com) without
-        # moving the allowlist and every download fails as a non-Zoom host.
+        # Point the client at Zoom for Government without moving the allowlist
+        # and every download fails as a non-Zoom host.
         api_host = urlparse(_API_BASE_URL).hostname or ""
         assert api_host == _ZOOM_HOST or api_host.endswith(f".{_ZOOM_HOST}")
 
-    @patch("onyx.connectors.zoom.client.requests.get")
-    def test_the_guard_runs_before_the_token_is_sent(self, get: MagicMock) -> None:
+    def test_the_guard_runs_before_the_token_is_sent(self) -> None:
         client = _client()
+        client._session = MagicMock()
 
         with pytest.raises(ValueError):
             client.download_transcript_vtt("https://evil.example.com/steal.vtt")
 
-        get.assert_not_called()
+        client._session.get.assert_not_called()
+
+
+class TestTranscriptReadiness:
+    def test_the_documented_example_is_not_treated_as_ready(self) -> None:
+        # can_download says yes while the reason says still processing.
+        transcript = ZoomTranscript.model_validate(_DOCUMENTED_TRANSCRIPT)
+
+        assert transcript.is_downloadable is False
+
+    def test_ready_when_nothing_objects(self) -> None:
+        transcript = ZoomTranscript(can_download=True, download_url=_ZOOM_DOWNLOAD_URL)
+
+        assert transcript.is_downloadable is True
+
+    def test_a_missing_can_download_still_counts_as_ready(self) -> None:
+        # The field is absent on older responses, and reading absent as a refusal
+        # would index nothing at all.
+        transcript = ZoomTranscript(download_url=_ZOOM_DOWNLOAD_URL)
+
+        assert transcript.is_downloadable is True
+
+    @pytest.mark.parametrize(
+        "transcript",
+        [
+            ZoomTranscript(can_download=False, download_url=_ZOOM_DOWNLOAD_URL),
+            ZoomTranscript(can_download=True, download_url=None),
+            ZoomTranscript(
+                can_download=True,
+                download_url=_ZOOM_DOWNLOAD_URL,
+                download_restriction_reason="DELETED_OR_TRASHED",
+            ),
+        ],
+        ids=["refused", "no_url", "restricted"],
+    )
+    def test_any_single_objection_is_enough(self, transcript: ZoomTranscript) -> None:
+        assert transcript.is_downloadable is False
+
+
+class TestZoomErrorMessages:
+    def test_the_zoom_code_reaches_the_message(self) -> None:
+        # A meeting over a year old fails with 12702, and without this the log
+        # says only "400 Client Error".
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            400,
+            {"code": 12702, "message": "You cannot access a meeting older than a year"},
+        )
+
+        with pytest.raises(requests.HTTPError) as exc:
+            client.get_past_meeting_details("111")
+
+        assert "12702" in str(exc.value)
+        assert "older than a year" in str(exc.value)
+
+    def test_a_body_that_is_not_json_still_raises(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        response = _response(500)
+        response.json.side_effect = ValueError("not json")
+        client._session.request.return_value = response
+
+        with pytest.raises(requests.HTTPError):
+            client.list_past_meeting_occurrences("111")

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -14,7 +14,6 @@ from onyx.connectors.exceptions import (
 from onyx.connectors.zoom.client import (
     _API_BASE_URL,
     _OAUTH_TOKEN_URL,
-    _ZOOM_HOST,
     ZoomClient,
     _encode_meeting_identifier,
     _reject_non_zoom_download_url,
@@ -389,11 +388,16 @@ class TestDownloadUrlGuard:
     ) -> None:
         _reject_non_zoom_download_url(url)
 
-    def test_the_allowlist_tracks_whichever_zoom_the_client_talks_to(self) -> None:
-        # Point the client at Zoom for Government without moving the allowlist
-        # and every download fails as a non-Zoom host.
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
+    def test_the_guard_accepts_the_host_the_client_talks_to(
+        self,
+        ssrf: MagicMock,  # noqa: ARG002
+    ) -> None:
+        # _ZOOM_HOST and _API_BASE_URL have to move together: point the client at
+        # Zoom for Government without the allowlist and every download is refused.
         api_host = urlparse(_API_BASE_URL).hostname or ""
-        assert api_host == _ZOOM_HOST or api_host.endswith(f".{_ZOOM_HOST}")
+
+        _reject_non_zoom_download_url(f"https://{api_host}/rec/download/abc.vtt")
 
     def test_the_guard_runs_before_the_token_is_sent(self) -> None:
         client = _client()

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -21,17 +21,13 @@ def _response(status: int, payload: Any = None, text: str = "") -> MagicMock:
 
 def _client() -> ZoomClient:
     client = ZoomClient(account_id="acct", client_id="cid", client_secret="secret")
-    # Skip the OAuth round trip; token handling has its own tests below.
+    # Token handling has its own tests, so skip the OAuth round trip here.
     client._access_token = "tok"
     client._token_expires_at = float("inf")
     return client
 
 
 class TestEncodeMeetingIdentifier:
-    """Zoom's docs require encoding a uuid twice when it starts with "/" or
-    contains "//", because something in front of their API decodes one layer
-    before the request arrives."""
-
     def test_plain_numeric_id_is_untouched(self) -> None:
         assert _encode_meeting_identifier("81234567890") == "81234567890"
 
@@ -75,8 +71,6 @@ class TestAccessToken:
         client = ZoomClient(account_id="a", client_id="c", client_secret="s")
         assert client._get_access_token() == "t1"
 
-        # Inside the refresh margin: a request must not go out holding a token
-        # that lapses mid-flight.
         client._token_expires_at = 0.0
 
         assert client._get_access_token() == "t2"
@@ -91,8 +85,36 @@ class TestAccessToken:
             client._get_access_token()
 
 
-class TestRequestErrorMapping:
-    def test_unauthorized_raises_credential_expired(self) -> None:
+class TestStaleTokenIsRetried:
+    """Delete the retry and a stale token starts reporting itself as a bad
+    credential, which eventually marks the connector invalid."""
+
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_stale_token_is_refreshed_and_the_request_succeeds(
+        self, post: MagicMock
+    ) -> None:
+        post.return_value = _response(
+            200, {"access_token": "fresh", "expires_in": 3600}
+        )
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.side_effect = [_response(401), _response(200, {})]
+
+        response = client._request("GET", "/anything")
+
+        assert response.status_code == 200
+        assert client._session.request.call_count == 2
+        # The retry must carry the new token, not the rejected one.
+        assert (
+            client._session.request.call_args.kwargs["headers"]["Authorization"]
+            == "Bearer fresh"
+        )
+
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_a_second_rejection_is_reported_as_expired(self, post: MagicMock) -> None:
+        post.return_value = _response(
+            200, {"access_token": "fresh", "expires_in": 3600}
+        )
         client = _client()
         client._session = MagicMock()
         client._session.request.return_value = _response(401)
@@ -100,6 +122,41 @@ class TestRequestErrorMapping:
         with pytest.raises(CredentialExpiredError):
             client._request("GET", "/anything")
 
+        assert client._session.request.call_count == 2
+
+    @patch("onyx.connectors.zoom.client.requests.get")
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_transcript_download_also_retries(
+        self, post: MagicMock, get: MagicMock
+    ) -> None:
+        post.return_value = _response(
+            200, {"access_token": "fresh", "expires_in": 3600}
+        )
+        get.side_effect = [_response(401), _response(200, text="WEBVTT\n")]
+        client = _client()
+
+        assert (
+            client.download_transcript_vtt("https://zoom.example/t.vtt") == "WEBVTT\n"
+        )
+        assert get.call_count == 2
+
+    @patch("onyx.connectors.zoom.client.requests.get")
+    @patch("onyx.connectors.zoom.client.requests.post")
+    def test_transcript_download_reports_a_typed_error(
+        self, post: MagicMock, get: MagicMock
+    ) -> None:
+        post.return_value = _response(
+            200, {"access_token": "fresh", "expires_in": 3600}
+        )
+        get.return_value = _response(403)
+        client = _client()
+
+        # Not a bare HTTPError: the download shares the API's error mapping.
+        with pytest.raises(InsufficientPermissionsError):
+            client.download_transcript_vtt("https://zoom.example/t.vtt")
+
+
+class TestRequestErrorMapping:
     def test_forbidden_raises_insufficient_permissions(self) -> None:
         client = _client()
         client._session = MagicMock()

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -1,5 +1,6 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -7,7 +8,15 @@ from onyx.connectors.exceptions import (
     CredentialExpiredError,
     InsufficientPermissionsError,
 )
-from onyx.connectors.zoom.client import ZoomClient, _encode_meeting_identifier
+from onyx.connectors.zoom.client import (
+    _API_BASE_URL,
+    _ZOOM_HOST,
+    ZoomClient,
+    _encode_meeting_identifier,
+    _reject_non_zoom_download_url,
+)
+
+_ZOOM_DOWNLOAD_URL = "https://zoom.us/rec/download/abc.vtt"
 
 
 def _response(status: int, payload: Any = None, text: str = "") -> MagicMock:
@@ -124,10 +133,14 @@ class TestStaleTokenIsRetried:
 
         assert client._session.request.call_count == 2
 
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
     @patch("onyx.connectors.zoom.client.requests.get")
     @patch("onyx.connectors.zoom.client.requests.post")
     def test_transcript_download_also_retries(
-        self, post: MagicMock, get: MagicMock
+        self,
+        post: MagicMock,
+        get: MagicMock,
+        ssrf: MagicMock,  # noqa: ARG002
     ) -> None:
         post.return_value = _response(
             200, {"access_token": "fresh", "expires_in": 3600}
@@ -135,15 +148,17 @@ class TestStaleTokenIsRetried:
         get.side_effect = [_response(401), _response(200, text="WEBVTT\n")]
         client = _client()
 
-        assert (
-            client.download_transcript_vtt("https://zoom.example/t.vtt") == "WEBVTT\n"
-        )
+        assert client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL) == "WEBVTT\n"
         assert get.call_count == 2
 
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
     @patch("onyx.connectors.zoom.client.requests.get")
     @patch("onyx.connectors.zoom.client.requests.post")
     def test_transcript_download_reports_a_typed_error(
-        self, post: MagicMock, get: MagicMock
+        self,
+        post: MagicMock,
+        get: MagicMock,
+        ssrf: MagicMock,  # noqa: ARG002
     ) -> None:
         post.return_value = _response(
             200, {"access_token": "fresh", "expires_in": 3600}
@@ -151,9 +166,8 @@ class TestStaleTokenIsRetried:
         get.return_value = _response(403)
         client = _client()
 
-        # Not a bare HTTPError: the download shares the API's error mapping.
         with pytest.raises(InsufficientPermissionsError):
-            client.download_transcript_vtt("https://zoom.example/t.vtt")
+            client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL)
 
 
 class TestRequestErrorMapping:
@@ -273,12 +287,69 @@ class TestListPastMeetingOccurrences:
 
 
 class TestDownloadTranscriptVtt:
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
     @patch("onyx.connectors.zoom.client.requests.get")
-    def test_returns_body_and_authenticates(self, get: MagicMock) -> None:
+    def test_returns_body_and_authenticates(
+        self,
+        get: MagicMock,
+        ssrf: MagicMock,  # noqa: ARG002
+    ) -> None:
         get.return_value = _response(200, text="WEBVTT\n")
         client = _client()
 
-        body = client.download_transcript_vtt("https://zoom.example/t.vtt")
+        body = client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL)
 
         assert body == "WEBVTT\n"
         assert get.call_args.kwargs["headers"]["Authorization"] == "Bearer tok"
+
+
+class TestDownloadUrlGuard:
+    """Relax the host check and the account-wide bearer token goes to whatever
+    host the URL names."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://evil.example.com/steal.vtt",
+            "https://zoom.us.evil.example.com/steal.vtt",
+            "http://169.254.169.254/latest/meta-data/",
+            "https://notzoom.us/x.vtt",
+        ],
+    )
+    def test_non_zoom_host_is_refused(self, url: str) -> None:
+        with pytest.raises(ValueError):
+            _reject_non_zoom_download_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Real shapes from Zoom's docs, not invented ones.
+            "https://us02web.zoom.us/rec/download/3lwWGTDTAhGO9UHg",
+            "https://us02web.zoom.us/rec/webhook_download/14q-E-JtEehWe",
+            "https://mycompany.zoom.us/rec/download/abc.vtt",
+            "https://zoom.us/rec/download/abc.vtt",
+            "https://ZOOM.US/rec/download/abc.vtt",
+        ],
+    )
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
+    def test_zoom_hosts_are_allowed(
+        self,
+        ssrf: MagicMock,  # noqa: ARG002
+        url: str,
+    ) -> None:
+        _reject_non_zoom_download_url(url)
+
+    def test_the_allowlist_tracks_whichever_zoom_the_client_talks_to(self) -> None:
+        # Point the client at Zoom for Government (api.zoomgov.com) without
+        # moving the allowlist and every download fails as a non-Zoom host.
+        api_host = urlparse(_API_BASE_URL).hostname or ""
+        assert api_host == _ZOOM_HOST or api_host.endswith(f".{_ZOOM_HOST}")
+
+    @patch("onyx.connectors.zoom.client.requests.get")
+    def test_the_guard_runs_before_the_token_is_sent(self, get: MagicMock) -> None:
+        client = _client()
+
+        with pytest.raises(ValueError):
+            client.download_transcript_vtt("https://evil.example.com/steal.vtt")
+
+        get.assert_not_called()

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -35,10 +35,17 @@ _DOCUMENTED_TRANSCRIPT = {
 }
 
 
-def _response(status: int, payload: Any = None, text: str = "") -> MagicMock:
+def _response(
+    status: int,
+    payload: Any = None,
+    text: str = "",
+    location: str | None = None,
+) -> MagicMock:
     response = MagicMock()
     response.status_code = status
     response.ok = status < 400
+    response.is_redirect = location is not None
+    response.headers = {"Location": location} if location else {}
     response.json.return_value = payload if payload is not None else {}
     response.text = text
     return response
@@ -451,3 +458,54 @@ class TestZoomErrorMessages:
 
         with pytest.raises(requests.HTTPError):
             client.list_past_meeting_occurrences("111")
+
+
+class TestDownloadRedirects:
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
+    def test_a_redirect_to_a_private_address_is_refused(
+        self,
+        ssrf: MagicMock,  # noqa: ARG002
+    ) -> None:
+        # ssrf_safe_get runs unpatched here, or this stops testing SSRF at all.
+        client = _client()
+        client._session = MagicMock()
+        client._session.get.return_value = _response(
+            302, location="https://169.254.169.254/latest/meta-data/"
+        )
+
+        with pytest.raises(ValueError):
+            client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL)
+
+    @patch("onyx.connectors.zoom.client.ssrf_safe_get")
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
+    def test_the_token_does_not_follow_the_redirect(
+        self,
+        ssrf: MagicMock,  # noqa: ARG002
+        safe_get: MagicMock,
+    ) -> None:
+        safe_get.return_value = _response(200, text="WEBVTT\n")
+        client = _client()
+        client._session = MagicMock()
+        client._session.get.return_value = _response(
+            302, location="https://cdn.example.com/t.vtt"
+        )
+
+        client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL)
+
+        assert "Authorization" not in (safe_get.call_args.kwargs.get("headers") or {})
+        assert "tok" not in str(safe_get.call_args)
+
+    @patch("onyx.connectors.zoom.client.ssrf_safe_get")
+    @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
+    def test_a_relative_location_resolves_against_the_download_url(
+        self,
+        ssrf: MagicMock,  # noqa: ARG002
+        safe_get: MagicMock,
+    ) -> None:
+        safe_get.return_value = _response(200, text="WEBVTT\n")
+        client = _client()
+        client._session = MagicMock()
+        client._session.get.return_value = _response(302, location="/rec/other.vtt")
+
+        assert client.download_transcript_vtt(_ZOOM_DOWNLOAD_URL) == "WEBVTT\n"
+        assert safe_get.call_args.args[0] == "https://zoom.us/rec/other.vtt"

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -302,12 +302,19 @@ class TestGetMeetingTranscript:
         assert transcript is not None
         assert transcript.model_dump() == _DOCUMENTED_TRANSCRIPT
 
-    def test_404_means_never_recorded_not_an_error(self) -> None:
+    def test_404_is_reported_not_swallowed(self) -> None:
+        # A session that was never recorded answers 404. Reading that as "skip
+        # this one" is the caller's decision, so the client only reports it.
         client = _client()
         client._session = MagicMock()
-        client._session.request.return_value = _response(404)
+        client._session.request.return_value = _response(
+            404, {"code": 3322, "message": "This meeting transcript does not exist."}
+        )
 
-        assert client.get_meeting_transcript("111") is None
+        with pytest.raises(requests.HTTPError) as exc:
+            client.get_meeting_transcript("111")
+
+        assert "Zoom code 3322" in str(exc.value)
 
     def test_identifier_is_encoded_into_the_path(self) -> None:
         client = _client()
@@ -357,12 +364,13 @@ class TestGetPastMeetingDetails:
         with pytest.raises(ValidationError):
             client.get_past_meeting_details("111")
 
-    def test_404_returns_none(self) -> None:
+    def test_404_is_reported_not_swallowed(self) -> None:
         client = _client()
         client._session = MagicMock()
         client._session.request.return_value = _response(404)
 
-        assert client.get_past_meeting_details("111") is None
+        with pytest.raises(requests.HTTPError):
+            client.get_past_meeting_details("111")
 
 
 class TestListPastMeetingOccurrences:
@@ -384,12 +392,13 @@ class TestListPastMeetingOccurrences:
         assert [o.uuid for o in occurrences] == ["u1", "u2"]
         assert occurrences[0].start_time == "2026-01-01T10:00:00Z"
 
-    def test_404_yields_an_empty_list(self) -> None:
+    def test_404_is_reported_not_swallowed(self) -> None:
         client = _client()
         client._session = MagicMock()
         client._session.request.return_value = _response(404)
 
-        assert client.list_past_meeting_occurrences("111") == []
+        with pytest.raises(requests.HTTPError):
+            client.list_past_meeting_occurrences("111")
 
     def test_missing_meetings_key_yields_an_empty_list(self) -> None:
         client = _client()

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -139,6 +139,25 @@ class TestAccessToken:
         assert client._get_access_token() == "t2"
         assert post.call_count == 2
 
+    def test_a_token_response_without_a_token_names_the_missing_field(self) -> None:
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+        client._session = MagicMock()
+        client._session.post.return_value = _response(200, {"expires_in": 3600})
+
+        with pytest.raises(ValidationError) as exc:
+            client._get_access_token()
+
+        assert "access_token" in str(exc.value)
+
+    def test_an_expiry_zoom_did_not_send_is_not_invented(self) -> None:
+        # Inventing an expiry keeps a token Zoom ended early in use until a 401.
+        client = ZoomClient(account_id="a", client_id="c", client_secret="s")
+        client._session = MagicMock()
+        client._session.post.return_value = _response(200, {"access_token": "t1"})
+
+        with pytest.raises(ValidationError):
+            client._get_access_token()
+
     @pytest.mark.parametrize(
         "status, expected",
         [(401, CredentialInvalidError), (403, InsufficientPermissionsError)],

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 import pytest
 import requests
+from pydantic import ValidationError
 from requests.adapters import HTTPAdapter
 
 from onyx.connectors.exceptions import (
@@ -26,13 +27,42 @@ _ZOOM_DOWNLOAD_URL = "https://zoom.us/rec/download/abc.vtt"
 # once even though their field docs say that cannot happen.
 _DOCUMENTED_TRANSCRIPT = {
     "meeting_id": "uaFkQyFCSwya8iNYtkAw3A==",
+    "account_id": "Cx3wERazSgup7ZWRHQM8-w",
     "meeting_topic": "My Personal Meeting",
     "host_id": "_0ctZtY0REqWalTmwvrdIw",
     "transcript_created_time": "2025-06-27T13:48:24Z",
     "can_download": True,
+    "auto_delete": True,
+    "auto_delete_date": "2052-11-07",
     "download_url": "https://zoom.example/t.vtt",
     "download_restriction_reason": "NOT_READY",
 }
+
+
+_DOCUMENTED_PAST_MEETING = {
+    "id": 5638296721,
+    "uuid": "4444AAAiAAAAAiAiAiiAii==",
+    "duration": 60,
+    "start_time": "2021-07-13T21:44:51Z",
+    "end_time": "2021-07-13T23:00:51Z",
+    "host_id": "x1yCzABCDEfg23HiJKl4mN",
+    "dept": "Developers",
+    "participants_count": 2,
+    "source": "Zoom",
+    "topic": "My Meeting",
+    "total_minutes": 55,
+    "type": 1,
+    "user_email": "jchill@example.com",
+    "user_name": "Jill Chill",
+    "has_meeting_summary": False,
+}
+
+
+def _transcript(**overrides: Any) -> ZoomTranscript:
+    """Most fields are required, so a readiness case has to start from a whole
+    response rather than the two fields it exercises.
+    """
+    return ZoomTranscript.model_validate({**_DOCUMENTED_TRANSCRIPT, **overrides})
 
 
 def _response(
@@ -260,6 +290,18 @@ class TestGetMeetingTranscript:
         assert transcript.host_id == "_0ctZtY0REqWalTmwvrdIw"
         assert transcript.transcript_created_time == "2025-06-27T13:48:24Z"
 
+    def test_keeps_every_documented_field(self) -> None:
+        # Nothing reads account_id or the auto-delete pair yet, so without this
+        # test they look like dead fields someone can safely delete.
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, _DOCUMENTED_TRANSCRIPT)
+
+        transcript = client.get_meeting_transcript("111")
+
+        assert transcript is not None
+        assert transcript.model_dump() == _DOCUMENTED_TRANSCRIPT
+
     def test_404_means_never_recorded_not_an_error(self) -> None:
         client = _client()
         client._session = MagicMock()
@@ -270,7 +312,7 @@ class TestGetMeetingTranscript:
     def test_identifier_is_encoded_into_the_path(self) -> None:
         client = _client()
         client._session = MagicMock()
-        client._session.request.return_value = _response(200, {})
+        client._session.request.return_value = _response(200, _DOCUMENTED_TRANSCRIPT)
 
         client.get_meeting_transcript("ab/cd==")
 
@@ -283,15 +325,37 @@ class TestGetPastMeetingDetails:
     def test_parses_the_response(self) -> None:
         client = _client()
         client._session = MagicMock()
-        client._session.request.return_value = _response(
-            200, {"topic": "Weekly Sync", "start_time": "2026-01-15T10:00:00Z"}
-        )
+        client._session.request.return_value = _response(200, _DOCUMENTED_PAST_MEETING)
 
         details = client.get_past_meeting_details("111")
 
         assert details is not None
-        assert details.topic == "Weekly Sync"
-        assert details.start_time == "2026-01-15T10:00:00Z"
+        assert details.topic == "My Meeting"
+        assert details.start_time == "2021-07-13T21:44:51Z"
+
+    def test_keeps_every_documented_field(self) -> None:
+        # Nothing reads most of these yet, so without this test they look like
+        # dead fields someone can safely delete.
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, _DOCUMENTED_PAST_MEETING)
+
+        details = client.get_past_meeting_details("111")
+
+        assert details is not None
+        assert details.model_dump() == _DOCUMENTED_PAST_MEETING
+
+    def test_an_undocumented_shape_fails_here_not_in_the_connector(self) -> None:
+        # Zoom documents every field on this response as always sent. If that is
+        # wrong, the client has to say so rather than pass a None downstream.
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            200, {k: v for k, v in _DOCUMENTED_PAST_MEETING.items() if k != "dept"}
+        )
+
+        with pytest.raises(ValidationError):
+            client.get_past_meeting_details("111")
 
     def test_404_returns_none(self) -> None:
         client = _client()
@@ -417,23 +481,28 @@ class TestTranscriptReadiness:
         assert transcript.is_downloadable is False
 
     def test_ready_when_nothing_objects(self) -> None:
-        transcript = ZoomTranscript(can_download=True, download_url=_ZOOM_DOWNLOAD_URL)
-
-        assert transcript.is_downloadable is True
-
-    def test_a_missing_can_download_still_counts_as_ready(self) -> None:
-        # The field is absent on older responses, and reading absent as a refusal
-        # would index nothing at all.
-        transcript = ZoomTranscript(download_url=_ZOOM_DOWNLOAD_URL)
+        transcript = _transcript(
+            can_download=True,
+            download_url=_ZOOM_DOWNLOAD_URL,
+            download_restriction_reason=None,
+        )
 
         assert transcript.is_downloadable is True
 
     @pytest.mark.parametrize(
         "transcript",
         [
-            ZoomTranscript(can_download=False, download_url=_ZOOM_DOWNLOAD_URL),
-            ZoomTranscript(can_download=True, download_url=None),
-            ZoomTranscript(
+            _transcript(
+                can_download=False,
+                download_url=_ZOOM_DOWNLOAD_URL,
+                download_restriction_reason=None,
+            ),
+            _transcript(
+                can_download=True,
+                download_url=None,
+                download_restriction_reason=None,
+            ),
+            _transcript(
                 can_download=True,
                 download_url=_ZOOM_DOWNLOAD_URL,
                 download_restriction_reason="DELETED_OR_TRASHED",

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_vtt.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_vtt.py
@@ -1,3 +1,5 @@
+import pytest
+
 from onyx.connectors.zoom.recordings.vtt import parse_vtt_transcript
 
 # A real Zoom audio_transcript.vtt shape, not an invented one.
@@ -134,3 +136,30 @@ class TestParseVttDecodesCharacterReferences:
         )
         # Guards the order: decoding first would read this as a tag.
         assert parse_vtt_transcript(vtt) == "<v Jane>hello</v>"
+
+
+class TestParseVttKeepsCuesNamedLikeReservedWords:
+    """A cue identifier is free text, so matching these words too loosely throws
+    away the block and the speech under it."""
+
+    @pytest.mark.parametrize(
+        "identifier", ["1", "NOTE-1", "REGION:2", "STYLE 3", "note-x", "NOTES"]
+    )
+    def test_identifier_starting_with_a_reserved_word_is_still_a_cue(
+        self, identifier: str
+    ) -> None:
+        vtt = (
+            f"WEBVTT\n\n{identifier}\n"
+            "00:00:01.000 --> 00:00:02.000\nJane: real speech\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: real speech"
+
+    @pytest.mark.parametrize(
+        "block", ["NOTE a comment", "NOTE", "STYLE", "REGION", "WEBVTT - title"]
+    )
+    def test_genuine_non_cue_blocks_are_still_dropped(self, block: str) -> None:
+        vtt = (
+            f"WEBVTT\n\n{block}\npayload\n\n"
+            "1\n00:00:01.000 --> 00:00:02.000\nJane: kept\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: kept"

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_vtt.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_vtt.py
@@ -1,0 +1,110 @@
+from onyx.connectors.zoom.recordings.vtt import parse_vtt_transcript
+
+# Shaped after a real Zoom audio_transcript.vtt: numbered cue, timing line,
+# then the speaker name inline with the speech.
+_ZOOM_VTT = """WEBVTT
+
+1
+00:00:03.120 --> 00:00:06.480
+Sarah Chen: So the thing I keep coming back to is
+
+2
+00:00:06.480 --> 00:00:09.760
+Sarah Chen: that I can't tell if I'm building the right thing.
+
+3
+00:00:09.760 --> 00:00:11.200
+Marcus Webb: Yeah.
+"""
+
+
+class TestParseVttTranscript:
+    def test_keeps_speech_and_drops_cue_scaffolding(self) -> None:
+        text = parse_vtt_transcript(_ZOOM_VTT)
+
+        assert text == (
+            "Sarah Chen: So the thing I keep coming back to is\n\n"
+            "Sarah Chen: that I can't tell if I'm building the right thing.\n\n"
+            "Marcus Webb: Yeah."
+        )
+
+    def test_empty_vtt_yields_empty_string(self) -> None:
+        assert parse_vtt_transcript("WEBVTT\n") == ""
+
+    def test_multiline_cue_is_joined(self) -> None:
+        vtt = (
+            "WEBVTT\n\n"
+            "1\n"
+            "00:00:00.000 --> 00:00:02.000\n"
+            "Jane Doe: This sentence wraps\n"
+            "across two lines.\n"
+        )
+        assert (
+            parse_vtt_transcript(vtt)
+            == "Jane Doe: This sentence wraps across two lines."
+        )
+
+    def test_crlf_line_endings(self) -> None:
+        vtt = "WEBVTT\r\n\r\n1\r\n00:00:01.000 --> 00:00:02.000\r\nJane: hello\r\n"
+        assert parse_vtt_transcript(vtt) == "Jane: hello"
+
+    def test_cue_settings_on_timing_line_are_dropped(self) -> None:
+        vtt = (
+            "WEBVTT\n\n1\n"
+            "00:00:01.000 --> 00:00:02.000 align:start position:0%\n"
+            "Jane: hello\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: hello"
+
+
+class TestParseVttKeepsSpeechThatLooksLikeScaffolding:
+    """These cues would be dropped by shape-matching on "is it a number" or
+    "does it contain an arrow", which silently loses what someone said."""
+
+    def test_speech_containing_an_arrow_is_kept(self) -> None:
+        vtt = (
+            "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\n"
+            "Jane: the flow goes A --> B here\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: the flow goes A --> B here"
+
+    def test_cue_that_is_only_a_number_is_kept(self) -> None:
+        vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\n42\n"
+        assert parse_vtt_transcript(vtt) == "42"
+
+
+class TestParseVttDropsNonSpeechBlocks:
+    """Anything that reaches the return value gets indexed and shows up in
+    search, so non-speech blocks have to be excluded."""
+
+    def test_header_with_trailing_text_is_dropped(self) -> None:
+        vtt = (
+            "WEBVTT - This file has a title\n\n"
+            "1\n00:00:01.000 --> 00:00:02.000\nJane: hello\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: hello"
+
+    def test_byte_order_mark_is_dropped(self) -> None:
+        vtt = "﻿WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nJane: hello\n"
+        assert parse_vtt_transcript(vtt) == "Jane: hello"
+
+    def test_note_block_is_dropped(self) -> None:
+        vtt = (
+            "WEBVTT\n\nNOTE This transcript was auto-generated\n\n"
+            "1\n00:00:01.000 --> 00:00:02.000\nJane: hello\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: hello"
+
+    def test_style_block_is_dropped(self) -> None:
+        vtt = (
+            "WEBVTT\n\nSTYLE\n::cue { color: yellow }\n\n"
+            "1\n00:00:01.000 --> 00:00:02.000\nJane: hello\n"
+        )
+        assert parse_vtt_transcript(vtt) == "Jane: hello"
+
+    def test_cue_markup_is_stripped_but_speech_survives(self) -> None:
+        vtt = (
+            "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\n"
+            "<v Jane Doe>hello <i>there</i></v>\n"
+        )
+        assert parse_vtt_transcript(vtt) == "hello there"

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_vtt.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_vtt.py
@@ -1,7 +1,6 @@
 from onyx.connectors.zoom.recordings.vtt import parse_vtt_transcript
 
-# Shaped after a real Zoom audio_transcript.vtt: numbered cue, timing line,
-# then the speaker name inline with the speech.
+# A real Zoom audio_transcript.vtt shape, not an invented one.
 _ZOOM_VTT = """WEBVTT
 
 1
@@ -58,9 +57,6 @@ class TestParseVttTranscript:
 
 
 class TestParseVttKeepsSpeechThatLooksLikeScaffolding:
-    """These cues would be dropped by shape-matching on "is it a number" or
-    "does it contain an arrow", which silently loses what someone said."""
-
     def test_speech_containing_an_arrow_is_kept(self) -> None:
         vtt = (
             "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\n"
@@ -74,8 +70,8 @@ class TestParseVttKeepsSpeechThatLooksLikeScaffolding:
 
 
 class TestParseVttDropsNonSpeechBlocks:
-    """Anything that reaches the return value gets indexed and shows up in
-    search, so non-speech blocks have to be excluded."""
+    """Whatever this returns gets indexed, so parser scaffolding leaking
+    through would show up in search results."""
 
     def test_header_with_trailing_text_is_dropped(self) -> None:
         vtt = (
@@ -108,3 +104,33 @@ class TestParseVttDropsNonSpeechBlocks:
             "<v Jane Doe>hello <i>there</i></v>\n"
         )
         assert parse_vtt_transcript(vtt) == "hello there"
+
+
+class TestParseVttDecodesCharacterReferences:
+    """Drop the decoding and "R&D" gets indexed as "R&amp;D", so nobody
+    searching for it finds the meeting."""
+
+    def test_ampersand_is_decoded(self) -> None:
+        vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nJane: our R&amp;D team\n"
+        assert parse_vtt_transcript(vtt) == "Jane: our R&D team"
+
+    def test_angle_brackets_are_decoded(self) -> None:
+        vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nJane: a &lt;div&gt; tag\n"
+        assert parse_vtt_transcript(vtt) == "Jane: a <div> tag"
+
+    def test_numeric_reference_is_decoded(self) -> None:
+        vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nJane: it&#39;s fine\n"
+        assert parse_vtt_transcript(vtt) == "Jane: it's fine"
+
+    def test_non_breaking_space_becomes_a_normal_space(self) -> None:
+        vtt = "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nJane: a&nbsp;b\n"
+        assert parse_vtt_transcript(vtt) == "Jane: a b"
+        assert "\xa0" not in parse_vtt_transcript(vtt)
+
+    def test_escaped_markup_survives_as_text(self) -> None:
+        vtt = (
+            "WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\n"
+            "&lt;v Jane&gt;hello&lt;/v&gt;\n"
+        )
+        # Guards the order: decoding first would read this as a tag.
+        assert parse_vtt_transcript(vtt) == "<v Jane>hello</v>"


### PR DESCRIPTION
## Description

- Adds a Server-to-Server OAuth client that owns every call to Zoom, covering transcript fetch, occurrence details, and past-occurrence listing
- Adds a WebVTT parser for the transcripts Zoom returns
- No connector is registered yet, so indexing behaviour is unchanged

## How Has This Been Tested?

Unit tests added for the client and the parser (32 tests).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Zoom API client and WebVTT transcript parser as the foundation for the Zoom connector. No connector is registered yet, so indexing behavior is unchanged; the connector that uses this lands in a follow-up PR.

**New Features**
- Handles Server-to-Server OAuth with early token refresh, retries once when Zoom rejects a cached token, and maps token-endpoint 401s to invalid-credential errors and 403s to insufficient-permission errors.
- Double-encodes meeting UUIDs that start with "/" or contain "//" per Zoom's docs, and lists past occurrences because a recurring meeting's transcript endpoint only reaches the latest run.
- Parses WebVTT positionally per the W3C spec so cue-like speech (a lone number or "--->") survives, and decodes character references so "R&amp;D" is indexed as "R&D".
- Refuses transcript download URLs outside zoom.us, sends the account-wide bearer token only to that host, and validates every redirect hop so an open redirect cannot reach a private address.
- Raises on 404 with Zoom's error code so the caller can decide between a missing transcript and a missing meeting; downloads only when `can_download`, `download_url`, and `download_restriction_reason` agree.
- Types response models strictly from Zoom's documented shapes, with only the fields Zoom marks conditional left optional.
- Adds 32 unit tests covering the client and parser.

<sup>Written for commit 220a8e9788828b0a069a5346a821dae63c6d2271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



