### PR TITLE
fix(web): center the chat footer disclaimer when it wraps

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -651,6 +651,7 @@ function Footer() {
           color="text-03"
           as="p"
           wordWrap="wrap-anywhere"
+          textPosition="text-center"
         >
           {markdown(customFooterContent)}
         </Text>


### PR DESCRIPTION
## Description

The configurable chat footer disclaimer is left-aligned once it wraps to more
than one line.

The footer row centers with `justify-center`. That centers the text *box*, not
the lines inside it. While the disclaimer fits on one line the box hugs its
content, so it looks centered. As soon as the text wraps, the box fills the row
and the lines fall back to `text-align: start`.

The footer used to render through `MinimalMarkdown`, which set `text-center` on
both the wrapper and the markdown `p`. #12082 replaced that with `Text` +
`markdown()` and the alignment was not carried over, so the regression has been
present since v4.2.0.

`Text` strips `className` and `style` by design, so this sets the supported
`textPosition` prop instead. It is only offered when `as` is a block tag, which
this footer already uses.

Self-hosted deployments with a long disclaimer see this on every wrapped line.
It became easier to hit after the disclaimer limit went from 200 to 500
characters (#14499): 200 characters sat right on the one-line threshold at a
typical desktop width, while 500 wraps at every width.

## How Has This Been Tested?

`bun` is not available in my environment, so the repo hooks and `types:check`
did not run locally. CI covers both. What I verified by hand:

- `textPosition` is valid here: `TextProps` is a union, and the arm selected by
  a block `as` (`"p" | "li" | "h1" | "h2" | "h3"`) accepts
  `"text-start" | "text-center" | "text-end" | "text-justify"`. The footer
  already passes `as="p"`.
- `Text` passes `textPosition` straight into `cn(...)`, so the value is the
  emitted utility class. `Text.test.tsx` already covers that mapping for every
  `textPosition` value, so no new test is added for a one-prop application.

A visual check of a wrapped multi-line disclaimer before merge would be worth
doing, since the change is purely visual.

## Backports

Not auto-cherry-pickable — please leave the box below unchecked.

`textPosition` was added to `@opal/Text` by #14512, which is on `main` only. It
is absent from both `release/v4.7` and `release/v4.6`, so this exact diff would
apply as text on those branches but would not compile, and if it did it would
forward an unknown attribute to the DOM and silently center nothing.

The release branches will get a hand-ported equivalent instead: `text-center`
on the footer's wrapper `div`. `text-align` is inherited, so it reaches the text
either way, and it carries no type surface. (`release/v4.6` also still renders
the footer as a default `span` rather than `as="p"`, which the prop-based form
would not cover.)

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
