### PR TITLE
refactor(opal): Let `LineItemButton` props reach the row element

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -9,7 +9,7 @@ A composite component that wraps `Interactive.Stateful > Interactive.Container >
 ```
 Interactive.Stateful         <- selectVariant, state, interaction, onClick, href, ref
   └─ Interactive.Container   <- width, rounding
-       └─ ContentAction      <- withInteractive, padding
+       └─ ContentAction      <- padding
             ├─ Content       <- icon, title, description, sizePreset, variant, ...
             └─ rightChildren
 ```
@@ -18,8 +18,7 @@ The row renders as a focusable `<div role="button">` (with Enter/Space activatio
 native `<button>`, so interactive `rightChildren` such as action buttons don't produce invalid
 button-in-button nesting. With `href` it renders an anchor instead.
 
-`withInteractive` is always `true` and is not exposed. `padding` is forwarded to the inner
-`ContentAction`, on top of the row's own `p-1.5` inset.
+`padding` is forwarded to the inner `ContentAction`, on top of the row's own `p-1.5` inset.
 
 It is not an open `Spacing`: the prop is inherited from `ContentActionProps`, which narrows it to
 `0 | 0.5 | 1 | 2` — the four paddings `Interactive.Container` applies at its size presets, so that a
@@ -40,6 +39,23 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 | `group`         | `string`                           | —                | Interactive group key                             |
 | `ref`           | `React.Ref<HTMLElement>`           | —                | Forwarded ref                                     |
 | `disabled`      | `boolean`                          | `false`          | Disabled colors; suppresses the row's own click only — nested `rightChildren` stay clickable |
+
+### Row element
+
+These land on the row itself rather than on the content inside it. They are
+named individually because anything `LineItemButton` does not destructure goes
+to `ContentAction`, which never spreads onto a DOM node — a label or a handler
+left in that bag is silently dropped.
+
+| Prop                                                          | Type                                | Description                                     |
+| ------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- |
+| `aria-label` / `aria-labelledby` / `aria-describedby`          | `string`                            | Accessible name and description for the row     |
+| `onMouseEnter` / `onMouseLeave` / `onMouseMove` / `onMouseDown` | `MouseEventHandler<HTMLDivElement>`  | Mouse handlers, e.g. hover-to-open a flyout     |
+| `onPointerEnter` / `onPointerLeave`                            | `PointerEventHandler<HTMLDivElement>` | Pointer equivalents                             |
+
+`title` is deliberately *not* forwarded: it is the row's label to
+`ContentAction`, and forwarding it as the native attribute would put two
+meanings in one prop. Use `tooltip` for hover text.
 
 ### Sizing
 
@@ -63,7 +79,7 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 | `rightChildren` | `ReactNode`             | —              | Content after the label (e.g. action button) |
 | `color`         | `ColorTypes`            | `"interactive"` | Content colour mode. Defaults to `"interactive"`, which is what lets the row's hover / selected / disabled colours reach its title and icon — passing anything else opts out of that. `undefined` counts as not passing one. |
 
-All other `ContentAction` / `Content` props (`editable`, `onTitleChange`, `optional`, `auxIcon`, `tag`, etc.) are also passed through. Note: `withInteractive` is always `true` inside `LineItemButton` and cannot be overridden.
+All other `ContentAction` / `Content` props (`editable`, `onTitleChange`, `optional`, `auxIcon`, `tag`, etc.) are also passed through.
 
 ## Usage
 

--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -85,8 +85,7 @@ meanings in one prop. Use `tooltip` for hover text.
 | `variant`             | `ContentVariant`        | `"heading"`     | Content layout variant                                                                                                                                                                                                       |
 | `rightChildren`       | `ReactNode`             | —               | Content after the label (e.g. action button)                                                                                                                                                                                 |
 | `color`               | `ColorTypes`            | `"interactive"` | Content colour mode. Defaults to `"interactive"`, which is what lets the row's hover / selected / disabled colours reach its title and icon — passing anything else opts out of that. `undefined` counts as not passing one. |
-
-| `strikethrough` | `boolean` | `false` | Strike the label through, e.g. a row switched off |
+| `strikethrough`       | `boolean`               | `false`         | Strike the label through, e.g. a row switched off                                                                                                                                                                            |
 
 That table is the entire content surface. The remaining `ContentAction` /
 `Content` props — `editable`, `onTitleChange`, `auxIcon`, `tag`, and the rest —

--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -28,16 +28,16 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 
 ### Interactive surface
 
-| Prop            | Type                               | Default          | Description                                       |
-| --------------- | ---------------------------------- | ---------------- | ------------------------------------------------- |
-| `selectVariant` | `"select-light" \| "select-heavy"` | `"select-light"` | Interactive select variant                        |
-| `state`         | `InteractiveStatefulState`         | `"empty"`        | Value state (`"empty"`, `"filled"`, `"selected"`) |
-| `interaction`   | `InteractiveStatefulInteraction`   | `"rest"`         | JS-controlled interaction state override          |
-| `onClick`       | `MouseEventHandler<HTMLElement>`   | —                | Click handler                                     |
-| `href`          | `string`                           | —                | Renders an anchor instead of a div                |
-| `target`        | `string`                           | —                | Anchor target (e.g. `"_blank"`)                   |
-| `group`         | `string`                           | —                | Interactive group key                             |
-| `ref`           | `React.Ref<HTMLElement>`           | —                | Forwarded ref                                     |
+| Prop            | Type                               | Default          | Description                                                                                  |
+| --------------- | ---------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| `selectVariant` | `"select-light" \| "select-heavy"` | `"select-light"` | Interactive select variant                                                                   |
+| `state`         | `InteractiveStatefulState`         | `"empty"`        | Value state (`"empty"`, `"filled"`, `"selected"`)                                            |
+| `interaction`   | `InteractiveStatefulInteraction`   | `"rest"`         | JS-controlled interaction state override                                                     |
+| `onClick`       | `MouseEventHandler<HTMLElement>`   | —                | Click handler                                                                                |
+| `href`          | `string`                           | —                | Renders an anchor instead of a div                                                           |
+| `target`        | `string`                           | —                | Anchor target (e.g. `"_blank"`)                                                              |
+| `group`         | `string`                           | —                | Interactive group key                                                                        |
+| `ref`           | `React.Ref<HTMLElement>`           | —                | Forwarded ref                                                                                |
 | `disabled`      | `boolean`                          | `false`          | Disabled colors; suppresses the row's own click only — nested `rightChildren` stay clickable |
 
 ### Row element
@@ -53,13 +53,13 @@ latter two for Enter/Space activation. Pass your own and the row defers —
 handlers compose, yours first, and `preventDefault()` stops the row's own
 activation.
 
-| Prop                                                          | Type                                | Description                                     |
-| ------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- |
-| `aria-label` / `aria-labelledby` / `aria-describedby`          | `string`                            | Accessible name and description for the row     |
-| `onMouseEnter` / `onMouseLeave` / `onMouseMove` / `onMouseDown` | `MouseEventHandler<HTMLDivElement>`  | Mouse handlers, e.g. hover-to-open a flyout     |
-| `onPointerEnter` / `onPointerLeave`                            | `PointerEventHandler<HTMLDivElement>` | Pointer equivalents                             |
+| Prop                                                            | Type                                  | Description                                 |
+| --------------------------------------------------------------- | ------------------------------------- | ------------------------------------------- |
+| `aria-label` / `aria-labelledby` / `aria-describedby`           | `string`                              | Accessible name and description for the row |
+| `onMouseEnter` / `onMouseLeave` / `onMouseMove` / `onMouseDown` | `MouseEventHandler<HTMLDivElement>`   | Mouse handlers, e.g. hover-to-open a flyout |
+| `onPointerEnter` / `onPointerLeave`                             | `PointerEventHandler<HTMLDivElement>` | Pointer equivalents                         |
 
-`title` is deliberately *not* forwarded: it is the row's label to
+`title` is deliberately _not_ forwarded: it is the row's label to
 `ContentAction`, and forwarding it as the native attribute would put two
 meanings in one prop. Use `tooltip` for hover text.
 
@@ -75,17 +75,18 @@ meanings in one prop. Use `tooltip` for hover text.
 
 ### Content (pass-through to ContentAction)
 
-| Prop            | Type                    | Default        | Description                                  |
-| --------------- | ----------------------- | -------------- | -------------------------------------------- |
-| `title`         | `string`                | **(required)** | Row label                                    |
-| `icon`          | `IconFunctionComponent` | —              | Left icon                                    |
-| `description`   | `string`                | —              | Description below the title                  |
-| `sizePreset`    | `SizePreset`            | `"headline"`   | Content size preset                          |
-| `variant`       | `ContentVariant`        | `"heading"`    | Content layout variant                       |
-| `rightChildren` | `ReactNode`             | —              | Content after the label (e.g. action button) |
-| `color`         | `ColorTypes`            | `"interactive"` | Content colour mode. Defaults to `"interactive"`, which is what lets the row's hover / selected / disabled colours reach its title and icon — passing anything else opts out of that. `undefined` counts as not passing one. |
+| Prop                  | Type                    | Default         | Description                                                                                                                                                                                                                  |
+| --------------------- | ----------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`               | `string`                | **(required)**  | Row label                                                                                                                                                                                                                    |
+| `icon`                | `IconFunctionComponent` | —               | Left icon                                                                                                                                                                                                                    |
+| `description`         | `string`                | —               | Description below the title                                                                                                                                                                                                  |
+| `descriptionMaxLines` | `number`                | —               | Cap the description at N lines and truncate the rest. Unset wraps without a limit — a row showing user-authored text usually wants `1`                                                                                       |
+| `sizePreset`          | `SizePreset`            | `"headline"`    | Content size preset                                                                                                                                                                                                          |
+| `variant`             | `ContentVariant`        | `"heading"`     | Content layout variant                                                                                                                                                                                                       |
+| `rightChildren`       | `ReactNode`             | —               | Content after the label (e.g. action button)                                                                                                                                                                                 |
+| `color`               | `ColorTypes`            | `"interactive"` | Content colour mode. Defaults to `"interactive"`, which is what lets the row's hover / selected / disabled colours reach its title and icon — passing anything else opts out of that. `undefined` counts as not passing one. |
 
-| `strikethrough` | `boolean`               | `false`         | Strike the label through, e.g. a row switched off |
+| `strikethrough` | `boolean` | `false` | Strike the label through, e.g. a row switched off |
 
 That table is the entire content surface. The remaining `ContentAction` /
 `Content` props — `editable`, `onTitleChange`, `auxIcon`, `tag`, and the rest —

--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -42,10 +42,16 @@ row's label lines up with an adjacent button. A step outside that set is a type 
 
 ### Row element
 
-These land on the row itself rather than on the content inside it. They are
-named individually because anything `LineItemButton` does not destructure goes
-to `ContentAction`, which never spreads onto a DOM node — a label or a handler
-left in that bag is silently dropped.
+These land on the row itself rather than on the content inside it. Anything
+`LineItemButton` does not name reaches the row element, so the table below is
+illustrative, not exhaustive — `data-*`, the rest of `aria-*`, and the other
+`HTMLAttributes<HTMLDivElement>` handlers all arrive the same way.
+
+`role`, `tabIndex`, `onKeyDown` and `onKeyUp` are the exception: a non-anchor
+row sets the first two to make itself a focusable `"button"`, and uses the
+latter two for Enter/Space activation. Pass your own and the row defers —
+handlers compose, yours first, and `preventDefault()` stops the row's own
+activation.
 
 | Prop                                                          | Type                                | Description                                     |
 | ------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- |
@@ -79,7 +85,12 @@ meanings in one prop. Use `tooltip` for hover text.
 | `rightChildren` | `ReactNode`             | —              | Content after the label (e.g. action button) |
 | `color`         | `ColorTypes`            | `"interactive"` | Content colour mode. Defaults to `"interactive"`, which is what lets the row's hover / selected / disabled colours reach its title and icon — passing anything else opts out of that. `undefined` counts as not passing one. |
 
-All other `ContentAction` / `Content` props (`editable`, `onTitleChange`, `optional`, `auxIcon`, `tag`, etc.) are also passed through.
+| `strikethrough` | `boolean`               | `false`         | Strike the label through, e.g. a row switched off |
+
+That table is the entire content surface. The remaining `ContentAction` /
+`Content` props — `editable`, `onTitleChange`, `auxIcon`, `tag`, and the rest —
+are **not** part of `LineItemButton`'s type; no call site passed one. Naming
+only what a row uses is what lets everything else reach the row element.
 
 ## Usage
 

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -42,7 +42,18 @@ type LineItemButtonOwnProps = Pick<
 
   /** Which side the tooltip appears on. @default "top" */
   tooltipSide?: TooltipSide;
-};
+} & Pick<
+    React.HTMLAttributes<HTMLDivElement>,
+    | "aria-label"
+    | "aria-describedby"
+    | "aria-labelledby"
+    | "onMouseEnter"
+    | "onMouseLeave"
+    | "onMouseMove"
+    | "onMouseDown"
+    | "onPointerEnter"
+    | "onPointerLeave"
+  >;
 
 type LineItemButtonProps = ContentPassthroughProps & LineItemButtonOwnProps;
 
@@ -116,6 +127,24 @@ function LineItemButton({
    */
   color = "interactive",
 
+  /*
+   * Named individually so they reach the row element rather than the content
+   * inside it. Everything not destructured here goes to `ContentAction`, which
+   * does not spread onto a DOM node — so a label or a pointer handler left in
+   * that bag is silently dropped. Not a blanket `HTMLAttributes` extend either:
+   * `title` means the row's label to `ContentAction` and a native tooltip to
+   * the DOM, and the two would collide.
+   */
+  "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedBy,
+  "aria-labelledby": ariaLabelledBy,
+  onMouseEnter,
+  onMouseLeave,
+  onMouseMove,
+  onMouseDown,
+  onPointerEnter,
+  onPointerLeave,
+
   // ContentAction pass-through
   ...contentActionProps
 }: LineItemButtonProps) {
@@ -147,6 +176,15 @@ function LineItemButton({
         width={width}
         size="fit"
         rounding={rounding}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
+        aria-labelledby={ariaLabelledBy}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseMove={onMouseMove}
+        onMouseDown={onMouseDown}
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
         {...rowButtonProps}
       >
         <div className="w-full p-1.5">

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -2,20 +2,78 @@ import type React from "react";
 import { Interactive, type InteractiveStatefulProps } from "@opal/core";
 import type {
   ExtremaSizeVariants,
-  DistributiveOmit,
+  IconFunctionComponent,
+  ColorTypes,
+  RichStr,
   Rounding,
 } from "@opal/types";
 import { Tooltip, type TooltipSide } from "@opal/components";
-import { type ContentActionProps, ContentAction } from "@opal/layouts";
+import {
+  type ContentActionProps,
+  type ContentVariant,
+  type SizePreset,
+  ContentAction,
+} from "@opal/layouts";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type ContentPassthroughProps = DistributiveOmit<
-  ContentActionProps,
-  "width" | "ref"
->;
+/**
+ * The `ContentAction` props a row actually uses — nine of the twenty-two it
+ * offers. Listed rather than spread, so that everything a caller passes which
+ * is *not* here is DOM, and reaches the row element.
+ *
+ * That inversion is the point. Spreading the remainder into `ContentAction`
+ * put every unrecognised prop somewhere that never renders it, so a label or a
+ * handler was accepted and silently dropped. Now the leftover lands on the row
+ * instead, and the compiler has the last word on the rest.
+ *
+ * `sizePreset` and `variant` come from the flattened aliases, which loses the
+ * cross-constraint `ContentProps` keeps between them. Every call site states
+ * both explicitly, so what is given up is the compiler rejecting a pair that
+ * no one writes.
+ */
+type RowContentProps = {
+  /** Main label. */
+  title: string | RichStr;
+
+  /** Leading icon. */
+  icon?: IconFunctionComponent;
+
+  /** Secondary line under the title. */
+  description?: string | RichStr;
+
+  /** Content after the label — an action button, a count, a chevron. */
+  rightChildren?: React.ReactNode;
+
+  /** Content size preset. @default "headline" */
+  sizePreset?: SizePreset;
+
+  /** Content layout variant. @default "heading" */
+  variant?: ContentVariant;
+
+  /**
+   * Content colour mode. `"interactive"` is what lets the row's hover,
+   * selected and disabled colours reach its title and icon; anything else
+   * opts out of that.
+   *
+   * @default "interactive"
+   */
+  color?: ColorTypes;
+
+  /** Strike the label through, e.g. a row switched off. */
+  strikethrough?: boolean;
+
+  /**
+   * Padding around the inner `ContentAction`, on top of the row's own inset.
+   * Narrowed to the four `Interactive.Container` applies at its size presets,
+   * which is what lines a label up with an adjacent button.
+   *
+   * @default 0.5
+   */
+  padding?: 0 | 0.5 | 1 | 2;
+};
 
 type LineItemButtonOwnProps = Pick<
   InteractiveStatefulProps,
@@ -42,20 +100,17 @@ type LineItemButtonOwnProps = Pick<
 
   /** Which side the tooltip appears on. @default "top" */
   tooltipSide?: TooltipSide;
-} & Pick<
-    React.HTMLAttributes<HTMLDivElement>,
-    | "aria-label"
-    | "aria-describedby"
-    | "aria-labelledby"
-    | "onMouseEnter"
-    | "onMouseLeave"
-    | "onMouseMove"
-    | "onMouseDown"
-    | "onPointerEnter"
-    | "onPointerLeave"
-  >;
+};
 
-type LineItemButtonProps = ContentPassthroughProps & LineItemButtonOwnProps;
+/**
+ * `title` and `color` are omitted from the DOM attributes because the row
+ * already means something by them — its label and its colour mode — and the
+ * native attributes would put two meanings in one prop. `children` is omitted
+ * because a row renders none: its content comes from `title` and friends.
+ */
+type LineItemButtonProps = LineItemButtonOwnProps &
+  RowContentProps &
+  Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "color" | "children">;
 
 // ---------------------------------------------------------------------------
 // LineItemButton
@@ -112,9 +167,18 @@ function LineItemButton({
   // Sizing
   rounding = 3,
   width = "full",
-  padding = 0.5,
   tooltip,
   tooltipSide = "top",
+
+  // Content
+  title,
+  icon,
+  description,
+  rightChildren,
+  sizePreset,
+  variant,
+  strikethrough,
+  padding,
 
   /*
    * Taken out of the pass-through and defaulted here rather than written
@@ -128,25 +192,12 @@ function LineItemButton({
   color = "interactive",
 
   /*
-   * Named individually so they reach the row element rather than the content
-   * inside it. Everything not destructured here goes to `ContentAction`, which
-   * does not spread onto a DOM node — so a label or a pointer handler left in
-   * that bag is silently dropped. Not a blanket `HTMLAttributes` extend either:
-   * `title` means the row's label to `ContentAction` and a native tooltip to
-   * the DOM, and the two would collide.
+   * Whatever is left is DOM — labels, handlers, `data-*` — and belongs on the
+   * row. It used to go the other way, into `ContentAction`, which never
+   * spreads onto an element, so an unrecognised prop was accepted and then
+   * silently dropped.
    */
-  "aria-label": ariaLabel,
-  "aria-describedby": ariaDescribedBy,
-  "aria-labelledby": ariaLabelledBy,
-  onMouseEnter,
-  onMouseLeave,
-  onMouseMove,
-  onMouseDown,
-  onPointerEnter,
-  onPointerLeave,
-
-  // ContentAction pass-through
-  ...contentActionProps
+  ...rowProps
 }: LineItemButtonProps) {
   // The row renders as a focusable div (role="button") instead of a native
   // <button> so interactive `rightChildren` (e.g. action buttons) don't nest
@@ -176,22 +227,31 @@ function LineItemButton({
         width={width}
         size="fit"
         rounding={rounding}
-        aria-label={ariaLabel}
-        aria-describedby={ariaDescribedBy}
-        aria-labelledby={ariaLabelledBy}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onMouseMove={onMouseMove}
-        onMouseDown={onMouseDown}
-        onPointerEnter={onPointerEnter}
-        onPointerLeave={onPointerLeave}
+        {...rowProps}
         {...rowButtonProps}
       >
         <div className="w-full p-1.5">
           <ContentAction
-            color={color}
-            {...(contentActionProps as ContentActionProps)}
-            padding={padding}
+            {...({
+              title,
+              icon,
+              description,
+              rightChildren,
+              sizePreset,
+              variant,
+              strikethrough,
+              color,
+              padding: padding ?? 0.5,
+              /*
+               * `ContentActionProps` is a union whose arms pair a `sizePreset`
+               * with the `variant`s valid for it. Flattening the two into
+               * `SizePreset` and `ContentVariant` is what keeps a row's props
+               * flat for its callers, and it costs that pairing — so the
+               * assertion is the flattening, stated once, over a set this
+               * component names in full. It is not the old blanket cast over
+               * whatever a caller happened to pass.
+               */
+            } as ContentActionProps)}
           />
         </div>
       </Interactive.Container>

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -20,7 +20,7 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * The `ContentAction` props a row actually uses — nine of the twenty-two it
+ * The `ContentAction` props a row actually uses — ten of the twenty-two it
  * offers. Listed rather than spread, so that everything a caller passes which
  * is *not* here is DOM, and reaches the row element.
  *
@@ -43,6 +43,12 @@ type RowContentProps = {
 
   /** Secondary line under the title. */
   description?: string | RichStr;
+
+  /**
+   * Cap the description at N lines and truncate the rest. Unset wraps without
+   * a limit, so a row showing user-authored text usually wants `1`.
+   */
+  descriptionMaxLines?: number;
 
   /** Content after the label — an action button, a count, a chevron. */
   rightChildren?: React.ReactNode;
@@ -189,6 +195,7 @@ function LineItemButton({
   title,
   icon,
   description,
+  descriptionMaxLines,
   rightChildren,
   sizePreset,
   variant,
@@ -263,6 +270,7 @@ function LineItemButton({
               title,
               icon,
               description,
+              descriptionMaxLines,
               rightChildren,
               sizePreset,
               variant,

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -137,6 +137,21 @@ function handleRowKeyUp(e: React.KeyboardEvent<HTMLDivElement>) {
   }
 }
 
+// The caller's handler runs first and can stop the row's own activation with
+// `preventDefault()` — the order a native control gives you. Composed rather
+// than replaced, because a row that accepts a handler and then overwrites it
+// is the same silent drop this component exists to avoid.
+function composeKeyHandler(
+  caller: React.KeyboardEventHandler<HTMLDivElement> | undefined,
+  row: React.KeyboardEventHandler<HTMLDivElement>
+): React.KeyboardEventHandler<HTMLDivElement> {
+  if (!caller) return row;
+  return (e) => {
+    caller(e);
+    if (!e.defaultPrevented) row(e);
+  };
+}
+
 // Ignore clicks originating from nested interactive children (e.g.
 // `rightChildren` action buttons) so they don't also activate the row.
 function guardNestedInteractiveClick(
@@ -192,6 +207,16 @@ function LineItemButton({
   color = "interactive",
 
   /*
+   * Named so the row can defer to a caller's value instead of overwriting it.
+   * They would otherwise ride `rowProps` onto the container and be replaced by
+   * the button semantics spread after it — accepted by the type, then gone.
+   */
+  role,
+  tabIndex,
+  onKeyDown,
+  onKeyUp,
+
+  /*
    * Whatever is left is DOM — labels, handlers, `data-*` — and belongs on the
    * row. It used to go the other way, into `ContentAction`, which never
    * spreads onto an element, so an unrecognised prop was accepted and then
@@ -201,15 +226,17 @@ function LineItemButton({
 }: LineItemButtonProps) {
   // The row renders as a focusable div (role="button") instead of a native
   // <button> so interactive `rightChildren` (e.g. action buttons) don't nest
-  // a <button> inside a <button> — invalid HTML that breaks hydration.
+  // a <button> inside a <button> — invalid HTML that breaks hydration. An
+  // anchor row is already focusable and already activates on Enter, so it
+  // takes the caller's values unchanged.
   const rowButtonProps = href
-    ? undefined
-    : ({
-        role: "button",
-        tabIndex: 0,
-        onKeyDown: handleRowKeyDown,
-        onKeyUp: handleRowKeyUp,
-      } as const);
+    ? { role, tabIndex, onKeyDown, onKeyUp }
+    : {
+        role: role ?? "button",
+        tabIndex: tabIndex ?? 0,
+        onKeyDown: composeKeyHandler(onKeyDown, handleRowKeyDown),
+        onKeyUp: composeKeyHandler(onKeyUp, handleRowKeyUp),
+      };
 
   const item = (
     <Interactive.Stateful


### PR DESCRIPTION
## Description

Opal-only. This clears the obstacle that was blocking most `LineItem` call sites from moving to `LineItemButton`; the call-site migrations themselves are stacked on top in a follow-up so this one stays reviewable as a design-system change.

**The residue was pointed the wrong way.** Anything `LineItemButton` did not de-structure was spread into `ContentAction`, which never spreads onto a DOM element — so an unrecognized prop was accepted, cast, and silently dropped. That is what ate the tools-popover e2e selector in #14476, then `aria-label`, and would have eaten `data-*` next.

Naming the nine `ContentAction` props a row actually uses inverts it: whatever is left over is DOM, and it lands on the row. `data-*`, `aria-*`, `onFocus`, pointer handlers — all reach the element now.

**Twelve of the twenty-two `ContentAction` props were never passed** by any of the 132 `LineItemButton` call sites: `auxIcon`, `editHandle`, `editable`, `moreIcon1`, `moreIcon2`, `onTitleChange`, `orientation`, `ref`, `role`, `suffix`, `tag`, `titleMaxLines`. They leave the public type. `descriptionMaxLines` was originally in that list; it is kept, because unset means unbounded wrap, so removing it would leave no way to bound a description at a call site migrating off `LineItem` — which truncated by default.

The type goes from four clauses to three, and `DistributiveOmit` is no longer needed:

```ts
type LineItemButtonProps = LineItemButtonOwnProps &
  RowContentProps &
  Omit<React.HTMLAttributes<HTMLDivElement>, "title" | "color" | "children">;
```

**Two costs, both deliberate.** `title`, `color` and `children` are omitted from the DOM attributes because a row already means something by each — `title` in particular is its label, and `RichStr`, so the native attribute would narrow it and break `markdown()` titles. And flattening `sizePreset`/`variant` gives up the pairing `ContentProps` enforces between them; that is now one assertion over a set this component names in full, rather than the old blanket cast over whatever arrived.

**Also fixed:** the README documented `withInteractive` as "always true and cannot be overridden". No such prop exists — those three mentions were its only occurrences in the repo.

No call site changes here, so nothing renders differently from this PR alone.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check