### PR TITLE
docs(terraform-provider): correct the publishing section and group the known limitations

### DIFF
--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -140,13 +140,28 @@ that uses the twin clears it from state and moves the resource onto the write-on
 
 ## Known limitations (by API design)
 
+Each of these follows from how the Onyx API behaves, not from a gap in the provider, so each
+one is a thing to design around rather than a bug to wait on.
+
+A few are marked **fixed upstream**. The backend change is merged but is not in a released
+Onyx yet, so the provider keeps the workaround and the limitation still applies. They go away
+once the fix ships in a release and the provider drops the workaround.
+
+### Secrets
+
 - **Secret drift is undetectable.** The API masks `api_key`/`custom_config` on read, so
   rotating them out-of-band (e.g. in the admin UI) is invisible to `terraform plan`. The
   configured value is authoritative and is re-asserted on the next apply.
+
+### Settings and deployment defaults
+
 - **`onyx_settings` and `onyx_llm_provider_default` don't really delete.** Onyx has no
   reset-settings API and no unset API for the text/vision defaults; destroy removes them
   from state with a warning and leaves the live values alone. The chat-naming default is
   the exception: it has an unset API and is cleared on destroy when managed.
+
+### LLM and embedding providers
+
 - **`onyx_embedding_provider` updates replace all fields.** Keep `api_key` (or
   `api_key_wo`) in configuration — an update applied without it clears the stored key (the
   API has no keep-stored-key flag). The currently-active embedding provider also cannot be
@@ -154,36 +169,45 @@ that uses the twin clears it from state and moves the resource onto the write-on
 - **`model_configurations` is the list of record.** Models omitted from it are removed
   server-side, and removing the model currently set as deployment default fails — repoint
   `onyx_llm_provider_default` first (references order this correctly).
+- **The model list read is the API's display view.** It hides obsolete models and dated
+  duplicates, so writes (including the auto-mode pass-through, which is also not atomic
+  with its read) cannot preserve rows the API hides. The admin UI round-trips the same
+  filtered view. *Fixed upstream:* the upsert now takes a `keep_existing_models` flag.
+
+### Credentials and connectors
+
 - **`onyx_credential` payloads are never read back.** The API always returns the payload
   masked, so it is never refreshed or diffed. `admin_public`, `curator_public` and `groups`
   have no update endpoint and force replacement instead.
-- **`onyx_connector` does not own its access control.** `access_type` and `groups` are
-  validated on write but stored on the cc-pair, so Terraform cannot refresh them. Onyx also
-  rewrites an unset `prune_freq` to 7 days on the first update, which the provider then
-  keeps as the value of record.
-- **`onyx_connector` does not set access control.** Onyx applies it when a credential is
-  associated, so it belongs to the connector-credential pair. The connector endpoints still
-  require an `access_type` in the request body but ignore it, so the provider sends a fixed
-  value rather than offering a knob that would do nothing.
 - **A private credential can look deleted.** The API hides a credential with
   `admin_public = false` from admins other than its creator, and that is indistinguishable
   from a deleted one, so Terraform would drop it from state and recreate it. Keep
   `admin_public = true` (the default) for credentials Terraform manages, or run Terraform
   with the key that created them.
+- **`onyx_connector` does not own its access control.** Onyx applies access when a
+  credential is associated, so `access_type` and `groups` belong to the connector-credential
+  pair. The connector endpoints still require an `access_type` in the request body and then
+  ignore it, so the provider sends a fixed value rather than offering a knob that would do
+  nothing. Set access control on `onyx_cc_pair`.
+- **Onyx rewrites an unset `prune_freq` to 7 days** on a connector's first update, which the
+  provider then keeps as the value of record.
+
+### Agents and actions
+
 - **Deleting an agent leaves a tombstone.** Onyx marks the row deleted instead of removing
   it, so the name stays taken. A later create under that name revives the tombstone, which
   is why destroy-then-apply returns the same agent id rather than a new one.
 - **A deleted agent answers 400, not 404.** The lookup raises a plain `ValueError`, which
   Onyx renders as a bad request, so "gone" cannot be read off the status. The provider
-  confirms against the agent listing instead of matching on the message text. Making that
-  endpoint return 404 is a worthwhile backend fix.
+  confirms against the agent listing instead of matching on the message text.
+  *Fixed upstream:* the route now answers a typed `PERSONA_NOT_FOUND`.
 - **`onyx_agent` does not own every field on an agent.** Attached folders and documents
   are cleared by an omitted list, and sending null is rejected (422), so the provider reads
   them and sends them back unchanged. That leaves a narrow window in which an attachment
-  added between the read and the write is reverted; making the two fields nullable
-  server-side would close it. Also,
-  `search_start_date` is sent but never read back, because Onyx returns it as a parsed
-  timestamp that would not match a plain date. Avatar images are not managed at all.
+  added between the read and the write is reverted. *Fixed upstream:* both fields are
+  nullable now. Also, `search_start_date` is sent but never read back, because Onyx returns
+  it as a parsed timestamp that would not match a plain date. Avatar images are not managed
+  at all.
 - **`display_priority` is create-only on the upsert.** Onyx reads it when an agent is
   created and ignores it on every later write, so the provider applies a change through
   the display-priority endpoint as a second call. That endpoint only sets a number, so the
@@ -195,6 +219,9 @@ that uses the twin clears it from state and moves the resource onto the write-on
   built-ins instead.
 - **Deleting a custom action detaches it from every agent that uses it**, including agents
   Terraform does not manage, without an error or a warning.
+
+### User groups (Enterprise Edition)
+
 - **`onyx_user_group` is Enterprise Edition only.** The routes live in the EE application
   and do not exist on Community Edition, where every call answers 404. Its acceptance tests
   skip when `ee_features_enabled` is false.
@@ -224,6 +251,7 @@ that uses the twin clears it from state and moves the resource onto the write-on
   this right. So a 404 from any of them does not mean the group is gone — the destroy
   confirms each one against the listing before reporting success, since trusting it would
   drop a live group out of state and leave the next apply failing on the name it still holds.
+  *Fixed upstream:* the sync gate now raises a distinct `RESOURCE_SYNCING` conflict.
 - **`onyx_user_group` permissions use Onyx's wire tokens**, for example `manage:connectors`,
   not the enum names. Only toggleable permissions can be set; `basic`, `admin`,
   `craft_sandbox`, `manage:skills` and the implied read tokens are managed by Onyx and are
@@ -236,6 +264,9 @@ that uses the twin clears it from state and moves the resource onto the write-on
   way, because it drops the whole roster, so a `terraform destroy` can fail on a member whose
   only group this is. It also guards self-removal by a manager, privilege amplification, and
   the survival of admin access.
+
+### MCP servers
+
 - **`onyx_mcp_server` manages only servers that need no interactive sign-in.** `NONE` and
   `API_TOKEN` are supported; `OAUTH` and `PT_OAUTH` need a browser round-trip and are
   refused while the plan is built, with a diagnostic naming the admin panel.
@@ -271,10 +302,6 @@ that uses the twin clears it from state and moves the resource onto the write-on
   admin panel.
 - **An MCP server URL cannot point at the Onyx host.** The SSRF guard refuses `localhost`
   and link-local addresses by name at every protection level, not only the strictest.
-- **The model list read is the API's display view.** It hides obsolete models and dated
-  duplicates, so writes (including the auto-mode pass-through, which is also not atomic
-  with its read) cannot preserve rows the API hides. The admin UI round-trips the same
-  filtered view; a keep-models flag on the upsert API is the planned structural fix.
 
 ## Development
 

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -140,168 +140,134 @@ that uses the twin clears it from state and moves the resource onto the write-on
 
 ## Known limitations (by API design)
 
-Each of these follows from how the Onyx API behaves, not from a gap in the provider, so each
-one is a thing to design around rather than a bug to wait on.
+These follow from how the Onyx API behaves, so each is something to design around rather than
+a bug to wait on.
 
-A few are marked **fixed upstream**. The backend change is merged but is not in a released
-Onyx yet, so the provider keeps the workaround and the limitation still applies. They go away
-once the fix ships in a release and the provider drops the workaround.
+**Fixed upstream** marks a limitation the backend has already changed. The fix is not in a
+released Onyx yet, so the provider keeps its workaround and the limitation still applies.
 
 ### Secrets
 
-- **Secret drift is undetectable.** The API masks `api_key`/`custom_config` on read, so
-  rotating them out-of-band (e.g. in the admin UI) is invisible to `terraform plan`. The
-  configured value is authoritative and is re-asserted on the next apply.
+- **Secret drift is undetectable.** The API masks secrets on read, so rotating one in the
+  admin UI is invisible to `terraform plan`. The configured value is authoritative and is
+  re-asserted on the next apply.
 
 ### Settings and deployment defaults
 
-- **`onyx_settings` and `onyx_llm_provider_default` don't really delete.** Onyx has no
-  reset-settings API and no unset API for the text/vision defaults; destroy removes them
-  from state with a warning and leaves the live values alone. The chat-naming default is
-  the exception: it has an unset API and is cleared on destroy when managed.
+- **`onyx_settings` and `onyx_llm_provider_default` do not really delete.** Onyx has no
+  reset-settings API and no unset API for the text and vision defaults, so destroy drops them
+  from state and leaves the live values alone. The chat-naming default does have an unset API
+  and is cleared.
 
 ### LLM and embedding providers
 
-- **`onyx_embedding_provider` updates replace all fields.** Keep `api_key` (or
-  `api_key_wo`) in configuration — an update applied without it clears the stored key (the
-  API has no keep-stored-key flag). The currently-active embedding provider also cannot be
-  deleted.
-- **`model_configurations` is the list of record.** Models omitted from it are removed
-  server-side, and removing the model currently set as deployment default fails — repoint
-  `onyx_llm_provider_default` first (references order this correctly).
-- **The model list read is the API's display view.** It hides obsolete models and dated
-  duplicates, so writes (including the auto-mode pass-through, which is also not atomic
-  with its read) cannot preserve rows the API hides. The admin UI round-trips the same
-  filtered view. *Fixed upstream:* the upsert now takes a `keep_existing_models` flag.
+- **`onyx_embedding_provider` updates replace all fields.** Keep `api_key` (or `api_key_wo`)
+  in the configuration or an update clears the stored key. The active embedding provider
+  cannot be deleted.
+- **`model_configurations` is the list of record.** Omitted models are removed server-side,
+  and removing the current deployment default fails — repoint `onyx_llm_provider_default`
+  first, which references order correctly.
+- **The model list read is the API's display view.** It hides obsolete and dated-duplicate
+  models, so no write can preserve rows it does not return. The admin UI has the same
+  behaviour. *Fixed upstream:* the upsert takes `keep_existing_models`.
 
 ### Credentials and connectors
 
-- **`onyx_credential` payloads are never read back.** The API always returns the payload
-  masked, so it is never refreshed or diffed. `admin_public`, `curator_public` and `groups`
-  have no update endpoint and force replacement instead.
-- **A private credential can look deleted.** The API hides a credential with
-  `admin_public = false` from admins other than its creator, and that is indistinguishable
-  from a deleted one, so Terraform would drop it from state and recreate it. Keep
-  `admin_public = true` (the default) for credentials Terraform manages, or run Terraform
-  with the key that created them.
-- **`onyx_connector` does not own its access control.** Onyx applies access when a
-  credential is associated, so `access_type` and `groups` belong to the connector-credential
-  pair. The connector endpoints still require an `access_type` in the request body and then
-  ignore it, so the provider sends a fixed value rather than offering a knob that would do
-  nothing. Set access control on `onyx_cc_pair`.
-- **Onyx rewrites an unset `prune_freq` to 7 days** on a connector's first update, which the
-  provider then keeps as the value of record.
+- **`onyx_credential` payloads are never read back.** The API always masks the payload, so it
+  is never refreshed or diffed. `admin_public`, `curator_public` and `groups` have no update
+  endpoint and force replacement.
+- **A private credential can look deleted.** Onyx hides a credential with
+  `admin_public = false` from every admin but its creator, which is indistinguishable from
+  deletion, so Terraform would drop it and recreate it. Keep the default `admin_public = true`
+  for managed credentials, or apply with the key that created them.
+- **`onyx_connector` does not own its access control.** Onyx applies access when a credential
+  is associated, so `access_type` and `groups` live on the connector-credential pair. The
+  connector endpoints still require `access_type` in the body and ignore it, so the provider
+  sends a fixed value rather than offering a knob that does nothing. Set access on
+  `onyx_cc_pair`.
+- **An unset `prune_freq` becomes 7 days** on a connector's first update, and the provider
+  then keeps that as the value of record.
 
 ### Agents and actions
 
-- **Deleting an agent leaves a tombstone.** Onyx marks the row deleted instead of removing
-  it, so the name stays taken. A later create under that name revives the tombstone, which
-  is why destroy-then-apply returns the same agent id rather than a new one.
-- **A deleted agent answers 400, not 404.** The lookup raises a plain `ValueError`, which
-  Onyx renders as a bad request, so "gone" cannot be read off the status. The provider
-  confirms against the agent listing instead of matching on the message text.
-  *Fixed upstream:* the route now answers a typed `PERSONA_NOT_FOUND`.
-- **`onyx_agent` does not own every field on an agent.** Attached folders and documents
-  are cleared by an omitted list, and sending null is rejected (422), so the provider reads
-  them and sends them back unchanged. That leaves a narrow window in which an attachment
-  added between the read and the write is reverted. *Fixed upstream:* both fields are
-  nullable now. Also, `search_start_date` is sent but never read back, because Onyx returns
-  it as a parsed timestamp that would not match a plain date. Avatar images are not managed
-  at all.
-- **`display_priority` is create-only on the upsert.** Onyx reads it when an agent is
-  created and ignores it on every later write, so the provider applies a change through
-  the display-priority endpoint as a second call. That endpoint only sets a number, so the
-  attribute is computed: removing it from the configuration leaves the last value rather
-  than reporting a difference that never settles.
+- **Deleting an agent leaves a tombstone.** The row is marked deleted, so the name stays
+  taken and a later create under it revives the same agent. Destroy-then-apply returns the
+  original id, not a new one.
+- **A deleted agent answers 400, not 404**, so "gone" cannot be read off the status. The
+  provider confirms against the agent listing rather than matching error text.
+  *Fixed upstream:* the route answers a typed `PERSONA_NOT_FOUND`.
+- **`onyx_agent` does not own every field.** Attached folders and documents are cleared by an
+  omitted list and reject an explicit null, so the provider reads them and writes them back —
+  leaving a one-round-trip window where an attachment added in between is reverted.
+  *Fixed upstream:* both fields are nullable. Separately, `search_start_date` is written but
+  never read back, and avatars are not managed.
+- **`display_priority` is create-only on the upsert.** Onyx ignores it on later writes, so a
+  change costs a second call to the display-priority endpoint. That endpoint can only set a
+  number, so the attribute is computed: removing it keeps the last value.
 - **Two built-in actions are hidden from the API.** `OktaProfileTool` and `MemoryTool` are
-  left out of the agent snapshot, so an agent holding one reports fewer `tool_ids` than
-  were written and the difference never settles. Attach custom actions and the ordinary
-  built-ins instead.
-- **Deleting a custom action detaches it from every agent that uses it**, including agents
-  Terraform does not manage, without an error or a warning.
+  left out of the agent snapshot, so an agent holding one reports fewer `tool_ids` than were
+  written and never settles. Use custom actions and the other built-ins.
+- **Deleting a custom action detaches it from every agent using it**, including agents
+  Terraform does not manage, with no error or warning.
 
 ### User groups (Enterprise Edition)
 
-- **`onyx_user_group` is Enterprise Edition only.** The routes live in the EE application
-  and do not exist on Community Edition, where every call answers 404. Its acceptance tests
-  skip when `ee_features_enabled` is false.
+- **`onyx_user_group` is Enterprise Edition only.** The routes do not exist on Community
+  Edition, where every call answers 404.
 - **`onyx_user_group` does not manage what a group can see.** Connectors, document sets,
-  agents, LLM providers, MCP servers and credentials each carry their own `groups`
-  attribute and own that link. The group exposes `cc_pair_ids`, `document_set_ids` and
-  `agent_ids` read-only, so the two sides never fight over the same edge.
-- **A roster change must not disturb those links, and how it avoids that depends on the
-  change.** Onyx's update endpoint replaces connector links along with members. A roster
-  that only gains members therefore goes through the add-users endpoint instead, which
-  takes members alone and lets Onyx preserve the links itself, inside the transaction that
-  holds the membership lock. A roster that loses one has no such endpoint: the provider
-  reads the connector ids and sends them back, so a connector share made between that read
-  and the write is overwritten by the older list. The window is one round-trip and only
-  opens for a removal. Sending an empty list instead — the obvious-looking alternative —
-  would unshare every connector from the group with nothing in the plan saying so.
-- **A group's computed links lag by one apply.** Terraform creates a group before the
-  `onyx_cc_pair` that references it, so `cc_pair_ids` is still empty in the state written
-  by that first apply and fills in on the next refresh.
-- **Onyx refuses membership, rename and delete while a group is syncing**, and a newly
-  created group starts out syncing, so the provider waits before each of those. Managers,
-  incognito and permissions are not gated. **The user group tests therefore need Celery
-  beat as well as the workers** — the sync that clears the gate is beat-scheduled every 20
-  seconds, so without beat every one of those writes waits until it times out.
-- **A syncing group answers HTTP 404**, not a conflict, on the membership routes *and on
-  delete*, because those handlers map every `ValueError` to not-found. The rename route gets
-  this right. So a 404 from any of them does not mean the group is gone — the destroy
-  confirms each one against the listing before reporting success, since trusting it would
-  drop a live group out of state and leave the next apply failing on the name it still holds.
-  *Fixed upstream:* the sync gate now raises a distinct `RESOURCE_SYNCING` conflict.
-- **`onyx_user_group` permissions use Onyx's wire tokens**, for example `manage:connectors`,
-  not the enum names. Only toggleable permissions can be set; `basic`, `admin`,
-  `craft_sandbox`, `manage:skills` and the implied read tokens are managed by Onyx and are
-  neither read back nor writable.
-- **A seeded default group (`Admin`, `Basic`) holds members and nothing else.** Importing
-  one and managing its roster works, but a rename, a delete, or a permission or incognito
-  change is refused with a conflict.
-- **Onyx refuses a membership removal that would strand someone**, leaving them in no group
-  at all — a person with no group has no permissions. Destroying a group is checked the same
-  way, because it drops the whole roster, so a `terraform destroy` can fail on a member whose
-  only group this is. It also guards self-removal by a manager, privilege amplification, and
-  the survival of admin access.
+  agents, LLM providers, MCP servers and credentials each carry their own `groups` and own
+  that link. The group exposes `cc_pair_ids`, `document_set_ids` and `agent_ids` read-only, so
+  the two sides never fight over one edge.
+- **Removing a member can overwrite a concurrent connector share.** Onyx's update endpoint
+  replaces connector links along with members, and there is no removal-only route, so the
+  provider reads the links and writes them back. The window is one round-trip and only opens
+  for a removal; adding members uses an endpoint that preserves the links server-side.
+- **A group's computed links lag one apply.** Terraform creates the group before the
+  `onyx_cc_pair` referencing it, so `cc_pair_ids` fills in on the next refresh.
+- **Onyx refuses membership, rename and delete while a group is syncing**, and a new group
+  starts out syncing, so the provider waits before each. Managers, incognito and permissions
+  are not gated.
+- **A syncing group answers 404, not a conflict**, on the membership and delete routes, which
+  map every error to not-found. So a 404 does not prove the group is gone, and destroy
+  confirms against the listing before reporting success. *Fixed upstream:* the gate raises a
+  distinct `RESOURCE_SYNCING` conflict.
+- **Permissions use Onyx's wire tokens**, such as `manage:connectors`, not the enum names.
+  Only toggleable permissions can be set; `basic`, `admin`, `craft_sandbox`, `manage:skills`
+  and the implied read tokens are managed by Onyx.
+- **A seeded default group (`Admin`, `Basic`) holds members and nothing else.** Managing its
+  roster works; rename, delete, permission and incognito changes are refused.
+- **Onyx refuses a removal that would strand someone** in no group at all, since a person with
+  no group has no permissions. Destroying a group is checked the same way, so a destroy can
+  fail on a member whose only group it is. Self-removal by a manager, privilege amplification
+  and the survival of admin access are guarded too.
 
 ### MCP servers
 
-- **`onyx_mcp_server` manages only servers that need no interactive sign-in.** `NONE` and
-  `API_TOKEN` are supported; `OAUTH` and `PT_OAUTH` need a browser round-trip and are
-  refused while the plan is built, with a diagnostic naming the admin panel.
-- **Which tools an MCP server exposes is not managed.** Onyx only learns them by calling
-  the server, and it rejects both a tool selection and a Craft approval policy naming a
-  tool it has never seen. Neither attribute is exposed rather than exposing one that
-  silently does nothing on a server Terraform just created.
-- **An MCP server's `description` left out of the configuration is cleared, not kept.** Onyx
-  reads a missing description as "leave it alone", so the provider always sends the field and
-  an unstated one goes out empty — the same rule as `groups` and `users` below. The upsert
-  cannot carry `available_in_craft`, which lives on a different endpoint, so setting it costs
-  a second call.
-- **An MCP server added from the admin panel but never configured imports with empty strings.**
-  That flow leaves `auth_type` and `transport` unset, and Terraform has no value to show for
-  them, so the first plan after such an import moves them to the schema defaults. It settles
-  in one apply.
-- **A configured `auth_template_headers` is never refreshed from Onyx.** A header value may be
-  a literal rather than a `{placeholder}`, and Onyx masks those on the way out, so refreshing
-  would store the mask and leave a difference that never settles. Onyx's own template is read
-  back only when the configuration states none. Editing the headers in the admin panel is
-  therefore invisible to `terraform plan`, like any other secret.
-- **`auth_performer = "PER_USER"` credentials belong to the identity that applied them.**
-  Onyx stores `admin_credentials` against the applying user rather than the server, so a
-  Terraform-managed per-user server holds the API key's own credentials, not an
-  administrator's. It also masks them partially rather than fully, unlike a shared token.
-- **An MCP server's header template is never reset.** Onyx keeps the stored template
-  whenever a write omits one, so switching a server from `PER_USER` to a shared token
-  leaves the per-user headers in place rather than restoring the default `Authorization`
-  header. Recreate the server to start over.
-- **`groups` and `users` on an MCP server are owned by the configuration.** Onyx reads a
-  missing list as "leave it alone", so the provider sends an empty one instead. Removing
-  either from the configuration clears it on the server, including entries added from the
-  admin panel.
-- **An MCP server URL cannot point at the Onyx host.** The SSRF guard refuses `localhost`
-  and link-local addresses by name at every protection level, not only the strictest.
+- **Only servers needing no interactive sign-in are managed.** `NONE` and `API_TOKEN` work;
+  `OAUTH` and `PT_OAUTH` need a browser round-trip and are refused at plan time.
+- **Which tools a server exposes is not managed.** Onyx learns them by calling the server and
+  rejects a tool selection or Craft policy naming one it has never seen, so a server Terraform
+  just created has none to name.
+- **An omitted `description` is cleared, not kept**, because Onyx reads a missing one as
+  "leave alone" and the provider therefore always sends the field. The same rule applies to
+  `groups` and `users`: removing either from the configuration clears it on the server,
+  including entries added from the admin panel. `available_in_craft` lives on another
+  endpoint, so setting it costs a second call.
+- **A server added from the admin panel but never configured imports with empty strings.**
+  `auth_type` and `transport` are unset there, so the first plan after import moves them to
+  the schema defaults. It settles in one apply.
+- **`auth_template_headers` is never refreshed.** A header value may be a literal rather than
+  a `{placeholder}`, and Onyx masks those, so refreshing would store the mask and never
+  settle. Onyx's own template is read back only when the configuration states none. Admin-panel
+  edits are invisible to `terraform plan`, like any other secret.
+- **The header template is never reset.** Onyx keeps the stored template whenever a write
+  omits one, so moving a server from `PER_USER` to a shared token leaves the per-user headers
+  in place. Recreate the server to start over.
+- **`auth_performer = "PER_USER"` credentials belong to the identity that applied them.** Onyx
+  stores `admin_credentials` against the applying user, so a Terraform-managed per-user server
+  holds the API key's own credentials, not an administrator's, and masks them only partially.
+- **A server URL cannot point at the Onyx host.** The SSRF guard refuses `localhost` and
+  link-local addresses at every protection level, not just the strictest.
 
 ## Development
 
@@ -457,14 +423,22 @@ $ ods release tf-provider --dry-run    # computes the version, tags nothing
 To rehearse, run **Publish** by hand from the mirror's Actions tab. It defaults to a dry
 run, which builds every archive and publishes none of them.
 
-If a release fails after the tag is pushed, re-drive it from the monorepo's Actions tab, or
-with the command below. Do not delete and re-push the tag: the mirror step commits the tree
-at the ref you dispatch from, so dispatching from `main` also picks up any fix merged since
-the tag was cut.
+How a failed release is recovered depends on whether the mirror push got through. Check
+whether the mirror already carries the tag.
+
+**It does not** — the monorepo's *Release Terraform Provider* failed. Re-drive it from that
+repo's Actions tab, or with the command below. Do not delete and re-push the `tf-provider`
+tag: the mirror step commits the tree at the ref you dispatch from, so dispatching from `main`
+also picks up any fix merged since the tag was cut.
 
 ```console
 $ gh workflow run release-terraform-provider.yml --ref main -f version=0.3.0
 ```
+
+**It does** — the mirror push succeeded and the mirror's *Publish* failed (goreleaser,
+signing, the registry). Re-run that workflow from the **mirror's** Actions tab. Dispatching
+the monorepo workflow again will not work: it pushes `main` and the tag atomically, so a tag
+the mirror already holds rejects the whole push and nothing moves.
 
 ### One-time setup
 

--- a/terraform-provider-onyx/README.md
+++ b/terraform-provider-onyx/README.md
@@ -411,18 +411,38 @@ them into every artifact name.
 
 ### Cutting a release
 
+Add the version's section to [`CHANGELOG.md`](./CHANGELOG.md) first. Publish reads it and
+uses it as the GitHub release body, which is what a user sees before upgrading. A version
+with no section fails the release rather than publishing empty notes.
+
 ```console
 $ ods release tf-provider              # bumps the patch version
 $ ods release tf-provider --bump minor
 $ ods release tf-provider --version 1.0.0
+$ ods release tf-provider --dry-run    # computes the version, tags nothing
 ```
+
+> [!IMPORTANT]
+> `ods release` tags **`HEAD`**, not `main`, and does not check which branch you are on.
+> Run `git rev-parse HEAD` and `git rev-parse origin/main` and compare them first. Tagging
+> from a stale branch publishes that branch's provider under the new version.
 
 To rehearse, run **Publish** by hand from the mirror's Actions tab. It defaults to a dry
 run, which builds every archive and publishes none of them.
 
+If a release fails after the tag is pushed, re-drive it from the monorepo's Actions tab, or
+with the command below. Do not delete and re-push the tag: the mirror step commits the tree
+at the ref you dispatch from, so dispatching from `main` also picks up any fix merged since
+the tag was cut.
+
+```console
+$ gh workflow run release-terraform-provider.yml --ref main -f version=0.3.0
+```
+
 ### One-time setup
 
-`v0.1.0` is published, so everything the registry needs is in place:
+All of it is done, and releases have been automated since `v0.2.0`. This records what
+exists, for whoever has to rebuild or rotate it:
 
 - [x] The public repo `onyx-dot-app/terraform-provider-onyx` exists.
 - [x] The mirror carries its own `LICENSE`.
@@ -431,21 +451,20 @@ run, which builds every archive and publishes none of them.
 - [x] The mirror holds `TF_PROVIDER_GPG_PRIVATE_KEY` and `TF_PROVIDER_GPG_PASSPHRASE`,
       which is where the signing happens. The monorepo never holds the key.
 - [x] The mirror is linked on registry.terraform.io as the `onyx-dot-app` organisation.
+- [x] The `release-terraform-provider` environment holds the mirror credential: variable
+      `TF_PROVIDER_RELEASE_APP_CLIENT_ID` — the App's **Client ID** (`Iv23li...`), *not*
+      the numeric App ID — and secret `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY`, the whole
+      generated `.pem` including its `BEGIN`/`END` lines.
 
-One step is left, and it is the only reason a release is still cut by hand:
+Two properties of that App are load-bearing, and each one failed a release once:
 
-- [ ] Give this repo a credential that can push to the mirror. The
-      `release-terraform-provider` environment exists but is empty, so
-      `release-terraform-provider.yml` has nothing to authenticate with and has never
-      run. Create a GitHub App, install it on the mirror alone with **contents: write**,
-      and put two values in that environment:
-      - variable `TF_PROVIDER_RELEASE_APP_CLIENT_ID` — the App's **Client ID**
-        (`Iv23li...`) from its settings page, *not* the numeric App ID.
-      - secret `TF_PROVIDER_RELEASE_APP_PRIVATE_KEY` — the whole generated `.pem`,
-        `BEGIN`/`END` lines included.
-
-Until that exists, a release is the workflow's own commands run locally against the
-mirror, followed by the tag — about a minute. That is how `v0.1.0` shipped.
+- It needs **contents: write** *and* **workflows: write**. The mirrored tree contains
+  `.github/workflows/publish.yml`, and GitHub refuses a push from an App that changes a
+  workflow file without the second one. It only bites on a release that edits that file,
+  so the first releases did not need it.
+- It must be a **bypass actor on the mirror's `Read-only mirror` rulesets**, for both the
+  branch and the tag rule. Without that the push is refused with `GH013` and nothing
+  reaches the mirror.
 
 ## Licence
 


### PR DESCRIPTION
## Description

The provider README is the mirror repo's front page — the first thing anyone arriving from
the Terraform Registry reads — and its publishing section describes a world that stopped
existing at `v0.2.0`. It currently tells a new maintainer:

* *"`v0.1.0` is published"* — we are on `v0.3.0`.
* *"One step is left, and it is the only reason a release is still cut by hand"* — releases
  have been automated since `v0.2.0`.
* *"The `release-terraform-provider` environment exists but is empty … and has never run"* —
  it is populated and has run successfully.
* Set the App up with **contents: write** — which is exactly the gap that failed the `v0.3.0`
  release today.

Someone following it would conclude the release pipeline does not exist and go build a second
one by hand.

Replaces that with what is actually true, plus the parts that were never written down:

* **The two load-bearing properties of the release App**, each of which has failed a release
  once: it needs `workflows: write` as well as `contents: write`, because the mirrored tree
  carries `.github/workflows/publish.yml` and GitHub refuses an App push that changes a
  workflow file without it; and it must be a bypass actor on the mirror's `Read-only mirror`
  rulesets for both the branch and tag rule, or the push is refused with `GH013`.
* **`CHANGELOG.md` is now the release body.** A version with no section fails the release
  rather than publishing empty notes, so the section has to exist before the tag.
* **How to recover a failed release** — dispatch with `-f version=X.Y.Z` rather than deleting
  and re-pushing the tag. The mirror step commits the tree at the ref you dispatch from, so
  dispatching from `main` also picks up a fix merged after the tag was cut. That is how
  `v0.3.0` shipped.
* **`ods release` tags `HEAD`, not `main`, and checks no branch.** During the `v0.3.0` release
  this put the tag on a stale feature branch whose tree predated the `onyx_agent` rename.

Note this file is edited here and never in the mirror: a release replaces the mirror's whole
tree with this directory's, so a mirror-only edit is silently dropped by the next release.

## How Has This Been Tested?

Documentation only — no code paths change. Every claim added was verified during today's
`v0.3.0` release rather than written from memory:

* App permissions read back from `/orgs/onyx-dot-app/installations`.
* The `GH013` workflow-permission and ruleset-bypass failures were both observed on real runs.
* The dispatch recovery path is what actually shipped `v0.3.0`.
* `ods release --dry-run` output checked for the documented flags.

Checked the rest of the README for related drift while here: the resource table is accurate,
including `onyx_agent` and its `/persona` endpoint.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!--
Override Linear Check: ENG-4322 is an umbrella issue tracking the whole Terraform provider
rollout. A closing keyword would close the entire plan on merge, so it is context only.
-->

Context: ENG-4322 (Terraform provider rollout plan).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Terraform provider README's publishing section, which still described releases as cut by hand and the release credential as missing — both stopped being true at `v0.2.0`. It also reorganizes the known-limitations list by resource family and marks four backend fixes as pending until a released Onyx lets the provider drop its workarounds.

- Records the two load-bearing App properties: `workflows: write` on top of `contents: write`, and bypass-actor status on the mirror's read-only rulesets.
- Documents that a missing `CHANGELOG.md` section fails the release, and splits failed-release recovery into two cases: re-dispatch the monorepo workflow when the mirror lacks the tag, re-run the mirror's Publish when it already has one.
- Warns that `ods release` tags HEAD and checks no branch, which is how a tag landed on a stale branch during the `v0.3.0` release.
- Groups the thirty-three limitations under their resource families, merges the connector access-control and MCP description bullets, drops the duplicate Celery-beat note, and marks persona lookup, group sync, nullable attachments, and `keep_existing_models` as fixed upstream since their proposed-fix wording now reads as stale.
- Documentation only — no code paths change.

<sup>Written for commit 485c66d049c189b331366fcfe6eea072ea1c2945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Second commit — Known limitations

Thirty-three undifferentiated bullets are hard to use, so they are now grouped under the
resource family each belongs to: Secrets, Settings and deployment defaults, LLM and embedding
providers, Credentials and connectors, Agents and actions, User groups, MCP servers.

**Nothing was deleted — bullet count is 33 before and after.** That is deliberate. Four of
these describe behaviour the backend has since changed:

| Limitation | Backend change |
| --- | --- |
| A deleted agent answers 400, not 404 | route now raises a typed `PERSONA_NOT_FOUND` |
| A syncing group answers 404 | sync gate raises `RESOURCE_SYNCING` (409) |
| Agent attachment lists cleared by omission | `hierarchy_node_ids` / `document_ids` are nullable |
| Model list read hides rows a write cannot preserve | upsert takes `keep_existing_models` |

**None of that is in a released Onyx**, so the provider keeps its workarounds and every one of
these limitations still applies to anyone using the provider today. Deleting them would make
the README wrong in the other direction. They are marked *fixed upstream* instead, with a note
at the top of the section explaining what that means and when they go away.

Three of them previously ended by proposing the fix as future work ("a keep-models flag ... is
the planned structural fix", "making that endpoint return 404 is a worthwhile backend fix"),
which now reads as stale.

Two smaller fixes: the two bullets that both described connector access control are merged, and
the `prune_freq` rewrite is now its own bullet rather than buried inside one of them.

Each of the four upstream fixes was verified against `origin/main` before being marked, not
taken from the rollout notes — one of them (`PERSONA_NOT_FOUND`) is not in `db/persona.py` at
all and is done at the route layer, so a shallower check would have got it wrong.


---

## Third commit — shorter, and a review fix

The grouping commit made the section *longer* (138 → 165 lines), which missed the point of
the request. Several bullets were carrying the design rationale for a workaround rather than
what a reader has to do about it.

| | before this PR | after grouping | now |
| --- | --- | --- | --- |
| lines | 138 | 165 | **131** |
| words | 1,741 | 1,828 | **1,324** |
| limitations | 33 | 33 | **32** |

No limitation was dropped. The count falls by one because the MCP `description` bullet only
existed to point at the `groups`/`users` bullet for the same rule, so the two are merged. One
outright duplicate is gone: the note that the user group tests need Celery beat is already
stated, at more length, under **Acceptance tests**.

**Greptile P1 — "Recovery Fails After Publishing". Valid.** The recovery procedure I added
only worked for a failure *before* the mirror push. If the mirror push succeeded and the
mirror's Publish failed, the mirror already holds the tag — and the monorepo workflow pushes
`main` and the tag with `git push --atomic`, so re-dispatching it is rejected whole and
nothing moves. (That behaviour was verified when the publishing workflow was built: re-running
a shipped version is rejected on both refs and `main` stays put.)

The two cases are now split by the one thing that distinguishes them — whether the mirror
carries the tag — with the publish-stage failure re-run from the mirror's own Actions tab.

Worth noting both of today's real failures were the *first* kind, which is why the gap wasn't
visible from experience.
