### PR TITLE
fix(onyxbot,api): sanitize allowlist member filters and allow anonymous agent avatar access

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -134,7 +134,12 @@ def _resolve_allowlist_user_ids(
     when no allowlist is configured, meaning the bot has no invocation gate or
     response-visibility scope for the channel.
     """
-    allowlist = (channel_conf or {}).get("respond_member_group_list") or None
+    raw_allowlist = (channel_conf or {}).get("respond_member_group_list") or None
+    if not raw_allowlist:
+        return None, []
+
+    # Strip whitespace and drop blank/empty entries
+    allowlist = [item.strip() for item in raw_allowlist if isinstance(item, str) and item.strip()]
     if not allowlist:
         return None, []
 

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -252,13 +252,13 @@ def respond_in_thread_or_channel(
     receiver_ids: list[str] | None = None,
     metadata: Metadata | None = None,
     unfurl: bool = True,
-    send_as_ephemeral: bool | None = True,  # noqa: ARG001
+    send_as_ephemeral: bool | None = True,
 ) -> list[str]:
     if not text and not blocks:
         raise ValueError("One of `text` or `blocks` must be provided")
 
     message_ids: list[str] = []
-    if not receiver_ids:
+    if not receiver_ids or not send_as_ephemeral:
         try:
             response = client.chat_postMessage(
                 channel=channel,

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -23,8 +23,10 @@ from onyx.auth.permissions import (
 from onyx.auth.users import (
     current_chat_accessible_user,
     current_limited_user,
+    optional_user,
     scope_exempt,
 )
+
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS, FileOrigin, MilestoneRecordType
 from onyx.db.engine.sql_engine import get_session
@@ -765,7 +767,7 @@ def get_persona(
     return snapshot
 
 
-@basic_router.get("/{persona_id}/avatar")
+@basic_router.get("/{persona_id}/avatar", dependencies=[Depends(scope_exempt)])
 def get_persona_avatar(
     persona_id: int,
     request: Request,
@@ -784,7 +786,11 @@ def get_persona_avatar(
     except ValueError:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
 
+    if user is None and not persona.is_public:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
+
     file_id = persona.uploaded_image_id
+
     if not file_id:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
 

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -769,7 +769,7 @@ def get_persona(
 def get_persona_avatar(
     persona_id: int,
     request: Request,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User | None = Depends(optional_user),
     db_session: Session = Depends(get_session),
 ) -> Response:
     # Mirror `fetch_chat_file`: return 404 (not 403) for any failure so

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -89,7 +89,9 @@ def _form_channel_config(
     if respond_tag_only is not None:
         channel_config["respond_tag_only"] = respond_tag_only
     if respond_member_group_list:
-        channel_config["respond_member_group_list"] = respond_member_group_list
+        cleaned_members = [m.strip() for m in respond_member_group_list if isinstance(m, str) and m.strip()]
+        if cleaned_members:
+            channel_config["respond_member_group_list"] = cleaned_members
     if answer_filters:
         channel_config["answer_filters"] = answer_filters
     if follow_up_tags is not None:

--- a/backend/tests/unit/onyx/onyxbot/slack/test_slack_allowlist.py
+++ b/backend/tests/unit/onyx/onyxbot/slack/test_slack_allowlist.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+from onyx.onyxbot.slack.handlers.handle_message import _resolve_allowlist_user_ids
+
+
+def test_resolve_allowlist_empty_or_blank_returns_none():
+    client = MagicMock()
+
+    # Empty list
+    resolved, missing = _resolve_allowlist_user_ids({"respond_member_group_list": []}, client)
+    assert resolved is None
+    assert missing == []
+
+    # List of blank / whitespace strings
+    resolved, missing = _resolve_allowlist_user_ids({"respond_member_group_list": ["", "  ", "\t"]}, client)
+    assert resolved is None
+    assert missing == []
+
+
+def test_resolve_allowlist_strips_valid_entries():
+    client = MagicMock()
+    client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U12345"}}
+
+    resolved, missing = _resolve_allowlist_user_ids(
+        {"respond_member_group_list": ["  user@example.com  ", ""]},
+        client,
+    )
+    assert resolved == ["U12345"]
+    assert missing == []

--- a/backend/tests/unit/onyx/onyxbot/slack/test_slack_allowlist.py
+++ b/backend/tests/unit/onyx/onyxbot/slack/test_slack_allowlist.py
@@ -18,7 +18,9 @@ def test_resolve_allowlist_empty_or_blank_returns_none():
 
 def test_resolve_allowlist_strips_valid_entries():
     client = MagicMock()
-    client.users_lookupByEmail.return_value = {"ok": True, "user": {"id": "U12345"}}
+    mock_user_resp = MagicMock()
+    mock_user_resp.data = {"ok": True, "user": {"id": "U12345"}}
+    client.users_lookupByEmail.return_value = mock_user_resp
 
     resolved, missing = _resolve_allowlist_user_ids(
         {"respond_member_group_list": ["  user@example.com  ", ""]},
@@ -26,3 +28,4 @@ def test_resolve_allowlist_strips_valid_entries():
     )
     assert resolved == ["U12345"]
     assert missing == []
+

--- a/backend/tests/unit/onyx/server/test_persona_avatar_api.py
+++ b/backend/tests/unit/onyx/server/test_persona_avatar_api.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock, patch
+import pytest
+from onyx.server.features.persona.api import get_persona_avatar
+from onyx.error_handlers import OnyxError
+
+
+def test_get_persona_avatar_handles_none_user():
+    request = MagicMock()
+    request.headers.get.return_value = None
+    db_session = MagicMock()
+
+    with patch("onyx.server.features.persona.api.get_persona_by_id", side_effect=ValueError("Not found")):
+        with pytest.raises(OnyxError) as exc_info:
+            get_persona_avatar(
+                persona_id=999,
+                request=request,
+                user=None,
+                db_session=db_session,
+            )
+        assert exc_info.value.status_code == 404

--- a/backend/tests/unit/onyx/server/test_persona_avatar_api.py
+++ b/backend/tests/unit/onyx/server/test_persona_avatar_api.py
@@ -1,10 +1,12 @@
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 import pytest
+from onyx.configs.constants import FileOrigin
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.persona.api import get_persona_avatar
-from onyx.error_handlers import OnyxError
 
 
-def test_get_persona_avatar_handles_none_user():
+def test_get_persona_avatar_not_found():
     request = MagicMock()
     request.headers.get.return_value = None
     db_session = MagicMock()
@@ -18,3 +20,55 @@ def test_get_persona_avatar_handles_none_user():
                 db_session=db_session,
             )
         assert exc_info.value.status_code == 404
+
+
+def test_get_persona_avatar_private_anonymous_rejected():
+    request = MagicMock()
+    request.headers.get.return_value = None
+    db_session = MagicMock()
+
+    mock_persona = MagicMock()
+    mock_persona.is_public = False
+    mock_persona.uploaded_image_id = "img-123"
+
+    with patch("onyx.server.features.persona.api.get_persona_by_id", return_value=mock_persona):
+        with pytest.raises(OnyxError) as exc_info:
+            get_persona_avatar(
+                persona_id=1,
+                request=request,
+                user=None,
+                db_session=db_session,
+            )
+        assert exc_info.value.status_code == 404
+
+
+def test_get_persona_avatar_public_anonymous_success():
+    request = MagicMock()
+    request.headers.get.return_value = None
+    db_session = MagicMock()
+
+    mock_persona = MagicMock()
+    mock_persona.is_public = True
+    mock_persona.uploaded_image_id = "img-123"
+
+    mock_file_record = MagicMock()
+    mock_file_record.file_origin = FileOrigin.CHAT_UPLOAD
+    mock_file_record.file_type = "image/png"
+
+    mock_file_store = MagicMock()
+    mock_file_store.read_file.return_value = BytesIO(b"png-data")
+
+    with (
+        patch("onyx.server.features.persona.api.get_persona_by_id", return_value=mock_persona),
+        patch("onyx.server.features.persona.api.get_filerecord_by_file_id_optional", return_value=mock_file_record),
+        patch("onyx.server.features.persona.api.get_default_file_store", return_value=mock_file_store),
+    ):
+        response = get_persona_avatar(
+            persona_id=1,
+            request=request,
+            user=None,
+            db_session=db_session,
+        )
+        assert response.status_code == 200
+        assert response.media_type == "image/png"
+


### PR DESCRIPTION
### Summary
This PR addresses two Slack bot and persona accessibility issues:
1. **OnyxBot Channel Member Filter Sanitization & Visibility** (Fixes #14458, #14460): When a Slack channel configuration has `respond_member_group_list` containing empty strings, whitespace, or invalid blanks (e.g. `[""]`), OnyxBot previously treated the allowlist as configured, failed all user lookups, and silently dropped all incoming messages and DMs. `_resolve_allowlist_user_ids` and channel creation endpoints now strip whitespace and filter out blank strings before resolution. Additionally, `respond_in_thread_or_channel` now properly respects `send_as_ephemeral` so configured non-ephemeral responses are posted to the channel.
2. **Persona Avatar Public Retrieval for Anonymous Users** (Fixes #14399): The `GET /{persona_id}/avatar` endpoint previously required `Permission.BASIC_ACCESS` via an authenticated session, blocking unauthenticated users in anonymous chat from seeing customized agent avatars. Switched to `user: User | None = Depends(optional_user)` allowing public personas to serve their avatars to anonymous chat sessions.

### Changes
- **`backend/onyx/onyxbot/slack/handlers/handle_message.py`**: Clean whitespace and filter blank items in `_resolve_allowlist_user_ids`.
- **`backend/onyx/onyxbot/slack/utils.py`**: Read and respect `send_as_ephemeral` in `respond_in_thread_or_channel`.
- **`backend/onyx/server/manage/slack_bot.py`**: Clean `respond_member_group_list` when creating/updating channel configurations.
- **`backend/onyx/server/features/persona/api.py`**: Use `optional_user` in `get_persona_avatar` endpoint.
- **`backend/tests/unit/onyx/onyxbot/slack/test_slack_allowlist.py`**: Unit tests verifying allowlist resolution with empty, whitespace-only, and mixed entries.
- **`backend/tests/unit/onyx/server/test_persona_avatar_api.py`**: Unit tests verifying `get_persona_avatar` works gracefully with `user=None`.

### Verification
- Tested allowlist resolution returns `None` for empty/blank lists to keep channel open.
- Tested avatar endpoint behavior with unauthenticated callers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack allowlists with blank entries blocking bot responses (#14458, #14460) and lets anonymous users fetch public persona avatars (#14399).

**Fixes**
- Trims and filters `respond_member_group_list` entries when configuring channels and resolving allowlist user IDs, so a blank list is treated as unrestricted.
- Makes Slack responses respect the `send_as_ephemeral` setting instead of always using ephemeral messages.
- Removes the authentication requirement from the persona avatar endpoint; public personas serve avatars to anonymous chat sessions, while private personas still return 404.

<sup>Written for commit 341fe3ab44f06d9d6ee4fee674b0728e8f8c45c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

