### PR TITLE
feat(embeddings): support OpenAI-compatible embedding provider with dimensions and custom base URL

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -352,7 +352,9 @@ class CloudEmbedding:
 
         # Use the OpenAI specific timeout for this one
         client = openai.AsyncOpenAI(
-            api_key=self.api_key, timeout=OPENAI_EMBEDDING_TIMEOUT
+            api_key=self.api_key,
+            base_url=self.api_url or None,
+            timeout=OPENAI_EMBEDDING_TIMEOUT,
         )
 
         final_embeddings: list[Embedding] = []
@@ -593,7 +595,7 @@ class CloudEmbedding:
         import openai
 
         try:
-            if self.provider == EmbeddingProvider.OPENAI:
+            if self.provider in (EmbeddingProvider.OPENAI, EmbeddingProvider.OPENAI_COMPATIBLE):
                 return await self._embed_openai(texts, model_name, reduced_dimension)
             elif self.provider == EmbeddingProvider.AZURE:
                 return await self._embed_azure(texts, f"azure/{deployment_name}")

--- a/backend/shared_configs/enums.py
+++ b/backend/shared_configs/enums.py
@@ -8,6 +8,7 @@ class EmbeddingProvider(str, Enum):
     GOOGLE = "google"
     LITELLM = "litellm"
     AZURE = "azure"
+    OPENAI_COMPATIBLE = "openai_compatible"
 
 
 class RerankerProvider(str, Enum):

--- a/backend/tests/unit/onyx/indexing/test_embedder.py
+++ b/backend/tests/unit/onyx/indexing/test_embedder.py
@@ -29,7 +29,7 @@ def test_default_indexing_embedder_embed_chunks(
         normalize=True,
         query_prefix=None,
         passage_prefix=None,
-        provider_type=EmbeddingProvider.OPENAI,
+        provider_type=EmbeddingProvider.OPENAI_COMPATIBLE,
     )
 
     # Mock the encode method of the embedding model

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -79,6 +79,44 @@ async def test_openai_embedding(
         mock_client.embeddings.create.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_openai_compatible_embedding_with_dimensions_and_base_url(
+    sample_embeddings: list[list[float]],
+) -> None:
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_client = AsyncMock()
+        mock_openai.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=emb) for emb in sample_embeddings]
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        custom_base_url = "https://custom-ai.example.com/v1"
+        embedding = CloudEmbedding(
+            api_key="fake-custom-key",
+            provider=EmbeddingProvider.OPENAI_COMPATIBLE,
+            api_url=custom_base_url,
+        )
+        result = await embedding._embed(
+            texts=["test1", "test2"],
+            text_type=EmbedTextType.QUERY,
+            model_name="qwen3-embedding-8b",
+            reduced_dimension=1024,
+        )
+
+        assert result == sample_embeddings
+        mock_openai.assert_called_with(
+            api_key="fake-custom-key",
+            base_url=custom_base_url,
+            timeout=OPENAI_EMBEDDING_TIMEOUT,
+        )
+        mock_client.embeddings.create.assert_called_once_with(
+            input=["test1", "test2"],
+            model="qwen3-embedding-8b",
+            dimensions=1024,
+        )
+
+
 def _build_google_embed_response(
     embeddings: list[list[float]],
 ) -> MagicMock:

--- a/backend/tests/unit/server/metrics/test_embedding_metrics.py
+++ b/backend/tests/unit/server/metrics/test_embedding_metrics.py
@@ -25,6 +25,7 @@ class TestProviderLabel:
     def test_enum_maps_to_value(self) -> None:
         assert provider_label(EmbeddingProvider.OPENAI) == "openai"
         assert provider_label(EmbeddingProvider.COHERE) == "cohere"
+        assert provider_label(EmbeddingProvider.OPENAI_COMPATIBLE) == "openai_compatible"
 
 
 class TestObserveEmbeddingClient:


### PR DESCRIPTION
## Description

Adds support for generic OpenAI-compatible embedding providers (`EmbeddingProvider.OPENAI_COMPATIBLE`) with custom base URL and `dimensions` (MRL trimming) parameter forwarding.

Fixes #14335.

### Changes (5 files)
- **`backend/shared_configs/enums.py`**: Added `OPENAI_COMPATIBLE = "openai_compatible"` to the `EmbeddingProvider` enum.
- **`backend/onyx/natural_language_processing/search_nlp_models.py`**: Passed `self.api_url` as `base_url` to `openai.AsyncOpenAI` and routed `OPENAI_COMPATIBLE` requests through `_embed_openai` with `dimensions=reduced_dimension`.
- **`backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`**: Added unit tests validating `OPENAI_COMPATIBLE` provider routing, custom base URL configuration, and reduced dimensions parameters.
- **`backend/tests/unit/onyx/indexing/test_embedder.py`**: Updated unit tests verifying indexing embedder behavior with `OPENAI_COMPATIBLE`.
- **`backend/tests/unit/server/metrics/test_embedding_metrics.py`**: Added metric label tests for `OPENAI_COMPATIBLE` provider.

### Validation
- Validated unit tests for embedding models, client instantiation, and Prometheus metrics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OpenAI-compatible embedding providers so any OpenAI-compatible API can be used as an embedding source, fixing #14335. Also forwards a `dimensions` parameter for embedding size trimming and preserves the configured provider in authentication errors.

- Adds `OPENAI_COMPATIBLE` to `EmbeddingProvider`.
- Routes these providers through the existing OpenAI path using `api_url` as the base URL.
- Reports the provider name in authentication errors instead of hardcoding OpenAI.
- Adds tests for custom base URLs, dimension forwarding, metric labels, and provider routing through the public embed API.

<sup>Written for commit 51edab63c8e1d815397a0aa74818a1848c445cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

