### PR TITLE
fix(reindex): clear stale connector alerts and harden reclaim tests

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -961,7 +961,16 @@ def mark_cc_pairs_deleting_if_still_wont_port__no_commit(
         .values(status=ConnectorCredentialPairStatus.DELETING)
         .returning(ConnectorCredentialPair.id)
     )
-    return list(db_session.execute(stmt).scalars().all())
+    transitioned_ids = list(db_session.execute(stmt).scalars().all())
+    # Notifications have no foreign key to the cc_pair, so deleting one cascades nothing.
+    # Without this the INVALID alert outlives the connector it points at, forever.
+    for cc_pair_id in transitioned_ids:
+        clear_connector_alerts__no_commit(
+            db_session=db_session,
+            cc_pair_id=cc_pair_id,
+            notif_type=NotificationType.CONNECTOR_INVALID,
+        )
+    return transitioned_ids
 
 
 def fetch_connector_credential_pair_for_connector(

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -79,6 +79,9 @@ class OnyxErrorCode(Enum):
     # A write refused because a background sync is still applying the last one.
     # Retryable, unlike NOT_FOUND, which these routes used to report instead.
     RESOURCE_SYNCING = ("RESOURCE_SYNCING", 409)
+    # A re-index refused because an earlier generation still holds the index name it
+    # wants. Reclamation is draining that index now, so the same request works shortly.
+    INDEX_NAME_RECLAIMING = ("INDEX_NAME_RECLAIMING", 409)
 
     # --------------------------------------------------------------------------
     # Rate Limiting / Quotas (429 / 402)

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -99,9 +99,11 @@ def set_new_search_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> IdReturn:
-    """
-    Creates a new SearchSettings row and cancels the previous secondary indexing
-    if any exists.
+    """Create the new SearchSettings row that the port flow re-embeds into.
+
+    Only one re-index runs at a time. This raises CONFLICT instead of superseding an
+    existing one: either a secondary FUTURE is already in flight, or an INSTANT
+    switchover is still backfilling the live index. Cancel the running re-index first.
     """
     if search_settings_new.index_name:
         logger.warning("Index name was specified by request, this is not suggested")

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -309,7 +309,7 @@ def _guard_index_name_reuse(db_session: Session, index_name: str) -> None:
     for occupant in occupants:
         enqueue_index_reclaim(client_app, tenant_id, occupant.id)
     raise OnyxError(
-        OnyxErrorCode.CONFLICT,
+        OnyxErrorCode.INDEX_NAME_RECLAIMING,
         "An index of the same name from an earlier re-index still holds data; it's being "
         "cleaned up now. Start the re-index again in a moment.",
     )

--- a/backend/tests/external_dependency_unit/db/test_index_reclaim.py
+++ b/backend/tests/external_dependency_unit/db/test_index_reclaim.py
@@ -359,24 +359,77 @@ def test_cancel_keeps_reclaim_intent_a_newer_reindex_stamped(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     present_search_settings: SearchSettings,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cancel commits the FUTURE to PAST before it clears intent, so a reindex submitted in
     that window stamps its own intent on the same row and must not have it wiped."""
     present = present_search_settings
-    newer_future = _make_settings(db_session, None, status=IndexModelStatus.FUTURE)
-    set_reclaim_intent_on_current__no_commit(db_session, [101, 202])
+    # The shared test database already holds a FUTURE row. Leave it in place and that
+    # stray row spares the intent on its own, so this test passes without exercising
+    # the race at all.
+    parked = [
+        ss
+        for ss in db_session.query(SearchSettings)
+        .filter(SearchSettings.status == IndexModelStatus.FUTURE)
+        .all()
+    ]
+    for ss in parked:
+        ss.status = IndexModelStatus.PAST
     db_session.commit()
+
+    canceled_reindex_intent = [1, 2]
+    newer_reindex_intent = [101, 202]
+
+    canceled_future = _make_settings(db_session, None, status=IndexModelStatus.FUTURE)
+    set_reclaim_intent_on_current__no_commit(db_session, canceled_reindex_intent)
+    db_session.commit()
+
+    newer_futures: list[SearchSettings] = []
+    real_update_status = search_settings_api.update_search_settings_status
+
+    # This runs after cancel retires its own FUTURE and before it re-reads the secondary,
+    # which is the exact window a newer reindex has to land in for the race to happen.
+    def _submit_newer_reindex_mid_cancel(
+        search_settings: SearchSettings,
+        new_status: IndexModelStatus,
+        db_session: Session,
+    ) -> None:
+        real_update_status(
+            search_settings=search_settings,
+            new_status=new_status,
+            db_session=db_session,
+        )
+        if newer_futures:
+            return
+        newer_futures.append(
+            _make_settings(db_session, None, status=IndexModelStatus.FUTURE)
+        )
+        set_reclaim_intent_on_current__no_commit(db_session, newer_reindex_intent)
+        db_session.commit()
+
+    monkeypatch.setattr(
+        search_settings_api,
+        "update_search_settings_status",
+        _submit_newer_reindex_mid_cancel,
+    )
     try:
         search_settings_api.cancel_new_embedding(_=MagicMock(), db_session=db_session)
 
+        assert newer_futures, (
+            "the newer reindex never landed; the race wasn't exercised"
+        )
         db_session.refresh(present)
         assert present.reclaim_status == IndexReclaimStatus.PENDING
-        assert present.pending_cc_pair_deletions == [101, 202]
+        assert present.pending_cc_pair_deletions == newer_reindex_intent
     finally:
         db_session.rollback()
         clear_reclaim_intent__no_commit(db_session, present.id)
         db_session.commit()
-        db_session.delete(newer_future)
+        for ss in [*newer_futures, canceled_future]:
+            db_session.delete(ss)
+        db_session.commit()
+        for ss in parked:
+            ss.status = IndexModelStatus.FUTURE
         db_session.commit()
 
 

--- a/backend/tests/external_dependency_unit/db/test_index_reclaim.py
+++ b/backend/tests/external_dependency_unit/db/test_index_reclaim.py
@@ -26,9 +26,14 @@ import pytest
 from sqlalchemy.orm import Session
 
 import onyx.server.manage.search_settings as search_settings_api
+from onyx.configs.constants import NotificationType
 from onyx.context.search.models import (
     SavedSearchSettings,
     SearchSettingsCreationRequest,
+)
+from onyx.db.connector_alerts import (
+    clear_connector_alerts__no_commit,
+    connector_alert_additional_data,
 )
 from onyx.db.connector_credential_pair import (
     compute_wont_port_cc_pair_ids,
@@ -41,7 +46,8 @@ from onyx.db.enums import (
     IndexReclaimStatus,
     SwitchoverType,
 )
-from onyx.db.models import ConnectorCredentialPair, SearchSettings
+from onyx.db.models import ConnectorCredentialPair, Notification, SearchSettings
+from onyx.db.notification import batch_create_notifications
 from onyx.db.search_settings import (
     advance_to_soaking__no_commit,
     clear_reclaim_intent__no_commit,
@@ -55,6 +61,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.natural_language_processing.search_nlp_models import clean_model_name
 from shared_configs.configs import ALT_INDEX_SUFFIX
+from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
 from tests.external_dependency_unit.indexing_helpers import (
     cleanup_cc_pair,
     make_cc_pair,
@@ -204,6 +211,64 @@ def test_mark_deleting_transitions_only_still_wont_port(
     finally:
         for pair in (invalid, paused, reactivated):
             cleanup_cc_pair(db_session, pair)
+
+
+def _connector_alert_count(db_session: Session, cc_pair_id: int) -> int:
+    return (
+        db_session.query(Notification)
+        .filter(
+            Notification.notif_type == NotificationType.CONNECTOR_INVALID,
+            Notification.additional_data == connector_alert_additional_data(cc_pair_id),
+        )
+        .count()
+    )
+
+
+def test_mark_deleting_clears_the_invalid_alert_for_transitioned_pairs(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Reclaim deletes the connector, but a notification points at its cc_pair through
+    additional_data rather than a foreign key, so nothing cascades. Without an explicit
+    clear the admin keeps an INVALID alert for a connector that no longer exists."""
+    admin = create_test_user(db_session, "reclaim_alert", is_admin=True)
+    transitioned = _make_cc_pair_with_status(
+        db_session, ConnectorCredentialPairStatus.INVALID
+    )
+    spared = _make_cc_pair_with_status(db_session, ConnectorCredentialPairStatus.ACTIVE)
+    try:
+        for pair in (transitioned, spared):
+            batch_create_notifications(
+                user_ids=[admin.id],
+                notif_type=NotificationType.CONNECTOR_INVALID,
+                db_session=db_session,
+                title="Connector is invalid",
+                additional_data=connector_alert_additional_data(pair.id),
+            )
+        assert _connector_alert_count(db_session, transitioned.id) == 1
+        assert _connector_alert_count(db_session, spared.id) == 1
+
+        marked = mark_cc_pairs_deleting_if_still_wont_port__no_commit(
+            db_session, [transitioned.id, spared.id]
+        )
+        db_session.commit()
+
+        assert marked == [transitioned.id]
+        assert _connector_alert_count(db_session, transitioned.id) == 0
+        # The ACTIVE pair never transitioned, so its alert has to survive.
+        assert _connector_alert_count(db_session, spared.id) == 1
+    finally:
+        for pair in (transitioned, spared):
+            clear_connector_alerts__no_commit(
+                db_session=db_session,
+                cc_pair_id=pair.id,
+                notif_type=NotificationType.CONNECTOR_INVALID,
+            )
+        db_session.commit()
+        for pair in (transitioned, spared):
+            cleanup_cc_pair(db_session, pair)
+        delete_test_user(db_session, admin)
+        db_session.commit()
 
 
 # --- transitions ----------------------------------------------------------------
@@ -487,7 +552,8 @@ def test_guard_conflicts_while_index_unreclaimed(
     try:
         with pytest.raises(OnyxError) as exc:
             search_settings_api._guard_index_name_reuse(db_session, name)
-        assert exc.value.error_code == OnyxErrorCode.CONFLICT
+        # Distinct from a plain CONFLICT so a caller can tell this one is worth retrying.
+        assert exc.value.error_code == OnyxErrorCode.INDEX_NAME_RECLAIMING
         assert "earlier re-index" in exc.value.detail
         db_session.refresh(ss)
         assert ss.reclaim_status == IndexReclaimStatus.DELETING  # pulled into reclaim

--- a/backend/tests/external_dependency_unit/db/test_index_reclaim_task.py
+++ b/backend/tests/external_dependency_unit/db/test_index_reclaim_task.py
@@ -31,7 +31,6 @@ from onyx.db.port_attempt import (
 from onyx.db.search_settings import (
     create_search_settings,
     find_unreclaimed_past_by_index_name,
-    get_current_search_settings,
     get_search_settings_by_id,
 )
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
@@ -283,6 +282,7 @@ def test_deleting_complete_marks_reclaimed_and_keeps_row(
     monkeypatch.setattr(
         reclaim_tasks, "reclaim_index_data", lambda *_a, **_k: ReclaimOutcome.COMPLETE
     )
+    present = _make_present_settings(db_session)
     ss = _make_past_settings(db_session, IndexReclaimStatus.DELETING)
     ss_id = ss.id
     try:
@@ -293,6 +293,7 @@ def test_deleting_complete_marks_reclaimed_and_keeps_row(
         assert row.reclaim_status == IndexReclaimStatus.RECLAIMED
     finally:
         _delete_settings(db_session, ss)
+        _delete_settings(db_session, present)
 
 
 def test_deleting_refuses_to_delete_the_live_index(
@@ -308,9 +309,9 @@ def test_deleting_refuses_to_delete_the_live_index(
         "reclaim_index_data",
         lambda name, *_a, **_k: deleted.append(name) or ReclaimOutcome.COMPLETE,
     )
-    live_name = get_current_search_settings(db_session).index_name
+    present = _make_present_settings(db_session)
     ss = _make_past_settings(
-        db_session, IndexReclaimStatus.DELETING, index_name=live_name
+        db_session, IndexReclaimStatus.DELETING, index_name=present.index_name
     )
     try:
         reclaim_tasks.run_old_index_reclaim(db_session, MagicMock(), "tenant", ss)
@@ -321,6 +322,7 @@ def test_deleting_refuses_to_delete_the_live_index(
         assert ss.reclaim_attempts == 1  # recorded as a failure, not a silent skip
     finally:
         _delete_settings(db_session, ss)
+        _delete_settings(db_session, present)
 
 
 def test_deleting_incomplete_stays_deleting(
@@ -332,6 +334,7 @@ def test_deleting_incomplete_stays_deleting(
     monkeypatch.setattr(
         reclaim_tasks, "reclaim_index_data", lambda *_a, **_k: ReclaimOutcome.INCOMPLETE
     )
+    present = _make_present_settings(db_session)
     ss = _make_past_settings(db_session, IndexReclaimStatus.DELETING)
     try:
         reclaim_tasks.run_old_index_reclaim(db_session, MagicMock(), "tenant", ss)
@@ -339,6 +342,7 @@ def test_deleting_incomplete_stays_deleting(
         assert ss.reclaim_status == IndexReclaimStatus.DELETING
     finally:
         _delete_settings(db_session, ss)
+        _delete_settings(db_session, present)
 
 
 def test_deleting_single_tenant_end_to_end_drops_real_index(
@@ -351,6 +355,7 @@ def test_deleting_single_tenant_end_to_end_drops_real_index(
     client = OpenSearchIndexClient(index_name=index_name)
     # Single-tenant reclaim drops the whole index, so it needs no mappings or documents.
     client._client.indices.create(index=index_name)
+    present = _make_present_settings(db_session)
     ss = _make_past_settings(
         db_session, IndexReclaimStatus.DELETING, index_name=index_name
     )
@@ -369,6 +374,7 @@ def test_deleting_single_tenant_end_to_end_drops_real_index(
             pass
         client.close()
         _delete_settings(db_session, ss)
+        _delete_settings(db_session, present)
 
 
 def test_reverted_future_reclaim_gates_on_port_then_drops_index_and_unblocks_retry(
@@ -386,6 +392,7 @@ def test_reverted_future_reclaim_gates_on_port_then_drops_index_and_unblocks_ret
     index_name = f"test_revert_reclaim_{uuid4().hex[:8]}"
     client = OpenSearchIndexClient(index_name=index_name)
     client._client.indices.create(index=index_name)
+    present = _make_present_settings(db_session)
     ss = _make_past_settings(
         db_session, IndexReclaimStatus.DELETING, index_name=index_name
     )
@@ -421,6 +428,7 @@ def test_reverted_future_reclaim_gates_on_port_then_drops_index_and_unblocks_ret
         ).delete(synchronize_session="fetch")
         db_session.commit()
         _delete_settings(db_session, ss)
+        _delete_settings(db_session, present)
         cleanup_cc_pair(db_session, cc_pair)
 
 
@@ -435,6 +443,7 @@ def test_step_failure_bumps_attempts_then_blocks_at_cap(
         raise RuntimeError("opensearch down")
 
     monkeypatch.setattr(reclaim_tasks, "reclaim_index_data", _boom)
+    present = _make_present_settings(db_session)
     ss = _make_past_settings(db_session, IndexReclaimStatus.DELETING)
     try:
         reclaim_tasks.run_old_index_reclaim(db_session, MagicMock(), "tenant", ss)
@@ -449,6 +458,7 @@ def test_step_failure_bumps_attempts_then_blocks_at_cap(
         assert ss.reclaim_status == IndexReclaimStatus.BLOCKED
     finally:
         _delete_settings(db_session, ss)
+        _delete_settings(db_session, present)
 
 
 def _enqueued_settings_ids(celery_app: MagicMock) -> list[int]:

--- a/backend/tests/integration/common_utils/managers/reindex_port.py
+++ b/backend/tests/integration/common_utils/managers/reindex_port.py
@@ -6,18 +6,13 @@ import httpx
 from onyx.configs.constants import DEFAULT_CC_PAIR_ID
 from onyx.db.enums import ConnectorCredentialPairStatus, SwitchoverType
 from onyx.db.port_attempt import ReindexErrorRow, ReindexProgressCounts
+from onyx.error_handling.error_codes import OnyxErrorCode
 from tests.integration.common_utils.constants import API_SERVER_URL, MAX_DELAY
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.test_models import DATestUser
 
 SEARCH_SETTINGS_URL = f"{API_SERVER_URL}/search-settings"
-
-
-# Must stay in sync with the detail _guard_index_name_reuse raises in
-# onyx/server/manage/search_settings.py. Nothing enforces that, so rewording the message
-# there silently turns every retry here into an immediate failure.
-_RETRYABLE_CONFLICT = "it's being cleaned up now"
 
 
 class ReindexPortManager:
@@ -156,7 +151,12 @@ class ReindexPortManager:
 
             # The other 409s -- a reindex already running, a backfill still draining --
             # never clear on their own, so waiting on them just burns the full timeout.
-            if _RETRYABLE_CONFLICT not in response.text:
+            error_code = ""
+            try:
+                error_code = response.json().get("error_code", "")
+            except ValueError:
+                pass
+            if error_code != OnyxErrorCode.INDEX_NAME_RECLAIMING.code:
                 raise RuntimeError(f"Reindex was refused: {response.text}")
 
             elapsed = time.monotonic() - start

--- a/backend/tests/integration/common_utils/managers/reindex_port.py
+++ b/backend/tests/integration/common_utils/managers/reindex_port.py
@@ -14,6 +14,12 @@ from tests.integration.common_utils.test_models import DATestUser
 SEARCH_SETTINGS_URL = f"{API_SERVER_URL}/search-settings"
 
 
+# Must stay in sync with the detail _guard_index_name_reuse raises in
+# onyx/server/manage/search_settings.py. Nothing enforces that, so rewording the message
+# there silently turns every retry here into an immediate failure.
+_RETRYABLE_CONFLICT = "it's being cleaned up now"
+
+
 class ReindexPortManager:
     """Drives the reindex *port* flow through the real API + worker fleet.
 
@@ -147,6 +153,11 @@ class ReindexPortManager:
             if response.status_code != 409:
                 response.raise_for_status()
                 return int(response.json()["id"])
+
+            # The other 409s -- a reindex already running, a backfill still draining --
+            # never clear on their own, so waiting on them just burns the full timeout.
+            if _RETRYABLE_CONFLICT not in response.text:
+                raise RuntimeError(f"Reindex was refused: {response.text}")
 
             elapsed = time.monotonic() - start
             if elapsed > timeout:

--- a/backend/tests/integration/tests/craft/k8s/test_skill_push.py
+++ b/backend/tests/integration/tests/craft/k8s/test_skill_push.py
@@ -155,6 +155,7 @@ def user_group_factory(
     finally:
         for group in reversed(groups):
             try:
+                UserGroupManager.wait_for_sync(k8s_admin_user, [group])
                 UserGroupManager.delete(group, k8s_admin_user)
             except httpx.HTTPStatusError as e:
                 if e.response.status_code != 404:

--- a/backend/tests/unit/onyx/server/manage/test_reindex_serialize_guard.py
+++ b/backend/tests/unit/onyx/server/manage/test_reindex_serialize_guard.py
@@ -104,7 +104,7 @@ def test_name_reuse_guard_pulls_occupant_into_reclaim(
 
     with pytest.raises(OnyxError) as exc:
         _guard_index_name_reuse(db_session, "danswer_chunk_x")
-    assert exc.value.error_code == OnyxErrorCode.CONFLICT
+    assert exc.value.error_code == OnyxErrorCode.INDEX_NAME_RECLAIMING
     mock_mark.assert_called_once_with(occupant)
     db_session.commit.assert_called_once()
     mock_enqueue.assert_called_once()


### PR DESCRIPTION
## Description

- Clears the `CONNECTOR_INVALID` alert when reclaim deletes a won't-port connector. The bulk `UPDATE` skipped the usual leaving-INVALID cleanup, and notifications have no foreign key to the cc_pair, so admins kept an alert pointing at a connector that no longer exists.
- Gives each DELETING reclaim test its own PRESENT search-settings row. They relied on whatever the shared test database held; `test_step_failure_bumps_attempts_then_blocks_at_cap` passed on the missing-PRESENT error instead of the failure it meant to exercise.
- Makes `test_cancel_keeps_reclaim_intent_a_newer_reindex_stamped` actually exercise its race. The newer reindex now lands mid-cancel, and the two intents differ so the assertion shows which one survived.
- Fails `wait_for_reindex_accepted` immediately on conflicts that never clear (a reindex already running, a backfill still draining) instead of waiting out the full timeout. Only the occupied-index-name conflict retries, as its docstring already promised.
- Corrects the `set_new_search_settings` docstring, which still said it cancels the previous secondary indexing rather than rejecting.

## How Has This Been Tested?

`backend/tests/external_dependency_unit/db` — 499 passed (one pre-existing local failure from an unrelated connector enum). The rewritten cancel-race test was mutation-checked: it fails when the newer reindex does not land, where the previous version passed either way.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale `CONNECTOR_INVALID` alerts when reclaim deletes a won't-port connector, and hardens the reclaim tests so they exercise the code paths they claim to cover.

**Bug Fixes**
- Restores the leaving-INVALID cleanup for cc_pairs moved to `DELETING` by the bulk reclaim `UPDATE`, so the alert no longer points at a deleted connector.
- Adds an `INDEX_NAME_RECLAIMING` error code for the retryable occupied-index-name conflict, replacing message-fragment matching in `wait_for_reindex_accepted`.
- `wait_for_reindex_accepted` now fails immediately on 409s that never clear (reindex already running, backfill draining); only `INDEX_NAME_RECLAIMING` retries.
- Updates the `set_new_search_settings` docstring to state it rejects an existing re-index rather than cancels it.

**Test Hardening**
- Gives each DELETING reclaim test its own PRESENT `SearchSettings` row so failures aren't masked by whatever the shared database happened to hold.
- Adds a regression test seeding `CONNECTOR_INVALID` alerts for a transitioned and a spared pair, asserting only the transitioned pair's alert clears.
- Rewrites the cancel/reindex race test to actually submit a newer reindex mid-cancel and assert which intent survives, instead of passing due to a stray FUTURE row.
- Waits for the user group sync in the skill-push teardown so a still-syncing group no longer rejects the delete with a 409.

<sup>Written for commit 840665ec89d2c9f6f92cc91f2315cce4b922463d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



