### PR TITLE
perf(web): composite text shimmer on the GPU

### DIFF
--- a/web/src/app/app/message/messageComponents/timeline/AgentTimeline.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/AgentTimeline.tsx
@@ -6,7 +6,7 @@ import { FullChatState, RenderType } from "../interfaces";
 import { TurnGroup } from "./transformers";
 import { cn } from "@opal/utils";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
-import Text from "@/refresh-components/texts/Text";
+import ShimmerText from "@/refresh-components/texts/ShimmerText";
 import { useTimelineExpansion } from "@/app/app/message/messageComponents/timeline/hooks/useTimelineExpansion";
 import { useTimelineMetrics } from "@/app/app/message/messageComponents/timeline/hooks/useTimelineMetrics";
 import { useTimelineHeader } from "@/app/app/message/messageComponents/timeline/hooks/useTimelineHeader";
@@ -348,9 +348,7 @@ export const AgentTimeline = React.memo(function AgentTimeline({
         agent={chatState.agent}
         headerContent={
           <div className="flex w-full h-full items-center ps-(--timeline-header-padding-left) pe-(--timeline-header-padding-right)">
-            <Text as="p" mainUiAction text03 className="shimmer-text">
-              {headerText}
-            </Text>
+            <ShimmerText>{headerText}</ShimmerText>
           </div>
         }
       />

--- a/web/src/app/app/message/messageComponents/timeline/headers/StreamingHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/StreamingHeader.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useTranslations } from "next-intl";
 import { SvgFold, SvgExpand } from "@opal/icons";
 import { Button } from "@opal/components";
-import Text from "@/refresh-components/texts/Text";
+import ShimmerText from "@/refresh-components/texts/ShimmerText";
 import { useStreamingDuration } from "../hooks/useStreamingDuration";
 import { formatDurationSeconds } from "@opal/time";
 
@@ -42,9 +42,7 @@ export const StreamingHeader = React.memo(function StreamingHeader({
   return (
     <>
       <div className="px-(--timeline-header-text-padding-x) py-(--timeline-header-text-padding-y)">
-        <Text as="p" mainUiAction text03 className="shimmer-text">
-          {headerText}
-        </Text>
+        <ShimmerText>{headerText}</ShimmerText>
       </div>
 
       {collapsible &&

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -253,6 +253,71 @@
   /* Preserves whitespace and wraps text */
 }
 
+/* Text shimmer for streaming status lines (see ShimmerText.tsx). The base
+   text renders normally; an inert clone above it is masked to its own glyphs,
+   and a highlight bar slides across the clone. Only `translate` animates, so
+   the effect composites on the GPU instead of repainting every frame. */
+.shimmer-text {
+  position: relative;
+  color: var(--shimmer-base);
+}
+
+.shimmer-text-overlay {
+  position: absolute;
+  inset: 0;
+  overflow: clip;
+  color: transparent;
+  contain: strict;
+  pointer-events: none;
+  mask-image: linear-gradient(#fff, #fff);
+  -webkit-mask-clip: text;
+}
+
+.shimmer-text-overlay::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    90deg,
+    transparent 35%,
+    var(--shimmer-highlight) 50%,
+    transparent 65%
+  );
+  will-change: transform;
+  animation: shimmer-slide 1s ease-out infinite;
+}
+
+@keyframes shimmer-slide {
+  from {
+    translate: -100% 0;
+  }
+  to {
+    translate: 100% 0;
+  }
+}
+
+/* Browsers without text mask clipping (Firefox) fall back to the animated
+   background gradient. It repaints each frame but looks the same. */
+@supports not (-webkit-mask-clip: text) {
+  .shimmer-text {
+    animation: shimmer 1s ease-out infinite;
+    background-size: 300% 100%;
+    background-image: linear-gradient(
+      90deg,
+      var(--shimmer-base) 35%,
+      var(--shimmer-highlight) 50%,
+      var(--shimmer-base) 65%
+    );
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+  }
+
+  .shimmer-text-overlay {
+    display: none;
+  }
+}
+
 @keyframes shimmer {
   0% {
     background-position: 100% 0;
@@ -262,18 +327,18 @@
   }
 }
 
-.shimmer-text {
-  animation: shimmer 1s ease-out infinite;
-  background-size: 300% 100%;
-  background-image: linear-gradient(
-    90deg,
-    var(--shimmer-base) 35%,
-    var(--shimmer-highlight) 50%,
-    var(--shimmer-base) 65%
-  );
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
+@media (prefers-reduced-motion: reduce) {
+  .shimmer-text {
+    animation: none;
+    background-image: none;
+    background-clip: border-box;
+    -webkit-background-clip: border-box;
+    color: var(--shimmer-base);
+  }
+
+  .shimmer-text-overlay {
+    display: none;
+  }
 }
 
 .collapsible {

--- a/web/src/refresh-components/texts/ShimmerText.tsx
+++ b/web/src/refresh-components/texts/ShimmerText.tsx
@@ -1,7 +1,8 @@
 import { Text } from "@opal/components";
+import type { RichStr } from "@opal/types";
 
 interface ShimmerTextProps {
-  children: string;
+  children: string | RichStr;
 }
 
 /**

--- a/web/src/refresh-components/texts/ShimmerText.tsx
+++ b/web/src/refresh-components/texts/ShimmerText.tsx
@@ -1,0 +1,32 @@
+import { Text } from "@opal/components";
+
+interface ShimmerTextProps {
+  children: string;
+}
+
+/**
+ * Status text with a shimmer sweep, used while an agent streams.
+ *
+ * Renders the text twice: the visible base text and an inert clone that is
+ * masked to its own glyphs (`-webkit-mask-clip: text`). A highlight bar
+ * slides across the clone with a transform animation, so the effect runs on
+ * the compositor instead of repainting the text every frame. The clone (vs.
+ * a pseudo-element on the base text) avoids sub-pixel thinning of the
+ * glyphs. Styles live in `globals.css` (`.shimmer-text`).
+ *
+ * Technique: https://codepen.io/editor/devongovett/pen/01a0439c-4b7f-7f44-bf84-205c514ad139
+ */
+export default function ShimmerText({ children }: ShimmerTextProps) {
+  return (
+    <div className="shimmer-text">
+      <Text as="p" font="main-ui-action" color="inherit">
+        {children}
+      </Text>
+      <div aria-hidden="true" inert className="shimmer-text-overlay">
+        <Text as="p" font="main-ui-action" color="inherit">
+          {children}
+        </Text>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

The streaming-header shimmer animated `background-position` on a text-clipped gradient. That property is not compositor-accelerated, so the browser repainted the text every frame for the entire streaming phase — exactly when the main thread is busiest. Devon Govett measured this pattern at ~20% CPU for one line of text, and his mask-based alternative at <2% ([pen](https://codepen.io/editor/devongovett/pen/01a0439c-4b7f-7f44-bf84-205c514ad139), technique credit to him).

This PR adopts that technique via a new `ShimmerText` component:

- The text renders twice: the visible base text, and an `inert` `aria-hidden` clone masked to its own glyphs with `-webkit-mask-clip: text`.
- A highlight bar slides across the clone with a `translate` animation. Only a transform animates, so the effect composites on the GPU with no per-frame repaint.
- The clone (instead of a pseudo-element on the base text) avoids sub-pixel thinning of the glyphs.
- Firefox has no text mask clipping; an `@supports` block keeps the old `background-position` animation there, so it looks the same.
- `prefers-reduced-motion: reduce` now disables the sweep (it did not before).

Colors still come from the `--shimmer-base` / `--shimmer-highlight` tokens, and the timing (1s ease-out) is unchanged, so the effect looks the same as before.

## How Has This Been Tested?

- Rendered the exact component markup + compiled CSS in headless Chromium and captured the animation at several phases: the highlight sweeps across and is clipped to the glyphs.
- Verified the dev build serves the new rules intact (Lightning CSS keeps `-webkit-mask-clip: text` and adds the `-webkit-mask-image` fallback).
- `pre-commit` (oxfmt, oxlint, TypeScript) passes on the touched files; `types:check` reports the same pre-existing errors as `main`, none in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the streaming-header shimmer's `background-position` animation (which repainted text every frame) with a GPU-composited transform on a masked text clone. The visual effect stays the same, and `prefers-reduced-motion` now disables the sweep.

**Details**
- Adds `ShimmerText`, used by `StreamingHeader` and `AgentTimeline`, which renders visible base text plus an inert `aria-hidden` clone masked to its glyphs.
- A highlight bar slides across the clone with a `translate` animation, so the browser composites the effect on the GPU instead of repainting each frame.
- Firefox doesn't support `-webkit-mask-clip: text`, so an `@supports` fallback keeps the old animation there (same look, same repaint cost).
- `ShimmerText` accepts `string | RichStr` children so callers can opt into inline markdown.
- Colors and timing are unchanged.

<sup>Written for commit fa5f04817a16c9bd78ad39aace3b3066e726ac51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

