### PR TITLE
refactor(appearance): Enforce the appearance length caps on the API

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/models.py
+++ b/backend/ee/onyx/server/enterprise_settings/models.py
@@ -38,14 +38,29 @@ class LogoDisplayStyle(str, Enum):
 #
 # The theme page keeps its own copy for its character counters. Keep the two in
 # step; `test_appearance_char_limits.py` fails when they drift.
-MAX_APPLICATION_NAME_LEN = 50
-MAX_GREETING_MESSAGE_LEN = 50
-MAX_LOGIN_SUBTITLE_LEN = 100
-MAX_HEADER_CONTENT_LEN = 100
-MAX_LOWER_DISCLAIMER_CONTENT_LEN = 500
-MAX_POPUP_HEADER_LEN = 100
-MAX_POPUP_CONTENT_LEN = 500
-MAX_CONSENT_SCREEN_PROMPT_LEN = 200
+MAX_APPLICATION_NAME_LEN: int = 50
+MAX_GREETING_MESSAGE_LEN: int = 50
+MAX_LOGIN_SUBTITLE_LEN: int = 100
+MAX_HEADER_CONTENT_LEN: int = 100
+MAX_LOWER_DISCLAIMER_CONTENT_LEN: int = 500
+MAX_POPUP_HEADER_LEN: int = 100
+MAX_POPUP_CONTENT_LEN: int = 500
+MAX_CONSENT_SCREEN_PROMPT_LEN: int = 200
+
+# Field name to cap, for callers that have to reconcile a stored value against
+# these limits rather than reject it. `load_settings` is the one that does:
+# the caps validate on deserialisation too, so a blob written before they
+# existed would otherwise make the settings endpoint unreadable.
+APPEARANCE_FIELD_MAX_LENGTHS: dict[str, int] = {
+    "application_name": MAX_APPLICATION_NAME_LEN,
+    "custom_greeting_message": MAX_GREETING_MESSAGE_LEN,
+    "custom_login_subtitle": MAX_LOGIN_SUBTITLE_LEN,
+    "custom_header_content": MAX_HEADER_CONTENT_LEN,
+    "custom_lower_disclaimer_content": MAX_LOWER_DISCLAIMER_CONTENT_LEN,
+    "custom_popup_header": MAX_POPUP_HEADER_LEN,
+    "custom_popup_content": MAX_POPUP_CONTENT_LEN,
+    "consent_screen_prompt": MAX_CONSENT_SCREEN_PROMPT_LEN,
+}
 
 
 class EnterpriseSettings(BaseModel):

--- a/backend/ee/onyx/server/enterprise_settings/models.py
+++ b/backend/ee/onyx/server/enterprise_settings/models.py
@@ -29,12 +29,33 @@ class LogoDisplayStyle(str, Enum):
     NAME_ONLY = "name_only"
 
 
+# Length caps for the admin-authored appearance strings.
+#
+# Enforced here rather than only in the form, because the form is the client
+# and a client cannot be trusted to bound what it sends. Everything below is
+# stored in one KV blob and served without auth, so an unbounded field is
+# served to every anonymous caller.
+#
+# The theme page keeps its own copy for its character counters. Keep the two in
+# step; `test_appearance_char_limits.py` fails when they drift.
+MAX_APPLICATION_NAME_LEN = 50
+MAX_GREETING_MESSAGE_LEN = 50
+MAX_LOGIN_SUBTITLE_LEN = 100
+MAX_HEADER_CONTENT_LEN = 100
+MAX_LOWER_DISCLAIMER_CONTENT_LEN = 500
+MAX_POPUP_HEADER_LEN = 100
+MAX_POPUP_CONTENT_LEN = 500
+MAX_CONSENT_SCREEN_PROMPT_LEN = 200
+
+
 class EnterpriseSettings(BaseModel):
     """General settings that only apply to the Enterprise Edition of Onyx
 
     NOTE: don't put anything sensitive in here, as this is accessible without auth."""
 
-    application_name: str | None = None
+    application_name: str | None = Field(
+        default=None, max_length=MAX_APPLICATION_NAME_LEN
+    )
     use_custom_logo: bool = False
     use_custom_logotype: bool = False
     logo_display_style: LogoDisplayStyle | None = None
@@ -44,17 +65,31 @@ class EnterpriseSettings(BaseModel):
 
     # custom Chat components
     two_lines_for_chat_header: bool | None = None
-    custom_lower_disclaimer_content: str | None = None
-    custom_header_content: str | None = None
-    custom_popup_header: str | None = None
-    custom_popup_content: str | None = None
+    custom_lower_disclaimer_content: str | None = Field(
+        default=None, max_length=MAX_LOWER_DISCLAIMER_CONTENT_LEN
+    )
+    custom_header_content: str | None = Field(
+        default=None, max_length=MAX_HEADER_CONTENT_LEN
+    )
+    custom_popup_header: str | None = Field(
+        default=None, max_length=MAX_POPUP_HEADER_LEN
+    )
+    custom_popup_content: str | None = Field(
+        default=None, max_length=MAX_POPUP_CONTENT_LEN
+    )
     enable_consent_screen: bool | None = None
-    consent_screen_prompt: str | None = None
+    consent_screen_prompt: str | None = Field(
+        default=None, max_length=MAX_CONSENT_SCREEN_PROMPT_LEN
+    )
     show_first_visit_notice: bool | None = None
-    custom_greeting_message: str | None = None
+    custom_greeting_message: str | None = Field(
+        default=None, max_length=MAX_GREETING_MESSAGE_LEN
+    )
     # login page subtitle under the "Welcome to <app name>" heading. Blank
     # falls back to the default Onyx tagline.
-    custom_login_subtitle: str | None = None
+    custom_login_subtitle: str | None = Field(
+        default=None, max_length=MAX_LOGIN_SUBTITLE_LEN
+    )
 
     # custom help link surfaced in the profile dropdown alongside the
     # built-in "Help & FAQ" item

--- a/backend/ee/onyx/server/enterprise_settings/store.py
+++ b/backend/ee/onyx/server/enterprise_settings/store.py
@@ -5,6 +5,7 @@ from typing import IO, Any, cast
 from fastapi import HTTPException, UploadFile
 
 from ee.onyx.server.enterprise_settings.models import (
+    APPEARANCE_FIELD_MAX_LENGTHS,
     AnalyticsScriptUpload,
     EnterpriseSettings,
 )
@@ -25,6 +26,32 @@ _LOGO_FILENAME = "__logo__"
 _LOGOTYPE_FILENAME = "__logotype__"
 
 
+def _clamp_appearance_fields(stored: dict[str, Any]) -> dict[str, Any]:
+    """Trims stored appearance strings to their caps.
+
+    The caps are `max_length` on the model, so they validate on the way in as
+    well as on the way out. A blob written before a cap existed, or under a
+    larger one, would otherwise raise on load — and `ee_fetch_settings` is
+    unauthenticated, so that is a 500 to every caller and an admin page that
+    cannot open to repair the value. Trimming keeps the settings readable and
+    leaves the admin looking at what is now stored, rather than at nothing.
+    """
+    clamped = dict(stored)
+    for field, limit in APPEARANCE_FIELD_MAX_LENGTHS.items():
+        value = clamped.get(field)
+        if isinstance(value, str) and len(value) > limit:
+            logger.warning(
+                "Enterprise setting %s was %d characters, over its %d limit; "
+                "trimming it to load. Re-save the theme settings to keep the "
+                "shortened value.",
+                field,
+                len(value),
+                limit,
+            )
+            clamped[field] = value[:limit]
+    return clamped
+
+
 def load_settings() -> EnterpriseSettings:
     """Loads settings data directly from DB. This should be used primarily
     for checking what is actually in the DB, aka for editing and saving back settings.
@@ -36,7 +63,9 @@ def load_settings() -> EnterpriseSettings:
     dynamic_config_store = get_kv_store()
     try:
         settings = EnterpriseSettings(
-            **cast(dict, dynamic_config_store.load(KV_ENTERPRISE_SETTINGS_KEY))
+            **_clamp_appearance_fields(
+                cast(dict, dynamic_config_store.load(KV_ENTERPRISE_SETTINGS_KEY))
+            )
         )
     except KvKeyNotFoundError:
         settings = EnterpriseSettings()

--- a/backend/tests/unit/onyx/server/test_appearance_char_limits.py
+++ b/backend/tests/unit/onyx/server/test_appearance_char_limits.py
@@ -10,9 +10,11 @@ face.
 import re
 from pathlib import Path
 
+import pydantic
 import pytest
 
 from ee.onyx.server.enterprise_settings.models import (
+    APPEARANCE_FIELD_MAX_LENGTHS,
     MAX_APPLICATION_NAME_LEN,
     MAX_CONSENT_SCREEN_PROMPT_LEN,
     MAX_GREETING_MESSAGE_LEN,
@@ -21,7 +23,9 @@ from ee.onyx.server.enterprise_settings.models import (
     MAX_LOWER_DISCLAIMER_CONTENT_LEN,
     MAX_POPUP_CONTENT_LEN,
     MAX_POPUP_HEADER_LEN,
+    EnterpriseSettings,
 )
+from ee.onyx.server.enterprise_settings.store import _clamp_appearance_fields
 from onyx.server.features.admin_banner.api import MAX_CONTENT_LEN, MAX_TITLE_LEN
 
 THEME_PAGE = (
@@ -77,3 +81,45 @@ def test_frontend_limit_matches_backend(field: str) -> None:
         f"{field}: the theme page says {_frontend_limits()[field]}, the API "
         f"enforces {BACKEND_LIMITS[field]}. Update whichever is stale."
     )
+
+
+# The comparison above only proves the two sets of numbers agree. It would keep
+# passing with every `max_length=` deleted, so the enforcement those numbers are
+# supposed to describe needs its own coverage.
+# `model_validate` rather than kwargs, and `model_dump` rather than `getattr`:
+# the field name is a parameter here, and both keep that dynamic access
+# something the type checker can still follow.
+@pytest.mark.parametrize("field,limit", sorted(APPEARANCE_FIELD_MAX_LENGTHS.items()))
+def test_field_accepts_its_limit(field: str, limit: int) -> None:
+    settings = EnterpriseSettings.model_validate({field: "x" * limit})
+    assert settings.model_dump()[field] == "x" * limit
+
+
+@pytest.mark.parametrize("field,limit", sorted(APPEARANCE_FIELD_MAX_LENGTHS.items()))
+def test_field_rejects_one_over(field: str, limit: int) -> None:
+    with pytest.raises(pydantic.ValidationError) as caught:
+        EnterpriseSettings.model_validate({field: "x" * (limit + 1)})
+    assert any(e["type"] == "string_too_long" for e in caught.value.errors())
+
+
+# A cap validates on the way out as well as in, so a blob stored before the cap
+# existed would make the settings endpoint unreadable. It is unauthenticated,
+# so that is a 500 for every caller and an admin page that cannot open to fix
+# the value.
+def test_oversized_stored_value_is_trimmed_rather_than_fatal() -> None:
+    field = "custom_lower_disclaimer_content"
+    limit = APPEARANCE_FIELD_MAX_LENGTHS[field]
+    stored = {field: "x" * (limit + 250), "application_name": "Onyx"}
+
+    settings = EnterpriseSettings.model_validate(_clamp_appearance_fields(stored))
+
+    assert settings.custom_lower_disclaimer_content is not None
+    assert len(settings.custom_lower_disclaimer_content) == limit
+    # Trimming one field must not discard the rest of the configuration.
+    assert settings.application_name == "Onyx"
+
+
+def test_clamping_leaves_a_value_within_its_limit_alone() -> None:
+    field = "custom_popup_header"
+    value = "x" * APPEARANCE_FIELD_MAX_LENGTHS[field]
+    assert _clamp_appearance_fields({field: value})[field] == value

--- a/backend/tests/unit/onyx/server/test_appearance_char_limits.py
+++ b/backend/tests/unit/onyx/server/test_appearance_char_limits.py
@@ -1,0 +1,79 @@
+"""The theme page duplicates the appearance length caps so it can draw its
+character counters without an API round-trip. Duplication is fine; drifting is
+not, and drifting upward is the harmful direction — the form would let an admin
+type past what the API accepts, and the save would fail at submit.
+
+This pins the two copies together, so drift fails here rather than in a user's
+face.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from ee.onyx.server.enterprise_settings.models import (
+    MAX_APPLICATION_NAME_LEN,
+    MAX_CONSENT_SCREEN_PROMPT_LEN,
+    MAX_GREETING_MESSAGE_LEN,
+    MAX_HEADER_CONTENT_LEN,
+    MAX_LOGIN_SUBTITLE_LEN,
+    MAX_LOWER_DISCLAIMER_CONTENT_LEN,
+    MAX_POPUP_CONTENT_LEN,
+    MAX_POPUP_HEADER_LEN,
+)
+from onyx.server.features.admin_banner.api import MAX_CONTENT_LEN, MAX_TITLE_LEN
+
+THEME_PAGE = (
+    Path(__file__).resolve().parents[5]
+    / "web"
+    / "src"
+    / "app"
+    / "ee"
+    / "admin"
+    / "theme"
+    / "page.tsx"
+)
+
+# The announcement fields are the admin banner, which is a separate endpoint
+# and model from the enterprise settings blob.
+BACKEND_LIMITS = {
+    "application_name": MAX_APPLICATION_NAME_LEN,
+    "custom_greeting_message": MAX_GREETING_MESSAGE_LEN,
+    "custom_login_subtitle": MAX_LOGIN_SUBTITLE_LEN,
+    "custom_header_content": MAX_HEADER_CONTENT_LEN,
+    "custom_lower_disclaimer_content": MAX_LOWER_DISCLAIMER_CONTENT_LEN,
+    "custom_popup_header": MAX_POPUP_HEADER_LEN,
+    "custom_popup_content": MAX_POPUP_CONTENT_LEN,
+    "consent_screen_prompt": MAX_CONSENT_SCREEN_PROMPT_LEN,
+    "system_announcement_header": MAX_TITLE_LEN,
+    "system_announcement_content": MAX_CONTENT_LEN,
+}
+
+
+def _frontend_limits() -> dict[str, int]:
+    source = THEME_PAGE.read_text()
+    block = re.search(r"const CHAR_LIMITS = \{(.*?)\n\};", source, re.DOTALL)
+    assert block, f"could not find CHAR_LIMITS in {THEME_PAGE}"
+    return {
+        name: int(value)
+        for name, value in re.findall(r"(\w+):\s*(\d+),", block.group(1))
+    }
+
+
+def test_theme_page_is_readable() -> None:
+    # A moved or renamed file would otherwise make every case below vacuous.
+    assert THEME_PAGE.is_file(), f"{THEME_PAGE} not found"
+    assert _frontend_limits(), "CHAR_LIMITS parsed as empty"
+
+
+def test_every_backend_cap_has_a_frontend_counterpart() -> None:
+    assert set(_frontend_limits()) == set(BACKEND_LIMITS)
+
+
+@pytest.mark.parametrize("field", sorted(BACKEND_LIMITS))
+def test_frontend_limit_matches_backend(field: str) -> None:
+    assert _frontend_limits()[field] == BACKEND_LIMITS[field], (
+        f"{field}: the theme page says {_frontend_limits()[field]}, the API "
+        f"enforces {BACKEND_LIMITS[field]}. Update whichever is stale."
+    )

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -22,6 +22,9 @@ import { invalidateNotificationCaches } from "@/lib/notifications/api";
 
 const route = ADMIN_ROUTES.THEME;
 
+// NOTE(@raunakab): these constants are enforced by the backend; if those are
+// updated, please update these ones as well. We duplicate them here to avoid
+// unnecessary API fetches to get max-values.
 const CHAR_LIMITS = {
   application_name: 50,
   custom_greeting_message: 50,


### PR DESCRIPTION
## Description

The theme page's `CHAR_LIMITS` was the only thing bounding these fields. A client-side limit bounds a form, not an API. `admin_ee_put_settings` accepted any length, `check_validity()` is a no-op, and `EnterpriseSettings` carried no `max_length`. Since everything there is stored in one JSONB blob and served by `ee_fetch_settings` without auth, an oversized field is then served to every anonymous caller.

**Caps now live on the model.** Eight fields on `EnterpriseSettings` gain `Field(max_length=...)`, driven by module-level constants. This follows what `admin_banner/api.py` already does with `MAX_TITLE_LEN` / `MAX_CONTENT_LEN` — the announcement header and content were the only appearance strings already bounded, which is why they needed nothing here.

**The frontend keeps its copy, and a test pins them together.** Serving the limits over the API was the alternative. It was rejected because the form needs them synchronously to build its Yup schema and character counters: fetching them means either a loading state on the form or frontend defaults as a fallback, and a fallback is a second copy plus a runtime override — worse to reason about than a plain duplicate. So the duplication stays, with a note at the call site, and `test_appearance_char_limits.py` fails when the two disagree.

Drift is one-directional in its harm. Frontend lower than backend is invisible. Frontend *higher* means the form invites text the API then refuses, so the save fails at submit. The test catches either.

## Screenshots + Videos

No UI changes; screenshots / videos not needed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the appearance length caps on the API: eight `EnterpriseSettings` fields now have `max_length`, so `admin_ee_put_settings` rejects oversized text instead of accepting it and serving it to anonymous callers. Previously only the theme page's client-side `CHAR_LIMITS` bounded these fields.

**Notes**
- Loading now trims stored values that exceed a cap, so blobs written before the caps existed don't break the unauthenticated settings endpoint.
- The theme page keeps its duplicate copy for its character counters and Yup schema; `test_appearance_char_limits.py` fails CI when the copies drift, and now also exercises the caps and the trimming path.
- `custom_help_link_url` and `custom_help_link_label` stay unbounded — no frontend limit exists for them today, so a backend cap alone would invite text the API then refuses.
- Stacked on `feat/update-footer-max-chars`, which raises the footer limit to 500; basing on `main` would pin the backend to 500 while the frontend says 200.

<sup>Written for commit bcf8f6f5fb7b9af2ff590217fc3b1d04f2c39bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

