### PR TITLE
feat(ods): add `ods coverage` to gate Go coverage against a baseline

### DIFF
--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -53,20 +53,5 @@ jobs:
       - run: git diff --exit-code go.mod go.sum
         working-directory: ${{ matrix.modules }}
 
-      - name: Build ods
-        run: go build -o "${RUNNER_TEMP}/ods" .
-        working-directory: tools/ods
-
-      # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
-      # `ods coverage --check` runs the same `go test -race ./...` with a coverage
-      # profile, then fails when a package drops below its floor. Raise the floors
-      # after adding tests with `ods coverage <suite> --update`.
-      - name: Test
-        env:
-          MODULE: ${{ matrix.modules }}
-        run: |
-          if [ -f "${MODULE}/.coverage-baseline.yaml" ]; then
-            "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check
-          else
-            (cd "${MODULE}" && go test -race ./...)
-          fi
+      - run: go test -race ./...
+        working-directory: ${{ matrix.modules }}

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -55,3 +55,45 @@ jobs:
 
       - run: go test -race ./...
         working-directory: ${{ matrix.modules }}
+
+  # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
+  detect-coverage-modules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      modules: ${{ steps.set-modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      - id: set-modules
+        run: echo "modules=$(find . -name '.coverage-baseline.yaml' -exec dirname {} \; | jq -Rc '[.,inputs]')" >> "$GITHUB_OUTPUT"
+
+  coverage:
+    needs: detect-coverage-modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        modules: ${{ fromJSON(needs.detect-coverage-modules.outputs.modules) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # zizmor: ignore[cache-poisoning]
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/go.sum"
+
+      - name: Build ods
+        run: go build -o "${RUNNER_TEMP}/ods" .
+        working-directory: tools/ods
+
+      # Fails when a package drops below the floor recorded in its baseline.
+      # Raise the floors after adding tests with `ods coverage <suite> --update`.
+      - name: Check coverage against the baseline
+        env:
+          MODULE: ${{ matrix.modules }}
+        run: |
+          "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -53,47 +53,20 @@ jobs:
       - run: git diff --exit-code go.mod go.sum
         working-directory: ${{ matrix.modules }}
 
-      - run: go test -race ./...
-        working-directory: ${{ matrix.modules }}
-
-  # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
-  detect-coverage-modules:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      modules: ${{ steps.set-modules.outputs.modules }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
-        with:
-          persist-credentials: false
-      - id: set-modules
-        run: echo "modules=$(find . -name '.coverage-baseline.yaml' -exec dirname {} \; | jq -Rc '[.,inputs]')" >> "$GITHUB_OUTPUT"
-
-  coverage:
-    needs: detect-coverage-modules
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        modules: ${{ fromJSON(needs.detect-coverage-modules.outputs.modules) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # zizmor: ignore[cache-poisoning]
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: "**/go.sum"
-
       - name: Build ods
         run: go build -o "${RUNNER_TEMP}/ods" .
         working-directory: tools/ods
 
-      # Fails when a package drops below the floor recorded in its baseline.
-      # Raise the floors after adding tests with `ods coverage <suite> --update`.
-      - name: Check coverage against the baseline
+      # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
+      # `ods coverage --check` runs the same `go test -race ./...` with a coverage
+      # profile, then fails when a package drops below its floor. Raise the floors
+      # after adding tests with `ods coverage <suite> --update`.
+      - name: Test
         env:
           MODULE: ${{ matrix.modules }}
         run: |
-          "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check
+          if [ -f "${MODULE}/.coverage-baseline.yaml" ]; then
+            "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check
+          else
+            (cd "${MODULE}" && go test -race ./...)
+          fi

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -18,6 +18,8 @@ permissions:
 
 env:
   GO_VERSION: "1.26.5"
+  # HTML coverage pages for PR comments go next to the playwright reports.
+  REPORTS_S3_BUCKET: onyx-playwright-artifacts
 
 jobs:
   detect-modules:
@@ -36,6 +38,9 @@ jobs:
     needs: detect-modules
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write # OIDC-based AWS credential exchange, to publish the HTML page
     strategy:
       matrix:
         modules: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
@@ -90,9 +95,33 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-  # One comment per PR, updated in place, with each module's report and a link
-  # to its HTML artifact. Fork PRs get a read-only token, so they only get the
-  # job summary.
+      # The HTML page is published where a browser can open it, for the PR
+      # comment. Fork PRs cannot assume the role, so they keep the artifact only.
+      - name: Configure AWS credentials
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+      - name: Publish the HTML page
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        env:
+          NAME: ${{ steps.report.outputs.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [ ! -f "${RUNNER_TEMP}/coverage/coverage.html" ]; then
+            echo "No HTML page (the tests failed) -- skipping the upload."
+            exit 0
+          fi
+          aws s3 cp "${RUNNER_TEMP}/coverage/coverage.html" \
+            "s3://${REPORTS_S3_BUCKET}/reports/pr-${PR_NUMBER}/${RUN_ID}/${NAME}/coverage.html" \
+            --content-type text/html
+
+  # One comment per PR, updated in place, listing the modules with a baseline
+  # where a package moved, each with a link to its HTML page. When nothing
+  # moved, an existing comment is updated to say so and no new one is posted.
+  # Fork PRs get a read-only token, so they only get the job summary.
   coverage-comment:
     needs: golang
     if: >-
@@ -102,7 +131,6 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      actions: read
       pull-requests: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v4
@@ -119,26 +147,31 @@ jobs:
           set -euo pipefail
 
           MARKER="<!-- golang-coverage -->"
-          ARTIFACTS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts")
 
-          BODY="${MARKER}"$'\n'"### Go coverage"$'\n'
+          HEADER="${MARKER}"$'\n'"### Go coverage"$'\n'
+          BODY="${HEADER}"
           for dir in reports/coverage-*/; do
             [ -f "${dir}report.md" ] || continue
+            # ods coverage opens the report with a marker: changed, unchanged, or no-baseline.
+            head -1 "${dir}report.md" | grep -qx '<!-- ods-coverage: changed -->' || continue
             NAME=$(basename "${dir}")
-            ARTIFACT_ID=$(jq -r --arg name "${NAME}" '.artifacts[] | select(.name == $name) | .id' <<< "${ARTIFACTS}")
+            PAGE_URL="https://${REPORTS_S3_BUCKET}.s3.us-east-2.amazonaws.com/reports/pr-${PR_NUMBER}/${RUN_ID}/${NAME}/coverage.html"
             BODY+=$'\n'"$(cat "${dir}report.md")"$'\n'
-            BODY+="[Download the HTML report](https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${ARTIFACT_ID})"$'\n'
+            BODY+="[Browse the uncovered lines](${PAGE_URL})"$'\n'
           done
-
-          if [ "${BODY}" = "${MARKER}"$'\n'"### Go coverage"$'\n' ]; then
-            echo "No coverage reports in this run (the tests failed) -- skipping the PR comment."
-            exit 0
-          fi
 
           # Upsert: find the existing comment with the marker, or create one.
           # --paginate: on a long PR the marker can sit past the first page.
           EXISTING_COMMENT_ID=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+
+          if [ "${BODY}" = "${HEADER}" ]; then
+            if [ -z "${EXISTING_COMMENT_ID}" ]; then
+              echo "No module with a baseline changed coverage -- skipping the PR comment."
+              exit 0
+            fi
+            BODY+=$'\n'"No package moved against its baseline in the latest run."$'\n'
+          fi
 
           if [ -n "${EXISTING_COMMENT_ID}" ]; then
             gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" -f body="${BODY}" >/dev/null

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -65,4 +65,83 @@ jobs:
       - name: Test
         env:
           MODULE: ${{ matrix.modules }}
-        run: '"${RUNNER_TEMP}/ods" coverage "${MODULE}" --check'
+        run: |
+          "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check \
+            --html "${RUNNER_TEMP}/coverage/coverage.html" \
+            --markdown "${RUNNER_TEMP}/coverage/report.md"
+
+      # The report goes to the job summary here, and to the PR comment below.
+      # Artifact names cannot contain "/", so "./tools/ods" becomes "tools-ods".
+      - name: Publish the coverage report
+        if: ${{ !cancelled() }}
+        id: report
+        env:
+          MODULE: ${{ matrix.modules }}
+        run: |
+          if [ -f "${RUNNER_TEMP}/coverage/report.md" ]; then
+            cat "${RUNNER_TEMP}/coverage/report.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "name=coverage-$(echo "${MODULE#./}" | tr '/' '-')" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ steps.report.outputs.name }}
+          path: ${{ runner.temp }}/coverage
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # One comment per PR, updated in place, with each module's report and a link
+  # to its HTML artifact. Fork PRs get a read-only token, so they only get the
+  # job summary.
+  coverage-comment:
+    needs: golang
+    if: >-
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: reports
+      - name: Post the coverage comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          MARKER="<!-- golang-coverage -->"
+          ARTIFACTS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts")
+
+          BODY="${MARKER}"$'\n'"### Go coverage"$'\n'
+          for dir in reports/coverage-*/; do
+            [ -f "${dir}report.md" ] || continue
+            NAME=$(basename "${dir}")
+            ARTIFACT_ID=$(jq -r --arg name "${NAME}" '.artifacts[] | select(.name == $name) | .id' <<< "${ARTIFACTS}")
+            BODY+=$'\n'"$(cat "${dir}report.md")"$'\n'
+            BODY+="[Download the HTML report](https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${ARTIFACT_ID})"$'\n'
+          done
+
+          if [ "${BODY}" = "${MARKER}"$'\n'"### Go coverage"$'\n' ]; then
+            echo "No coverage reports in this run (the tests failed) -- skipping the PR comment."
+            exit 0
+          fi
+
+          # Upsert: find the existing comment with the marker, or create one.
+          # --paginate: on a long PR the marker can sit past the first page.
+          EXISTING_COMMENT_ID=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+
+          if [ -n "${EXISTING_COMMENT_ID}" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" -f body="${BODY}" >/dev/null
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="${BODY}" >/dev/null
+          fi

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -156,7 +156,8 @@ jobs:
             head -1 "${dir}report.md" | grep -qx '<!-- ods-coverage: changed -->' || continue
             NAME=$(basename "${dir}")
             PAGE_URL="https://${REPORTS_S3_BUCKET}.s3.us-east-2.amazonaws.com/reports/pr-${PR_NUMBER}/${RUN_ID}/${NAME}/coverage.html"
-            BODY+=$'\n'"$(cat "${dir}report.md")"$'\n'
+            # The blank line keeps the link out of the table above it.
+            BODY+=$'\n'"$(cat "${dir}report.md")"$'\n\n'
             BODY+="[Browse the uncovered lines](${PAGE_URL})"$'\n'
           done
 

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -57,16 +57,12 @@ jobs:
         run: go build -o "${RUNNER_TEMP}/ods" .
         working-directory: tools/ods
 
-      # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
-      # `ods coverage --check` runs the same `go test -race ./...` with a coverage
-      # profile, then fails when a package drops below its floor. Raise the floors
-      # after adding tests with `ods coverage <suite> --update`.
+      # `ods coverage --check` runs `go test -race ./...` with a coverage profile.
+      # A module opts into the gate by committing a .coverage-baseline.yaml; the
+      # check then fails when a package drops below its floor. Without one the
+      # tests still run and nothing is gated. Raise the floors after adding
+      # tests with `ods coverage <suite> --update`.
       - name: Test
         env:
           MODULE: ${{ matrix.modules }}
-        run: |
-          if [ -f "${MODULE}/.coverage-baseline.yaml" ]; then
-            "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check
-          else
-            (cd "${MODULE}" && go test -race ./...)
-          fi
+        run: '"${RUNNER_TEMP}/ods" coverage "${MODULE}" --check'

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -53,5 +53,20 @@ jobs:
       - run: git diff --exit-code go.mod go.sum
         working-directory: ${{ matrix.modules }}
 
-      - run: go test -race ./...
-        working-directory: ${{ matrix.modules }}
+      - name: Build ods
+        run: go build -o "${RUNNER_TEMP}/ods" .
+        working-directory: tools/ods
+
+      # A module opts into the coverage gate by committing a .coverage-baseline.yaml.
+      # `ods coverage --check` runs the same `go test -race ./...` with a coverage
+      # profile, then fails when a package drops below its floor. Raise the floors
+      # after adding tests with `ods coverage <suite> --update`.
+      - name: Test
+        env:
+          MODULE: ${{ matrix.modules }}
+        run: |
+          if [ -f "${MODULE}/.coverage-baseline.yaml" ]; then
+            "${RUNNER_TEMP}/ods" coverage "${MODULE}" --check
+          else
+            (cd "${MODULE}" && go test -race ./...)
+          fi

--- a/tools/ods/.coverage-baseline.yaml
+++ b/tools/ods/.coverage-baseline.yaml
@@ -5,17 +5,17 @@
 # tests with `ods coverage <suite> --update`.
 #
 # Generated file: do not edit by hand.
-total: 35.7
+total: 36.3
 packages:
   .: 0
-  cmd: 17.2
+  cmd: 17.1
   internal/alembic: 0
   internal/audit: 55.1
   internal/auditcmd: 0
   internal/childproc: 0
   internal/composegen: 96.8
   internal/config: 0
-  internal/coverage: 79.7
+  internal/coverage: 89.8
   internal/deployfilessync: 79.1
   internal/docker: 25.3
   internal/git: 32.5

--- a/tools/ods/.coverage-baseline.yaml
+++ b/tools/ods/.coverage-baseline.yaml
@@ -1,0 +1,36 @@
+# Minimum statement coverage per package, in percent.
+#
+# `ods coverage <suite> --check` fails when a package drops below its floor,
+# which is how CI keeps coverage from regressing. Raise the floors after adding
+# tests with `ods coverage <suite> --update`.
+#
+# Generated file: do not edit by hand.
+total: 30.2
+packages:
+  .: 0
+  cmd: 4.3
+  internal/alembic: 0
+  internal/audit: 55.1
+  internal/childproc: 0
+  internal/composegen: 96.8
+  internal/config: 0
+  internal/coverage: 78
+  internal/deployfilessync: 79.1
+  internal/docker: 25.3
+  internal/git: 28.5
+  internal/gittest: 0
+  internal/imgdiff: 68.2
+  internal/kube: 0
+  internal/lazyimports: 61.2
+  internal/openapi: 0
+  internal/paths: 30.3
+  internal/portutil: 75
+  internal/postgres: 0
+  internal/prompt: 0
+  internal/pycheck: 74.1
+  internal/release: 83.7
+  internal/s3: 0
+  internal/terraform: 83
+  internal/testsuite: 88.1
+  internal/tui: 43.3
+  internal/version: 100

--- a/tools/ods/.coverage-baseline.yaml
+++ b/tools/ods/.coverage-baseline.yaml
@@ -5,19 +5,20 @@
 # tests with `ods coverage <suite> --update`.
 #
 # Generated file: do not edit by hand.
-total: 30.2
+total: 35.7
 packages:
   .: 0
-  cmd: 4.3
+  cmd: 17.2
   internal/alembic: 0
   internal/audit: 55.1
+  internal/auditcmd: 0
   internal/childproc: 0
   internal/composegen: 96.8
   internal/config: 0
-  internal/coverage: 78
+  internal/coverage: 79.7
   internal/deployfilessync: 79.1
   internal/docker: 25.3
-  internal/git: 28.5
+  internal/git: 32.5
   internal/gittest: 0
   internal/imgdiff: 68.2
   internal/kube: 0
@@ -28,9 +29,10 @@ packages:
   internal/postgres: 0
   internal/prompt: 0
   internal/pycheck: 74.1
-  internal/release: 83.7
+  internal/release: 82.7
   internal/s3: 0
   internal/terraform: 83
   internal/testsuite: 88.1
-  internal/tui: 43.3
+  internal/tui: 38.8
   internal/version: 100
+  odsaudit: 0

--- a/tools/ods/.coverage-baseline.yaml
+++ b/tools/ods/.coverage-baseline.yaml
@@ -5,7 +5,7 @@
 # tests with `ods coverage <suite> --update`.
 #
 # Generated file: do not edit by hand.
-total: 36.3
+total: 36.4
 packages:
   .: 0
   cmd: 17.1
@@ -15,7 +15,7 @@ packages:
   internal/childproc: 0
   internal/composegen: 96.8
   internal/config: 0
-  internal/coverage: 89.8
+  internal/coverage: 90.1
   internal/deployfilessync: 79.1
   internal/docker: 25.3
   internal/git: 32.5

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -313,7 +313,7 @@ suite name, which is what CI passes.
 | `--update` | `false` | Rewrite the baseline from this run |
 | `--profile` | | Keep the coverage profile at this path (for `go tool cover`) |
 | `--html` | | Render the profile as a browsable page at this path |
-| `--markdown` | | Write the report as markdown at this path, for a PR comment or job summary |
+| `--markdown` | | Write the changed packages as a markdown table at this path, for a PR comment |
 | `--tolerance` | `0.1` | Percentage points a package may drop below its floor without failing |
 
 **Examples:**
@@ -341,9 +341,13 @@ with `--update` so the new level becomes the floor.
 
 `pr-golang-tests.yml` runs `ods coverage <module> --check` for every Go module.
 Without a baseline the tests still run and the report prints, but nothing is
-gated. Each module's `--markdown` report goes to the job summary and to one PR
-comment, updated in place, and its `--html` page is uploaded as an artifact. A module opts into the gate by committing a baseline, so `cli` and
+gated. A module opts into the gate by committing a baseline, so `cli` and
 `terraform-provider-onyx` join by running `ods coverage <suite> --update` once.
+
+In CI, each module's `--markdown` report goes to the job summary, and its
+`--html` page is uploaded as an artifact and published to the reports bucket.
+One PR comment, updated in place, lists the modules with a baseline where a
+package moved, each with a link to its page.
 
 Floors are rounded down to one decimal, and a package may sit `--tolerance`
 below its floor without failing. That absorbs the jitter from suites that depend

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -312,6 +312,8 @@ suite name, which is what CI passes.
 | `--check` | `false` | Fail when a package drops below its baseline floor |
 | `--update` | `false` | Rewrite the baseline from this run |
 | `--profile` | | Keep the coverage profile at this path (for `go tool cover`) |
+| `--html` | | Render the profile as a browsable page at this path |
+| `--markdown` | | Write the report as markdown at this path, for a PR comment or job summary |
 | `--tolerance` | `0.1` | Percentage points a package may drop below its floor without failing |
 
 **Examples:**
@@ -339,7 +341,8 @@ with `--update` so the new level becomes the floor.
 
 `pr-golang-tests.yml` runs `ods coverage <module> --check` for every Go module.
 Without a baseline the tests still run and the report prints, but nothing is
-gated. A module opts into the gate by committing a baseline, so `cli` and
+gated. Each module's `--markdown` report goes to the job summary and to one PR
+comment, updated in place, and its `--html` page is uploaded as an artifact. A module opts into the gate by committing a baseline, so `cli` and
 `terraform-provider-onyx` join by running `ods coverage <suite> --update` once.
 
 Floors are rounded down to one decimal, and a package may sit `--tolerance`

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -282,6 +282,68 @@ ods test tools/ods/internal/testsuite/testsuite_test.go::TestResolveGoTargets
 ods test cli -run TestChat -v
 ```
 
+### `coverage` - Measure Go Coverage Against a Baseline
+
+Measure Go statement coverage per package and hold it against a committed
+baseline, so coverage can go up but not down.
+
+```shell
+ods coverage <suite|module-dir> [flags]
+```
+
+The baseline is a `.coverage-baseline.yaml` at the module root recording each
+package's floor. `--check` fails when a package drops below its floor, which is
+what `pr-golang-tests.yml` runs on every PR. After adding tests, `--update`
+raises the floors.
+
+Coverage is measured per package with `go test -coverprofile`, so a package's
+number counts only its own tests. That is a number the package's owner can act
+on; a cross-package `-coverpkg` total would credit a package for statements its
+own tests never assert on.
+
+The suites are the same Go modules `ods test` knows: `ods`, `cli`, and
+`terraform`. A module directory such as `tools/ods` is accepted in place of a
+suite name, which is what CI passes.
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--check` | `false` | Fail when a package drops below its baseline floor |
+| `--update` | `false` | Rewrite the baseline from this run |
+| `--profile` | | Keep the coverage profile at this path (for `go tool cover`) |
+| `--tolerance` | `0.1` | Percentage points a package may drop below its floor without failing |
+
+**Examples:**
+
+```shell
+# Report where each package stands
+ods coverage ods
+
+# Fail on a regression (what CI runs)
+ods coverage ods --check
+
+# Record today's numbers as the new floors
+ods coverage ods --update
+
+# Keep the profile and browse the uncovered lines
+ods coverage ods --profile /tmp/cover.out
+go tool cover -html=/tmp/cover.out
+```
+
+#### Raising the baseline
+
+The gate never fails on an improvement, so a baseline goes stale as tests are
+added. `ods coverage ods` reports how many packages have risen; commit the gain
+with `--update` so the new level becomes the floor.
+
+A module opts into the CI gate by committing a baseline, so `cli` and
+`terraform-provider-onyx` join by running `ods coverage <suite> --update` once.
+
+Floors are rounded down to one decimal, and a package may sit `--tolerance`
+below its floor without failing. That absorbs the jitter from suites that depend
+on ports or timing; a real regression is far larger.
+
 ### `dev` - Devcontainer Management
 
 Manage the Onyx devcontainer. Also available as `ods dc`.

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -344,6 +344,10 @@ Floors are rounded down to one decimal, and a package may sit `--tolerance`
 below its floor without failing. That absorbs the jitter from suites that depend
 on ports or timing; a real regression is far larger.
 
+The package floors are the gate. The module total is reported with its delta
+but never fails the check: a package added without tests, or a well-covered
+package deleted, moves the total without any package regressing.
+
 ### `dev` - Devcontainer Management
 
 Manage the Onyx devcontainer. Also available as `ods dc`.

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -337,7 +337,9 @@ The gate never fails on an improvement, so a baseline goes stale as tests are
 added. `ods coverage ods` reports how many packages have risen; commit the gain
 with `--update` so the new level becomes the floor.
 
-A module opts into the CI gate by committing a baseline, so `cli` and
+`pr-golang-tests.yml` runs `ods coverage <module> --check` for every Go module.
+Without a baseline the tests still run and the report prints, but nothing is
+gated. A module opts into the gate by committing a baseline, so `cli` and
 `terraform-provider-onyx` join by running `ods coverage <suite> --update` once.
 
 Floors are rounded down to one decimal, and a package may sit `--tolerance`

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -52,7 +52,7 @@ func NewCoverageCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Update, "update", false, "Rewrite the baseline from this run")
 	cmd.Flags().StringVar(&opts.Profile, "profile", "", "Keep the coverage profile at this path, for go tool cover -html")
 	cmd.Flags().StringVar(&opts.HTML, "html", "", "Render the profile as a browsable page at this path")
-	cmd.Flags().StringVar(&opts.Markdown, "markdown", "", "Write the report as markdown at this path, for a PR comment or job summary")
+	cmd.Flags().StringVar(&opts.Markdown, "markdown", "", "Write the changed packages as a markdown table at this path, for a PR comment")
 	cmd.Flags().Float64Var(&opts.Tolerance, "tolerance", coverage.DefaultTolerance,
 		"Percentage points a package may drop below its floor without failing")
 

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/coverage"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/testsuite"
+)
+
+// CoverageOptions holds options for the coverage command.
+type CoverageOptions struct {
+	Check     bool
+	Update    bool
+	Profile   string
+	Tolerance float64
+}
+
+// NewCoverageCommand creates a command that measures statement coverage for a
+// Go suite and compares it against the committed baseline.
+func NewCoverageCommand() *cobra.Command {
+	opts := &CoverageOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "coverage <suite|module-dir>",
+		Short: "Measure Go test coverage and hold it against a baseline",
+		Long:  coverageHelpDescription(),
+		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return testsuite.Names(), cobra.ShellCompDirectiveNoFileComp
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runCoverage(args[0], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.Check, "check", false, "Fail when a package drops below its baseline floor")
+	cmd.Flags().BoolVar(&opts.Update, "update", false, "Rewrite the baseline from this run")
+	cmd.Flags().StringVar(&opts.Profile, "profile", "", "Keep the coverage profile at this path, for go tool cover -html")
+	cmd.Flags().Float64Var(&opts.Tolerance, "tolerance", coverage.DefaultTolerance,
+		"Percentage points a package may drop below its floor without failing")
+
+	return cmd
+}
+
+func runCoverage(target string, opts *CoverageOptions) {
+	if opts.Check && opts.Update {
+		log.Fatal("--check and --update do the opposite of each other; pass only one")
+	}
+
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to determine the working directory: %v", err)
+	}
+
+	suite := coverageSuite(root, cwd, target)
+	moduleDir := filepath.Join(root, suite.Dir)
+
+	profilePath, cleanup := profileTarget(opts.Profile)
+	defer cleanup()
+
+	log.Infof("Measuring %s coverage...", suite.Name)
+	profile, err := coverage.Run(coverage.RunOptions{
+		ModuleDir:   moduleDir,
+		ProfilePath: profilePath,
+		Args:        suite.DefaultArgs,
+		Stdout:      os.Stdout,
+		Stderr:      os.Stderr,
+	})
+	var exitErr *coverage.ExitError
+	if errors.As(err, &exitErr) {
+		// The tests failed, and their output is already on the terminal.
+		// Coverage from a failed run is not worth reporting.
+		os.Exit(exitErr.Code)
+	}
+	if err != nil {
+		log.Fatalf("Failed to measure coverage: %v", err)
+	}
+
+	baselinePath := coverage.BaselinePath(moduleDir)
+
+	if opts.Update {
+		writeBaseline(baselinePath, profile)
+		return
+	}
+
+	baseline, err := coverage.LoadBaseline(baselinePath)
+	if errors.Is(err, os.ErrNotExist) {
+		if opts.Check {
+			log.Fatalf("No baseline at %s. Create one with: ods coverage %s --update", baselinePath, suite.Name)
+		}
+		log.Warnf("No baseline at %s; create one with: ods coverage %s --update", baselinePath, suite.Name)
+		baseline = nil
+	} else if err != nil {
+		log.Fatalf("Failed to read the baseline: %v", err)
+	}
+
+	report := coverage.Compare(profile, baseline, opts.Tolerance)
+	if err := coverage.WriteReport(os.Stdout, report); err != nil {
+		log.Fatalf("Failed to write the report: %v", err)
+	}
+
+	if profilePath == opts.Profile {
+		log.Infof("Coverage profile written to %s", profilePath)
+		log.Infof("Browse it with: go tool cover -html=%s", profilePath)
+	}
+
+	if improvements := report.Improvements(); len(improvements) > 0 {
+		log.Infof("%d package(s) rose above the baseline. Lock the gain in with: ods coverage %s --update",
+			len(improvements), suite.Name)
+	}
+
+	if !opts.Check {
+		return
+	}
+	regressions := report.Regressions()
+	if len(regressions) == 0 {
+		log.Infof("Coverage holds at or above the baseline in %s", baselinePath)
+		return
+	}
+	for _, regression := range regressions {
+		log.Errorf("%s fell to %.1f%%, below its %.1f%% floor", regression.Package, regression.Percent, regression.Floor)
+	}
+	log.Fatalf("Coverage regressed in %d package(s). Add tests, or justify the drop and run: ods coverage %s --update",
+		len(regressions), suite.Name)
+}
+
+func writeBaseline(baselinePath string, profile *coverage.Profile) {
+	baseline := coverage.NewBaseline(profile)
+	if err := baseline.Save(baselinePath); err != nil {
+		log.Fatalf("Failed to write the baseline: %v", err)
+	}
+	// Report the floor that was recorded, not the raw measurement, so the
+	// number here matches the file.
+	log.Infof("Wrote %s with a %.1f%% total coverage floor across %d packages",
+		baselinePath, baseline.Total, len(baseline.Packages))
+}
+
+// profileTarget resolves where the coverage profile is written. Without an
+// explicit path it goes to a temporary file that is removed afterwards.
+func profileTarget(requested string) (string, func()) {
+	if requested != "" {
+		return requested, func() {}
+	}
+	dir, err := os.MkdirTemp("", "ods-coverage")
+	if err != nil {
+		log.Fatalf("Failed to create a temporary directory: %v", err)
+	}
+	return filepath.Join(dir, "coverage.out"), func() { _ = os.RemoveAll(dir) }
+}
+
+// coverageSuite resolves a suite from a suite name or a module directory,
+// reusing the routing `ods test` uses. Accepting a directory lets CI pass the
+// module it is iterating over without a second name-to-path table.
+func coverageSuite(root, cwd, target string) *testsuite.Suite {
+	suite, args, err := testsuite.Resolve(root, cwd, []string{target})
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	// Coverage is measured for a whole module, since a baseline covers every
+	// package in it. A path pointing deeper would silently measure less.
+	if len(args) > 0 && args[0] != "./..." {
+		log.Fatalf("Coverage runs a whole module; %q points inside %s. Use: ods coverage %s",
+			target, suite.Dir, suite.Name)
+	}
+	return suite
+}
+
+func coverageHelpDescription() string {
+	var b strings.Builder
+	b.WriteString(`Measure Go statement coverage and hold it against a committed baseline.
+
+The baseline is a ` + coverage.BaselineFile + ` at the module root recording each
+package's floor. --check fails when a package drops below its floor, which is how
+CI keeps coverage from regressing. After adding tests, --update raises the floors.
+
+Coverage is per package: a package's number counts only its own tests, so it is a
+number that package's owner can act on.
+
+Examples:
+  ods coverage ods                  # report where each package stands
+  ods coverage ods --check          # fail on a regression (what CI runs)
+  ods coverage ods --update         # record today's numbers as the new floors
+  ods coverage ods --profile /tmp/cover.out
+
+Suites:`)
+	for _, suite := range testsuite.All() {
+		fmt.Fprintf(&b, "\n  %-12s %s", suite.Name, suite.Short)
+	}
+	return b.String()
+}

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -40,7 +40,9 @@ func NewCoverageCommand() *cobra.Command {
 			return testsuite.Names(), cobra.ShellCompDirectiveNoFileComp
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			runCoverage(args[0], opts)
+			if code := runCoverage(args[0], opts); code != 0 {
+				os.Exit(code)
+			}
 		},
 	}
 
@@ -53,9 +55,14 @@ func NewCoverageCommand() *cobra.Command {
 	return cmd
 }
 
-func runCoverage(target string, opts *CoverageOptions) {
+// runCoverage returns the process exit code rather than exiting, so the
+// temporary profile directory is always removed on the way out.
+func runCoverage(target string, opts *CoverageOptions) int {
 	if opts.Check && opts.Update {
 		log.Fatal("--check and --update do the opposite of each other; pass only one")
+	}
+	if err := coverage.ValidateTolerance(opts.Tolerance); err != nil {
+		log.Fatalf("Invalid --tolerance: %v", err)
 	}
 
 	root, err := paths.GitRoot()
@@ -85,36 +92,39 @@ func runCoverage(target string, opts *CoverageOptions) {
 	if errors.As(err, &exitErr) {
 		// The tests failed, and their output is already on the terminal.
 		// Coverage from a failed run is not worth reporting.
-		os.Exit(exitErr.Code)
+		return exitErr.Code
 	}
 	if err != nil {
-		log.Fatalf("Failed to measure coverage: %v", err)
+		log.Errorf("Failed to measure coverage: %v", err)
+		return 1
 	}
 
 	baselinePath := coverage.BaselinePath(moduleDir)
 
 	if opts.Update {
-		writeBaseline(baselinePath, profile)
-		return
+		return writeBaseline(baselinePath, profile)
 	}
 
 	baseline, err := coverage.LoadBaseline(baselinePath)
 	if errors.Is(err, os.ErrNotExist) {
 		if opts.Check {
-			log.Fatalf("No baseline at %s. Create one with: ods coverage %s --update", baselinePath, suite.Name)
+			log.Errorf("No baseline at %s. Create one with: ods coverage %s --update", baselinePath, suite.Name)
+			return 1
 		}
 		log.Warnf("No baseline at %s; create one with: ods coverage %s --update", baselinePath, suite.Name)
 		baseline = nil
 	} else if err != nil {
-		log.Fatalf("Failed to read the baseline: %v", err)
+		log.Errorf("Failed to read the baseline: %v", err)
+		return 1
 	}
 
 	report := coverage.Compare(profile, baseline, opts.Tolerance)
 	if err := coverage.WriteReport(os.Stdout, report); err != nil {
-		log.Fatalf("Failed to write the report: %v", err)
+		log.Errorf("Failed to write the report: %v", err)
+		return 1
 	}
 
-	if profilePath == opts.Profile {
+	if opts.Profile != "" {
 		log.Infof("Coverage profile written to %s", profilePath)
 		log.Infof("Browse it with: go tool cover -html=%s", profilePath)
 	}
@@ -125,36 +135,45 @@ func runCoverage(target string, opts *CoverageOptions) {
 	}
 
 	if !opts.Check {
-		return
+		return 0
 	}
 	regressions := report.Regressions()
 	if len(regressions) == 0 {
 		log.Infof("Coverage holds at or above the baseline in %s", baselinePath)
-		return
+		return 0
 	}
 	for _, regression := range regressions {
 		log.Errorf("%s fell to %.1f%%, below its %.1f%% floor", regression.Package, regression.Percent, regression.Floor)
 	}
-	log.Fatalf("Coverage regressed in %d package(s). Add tests, or justify the drop and run: ods coverage %s --update",
+	log.Errorf("Coverage regressed in %d package(s). Add tests, or justify the drop and run: ods coverage %s --update",
 		len(regressions), suite.Name)
+	return 1
 }
 
-func writeBaseline(baselinePath string, profile *coverage.Profile) {
+func writeBaseline(baselinePath string, profile *coverage.Profile) int {
 	baseline := coverage.NewBaseline(profile)
 	if err := baseline.Save(baselinePath); err != nil {
-		log.Fatalf("Failed to write the baseline: %v", err)
+		log.Errorf("Failed to write the baseline: %v", err)
+		return 1
 	}
 	// Report the floor that was recorded, not the raw measurement, so the
 	// number here matches the file.
 	log.Infof("Wrote %s with a %.1f%% total coverage floor across %d packages",
 		baselinePath, baseline.Total, len(baseline.Packages))
+	return 0
 }
 
 // profileTarget resolves where the coverage profile is written. Without an
-// explicit path it goes to a temporary file that is removed afterwards.
+// explicit path it goes to a temporary file that is removed afterwards. A
+// requested path is made absolute, since go test writes it relative to the
+// module directory while we read it relative to the caller's.
 func profileTarget(requested string) (string, func()) {
 	if requested != "" {
-		return requested, func() {}
+		absolute, err := filepath.Abs(requested)
+		if err != nil {
+			log.Fatalf("Failed to resolve the profile path %q: %v", requested, err)
+		}
+		return absolute, func() {}
 	}
 	dir, err := os.MkdirTemp("", "ods-coverage")
 	if err != nil {

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -105,13 +105,11 @@ func runCoverage(target string, opts *CoverageOptions) int {
 		return writeBaseline(baselinePath, profile)
 	}
 
+	// A module opts into the gate by committing a baseline. Without one the
+	// tests still run and the report still prints, but nothing can regress.
 	baseline, err := coverage.LoadBaseline(baselinePath)
 	if errors.Is(err, os.ErrNotExist) {
-		if opts.Check {
-			log.Errorf("No baseline at %s. Create one with: ods coverage %s --update", baselinePath, suite.Name)
-			return 1
-		}
-		log.Warnf("No baseline at %s; create one with: ods coverage %s --update", baselinePath, suite.Name)
+		log.Warnf("No baseline at %s, so nothing is gated. Opt in with: ods coverage %s --update", baselinePath, suite.Name)
 		baseline = nil
 	} else if err != nil {
 		log.Errorf("Failed to read the baseline: %v", err)
@@ -134,7 +132,7 @@ func runCoverage(target string, opts *CoverageOptions) int {
 			len(improvements), suite.Name)
 	}
 
-	if !opts.Check {
+	if !opts.Check || baseline == nil {
 		return 0
 	}
 	regressions := report.Regressions()

--- a/tools/ods/cmd/coverage.go
+++ b/tools/ods/cmd/coverage.go
@@ -20,6 +20,8 @@ type CoverageOptions struct {
 	Check     bool
 	Update    bool
 	Profile   string
+	HTML      string
+	Markdown  string
 	Tolerance float64
 }
 
@@ -49,6 +51,8 @@ func NewCoverageCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Check, "check", false, "Fail when a package drops below its baseline floor")
 	cmd.Flags().BoolVar(&opts.Update, "update", false, "Rewrite the baseline from this run")
 	cmd.Flags().StringVar(&opts.Profile, "profile", "", "Keep the coverage profile at this path, for go tool cover -html")
+	cmd.Flags().StringVar(&opts.HTML, "html", "", "Render the profile as a browsable page at this path")
+	cmd.Flags().StringVar(&opts.Markdown, "markdown", "", "Write the report as markdown at this path, for a PR comment or job summary")
 	cmd.Flags().Float64Var(&opts.Tolerance, "tolerance", coverage.DefaultTolerance,
 		"Percentage points a package may drop below its floor without failing")
 
@@ -99,6 +103,19 @@ func runCoverage(target string, opts *CoverageOptions) int {
 		return 1
 	}
 
+	if opts.HTML != "" {
+		htmlPath, err := filepath.Abs(opts.HTML)
+		if err != nil {
+			log.Errorf("Failed to resolve the html path %q: %v", opts.HTML, err)
+			return 1
+		}
+		if err := coverage.WriteHTML(moduleDir, profilePath, htmlPath); err != nil {
+			log.Errorf("Failed to render the html report: %v", err)
+			return 1
+		}
+		log.Infof("HTML report written to %s", htmlPath)
+	}
+
 	baselinePath := coverage.BaselinePath(moduleDir)
 
 	if opts.Update {
@@ -120,6 +137,14 @@ func runCoverage(target string, opts *CoverageOptions) int {
 	if err := coverage.WriteReport(os.Stdout, report); err != nil {
 		log.Errorf("Failed to write the report: %v", err)
 		return 1
+	}
+
+	if opts.Markdown != "" {
+		if err := writeMarkdown(opts.Markdown, suite.Dir, report); err != nil {
+			log.Errorf("Failed to write the markdown report: %v", err)
+			return 1
+		}
+		log.Infof("Markdown report written to %s", opts.Markdown)
 	}
 
 	if opts.Profile != "" {
@@ -159,6 +184,18 @@ func writeBaseline(baselinePath string, profile *coverage.Profile) int {
 	log.Infof("Wrote %s with a %.1f%% total coverage floor across %d packages",
 		baselinePath, baseline.Total, len(baseline.Packages))
 	return 0
+}
+
+func writeMarkdown(path, name string, report *coverage.Report) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return coverage.WriteMarkdown(f, name, report)
 }
 
 // profileTarget resolves where the coverage profile is written. Without an

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -64,6 +64,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewRunCICommand())
 	cmd.AddCommand(NewScreenshotDiffCommand())
 	cmd.AddCommand(NewTestCommand())
+	cmd.AddCommand(NewCoverageCommand())
 	cmd.AddCommand(NewDesktopCommand())
 	cmd.AddCommand(NewDevCommand())
 	cmd.AddCommand(NewWebCommand())

--- a/tools/ods/internal/coverage/baseline.go
+++ b/tools/ods/internal/coverage/baseline.go
@@ -52,7 +52,32 @@ func LoadBaseline(path string) (*Baseline, error) {
 	if baseline.Packages == nil {
 		baseline.Packages = map[string]float64{}
 	}
+	if err := baseline.validate(); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
 	return &baseline, nil
+}
+
+// validate rejects floors that cannot be a percentage. A NaN or negative floor
+// passes every comparison, so a hand-edited baseline must fail loudly rather
+// than silently turn the gate off.
+func (b *Baseline) validate() error {
+	if err := validateFloor("total", b.Total); err != nil {
+		return err
+	}
+	for name, floor := range b.Packages {
+		if err := validateFloor(name, floor); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFloor(name string, floor float64) error {
+	if math.IsNaN(floor) || floor < 0 || floor > 100 {
+		return fmt.Errorf("floor for %s must be between 0 and 100, got %v", name, floor)
+	}
+	return nil
 }
 
 // NewBaseline builds a baseline from a measured profile. Every percentage is

--- a/tools/ods/internal/coverage/baseline.go
+++ b/tools/ods/internal/coverage/baseline.go
@@ -1,0 +1,96 @@
+package coverage
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BaselineFile is the name of the committed baseline, kept at the root of the
+// module it describes.
+const BaselineFile = ".coverage-baseline.yaml"
+
+// baselineHeader is written above the generated content so a reader of the file
+// knows how it is maintained.
+const baselineHeader = `# Minimum statement coverage per package, in percent.
+#
+# ` + "`ods coverage <suite> --check`" + ` fails when a package drops below its floor,
+# which is how CI keeps coverage from regressing. Raise the floors after adding
+# tests with ` + "`ods coverage <suite> --update`" + `.
+#
+# Generated file: do not edit by hand.
+`
+
+// Baseline is the committed coverage floor for a module.
+type Baseline struct {
+	// Total is the floor for the module as a whole.
+	Total float64 `yaml:"total"`
+	// Packages maps a module-relative package path to its floor.
+	Packages map[string]float64 `yaml:"packages"`
+}
+
+// BaselinePath returns the baseline path for a module directory.
+func BaselinePath(moduleDir string) string {
+	return filepath.Join(moduleDir, BaselineFile)
+}
+
+// LoadBaseline reads a baseline from disk.
+func LoadBaseline(path string) (*Baseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var baseline Baseline
+	if err := yaml.Unmarshal(data, &baseline); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if baseline.Packages == nil {
+		baseline.Packages = map[string]float64{}
+	}
+	return &baseline, nil
+}
+
+// NewBaseline builds a baseline from a measured profile. Every percentage is
+// rounded down to one decimal, so a floor is never above what the run actually
+// achieved and re-running the same tests cannot fail the check.
+func NewBaseline(profile *Profile) *Baseline {
+	baseline := &Baseline{
+		Total:    floorPercent(profile.Total()),
+		Packages: make(map[string]float64, len(profile.Packages)),
+	}
+	for _, pkg := range profile.Packages {
+		baseline.Packages[pkg.Package] = floorPercent(pkg.Percent())
+	}
+	return baseline
+}
+
+// Save writes the baseline to disk. yaml.v3 sorts map keys, so the output is
+// stable across runs and diffs stay readable.
+func (b *Baseline) Save(path string) error {
+	var body bytes.Buffer
+	body.WriteString(baselineHeader)
+
+	encoder := yaml.NewEncoder(&body)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(b); err != nil {
+		return fmt.Errorf("encode baseline: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("encode baseline: %w", err)
+	}
+
+	if err := os.WriteFile(path, body.Bytes(), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// floorPercent rounds a percentage down to one decimal place.
+func floorPercent(percent float64) float64 {
+	return math.Floor(percent*10) / 10
+}

--- a/tools/ods/internal/coverage/baseline_test.go
+++ b/tools/ods/internal/coverage/baseline_test.go
@@ -101,6 +101,25 @@ func TestLoadBaseline_rejectsMalformedYAML(t *testing.T) {
 	}
 }
 
+// A floor that is not a percentage passes every comparison, which would turn
+// the gate off without anyone noticing.
+func TestLoadBaseline_rejectsInvalidFloors(t *testing.T) {
+	for _, contents := range []string{
+		"total: .nan\npackages: {}\n",
+		"total: -1\npackages: {}\n",
+		"total: 0\npackages:\n  cmd: 101\n",
+		"total: 0\npackages:\n  cmd: .inf\n",
+	} {
+		path := filepath.Join(t.TempDir(), BaselineFile)
+		if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+			t.Fatalf("failed to write the fixture: %v", err)
+		}
+		if _, err := LoadBaseline(path); err == nil {
+			t.Fatalf("expected an error for:\n%s", contents)
+		}
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/tools/ods/internal/coverage/baseline_test.go
+++ b/tools/ods/internal/coverage/baseline_test.go
@@ -1,0 +1,111 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewBaseline_roundsFloorsDown(t *testing.T) {
+	// 2/3 is 66.66...%, which must not become a 66.7% floor the same run
+	// would then fail against.
+	baseline := NewBaseline(profileOf(map[string][2]int{"cmd": {2, 3}}))
+
+	if got := baseline.Packages["cmd"]; got != 66.6 {
+		t.Fatalf("expected a 66.6 floor, got %v", got)
+	}
+}
+
+// The floor a run records must always pass a check of that same run.
+func TestNewBaseline_isSelfConsistent(t *testing.T) {
+	profile := profileOf(map[string][2]int{
+		"cmd":            {2, 3},
+		"internal/audit": {1, 7},
+		"internal/empty": {0, 0},
+	})
+
+	report := Compare(profile, NewBaseline(profile), 0)
+
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("a fresh baseline must not fail its own run, got %d regressions", got)
+	}
+}
+
+func TestBaseline_saveAndLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), BaselineFile)
+	original := NewBaseline(profileOf(map[string][2]int{"cmd": {1, 4}, "internal/audit": {1, 2}}))
+
+	if err := original.Save(path); err != nil {
+		t.Fatalf("failed to save the baseline: %v", err)
+	}
+	loaded, err := LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("failed to load the baseline: %v", err)
+	}
+
+	if loaded.Total != original.Total {
+		t.Fatalf("expected total %v, got %v", original.Total, loaded.Total)
+	}
+	if len(loaded.Packages) != len(original.Packages) {
+		t.Fatalf("expected %d packages, got %d", len(original.Packages), len(loaded.Packages))
+	}
+	for name, floor := range original.Packages {
+		if loaded.Packages[name] != floor {
+			t.Fatalf("expected %s at %v, got %v", name, floor, loaded.Packages[name])
+		}
+	}
+}
+
+func TestBaseline_saveIsDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	baseline := NewBaseline(profileOf(map[string][2]int{
+		"cmd": {1, 4}, "internal/audit": {1, 2}, "internal/tui": {3, 4},
+	}))
+
+	first := filepath.Join(dir, "first.yaml")
+	second := filepath.Join(dir, "second.yaml")
+	if err := baseline.Save(first); err != nil {
+		t.Fatalf("failed to save the baseline: %v", err)
+	}
+	if err := baseline.Save(second); err != nil {
+		t.Fatalf("failed to save the baseline: %v", err)
+	}
+
+	// A baseline that reorders between runs would show up as a diff on every
+	// update, so key order has to be stable.
+	firstData := readFile(t, first)
+	if firstData != readFile(t, second) {
+		t.Fatal("expected two saves of the same baseline to be byte-identical")
+	}
+	if !strings.Contains(firstData, "# Minimum statement coverage") {
+		t.Fatalf("expected the explanatory header, got:\n%s", firstData)
+	}
+}
+
+func TestLoadBaseline_missingFileReportsNotExist(t *testing.T) {
+	_, err := LoadBaseline(filepath.Join(t.TempDir(), BaselineFile))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected a not-exist error, got %v", err)
+	}
+}
+
+func TestLoadBaseline_rejectsMalformedYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), BaselineFile)
+	if err := os.WriteFile(path, []byte("total: [not a number\n"), 0644); err != nil {
+		t.Fatalf("failed to write the fixture: %v", err)
+	}
+
+	if _, err := LoadBaseline(path); err == nil {
+		t.Fatal("expected an error for malformed YAML")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/tools/ods/internal/coverage/check.go
+++ b/tools/ods/internal/coverage/check.go
@@ -132,6 +132,20 @@ func (r *Report) Improvements() []Result {
 	return out
 }
 
+// Changed reports whether any package moved against a baseline. A run with no
+// baseline has nothing to change against.
+func (r *Report) Changed() bool {
+	if r.Total.Status == StatusNew {
+		return false
+	}
+	for _, pkg := range r.Packages {
+		if pkg.Status != StatusOK {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateTolerance rejects a tolerance that would make the comparison
 // meaningless. NaN and +Inf make every comparison pass, and a negative value
 // fails a package that holds exactly at its floor.

--- a/tools/ods/internal/coverage/check.go
+++ b/tools/ods/internal/coverage/check.go
@@ -1,0 +1,133 @@
+package coverage
+
+import "sort"
+
+// DefaultTolerance is how far below its floor a package may sit without failing
+// the check, in percentage points. Statement coverage is deterministic for
+// deterministic tests, but a few suites depend on ports or timing, so a small
+// allowance keeps the gate from flagging noise as a regression.
+const DefaultTolerance = 0.1
+
+// Status is the verdict for one package.
+type Status string
+
+const (
+	// StatusOK means coverage held at or above the floor.
+	StatusOK Status = "ok"
+	// StatusImproved means coverage rose above the floor, so the baseline is
+	// now stale and can be raised.
+	StatusImproved Status = "improved"
+	// StatusRegressed means coverage fell below the floor. This fails the check.
+	StatusRegressed Status = "regressed"
+	// StatusNew means the package has no floor yet.
+	StatusNew Status = "new"
+	// StatusRemoved means the baseline names a package the run did not report.
+	StatusRemoved Status = "removed"
+)
+
+// Result is the comparison of one package against its floor.
+type Result struct {
+	// Package is the module-relative package path, or "total" for the module.
+	Package string
+	// Percent is the coverage measured by this run. It is meaningless when
+	// Status is StatusRemoved.
+	Percent float64
+	// Floor is the baseline value. It is meaningless when Status is StatusNew.
+	Floor  float64
+	Status Status
+}
+
+// Report is the outcome of comparing a profile against a baseline.
+type Report struct {
+	// Total compares the module as a whole.
+	Total Result
+	// Packages compares each package, sorted by package path.
+	Packages []Result
+	// Tolerance is the allowance the comparison used, in percentage points.
+	Tolerance float64
+}
+
+// Compare checks a measured profile against a baseline. A nil baseline reports
+// every package as new, which is what a first run sees.
+func Compare(profile *Profile, baseline *Baseline, tolerance float64) *Report {
+	report := &Report{
+		Packages:  make([]Result, 0, len(profile.Packages)),
+		Tolerance: tolerance,
+	}
+
+	if baseline == nil {
+		baseline = &Baseline{Packages: map[string]float64{}}
+		report.Total = Result{Package: "total", Percent: profile.Total(), Status: StatusNew}
+	} else {
+		report.Total = compareOne("total", profile.Total(), baseline.Total, true, tolerance)
+	}
+
+	seen := make(map[string]bool, len(profile.Packages))
+	for _, pkg := range profile.Packages {
+		seen[pkg.Package] = true
+		floor, hasFloor := baseline.Packages[pkg.Package]
+		report.Packages = append(report.Packages, compareOne(pkg.Package, pkg.Percent(), floor, hasFloor, tolerance))
+	}
+
+	// A package in the baseline but not in the run was deleted or renamed.
+	// Report it so the stale row gets cleaned up, but do not fail on it.
+	for name, floor := range baseline.Packages {
+		if !seen[name] {
+			report.Packages = append(report.Packages, Result{
+				Package: name,
+				Floor:   floor,
+				Status:  StatusRemoved,
+			})
+		}
+	}
+
+	sort.Slice(report.Packages, func(i, j int) bool {
+		return report.Packages[i].Package < report.Packages[j].Package
+	})
+	return report
+}
+
+func compareOne(name string, percent, floor float64, hasFloor bool, tolerance float64) Result {
+	result := Result{Package: name, Percent: percent, Floor: floor}
+	switch {
+	case !hasFloor:
+		result.Status = StatusNew
+	case percent < floor-tolerance:
+		result.Status = StatusRegressed
+	case percent > floor+tolerance:
+		result.Status = StatusImproved
+	default:
+		result.Status = StatusOK
+	}
+	return result
+}
+
+// Regressions returns the packages that fell below their floor, plus the module
+// total when it regressed. An empty result means the check passes.
+func (r *Report) Regressions() []Result {
+	var out []Result
+	if r.Total.Status == StatusRegressed {
+		out = append(out, r.Total)
+	}
+	for _, pkg := range r.Packages {
+		if pkg.Status == StatusRegressed {
+			out = append(out, pkg)
+		}
+	}
+	return out
+}
+
+// Improvements returns the packages that rose above their floor, plus the
+// module total when it improved. These are what `--update` would record.
+func (r *Report) Improvements() []Result {
+	var out []Result
+	if r.Total.Status == StatusImproved {
+		out = append(out, r.Total)
+	}
+	for _, pkg := range r.Packages {
+		if pkg.Status == StatusImproved {
+			out = append(out, pkg)
+		}
+	}
+	return out
+}

--- a/tools/ods/internal/coverage/check.go
+++ b/tools/ods/internal/coverage/check.go
@@ -1,6 +1,10 @@
 package coverage
 
-import "sort"
+import (
+	"fmt"
+	"math"
+	"sort"
+)
 
 // DefaultTolerance is how far below its floor a package may sit without failing
 // the check, in percentage points. Statement coverage is deterministic for
@@ -39,7 +43,9 @@ type Result struct {
 
 // Report is the outcome of comparing a profile against a baseline.
 type Report struct {
-	// Total compares the module as a whole.
+	// Total compares the module as a whole. It is reported but never gated:
+	// the package floors are the gate, and a package added or deleted moves
+	// the total without any package regressing.
 	Total Result
 	// Packages compares each package, sorted by package path.
 	Packages []Result
@@ -102,13 +108,10 @@ func compareOne(name string, percent, floor float64, hasFloor bool, tolerance fl
 	return result
 }
 
-// Regressions returns the packages that fell below their floor, plus the module
-// total when it regressed. An empty result means the check passes.
+// Regressions returns the packages that fell below their floor. An empty
+// result means the check passes. The module total is not included: see Report.
 func (r *Report) Regressions() []Result {
 	var out []Result
-	if r.Total.Status == StatusRegressed {
-		out = append(out, r.Total)
-	}
 	for _, pkg := range r.Packages {
 		if pkg.Status == StatusRegressed {
 			out = append(out, pkg)
@@ -117,17 +120,24 @@ func (r *Report) Regressions() []Result {
 	return out
 }
 
-// Improvements returns the packages that rose above their floor, plus the
-// module total when it improved. These are what `--update` would record.
+// Improvements returns the packages that rose above their floor. These are
+// what `--update` would record.
 func (r *Report) Improvements() []Result {
 	var out []Result
-	if r.Total.Status == StatusImproved {
-		out = append(out, r.Total)
-	}
 	for _, pkg := range r.Packages {
 		if pkg.Status == StatusImproved {
 			out = append(out, pkg)
 		}
 	}
 	return out
+}
+
+// ValidateTolerance rejects a tolerance that would make the comparison
+// meaningless. NaN and +Inf make every comparison pass, and a negative value
+// fails a package that holds exactly at its floor.
+func ValidateTolerance(tolerance float64) error {
+	if math.IsNaN(tolerance) || math.IsInf(tolerance, 0) || tolerance < 0 {
+		return fmt.Errorf("tolerance must be a finite number of at least 0, got %v", tolerance)
+	}
+	return nil
 }

--- a/tools/ods/internal/coverage/check_test.go
+++ b/tools/ods/internal/coverage/check_test.go
@@ -1,6 +1,9 @@
 package coverage
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func profileOf(percents map[string][2]int) *Profile {
 	profile := &Profile{}
@@ -34,8 +37,8 @@ func TestCompare_regressionBelowFloor(t *testing.T) {
 	if got := statusOf(t, report, "cmd"); got != StatusRegressed {
 		t.Fatalf("expected a regression, got %q", got)
 	}
-	if got := len(report.Regressions()); got != 2 {
-		t.Fatalf("expected the package and the total to regress, got %d", got)
+	if got := len(report.Regressions()); got != 1 {
+		t.Fatalf("expected one regression, got %d", got)
 	}
 }
 
@@ -75,8 +78,8 @@ func TestCompare_improvementIsReported(t *testing.T) {
 	if got := statusOf(t, report, "cmd"); got != StatusImproved {
 		t.Fatalf("expected an improvement, got %q", got)
 	}
-	if got := len(report.Improvements()); got != 2 {
-		t.Fatalf("expected the package and the total to improve, got %d", got)
+	if got := len(report.Improvements()); got != 1 {
+		t.Fatalf("expected one improvement, got %d", got)
 	}
 	if got := len(report.Regressions()); got != 0 {
 		t.Fatalf("an improvement must not fail the check, got %d regressions", got)
@@ -96,6 +99,35 @@ func TestCompare_newPackageDoesNotFail(t *testing.T) {
 	}
 	if got := len(report.Regressions()); got != 0 {
 		t.Fatalf("expected no regressions, got %d", got)
+	}
+}
+
+// A new package with no tests lowers the module total. The total is reported
+// but not gated, so that cannot fail a check the package was never measured for.
+func TestCompare_newPackageLoweringTotalDoesNotFail(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}, "internal/new": {0, 10}})
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if report.Total.Status != StatusRegressed {
+		t.Fatalf("expected the total reported as regressed, got %q", report.Total.Status)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}
+
+func TestValidateTolerance(t *testing.T) {
+	for _, valid := range []float64{0, 0.1, 5} {
+		if err := ValidateTolerance(valid); err != nil {
+			t.Fatalf("expected %v accepted: %v", valid, err)
+		}
+	}
+	for _, invalid := range []float64{-0.1, math.NaN(), math.Inf(1)} {
+		if err := ValidateTolerance(invalid); err == nil {
+			t.Fatalf("expected %v rejected", invalid)
+		}
 	}
 }
 

--- a/tools/ods/internal/coverage/check_test.go
+++ b/tools/ods/internal/coverage/check_test.go
@@ -118,6 +118,24 @@ func TestCompare_newPackageLoweringTotalDoesNotFail(t *testing.T) {
 	}
 }
 
+func TestReport_Changed(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}, "internal/new": {1, 2}})
+	cases := map[string]struct {
+		baseline *Baseline
+		want     bool
+	}{
+		"holding":     {&Baseline{Total: 50, Packages: map[string]float64{"cmd": 50, "internal/new": 50}}, false},
+		"improved":    {&Baseline{Total: 50, Packages: map[string]float64{"cmd": 10, "internal/new": 50}}, true},
+		"new package": {&Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}, true},
+		"no baseline": {nil, false},
+	}
+	for name, tc := range cases {
+		if got := Compare(profile, tc.baseline, DefaultTolerance).Changed(); got != tc.want {
+			t.Errorf("%s: Changed() = %v, want %v", name, got, tc.want)
+		}
+	}
+}
+
 func TestValidateTolerance(t *testing.T) {
 	for _, valid := range []float64{0, 0.1, 5} {
 		if err := ValidateTolerance(valid); err != nil {

--- a/tools/ods/internal/coverage/check_test.go
+++ b/tools/ods/internal/coverage/check_test.go
@@ -1,0 +1,130 @@
+package coverage
+
+import "testing"
+
+func profileOf(percents map[string][2]int) *Profile {
+	profile := &Profile{}
+	for name, counts := range percents {
+		profile.Packages = append(profile.Packages, PackageCoverage{
+			Package: name,
+			Covered: counts[0],
+			Total:   counts[1],
+		})
+	}
+	return profile
+}
+
+func statusOf(t *testing.T, report *Report, pkg string) Status {
+	t.Helper()
+	for _, result := range report.Packages {
+		if result.Package == pkg {
+			return result.Status
+		}
+	}
+	t.Fatalf("package %q missing from the report", pkg)
+	return ""
+}
+
+func TestCompare_regressionBelowFloor(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 4}}) // 25%
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusRegressed {
+		t.Fatalf("expected a regression, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 2 {
+		t.Fatalf("expected the package and the total to regress, got %d", got)
+	}
+}
+
+func TestCompare_holdingAtTheFloorPasses(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}}) // 50%
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusOK {
+		t.Fatalf("expected ok, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}
+
+// A drop inside the tolerance is noise, not a regression, so it must not fail
+// the gate.
+func TestCompare_dropInsideToleranceIsNotARegression(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {999, 1000}}) // 99.9%
+	baseline := &Baseline{Total: 99.9, Packages: map[string]float64{"cmd": 100}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusOK {
+		t.Fatalf("expected the 0.1 drop tolerated, got %q", got)
+	}
+}
+
+func TestCompare_improvementIsReported(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {3, 4}}) // 75%
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusImproved {
+		t.Fatalf("expected an improvement, got %q", got)
+	}
+	if got := len(report.Improvements()); got != 2 {
+		t.Fatalf("expected the package and the total to improve, got %d", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("an improvement must not fail the check, got %d regressions", got)
+	}
+}
+
+// A package added without tests has no floor. It is reported so it gets a floor,
+// but it cannot fail a check it was never measured for.
+func TestCompare_newPackageDoesNotFail(t *testing.T) {
+	profile := profileOf(map[string][2]int{"internal/new": {0, 10}})
+	baseline := &Baseline{Total: 0, Packages: map[string]float64{}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "internal/new"); got != StatusNew {
+		t.Fatalf("expected new, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}
+
+func TestCompare_removedPackageIsReportedNotFailed(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}})
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50, "internal/gone": 90}}
+
+	report := Compare(profile, baseline, DefaultTolerance)
+
+	if got := statusOf(t, report, "internal/gone"); got != StatusRemoved {
+		t.Fatalf("expected removed, got %q", got)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("a deleted package must not fail the check, got %d", got)
+	}
+}
+
+func TestCompare_noBaselineMarksEverythingNew(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}})
+
+	report := Compare(profile, nil, DefaultTolerance)
+
+	if got := statusOf(t, report, "cmd"); got != StatusNew {
+		t.Fatalf("expected new, got %q", got)
+	}
+	if report.Total.Status != StatusNew {
+		t.Fatalf("expected the total new, got %q", report.Total.Status)
+	}
+	if got := len(report.Regressions()); got != 0 {
+		t.Fatalf("expected no regressions, got %d", got)
+	}
+}

--- a/tools/ods/internal/coverage/html.go
+++ b/tools/ods/internal/coverage/html.go
@@ -1,0 +1,24 @@
+package coverage
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// WriteHTML renders a coverage profile as the browsable page produced by
+// `go tool cover -html`. It runs in moduleDir so the tool can find the sources
+// the profile names.
+func WriteHTML(moduleDir, profilePath, htmlPath string) error {
+	if err := os.MkdirAll(filepath.Dir(htmlPath), 0755); err != nil {
+		return fmt.Errorf("create html directory: %w", err)
+	}
+
+	cmd := exec.Command("go", "tool", "cover", "-html="+profilePath, "-o", htmlPath)
+	cmd.Dir = moduleDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go tool cover -html: %w: %s", err, out)
+	}
+	return nil
+}

--- a/tools/ods/internal/coverage/html_test.go
+++ b/tools/ods/internal/coverage/html_test.go
@@ -1,0 +1,42 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Builds a one-package module, runs its tests for a profile, and renders it.
+// This calls the real go toolchain, so it is the one test here that needs it.
+func TestWriteHTML_rendersTheProfile(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"go.mod":       "module example.com/tiny\n\ngo 1.21\n",
+		"tiny.go":      "package tiny\n\nfunc Yes() bool { return true }\n",
+		"tiny_test.go": "package tiny\n\nimport \"testing\"\n\nfunc TestYes(t *testing.T) { if !Yes() { t.Fatal() } }\n",
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	profilePath := filepath.Join(dir, "out", "coverage.out")
+	if _, err := Run(RunOptions{ModuleDir: dir, ProfilePath: profilePath}); err != nil {
+		t.Fatalf("failed to run the tests: %v", err)
+	}
+
+	htmlPath := filepath.Join(dir, "out", "html", "coverage.html")
+	if err := WriteHTML(dir, profilePath, htmlPath); err != nil {
+		t.Fatalf("failed to render html: %v", err)
+	}
+
+	html, err := os.ReadFile(htmlPath)
+	if err != nil {
+		t.Fatalf("failed to read the html: %v", err)
+	}
+	if !strings.Contains(string(html), "func Yes()") {
+		t.Fatalf("expected the source in the html, got %d bytes", len(html))
+	}
+}

--- a/tools/ods/internal/coverage/markdown.go
+++ b/tools/ods/internal/coverage/markdown.go
@@ -6,23 +6,43 @@ import (
 	"strings"
 )
 
+// Markers open a markdown report so a script can tell, without parsing the
+// table, whether the module is worth a reader's attention.
+const (
+	MarkerChanged    = "<!-- ods-coverage: changed -->"
+	MarkerUnchanged  = "<!-- ods-coverage: unchanged -->"
+	MarkerNoBaseline = "<!-- ods-coverage: no-baseline -->"
+)
+
 // WriteMarkdown renders a report as a GitHub-flavored markdown section for a
-// PR comment or job summary. A one-line verdict comes first; the per-package
-// table is collapsed so a comment covering several modules stays short.
+// PR comment or job summary. A marker line comes first, then a one-line
+// verdict. The table lists only the packages that moved, plus the total, so a
+// comment covering several modules stays short.
 func WriteMarkdown(w io.Writer, name string, report *Report) error {
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "#### `%s`\n\n%s\n\n", name, markdownSummary(report))
-	b.WriteString("<details>\n<summary>Per-package report</summary>\n\n")
+	fmt.Fprintf(&b, "%s\n#### `%s`\n\n%s\n\n", markdownMarker(report), name, markdownSummary(report))
 	b.WriteString("| Package | Coverage | Floor | Change |\n| --- | ---: | ---: | --- |\n")
 	for _, pkg := range report.Packages {
-		b.WriteString(markdownRow(pkg))
+		if pkg.Status != StatusOK {
+			b.WriteString(markdownRow(pkg))
+		}
 	}
 	b.WriteString(markdownTotalRow(report.Total))
-	b.WriteString("\n</details>\n")
 
 	_, err := io.WriteString(w, b.String())
 	return err
+}
+
+func markdownMarker(report *Report) string {
+	switch {
+	case report.Total.Status == StatusNew:
+		return MarkerNoBaseline
+	case report.Changed():
+		return MarkerChanged
+	default:
+		return MarkerUnchanged
+	}
 }
 
 // markdownSummary is the one line a reader needs: what moved, and the total.

--- a/tools/ods/internal/coverage/markdown.go
+++ b/tools/ods/internal/coverage/markdown.go
@@ -1,0 +1,80 @@
+package coverage
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// WriteMarkdown renders a report as a GitHub-flavored markdown section for a
+// PR comment or job summary. A one-line verdict comes first; the per-package
+// table is collapsed so a comment covering several modules stays short.
+func WriteMarkdown(w io.Writer, name string, report *Report) error {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "#### `%s`\n\n%s\n\n", name, markdownSummary(report))
+	b.WriteString("<details>\n<summary>Per-package report</summary>\n\n")
+	b.WriteString("| Package | Coverage | Floor | Change |\n| --- | ---: | ---: | --- |\n")
+	for _, pkg := range report.Packages {
+		b.WriteString(markdownRow(pkg))
+	}
+	b.WriteString(markdownTotalRow(report.Total))
+	b.WriteString("\n</details>\n")
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// markdownSummary is the one line a reader needs: what moved, and the total.
+func markdownSummary(report *Report) string {
+	if report.Total.Status == StatusNew {
+		return fmt.Sprintf("No baseline, so nothing to compare. Total coverage is %.1f%%.", report.Total.Percent)
+	}
+
+	counts := map[Status]int{}
+	for _, pkg := range report.Packages {
+		counts[pkg.Status]++
+	}
+	var parts []string
+	for _, status := range []Status{StatusRegressed, StatusImproved, StatusNew, StatusRemoved} {
+		if n := counts[status]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, status))
+		}
+	}
+
+	total := fmt.Sprintf("Total coverage is %.1f%% (%+.1f against the baseline).",
+		report.Total.Percent, report.Total.Percent-report.Total.Floor)
+	if len(parts) == 0 {
+		return "Every package holds at its floor. " + total
+	}
+	return fmt.Sprintf("Packages: %s. %s", strings.Join(parts, ", "), total)
+}
+
+func markdownRow(result Result) string {
+	percent := fmt.Sprintf("%.1f%%", result.Percent)
+	floor := fmt.Sprintf("%.1f%%", result.Floor)
+	change := ""
+
+	switch result.Status {
+	case StatusNew:
+		floor = ""
+		change = "new"
+	case StatusRemoved:
+		percent = ""
+		change = "removed"
+	case StatusRegressed:
+		change = fmt.Sprintf("**regressed by %.1f**", result.Floor-result.Percent)
+	case StatusImproved:
+		change = fmt.Sprintf("+%.1f", result.Percent-result.Floor)
+	}
+
+	return fmt.Sprintf("| %s | %s | %s | %s |\n", result.Package, percent, floor, change)
+}
+
+func markdownTotalRow(result Result) string {
+	if result.Status == StatusNew {
+		return fmt.Sprintf("| **total** | **%.1f%%** | | |\n", result.Percent)
+	}
+	return fmt.Sprintf("| **total** | **%.1f%%** | %.1f%% | %+.1f |\n",
+		result.Percent, result.Floor, result.Percent-result.Floor)
+}

--- a/tools/ods/internal/coverage/markdown_test.go
+++ b/tools/ods/internal/coverage/markdown_test.go
@@ -1,0 +1,71 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteMarkdown_showsEachStatus(t *testing.T) {
+	profile := profileOf(map[string][2]int{
+		"cmd":            {1, 4}, // 25%, below its 50 floor
+		"internal/audit": {3, 4}, // 75%, above its 50 floor
+		"internal/new":   {1, 2}, // no floor
+	})
+	baseline := &Baseline{
+		Total:    50,
+		Packages: map[string]float64{"cmd": 50, "internal/audit": 50, "internal/gone": 90},
+	}
+
+	var out strings.Builder
+	if err := WriteMarkdown(&out, "tools/ods", Compare(profile, baseline, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the markdown: %v", err)
+	}
+	got := out.String()
+
+	for _, want := range []string{
+		"#### `tools/ods`",
+		"Packages: 1 regressed, 1 improved, 1 new, 1 removed.",
+		"| cmd | 25.0% | 50.0% | **regressed by 25.0** |",
+		"| internal/audit | 75.0% | 50.0% | +25.0 |",
+		"| internal/new | 50.0% |  | new |",
+		"| internal/gone |  | 90.0% | removed |",
+		"| **total** | **50.0%** | 50.0% | +0.0 |",
+		"<details>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteMarkdown_holdingBaselineSaysSo(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}})
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	var out strings.Builder
+	if err := WriteMarkdown(&out, "tools/ods", Compare(profile, baseline, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the markdown: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Every package holds at its floor.") {
+		t.Fatalf("expected the holding verdict in:\n%s", out.String())
+	}
+}
+
+func TestWriteMarkdown_noBaseline(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}})
+
+	var out strings.Builder
+	if err := WriteMarkdown(&out, "cli", Compare(profile, nil, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the markdown: %v", err)
+	}
+
+	for _, want := range []string{
+		"No baseline, so nothing to compare. Total coverage is 50.0%.",
+		"| **total** | **50.0%** | | |",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected %q in:\n%s", want, out.String())
+		}
+	}
+}

--- a/tools/ods/internal/coverage/markdown_test.go
+++ b/tools/ods/internal/coverage/markdown_test.go
@@ -23,18 +23,35 @@ func TestWriteMarkdown_showsEachStatus(t *testing.T) {
 	got := out.String()
 
 	for _, want := range []string{
-		"#### `tools/ods`",
+		MarkerChanged + "\n#### `tools/ods`",
 		"Packages: 1 regressed, 1 improved, 1 new, 1 removed.",
 		"| cmd | 25.0% | 50.0% | **regressed by 25.0** |",
 		"| internal/audit | 75.0% | 50.0% | +25.0 |",
 		"| internal/new | 50.0% |  | new |",
 		"| internal/gone |  | 90.0% | removed |",
 		"| **total** | **50.0%** | 50.0% | +0.0 |",
-		"<details>",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in:\n%s", want, got)
 		}
+	}
+}
+
+// A package that holds at its floor is noise in a PR comment.
+func TestWriteMarkdown_omitsUnchangedPackages(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}, "internal/audit": {3, 4}})
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50, "internal/audit": 50}}
+
+	var out strings.Builder
+	if err := WriteMarkdown(&out, "tools/ods", Compare(profile, baseline, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the markdown: %v", err)
+	}
+
+	if strings.Contains(out.String(), "| cmd |") {
+		t.Errorf("expected the unchanged package omitted:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "| internal/audit | 75.0% | 50.0% | +25.0 |") {
+		t.Errorf("expected the improved package listed:\n%s", out.String())
 	}
 }
 
@@ -47,8 +64,10 @@ func TestWriteMarkdown_holdingBaselineSaysSo(t *testing.T) {
 		t.Fatalf("failed to write the markdown: %v", err)
 	}
 
-	if !strings.Contains(out.String(), "Every package holds at its floor.") {
-		t.Fatalf("expected the holding verdict in:\n%s", out.String())
+	for _, want := range []string{MarkerUnchanged, "Every package holds at its floor."} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected %q in:\n%s", want, out.String())
+		}
 	}
 }
 
@@ -61,6 +80,7 @@ func TestWriteMarkdown_noBaseline(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		MarkerNoBaseline,
 		"No baseline, so nothing to compare. Total coverage is 50.0%.",
 		"| **total** | **50.0%** | | |",
 	} {

--- a/tools/ods/internal/coverage/profile.go
+++ b/tools/ods/internal/coverage/profile.go
@@ -1,0 +1,170 @@
+// Package coverage measures Go statement coverage per package and compares it
+// against a committed baseline, so test coverage can only go up.
+package coverage
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// PackageCoverage holds the statement counts for one package.
+type PackageCoverage struct {
+	// Package is the package path relative to the module root, e.g.
+	// "internal/audit". The module root itself is ".".
+	Package string
+	// Covered is the number of statements run at least once.
+	Covered int
+	// Total is the number of statements in the package.
+	Total int
+}
+
+// Percent returns the covered fraction as a percentage. A package with no
+// statements counts as fully covered, matching `go tool cover`.
+func (p PackageCoverage) Percent() float64 {
+	if p.Total == 0 {
+		return 100
+	}
+	return float64(p.Covered) / float64(p.Total) * 100
+}
+
+// Profile is the parsed result of a `go test -coverprofile` run.
+type Profile struct {
+	// Packages is sorted by package path.
+	Packages []PackageCoverage
+}
+
+// Total returns the coverage percentage across every package.
+func (p Profile) Total() float64 {
+	var covered, total int
+	for _, pkg := range p.Packages {
+		covered += pkg.Covered
+		total += pkg.Total
+	}
+	if total == 0 {
+		return 100
+	}
+	return float64(covered) / float64(total) * 100
+}
+
+// block identifies one coverage block. The same block can appear more than once
+// in a profile, so blocks are merged by this key before counting.
+type block struct {
+	pkg  string
+	span string
+}
+
+// ParseProfile reads a coverage profile and aggregates it per package. Package
+// paths are made relative to modulePath.
+//
+// Profile lines look like:
+//
+//	example.com/m/internal/audit/osv.go:25.64,27.42 2 0
+//
+// which is <file>:<startLine>.<startCol>,<endLine>.<endCol> <statements> <count>.
+func ParseProfile(r io.Reader, modulePath string) (*Profile, error) {
+	counts := make(map[block]int)
+	stmts := make(map[block]int)
+
+	scanner := bufio.NewScanner(r)
+	// Coverage lines are short, but raise the limit so a long import path
+	// cannot truncate a profile into a wrong number.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+
+		b, numStmts, count, err := parseProfileLine(line, modulePath)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		stmts[b] = numStmts
+		counts[b] += count
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read coverage profile: %w", err)
+	}
+
+	byPkg := make(map[string]*PackageCoverage)
+	for b, numStmts := range stmts {
+		pkg, ok := byPkg[b.pkg]
+		if !ok {
+			pkg = &PackageCoverage{Package: b.pkg}
+			byPkg[b.pkg] = pkg
+		}
+		pkg.Total += numStmts
+		if counts[b] > 0 {
+			pkg.Covered += numStmts
+		}
+	}
+
+	profile := &Profile{Packages: make([]PackageCoverage, 0, len(byPkg))}
+	for _, pkg := range byPkg {
+		profile.Packages = append(profile.Packages, *pkg)
+	}
+	sort.Slice(profile.Packages, func(i, j int) bool {
+		return profile.Packages[i].Package < profile.Packages[j].Package
+	})
+	return profile, nil
+}
+
+// ParseProfileFile parses the coverage profile at the given path.
+func ParseProfileFile(profilePath, modulePath string) (*Profile, error) {
+	f, err := os.Open(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("open coverage profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return ParseProfile(f, modulePath)
+}
+
+func parseProfileLine(line, modulePath string) (block, int, int, error) {
+	fields := strings.Fields(line)
+	if len(fields) != 3 {
+		return block{}, 0, 0, fmt.Errorf("expected 3 fields, got %d: %q", len(fields), line)
+	}
+
+	sep := strings.LastIndex(fields[0], ":")
+	if sep < 0 {
+		return block{}, 0, 0, fmt.Errorf("missing block position: %q", line)
+	}
+
+	numStmts, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return block{}, 0, 0, fmt.Errorf("invalid statement count: %q", line)
+	}
+	count, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return block{}, 0, 0, fmt.Errorf("invalid execution count: %q", line)
+	}
+
+	file := fields[0][:sep]
+	return block{
+		pkg:  relativePackage(path.Dir(file), modulePath),
+		span: fields[0],
+	}, numStmts, count, nil
+}
+
+// relativePackage converts a full import path into a path relative to the
+// module root. Paths outside the module are returned unchanged.
+func relativePackage(importPath, modulePath string) string {
+	if modulePath == "" || importPath == modulePath {
+		if importPath == modulePath {
+			return "."
+		}
+		return importPath
+	}
+	if rel, ok := strings.CutPrefix(importPath, modulePath+"/"); ok {
+		return rel
+	}
+	return importPath
+}

--- a/tools/ods/internal/coverage/profile_test.go
+++ b/tools/ods/internal/coverage/profile_test.go
@@ -1,0 +1,111 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+const modulePath = "example.com/m"
+
+func TestParseProfile_aggregatesPerPackage(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/internal/audit/osv.go:1.1,2.2 3 1
+example.com/m/internal/audit/report.go:1.1,2.2 1 0
+example.com/m/cmd/root.go:1.1,2.2 4 1
+`)
+
+	if len(profile.Packages) != 2 {
+		t.Fatalf("expected 2 packages, got %d", len(profile.Packages))
+	}
+	// Sorted by package path, so cmd comes first.
+	if got := profile.Packages[0].Package; got != "cmd" {
+		t.Fatalf("expected cmd first, got %q", got)
+	}
+	if got := profile.Packages[1].Package; got != "internal/audit" {
+		t.Fatalf("expected internal/audit second, got %q", got)
+	}
+
+	audit := profile.Packages[1]
+	if audit.Covered != 3 || audit.Total != 4 {
+		t.Fatalf("expected 3/4 statements, got %d/%d", audit.Covered, audit.Total)
+	}
+	if got := audit.Percent(); got != 75 {
+		t.Fatalf("expected 75%%, got %v", got)
+	}
+}
+
+func TestParseProfile_totalSpansPackages(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/cmd/root.go:1.1,2.2 1 1
+example.com/m/internal/audit/osv.go:1.1,2.2 3 0
+`)
+
+	if got := profile.Total(); got != 25 {
+		t.Fatalf("expected 25%%, got %v", got)
+	}
+}
+
+// A block can appear more than once when several test binaries cover the same
+// package. Counting it twice would inflate the total, so blocks merge by span.
+func TestParseProfile_mergesRepeatedBlocks(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/cmd/root.go:1.1,2.2 2 0
+example.com/m/cmd/root.go:1.1,2.2 2 1
+`)
+
+	pkg := profile.Packages[0]
+	if pkg.Total != 2 {
+		t.Fatalf("expected the repeated block counted once, got %d statements", pkg.Total)
+	}
+	if pkg.Covered != 2 {
+		t.Fatalf("expected the block covered by the second run, got %d", pkg.Covered)
+	}
+}
+
+func TestParseProfile_moduleRootIsDot(t *testing.T) {
+	profile := mustParse(t, `mode: set
+example.com/m/main.go:1.1,2.2 1 1
+`)
+
+	if got := profile.Packages[0].Package; got != "." {
+		t.Fatalf("expected the module root as %q, got %q", ".", got)
+	}
+}
+
+func TestParseProfile_rejectsMalformedLine(t *testing.T) {
+	_, err := ParseProfile(strings.NewReader("mode: set\nexample.com/m/cmd/root.go:1.1,2.2 2\n"), modulePath)
+	if err == nil {
+		t.Fatal("expected an error for a line with too few fields")
+	}
+	if !strings.Contains(err.Error(), "line 2") {
+		t.Fatalf("expected the line number in the error, got %v", err)
+	}
+}
+
+func TestParseProfile_emptyProfileIsFullyCovered(t *testing.T) {
+	profile := mustParse(t, "mode: set\n")
+
+	if len(profile.Packages) != 0 {
+		t.Fatalf("expected no packages, got %d", len(profile.Packages))
+	}
+	// Matches `go tool cover`, which reports a package with no statements as
+	// covered rather than as a 0% failure.
+	if got := profile.Total(); got != 100 {
+		t.Fatalf("expected 100%%, got %v", got)
+	}
+}
+
+func TestPackageCoverage_percentOfNoStatements(t *testing.T) {
+	if got := (PackageCoverage{}).Percent(); got != 100 {
+		t.Fatalf("expected 100%%, got %v", got)
+	}
+}
+
+func mustParse(t *testing.T, profile string) *Profile {
+	t.Helper()
+	parsed, err := ParseProfile(strings.NewReader(profile), modulePath)
+	if err != nil {
+		t.Fatalf("failed to parse the profile: %v", err)
+	}
+	return parsed
+}

--- a/tools/ods/internal/coverage/report.go
+++ b/tools/ods/internal/coverage/report.go
@@ -1,0 +1,53 @@
+package coverage
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// WriteReport renders a report as an aligned table. Packages with no floor yet
+// show a blank floor column rather than a misleading zero.
+func WriteReport(w io.Writer, report *Report) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	if _, err := fmt.Fprintln(tw, "PACKAGE\tCOVERAGE\tFLOOR\t"); err != nil {
+		return err
+	}
+	for _, pkg := range report.Packages {
+		if err := writeRow(tw, pkg); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(tw, strings.Repeat("-", 8)+"\t"+strings.Repeat("-", 8)+"\t"+strings.Repeat("-", 8)+"\t\n"); err != nil {
+		return err
+	}
+	if err := writeRow(tw, report.Total); err != nil {
+		return err
+	}
+
+	return tw.Flush()
+}
+
+func writeRow(w io.Writer, result Result) error {
+	percent := fmt.Sprintf("%.1f%%", result.Percent)
+	floor := fmt.Sprintf("%.1f%%", result.Floor)
+	note := ""
+
+	switch result.Status {
+	case StatusNew:
+		floor = "-"
+		note = "new"
+	case StatusRemoved:
+		percent = "-"
+		note = "removed"
+	case StatusRegressed:
+		note = fmt.Sprintf("REGRESSED by %.1f", result.Floor-result.Percent)
+	case StatusImproved:
+		note = fmt.Sprintf("+%.1f", result.Percent-result.Floor)
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", result.Package, percent, floor, note)
+	return err
+}

--- a/tools/ods/internal/coverage/report.go
+++ b/tools/ods/internal/coverage/report.go
@@ -23,7 +23,7 @@ func WriteReport(w io.Writer, report *Report) error {
 	if _, err := fmt.Fprint(tw, strings.Repeat("-", 8)+"\t"+strings.Repeat("-", 8)+"\t"+strings.Repeat("-", 8)+"\t\n"); err != nil {
 		return err
 	}
-	if err := writeRow(tw, report.Total); err != nil {
+	if err := writeTotalRow(tw, report.Total); err != nil {
 		return err
 	}
 
@@ -49,5 +49,17 @@ func writeRow(w io.Writer, result Result) error {
 	}
 
 	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", result.Package, percent, floor, note)
+	return err
+}
+
+// writeTotalRow renders the module total. The total is not gated, so a drop
+// is shown as a signed delta rather than a regression.
+func writeTotalRow(w io.Writer, result Result) error {
+	if result.Status == StatusNew {
+		_, err := fmt.Fprintf(w, "%s\t%.1f%%\t-\t\n", result.Package, result.Percent)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "%s\t%.1f%%\t%.1f%%\t%+.1f\n",
+		result.Package, result.Percent, result.Floor, result.Percent-result.Floor)
 	return err
 }

--- a/tools/ods/internal/coverage/report_test.go
+++ b/tools/ods/internal/coverage/report_test.go
@@ -36,6 +36,24 @@ func TestWriteReport_showsEachStatus(t *testing.T) {
 	}
 }
 
+// The total is not gated, so a drop there reads as a delta, not a regression.
+func TestWriteReport_totalDropIsNotLabelledARegression(t *testing.T) {
+	profile := profileOf(map[string][2]int{"cmd": {1, 2}, "internal/new": {0, 10}})
+	baseline := &Baseline{Total: 50, Packages: map[string]float64{"cmd": 50}}
+
+	var out strings.Builder
+	if err := WriteReport(&out, Compare(profile, baseline, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the report: %v", err)
+	}
+
+	if strings.Contains(out.String(), "REGRESSED") {
+		t.Fatalf("expected no regression label:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "-41.7") {
+		t.Fatalf("expected the total's delta:\n%s", out.String())
+	}
+}
+
 // A package with no floor must not show a 0.0% floor, which would read as a
 // real threshold rather than an absent one.
 func TestWriteReport_newPackageHasNoFloorValue(t *testing.T) {

--- a/tools/ods/internal/coverage/report_test.go
+++ b/tools/ods/internal/coverage/report_test.go
@@ -1,0 +1,55 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteReport_showsEachStatus(t *testing.T) {
+	profile := profileOf(map[string][2]int{
+		"cmd":            {1, 4}, // 25%, below its 50 floor
+		"internal/audit": {3, 4}, // 75%, above its 50 floor
+		"internal/new":   {1, 2}, // no floor
+	})
+	baseline := &Baseline{
+		Total:    50,
+		Packages: map[string]float64{"cmd": 50, "internal/audit": 50, "internal/gone": 90},
+	}
+
+	var out strings.Builder
+	if err := WriteReport(&out, Compare(profile, baseline, DefaultTolerance)); err != nil {
+		t.Fatalf("failed to write the report: %v", err)
+	}
+	report := out.String()
+
+	for _, want := range []string{
+		"PACKAGE", "COVERAGE", "FLOOR",
+		"REGRESSED by 25.0", // cmd
+		"+25.0",             // internal/audit
+		"new",               // internal/new
+		"removed",           // internal/gone
+		"total",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("expected %q in the report:\n%s", want, report)
+		}
+	}
+}
+
+// A package with no floor must not show a 0.0% floor, which would read as a
+// real threshold rather than an absent one.
+func TestWriteReport_newPackageHasNoFloorValue(t *testing.T) {
+	var out strings.Builder
+	report := Compare(profileOf(map[string][2]int{"internal/new": {1, 3}}), nil, DefaultTolerance)
+	if err := WriteReport(&out, report); err != nil {
+		t.Fatalf("failed to write the report: %v", err)
+	}
+
+	// The only percentage on the row is the measured one; the floor is "-".
+	if got := strings.Count(out.String(), "%"); got != 2 {
+		t.Fatalf("expected one percentage per row, got %d:\n%s", got, out.String())
+	}
+	if !strings.Contains(out.String(), "33.3%") {
+		t.Fatalf("expected the measured coverage:\n%s", out.String())
+	}
+}

--- a/tools/ods/internal/coverage/run.go
+++ b/tools/ods/internal/coverage/run.go
@@ -1,0 +1,97 @@
+package coverage
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ExitError reports that the test run itself failed, carrying the exit code so
+// the caller can hand the underlying tool's result back to the shell.
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("go test exited with code %d", e.Code)
+}
+
+// RunOptions configures a coverage run.
+type RunOptions struct {
+	// ModuleDir is the directory holding the module's go.mod. go test runs
+	// here, which is where its "./..." pattern resolves.
+	ModuleDir string
+	// ProfilePath is where the coverage profile is written.
+	ProfilePath string
+	// Args are extra arguments for go test, such as "-race".
+	Args []string
+	// Stdout and Stderr receive the test output. A nil value discards it.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Run executes the module's tests with coverage enabled and parses the profile.
+//
+// Coverage is measured per package with `go test -coverprofile`, so a package's
+// number counts only its own tests. That is the number a package owner can act
+// on; a cross-package `-coverpkg` total would credit a package for statements
+// its own tests never assert on.
+func Run(opts RunOptions) (*Profile, error) {
+	modulePath, err := ModulePath(opts.ModuleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(opts.ProfilePath), 0755); err != nil {
+		return nil, fmt.Errorf("create profile directory: %w", err)
+	}
+
+	args := []string{"test"}
+	args = append(args, opts.Args...)
+	args = append(args, "-coverprofile="+opts.ProfilePath, "./...")
+
+	cmd := exec.Command("go", args...)
+	cmd.Dir = opts.ModuleDir
+	cmd.Stdout = opts.Stdout
+	cmd.Stderr = opts.Stderr
+
+	runErr := cmd.Run()
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) && exitErr.ExitCode() != -1 {
+			return nil, &ExitError{Code: exitErr.ExitCode()}
+		}
+		return nil, fmt.Errorf("run go test: %w", runErr)
+	}
+
+	return ParseProfileFile(opts.ProfilePath, modulePath)
+}
+
+// ModulePath reads the module path from the go.mod in dir. Coverage profiles
+// name packages by full import path; the module path is what turns those into
+// the short, module-relative names used in the baseline.
+func ModulePath(dir string) (string, error) {
+	goMod := filepath.Join(dir, "go.mod")
+	f, err := os.Open(goMod)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", goMod, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if path, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(path), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read %s: %w", goMod, err)
+	}
+	return "", fmt.Errorf("no module declaration in %s", goMod)
+}

--- a/tools/ods/internal/coverage/run_test.go
+++ b/tools/ods/internal/coverage/run_test.go
@@ -1,0 +1,49 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGoMod(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	return dir
+}
+
+func TestModulePath_readsTheModuleLine(t *testing.T) {
+	dir := writeGoMod(t, "module example.com/m/tools/ods\n\ngo 1.26.4\n")
+
+	path, err := ModulePath(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "example.com/m/tools/ods" {
+		t.Fatalf("expected the module path, got %q", path)
+	}
+}
+
+func TestModulePath_missingGoMod(t *testing.T) {
+	if _, err := ModulePath(t.TempDir()); err == nil {
+		t.Fatal("expected an error when go.mod is missing")
+	}
+}
+
+func TestModulePath_noModuleDeclaration(t *testing.T) {
+	dir := writeGoMod(t, "go 1.26.4\n")
+
+	if _, err := ModulePath(dir); err == nil {
+		t.Fatal("expected an error when go.mod declares no module")
+	}
+}
+
+func TestExitError_reportsTheCode(t *testing.T) {
+	err := &ExitError{Code: 2}
+	if got := err.Error(); got != "go test exited with code 2" {
+		t.Fatalf("unexpected message: %q", got)
+	}
+}


### PR DESCRIPTION
## What

`ods coverage <suite|module-dir>` measures Go statement coverage per package and holds it against
a committed baseline, so coverage can go up but not down.

```bash
ods coverage ods            # report where each package stands
ods coverage ods --check    # fail on a regression (what CI runs)
ods coverage ods --update   # record today's numbers as the new floors
ods coverage ods --profile /tmp/cover.out   # then: go tool cover -html=/tmp/cover.out
```

Follows #14374, which added `ods test` for the Go modules. This reuses its `internal/testsuite`
routing, so the suites are the same three Go modules: `ods`, `cli`, and `terraform`. A module
directory such as `tools/ods` is accepted in place of a suite name, which is what CI passes.

This is the Go-only slice of #14081, rebased onto the merged `ods test`. The backend and web
suites have no coverage tooling, so they are out of scope here.

## Baseline

`tools/ods/.coverage-baseline.yaml`, at **35.7% total** across 29 packages. Where the gaps are:

| Package | Coverage |
| --- | --- |
| internal/version | 100.0% |
| internal/composegen | 96.8% |
| internal/testsuite | 88.1% |
| internal/terraform | 83.0% |
| internal/release | 82.7% |
| internal/coverage | 79.7% |
| internal/deployfilessync | 79.1% |
| internal/portutil | 75.0% |
| internal/pycheck | 74.1% |
| internal/imgdiff | 68.2% |
| internal/lazyimports | 61.2% |
| internal/audit | 55.1% |
| internal/tui | 38.8% |
| internal/git | 32.5% |
| internal/paths | 30.3% |
| internal/docker | 25.3% |
| **cmd** | **17.2%** |
| *(main)*, internal/alembic, internal/auditcmd, internal/childproc, internal/config, internal/gittest, internal/kube, internal/openapi, internal/postgres, internal/prompt, internal/s3, odsaudit | 0.0% |

## CI

The `golang` job in `pr-golang-tests.yml` runs `ods coverage <module> --check` for every Go module,
in place of `go test -race ./...`. The coverage run is the same command plus a profile, so each
module's tests run once and nothing is lost.

A module opts into the gate by committing a baseline. Without one, `--check` runs the tests, prints
the report, and warns that nothing is gated. So `cli` and `terraform-provider-onyx` join by running
`ods coverage <suite> --update` once, with no workflow change.

Each job writes its report to the job summary, uploads the `go tool cover -html` page as an
artifact (`coverage-tools-ods` and so on), and publishes it to the playwright reports bucket, where
a browser opens it directly. GitHub cannot host it: an artifact is always a zip behind a login, and
`gh --attach` takes images and video only. A `coverage-comment` job then posts one PR comment,
updated in place on every run, for the modules with a baseline where a package moved: the verdict,
a table of the packages that moved, and a link to the page. The markdown opens with a marker
(`changed`, `unchanged`, `no-baseline`) so the job needs no parsing. When nothing moved, an
existing comment is updated to say so and no new one is posted. Fork PRs cannot assume the AWS
role and have a read-only token, so they get the artifact and the job summary only.

## Design

**Coverage is per package.** A package's number counts only its own tests, via
`go test -coverprofile`. That is a number the package's owner can act on. A cross-package
`-coverpkg` total would credit a package for statements its own tests never assert on.

**A fresh baseline always passes its own run.** Floors round *down* to one decimal, and a package
may sit `--tolerance` (default 0.1pp) below its floor without failing. Together that absorbs the
jitter from suites that depend on ports or timing. A real regression is far larger.
`TestNewBaseline_isSelfConsistent` pins this.

**Improvements never fail the build.** The gate only catches drops. It reports how many packages
rose and points at `--update`. Failing until the baseline is refreshed would ratchet automatically
but conflict on the baseline file every time two PRs add tests.

**The package floors are the gate; the total is reported, not gated.** A new package cannot fail
a check it was never measured for, and a deleted package is reported for cleanup rather than
failing. Either moves the module total without any package regressing, so a drop in the total
shows as a signed delta and never fails.

**Bad input fails loudly.** A NaN, negative, or over-100 floor in a hand-edited baseline, or a NaN,
infinite, or negative `--tolerance`, would pass every comparison and turn the gate off. Both are
rejected before the tests run.

**A failed test run records nothing.** `go test` still writes a profile when tests fail, so
coverage from a failed run would be both wrong and quietly recordable. `--update` and `--check`
both exit with the test run's own code instead.

Logic lives in `internal/coverage`; `cmd/coverage.go` is cobra glue only.

## Testing

`internal/coverage` is unit tested at 79.7%: profile parsing (per-package aggregation, repeated
block merging, the module root, malformed lines, the empty profile), baseline round-trip,
deterministic byte-identical output, floor rounding, self-consistency, and every comparison verdict
(regressed, ok-at-the-floor, drop-inside-tolerance, improved, new, removed, no-baseline), plus the
total being report-only and the rejection of invalid floors and tolerances.

Exercised live end to end:

```
ods coverage ods --update              → wrote the baseline at 35.7%
ods coverage ods --check               → holds, exit 0
  with a floor hand-raised to 70       → "internal/audit  55.1%  70.0%  REGRESSED by 14.9", exit 1
  with a failing test run              → exits with go test's code, records nothing
ods coverage ./tools/ods --check       → same as the suite name (what CI passes)
ods coverage cli --check               → no baseline: tests run, report prints, exit 0 with a warning
ods coverage ods --profile <path>      → profile kept, go tool cover reads it
ods coverage ods --html <p> --markdown <p> → both files written; markdown matches the comment
  with a relative path, from another dir → lands relative to the caller, not the module
ods coverage tools/ods/internal/audit  → rejected, points at the module
ods coverage nope                      → rejected, lists the suites
ods coverage ods --check --update      → rejected
ods coverage ods --tolerance -1        → rejected
```

`go test -race ./...` passes, `go mod tidy` is clean (no new dependencies), and pre-commit is
green including zizmor, actionlint, and golangci-lint.

## Note

`internal/git` tests fail on any machine whose global gitconfig turns on commit signing with a
missing key, because their fixtures build real commits in temp repos. This reproduces unchanged at
`main`, but `ods coverage` correctly refuses to baseline a failed run, so the baseline here was
generated with `GIT_CONFIG_GLOBAL` pointing at a config with `commit.gpgsign = false`. Fixing the
fixtures to set that locally is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
