### PR TITLE
feat: add RustFS connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -285,6 +285,7 @@ class DocumentSource(str, Enum):
     WIKIPEDIA = "wikipedia"
     ASANA = "asana"
     S3 = "s3"
+    RUSTFS = "rustfs"
     R2 = "r2"
     GOOGLE_CLOUD_STORAGE = "google_cloud_storage"
     OCI_STORAGE = "oci_storage"
@@ -342,6 +343,7 @@ class NotificationType(str, Enum):
 class BlobType(str, Enum):
     R2 = "r2"
     S3 = "s3"
+    RUSTFS = "rustfs"
     GOOGLE_CLOUD_STORAGE = "google_cloud_storage"
     OCI_STORAGE = "oci_storage"
 
@@ -806,6 +808,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.WIKIPEDIA: "Encyclopedia articles",
     DocumentSource.ASANA: "Tasks and project management",
     DocumentSource.S3: "Cloud-stored files and objects",
+    DocumentSource.RUSTFS: "Cloud-stored files and objects",
     DocumentSource.R2: "Cloud-stored files and objects",
     DocumentSource.GOOGLE_CLOUD_STORAGE: "Cloud-stored files and objects",
     DocumentSource.OCI_STORAGE: "Cloud-stored files and objects",

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -46,7 +46,10 @@ from onyx.connectors.models import (
 from onyx.file_processing.extract_file_text import extract_text_and_images, get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.image_utils import store_image_and_create_section
+from onyx.server.security.models import web_connector_ssrf_enforced
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException, validate_outbound_http_url
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
@@ -67,6 +70,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         batch_size: int = INDEX_BATCH_SIZE,
         european_residency: bool = False,
         region_name: str | None = None,
+        endpoint_url: str | None = None,
     ) -> None:
         self.bucket_type: BlobType = BlobType(bucket_type)
         self.bucket_name = bucket_name.strip()
@@ -83,6 +87,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         self.region_name: str | None = (
             region_name.strip() if region_name and region_name.strip() else None
         )
+        self.endpoint_url = endpoint_url
 
     def set_allow_images(  # ty: ignore[invalid-method-override]
         self, allow_images: bool
@@ -113,12 +118,29 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         except Exception as e:
             logger.warning("Failed to detect bucket region via head_bucket: %s", e)
 
+    def _validated_rustfs_endpoint(self) -> str:
+        if not self.endpoint_url:
+            raise ConnectorValidationError("A RustFS endpoint URL is required.")
+
+        enforce_ssrf = web_connector_ssrf_enforced(
+            get_security_settings().ssrf_protection_level
+        )
+        try:
+            return validate_outbound_http_url(
+                self.endpoint_url,
+                allow_private_network=not enforce_ssrf,
+                block_link_local_only=not enforce_ssrf,
+            ).rstrip("/")
+        except (SSRFException, ValueError) as e:
+            raise ConnectorValidationError(f"Invalid RustFS endpoint URL: {e}") from e
+
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         """Checks for boto3 credentials based on the bucket type.
         (1) R2: Access Key ID, Secret Access Key, Account ID
         (2) S3: AWS Access Key ID, AWS Secret Access Key or IAM role or Assume Role
-        (3) GOOGLE_CLOUD_STORAGE: Access Key ID, Secret Access Key, Project ID
-        (4) OCI_STORAGE: Namespace, Region, Access Key ID, Secret Access Key
+        (3) RUSTFS: Access Key, Secret Key, custom endpoint
+        (4) GOOGLE_CLOUD_STORAGE: Access Key ID, Secret Access Key, Project ID
+        (5) OCI_STORAGE: Namespace, Region, Access Key ID, Secret Access Key
 
         For each bucket type, the method initializes the appropriate S3 client:
         - R2: Uses Cloudflare R2 endpoint with S3v4 signature
@@ -223,6 +245,22 @@ class BlobStorageConnector(LoadConnector, PollConnector):
             # NOTE: the client region actually doesn't matter for accessing the bucket
             self._detect_bucket_region()
 
+        elif self.bucket_type == BlobType.RUSTFS:
+            if not all(credentials.get(key) for key in ("access_key", "secret_key")):
+                raise ConnectorMissingCredentialError("RustFS")
+
+            self.s3_client = boto3.client(
+                "s3",
+                endpoint_url=self._validated_rustfs_endpoint(),
+                aws_access_key_id=credentials["access_key"],
+                aws_secret_access_key=credentials["secret_key"],
+                region_name=self.region_name or "us-east-1",
+                config=Config(
+                    signature_version="s3v4",
+                    s3={"addressing_style": "path"},
+                ),
+            )
+
         elif self.bucket_type == BlobType.GOOGLE_CLOUD_STORAGE:
             if not all(
                 credentials.get(key) for key in ["access_key_id", "secret_access_key"]
@@ -313,6 +351,9 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         # NOTE: We store the object dashboard URL instead of the actual object URL
         # This is because the actual object URL requires S3 client authentication
         # Accessing through the browser will always return an unauthorized error
+
+        if self.bucket_type == BlobType.RUSTFS:
+            return ""
 
         if self.s3_client is None:
             raise ConnectorMissingCredentialError("Blob storage")

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -164,6 +164,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.blob.connector",
         class_name="BlobStorageConnector",
     ),
+    DocumentSource.RUSTFS: ConnectorMapping(
+        module_path="onyx.connectors.blob.connector",
+        class_name="BlobStorageConnector",
+    ),
     DocumentSource.R2: ConnectorMapping(
         module_path="onyx.connectors.blob.connector",
         class_name="BlobStorageConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -45,6 +45,7 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.WIKIPEDIA: "Wikipedia.png",
     DocumentSource.ASANA: "Asana.png",
     DocumentSource.S3: "S3.png",
+    DocumentSource.RUSTFS: "S3.png",
     DocumentSource.R2: "R2.png",
     DocumentSource.GOOGLE_CLOUD_STORAGE: "GoogleCloudStorage.png",
     DocumentSource.OCI_STORAGE: "OCI.png",

--- a/backend/tests/unit/onyx/connectors/blob/test_blob_connector_rustfs.py
+++ b/backend/tests/unit/onyx/connectors/blob/test_blob_connector_rustfs.py
@@ -1,0 +1,116 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.configs.constants import BlobType
+from onyx.connectors.blob.connector import BlobStorageConnector
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.utils.url import SSRFException
+
+
+def _make_connector(endpoint_url: str = "http://rustfs:9000/") -> BlobStorageConnector:
+    return BlobStorageConnector(
+        bucket_type=BlobType.RUSTFS.value,
+        bucket_name="documents",
+        prefix="research",
+        endpoint_url=endpoint_url,
+        region_name="us-east-1",
+    )
+
+
+def test_rustfs_uses_custom_endpoint_and_path_style() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "onyx.connectors.blob.connector.web_connector_ssrf_enforced",
+            return_value=False,
+        ),
+        patch(
+            "onyx.connectors.blob.connector.validate_outbound_http_url",
+            return_value="http://rustfs:9000/",
+        ) as mock_validate,
+        patch("onyx.connectors.blob.connector.boto3.client") as mock_client,
+    ):
+        connector.load_credentials(
+            {"access_key": "rustfs-access-key", "secret_key": "rustfs-secret-key"}
+        )
+
+    mock_validate.assert_called_once_with(
+        "http://rustfs:9000/",
+        allow_private_network=True,
+        block_link_local_only=True,
+    )
+    _, kwargs = mock_client.call_args
+    assert kwargs["endpoint_url"] == "http://rustfs:9000"
+    assert kwargs["region_name"] == "us-east-1"
+    assert kwargs["config"].s3["addressing_style"] == "path"
+
+
+@pytest.mark.parametrize("missing_key", ["access_key", "secret_key"])
+def test_rustfs_requires_both_credentials(missing_key: str) -> None:
+    credentials = {
+        "access_key": "rustfs-access-key",
+        "secret_key": "rustfs-secret-key",
+    }
+    del credentials[missing_key]
+
+    with pytest.raises(ConnectorMissingCredentialError):
+        _make_connector().load_credentials(credentials)
+
+
+def test_rustfs_requires_an_endpoint() -> None:
+    with pytest.raises(ConnectorValidationError, match="endpoint URL is required"):
+        _make_connector(endpoint_url="").load_credentials(
+            {"access_key": "key", "secret_key": "secret"}
+        )
+
+
+def test_rustfs_rejects_unsafe_endpoint() -> None:
+    with (
+        patch(
+            "onyx.connectors.blob.connector.web_connector_ssrf_enforced",
+            return_value=True,
+        ),
+        patch(
+            "onyx.connectors.blob.connector.validate_outbound_http_url",
+            side_effect=SSRFException("Access to internal/private IP is not allowed."),
+        ),
+        pytest.raises(ConnectorValidationError, match="Invalid RustFS endpoint URL"),
+    ):
+        _make_connector(endpoint_url="http://169.254.169.254").load_credentials(
+            {"access_key": "key", "secret_key": "secret"}
+        )
+
+
+def test_rustfs_poll_skips_unchanged_objects() -> None:
+    connector = _make_connector()
+    client = MagicMock()
+    connector.s3_client = client
+    now = datetime.now(timezone.utc)
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Contents": [
+                {
+                    "Key": "research/unchanged.pdf",
+                    "LastModified": now - timedelta(hours=2),
+                }
+            ]
+        }
+    ]
+
+    assert (
+        list(
+            connector.poll_source(
+                (now - timedelta(hours=1)).timestamp(),
+                now.timestamp(),
+            )
+        )
+        == []
+    )
+    client.get_object.assert_not_called()
+
+
+def test_rustfs_does_not_expose_private_object_links() -> None:
+    assert _make_connector()._get_blob_link("research/paper.pdf") == ""

--- a/backend/tests/unit/onyx/connectors/test_connector_factory.py
+++ b/backend/tests/unit/onyx/connectors/test_connector_factory.py
@@ -79,6 +79,7 @@ class TestConnectorMappingValidation:
         """Test that all blob storage sources map to the same connector."""
         blob_sources = [
             DocumentSource.S3,
+            DocumentSource.RUSTFS,
             DocumentSource.R2,
             DocumentSource.GOOGLE_CLOUD_STORAGE,
             DocumentSource.OCI_STORAGE,

--- a/docs/rustfs-connector.md
+++ b/docs/rustfs-connector.md
@@ -1,0 +1,74 @@
+# RustFS connector
+
+The RustFS connector indexes objects from an S3-compatible RustFS bucket. It
+uses Onyx's existing file extraction and indexing pipeline.
+
+## Configure
+
+Create a RustFS connector in the Onyx administration UI and provide:
+
+- **Endpoint URL**: The RustFS S3 API endpoint, including `http://` or
+  `https://`.
+- **Bucket Name**: The source bucket.
+- **Prefix**: An optional object-key prefix.
+- **Region**: The signing region. The default is `us-east-1`.
+- **Access Key** and **Secret Key**: Credentials for a dedicated RustFS user.
+
+The connector uses path-style S3 addressing. The endpoint must be reachable
+from the Onyx background workers.
+
+Onyx applies its outbound-request security policy to the endpoint. The default
+policy blocks private network addresses. An operator can relax connector URL
+validation when RustFS runs on a trusted private network. Link-local and cloud
+metadata addresses remain blocked.
+
+## Permissions
+
+Use credentials with read-only access to the configured bucket and prefix. The
+equivalent S3 permissions are:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::documents"],
+      "Condition": {
+        "StringLike": {"s3:prefix": ["research/*"]}
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3:::documents/research/*"]
+    }
+  ]
+}
+```
+
+The connector does not require write or delete permission.
+
+## Indexing behavior
+
+The connector lists objects under the configured prefix. Initial indexing
+processes all matching objects. Scheduled polling uses each object's
+`LastModified` value to process new and modified objects. Folder markers ending
+in `/` are ignored.
+
+Object links are not exposed because RustFS endpoints and buckets are commonly
+private. Onyx still provides citations to the indexed document.
+
+Objects larger than `BLOB_STORAGE_SIZE_THRESHOLD` are skipped. Repeated object
+listing can become expensive for very large prefixes.
+
+## Test
+
+Run the focused connector tests from the repository root:
+
+```bash
+uv run pytest -q \
+  backend/tests/unit/onyx/connectors/blob/test_blob_connector_rustfs.py \
+  backend/tests/unit/onyx/connectors/test_connector_factory.py
+```

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -1534,6 +1534,51 @@ For example, specifying .*-alerts as a "channel to exclude" will cause the conne
     advanced_values: [],
     overrideDefaultFreq: 60 * 60 * 24,
   },
+  rustfs: {
+    description: "Configure RustFS connector",
+    values: [
+      {
+        type: "text",
+        query: "Enter the RustFS endpoint URL:",
+        label: "Endpoint URL",
+        name: "endpoint_url",
+        description: "For example: http://rustfs:9000",
+        optional: false,
+      },
+      {
+        type: "text",
+        query: "Enter the bucket name:",
+        label: "Bucket Name",
+        name: "bucket_name",
+        optional: false,
+      },
+      {
+        type: "text",
+        query: "Enter the prefix:",
+        label: "Prefix",
+        name: "prefix",
+        optional: true,
+      },
+      {
+        type: "text",
+        query: "Enter the S3 region:",
+        label: "Region",
+        name: "region_name",
+        default: "us-east-1",
+        optional: false,
+      },
+      {
+        type: "text",
+        label: "Bucket Type",
+        name: "bucket_type",
+        optional: false,
+        default: "rustfs",
+        hidden: true,
+      },
+    ],
+    advanced_values: [],
+    overrideDefaultFreq: 60 * 60,
+  },
   r2: {
     description: "Configure R2 connector",
     values: [
@@ -2317,6 +2362,14 @@ export interface S3Config {
   bucket_type: "s3";
   bucket_name: string;
   prefix: string;
+}
+
+export interface RustFSConfig {
+  bucket_type: "rustfs";
+  endpoint_url: string;
+  bucket_name: string;
+  prefix: string;
+  region_name: string;
 }
 
 export interface R2Config {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -205,6 +205,11 @@ export interface S3CredentialJson {
   aws_role_arn?: string;
 }
 
+export interface RustFSCredentialJson {
+  access_key: string;
+  secret_key: string;
+}
+
 export interface GCSCredentialJson {
   access_key_id: string;
   secret_access_key: string;
@@ -475,6 +480,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
       },
     ],
   } as CredentialTemplateWithAuth<S3CredentialJson>,
+  rustfs: {
+    access_key: "",
+    secret_key: "",
+  } as RustFSCredentialJson,
   r2: {
     account_id: "",
     r2_access_key_id: "",
@@ -668,6 +677,10 @@ export const credentialDisplayNames: Record<string, string> = {
   aws_secret_access_key: "AWS Secret Access Key",
   aws_role_arn: "AWS Role ARN",
   authentication_method: "Authentication Method",
+
+  // RustFS
+  access_key: "RustFS Access Key",
+  secret_key: "RustFS Secret Key",
 
   // GCS
   access_key_id: "GCS Access Key ID",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -231,6 +231,11 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Storage,
     docs: `${DOCS_ADMINS_PATH}/connectors/official/s3`,
   },
+  rustfs: {
+    icon: S3Icon,
+    displayName: "RustFS",
+    category: SourceCategory.Storage,
+  },
   google_cloud_storage: {
     icon: GoogleStorageIcon,
     displayName: "Google Storage",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -637,6 +637,7 @@ export enum ValidSources {
   Mediawiki = "mediawiki",
   Asana = "asana",
   S3 = "s3",
+  RustFS = "rustfs",
   R2 = "r2",
   GoogleCloudStorage = "google_cloud_storage",
   Xenforo = "xenforo",


### PR DESCRIPTION
## Summary

- add RustFS as an S3-compatible storage source
- reuse the existing blob extraction and polling pipeline
- configure the endpoint with path-style S3v4 requests
- validate custom endpoints with the existing connector SSRF policy
- add admin UI configuration, credential fields, tests, and setup documentation

Closes #14479.
Supersedes #14480 (closed to rebuild from fresh main).

## Scope

Limited to RustFS registration and provider-specific client setup. No change to S3, R2, GCS, OCI, pruning, or indexing behavior. Object links omitted (private endpoints/buckets). Read-only ListBucket + GetObject.

## Testing

- uv run pytest -q backend/tests/unit/onyx/connectors/blob/test_blob_connector_rustfs.py backend/tests/unit/onyx/connectors/test_connector_factory.py (23 passed)
- uv run ty check backend/onyx/connectors/blob/connector.py backend/onyx/configs/constants.py backend/onyx/connectors/registry.py backend/onyx/onyxbot/slack/icons.py (pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RustFS as a new S3-compatible storage source. Onyx can now index RustFS buckets through the existing blob extraction and polling pipeline; existing storage sources behave the same. Closes #14479.

**New Features**
- Registers `rustfs` in the connector registry, `BlobType` enum, and admin UI source list.
- Requires `endpoint_url`, `access_key`, `secret_key`, and `bucket_name`; `prefix` is optional and region defaults to `us-east-1`.
- Configures the S3 client with path-style addressing and S3v4 signatures.
- Validates the endpoint with the existing SSRF policy; private and link-local addresses are blocked by default.
- Omits object links since RustFS buckets are typically private.
- Adds credential templates, setup documentation, and unit tests.

<sup>Written for commit 669dab2d96fa638547c742f344a697ead0326fa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

