### PR TITLE
Add Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -259,6 +259,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -780,6 +781,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Service requests, tickets, and service desk projects",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -395,6 +395,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -487,7 +488,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -516,6 +517,9 @@ class JiraConnector(
     SlimConnector,
     SlimConnectorWithPermSync,
 ):
+    # Source stamped on produced documents; subclasses (e.g. JSM) override this.
+    document_source: DocumentSource = DocumentSource.JIRA
+
     def __init__(
         self,
         jira_base_url: str,
@@ -833,6 +837,7 @@ class JiraConnector(
                     comment_email_blacklist=self.comment_email_blacklist,
                     labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+                    source=self.document_source,
                 ):
                     # Add permission information to the document if requested
                     if include_permissions:

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,44 @@
+from onyx.configs.app_configs import (
+    INDEX_BATCH_SIZE,
+    JIRA_CONNECTOR_LABELS_TO_SKIP,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.connector import JiraConnector
+
+# JQL filter that matches only Jira Service Management (service-desk) projects
+JSM_PROJECT_TYPE_JQL = "projectType = service_desk"
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    """Connector for Jira Service Management (JSM).
+
+    Reuses the Jira connector; when no project key or custom JQL is given,
+    indexing is scoped to service-desk projects so plain Jira Software
+    projects are excluded.
+    """
+
+    document_source = DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str | None = None,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] = JIRA_CONNECTOR_LABELS_TO_SKIP,
+        jql_query: str | None = None,
+        scoped_token: bool = False,
+    ) -> None:
+        # Default to service-desk projects if no explicit scope was provided
+        if not project_key and not jql_query:
+            jql_query = JSM_PROJECT_TYPE_JQL
+
+        super().__init__(
+            jira_base_url=jira_base_url,
+            project_key=project_key,
+            comment_email_blacklist=comment_email_blacklist,
+            batch_size=batch_size,
+            labels_to_skip=labels_to_skip,
+            jql_query=jql_query,
+            scoped_token=scoped_token,
+        )

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -19,6 +19,7 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Outline.png",
     DocumentSource.CONFLUENCE: "Confluence.png",
     DocumentSource.JIRA: "Jira.png",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Jira.png",
     DocumentSource.SLAB: "Slab.png",
     DocumentSource.PRODUCTBOARD: "Productboard.png",
     DocumentSource.FILE: _DEFAULT_SOURCE_IMAGE_FILENAME,

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management.py
@@ -1,0 +1,134 @@
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+import pytest
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.connector import JiraConnectorCheckpoint, process_jira_issue
+from onyx.connectors.jira_service_management.connector import (
+    JSM_PROJECT_TYPE_JQL,
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.models import Document
+
+
+@pytest.fixture
+def mock_jira_client() -> MagicMock:
+    mock = MagicMock(spec=JIRA)
+    mock.search_issues = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def create_mock_issue() -> Callable[..., MagicMock]:
+    def _create_mock_issue(
+        key: str = "IT-123",
+        summary: str = "Broken laptop",
+        project_key: str = "IT",
+    ) -> MagicMock:
+        mock_issue = MagicMock(spec=Issue)
+        mock_issue.fields = MagicMock()
+        mock_issue.key = key
+        mock_issue.fields.summary = summary
+        mock_issue.fields.updated = "2023-01-01T12:00:00.000+0000"
+        mock_issue.fields.created = "2023-01-01T12:00:00.000+0000"
+        mock_issue.fields.description = "Some description"
+        mock_issue.fields.labels = []
+        mock_issue.fields.reporter = None
+        mock_issue.fields.assignee = None
+        mock_issue.fields.priority = None
+        mock_issue.fields.status = None
+        mock_issue.fields.resolution = None
+        mock_issue.fields.resolutiondate = None
+        mock_issue.fields.duedate = None
+        mock_issue.fields.issuetype = None
+        mock_issue.fields.parent = None
+        project = MagicMock()
+        project.key = project_key
+        project.name = "IT Support"
+        mock_issue.fields.project = project
+        return mock_issue
+
+    return _create_mock_issue
+
+
+def test_scope_defaults_to_service_desk_projects() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net"
+    )
+    assert connector.jql_query == JSM_PROJECT_TYPE_JQL
+
+    jql = connector._get_jql_query(0, 1000)
+    assert JSM_PROJECT_TYPE_JQL in jql
+    assert "updated >= 0" in jql
+    assert "updated <= 1000000" in jql
+
+
+def test_explicit_project_key_preserved() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+        project_key="IT",
+    )
+    assert connector.jql_query is None
+    assert 'project = "IT"' in connector._get_jql_query(0, 1000)
+
+
+def test_explicit_jql_preserved() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+        jql_query='project = "CUSTOM"',
+    )
+    assert connector.jql_query == 'project = "CUSTOM"'
+
+
+def test_documents_stamped_as_jira_service_management(
+    mock_jira_client: MagicMock, create_mock_issue: Callable[..., MagicMock]
+) -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net"
+    )
+    connector._jira_client = mock_jira_client
+    # force the v2 (server) path so we can avoid the v3 id-fetch flow
+    mock_jira_client._options = {"rest_api_version": "2"}
+
+    issue = create_mock_issue()
+    with patch(
+        "onyx.connectors.jira.connector._perform_jql_search",
+        return_value=iter([issue]),
+    ):
+        checkpoint = connector.build_dummy_checkpoint()
+        checkpoint.has_more = False
+        output = list(connector.load_from_checkpoint(0, 1000, checkpoint))
+
+    docs = [item for item in output if isinstance(item, Document)]
+    assert len(docs) == 1
+    assert docs[0].source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+
+def test_process_jira_issue_default_source_unchanged(
+    create_mock_issue: Callable[..., MagicMock],
+) -> None:
+    """The Jira connector still stamps plain JIRA on its documents."""
+    issue = create_mock_issue()
+    doc = process_jira_issue(jira_base_url="https://example.atlassian.net", issue=issue)
+    assert doc is not None
+    assert doc.source == DocumentSource.JIRA
+
+    doc = process_jira_issue(
+        jira_base_url="https://example.atlassian.net",
+        issue=issue,
+        source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+    )
+    assert doc is not None
+    assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+
+def test_checkpoint_type_is_jira_checkpoint() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net"
+    )
+    checkpoint = connector.build_dummy_checkpoint()
+    assert isinstance(checkpoint, JiraConnectorCheckpoint)
+    assert checkpoint.has_more is True

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -862,6 +862,91 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management content to index. By default, only service desk projects are indexed. You can also specify a particular project or custom JQL query.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "How Should We Index Your Jira Service Management?",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "All Service Desks",
+            fields: [
+              {
+                type: "string_tab",
+                label: "All Service Desks",
+                name: "everything",
+                description:
+                  "This connector will index all issues in service desk projects the provided credentials have access to!",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Project",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "The key of a specific service desk project to index (e.g., 'IT').",
+              },
+            ],
+          },
+          {
+            value: "jql",
+            label: "JQL Query",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the JQL query:",
+                label: "JQL Query",
+                name: "jql_query",
+                description:
+                  "A custom JQL query to filter Jira Service Management issues." +
+                  "\n\nIMPORTANT: Do not include any time-based filters in the JQL query as that will conflict with the connector's logic. Additionally, do not include ORDER BY clauses." +
+                  "\n\nSee Atlassian's [JQL documentation](https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-fields/) for more details on syntax.",
+              },
+            ],
+          },
+        ],
+        defaultTab: "everything",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -2193,6 +2278,14 @@ export interface ConfluenceConfig {
 
 export interface JiraConfig {
   jira_project_url: string;
+  project_key?: string;
+  comment_email_blacklist?: string[];
+  jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  scoped_token?: boolean;
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -354,6 +354,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -264,6 +264,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -609,6 +609,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
/claim #2281

Adds a Jira Service Management connector. It subclasses the existing Jira connector: unscoped indexing targets service desk projects via the projectType = service_desk JQL filter, and documents stamp as JIRA_SERVICE_MANAGEMENT. Wired through the backend registry and frontend source metadata/form. Unit tests cover scoping, source stamping, and checkpoint handling.
