### PR TITLE
fix(appearance): Give the chat footer 500 characters

### DIFF
--- a/web/lib/opal/src/components/text/README.md
+++ b/web/lib/opal/src/components/text/README.md
@@ -13,11 +13,12 @@ inline markdown rendering via `RichStr` — pass `markdown("*bold* text")` as ch
 | `color`    | `TextColor`                                     | `"text-04"`      | Text color                                                                                     |
 | `as`       | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"`         | HTML tag to render                                                                             |
 | `nowrap`   | `boolean`                                       | `false`          | Prevent text wrapping                                                                          |
+| `wordWrap` | `"wrap-normal" \| "wrap-break-word" \| "wrap-anywhere" \| "break-all" \| "break-keep"` | — | How a run of characters with nowhere to wrap behaves; unset leaves normal CSS wrapping |
 | `maxLines` | `number`                                        | —                | Truncate to N lines with an ellipsis (`1` = single-line truncate; `2+` = `-webkit-line-clamp`) |
 | `children` | `string \| RichStr \| RichNodes`                | —                | Plain string, `markdown()` for inline markdown, or `richNodes()` for inline React nodes        |
 
 > **No `className` or `style`.** `Text` strips both (its props extend `WithoutStyles`); every
-> aspect of its appearance is driven by `font`, `color`, `nowrap`, and `maxLines`. For layout
+> aspect of its appearance is driven by `font`, `color`, `nowrap`, `wordWrap`, and `maxLines`. For layout
 > concerns (margin, flex, width, alignment) wrap `Text` in a container or move the utility class
 > to the parent — don't reach for `className`. All other HTML attributes (`id`, `onClick`,
 > `title`, `aria-*`, `data-*`) pass straight through to the rendered element.

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -25,6 +25,32 @@ interface TextProps extends WithoutStyles<
   /** Prevent text wrapping. */
   nowrap?: boolean;
 
+  /**
+   * How a run of characters with nowhere to wrap should behave. Ordinary
+   * wrapping only breaks at whitespace, so a URL, an identifier or any single
+   * long token overflows its container instead of wrapping.
+   *
+   * - `"wrap-normal"` — the CSS default: break at whitespace only, and let a
+   *   long run overflow. Spell it out to override an inherited value, since
+   *   `overflow-wrap` inherits and omitting this prop cannot undo an
+   *   ancestor's.
+   * - `"wrap-break-word"` — break only when the run would otherwise overflow.
+   * - `"wrap-anywhere"` — as above, and count the break when min-content is
+   *   measured, so the element can shrink as a flex item.
+   * - `"break-all"` — break between any two characters.
+   * - `"break-keep"` — never break within a word (CJK).
+   *
+   * Overlaps `nowrap`, which is the older way to say "one line" and wins
+   * because it removes the wrap opportunities this would act on. Prefer this
+   * prop; `nowrap` is kept so existing callers are undisturbed.
+   */
+  wordWrap?:
+    | "wrap-normal"
+    | "wrap-break-word"
+    | "wrap-anywhere"
+    | "break-all"
+    | "break-keep";
+
   /** Truncate text to N lines with ellipsis. `1` uses simple truncation; `2+` uses `-webkit-line-clamp`. */
   maxLines?: number;
 
@@ -101,6 +127,7 @@ function Text({
   color = "text-04",
   as: Tag = "span",
   nowrap,
+  wordWrap,
   maxLines,
   strikethrough,
   children,
@@ -111,6 +138,7 @@ function Text({
     FONT_CONFIG[font],
     COLOR_CONFIG[color],
     nowrap && "whitespace-nowrap",
+    wordWrap,
     maxLines === 1 && "truncate",
     maxLines && maxLines > 1 && "overflow-hidden",
     strikethrough && "line-through"

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -27,7 +27,7 @@ const CHAR_LIMITS = {
   custom_greeting_message: 50,
   custom_login_subtitle: 100,
   custom_header_content: 100,
-  custom_lower_disclaimer_content: 200,
+  custom_lower_disclaimer_content: 500,
   custom_popup_header: 100,
   custom_popup_content: 500,
   consent_screen_prompt: 200,

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -622,7 +622,13 @@ function Footer() {
     <RootLayout.Footer>
       <div
         className={cn(
-          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto",
+          // Wrapping a long disclaimer needs both halves. `[&>*]:min-w-0`
+          // lets the text shrink, since a flex item's min-width is `auto`
+          // and otherwise holds it at its min-content width. `wordWrap` on
+          // the Text below then lets an unbroken run split, which ordinary
+          // wrapping will not do — it only breaks at whitespace, so a
+          // pasted URL or one long token would still overflow.
+          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto [&>*]:min-w-0",
           // # Note (from @raunakab):
           //
           // The conditional rendering of vertical padding based on the current page is intentional.
@@ -640,7 +646,12 @@ function Footer() {
           appPosition.isChat() ? "pb-2" : "py-2"
         )}
       >
-        <Text font="secondary-action" color="text-03">
+        <Text
+          font="secondary-action"
+          color="text-03"
+          as="p"
+          wordWrap="wrap-anywhere"
+        >
           {markdown(customFooterContent)}
         </Text>
       </div>


### PR DESCRIPTION
## Description

Raises the chat footer's character limit from 200 to 500. 200 is cramped for a disclaimer, which is what most deployments put there.

One line. `CHAR_LIMITS` is read by both the Yup rule and the character counter, so the validation, the counter and the error message all move together — there is no second place to update.

Nothing downstream constrains the field: it is a plain `str | None` on `EnterpriseSettings`, and enterprise settings persist as a single JSONB blob in the key-value store rather than as typed columns.

That last point is worth stating plainly, since it is the reason this change is safe and also a problem in its own right: **the limit is advisory**. There is no `max_length` on the model, no length check in `admin_ee_put_settings`, and `check_validity()` is a no-op, so the API accepts a footer of any size at 200 or at 500. The blob is also served unauthenticated by `ee_fetch_settings`. Hardening that is deliberately not in this PR — it needs a decision on the real limits and a single source of truth shared with the frontend, and it is the next PR in this sequence.

## Screenshots + Videos

Full image:

<img width="1375" height="2123" alt="image" src="https://github.com/user-attachments/assets/5800c89d-3d82-462f-93a4-e0c0ced27dd3" />

Zoomed in on the footer:

<img width="1388" height="155" alt="image" src="https://github.com/user-attachments/assets/cf80b81d-d256-4ae7-8303-6c80381fe02f" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the chat footer's character limit from 200 to 500 and lets long disclaimers wrap instead of overflowing the row, since 200 was cramped and footers with no whitespace ran off the edge.

- The `Text` component gains a `wordWrap` prop; `nowrap` still wins when both are set.
- The limit remains advisory—the backend accepts any length, so only frontend validation, the counter, and the error message change.

<sup>Written for commit f19ac06c2a2b4217521b28c5f31dbec2ae2f03fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->