### PR TITLE
feat: add metadata-only system LLM tracing

### DIFF
--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -21,6 +21,7 @@ from onyx.llm.models import (
 from onyx.llm.utils import llm_response_to_string
 from onyx.server.metrics.image_processing import track_image_summarization
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
@@ -136,8 +137,8 @@ def _summarize_image(
             llm=llm,
             flow=LLMFlow.IMAGE_SUMMARIZATION,
             input_messages=[{"type": "image_summarization_request"}],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
-            # Note: We don't include the actual image in the span input to avoid bloating traces
             response = llm.invoke(
                 messages, total_timeout_override=IMAGE_SUMMARIZATION_TIMEOUT
             )

--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -136,7 +136,6 @@ def _summarize_image(
         with llm_generation_span(
             llm=llm,
             flow=LLMFlow.IMAGE_SUMMARIZATION,
-            input_messages=[{"type": "image_summarization_request"}],
             content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1,7 +1,7 @@
 import time
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import NamedTuple, Protocol
 
 import sentry_sdk
@@ -104,6 +104,8 @@ from onyx.prompts.contextual_retrieval import (
     DOCUMENT_SUMMARY_PROMPT,
 )
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
@@ -116,6 +118,7 @@ logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
+INDEXING_PIPELINE_TRACE_NAME = "indexing_pipeline"
 
 # Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
 # model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the
@@ -884,6 +887,7 @@ def add_document_summaries(
         llm=llm,
         flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
         input_messages=[prompt_msg],
+        content_mode=TraceContentMode.METADATA_ONLY,
     ) as span_generation:
         response = llm.invoke(
             prompt_msg,
@@ -938,6 +942,7 @@ def add_chunk_summaries(
             llm=llm,
             flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
             input_messages=[fallback_prompt],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(
                 fallback_prompt,
@@ -968,6 +973,7 @@ def add_chunk_summaries(
                 llm=llm,
                 flow=LLMFlow.CONTEXTUAL_RAG_CHUNK_CONTEXT,
                 input_messages=[processed_prompt],
+                content_mode=TraceContentMode.METADATA_ONLY,
             ) as span_generation:
                 response = llm.invoke(
                     processed_prompt,
@@ -1568,6 +1574,9 @@ def run_indexing_pipeline(
     enable_contextual_rag = (
         search_settings.enable_contextual_rag or ENABLE_CONTEXTUAL_RAG
     )
+    llm_enrichment_configured = (
+        enable_contextual_rag or get_image_extraction_and_analysis_enabled()
+    )
     llm = None
     if enable_contextual_rag:
         llm = get_contextual_rag_llm_for_search_settings(search_settings)
@@ -1580,17 +1589,26 @@ def run_indexing_pipeline(
         # after every doc, update status in case there are a bunch of really long docs
     )
 
-    return index_doc_batch_with_handler(
-        chunker=chunker,
-        embedder=embedder,
-        document_indices=document_indices,
-        document_batch=document_batch,
-        request_id=request_id,
-        tenant_id=tenant_id,
-        adapter=adapter,
-        enable_contextual_rag=enable_contextual_rag,
-        llm=llm,
-        ignore_time_skip=ignore_time_skip,
-        index_to_secondary=index_to_secondary,
-        from_beginning=from_beginning,
+    trace_context = (
+        ensure_trace(
+            INDEXING_PIPELINE_TRACE_NAME,
+            content_mode=TraceContentMode.METADATA_ONLY,
+        )
+        if llm_enrichment_configured
+        else nullcontext()
     )
+    with trace_context:
+        return index_doc_batch_with_handler(
+            chunker=chunker,
+            embedder=embedder,
+            document_indices=document_indices,
+            document_batch=document_batch,
+            request_id=request_id,
+            tenant_id=tenant_id,
+            adapter=adapter,
+            enable_contextual_rag=enable_contextual_rag,
+            llm=llm,
+            ignore_time_skip=ignore_time_skip,
+            index_to_secondary=index_to_secondary,
+            from_beginning=from_beginning,
+        )

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -59,10 +59,15 @@ from onyx.indexing.chunker import (
 )
 from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import DocAwareChunk, IndexChunk
+from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.traces import TraceContentMode
 
 if TYPE_CHECKING:
     from onyx.llm.interfaces import LLM
     from onyx.natural_language_processing.utils import BaseTokenizer
+
+
+CONTEXTUAL_RAG_REEMBED_TRACE_NAME = "contextual_rag_reembed"
 
 
 class ReembedStrategy(enum.Enum):
@@ -430,12 +435,16 @@ def _augmentation_reembed(
         from onyx.indexing.indexing_pipeline import add_contextual_summaries
 
         # Groups by source_document.id internally, so the mixed-doc input is fine.
-        add_contextual_summaries(
-            chunks=doc_aware_chunks,
-            llm=ctx.llm,
-            tokenizer=ctx.tokenizer,
-            chunk_token_limit=ctx.chunk_token_limit,
-        )
+        with ensure_trace(
+            CONTEXTUAL_RAG_REEMBED_TRACE_NAME,
+            content_mode=TraceContentMode.METADATA_ONLY,
+        ):
+            add_contextual_summaries(
+                chunks=doc_aware_chunks,
+                llm=ctx.llm,
+                tokenizer=ctx.tokenizer,
+                chunk_token_limit=ctx.chunk_token_limit,
+            )
 
     embedded = embedder.embed_chunks(doc_aware_chunks)
     # Pair each stored chunk with its OWN vector by identity, not list position.

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -39,10 +39,14 @@ from onyx.prompts.kg_prompts import (
     MASTER_EXTRACTION_PROMPT,
 )
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+KG_DOCUMENT_PROCESSING_TRACE_NAME = "kg_document_processing"
 
 
 def get_entity_types_str(active: bool | None = None) -> str:
@@ -335,9 +339,29 @@ def kg_deep_extraction(
     index_name: str,
     kg_config_settings: KGConfigSettings,
 ) -> KGDocumentDeepExtractionResults:
-    """
-    Perform deep extraction and classification on the document.
-    """
+    """Perform one document's deep extraction and classification workflow."""
+    with ensure_trace(
+        KG_DOCUMENT_PROCESSING_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
+    ):
+        return _kg_deep_extraction(
+            document_id=document_id,
+            metadata=metadata,
+            implied_extraction=implied_extraction,
+            tenant_id=tenant_id,
+            index_name=index_name,
+            kg_config_settings=kg_config_settings,
+        )
+
+
+def _kg_deep_extraction(
+    document_id: str,
+    metadata: KGEnhancedDocumentMetadata,
+    implied_extraction: KGImpliedExtractionResults,
+    tenant_id: str,
+    index_name: str,
+    kg_config_settings: KGConfigSettings,
+) -> KGDocumentDeepExtractionResults:
     result = KGDocumentDeepExtractionResults(
         classification_result=None,
         deep_extracted_entities=set(),
@@ -427,6 +451,7 @@ def kg_classify_document(
             llm=llm,
             flow=LLMFlow.KG_DOCUMENT_CLASSIFICATION,
             input_messages=[prompt_msg],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, response)
@@ -499,7 +524,10 @@ def kg_deep_extract_chunks(
     try:
         prompt_msg = UserMessage(content=prompt)
         with llm_generation_span(
-            llm=llm, flow=LLMFlow.KG_DEEP_EXTRACTION, input_messages=[prompt_msg]
+            llm=llm,
+            flow=LLMFlow.KG_DEEP_EXTRACTION,
+            input_messages=[prompt_msg],
+            content_mode=TraceContentMode.METADATA_ONLY,
         ) as span_generation:
             response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, response)

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -12,7 +12,7 @@ from shared_configs.contextvars import get_current_tenant_id
 from .setup import get_trace_provider
 from .span_data import AgentSpanData, FunctionSpanData, GenerationSpanData
 from .spans import Span
-from .traces import Trace
+from .traces import Trace, TraceContentMode
 
 if TYPE_CHECKING:
     pass
@@ -31,6 +31,7 @@ def trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
 ) -> Trace:
     """
@@ -67,6 +68,7 @@ def trace(
         trace_id=trace_id,
         group_id=group_id,
         metadata=metadata,
+        content_mode=content_mode,
         disabled=disabled,
     )
 
@@ -77,6 +79,7 @@ def ensure_trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
 ) -> Iterator[Trace | None]:
     """
@@ -93,6 +96,7 @@ def ensure_trace(
         trace_id=trace_id,
         group_id=group_id,
         metadata=metadata,
+        content_mode=content_mode,
         disabled=disabled,
     ) as created_trace:
         yield created_trace
@@ -190,6 +194,7 @@ def generation_span(
     tools: Sequence[Mapping[str, Any]] | None = None,
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
+    content_mode: TraceContentMode | None = None,
     disabled: bool = False,
 ) -> Span[GenerationSpanData]:
     """Create a new generation span. The span will not be started automatically, you should either
@@ -234,5 +239,6 @@ def generation_span(
         ),
         span_id=span_id,
         parent=parent,
+        content_mode=content_mode,
         disabled=disabled,
     )

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -31,8 +31,8 @@ def trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
-    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
 ) -> Trace:
     """
     Create a new trace. The trace will not be started automatically; you should either use
@@ -79,8 +79,8 @@ def ensure_trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
-    content_mode: TraceContentMode = TraceContentMode.FULL,
     disabled: bool = False,
+    content_mode: TraceContentMode = TraceContentMode.FULL,
 ) -> Iterator[Trace | None]:
     """
     Ensure a trace exists. If a trace is already active, reuse it.
@@ -194,8 +194,8 @@ def generation_span(
     tools: Sequence[Mapping[str, Any]] | None = None,
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
-    content_mode: TraceContentMode | None = None,
     disabled: bool = False,
+    content_mode: TraceContentMode | None = None,
 ) -> Span[GenerationSpanData]:
     """Create a new generation span. The span will not be started automatically, you should either
     do `with generation_span() ...` or call `span.start()` + `span.finish()` manually.

--- a/backend/onyx/tracing/framework/processor_interface.py
+++ b/backend/onyx/tracing/framework/processor_interface.py
@@ -68,7 +68,7 @@ class TracingProcessor(abc.ABC):
         """Called when a trace completes execution.
 
         Args:
-            trace: The completed trace containing all spans and results.
+            trace: The completed workflow correlation root.
 
         Notes:
             - Called synchronously when trace finishes

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -10,8 +10,9 @@ from onyx.utils.logger import setup_logger
 
 from .processor_interface import TracingProcessor
 from .scope import Scope
+from .span_data import GenerationSpanData
 from .spans import NoOpSpan, Span, SpanImpl, TSpanData
-from .traces import NoOpTrace, Trace, TraceImpl
+from .traces import NoOpTrace, Trace, TraceContentMode, TraceImpl
 
 logger = setup_logger(__name__)
 
@@ -39,6 +40,9 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
         """
         with self._lock:
             self._processors = tuple(processors)
+
+    def has_processors(self) -> bool:
+        return bool(self._processors)
 
     def on_trace_start(self, trace: Trace) -> None:
         """
@@ -154,6 +158,7 @@ class TraceProvider(ABC):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
     ) -> Trace:
         """Create a new trace."""
@@ -164,6 +169,7 @@ class TraceProvider(ABC):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
+        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
     ) -> Span[TSpanData]:
         """Create a new span."""
@@ -223,6 +229,7 @@ class DefaultTraceProvider(TraceProvider):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
     ) -> Trace:
         """
@@ -230,7 +237,7 @@ class DefaultTraceProvider(TraceProvider):
         """
         if disabled:
             logger.debug("Tracing is disabled. Not creating trace %s", name)
-            return NoOpTrace()
+            return NoOpTrace(content_mode)
 
         trace_id = trace_id or self.gen_trace_id()
 
@@ -242,6 +249,7 @@ class DefaultTraceProvider(TraceProvider):
             group_id=group_id,
             metadata=metadata,
             processor=self._multi_processor,
+            content_mode=content_mode,
         )
 
     def create_span(
@@ -249,6 +257,7 @@ class DefaultTraceProvider(TraceProvider):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
+        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
     ) -> Span[TSpanData]:
         """
@@ -265,10 +274,6 @@ class DefaultTraceProvider(TraceProvider):
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
             if current_trace is None:
-                # Expected when tracing is disabled or a caller creates a span
-                # outside an active trace context (e.g. celery tasks with
-                # SENTRY_CELERY_TRACES_SAMPLE_RATE=0). Fall through to NoOpSpan
-                # silently — matches the other no-op branches below.
                 logger.debug("No active trace; returning NoOpSpan for %s", span_data)
                 return NoOpSpan(span_data)
             elif isinstance(current_trace, NoOpTrace) or isinstance(
@@ -283,6 +288,11 @@ class DefaultTraceProvider(TraceProvider):
 
             parent_id = current_span.span_id if current_span else None
             trace_id = current_trace.trace_id
+            inherited_content_mode = (
+                current_span.content_mode
+                if current_span
+                else current_trace.content_mode
+            )
 
         elif isinstance(parent, Trace):
             if isinstance(parent, NoOpTrace):
@@ -290,15 +300,23 @@ class DefaultTraceProvider(TraceProvider):
                 return NoOpSpan(span_data)
             trace_id = parent.trace_id
             parent_id = None
+            inherited_content_mode = parent.content_mode
         elif isinstance(parent, Span):
             if isinstance(parent, NoOpSpan):
                 logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
                 return NoOpSpan(span_data)
             parent_id = parent.span_id
             trace_id = parent.trace_id
+            inherited_content_mode = parent.content_mode
         else:
             # This should never happen, but type-checking needs it
             raise ValueError(f"Invalid parent type: {type(parent)}")
+
+        resolved_content_mode = content_mode or inherited_content_mode
+        if resolved_content_mode == TraceContentMode.METADATA_ONLY and isinstance(
+            span_data, GenerationSpanData
+        ):
+            span_data.disable_content_capture()
 
         return SpanImpl(
             trace_id=trace_id,
@@ -306,6 +324,7 @@ class DefaultTraceProvider(TraceProvider):
             parent_id=parent_id,
             processor=self._multi_processor,
             span_data=span_data,
+            content_mode=resolved_content_mode,
         )
 
     def shutdown(self) -> None:

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -10,7 +10,7 @@ from onyx.utils.logger import setup_logger
 
 from .processor_interface import TracingProcessor
 from .scope import Scope
-from .span_data import GenerationSpanData
+from .span_data import GenerationSpanData, SpanData
 from .spans import NoOpSpan, Span, SpanImpl, TSpanData
 from .traces import NoOpTrace, Trace, TraceContentMode, TraceImpl
 
@@ -40,9 +40,6 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
         """
         with self._lock:
             self._processors = tuple(processors)
-
-    def has_processors(self) -> bool:
-        return bool(self._processors)
 
     def on_trace_start(self, trace: Trace) -> None:
         """
@@ -263,10 +260,6 @@ class DefaultTraceProvider(TraceProvider):
         """
         Create a new span.
         """
-        if disabled:
-            logger.debug("Tracing is disabled. Not creating span %s", span_data)
-            return NoOpSpan(span_data)
-
         trace_id: str
         parent_id: str | None
 
@@ -275,7 +268,12 @@ class DefaultTraceProvider(TraceProvider):
             current_trace = Scope.get_current_trace()
             if current_trace is None:
                 logger.debug("No active trace; returning NoOpSpan for %s", span_data)
-                return NoOpSpan(span_data)
+                inherited_content_mode = (
+                    current_span.content_mode if current_span else TraceContentMode.FULL
+                )
+                return self._create_noop_span(
+                    span_data, content_mode or inherited_content_mode
+                )
             elif isinstance(current_trace, NoOpTrace) or isinstance(
                 current_span, NoOpSpan
             ):
@@ -284,7 +282,14 @@ class DefaultTraceProvider(TraceProvider):
                     current_span,
                     current_trace,
                 )
-                return NoOpSpan(span_data)
+                inherited_content_mode = (
+                    current_span.content_mode
+                    if current_span
+                    else current_trace.content_mode
+                )
+                return self._create_noop_span(
+                    span_data, content_mode or inherited_content_mode
+                )
 
             parent_id = current_span.span_id if current_span else None
             trace_id = current_trace.trace_id
@@ -297,14 +302,18 @@ class DefaultTraceProvider(TraceProvider):
         elif isinstance(parent, Trace):
             if isinstance(parent, NoOpTrace):
                 logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
-                return NoOpSpan(span_data)
+                return self._create_noop_span(
+                    span_data, content_mode or parent.content_mode
+                )
             trace_id = parent.trace_id
             parent_id = None
             inherited_content_mode = parent.content_mode
         elif isinstance(parent, Span):
             if isinstance(parent, NoOpSpan):
                 logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
-                return NoOpSpan(span_data)
+                return self._create_noop_span(
+                    span_data, content_mode or parent.content_mode
+                )
             parent_id = parent.span_id
             trace_id = parent.trace_id
             inherited_content_mode = parent.content_mode
@@ -313,10 +322,11 @@ class DefaultTraceProvider(TraceProvider):
             raise ValueError(f"Invalid parent type: {type(parent)}")
 
         resolved_content_mode = content_mode or inherited_content_mode
-        if resolved_content_mode == TraceContentMode.METADATA_ONLY and isinstance(
-            span_data, GenerationSpanData
-        ):
-            span_data.disable_content_capture()
+        if disabled:
+            logger.debug("Tracing is disabled. Not creating span %s", span_data)
+            return self._create_noop_span(span_data, resolved_content_mode)
+
+        self._disable_generation_content(span_data, resolved_content_mode)
 
         return SpanImpl(
             trace_id=trace_id,
@@ -326,6 +336,22 @@ class DefaultTraceProvider(TraceProvider):
             span_data=span_data,
             content_mode=resolved_content_mode,
         )
+
+    @staticmethod
+    def _disable_generation_content(
+        span_data: SpanData, content_mode: TraceContentMode
+    ) -> None:
+        if content_mode == TraceContentMode.METADATA_ONLY and isinstance(
+            span_data, GenerationSpanData
+        ):
+            span_data.disable_content_capture()
+
+    @classmethod
+    def _create_noop_span(
+        cls, span_data: TSpanData, content_mode: TraceContentMode
+    ) -> NoOpSpan[TSpanData]:
+        cls._disable_generation_content(span_data, content_mode)
+        return NoOpSpan(span_data, content_mode)
 
     def shutdown(self) -> None:
         try:

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -155,8 +155,8 @@ class TraceProvider(ABC):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
-        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ) -> Trace:
         """Create a new trace."""
 
@@ -166,8 +166,8 @@ class TraceProvider(ABC):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
-        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
+        content_mode: TraceContentMode | None = None,
     ) -> Span[TSpanData]:
         """Create a new span."""
 
@@ -226,8 +226,8 @@ class DefaultTraceProvider(TraceProvider):
         trace_id: str | None = None,
         group_id: str | None = None,
         metadata: dict[str, Any] | None = None,
-        content_mode: TraceContentMode = TraceContentMode.FULL,
         disabled: bool = False,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ) -> Trace:
         """
         Create a new trace.
@@ -254,8 +254,8 @@ class DefaultTraceProvider(TraceProvider):
         span_data: TSpanData,
         span_id: str | None = None,
         parent: Trace | Span[Any] | None = None,
-        content_mode: TraceContentMode | None = None,
         disabled: bool = False,
+        content_mode: TraceContentMode | None = None,
     ) -> Span[TSpanData]:
         """
         Create a new span.

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -266,6 +266,12 @@ class DefaultTraceProvider(TraceProvider):
         if not parent:
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
+            if (
+                current_span
+                and current_trace
+                and current_span.trace_id != current_trace.trace_id
+            ):
+                current_span = None
             if current_trace is None:
                 logger.debug("No active trace; returning NoOpSpan for %s", span_data)
                 inherited_content_mode = (

--- a/backend/onyx/tracing/framework/span_data.py
+++ b/backend/onyx/tracing/framework/span_data.py
@@ -93,16 +93,17 @@ class GenerationSpanData(SpanData):
     """
 
     __slots__ = (
-        "input",
-        "output",
-        "reasoning",
+        "_capture_content",
+        "_input",
+        "_output",
+        "_reasoning",
+        "_tools",
+        "_request_params",
         "model",
         "model_config",
         "image_count",
         "usage",
         "time_to_first_action_seconds",
-        "tools",
-        "request_params",
     )
 
     def __init__(
@@ -120,6 +121,7 @@ class GenerationSpanData(SpanData):
     ):
         if image_count is not None and image_count < 1:
             raise ValueError("image_count must be positive")
+        self._capture_content = True
         self.input = input
         self.output = output
         self.reasoning = reasoning
@@ -149,3 +151,52 @@ class GenerationSpanData(SpanData):
             "tools": self.tools,
             "request_params": self.request_params,
         }
+
+    @property
+    def input(self) -> Sequence[Mapping[str, Any]] | None:
+        return self._input
+
+    @input.setter
+    def input(self, value: Sequence[Mapping[str, Any]] | None) -> None:
+        self._input = value if self._capture_content else None
+
+    @property
+    def output(self) -> Sequence[Mapping[str, Any]] | None:
+        return self._output
+
+    @output.setter
+    def output(self, value: Sequence[Mapping[str, Any]] | None) -> None:
+        self._output = value if self._capture_content else None
+
+    @property
+    def reasoning(self) -> str | None:
+        return self._reasoning
+
+    @reasoning.setter
+    def reasoning(self, value: str | None) -> None:
+        self._reasoning = value if self._capture_content else None
+
+    @property
+    def tools(self) -> Sequence[Mapping[str, Any]] | None:
+        return self._tools
+
+    @tools.setter
+    def tools(self, value: Sequence[Mapping[str, Any]] | None) -> None:
+        self._tools = value if self._capture_content else None
+
+    @property
+    def request_params(self) -> Mapping[str, Any] | None:
+        return self._request_params
+
+    @request_params.setter
+    def request_params(self, value: Mapping[str, Any] | None) -> None:
+        self._request_params = value if self._capture_content else None
+
+    def disable_content_capture(self) -> None:
+        """Retain generation metadata but reject all operation content."""
+        self._capture_content = False
+        self._input = None
+        self._output = None
+        self._reasoning = None
+        self._tools = None
+        self._request_params = None

--- a/backend/onyx/tracing/framework/spans.py
+++ b/backend/onyx/tracing/framework/spans.py
@@ -11,6 +11,7 @@ from . import util
 from .processor_interface import TracingProcessor
 from .scope import Scope
 from .span_data import SpanData
+from .traces import TraceContentMode
 
 TSpanData = TypeVar("TSpanData", bound=SpanData)
 
@@ -92,6 +93,11 @@ class Span(abc.ABC, Generic[TSpanData]):
         Returns:
             TSpanData: Data specific to this type of span (e.g., LLM generation data).
         """
+
+    @property
+    @abc.abstractmethod
+    def content_mode(self) -> TraceContentMode:
+        """Control whether processors can include operation content."""
 
     @abc.abstractmethod
     def start(self, mark_as_current: bool = False) -> None:
@@ -178,9 +184,14 @@ class NoOpSpan(Span[TSpanData]):
         span_data: The operation-specific data for this span.
     """
 
-    __slots__ = ("_span_data", "_prev_span_token")
+    __slots__ = ("_content_mode", "_span_data", "_prev_span_token")
 
-    def __init__(self, span_data: TSpanData):
+    def __init__(
+        self,
+        span_data: TSpanData,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
+    ):
+        self._content_mode = content_mode
         self._span_data = span_data
         self._prev_span_token: contextvars.Token[Span[TSpanData] | None] | None = None
 
@@ -195,6 +206,10 @@ class NoOpSpan(Span[TSpanData]):
     @property
     def span_data(self) -> TSpanData:
         return self._span_data
+
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
 
     @property
     def parent_id(self) -> str | None:
@@ -249,6 +264,7 @@ class SpanImpl(Span[TSpanData]):
         "_trace_id",
         "_span_id",
         "_parent_id",
+        "_content_mode",
         "_started_at",
         "_ended_at",
         "_error",
@@ -264,10 +280,12 @@ class SpanImpl(Span[TSpanData]):
         parent_id: str | None,
         processor: TracingProcessor,
         span_data: TSpanData,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ):
         self._trace_id = trace_id
         self._span_id = span_id or util.gen_span_id()
         self._parent_id = parent_id
+        self._content_mode = content_mode
         self._started_at: str | None = None
         self._ended_at: str | None = None
         self._processor = processor
@@ -286,6 +304,10 @@ class SpanImpl(Span[TSpanData]):
     @property
     def span_data(self) -> TSpanData:
         return self._span_data
+
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
 
     @property
     def parent_id(self) -> str | None:

--- a/backend/onyx/tracing/framework/spans.py
+++ b/backend/onyx/tracing/framework/spans.py
@@ -97,7 +97,7 @@ class Span(abc.ABC, Generic[TSpanData]):
     @property
     @abc.abstractmethod
     def content_mode(self) -> TraceContentMode:
-        """Control whether processors can include operation content."""
+        """Control whether a generation span can capture model content."""
 
     @abc.abstractmethod
     def start(self, mark_as_current: bool = False) -> None:

--- a/backend/onyx/tracing/framework/traces.py
+++ b/backend/onyx/tracing/framework/traces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import contextvars
+from enum import StrEnum
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -12,12 +13,13 @@ if TYPE_CHECKING:
     from .processor_interface import TracingProcessor
 
 
-class Trace(abc.ABC):
-    """A complete end-to-end workflow containing related spans and metadata.
+class TraceContentMode(StrEnum):
+    FULL = "full"
+    METADATA_ONLY = "metadata_only"
 
-    A trace represents a logical workflow or operation (e.g., "Customer Service Query"
-    or "Code Generation") and contains all the spans (individual operations) that occur
-    during that workflow.
+
+class Trace(abc.ABC):
+    """A workflow lifecycle and correlation root for independently processed spans.
 
     Example:
         ```python
@@ -81,7 +83,6 @@ class Trace(abc.ABC):
 
         Notes:
             - Must be called to complete the trace
-            - Finalizes all open spans
             - Thread-safe when using reset_current
         """
 
@@ -113,6 +114,11 @@ class Trace(abc.ABC):
             - Helps identify the purpose of the trace
         """
 
+    @property
+    @abc.abstractmethod
+    def content_mode(self) -> TraceContentMode:
+        """Control whether child spans can capture operation content."""
+
     @abc.abstractmethod
     def export(self) -> dict[str, Any] | None:
         """Export the trace data as a serializable dictionary.
@@ -121,7 +127,6 @@ class Trace(abc.ABC):
             dict | None: Dictionary containing trace data, or None if tracing is disabled.
 
         Notes:
-            - Includes all spans and their data
             - Used for sending traces to backends
             - May include metadata and group ID
         """
@@ -142,8 +147,9 @@ class NoOpTrace(Trace):
         ```
     """
 
-    def __init__(self) -> None:
+    def __init__(self, content_mode: TraceContentMode = TraceContentMode.FULL) -> None:
         self._started = False
+        self._content_mode = content_mode
         self._prev_context_token: contextvars.Token[Trace | None] | None = None
 
     def __enter__(self) -> Trace:
@@ -190,6 +196,10 @@ class NoOpTrace(Trace):
         """
         return "no-op"
 
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
+
     def export(self) -> dict[str, Any] | None:
         """Export the trace data as a dictionary.
 
@@ -210,6 +220,7 @@ class TraceImpl(Trace):
     __slots__ = (
         "_name",
         "_trace_id",
+        "_content_mode",
         "group_id",
         "metadata",
         "_prev_context_token",
@@ -224,9 +235,11 @@ class TraceImpl(Trace):
         group_id: str | None,
         metadata: dict[str, Any] | None,
         processor: TracingProcessor,
+        content_mode: TraceContentMode = TraceContentMode.FULL,
     ):
         self._name = name
         self._trace_id = trace_id or util.gen_trace_id()
+        self._content_mode = content_mode
         self.group_id = group_id
         self.metadata = metadata
         self._prev_context_token: contextvars.Token[Trace | None] | None = None
@@ -240,6 +253,10 @@ class TraceImpl(Trace):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def content_mode(self) -> TraceContentMode:
+        return self._content_mode
 
     def start(self, mark_as_current: bool = False) -> None:
         if self._started:

--- a/backend/onyx/tracing/framework/traces.py
+++ b/backend/onyx/tracing/framework/traces.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 
 class TraceContentMode(StrEnum):
+    """Generation content policy; explicit span modes override trace defaults."""
+
     FULL = "full"
     METADATA_ONLY = "metadata_only"
 
@@ -117,7 +119,7 @@ class Trace(abc.ABC):
     @property
     @abc.abstractmethod
     def content_mode(self) -> TraceContentMode:
-        """Control whether child spans can capture operation content."""
+        """Set the default model-content policy for child generation spans."""
 
     @abc.abstractmethod
     def export(self) -> dict[str, Any] | None:

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -11,6 +11,7 @@ from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span, get_current_span
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
+from onyx.tracing.framework.traces import TraceContentMode
 
 
 def build_llm_model_config(llm: LLM, flow: LLMFlow | None = None) -> dict[str, str]:
@@ -30,14 +31,16 @@ def llm_generation_span(
     input_messages: Sequence[Any] | Any | None = None,
     tools: Sequence[Mapping[str, Any]] | None = None,
     parent: Any | None = None,
+    content_mode: TraceContentMode | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     with generation_span(
         model=llm.config.model_name,
         model_config=build_llm_model_config(llm, flow),
         tools=tools,
         parent=parent,
+        content_mode=content_mode,
     ) as span:
-        if input_messages is not None:
+        if input_messages is not None and span.content_mode == TraceContentMode.FULL:
             if isinstance(input_messages, Sequence) and not isinstance(
                 input_messages, (str, bytes)
             ):
@@ -60,6 +63,7 @@ def traced_llm_call(
     input_messages: Sequence[Any] | Any | None = None,
     tools: Sequence[Mapping[str, Any]] | None = None,
     parent: Any | None = None,
+    content_mode: TraceContentMode | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     """Open a generation span for call sites that don't go through ``LLM``.
 
@@ -80,8 +84,9 @@ def traced_llm_call(
         image_count=image_count,
         tools=tools,
         parent=parent,
+        content_mode=content_mode,
     ) as span:
-        if input_messages is not None:
+        if input_messages is not None and span.content_mode == TraceContentMode.FULL:
             if isinstance(input_messages, Sequence) and not isinstance(
                 input_messages, (str, bytes)
             ):
@@ -101,6 +106,8 @@ def record_llm_request_params(params: Mapping[str, Any]) -> None:
     span = get_current_span()
     if span is None or not isinstance(span.span_data, GenerationSpanData):
         return
+    if span.content_mode == TraceContentMode.METADATA_ONLY:
+        return
     span.span_data.request_params = dict(params)
 
 
@@ -117,22 +124,16 @@ def record_llm_response(
         span: The generation span to record to.
         response: The ModelResponse from the LLM.
     """
-    message = response.choice.message
-
-    # Build output dict matching AssistantMessage format
-    output_dict: dict[str, Any] = {"role": "assistant"}
-
-    if message.content is not None:
-        output_dict["content"] = message.content
-
-    if message.tool_calls:
-        output_dict["tool_calls"] = [tc.model_dump() for tc in message.tool_calls]
-
-    span.span_data.output = [output_dict]
-
-    # Record reasoning (extended thinking from reasoning models)
-    if message.reasoning_content:
-        span.span_data.reasoning = message.reasoning_content
+    if span.content_mode == TraceContentMode.FULL:
+        message = response.choice.message
+        output_dict: dict[str, Any] = {"role": "assistant"}
+        if message.content is not None:
+            output_dict["content"] = message.content
+        if message.tool_calls:
+            output_dict["tool_calls"] = [tc.model_dump() for tc in message.tool_calls]
+        span.span_data.output = [output_dict]
+        if message.reasoning_content:
+            span.span_data.reasoning = message.reasoning_content
 
     # Record usage
     if response.usage:
@@ -160,24 +161,25 @@ def record_llm_span_output(
         reasoning: Optional reasoning/extended thinking content.
         tool_calls: Optional list of tool calls.
     """
-    if output is None:
-        output_dict: dict[str, Any] = {"role": "assistant", "content": None}
-        if tool_calls:
-            output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
-        span.span_data.output = [output_dict]
-    elif isinstance(output, str):
-        output_dict = {"role": "assistant", "content": output}
-        if tool_calls:
-            output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
-        span.span_data.output = [output_dict]
-    else:
-        span.span_data.output = cast(Sequence[Mapping[str, Any]], output)
+    if span.content_mode == TraceContentMode.FULL:
+        if output is None:
+            output_dict: dict[str, Any] = {"role": "assistant", "content": None}
+            if tool_calls:
+                output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+            span.span_data.output = [output_dict]
+        elif isinstance(output, str):
+            output_dict = {"role": "assistant", "content": output}
+            if tool_calls:
+                output_dict["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+            span.span_data.output = [output_dict]
+        else:
+            span.span_data.output = cast(Sequence[Mapping[str, Any]], output)
 
     usage_dict = _build_usage_dict(usage)
     if usage_dict:
         span.span_data.usage = usage_dict
 
-    if reasoning:
+    if reasoning and span.content_mode == TraceContentMode.FULL:
         span.span_data.reasoning = reasoning
 
 

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -10,6 +10,7 @@ from the raw stored content (here) is equivalent to proving the resulting vector
 differs; the real-embedder path is exercised once the port task is wired.
 """
 
+from contextlib import nullcontext
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -38,6 +39,7 @@ from onyx.indexing.chunker import get_metadata_suffix_for_document_index
 from onyx.indexing.embedder import DefaultIndexingEmbedder, IndexingEmbedder
 from onyx.indexing.models import ChunkEmbedding, DocAwareChunk, IndexChunk
 from onyx.indexing.port_reembed import (
+    CONTEXTUAL_RAG_REEMBED_TRACE_NAME,
     AugmentationReembedContext,
     ReembedStrategy,
     _bare_contents,
@@ -49,6 +51,7 @@ from onyx.indexing.port_reembed import (
     select_reembed_strategy,
 )
 from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.utils.pydantic_util import shallow_model_dump
 from shared_configs.configs import (
     DOC_EMBEDDING_CONTEXT_SIZE,
@@ -431,6 +434,8 @@ def test_augmentation_enrich_on_generates_and_reembeds(
     monkeypatch.setattr(
         "onyx.indexing.indexing_pipeline.add_contextual_summaries", _fake_enrich
     )
+    ensure_trace = MagicMock(return_value=nullcontext())
+    monkeypatch.setattr("onyx.indexing.port_reembed.ensure_trace", ensure_trace)
 
     bare = "the body text"
     metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
@@ -466,6 +471,10 @@ def test_augmentation_enrich_on_generates_and_reembeds(
     assert result.chunk_context == " CONTEXT."
     assert (
         result.content == f"My Title{RETURN_SEPARATOR}SUMMARY. {bare} CONTEXT.{keyword}"
+    )
+    ensure_trace.assert_called_once_with(
+        CONTEXTUAL_RAG_REEMBED_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
     )
 
     # the embedded text carries the new summaries; vector differs from strip-only

--- a/backend/tests/external_dependency_unit/tracing/test_llm_span_recording.py
+++ b/backend/tests/external_dependency_unit/tracing/test_llm_span_recording.py
@@ -15,6 +15,7 @@ from onyx.llm.model_response import (
 from onyx.llm.model_response import FunctionCall as ModelResponseFunctionCall
 from onyx.llm.models import FunctionCall, ToolCall
 from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.traces import TraceContentMode
 from onyx.tracing.llm_utils import record_llm_response, record_llm_span_output
 
 
@@ -22,6 +23,7 @@ from onyx.tracing.llm_utils import record_llm_response, record_llm_span_output
 def mock_span() -> MagicMock:
     """Create a mock span with GenerationSpanData."""
     span = MagicMock()
+    span.content_mode = TraceContentMode.FULL
     span.span_data = GenerationSpanData()
     return span
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -1,7 +1,9 @@
 import random
 import threading
 import time
+from contextlib import nullcontext
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, List, cast
 from unittest.mock import MagicMock, Mock, patch
 
@@ -22,15 +24,18 @@ from onyx.hooks.points.document_ingestion import (
 from onyx.indexing.chunker import Chunker
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import (
+    INDEXING_PIPELINE_TRACE_NAME,
     _apply_document_ingestion_hook,
     add_contextual_summaries,
     filter_documents,
     get_docs_to_update,
     process_image_sections,
+    run_indexing_pipeline,
 )
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.llm.model_response import Choice, Message, ModelResponse
+from onyx.tracing.framework.traces import TraceContentMode
 
 
 def create_test_document(
@@ -654,6 +659,45 @@ def test_document_ingestion_hook_mixed_batch() -> None:
 # ---------------------------------------------------------------------------
 
 _PATCH_PREFIX = "onyx.indexing.indexing_pipeline"
+
+
+def test_run_pipeline_owns_llm_enrichment_trace() -> None:
+    search_settings = SimpleNamespace(enable_contextual_rag=False)
+    all_search_settings = SimpleNamespace(primary=search_settings, secondary=None)
+    expected_result = MagicMock()
+
+    with (
+        patch(
+            f"{_PATCH_PREFIX}.get_active_search_settings",
+            return_value=all_search_settings,
+        ),
+        patch(f"{_PATCH_PREFIX}.get_multipass_config"),
+        patch(
+            f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
+            return_value=True,
+        ),
+        patch(
+            f"{_PATCH_PREFIX}.index_doc_batch_with_handler",
+            return_value=expected_result,
+        ),
+        patch(f"{_PATCH_PREFIX}.ensure_trace", return_value=nullcontext()) as ensure,
+    ):
+        result = run_indexing_pipeline(
+            document_batch=[],
+            request_id=None,
+            embedder=MagicMock(),
+            document_indices=[],
+            db_session=MagicMock(),
+            tenant_id="tenant",
+            adapter=MagicMock(),
+            chunker=MagicMock(),
+        )
+
+    assert result is expected_result
+    ensure.assert_called_once_with(
+        INDEXING_PIPELINE_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
+    )
 
 
 def _mock_file_store(image_map: dict[str, bytes]) -> MagicMock:

--- a/backend/tests/unit/onyx/kg/test_kg_extraction_tracing.py
+++ b/backend/tests/unit/onyx/kg/test_kg_extraction_tracing.py
@@ -1,0 +1,37 @@
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from onyx.kg.utils.extraction_utils import (
+    KG_DOCUMENT_PROCESSING_TRACE_NAME,
+    kg_deep_extraction,
+)
+from onyx.tracing.framework.traces import TraceContentMode
+
+_EXTRACTION_UTILS = "onyx.kg.utils.extraction_utils"
+
+
+def test_kg_deep_extraction_owns_document_trace() -> None:
+    expected_result = MagicMock()
+    with (
+        patch(
+            f"{_EXTRACTION_UTILS}._kg_deep_extraction",
+            return_value=expected_result,
+        ),
+        patch(
+            f"{_EXTRACTION_UTILS}.ensure_trace", return_value=nullcontext()
+        ) as ensure,
+    ):
+        result = kg_deep_extraction(
+            document_id="document",
+            metadata=MagicMock(),
+            implied_extraction=MagicMock(),
+            tenant_id="tenant",
+            index_name="index",
+            kg_config_settings=MagicMock(),
+        )
+
+    assert result is expected_result
+    ensure.assert_called_once_with(
+        KG_DOCUMENT_PROCESSING_TRACE_NAME,
+        content_mode=TraceContentMode.METADATA_ONLY,
+    )

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -1,0 +1,117 @@
+"""Metadata-only traces retain metering data without capturing model content."""
+
+from typing import Any
+
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.processor_interface import TracingProcessor
+from onyx.tracing.framework.provider import DefaultTraceProvider
+from onyx.tracing.framework.setup import get_trace_provider, set_trace_provider
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import NoOpSpan, Span
+from onyx.tracing.framework.traces import Trace, TraceContentMode
+from onyx.tracing.llm_utils import record_llm_span_output, traced_llm_call
+
+
+class _CaptureProcessor(TracingProcessor):
+    def __init__(self) -> None:
+        self.started_traces: list[Trace] = []
+        self.ended_traces: list[Trace] = []
+        self.ended_spans: list[Span[Any]] = []
+
+    def on_trace_start(self, trace: Trace) -> None:
+        self.started_traces.append(trace)
+
+    def on_trace_end(self, trace: Trace) -> None:
+        self.ended_traces.append(trace)
+
+    def on_span_start(self, span: Span[Any]) -> None:
+        pass
+
+    def on_span_end(self, span: Span[Any]) -> None:
+        self.ended_spans.append(span)
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self) -> None:
+        pass
+
+
+def test_metadata_only_trace_removes_generation_content() -> None:
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+
+    with provider.create_trace(
+        "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+    ) as trace:
+        span = provider.create_span(
+            GenerationSpanData(
+                input=[{"role": "user", "content": "private document"}],
+                output=[{"role": "assistant", "content": "private response"}],
+                reasoning="private reasoning",
+                model="claude-sonnet",
+                tools=[{"name": "private_tool"}],
+                request_params={"private": "parameter"},
+            )
+        )
+        with span:
+            span.span_data.output = [
+                {"role": "assistant", "content": "late private response"}
+            ]
+            span.span_data.usage = {"input_tokens": 5, "output_tokens": 2}
+
+    assert processor.started_traces == [trace]
+    assert processor.ended_traces == [trace]
+    assert processor.ended_spans == [span]
+    assert span.trace_id == trace.trace_id
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+    assert span.span_data.input is None
+    assert span.span_data.output is None
+    assert span.span_data.reasoning is None
+    assert span.span_data.tools is None
+    assert span.span_data.request_params is None
+    assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
+
+
+def test_span_without_trace_remains_noop() -> None:
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+
+    span = provider.create_span(GenerationSpanData(model="claude-sonnet"))
+    with span:
+        span.span_data.usage = {"input_tokens": 5, "output_tokens": 2}
+
+    assert isinstance(span, NoOpSpan)
+    assert processor.ended_spans == []
+
+
+def test_llm_helper_does_not_create_workflow_trace() -> None:
+    original_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+    set_trace_provider(provider)
+
+    try:
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_SUMMARIZATION,
+            model="claude-sonnet",
+            provider="anthropic",
+            input_messages=[{"role": "user", "content": "private document"}],
+        ) as span:
+            record_llm_span_output(
+                span,
+                output="private response",
+                reasoning="private reasoning",
+                usage={"input_tokens": 5, "output_tokens": 2},
+            )
+    finally:
+        set_trace_provider(original_provider)
+
+    assert isinstance(span, NoOpSpan)
+    assert processor.started_traces == []
+    assert processor.ended_traces == []
+    assert processor.ended_spans == []
+    assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -80,6 +80,26 @@ def test_metadata_only_trace_removes_generation_content() -> None:
     assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
 
 
+def test_new_trace_ignores_stale_noop_span() -> None:
+    provider = DefaultTraceProvider()
+    stale_span = NoOpSpan(GenerationSpanData(model="claude-sonnet"))
+    stale_span.start(mark_as_current=True)
+    stale_span.__exit__(GeneratorExit, GeneratorExit(), None)
+
+    try:
+        with provider.create_trace(
+            "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+        ) as trace:
+            span = provider.create_span(GenerationSpanData(model="claude-sonnet"))
+    finally:
+        stale_span.finish(reset_current=True)
+
+    assert not isinstance(span, NoOpSpan)
+    assert span.trace_id == trace.trace_id
+    assert span.parent_id is None
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+
+
 def test_full_span_overrides_metadata_only_trace() -> None:
     provider = DefaultTraceProvider()
 

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -1,15 +1,21 @@
 """Metadata-only traces retain metering data without capturing model content."""
 
 from typing import Any
+from unittest.mock import MagicMock
 
 from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import ensure_trace
 from onyx.tracing.framework.processor_interface import TracingProcessor
 from onyx.tracing.framework.provider import DefaultTraceProvider
 from onyx.tracing.framework.setup import get_trace_provider, set_trace_provider
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import NoOpSpan, Span
 from onyx.tracing.framework.traces import Trace, TraceContentMode
-from onyx.tracing.llm_utils import record_llm_span_output, traced_llm_call
+from onyx.tracing.llm_utils import (
+    llm_generation_span,
+    record_llm_span_output,
+    traced_llm_call,
+)
 
 
 class _CaptureProcessor(TracingProcessor):
@@ -74,17 +80,92 @@ def test_metadata_only_trace_removes_generation_content() -> None:
     assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
 
 
-def test_span_without_trace_remains_noop() -> None:
+def test_full_span_overrides_metadata_only_trace() -> None:
+    provider = DefaultTraceProvider()
+
+    with provider.create_trace(
+        "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+    ):
+        span = provider.create_span(
+            GenerationSpanData(
+                input=[{"role": "user", "content": "captured document"}],
+                model="claude-sonnet",
+            ),
+            content_mode=TraceContentMode.FULL,
+        )
+
+    assert span.content_mode == TraceContentMode.FULL
+    assert span.span_data.input == [{"role": "user", "content": "captured document"}]
+
+
+def test_metadata_only_span_without_trace_remains_redacted_noop() -> None:
     provider = DefaultTraceProvider()
     processor = _CaptureProcessor()
     provider.register_processor(processor)
 
-    span = provider.create_span(GenerationSpanData(model="claude-sonnet"))
+    span = provider.create_span(
+        GenerationSpanData(
+            input=[{"role": "user", "content": "private document"}],
+            model="claude-sonnet",
+        ),
+        content_mode=TraceContentMode.METADATA_ONLY,
+    )
     with span:
+        span.span_data.output = [{"role": "assistant", "content": "private response"}]
         span.span_data.usage = {"input_tokens": 5, "output_tokens": 2}
 
     assert isinstance(span, NoOpSpan)
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+    assert span.span_data.input is None
+    assert span.span_data.output is None
+    assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
     assert processor.ended_spans == []
+
+
+def test_llm_helper_inherits_metadata_only_trace() -> None:
+    original_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    set_trace_provider(provider)
+    llm = MagicMock()
+    llm.config.model_name = "claude-sonnet"
+    llm.config.model_provider = "anthropic"
+    llm.config.api_base = None
+
+    try:
+        with provider.create_trace(
+            "background_llm_call", content_mode=TraceContentMode.METADATA_ONLY
+        ):
+            with llm_generation_span(
+                llm=llm,
+                flow=LLMFlow.IMAGE_SUMMARIZATION,
+                input_messages=[{"role": "user", "content": "private document"}],
+            ) as span:
+                pass
+    finally:
+        set_trace_provider(original_provider)
+
+    assert span.content_mode == TraceContentMode.METADATA_ONLY
+    assert span.span_data.input is None
+
+
+def test_ensure_trace_reuses_active_trace() -> None:
+    original_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    processor = _CaptureProcessor()
+    provider.register_processor(processor)
+    set_trace_provider(provider)
+
+    try:
+        with provider.create_trace("existing_trace") as existing_trace:
+            with ensure_trace(
+                "unused_trace", content_mode=TraceContentMode.METADATA_ONLY
+            ) as reused_trace:
+                assert reused_trace is existing_trace
+    finally:
+        set_trace_provider(original_provider)
+
+    assert processor.started_traces == [existing_trace]
+    assert processor.ended_traces == [existing_trace]
 
 
 def test_llm_helper_does_not_create_workflow_trace() -> None:

--- a/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
+++ b/backend/tests/unit/onyx/tracing/test_metadata_only_tracing.py
@@ -10,7 +10,7 @@ from onyx.tracing.framework.provider import DefaultTraceProvider
 from onyx.tracing.framework.setup import get_trace_provider, set_trace_provider
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import NoOpSpan, Span
-from onyx.tracing.framework.traces import Trace, TraceContentMode
+from onyx.tracing.framework.traces import NoOpTrace, Trace, TraceContentMode
 from onyx.tracing.llm_utils import (
     llm_generation_span,
     record_llm_span_output,
@@ -120,6 +120,21 @@ def test_metadata_only_span_without_trace_remains_redacted_noop() -> None:
     assert span.span_data.output is None
     assert span.span_data.usage == {"input_tokens": 5, "output_tokens": 2}
     assert processor.ended_spans == []
+
+
+def test_provider_preserves_positional_disabled_arguments() -> None:
+    provider = DefaultTraceProvider()
+
+    disabled_trace = provider.create_trace("disabled", None, None, None, True)
+    with provider.create_trace("active"):
+        disabled_span = provider.create_span(
+            GenerationSpanData(model="claude-sonnet"), None, None, True
+        )
+
+    assert isinstance(disabled_trace, NoOpTrace)
+    assert disabled_trace.content_mode == TraceContentMode.FULL
+    assert isinstance(disabled_span, NoOpSpan)
+    assert disabled_span.content_mode == TraceContentMode.FULL
 
 
 def test_llm_helper_inherits_metadata_only_trace() -> None:


### PR DESCRIPTION
## Description

Add metadata-only trace policy support and apply it to background indexing and knowledge graph LLM workflows. These traces retain model, usage, timing, and error metadata without capturing prompts, outputs, reasoning, tools, or request parameters.

## How Has This Been Tested?

- Focused tracing, indexing, knowledge graph, image summarization, and LLM wrapper tests
- Targeted Ruff and `ty` checks
- Pre-commit hooks

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
