### PR TITLE
refactor(deps): drop the unstructured package

### DIFF
--- a/backend/onyx/file_processing/unstructured.py
+++ b/backend/onyx/file_processing/unstructured.py
@@ -52,7 +52,6 @@ def _sdk_partition_request(
 
 
 def unstructured_to_text(file: IO[Any], file_name: str) -> str:
-    from unstructured.staging.base import dict_to_elements
     from unstructured_client import UnstructuredClient
 
     logger.debug("Starting to read file: %s", file_name)
@@ -67,5 +66,5 @@ def unstructured_to_text(file: IO[Any], file_name: str) -> str:
         logger.error(err)
         raise ValueError(err)
 
-    elements = dict_to_elements(response.elements or [])
-    return "\n\n".join(str(el) for el in elements)
+    # The API returns one dict per document element; only its text is needed.
+    return "\n\n".join(el.get("text", "") for el in response.elements or [])

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -3129,9 +3129,9 @@ uncalled-for==0.2.0 \
     --hash=sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f \
     --hash=sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f
     # via fastmcp
-unstructured==0.18.27 \
-    --hash=sha256:be73b39fdd6ed89151849dd3588d20e44aede93c2ed008fb88291e9f7fcace4e \
-    --hash=sha256:fae7fbe5d664cd5ebc558a54ab12d2c924e19b85061a614f58fd0b1fdb8e1c2e
+unstructured==0.24.0 \
+    --hash=sha256:23824fc1628109aa8c3fd03ac1423c5056e1d80e8357bfd76c03aa5b5b614837 \
+    --hash=sha256:8f98b2f1be057acff67df7be3a8a2b69a3e09c4543beb923ffa42d15d057d1b0
 unstructured-client==0.42.6 \
     --hash=sha256:c93b1d9d1b9f63a8e961729d00224b3659ef9ef3e14996ea4e53ddc95df671a9 \
     --hash=sha256:ea54f2c4ca3e7a1330f9e77cbc96f88f829518beeec5e1b797b5352f4d76a73a

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -3129,9 +3129,9 @@ uncalled-for==0.2.0 \
     --hash=sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f \
     --hash=sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f
     # via fastmcp
-unstructured==0.24.0 \
-    --hash=sha256:23824fc1628109aa8c3fd03ac1423c5056e1d80e8357bfd76c03aa5b5b614837 \
-    --hash=sha256:8f98b2f1be057acff67df7be3a8a2b69a3e09c4543beb923ffa42d15d057d1b0
+unstructured==0.18.27 \
+    --hash=sha256:be73b39fdd6ed89151849dd3588d20e44aede93c2ed008fb88291e9f7fcace4e \
+    --hash=sha256:fae7fbe5d664cd5ebc558a54ab12d2c924e19b85061a614f58fd0b1fdb8e1c2e
 unstructured-client==0.42.6 \
     --hash=sha256:c93b1d9d1b9f63a8e961729d00224b3659ef9ef3e14996ea4e53ddc95df671a9 \
     --hash=sha256:ea54f2c4ca3e7a1330f9e77cbc96f88f829518beeec5e1b797b5352f4d76a73a

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -554,6 +554,7 @@ click==8.4.2 \
     #   huggingface-hub
     #   litellm
     #   magika
+    #   nltk
     #   typer
     #   uvicorn
     #   zulip
@@ -681,6 +682,7 @@ defusedxml==0.7.1 \
     # via
     #   jira
     #   markitdown
+    #   nltk
 deprecated==1.3.1 \
     --hash=sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f \
     --hash=sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223
@@ -1273,6 +1275,10 @@ jmespath==1.0.1 \
     #   atlassian-python-api
     #   boto3
     #   botocore
+joblib==1.5.2 \
+    --hash=sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55 \
+    --hash=sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241
+    # via nltk
 jsonpatch==1.33 \
     --hash=sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade \
     --hash=sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c
@@ -1695,6 +1701,9 @@ mwparserfromhell==0.7.2 \
 nest-asyncio==1.6.0 \
     --hash=sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe \
     --hash=sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
+nltk==3.10.3 \
+    --hash=sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4 \
+    --hash=sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c
 numpy==2.4.1 \
     --hash=sha256:178de8f87948163d98a4c9ab5bee4ce6519ca918926ec8df195af582de28544d \
     --hash=sha256:20d4649c773f66cc2fc36f663e091f57c3b7655f936a4c681b4250855d1da8f5 \
@@ -2611,6 +2620,7 @@ regex==2025.11.3 \
     --hash=sha256:ffcca5b9efe948ba0661e9df0fa50d2bc4b097c70b9810212d6b62f05d83b2dd
     # via
     #   dateparser
+    #   nltk
     #   tiktoken
 reportlab==5.0.0 \
     --hash=sha256:9d5a3affa84919e1111ede580031266a570e93b1ce388219621347965ff1d93c \
@@ -2976,6 +2986,7 @@ tqdm==4.70.0 \
     #   braintrust
     #   chonkie
     #   huggingface-hub
+    #   nltk
     #   openai
 trafilatura==1.12.2 \
     --hash=sha256:4c9cb1434f7e13ef0b16cb44ee1d44e84523ec7268940b9559c374e7effc9a96 \

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -287,9 +287,7 @@ babel==2.17.0 \
 backoff==2.2.1 \
     --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
     --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
-    # via
-    #   langfuse
-    #   unstructured
+    # via langfuse
 bcrypt==5.0.0 \
     --hash=sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a \
     --hash=sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464 \
@@ -364,7 +362,6 @@ beautifulsoup4==4.12.3 \
     #   atlassian-python-api
     #   markdownify
     #   markitdown
-    #   unstructured
 billiard==4.2.3 \
     --hash=sha256:96486f0885afc38219d02d5f0ccd5bec8226a414b834ab244008cbb0025b8dcb \
     --hash=sha256:989e9b688e3abf153f307b68a1328dfacfb954e30a4f920005654e276c69236b
@@ -535,7 +532,6 @@ charset-normalizer==3.4.4 \
     #   reportlab
     #   requests
     #   trafilatura
-    #   unstructured
 chevron==0.14.0 \
     --hash=sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf \
     --hash=sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443
@@ -558,8 +554,6 @@ click==8.4.2 \
     #   huggingface-hub
     #   litellm
     #   magika
-    #   nltk
-    #   python-oxmsg
     #   typer
     #   uvicorn
     #   zulip
@@ -677,10 +671,6 @@ dask==2026.1.1 \
     --hash=sha256:12b1dbb0d6e92f287feb4076871600b2fba3a843d35ff214776ada5e9e7a1529 \
     --hash=sha256:146b0ef2918eb581e06139183a88801b4a8c52d7c37758a91f8c3b75c54b0e15
     # via distributed
-dataclasses-json==0.6.7 \
-    --hash=sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a \
-    --hash=sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0
-    # via unstructured
 dateparser==1.2.2 \
     --hash=sha256:5a5d7211a09013499867547023a2a0c91d5a27d15dd4dbcea676ea9fe66f2482 \
     --hash=sha256:986316f17cb8cdc23ea8ce563027c5ef12fc725b6fb1d137c14ca08777c5ecf7
@@ -691,7 +681,6 @@ defusedxml==0.7.1 \
     # via
     #   jira
     #   markitdown
-    #   nltk
 deprecated==1.3.1 \
     --hash=sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f \
     --hash=sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223
@@ -741,10 +730,6 @@ email-validator==2.2.0 \
     # via
     #   fastapi-users
     #   pydantic
-emoji==2.15.0 \
-    --hash=sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb \
-    --hash=sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4
-    # via unstructured
 et-xmlfile==2.0.0 \
     --hash=sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa \
     --hash=sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54
@@ -834,10 +819,6 @@ filelock==3.20.3 \
     --hash=sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1 \
     --hash=sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
     # via huggingface-hub
-filetype==1.2.0 \
-    --hash=sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb \
-    --hash=sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25
-    # via unstructured
 flask==3.1.3 \
     --hash=sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb \
     --hash=sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c
@@ -1124,10 +1105,6 @@ hpack==4.2.0 \
     --hash=sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0 \
     --hash=sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986
     # via h2
-html5lib==1.1 \
-    --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
-    --hash=sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
-    # via unstructured
 htmldate==1.9.4 \
     --hash=sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0 \
     --hash=sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c
@@ -1296,10 +1273,6 @@ jmespath==1.0.1 \
     #   atlassian-python-api
     #   boto3
     #   botocore
-joblib==1.5.2 \
-    --hash=sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55 \
-    --hash=sha256:4e1f0bdbb987e6d843c70cf43714cb276623def372df3c22fe5266b2670bc241
-    # via nltk
 jsonpatch==1.33 \
     --hash=sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade \
     --hash=sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c
@@ -1352,9 +1325,6 @@ langchain-protocol==0.0.15 \
     --hash=sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79 \
     --hash=sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade
     # via langchain-core
-langdetect==1.0.9 \
-    --hash=sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
-    # via unstructured
 langfuse==4.14.4 \
     --hash=sha256:48c4bdefc290f61a42881b8048a904ab6b81d37e02496473166836e71ee0ab3a \
     --hash=sha256:78692a1d4785a8c255bf6ea967e673e1ee30ce078d646e7b5f7ff44549d45cce
@@ -1447,7 +1417,6 @@ lxml==6.1.1 \
     #   python-pptx
     #   python3-saml
     #   trafilatura
-    #   unstructured
     #   xmlsec
     #   zeep
 lxml-html-clean==0.4.5 \
@@ -1535,10 +1504,6 @@ markupsafe==3.0.3 \
     #   jinja2
     #   mako
     #   werkzeug
-marshmallow==3.26.2 \
-    --hash=sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73 \
-    --hash=sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57
-    # via dataclasses-json
 matrix-client==0.3.2 \
     --hash=sha256:2855a2614a177db66f9bc3ba38cbd2876041456f663c334f72a160ab6bb11c49 \
     --hash=sha256:dce3ccb8665df0d519f08e07a16e6d3f9fab3a947df4b7a7c4bb26573d68f2d5
@@ -1727,17 +1692,9 @@ mwparserfromhell==0.7.2 \
     --hash=sha256:f4193072e9ea93b9e88f772f60a02125c0602d32890d0bbdcb275ed58c8b3763 \
     --hash=sha256:fef24a97b0b08f02646be2e018284884f8e6cb9740eea60a10404b5369c04ef6
     # via pywikibot
-mypy-extensions==1.0.0 \
-    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
-    --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-    # via typing-inspect
 nest-asyncio==1.6.0 \
     --hash=sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe \
     --hash=sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
-nltk==3.10.3 \
-    --hash=sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4 \
-    --hash=sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c
-    # via unstructured
 numpy==2.4.1 \
     --hash=sha256:178de8f87948163d98a4c9ab5bee4ce6519ca918926ec8df195af582de28544d \
     --hash=sha256:20d4649c773f66cc2fc36f663e091f57c3b7655f936a4c681b4250855d1da8f5 \
@@ -1786,7 +1743,6 @@ numpy==2.4.1 \
     #   magika
     #   onnxruntime
     #   pandas
-    #   unstructured
     #   voyageai
 oauthlib==3.2.2 \
     --hash=sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca \
@@ -1801,9 +1757,7 @@ office365-rest-python-client==2.6.2 \
 olefile==0.47 \
     --hash=sha256:543c7da2a7adadf21214938bb79c83ea12b473a4b6ee4ad4bf854e7715e13d1f \
     --hash=sha256:599383381a0bf3dfbd932ca0ca6515acd174ed48870cbf7fee123d698c192c1c
-    # via
-    #   msoffcrypto-tool
-    #   python-oxmsg
+    # via msoffcrypto-tool
 onnxruntime==1.20.1 \
     --hash=sha256:0df6f2df83d61f46e842dbcde610ede27218947c33e994545a22333491e72a3b \
     --hash=sha256:bda6aebdf7917c1d811f21d41633df00c58aff2bef2f598f69289c1f1dabc4b3 \
@@ -1826,9 +1780,9 @@ openapi-pydantic==0.5.1 \
 openinference-instrumentation==0.1.42 \
     --hash=sha256:2275babc34022e151b5492cfba41d3b12e28377f8e08cb45e5d64fe2d9d7fe37 \
     --hash=sha256:e7521ff90833ef7cc65db526a2f59b76a496180abeaaee30ec6abbbc0b43f8ec
-openinference-semantic-conventions==0.1.25 \
-    --hash=sha256:3814240f3bd61f05d9562b761de70ee793d55b03bca1634edf57d7a2735af238 \
-    --hash=sha256:f0a8c2cfbd00195d1f362b4803518341e80867d446c2959bf1743f1894fce31d
+openinference-semantic-conventions==0.1.34 \
+    --hash=sha256:955af862541190827e8b34b7afe9dabb7465ec504da1368c0ca0efcf4f47430d \
+    --hash=sha256:ae5c8b4fd69d099cca1b1bfcddc9a44e340891a7b16a6cf23665c27c435e1104
     # via openinference-instrumentation
 openpyxl==3.0.10 \
     --hash=sha256:0ab6d25d01799f97a9464630abacbb34aafecdcaa0ef3cba6d6b3499867d0355 \
@@ -1923,7 +1877,6 @@ packaging==25.0 \
     #   langchain-core
     #   langfuse
     #   langsmith
-    #   marshmallow
     #   onnxruntime
     #   pywikibot
 pandas==2.3.3 \
@@ -2172,9 +2125,7 @@ psutil==7.1.3 \
     --hash=sha256:c525ffa774fe4496282fb0b1187725793de3e7c6b29e41562733cae9ada151ee \
     --hash=sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd \
     --hash=sha256:fac9cd332c67f4422504297889da5ab7e05fd11e3c4392140f7370f4208ded1f
-    # via
-    #   distributed
-    #   unstructured
+    # via distributed
 psycopg2-binary==2.9.10 \
     --hash=sha256:230eeae2d71594103cd5b93fd29d1ace6420d0b86f4778739cb1a5a32f607d1f \
     --hash=sha256:245159e7ab20a71d989da00f280ca57da7641fa2cdcf71749c193cea540a74f7 \
@@ -2457,28 +2408,16 @@ python-http-client==3.3.7 \
     --hash=sha256:ad371d2bbedc6ea15c26179c6222a78bc9308d272435ddf1d5c84f068f249a36 \
     --hash=sha256:bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0
     # via sendgrid
-python-iso639==2025.11.16 \
-    --hash=sha256:65f6ac6c6d8e8207f6175f8bf7fff7db486c6dc5c1d8866c2b77d2a923370896 \
-    --hash=sha256:aabe941267898384415a509f5236d7cfc191198c84c5c6f73dac73d9783f5169
-    # via unstructured
 python-json-logger==4.1.0 \
     --hash=sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2 \
     --hash=sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
     # via onyx
-python-magic==0.4.27 \
-    --hash=sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b \
-    --hash=sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3
-    # via unstructured
 python-multipart==0.0.31 \
     --hash=sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28 \
     --hash=sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680
     # via
     #   fastapi-users
     #   mcp
-python-oxmsg==0.0.2 \
-    --hash=sha256:22be29b14c46016bcd05e34abddfd8e05ee82082f53b82753d115da3fc7d0355 \
-    --hash=sha256:a6aff4deb1b5975d44d49dab1d9384089ffeec819e19c6940bc7ffbc84775fad
-    # via unstructured
 python-pptx==0.6.23 \
     --hash=sha256:587497ff28e779ab18dbb074f6d4052893c85dedc95ed75df319364f331fedee \
     --hash=sha256:dd0527194627a2b7cc05f3ba23ecaa2d9a0d5ac9b6193a28ed1b7a716f4217d4
@@ -2598,7 +2537,6 @@ rapidfuzz==3.14.5 \
     --hash=sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6 \
     --hash=sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3 \
     --hash=sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a
-    # via unstructured
 readerwriterlock==1.0.9 \
     --hash=sha256:8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7 \
     --hash=sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea
@@ -2673,7 +2611,6 @@ regex==2025.11.3 \
     --hash=sha256:ffcca5b9efe948ba0661e9df0fa50d2bc4b097c70b9810212d6b62f05d83b2dd
     # via
     #   dateparser
-    #   nltk
     #   tiktoken
 reportlab==5.0.0 \
     --hash=sha256:9d5a3affa84919e1111ede580031266a570e93b1ce388219621347965ff1d93c \
@@ -2715,7 +2652,6 @@ requests==2.33.0 \
     #   simple-salesforce
     #   stripe
     #   tiktoken
-    #   unstructured
     #   voyageai
     #   zeep
     #   zulip
@@ -2853,10 +2789,8 @@ six==1.17.0 \
     #   asana
     #   dropbox
     #   google-auth-httplib2
-    #   html5lib
     #   hubspot-api-client
     #   kubernetes
-    #   langdetect
     #   markdownify
     #   python-dateutil
     #   stone
@@ -3035,16 +2969,14 @@ tornado==6.5.8 \
     # via
     #   distributed
     #   mitmproxy
-tqdm==4.67.1 \
-    --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
-    --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
+tqdm==4.70.0 \
+    --hash=sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220 \
+    --hash=sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
     # via
     #   braintrust
     #   chonkie
     #   huggingface-hub
-    #   nltk
     #   openai
-    #   unstructured
 trafilatura==1.12.2 \
     --hash=sha256:4c9cb1434f7e13ef0b16cb44ee1d44e84523ec7268940b9559c374e7effc9a96 \
     --hash=sha256:6df5b666f625c9579a50d7cc715005f450fa75606696aceab73eeda0a76dbe96
@@ -3091,21 +3023,14 @@ typing-extensions==4.15.0 \
     #   pyee
     #   pygithub
     #   python-docx
-    #   python-oxmsg
     #   readerwriterlock
     #   simple-salesforce
     #   sqlalchemy
     #   stripe
     #   typer
-    #   typing-inspect
     #   typing-inspection
-    #   unstructured
     #   urwid
     #   zulip
-typing-inspect==0.9.0 \
-    --hash=sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f \
-    --hash=sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78
-    # via dataclasses-json
 typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
@@ -3129,13 +3054,9 @@ uncalled-for==0.2.0 \
     --hash=sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f \
     --hash=sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f
     # via fastmcp
-unstructured==0.18.27 \
-    --hash=sha256:be73b39fdd6ed89151849dd3588d20e44aede93c2ed008fb88291e9f7fcace4e \
-    --hash=sha256:fae7fbe5d664cd5ebc558a54ab12d2c924e19b85061a614f58fd0b1fdb8e1c2e
 unstructured-client==0.42.6 \
     --hash=sha256:c93b1d9d1b9f63a8e961729d00224b3659ef9ef3e14996ea4e53ddc95df671a9 \
     --hash=sha256:ea54f2c4ca3e7a1330f9e77cbc96f88f829518beeec5e1b797b5352f4d76a73a
-    # via unstructured
 uritemplate==4.2.0 \
     --hash=sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e \
     --hash=sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686
@@ -3255,10 +3176,6 @@ wcwidth==0.2.14 \
     # via
     #   prompt-toolkit
     #   urwid
-webencodings==0.5.1 \
-    --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
-    --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-    # via html5lib
 websocket-client==1.9.0 \
     --hash=sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98 \
     --hash=sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef
@@ -3326,7 +3243,6 @@ wrapt==1.17.3 \
     #   deprecated
     #   langfuse
     #   openinference-instrumentation
-    #   unstructured
 wsproto==1.2.0 \
     --hash=sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065 \
     --hash=sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -1951,9 +1951,9 @@ tornado==6.5.8 \
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.67.1 \
-    --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
-    --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
+tqdm==4.70.0 \
+    --hash=sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220 \
+    --hash=sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
     # via
     #   huggingface-hub
     #   openai

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -1323,9 +1323,9 @@ tokenizers==0.22.2 \
     # via
     #   cohere
     #   litellm
-tqdm==4.67.1 \
-    --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
-    --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
+tqdm==4.70.0 \
+    --hash=sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220 \
+    --hash=sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
     # via
     #   huggingface-hub
     #   openai

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -1605,9 +1605,9 @@ torch==2.9.1 \
     # via
     #   accelerate
     #   sentence-transformers
-tqdm==4.67.1 \
-    --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
-    --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
+tqdm==4.70.0 \
+    --hash=sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220 \
+    --hash=sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
     # via
     #   huggingface-hub
     #   openai

--- a/backend/tests/unit/onyx/file_processing/fixtures/unstructured_partition_elements.json
+++ b/backend/tests/unit/onyx/file_processing/fixtures/unstructured_partition_elements.json
@@ -1,0 +1,77 @@
+[
+  {
+    "element_id": "5e26385e9688cd34233e6d36fd41840f",
+    "metadata": {
+      "category_depth": 0,
+      "filetype": "text/html",
+      "languages": [
+        "eng"
+      ]
+    },
+    "text": "Quarterly Report",
+    "type": "Title"
+  },
+  {
+    "element_id": "2b7a9e18f3f450735e308cc7ab1472e7",
+    "metadata": {
+      "filetype": "text/html",
+      "languages": [
+        "eng"
+      ],
+      "parent_id": "5e26385e9688cd34233e6d36fd41840f"
+    },
+    "text": "Revenue grew 12% this quarter.",
+    "type": "NarrativeText"
+  },
+  {
+    "element_id": "61dc3a95faa19e7c1832f4955e4285e6",
+    "metadata": {
+      "category_depth": 1,
+      "filetype": "text/html",
+      "languages": [
+        "eng"
+      ],
+      "parent_id": "5e26385e9688cd34233e6d36fd41840f"
+    },
+    "text": "North America: up 8%",
+    "type": "ListItem"
+  },
+  {
+    "element_id": "b65da13930f1cd18536472607d6e6417",
+    "metadata": {
+      "category_depth": 1,
+      "filetype": "text/html",
+      "languages": [
+        "eng"
+      ],
+      "parent_id": "5e26385e9688cd34233e6d36fd41840f"
+    },
+    "text": "EMEA: up 19%",
+    "type": "ListItem"
+  },
+  {
+    "element_id": "8df17bc7eab6cb86c0c0b1297dd9138b",
+    "metadata": {
+      "filetype": "text/html",
+      "languages": [
+        "eng"
+      ],
+      "parent_id": "5e26385e9688cd34233e6d36fd41840f",
+      "text_as_html": "<table><tr><td>Region</td><td>Total</td></tr><tr><td>NA</td><td>4.2M</td></tr></table>"
+    },
+    "text": "Region Total NA 4.2M",
+    "type": "Table"
+  },
+  {
+    "element_id": "18d4d9e4997bf5dac4a450e80cfac0d1",
+    "metadata": {
+      "filetype": "text/html",
+      "image_url": "chart.png",
+      "languages": [
+        "eng"
+      ]
+    },
+    "text": "chart",
+    "type": "Image"
+  }
+]

--- a/backend/tests/unit/onyx/file_processing/test_unstructured_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_unstructured_to_text.py
@@ -1,0 +1,122 @@
+import json
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from onyx.file_processing.unstructured import unstructured_to_text
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _mock_client(
+    elements: list[dict[str, Any]] | None, status_code: int = 200
+) -> mock.MagicMock:
+    """Build a stand-in UnstructuredClient whose partition call returns `elements`."""
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.elements = elements
+
+    client = mock.MagicMock()
+    client.general.partition.return_value = response
+    return client
+
+
+def _run(elements: list[dict[str, Any]] | None, status_code: int = 200) -> str:
+    client_cls = mock.MagicMock(return_value=_mock_client(elements, status_code))
+    with (
+        mock.patch("unstructured_client.UnstructuredClient", client_cls),
+        mock.patch(
+            "onyx.file_processing.unstructured.get_unstructured_api_key",
+            return_value="fake-key",
+        ),
+    ):
+        return unstructured_to_text(BytesIO(b"file contents"), "test.pdf")
+
+
+def test_elements_are_joined_with_blank_lines() -> None:
+    """Element text is concatenated in order, separated by a blank line."""
+    elements = [
+        {"type": "Title", "element_id": "a", "text": "The Title"},
+        {"type": "NarrativeText", "element_id": "b", "text": "First paragraph."},
+        {"type": "NarrativeText", "element_id": "c", "text": "Second paragraph."},
+    ]
+    assert _run(elements) == "The Title\n\nFirst paragraph.\n\nSecond paragraph."
+
+
+def test_element_metadata_is_ignored() -> None:
+    """Only the text of each element reaches the output, never its metadata."""
+    elements = [
+        {
+            "type": "NarrativeText",
+            "element_id": "a",
+            "text": "Body text.",
+            "metadata": {"filename": "test.pdf", "page_number": 1},
+        }
+    ]
+    assert _run(elements) == "Body text."
+
+
+def test_textless_elements_become_empty_strings() -> None:
+    """Elements that carry no text still occupy their position in the output."""
+    elements = [
+        {"type": "Title", "element_id": "a", "text": "Heading"},
+        {"type": "Image", "element_id": "b", "text": ""},
+        {"type": "NarrativeText", "element_id": "c", "text": "Body."},
+    ]
+    assert _run(elements) == "Heading\n\n\n\nBody."
+
+
+def test_no_elements_returns_empty_string() -> None:
+    """An empty element list and a null element list both yield no text."""
+    assert _run([]) == ""
+    assert _run(None) == ""
+
+
+def test_non_200_status_raises() -> None:
+    """A failed partition call raises instead of returning partial text."""
+    with pytest.raises(ValueError, match="unexpected status code 500"):
+        _run([{"type": "Title", "element_id": "a", "text": "x"}], status_code=500)
+
+
+def test_file_is_read_from_the_start() -> None:
+    """An already-consumed file is rewound so its full contents are uploaded."""
+    file = BytesIO(b"file contents")
+    file.read()
+
+    client = _mock_client([{"type": "Title", "element_id": "a", "text": "x"}])
+    with (
+        mock.patch("unstructured_client.UnstructuredClient", return_value=client),
+        mock.patch(
+            "onyx.file_processing.unstructured.get_unstructured_api_key",
+            return_value="fake-key",
+        ),
+    ):
+        unstructured_to_text(file, "test.pdf")
+
+    request = client.general.partition.call_args.kwargs["request"]
+    assert request.partition_parameters.files.content == b"file contents"
+
+
+def test_real_partition_payload() -> None:
+    """A recorded Unstructured payload produces the same text the old path did.
+
+    The fixture is the API's own serialization of a partitioned HTML document,
+    so it carries the real element shape: mixed types, nested metadata, a table
+    with `text_as_html`, and an image whose text is its alt attribute. The
+    expected string was captured from the previous `dict_to_elements`
+    implementation before it was removed.
+    """
+    elements = json.loads(
+        (FIXTURES_DIR / "unstructured_partition_elements.json").read_text()
+    )
+    assert _run(elements) == (
+        "Quarterly Report\n\n"
+        "Revenue grew 12% this quarter.\n\n"
+        "North America: up 8%\n\n"
+        "EMEA: up 19%\n\n"
+        "Region Total NA 4.2M\n\n"
+        "chart"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 requires-python = ">=3.13"
 # Shared dependencies between backend and model_server
 dependencies = [
-    "aioboto3==15.1.0",
+    "aioboto3==15.5.0",
+    "aiobotocore==3.9.1",
     "cohere==7.0.5",
     "fastapi==0.133.1",
     "google-genai==2.18.1",
@@ -34,8 +35,8 @@ backend = [
     "azure-cognitiveservices-speech==1.50.0",
     "azure-identity>=1.23.0,<2.0.0",
     "azure-storage-blob>=12.24.0,<13.0.0",
-    "beautifulsoup4==4.12.3",
-    "boto3==1.39.11",
+    "beautifulsoup4==4.15.0",
+    "boto3==1.40.46",
     "boxsdk==10.12.0",
     "celery==5.5.1",
     "chardet==5.2.0",
@@ -82,7 +83,7 @@ backend = [
     # `crypt` module, which was removed in Python 3.13.
     "libpass==1.9.3",
     "playwright==1.58.0",
-    "psutil==7.1.3",
+    "psutil==7.2.2",
     "psycopg2-binary==2.9.10",
     "puremagic==1.28",
     "pyairtable==3.0.1",
@@ -111,7 +112,7 @@ backend = [
     "RapidFuzz==3.14.5",
     "tiktoken==0.13.0",
     "timeago==1.0.16",
-    "unstructured==0.18.27",
+    "unstructured==0.24.0",
     "unstructured-client==0.42.6",
     "zulip==0.8.2",
     "hubspot-api-client==12.0.0",
@@ -126,7 +127,7 @@ backend = [
     "braintrust==0.3.9",
     "langfuse==4.14.4",
     "nest_asyncio==1.6.0",
-    "openinference-instrumentation==0.1.42",
+    "openinference-instrumentation==0.1.60",
     "opentelemetry-proto>=1.42.1",
     "python3-saml==1.15.0",
     "xmlsec==1.3.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.13"
 # Shared dependencies between backend and model_server
 dependencies = [
-    "aioboto3==15.5.0",
-    "aiobotocore==3.9.1",
+    "aioboto3==15.1.0",
     "cohere==7.0.5",
     "fastapi==0.133.1",
     "google-genai==2.18.1",
@@ -35,8 +34,8 @@ backend = [
     "azure-cognitiveservices-speech==1.50.0",
     "azure-identity>=1.23.0,<2.0.0",
     "azure-storage-blob>=12.24.0,<13.0.0",
-    "beautifulsoup4==4.15.0",
-    "boto3==1.40.46",
+    "beautifulsoup4==4.12.3",
+    "boto3==1.39.11",
     "boxsdk==10.12.0",
     "celery==5.5.1",
     "chardet==5.2.0",
@@ -83,7 +82,7 @@ backend = [
     # `crypt` module, which was removed in Python 3.13.
     "libpass==1.9.3",
     "playwright==1.58.0",
-    "psutil==7.2.2",
+    "psutil==7.1.3",
     "psycopg2-binary==2.9.10",
     "puremagic==1.28",
     "pyairtable==3.0.1",
@@ -112,7 +111,6 @@ backend = [
     "RapidFuzz==3.14.5",
     "tiktoken==0.13.0",
     "timeago==1.0.16",
-    "unstructured==0.24.0",
     "unstructured-client==0.42.6",
     "zulip==0.8.2",
     "hubspot-api-client==12.0.0",
@@ -127,7 +125,7 @@ backend = [
     "braintrust==0.3.9",
     "langfuse==4.14.4",
     "nest_asyncio==1.6.0",
-    "openinference-instrumentation==0.1.60",
+    "openinference-instrumentation==0.1.42",
     "opentelemetry-proto>=1.42.1",
     "python3-saml==1.15.0",
     "xmlsec==1.3.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ backend = [
     "mcp[cli]==1.28.1",
     "msal==1.34.0",
     "msoffcrypto-tool==6.0.0",
+    "nltk==3.10.3",
     "Office365-REST-Python-Client==2.6.2",
     "oauthlib==3.2.2",
     # NOTE: This is frozen to avoid https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2147

--- a/uv.lock
+++ b/uv.lock
@@ -3920,6 +3920,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nltk"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "defusedxml" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4239,6 +4255,7 @@ backend = [
     { name = "msal" },
     { name = "msoffcrypto-tool" },
     { name = "nest-asyncio" },
+    { name = "nltk" },
     { name = "oauthlib" },
     { name = "office365-rest-python-client" },
     { name = "openinference-instrumentation" },
@@ -4413,6 +4430,7 @@ backend = [
     { name = "msal", specifier = "==1.34.0" },
     { name = "msoffcrypto-tool", specifier = "==6.0.0" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
+    { name = "nltk", specifier = "==3.10.3" },
     { name = "oauthlib", specifier = "==3.2.2" },
     { name = "office365-rest-python-client", specifier = "==2.6.2" },
     { name = "openinference-instrumentation", specifier = "==0.1.42" },

--- a/uv.lock
+++ b/uv.lock
@@ -1320,19 +1320,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dataclasses-json"
-version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marshmallow" },
-    { name = "typing-inspect" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
-]
-
-[[package]]
 name = "dateparser"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1535,15 +1522,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967, upload-time = "2024-06-20T11:30:30.034Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521, upload-time = "2024-06-20T11:30:28.248Z" },
-]
-
-[[package]]
-name = "emoji"
-version = "2.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/78/0d2db9382c92a163d7095fc08efff7800880f830a152cfced40161e7638d/emoji-2.15.0.tar.gz", hash = "sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4", size = 615483, upload-time = "2025-09-21T12:13:02.755Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/5e/4b5aaaabddfacfe36ba7768817bd1f71a7a810a43705e531f3ae4c690767/emoji-2.15.0-py3-none-any.whl", hash = "sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb", size = 608433, upload-time = "2025-09-21T12:13:01.197Z" },
 ]
 
 [[package]]
@@ -1775,15 +1753,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
-]
-
-[[package]]
-name = "filetype"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
 
 [[package]]
@@ -2458,19 +2427,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
-]
-
-[[package]]
-name = "html5lib"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
 ]
 
 [[package]]
@@ -3154,15 +3110,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langdetect"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
-
-[[package]]
 name = "langfuse"
 version = "4.14.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3540,18 +3487,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "marshmallow"
-version = "3.26.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
 ]
 
 [[package]]
@@ -3967,15 +3902,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload-time = "2023-02-04T12:11:27.157Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload-time = "2023-02-04T12:11:25.002Z" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3991,22 +3917,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
-]
-
-[[package]]
-name = "nltk"
-version = "3.10.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "defusedxml" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -4105,7 +4015,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4116,7 +4026,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4143,9 +4053,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4156,7 +4066,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4368,7 +4278,6 @@ backend = [
     { name = "tiktoken" },
     { name = "timeago" },
     { name = "trafilatura" },
-    { name = "unstructured" },
     { name = "unstructured-client" },
     { name = "urllib3" },
     { name = "xmlsec" },
@@ -4543,7 +4452,6 @@ backend = [
     { name = "tiktoken", specifier = "==0.13.0" },
     { name = "timeago", specifier = "==1.0.16" },
     { name = "trafilatura", specifier = "==1.12.2" },
-    { name = "unstructured", specifier = "==0.18.27" },
     { name = "unstructured-client", specifier = "==0.42.6" },
     { name = "urllib3", specifier = "==2.7.0" },
     { name = "xmlsec", specifier = "==1.3.17" },
@@ -4679,11 +4587,11 @@ wheels = [
 
 [[package]]
 name = "openinference-semantic-conventions"
-version = "0.1.25"
+version = "0.1.34"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/68/81c8a0b90334ff11e4f285e4934c57f30bea3ef0c0b9f99b65e7b80fae3b/openinference_semantic_conventions-0.1.25.tar.gz", hash = "sha256:f0a8c2cfbd00195d1f362b4803518341e80867d446c2959bf1743f1894fce31d", size = 12767, upload-time = "2025-11-05T01:37:45.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8b/fadf6f310d309e5475280e1851b4e00ffd5a8ef19609b607ec87841e9fce/openinference_semantic_conventions-0.1.34.tar.gz", hash = "sha256:955af862541190827e8b34b7afe9dabb7465ec504da1368c0ca0efcf4f47430d", size = 14209, upload-time = "2026-09-01T16:17:29.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/3d/dd14ee2eb8a3f3054249562e76b253a1545c76adbbfd43a294f71acde5c3/openinference_semantic_conventions-0.1.25-py3-none-any.whl", hash = "sha256:3814240f3bd61f05d9562b761de70ee793d55b03bca1634edf57d7a2735af238", size = 10395, upload-time = "2025-11-05T01:37:43.697Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/58/d7a56f1a3b1af092a5fc618e6398e8092ab6dac6bde175873cde65ffdcd6/openinference_semantic_conventions-0.1.34-py3-none-any.whl", hash = "sha256:ae5c8b4fd69d099cca1b1bfcddc9a44e340891a7b16a6cf23665c27c435e1104", size = 11455, upload-time = "2026-09-01T16:17:28.182Z" },
 ]
 
 [[package]]
@@ -4953,7 +4861,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5882,15 +5790,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-iso639"
-version = "2025.11.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/3b/3e07aadeeb7bbb2574d6aa6ccacbc58b17bd2b1fb6c7196bf96ab0e45129/python_iso639-2025.11.16.tar.gz", hash = "sha256:aabe941267898384415a509f5236d7cfc191198c84c5c6f73dac73d9783f5169", size = 174186, upload-time = "2025-11-16T21:53:37.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/2d/563849c31e58eb2e273fa0c391a7d9987db32f4d9152fe6ecdac0a8ffe93/python_iso639-2025.11.16-py3-none-any.whl", hash = "sha256:65f6ac6c6d8e8207f6175f8bf7fff7db486c6dc5c1d8866c2b77d2a923370896", size = 167818, upload-time = "2025-11-16T21:53:35.36Z" },
-]
-
-[[package]]
 name = "python-json-logger"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5900,35 +5799,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-magic"
-version = "0.4.27"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
-]
-
-[[package]]
-name = "python-oxmsg"
-version = "0.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "olefile" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/4e/869f34faedbc968796d2c7e9837dede079c9cb9750917356b1f1eda926e9/python_oxmsg-0.0.2.tar.gz", hash = "sha256:a6aff4deb1b5975d44d49dab1d9384089ffeec819e19c6940bc7ffbc84775fad", size = 34713, upload-time = "2025-02-03T17:13:47.415Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/67/f56c69a98c7eb244025845506387d0f961681657c9fcd8b2d2edd148f9d2/python_oxmsg-0.0.2-py3-none-any.whl", hash = "sha256:22be29b14c46016bcd05e34abddfd8e05ee82082f53b82753d115da3fc7d0355", size = 31455, upload-time = "2025-02-03T17:13:46.061Z" },
 ]
 
 [[package]]
@@ -6590,8 +6466,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -7098,14 +6974,14 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.67.1"
+version = "4.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]
@@ -7392,19 +7268,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
-]
-
-[[package]]
 name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7444,38 +7307,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/7c/b5b7d8136f872e3f13b0584e576886de0489d7213a12de6bebf29ff6ebfc/uncalled_for-0.2.0.tar.gz", hash = "sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f", size = 49488, upload-time = "2026-02-27T17:40:58.137Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/7f/4320d9ce3be404e6310b915c3629fe27bf1e2f438a1a7a3cb0396e32e9a9/uncalled_for-0.2.0-py3-none-any.whl", hash = "sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f", size = 11351, upload-time = "2026-02-27T17:40:56.804Z" },
-]
-
-[[package]]
-name = "unstructured"
-version = "0.18.27"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backoff" },
-    { name = "beautifulsoup4" },
-    { name = "charset-normalizer" },
-    { name = "dataclasses-json" },
-    { name = "emoji" },
-    { name = "filetype" },
-    { name = "html5lib" },
-    { name = "langdetect" },
-    { name = "lxml" },
-    { name = "nltk" },
-    { name = "numpy" },
-    { name = "psutil" },
-    { name = "python-iso639" },
-    { name = "python-magic" },
-    { name = "python-oxmsg" },
-    { name = "rapidfuzz" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-    { name = "unstructured-client" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/59/cc8ac124ec1f1ad8643219ed09f818c9d54010a263078409c19992ebe18c/unstructured-0.18.27.tar.gz", hash = "sha256:fae7fbe5d664cd5ebc558a54ab12d2c924e19b85061a614f58fd0b1fdb8e1c2e", size = 1698730, upload-time = "2026-01-09T15:51:33.827Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/2a/68d1ea2febaef1c270227c627b6c52855e414303a42f24025dbcf549255b/unstructured-0.18.27-py3-none-any.whl", hash = "sha256:be73b39fdd6ed89151849dd3588d20e44aede93c2ed008fb88291e9f7fcace4e", size = 1785665, upload-time = "2026-01-09T15:51:31.808Z" },
 ]
 
 [[package]]
@@ -7665,15 +7496,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
-]
-
-[[package]]
-name = "webencodings"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Removes the `unstructured` package. It was used for exactly one call — `dict_to_elements` in `unstructured_to_text` — which built `Element` objects out of the API's response dicts only so that `str(el)` could return `el.text`. The code now reads the text off those dicts directly.

`unstructured-client`, the thin API client that does the actual partitioning, stays. Nothing else in the tree imports `unstructured`.

## Why

This started as the `unstructured` 0.18.27 → 0.24.0 bump (#14472, which merged as an empty commit). That upgrade does not resolve:

| package | requires |
| --- | --- |
| `aiobotocore` (pinned transitively by `aioboto3`) | `wrapt>=1.10.10,<2.0.0` |
| `unstructured 0.24.0` | `wrapt>=2.1.1,<3.0.0` |

`unstructured` moved to wrapt 2 in 0.22.6. No `aioboto3` release depends on the `aiobotocore` 3.x line yet, so the two cannot coexist. The alternatives were pinning `unstructured` back to 0.21.5 (the last wrapt 1 release) or forcing `wrapt` through `override-dependencies`. Dropping the package removes the conflict instead of holding it down.

Doing so also drops **27 transitive packages**, including `spacy`, `numba`, `llvmlite`, `blis`, `thinc`, `nltk` and `langdetect` — a meaningful cut to image size and build time. `wrapt` stays on 1.17.3 and needs no override.

## Behavior change

An element whose `type` falls outside `unstructured`'s taxonomy was previously dropped; it now contributes its text. This is a deliberate choice against silent data loss. Recognized types are unaffected, including the empty ones such as `Image` and `PageBreak`, which contributed empty strings before and still do.

## Verification

The unit tests in `test_unstructured_to_text.py` were written against the **old** implementation and pass unchanged on both sides of the refactor: green with the real `unstructured 0.24.0` installed, and green again with the package fully uninstalled.

Three further checks were run locally to close the gap between "the transform is pinned" and "the transform is right":

**Exhaustive differential check.** Both implementations were run over 122 generated cases — every one of the 37 types in `TYPE_TO_TEXT_ELEMENT_MAP`, each with populated text, empty text and nested metadata, plus `CheckBox`, unicode, embedded newlines, missing `element_id`, null metadata, and empty/null element lists. 120 cases produced byte-identical output. The 2 divergences are the two documented above: an unrecognized `type`, and a missing `text` key, where the old path raised `KeyError` and the new one yields `""`.

**End-to-end against real documents.** Thirteen documents (the repo's PDF fixtures plus HTML and plain text) were partitioned with `unstructured 0.24.0` and serialized with `elements_to_dicts` — the same serializer the hosted API uses to build its response. Every element dict carried a `text` key, and old and new output matched on all thirteen.

**Recorded payload as a committed test.** `fixtures/unstructured_partition_elements.json` is that serializer's output for an HTML document, so the committed test now runs authentic API-shaped data — mixed types, nested metadata, a table with `text_as_html`, an image whose text is its alt attribute — rather than a hand-written mock. The expected string was captured from the `dict_to_elements` path before it was removed.

What none of this reaches is a live call to Unstructured's hosted SaaS. That would need a real key (there is no `UNSTRUCTURED_API_KEY` in `TestSecret` today) and belongs in `backend/tests/daily/` rather than a PR gate. The evidence that the live dicts carry `text` is the old code itself, which subscripted `item["text"]` unconditionally for every recognized type and has run against this API in production without a `KeyError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
