### PR TITLE
feat(zoom): index webinars alongside meetings

### DIFF
--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -75,6 +75,20 @@ def _reject_non_zoom_download_url(download_url: str) -> None:
         raise ValueError(f"Unsafe Zoom transcript download URL: {e}") from e
 
 
+def _not_entitled_message(response: requests.Response) -> str | None:
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    # Compared as text: if Zoom ever sends the code as a string, an int
+    # comparison falls through and the admin loses the add-on hint.
+    if str(body.get("code")) != str(_ZOOM_NOT_ENTITLED_ERROR_CODE):
+        return None
+    return str(body.get("message") or "no permission")
+
+
 def _raise_for_zoom_error(response: requests.Response, description: str) -> None:
     """requests' own message stops at "400 Client Error" and drops Zoom's
     explanation, which is where codes like 12702 (meeting over a year old) live.
@@ -202,7 +216,7 @@ class ZoomClient:
             raise InsufficientPermissionsError(f"{_WEBINAR_ACCESS_HINT} ({e})") from e
 
         if response.status_code == 400:
-            denial = self._not_entitled_message(response)
+            denial = _not_entitled_message(response)
             if denial is not None:
                 # Zoom's message names the user whose licence is missing, which
                 # the hint can't know.
@@ -210,20 +224,6 @@ class ZoomClient:
                     f"{_WEBINAR_ACCESS_HINT} Zoom said: {denial}"
                 )
         return response
-
-    @staticmethod
-    def _not_entitled_message(response: requests.Response) -> str | None:
-        try:
-            body = response.json()
-        except ValueError:
-            return None
-        if not isinstance(body, dict):
-            return None
-        # Compared as text: if Zoom ever sends the code as a string, an int
-        # comparison falls through and the admin loses the add-on hint.
-        if str(body.get("code")) != str(_ZOOM_NOT_ENTITLED_ERROR_CODE):
-            return None
-        return str(body.get("message") or "no permission")
 
     def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript:
         """Takes a meeting ID, a webinar ID, or one occurrence's UUID. Zoom has

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -16,8 +16,8 @@ from onyx.connectors.exceptions import (
 )
 from onyx.connectors.zoom.models import (
     ZoomAccessToken,
-    ZoomMeetingOccurrence,
-    ZoomPastMeetingDetails,
+    ZoomSessionDetails,
+    ZoomSessionOccurrence,
     ZoomTranscript,
 )
 from onyx.utils.url import (
@@ -35,6 +35,17 @@ _TOKEN_REFRESH_MARGIN_SECONDS = 60
 
 # Zoom's date-scoped query parameters are whole UTC days.
 _ZOOM_DATE_FORMAT = "%Y-%m-%d"
+
+_WEBINAR_ACCESS_HINT = (
+    "Zoom refused a webinar request. Webinars need the Webinar add-on enabled for "
+    "the host, and the app needs the webinar:read:admin scope. Meetings need "
+    "neither, so a connector that indexes meetings can still fail here."
+)
+
+# Zoom's own error code from the response body, not an HTTP status. It covers
+# every "this account may not do that" case, and Zoom sends it under HTTP 400
+# rather than 403.
+_ZOOM_NOT_ENTITLED_ERROR_CODE = 200
 
 
 def _encode_meeting_identifier(identifier: str) -> str:
@@ -179,6 +190,40 @@ class ZoomClient:
 
         return self._send_authorized(endpoint, send)
 
+    def _request_webinar(self, endpoint: str) -> requests.Response:
+        """Every webinar endpoint fails the same way without the Webinar add-on,
+        and the generic scope message sends the admin to check scopes that are
+        already correct.
+        """
+        try:
+            response = self._request("GET", endpoint)
+        except InsufficientPermissionsError as e:
+            raise InsufficientPermissionsError(f"{_WEBINAR_ACCESS_HINT} ({e})") from e
+
+        if response.status_code == 400:
+            denial = self._not_entitled_message(response)
+            if denial is not None:
+                # Zoom's message names the user whose licence is missing, which
+                # the hint can't know.
+                raise InsufficientPermissionsError(
+                    f"{_WEBINAR_ACCESS_HINT} Zoom said: {denial}"
+                )
+        return response
+
+    @staticmethod
+    def _not_entitled_message(response: requests.Response) -> str | None:
+        try:
+            body = response.json()
+        except ValueError:
+            return None
+        if not isinstance(body, dict):
+            return None
+        # Compared as text: if Zoom ever sends the code as a string, an int
+        # comparison falls through and the admin loses the add-on hint.
+        if str(body.get("code")) != str(_ZOOM_NOT_ENTITLED_ERROR_CODE):
+            return None
+        return str(body.get("message") or "no permission")
+
     def get_meeting_transcript(self, meeting_identifier: str) -> ZoomTranscript:
         """Takes a meeting ID, a webinar ID, or one occurrence's UUID. Zoom has
         no webinar transcript endpoint, so webinars come through here too.
@@ -193,21 +238,19 @@ class ZoomClient:
         _raise_for_zoom_error(response, f"the transcript for {meeting_identifier}")
         return ZoomTranscript.model_validate(response.json())
 
-    def get_past_meeting_details(
-        self, meeting_identifier: str
-    ) -> ZoomPastMeetingDetails:
+    def get_past_meeting_details(self, meeting_identifier: str) -> ZoomSessionDetails:
         response = self._request(
             "GET", f"/past_meetings/{_encode_meeting_identifier(meeting_identifier)}"
         )
         _raise_for_zoom_error(response, f"the details for {meeting_identifier}")
-        return ZoomPastMeetingDetails.model_validate(response.json())
+        return ZoomSessionDetails.model_validate(response.json())
 
     def list_past_meeting_occurrences(
         self,
         meeting_id: str,
         window_start: datetime | None = None,
         window_end: datetime | None = None,
-    ) -> list[ZoomMeetingOccurrence]:
+    ) -> list[ZoomSessionOccurrence]:
         """A recurring meeting records each run separately, and the bare
         meeting_id only ever reaches the latest one, so call this first for every
         occurrence's UUID. This endpoint is not paginated. Zoom returns nothing
@@ -232,7 +275,35 @@ class ZoomClient:
         )
         _raise_for_zoom_error(response, f"the occurrences for {meeting_id}")
         occurrences = response.json().get("meetings", [])
-        return [ZoomMeetingOccurrence.model_validate(o) for o in occurrences]
+        return [ZoomSessionOccurrence.model_validate(o) for o in occurrences]
+
+    def get_webinar_details(self, webinar_identifier: str) -> ZoomSessionDetails | None:
+        """Takes a webinar ID or one occurrence's UUID. Zoom has no
+        `/past_webinars/{id}` to match the meeting details endpoint, so a past
+        occurrence is read back through this one.
+        """
+        response = self._request_webinar(
+            f"/webinars/{_encode_meeting_identifier(webinar_identifier)}"
+        )
+        if response.status_code == 404:
+            return None
+        _raise_for_zoom_error(response, f"the details for webinar {webinar_identifier}")
+        return ZoomSessionDetails.model_validate(response.json())
+
+    def list_past_webinar_occurrences(
+        self, webinar_id: str
+    ) -> list[ZoomSessionOccurrence]:
+        """Unlike the meeting equivalent, this endpoint declares no age limit,
+        so webinar history is not cut off at 15 months.
+        """
+        response = self._request_webinar(
+            f"/past_webinars/{_encode_meeting_identifier(webinar_id)}/instances"
+        )
+        if response.status_code == 404:
+            return []
+        _raise_for_zoom_error(response, f"the occurrences for webinar {webinar_id}")
+        occurrences = response.json().get("webinars", [])
+        return [ZoomSessionOccurrence.model_validate(o) for o in occurrences]
 
     def download_transcript_vtt(self, download_url: str) -> str:
         """The download redirects to a storage host, so every hop is checked

--- a/backend/onyx/connectors/zoom/client.py
+++ b/backend/onyx/connectors/zoom/client.py
@@ -16,9 +16,10 @@ from onyx.connectors.exceptions import (
 )
 from onyx.connectors.zoom.models import (
     ZoomAccessToken,
-    ZoomSessionDetails,
+    ZoomPastMeetingDetails,
     ZoomSessionOccurrence,
     ZoomTranscript,
+    ZoomWebinarDetails,
 )
 from onyx.utils.url import (
     SSRFException,
@@ -39,7 +40,7 @@ _ZOOM_DATE_FORMAT = "%Y-%m-%d"
 _WEBINAR_ACCESS_HINT = (
     "Zoom refused a webinar request. Webinars need the Webinar add-on enabled for "
     "the host, and the app needs the webinar:read:admin scope. Meetings need "
-    "neither, so a connector that indexes meetings can still fail here."
+    "neither, so credentials that read meetings can still fail here."
 )
 
 # Zoom's own error code from the response body, not an HTTP status. It covers
@@ -238,12 +239,14 @@ class ZoomClient:
         _raise_for_zoom_error(response, f"the transcript for {meeting_identifier}")
         return ZoomTranscript.model_validate(response.json())
 
-    def get_past_meeting_details(self, meeting_identifier: str) -> ZoomSessionDetails:
+    def get_past_meeting_details(
+        self, meeting_identifier: str
+    ) -> ZoomPastMeetingDetails:
         response = self._request(
             "GET", f"/past_meetings/{_encode_meeting_identifier(meeting_identifier)}"
         )
         _raise_for_zoom_error(response, f"the details for {meeting_identifier}")
-        return ZoomSessionDetails.model_validate(response.json())
+        return ZoomPastMeetingDetails.model_validate(response.json())
 
     def list_past_meeting_occurrences(
         self,
@@ -277,7 +280,7 @@ class ZoomClient:
         occurrences = response.json().get("meetings", [])
         return [ZoomSessionOccurrence.model_validate(o) for o in occurrences]
 
-    def get_webinar_details(self, webinar_identifier: str) -> ZoomSessionDetails | None:
+    def get_webinar_details(self, webinar_identifier: str) -> ZoomWebinarDetails:
         """Takes a webinar ID or one occurrence's UUID. Zoom has no
         `/past_webinars/{id}` to match the meeting details endpoint, so a past
         occurrence is read back through this one.
@@ -285,22 +288,21 @@ class ZoomClient:
         response = self._request_webinar(
             f"/webinars/{_encode_meeting_identifier(webinar_identifier)}"
         )
-        if response.status_code == 404:
-            return None
         _raise_for_zoom_error(response, f"the details for webinar {webinar_identifier}")
-        return ZoomSessionDetails.model_validate(response.json())
+        return ZoomWebinarDetails.model_validate(response.json())
 
     def list_past_webinar_occurrences(
         self, webinar_id: str
     ) -> list[ZoomSessionOccurrence]:
         """Unlike the meeting equivalent, this endpoint declares no age limit,
         so webinar history is not cut off at 15 months.
+
+        An unknown webinar answers 404, which raises here rather than reading as
+        a webinar that ran no times.
         """
         response = self._request_webinar(
             f"/past_webinars/{_encode_meeting_identifier(webinar_id)}/instances"
         )
-        if response.status_code == 404:
-            return []
         _raise_for_zoom_error(response, f"the occurrences for webinar {webinar_id}")
         occurrences = response.json().get("webinars", [])
         return [ZoomSessionOccurrence.model_validate(o) for o in occurrences]

--- a/backend/onyx/connectors/zoom/connector.py
+++ b/backend/onyx/connectors/zoom/connector.py
@@ -34,8 +34,12 @@ class ZoomConnectorCheckpoint(ConnectorCheckpoint):
 
 
 class ZoomConnector(CheckpointedConnector[ZoomConnectorCheckpoint]):
-    def __init__(self, meeting_ids: list[str] | None = None) -> None:
-        self._sources = build_discovery_sources(meeting_ids)
+    def __init__(
+        self,
+        meeting_ids: list[str] | None = None,
+        webinar_ids: list[str] | None = None,
+    ) -> None:
+        self._sources = build_discovery_sources(meeting_ids, webinar_ids)
         self.client: ZoomClient | None = None
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:

--- a/backend/onyx/connectors/zoom/models.py
+++ b/backend/onyx/connectors/zoom/models.py
@@ -50,12 +50,26 @@ class ZoomTranscript(BaseModel):
 
 
 class ZoomSessionDetails(BaseModel):
-    """The fields the connector reads from `GET /past_meetings/{meetingId}` and
-    from `GET /webinars/{webinarId}`, which return much more than this."""
+    """The two fields both details endpoints always carry. Meetings and webinars
+    answer with different shapes, so each gets its own subclass below.
+    """
+
+    topic: str
+    start_time: str | None = None
+
+
+class ZoomPastMeetingDetails(ZoomSessionDetails):
+    """Response shape of `GET /past_meetings/{meetingId}` — every documented field.
+
+    Zoom documents all of them as always sent, so a missing one means Zoom
+    changed the contract. Failing here says so, where a default would instead
+    index the meeting under a title nobody chose.
+    """
 
     uuid: str
     id: int
-    topic: str
+    # A past meeting has already ended, so it always carries both timestamps
+    # where a scheduled one may not.
     start_time: str
     end_time: str
     duration: int
@@ -68,6 +82,45 @@ class ZoomSessionDetails(BaseModel):
     type: int
     user_email: str
     user_name: str
+
+
+class ZoomWebinarDetails(ZoomSessionDetails):
+    """Response shape of `GET /webinars/{webinarId}` — every documented scalar
+    field.
+
+    This endpoint answers with the webinar's configuration, so most fields
+    arrive only when the host turned that feature on. Only the fields that
+    identify the webinar are required.
+
+    Zoom also returns `occurrences`, `recurrence`, `settings`,
+    `simulive_delay_start` and `tracking_fields`. Nothing here reads them and
+    `settings` alone nests 77 more fields, so they are left off rather than
+    half-modelled. `occurrences` cannot stand in for
+    `/past_webinars/{id}/instances` anyway: it carries `occurrence_id` and the
+    transcript call needs the `uuid`.
+    """
+
+    id: int
+    uuid: str
+    host_id: str
+    type: int
+
+    agenda: str | None = None
+    created_at: str | None = None
+    creation_source: str | None = None
+    duration: int | None = None
+    encrypted_passcode: str | None = None
+    h323_passcode: str | None = None
+    host_email: str | None = None
+    is_simulive: bool | None = None
+    join_url: str | None = None
+    password: str | None = None
+    record_file_id: str | None = None
+    registration_url: str | None = None
+    start_url: str | None = None
+    template_id: str | None = None
+    timezone: str | None = None
+    transition_to_live: bool | None = None
 
 
 class ZoomSessionOccurrence(BaseModel):

--- a/backend/onyx/connectors/zoom/models.py
+++ b/backend/onyx/connectors/zoom/models.py
@@ -49,8 +49,9 @@ class ZoomTranscript(BaseModel):
         )
 
 
-class ZoomPastMeetingDetails(BaseModel):
-    """Response shape of `GET /past_meetings/{meetingId}`."""
+class ZoomSessionDetails(BaseModel):
+    """The fields the connector reads from `GET /past_meetings/{meetingId}` and
+    from `GET /webinars/{webinarId}`, which return much more than this."""
 
     uuid: str
     id: int
@@ -69,8 +70,10 @@ class ZoomPastMeetingDetails(BaseModel):
     user_name: str
 
 
-class ZoomMeetingOccurrence(BaseModel):
-    """One entry from `GET /past_meetings/{meetingId}/instances`."""
+class ZoomSessionOccurrence(BaseModel):
+    """One entry from `GET /past_meetings/{meetingId}/instances` or
+    `GET /past_webinars/{webinarId}/instances` — identical shapes under
+    different response keys."""
 
     uuid: str
     start_time: str

--- a/backend/onyx/connectors/zoom/recordings/discovery.py
+++ b/backend/onyx/connectors/zoom/recordings/discovery.py
@@ -22,7 +22,7 @@ from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import ConnectorFailure, EntityFailure
 from onyx.connectors.zoom.client import ZoomClient
-from onyx.connectors.zoom.models import ZoomMeetingOccurrence
+from onyx.connectors.zoom.models import ZoomSessionOccurrence
 from onyx.connectors.zoom.recordings.models import (
     OccurrenceWork,
     ZoomSessionType,
@@ -44,7 +44,7 @@ _MAX_WORK_PER_STEP = 200
 
 
 def _occurrence_in_poll_window(
-    occurrence: ZoomMeetingOccurrence,
+    occurrence: ZoomSessionOccurrence,
     start: SecondsSinceUnixEpoch,
     end: SecondsSinceUnixEpoch,
 ) -> bool:
@@ -88,9 +88,14 @@ class _AllowlistCursor(BaseModel):
 
 
 class IdAllowlistSource(DiscoverySource):
-    def __init__(self, meeting_ids: list[str]) -> None:
+    def __init__(
+        self, meeting_ids: list[str], webinar_ids: list[str] | None = None
+    ) -> None:
         self._refs: list[tuple[ZoomSessionType, str]] = [
             (ZoomSessionType.MEETING, meeting_id) for meeting_id in meeting_ids
+        ]
+        self._refs += [
+            (ZoomSessionType.WEBINAR, webinar_id) for webinar_id in webinar_ids or []
         ]
 
     def discover_step(
@@ -114,7 +119,7 @@ class IdAllowlistSource(DiscoverySource):
         window_end = datetime_from_utc_timestamp(int(end))
 
         failures: list[ConnectorFailure] = []
-        occurrences: list[ZoomMeetingOccurrence] = []
+        occurrences: list[ZoomSessionOccurrence] = []
         try:
             occurrences = handler.list_occurrences(
                 client, session_id, window_start, window_end
@@ -187,8 +192,10 @@ class IdAllowlistSource(DiscoverySource):
         )
 
 
-def build_discovery_sources(meeting_ids: list[str] | None) -> list[DiscoverySource]:
+def build_discovery_sources(
+    meeting_ids: list[str] | None, webinar_ids: list[str] | None = None
+) -> list[DiscoverySource]:
     sources: list[DiscoverySource] = []
-    if meeting_ids:
-        sources.append(IdAllowlistSource(meeting_ids))
+    if meeting_ids or webinar_ids:
+        sources.append(IdAllowlistSource(meeting_ids or [], webinar_ids or []))
     return sources

--- a/backend/onyx/connectors/zoom/recordings/discovery.py
+++ b/backend/onyx/connectors/zoom/recordings/discovery.py
@@ -92,10 +92,11 @@ class IdAllowlistSource(DiscoverySource):
         self, meeting_ids: list[str], webinar_ids: list[str] | None = None
     ) -> None:
         self._refs: list[tuple[ZoomSessionType, str]] = [
-            (ZoomSessionType.MEETING, meeting_id) for meeting_id in meeting_ids
-        ]
-        self._refs += [
-            (ZoomSessionType.WEBINAR, webinar_id) for webinar_id in webinar_ids or []
+            *((ZoomSessionType.MEETING, meeting_id) for meeting_id in meeting_ids),
+            *(
+                (ZoomSessionType.WEBINAR, webinar_id)
+                for webinar_id in webinar_ids or []
+            ),
         ]
 
     def discover_step(

--- a/backend/onyx/connectors/zoom/recordings/processing.py
+++ b/backend/onyx/connectors/zoom/recordings/processing.py
@@ -115,7 +115,9 @@ def process_occurrence(
         )
         return None
 
-    topic = work.topic
+    # Zoom caps the details endpoint below at one year, so a title taken from
+    # here is the only one an older meeting gets.
+    topic = work.topic or transcript.meeting_topic
     started_at = work.start_time
     if not topic or not started_at:
         try:

--- a/backend/onyx/connectors/zoom/recordings/processing.py
+++ b/backend/onyx/connectors/zoom/recordings/processing.py
@@ -133,7 +133,7 @@ def process_occurrence(
                 work.session_id,
                 occurrence_uuid,
             )
-    topic = topic or f"Zoom Meeting {work.session_id}"
+    topic = topic or f"Zoom {work.session_type.value.capitalize()} {work.session_id}"
     occurrence_time = time_str_to_utc(started_at) if started_at else None
 
     return Document(

--- a/backend/onyx/connectors/zoom/recordings/processing.py
+++ b/backend/onyx/connectors/zoom/recordings/processing.py
@@ -123,9 +123,8 @@ def process_occurrence(
         try:
             handler = get_session_type_handler(work.session_type)
             details = handler.get_occurrence_details(client, occurrence_uuid)
-            if details:
-                topic = topic or details.topic
-                started_at = started_at or details.start_time
+            topic = topic or details.topic
+            started_at = started_at or details.start_time
         except Exception:
             # The transcript is already downloaded, so a missing title or
             # timestamp isn't worth throwing away an indexable document.

--- a/backend/onyx/connectors/zoom/recordings/session_types.py
+++ b/backend/onyx/connectors/zoom/recordings/session_types.py
@@ -7,7 +7,7 @@ import abc
 from datetime import datetime
 
 from onyx.connectors.zoom.client import ZoomClient
-from onyx.connectors.zoom.models import ZoomMeetingOccurrence, ZoomPastMeetingDetails
+from onyx.connectors.zoom.models import ZoomSessionDetails, ZoomSessionOccurrence
 from onyx.connectors.zoom.recordings.models import ZoomSessionType
 
 
@@ -21,7 +21,7 @@ class SessionTypeHandler(abc.ABC):
         session_id: str,
         window_start: datetime,
         window_end: datetime,
-    ) -> list[ZoomMeetingOccurrence]:
+    ) -> list[ZoomSessionOccurrence]:
         """The window is a request to Zoom, not a promise: an endpoint that
         can't scope by date ignores it and hands back everything."""
         raise NotImplementedError
@@ -29,7 +29,7 @@ class SessionTypeHandler(abc.ABC):
     @abc.abstractmethod
     def get_occurrence_details(
         self, client: ZoomClient, occurrence_uuid: str
-    ) -> ZoomPastMeetingDetails | None:
+    ) -> ZoomSessionDetails | None:
         raise NotImplementedError
 
 
@@ -42,19 +42,39 @@ class MeetingSessionType(SessionTypeHandler):
         session_id: str,
         window_start: datetime,
         window_end: datetime,
-    ) -> list[ZoomMeetingOccurrence]:
+    ) -> list[ZoomSessionOccurrence]:
         return client.list_past_meeting_occurrences(
             session_id, window_start, window_end
         )
 
     def get_occurrence_details(
         self, client: ZoomClient, occurrence_uuid: str
-    ) -> ZoomPastMeetingDetails | None:
+    ) -> ZoomSessionDetails | None:
         return client.get_past_meeting_details(occurrence_uuid)
+
+
+class WebinarSessionType(SessionTypeHandler):
+    session_type = ZoomSessionType.WEBINAR
+
+    def list_occurrences(
+        self,
+        client: ZoomClient,
+        session_id: str,
+        window_start: datetime,  # noqa: ARG002
+        window_end: datetime,  # noqa: ARG002
+    ) -> list[ZoomSessionOccurrence]:
+        # Zoom's past-webinar instances endpoint takes no date scope.
+        return client.list_past_webinar_occurrences(session_id)
+
+    def get_occurrence_details(
+        self, client: ZoomClient, occurrence_uuid: str
+    ) -> ZoomSessionDetails | None:
+        return client.get_webinar_details(occurrence_uuid)
 
 
 _HANDLERS: dict[ZoomSessionType, SessionTypeHandler] = {
     ZoomSessionType.MEETING: MeetingSessionType(),
+    ZoomSessionType.WEBINAR: WebinarSessionType(),
 }
 
 

--- a/backend/onyx/connectors/zoom/recordings/session_types.py
+++ b/backend/onyx/connectors/zoom/recordings/session_types.py
@@ -29,7 +29,7 @@ class SessionTypeHandler(abc.ABC):
     @abc.abstractmethod
     def get_occurrence_details(
         self, client: ZoomClient, occurrence_uuid: str
-    ) -> ZoomSessionDetails | None:
+    ) -> ZoomSessionDetails:
         raise NotImplementedError
 
 
@@ -49,7 +49,7 @@ class MeetingSessionType(SessionTypeHandler):
 
     def get_occurrence_details(
         self, client: ZoomClient, occurrence_uuid: str
-    ) -> ZoomSessionDetails | None:
+    ) -> ZoomSessionDetails:
         return client.get_past_meeting_details(occurrence_uuid)
 
 
@@ -68,7 +68,7 @@ class WebinarSessionType(SessionTypeHandler):
 
     def get_occurrence_details(
         self, client: ZoomClient, occurrence_uuid: str
-    ) -> ZoomSessionDetails | None:
+    ) -> ZoomSessionDetails:
         return client.get_webinar_details(occurrence_uuid)
 
 

--- a/backend/tests/daily/connectors/zoom/test_zoom.py
+++ b/backend/tests/daily/connectors/zoom/test_zoom.py
@@ -12,17 +12,13 @@ pytestmark = pytest.mark.secrets(
     TestSecret.ZOOM_CLIENT_ID,
     TestSecret.ZOOM_CLIENT_SECRET,
     TestSecret.ZOOM_TEST_MEETING_ID,
+    TestSecret.ZOOM_TEST_WEBINAR_ID,
 )
 
 
-@pytest.fixture
-def zoom_connector(
-    test_secrets: dict[TestSecret, str],
+def _authenticated(
+    connector: ZoomConnector, test_secrets: dict[TestSecret, str]
 ) -> ZoomConnector:
-    connector = ZoomConnector(
-        meeting_ids=[test_secrets[TestSecret.ZOOM_TEST_MEETING_ID]]
-    )
-
     connector.load_credentials(
         {
             "zoom_account_id": test_secrets[TestSecret.ZOOM_ACCOUNT_ID],
@@ -30,8 +26,29 @@ def zoom_connector(
             "zoom_client_secret": test_secrets[TestSecret.ZOOM_CLIENT_SECRET],
         }
     )
-
     return connector
+
+
+@pytest.fixture
+def zoom_connector(
+    test_secrets: dict[TestSecret, str],
+) -> ZoomConnector:
+    return _authenticated(
+        ZoomConnector(meeting_ids=[test_secrets[TestSecret.ZOOM_TEST_MEETING_ID]]),
+        test_secrets,
+    )
+
+
+@pytest.fixture
+def zoom_webinar_connector(
+    test_secrets: dict[TestSecret, str],
+) -> ZoomConnector:
+    # The account behind these secrets needs the Webinar add-on, or every
+    # webinar call fails whatever the scopes are.
+    return _authenticated(
+        ZoomConnector(webinar_ids=[test_secrets[TestSecret.ZOOM_TEST_WEBINAR_ID]]),
+        test_secrets,
+    )
 
 
 def test_zoom_basic(zoom_connector: ZoomConnector) -> None:
@@ -48,4 +65,21 @@ def test_zoom_basic(zoom_connector: ZoomConnector) -> None:
     assert len(docs) >= 1
     assert all(doc.id.startswith("ZOOM_MEETING_") for doc in docs)
     assert all(doc.metadata == {"session_type": "meeting"} for doc in docs)
+    assert all(doc.sections[0].text for doc in docs)
+
+
+def test_zoom_webinar(zoom_webinar_connector: ZoomConnector) -> None:
+    outputs = load_everything_from_checkpoint_connector(
+        zoom_webinar_connector, 0, time.time()
+    )
+    docs = [
+        item
+        for output in outputs
+        for item in output.items
+        if isinstance(item, Document)
+    ]
+
+    assert len(docs) >= 1
+    assert all(doc.id.startswith("ZOOM_WEBINAR_") for doc in docs)
+    assert all(doc.metadata == {"session_type": "webinar"} for doc in docs)
     assert all(doc.sections[0].text for doc in docs)

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -59,6 +59,52 @@ _DOCUMENTED_PAST_MEETING = {
 }
 
 
+# The five configuration objects ZoomWebinarDetails deliberately leaves off.
+# Naming them keeps the round-trip assertion honest about what it skips.
+_WEBINAR_CONFIG_FIELDS = frozenset(
+    {
+        "occurrences",
+        "recurrence",
+        "settings",
+        "simulive_delay_start",
+        "tracking_fields",
+    }
+)
+
+# Every field of Zoom's documented `GET /webinars/{webinarId}` example. The five
+# configuration objects are trimmed to one entry each, since nothing reads inside
+# them and `settings` alone holds 77 more fields.
+_DOCUMENTED_WEBINAR = {
+    "id": 97871060099,
+    "uuid": "m3WqMkvuRXyYqH+eKWhk9w==",
+    "host_id": "30R7kT7bTIKSNUFEuH_Qlg",
+    "host_email": "jchill@example.com",
+    "topic": "My Webinar",
+    "type": 5,
+    "agenda": "My webinar",
+    "duration": 60,
+    "start_time": "2022-03-26T06:44:14Z",
+    "timezone": "America/Los_Angeles",
+    "created_at": "2022-03-26T07:18:32Z",
+    "creation_source": "open_api",
+    "join_url": "https://example.com/j/11111",
+    "start_url": "https://example.com/s/11111",
+    "registration_url": "https://example.com/webinar/register/7ksAkRCoEpt1",
+    "password": "123456",
+    "encrypted_passcode": "8pEkRweVXPV3Ob2KJYgFTRlDtl1gSn.1",
+    "h323_passcode": "123456",
+    "template_id": "ull6574eur",
+    "record_file_id": "f09340e1-cdc3-4eae-9a74-98f9777ed908",
+    "is_simulive": True,
+    "transition_to_live": False,
+    "simulive_delay_start": {"enable": True, "time": 10, "timeunit": "second"},
+    "occurrences": [{"occurrence_id": "1648194360000", "status": "available"}],
+    "recurrence": {"type": 1, "repeat_interval": 1},
+    "settings": {"approval_type": 0, "auto_recording": "cloud"},
+    "tracking_fields": [{"field": "field1", "value": "value1"}],
+}
+
+
 def _transcript(**overrides: Any) -> ZoomTranscript:
     """Most fields are required, so a readiness case has to start from a whole
     response rather than the two fields it exercises.
@@ -459,27 +505,58 @@ class TestGetWebinarDetails:
     def test_parses_the_response(self) -> None:
         client = _client()
         client._session = MagicMock()
+        client._session.request.return_value = _response(200, _DOCUMENTED_WEBINAR)
+
+        details = client.get_webinar_details("222")
+
+        assert details.topic == "My Webinar"
+        assert details.start_time == "2022-03-26T06:44:14Z"
+
+    def test_keeps_every_documented_scalar_field(self) -> None:
+        # Sharing one model with /past_meetings parses no webinar at all, because
+        # that model requires seven fields a webinar never carries.
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, _DOCUMENTED_WEBINAR)
+
+        details = client.get_webinar_details("222")
+
+        # Guards the fixture too: trimming the five out of it would quietly
+        # turn the comparison below into a weaker test.
+        assert _WEBINAR_CONFIG_FIELDS <= set(_DOCUMENTED_WEBINAR)
+        expected = {
+            k: v
+            for k, v in _DOCUMENTED_WEBINAR.items()
+            if k not in _WEBINAR_CONFIG_FIELDS
+        }
+        assert details.model_dump() == expected
+
+    def test_a_webinar_configured_with_nothing_optional_still_parses(self) -> None:
+        client = _client()
+        client._session = MagicMock()
         client._session.request.return_value = _response(
             200,
             {
-                **_DOCUMENTED_PAST_MEETING,
-                "topic": "Product Launch",
-                "start_time": "2026-01-15T10:00:00Z",
+                "id": 97871060099,
+                "uuid": "m3WqMkvuRXyYqH+eKWhk9w==",
+                "host_id": "30R7kT7bTIKSNUFEuH_Qlg",
+                "topic": "Bare Webinar",
+                "type": 5,
             },
         )
 
         details = client.get_webinar_details("222")
 
-        assert details is not None
-        assert details.topic == "Product Launch"
-        assert details.start_time == "2026-01-15T10:00:00Z"
+        assert details.topic == "Bare Webinar"
+        assert details.start_time is None
 
-    def test_404_returns_none(self) -> None:
+    def test_404_is_reported_not_swallowed(self) -> None:
         client = _client()
         client._session = MagicMock()
         client._session.request.return_value = _response(404)
 
-        assert client.get_webinar_details("222") is None
+        with pytest.raises(requests.HTTPError):
+            client.get_webinar_details("222")
 
 
 class TestListPastWebinarOccurrences:
@@ -511,12 +588,13 @@ class TestListPastWebinarOccurrences:
         url = client._session.request.call_args.args[1]
         assert url == f"{_API_BASE_URL}/past_webinars/222/instances"
 
-    def test_404_yields_an_empty_list(self) -> None:
+    def test_404_is_reported_not_read_as_no_occurrences(self) -> None:
         client = _client()
         client._session = MagicMock()
         client._session.request.return_value = _response(404)
 
-        assert client.list_past_webinar_occurrences("222") == []
+        with pytest.raises(requests.HTTPError):
+            client.list_past_webinar_occurrences("222")
 
     def test_missing_webinars_key_yields_an_empty_list(self) -> None:
         client = _client()

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_client.py
@@ -455,6 +455,145 @@ class TestListPastMeetingOccurrences:
         assert client._session.request.call_args.kwargs["params"] == {}
 
 
+class TestGetWebinarDetails:
+    def test_parses_the_response(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            200,
+            {
+                **_DOCUMENTED_PAST_MEETING,
+                "topic": "Product Launch",
+                "start_time": "2026-01-15T10:00:00Z",
+            },
+        )
+
+        details = client.get_webinar_details("222")
+
+        assert details is not None
+        assert details.topic == "Product Launch"
+        assert details.start_time == "2026-01-15T10:00:00Z"
+
+    def test_404_returns_none(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(404)
+
+        assert client.get_webinar_details("222") is None
+
+
+class TestListPastWebinarOccurrences:
+    def test_reads_the_webinars_key(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            200,
+            {
+                "webinars": [
+                    {"uuid": "w1", "start_time": "2026-01-01T10:00:00Z"},
+                    {"uuid": "w2", "start_time": "2026-01-08T10:00:00Z"},
+                ]
+            },
+        )
+
+        occurrences = client.list_past_webinar_occurrences("222")
+
+        assert [o.uuid for o in occurrences] == ["w1", "w2"]
+        assert occurrences[0].start_time == "2026-01-01T10:00:00Z"
+
+    def test_calls_the_webinar_endpoint_not_the_meeting_one(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, {"webinars": []})
+
+        client.list_past_webinar_occurrences("222")
+
+        url = client._session.request.call_args.args[1]
+        assert url == f"{_API_BASE_URL}/past_webinars/222/instances"
+
+    def test_404_yields_an_empty_list(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(404)
+
+        assert client.list_past_webinar_occurrences("222") == []
+
+    def test_missing_webinars_key_yields_an_empty_list(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(200, {})
+
+        assert client.list_past_webinar_occurrences("222") == []
+
+
+class TestWebinarAddOnErrors:
+    """A Pro account without the Webinar add-on fails every webinar call, and
+    the generic scope message sends the admin to re-check scopes that are
+    already correct."""
+
+    def test_403_names_the_add_on(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(403)
+
+        with pytest.raises(InsufficientPermissionsError) as caught:
+            client.list_past_webinar_occurrences("222")
+
+        assert "Webinar add-on" in str(caught.value)
+
+    def test_400_with_zooms_no_permission_code_names_the_add_on(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            400, {"code": 200, "message": "No permission."}
+        )
+
+        with pytest.raises(InsufficientPermissionsError) as caught:
+            client.list_past_webinar_occurrences("222")
+
+        assert "Webinar add-on" in str(caught.value)
+
+    def test_a_missing_plan_keeps_the_user_zoom_named(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            400,
+            {
+                "code": 200,
+                "message": (
+                    "Webinar plan is missing. You must subscribe to the webinar "
+                    "plan and enable webinars for user abc123 to perform this action."
+                ),
+            },
+        )
+
+        with pytest.raises(InsufficientPermissionsError) as caught:
+            client.get_webinar_details("222")
+
+        assert "Webinar add-on" in str(caught.value)
+        assert "abc123" in str(caught.value)
+
+    def test_a_string_error_code_is_still_recognised(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            400, {"code": "200", "message": "No permission."}
+        )
+
+        with pytest.raises(InsufficientPermissionsError):
+            client.list_past_webinar_occurrences("222")
+
+    def test_an_unrelated_400_is_still_an_http_error(self) -> None:
+        client = _client()
+        client._session = MagicMock()
+        client._session.request.return_value = _response(
+            400, {"code": 300, "message": "Invalid webinar ID."}
+        )
+
+        with pytest.raises(requests.HTTPError):
+            client.list_past_webinar_occurrences("222")
+
+
 class TestDownloadTranscriptVtt:
     @patch("onyx.connectors.zoom.client.validate_outbound_http_url")
     def test_returns_body_and_authenticates(

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
@@ -14,7 +14,7 @@ from onyx.connectors.models import (
 )
 from onyx.connectors.zoom.client import ZoomClient
 from onyx.connectors.zoom.connector import ZoomConnector, ZoomConnectorCheckpoint
-from onyx.connectors.zoom.models import ZoomMeetingOccurrence, ZoomTranscript
+from onyx.connectors.zoom.models import ZoomSessionOccurrence, ZoomTranscript
 from onyx.connectors.zoom.recordings.models import (
     OccurrenceWork,
     RecordingsState,
@@ -25,7 +25,7 @@ from tests.unit.onyx.connectors.utils import (
     load_everything_from_checkpoint_connector_from_checkpoint,
 )
 from tests.unit.onyx.connectors.zoom.zoom_api_shapes import (
-    past_meeting_details,
+    session_details,
     transcript,
 )
 
@@ -62,12 +62,14 @@ John Smith: Thanks for having me.
 
 def _make_connector(
     meeting_ids: list[str] | None = None,
+    webinar_ids: list[str] | None = None,
 ) -> tuple[ZoomConnector, MagicMock]:
     # Don't write `meeting_ids or [...]` here: it swaps a caller's empty list
     # for the default, and the empty-allowlist tests below then pass for the
     # wrong reason.
     connector = ZoomConnector(
-        meeting_ids=["111"] if meeting_ids is None else meeting_ids
+        meeting_ids=["111"] if meeting_ids is None else meeting_ids,
+        webinar_ids=webinar_ids,
     )
     connector.load_credentials(_ZOOM_CREDS)
     mock_client = MagicMock(spec=ZoomClient)
@@ -78,15 +80,21 @@ def _make_connector(
 def _configure_happy_path(mock_client: MagicMock) -> None:
     mock_client.list_past_meeting_occurrences.side_effect = (
         lambda session_id, *_window: [
-            ZoomMeetingOccurrence(uuid=f"uuid-{session_id}", start_time=_days_ago(7))
+            ZoomSessionOccurrence(uuid=f"uuid-{session_id}", start_time=_days_ago(7))
         ]
     )
     mock_client.get_meeting_transcript.side_effect = lambda uuid: transcript(
         download_url=f"https://zoom.example/{uuid}.vtt"
     )
     mock_client.download_transcript_vtt.return_value = _SAMPLE_VTT
-    mock_client.get_past_meeting_details.return_value = past_meeting_details(
+    mock_client.get_past_meeting_details.return_value = session_details(
         topic="Weekly Sync"
+    )
+    mock_client.list_past_webinar_occurrences.side_effect = lambda session_id: [
+        ZoomSessionOccurrence(uuid=f"uuid-{session_id}", start_time=_days_ago(7))
+    ]
+    mock_client.get_webinar_details.return_value = session_details(
+        topic="Product Launch"
     )
 
 
@@ -111,6 +119,10 @@ class TestZoomConnectorValidateSettings:
 
     def test_configured_meeting_ids_accepted(self) -> None:
         connector = ZoomConnector(meeting_ids=["111"])
+        connector.validate_connector_settings()
+
+    def test_webinar_ids_alone_are_a_discovery_mechanism(self) -> None:
+        connector = ZoomConnector(webinar_ids=["222"])
         connector.validate_connector_settings()
 
 
@@ -172,9 +184,9 @@ class TestZoomConnectorCheckpoint:
         _configure_happy_path(mock_client)
         mock_client.list_past_meeting_occurrences.side_effect = None
         mock_client.list_past_meeting_occurrences.return_value = [
-            ZoomMeetingOccurrence(uuid="uuid-1", start_time=_days_ago(21)),
-            ZoomMeetingOccurrence(uuid="uuid-2", start_time=_days_ago(14)),
-            ZoomMeetingOccurrence(uuid="uuid-3", start_time=_days_ago(7)),
+            ZoomSessionOccurrence(uuid="uuid-1", start_time=_days_ago(21)),
+            ZoomSessionOccurrence(uuid="uuid-2", start_time=_days_ago(14)),
+            ZoomSessionOccurrence(uuid="uuid-3", start_time=_days_ago(7)),
         ]
 
         outputs = load_everything_from_checkpoint_connector(
@@ -199,9 +211,9 @@ class TestZoomConnectorCheckpoint:
         _configure_happy_path(mock_client)
         mock_client.list_past_meeting_occurrences.side_effect = None
         mock_client.list_past_meeting_occurrences.return_value = [
-            ZoomMeetingOccurrence(uuid="uuid-1", start_time=_days_ago(21)),
-            ZoomMeetingOccurrence(uuid="uuid-2", start_time=_days_ago(14)),
-            ZoomMeetingOccurrence(uuid="uuid-3", start_time=_days_ago(7)),
+            ZoomSessionOccurrence(uuid="uuid-1", start_time=_days_ago(21)),
+            ZoomSessionOccurrence(uuid="uuid-2", start_time=_days_ago(14)),
+            ZoomSessionOccurrence(uuid="uuid-3", start_time=_days_ago(7)),
         ]
 
         def _transcript(uuid: str) -> ZoomTranscript:
@@ -233,11 +245,11 @@ class TestZoomConnectorCheckpoint:
 
         def _occurrences(
             session_id: str, *_window: datetime
-        ) -> list[ZoomMeetingOccurrence]:
+        ) -> list[ZoomSessionOccurrence]:
             if session_id == "111":
                 raise RuntimeError("boom")
             return [
-                ZoomMeetingOccurrence(
+                ZoomSessionOccurrence(
                     uuid=f"uuid-{session_id}", start_time=_days_ago(7)
                 )
             ]
@@ -416,3 +428,94 @@ class TestSystemicFailureDoesNotAdvanceWork:
 
         assert [isinstance(item, ConnectorFailure) for item in items] == [True]
         assert returned.recordings.work_index == 1
+
+
+class TestSessionSourceTypes:
+    """The admin picks Meeting only, Webinar only, or Both at setup, so
+    nothing has to detect a session's type at runtime."""
+
+    def _documents(self, connector: ZoomConnector) -> list[Document]:
+        outputs = load_everything_from_checkpoint_connector(
+            connector, 0, _FULL_HISTORY_END
+        )
+        assert outputs[-1].next_checkpoint.has_more is False
+        return [
+            item
+            for output in outputs
+            for item in output.items
+            if isinstance(item, Document)
+        ]
+
+    def test_meeting_only_never_calls_a_webinar_endpoint(self) -> None:
+        connector, mock_client = _make_connector(meeting_ids=["111"])
+        _configure_happy_path(mock_client)
+
+        docs = self._documents(connector)
+
+        assert [d.id for d in docs] == ["ZOOM_MEETING_uuid-111"]
+        mock_client.list_past_webinar_occurrences.assert_not_called()
+
+    def test_webinar_only_indexes_a_tagged_webinar_document(self) -> None:
+        connector, mock_client = _make_connector(meeting_ids=[], webinar_ids=["222"])
+        _configure_happy_path(mock_client)
+
+        docs = self._documents(connector)
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc.id == "ZOOM_WEBINAR_uuid-222"
+        assert doc.metadata == {"session_type": "webinar"}
+        assert doc.semantic_identifier == "Product Launch"
+        # A webinar's transcript comes from the meeting endpoint; Zoom has no
+        # webinar one.
+        mock_client.get_meeting_transcript.assert_called_once_with("uuid-222")
+        mock_client.list_past_meeting_occurrences.assert_not_called()
+
+    def test_both_dispatches_each_id_to_its_own_endpoint(self) -> None:
+        connector, mock_client = _make_connector(
+            meeting_ids=["111"], webinar_ids=["222"]
+        )
+        _configure_happy_path(mock_client)
+
+        docs = self._documents(connector)
+
+        assert [d.id for d in docs] == [
+            "ZOOM_MEETING_uuid-111",
+            "ZOOM_WEBINAR_uuid-222",
+        ]
+        assert [d.metadata["session_type"] for d in docs] == ["meeting", "webinar"]
+        # The meeting endpoint also takes the poll window; only the id matters here.
+        assert mock_client.list_past_meeting_occurrences.call_args.args[0] == "111"
+        mock_client.list_past_webinar_occurrences.assert_called_once_with("222")
+
+    def test_the_same_id_in_both_fields_is_indexed_as_two_documents(self) -> None:
+        # The same number can be a meeting id and a webinar id, and those are
+        # two different sessions.
+        connector, mock_client = _make_connector(
+            meeting_ids=["111"], webinar_ids=["111"]
+        )
+        _configure_happy_path(mock_client)
+        mock_client.list_past_meeting_occurrences.side_effect = None
+        mock_client.list_past_meeting_occurrences.return_value = [
+            ZoomSessionOccurrence(uuid="shared-uuid", start_time=_days_ago(7))
+        ]
+        mock_client.list_past_webinar_occurrences.side_effect = None
+        mock_client.list_past_webinar_occurrences.return_value = [
+            ZoomSessionOccurrence(uuid="shared-uuid", start_time=_days_ago(7))
+        ]
+
+        docs = self._documents(connector)
+
+        assert [d.id for d in docs] == [
+            "ZOOM_MEETING_shared-uuid",
+            "ZOOM_WEBINAR_shared-uuid",
+        ]
+
+    def test_a_webinar_without_a_title_is_not_labelled_a_meeting(self) -> None:
+        connector, mock_client = _make_connector(meeting_ids=[], webinar_ids=["222"])
+        _configure_happy_path(mock_client)
+        mock_client.get_webinar_details.return_value = None
+
+        docs = self._documents(connector)
+
+        assert docs[0].semantic_identifier == "Zoom Webinar 222"

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
@@ -25,8 +25,9 @@ from tests.unit.onyx.connectors.utils import (
     load_everything_from_checkpoint_connector_from_checkpoint,
 )
 from tests.unit.onyx.connectors.zoom.zoom_api_shapes import (
-    session_details,
+    past_meeting_details,
     transcript,
+    webinar_details,
 )
 
 _ZOOM_CREDS = {
@@ -88,13 +89,13 @@ def _configure_happy_path(mock_client: MagicMock) -> None:
         meeting_topic="Recorded Session",
     )
     mock_client.download_transcript_vtt.return_value = _SAMPLE_VTT
-    mock_client.get_past_meeting_details.return_value = session_details(
+    mock_client.get_past_meeting_details.return_value = past_meeting_details(
         topic="Weekly Sync"
     )
     mock_client.list_past_webinar_occurrences.side_effect = lambda session_id: [
         ZoomSessionOccurrence(uuid=f"uuid-{session_id}", start_time=_days_ago(7))
     ]
-    mock_client.get_webinar_details.return_value = session_details(
+    mock_client.get_webinar_details.return_value = webinar_details(
         topic="Product Launch"
     )
 

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
@@ -84,7 +84,7 @@ def _configure_happy_path(mock_client: MagicMock) -> None:
         ]
     )
     mock_client.get_meeting_transcript.side_effect = lambda uuid: transcript(
-        download_url=f"https://zoom.example/{uuid}.vtt"
+        download_url=f"https://zoom.example/{uuid}.vtt", meeting_topic=""
     )
     mock_client.download_transcript_vtt.return_value = _SAMPLE_VTT
     mock_client.get_past_meeting_details.return_value = session_details(

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_connector.py
@@ -84,7 +84,8 @@ def _configure_happy_path(mock_client: MagicMock) -> None:
         ]
     )
     mock_client.get_meeting_transcript.side_effect = lambda uuid: transcript(
-        download_url=f"https://zoom.example/{uuid}.vtt", meeting_topic=""
+        download_url=f"https://zoom.example/{uuid}.vtt",
+        meeting_topic="Recorded Session",
     )
     mock_client.download_transcript_vtt.return_value = _SAMPLE_VTT
     mock_client.get_past_meeting_details.return_value = session_details(
@@ -95,6 +96,14 @@ def _configure_happy_path(mock_client: MagicMock) -> None:
     ]
     mock_client.get_webinar_details.return_value = session_details(
         topic="Product Launch"
+    )
+
+
+def _transcript_without_a_topic(mock_client: MagicMock) -> None:
+    """Zoom names the session in the transcript response, so the details
+    endpoints are only reached when it doesn't."""
+    mock_client.get_meeting_transcript.side_effect = lambda uuid: transcript(
+        download_url=f"https://zoom.example/{uuid}.vtt", meeting_topic=""
     )
 
 
@@ -175,7 +184,10 @@ class TestZoomConnectorCheckpoint:
         # meeting id would silently index only the most recent occurrence.
         assert doc.id == "ZOOM_MEETING_uuid-111"
         mock_client.get_meeting_transcript.assert_called_once_with("uuid-111")
-        assert doc.semantic_identifier == "Weekly Sync"
+        # The transcript names the session, so the details endpoint — and the
+        # one-year cap that comes with it — is never reached.
+        assert doc.semantic_identifier == "Recorded Session"
+        mock_client.get_past_meeting_details.assert_not_called()
         assert doc.metadata == {"session_type": "meeting"}
         assert outputs[-1].next_checkpoint.has_more is False
 
@@ -465,7 +477,8 @@ class TestSessionSourceTypes:
         doc = docs[0]
         assert doc.id == "ZOOM_WEBINAR_uuid-222"
         assert doc.metadata == {"session_type": "webinar"}
-        assert doc.semantic_identifier == "Product Launch"
+        assert doc.semantic_identifier == "Recorded Session"
+        mock_client.get_webinar_details.assert_not_called()
         # A webinar's transcript comes from the meeting endpoint; Zoom has no
         # webinar one.
         mock_client.get_meeting_transcript.assert_called_once_with("uuid-222")
@@ -511,9 +524,23 @@ class TestSessionSourceTypes:
             "ZOOM_WEBINAR_shared-uuid",
         ]
 
+    def test_a_titleless_webinar_falls_back_to_its_own_details_endpoint(
+        self,
+    ) -> None:
+        connector, mock_client = _make_connector(meeting_ids=[], webinar_ids=["222"])
+        _configure_happy_path(mock_client)
+        _transcript_without_a_topic(mock_client)
+
+        docs = self._documents(connector)
+
+        assert docs[0].semantic_identifier == "Product Launch"
+        mock_client.get_webinar_details.assert_called_once_with("uuid-222")
+        mock_client.get_past_meeting_details.assert_not_called()
+
     def test_a_webinar_without_a_title_is_not_labelled_a_meeting(self) -> None:
         connector, mock_client = _make_connector(meeting_ids=[], webinar_ids=["222"])
         _configure_happy_path(mock_client)
+        _transcript_without_a_topic(mock_client)
         mock_client.get_webinar_details.return_value = None
 
         docs = self._documents(connector)

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_discovery.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_discovery.py
@@ -8,9 +8,12 @@ import requests
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     datetime_from_utc_timestamp,
 )
-from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import (
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+)
 from onyx.connectors.zoom.client import ZoomClient
-from onyx.connectors.zoom.models import ZoomMeetingOccurrence
+from onyx.connectors.zoom.models import ZoomSessionOccurrence
 from onyx.connectors.zoom.recordings.discovery import (
     _MAX_WORK_PER_STEP,
     _OCCURRENCE_POLL_OVERLAP_SECONDS,
@@ -31,15 +34,15 @@ _ONE_HOUR = 60 * 60
 _NARROW_WINDOW_SECONDS = 60.0
 
 
-def _occurrence_at(uuid: str, epoch_seconds: float) -> ZoomMeetingOccurrence:
-    return ZoomMeetingOccurrence(
+def _occurrence_at(uuid: str, epoch_seconds: float) -> ZoomSessionOccurrence:
+    return ZoomSessionOccurrence(
         uuid=uuid,
         start_time=datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat(),
     )
 
 
 def _client_with_occurrences(
-    occurrences: list[ZoomMeetingOccurrence],
+    occurrences: list[ZoomSessionOccurrence],
 ) -> MagicMock:
     client = MagicMock(spec=ZoomClient)
     client.list_past_meeting_occurrences.return_value = occurrences
@@ -67,7 +70,7 @@ class TestIdAllowlistSource:
     def test_work_items_carry_session_identity(self) -> None:
         source = IdAllowlistSource(["111"])
         client = _client_with_occurrences(
-            [ZoomMeetingOccurrence(uuid="uuid-1", start_time="2026-01-15T10:00:00Z")]
+            [ZoomSessionOccurrence(uuid="uuid-1", start_time="2026-01-15T10:00:00Z")]
         )
 
         result = source.discover_step(client, _START, _END, None)
@@ -82,9 +85,9 @@ class TestIdAllowlistSource:
         source = IdAllowlistSource(["111"])
         client = _client_with_occurrences(
             [
-                ZoomMeetingOccurrence(uuid="uuid-1", start_time="2026-01-01T10:00:00Z"),
-                ZoomMeetingOccurrence(uuid="uuid-2", start_time="2026-01-08T10:00:00Z"),
-                ZoomMeetingOccurrence(uuid="uuid-3", start_time="2026-01-15T10:00:00Z"),
+                ZoomSessionOccurrence(uuid="uuid-1", start_time="2026-01-01T10:00:00Z"),
+                ZoomSessionOccurrence(uuid="uuid-2", start_time="2026-01-08T10:00:00Z"),
+                ZoomSessionOccurrence(uuid="uuid-3", start_time="2026-01-15T10:00:00Z"),
             ]
         )
 
@@ -208,7 +211,7 @@ class TestIdAllowlistPollWindow:
         source = IdAllowlistSource(["111"])
         now = time.time()
         client = _client_with_occurrences(
-            [ZoomMeetingOccurrence(uuid="uuid-junk", start_time="not-a-date")]
+            [ZoomSessionOccurrence(uuid="uuid-junk", start_time="not-a-date")]
         )
 
         with pytest.raises(ValueError):
@@ -218,7 +221,7 @@ class TestIdAllowlistPollWindow:
         source = IdAllowlistSource(["111"])
         now = time.time()
         client = _client_with_occurrences(
-            [ZoomMeetingOccurrence(uuid="uuid-no-time", start_time="")]
+            [ZoomSessionOccurrence(uuid="uuid-no-time", start_time="")]
         )
 
         result = source.discover_step(client, now - _NARROW_WINDOW_SECONDS, now, None)
@@ -232,7 +235,7 @@ class TestIdAllowlistPaging:
         source = IdAllowlistSource(["111"])
         client = _client_with_occurrences(
             [
-                ZoomMeetingOccurrence(
+                ZoomSessionOccurrence(
                     uuid=f"uuid-{i:04d}",
                     start_time=f"2026-01-01T{i // 60:02d}:{i % 60:02d}:00Z",
                 )
@@ -260,7 +263,7 @@ class TestIdAllowlistPaging:
         source = IdAllowlistSource(["111"])
         client = _client_with_occurrences(
             [
-                ZoomMeetingOccurrence(
+                ZoomSessionOccurrence(
                     uuid=f"uuid-{i:04d}",
                     start_time=f"2026-01-01T00:{i // 60:02d}:{i % 60:02d}Z",
                 )
@@ -279,7 +282,7 @@ class TestIdAllowlistPaging:
     def test_unrecognised_cursor_restarts_the_id_instead_of_raising(self) -> None:
         source = IdAllowlistSource(["111"])
         client = _client_with_occurrences(
-            [ZoomMeetingOccurrence(uuid="uuid-1", start_time="2026-01-15T10:00:00Z")]
+            [ZoomSessionOccurrence(uuid="uuid-1", start_time="2026-01-15T10:00:00Z")]
         )
 
         result = source.discover_step(client, _START, _END, {"bogus": "value"})
@@ -290,7 +293,7 @@ class TestIdAllowlistPaging:
         source = IdAllowlistSource(["111", "222"])
         client = _client_with_occurrences(
             [
-                ZoomMeetingOccurrence(
+                ZoomSessionOccurrence(
                     uuid=f"uuid-{i:04d}",
                     start_time=f"2026-01-01T00:{i // 60:02d}:{i % 60:02d}Z",
                 )
@@ -309,7 +312,7 @@ class TestIdAllowlistPaging:
         source = IdAllowlistSource(["111"])
         client = MagicMock(spec=ZoomClient)
         base = [
-            ZoomMeetingOccurrence(
+            ZoomSessionOccurrence(
                 uuid=f"uuid-{i:04d}",
                 start_time=f"2026-01-01T00:{i // 60:02d}:{i % 60:02d}Z",
             )
@@ -318,7 +321,7 @@ class TestIdAllowlistPaging:
         # The meeting runs again between the two steps, and Zoom lists the newest
         # occurrence first, so the second page arrives in a different order.
         later = [
-            ZoomMeetingOccurrence(uuid="uuid-9999", start_time="2026-06-01T00:00:00Z")
+            ZoomSessionOccurrence(uuid="uuid-9999", start_time="2026-06-01T00:00:00Z")
         ] + base
         client.list_past_meeting_occurrences.side_effect = [base, later]
 
@@ -332,7 +335,7 @@ class TestIdAllowlistPaging:
     def test_old_cursor_without_offset_still_loads(self) -> None:
         source = IdAllowlistSource(["111", "222"])
         client = _client_with_occurrences(
-            [ZoomMeetingOccurrence(uuid="uuid-1", start_time="2026-01-15T10:00:00Z")]
+            [ZoomSessionOccurrence(uuid="uuid-1", start_time="2026-01-15T10:00:00Z")]
         )
 
         # A checkpoint written before paging existed carries only "index".
@@ -374,11 +377,21 @@ class TestBuildDiscoverySources:
     def test_no_config_yields_no_sources(self) -> None:
         assert build_discovery_sources(None) == []
         assert build_discovery_sources([]) == []
+        assert build_discovery_sources([], []) == []
 
     def test_meeting_ids_yield_allowlist_source(self) -> None:
         sources = build_discovery_sources(["111"])
         assert len(sources) == 1
         assert isinstance(sources[0], IdAllowlistSource)
+
+    def test_webinar_ids_alone_still_yield_a_source(self) -> None:
+        sources = build_discovery_sources(None, ["222"])
+        assert len(sources) == 1
+        assert isinstance(sources[0], IdAllowlistSource)
+
+    def test_both_kinds_of_id_share_one_source(self) -> None:
+        sources = build_discovery_sources(["111"], ["222"])
+        assert len(sources) == 1
 
 
 class TestDiscoverySystemicFailures:
@@ -417,4 +430,73 @@ class TestDiscoverySystemicFailures:
         )
 
         with pytest.raises(requests.exceptions.JSONDecodeError):
+            source.discover_step(client, _START, _END, None)
+
+
+class TestIdAllowlistWebinars:
+    def _client_with_webinar_occurrences(
+        self, occurrences: list[ZoomSessionOccurrence]
+    ) -> MagicMock:
+        client = MagicMock(spec=ZoomClient)
+        client.list_past_webinar_occurrences.return_value = occurrences
+        return client
+
+    def test_webinar_id_is_listed_through_the_webinar_endpoint(self) -> None:
+        source = IdAllowlistSource([], ["222"])
+        client = self._client_with_webinar_occurrences(
+            [ZoomSessionOccurrence(uuid="w-1", start_time="2026-01-15T10:00:00Z")]
+        )
+
+        result = source.discover_step(client, _START, _END, None)
+
+        client.list_past_webinar_occurrences.assert_called_once_with("222")
+        client.list_past_meeting_occurrences.assert_not_called()
+        work = result.work[0]
+        assert work.session_type == ZoomSessionType.WEBINAR
+        assert work.session_id == "222"
+        assert work.occurrence_uuid == "w-1"
+
+    def test_meetings_run_before_webinars_in_one_cursor_walk(self) -> None:
+        source = IdAllowlistSource(["111"], ["222"])
+        client = MagicMock(spec=ZoomClient)
+        client.list_past_meeting_occurrences.return_value = [
+            ZoomSessionOccurrence(uuid="m-1", start_time="2026-01-15T10:00:00Z")
+        ]
+        client.list_past_webinar_occurrences.return_value = [
+            ZoomSessionOccurrence(uuid="w-1", start_time="2026-01-16T10:00:00Z")
+        ]
+
+        first = source.discover_step(client, _START, _END, None)
+        second = source.discover_step(client, _START, _END, first.next_cursor)
+
+        assert [(w.session_type, w.occurrence_uuid) for w in first.work] == [
+            (ZoomSessionType.MEETING, "m-1")
+        ]
+        assert [(w.session_type, w.occurrence_uuid) for w in second.work] == [
+            (ZoomSessionType.WEBINAR, "w-1")
+        ]
+        assert second.done is True
+
+    def test_failure_names_the_webinar_rather_than_the_bare_id(self) -> None:
+        source = IdAllowlistSource([], ["111"])
+        client = MagicMock(spec=ZoomClient)
+        client.list_past_webinar_occurrences.side_effect = RuntimeError("boom")
+
+        result = source.discover_step(client, _START, _END, None)
+
+        assert result.failures[0].failed_entity is not None
+        assert result.failures[0].failed_entity.entity_id == "webinar:111"
+
+    def test_a_missing_add_on_stops_discovery_instead_of_skipping_webinars(
+        self,
+    ) -> None:
+        # Without the add-on every webinar call fails, so skipping this one
+        # silently skips them all and still reports success.
+        source = IdAllowlistSource([], ["222", "333"])
+        client = MagicMock(spec=ZoomClient)
+        client.list_past_webinar_occurrences.side_effect = InsufficientPermissionsError(
+            "no add-on"
+        )
+
+        with pytest.raises(InsufficientPermissionsError):
             source.discover_step(client, _START, _END, None)

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_processing.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_processing.py
@@ -47,7 +47,7 @@ def _work(
 def _client_with_transcript() -> MagicMock:
     client = MagicMock(spec=ZoomClient)
     client.get_meeting_transcript.return_value = transcript(
-        download_url="https://zoom.example/transcript.vtt"
+        download_url="https://zoom.example/transcript.vtt", meeting_topic=""
     )
     client.download_transcript_vtt.return_value = _SAMPLE_VTT
     client.get_past_meeting_details.return_value = session_details(topic="Weekly Sync")
@@ -299,3 +299,53 @@ class TestSystemicFailuresStopTheRun:
 
         assert len(items) == 1
         assert isinstance(items[0], ConnectorFailure)
+
+
+class TestTopicComesFromTheTranscript:
+    """The transcript already names the session, so the details endpoint is a
+    second call for a field we hold, and Zoom caps it at one year."""
+
+    def test_transcript_topic_is_used_without_a_details_call(self) -> None:
+        client = _client_with_transcript()
+        client.get_meeting_transcript.return_value = transcript(
+            download_url="https://zoom.example/transcript.vtt",
+            meeting_topic="Quarterly Review",
+        )
+
+        docs = _run(client, _work())
+
+        assert isinstance(docs[0], Document)
+        assert docs[0].semantic_identifier == "Quarterly Review"
+        client.get_past_meeting_details.assert_not_called()
+
+    def test_details_still_fill_in_when_the_transcript_has_no_topic(self) -> None:
+        client = _client_with_transcript()
+
+        docs = _run(client, _work())
+
+        assert isinstance(docs[0], Document)
+        assert docs[0].semantic_identifier == "Weekly Sync"
+        client.get_past_meeting_details.assert_called_once_with("uuid-abc")
+
+    def test_discovery_topic_still_wins_over_the_transcript(self) -> None:
+        client = _client_with_transcript()
+        client.get_meeting_transcript.return_value = transcript(
+            download_url="https://zoom.example/transcript.vtt",
+            meeting_topic="Quarterly Review",
+        )
+
+        docs = _run(client, _work(topic="From Discovery"))
+
+        assert isinstance(docs[0], Document)
+        assert docs[0].semantic_identifier == "From Discovery"
+
+    def test_a_missing_start_time_still_costs_a_details_call(self) -> None:
+        client = _client_with_transcript()
+        client.get_meeting_transcript.return_value = transcript(
+            download_url="https://zoom.example/transcript.vtt",
+            meeting_topic="Quarterly Review",
+        )
+
+        _run(client, _work(start_time=None))
+
+        client.get_past_meeting_details.assert_called_once_with("uuid-abc")

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_processing.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_processing.py
@@ -15,7 +15,7 @@ from onyx.connectors.zoom.recordings.processing import (
     zoom_document_id,
 )
 from tests.unit.onyx.connectors.zoom.zoom_api_shapes import (
-    session_details,
+    past_meeting_details,
     transcript,
 )
 
@@ -50,7 +50,9 @@ def _client_with_transcript() -> MagicMock:
         download_url="https://zoom.example/transcript.vtt", meeting_topic=""
     )
     client.download_transcript_vtt.return_value = _SAMPLE_VTT
-    client.get_past_meeting_details.return_value = session_details(topic="Weekly Sync")
+    client.get_past_meeting_details.return_value = past_meeting_details(
+        topic="Weekly Sync"
+    )
     return client
 
 
@@ -59,6 +61,12 @@ def _run(client: MagicMock, work: OccurrenceWork) -> list[Document | ConnectorFa
     list so an unexpected extra one would show up as a length mismatch."""
     processed = process_occurrence(client, work)
     return [] if processed is None else [processed]
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = status
+    return requests.HTTPError(f"{status}", response=response)
 
 
 class TestZoomDocumentId:
@@ -170,9 +178,11 @@ class TestProcessOccurrence:
 
         assert _run(client, _work()) == []
 
-    def test_missing_details_falls_back_to_generic_title(self) -> None:
+    def test_a_session_zoom_no_longer_has_falls_back_to_a_generic_title(self) -> None:
+        # Zoom answers 404 once a meeting ages past the details endpoint's
+        # one-year window.
         client = _client_with_transcript()
-        client.get_past_meeting_details.return_value = None
+        client.get_past_meeting_details.side_effect = _http_error(404)
 
         items = _run(client, _work(start_time=None))
 
@@ -194,7 +204,7 @@ class TestProcessOccurrence:
 
     def test_details_fill_in_a_timestamp_discovery_did_not_have(self) -> None:
         client = _client_with_transcript()
-        client.get_past_meeting_details.return_value = session_details(
+        client.get_past_meeting_details.return_value = past_meeting_details(
             topic="Weekly Sync", start_time="2026-01-15T10:00:00Z"
         )
 
@@ -207,7 +217,7 @@ class TestProcessOccurrence:
 
     def test_empty_prefetched_topic_still_asks_for_details(self) -> None:
         client = _client_with_transcript()
-        client.get_past_meeting_details.return_value = session_details(
+        client.get_past_meeting_details.return_value = past_meeting_details(
             topic="Weekly Sync", start_time="2026-01-15T10:00:00Z"
         )
 
@@ -226,12 +236,6 @@ class TestProcessOccurrence:
         assert isinstance(doc, Document)
         assert doc.semantic_identifier == "Town Hall"
         client.get_past_meeting_details.assert_not_called()
-
-
-def _http_error(status: int) -> requests.HTTPError:
-    response = requests.Response()
-    response.status_code = status
-    return requests.HTTPError(f"{status}", response=response)
 
 
 class TestSystemicFailuresStopTheRun:
@@ -288,6 +292,26 @@ class TestSystemicFailuresStopTheRun:
 
         assert len(items) == 1
         assert isinstance(items[0], ConnectorFailure)
+
+    @pytest.mark.parametrize(
+        "error",
+        [_http_error(429), CredentialExpiredError("expired")],
+    )
+    def test_a_systemic_details_failure_still_yields_the_document(
+        self, error: Exception
+    ) -> None:
+        # The details call runs last, once the transcript is downloaded, so even
+        # a systemic error here costs a title rather than the document. The next
+        # occurrence fetches its transcript first and stops the run there.
+        client = _client_with_transcript()
+        client.get_past_meeting_details.side_effect = error
+
+        items = _run(client, _work(topic="", start_time=None))
+
+        assert len(items) == 1
+        doc = items[0]
+        assert isinstance(doc, Document)
+        assert doc.semantic_identifier == "Zoom Meeting 111"
 
     def test_an_http_error_carrying_no_response_is_not_treated_as_systemic(
         self,

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_processing.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_processing.py
@@ -15,7 +15,7 @@ from onyx.connectors.zoom.recordings.processing import (
     zoom_document_id,
 )
 from tests.unit.onyx.connectors.zoom.zoom_api_shapes import (
-    past_meeting_details,
+    session_details,
     transcript,
 )
 
@@ -50,9 +50,7 @@ def _client_with_transcript() -> MagicMock:
         download_url="https://zoom.example/transcript.vtt"
     )
     client.download_transcript_vtt.return_value = _SAMPLE_VTT
-    client.get_past_meeting_details.return_value = past_meeting_details(
-        topic="Weekly Sync"
-    )
+    client.get_past_meeting_details.return_value = session_details(topic="Weekly Sync")
     return client
 
 
@@ -196,7 +194,7 @@ class TestProcessOccurrence:
 
     def test_details_fill_in_a_timestamp_discovery_did_not_have(self) -> None:
         client = _client_with_transcript()
-        client.get_past_meeting_details.return_value = past_meeting_details(
+        client.get_past_meeting_details.return_value = session_details(
             topic="Weekly Sync", start_time="2026-01-15T10:00:00Z"
         )
 
@@ -209,7 +207,7 @@ class TestProcessOccurrence:
 
     def test_empty_prefetched_topic_still_asks_for_details(self) -> None:
         client = _client_with_transcript()
-        client.get_past_meeting_details.return_value = past_meeting_details(
+        client.get_past_meeting_details.return_value = session_details(
             topic="Weekly Sync", start_time="2026-01-15T10:00:00Z"
         )
 

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_session_types.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_session_types.py
@@ -5,11 +5,12 @@ from onyx.connectors.zoom.client import ZoomClient
 from onyx.connectors.zoom.recordings.models import ZoomSessionType
 from onyx.connectors.zoom.recordings.session_types import (
     MeetingSessionType,
+    WebinarSessionType,
     get_session_type_handler,
 )
 from tests.unit.onyx.connectors.zoom.zoom_api_shapes import (
     occurrence,
-    past_meeting_details,
+    session_details,
 )
 
 
@@ -18,6 +19,17 @@ class TestGetSessionTypeHandler:
         handler = get_session_type_handler(ZoomSessionType.MEETING)
         assert isinstance(handler, MeetingSessionType)
         assert handler.session_type == ZoomSessionType.MEETING
+
+    def test_webinar_resolves_to_webinar_handler(self) -> None:
+        handler = get_session_type_handler(ZoomSessionType.WEBINAR)
+        assert isinstance(handler, WebinarSessionType)
+        assert handler.session_type == ZoomSessionType.WEBINAR
+
+    def test_every_session_type_has_a_handler(self) -> None:
+        # A type with no entry raises KeyError deep inside discovery, so catch
+        # a new one here instead.
+        for session_type in ZoomSessionType:
+            assert get_session_type_handler(session_type) is not None
 
 
 class TestMeetingSessionType:
@@ -41,11 +53,43 @@ class TestMeetingSessionType:
 
     def test_get_occurrence_details_delegates_to_meeting_endpoint(self) -> None:
         mock_client = MagicMock(spec=ZoomClient)
-        mock_client.get_past_meeting_details.return_value = past_meeting_details(
+        mock_client.get_past_meeting_details.return_value = session_details(
             topic="Weekly Sync"
         )
 
         result = MeetingSessionType().get_occurrence_details(mock_client, "uuid-1")
 
         mock_client.get_past_meeting_details.assert_called_once_with("uuid-1")
-        assert result == past_meeting_details(topic="Weekly Sync")
+        assert result == session_details(topic="Weekly Sync")
+
+
+class TestWebinarSessionType:
+    def test_list_occurrences_delegates_to_the_webinar_endpoint(self) -> None:
+        mock_client = MagicMock(spec=ZoomClient)
+        mock_client.list_past_webinar_occurrences.return_value = [
+            occurrence(uuid="uuid-1")
+        ]
+
+        result = WebinarSessionType().list_occurrences(
+            mock_client,
+            "222",
+            datetime(2026, 1, 1, tzinfo=timezone.utc),
+            datetime(2026, 1, 31, tzinfo=timezone.utc),
+        )
+
+        # The webinar endpoint takes no date scope, so the window is dropped.
+        mock_client.list_past_webinar_occurrences.assert_called_once_with("222")
+        mock_client.list_past_meeting_occurrences.assert_not_called()
+        assert result == [occurrence(uuid="uuid-1")]
+
+    def test_get_occurrence_details_delegates_to_the_webinar_endpoint(self) -> None:
+        mock_client = MagicMock(spec=ZoomClient)
+        mock_client.get_webinar_details.return_value = session_details(
+            topic="Product Launch"
+        )
+
+        result = WebinarSessionType().get_occurrence_details(mock_client, "uuid-1")
+
+        mock_client.get_webinar_details.assert_called_once_with("uuid-1")
+        mock_client.get_past_meeting_details.assert_not_called()
+        assert result == session_details(topic="Product Launch")

--- a/backend/tests/unit/onyx/connectors/zoom/test_zoom_session_types.py
+++ b/backend/tests/unit/onyx/connectors/zoom/test_zoom_session_types.py
@@ -10,7 +10,8 @@ from onyx.connectors.zoom.recordings.session_types import (
 )
 from tests.unit.onyx.connectors.zoom.zoom_api_shapes import (
     occurrence,
-    session_details,
+    past_meeting_details,
+    webinar_details,
 )
 
 
@@ -53,14 +54,14 @@ class TestMeetingSessionType:
 
     def test_get_occurrence_details_delegates_to_meeting_endpoint(self) -> None:
         mock_client = MagicMock(spec=ZoomClient)
-        mock_client.get_past_meeting_details.return_value = session_details(
+        mock_client.get_past_meeting_details.return_value = past_meeting_details(
             topic="Weekly Sync"
         )
 
         result = MeetingSessionType().get_occurrence_details(mock_client, "uuid-1")
 
         mock_client.get_past_meeting_details.assert_called_once_with("uuid-1")
-        assert result == session_details(topic="Weekly Sync")
+        assert result == past_meeting_details(topic="Weekly Sync")
 
 
 class TestWebinarSessionType:
@@ -84,7 +85,7 @@ class TestWebinarSessionType:
 
     def test_get_occurrence_details_delegates_to_the_webinar_endpoint(self) -> None:
         mock_client = MagicMock(spec=ZoomClient)
-        mock_client.get_webinar_details.return_value = session_details(
+        mock_client.get_webinar_details.return_value = webinar_details(
             topic="Product Launch"
         )
 
@@ -92,4 +93,4 @@ class TestWebinarSessionType:
 
         mock_client.get_webinar_details.assert_called_once_with("uuid-1")
         mock_client.get_past_meeting_details.assert_not_called()
-        assert result == session_details(topic="Product Launch")
+        assert result == webinar_details(topic="Product Launch")

--- a/backend/tests/unit/onyx/connectors/zoom/zoom_api_shapes.py
+++ b/backend/tests/unit/onyx/connectors/zoom/zoom_api_shapes.py
@@ -8,8 +8,8 @@ the field under test as an override.
 from typing import Any
 
 from onyx.connectors.zoom.models import (
-    ZoomMeetingOccurrence,
-    ZoomPastMeetingDetails,
+    ZoomSessionDetails,
+    ZoomSessionOccurrence,
     ZoomTranscript,
 )
 
@@ -26,7 +26,7 @@ def transcript(**overrides: Any) -> ZoomTranscript:
     return ZoomTranscript(**(fields | overrides))
 
 
-def past_meeting_details(**overrides: Any) -> ZoomPastMeetingDetails:
+def session_details(**overrides: Any) -> ZoomSessionDetails:
     fields: dict[str, Any] = {
         "uuid": "uaFkQyFCSwya8iNYtkAw3A==",
         "id": 111,
@@ -44,12 +44,12 @@ def past_meeting_details(**overrides: Any) -> ZoomPastMeetingDetails:
         "user_email": "host@example.com",
         "user_name": "Host User",
     }
-    return ZoomPastMeetingDetails(**(fields | overrides))
+    return ZoomSessionDetails(**(fields | overrides))
 
 
-def occurrence(**overrides: Any) -> ZoomMeetingOccurrence:
+def occurrence(**overrides: Any) -> ZoomSessionOccurrence:
     fields: dict[str, Any] = {
         "uuid": "uuid-1",
         "start_time": "2026-01-15T10:00:00Z",
     }
-    return ZoomMeetingOccurrence(**(fields | overrides))
+    return ZoomSessionOccurrence(**(fields | overrides))

--- a/backend/tests/unit/onyx/connectors/zoom/zoom_api_shapes.py
+++ b/backend/tests/unit/onyx/connectors/zoom/zoom_api_shapes.py
@@ -8,9 +8,10 @@ the field under test as an override.
 from typing import Any
 
 from onyx.connectors.zoom.models import (
-    ZoomSessionDetails,
+    ZoomPastMeetingDetails,
     ZoomSessionOccurrence,
     ZoomTranscript,
+    ZoomWebinarDetails,
 )
 
 
@@ -26,7 +27,7 @@ def transcript(**overrides: Any) -> ZoomTranscript:
     return ZoomTranscript(**(fields | overrides))
 
 
-def session_details(**overrides: Any) -> ZoomSessionDetails:
+def past_meeting_details(**overrides: Any) -> ZoomPastMeetingDetails:
     fields: dict[str, Any] = {
         "uuid": "uaFkQyFCSwya8iNYtkAw3A==",
         "id": 111,
@@ -44,7 +45,7 @@ def session_details(**overrides: Any) -> ZoomSessionDetails:
         "user_email": "host@example.com",
         "user_name": "Host User",
     }
-    return ZoomSessionDetails(**(fields | overrides))
+    return ZoomPastMeetingDetails(**(fields | overrides))
 
 
 def occurrence(**overrides: Any) -> ZoomSessionOccurrence:
@@ -53,3 +54,15 @@ def occurrence(**overrides: Any) -> ZoomSessionOccurrence:
         "start_time": "2026-01-15T10:00:00Z",
     }
     return ZoomSessionOccurrence(**(fields | overrides))
+
+
+def webinar_details(**overrides: Any) -> ZoomWebinarDetails:
+    fields: dict[str, Any] = {
+        "id": 97871060099,
+        "uuid": "m3WqMkvuRXyYqH+eKWhk9w==",
+        "host_id": "30R7kT7bTIKSNUFEuH_Qlg",
+        "type": 5,
+        "topic": "Product Launch",
+        "start_time": "2026-01-15T10:00:00Z",
+    }
+    return ZoomWebinarDetails(**(fields | overrides))

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -88,6 +88,7 @@ class TestSecret(StrEnum):
     ZOOM_CLIENT_ID = "zoom-client-id"
     ZOOM_CLIENT_SECRET = "zoom-client-secret"
     ZOOM_TEST_MEETING_ID = "zoom-test-meeting-id"
+    ZOOM_TEST_WEBINAR_ID = "zoom-test-webinar-id"
     CANVAS_ADMIN_ACCESS_TOKEN = "canvas-admin-access-token"
     CANVAS_TEACHER_ACCESS_TOKEN = "canvas-teacher-access-token"
     CANVAS_STUDENT_ACCESS_TOKEN = "canvas-student-access-token"


### PR DESCRIPTION
## Description

- Zoom Webinars can now be indexed. A connector takes `meeting_ids`, `webinar_ids`, or both, and every document is tagged with its session type so users can tell a webinar apart from a meeting in search.
- Webinar history is not cut off at 15 months the way meeting-ID history is, so an admin scoping by webinar ID reaches as far back as their recording retention allows.
- An account without the Zoom Webinar add-on now gets an error naming the add-on and the host who is missing it, instead of a generic permissions message that sends them to re-check scopes that are already correct. It fails the run rather than skipping every webinar and reporting success.
- Sessions older than a year keep their real title. The title now comes from the transcript response we already fetch, so the details endpoint and its one-year cap are off the normal path — which also removes one API call per occurrence.
- The two occurrence/details models are renamed to session-neutral names, since they now describe both meetings and webinars.

The admin UI that exposes these fields is a later ticket, so the connector is still reachable only from tests and the API.

## How Has This Been Tested?

Unit tests — 188 in the Zoom suite, covering meeting-only, webinar-only and both-mode dispatch, the add-on error paths, and the title fallbacks. The daily suite gains a real webinar transcript fetch, which needs a new `zoom-test-webinar-id` secret on an account with the Webinar add-on enabled; without it that one test cannot run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Zoom connector now indexes webinars alongside meetings, tagging every document with its session type so webinars are distinguishable from meetings in search. It accepts `webinar_ids` alongside `meeting_ids`, and webinar history reaches as far back as recording retention allows instead of the 15-month cap that applies to meeting IDs.

**Behavior changes**
- An account without the Webinar add-on now gets an error naming the add-on and the missing host, failing the run instead of silently skipping every webinar.
- Session titles now come from the transcript response already fetched, so sessions older than a year keep their real title and the details endpoint call is dropped from the normal path.
- Meetings and webinars now parse their own details response shapes, since the two endpoints return different fields.
- An unknown webinar ID now raises as an error instead of being read as a webinar that ran no times.

**Testing and rollout**
- Unit tests cover meeting-only, webinar-only, and both-mode dispatch, add-on error paths, and title fallbacks.
- The daily suite gains a real webinar transcript fetch requiring a new `zoom-test-webinar-id` secret on an account with the Webinar add-on enabled; tests skip when that secret is unavailable.
- The admin UI exposing `webinar_ids` is a later ticket, so the connector is reachable only from tests and the API for now.

<sup>Written for commit 73a004467dba43b540abf85b355111030bd45a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



