### PR TITLE
feat(ci): show before/after/diff images in the visual regression comment

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -955,6 +955,8 @@ jobs:
       - runner=2cpu-linux-arm64
       - "run-id=${{ github.run_id }}-visual-regression-${{ matrix.project }}"
     timeout-minutes: 5
+    env:
+      GO_VERSION: "1.26.5"
     strategy:
       fail-fast: false
       matrix:
@@ -1000,11 +1002,20 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
 
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # ratchet:astral-sh/setup-uv@v10.0.1
+      # Build `ods` from this checkout rather than installing the published
+      # onyx-devtools wheel. The screenshot-diff output this job depends on
+      # (summary.json, images/) changes with tools/ods, so a source build keeps
+      # CI in step with the PR instead of waiting for the next release.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v5 # zizmor: ignore[cache-poisoning]
         with:
-          enable-cache: false
-          version: "0.11.25"
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: tools/ods/go.sum
+
+      - name: Build ods
+        run: |
+          go build -o "${RUNNER_TEMP}/bin/ods" .
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+        working-directory: tools/ods
 
       - name: Determine baseline revision
         id: baseline-rev
@@ -1036,7 +1047,7 @@ jobs:
           PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
           BASELINE_REV: ${{ steps.baseline-rev.outputs.rev }}
         run: |
-          uv run --no-sync --with onyx-devtools ods screenshot-diff compare \
+          ods screenshot-diff compare \
             --project "${PROJECT}" \
             --rev "${BASELINE_REV}"
 
@@ -1113,7 +1124,7 @@ jobs:
           BASELINE_REV: ${{ steps.baseline-rev.outputs.rev }}
         run: |
           if [ -d "web/output/screenshots/" ] && [ "$(ls -A web/output/screenshots/)" ]; then
-            uv run --no-sync --with onyx-devtools ods screenshot-diff upload-baselines \
+            ods screenshot-diff upload-baselines \
               --project "${PROJECT}" \
               --rev "${BASELINE_REV}" \
               --delete

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -1065,12 +1065,18 @@ jobs:
           aws s3 sync "web/output/screenshot-diff/${PROJECT}/" \
             "s3://${PLAYWRIGHT_S3_BUCKET}/reports/pr-${PR_NUMBER}/${RUN_ID}/${PROJECT}/"
 
-      - name: Upload visual diff summary
+      # Feeds the visual-regression-comment job: the counts it renders plus the
+      # per-screenshot PNGs it attaches to the comment. Deliberately excludes
+      # index.html, which base64-inlines every image and dwarfs everything else
+      # here — the full report is published separately below.
+      - name: Upload visual diff summary and images
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
-          name: screenshot-diff-summary-${{ matrix.project }}
-          path: ./web/output/screenshot-diff/${{ matrix.project }}/summary.json
+          name: screenshot-diff-comment-${{ matrix.project }}
+          path: |
+            ./web/output/screenshot-diff/${{ matrix.project }}/summary.json
+            ./web/output/screenshot-diff/${{ matrix.project }}/images/
           if-no-files-found: ignore
           retention-days: 5
 
@@ -1127,30 +1133,73 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: write
+    env:
+      # `gh ... --attach` (which uploads the before/after/diff images) landed in
+      # 2.99.0. The runner image does not pin a version, so check and install.
+      GH_MIN_VERSION: "2.99.0"
+      # Cap on delta table rows across ALL projects. Each row uploads three
+      # images, so this bounds both comment length and upload time.
+      MAX_DIFF_ROWS: "6"
     steps:
-      - name: Download visual diff summaries
+      - name: Download visual diff summaries and images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          pattern: screenshot-diff-summary-*
+          pattern: screenshot-diff-comment-*
           path: summaries/
+
+      - name: Ensure gh supports attachments
+        run: |
+          CURRENT=$(gh --version 2>/dev/null | head -1 | awk '{print $3}')
+          echo "Runner gh version: ${CURRENT:-none}"
+          OLDEST=$(printf '%s\n%s\n' "${GH_MIN_VERSION}" "${CURRENT:-0.0.0}" | sort -V | head -1)
+          if [ "${OLDEST}" = "${GH_MIN_VERSION}" ] && [ -n "${CURRENT}" ]; then
+            echo "gh is new enough."
+            exit 0
+          fi
+          echo "Installing gh ${GH_MIN_VERSION}..."
+          TARBALL="gh_${GH_MIN_VERSION}_linux_amd64"
+          curl -fsSL \
+            "https://github.com/cli/cli/releases/download/v${GH_MIN_VERSION}/${TARBALL}.tar.gz" \
+            -o "${RUNNER_TEMP}/gh.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/gh.tar.gz" -C "${RUNNER_TEMP}"
+          echo "${RUNNER_TEMP}/${TARBALL}/bin" >> "${GITHUB_PATH}"
 
       - name: Post combined PR comment
         env:
           GH_TOKEN: ${{ github.token }}
+          # The asset upload endpoint behind `--attach` rejects the Actions
+          # installation token (ghs_*); it accepts OAuth tokens and classic
+          # PATs. Without this secret — notably on fork PRs, which get no
+          # secrets — the comment degrades to counts only.
+          ATTACH_PAT: ${{ secrets.VISUAL_REGRESSION_ATTACH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_ID: ${{ github.run_id }}
           REPO: ${{ github.repository }}
           S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
         run: |
           MARKER="<!-- visual-regression-report -->"
+          BODY_PLAIN="${RUNNER_TEMP}/body-plain.md"
+          BODY_RICH="${RUNNER_TEMP}/body-rich.md"
+          ROWS_FILE="${RUNNER_TEMP}/delta-rows.md"
 
-          # Build the markdown table from all summary files
-          TABLE_HEADER="| Project | Changed | Added | Removed | Unchanged | Report |"
-          TABLE_DIVIDER="|---------|---------|-------|---------|-----------|--------|"
-          TABLE_ROWS=""
+          # GitHub rejects attachments over 10 MB.
+          MAX_IMAGE_BYTES=10485760
+
           HAS_ANY_SUMMARY=false
+          TOTAL_CHANGED=0
+          ROWS=0
+          ATTACH_ARGS=()
 
-          for SUMMARY_DIR in summaries/screenshot-diff-summary-*/; do
+          {
+            echo "${MARKER}"
+            echo "### 🖼️ Visual Regression Report"
+            echo ""
+            echo "| Project | Changed | Added | Removed | Unchanged | Report |"
+            echo "|---------|---------|-------|---------|-----------|--------|"
+          } > "${BODY_PLAIN}"
+          : > "${ROWS_FILE}"
+
+          for SUMMARY_DIR in summaries/screenshot-diff-comment-*/; do
             SUMMARY_FILE="${SUMMARY_DIR}summary.json"
             if [ ! -f "${SUMMARY_FILE}" ]; then
               continue
@@ -1174,7 +1223,51 @@ jobs:
               REPORT_LINK="✅ No changes"
             fi
 
-            TABLE_ROWS="${TABLE_ROWS}| \`${PROJECT}\` | ${CHANGED} | ${ADDED} | ${REMOVED} | ${UNCHANGED} | ${REPORT_LINK} |\n"
+            printf '| `%s` | %s | %s | %s | %s | %s |\n' \
+              "${PROJECT}" "${CHANGED}" "${ADDED}" "${REMOVED}" "${UNCHANGED}" "${REPORT_LINK}" \
+              >> "${BODY_PLAIN}"
+
+            TOTAL_CHANGED=$((TOTAL_CHANGED + CHANGED))
+
+            # `screenshots` is ordered by diff percent descending, so taking the
+            # first MAX_DIFF_ROWS shows the most significant changes.
+            while IFS=$'\t' read -r NAME PERCENT; do
+              if [ -z "${NAME}" ]; then
+                continue
+              fi
+              if [ "${ROWS}" -ge "${MAX_DIFF_ROWS}" ]; then
+                break
+              fi
+
+              BEFORE="${SUMMARY_DIR}images/baseline/${NAME}"
+              AFTER="${SUMMARY_DIR}images/current/${NAME}"
+              DIFF="${SUMMARY_DIR}images/diff/${NAME}"
+
+              SKIP=false
+              for IMG in "${BEFORE}" "${AFTER}" "${DIFF}"; do
+                if [ ! -f "${IMG}" ]; then
+                  echo "::warning::${IMG} is missing — skipping this row."
+                  SKIP=true
+                elif [ "$(stat -c%s "${IMG}")" -gt "${MAX_IMAGE_BYTES}" ]; then
+                  echo "::warning::${IMG} exceeds the 10 MB attachment limit — skipping this row."
+                  SKIP=true
+                fi
+              done
+              if [ "${SKIP}" = "true" ]; then
+                continue
+              fi
+
+              printf '| `%s` / `%s` (%.2f%%) | ![before](%s) | ![after](%s) | ![diff](%s) |\n' \
+                "${PROJECT}" "${NAME}" "${PERCENT}" "${BEFORE}" "${AFTER}" "${DIFF}" \
+                >> "${ROWS_FILE}"
+              ATTACH_ARGS+=(--attach "${BEFORE}" --attach "${AFTER}" --attach "${DIFF}")
+              ROWS=$((ROWS + 1))
+            done < <(jq -r '
+              .screenshots // []
+              | map(select(.status == "changed"))
+              | .[]
+              | "\(.name)\t\(.diff_percent)"
+            ' "${SUMMARY_FILE}")
           done
 
           if [ "${HAS_ANY_SUMMARY}" = "false" ]; then
@@ -1182,31 +1275,58 @@ jobs:
             exit 0
           fi
 
-          BODY=$(printf '%s\n' \
-            "${MARKER}" \
-            "### 🖼️ Visual Regression Report" \
-            "" \
-            "${TABLE_HEADER}" \
-            "${TABLE_DIVIDER}" \
-            "$(printf '%b' "${TABLE_ROWS}")")
+          # The rich body adds the delta table; the plain one is the fallback if
+          # the upload fails or no PAT is available.
+          cp "${BODY_PLAIN}" "${BODY_RICH}"
+          if [ "${ROWS}" -gt 0 ]; then
+            {
+              echo ""
+              echo "#### Changed screenshots"
+              echo ""
+              echo "| Screenshot | Before | After | Diff |"
+              echo "|------------|--------|-------|------|"
+              cat "${ROWS_FILE}"
+            } >> "${BODY_RICH}"
 
-          # Upsert: find existing comment with the marker, or create a new one
-          EXISTING_COMMENT_ID=$(gh api \
-            "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
-            2>/dev/null | head -1)
-
-          if [ -n "${EXISTING_COMMENT_ID}" ]; then
-            gh api \
-              --method PATCH \
-              "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
-              -f body="${BODY}"
-          else
-            gh api \
-              --method POST \
-              "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              -f body="${BODY}"
+            REMAINING=$((TOTAL_CHANGED - ROWS))
+            if [ "${REMAINING}" -gt 0 ]; then
+              printf '\n_%s more changed screenshot(s) — see the full report._\n' \
+                "${REMAINING}" >> "${BODY_RICH}"
+            fi
           fi
+
+          # Capture the comments to clean up BEFORE posting, so the new comment
+          # is never a deletion candidate.
+          STALE_IDS=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" 2>/dev/null || true)
+
+          POSTED=false
+          if [ "${ROWS}" -gt 0 ] && [ -n "${ATTACH_PAT}" ]; then
+            # gh rewrites the local image paths in the body to the uploaded
+            # asset URLs.
+            if GH_TOKEN="${ATTACH_PAT}" gh pr comment "${PR_NUMBER}" \
+                 --repo "${REPO}" --body-file "${BODY_RICH}" "${ATTACH_ARGS[@]}"; then
+              POSTED=true
+            else
+              echo "::warning::Uploading the delta images failed — posting counts only."
+            fi
+          elif [ "${ROWS}" -gt 0 ]; then
+            echo "::warning::VISUAL_REGRESSION_ATTACH_PAT is not set — posting counts only."
+          fi
+
+          if [ "${POSTED}" = "false" ]; then
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file "${BODY_PLAIN}"
+          fi
+
+          # `--attach` only exists on `gh pr comment`, which cannot edit a
+          # specific comment, so each run posts fresh and removes its
+          # predecessors.
+          while read -r ID; do
+            if [ -n "${ID}" ]; then
+              echo "Deleting superseded comment ${ID}"
+              gh api --method DELETE "repos/${REPO}/issues/comments/${ID}" || true
+            fi
+          done <<< "${STALE_IDS}"
 
   playwright-required:
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -637,6 +637,40 @@ When set, the following defaults are applied:
 The S3 bucket defaults to `onyx-playwright-artifacts` and can be overridden with the
 `PLAYWRIGHT_S3_BUCKET` environment variable.
 
+**`compare` Output:**
+
+`compare` always writes `summary.json` next to the report. When it finds differences it
+also writes the HTML report and per-screenshot PNGs:
+
+```
+web/output/screenshot-diff/<project>/
+├── index.html              # self-contained report (images inlined as data URIs)
+├── summary.json            # counts plus a `screenshots` array of the differing images
+└── images/
+    ├── baseline/<name>.png # absent for added screenshots
+    ├── current/<name>.png  # absent for removed screenshots
+    └── diff/<name>.png     # changed screenshots only
+```
+
+The `images/` copies exist because `index.html` inlines everything as base64, which is
+convenient to share but unusable as input to other tools. CI attaches these files to the
+visual regression PR comment. Unchanged screenshots are skipped.
+
+`summary.json` lists differing screenshots in report order — changed first, by diff
+percent descending — so a consumer that shows only the top few gets the most significant
+changes:
+
+```json
+{
+  "project": "admin",
+  "changed": 1, "added": 0, "removed": 0, "unchanged": 42, "total": 43,
+  "has_differences": true,
+  "screenshots": [
+    { "name": "admin-users.png", "status": "changed", "diff_percent": 3.21 }
+  ]
+}
+```
+
 **`compare` Flags:**
 
 | Flag | Default | Description |

--- a/tools/ods/cmd/screenshot_diff.go
+++ b/tools/ods/cmd/screenshot_diff.go
@@ -387,7 +387,7 @@ func runCompare(opts *ScreenshotDiffCompareOptions) {
 		log.Warnf("Current screenshots directory does not exist: %s", currentDir)
 		log.Warn("No screenshots captured for this project — writing empty summary.")
 
-		summary := imgdiff.Summary{Project: project}
+		summary := imgdiff.BuildSummary(project, nil)
 		if err := imgdiff.WriteSummary(summary, summaryPath); err != nil {
 			log.Fatalf("Failed to write summary: %v", err)
 		}
@@ -417,11 +417,20 @@ func runCompare(opts *ScreenshotDiffCompareOptions) {
 
 	// Generate HTML report only if there are differences
 	if summary.HasDifferences {
+		reportDir := filepath.Dir(outputPath)
+
 		log.Infof("Generating report: %s", outputPath)
 		if err := imgdiff.GenerateReport(results, outputPath); err != nil {
 			log.Fatalf("Failed to generate report: %v", err)
 		}
 		log.Infof("Report generated successfully: %s", outputPath)
+
+		// The report inlines its images as data URIs. Write them as real files
+		// too so CI can attach them to the PR comment.
+		if err := imgdiff.WriteImages(results, reportDir); err != nil {
+			log.Fatalf("Failed to write diff images: %v", err)
+		}
+		log.Infof("Diff images written to: %s", filepath.Join(reportDir, imgdiff.ImagesDirName))
 	} else {
 		log.Infof("No visual differences detected — skipping report generation.")
 	}

--- a/tools/ods/internal/imgdiff/images.go
+++ b/tools/ods/internal/imgdiff/images.go
@@ -1,0 +1,82 @@
+package imgdiff
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// ImagesDirName is the sub-directory of the report directory that holds the
+// per-screenshot PNGs written by WriteImages.
+const ImagesDirName = "images"
+
+// WriteImages writes the baseline, current, and diff PNGs for every screenshot
+// that differs from the baseline into dir/images/{baseline,current,diff}/.
+//
+// The HTML report inlines its images as data URIs, which makes it
+// self-contained but useless to anything that needs real files. CI uploads
+// these copies so the PR comment can attach them.
+//
+// Unchanged screenshots are skipped. A changed screenshot produces all three
+// images; an added one has no baseline and a removed one has no current, so
+// only the images that exist are written.
+func WriteImages(results []Result, dir string) error {
+	imagesDir := filepath.Join(dir, ImagesDirName)
+
+	for _, r := range results {
+		if r.Status == StatusUnchanged {
+			continue
+		}
+
+		name := filepath.Base(r.Name)
+
+		if r.BaselinePath != "" {
+			dest := filepath.Join(imagesDir, "baseline", name)
+			if err := copyFile(r.BaselinePath, dest); err != nil {
+				return fmt.Errorf("failed to write baseline image %s: %w", r.Name, err)
+			}
+		}
+
+		if r.CurrentPath != "" {
+			dest := filepath.Join(imagesDir, "current", name)
+			if err := copyFile(r.CurrentPath, dest); err != nil {
+				return fmt.Errorf("failed to write current image %s: %w", r.Name, err)
+			}
+		}
+
+		if r.DiffImage != nil {
+			dest := filepath.Join(imagesDir, "diff", name)
+			if err := SaveDiffImage(r.DiffImage, dest); err != nil {
+				return fmt.Errorf("failed to write diff image %s: %w", r.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies src to dest, creating parent directories as needed.
+func copyFile(src, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return out.Close()
+}

--- a/tools/ods/internal/imgdiff/images_test.go
+++ b/tools/ods/internal/imgdiff/images_test.go
@@ -1,0 +1,136 @@
+package imgdiff
+
+import (
+	"image"
+	"image/color"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildResults produces one result per status against real PNG files on disk,
+// so WriteImages has something to copy.
+func buildResults(t *testing.T, srcDir string) []Result {
+	t.Helper()
+
+	changedBaseline := filepath.Join(srcDir, "changed-baseline.png")
+	changedCurrent := filepath.Join(srcDir, "changed-current.png")
+	addedCurrent := filepath.Join(srcDir, "added-current.png")
+	removedBaseline := filepath.Join(srcDir, "removed-baseline.png")
+	unchangedBaseline := filepath.Join(srcDir, "unchanged-baseline.png")
+	unchangedCurrent := filepath.Join(srcDir, "unchanged-current.png")
+
+	createTestPNG(t, changedBaseline, 4, 4, color.White)
+	createTestPNG(t, changedCurrent, 4, 4, color.Black)
+	createTestPNG(t, addedCurrent, 4, 4, color.Black)
+	createTestPNG(t, removedBaseline, 4, 4, color.White)
+	createTestPNG(t, unchangedBaseline, 4, 4, color.White)
+	createTestPNG(t, unchangedCurrent, 4, 4, color.White)
+
+	return []Result{
+		{
+			Name:         "changed.png",
+			Status:       StatusChanged,
+			DiffPercent:  12.5,
+			BaselinePath: changedBaseline,
+			CurrentPath:  changedCurrent,
+			DiffImage:    image.NewRGBA(image.Rect(0, 0, 4, 4)),
+		},
+		{
+			Name:        "added.png",
+			Status:      StatusAdded,
+			CurrentPath: addedCurrent,
+		},
+		{
+			Name:         "removed.png",
+			Status:       StatusRemoved,
+			BaselinePath: removedBaseline,
+		},
+		{
+			Name:         "unchanged.png",
+			Status:       StatusUnchanged,
+			BaselinePath: unchangedBaseline,
+			CurrentPath:  unchangedCurrent,
+		},
+	}
+}
+
+func TestWriteImages(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	outDir := filepath.Join(tmp, "report")
+
+	if err := WriteImages(buildResults(t, srcDir), outDir); err != nil {
+		t.Fatalf("WriteImages failed: %v", err)
+	}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Changed screenshots get all three images.
+		{filepath.Join("baseline", "changed.png"), true},
+		{filepath.Join("current", "changed.png"), true},
+		{filepath.Join("diff", "changed.png"), true},
+		// Added screenshots have no baseline.
+		{filepath.Join("current", "added.png"), true},
+		{filepath.Join("baseline", "added.png"), false},
+		{filepath.Join("diff", "added.png"), false},
+		// Removed screenshots have no current.
+		{filepath.Join("baseline", "removed.png"), true},
+		{filepath.Join("current", "removed.png"), false},
+		{filepath.Join("diff", "removed.png"), false},
+		// Unchanged screenshots are skipped entirely.
+		{filepath.Join("baseline", "unchanged.png"), false},
+		{filepath.Join("current", "unchanged.png"), false},
+		{filepath.Join("diff", "unchanged.png"), false},
+	}
+
+	for _, tt := range tests {
+		full := filepath.Join(outDir, ImagesDirName, tt.path)
+		_, err := os.Stat(full)
+		if tt.want && err != nil {
+			t.Errorf("expected %s to exist, got error: %v", tt.path, err)
+		}
+		if !tt.want && err == nil {
+			t.Errorf("expected %s to be absent, but it exists", tt.path)
+		}
+	}
+}
+
+func TestWriteImages_CopiesContent(t *testing.T) {
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	outDir := filepath.Join(tmp, "report")
+
+	results := buildResults(t, srcDir)
+	if err := WriteImages(results, outDir); err != nil {
+		t.Fatalf("WriteImages failed: %v", err)
+	}
+
+	want, err := os.ReadFile(results[0].BaselinePath)
+	if err != nil {
+		t.Fatalf("failed to read source: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, ImagesDirName, "baseline", "changed.png"))
+	if err != nil {
+		t.Fatalf("failed to read copy: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Error("copied baseline image does not match the source")
+	}
+}
+
+func TestWriteImages_NoDifferences(t *testing.T) {
+	tmp := t.TempDir()
+	outDir := filepath.Join(tmp, "report")
+
+	if err := WriteImages(nil, outDir); err != nil {
+		t.Fatalf("WriteImages failed: %v", err)
+	}
+
+	// Nothing to write means no images directory at all.
+	if _, err := os.Stat(filepath.Join(outDir, ImagesDirName)); !os.IsNotExist(err) {
+		t.Errorf("expected no images directory, got err=%v", err)
+	}
+}

--- a/tools/ods/internal/imgdiff/summary.go
+++ b/tools/ods/internal/imgdiff/summary.go
@@ -7,6 +7,15 @@ import (
 	"path/filepath"
 )
 
+// ScreenshotSummary describes a single screenshot that differs from the
+// baseline. Unchanged screenshots are omitted, so consumers can iterate the
+// list directly without filtering.
+type ScreenshotSummary struct {
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	DiffPercent float64 `json:"diff_percent"`
+}
+
 // Summary holds aggregate comparison results in a JSON-friendly format.
 // It is written alongside the HTML report so that CI pipelines can read it
 // without parsing HTML.
@@ -18,11 +27,17 @@ type Summary struct {
 	Unchanged      int    `json:"unchanged"`
 	Total          int    `json:"total"`
 	HasDifferences bool   `json:"has_differences"`
+
+	// Screenshots lists the differing screenshots in the order produced by
+	// CompareDirectories: changed first (by diff percent descending), then
+	// added, then removed. The PR comment relies on this order to show the
+	// most significant changes when it caps the number of rows.
+	Screenshots []ScreenshotSummary `json:"screenshots"`
 }
 
 // BuildSummary computes a Summary from a slice of comparison results.
 func BuildSummary(project string, results []Result) Summary {
-	s := Summary{Project: project}
+	s := Summary{Project: project, Screenshots: []ScreenshotSummary{}}
 	for _, r := range results {
 		switch r.Status {
 		case StatusChanged:
@@ -33,6 +48,14 @@ func BuildSummary(project string, results []Result) Summary {
 			s.Removed++
 		case StatusUnchanged:
 			s.Unchanged++
+		}
+
+		if r.Status != StatusUnchanged {
+			s.Screenshots = append(s.Screenshots, ScreenshotSummary{
+				Name:        r.Name,
+				Status:      r.Status.String(),
+				DiffPercent: r.DiffPercent,
+			})
 		}
 	}
 	s.Total = len(results)

--- a/tools/ods/internal/imgdiff/summary_test.go
+++ b/tools/ods/internal/imgdiff/summary_test.go
@@ -1,0 +1,107 @@
+package imgdiff
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildSummary_Screenshots(t *testing.T) {
+	results := []Result{
+		{Name: "b.png", Status: StatusChanged, DiffPercent: 9.5},
+		{Name: "a.png", Status: StatusChanged, DiffPercent: 1.25},
+		{Name: "c.png", Status: StatusAdded},
+		{Name: "d.png", Status: StatusRemoved},
+		{Name: "e.png", Status: StatusUnchanged},
+	}
+
+	summary := BuildSummary("admin", results)
+
+	if summary.Changed != 2 || summary.Added != 1 || summary.Removed != 1 || summary.Unchanged != 1 {
+		t.Errorf("unexpected counts: %+v", summary)
+	}
+	if summary.Total != 5 {
+		t.Errorf("Total = %d, want 5", summary.Total)
+	}
+	if !summary.HasDifferences {
+		t.Error("HasDifferences = false, want true")
+	}
+
+	// Unchanged entries are omitted; the input order is preserved so the PR
+	// comment shows the largest diffs first when it caps rows.
+	want := []ScreenshotSummary{
+		{Name: "b.png", Status: "changed", DiffPercent: 9.5},
+		{Name: "a.png", Status: "changed", DiffPercent: 1.25},
+		{Name: "c.png", Status: "added"},
+		{Name: "d.png", Status: "removed"},
+	}
+
+	if len(summary.Screenshots) != len(want) {
+		t.Fatalf("got %d screenshots, want %d: %+v", len(summary.Screenshots), len(want), summary.Screenshots)
+	}
+	for i, w := range want {
+		if summary.Screenshots[i] != w {
+			t.Errorf("screenshot %d = %+v, want %+v", i, summary.Screenshots[i], w)
+		}
+	}
+}
+
+func TestBuildSummary_NoResults(t *testing.T) {
+	summary := BuildSummary("admin", nil)
+
+	if summary.HasDifferences {
+		t.Error("HasDifferences = true, want false")
+	}
+	if summary.Total != 0 {
+		t.Errorf("Total = %d, want 0", summary.Total)
+	}
+
+	// The comment job iterates this array with jq, so it must serialize as []
+	// rather than null.
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("failed to marshal summary: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal summary: %v", err)
+	}
+	screenshots, ok := decoded["screenshots"].([]any)
+	if !ok {
+		t.Fatalf("screenshots is not a JSON array: %v", decoded["screenshots"])
+	}
+	if len(screenshots) != 0 {
+		t.Errorf("got %d screenshots, want 0", len(screenshots))
+	}
+}
+
+func TestWriteSummary_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "summary.json")
+
+	want := BuildSummary("exclusive", []Result{
+		{Name: "a.png", Status: StatusChanged, DiffPercent: 3.5},
+	})
+	if err := WriteSummary(want, path); err != nil {
+		t.Fatalf("WriteSummary failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read summary: %v", err)
+	}
+	var got Summary
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal summary: %v", err)
+	}
+
+	if got.Project != "exclusive" || got.Changed != 1 || !got.HasDifferences {
+		t.Errorf("unexpected summary: %+v", got)
+	}
+	if len(got.Screenshots) != 1 || got.Screenshots[0].Name != "a.png" {
+		t.Errorf("unexpected screenshots: %+v", got.Screenshots)
+	}
+	if got.Screenshots[0].DiffPercent != 3.5 {
+		t.Errorf("DiffPercent = %v, want 3.5", got.Screenshots[0].DiffPercent)
+	}
+}


### PR DESCRIPTION
## Description

The visual regression PR comment reported only counts, so seeing what actually changed meant opening the S3-hosted report. This puts the images directly in the comment using the GitHub CLI `--attach` flag added in [gh 2.99.0](https://github.com/cli/cli/releases/tag/v2.99.0).

**`ods screenshot-diff` (`tools/ods`)**

- `compare` base64-inlines its images into `index.html`, so no image files existed to attach. It now also writes them to `images/{baseline,current,diff}/`, reusing the previously unused `SaveDiffImage`.
- `summary.json` gains a `screenshots` array (`name`, `status`, `diff_percent`), ordered by diff percent descending, so the comment job knows which screenshots changed and by how much.

**`pr-playwright-tests.yml`**

- The summary artifact now carries `summary.json` + `images/` (renamed `screenshot-diff-comment-*`). It excludes `index.html`, which base64-inlines every image and dwarfs everything else; the full report is still published separately.
- The comment job installs gh ≥ 2.99.0 if the runner's is older, then renders a `Before | After | Diff` table capped at 6 rows across all projects.

### Two things reviewers should know

- **The comment is now recreated, not edited in place.** `--attach` only exists on `gh pr comment`, not `gh api`, so the job posts fresh and deletes its predecessors. It moves to the bottom of the PR and re-notifies subscribers on each run. `--edit-last` isn't usable here because `preview.yml` and `pr-desktop-build.yml` also comment as `github-actions[bot]` and could get clobbered.
- **This needs a new `VISUAL_REGRESSION_ATTACH_PAT` secret** — a *classic* PAT with `repo` scope. The [changelog](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) says uploads accept OAuth tokens and classic PATs, and [cli/cli#14177](https://github.com/cli/cli/pull/14177) added token-type classification because "the upload endpoint only accepts some kinds of credential" — the Actions `GITHUB_TOKEN` is a `ghs_` installation token. I could not verify this empirically without merging. Without the secret (including on fork PRs, which get no secrets) the comment degrades to counts only and logs a warning; nothing breaks. If the first run shows images without the secret, the `ATTACH_PAT` block can be dropped.

## How Has This Been Tested?

- **New Go unit tests** in `images_test.go` / `summary_test.go` cover the files `WriteImages` creates per status and the `screenshots` array ordering, filtering, and `[]`-not-`null` serialization.
- **Ran the real `ods screenshot-diff compare`** against fixtures covering all four statuses. It produced exactly the expected file set — no baseline for added, no current for removed, diff only for changed, unchanged skipped — and a valid diff overlay.
- **Drove the workflow's shell block against a fake artifact tree**, confirming: the 6-row cap and "_N more_" line, 2-decimal percentages, skipping of missing and >10 MB images, the no-PAT fallback, the upload-failure fallback, the no-summaries early exit, and stale-comment deletion.
- `pre-commit run` passes zizmor, actionlint, golangci-lint, YAML, and ripsecrets.

Not verified until this runs for real: whether `--attach` substitutes local paths **inside markdown table cells** (the docs say it rewrites paths referenced in the body, but don't say whether that holds in tables). If it doesn't, images append below the table instead of filling cells — fixable by post-processing the body with the returned asset URLs.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The visual regression PR comment now embeds before/after/diff images instead of only showing change counts.

**`ods screenshot-diff`**
- `compare` now writes per-screenshot PNGs to `images/{baseline,current,diff}/` alongside the self-contained HTML report.
- `summary.json` gains a `screenshots` array (name, status, diff percent), ordered by diff percent descending.
- The visual regression job now builds `ods` from the checkout instead of installing the published `onyx-devtools` wheel, so these changes take effect in the same PR.

**Comment workflow**
- The comment job builds a Before | After | Diff table capped at 6 rows across all projects.
- The comment is now recreated on each run and its predecessors deleted; `--edit-last` isn't usable because other workflows also comment as `github-actions[bot]`.
- Requires a new `VISUAL_REGRESSION_ATTACH_PAT` classic PAT with `repo` scope; without it (including fork PRs) the comment falls back to counts only.

<sup>Written for commit 6cbd7399e3b20248d46d8992ef36a770b3fe8381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

