### PR TITLE
docs: drop duplicated words in onyx comments and docstrings

### DIFF
--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -589,7 +589,7 @@ def kg_extraction(
                     )
                     db_session.commit()
 
-        # Update the the Skipped Docs back to Not Started
+        # Update the Skipped Docs back to Not Started
         with get_session_with_current_tenant() as db_session:
             skipped_documents = get_skipped_kg_documents(db_session)
             for document_id in skipped_documents:

--- a/backend/onyx/prompts/kg_prompts.py
+++ b/backend/onyx/prompts/kg_prompts.py
@@ -1427,7 +1427,7 @@ questions about entities and their relationships."""
 
 # Just in case, for best practice, send a system message with key rules.
 # (The db user permissions executing the SQL will avoid issues anyway,
-# but it does not hurt to to put multiple checks in place.)
+# but it does not hurt to put multiple checks in place.)
 SQL_INSTRUCTIONS_RELATIONSHIP_PROMPT = """
 You are an expert at generating SQL queries to answer questions about a knowledge graph.
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -2134,7 +2134,7 @@ def _sync_tools_for_server(
 ) -> int:
     """Toggle enabled state for MCP tools that exist for the server.
     Updates to the db model of a tool all happen when the user Lists Tools.
-    This ensures that the the tools added to the db match what the user sees in the UI,
+    This ensures that the tools added to the db match what the user sees in the UI,
     even if the underlying tool has changed on the server after list tools is called.
     That's a corner case anyways; the admin should go back and update the server by re-listing tools.
     """


### PR DESCRIPTION
Three doubled words:

- `server/features/mcp/api.py` (`_sync_tools_for_server` docstring): "that **the the** tools added"
- `kg/extractions/extraction_processing.py`: "Update **the the** Skipped Docs"
- `kg/prompts/kg_prompts.py`: "does not hurt **to to** put multiple checks in place" (inside a prompt text — user/model-visible)

Comments/docstrings only; none touch `ee/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes duplicated words in three Onyx comments and docstrings without affecting code behavior.

<sup>Written for commit 09d32e08b1aa6404335de598f54b60f49842d685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

