### PR TITLE
fix(tools): Don't make declared sources wait on the connector fetch

### DIFF
--- a/web/src/lib/searchFilters/sourcePreferences.test.tsx
+++ b/web/src/lib/searchFilters/sourcePreferences.test.tsx
@@ -8,19 +8,20 @@ beforeEach(() => {
   localStorage.clear();
 });
 
-function setup(availableSources: ValidSources[]) {
+function setup(availableSources: ValidSources[], ready = true) {
   const state: { selected: SourceMetadata[] } = { selected: [] };
 
   const hook = renderHook(
-    ({ avail }) =>
+    ({ avail, ready: isReady }) =>
       useSourcePreferences({
         availableSources: avail,
         selectedSources: state.selected,
         setSelectedSources: (sources: SourceMetadata[]) => {
           state.selected = sources;
         },
+        ready: isReady,
       }),
-    { initialProps: { avail: availableSources } }
+    { initialProps: { avail: availableSources, ready } }
   );
 
   return { hook, state };
@@ -75,6 +76,7 @@ describe("useSourcePreferences — agent switching", () => {
 
     hook.rerender({
       avail: [ValidSources.Notion, ValidSources.UserFile],
+      ready: true,
     });
 
     expect(sourceNames(state.selected)).toEqual(["notion", "user_file"]);
@@ -89,6 +91,7 @@ describe("useSourcePreferences — agent switching", () => {
 
     hook.rerender({
       avail: [ValidSources.Notion, ValidSources.Web, ValidSources.Confluence],
+      ready: true,
     });
 
     expect(sourceNames(state.selected)).toEqual([
@@ -152,5 +155,46 @@ describe("buildFilters — source_type payload", () => {
 
     const filters = buildFilters(state.selected, [], null, []);
     expect(filters.source_type).toEqual(["user_file"]);
+  });
+});
+
+describe("useSourcePreferences — readiness", () => {
+  test("an unsettled list does not initialise preferences", () => {
+    const { hook, state } = setup([ValidSources.Notion], false);
+
+    expect(state.selected).toEqual([]);
+    expect(hook.result.current.sourcesInitialized).toBe(false);
+    expect(localStorage.getItem("selectedInternalSearchSources")).toBeNull();
+  });
+
+  test("initialising waits for the list to settle", () => {
+    const { hook, state } = setup([ValidSources.Notion], false);
+    expect(state.selected).toEqual([]);
+
+    hook.rerender({ avail: [ValidSources.Notion], ready: true });
+
+    expect(sourceNames(state.selected)).toEqual(["notion"]);
+    expect(hook.result.current.sourcesInitialized).toBe(true);
+  });
+
+  test("a partial list is never persisted as the choice", () => {
+    // The connector fetch has only returned one of two sources so far.
+    const { hook, state } = setup([ValidSources.Notion], false);
+    expect(localStorage.getItem("selectedInternalSearchSources")).toBeNull();
+
+    // It settles, and the complete set arrives together with readiness.
+    hook.rerender({
+      avail: [ValidSources.Notion, ValidSources.Confluence],
+      ready: true,
+    });
+
+    expect(sourceNames(state.selected)).toEqual(["confluence", "notion"]);
+    const saved = JSON.parse(
+      localStorage.getItem("selectedInternalSearchSources")!
+    );
+    expect(Object.keys(saved.sourcePreferences).sort()).toEqual([
+      "confluence",
+      "notion",
+    ]);
   });
 });

--- a/web/src/lib/tools/providers.tsx
+++ b/web/src/lib/tools/providers.tsx
@@ -87,7 +87,13 @@ function useToolsPopoverState({
 
   // A partial list must not become the user's persisted choice, but it is
   // still worth showing. Only initialisation waits for the fetch to settle.
-  const sourcesReady = !sourcesLoading && !sourcesError;
+  //
+  // An agent that declares its own knowledge_sources never reads the fetch,
+  // so waiting on it would leave those sources unselected for as long as the
+  // connector request is in flight, or forever if it fails.
+  const declaresOwnSources =
+    !isAssistant(agent) && (agent.knowledge_sources?.length ?? 0) > 0;
+  const sourcesReady = declaresOwnSources || (!sourcesLoading && !sourcesError);
 
   const hasSearchTool = agent.tools.some(
     (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID

--- a/web/tests/e2e/pages/ToolsPopover.ts
+++ b/web/tests/e2e/pages/ToolsPopover.ts
@@ -160,7 +160,10 @@ export class ToolsPopover {
   // ---------------------------------------------------------------------------
 
   serverRow(serverName: string): Locator {
-    return this.row(new RegExp(escapeRegex(serverName)));
+    // Anchored: a server row is named exactly for its server, while a tool row
+    // above it can merely contain that name (a "GitHub" server whose tools are
+    // titled "GitHub issues"), and `.first()` would take the tool row.
+    return this.row(new RegExp(`^${escapeRegex(serverName)}$`));
   }
 
   async expectServerVisible(serverName: string): Promise<void> {

--- a/web/tests/e2e/pages/ToolsPopover.ts
+++ b/web/tests/e2e/pages/ToolsPopover.ts
@@ -160,10 +160,11 @@ export class ToolsPopover {
   // ---------------------------------------------------------------------------
 
   serverRow(serverName: string): Locator {
-    // Anchored: a server row is named exactly for its server, while a tool row
-    // above it can merely contain that name (a "GitHub" server whose tools are
-    // titled "GitHub issues"), and `.first()` would take the tool row.
-    return this.row(new RegExp(`^${escapeRegex(serverName)}$`));
+    // Deliberately unanchored. A server row's accessible name is not just its
+    // name: an authenticated server with some of its tools enabled renders a
+    // visible count beside it, which the name picks up. Anchoring the end
+    // would drop exactly those rows.
+    return this.row(new RegExp(escapeRegex(serverName)));
   }
 
   async expectServerVisible(serverName: string): Promise<void> {


### PR DESCRIPTION
## Description

Declared sources no longer wait on the connector fetch.

`useToolsPopoverState` gated source initialisation on connector readiness for every agent. An agent that is not an assistant and declares its own `knowledge_sources` never reads that fetch: `effectiveAvailableSources` returns the declared list directly. Those agents kept their sources unselected for as long as the connector request was in flight, and permanently if it failed, so the search tool was never reconciled.

Readiness now counts as settled for a declared-source agent. The comment above that line already claimed they were unaffected; the code now agrees with it.

**`serverRow` stays unanchored, on purpose**

This started as an anchored match (`^name$`) to stop a tool row from being picked instead of a server row. That was wrong and is reverted. `MCPLineItem` marks only its chevron and key spans `aria-hidden`; `EnabledCount` is not hidden, so an authenticated server with some of its tools enabled contributes visible count text to the row's accessible name, and the anchor dropped exactly those rows.

An anchored form with an optional count (`^name( \d+ of \d+)?$`) was considered and rejected: `EnabledCount` renders a hardcoded English `" of "`, so it would bake an untranslated literal into a locator while the app is mid-i18n-migration, and break silently once that component is localised.

What remains is the form that shipped in #14476 and that the MCP specs pass against. The false match it permits needs a fixture titling a tool after its own server, which none produce. The durable fix is to stop deriving row identity from concatenated descendant text — an explicit `aria-label` on the row — which needs `LineItemButton` to forward DOM props, and belongs in its own change.

## How Has This Been Tested?

`bunx jest src/lib/searchFilters/sourcePreferences.test.tsx` — 14 passing, three of them new and covering the readiness gate:

- an unsettled list initialises nothing and writes nothing to localStorage
- initialisation happens once the list settles
- a partial list is never persisted as the user's choice

I checked they are not vacuous: with the `ready &&` removed from the gate in `useSourcePreferences`, all three fail and the other eleven still pass.

`bun run types:check`, `oxfmt` and `oxlint` also pass.

Not covered by a test: the provider-level wiring that decides *when* readiness is settled — that a declared-source agent passes `ready` as true. Worth confirming by hand that such an agent has its sources selected while connectors are still loading, and still does if the connector request fails.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declared sources for non-assistant agents now initialize without waiting on the connector fetch, so their sources get selected immediately while connectors are still loading or fail.

**Bug Fixes**
- Added tests covering the readiness gate: unsettled lists don't initialize, initialization waits for the list to settle, and partial lists are never persisted.

<sup>Written for commit 990d14f3a4904e6e8eacc3273efbfda8777dc594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

