### PR TITLE
docs(web): cut web/AGENTS.md by 80% and fix stale references

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,688 +1,78 @@
 # Frontend Standards
 
-This file is the single source of truth for frontend coding standards across all Onyx frontend
-projects (including, but not limited to, `/web`, `/desktop`).
-
-# Components
-
-UI components are spread across several directories while the codebase migrates to Opal:
-
-- **`web/lib/opal/src/`** — The Opal design system. Preferred for all new components.
-- **`web/src/refresh-components/`** — Production components not yet migrated to Opal.
-- **`web/src/sections/`** — Feature-specific composite components (cards, modals, etc.).
-- **`web/src/layouts/`** — Page-level layout components (settings pages, etc.).
-
-**Do NOT use anything from `web/src/components/`** — this directory contains legacy components
-that are being phased out. Always prefer Opal first; fall back to `refresh-components` only for
-components not yet available in Opal.
-
-## Opal Layouts (`lib/opal/src/layouts/`)
-
-All layout primitives are imported from `@opal/layouts`. They handle sizing, font selection, icon
-alignment, and optional inline editing.
-
-```typescript
-import { Content, ContentAction, IllustrationContent } from "@opal/layouts";
-```
-
-### Content
-
-**Use this for any combination of icon + title + description.**
-
-A two-axis layout component that automatically routes to the correct internal layout
-(`ContentXl`, `ContentLg`, `ContentMd`, `ContentSm`) based on `sizePreset` and `variant`:
-
-| sizePreset                               | variant               | Routes to   | Layout                 |
-| ---------------------------------------- | --------------------- | ----------- | ---------------------- |
-| `headline` / `section`                   | `heading`             | `ContentXl` | Icon on top (flex-col) |
-| `headline` / `section`                   | `section`             | `ContentLg` | Icon inline (flex-row) |
-| `main-content` / `main-ui` / `secondary` | `section` / `heading` | `ContentMd` | Compact inline         |
-| `main-content` / `main-ui` / `secondary` | `body`                | `ContentSm` | Body text layout       |
-
-```typescript
-<Content
-  sizePreset="main-ui"
-  variant="section"
-  icon={SvgSettings}
-  title="Settings"
-  description="Manage your preferences"
-/>
-```
-
-### ContentAction
-
-**Use this when a Content block needs right-side actions** (buttons, badges, icons, etc.).
-
-Wraps `Content` and adds a `rightChildren` slot. Accepts all `Content` props plus:
-
-- `rightChildren`: `ReactNode` — actions rendered on the right
-- `padding`: `SizeVariant` — controls outer padding
-
-```typescript
-<ContentAction
-  sizePreset="main-ui"
-  variant="section"
-  icon={SvgUser}
-  title="John Doe"
-  description="Admin"
-  rightChildren={<Button icon={SvgEdit}>Edit</Button>}
-/>
-```
-
-### IllustrationContent
-
-**Use this for empty states, error pages, and informational placeholders.**
-
-A vertically-stacked, center-aligned layout that pairs a large illustration (7.5rem x 7.5rem)
-with a title and optional description.
-
-```typescript
-import SvgNoResult from "@opal/illustrations/no-result";
-
-<IllustrationContent
-  illustration={SvgNoResult}
-  title="No results found"
-  description="Try adjusting your search or filters."
-/>
-```
-
-Props:
-
-- `illustration`: `IconFunctionComponent` — optional, from `@opal/illustrations`
-- `title`: `string` — required
-- `description`: `string` — optional
-
-## Settings Page Layout (`src/layouts/settings-layouts.tsx`)
-
-**Use this for all admin/settings pages.** Provides a standardized layout with scroll-aware
-sticky headers, centered content containers, and responsive behavior.
-
-```typescript
-import SettingsLayouts from "@/layouts/settings-layouts";
-
-function MySettingsPage() {
-  return (
-    <SettingsLayouts.Root>
-      <SettingsLayouts.Header
-        icon={SvgSettings}
-        title="Account Settings"
-        description="Manage your account preferences"
-        rightChildren={<Button>Save</Button>}
-      >
-        <InputTypeIn placeholder="Search settings..." />
-      </SettingsLayouts.Header>
-
-      <SettingsLayouts.Body>
-        <Card>Settings content here</Card>
-      </SettingsLayouts.Body>
-    </SettingsLayouts.Root>
-  );
-}
-```
-
-Sub-components:
-
-- **`SettingsLayouts.Root`** — Wrapper with centered, scrollable container. Width options:
-  `"sm"` (672px), `"sm-md"` (752px), `"md"` (872px, default), `"lg"` (992px), `"full"` (100%).
-- **`SettingsLayouts.Header`** — Sticky header with icon, title, description, optional
-  `rightChildren` actions, optional `children` below (e.g., search/filter), optional `backButton`,
-  and optional `separator`. Automatically shows a scroll shadow when scrolled.
-- **`SettingsLayouts.Body`** — Content container with consistent padding and vertical spacing.
-
-## Cards (`src/sections/cards/`)
-
-**When building a card that displays information about a specific entity (agent, document set,
-file, connector, etc.), add it to `web/src/sections/cards/`.**
-
-Each card is a self-contained component focused on a single entity type. Cards typically include
-entity identification (name, avatar, icon), summary information, and quick actions.
-
-```typescript
-import AgentCard from "@/sections/cards/AgentCard";
-import DocumentSetCard from "@/sections/cards/DocumentSetCard";
-import FileCard from "@/sections/cards/FileCard";
-```
-
-Guidelines:
-
-- One card per entity type — keep card-specific logic within the card component.
-- Cards should be reusable across different pages and contexts.
-- Use shared components from `@opal/components`, `@opal/layouts`, and `@/refresh-components`
-  inside cards — do not duplicate layout or styling logic.
-
-## Button (`components/buttons/button/`)
-
-**Always use the Opal `Button`.** Do not use raw `<button>` elements.
-
-Built on `Interactive.Stateless` > `Interactive.Container`, so it inherits the full color/state
-system automatically.
-
-```typescript
-import { Button } from "@opal/components/buttons/button/components";
-
-// Labeled button
-<Button variant="default" prominence="primary" icon={SvgPlus}>
-  Create
-</Button>
-
-// Icon-only button (omit children)
-<Button variant="default" prominence="tertiary" icon={SvgTrash} size="sm" />
-```
-
-Key props:
-
-- `variant`: `"default"` | `"action"` | `"danger"` | `"none"`
-- `prominence`: `"primary"` | `"secondary"` | `"tertiary"` | `"internal"`
-- `size`: `"lg"` | `"md"` | `"sm"` | `"xs"` | `"2xs"` | `"fit"`
-- `icon`, `rightIcon`, `children`, `disabled`, `href`, `tooltip`
-
-## Core Primitives (`core/`)
-
-The `core/` directory contains the lowest-level building blocks that power all Opal components.
-**Most code should not interface with these directly** — use higher-level components like `Button`,
-`Content`, and `ContentAction` instead. These are documented here for understanding, not everyday use.
-
-### Interactive (`core/interactive/`)
-
-The foundational layer for all clickable/interactive surfaces. Defines the color matrix for
-hover, active, and disabled states.
-
-- **`Interactive.Stateless`** — Color system for stateless elements (buttons, links). Applies
-  variant/prominence/state combinations via CSS custom properties.
-- **`Interactive.Stateful`** — Color system for stateful elements (toggles, sidebar items, selects).
-  Uses `state` (`"empty"` | `"filled"` | `"selected"`) instead of prominence.
-- **`Interactive.Container`** — Structural box providing height, rounding, padding, and border.
-  Shared by both Stateless and Stateful. Renders as `<div>`, `<button>`, or `<Link>` depending
-  on context.
-- **`Interactive.Foldable`** — Zero-width collapsible wrapper with CSS grid animation.
-
-### Disabled (`core/disabled/`)
-
-A pure CSS wrapper that applies disabled visuals (`opacity-50`, `cursor-not-allowed`,
-`pointer-events: none`) to a single child element via Radix `Slot`. Supports an optional `tooltip`
-prop (shown on hover when disabled) and `allowClick` to re-enable pointer events. The child must
-be a single DOM element. Interactive primitives and buttons manage their own disabled state via a
-`disabled` prop.
-
-### Hoverable (`core/animations/`)
-
-A standardized way to provide "opacity-100 on hover" behavior. Instead of manually wiring
-`opacity-0 group-hover:opacity-100` with Tailwind, use `Hoverable` for consistent, coordinated
-hover-to-reveal patterns. It is entirely CSS-driven (no React state), and on devices whose
-primary input cannot hover (touch), items are always shown in their revealed state so actions
-stay reachable on mobile.
-
-- **`Hoverable.Root`** — Wraps a hover group. Renders a container with a `data-hover-group`
-  attribute; CSS `:hover`/`:has(:focus-visible)` on it reveals descendant items. Focus reveals
-  only where a focus ring is warranted, so a mouse press on a link or button does not leave the
-  items stuck open after the pointer moves away.
-- **`Hoverable.Item`** — Marks an element that should appear on hover. Supports two modes:
-  - **Group mode** (`group` prop provided): visibility driven by CSS `:hover` on the
-    `Hoverable.Root` ancestor.
-  - **Local mode** (`group` omitted): uses CSS `:hover` on the item itself.
-
-For hover-reveal styling that cannot go through `Hoverable`, pair the hover utilities with the
-`no-hover:` variant (defined in opal's `_reference.css`, matching `@media (hover: none)`) so the
-element stays visible on touch devices, e.g. `opacity-0 group-hover:opacity-100 no-hover:opacity-100`.
-
-```typescript
-import { Hoverable } from "@opal/core";
-
-// Group mode — hovering anywhere on the row reveals the trash icon
-<Hoverable.Root group="row">
-  <div className="flex items-center gap-2">
-    <span>Row content</span>
-    <Hoverable.Item group="row" variant="opacity-on-hover">
-      <SvgTrash />
-    </Hoverable.Item>
-  </div>
-</Hoverable.Root>
-
-// Local mode — hovering the item itself reveals it
-<Hoverable.Item variant="opacity-on-hover">
-  <SvgTrash />
-</Hoverable.Item>
-```
-
-# Best Practices
-
-## 0. Size Variant Defaults
-
-**When using `SizeVariants` (or any subset like `PaddingVariants`, `RoundingVariants`) as a prop
-type, always default to `"md"`.**
-
-**Reason:** `"md"` is the standard middle-of-the-road preset across the design system. Consistent
-defaults make components predictable — callers only need to specify a size when they want something
-other than the norm.
-
-```typescript
-// ✅ Good — default to "md"
-function MyCard({ padding = "md", rounding = "md" }: MyCardProps) { ... }
-
-// ❌ Bad — arbitrary or inconsistent defaults
-function MyCard({ padding = "sm", rounding = "lg" }: MyCardProps) { ... }
-```
-
-## 1. Tailwind Dark Mode
-
-**Strictly forbid using the `dark:` modifier in Tailwind classes, except for logo icon handling.**
-
-**Reason:** The `colors.css` file already, VERY CAREFULLY, defines what the exact opposite colour of each light-mode colour is. Overriding this behaviour is VERY bad and will lead to horrible UI breakages.
-
-**Exception:** The `createLogoIcon` helper in `web/src/components/icons/icons.tsx` uses `dark:` modifiers (`dark:invert`, `dark:hidden`, `dark:block`) to handle third-party logo icons that cannot automatically adapt through `colors.css`. This is the ONLY acceptable use of dark mode modifiers.
-
-```typescript
-// ✅ Good - Standard components use `tailwind-themes/tailwind.config.js` / `src/app/css/colors.css`
-<div className="bg-background-neutral-03 text-text-02">
-  Content
-</div>
-
-// ✅ Good - Logo icons with dark mode handling via createLogoIcon
-export const GithubIcon = createLogoIcon(githubLightIcon, {
-  monochromatic: true,  // Will apply dark:invert internally
-});
-
-export const GitbookIcon = createLogoIcon(gitbookLightIcon, {
-  darkSrc: gitbookDarkIcon,  // Will use dark:hidden/dark:block internally
-});
-
-// ❌ Bad - Manual dark mode overrides
-<div className="bg-white dark:bg-black text-black dark:text-white">
-  Content
-</div>
-```
-
-## 2. Icon Usage
-
-**ONLY use icons from the `web/src/icons` directory. Do NOT use icons from `react-icons`, `lucide`, or other external libraries.**
-
-**Reason:** We have a very carefully curated selection of icons that match our Onyx guidelines. We do NOT want to muddy those up with different aesthetic stylings.
-
-```typescript
-// ✅ Good
-import SvgX from "@/icons/x";
-import SvgMoreHorizontal from "@/icons/more-horizontal";
-
-// ❌ Bad
-import { User } from "lucide-react";
-import { FiSearch } from "react-icons/fi";
-```
-
-**Missing Icons**: If an icon is needed but doesn't exist in the `web/src/icons` directory, import it from Figma using the Figma MCP tool and add it to the icons directory.
-If you need help with this step, reach out to `raunak@onyx.app`.
-
-## 3. Text Rendering
-
-**Use the Opal `Text` component for all text rendering. Avoid "naked" text nodes.**
-
-**Reason:** The `Text` component is fully compliant with the stylings provided in Figma. It uses
-string-enum props (`font` and `color`) for font preset and color selection. Inline markdown is
-opt-in via the `markdown()` function from `@opal/types`.
-
-```typescript
-// ✅ Good — Opal Text with string-enum props
-import { Text } from "@opal/components";
-
-function UserCard({ name }: { name: string }) {
-  return (
-    <Text font="main-ui-action" color="text-03">
-      {name}
-    </Text>
-  )
-}
-
-// ✅ Good — inline markdown via markdown()
-import { markdown } from "@opal/utils";
-
-<Text font="main-ui-body" color="text-05">
-  {markdown("*Hello*, **world**! Visit [Onyx](https://onyx.app) and run `onyx start`.")}
-</Text>
-
-// ✅ Good — plain strings are never parsed as markdown
-<Text font="main-ui-body" color="text-03">
-  {userProvidedString}
-</Text>
-
-// ✅ Good — component props that support optional markdown use `string | RichStr`
-import type { RichStr } from "@opal/types";
-
-interface MyCardProps {
-  title: string | RichStr;
-}
-
-// ❌ Bad — legacy boolean-flag API (still works but deprecated)
-import Text from "@/refresh-components/texts/Text";
-<Text text03 mainUiAction>{name}</Text>
-
-// ❌ Bad — naked text nodes
-<div>
-  <h2>{name}</h2>
-  <p>User details</p>
-</div>
-```
-
-Key props:
-
-- `font`: `TextFont` — font preset (e.g., `"main-ui-body"`, `"heading-h2"`, `"secondary-action"`)
-- `color`: `TextColor` — text color (e.g., `"text-03"`, `"text-inverted-05"`)
-- `as`: `"p" | "span" | "li" | "h1" | "h2" | "h3"` — HTML tag (default: `"span"`)
-- `wordWrap`: `"whitespace-nowrap" | "wrap-normal" | "wrap-break-word" | "wrap-anywhere" | "break-all" | "break-keep"` — how the text wraps. `"whitespace-nowrap"` keeps it on one line; the `wrap-*` and `break-*` values let a long unbroken run split rather than overflow
-- `textPosition`: `"text-start" | "text-center" | "text-end" | "text-justify"` — how the text sits in its box. Only offered when `as` is a block tag, since `text-align` has nothing to align within on an inline `span`
-
-**`RichStr` convention:** When creating new components, any string prop that will be rendered as
-visible text in the DOM (e.g., `title`, `description`, `label`) should be typed as
-`string | RichStr` instead of plain `string`. This gives callers opt-in markdown support via
-`markdown()` without requiring any additional props or API surface on the component.
-
-```typescript
-import type { RichStr } from "@opal/types";
-import { Text } from "@opal/components";
-
-// ✅ Good — new components accept string | RichStr and render via Text
-interface InfoCardProps {
-  title: string | RichStr;
-  description?: string | RichStr;
-}
-
-function InfoCard({ title, description }: InfoCardProps) {
-  return (
-    <div>
-      <Text font="main-ui-action">{title}</Text>
-      {description && (
-        <Text font="secondary-body" color="text-03">{description}</Text>
-      )}
-    </div>
-  );
-}
-
-// ❌ Bad — plain string props block markdown support for callers
-interface InfoCardProps {
-  title: string;
-  description?: string;
-}
-```
-
-## 4. Component Usage
-
-**Heavily avoid raw HTML input components. Always use components from the `web/src/refresh-components` or `web/lib/opal/src` directory.**
-
-**Reason:** We've put in a lot of effort to unify the components that are rendered in the Onyx app. Using raw components breaks the entire UI of the application, and leaves it in a muddier state than before.
-
-```typescript
-// ✅ Good
-import { Button, InputTypeIn } from '@opal/components'
-import { SvgPlusCircle } from '@opal/icons'
-
-function ContactForm() {
-  return (
-    <form>
-      <InputTypeIn placeholder="Search..." />
-      <Button type="submit" icon={SvgPlusCircle}>Submit</Button>
-    </form>
-  )
-}
-
-// ❌ Bad
-function ContactForm() {
-  return (
-    <form>
-      <input placeholder="Name" />
-      <textarea placeholder="Message" />
-      <button type="submit">Submit</button>
-    </form>
-  )
-}
-```
-
-## 5. Colors
-
-**Always use custom overrides for colors and borders rather than built in Tailwind CSS colors. These overrides live in `web/tailwind-themes/tailwind.config.js`.**
-
-**Reason:** Our custom color system uses CSS variables that automatically handle dark mode and maintain design consistency across the app. Standard Tailwind colors bypass this system.
-
-**Available color categories:**
-
-- **Text:** `text-01` through `text-05`, `text-inverted-XX`
-- **Backgrounds:** `background-neutral-XX`, `background-tint-XX` (and inverted variants)
-- **Borders:** `border-01` through `border-05`, `border-inverted-XX`
-- **Actions:** `action-selection-XX`, `action-danger-XX`
-- **Status:** `status-info-XX`, `status-success-XX`, `status-warning-XX`, `status-error-XX`
-- **Theme:** `theme-primary-XX`, `theme-red-XX`, `theme-blue-XX`, etc.
-
-```typescript
-// ✅ Good - Use custom Onyx color classes
-<div className="bg-background-neutral-01 border border-border-02" />
-<div className="bg-background-tint-02 border border-border-01" />
-<div className="bg-status-success-01" />
-<div className="bg-action-selection-01" />
-<div className="bg-theme-primary-05" />
-
-// ❌ Bad - Do NOT use standard Tailwind colors
-<div className="bg-gray-100 border border-gray-300 text-gray-600" />
-<div className="bg-white border border-slate-200" />
-<div className="bg-green-100 text-green-700" />
-<div className="bg-blue-100 text-blue-600" />
-<div className="bg-indigo-500" />
-```
-
-## 6. Data Fetching
-
-**Prefer using `useSWR` for data fetching. Data should generally be fetched on the client side. Components that need data should display a loader / placeholder while waiting for that data. Prefer loading data within the component that needs it rather than at the top level and passing it down.**
-
-**Reason:** Client side fetching allows us to load the skeleton of the page without waiting for data to load, leading to a snappier UX. Loading data where needed reduces dependencies between a component and its parent component(s).
-
-## 7. Internationalization (i18n)
-
-The UI is being migrated to next-intl. English message catalogs live in
-`web/src/i18n/messages/en.json`; the locale registry is `web/src/i18n/config.ts`.
-
-- **In migrated directories** (listed in the `i18n/no-raw-jsx-text` override in
-  `web/.oxlintrc.json`), never hardcode user-facing strings. Use
-  `const t = useTranslations("<namespace>")` (client) or
-  `await getTranslations("<namespace>")` (server) and add the English value to
-  `en.json`. The oxlint rule and the `types:check` key augmentation both fail on
-  violations.
-- **Update every locale when you touch a key.** `en.json` is the source of
-  truth. When you add or change a key, also give `es/pt/fr/de.json` your best
-  translation of the English value. Key parity is a compile-time check:
-  `src/i18n/messages/keyParity.ts` makes a missing or extra locale key fail
-  `types:check` (pre-commit, CI, IDE). Keep the ICU shape (arguments, tags,
-  plurals) identical across locales — `web/src/i18n/__tests__/catalog.test.ts`
-  enforces this.
-- Keys are stable identifiers, not English sentences:
-  `<namespace>.<section>.<element>.<role>` in camelCase
-  (e.g. `settings.appearance.colorMode.title`). Rewording English copy must not
-  change the key.
-- Use ICU for interpolation and plurals: `"Hello {name}"`,
-  `"{count, plural, one {# item} other {# items}}"`. Never concatenate
-  translated fragments.
-- When you finish migrating a directory, add its glob to the
-  `i18n/no-raw-jsx-text` override in `.oxlintrc.json` so it cannot regress.
-- Locale-aware date/number formatting: prefer `useFormatter`/`useLocale` from
-  next-intl over hardcoded `"en-US"` `Intl` calls.
-- Prefer CSS logical properties (`ms-`/`me-`/`ps-`/`pe-`/`start-`/`end-`) over
-  physical ones (`ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`) in new styles so a
-  future RTL locale does not require re-touching them.
-
-# Stylistic Preferences
-
-## 1. Import Standards
-
-**Always use absolute imports with the `@` prefix.**
-
-**Reason:** Moving files around becomes easier since you don't also have to update those import statements. This makes modifications to the codebase much nicer.
-
-```typescript
-// ✅ Good
-import { Button } from "@/components/ui/button";
-import { useAuth } from "@/hooks/useAuth";
-import { Text } from "@/refresh-components/texts/Text";
-
-// ❌ Bad
-import { Button } from "../../../components/ui/button";
-import { useAuth } from "./hooks/useAuth";
-```
-
-## 2. React Component Functions
-
-**Prefer regular functions over arrow functions for React components.**
-
-**Reason:** Functions just become easier to read.
-
-```typescript
-// ✅ Good
-function UserProfile({ userId }: UserProfileProps) {
-  return <div>User Profile</div>
-}
-
-// ❌ Bad
-const UserProfile = ({ userId }: UserProfileProps) => {
-  return <div>User Profile</div>
-}
-```
-
-## 3. Props Interface Extraction
-
-**Extract prop types into their own interface definitions. Keep prop interfaces in the same file
-as the component they belong to. Non-prop types (shared models, API response shapes, enums, etc.)
-should be placed in a co-located `types.ts` file.**
-
-**Reason:** Prop interfaces are tightly coupled to their component and rarely imported elsewhere,
-so co-location keeps things simple. Shared types belong in `types.ts` so they can be
-imported without pulling in component code.
-
-Some feature directories still use `interfaces.ts`; they predate this rule. Use `types.ts` for new
-files, and rename an existing one when you are already working in that feature.
-
-```typescript
-// ✅ Good — props interface in the same file as the component
-// UserCard.tsx
-interface UserCardProps {
-  user: User
-  showActions?: boolean
-  onEdit?: (userId: string) => void
-}
-
-function UserCard({ user, showActions = false, onEdit }: UserCardProps) {
-  return <div>User Card</div>
-}
-
-// ✅ Good — shared types in types.ts
-// types.ts
-export interface User {
-  id: string
-  name: string
-  accessLevel: AccessLevel
-}
-
-export type AccessLevel = "admin" | "member" | "viewer"
-
-// ❌ Bad — inline prop types
-function UserCard({
-  user,
-  showActions = false,
-  onEdit
-}: {
-  user: User
-  showActions?: boolean
-  onEdit?: (userId: string) => void
-}) {
-  return <div>User Card</div>
-}
-```
-
-## 4. Spacing Guidelines
-
-**Prefer padding over margins for spacing. When a library component exposes a padding prop
-(e.g., `padding`), use that prop instead of wrapping it in a `<div>` with padding classes.
-If a library component does not expose a padding override and you find yourself adding a wrapper
-div for spacing, consider updating the library component to accept one.**
-
-**Reason:** We want to consolidate usage to paddings instead of margins, and minimize wrapper
-divs that exist solely for spacing.
-
-```typescript
-// ✅ Good — use the component's padding prop
-<ContentAction padding="md" ... />
-
-// ✅ Good — padding utilities when no component prop exists
-<div className="p-4 space-y-2">
-  <div className="p-2">Content</div>
-</div>
-
-// ❌ Bad — wrapper div just for spacing
-<div className="p-4">
-  <ContentAction ... />
-</div>
-
-// ❌ Bad — margins
-<div className="m-4 space-y-2">
-  <div className="m-2">Content</div>
-</div>
-```
-
-## 5. Class Name Utilities
-
-**Use the `cn` utility instead of raw string formatting for classNames.**
-
-**Reason:** `cn`s are easier to read. They also allow for more complex types (i.e., string-arrays) to get formatted properly (it flattens each element in that string array down). As a result, it can allow things such as conditionals (i.e., `myCondition && "some-tailwind-class"`, which evaluates to `false` when `myCondition` is `false`) to get filtered out.
-
-```typescript
-import { cn } from "@opal/utils";
-
-// ✅ Good
-<div className={cn(
-  'base-class',
-  isActive && 'active-class',
-  className
-)}>
-  Content
-</div>
-
-// ❌ Bad
-<div className={`base-class ${isActive ? 'active-class' : ''} ${className}`}>
-  Content
-</div>
-```
-
-## 6. Custom Hooks Organization
-
-**Place hooks in the `hooks.ts` file of the most relevant `lib/` feature directory.
-Only fall back to `web/src/hooks/` for genuinely general-purpose hooks with no feature home.**
-
-Priority order:
-
-1. **Feature hook** (`web/src/lib/<feature>/hooks.ts`) — if the hook is specific to a domain
-   (users, billing, connectors, etc.), it lives alongside the rest of that feature's code.
-2. **Opal** (`web/lib/opal/src/`) — if the hook is a reusable UI primitive with no
-   app-specific knowledge (e.g. `useClickOutside`, `useScreenSize`), consider contributing
-   it to Opal so it can be shared across products.
-3. **`web/src/hooks/`** — last resort for general-purpose hooks that don't belong to any
-   feature and aren't Opal-worthy.
-
-```typescript
-// ✅ Good — feature hook lives next to the feature's other lib code
-// web/src/lib/users/hooks.ts
-export function useCurrentUser() { ... }
-export function useSessionWatcher() { ... }
-
-// ✅ Good — general-purpose UI hook with no app knowledge → Opal candidate
-// web/lib/opal/src/hooks/useClickOutside.ts
-export function useClickOutside(...) { ... }
-
-// ✅ Good — genuinely cross-cutting, no feature home, not Opal-worthy
-// web/src/hooks/useToast.ts
-export function useToast() { ... }
-
-// ❌ Bad — user/session hook dumped in the global hooks directory
-// web/src/hooks/useSessionWatcher.ts
-```
-
-# Tests
-
-- Jest + React Testing Library guide for component tests: `web/tests/README.md`.
-- Playwright e2e specs live in `web/tests/e2e`; hard rules (Page Object Model, locator priority)
-  are in `web/tests/e2e/README.md`.
-- Run an e2e test with the repo-pinned Playwright: `cd web && bun run playwright <TEST_NAME>`
-  (the `playwright` script expands to `playwright test`; avoid `bunx`/`npx`, which can silently
-  fetch an unpinned version).
+Standards for `web/` and `desktop/`. Every Opal component and layout has a `README.md` beside it.
+Read that README instead of guessing props.
+
+## Where components come from
+
+Use, in priority order:
+
+1. `web/lib/opal/src/` (`@opal/*`): the design system.
+2. `web/src/refresh-components/`: production components not yet in Opal.
+3. `web/src/sections/` (feature composites; entity cards in `sections/cards/`) and `web/src/layouts/`.
+
+Never import from `web/src/components/`. It is legacy and being deleted. The one exception is
+`createLogoIcon` in `src/components/icons/icons.tsx`.
+
+- Admin and settings pages: `SettingsLayouts.{Root,Header,Body}` from `@opal/layouts`.
+- Icon + title + description: `Content` or `ContentAction` from `@opal/layouts`. Empty states and
+  error pages: `IllustrationContent`.
+- Buttons: `Button` from `@opal/components`. No raw `<button>`.
+- Inputs: Opal or refresh-components. No raw `<input>`, `<textarea>`, or `<select>`.
+- Text: `Text` from `@opal/components` with `font` and `color` props. No naked text nodes. The
+  boolean-flag API in `refresh-components/texts/Text` is deprecated.
+- Icons: only `@opal/icons`. Never `lucide-react` or `react-icons`. If an icon is missing, import
+  it from Figma with the Figma MCP tool and add it to `lib/opal/src/icons/`.
+- Hover-reveal: `Hoverable` from `@opal/core`. If you must hand-write it, add `no-hover:opacity-100`
+  so touch devices still show the item.
+- `@opal/core` primitives (`Interactive`, `Disabled`) build components. App code does not use them.
+
+## Rules with a reason
+
+- **No `dark:` Tailwind modifier.** The tokens already define both themes, and overrides break dark
+  mode. Only `createLogoIcon` may use it.
+- **No built-in Tailwind colors** (`bg-gray-100`, `text-blue-600`). Use the token classes:
+  `text-0X`, `background-neutral-0X`, `background-tint-0X`, `border-0X`, `action-selection-0X`,
+  `action-danger-0X`, `status-{info,success,warning,error}-0X`, `theme-*`. Tokens live in
+  `web/lib/shared/tokens/`.
+- **Text props accept markdown.** Type any prop rendered as visible text (`title`, `description`,
+  `label`) as `string | RichStr` from `@opal/types` and render it with `Text`. Callers opt in with
+  `markdown()` from `@opal/utils`. Plain strings are never parsed.
+- **Size props default to `"md"`** when the prop type is `SizeVariants` from `@opal/types` or a
+  subset of it.
+- **Padding over margin.** Use a component's `padding` prop before wrapping it in a `<div>`. If a
+  library component has no such prop, add one to the component instead of adding a wrapper.
+- **Data fetching:** `useSWR`, on the client, inside the component that needs the data, with a
+  loader while pending. Do not fetch at the top of the page and pass data down.
+
+## Style
+
+- Absolute imports only: `@/` for `src/`, `@opal/` for Opal. No `../` paths.
+- Components are `function` declarations, not arrow functions.
+- Put the props interface (`FooProps`) in the same file as the component. Put shared types in a
+  co-located `types.ts`. `interfaces.ts` is the old name; rename it when you touch one.
+- Class names: `cn` from `@opal/utils`, never template strings.
+- Hooks: feature hooks go in `web/src/lib/<feature>/hooks.ts`. UI hooks with no app knowledge go
+  in Opal. `web/src/hooks/` is the last resort.
+
+## i18n (next-intl)
+
+- No hard-coded user-facing strings under `src/`. The oxlint rule `i18n/no-raw-jsx-text` fails on
+  them. Use `useTranslations("<namespace>")` on the client or `await getTranslations(...)` on the
+  server.
+- `web/src/i18n/messages/en.json` is the source of truth. When you add or change a key, add your
+  best translation to every other locale file in that directory. Missing or extra keys fail
+  `types:check`. ICU shape must match across locales (`src/i18n/__tests__/catalog.test.ts`).
+- Keys are stable identifiers: `<namespace>.<section>.<element>.<role>` in camelCase, for example
+  `settings.appearance.colorMode.title`. Rewording the English never changes the key.
+- Use ICU for arguments and plurals. Never concatenate translated fragments.
+- Dates and numbers: `useFormatter` and `useLocale`, not hard-coded `"en-US"`.
+- New styles use logical properties (`ms-`, `pe-`, `start-`) instead of `ml-`, `pr-`, `left-`.
+
+## Tests
+
+- Component tests (Jest + React Testing Library): `web/tests/README.md`.
+- E2E (Playwright): `web/tests/e2e/README.md` holds the hard rules (Page Object Model, locator
+  priority).
+- Run an e2e test with `cd web && bun run playwright <TEST_NAME>`. Do not use `bunx` or `npx`;
+  they can fetch an unpinned Playwright.


### PR DESCRIPTION
## Description

Anthropic now recommends CLAUDE.md files stay under 200 lines and omit anything an agent can derive from the code ([memory docs](https://code.claude.com/docs/en/memory#write-effective-instructions), [best practices](https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md)). `web/AGENTS.md` (the target of the `web/CLAUDE.md` symlink) was 687 lines and 3,307 words. It is now 78 lines and 623 words.

**What was cut**

- The Opal component walkthroughs (`Content`, `ContentAction`, `IllustrationContent`, `SettingsLayouts`, `Button`, `Interactive`, `Disabled`, `Hoverable`). Each of these has a `README.md` beside the component, and the file now points there instead.
- Every ✅/❌ code block. Each rule is one concrete sentence.
- "Reason" paragraphs where the reason was self-evident. Real pitfalls (dark mode, colors) keep a short clause.

**What was stale and is now fixed**

- `web/src/icons` does not exist. Icons live in `@opal/icons`.
- `src/layouts/settings-layouts.tsx` does not exist. `SettingsLayouts` comes from `@opal/layouts`.
- `src/app/css/colors.css` does not exist. Tokens live in `web/lib/shared/tokens/`.
- `markdown()` was attributed to `@opal/types`. It lives in `@opal/utils`.
- `PaddingVariants` and `RoundingVariants` were removed from Opal. Padding is a numeric `Spacing`.
- The i18n section listed four locales and said the lint rule covers "migrated directories". There are nine locales and the rule covers all of `src/**`.
- The import example used `@/components/ui/button`, a path the same file forbids.

**Open questions for reviewers**

- The "size props default to `md`" rule conflicts with Opal itself, which defaults `size` to `"lg"` in eight components. The rule is kept as written. One of the two should change.
- The "reach out to raunak@onyx.app for icon help" line is dropped because an agent cannot act on it. Add it back if it is wanted for human readers.

## How Has This Been Tested?

- Confirmed every path and export the new file references exists in the tree (`@opal/layouts` `SettingsLayouts`, `@opal/components` `Button` and `Text`, `RichStr` in `@opal/types`, `SizeVariants`, the i18n override in `.oxlintrc.json`, both test READMEs).
- `pre-commit run --files web/AGENTS.md` passes.
- Docs-only change. No runtime behavior is affected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts `web/AGENTS.md` from 687 to 78 lines by pointing agents at the README beside each Opal component instead of restating it, and fixes stale references so the file matches the code. Docs-only change; no runtime behavior is affected.

**Bug Fixes**

- Icons now point to `@opal/icons`; `web/src/icons` does not exist.
- `SettingsLayouts` comes from `@opal/layouts`, not `src/layouts/settings-layouts.tsx`.
- Tokens live in `web/lib/shared/tokens/`, not `src/app/css/colors.css`.
- `markdown()` is exported from `@opal/utils`, not `@opal/types`.
- Removed `PaddingVariants` and `RoundingVariants`; padding is a numeric `Spacing`.
- i18n section now lists nine locales and the lint rule covers all of `src/**`.

The rule that size props default to `"md"` conflicts with eight components that default to `"lg"`; one of the two should change.

<sup>Written for commit 5ad6a7b44a743a6677299077cdc6dd4acb385513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

