### PR TITLE
fix(connectors/web): make the HEAD content-type precheck non-fatal

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -472,14 +472,32 @@ class WebConnector(LoadConnector, SlimConnector):
         # Handle cookies for the URL
         _handle_cookies(session_ctx.playwright_context, initial_url)
 
-        # First do a HEAD request to check content type without downloading the entire content
-        head_response = requests.head(
-            initial_url,
-            headers=DEFAULT_HEADERS,
-            allow_redirects=True,
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        content_type = head_response.headers.get("content-type")
+        # First do a HEAD request to check content type without downloading the
+        # entire content. This is only a precheck, so it must never abort the
+        # scrape. One real case: `requests` resolves a redirect by doing
+        # `location.encode("latin1").decode("utf8")`, so a `Location` holding
+        # non-UTF-8 bytes (an accented path served as latin-1) raises
+        # UnicodeDecodeError. Fall through to the browser fetch below, which
+        # percent-encodes those bytes and follows the redirect, instead of
+        # burning the URL's retries on the precheck.
+        content_type: str | None
+        try:
+            head_response = requests.head(
+                initial_url,
+                headers=DEFAULT_HEADERS,
+                allow_redirects=True,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            content_type = head_response.headers.get("content-type")
+        except (requests.RequestException, UnicodeDecodeError) as e:
+            logger.warning(
+                "HEAD precheck failed for %s (%s: %s) - skipping content-type "
+                "based PDF detection and falling through to the browser fetch",
+                initial_url,
+                type(e).__name__,
+                e,
+            )
+            content_type = None
         is_pdf = is_pdf_resource(initial_url, content_type)
 
         if is_pdf:

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -230,6 +230,20 @@ def check_internet_connection(url: str) -> None:
             else e.args
         )
         raise Exception(f"SSL error {str(cause)}")
+    except UnicodeDecodeError as e:
+        # Not a reachability problem: `requests` resolves a redirect by doing
+        # `location.encode("latin1").decode("utf8")`, so a `Location` holding
+        # non-UTF-8 bytes raises here. The browser fetch percent-encodes those
+        # bytes and follows the redirect, so let the scrape proceed. Listed
+        # before the ValueError clause below, which would otherwise catch it
+        # (UnicodeDecodeError subclasses ValueError) and abort the run.
+        logger.warning(
+            "Could not resolve redirects for %s (%s) - continuing, the browser "
+            "fetch follows these natively",
+            url,
+            e,
+        )
+        return
     except (requests.RequestException, ValueError) as e:
         raise Exception(f"Unable to reach {url} - check your internet connection: {e}")
 

--- a/backend/tests/unit/onyx/connectors/web/test_head_precheck.py
+++ b/backend/tests/unit/onyx/connectors/web/test_head_precheck.py
@@ -9,7 +9,11 @@ import pytest
 import requests
 
 from onyx.connectors.models import Document
-from onyx.connectors.web.connector import WEB_CONNECTOR_VALID_SETTINGS, WebConnector
+from onyx.connectors.web.connector import (
+    WEB_CONNECTOR_VALID_SETTINGS,
+    WebConnector,
+    check_internet_connection,
+)
 
 BASE_URL = "http://example.com"
 PAGE_HTML = "<html><body><p>Indexable content</p></body></html>"
@@ -83,3 +87,29 @@ def test_failed_head_precheck_still_indexes_the_page(
     assert doc.id == BASE_URL + "/"
     # Proves the browser fetch below the precheck actually ran.
     assert "Indexable content" in doc.get_text_content()
+
+
+@pytest.mark.parametrize(
+    ("probe_error", "expect_raise"),
+    [
+        # Reachability probe on the base URL. A non-UTF-8 redirect `Location` is
+        # not a connectivity problem, so it must not abort the run.
+        (
+            UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid continuation byte"),
+            False,
+        ),
+        (requests.ConnectionError("connection reset"), True),
+    ],
+    ids=["unicode_decode_error", "connection_error"],
+)
+def test_check_internet_connection_ignores_undecodable_redirects(
+    probe_error: Exception, expect_raise: bool
+) -> None:
+    """`check_internet_connection` runs on the base URL before the scrape loop,
+    and it follows redirects too. A genuinely unreachable host still raises."""
+    with patch.object(requests.Session, "get", side_effect=probe_error):
+        if expect_raise:
+            with pytest.raises(Exception, match="check your internet connection"):
+                check_internet_connection(BASE_URL + "/")
+        else:
+            check_internet_connection(BASE_URL + "/")

--- a/backend/tests/unit/onyx/connectors/web/test_head_precheck.py
+++ b/backend/tests/unit/onyx/connectors/web/test_head_precheck.py
@@ -1,0 +1,85 @@
+"""The HEAD content-type precheck must never abort a scrape."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from onyx.connectors.models import Document
+from onyx.connectors.web.connector import WEB_CONNECTOR_VALID_SETTINGS, WebConnector
+
+BASE_URL = "http://example.com"
+PAGE_HTML = "<html><body><p>Indexable content</p></body></html>"
+
+
+@pytest.fixture(autouse=True)
+def _skip_web_connector_ssrf_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default SSRF level does a real DNS lookup per fetch; neutralize the
+    gate so these tests stay hermetic."""
+    monkeypatch.setattr(
+        "onyx.connectors.web.connector.protected_url_check", lambda _url: None
+    )
+
+
+def _make_playwright_context_mock() -> MagicMock:
+    context = MagicMock()
+
+    def _new_page() -> MagicMock:
+        page = MagicMock()
+
+        def _goto(url: str, **kwargs: Any) -> MagicMock:  # noqa: ARG001
+            page.url = url
+            response = MagicMock()
+            response.status = 200
+            response.header_value.return_value = None  # no cf-ray
+            return response
+
+        page.goto.side_effect = _goto
+        page.content.return_value = PAGE_HTML
+        return page
+
+    context.new_page.side_effect = _new_page
+    return context
+
+
+@pytest.mark.parametrize(
+    "head_error",
+    [
+        # `requests` resolves a redirect by re-decoding the latin-1 header as
+        # UTF-8, so a `Location` holding non-UTF-8 bytes raises this. Chromium
+        # percent-encodes the same bytes and follows the redirect fine.
+        UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid continuation byte"),
+        requests.ConnectionError("connection reset"),
+    ],
+    ids=["unicode_decode_error", "connection_error"],
+)
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_failed_head_precheck_still_indexes_the_page(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+    head_error: Exception,
+) -> None:
+    """A failing HEAD only disables content-type based PDF detection; the browser
+    fetch below still runs and the page is indexed."""
+    mock_start_playwright.return_value = (MagicMock(), _make_playwright_context_mock())
+    mock_head.side_effect = head_error
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    docs = [doc for batch in connector.load_from_state() for doc in batch]
+
+    assert len(docs) == 1
+    doc = docs[0]
+    assert isinstance(doc, Document)
+    assert doc.id == BASE_URL + "/"
+    # Proves the browser fetch below the precheck actually ran.
+    assert "Indexable content" in doc.get_text_content()


### PR DESCRIPTION
## Description

`_do_scrape` starts with a `requests.head` to detect PDFs without downloading the body. Any exception there aborted the whole scrape of that URL, so the caller burned all of its retries and the URL stayed permanently unindexed.

One reproducible case: `requests.sessions.resolve_redirects` re-decodes the `Location` header with `location.encode("latin1").decode("utf8")`. urllib3 decodes headers as latin-1 (which never fails), then `requests` re-encodes and attempts a UTF-8 decode, so a server that sends non-UTF-8 bytes in `Location` - an accented path served as latin-1 - raises `UnicodeDecodeError`. Chromium percent-encodes the same bytes and follows the redirect without trouble, so only the precheck failed.

The HEAD is only a precheck, so catch `RequestException` and `UnicodeDecodeError`, log, and fall through to the Playwright fetch. `is_pdf_resource` already accepts `content_type=None` and still detects PDFs by URL extension.

## How Has This Been Tested?

New unit test `backend/tests/unit/onyx/connectors/web/test_head_precheck.py`, parametrised over `UnicodeDecodeError` and `ConnectionError`, asserting the page is still fetched and indexed. Confirmed it fails on unpatched `main` (both cases) and passes with the fix.

Separately reproduced the redirect behaviour against a local `http.server` sending a raw `Location` header, to check which encoding actually triggers it and that the browser fetch recovers:

```
Location: /aide/cong\xc3\xa9s   (UTF-8)    requests.head -> 200, follows to /aide/cong%C3%A9s
Location: /aide/cong\xe9s       (latin-1)  requests.head -> UnicodeDecodeError: byte 0xe9 invalid continuation byte
                                           chromium goto -> 200, page.url /aide/cong%E9s, content received
```

`pre-commit run` passes on both touched files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the web connector's HEAD content-type precheck and reachability probe so a `requests` redirect bug that raises `UnicodeDecodeError` on URLs with latin-1 accented paths no longer aborts the scrape or the entire connector run; those URLs now get indexed via the browser fetch.

**Bug Fixes**
- Catches `RequestException` and `UnicodeDecodeError` in the precheck, logs, and falls through to the browser fetch.
- Catches `UnicodeDecodeError` in the reachability probe and continues; genuine connection errors still raise.
- PDF detection still works with unknown content-type because `is_pdf_resource` checks the URL extension.

<sup>Written for commit fd7d9c1ea8a25466531254f6fe00badec05300a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

