### PR TITLE
refactor(opal): Text wrapping and alignment props on `@opal/Text`

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -366,7 +366,8 @@ Key props:
 - `font`: `TextFont` — font preset (e.g., `"main-ui-body"`, `"heading-h2"`, `"secondary-action"`)
 - `color`: `TextColor` — text color (e.g., `"text-03"`, `"text-inverted-05"`)
 - `as`: `"p" | "span" | "li" | "h1" | "h2" | "h3"` — HTML tag (default: `"span"`)
-- `nowrap`: `boolean` — prevent text wrapping
+- `wordWrap`: `"whitespace-nowrap" | "wrap-normal" | "wrap-break-word" | "wrap-anywhere" | "break-all" | "break-keep"` — how the text wraps. `"whitespace-nowrap"` keeps it on one line; the `wrap-*` and `break-*` values let a long unbroken run split rather than overflow
+- `textPosition`: `"text-start" | "text-center" | "text-end" | "text-justify"` — how the text sits in its box. Only offered when `as` is a block tag, since `text-align` has nothing to align within on an inline `span`
 
 **`RichStr` convention:** When creating new components, any string prop that will be rendered as
 visible text in the DOM (e.g., `title`, `description`, `label`) should be typed as

--- a/web/lib/opal/src/components/buttons/button/components.tsx
+++ b/web/lib/opal/src/components/buttons/button/components.tsx
@@ -79,7 +79,7 @@ function Button({
       <Text
         font={isLarge ? "main-ui-body" : "secondary-body"}
         color="inherit"
-        nowrap
+        wordWrap="whitespace-nowrap"
       >
         {children}
       </Text>

--- a/web/lib/opal/src/components/buttons/filter-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/filter-button/components.tsx
@@ -68,7 +68,11 @@ function FilterButton({
         <Interactive.Container type="button">
           <div className="flex flex-row items-center gap-1">
             {iconWrapper(Icon, "lg", true)}
-            <Text font="main-ui-action" color="inherit" nowrap>
+            <Text
+              font="main-ui-action"
+              color="inherit"
+              wordWrap="whitespace-nowrap"
+            >
               {children}
             </Text>
             <div style={{ visibility: active ? "hidden" : "visible" }}>

--- a/web/lib/opal/src/components/buttons/open-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/open-button/components.tsx
@@ -123,7 +123,7 @@ function OpenButton({
     <Text
       font={labelFont ?? (isLarge ? "main-ui-body" : "secondary-body")}
       color={labelColor ?? "inherit"}
-      nowrap
+      wordWrap="whitespace-nowrap"
     >
       {children}
     </Text>

--- a/web/lib/opal/src/components/buttons/select-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/select-button/components.tsx
@@ -86,7 +86,7 @@ function SelectButton({
     <Text
       font={isLarge ? "main-ui-body" : "secondary-body"}
       color="inherit"
-      nowrap
+      wordWrap="whitespace-nowrap"
     >
       {children}
     </Text>

--- a/web/lib/opal/src/components/buttons/text-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/text-button/components.tsx
@@ -61,7 +61,12 @@ function TextButton({
   ...rest
 }: TextButtonProps) {
   const label = (
-    <Text font={font} color="inherit" as="p" nowrap={nowrap}>
+    <Text
+      font={font}
+      color="inherit"
+      as="p"
+      wordWrap={nowrap ? "whitespace-nowrap" : undefined}
+    >
       {children}
     </Text>
   );

--- a/web/lib/opal/src/components/divider/components.tsx
+++ b/web/lib/opal/src/components/divider/components.tsx
@@ -129,7 +129,11 @@ function Divider(props: DividerProps) {
       <div className="opal-divider-row">
         {title && (
           <div className="opal-divider-title">
-            <Text font="secondary-body" color="text-03" nowrap>
+            <Text
+              font="secondary-body"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {title}
             </Text>
           </div>
@@ -180,7 +184,11 @@ function FoldableDivider({
           <div className="opal-divider">
             <div className="opal-divider-row">
               <div className="opal-divider-title">
-                <Text font="secondary-body" color="inherit" nowrap>
+                <Text
+                  font="secondary-body"
+                  color="inherit"
+                  wordWrap="whitespace-nowrap"
+                >
                   {title}
                 </Text>
               </div>

--- a/web/lib/opal/src/components/end-of-list/components.tsx
+++ b/web/lib/opal/src/components/end-of-list/components.tsx
@@ -12,7 +12,7 @@ function EndOfList({ title }: EndOfListProps) {
   return (
     <div className="opal-end-of-list">
       <Divider paddingParallel={0} paddingPerpendicular={0} />
-      <Text font="secondary-body" color="text-03" nowrap>
+      <Text font="secondary-body" color="text-03" wordWrap="whitespace-nowrap">
         {title}
       </Text>
       <Divider paddingParallel={0} paddingPerpendicular={0} />

--- a/web/lib/opal/src/components/icon-container/components.tsx
+++ b/web/lib/opal/src/components/icon-container/components.tsx
@@ -81,7 +81,11 @@ function IconContainer({
     const initial = (name?.trim()[0] ?? "?").toUpperCase();
     content = (
       <div className="opal-icon-container-avatar opal-icon-container-avatar-user">
-        <Text font="secondary-action" color="text-inverted-05" nowrap>
+        <Text
+          font="secondary-action"
+          color="text-inverted-05"
+          wordWrap="whitespace-nowrap"
+        >
           {initial}
         </Text>
       </div>

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -91,7 +91,7 @@ function TruncatedDisplay({
   }, [children]);
 
   const text = (
-    <Text color={dimmed ? "text-01" : "text-04"} nowrap>
+    <Text color={dimmed ? "text-01" : "text-04"} wordWrap="whitespace-nowrap">
       {children}
     </Text>
   );

--- a/web/lib/opal/src/components/inputs/password-input-type-in/components.tsx
+++ b/web/lib/opal/src/components/inputs/password-input-type-in/components.tsx
@@ -182,7 +182,11 @@ function PasswordInputTypeIn({
           aria-hidden
           className="pointer-events-none absolute inset-y-0 start-[6px] end-10 flex items-center overflow-hidden"
         >
-          <Text font="main-ui-body" color="text-04" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-04"
+            wordWrap="whitespace-nowrap"
+          >
             {"✱".repeat(realValue.length)}
           </Text>
         </div>

--- a/web/lib/opal/src/components/tag/components.tsx
+++ b/web/lib/opal/src/components/tag/components.tsx
@@ -105,13 +105,13 @@ function Tag({
             capped && "opal-auxiliary-tag-capped"
           )}
         >
-          <Text font={font} color="inherit" nowrap>
+          <Text font={font} color="inherit" wordWrap="whitespace-nowrap">
             {title}
           </Text>
         </span>
         {value !== undefined && (
           <span className="opal-auxiliary-tag-value">
-            <Text font={font} color="inherit" nowrap>
+            <Text font={font} color="inherit" wordWrap="whitespace-nowrap">
               {value}
             </Text>
           </span>

--- a/web/lib/opal/src/components/text/README.md
+++ b/web/lib/opal/src/components/text/README.md
@@ -13,7 +13,7 @@ inline markdown rendering via `RichStr` — pass `markdown("*bold* text")` as ch
 | `color`    | `TextColor`                                     | `"text-04"`      | Text color                                                                                     |
 | `as`       | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"`         | HTML tag to render                                                                             |
 | `wordWrap` | `"whitespace-nowrap" \| "wrap-normal" \| "wrap-break-word" \| "wrap-anywhere" \| "break-all" \| "break-keep"` | — | How a run of characters with nowhere to wrap behaves; unset leaves normal CSS wrapping |
-| `textPosition` | `"text-start" \| "text-center" \| "text-end" \| "text-justify"` | — | How the text sits within its own box; logical, so it follows reading direction |
+| `textPosition` | `"text-start" \| "text-center" \| "text-end" \| "text-justify"` | — | How the text sits within its own box; logical, so it follows reading direction. Only offered when `as` is a block tag |
 | `maxLines` | `number`                                        | —                | Truncate to N lines with an ellipsis (`1` = single-line truncate; `2+` = `-webkit-line-clamp`) |
 | `children` | `string \| RichStr \| RichNodes`                | —                | Plain string, `markdown()` for inline markdown, or `richNodes()` for inline React nodes        |
 

--- a/web/lib/opal/src/components/text/README.md
+++ b/web/lib/opal/src/components/text/README.md
@@ -12,14 +12,14 @@ inline markdown rendering via `RichStr` — pass `markdown("*bold* text")` as ch
 | `font`     | `TextFont`                                      | `"main-ui-body"` | Font preset (size, weight, line-height)                                                        |
 | `color`    | `TextColor`                                     | `"text-04"`      | Text color                                                                                     |
 | `as`       | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"`         | HTML tag to render                                                                             |
-| `nowrap`   | `boolean`                                       | `false`          | Prevent text wrapping                                                                          |
-| `wordWrap` | `"wrap-normal" \| "wrap-break-word" \| "wrap-anywhere" \| "break-all" \| "break-keep"` | — | How a run of characters with nowhere to wrap behaves; unset leaves normal CSS wrapping |
+| `wordWrap` | `"whitespace-nowrap" \| "wrap-normal" \| "wrap-break-word" \| "wrap-anywhere" \| "break-all" \| "break-keep"` | — | How a run of characters with nowhere to wrap behaves; unset leaves normal CSS wrapping |
+| `textPosition` | `"text-start" \| "text-center" \| "text-end" \| "text-justify"` | — | How the text sits within its own box; logical, so it follows reading direction |
 | `maxLines` | `number`                                        | —                | Truncate to N lines with an ellipsis (`1` = single-line truncate; `2+` = `-webkit-line-clamp`) |
 | `children` | `string \| RichStr \| RichNodes`                | —                | Plain string, `markdown()` for inline markdown, or `richNodes()` for inline React nodes        |
 
 > **No `className` or `style`.** `Text` strips both (its props extend `WithoutStyles`); every
-> aspect of its appearance is driven by `font`, `color`, `nowrap`, `wordWrap`, and `maxLines`. For layout
-> concerns (margin, flex, width, alignment) wrap `Text` in a container or move the utility class
+> aspect of its appearance is driven by `font`, `color`, `wordWrap`, `textPosition`, and `maxLines`. For layout
+> concerns (margin, flex, width, and where the element itself sits) wrap `Text` in a container or move the utility class
 > to the parent — don't reach for `className`. All other HTML attributes (`id`, `onClick`,
 > `title`, `aria-*`, `data-*`) pass straight through to the rendered element.
 

--- a/web/lib/opal/src/components/text/Text.stories.tsx
+++ b/web/lib/opal/src/components/text/Text.stories.tsx
@@ -51,6 +51,79 @@ export const Nowrap: Story = {
 };
 
 // ---------------------------------------------------------------------------
+// Wrapping
+// ---------------------------------------------------------------------------
+
+// A long token with no whitespace in it, which is the case ordinary wrapping
+// cannot handle: there is nowhere to break, so it overflows instead.
+const UNBROKEN = "supercalifragilisticexpialidocious".repeat(3);
+
+/** Every `wordWrap` value against the same unbreakable string, in one narrow box. */
+export const Wrapping: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(
+        [
+          "wrap-normal",
+          "whitespace-nowrap",
+          "wrap-break-word",
+          "wrap-anywhere",
+          "break-all",
+          "break-keep",
+        ] as const
+      ).map((mode) => (
+        <div key={mode} className="flex flex-col gap-1">
+          <Text font="secondary-mono" color="text-03">
+            {mode}
+          </Text>
+          <div className="w-48 border border-border-02 rounded-sm p-2">
+            <Text font="main-ui-body" color="text-05" wordWrap={mode}>
+              {UNBROKEN}
+            </Text>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Alignment
+// ---------------------------------------------------------------------------
+
+/**
+ * `textPosition` needs a block box to align within, so it is only offered when
+ * `as` is a block tag — `<Text textPosition="text-center">` on the default
+ * inline `span` does not compile.
+ */
+export const Alignment: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(["text-start", "text-center", "text-end", "text-justify"] as const).map(
+        (position) => (
+          <div key={position} className="flex flex-col gap-1">
+            <Text font="secondary-mono" color="text-03">
+              {position}
+            </Text>
+            <div className="w-96 border border-border-02 rounded-sm p-2">
+              <Text
+                as="p"
+                font="main-ui-body"
+                color="text-05"
+                textPosition={position}
+              >
+                The quick brown fox jumps over the lazy dog, and then keeps
+                going for long enough to occupy more than a single line.
+              </Text>
+            </div>
+          </div>
+        )
+      )}
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
 // Fonts
 // ---------------------------------------------------------------------------
 

--- a/web/lib/opal/src/components/text/Text.stories.tsx
+++ b/web/lib/opal/src/components/text/Text.stories.tsx
@@ -43,7 +43,7 @@ export const AsParagraph: Story = {
 export const Nowrap: Story = {
   render: () => (
     <div className="w-48 border border-border-02 rounded-sm p-2">
-      <Text font="main-ui-body" color="text-05" nowrap>
+      <Text font="main-ui-body" color="text-05" wordWrap="whitespace-nowrap">
         This text will not wrap even though the container is narrow
       </Text>
     </div>

--- a/web/lib/opal/src/components/text/Text.test.tsx
+++ b/web/lib/opal/src/components/text/Text.test.tsx
@@ -36,3 +36,111 @@ describe("Text with RichNodes children", () => {
     expect(wrapper.querySelector("em")).toHaveTextContent("emphasis");
   });
 });
+
+// `wordWrap` and `textPosition` map their value straight to the utility class,
+// so what is worth pinning is that the mapping happens at all and that nothing
+// is emitted when the caller says nothing. A mistyped value would otherwise
+// reach the DOM as a class that does not exist and fail silently.
+describe("Text wordWrap", () => {
+  const LONG_TOKEN = "asdf".repeat(125);
+
+  it("emits no wrapping class when unset", () => {
+    render(
+      <Text font="main-ui-body" color="text-04" data-testid="unset">
+        {LONG_TOKEN}
+      </Text>
+    );
+
+    const el = screen.getByTestId("unset");
+    for (const cls of [
+      "whitespace-nowrap",
+      "wrap-normal",
+      "wrap-break-word",
+      "wrap-anywhere",
+      "break-all",
+      "break-keep",
+    ]) {
+      expect(el).not.toHaveClass(cls);
+    }
+  });
+
+  it.each([
+    "whitespace-nowrap",
+    "wrap-normal",
+    "wrap-break-word",
+    "wrap-anywhere",
+    "break-all",
+    "break-keep",
+  ] as const)("applies %s", (mode) => {
+    render(
+      <Text
+        font="main-ui-body"
+        color="text-04"
+        wordWrap={mode}
+        data-testid="wrapped"
+      >
+        {LONG_TOKEN}
+      </Text>
+    );
+
+    expect(screen.getByTestId("wrapped")).toHaveClass(mode);
+  });
+
+  // `overflow-wrap` inherits, so omitting the prop cannot undo a value an
+  // ancestor set. Stating `wrap-normal` is the only way to say "do not break".
+  it("can state normal wrapping explicitly, to override an inherited value", () => {
+    render(
+      <div className="wrap-anywhere">
+        <Text
+          font="main-ui-body"
+          color="text-04"
+          wordWrap="wrap-normal"
+          data-testid="reset"
+        >
+          {LONG_TOKEN}
+        </Text>
+      </div>
+    );
+
+    expect(screen.getByTestId("reset")).toHaveClass("wrap-normal");
+  });
+});
+
+describe("Text textPosition", () => {
+  it.each(["text-start", "text-center", "text-end", "text-justify"] as const)(
+    "applies %s on a block tag",
+    (position) => {
+      render(
+        <Text
+          as="p"
+          font="main-ui-body"
+          color="text-04"
+          textPosition={position}
+          data-testid="aligned"
+        >
+          Aligned text
+        </Text>
+      );
+
+      expect(screen.getByTestId("aligned")).toHaveClass(position);
+    }
+  );
+
+  it("emits no alignment class when unset", () => {
+    render(
+      <Text as="p" font="main-ui-body" color="text-04" data-testid="plain">
+        Plain text
+      </Text>
+    );
+
+    const el = screen.getByTestId("plain");
+    for (const cls of [
+      "text-start",
+      "text-center",
+      "text-end",
+      "text-justify",
+    ]) {
+      expect(el).not.toHaveClass(cls);
+    }
+  });
+});

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -10,7 +10,14 @@ import { resolveStr } from "@opal/components/text/InlineMarkdown";
 // Types
 // ---------------------------------------------------------------------------
 
-interface TextProps extends WithoutStyles<
+/**
+ * Tags that establish a block box, so `text-align` has something to align
+ * within. `span` is deliberately absent: it is inline, and aligning an inline
+ * element is the parent's job, not its own.
+ */
+type BlockTag = "p" | "li" | "h1" | "h2" | "h3";
+
+interface TextBaseProps extends WithoutStyles<
   Omit<HTMLAttributes<HTMLElement>, "color" | "children">
 > {
   /** Font preset. Default: `"main-ui-body"`. */
@@ -18,9 +25,6 @@ interface TextProps extends WithoutStyles<
 
   /** Color variant. Default: `"text-04"`. */
   color?: TextColor;
-
-  /** HTML tag to render. Default: `"span"`. */
-  as?: "p" | "span" | "li" | "h1" | "h2" | "h3";
 
   /**
    * How this text wraps. Ordinary wrapping only breaks at whitespace, so a
@@ -46,17 +50,6 @@ interface TextProps extends WithoutStyles<
     | "break-all"
     | "break-keep";
 
-  /**
-   * How the text sits within its own box. Logical values, so they follow the
-   * reading direction rather than the screen: `"text-start"` is left in an
-   * LTR locale and right in an RTL one.
-   *
-   * This aligns the text inside the element `Text` renders. Positioning that
-   * element within its parent is the parent's business — see the note on
-   * layout below.
-   */
-  textPosition?: "text-start" | "text-center" | "text-end" | "text-justify";
-
   /** Truncate text to N lines with ellipsis. `1` uses simple truncation; `2+` uses `-webkit-line-clamp`. */
   maxLines?: number;
 
@@ -73,6 +66,30 @@ interface TextProps extends WithoutStyles<
    */
   children?: string | RichStr | RichNodes;
 }
+
+/**
+ * `textPosition` is only offered on a tag that makes a block box. On an inline
+ * `span` the property has nothing to align against — `text-align` positions a
+ * block's inline content, not the element itself — so allowing it there would
+ * be a prop that silently does nothing.
+ */
+type TextProps =
+  | (TextBaseProps & {
+      /** HTML tag to render. Default: `"span"`. */
+      as?: "span";
+      textPosition?: never;
+    })
+  | (TextBaseProps & {
+      /** HTML tag to render. */
+      as: BlockTag;
+
+      /**
+       * How the text sits within this element's box. Logical values, so they
+       * follow the reading direction rather than the screen: `"text-start"` is
+       * left in an LTR locale and right in an RTL one.
+       */
+      textPosition?: "text-start" | "text-center" | "text-end" | "text-justify";
+    });
 
 // ---------------------------------------------------------------------------
 // Config

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -22,14 +22,12 @@ interface TextProps extends WithoutStyles<
   /** HTML tag to render. Default: `"span"`. */
   as?: "p" | "span" | "li" | "h1" | "h2" | "h3";
 
-  /** Prevent text wrapping. */
-  nowrap?: boolean;
-
   /**
-   * How a run of characters with nowhere to wrap should behave. Ordinary
-   * wrapping only breaks at whitespace, so a URL, an identifier or any single
-   * long token overflows its container instead of wrapping.
+   * How this text wraps. Ordinary wrapping only breaks at whitespace, so a
+   * URL, an identifier or any single long token overflows its container
+   * instead of wrapping.
    *
+   * - `"whitespace-nowrap"` — do not wrap at all; the text stays on one line.
    * - `"wrap-normal"` — the CSS default: break at whitespace only, and let a
    *   long run overflow. Spell it out to override an inherited value, since
    *   `overflow-wrap` inherits and omitting this prop cannot undo an
@@ -39,17 +37,25 @@ interface TextProps extends WithoutStyles<
    *   measured, so the element can shrink as a flex item.
    * - `"break-all"` — break between any two characters.
    * - `"break-keep"` — never break within a word (CJK).
-   *
-   * Overlaps `nowrap`, which is the older way to say "one line" and wins
-   * because it removes the wrap opportunities this would act on. Prefer this
-   * prop; `nowrap` is kept so existing callers are undisturbed.
    */
   wordWrap?:
+    | "whitespace-nowrap"
     | "wrap-normal"
     | "wrap-break-word"
     | "wrap-anywhere"
     | "break-all"
     | "break-keep";
+
+  /**
+   * How the text sits within its own box. Logical values, so they follow the
+   * reading direction rather than the screen: `"text-start"` is left in an
+   * LTR locale and right in an RTL one.
+   *
+   * This aligns the text inside the element `Text` renders. Positioning that
+   * element within its parent is the parent's business — see the note on
+   * layout below.
+   */
+  textPosition?: "text-start" | "text-center" | "text-end" | "text-justify";
 
   /** Truncate text to N lines with ellipsis. `1` uses simple truncation; `2+` uses `-webkit-line-clamp`. */
   maxLines?: number;
@@ -126,8 +132,8 @@ function Text({
   font = "main-ui-body",
   color = "text-04",
   as: Tag = "span",
-  nowrap,
   wordWrap,
+  textPosition,
   maxLines,
   strikethrough,
   children,
@@ -137,8 +143,8 @@ function Text({
     "px-[2px]",
     FONT_CONFIG[font],
     COLOR_CONFIG[color],
-    nowrap && "whitespace-nowrap",
     wordWrap,
+    textPosition,
     maxLines === 1 && "truncate",
     maxLines && maxLines > 1 && "overflow-hidden",
     strikethrough && "line-through"

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/AvgTimeCell.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/AvgTimeCell.tsx
@@ -31,7 +31,7 @@ export default function AvgTimeCell({ stage, maxAvgMs }: AvgTimeCellProps) {
       height="fit"
       gap={1}
     >
-      <Text font="secondary-body" color="text-05" nowrap>
+      <Text font="secondary-body" color="text-05" wordWrap="whitespace-nowrap">
         {avgLabel}
       </Text>
       {avgPct > 0 && (

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/PerBatchTable.tsx
@@ -21,7 +21,7 @@ const tc = createTableColumns<IndexAttemptStageMetric>();
 // `StageLabelCell`/`AvgTimeCell` so all cells share the same type style.
 function TextCell({ children }: { children: string | number }) {
   return (
-    <Text font="secondary-body" color="text-05" nowrap>
+    <Text font="secondary-body" color="text-05" wordWrap="whitespace-nowrap">
       {String(children)}
     </Text>
   );

--- a/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageLabelCell.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/stage-metrics/StageLabelCell.tsx
@@ -34,7 +34,7 @@ export default function StageLabelCell({ stage }: StageLabelCellProps) {
           colorClassForStage(stage)
         )}
       />
-      <Text font="secondary-body" color="text-05" nowrap>
+      <Text font="secondary-body" color="text-05" wordWrap="whitespace-nowrap">
         {t(STAGE_LABEL_KEYS[stage])}
       </Text>
       <Button

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -273,7 +273,11 @@ function TokenBudgetField() {
       variant={meta.touched && meta.error ? "error" : "primary"}
       rightChildren={
         <div className="pe-1">
-          <Text font="secondary-action" color="text-03" nowrap>
+          <Text
+            font="secondary-action"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {t("modal.tokenBudget.unit")}
           </Text>
         </div>
@@ -609,7 +613,7 @@ export default function CreateRateLimitModal({
                             <Text
                               font="secondary-action"
                               color="text-03"
-                              nowrap
+                              wordWrap="whitespace-nowrap"
                             >
                               {t("modal.costBudget.unit")}
                             </Text>
@@ -640,7 +644,7 @@ export default function CreateRateLimitModal({
                             <Text
                               font="secondary-action"
                               color="text-03"
-                              nowrap
+                              wordWrap="whitespace-nowrap"
                             >
                               {t("modal.period.unit")}
                             </Text>

--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -139,7 +139,11 @@ export default function MultiModelPanel({
             isPreferred ? (
               <div className="flex items-center px-2">
                 <span className="text-action-selection-05 shrink-0">
-                  <Text font="secondary-body" color="inherit" nowrap>
+                  <Text
+                    font="secondary-body"
+                    color="inherit"
+                    wordWrap="whitespace-nowrap"
+                  >
                     {t("multiModelPanel.preferredResponse.label")}
                   </Text>
                 </span>
@@ -151,7 +155,11 @@ export default function MultiModelPanel({
               {isPreferred && (
                 <>
                   <span className="text-action-selection-05 shrink-0">
-                    <Text font="secondary-body" color="inherit" nowrap>
+                    <Text
+                      font="secondary-body"
+                      color="inherit"
+                      wordWrap="whitespace-nowrap"
+                    >
                       {t("multiModelPanel.preferredResponse.label")}
                     </Text>
                   </span>

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -99,7 +99,11 @@ export default function Layout({ children }: LayoutProps) {
             >
               <InputSelect.Trigger placeholder={t("sectionSelect.placeholder")}>
                 {activeTab && (
-                  <Text font="main-ui-body" color="text-04" nowrap>
+                  <Text
+                    font="main-ui-body"
+                    color="text-04"
+                    wordWrap="whitespace-nowrap"
+                  >
                     {activeTab.label}
                   </Text>
                 )}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -126,7 +126,11 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
                         {row.model}
                       </Text>
                     </Section>
-                    <Text font="main-ui-action" color="text-03" nowrap>
+                    <Text
+                      font="main-ui-action"
+                      color="text-03"
+                      wordWrap="whitespace-nowrap"
+                    >
                       {formatDollars(row.cost_cents)}
                     </Text>
                   </Section>
@@ -313,14 +317,22 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
                           key={`${provider}-${price.model}`}
                           className="flex flex-row items-center justify-between gap-2 py-1 ps-3"
                         >
-                          <Text font="secondary-body" color="text-05" nowrap>
+                          <Text
+                            font="secondary-body"
+                            color="text-05"
+                            wordWrap="whitespace-nowrap"
+                          >
                             {isSameModelPrice(price, defaultPrice)
                               ? t("modelPrices.defaultTag.label", {
                                   model: price.model,
                                 })
                               : price.model}
                           </Text>
-                          <Text font="secondary-body" color="text-03" nowrap>
+                          <Text
+                            font="secondary-body"
+                            color="text-03"
+                            wordWrap="whitespace-nowrap"
+                          >
                             {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
                               price.output_per_mtok
                             )} out · ${formatMtok(

--- a/web/src/app/craft/components/AgentSwitcher.tsx
+++ b/web/src/app/craft/components/AgentSwitcher.tsx
@@ -101,7 +101,7 @@ export default function AgentSwitcher() {
       {isViewingSubagent && (
         <SvgCpu className="w-4 h-4 stroke-text-03 shrink-0" />
       )}
-      <Text font="main-ui-action" color="text-04" nowrap>
+      <Text font="main-ui-action" color="text-04" wordWrap="whitespace-nowrap">
         {triggerLabel}
       </Text>
       {isViewingSubagent && viewedSubagent && (

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -335,7 +335,7 @@ export function BuildLLMPopover({
                                   <Text
                                     font="secondary-body"
                                     color="text-03"
-                                    nowrap
+                                    wordWrap="whitespace-nowrap"
                                   >
                                     {group.displayName}
                                   </Text>

--- a/web/src/app/craft/components/CompactionMarker.tsx
+++ b/web/src/app/craft/components/CompactionMarker.tsx
@@ -28,7 +28,7 @@ export default function CompactionMarker({ summary }: CompactionMarkerProps) {
     return (
       <span className="flex items-center gap-1.5">
         <SvgFold className="size-3.5 shrink-0 stroke-text-04" />
-        <Text font="main-ui-muted" color="text-04" nowrap>
+        <Text font="main-ui-muted" color="text-04" wordWrap="whitespace-nowrap">
           {t("marker.label")}
         </Text>
         {withChevron && (

--- a/web/src/app/craft/components/ContextRing.tsx
+++ b/web/src/app/craft/components/ContextRing.tsx
@@ -50,7 +50,11 @@ export default function ContextRing({
         aria-label={`${view.displayPct} percent of context window used`}
       >
         {view.level !== "ok" && (
-          <Text font="secondary-body" color="text-03" nowrap>
+          <Text
+            font="secondary-body"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {`${view.displayPct}%`}
           </Text>
         )}

--- a/web/src/app/craft/components/OpencodeDebugLogs.tsx
+++ b/web/src/app/craft/components/OpencodeDebugLogs.tsx
@@ -366,7 +366,11 @@ function StatusBar({
     <div className="flex items-center gap-3 px-3 py-2">
       <div className="flex items-center gap-2 shrink-0">
         <StatusDot status={status} paused={paused} />
-        <Text font="secondary-body" color="text-05" nowrap>
+        <Text
+          font="secondary-body"
+          color="text-05"
+          wordWrap="whitespace-nowrap"
+        >
           {stateLabel}
         </Text>
         {status !== "connecting" && status !== "error" && (
@@ -375,7 +379,11 @@ function StatusBar({
               className="h-3 w-px bg-border-02 shrink-0"
               aria-hidden="true"
             />
-            <Text font="secondary-body" color="text-05" nowrap>
+            <Text
+              font="secondary-body"
+              color="text-05"
+              wordWrap="whitespace-nowrap"
+            >
               {filtered
                 ? t("lines.filteredCount", {
                     visible: visibleLines,

--- a/web/src/app/craft/components/SandboxStatusIndicator.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.tsx
@@ -90,7 +90,11 @@ export function SandboxStatusIndicatorView({
             exit={{ opacity: 0, y: -5 }}
             transition={{ duration: 0.2 }}
           >
-            <Text font="main-ui-body" color="text-05" nowrap>
+            <Text
+              font="main-ui-body"
+              color="text-05"
+              wordWrap="whitespace-nowrap"
+            >
               {label}
             </Text>
           </motion.span>

--- a/web/src/app/craft/components/ScheduledRunBanner.tsx
+++ b/web/src/app/craft/components/ScheduledRunBanner.tsx
@@ -102,7 +102,11 @@ export default function ScheduledRunBanner({
           >
             <SvgClock size={14} className="shrink-0 text-text-03" />
             <span className="flex h-5 shrink-0 items-center">
-              <Text font="figure-small-label" color="text-03" nowrap>
+              <Text
+                font="figure-small-label"
+                color="text-03"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("badge.label")}
               </Text>
             </span>
@@ -116,7 +120,11 @@ export default function ScheduledRunBanner({
           >
             <SvgExternalLink size={14} className="shrink-0 text-text-03" />
             <span className="flex h-5 shrink-0 items-center">
-              <Text font="figure-small-label" color="text-03" nowrap>
+              <Text
+                font="figure-small-label"
+                color="text-03"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("viewTask.label")}
               </Text>
             </span>
@@ -136,12 +144,21 @@ export default function ScheduledRunBanner({
         >
           <div className="h-3 w-px shrink-0 bg-border-01" />
           <span className="flex h-5 min-w-0 -translate-y-px items-center overflow-hidden">
-            <Text font="main-ui-action" color="text-05" nowrap maxLines={1}>
+            <Text
+              font="main-ui-action"
+              color="text-05"
+              wordWrap="whitespace-nowrap"
+              maxLines={1}
+            >
               {data.task_name}
             </Text>
           </span>
           <span className="hidden h-5 shrink-0 items-center xl:flex">
-            <Text font="secondary-body" color="text-03" nowrap>
+            <Text
+              font="secondary-body"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {t("startedAt.label", { time: formatAbsolute(data.started_at) })}
             </Text>
           </span>

--- a/web/src/app/craft/components/ThinkingCard.tsx
+++ b/web/src/app/craft/components/ThinkingCard.tsx
@@ -126,7 +126,11 @@ export default function ThinkingCard({
         >
           <div className="flex items-center gap-2 min-w-0 w-full">
             <ThinkingActivityIcon isStreaming={isStreaming} />
-            <Text font="main-ui-muted" color="text-04" nowrap>
+            <Text
+              font="main-ui-muted"
+              color="text-04"
+              wordWrap="whitespace-nowrap"
+            >
               {isStreaming ? "Thinking..." : "Thinking"}
             </Text>
             <SvgChevronDown

--- a/web/src/app/craft/components/TodoListCard.tsx
+++ b/web/src/app/craft/components/TodoListCard.tsx
@@ -127,12 +127,20 @@ export default function TodoListCard({
               )}
 
               {/* Title */}
-              <Text font="main-ui-action" color="text-04" nowrap>
+              <Text
+                font="main-ui-action"
+                color="text-04"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("header.title")}
               </Text>
 
               {/* Progress count */}
-              <Text font="secondary-body" color="text-03" nowrap>
+              <Text
+                font="secondary-body"
+                color="text-03"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("progress.label", { completed, total })}
               </Text>
             </div>

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -615,7 +615,11 @@ function LibraryTreeView({
 
             {/* File size */}
             {!entry.is_directory && entry.file_size !== null && (
-              <Text font="secondary-body" color="text-03" nowrap>
+              <Text
+                font="secondary-body"
+                color="text-03"
+                wordWrap="whitespace-nowrap"
+              >
                 {formatFileSize(entry.file_size)}
               </Text>
             )}

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -202,7 +202,11 @@ export default function ApprovalCard({
                 ) : (
                   <SvgLoader className="size-4 shrink-0 stroke-status-info-05 animate-spin" />
                 )}
-                <Text font="main-ui-muted" color="text-04" nowrap>
+                <Text
+                  font="main-ui-muted"
+                  color="text-04"
+                  wordWrap="whitespace-nowrap"
+                >
                   {headerText}
                 </Text>
               </button>
@@ -214,7 +218,11 @@ export default function ApprovalCard({
                   approved ? "text-status-success-05" : "text-status-error-05"
                 )}
               >
-                <Text font="main-ui-action" color="inherit" nowrap>
+                <Text
+                  font="main-ui-action"
+                  color="inherit"
+                  wordWrap="whitespace-nowrap"
+                >
                   {approved ? t("status.approved") : t("status.rejected")}
                 </Text>
               </div>

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
@@ -54,18 +54,22 @@ function primaryText(toolCall: ToolCallState): string {
 function verbWithCode(verb: string, code: string, suffix?: string): ReactNode {
   return (
     <>
-      <Text font="main-ui-muted" color="text-04" nowrap>
+      <Text font="main-ui-muted" color="text-04" wordWrap="whitespace-nowrap">
         {verb}
       </Text>
       {/* 12px mono (vs the 14px sans verb): DM Mono renders visually larger
           than the sans face, so the smaller step matches their apparent size. */}
       <span className="rounded-sm bg-background-tint-01 px-1">
-        <Text font="secondary-mono" color="text-04" nowrap>
+        <Text
+          font="secondary-mono"
+          color="text-04"
+          wordWrap="whitespace-nowrap"
+        >
           {code}
         </Text>
       </span>
       {suffix && (
-        <Text font="main-ui-muted" color="text-04" nowrap>
+        <Text font="main-ui-muted" color="text-04" wordWrap="whitespace-nowrap">
           {suffix}
         </Text>
       )}
@@ -82,7 +86,7 @@ function renderPrimary(toolCall: ToolCallState): ReactNode {
   if (toolCall.kind === "execute" && toolCall.command) {
     if (toolCall.skillName && toolCall.description) {
       return (
-        <Text font="main-ui-muted" color="text-04" nowrap>
+        <Text font="main-ui-muted" color="text-04" wordWrap="whitespace-nowrap">
           {toolCall.description}
         </Text>
       );
@@ -102,7 +106,7 @@ function renderPrimary(toolCall: ToolCallState): ReactNode {
     return verbWithCode(`${toolCall.title} `, toolCall.description);
   }
   return (
-    <Text font="main-ui-muted" color="text-04" nowrap>
+    <Text font="main-ui-muted" color="text-04" wordWrap="whitespace-nowrap">
       {primaryText(toolCall)}
     </Text>
   );

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -93,7 +93,11 @@ export default function CraftToolGroup({
             >
               <div className="flex items-center gap-2 min-w-0 w-full">
                 {renderStatusIcon(toolCalls)}
-                <Text font="main-ui-muted" color="text-04" nowrap>
+                <Text
+                  font="main-ui-muted"
+                  color="text-04"
+                  wordWrap="whitespace-nowrap"
+                >
                   {t("working.label")}
                 </Text>
                 <span className="ms-auto shrink-0 flex items-center gap-2">

--- a/web/src/app/craft/components/tool-cards/DiffBody.tsx
+++ b/web/src/app/craft/components/tool-cards/DiffBody.tsx
@@ -316,7 +316,11 @@ export default function DiffBody({ toolCall }: ToolCardBodyProps) {
       >
         {toolCall.description && (
           <span className="truncate flex-1 min-w-0">
-            <Text font="secondary-mono" color="text-03" nowrap>
+            <Text
+              font="secondary-mono"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {toolCall.description}
             </Text>
           </span>

--- a/web/src/app/craft/components/tool-cards/TaskBody.tsx
+++ b/web/src/app/craft/components/tool-cards/TaskBody.tsx
@@ -61,7 +61,11 @@ export default function TaskBody({ toolCall }: ToolCardBodyProps) {
           delegated subagent you can open, without washing the whole surface. */}
       <SvgCpu className="w-4 h-4 stroke-action-selection-05 shrink-0" />
       <span className="min-w-0 flex-1 truncate">
-        <Text font="main-ui-action" color="text-04" nowrap>
+        <Text
+          font="main-ui-action"
+          color="text-04"
+          wordWrap="whitespace-nowrap"
+        >
           {label}
         </Text>
       </span>

--- a/web/src/app/craft/components/tool-cards/WebSearchBody.tsx
+++ b/web/src/app/craft/components/tool-cards/WebSearchBody.tsx
@@ -102,13 +102,21 @@ export default function WebSearchBody({ toolCall }: ToolCardBodyProps) {
             <div className="flex items-center gap-2 min-w-0">
               <SvgGlobe className="size-3.5 stroke-text-03 shrink-0" />
               <span className="truncate min-w-0">
-                <Text font="main-ui-action" color="text-04" nowrap>
+                <Text
+                  font="main-ui-action"
+                  color="text-04"
+                  wordWrap="whitespace-nowrap"
+                >
                   {result.title ?? domainFromUrl(result.url)}
                 </Text>
               </span>
             </div>
             <div className="ps-5 truncate">
-              <Text font="secondary-mono" color="text-02" nowrap>
+              <Text
+                font="secondary-mono"
+                color="text-02"
+                wordWrap="whitespace-nowrap"
+              >
                 {result.url}
               </Text>
             </div>

--- a/web/src/app/craft/onboarding/components/LivingMapDiagram.tsx
+++ b/web/src/app/craft/onboarding/components/LivingMapDiagram.tsx
@@ -486,7 +486,11 @@ export default function LivingMapDiagram({
                 <SourceIcon
                   className={cn("h-3.5 w-3.5", source.tint && "stroke-text-04")}
                 />
-                <Text font="secondary-action" color="text-04" nowrap>
+                <Text
+                  font="secondary-action"
+                  color="text-04"
+                  wordWrap="whitespace-nowrap"
+                >
                   {displayLabel}
                 </Text>
               </div>
@@ -506,7 +510,11 @@ export default function LivingMapDiagram({
           <div className="flex w-[200px] flex-col gap-1.5 rounded-12 border border-border-01 bg-background-tint-00 p-3 shadow-sm">
             <div className="flex items-center gap-1.5">
               <SvgBubbleText className="h-3.5 w-3.5 stroke-text-04" />
-              <Text font="secondary-action" color="text-04" nowrap>
+              <Text
+                font="secondary-action"
+                color="text-04"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("prompt.label")}
               </Text>
             </div>
@@ -568,13 +576,21 @@ export default function LivingMapDiagram({
               <div className="flex items-center justify-between px-3 py-2">
                 <div className="flex items-center gap-1.5">
                   <SvgCpu className="h-3.5 w-3.5 stroke-text-04" />
-                  <Text font="secondary-action" color="text-04" nowrap>
+                  <Text
+                    font="secondary-action"
+                    color="text-04"
+                    wordWrap="whitespace-nowrap"
+                  >
                     {t("workspace.label")}
                   </Text>
                 </div>
                 <div className="flex items-center gap-1">
                   <SvgShield className="h-3 w-3 stroke-text-03" />
-                  <Text font="figure-small-label" color="text-03" nowrap>
+                  <Text
+                    font="figure-small-label"
+                    color="text-03"
+                    wordWrap="whitespace-nowrap"
+                  >
                     {t("workspace.sandboxBadge")}
                   </Text>
                 </div>
@@ -593,7 +609,7 @@ export default function LivingMapDiagram({
                       <Text
                         font="secondary-mono"
                         color="text-inverted-03"
-                        nowrap
+                        wordWrap="whitespace-nowrap"
                       >
                         {line}
                       </Text>
@@ -614,7 +630,11 @@ export default function LivingMapDiagram({
                   className="flex items-center gap-1.5 rounded-08 border-[0.5px] border-border-01 bg-background-neutral-01 px-2 py-1"
                 >
                   <SvgAlertCircle className="h-3 w-3 shrink-0 stroke-text-04" />
-                  <Text font="figure-small-label" color="text-04" nowrap>
+                  <Text
+                    font="figure-small-label"
+                    color="text-04"
+                    wordWrap="whitespace-nowrap"
+                  >
                     {t("workspace.approvalPill")}
                   </Text>
                 </motion.div>
@@ -650,11 +670,19 @@ export default function LivingMapDiagram({
                       output.tint && "stroke-text-05"
                     )}
                   />
-                  <Text font="secondary-action" color="text-04" nowrap>
+                  <Text
+                    font="secondary-action"
+                    color="text-04"
+                    wordWrap="whitespace-nowrap"
+                  >
                     {output.label}
                   </Text>
                 </div>
-                <Text font="figure-small-label" color="text-03" nowrap>
+                <Text
+                  font="figure-small-label"
+                  color="text-03"
+                  wordWrap="whitespace-nowrap"
+                >
                   {output.caption}
                 </Text>
               </div>
@@ -674,11 +702,19 @@ export default function LivingMapDiagram({
           <div className="flex flex-col gap-0.5 rounded-12 border border-border-01 bg-background-tint-00 px-3 py-2">
             <div className="flex items-center gap-1.5">
               <SvgClock className="h-3.5 w-3.5 stroke-text-04" />
-              <Text font="secondary-action" color="text-04" nowrap>
+              <Text
+                font="secondary-action"
+                color="text-04"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("schedule.label")}
               </Text>
             </div>
-            <Text font="figure-small-label" color="text-03" nowrap>
+            <Text
+              font="figure-small-label"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {t("schedule.caption")}
             </Text>
           </div>
@@ -696,11 +732,19 @@ export default function LivingMapDiagram({
           <div className="flex flex-col gap-0.5 rounded-12 border border-border-01 bg-background-tint-00 px-3 py-2">
             <div className="flex items-center gap-1.5">
               <SvgUsers className="h-3.5 w-3.5 stroke-text-04" />
-              <Text font="secondary-action" color="text-04" nowrap>
+              <Text
+                font="secondary-action"
+                color="text-04"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("team.label")}
               </Text>
             </div>
-            <Text font="figure-small-label" color="text-03" nowrap>
+            <Text
+              font="figure-small-label"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {t("team.caption")}
             </Text>
           </div>

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -133,7 +133,11 @@ function buildColumns(t: RunHistoryTranslate, tReason: RunReasonTranslate) {
       cell: (value, row) => (
         <NonClickableCell reason={getNonClickableReason(row, tReason)}>
           <div className="flex flex-col gap-0.5">
-            <Text font="main-ui-body" color="text-05" nowrap>
+            <Text
+              font="main-ui-body"
+              color="text-05"
+              wordWrap="whitespace-nowrap"
+            >
               {formatAbsolute(value)}
             </Text>
             <Text font="secondary-body" color="text-03">
@@ -176,7 +180,11 @@ function buildColumns(t: RunHistoryTranslate, tReason: RunReasonTranslate) {
       width: { weight: 12 },
       cell: (row) => (
         <NonClickableCell reason={getNonClickableReason(row, tReason)}>
-          <Text font="main-ui-body" color="text-03" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {formatRunDuration(row.started_at, row.finished_at)}
           </Text>
         </NonClickableCell>
@@ -194,7 +202,11 @@ function buildColumns(t: RunHistoryTranslate, tReason: RunReasonTranslate) {
       enableSorting: false,
       cell: (value, row) => (
         <NonClickableCell reason={getNonClickableReason(row, tReason)}>
-          <Text font="main-ui-body" color="text-03" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {value === "MANUAL_RUN_NOW"
               ? t("trigger.runNow")
               : t("trigger.schedule")}

--- a/web/src/app/craft/v1/tasks/page.tsx
+++ b/web/src/app/craft/v1/tasks/page.tsx
@@ -62,7 +62,7 @@ function buildColumns(handlers: RowActionHandlers, t: TasksListTranslate) {
       weight: 25,
       enableSorting: false,
       cell: (value) => (
-        <Text font="main-ui-body" color="text-05" nowrap>
+        <Text font="main-ui-body" color="text-05" wordWrap="whitespace-nowrap">
           {value}
         </Text>
       ),
@@ -72,7 +72,7 @@ function buildColumns(handlers: RowActionHandlers, t: TasksListTranslate) {
       weight: 22,
       enableSorting: false,
       cell: (value) => (
-        <Text font="main-ui-body" color="text-03" nowrap>
+        <Text font="main-ui-body" color="text-03" wordWrap="whitespace-nowrap">
           {value}
         </Text>
       ),
@@ -119,7 +119,11 @@ function buildColumns(handlers: RowActionHandlers, t: TasksListTranslate) {
         }
         return (
           <Tooltip tooltip={formatAbsolute(nextRunAt)} side="top">
-            <Text font="main-ui-body" color="text-03" nowrap>
+            <Text
+              font="main-ui-body"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {formatRelativeShort(nextRunAt)}
             </Text>
           </Tooltip>

--- a/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
@@ -55,7 +55,11 @@ function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
       >
         {/* 1. Timestamp */}
         <span className="shrink-0 text-code-code">
-          <Text font="secondary-mono-label" color="inherit" nowrap>
+          <Text
+            font="secondary-mono-label"
+            color="inherit"
+            wordWrap="whitespace-nowrap"
+          >
             {formatDateTimeLog(log.created_at)}
           </Text>
         </span>

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -726,7 +726,7 @@ export default function MCPAuthenticationModal({
                             as="p"
                             font="secondary-body"
                             color="text-03"
-                            nowrap
+                            wordWrap="whitespace-nowrap"
                           >
                             {markdown(t("mcpAuthModal.redirectUri.label"))}
                           </Text>

--- a/web/src/sections/input/EntryPickerPopover.tsx
+++ b/web/src/sections/input/EntryPickerPopover.tsx
@@ -343,7 +343,11 @@ function ConnectableRow({
         }}
         rightChildren={
           unauth ? (
-            <Text font="secondary-action" color="text-03" nowrap>
+            <Text
+              font="secondary-action"
+              color="text-03"
+              wordWrap="whitespace-nowrap"
+            >
               {t("entryPickerPopover.connectAction.label")}
             </Text>
           ) : undefined

--- a/web/src/sections/input/InputChipStrip.tsx
+++ b/web/src/sections/input/InputChipStrip.tsx
@@ -50,7 +50,11 @@ function InputChip({
     <>
       {icon}
       <span className="max-w-[120px] truncate">
-        <Text font="secondary-body" color="inherit" nowrap>
+        <Text
+          font="secondary-body"
+          color="inherit"
+          wordWrap="whitespace-nowrap"
+        >
           {label}
         </Text>
       </span>

--- a/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
+++ b/web/src/sections/modals/languageModels/ModelSettingsPopover.tsx
@@ -91,7 +91,11 @@ function SectionHeader({
         rightChildren={
           rightValue !== undefined ? (
             <Tooltip tooltip={rightValueTooltip} side="top">
-              <Text font="secondary-mono" color="text-04" nowrap>
+              <Text
+                font="secondary-mono"
+                color="text-04"
+                wordWrap="whitespace-nowrap"
+              >
                 {rightValue}
               </Text>
             </Tooltip>
@@ -132,7 +136,11 @@ function PolicySlider({
       className="ms-8 me-2"
     >
       <Section alignItems="start" width="auto" height="auto" className="mx-0.5">
-        <Text font="secondary-action" color="text-03" nowrap>
+        <Text
+          font="secondary-action"
+          color="text-03"
+          wordWrap="whitespace-nowrap"
+        >
           {label}
         </Text>
       </Section>
@@ -152,7 +160,7 @@ function PolicySlider({
               key={mark}
               font="figure-small-value"
               color={index === activeMark ? "text-04" : "text-02"}
-              nowrap
+              wordWrap="whitespace-nowrap"
             >
               {mark}
             </Text>
@@ -260,7 +268,11 @@ export function ModelSettingsPopover({
             gap={0}
             className="mx-2.5 my-2"
           >
-            <Text font="main-ui-body" color="text-02" nowrap>
+            <Text
+              font="main-ui-body"
+              color="text-02"
+              wordWrap="whitespace-nowrap"
+            >
               {modelDisplayName(model)}
             </Text>
             <Text font="secondary-body" color="text-02">

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -237,7 +237,11 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
           onClick={onBack}
         />
         <div className="flex min-w-0 flex-1 flex-row items-baseline justify-between gap-2">
-          <Text font="main-ui-body" color="text-02" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-02"
+            wordWrap="whitespace-nowrap"
+          >
             {option.displayName}
           </Text>
           <div className="min-w-0 truncate">
@@ -355,7 +359,7 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
                           ? "text-04"
                           : "text-02"
                       }
-                      nowrap
+                      wordWrap="whitespace-nowrap"
                     >
                       {reasoningStopLabels[stop]}
                     </Text>

--- a/web/src/sections/usage/SpendByUserTable.tsx
+++ b/web/src/sections/usage/SpendByUserTable.tsx
@@ -84,7 +84,11 @@ function buildColumns(t: UsageTranslate) {
       weight: 38,
       cell: (value) => (
         <span className="underline-offset-2 group-hover/row:underline">
-          <Text font="main-ui-body" color="text-05" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-05"
+            wordWrap="whitespace-nowrap"
+          >
             {value}
           </Text>
         </span>
@@ -96,7 +100,11 @@ function buildColumns(t: UsageTranslate) {
       alignment: "right",
       cell: (value) => (
         <span className="tabular-nums">
-          <Text font="main-ui-action" color="text-05" nowrap>
+          <Text
+            font="main-ui-action"
+            color="text-05"
+            wordWrap="whitespace-nowrap"
+          >
             {formatCost(value)}
           </Text>
         </span>
@@ -108,7 +116,11 @@ function buildColumns(t: UsageTranslate) {
       alignment: "right",
       cell: (value) => (
         <span className="tabular-nums">
-          <Text font="main-ui-action" color="text-05" nowrap>
+          <Text
+            font="main-ui-action"
+            color="text-05"
+            wordWrap="whitespace-nowrap"
+          >
             {formatTokens(value)}
           </Text>
         </span>
@@ -120,7 +132,11 @@ function buildColumns(t: UsageTranslate) {
       alignment: "right",
       cell: (value) => (
         <span className="tabular-nums">
-          <Text font="main-ui-body" color="text-03" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {formatTokens(value)}
           </Text>
         </span>
@@ -132,7 +148,11 @@ function buildColumns(t: UsageTranslate) {
       alignment: "right",
       cell: (value) => (
         <span className="tabular-nums">
-          <Text font="main-ui-body" color="text-03" nowrap>
+          <Text
+            font="main-ui-body"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {formatTokens(value)}
           </Text>
         </span>

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -68,11 +68,11 @@ function dailySpend(user: UsageExportUser): DailySpend[] {
 function StatCell({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex min-w-0 flex-col gap-0.5 px-3 first:ps-0 last:pe-0">
-      <Text font="secondary-body" color="text-03" nowrap>
+      <Text font="secondary-body" color="text-03" wordWrap="whitespace-nowrap">
         {label}
       </Text>
       <span className="tabular-nums">
-        <Text font="main-content-emphasis" nowrap>
+        <Text font="main-content-emphasis" wordWrap="whitespace-nowrap">
           {value}
         </Text>
       </span>
@@ -135,7 +135,11 @@ function BreakdownList({
                 <span className="flex min-w-0 items-center gap-1.5">
                   {Icon && <Icon size={16} className="shrink-0" />}
                   <span className="min-w-0 truncate">
-                    <Text font="main-ui-body" color="text-05" nowrap>
+                    <Text
+                      font="main-ui-body"
+                      color="text-05"
+                      wordWrap="whitespace-nowrap"
+                    >
                       {slice.label}
                     </Text>
                   </span>

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1376,7 +1376,11 @@ function ChatPreferencesSettings() {
                     />
                   </Section>
                   <Section width={4} height="auto" alignItems="end">
-                    <Text font="secondary-mono" color="text-04" nowrap>
+                    <Text
+                      font="secondary-mono"
+                      color="text-04"
+                      wordWrap="whitespace-nowrap"
+                    >
                       {draftTemperature.toFixed(1)}
                     </Text>
                   </Section>
@@ -1411,7 +1415,11 @@ function ChatPreferencesSettings() {
                       />
                     </Section>
                     <Section width={4} height="auto" alignItems="end">
-                      <Text font="secondary-mono" color="text-04" nowrap>
+                      <Text
+                        font="secondary-mono"
+                        color="text-04"
+                        wordWrap="whitespace-nowrap"
+                      >
                         {tModelSelector(
                           REASONING_STOP_LABEL_KEYS[
                             ALL_REASONING_STOPS[draftEffortStop] ?? "medium"

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -261,7 +261,11 @@ function OverrideRow({ override }: OverrideRowProps) {
       <Card border="solid" rounding={4} padding={2}>
         <div className="flex flex-row items-center justify-between gap-2 p-2">
           <div className="flex flex-col gap-0.5 min-w-0">
-            <Text font="main-ui-action" color="text-04" nowrap>
+            <Text
+              font="main-ui-action"
+              color="text-04"
+              wordWrap="whitespace-nowrap"
+            >
               {override.model}
             </Text>
             <Text font="secondary-body" color="text-03">

--- a/web/src/views/admin/ExternalAppsPage/IntegrationCard.tsx
+++ b/web/src/views/admin/ExternalAppsPage/IntegrationCard.tsx
@@ -87,7 +87,11 @@ export default function IntegrationCard({ integration }: IntegrationCardProps) {
             {/* Toggles org-wide availability, never a single member's
                 connection; the label fades in on hover or focus. */}
             <Hoverable.Item group="integration-row" variant="appear-on-hover">
-              <Text font="secondary-body" color="text-03" nowrap>
+              <Text
+                font="secondary-body"
+                color="text-03"
+                wordWrap="whitespace-nowrap"
+              >
                 {t("card.availableInCraft.label")}
               </Text>
             </Hoverable.Item>

--- a/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
@@ -105,7 +105,11 @@ export default function ReindexErrorsModal({
         header: t("errorsModal.columns.id"),
         width: { weight: 12 },
         cell: (row) => (
-          <Text font="secondary-body" color="text-03" nowrap>
+          <Text
+            font="secondary-body"
+            color="text-03"
+            wordWrap="whitespace-nowrap"
+          >
             {row.cc_pair_id != null
               ? String(row.cc_pair_id)
               : row.user_id

--- a/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
@@ -69,7 +69,11 @@ export default function ReindexProgressBanner({
           <div className="flex flex-row items-center gap-4 px-2 py-1">
             <div className="flex flex-1 flex-col gap-2 min-w-0">
               <div className="flex flex-row items-center justify-between gap-2">
-                <Text font="main-ui-body" color="text-03" nowrap>
+                <Text
+                  font="main-ui-body"
+                  color="text-03"
+                  wordWrap="whitespace-nowrap"
+                >
                   {t("progressBanner.status.label")}
                 </Text>
                 <div className="flex flex-row items-center gap-1.5">

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -1345,7 +1345,7 @@ export default function IndexSettingsPage() {
                                 <Text
                                   font="secondary-body"
                                   color="text-03"
-                                  nowrap
+                                  wordWrap="whitespace-nowrap"
                                 >
                                   {t("changesBanner.orSeparator.label")}
                                 </Text>


### PR DESCRIPTION
## Description

`Text` owns how its own text renders, but had no way to express either of these.

**Wrapping was a `nowrap` boolean and nothing else.** A URL, an identifier, or any run of characters without whitespace overflowed its container, and no caller could do anything about it — `Text` strips `className`, so there was no escape hatch either. That is one decision with several settings rather than a pair of independent switches, so `nowrap` folds into `wordWrap` as `"whitespace-nowrap"` and its 95 call sites move with it.

Values map 1:1 to the Tailwind utilities and go straight into `cn(...)`, so there is no lookup table to drift. `"wrap-normal"` earns its place because `overflow-wrap` inherits: omitting the prop cannot undo a value an ancestor set, while stating it can.

**Alignment had no prop at all**, so callers wrapped `Text` in a `span` purely to carry `text-center`. `textPosition` takes logical values — `text-start` is left in an LTR locale and right in an RTL one — matching the repo's preference for logical properties.

**One judgement worth flagging.** The README listed *alignment* among the layout concerns that belong on a container, which `textPosition` contradicts. Rather than quietly ignoring it, the line is redrawn: `Text` aligns text within its own box, and where that box sits remains the parent's business. If you would rather keep the original boundary, this prop is the thing to reconsider.

**Scope of the migration.** Only Opal's `Text` is touched. `TextButton` and the legacy `refresh-components` `Text` and `Truncated` keep their own `nowrap` props — the migration matched `<Text>` elements in files the typechecker flagged, so those were never in range.

## Screenshots + Videos

No UI changes; screenshots + videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `Text`'s `nowrap` boolean with a `wordWrap` prop (values map 1:1 to Tailwind utilities) so callers control wrapping, and adds `textPosition` for logical alignment. Existing `nowrap` call sites migrate to `wordWrap="whitespace-nowrap"` and emit the same class, so rendering is unchanged; `textPosition` is new and currently unused.

- `wordWrap` includes `"whitespace-nowrap"`, `"wrap-normal"`, `"wrap-break-word"`, `"wrap-anywhere"`, `"break-all"`, and `"break-keep"`; `"wrap-normal"` overrides inherited values that `overflow-wrap` picks up.
- `textPosition` takes `"text-start"`, `"text-center"`, `"text-end"`, and `"text-justify"`, following the reading direction, and is only accepted when `as` is a block tag (`p`, `li`, `h1`–`h3`) — on the default inline `span` it would do nothing, so `TextProps` became a union that rejects it at compile time.
- README boundary redrawn: `Text` aligns text within its box; positioning that box remains the parent's job.
- Migration covers Opal `Text` only; `TextButton` and the legacy `refresh-components` components keep their own `nowrap` props.

<sup>Written for commit ee716df0b48d39ece5a00e5c571a6fa5c9872f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

