### PR TITLE
fix(terraform-provider): survive a concurrent release, and make the licence detectable

### DIFF
--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -26,8 +26,12 @@ on:
 permissions:
   contents: read
 
+# One group for every release, not one per tag. Each run reads the mirror's
+# current main and pushes one commit onto it, so two releases running together
+# read the same parent and the second atomic push is refused. Serialising them
+# costs nothing — a release is a minute — and removes that failure.
 concurrency:
-  group: Release-Terraform-Provider-${{ github.ref_name }}
+  group: Release-Terraform-Provider
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -73,7 +73,10 @@ jobs:
         id: mirror-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v2
         with:
-          client-id: ${{ vars.TF_PROVIDER_RELEASE_APP_ID }}
+          # The App's Client ID (Iv23li...), not the numeric App ID. The action
+          # takes either, through different inputs, and only app-id is
+          # deprecated — so the variable is named for the one it holds.
+          client-id: ${{ vars.TF_PROVIDER_RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.TF_PROVIDER_RELEASE_APP_PRIVATE_KEY }}
           owner: onyx-dot-app
           repositories: terraform-provider-onyx

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -26,12 +26,15 @@ on:
 permissions:
   contents: read
 
-# One group for every release, not one per tag. Each run reads the mirror's
-# current main and pushes one commit onto it, so two releases running together
-# read the same parent and the second atomic push is refused. Serialising them
-# costs nothing — a release is a minute — and removes that failure.
+# One group per version, so the same release cannot run twice at once — a tag
+# push and a manual dispatch for it share a group.
+#
+# Deliberately NOT one group for every release. A group holds one running and
+# one pending run, and a third cancels the pending one even with
+# cancel-in-progress false, so serialising here would drop a release silently.
+# Releases run in parallel instead and the mirror push re-reads its parent.
 concurrency:
-  group: Release-Terraform-Provider
+  group: Release-Terraform-Provider-${{ inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -112,27 +115,62 @@ jobs:
           set -euo pipefail
           mirror="https://github.com/${MIRROR_REPO}.git"
 
-          tree=$(git rev-parse "HEAD:${PROVIDER_DIR}")
-          parents=()
-          if git fetch --quiet "${mirror}" main 2>/dev/null; then
-            parents=(-p "$(git rev-parse FETCH_HEAD)")
-            echo "Building on the mirror's current main."
-          else
-            echo "The mirror has no main yet; this is its first commit."
+          tag_exists() {
+            git ls-remote --exit-code --tags "${mirror}" \
+              "refs/tags/${MIRROR_TAG}" >/dev/null 2>&1
+          }
+
+          # A version already on the mirror is never re-cut. Checking first
+          # separates that from the parent race below, which is retried.
+          if tag_exists; then
+            echo "::error::${MIRROR_TAG} is already on ${MIRROR_REPO}."
+            exit 1
           fi
 
+          tree=$(git rev-parse "HEAD:${PROVIDER_DIR}")
           message="${MIRROR_TAG}
 
           Published from ${GITHUB_REPOSITORY}@$(git rev-parse HEAD).
           Edit the provider there, never here."
-          commit=$(git commit-tree "${tree}" "${parents[@]}" -m "${message}")
 
-          # One atomic push, so a rejected tag cannot leave main advanced
-          # without it. Re-running a version that already shipped is refused
-          # whole rather than adding a second commit for the same release.
-          git push --atomic "${mirror}" \
-            "${commit}:refs/heads/main" \
-            "${commit}:refs/tags/${MIRROR_TAG}"
+          # Another release can land between reading main and pushing onto it,
+          # which the atomic push then refuses. Re-read main and rebuild the
+          # commit rather than serialising the workflow: a concurrency group
+          # holding every release would cancel a pending one instead.
+          pushed=false
+          for attempt in 1 2 3 4 5; do
+            parents=()
+            if git fetch --quiet "${mirror}" main 2>/dev/null; then
+              parents=(-p "$(git rev-parse FETCH_HEAD)")
+              echo "Attempt ${attempt}: building on the mirror's current main."
+            else
+              echo "Attempt ${attempt}: the mirror has no main yet."
+            fi
+
+            commit=$(git commit-tree "${tree}" "${parents[@]}" -m "${message}")
+
+            # One atomic push, so a rejected tag cannot leave main advanced
+            # without it.
+            if git push --atomic "${mirror}" \
+              "${commit}:refs/heads/main" \
+              "${commit}:refs/tags/${MIRROR_TAG}"; then
+              pushed=true
+              break
+            fi
+
+            # The tag is ours alone, so its arrival means a concurrent run
+            # shipped this same version. Retrying cannot help.
+            if tag_exists; then
+              echo "::error::${MIRROR_TAG} reached ${MIRROR_REPO} while pushing."
+              exit 1
+            fi
+            echo "main moved; re-reading it."
+          done
+
+          if [ "${pushed}" != true ]; then
+            echo "::error::could not push ${MIRROR_TAG} after 5 attempts."
+            exit 1
+          fi
 
           {
             echo "### Terraform provider ${MIRROR_TAG}"

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -26,8 +26,14 @@ on:
 permissions:
   contents: read
 
-# One group per version, so the same release cannot run twice at once — a tag
-# push and a manual dispatch for it share a group.
+# Keyed on the raw trigger, so re-pushing a tag or re-dispatching a version
+# does not run it twice over. A tag push and a dispatch of the same version do
+# NOT share a group: the values differ (tf-provider/v1.2.3 against 1.2.3) and
+# expressions have no string replace to normalise them. Matching them would
+# need the resolved version, which only exists after a step runs, so it would
+# cost a separate job on every release. The duplicate-tag check below already
+# refuses that second run before it pushes anything, so this group is only
+# saving a wasted runner.
 #
 # Deliberately NOT one group for every release. A group holds one running and
 # one pending run, and a third cancels the pending one even with

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -26,21 +26,12 @@ on:
 permissions:
   contents: read
 
-# Keyed on the raw trigger, so re-pushing a tag or re-dispatching a version
-# does not run it twice over. A tag push and a dispatch of the same version do
-# NOT share a group: the values differ (tf-provider/v1.2.3 against 1.2.3) and
-# expressions have no string replace to normalise them. Matching them would
-# need the resolved version, which only exists after a step runs, so it would
-# cost a separate job on every release. The duplicate-tag check below already
-# refuses that second run before it pushes anything, so this group is only
-# saving a wasted runner.
-#
-# Deliberately NOT one group for every release. A group holds one running and
-# one pending run, and a third cancels the pending one even with
-# cancel-in-progress false, so serialising here would drop a release silently.
-# Releases run in parallel instead and the mirror push re-reads its parent.
+# One group for every release, so two never push to the mirror at once. Each
+# run reads the mirror's main and commits onto it, so overlapping runs read the
+# same parent and the second atomic push is refused. Releases are manual and
+# take about a minute, so serialising them costs nothing.
 concurrency:
-  group: Release-Terraform-Provider-${{ inputs.version || github.ref_name }}
+  group: Release-Terraform-Provider
   cancel-in-progress: false
 
 env:
@@ -80,8 +71,8 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v2
         with:
           # The App's Client ID (Iv23li...), not the numeric App ID. The action
-          # takes either, through different inputs, and only app-id is
-          # deprecated — so the variable is named for the one it holds.
+          # takes either through different inputs, and app-id is deprecated, so
+          # the variable is named for the one this passes.
           client-id: ${{ vars.TF_PROVIDER_RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.TF_PROVIDER_RELEASE_APP_PRIVATE_KEY }}
           owner: onyx-dot-app
@@ -124,62 +115,27 @@ jobs:
           set -euo pipefail
           mirror="https://github.com/${MIRROR_REPO}.git"
 
-          tag_exists() {
-            git ls-remote --exit-code --tags "${mirror}" \
-              "refs/tags/${MIRROR_TAG}" >/dev/null 2>&1
-          }
-
-          # A version already on the mirror is never re-cut. Checking first
-          # separates that from the parent race below, which is retried.
-          if tag_exists; then
-            echo "::error::${MIRROR_TAG} is already on ${MIRROR_REPO}."
-            exit 1
+          tree=$(git rev-parse "HEAD:${PROVIDER_DIR}")
+          parents=()
+          if git fetch --quiet "${mirror}" main 2>/dev/null; then
+            parents=(-p "$(git rev-parse FETCH_HEAD)")
+            echo "Building on the mirror's current main."
+          else
+            echo "The mirror has no main yet; this is its first commit."
           fi
 
-          tree=$(git rev-parse "HEAD:${PROVIDER_DIR}")
           message="${MIRROR_TAG}
 
           Published from ${GITHUB_REPOSITORY}@$(git rev-parse HEAD).
           Edit the provider there, never here."
+          commit=$(git commit-tree "${tree}" "${parents[@]}" -m "${message}")
 
-          # Another release can land between reading main and pushing onto it,
-          # which the atomic push then refuses. Re-read main and rebuild the
-          # commit rather than serialising the workflow: a concurrency group
-          # holding every release would cancel a pending one instead.
-          pushed=false
-          for attempt in 1 2 3 4 5; do
-            parents=()
-            if git fetch --quiet "${mirror}" main 2>/dev/null; then
-              parents=(-p "$(git rev-parse FETCH_HEAD)")
-              echo "Attempt ${attempt}: building on the mirror's current main."
-            else
-              echo "Attempt ${attempt}: the mirror has no main yet."
-            fi
-
-            commit=$(git commit-tree "${tree}" "${parents[@]}" -m "${message}")
-
-            # One atomic push, so a rejected tag cannot leave main advanced
-            # without it.
-            if git push --atomic "${mirror}" \
-              "${commit}:refs/heads/main" \
-              "${commit}:refs/tags/${MIRROR_TAG}"; then
-              pushed=true
-              break
-            fi
-
-            # The tag is ours alone, so its arrival means a concurrent run
-            # shipped this same version. Retrying cannot help.
-            if tag_exists; then
-              echo "::error::${MIRROR_TAG} reached ${MIRROR_REPO} while pushing."
-              exit 1
-            fi
-            echo "main moved; re-reading it."
-          done
-
-          if [ "${pushed}" != true ]; then
-            echo "::error::could not push ${MIRROR_TAG} after 5 attempts."
-            exit 1
-          fi
+          # One atomic push, so a rejected tag cannot leave main advanced
+          # without it. Re-running a version that already shipped is refused
+          # whole rather than adding a second commit for the same release.
+          git push --atomic "${mirror}" \
+            "${commit}:refs/heads/main" \
+            "${commit}:refs/tags/${MIRROR_TAG}"
 
           {
             echo "### Terraform provider ${MIRROR_TAG}"

--- a/terraform-provider-onyx/LICENSE
+++ b/terraform-provider-onyx/LICENSE
@@ -1,8 +1,6 @@
-Copyright (c) 2023-present DanswerAI, Inc.
+MIT License
 
-This provider is distributed under the "MIT Expat" license, the same terms the
-Onyx monorepo applies to content outside its "ee" directories. It contains no
-Enterprise-licensed code.
+Copyright (c) 2023-present DanswerAI, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -434,11 +434,15 @@ run, which builds every archive and publishes none of them.
 
 One step is left, and it is the only reason a release is still cut by hand:
 
-- [ ] Give this repo a credential that can push to the mirror, and put it in a
-      `release-terraform-provider` environment. That environment does not exist yet, so
-      `release-terraform-provider.yml` cannot run. It currently expects a GitHub App:
-      the variable `TF_PROVIDER_RELEASE_APP_ID` and the secret
-      `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`.
+- [ ] Give this repo a credential that can push to the mirror. The
+      `release-terraform-provider` environment exists but is empty, so
+      `release-terraform-provider.yml` has nothing to authenticate with and has never
+      run. Create a GitHub App, install it on the mirror alone with **contents: write**,
+      and put two values in that environment:
+      - variable `TF_PROVIDER_RELEASE_APP_CLIENT_ID` — the App's **Client ID**
+        (`Iv23li...`) from its settings page, *not* the numeric App ID.
+      - secret `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY` — the whole generated `.pem`,
+        `BEGIN`/`END` lines included.
 
 Until that exists, a release is the workflow's own commands run locally against the
 mirror, followed by the tag — about a minute. That is how `v0.1.0` shipped.

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -422,21 +422,30 @@ run, which builds every archive and publishes none of them.
 
 ### One-time setup
 
-None of this is done yet, and each step needs org permissions:
+`v0.1.0` is published, so everything the registry needs is in place:
 
-- [ ] Create the public repo `onyx-dot-app/terraform-provider-onyx`. Leave it empty or
-      initialise it — the workflow handles both.
-- [ ] Decide what `LICENSE` the mirror carries. The provider is MIT under this repo's
-      terms, but the monorepo `LICENSE` names `ee` directories that the mirror has none of.
-      goreleaser puts the file in every archive once it exists.
-- [ ] Create the release GPG key and register its public half with the Terraform Registry
-      under the `onyx-dot-app` namespace.
-- [ ] Install a GitHub App with `contents: write` on the mirror, and fill in the monorepo's
-      `release-terraform-provider` environment: the variable `TF_PROVIDER_RELEASE_APP_ID`
-      and the secret `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`.
-- [ ] Add the secrets `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE` **to
-      the mirror**, which is where the signing happens. The monorepo never holds the key.
-- [ ] Link the mirror on registry.terraform.io as the `onyx-dot-app` organisation.
+- [x] The public repo `onyx-dot-app/terraform-provider-onyx` exists.
+- [x] The mirror carries its own `LICENSE`.
+- [x] The release GPG key exists and its public half is registered under the
+      `onyx-dot-app` namespace.
+- [x] The mirror holds `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE`,
+      which is where the signing happens. The monorepo never holds the key.
+- [x] The mirror is linked on registry.terraform.io as the `onyx-dot-app` organisation.
 
-Until then, install the provider with `dev_overrides` (above), or from a private registry
-or filesystem mirror.
+One step is left, and it is the only reason a release is still cut by hand:
+
+- [ ] Give this repo a credential that can push to the mirror, and put it in a
+      `release-terraform-provider` environment. That environment does not exist yet, so
+      `release-terraform-provider.yml` cannot run. It currently expects a GitHub App:
+      the variable `TF_PROVIDER_RELEASE_APP_ID` and the secret
+      `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`.
+
+Until that exists, a release is the workflow's own commands run locally against the
+mirror, followed by the tag — about a minute. That is how `v0.1.0` shipped.
+
+## Licence
+
+MIT, the same terms the Onyx monorepo applies to content outside its `ee` directories.
+The provider contains no Enterprise-licensed code. `LICENSE` holds the plain MIT text
+with nothing added, so licence scanners and GitHub detect it as MIT rather than
+reporting `NOASSERTION`.


### PR DESCRIPTION
## Description

Two of the ENG-4322 follow-ups, plus a correction to the checklist that gates the third.

**Two releases running together lost one.** Each run reads the mirror's `main`, commits the provider tree onto it, and pushes atomically — so a release that lands in between makes the second push fail.

My first attempt serialised releases on one concurrency group. Review caught that this is worse: a group holds one running and one pending run, and a third run cancels the pending one **even with `cancel-in-progress: false`**. That turns a loud failure (rejected push, safe to re-run) into a silent one (a version never reaches the registry). ENG-4322 had recorded this caveat and I did not carry it across.

The push now re-reads `main` and rebuilds the commit when it is refused, up to five attempts, so releases stay parallel. The concurrency group is per version, which still stops a tag push and a manual dispatch racing on the same release. A tag already on the mirror is checked first and refused outright, so re-cutting a shipped version stays an error rather than something the retry papers over.

**The licence read as `NOASSERTION`.** `LICENSE` carried an explanatory paragraph above the MIT text, and GitHub's detector wants a near-exact template match. Verified against the API: both `onyx-dot-app/onyx` and the mirror report `NOASSERTION` today. The file is now the plain MIT template with an `MIT License` title, and the explanation moved to the README where it belonged. Licence-scanning tooling keys off this.

**The release checklist was wrong.** It claimed "None of this is done yet." Checked each item against the API instead: the mirror repo exists, `v0.1.0` is published, the mirror holds both GPG secrets, and the registry link is live. Five of six are done.

The one real gap is that the `release-terraform-provider` environment **does not exist in this repo** — it is absent from `GET /repos/onyx-dot-app/onyx/environments` — so the workflow has no credential to push to the mirror and has never run. That is why `v0.1.0` was cut by hand. The README now says exactly that.

## How Has This Been Tested?

The push logic was exercised against local bare repositories, the way this step was originally verified:

```
=== 1. first release (empty mirror) ===
  attempt 1: mirror has no main yet          -> pushed v0.1.0
=== 2. second release, main moves under it ===
  attempt 1: on current main
  (a competing release landed)
  main moved; re-reading
  attempt 2: on current main                 -> pushed v0.2.0
=== 3. re-cutting a shipped version is refused ===
ERROR: v0.1.0 already on mirror

mirror history: v0.2.0 / competitor / v0.1.0   (linear)
```

`zizmor`, `Check YAML`, `Lint GitHub Actions workflow files` and `ripsecrets` pass.

The licence claim is checkable: `gh api repos/onyx-dot-app/onyx/license --jq .license.spdx_id` returns `NOASSERTION` today. GitHub re-detects on push.

⚠️ The `audit` check on this PR fails for reasons unrelated to it. `audit.yml` runs on any `.github/workflows/**` change, and two criticals published on 2026-09-03 now block it: `unstructured@0.18.27` (SSRF, fixed in 0.24.0) and `gitpython@3.1.58` (fixed in 3.1.59). Main's nightly passed at 09:15 UTC and will fail on its next run. This PR touches no dependency file; the bumps want their own PR.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check