### PR TITLE
feat(ods): let "ods release beta" cut a new release branch

### DIFF
--- a/tools/ods/cmd/release_beta.go
+++ b/tools/ods/cmd/release_beta.go
@@ -13,11 +13,12 @@ import (
 
 // ReleaseBetaOptions holds options for the release beta command.
 type ReleaseBetaOptions struct {
-	Ref     string
-	Version string
-	DryRun  bool
-	Yes     bool
-	Verify  bool
+	Ref       string
+	Version   string
+	NewBranch bool
+	DryRun    bool
+	Yes       bool
+	Verify    bool
 }
 
 // NewReleaseBetaCommand creates the `ods release beta` command.
@@ -26,17 +27,23 @@ func NewReleaseBetaCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "beta",
-		Short: "Cut the next beta release tag (vX.Y.Z-beta.N) on a release branch",
-		Long: `Cut the next beta release tag (vX.Y.Z-beta.N) and push it to origin.
+		Short: "Cut a beta release tag (vX.Y.Z-beta.N) on a new or existing release branch",
+		Long: `Cut a beta release tag (vX.Y.Z-beta.N) and push it to origin.
 
-The target branch is the newest release/vX.Y branch on origin. The base
-version is one patch past the highest stable vX.Y.* tag, so the first beta
-of a fresh branch is vX.Y.0-beta.0 and a beta cut after a stable release
-previews the next patch. N is one past the highest existing counter for the
-same base, starting at 0.
+The command asks which branch to cut on:
 
-By default the branch tip is tagged; --ref tags an older commit on the
-branch. --version pins the base outright and targets its release branch.
+  - The newest release/vX.Y branch on origin. The base version is one patch
+    past the highest stable vX.Y.* tag, so the first beta of a fresh branch is
+    vX.Y.0-beta.0 and a beta cut after a stable release previews the next
+    patch. N is one past the highest existing counter for the same base,
+    starting at 0.
+  - A new release/vX.Y+1 branch, one minor past the newest one, created from
+    origin/main and tagged vX.Y+1.0-beta.0. --new-branch picks this
+    non-interactively.
+
+By default the branch tip is tagged (origin/main for a new branch); --ref
+tags an older commit on it. --version pins the base outright and targets its
+release branch.
 
 Pushing the tag triggers deployment.yml, which builds the beta images and
 moves the "beta" Docker tags.
@@ -46,6 +53,7 @@ To validate an existing tag instead of cutting one, see "ods release --check".
 Example usage:
 
     $ ods release beta
+    $ ods release beta --new-branch
     $ ods release beta --dry-run
     $ ods release beta --ref 1a2b3c4d
     $ ods release beta --version 4.7.0`,
@@ -63,6 +71,7 @@ Example usage:
 
 	cmd.Flags().StringVar(&opts.Ref, "ref", "", "Commit-ish to tag; must be on the target release branch (default: its tip)")
 	cmd.Flags().StringVar(&opts.Version, "version", "", "Base version override (X.Y.Z, no leading v); skips branch and patch detection")
+	cmd.Flags().BoolVar(&opts.NewBranch, "new-branch", false, "Cut the first beta on a new release branch one minor past the newest one, instead of asking")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Compute and print the tag but don't tag or push")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
 	cmd.Flags().BoolVar(&opts.Verify, "verify", false, "Run pre-push hooks when pushing the tag; they are skipped by default")
@@ -76,6 +85,23 @@ Example usage:
 func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
 	if opts.Version != "" && !release.IsBareVersion(opts.Version) {
 		return "", fmt.Errorf("--version must be X.Y.Z with no leading v, got %q", opts.Version)
+	}
+	if opts.NewBranch && opts.Version != "" {
+		return "", fmt.Errorf("--new-branch derives the base from the new branch, so it cannot be combined with --version")
+	}
+
+	newBranch := opts.NewBranch
+	// --version names an existing branch, and the non-interactive modes keep
+	// their long-standing meaning: cut on the newest release branch.
+	if !newBranch && !opts.Yes && !opts.DryRun && opts.Version == "" {
+		chosen, err := chooseNewBranch()
+		if err != nil {
+			return "", err
+		}
+		newBranch = chosen
+	}
+	if newBranch {
+		return releaseBetaOnNewBranch(opts)
 	}
 
 	log.Info("Fetching the release branch and its tags from origin...")
@@ -115,6 +141,77 @@ func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
 			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
 		}
 		return "", fmt.Errorf("failed to push tag %s: %w", tag, err)
+	}
+	log.Infof("Pushed %s; deployment.yml will build the beta images.", tag)
+	return tag, nil
+}
+
+// chooseNewBranch asks whether to cut the first beta on a new release branch
+// (true) or the next beta on the newest existing one (false).
+func chooseNewBranch() (bool, error) {
+	version, err := release.NewestReleaseVersion()
+	if err != nil {
+		return false, fmt.Errorf("failed to detect the newest release branch (pass --version or --new-branch to override): %w", err)
+	}
+	options := []string{
+		fmt.Sprintf("Cut the next beta on the existing release/%s", version),
+		fmt.Sprintf("Create release/%s from origin/main and cut its first beta", version.NextMinor()),
+	}
+	return prompt.Choose("Which release branch should the beta be cut on?", options, 0) == 1, nil
+}
+
+// releaseBetaOnNewBranch creates the next minor's release branch from
+// origin/main and cuts its first beta on it. It returns the pushed tag name,
+// or an empty string when nothing was pushed.
+func releaseBetaOnNewBranch(opts *ReleaseBetaOptions) (string, error) {
+	log.Info("Fetching main, the release branches, and their tags from origin...")
+	branch, tag, sha, err := release.ComputeNewBetaBranch(opts.Ref)
+	if err != nil {
+		return "", err
+	}
+
+	if opts.DryRun {
+		log.Warnf("[DRY RUN] Would create %s at %.10s, tag it %s, and push both", branch, sha, tag)
+		fmt.Println(tag)
+		return "", nil
+	}
+
+	if !opts.Yes {
+		if !prompt.Confirm(fmt.Sprintf("Create %s at %.10s and tag it %s to trigger the beta build? (Y/n): ", branch, sha, tag)) {
+			log.Info("Exiting...")
+			return "", nil
+		}
+		// The prompt can wait a long time; recompute so the push reflects
+		// origin's current state, not the pre-prompt snapshot. This also keeps
+		// the window in which another cut could create the branch small, which
+		// the push itself only guards against for non-fast-forwards.
+		freshBranch, freshTag, freshSHA, err := release.ComputeNewBetaBranch(opts.Ref)
+		if err != nil {
+			return "", err
+		}
+		if freshBranch != branch || freshTag != tag || freshSHA != sha {
+			return "", fmt.Errorf("origin changed while waiting for confirmation: the cut was %s at %.10s tagged %s but is now %s at %.10s tagged %s; re-run to continue", branch, sha, tag, freshBranch, freshSHA, freshTag)
+		}
+	}
+
+	// The branch goes first: CI's tag check requires the beta's commit to be on
+	// origin/<branch>, and deployment.yml runs it as soon as the tag lands.
+	if err := git.PushBranch(sha, branch, opts.Verify); err != nil {
+		return "", fmt.Errorf("failed to push branch %s: %w", branch, err)
+	}
+	log.Infof("Created origin/%s at %.10s.", branch, sha)
+
+	if err := git.RunCommand("tag", tag, sha); err != nil {
+		return "", fmt.Errorf("failed to create tag %s (origin/%s now exists; re-run without --new-branch): %w", tag, branch, err)
+	}
+	if err := git.PushTag(tag, false, opts.Verify); err != nil {
+		// Roll back the local tag so the command stays retryable. The branch
+		// stays: a re-run without --new-branch now targets it and computes the
+		// same tag.
+		if delErr := git.RunCommand("tag", "-d", tag); delErr != nil {
+			log.Warnf("Also failed to delete local tag %s; remove it before retrying: %v", tag, delErr)
+		}
+		return "", fmt.Errorf("failed to push tag %s (origin/%s now exists; re-run without --new-branch): %w", tag, branch, err)
 	}
 	log.Infof("Pushed %s; deployment.yml will build the beta images.", tag)
 	return tag, nil

--- a/tools/ods/cmd/release_beta.go
+++ b/tools/ods/cmd/release_beta.go
@@ -159,8 +159,8 @@ func chooseNewBranch() (newBranch, ok bool, err error) {
 		return false, false, fmt.Errorf("failed to detect the newest release branch (pass --version or --new-branch to override): %w", err)
 	}
 	options := []string{
-		fmt.Sprintf("Cut the next beta on the existing release/%s", version),
-		fmt.Sprintf("Create release/%s from origin/main and cut its first beta", version.NextMinor()),
+		fmt.Sprintf("Create a new release/%s from origin/main and cut its first beta", version.NextMinor()),
+		fmt.Sprintf("Increment the existing release/%s beta", version),
 	}
 
 	index, ok := prompt.Select("Which release branch should the beta be cut on?", options, 0)
@@ -169,7 +169,7 @@ func chooseNewBranch() (newBranch, ok bool, err error) {
 	}
 	// The list clears itself on exit, so echo the choice into the transcript.
 	log.Info(options[index])
-	return index == 1, true, nil
+	return index == 0, true, nil
 }
 
 // releaseBetaOnNewBranch creates the next minor's release branch from

--- a/tools/ods/cmd/release_beta.go
+++ b/tools/ods/cmd/release_beta.go
@@ -94,9 +94,13 @@ func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
 	// --version names an existing branch, and the non-interactive modes keep
 	// their long-standing meaning: cut on the newest release branch.
 	if !newBranch && !opts.Yes && !opts.DryRun && opts.Version == "" {
-		chosen, err := chooseNewBranch()
+		chosen, ok, err := chooseNewBranch()
 		if err != nil {
 			return "", err
+		}
+		if !ok {
+			log.Info("Exiting...")
+			return "", nil
 		}
 		newBranch = chosen
 	}
@@ -147,17 +151,25 @@ func releaseBeta(opts *ReleaseBetaOptions) (string, error) {
 }
 
 // chooseNewBranch asks whether to cut the first beta on a new release branch
-// (true) or the next beta on the newest existing one (false).
-func chooseNewBranch() (bool, error) {
+// (true) or the next beta on the newest existing one (false). The second
+// return is false when the user cancels the prompt.
+func chooseNewBranch() (newBranch, ok bool, err error) {
 	version, err := release.NewestReleaseVersion()
 	if err != nil {
-		return false, fmt.Errorf("failed to detect the newest release branch (pass --version or --new-branch to override): %w", err)
+		return false, false, fmt.Errorf("failed to detect the newest release branch (pass --version or --new-branch to override): %w", err)
 	}
 	options := []string{
 		fmt.Sprintf("Cut the next beta on the existing release/%s", version),
 		fmt.Sprintf("Create release/%s from origin/main and cut its first beta", version.NextMinor()),
 	}
-	return prompt.Choose("Which release branch should the beta be cut on?", options, 0) == 1, nil
+
+	index, ok := prompt.Select("Which release branch should the beta be cut on?", options, 0)
+	if !ok {
+		return false, false, nil
+	}
+	// The list clears itself on exit, so echo the choice into the transcript.
+	log.Info(options[index])
+	return index == 1, true, nil
 }
 
 // releaseBetaOnNewBranch creates the next minor's release branch from

--- a/tools/ods/cmd/release_beta.go
+++ b/tools/ods/cmd/release_beta.go
@@ -194,9 +194,7 @@ func releaseBetaOnNewBranch(opts *ReleaseBetaOptions) (string, error) {
 			return "", nil
 		}
 		// The prompt can wait a long time; recompute so the push reflects
-		// origin's current state, not the pre-prompt snapshot. This also keeps
-		// the window in which another cut could create the branch small, which
-		// the push itself only guards against for non-fast-forwards.
+		// origin's current state, not the pre-prompt snapshot.
 		freshBranch, freshTag, freshSHA, err := release.ComputeNewBetaBranch(opts.Ref)
 		if err != nil {
 			return "", err
@@ -207,8 +205,10 @@ func releaseBetaOnNewBranch(opts *ReleaseBetaOptions) (string, error) {
 	}
 
 	// The branch goes first: CI's tag check requires the beta's commit to be on
-	// origin/<branch>, and deployment.yml runs it as soon as the tag lands.
-	if err := git.PushBranch(sha, branch, opts.Verify); err != nil {
+	// origin/<branch>, and deployment.yml runs it as soon as the tag lands. The
+	// push creates the branch or fails; it never moves one another cut created
+	// meanwhile.
+	if err := git.PushNewBranch(sha, branch, opts.Verify); err != nil {
 		return "", fmt.Errorf("failed to push branch %s: %w", branch, err)
 	}
 	log.Infof("Created origin/%s at %.10s.", branch, sha)

--- a/tools/ods/cmd/release_beta_test.go
+++ b/tools/ods/cmd/release_beta_test.go
@@ -17,8 +17,19 @@ package cmd
 //	E6 origin moves during the prompt        -> recompute mismatch aborts       TestReleaseBeta_staleStateAbortsBeforePush
 //	                                            before any tag or push          (tests the guard directly; the
 //	                                                                            prompt itself is interactive)
+//
+// With --new-branch the cut targets a new release/v4.6 at main's tip PostCutSHA
+// and tags it v4.6.0-beta.0. The branch choice prompt is interactive, so the
+// flag stands in for it here.
+//
+//	E7 real run                              -> branch and tag on origin at
+//	                                            the main tip                    TestReleaseBeta_newBranchCutsNextMinorFromMain
+//	E8 dry run                               -> creates neither branch nor tag  TestReleaseBeta_newBranchDryRunCreatesNothing
+//	E9 --new-branch with --version           -> rejected before any git work    TestReleaseBeta_newBranchRejectsVersionOverride
+//	E10 branch push rejected by origin       -> no tag created, no tag pushed   TestReleaseBeta_newBranchPushFailureLeavesNoTag
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -152,5 +163,86 @@ func TestReleaseBeta_pushFailureRollsBackLocalTag(t *testing.T) {
 	}
 	if gittest.TagExists(repo.Work, "v4.5.0-beta.0") {
 		t.Error("local tag must be rolled back after a failed push")
+	}
+}
+
+func TestReleaseBeta_newBranchCutsNextMinorFromMain(t *testing.T) {
+	// Precondition: the newest branch is release/v4.5; main's tip is PostCutSHA.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{NewBranch: true, Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v4.6.0-beta.0" {
+		t.Errorf("expected pushed tag v4.6.0-beta.0, got %q", tag)
+	}
+	branchSHA := gittest.Git(t, repo.Origin, "rev-parse", "refs/heads/release/v4.6")
+	if branchSHA != repo.PostCutSHA {
+		t.Errorf("expected origin/release/v4.6 at the main tip %s, got %s", repo.PostCutSHA, branchSHA)
+	}
+	// The tag must sit on the new branch, which is what CI's check requires.
+	taggedSHA := gittest.Git(t, repo.Origin, "rev-parse", "refs/tags/v4.6.0-beta.0^{commit}")
+	if taggedSHA != repo.PostCutSHA {
+		t.Errorf("expected origin tag at %s, got %s", repo.PostCutSHA, taggedSHA)
+	}
+}
+
+func TestReleaseBeta_newBranchDryRunCreatesNothing(t *testing.T) {
+	// Precondition.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{NewBranch: true, DryRun: true, Yes: true})
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "" {
+		t.Errorf("dry run must return no pushed tag, got %q", tag)
+	}
+	if gittest.TagExists(repo.Work, "v4.6.0-beta.0") || gittest.TagExists(repo.Origin, "v4.6.0-beta.0") {
+		t.Error("dry run must not create the tag")
+	}
+	if err := exec.Command("git", "-C", repo.Origin, "show-ref", "--verify", "--quiet", "refs/heads/release/v4.6").Run(); err == nil {
+		t.Error("dry run must not create the branch")
+	}
+}
+
+func TestReleaseBeta_newBranchRejectsVersionOverride(t *testing.T) {
+	// Precondition: the base of a new branch comes from the branch name, so the
+	// two flags cannot both hold.
+	gittest.SetupReleaseBranchRepo(t)
+
+	// Under test.
+	_, err := releaseBeta(&ReleaseBetaOptions{NewBranch: true, Version: "4.9.0", DryRun: true, Yes: true})
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with --version") {
+		t.Errorf("expected a flag conflict error, got %v", err)
+	}
+}
+
+func TestReleaseBeta_newBranchPushFailureLeavesNoTag(t *testing.T) {
+	// Precondition: origin rejects every push, so the branch never lands.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.RejectPushes(t, repo.Origin)
+
+	// Under test.
+	tag, err := releaseBeta(&ReleaseBetaOptions{NewBranch: true, Yes: true})
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "failed to push branch") {
+		t.Errorf("expected a branch push failure, got %v", err)
+	}
+	if tag != "" {
+		t.Errorf("failed push must return no pushed tag, got %q", tag)
+	}
+	if gittest.TagExists(repo.Work, "v4.6.0-beta.0") {
+		t.Error("the tag must not be created when the branch push fails")
 	}
 }

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	golang.org/x/term v0.44.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -155,7 +156,6 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	golang.org/x/vuln v1.3.0 // indirect

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -97,17 +97,20 @@ func PushTag(tag string, force, verify bool) error {
 	return HintAfter(PushHookHintDelay, hint, func() error { return RunCommand(args...) })
 }
 
-// PushBranch pushes commitSHA to origin as branch. Pre-push hooks are skipped
-// unless verify is true, for the same reason PushTag skips them: the commit
-// already passed CI, and the hooks run over the whole branch. The push is not
-// forced, so origin rejects it when branch already exists there and commitSHA
-// is not a fast-forward of it.
-func PushBranch(commitSHA, branch string, verify bool) error {
+// PushNewBranch pushes commitSHA to origin as a branch that must not exist
+// there yet. An empty --force-with-lease expectation makes origin reject the
+// push when the branch appeared meanwhile, which a plain push would instead
+// fast-forward. Pre-push hooks are skipped unless verify is true, for the same
+// reason PushTag skips them: the commit already passed CI, and the hooks run
+// over the whole branch.
+func PushNewBranch(commitSHA, branch string, verify bool) error {
 	args := []string{"push"}
 	if !verify {
 		args = append(args, "--no-verify")
 	}
-	args = append(args, "origin", fmt.Sprintf("%s:refs/heads/%s", commitSHA, branch))
+	args = append(args,
+		fmt.Sprintf("--force-with-lease=refs/heads/%s:", branch),
+		"origin", fmt.Sprintf("%s:refs/heads/%s", commitSHA, branch))
 	if !verify {
 		return RunCommand(args...)
 	}

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -97,6 +97,24 @@ func PushTag(tag string, force, verify bool) error {
 	return HintAfter(PushHookHintDelay, hint, func() error { return RunCommand(args...) })
 }
 
+// PushBranch pushes commitSHA to origin as branch. Pre-push hooks are skipped
+// unless verify is true, for the same reason PushTag skips them: the commit
+// already passed CI, and the hooks run over the whole branch. The push is not
+// forced, so origin rejects it when branch already exists there and commitSHA
+// is not a fast-forward of it.
+func PushBranch(commitSHA, branch string, verify bool) error {
+	args := []string{"push"}
+	if !verify {
+		args = append(args, "--no-verify")
+	}
+	args = append(args, "origin", fmt.Sprintf("%s:refs/heads/%s", commitSHA, branch))
+	if !verify {
+		return RunCommand(args...)
+	}
+	hint := "Push is slow because --verify runs the pre-push hooks over every commit on the branch. Re-run without --verify to skip them."
+	return HintAfter(PushHookHintDelay, hint, func() error { return RunCommand(args...) })
+}
+
 // GetCommitMessage gets the first line of a commit message
 func GetCommitMessage(commitSHA string) (string, error) {
 	cmd := exec.Command("git", "log", "-1", "--format=%s", commitSHA)

--- a/tools/ods/internal/git/push_test.go
+++ b/tools/ods/internal/git/push_test.go
@@ -1,0 +1,55 @@
+package git
+
+// PushNewBranch creates a branch or fails; it must never move a branch that
+// appeared on origin after the caller checked for it.
+//
+//	P1 branch absent on origin           -> created at the commit    TestPushNewBranch_createsTheBranch
+//	P2 branch appeared at an ancestor    -> rejected, origin
+//	                                        unchanged                TestPushNewBranch_rejectsABranchThatAppeared
+
+import (
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/gittest"
+)
+
+func TestPushNewBranch_createsTheBranch(t *testing.T) {
+	// Precondition.
+	origin, work := gittest.InitOriginAndWork(t)
+	sha := gittest.Commit(t, work, "a.txt")
+	gittest.PublishMain(t, work)
+	t.Chdir(work)
+
+	// Under test.
+	if err := PushNewBranch(sha, "release/v4.6", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Postcondition.
+	if got := gittest.Git(t, origin, "rev-parse", "refs/heads/release/v4.6"); got != sha {
+		t.Errorf("expected origin/release/v4.6 at %s, got %s", sha, got)
+	}
+}
+
+func TestPushNewBranch_rejectsABranchThatAppeared(t *testing.T) {
+	// Precondition: another cut created the branch at an ancestor of the
+	// commit. A plain push would fast-forward it, and the caller would then tag
+	// a branch it did not create.
+	origin, work := gittest.InitOriginAndWork(t)
+	ancestorSHA := gittest.Commit(t, work, "a.txt")
+	sha := gittest.Commit(t, work, "b.txt")
+	gittest.PublishMain(t, work)
+	gittest.PublishReleaseBranch(t, work, "release/v4.6", ancestorSHA)
+	t.Chdir(work)
+
+	// Under test.
+	err := PushNewBranch(sha, "release/v4.6", false)
+
+	// Postcondition.
+	if err == nil {
+		t.Fatal("expected the push to be rejected")
+	}
+	if got := gittest.Git(t, origin, "rev-parse", "refs/heads/release/v4.6"); got != ancestorSHA {
+		t.Errorf("origin/release/v4.6 must stay at %s, got %s", ancestorSHA, got)
+	}
+}

--- a/tools/ods/internal/prompt/prompt.go
+++ b/tools/ods/internal/prompt/prompt.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/tui"
 )
 
 // reader is the input reader, can be replaced for testing
@@ -28,6 +30,23 @@ func String(prompt string) string {
 		}
 		fmt.Println("Value cannot be empty.")
 	}
+}
+
+// Select asks the user to choose one of options and returns its index. The
+// options are shown as an arrow-key list; when the terminal cannot run one
+// (piped input, CI, no TTY) it falls back to the numbered Choose prompt. The
+// second return is false when the user cancels the list, which the numbered
+// fallback cannot do.
+func Select(title string, options []string, defaultIndex int) (int, bool) {
+	index, err := tui.Select(title, options, defaultIndex)
+	if err != nil {
+		log.Debugf("Arrow-key select unavailable: %v", err)
+		return Choose(title, options, defaultIndex), true
+	}
+	if index < 0 {
+		return 0, false
+	}
+	return index, true
 }
 
 // Choose prompts the user with a numbered list of options and returns the

--- a/tools/ods/internal/prompt/prompt.go
+++ b/tools/ods/internal/prompt/prompt.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -26,6 +27,33 @@ func String(prompt string) string {
 			return response
 		}
 		fmt.Println("Value cannot be empty.")
+	}
+}
+
+// Choose prompts the user with a numbered list of options and returns the
+// index of the chosen one. Empty input selects defaultIndex. It re-prompts
+// until the input names an option.
+func Choose(header string, options []string, defaultIndex int) int {
+	for {
+		fmt.Println(header)
+		for i, option := range options {
+			fmt.Printf("  %d) %s\n", i+1, option)
+		}
+		fmt.Printf("Choose 1-%d [%d]: ", len(options), defaultIndex+1)
+
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatalf("Failed to read input: %v", err)
+		}
+		response = strings.TrimSpace(response)
+		if response == "" {
+			return defaultIndex
+		}
+		choice, err := strconv.Atoi(response)
+		if err == nil && choice >= 1 && choice <= len(options) {
+			return choice - 1
+		}
+		fmt.Printf("Please enter a number between 1 and %d\n", len(options))
 	}
 }
 

--- a/tools/ods/internal/prompt/prompt.go
+++ b/tools/ods/internal/prompt/prompt.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/term"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/tui"
 )
@@ -38,6 +39,13 @@ func String(prompt string) string {
 // second return is false when the user cancels the list, which the numbered
 // fallback cannot do.
 func Select(title string, options []string, defaultIndex int) (int, bool) {
+	// tcell reads keys from /dev/tty, not stdin, so a list started next to a
+	// piped stdin would wait for the terminal and never see the piped answer.
+	// The numbered prompt reads the same stdin as every other prompt here.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return Choose(title, options, defaultIndex), true
+	}
+
 	index, err := tui.Select(title, options, defaultIndex)
 	if err != nil {
 		log.Debugf("Arrow-key select unavailable: %v", err)

--- a/tools/ods/internal/release/beta.go
+++ b/tools/ods/internal/release/beta.go
@@ -36,7 +36,7 @@ func ComputeBetaTag(ref, overrideVersion string) (tag, sha string, err error) {
 		}
 		minor = matches[1] + "." + matches[2]
 	} else {
-		version, err := newestReleaseVersion()
+		version, err := NewestReleaseVersion()
 		if err != nil {
 			return "", "", fmt.Errorf("failed to detect the target release branch (pass --version to override): %w", err)
 		}
@@ -114,9 +114,88 @@ func ComputeBetaTag(ref, overrideVersion string) (tag, sha string, err error) {
 	return tag, sha, nil
 }
 
-// newestReleaseVersion returns the version of the newest release/vX.Y branch
+// ComputeNewBetaBranch returns the release branch to create for the next minor
+// release, the first beta tag to cut on it, and the commit both should point
+// at. The branch is one minor past the newest release/vX.Y branch on origin —
+// the version cloud tags of main already preview — and it is cut from
+// origin/main. ref is the commit-ish to cut at; when empty, the main tip is
+// used. The commit must be on origin/main, the new branch must not exist on
+// origin yet, and its base must not have shipped as a stable tag.
+func ComputeNewBetaBranch(ref string) (branch, tag, sha string, err error) {
+	// The ancestry check below cannot be answered truthfully in a shallow
+	// clone; fail loudly instead.
+	shallow, err := git.IsShallowRepository()
+	if err != nil {
+		return "", "", "", err
+	}
+	if shallow {
+		return "", "", "", fmt.Errorf("this is a shallow clone, so a release branch cut cannot check main ancestry")
+	}
+
+	branchNames, err := listRemoteBranches()
+	if err != nil {
+		return "", "", "", err
+	}
+	versions := parseVersions(branchNames)
+	if len(versions) == 0 {
+		return "", "", "", fmt.Errorf("no release/vX.Y branches found on origin, so the next minor cannot be derived")
+	}
+	version := versions[0].NextMinor()
+	branch = fmt.Sprintf("release/%s", version)
+	for _, name := range branchNames {
+		if name == branch {
+			return "", "", "", fmt.Errorf("%s already exists on origin; re-run without --new-branch to cut its next beta", branch)
+		}
+	}
+	log.Infof("Newest release branch on origin: release/%s -> new branch %s", versions[0], branch)
+
+	// Cut points come from main, so the tip default and the ancestry check must
+	// run against its current state.
+	if err := git.RunCommand("fetch", "--quiet", "--force", "origin", "+refs/heads/main:refs/remotes/origin/main"); err != nil {
+		return "", "", "", fmt.Errorf("failed to fetch origin/main: %w", err)
+	}
+	if ref == "" {
+		ref = "origin/main"
+	}
+	sha, err = ResolveCommit(ref)
+	if err != nil {
+		return "", "", "", err
+	}
+	onMain, err := git.IsAncestor(sha, "origin/main")
+	if err != nil {
+		return "", "", "", err
+	}
+	if !onMain {
+		return "", "", "", fmt.Errorf("commit %.10s is not on origin/main; release branches are cut from main", sha)
+	}
+
+	// A beta of an already-released base is itself a new tag: origin would
+	// accept the push and only CI's check would reject it, so a failed fetch is
+	// an error rather than a stale-tags fallback.
+	base := version.String() + ".0"
+	if err := FetchTags(base + "*"); err != nil {
+		return "", "", "", fmt.Errorf("failed to fetch %s* tags: %w", base, err)
+	}
+	if tagExists(base) {
+		return "", "", "", fmt.Errorf("%s has already been released; a beta must precede its stable tag", base)
+	}
+	tag, err = nextSequencedTag(base+"-beta.", "")
+	if err != nil {
+		return "", "", "", err
+	}
+	// A fresh branch has no predecessor beta to anchor to, so betas of the base
+	// without the branch mean an earlier cut half-succeeded or the branch was
+	// deleted; both need a human.
+	if tag != base+"-beta.0" {
+		return "", "", "", fmt.Errorf("betas of %s already exist but %s does not, so the next tag would be %s with no branch to anchor it; resolve the branch state first", base, branch, tag)
+	}
+
+	return branch, tag, sha, nil
+}
+
+// NewestReleaseVersion returns the version of the newest release/vX.Y branch
 // on origin.
-func newestReleaseVersion() (Version, error) {
+func NewestReleaseVersion() (Version, error) {
 	branchNames, err := listRemoteBranches()
 	if err != nil {
 		return Version{}, err

--- a/tools/ods/internal/release/beta_test.go
+++ b/tools/ods/internal/release/beta_test.go
@@ -19,6 +19,16 @@ package release
 //	B9 shallow clone (even with --version) -> error                             TestComputeBetaTag_shallowCloneErrors
 //	B10 predecessor beta not an ancestor   -> error                             TestComputeBetaTag_predecessorNotAncestorErrors
 //	B11 origin unreachable                 -> error, no stale-state fallback    TestComputeBetaTag_fetchFailureErrors
+//
+// New branch cuts (ComputeNewBetaBranch) take the next minor after the newest
+// branch and cut it from origin/main, whose tip is PostCutSHA.
+//
+//	N1 newest branch release/v4.5          -> release/v4.6 at the main tip,
+//	                                          v4.6.0-beta.0                     TestComputeNewBetaBranch_cutsNextMinorFromMain
+//	N2 ref not on main                     -> error                             TestComputeNewBetaBranch_refNotOnMainErrors
+//	N3 another minor branch cut meanwhile  -> the cut follows the newest one     TestComputeNewBetaBranch_followsTheNewestBranch
+//	N4 next minor base already released    -> error                             TestComputeNewBetaBranch_releasedBaseErrors
+//	N5 shallow clone                       -> error                             TestComputeNewBetaBranch_shallowCloneErrors
 
 import (
 	"strings"
@@ -210,5 +220,92 @@ func TestComputeBetaTag_fetchFailureErrors(t *testing.T) {
 	// Postcondition.
 	if err == nil || !strings.Contains(err.Error(), "failed to fetch") {
 		t.Errorf("expected a fetch failure error, got %v", err)
+	}
+}
+
+func TestComputeNewBetaBranch_cutsNextMinorFromMain(t *testing.T) {
+	// Precondition: the newest branch is release/v4.5 and main's tip is
+	// PostCutSHA, which no release branch contains.
+	repo := gittest.SetupReleaseBranchRepo(t)
+
+	// Under test: an empty ref defaults to the main tip.
+	branch, tag, sha, err := ComputeNewBetaBranch("")
+
+	// Postcondition.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "release/v4.6" {
+		t.Errorf("expected release/v4.6, got %s", branch)
+	}
+	if tag != "v4.6.0-beta.0" {
+		t.Errorf("expected v4.6.0-beta.0, got %s", tag)
+	}
+	if sha != repo.PostCutSHA {
+		t.Errorf("expected the main tip %s, got %s", repo.PostCutSHA, sha)
+	}
+}
+
+func TestComputeNewBetaBranch_refNotOnMainErrors(t *testing.T) {
+	// Precondition: a commit that was never pushed to main.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "checkout", "--quiet", "-b", "side", repo.PreCutSHA)
+	sideSHA := gittest.Commit(t, repo.Work, "side.txt")
+	gittest.Git(t, repo.Work, "checkout", "--quiet", "main")
+
+	// Under test.
+	_, _, _, err := ComputeNewBetaBranch(sideSHA)
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "not on origin/main") {
+		t.Errorf("expected a not-on-main error, got %v", err)
+	}
+}
+
+func TestComputeNewBetaBranch_followsTheNewestBranch(t *testing.T) {
+	// Precondition: release/v4.6 was cut already, so the next minor after the
+	// newest branch is release/v4.7 and this cut is a no-op.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.PublishReleaseBranch(t, repo.Work, "release/v4.6", repo.PostCutSHA)
+
+	// Under test.
+	branch, _, _, err := ComputeNewBetaBranch("")
+
+	// Postcondition: the newest branch moved on, so v4.7 is cut instead.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "release/v4.7" {
+		t.Errorf("expected release/v4.7, got %s", branch)
+	}
+}
+
+func TestComputeNewBetaBranch_releasedBaseErrors(t *testing.T) {
+	// Precondition: v4.6.0 shipped without its release branch. A beta of it
+	// would move the "beta" Docker tags backwards.
+	repo := gittest.SetupReleaseBranchRepo(t)
+	gittest.Git(t, repo.Work, "tag", "v4.6.0", repo.PostCutSHA)
+	gittest.Git(t, repo.Work, "push", "--quiet", "origin", "v4.6.0")
+	gittest.Git(t, repo.Work, "tag", "-d", "v4.6.0")
+
+	// Under test.
+	_, _, _, err := ComputeNewBetaBranch("")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "already been released") {
+		t.Errorf("expected an already-released error, got %v", err)
+	}
+}
+
+func TestComputeNewBetaBranch_shallowCloneErrors(t *testing.T) {
+	// Precondition.
+	gittest.SetupShallowClone(t)
+
+	// Under test.
+	_, _, _, err := ComputeNewBetaBranch("")
+
+	// Postcondition.
+	if err == nil || !strings.Contains(err.Error(), "shallow clone") {
+		t.Errorf("expected shallow-clone error, got %v", err)
 	}
 }

--- a/tools/ods/internal/release/version.go
+++ b/tools/ods/internal/release/version.go
@@ -49,10 +49,16 @@ func (v Version) String() string {
 	return fmt.Sprintf("v%d.%d", v.Major, v.Minor)
 }
 
+// NextMinor returns the version of the next minor release after this branch,
+// e.g. v4.5 -> v4.6.
+func (v Version) NextMinor() Version {
+	return Version{Major: v.Major, Minor: v.Minor + 1}
+}
+
 // NextMinorBase returns the base version of the next minor release after this
 // branch, e.g. v4.5 -> "v4.6.0".
 func (v Version) NextMinorBase() string {
-	return fmt.Sprintf("v%d.%d.0", v.Major, v.Minor+1)
+	return fmt.Sprintf("%s.0", v.NextMinor())
 }
 
 // parseVersions extracts "release/vX.Y" versions from branch names and

--- a/tools/ods/internal/tui/select.go
+++ b/tools/ods/internal/tui/select.go
@@ -35,6 +35,12 @@ func Select(title string, options []string, defaultIndex int) (int, error) {
 		screen.Show()
 
 		switch ev := screen.PollEvent().(type) {
+		case nil:
+			// PollEvent returns nil once the screen stops, which would
+			// otherwise spin this loop forever.
+			return -1, fmt.Errorf("the terminal stopped delivering events")
+		case *tcell.EventError:
+			return -1, fmt.Errorf("terminal error: %w", ev)
 		case *tcell.EventResize:
 			screen.Sync()
 		case *tcell.EventKey:

--- a/tools/ods/internal/tui/select.go
+++ b/tools/ods/internal/tui/select.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Select shows a single-choice list the user moves through with the arrow
+// keys. It returns the index of the chosen option, or -1 when the user
+// cancels. It returns a non-nil error if the terminal cannot be initialised,
+// in which case the caller should fall back to a simpler prompt.
+func Select(title string, options []string, defaultIndex int) (int, error) {
+	if len(options) == 0 {
+		return -1, fmt.Errorf("select needs at least one option")
+	}
+
+	screen, err := tcell.NewScreen()
+	if err != nil {
+		return -1, err
+	}
+	if err := screen.Init(); err != nil {
+		return -1, err
+	}
+	defer screen.Fini()
+
+	cursor := defaultIndex
+	if cursor < 0 || cursor >= len(options) {
+		cursor = 0
+	}
+
+	for {
+		w, h := screen.Size()
+		drawSelect(screen, title, options, cursor, w, h)
+		screen.Show()
+
+		switch ev := screen.PollEvent().(type) {
+		case *tcell.EventResize:
+			screen.Sync()
+		case *tcell.EventKey:
+			switch keyAction(ev) {
+			case actionQuit:
+				return -1, nil
+			case actionConfirm:
+				return cursor, nil
+			case actionUp:
+				if cursor > 0 {
+					cursor--
+				}
+			case actionDown:
+				if cursor < len(options)-1 {
+					cursor++
+				}
+			case actionTop:
+				cursor = 0
+			case actionBottom:
+				cursor = len(options) - 1
+			}
+		}
+	}
+}
+
+var (
+	styleSelectItem = tcell.StyleDefault
+	styleSelectCur  = tcell.StyleDefault.Bold(true).Reverse(true)
+)
+
+func drawSelect(screen tcell.Screen, title string, options []string, cursor, w, h int) {
+	screen.Clear()
+
+	drawLine(screen, 0, 0, w, " "+title, styleTitle)
+
+	// The highlight covers the longest row rather than the whole terminal
+	// width, so a wide window does not turn into a full-width bar.
+	rowWidth := 0
+	for _, option := range options {
+		if len(option) > rowWidth {
+			rowWidth = len(option)
+		}
+	}
+	rowWidth += len("  > ") + 1
+	if rowWidth > w {
+		rowWidth = w
+	}
+
+	for i, option := range options {
+		y := headerLines + i
+		if y >= h-footerLines {
+			break
+		}
+		prefix := "    "
+		style := styleSelectItem
+		if i == cursor {
+			prefix = "  > "
+			style = styleSelectCur
+		}
+		drawLine(screen, 0, y, rowWidth, prefix+option, style)
+	}
+
+	drawLine(screen, 0, h-1, w, " ↑/↓ move  enter select  q/esc cancel", styleFooter)
+}


### PR DESCRIPTION
## What

`ods release beta` now asks which branch to cut the beta on, as an arrow-key list:

```
 Which release branch should the beta be cut on?

  > Create a new release/v4.6 from origin/main and cut its first beta
    Increment the existing release/v4.5 beta

 ↑/↓ move  enter select  q/esc cancel
```

The list is built on the tcell screen `internal/tui` already uses for the trace picker, so no new dependency is needed. Esc or `q` cancels the cut. When the terminal cannot run a list (piped input, CI, no TTY), a numbered prompt runs instead.

- The new branch is the highlighted default. It pushes `release/v4.6` at the `origin/main` tip (or `--ref`, which must be on main), then tags `v4.6.0-beta.0` on it. The minor is one past the newest release branch, which is the version cloud tags of main already preview.
- The second option is the previous behavior, unchanged.
- `--new-branch` picks the new branch non-interactively. `--yes` and `--dry-run` skip the prompt and keep their old meaning, so scripts and CI are unaffected.
- `--new-branch` with `--version` is rejected: the base comes from the branch name.

## Safety

- The branch push goes first, because CI's tag check requires the beta commit to be on `origin/release/vX.Y` and `deployment.yml` runs as soon as the tag lands.
- The cut is recomputed after the confirmation prompt, the same guard the existing path uses, so a branch or tag that appeared meanwhile aborts the push.
- Errors after the branch lands say to re-run without `--new-branch`; that run targets the new branch and computes the same tag.
- An already released `vX.Y+1.0`, a commit off main, or a shallow clone all fail before anything is pushed.

## Tests

- `internal/release/beta_test.go`: 5 cases (N1-N5) for `ComputeNewBetaBranch`.
- `cmd/release_beta_test.go`: 4 cases (E7-E10) for the command flow.

Both appended to the existing state matrices. I also ran the built binary against a scratch origin to confirm both prompt branches end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1902" height="616" alt="20260904_12h19m59s_grim" src="https://github.com/user-attachments/assets/8c9a9f4e-3748-4de7-9aca-46f5b879fba1" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ods release beta` now lets users choose between the newest existing release branch and a new next-minor branch from `origin/main`; `--new-branch` selects the new path non-interactively. New cuts push the branch before tagging its first beta so CI can validate it before deployment.

- Arrow-key selection falls back to a numbered prompt when stdin is not a terminal or the list cannot start; `q`, Esc, and terminal errors cancel safely.
- The branch push is create-only, so a branch appearing concurrently is rejected instead of being advanced.
- `--yes` and `--dry-run` keep their existing meanings, while `--new-branch` cannot be combined with `--version`.
- The command recomputes the cut after confirmation and rejects shallow clones, commits outside `origin/main`, existing branches, released bases, and stale origin state.
- If tagging fails after the branch is created, the error explains how to rerun against that branch.

<sup>Written for commit 9c14d4db265ec6abeabcf2307a7dbda2c97bca38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



