### PR TITLE
Add a Jira Service Management connector

### DIFF
--- a/backend/alembic/versions/62c62f2eac71_widen_capability_report_source.py
+++ b/backend/alembic/versions/62c62f2eac71_widen_capability_report_source.py
@@ -1,0 +1,24 @@
+"""Widen capability report sources for Jira Service Management.
+
+Revision ID: 62c62f2eac71
+Revises: 287021f3b46c
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "62c62f2eac71"
+down_revision = "287021f3b46c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "credential_capability_report", "source", type_=sa.String(length=50)
+    )
+
+
+def downgrade() -> None:
+    # Keep the wider column to avoid truncating saved source names.
+    pass

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -259,6 +259,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -780,6 +781,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Service requests and support tickets",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,145 @@
+from http import HTTPStatus
+from typing import Any
+
+from jira import JIRAError
+from requests import RequestException
+from typing_extensions import override
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE, JIRA_CONNECTOR_LABELS_TO_SKIP
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.exceptions import (
+    ConnectorValidationError,
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+    UnexpectedValidationError,
+)
+from onyx.connectors.interfaces import (
+    CheckpointedConnector,
+    CheckpointOutput,
+    GenerateSlimDocumentOutput,
+    SecondsSinceUnixEpoch,
+    SlimConnector,
+)
+from onyx.connectors.jira.connector import JiraConnector, JiraConnectorCheckpoint
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+
+_SERVICE_DESK_PROJECT_TYPE = "service_desk"
+
+
+class JiraServiceManagementConnector(
+    CheckpointedConnector[JiraConnectorCheckpoint], SlimConnector
+):
+    """Index one service project through the Jira API using an agent account.
+
+    Access is set in Onyx. Jira project roles do not represent JSM customer access,
+    so this connector does not advertise automatic permission sync.
+    """
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] = JIRA_CONNECTOR_LABELS_TO_SKIP,
+        scoped_token: bool = False,
+    ) -> None:
+        project_key = project_key.strip()
+        if not project_key:
+            raise ConnectorValidationError(
+                "Enter a Jira Service Management project key."
+            )
+        self.project_key = project_key
+        self.jira = JiraConnector(
+            jira_base_url=jira_base_url,
+            project_key=project_key,
+            comment_email_blacklist=comment_email_blacklist,
+            batch_size=batch_size,
+            labels_to_skip=labels_to_skip,
+            scoped_token=scoped_token,
+        )
+        self._validated = False
+
+    @override
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._validated = False
+        return self.jira.load_credentials(credentials)
+
+    @override
+    def validate_connector_settings(self) -> None:
+        self._validated = False
+        try:
+            project = self.jira.jira_client.project(self.project_key)
+        except JIRAError as exc:
+            if exc.status_code == HTTPStatus.UNAUTHORIZED:
+                raise CredentialExpiredError(
+                    "Jira credentials are invalid or expired."
+                ) from exc
+            if exc.status_code == HTTPStatus.FORBIDDEN:
+                raise InsufficientPermissionsError(
+                    "The Jira account cannot read the service project."
+                ) from exc
+            if exc.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+                raise ConnectorValidationError(
+                    "Jira rate limit reached. Retry validation later."
+                ) from exc
+            raise ConnectorValidationError(
+                f"Cannot read service project {self.project_key} "
+                f"(HTTP {exc.status_code}). Check the project key and account access."
+            ) from exc
+        except RequestException as exc:
+            raise UnexpectedValidationError(
+                "Cannot connect to Jira. Check the base URL and network connection."
+            ) from exc
+
+        if project.raw.get("projectTypeKey") != _SERVICE_DESK_PROJECT_TYPE:
+            raise ConnectorValidationError(
+                "The selected project is not a Jira Service Management project. "
+                "Use the Jira connector for other project types."
+            )
+        self._validated = True
+
+    @override
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JiraConnectorCheckpoint,
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        if not self._validated:
+            self.validate_connector_settings()
+        output = self.jira.load_from_checkpoint(start, end, checkpoint)
+        for document, hierarchy, failure, next_checkpoint in CheckpointOutputWrapper[
+            JiraConnectorCheckpoint
+        ]()(output):
+            if document is not None:
+                yield document.model_copy(
+                    update={"source": DocumentSource.JIRA_SERVICE_MANAGEMENT}
+                )
+            if hierarchy is not None:
+                yield hierarchy
+            if failure is not None:
+                yield failure
+            if next_checkpoint is not None:
+                return next_checkpoint
+        raise RuntimeError("Jira indexing ended without a checkpoint.")
+
+    @override
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        if not self._validated:
+            self.validate_connector_settings()
+        yield from self.jira.retrieve_all_slim_docs(start, end, callback)
+
+    @override
+    def build_dummy_checkpoint(self) -> JiraConnectorCheckpoint:
+        return self.jira.build_dummy_checkpoint()
+
+    @override
+    def validate_checkpoint_json(self, checkpoint_json: str) -> JiraConnectorCheckpoint:
+        return self.jira.validate_checkpoint_json(checkpoint_json)

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -22,6 +22,7 @@ from onyx.connectors.interfaces import (
     SlimConnector,
 )
 from onyx.connectors.jira.connector import JiraConnector, JiraConnectorCheckpoint
+from onyx.connectors.models import TextSection
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 
 _SERVICE_DESK_PROJECT_TYPE = "service_desk"
@@ -114,8 +115,19 @@ class JiraServiceManagementConnector(
             JiraConnectorCheckpoint
         ]()(output):
             if document is not None:
+                sections = document.sections
+                # Empty ticket bodies otherwise lose their links during chunking.
+                if not any(
+                    section.text and section.text.strip() for section in sections
+                ):
+                    sections = [
+                        TextSection(link=document.id, text=document.semantic_identifier)
+                    ]
                 yield document.model_copy(
-                    update={"source": DocumentSource.JIRA_SERVICE_MANAGEMENT}
+                    update={
+                        "source": DocumentSource.JIRA_SERVICE_MANAGEMENT,
+                        "sections": sections,
+                    }
                 )
             if hierarchy is not None:
                 yield hierarchy

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2122,7 +2122,7 @@ class CredentialCapabilityReportRow(Base):
     )
     # Denormalized for support queries by source.
     source: Mapped[DocumentSource] = mapped_column(
-        Enum(DocumentSource, native_enum=False), nullable=False
+        Enum(DocumentSource, native_enum=False, length=50), nullable=False
     )
     # sha256 of the canonical config JSON the report ran with; staleness signal
     # for connector-scoped reports.

--- a/backend/tests/daily/connectors/jira_service_management/test_jira_service_management.py
+++ b/backend/tests/daily/connectors/jira_service_management/test_jira_service_management.py
@@ -1,0 +1,51 @@
+import time
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.models import SlimDocument
+from tests.daily.connectors.utils import load_all_from_connector
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.secrets(
+    TestSecret.JIRA_BASE_URL,
+    TestSecret.JIRA_USER_EMAIL,
+    TestSecret.JIRA_API_TOKEN,
+    TestSecret.JSM_PROJECT_KEY,
+)
+
+
+def test_service_project_tickets(test_secrets: dict[TestSecret, str]) -> None:
+    """Use a service project with at least two tickets and no attachments."""
+    project_key = test_secrets[TestSecret.JSM_PROJECT_KEY]
+    connector = JiraServiceManagementConnector(
+        jira_base_url=test_secrets[TestSecret.JIRA_BASE_URL],
+        project_key=project_key,
+    )
+    connector.load_credentials(
+        {
+            "jira_user_email": test_secrets[TestSecret.JIRA_USER_EMAIL],
+            "jira_api_token": test_secrets[TestSecret.JIRA_API_TOKEN],
+        }
+    )
+    connector.validate_connector_settings()
+    output = load_all_from_connector(connector, start=0, end=time.time())
+    assert not output.failures
+    assert len(output.documents) >= 2
+    ids = {doc.id for doc in output.documents}
+    assert len(ids) == len(output.documents)
+    for doc in output.documents:
+        assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        assert doc.metadata["project"] == project_key
+        assert doc.sections
+        assert doc.doc_updated_at is not None
+    slim_ids = {
+        doc.id
+        for batch in connector.retrieve_all_slim_docs()
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    }
+    assert slim_ids == ids

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py
@@ -1,0 +1,276 @@
+from collections.abc import Generator
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from jira import JIRA, JIRAError
+from jira.resources import Issue, Project
+from requests import ConnectionError
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.exceptions import (
+    ConnectorValidationError,
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+    UnexpectedValidationError,
+)
+from onyx.connectors.interfaces import (
+    CheckpointedConnectorWithPermSync,
+    CheckpointOutput,
+    SlimConnectorWithPermSync,
+)
+from onyx.connectors.jira.connector import JiraConnector, JiraConnectorCheckpoint
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.models import (
+    ConnectorFailure,
+    ConnectorMissingCredentialError,
+    Document,
+    DocumentFailure,
+    HierarchyNode,
+    SlimDocument,
+    TextSection,
+)
+from onyx.connectors.registry import CONNECTOR_CLASS_MAP
+from onyx.db.enums import HierarchyNodeType
+
+
+@pytest.fixture
+def client() -> MagicMock:
+    client = MagicMock(spec=JIRA)
+    client.project.return_value = Project(
+        {}, MagicMock(), raw={"key": "HELP", "projectTypeKey": "service_desk"}
+    )
+    return client
+
+
+@pytest.fixture
+def connector(
+    client: MagicMock,
+) -> Generator[JiraServiceManagementConnector, None, None]:
+    with patch.object(JiraConnector, "jira_client", new_callable=PropertyMock) as prop:
+        prop.return_value = client
+        yield JiraServiceManagementConnector("https://example.atlassian.net", " HELP ")
+
+
+@pytest.mark.parametrize("key", ["", " ", "\n\t"])
+def test_empty_project_is_rejected(key: str) -> None:
+    with pytest.raises(ConnectorValidationError, match="project key"):
+        JiraServiceManagementConnector("https://example.atlassian.net", key)
+
+
+def test_credentials_are_required() -> None:
+    connector = JiraServiceManagementConnector("https://example.atlassian.net", "HELP")
+    with pytest.raises(ConnectorMissingCredentialError):
+        connector.validate_connector_settings()
+
+
+@pytest.mark.parametrize("project_type", ["software", "business", None])
+def test_project_type_must_be_confirmed(
+    connector: JiraServiceManagementConnector,
+    client: MagicMock,
+    project_type: str | None,
+) -> None:
+    client.project.return_value = Project(
+        {}, MagicMock(), raw={"key": "HELP", "projectTypeKey": project_type}
+    )
+    with pytest.raises(ConnectorValidationError, match="not a Jira Service Management"):
+        connector.validate_connector_settings()
+
+
+@pytest.mark.parametrize(
+    "status,exception",
+    [
+        (401, CredentialExpiredError),
+        (403, InsufficientPermissionsError),
+        (404, ConnectorValidationError),
+        (429, ConnectorValidationError),
+        (500, ConnectorValidationError),
+    ],
+)
+def test_http_errors_fail_validation(
+    connector: JiraServiceManagementConnector,
+    client: MagicMock,
+    status: int,
+    exception: type[Exception],
+) -> None:
+    client.project.side_effect = JIRAError(status_code=status)
+    with pytest.raises(exception):
+        connector.validate_connector_settings()
+
+
+def test_network_error_fails_validation(
+    connector: JiraServiceManagementConnector, client: MagicMock
+) -> None:
+    client.project.side_effect = ConnectionError("unreachable")
+    with pytest.raises(UnexpectedValidationError):
+        connector.validate_connector_settings()
+
+
+def test_source_conversion_preserves_checkpoint_hierarchy_and_failures(
+    connector: JiraServiceManagementConnector, client: MagicMock
+) -> None:
+    document = Document(
+        id="https://example.atlassian.net/browse/HELP-1",
+        sections=[
+            TextSection(
+                text="Printer broken",
+                link="https://example.atlassian.net/browse/HELP-1",
+            )
+        ],
+        source=DocumentSource.JIRA,
+        semantic_identifier="HELP-1",
+        metadata={"project": "HELP"},
+    )
+    hierarchy = HierarchyNode(
+        raw_node_id="HELP", display_name="Help", node_type=HierarchyNodeType.FOLDER
+    )
+    failure = ConnectorFailure(
+        failed_document=DocumentFailure(document_id="HELP-2"),
+        failure_message="Temporary ticket failure",
+    )
+    first = connector.build_dummy_checkpoint()
+    resumed = JiraConnectorCheckpoint(has_more=True, cursor="next-page", ids_done=True)
+
+    def page() -> CheckpointOutput[JiraConnectorCheckpoint]:
+        yield hierarchy
+        yield document
+        yield failure
+        return resumed
+
+    with patch.object(
+        connector.jira, "load_from_checkpoint", return_value=page()
+    ) as load:
+        output = list(
+            CheckpointOutputWrapper[JiraConnectorCheckpoint]()(
+                connector.load_from_checkpoint(1, 2, first)
+            )
+        )
+    load.assert_called_once_with(1, 2, first)
+    client.project.assert_called_once_with("HELP")
+    assert output[0][1] is hierarchy
+    converted = output[1][0]
+    assert converted is not None
+    assert converted.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+    assert converted.id == document.id
+    assert converted.sections == document.sections
+    assert document.source == DocumentSource.JIRA
+    assert output[2][2] is failure
+    assert output[-1][3] is resumed
+    assert connector.validate_checkpoint_json(resumed.model_dump_json()) == resumed
+
+
+def test_slim_scan_passes_time_range_and_heartbeat(
+    connector: JiraServiceManagementConnector,
+) -> None:
+    documents = [SlimDocument(id="https://example.atlassian.net/browse/HELP-1")]
+    heartbeat = MagicMock()
+    with patch.object(
+        connector.jira, "retrieve_all_slim_docs", return_value=iter([documents])
+    ) as scan:
+        assert list(connector.retrieve_all_slim_docs(1, 2, heartbeat)) == [documents]
+    scan.assert_called_once_with(1, 2, heartbeat)
+
+
+def test_invalid_project_cannot_start_indexing_or_pruning(
+    connector: JiraServiceManagementConnector, client: MagicMock
+) -> None:
+    client.project.side_effect = JIRAError(status_code=403)
+    with patch.object(connector.jira, "load_from_checkpoint") as load:
+        with pytest.raises(InsufficientPermissionsError):
+            list(
+                connector.load_from_checkpoint(0, 1, connector.build_dummy_checkpoint())
+            )
+        load.assert_not_called()
+    with patch.object(connector.jira, "retrieve_all_slim_docs") as slim:
+        with pytest.raises(InsufficientPermissionsError):
+            list(connector.retrieve_all_slim_docs())
+        slim.assert_not_called()
+
+
+def test_new_credentials_require_validation_again(
+    connector: JiraServiceManagementConnector, client: MagicMock
+) -> None:
+    connector.validate_connector_settings()
+    with patch.object(connector.jira, "load_credentials", return_value=None) as load:
+        connector.load_credentials({"jira_api_token": "replacement-test-token"})
+    load.assert_called_once_with({"jira_api_token": "replacement-test-token"})
+    client.project.side_effect = JIRAError(status_code=401)
+    with pytest.raises(CredentialExpiredError):
+        list(connector.retrieve_all_slim_docs())
+
+
+def test_jira_project_roles_are_not_advertised_as_jsm_permission_sync(
+    connector: JiraServiceManagementConnector,
+) -> None:
+    assert not isinstance(connector, CheckpointedConnectorWithPermSync)
+    assert not isinstance(connector, SlimConnectorWithPermSync)
+
+
+def test_connector_is_registered() -> None:
+    mapping = CONNECTOR_CLASS_MAP[DocumentSource.JIRA_SERVICE_MANAGEMENT]
+    assert mapping.module_path == JiraServiceManagementConnector.__module__
+    assert mapping.class_name == JiraServiceManagementConnector.__name__
+
+
+def test_real_jira_pipeline_keeps_project_scope_across_pages(
+    connector: JiraServiceManagementConnector, client: MagicMock
+) -> None:
+    client._options = {"rest_api_version": "2"}
+    issues = [
+        Issue(
+            {},
+            MagicMock(),
+            raw={
+                "key": f"HELP-{number}",
+                "fields": {
+                    "summary": f"Request {number}",
+                    "description": "Please help",
+                    "labels": [],
+                    "comment": {"comments": []},
+                    "created": "2026-01-01T00:00:00.000+0000",
+                    "updated": "2026-01-02T00:00:00.000+0000",
+                    "project": {"key": "HELP", "name": "Help desk"},
+                    "issuetype": {"name": "Service Request"},
+                },
+            },
+        )
+        for number in (1, 2)
+    ]
+    client.search_issues.side_effect = [[issues[0]], [issues[1]], []]
+    checkpoint = connector.build_dummy_checkpoint()
+    documents: list[Document] = []
+    with patch("onyx.connectors.jira.connector._JIRA_FULL_PAGE_SIZE", 1):
+        for _ in range(3):
+            for document, _, failure, next_checkpoint in CheckpointOutputWrapper[
+                JiraConnectorCheckpoint
+            ]()(connector.load_from_checkpoint(0, 1_800_000_000, checkpoint)):
+                assert failure is None
+                if document is not None:
+                    documents.append(document)
+                if next_checkpoint is not None:
+                    checkpoint = connector.validate_checkpoint_json(
+                        next_checkpoint.model_dump_json()
+                    )
+
+    assert not checkpoint.has_more
+    assert [document.semantic_identifier for document in documents] == [
+        "HELP-1: Request 1",
+        "HELP-2: Request 2",
+    ]
+    assert all(
+        document.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        for document in documents
+    )
+    assert all(document.metadata["project"] == "HELP" for document in documents)
+    assert [call.kwargs["startAt"] for call in client.search_issues.call_args_list] == [
+        0,
+        1,
+        2,
+    ]
+    assert all(
+        'project = "HELP"' in call.kwargs["jql_str"]
+        for call in client.search_issues.call_args_list
+    )
+    client.project.assert_called_once_with("HELP")

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py
@@ -214,8 +214,11 @@ def test_connector_is_registered() -> None:
     assert mapping.class_name == JiraServiceManagementConnector.__name__
 
 
+@pytest.mark.parametrize("description", ["Please help", None, " \n"])
 def test_real_jira_pipeline_keeps_project_scope_across_pages(
-    connector: JiraServiceManagementConnector, client: MagicMock
+    connector: JiraServiceManagementConnector,
+    client: MagicMock,
+    description: str | None,
 ) -> None:
     client._options = {"rest_api_version": "2"}
     issues = [
@@ -226,7 +229,7 @@ def test_real_jira_pipeline_keeps_project_scope_across_pages(
                 "key": f"HELP-{number}",
                 "fields": {
                     "summary": f"Request {number}",
-                    "description": "Please help",
+                    "description": description,
                     "labels": [],
                     "comment": {"comments": []},
                     "created": "2026-01-01T00:00:00.000+0000",
@@ -264,6 +267,12 @@ def test_real_jira_pipeline_keeps_project_scope_across_pages(
         for document in documents
     )
     assert all(document.metadata["project"] == "HELP" for document in documents)
+    for document in documents:
+        assert document.sections[0].link == document.id
+        expected_text = description.strip() if description else ""
+        section_text = document.sections[0].text
+        assert section_text is not None
+        assert section_text.strip() == (expected_text or document.semantic_identifier)
     assert [call.kwargs["startAt"] for call in client.search_issues.call_args_list] == [
         0,
         1,

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -42,6 +42,7 @@ class TestSecret(StrEnum):
     CONFLUENCE_ACCESS_TOKEN = "confluence-access-token"
     CONFLUENCE_ACCESS_TOKEN_SCOPED = "confluence-access-token-scoped"
     JIRA_BASE_URL = "jira-base-url"
+    JSM_PROJECT_KEY = "jsm-project-key"
     JIRA_ADMIN_USER_EMAIL = "jira-admin-user-email"
     JIRA_USER_EMAIL = "jira-user-email"
     JIRA_API_TOKEN = "jira-api-token"

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -516,14 +516,12 @@ export default function AddConnector({
             return;
           })();
 
-          const result = (await Promise.race([
+          const result = await Promise.race([
             connectorCreationPromise,
             timeoutPromise,
-          ])) as {
-            isTimeout?: true;
-          };
+          ]);
 
-          if (result.isTimeout) {
+          if (result && result.isTimeout) {
             timeoutErrorHappenedRef.current = true;
             toast.error(
               t("add.timeout.toast", {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -777,6 +777,42 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management",
+    subtext:
+      "Index tickets from one service project using an agent account. Access is managed in Onyx; Jira customer permissions are not synced. Ticket comments visible to the account are included.",
+    values: [
+      {
+        type: "text",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description: "For example, https://your-domain.atlassian.net",
+      },
+      {
+        type: "text",
+        label: "Service Project Key",
+        name: "project_key",
+        optional: false,
+        description: "The key of the service project to index, such as HELP.",
+      },
+      {
+        type: "checkbox",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "list",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        optional: true,
+        description: "Exclude comments from these email addresses.",
+      },
+    ],
+    advanced_values: [],
+  },
   jira: {
     description: "Configure Jira connector",
     subtext: `Configure which Jira content to index. You can index everything or specify a particular project.`,

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -354,6 +354,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -357,7 +357,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
   jira_service_management: {
     jira_user_email: null,
     jira_api_token: "",
-  } as JiraCredentialJson,
+  } satisfies JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -257,6 +257,11 @@ export const SOURCE_METADATA_MAP: SourceMap = {
   },
 
   // Ticketing & Task Management
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+  },
   jira: {
     icon: SvgJira,
     displayName: "Jira",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -261,6 +261,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     icon: SvgJira,
     displayName: "Jira Service Management",
     category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira_service_management`,
   },
   jira: {
     icon: SvgJira,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -609,6 +609,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
Refs #2281.

/claim #2281

Add Jira Service Management as a separate connector in the admin UI. Require one service project and reject other Jira project types before indexing or pruning. Reuse Jira parsing, pagination, and checkpoints. Preserve ticket links, comments, metadata, and update times. Tickets without descriptions or comments use their summaries as body text so chunking retains their links.

Widen the capability report source column to accept the new source name. Also handle the successful connector-creation promise returning no value. This previously caused a client error after creation.

Onyx manages access. This connector does not sync JSM customer portal permissions. Agent-visible comments can include internal notes. Business user-group access was not tested.

Test report (implementation `86876e3`, validation commit `e4a2e0d`):

| Check | Result |
| --- | --- |
| Jira/JSM regression tests | 56 passed |
| Real JSM Playwright tests | 2 passed, 0 failed, 0 skipped |
| Admin login and connector creation from Add Connector | Passed |
| Initial indexing and search | Passed |
| Search links for tickets with empty bodies | Passed |
| Incremental ticket creation and updates | Passed |
| Pruning after ticket deletion | Passed |
| Python lint and type checks | Passed |
| Full frontend type check | Passed |
| Changed-file frontend formatting and lint | Passed; 0 lint errors, existing warnings |
| PostgreSQL 15 migration and fresh database migration chain | Passed |

The live tests used a real JSM service project. The temporary test ticket was deleted after validation. Original test tickets remained unchanged. These results came from a separate validation workflow; they are not upstream PR checks.

The UI demonstration recording is retained locally and is not attached to this PR. Business user-group access was not tested.

Documentation PR: https://github.com/onyx-dot-app/documentation/pull/454

To reproduce the daily connector test, create a service project with at least two tickets. Include a description or comment on one ticket. Leave another ticket's body empty. Set `jira-base-url`, `jira-user-email`, `jira-api-token`, and `jsm-project-key` in the ignored `.vscode/.env`. With the project test environment installed, run:

```sh
PYTHONPATH=backend uv run pytest backend/tests/daily/connectors/jira_service_management -q
```
