### PR TITLE
ci(terraform-provider): publish the changelog as the release body

### DIFF
--- a/terraform-provider-onyx/.github/workflows/publish.yml
+++ b/terraform-provider-onyx/.github/workflows/publish.yml
@@ -67,7 +67,9 @@ jobs:
             found && /^## / { exit }
             found { print }
           ' CHANGELOG.md > "${notes}"
-          if [ ! -s "${notes}" ]; then
+          # Not -s: a heading with no entries under it yields a file of blank
+          # lines, which has a non-zero size but is an empty release body.
+          if ! grep -q '[^[:space:]]' "${notes}"; then
             if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
               echo "::error::CHANGELOG.md has no section for ${version}." >&2
               exit 1

--- a/terraform-provider-onyx/.github/workflows/publish.yml
+++ b/terraform-provider-onyx/.github/workflows/publish.yml
@@ -50,14 +50,16 @@ jobs:
           gpg_private_key: ${{ secrets.TF_PROVIDER_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.TF_PROVIDER_GPG_PASSPHRASE }}
 
-      # The GitHub release body is what a user reads before upgrading, and
-      # goreleaser's own changelog is disabled on purpose: the mirror carries one
-      # squashed commit per release, so a commit-derived changelog says nothing.
-      # Take the notes from CHANGELOG.md instead. A tag whose version has no
-      # section fails here rather than publishing an empty release.
+      # The GitHub release body is what a user reads before upgrading. The mirror
+      # carries one squashed commit per release, so a commit-derived changelog
+      # would say nothing; take the notes from CHANGELOG.md instead. Any release
+      # whose version has no section fails here rather than publishing empty.
+      #
       # Written outside the checkout on purpose: goreleaser refuses to release
       # from a dirty tree, and an untracked file in the repo root is dirty.
       - name: Extract the release notes
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           notes="${RUNNER_TEMP}/release-notes.md"
@@ -70,11 +72,14 @@ jobs:
           # Not -s: a heading with no entries under it yields a file of blank
           # lines, which has a non-zero size but is an empty release body.
           if ! grep -q '[^[:space:]]' "${notes}"; then
-            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            # Keyed on the dry run, not on the ref being a tag: a manual publish
+            # from a branch is a real publish and must fail closed too.
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "No notes for '${version}', but this is a dry run; continuing."
+            else
               echo "::error::CHANGELOG.md has no section for ${version}." >&2
               exit 1
             fi
-            echo "Not a tag, so there are no notes to extract; continuing."
           fi
           cat "${notes}"
 

--- a/terraform-provider-onyx/.github/workflows/publish.yml
+++ b/terraform-provider-onyx/.github/workflows/publish.yml
@@ -50,12 +50,38 @@ jobs:
           gpg_private_key: ${{ secrets.TF_PROVIDER_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.TF_PROVIDER_GPG_PASSPHRASE }}
 
+      # The GitHub release body is what a user reads before upgrading, and
+      # goreleaser's own changelog is disabled on purpose: the mirror carries one
+      # squashed commit per release, so a commit-derived changelog says nothing.
+      # Take the notes from CHANGELOG.md instead. A tag whose version has no
+      # section fails here rather than publishing an empty release.
+      # Written outside the checkout on purpose: goreleaser refuses to release
+      # from a dirty tree, and an untracked file in the repo root is dirty.
+      - name: Extract the release notes
+        run: |
+          set -euo pipefail
+          notes="${RUNNER_TEMP}/release-notes.md"
+          version="${GITHUB_REF_NAME#v}"
+          awk -v prefix="## ${version} " '
+            index($0, prefix) == 1 { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > "${notes}"
+          if [ ! -s "${notes}" ]; then
+            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+              echo "::error::CHANGELOG.md has no section for ${version}." >&2
+              exit 1
+            fi
+            echo "Not a tag, so there are no notes to extract; continuing."
+          fi
+          cat "${notes}"
+
       - name: Build and publish the release
         if: ${{ !inputs.dry_run }}
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # ratchet:goreleaser/goreleaser-action@v7.2.3
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --release-notes=${{ runner.temp }}/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}

--- a/terraform-provider-onyx/.goreleaser.yml
+++ b/terraform-provider-onyx/.goreleaser.yml
@@ -48,5 +48,8 @@ release:
     - glob: terraform-registry-manifest.json
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
 
-changelog:
-  disable: true
+# No changelog block. `changelog.disable: true` skips the whole pipe, and that
+# pipe is what reads --release-notes, so disabling it silently discards the
+# notes Publish extracts from CHANGELOG.md and the release body comes out empty.
+# Nothing generates a commit-derived changelog either: the pipe returns as soon
+# as --release-notes is set, which Publish always passes on the tag path.

--- a/terraform-provider-onyx/CHANGELOG.md
+++ b/terraform-provider-onyx/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.3.0 (Unreleased)
+The section headings are load-bearing: the mirror's Publish workflow extracts the
+block for the tag being released and uses it as the GitHub release body, which is
+what the Terraform Registry shows. A release whose version has no section here
+fails rather than publishing empty notes.
+
+## 0.3.0 (September 8, 2026)
 
 BREAKING CHANGES:
 


### PR DESCRIPTION
## Description

The GitHub release that the Terraform Registry links to has been **empty for every release
so far**. `.goreleaser.yml` disables goreleaser's own changelog, and that is correct — the
release mirror carries one squashed commit per release, so a commit-derived changelog would
say nothing useful. Nothing filled the gap, so the body stayed blank.

That is now a problem worth fixing rather than a cosmetic one. **0.3.0 renames
`onyx_persona` to `onyx_agent`** (#14543), and the entire user-facing story of that release
is a single `terraform state mv` command. An empty release body puts that instruction
nowhere a user upgrading would actually look — the registry renders `docs/`, not
`CHANGELOG.md`.

Changes:

* `publish.yml` extracts the section for the tag being released out of `CHANGELOG.md` and
  passes it to goreleaser as `--release-notes`.
* **It fails closed.** A tag whose version has no `## X.Y.Z` section fails the job rather
  than publishing an empty release, so a future release cannot silently regress to today's
  behaviour by someone forgetting to add a section.
* The notes are written to `RUNNER_TEMP`, not the repo root — goreleaser refuses to release
  from a dirty tree, and an untracked file there counts as dirty.
* Dates the `0.3.0` heading. The mirror is a snapshot of this directory taken at tag time,
  so `## 0.3.0 (Unreleased)` would have shipped *inside* the released artifact.

Note `publish.yml` lives in the mirror, `onyx-dot-app/terraform-provider-onyx`, and is inert
here — it is edited in the monorepo and copied across by the release workflow. Because a tag
push runs the workflow file as it exists at that tag, the version landing with 0.3.0 is the
one that will run for 0.3.0.

## How Has This Been Tested?

* Extraction run against the real `CHANGELOG.md`: `0.3.0` yields the full 21-line section,
  including the `terraform state mv` block.
* Negative case checked rather than assumed: a version with no section produces an empty
  file, which is what trips the fail-closed branch on the tag path.
* `pre-commit` passes `zizmor`, `actionlint`, `check-yaml` and `ripsecrets` on the changed
  workflow — worth noting these hooks genuinely reach this nested file, which they did not
  before the patterns were root-unanchored.

The first real exercise is the 0.3.0 tag itself. The failure mode is loud and safe: if
extraction breaks, the job fails before goreleaser signs or publishes anything, and nothing
reaches the mirror or the registry.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!--
Override Linear Check: ENG-4322 is an umbrella issue tracking the whole Terraform provider
rollout. Linking it with a closing keyword would close the entire plan on merge, so it is
referenced as context only.
-->

Context: ENG-4322 (Terraform provider rollout plan).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fills the empty GitHub release body for the Terraform provider by extracting the tag's section from `CHANGELOG.md` and passing it to goreleaser as release notes.

- Removes `changelog.disable` so goreleaser's changelog pipe reads the notes file instead of discarding it.
- A missing or whitespace-only section fails the job, unless it's a dry run; the guard keys on `dry_run` so manual publishes from a branch also fail closed.
- Notes are written to `RUNNER_TEMP` to avoid a dirty tree.
- Dates the 0.3.0 heading so "Unreleased" doesn't ship in the artifact.

<sup>Written for commit ce4c1a21d815e6dc03b6de31f7f17891d219b493. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Review fixes

**Greptile P2 — "Whitespace-only notes pass". Valid, and a hole in the exact guarantee this
PR claims.** `[ -s ]` only tests for a non-zero file size, so a version heading with no
entries beneath it extracts to a file of blank lines, passes the guard, and publishes a
visually empty release body. That is the outcome the guard exists to prevent, and adding a
heading before writing the entries under it is a plausible slip.

Fixed in `30a3094798` by testing for non-whitespace content instead. Verified across all
three cases:

| Extracted notes | Before | After |
| --- | --- | --- |
| Real `0.3.0` section | accepted | accepted |
| Heading with no entries | **accepted** | **rejected** |
| No section at all | rejected | rejected |


**cubic P1 — "GoReleaser still publishes an empty release body". Valid, and it defeated the
whole PR.** `changelog.disable: true` skips the entire changelog pipe, and that pipe is what
reads `--release-notes`. So the notes were extracted correctly and then silently discarded,
and 0.3.0 would have shipped the empty body this PR exists to prevent.

Verified experimentally rather than from reading alone — pointing `--release-notes` at a
missing file:

| Config | Result |
| --- | --- |
| `changelog.disable: true` | no error; the pipe never runs, so the flag is never read |
| no `changelog` block | `⨯ error=open /does/not/exist: no such file or directory` |

Fixed in `ce4c1a21d8` by removing the block. This does **not** reintroduce a commit-derived
changelog: the pipe returns as soon as `--release-notes` is set, which Publish always passes
on the tag path. `goreleaser check` still validates.

**cubic P2 — non-tag dispatch with `dry_run=false` slipped through. Valid.** The guard keyed
on the ref being a tag, so a manual publish from a branch reached goreleaser with empty
notes. It now keys on the dry run itself, so the only path that continues with no notes is an
explicit dry run.
