### PR TITLE
fix(gitlab): fix code-file exclusions and stop re-embedding on every poll

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1385,6 +1385,16 @@ GITLAB_CONNECTOR_INCLUDE_CODE_FILES = (
     os.environ.get("GITLAB_CONNECTOR_INCLUDE_CODE_FILES", "").lower() == "true"
 )
 
+# Comma-separated glob patterns appended to the built-in GitLab code-file
+# exclude list. Patterns without a "/" match against any path segment
+# (so "node_modules" excludes at any depth); patterns with a "/" match
+# against the full path via fnmatch.
+GITLAB_CONNECTOR_EXCLUDE_PATTERNS = [
+    pattern.strip()
+    for pattern in os.environ.get("GITLAB_CONNECTOR_EXCLUDE_PATTERNS", "").split(",")
+    if pattern.strip()
+]
+
 # Typically set to http://localhost:3000 for OAuth connector development
 CONNECTOR_LOCALHOST_OVERRIDE = os.getenv("CONNECTOR_LOCALHOST_OVERRIDE")
 

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -10,6 +10,7 @@ import pytz
 from gitlab.v4.objects import Project
 
 from onyx.configs.app_configs import (
+    GITLAB_CONNECTOR_EXCLUDE_PATTERNS,
     GITLAB_CONNECTOR_INCLUDE_CODE_FILES,
     INDEX_BATCH_SIZE,
 )
@@ -36,13 +37,102 @@ T = TypeVar("T")
 
 logger = setup_logger()
 
-# List of directories/Files to exclude
-exclude_patterns = [
+# Default set of files and directories to exclude when indexing GitLab code
+# files. These are near-universally either vendored third-party code, machine-
+# generated output, or minified/built artifacts that add cost and noise to
+# retrieval (and inflate contextual-RAG LLM spend) without adding real signal.
+#
+# Patterns are matched via fnmatch. Patterns without a "/" are matched against
+# every path segment, so a bare directory name like "node_modules" excludes at
+# any depth. Patterns containing "/" are matched against the full path.
+#
+# Operators can extend this list via the GITLAB_CONNECTOR_EXCLUDE_PATTERNS
+# environment variable (comma-separated).
+DEFAULT_EXCLUDE_PATTERNS: list[str] = [
+    # Historical entries.
     "logs",
     ".github/",
     ".gitlab/",
     ".pre-commit-config.yaml",
+    # Vendored / third-party dependencies.
+    "node_modules",
+    "vendor",
+    "bower_components",
+    "third_party",
+    "third-party",
+    ".bundle",
+    # Build / distribution output.
+    "dist",
+    "build",
+    "out",
+    "target",
+    "public/assets",
+    "public/packs",
+    ".next",
+    ".nuxt",
+    ".turbo",
+    ".cache",
+    # Test / coverage output.
+    "coverage",
+    ".nyc_output",
+    "htmlcov",
+    # Minified assets.
+    "*.min.js",
+    "*.min.css",
+    "*.min.map",
+    "*.map",
+    # Lockfiles (unhelpful for retrieval, large diffs on every bump).
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lock",
+    "bun.lockb",
+    "Gemfile.lock",
+    "Cargo.lock",
+    "poetry.lock",
+    "uv.lock",
+    "composer.lock",
+    "Pipfile.lock",
+    # Machine-generated code (Protobuf, gRPC).
+    "*_pb.rb",
+    "*_pb2.py",
+    "*_pb2_grpc.py",
+    "*.pb.go",
+    "*_pb.js",
+    "*_pb.ts",
+    "*.pb.cc",
+    "*.pb.h",
+    # Binary / non-text assets that don't decode meaningfully.
+    "*.png",
+    "*.jpg",
+    "*.jpeg",
+    "*.gif",
+    "*.webp",
+    "*.ico",
+    "*.svg",
+    "*.pdf",
+    "*.zip",
+    "*.tar",
+    "*.tar.gz",
+    "*.tgz",
+    "*.7z",
+    "*.woff",
+    "*.woff2",
+    "*.ttf",
+    "*.eot",
+    "*.mp3",
+    "*.mp4",
+    "*.mov",
+    # Runtime state.
+    "tmp",
+    ".DS_Store",
 ]
+
+# The effective exclude list is the built-in defaults plus any operator
+# overrides supplied via GITLAB_CONNECTOR_EXCLUDE_PATTERNS.
+exclude_patterns: list[str] = DEFAULT_EXCLUDE_PATTERNS + list(
+    GITLAB_CONNECTOR_EXCLUDE_PATTERNS
+)
 
 
 def _batch_gitlab_objects(git_objs: Iterable[T], batch_size: int) -> Iterator[list[T]]:
@@ -111,9 +201,31 @@ def _convert_issue_to_document(issue: Any) -> Document:
     return doc
 
 
+def _looks_like_binary(data: bytes, sample_size: int = 8192) -> bool:
+    """Heuristic to detect binary content that shouldn't be indexed as text.
+
+    Checks a leading sample for:
+      - A NUL byte (definitive signal of binary content in text formats).
+      - A high proportion (>30%) of bytes outside the printable ASCII / common
+        whitespace range, which reliably flags encoded images, fonts, archives
+        etc. even when they lack NUL bytes.
+
+    UTF-8 encoded text of any language passes because valid multi-byte
+    sequences are still counted as "text-like" per byte on average.
+    """
+    if not data:
+        return False
+    sample = data[:sample_size]
+    if b"\x00" in sample:
+        return True
+    text_bytes = set(range(0x20, 0x7F)) | {0x09, 0x0A, 0x0D, 0x0C}
+    non_text = sum(1 for b in sample if b not in text_bytes and b < 0x80)
+    return (non_text / len(sample)) > 0.30
+
+
 def _convert_code_to_document(
     project: Project, file: Any, url: str, projectName: str, projectOwner: str
-) -> Document:
+) -> Document | None:
     # Dynamically get the default branch from the project object
     default_branch = project.default_branch
 
@@ -122,10 +234,22 @@ def _convert_code_to_document(
         file_path=file["path"],
         ref=default_branch,  # Use the default branch
     )
+    raw_bytes = file_content_obj.decode()
+    if _looks_like_binary(raw_bytes):
+        # Skip binary blobs (images, fonts, archives, compiled artifacts).
+        # The extension-based exclude list catches most of these up front,
+        # but this is the last line of defense against binaries slipping
+        # through with unrecognized extensions.
+        logger.debug(
+            "Skipping likely-binary GitLab file %s", file.get("path", "<unknown>")
+        )
+        return None
     try:
-        file_content = file_content_obj.decode().decode("utf-8")
+        file_content = raw_bytes.decode("utf-8")
     except UnicodeDecodeError:
-        file_content = file_content_obj.decode().decode("latin-1")
+        # Fall back to latin-1 for legitimately text-encoded files that use
+        # a legacy single-byte encoding. Guarded by the binary check above.
+        file_content = raw_bytes.decode("latin-1")
 
     # Construct the file URL dynamically using the default branch
     file_url = (
@@ -146,8 +270,31 @@ def _convert_code_to_document(
 
 
 def _should_exclude(path: str) -> bool:
-    """Check if a path matches any of the exclude patterns."""
-    return any(fnmatch.fnmatch(path, pattern) for pattern in exclude_patterns)
+    """Check if a path matches any of the exclude patterns.
+
+    Matching rules:
+      - Patterns containing "/" match against the full path via fnmatch, and
+        also against anything nested under it. Trailing-slash patterns like
+        ".github/" are normalized to ".github" and treated as directory-name
+        patterns.
+      - Patterns without "/" match against any path segment, so a bare
+        directory or file name (e.g. "node_modules", "*.min.js") excludes
+        at any depth in the tree.
+    """
+    segments = path.split("/")
+    for raw_pattern in exclude_patterns:
+        pattern = raw_pattern.rstrip("/")
+        if not pattern:
+            continue
+        if "/" in pattern:
+            # Match the directory entry itself and everything under it, so
+            # "public/assets" excludes "public/assets/main.css" too.
+            if fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(path, f"{pattern}/*"):
+                return True
+            continue
+        if any(fnmatch.fnmatch(segment, pattern) for segment in segments):
+            return True
+    return False
 
 
 class GitlabConnector(LoadConnector, PollConnector):
@@ -199,15 +346,15 @@ class GitlabConnector(LoadConnector, PollConnector):
                             continue
 
                         if file["type"] == "blob":
-                            code_doc_batch.append(
-                                _convert_code_to_document(
-                                    project,
-                                    file,
-                                    self.gitlab_client.url,
-                                    self.project_name,
-                                    self.project_owner,
-                                )
+                            code_doc = _convert_code_to_document(
+                                project,
+                                file,
+                                self.gitlab_client.url,
+                                self.project_name,
+                                self.project_owner,
                             )
+                            if code_doc is not None:
+                                code_doc_batch.append(code_doc)
                         elif file["type"] == "tree":
                             queue.append(file["path"])
 

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -7,6 +7,7 @@ from typing import Any, TypeVar
 
 import gitlab
 import pytz
+from gitlab.exceptions import GitlabError, GitlabGetError
 from gitlab.v4.objects import Project
 
 from onyx.configs.app_configs import (
@@ -134,6 +135,12 @@ exclude_patterns: list[str] = DEFAULT_EXCLUDE_PATTERNS + list(
     GITLAB_CONNECTOR_EXCLUDE_PATTERNS
 )
 
+# Upper bound on commits a single poll will diff. Above this, the poll falls back
+# to a full tree walk: many commits usually mean a wide change set, and the walk
+# costs fewer API calls than diffing every commit. Also caps the very first poll,
+# which arrives with a window starting at the epoch.
+MAX_POLL_COMMITS = 100
+
 
 def _batch_gitlab_objects(git_objs: Iterable[T], batch_size: int) -> Iterator[list[T]]:
     it = iter(git_objs)
@@ -223,6 +230,48 @@ def _looks_like_binary(data: bytes, sample_size: int = 8192) -> bool:
     return (non_text / len(sample)) > 0.30
 
 
+def _decode_file_content(raw_bytes: bytes) -> str:
+    try:
+        return raw_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        # Fall back to latin-1 for legitimately text-encoded files that use
+        # a legacy single-byte encoding. Guarded by the binary check above.
+        return raw_bytes.decode("latin-1")
+
+
+def _build_code_document(
+    blob_id: str,
+    file_name: str,
+    file_path: str,
+    file_content: str,
+    url: str,
+    project_name: str,
+    project_owner: str,
+    default_branch: str,
+    doc_updated_at: datetime | None,
+) -> Document:
+    """Build a code-file Document.
+
+    `doc_updated_at` is the commit time that last touched the blob, or None when
+    the caller does not know it. Never use fetch time here: the indexing pipeline
+    treats an advanced timestamp as proof of change and then skips its content
+    hash check, so a fetch-time stamp re-embeds every file on every poll.
+    """
+    file_url = (
+        f"{url}/{project_owner}/{project_name}/-/blob/{default_branch}/{file_path}"
+    )
+
+    return Document(
+        id=blob_id,
+        sections=[TextSection(link=file_url, text=file_content)],
+        source=DocumentSource.GITLAB,
+        semantic_identifier=file_name,
+        doc_updated_at=doc_updated_at,
+        primary_owners=[],  # Add owners if needed
+        metadata={"type": "CodeFile"},
+    )
+
+
 def _convert_code_to_document(
     project: Project, file: Any, url: str, projectName: str, projectOwner: str
 ) -> Document | None:
@@ -244,29 +293,135 @@ def _convert_code_to_document(
             "Skipping likely-binary GitLab file %s", file.get("path", "<unknown>")
         )
         return None
+
+    return _build_code_document(
+        blob_id=file["id"],
+        file_name=file["name"],
+        file_path=file["path"],
+        file_content=_decode_file_content(raw_bytes),
+        url=url,
+        project_name=projectName,
+        project_owner=projectOwner,
+        default_branch=default_branch,
+        # A full walk has no per-file commit time. Leaving this unset lets the
+        # pipeline's content hash gate skip files whose bytes have not changed.
+        doc_updated_at=None,
+    )
+
+
+def _fetch_code_document_by_path(
+    project: Project,
+    file_path: str,
+    url: str,
+    project_name: str,
+    project_owner: str,
+    doc_updated_at: datetime | None,
+) -> Document | None:
+    """Fetch one blob by path. Returns None when the path is gone or is binary.
+
+    The blob id returned here is the same git object id that `repository_tree`
+    reports as `id`, so a document built by a poll and one built by a full walk
+    share an id. Pruning relies on that: it enumerates ids with `load_from_state`
+    and deletes indexed ids the walk does not produce.
+    """
+    default_branch = project.default_branch
+
     try:
-        file_content = raw_bytes.decode("utf-8")
-    except UnicodeDecodeError:
-        # Fall back to latin-1 for legitimately text-encoded files that use
-        # a legacy single-byte encoding. Guarded by the binary check above.
-        file_content = raw_bytes.decode("latin-1")
+        file_content_obj = project.files.get(file_path=file_path, ref=default_branch)
+    except GitlabGetError as e:
+        if e.response_code == 404:
+            # The branch moved between listing the commit and reading the blob.
+            logger.debug("Skipping %s: not present on %s", file_path, default_branch)
+            return None
+        raise
 
-    # Construct the file URL dynamically using the default branch
-    file_url = (
-        f"{url}/{projectOwner}/{projectName}/-/blob/{default_branch}/{file['path']}"
+    raw_bytes = file_content_obj.decode()
+    if _looks_like_binary(raw_bytes):
+        # Apply the same guard as the full walk, so a poll and a walk agree on
+        # which blobs produce a document.
+        logger.debug("Skipping likely-binary GitLab file %s", file_path)
+        return None
+
+    return _build_code_document(
+        blob_id=file_content_obj.blob_id,
+        file_name=file_content_obj.file_name,
+        file_path=file_path,
+        file_content=_decode_file_content(raw_bytes),
+        url=url,
+        project_name=project_name,
+        project_owner=project_owner,
+        default_branch=default_branch,
+        doc_updated_at=doc_updated_at,
     )
 
-    # Create and return a Document object
-    doc = Document(
-        id=file["id"],
-        sections=[TextSection(link=file_url, text=file_content)],
-        source=DocumentSource.GITLAB,
-        semantic_identifier=file["name"],
-        doc_updated_at=datetime.now().replace(tzinfo=timezone.utc),
-        primary_owners=[],  # Add owners if needed
-        metadata={"type": "CodeFile"},
-    )
-    return doc
+
+def _changed_paths_in_window(
+    project: Project, start: datetime, end: datetime
+) -> dict[str, datetime] | None:
+    """Map each path changed on the default branch in [start, end] to its commit time.
+
+    Returns None when the change set cannot be determined and the caller must fall
+    back to a full tree walk. An empty dict means the window held no commits, so
+    there is nothing to re-index.
+
+    Deleted paths are left out. `poll_source` cannot express a deletion — it only
+    yields documents that exist — so the pruning job removes those documents.
+    """
+    default_branch = project.default_branch
+    if not default_branch:
+        logger.warning("Project has no default branch; falling back to a full walk")
+        return None
+
+    try:
+        commits = list(
+            project.commits.list(
+                ref_name=default_branch,
+                since=start.isoformat(),
+                until=end.isoformat(),
+                page=1,
+                per_page=MAX_POLL_COMMITS,
+            )
+        )
+    except GitlabError:
+        logger.exception("Listing commits failed; falling back to a full walk")
+        return None
+
+    if len(commits) >= MAX_POLL_COMMITS:
+        logger.info(
+            "Window holds at least %s commits; falling back to a full walk",
+            MAX_POLL_COMMITS,
+        )
+        return None
+
+    path_to_updated_at: dict[str, datetime] = {}
+    for commit in commits:
+        # Fall back to the window end so an unparseable commit date still yields
+        # the file rather than dropping the change.
+        committed_at = _gitlab_datetime_to_utc(commit.committed_date) or end
+        try:
+            # For a merge commit GitLab diffs against the first parent, so a
+            # branch merged into the window contributes all of its changes even
+            # when its own commits are older than the window.
+            diffs = commit.diff(get_all=True)
+        except GitlabError:
+            logger.exception(
+                "Diffing commit %s failed; falling back to a full walk", commit.id
+            )
+            return None
+
+        for diff in diffs:
+            if diff.get("deleted_file"):
+                continue
+            # A rename reports the destination in new_path; the source path's
+            # document keeps its own id and the pruning job removes it.
+            path = diff.get("new_path") or diff.get("old_path")
+            if not path:
+                continue
+            known_at = path_to_updated_at.get(path)
+            if known_at is None or committed_at > known_at:
+                path_to_updated_at[path] = committed_at
+
+    return path_to_updated_at
 
 
 def _should_exclude(path: str) -> bool:
@@ -323,6 +478,88 @@ class GitlabConnector(LoadConnector, PollConnector):
         )
         return None
 
+    def _walk_all_code_files(self, project: Project) -> GenerateDocumentsOutput:
+        """Yield every blob on the default branch.
+
+        The pruning job calls `load_from_state` to enumerate the ids that still
+        exist and deletes any indexed id this walk does not produce. It must stay
+        complete, so a partial result here would delete live documents.
+        """
+        assert self.gitlab_client is not None
+
+        # Fetching using BFS as project.report_tree with recursion causing slow load
+        queue = deque([""])  # Start with the root directory
+        while queue:
+            current_path = queue.popleft()
+            files = project.repository_tree(path=current_path, all=True)
+            for file_batch in _batch_gitlab_objects(files, self.batch_size):
+                code_doc_batch: list[Document | HierarchyNode] = []
+                for file in file_batch:
+                    if _should_exclude(file["path"]):
+                        continue
+
+                    if file["type"] == "blob":
+                        code_doc = _convert_code_to_document(
+                            project,
+                            file,
+                            self.gitlab_client.url,
+                            self.project_name,
+                            self.project_owner,
+                        )
+                        if code_doc is not None:
+                            code_doc_batch.append(code_doc)
+                    elif file["type"] == "tree":
+                        queue.append(file["path"])
+
+                if code_doc_batch:
+                    yield code_doc_batch
+
+    def _fetch_changed_code_files(
+        self, project: Project, path_to_updated_at: dict[str, datetime]
+    ) -> GenerateDocumentsOutput:
+        """Yield only the blobs the poll window changed."""
+        assert self.gitlab_client is not None
+
+        paths = [
+            path for path in sorted(path_to_updated_at) if not _should_exclude(path)
+        ]
+        for path_batch in _batch_gitlab_objects(paths, self.batch_size):
+            code_doc_batch: list[Document | HierarchyNode] = []
+            for path in path_batch:
+                doc = _fetch_code_document_by_path(
+                    project,
+                    path,
+                    self.gitlab_client.url,
+                    self.project_name,
+                    self.project_owner,
+                    path_to_updated_at[path],
+                )
+                if doc is not None:
+                    code_doc_batch.append(doc)
+
+            if code_doc_batch:
+                yield code_doc_batch
+
+    def _fetch_code_files(
+        self, project: Project, start: datetime | None, end: datetime | None
+    ) -> GenerateDocumentsOutput:
+        if start is None or end is None:
+            yield from self._walk_all_code_files(project)
+            return
+
+        path_to_updated_at = _changed_paths_in_window(project, start, end)
+        if path_to_updated_at is None:
+            yield from self._walk_all_code_files(project)
+            return
+
+        logger.info(
+            "Poll window changed %s code file(s) in %s/%s",
+            len(path_to_updated_at),
+            self.project_owner,
+            self.project_name,
+        )
+        yield from self._fetch_changed_code_files(project, path_to_updated_at)
+
     def _fetch_from_gitlab(
         self, start: datetime | None = None, end: datetime | None = None
     ) -> GenerateDocumentsOutput:
@@ -334,32 +571,7 @@ class GitlabConnector(LoadConnector, PollConnector):
 
         # Fetch code files
         if self.include_code_files:
-            # Fetching using BFS as project.report_tree with recursion causing slow load
-            queue = deque([""])  # Start with the root directory
-            while queue:
-                current_path = queue.popleft()
-                files = project.repository_tree(path=current_path, all=True)
-                for file_batch in _batch_gitlab_objects(files, self.batch_size):
-                    code_doc_batch: list[Document | HierarchyNode] = []
-                    for file in file_batch:
-                        if _should_exclude(file["path"]):
-                            continue
-
-                        if file["type"] == "blob":
-                            code_doc = _convert_code_to_document(
-                                project,
-                                file,
-                                self.gitlab_client.url,
-                                self.project_name,
-                                self.project_owner,
-                            )
-                            if code_doc is not None:
-                                code_doc_batch.append(code_doc)
-                        elif file["type"] == "tree":
-                            queue.append(file["path"])
-
-                    if code_doc_batch:
-                        yield code_doc_batch
+            yield from self._fetch_code_files(project, start, end)
 
         if self.include_mrs:
             merge_requests = project.mergerequests.list(

--- a/backend/tests/unit/onyx/connectors/gitlab/test_code_file_filtering.py
+++ b/backend/tests/unit/onyx/connectors/gitlab/test_code_file_filtering.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.connectors.gitlab.connector import (
+    _looks_like_binary,
+    _should_exclude,
+    exclude_patterns,
+)
+
+
+class TestShouldExclude:
+    """Covers matcher behavior on the built-in DEFAULT_EXCLUDE_PATTERNS."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Vendored dependencies at any depth.
+            "node_modules/react/index.js",
+            "web/node_modules/react/index.js",
+            "packages/foo/node_modules/lodash/index.js",
+            "vendor/rails/activesupport.rb",
+            "backend/vendor/gems/foo.rb",
+            "bower_components/jquery/dist/jquery.js",
+            # Build output.
+            "dist/main.js",
+            "web/dist/main.js",
+            "backend/build/artifacts.tar",
+            "target/release/foo",
+            # Minified assets anywhere in the tree.
+            "assets/bootstrap.min.js",
+            "public/js/vendor.min.js",
+            "web/static/app.min.css",
+            "assets/main.min.map",
+            # Generated protobuf / gRPC.
+            "proto/gen/agent_services_pb.rb",
+            "app/rpc/executable_services_pb.rb",
+            "internal/gen/service.pb.go",
+            "python_gen/foo_pb2.py",
+            "python_gen/foo_pb2_grpc.py",
+            # Lockfiles.
+            "package-lock.json",
+            "web/package-lock.json",
+            "Gemfile.lock",
+            "backend/Cargo.lock",
+            # Binary/media assets.
+            "assets/logo.png",
+            "docs/screenshots/foo.jpg",
+            "static/font.woff2",
+            "media/intro.mp4",
+            # Legacy single-name entries still work.
+            "logs",
+            ".pre-commit-config.yaml",
+            # Legacy trailing-slash directory names match at any depth.
+            ".github/workflows/ci.yml",
+            "some/nested/.github/workflows/ci.yml",
+            ".gitlab/merge_request_templates/foo.md",
+        ],
+    )
+    def test_default_excludes_match(self, path: str) -> None:
+        assert _should_exclude(path), f"expected {path!r} to be excluded"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Actual source code.
+            "app/models/user.rb",
+            "app/controllers/api/v1/users_controller.rb",
+            "src/components/Button.tsx",
+            "backend/onyx/main.py",
+            "internal/service/foo.go",
+            # Files whose names contain but do not equal an excluded segment.
+            "app/models/vendor_details.rb",  # "vendor_details" != "vendor"
+            "docs/build_and_deploy.md",  # "build_and_deploy" != "build"
+            # Non-min .js.
+            "web/app.js",
+            "web/app.map.js",  # trailing .js, not .map
+            # README/Markdown.
+            "README.md",
+            "docs/architecture.md",
+        ],
+    )
+    def test_source_files_not_excluded(self, path: str) -> None:
+        assert not _should_exclude(path), f"expected {path!r} to be kept"
+
+    def test_bare_directory_name_matches_at_any_depth(self) -> None:
+        # Regression test: the previous fnmatch(path, "node_modules/*")
+        # implementation did NOT match nested node_modules folders.
+        assert _should_exclude("apps/web/node_modules/react/index.js")
+        assert _should_exclude("node_modules/react/index.js")
+
+    def test_slash_bearing_patterns_match_full_path(self) -> None:
+        # "public/assets" is a slash-bearing pattern -> full-path match.
+        assert _should_exclude("public/assets/main.css")
+        # But should NOT match segment-wise: a top-level "assets" file is kept.
+        assert not _should_exclude("assets/main.css")
+
+    def test_operator_can_extend_via_module_attribute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate GITLAB_CONNECTOR_EXCLUDE_PATTERNS by appending directly to
+        # the module-level list.
+        monkeypatch.setattr(
+            "onyx.connectors.gitlab.connector.exclude_patterns",
+            exclude_patterns + ["secrets", "*.custom_ext"],
+        )
+        assert _should_exclude("secrets/db.yml")
+        assert _should_exclude("app/config/foo.custom_ext")
+        # Sanity: unrelated files still pass.
+        assert not _should_exclude("app/models/user.rb")
+
+
+class TestLooksLikeBinary:
+    """Ensures we don't index arbitrary bytes as text via latin-1 fallback."""
+
+    def test_empty_returns_false(self) -> None:
+        assert not _looks_like_binary(b"")
+
+    def test_plain_ascii_text_is_not_binary(self) -> None:
+        assert not _looks_like_binary(b"def foo():\n    return 42\n")
+
+    def test_utf8_text_is_not_binary(self) -> None:
+        text = "def greet():\n    return 'héllo, 世界'\n"
+        assert not _looks_like_binary(text.encode("utf-8"))
+
+    def test_nul_byte_is_binary(self) -> None:
+        assert _looks_like_binary(b"MZ\x00\x00\x00some bytes")
+
+    def test_png_header_is_binary(self) -> None:
+        # First few bytes of the PNG magic number plus IHDR chunk marker.
+        png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR" + bytes(range(256)) * 4
+        assert _looks_like_binary(png)
+
+    def test_dense_non_text_bytes_are_binary(self) -> None:
+        # No NUL, but mostly control bytes -> should still be flagged.
+        payload = bytes(b for b in range(1, 32) if b not in (9, 10, 12, 13)) * 100
+        assert _looks_like_binary(payload)

--- a/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_code_files.py
+++ b/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_code_files.py
@@ -1,0 +1,308 @@
+"""Code-file behaviour of the GitLab connector.
+
+The connector used to walk the whole repository on every poll and stamp each
+file with the fetch time. The indexing pipeline reads an advanced
+`doc_updated_at` as proof of change and then skips its content hash gate, so
+every file was re-chunked and re-embedded on every poll. These tests pin the two
+fixes: a poll only yields files that commits in the window touched, and no code
+file ever carries a fetch-time stamp.
+"""
+
+import itertools
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from gitlab.exceptions import GitlabError, GitlabGetError
+
+from onyx.connectors.gitlab.connector import MAX_POLL_COMMITS, GitlabConnector
+from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.models import Document
+
+WINDOW_START = datetime(2026, 9, 5, 10, 0, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 9, 5, 12, 0, tzinfo=timezone.utc)
+COMMIT_TIME = "2026-09-05T11:00:00.000+00:00"
+DEFAULT_BRANCH = "main"
+
+
+def _blob(path: str, blob_id: str) -> dict[str, str]:
+    return {"id": blob_id, "name": path.split("/")[-1], "path": path, "type": "blob"}
+
+
+def _tree(path: str) -> dict[str, str]:
+    return {"id": f"tree-{path}", "name": path, "path": path, "type": "tree"}
+
+
+def _file_object(blob_id: str, path: str, content: bytes = b"file body") -> MagicMock:
+    obj = MagicMock()
+    obj.blob_id = blob_id
+    obj.file_name = path.split("/")[-1]
+    obj.file_path = path
+    obj.decode.return_value = content
+    return obj
+
+
+def _commit(
+    diffs: list[dict[str, Any]], committed_date: str = COMMIT_TIME
+) -> MagicMock:
+    commit = MagicMock()
+    commit.id = "abc123"
+    commit.committed_date = committed_date
+    commit.diff.return_value = diffs
+    return commit
+
+
+@pytest.fixture
+def project() -> MagicMock:
+    """A project whose tree holds two blobs under one subdirectory."""
+    project = MagicMock()
+    project.default_branch = DEFAULT_BRANCH
+
+    tree = {
+        "": [_blob("README.md", "blob-readme"), _tree("src")],
+        "src": [_blob("src/app.py", "blob-app")],
+    }
+    project.repository_tree.side_effect = lambda path, **_kwargs: tree[path]
+
+    blob_ids = {"README.md": "blob-readme", "src/app.py": "blob-app"}
+
+    def _get_file(file_path: str, **_kwargs: Any) -> MagicMock:
+        if file_path not in blob_ids:
+            raise GitlabGetError("404 File Not Found", response_code=404)
+        return _file_object(blob_ids[file_path], file_path)
+
+    project.files.get.side_effect = _get_file
+    project.commits.list.return_value = []
+    return project
+
+
+@pytest.fixture
+def connector(project: MagicMock) -> GitlabConnector:
+    connector = GitlabConnector(
+        project_owner="acme",
+        project_name="platform",
+        batch_size=10,
+        include_mrs=False,
+        include_issues=False,
+        include_code_files=True,
+    )
+    client = MagicMock()
+    client.url = "https://gitlab.example.com"
+    client.projects.get.return_value = project
+    connector.gitlab_client = client
+    return connector
+
+
+def _documents(batches: GenerateDocumentsOutput) -> list[Document]:
+    """Flatten batches to Documents. This connector yields no HierarchyNodes."""
+    return [doc for doc in itertools.chain(*batches) if isinstance(doc, Document)]
+
+
+def _poll(connector: GitlabConnector) -> list[Document]:
+    return _documents(
+        connector.poll_source(WINDOW_START.timestamp(), WINDOW_END.timestamp())
+    )
+
+
+def _walk(connector: GitlabConnector) -> list[Document]:
+    return _documents(connector.load_from_state())
+
+
+def test_poll_with_no_commits_yields_nothing(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """The regression that caused the bill: an idle window must cost nothing."""
+    project.commits.list.return_value = []
+
+    assert _poll(connector) == []
+    # No blob content was read, so no chunk reached the embedder.
+    project.files.get.assert_not_called()
+    project.repository_tree.assert_not_called()
+
+
+def test_poll_yields_only_changed_files_stamped_with_commit_time(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    project.commits.list.return_value = [
+        _commit([{"new_path": "src/app.py", "old_path": "src/app.py"}])
+    ]
+
+    docs = _poll(connector)
+
+    assert [doc.id for doc in docs] == ["blob-app"]
+    assert docs[0].doc_updated_at == datetime(2026, 9, 5, 11, 0, tzinfo=timezone.utc)
+    assert docs[0].semantic_identifier == "app.py"
+    assert docs[0].sections[0].link == (
+        "https://gitlab.example.com/acme/platform/-/blob/main/src/app.py"
+    )
+    # The untouched blob was never fetched.
+    assert project.files.get.call_count == 1
+
+
+def test_poll_omits_deleted_files(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """A deletion has no document to yield; pruning removes the indexed one."""
+    project.commits.list.return_value = [
+        _commit(
+            [
+                {
+                    "old_path": "src/gone.py",
+                    "new_path": "src/gone.py",
+                    "deleted_file": True,
+                },
+                {"old_path": "src/app.py", "new_path": "src/app.py"},
+            ]
+        )
+    ]
+
+    assert [doc.id for doc in _poll(connector)] == ["blob-app"]
+
+
+def test_poll_follows_a_rename_to_its_destination(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    project.commits.list.return_value = [
+        _commit(
+            [
+                {
+                    "old_path": "src/old_name.py",
+                    "new_path": "src/app.py",
+                    "renamed_file": True,
+                }
+            ]
+        )
+    ]
+
+    assert [doc.id for doc in _poll(connector)] == ["blob-app"]
+
+
+def test_poll_skips_a_blob_that_vanished_mid_poll(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """A moving branch 404s a path. That must not fail the whole attempt."""
+    project.commits.list.return_value = [
+        _commit(
+            [
+                {"new_path": "src/raced.py", "old_path": "src/raced.py"},
+                {"new_path": "src/app.py", "old_path": "src/app.py"},
+            ]
+        )
+    ]
+
+    assert [doc.id for doc in _poll(connector)] == ["blob-app"]
+
+
+def test_poll_skips_binary_blobs(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """A poll and a full walk must agree on which blobs produce a document."""
+    project.commits.list.return_value = [
+        _commit([{"new_path": "src/app.py", "old_path": "src/app.py"}])
+    ]
+    project.files.get.side_effect = lambda file_path, **_kwargs: _file_object(
+        "blob-app", file_path, content=b"\x89PNG\r\n\x1a\n\x00\x00binary"
+    )
+
+    assert _poll(connector) == []
+
+
+def test_poll_propagates_non_404_file_errors(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    project.commits.list.return_value = [
+        _commit([{"new_path": "src/app.py", "old_path": "src/app.py"}])
+    ]
+    project.files.get.side_effect = GitlabGetError("500 boom", response_code=500)
+
+    with pytest.raises(GitlabGetError):
+        _poll(connector)
+
+
+def test_poll_falls_back_to_full_walk_when_commit_listing_fails(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    project.commits.list.side_effect = GitlabError("gitlab is unhappy")
+
+    docs = _poll(connector)
+
+    assert sorted(doc.id for doc in docs) == ["blob-app", "blob-readme"]
+    # The fallback is the pre-existing walk, so it must not stamp fetch time.
+    assert all(doc.doc_updated_at is None for doc in docs)
+
+
+def test_poll_falls_back_to_full_walk_on_a_wide_change_set(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    project.commits.list.return_value = [
+        _commit([{"new_path": "src/app.py", "old_path": "src/app.py"}])
+    ] * MAX_POLL_COMMITS
+
+    assert sorted(doc.id for doc in _poll(connector)) == ["blob-app", "blob-readme"]
+
+
+def test_poll_falls_back_to_full_walk_without_a_default_branch(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    project.default_branch = None
+
+    docs = _poll(connector)
+
+    assert sorted(doc.id for doc in docs) == ["blob-app", "blob-readme"]
+    project.commits.list.assert_not_called()
+
+
+def test_load_from_state_still_yields_every_file(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """Pruning enumerates ids with this path, so it must stay complete."""
+    docs = _walk(connector)
+
+    assert sorted(doc.id for doc in docs) == ["blob-app", "blob-readme"]
+    project.commits.list.assert_not_called()
+
+
+def test_full_walk_never_stamps_fetch_time(connector: GitlabConnector) -> None:
+    """The fix: a fetch-time stamp disarms the pipeline's content hash gate."""
+    docs = _walk(connector)
+
+    assert docs
+    assert all(doc.doc_updated_at is None for doc in docs)
+
+
+def test_poll_queries_gitlab_with_the_window_and_paginates_diffs(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """Pin the API contract.
+
+    `commit.diff` forwards kwargs to `http_list`, which paginates only on
+    `get_all`. Without it a large commit returns one page and the poll silently
+    drops changed paths.
+    """
+    commit = _commit([{"new_path": "src/app.py", "old_path": "src/app.py"}])
+    project.commits.list.return_value = [commit]
+
+    _poll(connector)
+
+    commit.diff.assert_called_once_with(get_all=True)
+    _, kwargs = project.commits.list.call_args
+    assert kwargs["ref_name"] == DEFAULT_BRANCH
+    assert kwargs["since"] == WINDOW_START.isoformat()
+    assert kwargs["until"] == WINDOW_END.isoformat()
+    assert kwargs["per_page"] == MAX_POLL_COMMITS
+
+
+def test_poll_and_walk_agree_on_document_id(
+    connector: GitlabConnector, project: MagicMock
+) -> None:
+    """Pruning deletes indexed ids the walk does not produce, so ids must match."""
+    project.commits.list.return_value = [
+        _commit([{"new_path": "src/app.py", "old_path": "src/app.py"}])
+    ]
+    polled = {doc.id for doc in _poll(connector)}
+
+    project.commits.list.return_value = []
+    walked = {doc.id for doc in _walk(connector)}
+
+    assert polled <= walked


### PR DESCRIPTION
Head's up. This change is fully vibed. The GitLab code connector as-is was causing issues trying to index binary files, as well as doing a full repo index on every run ($$)


## Description

Two related fixes to GitLab code-file indexing. The connector was both indexing files it should never have touched and re-embedding every file it had already embedded.

### 1. Code-file exclusions never matched

`_should_exclude` used bare `fnmatch(path, pattern)`, which has no path semantics — so `.github/workflows/ci.yml` did **not** match `.github/`, and `logs/app.log` did **not** match `logs`. Only a top-level file named exactly `logs` or `.pre-commit-config.yaml` was ever excluded. The exclusion list was effectively dead code.

- Rewrites the matcher: patterns without `/` match any path segment (so `node_modules` excludes at any depth); patterns with `/` match the full path *and* anything nested under it; trailing slashes are normalised.
- Expands the defaults to cover vendored code, build output, lockfiles, generated protobuf/gRPC, and binary assets.
- Adds `_looks_like_binary` as a last line of defense for binaries with unrecognised extensions; `_convert_code_to_document` may now return `None` to skip them.
- Adds `GITLAB_CONNECTOR_EXCLUDE_PATTERNS` (comma-separated) so operators can extend the list.

### 2. Every code file was re-embedded on every poll

On one self-hosted instance: ~12.7k chunks re-embedded per attempt, ~31 attempts/day, against 4 genuinely-changed documents in 24h.

Two defects combined:

1. **`poll_source` ignored its time window for code files.** It passed `start`/`end` to `_fetch_from_gitlab`, but only the merge-request and issue blocks read them. The code-file block walked the whole tree and downloaded every blob, so a poll did the same work as a full sync.
2. **Code files were stamped `doc_updated_at=datetime.now()`.** `get_docs_to_update` treats an advanced timestamp as authoritative proof of change and *deliberately skips the content-hash gate* in that case. Since docprocessing runs with `ignore_time_skip=True`, that hash gate was the only thing between an unchanged file and the embedder — and the fetch-time stamp disarmed it.

The indexing pipeline is correct; it dedups before it embeds. The connector was defeating it.

Changes:

- Take `doc_updated_at` from the caller. A poll stamps the commit time that touched the file; a full walk leaves it unset so the content-hash gate can skip unchanged bytes.
- Filter a poll to paths that commits in the window changed. GitLab diffs a merge commit against its first parent, so a branch merged into the window contributes all of its changes even when its own commits predate the window.
- Fall back to the full walk whenever the change set can't be determined: no default branch, a failed API call, or a window holding at least `MAX_POLL_COMMITS` commits. That last case also covers the first poll, whose window starts at the epoch.
- Skip a blob that 404s mid-poll instead of failing the attempt (the `404 Commit Not Found` seen when the branch moves between listing a commit and reading a blob).
- Apply the binary guard to the poll path too, so a poll and a walk agree on which blobs produce a document.

## Notes for reviewers

- **`load_from_state` deliberately still yields every blob.** Pruning enumerates document ids through it (GitLab is not a `SlimConnector`, so `extract_ids_from_runnable_connector` falls to the `LoadConnector` branch) and deletes any indexed id the walk doesn't produce. A partial result there would delete live documents.
- **Deletions are unchanged.** `poll_source` cannot express a deletion — it only yields documents that exist — so pruning still handles them.
- **Config only, no migration.** `GITLAB_CONNECTOR_EXCLUDE_PATTERNS` is optional; unset preserves the built-in defaults. Document ids are unchanged, so no re-index is required — but existing indexes keep previously-indexed build output, lockfiles and binaries until the next prune.
- **Known gap:** a force-push whose rewritten commits fall outside the poll window is missed until the next prune or a manual re-index. `POLL_CONNECTOR_OFFSET` gives 30 minutes of overlap per window, which covers the ordinary cases.

## How Has This Been Tested?

Unit tests, in `backend/tests/unit/onyx/connectors/gitlab/`:

- `test_code_file_filtering.py` — the exclusion matcher and binary heuristic.
- `test_gitlab_code_files.py` (14 tests) — the poll path: the idle window (asserting `files.get` and `repository_tree` are never called, which is the actual cost fix), commit-time stamping, deletions, renames, binary blobs, the mid-poll 404, non-404 propagation, all three fallback paths, `load_from_state` completeness, and poll/walk document-id agreement.

One test pins an API contract: `commit.diff()` forwards kwargs to `http_list`, which paginates only on `get_all`. Without it a large commit returns one page and the poll silently drops changed paths. Verified against the python-gitlab 5.6.0 source rather than trusting the mock.

`uv run pytest backend/tests/unit/onyx/connectors/gitlab` — 66 passed. `ruff format`/`check` clean. `ty` reports only 4 pre-existing `pytz` `.replace(tzinfo=...)` errors in the merge-request/issue blocks, unchanged from main.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitLab code connector so its exclusion list actually matches nested paths and polls stop re-embedding every file in the repo. The old matcher never excluded anything beyond top-level files, and code files were stamped with fetch time, which disarmed the content-hash gate and sent the whole repo to the embedder on every poll; existing indexes keep previously-indexed build output, lockfiles, and binaries until the next prune, and this change is config-only with no migration required.

**Code-file exclusions**
- Bare patterns now match any path segment, so `node_modules` excludes at any depth; slash-bearing patterns match the full path and anything nested under it.
- Defaults now cover vendored code, build output, lockfiles, generated protobuf/gRPC, and binary assets.
- A binary-content heuristic skips blobs with unrecognized extensions instead of decoding them as junk text.
- `GITLAB_CONNECTOR_EXCLUDE_PATTERNS` lets operators extend the list without patching Python.

**Polling cost**
- Polls diff the default branch in the window and only fetch blobs the changed paths touch.
- `doc_updated_at` is the commit time on a poll; a full walk leaves it unset so the content-hash gate skips unchanged bytes.
- Falls back to a full walk when the change set can't be determined, including the first poll whose window starts at the epoch.
- A blob that 404s mid-poll is skipped instead of failing the attempt.
- A force-push whose rewritten commits fall outside the poll window is missed until the next prune or a manual re-index.

<sup>Written for commit cd3e02ec249788d40a16b2e6ac91f04b29f8516e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

