### PR TITLE
fix: keep citation numbers consistent for repeated documents

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -183,6 +183,7 @@ class DynamicCitationProcessor:
             SearchDoc
         ] = []  # SearchDocs in citation order
         self.cited_document_ids: set[str] = set()  # all cited document_ids
+        self.document_id_to_citation_number: dict[str, int] = {}
         self.recent_cited_documents: set[str] = (
             set()
         )  # recently cited (for deduplication)
@@ -504,8 +505,11 @@ class DynamicCitationProcessor:
             if self.citation_mode != CitationMode.HYPERLINK:
                 continue
 
-            # Format the citation text as [[n]](link)
-            formatted_citation_parts.append(f"[[{num}]]({link})")
+            # Reuse the first number emitted in CitationInfo for this document.
+            citation_number = self.document_id_to_citation_number.setdefault(
+                doc_id, num
+            )
+            formatted_citation_parts.append(f"[[{citation_number}]]({link})")
 
             # Skip creating CitationInfo for citations of the same work if cited recently (deduplication)
             if doc_id in self.recent_cited_documents:

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -553,6 +553,53 @@ def test_num_cited_documents_property(mock_search_docs: CitationMapping) -> None
     assert processor.num_cited_documents == 2
 
 
+@pytest.mark.parametrize("first_number, second_number", [(4, 8), (8, 4)])
+@pytest.mark.parametrize("citation_mode", list(CitationMode))
+def test_same_document_with_different_citation_numbers(
+    first_number: int, second_number: int, citation_mode: CitationMode
+) -> None:
+    processor = DynamicCitationProcessor(citation_mode=citation_mode)
+    first_doc = create_test_search_doc(chunk_ind=0)
+    second_doc = create_test_search_doc(
+        chunk_ind=1, link="https://example.com/doc1#chunk2"
+    )
+    processor.update_citation_mapping({first_number: first_doc})
+
+    first_output, first_citations = process_tokens(
+        processor, ["First [", str(first_number), "]."]
+    )
+    processor.update_citation_mapping({second_number: second_doc})
+    second_output, second_citations = process_tokens(
+        processor, [" More details [", str(second_number), "]."]
+    )
+
+    if citation_mode == CitationMode.HYPERLINK:
+        assert first_output + second_output == (
+            f"First [[{first_number}]]({first_doc.link})."
+            f" More details [[{first_number}]]({second_doc.link})."
+        )
+        assert first_citations == [
+            CitationInfo(
+                citation_number=first_number, document_id=first_doc.document_id
+            )
+        ]
+        assert processor.get_cited_documents() == [first_doc]
+    elif citation_mode == CitationMode.KEEP_MARKERS:
+        assert first_output + second_output == (
+            f"First [{first_number}]. More details [{second_number}]."
+        )
+        assert first_citations == []
+    else:
+        assert first_output + second_output == "First. More details."
+        assert first_citations == []
+
+    assert second_citations == []
+    assert processor.get_seen_citations() == {
+        first_number: first_doc,
+        second_number: second_doc,
+    }
+
+
 def test_multiple_citations_same_document_no_duplicate(
     mock_search_docs: CitationMapping,
 ) -> None:


### PR DESCRIPTION
## Description

Fixes #14334.

When a document is cited as `[4]` and later `[8]`, the second inline marker currently disagrees with the source footer, which only receives `CitationInfo` for `[4]`. Reuse the document's first cited number for subsequent hyperlink markers, while preserving each chunk's URL and the original raw citation mappings. `KEEP_MARKERS` and `REMOVE` behavior is unchanged.

AI assistance: OpenAI Codex was used to implement, test, and independently review this change.

## How Has This Been Tested?

- `uv run --no-sync pytest -q backend/tests/unit/onyx/chat/test_citation_processor.py`: **136 passed**. The new regression failed in both hyperlink cases before the fix; it covers both citation orders, mappings added during streaming, distinct chunk URLs, and all three citation modes.
- Changed-file pre-commit checks passed, including ty, ruff, formatting, ripsecrets, and the environment drift check.

Tests ran on Python 3.13.13 with lockfile-pinned dependencies. Full dependency sync was blocked by a local Cargo dylib error while building LiteLLM; broader chat and live bot integration tests were not completed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #14334. When a document is cited at different numbers (e.g., `[4]` then `[8]`), the inline hyperlink marker now reuses the document's first cited number so it agrees with the source footer, while preserving each chunk's URL and the raw citation mappings. KEEP_MARKERS and REMOVE behavior is unchanged.

Adds a regression test covering both citation orders, distinct chunk URLs, streaming mapping updates, and all three citation modes.

<sup>Written for commit cd4c436d3a11886d7464087de5f8cf8152763748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

