### PR TITLE
docs(tenant_cleanup): point the quick start at README.md

### DIFF
--- a/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
+++ b/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
@@ -123,7 +123,7 @@ The scripts include multiple safety checks:
 
 ## Need More Details?
 
-See [NO_BASTION_README.md](./NO_BASTION_README.md) for:
+See [README.md](./README.md) for:
 - Detailed explanations of each step
 - Troubleshooting guide
 - How it works under the hood


### PR DESCRIPTION
`backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md` links `./NO_BASTION_README.md`, which never existed in git history. The directory's actual doc is `README.md`; the link now points there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tenant cleanup quick start link so it points to the actual `README.md` instead of the non-existent `NO_BASTION_README.md`.

<sup>Written for commit d6fed33eb678f37e434102eb4efa3e4fd50531cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

