### PR TITLE
ci(terraform-provider): let the release App update the mirror's workflow

### DIFF
--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -78,6 +78,11 @@ jobs:
           owner: onyx-dot-app
           repositories: terraform-provider-onyx
           permission-contents: write
+          # The mirrored tree contains .github/workflows/publish.yml, and GitHub
+          # refuses a push from an App that changes a workflow file without this.
+          # Only bites on a release that alters publish.yml, so the first four
+          # releases did not need it.
+          permission-workflows: write
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6


### PR DESCRIPTION
## Description

The v0.3.0 release was rejected by the mirror with `GH013`:

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/publish.yml` without `workflows` permission
```

The mirrored tree contains `.github/workflows/publish.yml`, and GitHub refuses a push from a
GitHub App that creates or updates a workflow file unless the token carries the `workflows`
permission. `public-terraform-releaser` has only ever held `contents: write` and
`metadata: read`.

Nothing caught this before because it only bites on a release that **changes** `publish.yml`,
and the first four did not. #14546 is the first one that does.

The push is atomic, so both `main` and the tag were rejected together and nothing partial
reached the mirror.

> [!IMPORTANT]
> **This is only half the fix, and merging it alone makes things worse rather than better.**
> A token cannot request a permission the App does not hold, so until the App is granted
> **Workflows: Read and write** (and the installation accepts it), this change moves the
> failure earlier — the mint step fails instead of the push. Grant the permission first, then
> merge.

Once both are in place, the release is re-driven without re-tagging — the workflow takes a
`version` input:

```
gh workflow run release-terraform-provider.yml -f version=0.3.0
```

## How Has This Been Tested?

Not executed — it cannot be until the App permission is granted. Verified statically:

* `permission-workflows` is a real input on `actions/create-github-app-token` (`action.yml`).
* The App's granted permissions were read back from
  `/orgs/onyx-dot-app/installations` and are exactly `contents: write`, `metadata: read`,
  which matches the error.
* The mirror was confirmed unchanged after the rejection — `main` still at `432e8ef9d0`.
* `pre-commit` passes `zizmor`, `actionlint`, `check-yaml` and `ripsecrets`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!--
Override Linear Check: ENG-4322 is an umbrella issue tracking the whole Terraform provider
rollout. A closing keyword would close the entire plan on merge, so it is context only.
-->

Context: ENG-4322 (Terraform provider rollout plan).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `permission-workflows: write` to the release workflow's token request so the GitHub App can update `.github/workflows/publish.yml` in the mirror. This fixes the GH013 rejection that blocked the v0.3.0 release. Merging this before granting the App "Workflows: Read and write" will fail earlier at token minting, so grant the permission first.

<sup>Written for commit 6afe10997452b8cd89aaf2b28dc01769eb54a6e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

