### PR TITLE
fix(auth): bound the OAuth token refresh an authenticated request performs

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -47,6 +47,20 @@ OIDC_DISCOVERY_CACHE_TTL_SECONDS: int = int(
 # Negative entries retry quickly so a transient IdP outage self-heals fast.
 OIDC_DISCOVERY_NEGATIVE_TTL_SECONDS: int = 45
 
+# Hard cap on every outgoing OAuth/OIDC HTTP call. Without it an unreachable IdP
+# pins the DB session the request holds while refreshing, until the async pool is
+# exhausted and every authenticated endpoint times out.
+OAUTH_HTTP_TIMEOUT_SECONDS: float = float(
+    os.environ.get("OAUTH_HTTP_TIMEOUT_SECONDS") or 10.0
+)
+
+# Cap on the whole refresh pass a request performs before it is served. Bounds the
+# combined lock wait, DB reads and IdP round-trip so no request can hold its DB
+# session past this budget.
+OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS: float = float(
+    os.environ.get("OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS") or 15.0
+)
+
 # Per-discovery-URL locks so one IdP's hanging fetch never blocks another's.
 # Created on first use so they bind to the running event loop.
 _OIDC_DISCOVERY_LOCKS: Dict[str, asyncio.Lock] = {}
@@ -156,8 +170,8 @@ async def _get_oidc_token_endpoint(config_url: str) -> Optional[str]:
             return await _revalidate_cached_endpoint(cached)
         token_endpoint: Optional[str] = None
         try:
-            async with httpx.AsyncClient() as client:
-                response = await client.get(config_url, timeout=10.0)
+            async with httpx.AsyncClient(timeout=OAUTH_HTTP_TIMEOUT_SECONDS) as client:
+                response = await client.get(config_url)
                 response.raise_for_status()
                 config: Dict[str, Any] = response.json()
             raw_endpoint = config.get("token_endpoint")
@@ -318,7 +332,7 @@ async def refresh_oauth_token(
     try:
         logger.info("Refreshing OAuth token for %s's %s account", user.email, provider)
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=OAUTH_HTTP_TIMEOUT_SECONDS) as client:
             response = await client.post(
                 context.token_endpoint,
                 data={

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import os
 import time
 import uuid
@@ -47,18 +48,42 @@ OIDC_DISCOVERY_CACHE_TTL_SECONDS: int = int(
 # Negative entries retry quickly so a transient IdP outage self-heals fast.
 OIDC_DISCOVERY_NEGATIVE_TTL_SECONDS: int = 45
 
+
+def _timeout_from_env(name: str, default: float) -> float:
+    """Read a timeout from the environment, rejecting values that would remove
+    the bound. `inf` disables it entirely and `0` aborts every refresh on the
+    spot, so both fall back to the default rather than silently misbehaving."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("%s is not a number (%r) - using %ss", name, raw, default)
+        return default
+    if not math.isfinite(value) or value <= 0:
+        logger.warning(
+            "%s must be a finite positive number of seconds (got %r) - using %ss",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
+
 # Hard cap on every outgoing OAuth/OIDC HTTP call. Without it an unreachable IdP
 # pins the DB session the request holds while refreshing, until the async pool is
 # exhausted and every authenticated endpoint times out.
-OAUTH_HTTP_TIMEOUT_SECONDS: float = float(
-    os.environ.get("OAUTH_HTTP_TIMEOUT_SECONDS") or 10.0
+OAUTH_HTTP_TIMEOUT_SECONDS: float = _timeout_from_env(
+    "OAUTH_HTTP_TIMEOUT_SECONDS", 10.0
 )
 
 # Cap on the whole refresh pass a request performs before it is served. Bounds the
 # combined lock wait, DB reads and IdP round-trip so no request can hold its DB
 # session past this budget.
-OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS: float = float(
-    os.environ.get("OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS") or 15.0
+OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS: float = _timeout_from_env(
+    "OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS", 15.0
 )
 
 # Per-discovery-URL locks so one IdP's hanging fetch never blocks another's.

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextvars
 import hashlib
 import os
@@ -1902,7 +1903,10 @@ class FastAPIUserWithRefreshRouter(FastAPIUsers[models.UP, models.ID]):
         Provide a router for session token refreshing.
         """
         # Import the oauth_refresher here to avoid circular imports
-        from onyx.auth.oauth_refresher import check_and_refresh_oauth_tokens
+        from onyx.auth.oauth_refresher import (
+            OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS,
+            check_and_refresh_oauth_tokens,
+        )
 
         router = APIRouter()
 
@@ -1934,12 +1938,26 @@ class FastAPIUserWithRefreshRouter(FastAPIUsers[models.UP, models.ID]):
                 user, token = user_token
                 logger.info("Processing token refresh request for user %s", user.email)
 
-                # Check if user has OAuth accounts that need refreshing
-                await check_and_refresh_oauth_tokens(
-                    user=cast(User, user),
-                    db_session=db_session,
-                    user_manager=cast(Any, user_manager),
-                )
+                # Check if user has OAuth accounts that need refreshing.
+                # Bounded so a slow IdP cannot hold this request's DB session
+                # open. Refreshing the IdP token is opportunistic here, so a
+                # timeout still lets the session token refresh below proceed.
+                try:
+                    await asyncio.wait_for(
+                        check_and_refresh_oauth_tokens(
+                            user=cast(User, user),
+                            db_session=db_session,
+                            user_manager=cast(Any, user_manager),
+                        ),
+                        timeout=OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "OAuth token refresh for %s exceeded %ss - continuing "
+                        "with the session token refresh",
+                        user.email,
+                        OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS,
+                    )
 
                 # Check if strategy supports refreshing
                 supports_refresh = hasattr(strategy, "refresh_token") and callable(
@@ -2138,13 +2156,19 @@ async def _maybe_refresh_oauth_tokens(
     """
     # Local import mirrors the pattern at `get_refresh_router` to keep the auth
     # module's load order resilient.
-    from onyx.auth.oauth_refresher import check_and_refresh_oauth_tokens
+    from onyx.auth.oauth_refresher import (
+        OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS,
+        check_and_refresh_oauth_tokens,
+    )
 
     try:
-        await check_and_refresh_oauth_tokens(
-            user=user,
-            db_session=async_db_session,
-            user_manager=cast(Any, user_manager),
+        await asyncio.wait_for(
+            check_and_refresh_oauth_tokens(
+                user=user,
+                db_session=async_db_session,
+                user_manager=cast(Any, user_manager),
+            ),
+            timeout=OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS,
         )
     except Exception:
         logger.exception(

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -55,6 +55,10 @@ DR_REPORT_LLM_TIMEOUT_S = int(os.environ.get("DR_REPORT_LLM_TIMEOUT_S") or "60")
 SECONDARY_LLM_FLOW_TIMEOUT_S = int(
     os.environ.get("SECONDARY_LLM_FLOW_TIMEOUT_S") or "60"
 )
+# Timeout for the chat session auto-naming call. Naming is cosmetic and already
+# falls back to a title derived from the first user message, so it fails fast
+# rather than holding a serving thread while an overloaded provider stalls.
+CHAT_NAMING_TIMEOUT_S = int(os.environ.get("CHAT_NAMING_TIMEOUT_S") or "20")
 # Live buffer TTL. Refreshed per write.
 CHAT_STREAM_BUFFER_TTL_S = int(os.environ.get("CHAT_STREAM_BUFFER_TTL_S") or 3600)
 # Retention after the run is done.

--- a/backend/onyx/secondary_llm_flows/chat_session_naming.py
+++ b/backend/onyx/secondary_llm_flows/chat_session_naming.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 
 from onyx.chat.llm_step import translate_history_to_llm_format
 from onyx.chat.models import ChatMessageSimple
+from onyx.configs.chat_configs import CHAT_NAMING_TIMEOUT_S
 from onyx.configs.constants import MessageType
 from onyx.db.models import ChatMessage
 from onyx.llm.interfaces import LLM
@@ -61,7 +62,11 @@ def generate_chat_session_name(
         flow=LLMFlow.CHAT_SESSION_NAMING,
         input_messages=llm_facing_history,
     ) as span_generation:
-        response = llm.invoke(llm_facing_history, reasoning_effort=ReasoningEffort.OFF)
+        response = llm.invoke(
+            llm_facing_history,
+            reasoning_effort=ReasoningEffort.OFF,
+            timeout_override=CHAT_NAMING_TIMEOUT_S,
+        )
         record_llm_response(span_generation, response)
         new_name_raw = llm_response_to_string(response)
 

--- a/backend/tests/unit/onyx/auth/test_oauth_timeout_env.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_timeout_env.py
@@ -1,0 +1,33 @@
+"""`_timeout_from_env` must never yield a value that removes the timeout."""
+
+import pytest
+
+from onyx.auth.oauth_refresher import _timeout_from_env
+
+VAR = "ONYX_TEST_OAUTH_TIMEOUT"
+DEFAULT = 15.0
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, DEFAULT),  # unset
+        ("", DEFAULT),  # set but empty
+        ("30", 30.0),
+        ("0.5", 0.5),
+        ("inf", DEFAULT),  # would disable the bound
+        ("-inf", DEFAULT),
+        ("nan", DEFAULT),
+        ("0", DEFAULT),  # would abort every refresh immediately
+        ("-5", DEFAULT),
+        ("abc", DEFAULT),
+    ],
+)
+def test_timeout_from_env(
+    monkeypatch: pytest.MonkeyPatch, raw: str | None, expected: float
+) -> None:
+    if raw is None:
+        monkeypatch.delenv(VAR, raising=False)
+    else:
+        monkeypatch.setenv(VAR, raw)
+    assert _timeout_from_env(VAR, DEFAULT) == expected

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -301,6 +301,11 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # GOOGLE_OAUTH_CLIENT_SECRET=
 # OAUTH_CLIENT_ID=
 # OAUTH_CLIENT_SECRET=
+# Per-call timeout (seconds) on OAuth/OIDC HTTP requests to the IdP (default 10).
+# OAUTH_HTTP_TIMEOUT_SECONDS=
+# Budget (seconds) for the token refresh an authenticated request performs before
+# it is served (default 15). Bounds how long a slow IdP can hold a DB session.
+# OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS=
 # OPENID_CONFIG_URL=
 # SAML_CONF_DIR=
 # Comma-separated list of origins allowed to make cross-origin (CORS) requests,
@@ -317,6 +322,9 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # LLM_SOCKET_READ_TIMEOUT=
 # IMAGE_SUMMARIZATION_TIMEOUT=
 # CONTEXTUAL_RAG_LLM_TIMEOUT=
+# Timeout (seconds) on the chat auto-naming call (default 20). Naming falls back
+# to a title from the first user message, so it fails fast.
+# CHAT_NAMING_TIMEOUT_S=
 # MAX_CHUNKS_FED_TO_CHAT=
 # DISABLE_LITELLM_STREAMING=
 # LITELLM_EXTRA_HEADERS=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -301,6 +301,11 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # GOOGLE_OAUTH_CLIENT_SECRET=
 # OAUTH_CLIENT_ID=
 # OAUTH_CLIENT_SECRET=
+# Per-call timeout (seconds) on OAuth/OIDC HTTP requests to the IdP (default 10).
+# OAUTH_HTTP_TIMEOUT_SECONDS=
+# Budget (seconds) for the token refresh an authenticated request performs before
+# it is served (default 15). Bounds how long a slow IdP can hold a DB session.
+# OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS=
 # OPENID_CONFIG_URL=
 # SAML_CONF_DIR=
 # Comma-separated list of origins allowed to make cross-origin (CORS) requests,
@@ -317,6 +322,9 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # LLM_SOCKET_READ_TIMEOUT=
 # IMAGE_SUMMARIZATION_TIMEOUT=
 # CONTEXTUAL_RAG_LLM_TIMEOUT=
+# Timeout (seconds) on the chat auto-naming call (default 20). Naming falls back
+# to a title from the first user message, so it fails fast.
+# CHAT_NAMING_TIMEOUT_S=
 # MAX_CHUNKS_FED_TO_CHAT=
 # DISABLE_LITELLM_STREAMING=
 # LITELLM_EXTRA_HEADERS=

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1535,6 +1535,11 @@ configMap:
   # Set auth.userauth.enabled=true and provide auth.userauth.values.user_auth_secret
   # (signs password reset and email verification tokens and OAuth login state).
   AUTH_TYPE: "basic"
+  # Per-call timeout on OAuth/OIDC HTTP requests to the IdP.
+  OAUTH_HTTP_TIMEOUT_SECONDS: "10"
+  # Budget for the token refresh an authenticated request performs before it is
+  # served. Bounds how long a slow IdP can hold a DB session.
+  OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS: "15"
   # Opt-in: capture IdP directory claims at OAuth/OIDC login and use them to
   # enrich chat prompts and resolve {{user.<key>}} agent placeholders. Sends
   # directory data to the configured LLM, so off by default.
@@ -1587,6 +1592,9 @@ configMap:
   LLM_SOCKET_READ_TIMEOUT: "60"
   IMAGE_SUMMARIZATION_TIMEOUT: "300"
   CONTEXTUAL_RAG_LLM_TIMEOUT: "180"
+  # Timeout on the chat auto-naming call. Naming falls back to a title from the
+  # first user message, so it fails fast.
+  CHAT_NAMING_TIMEOUT_S: "20"
   MAX_CHUNKS_FED_TO_CHAT: ""
   # Usage / cost accounting
   # Records priced generation spans into the per-user usage ledger (default on).


### PR DESCRIPTION
## Description

Every authenticated request runs `check_and_refresh_oauth_tokens` while it holds its async DB session. That path POSTs to the IdP token endpoint through an `httpx.AsyncClient()` with **no timeout**. When the IdP is slow or unreachable the coroutine never returns its Postgres connection, so the async pool fills with connections stuck `idle in transaction` and every authenticated endpoint starts returning 504.

Two bounds, both env-configurable:

- `OAUTH_HTTP_TIMEOUT_SECONDS` (default 10) on both outgoing OAuth/OIDC clients in `oauth_refresher.py`. The discovery GET already had a hard-coded `timeout=10.0`; it now shares the constant.
- `OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS` (default 15) around the whole refresh pass at both call sites, so the combined lock wait, DB reads and IdP round-trip cannot exceed the budget.

The refresh is opportunistic, so a timeout degrades rather than fails. On `/refresh` the `asyncio.TimeoutError` is caught locally, because that handler's outer `except Exception` raises HTTP 400 and a slow IdP must not break session refresh outright.

A second commit bounds a related unbounded LLM call: `generate_chat_session_name` passed no timeout, so it inherited the generic 60s socket read timeout while running in the request thread pool, competing with the streaming chat generator. Naming is cosmetic and `_generate_or_fallback_chat_session_name` already falls back to a title from the first user message, so `CHAT_NAMING_TIMEOUT_S` (default 20) makes it fail fast, following the existing `SECONDARY_LLM_FLOW_TIMEOUT_S` pattern.

The three new env vars are documented in `env.template`, its embedded CLI copy, and the Helm `values.yaml`.

## How Has This Been Tested?

Timeout and config changes with no behavioural branch to assert on, so no new test. Verified `pre-commit run` passes on every touched file (`ty`, `ruff`, `env-drift-baseline`), and reviewed that both `check_and_refresh_oauth_tokens` call sites are now bounded (`grep` shows no third caller).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the OAuth token refresh and chat auto-naming so an unresponsive IdP or LLM can't hold DB sessions or serving threads indefinitely.

**OAuth refresh bounds**
- Every authenticated request runs `check_and_refresh_oauth_tokens` while holding its async DB session, and a slow IdP could exhaust the pool into 504s.
- Added `OAUTH_HTTP_TIMEOUT_SECONDS` (default 10) to both OAuth/OIDC clients and `OAUTH_REFRESH_TOTAL_TIMEOUT_SECONDS` (default 15) around each refresh pass.
- Timeout env values must be finite positive numbers; anything else falls back to the default with a warning, covered by a new unit test.
- The refresh degrades rather than fails; `/refresh` catches the timeout so session token refresh still proceeds.

**Chat naming bound**
- `generate_chat_session_name` had no timeout, so it inherited the generic 60s socket read timeout while holding a request thread.
- `CHAT_NAMING_TIMEOUT_S` (default 20) makes the naming call fail fast, and it already falls back to a title from the first user message.

The new env vars are documented in `env.template`, the embedded CLI copy, and the Helm `values.yaml`.

<sup>Written for commit 216460ffedb55a76e90970ec1ee94310029ae166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

