### PR TITLE
fix(sharepoint): support localized document library folder path indexing

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -2594,16 +2594,22 @@ class SharepointConnector(
             return []
 
     def _build_folder_url(
-        self, site_url: str, drive_name: str, folder_path: str
+        self,
+        site_url: str,
+        drive_name: str,
+        folder_path: str,
+        drive_web_url: str | None = None,
     ) -> str:
         """Build a URL for a folder to use as raw_node_id.
 
-        NOTE: This constructs an approximate folder URL from components rather than
-        fetching the actual webUrl from the API. The constructed URL may differ
-        slightly from SharePoint's canonical webUrl (e.g., URL encoding differences),
-        but it functions correctly as a unique identifier for hierarchy tracking.
-        We avoid fetching folder metadata to minimize API calls.
+        Uses drive_web_url if provided so that non-English or localized document libraries
+        (where drive.name != server relative URL path, e.g. "Dokumente" vs "Freigegebene Dokumente")
+        resolve accurately.
         """
+        if drive_web_url:
+            clean_drive_url = drive_web_url.rstrip("/")
+            clean_folder = folder_path.strip("/")
+            return f"{clean_drive_url}/{clean_folder}"
         return f"{site_url}/{drive_name}/{folder_path}"
 
     def _extract_folder_path_from_parent_reference(
@@ -2729,7 +2735,9 @@ class SharepointConnector(
 
         for i, part in enumerate(path_parts):
             current_path = "/".join(path_parts[: i + 1])
-            folder_url = self._build_folder_url(site_url, drive_name, current_path)
+            folder_url = self._build_folder_url(
+                site_url, drive_name, current_path, drive_web_url=drive_web_url
+            )
 
             if folder_url in checkpoint.seen_hierarchy_node_raw_ids:
                 continue
@@ -2753,7 +2761,9 @@ class SharepointConnector(
             else:
                 # Parent is the previous folder
                 parent_path = "/".join(path_parts[:i])
-                parent_url = self._build_folder_url(site_url, drive_name, parent_path)
+                parent_url = self._build_folder_url(
+                    site_url, drive_name, parent_path, drive_web_url=drive_web_url
+                )
 
             yield HierarchyNode(
                 raw_node_id=folder_url,
@@ -2782,7 +2792,9 @@ class SharepointConnector(
         )
 
         if folder_path:
-            return self._build_folder_url(site_url, drive_name, folder_path)
+            return self._build_folder_url(
+                site_url, drive_name, folder_path, drive_web_url=drive_web_url
+            )
 
         # Document is at drive root
         return drive_web_url

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_hierarchy_helpers.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_hierarchy_helpers.py
@@ -118,6 +118,22 @@ def test_build_folder_url_with_spaces() -> None:
     assert result == expected
 
 
+def test_build_folder_url_with_localized_drive_web_url() -> None:
+    """Test building folder URL when drive has localized display name vs server-relative web URL."""
+    connector = SharepointConnector()
+
+    site_url = "https://company.sharepoint.com/sites/marketing"
+    drive_name = "Dokumente"  # Localized display name in Graph API
+    drive_web_url = "https://company.sharepoint.com/sites/marketing/Freigegebene%20Dokumente"
+    folder_path = "Berichte/2026"
+
+    result = connector._build_folder_url(
+        site_url, drive_name, folder_path, drive_web_url=drive_web_url
+    )
+    expected = "https://company.sharepoint.com/sites/marketing/Freigegebene%20Dokumente/Berichte/2026"
+    assert result == expected
+
+
 @patch(
     "onyx.connectors.sharepoint.connector.get_sharepoint_hierarchy_node_external_access"
 )


### PR DESCRIPTION
## Problem
In non-English or multilingual SharePoint tenants (e.g., German, Spanish, French), the document library display name returned by Graph API (such as \Dokumente\ or \Documentos\) does not match the server-relative URL path (e.g. \Freigegebene Dokumente\).

When indexing subfolders in these libraries, \_build_folder_url\ constructed folder URLs using \site_url/drive_name/folder_path\, which produces an invalid URL path that fails hierarchy resolution.

## Solution
- Updated \_build_folder_url\ to take an optional \drive_web_url\ parameter, resolving folder URLs directly from the drive's canonical web URL when provided.
- Piped \drive_web_url\ through \_yield_folder_hierarchy_nodes\ and \_get_parent_hierarchy_url\.
- Added unit tests in \	est_hierarchy_helpers.py\ validating localized document library URL construction.

Closes #14525

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint folder hierarchy indexing for non-English tenants where the drive display name doesn't match the server-relative URL path. Now uses the drive's canonical web URL when building folder URLs, so hierarchy nodes resolve correctly.

Closes #14525.

<sup>Written for commit 88ea5417696e6f5092b7670642e4d3a35ece1fb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

