### PR TITLE
feat(i18n): route Opal labels and date formatting through the app locale

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -199,6 +199,7 @@ module.exports = {
         "**/src/hooks/**/*.test.tsx",
         "**/src/sections/**/*.test.tsx",
         "**/src/views/**/*.test.tsx",
+        "**/lib/opal/**/*.test.tsx",
         // Add more patterns here as you add more integration tests
       ],
     },

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -200,6 +200,7 @@ module.exports = {
         "**/src/sections/**/*.test.tsx",
         "**/src/views/**/*.test.tsx",
         "**/lib/opal/**/*.test.tsx",
+        "**/src/i18n/**/*.test.tsx",
         // Add more patterns here as you add more integration tests
       ],
     },

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -53,6 +53,10 @@
       "types": "./dist/hooks/index.d.ts",
       "import": "./dist/hooks/index.js"
     },
+    "./strings": {
+      "types": "./dist/strings.d.ts",
+      "import": "./dist/strings.js"
+    },
     "./time": {
       "types": "./dist/time.d.ts",
       "import": "./dist/time.js"

--- a/web/lib/opal/src/components/buttons/copy-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/copy-button/components.tsx
@@ -7,6 +7,7 @@ import {
 } from "@opal/components/buttons/button/components";
 import { copyText } from "@opal/utils";
 import { SvgAlertTriangle, SvgCheck, SvgCopy } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,6 +56,7 @@ export function CopyButton({
 }: CopyButtonProps) {
   const [copyState, setCopyState] = useState<CopyState>("idle");
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const strings = useOpalStrings();
 
   async function handleCopy() {
     const text = getCopyText();
@@ -112,7 +114,7 @@ export function CopyButton({
     onClick: handleCopy,
     // A labeled button already says what it does, so only icon-only buttons
     // get the default tooltip.
-    tooltip: tooltip ?? (children === undefined ? "Copy" : undefined),
+    tooltip: tooltip ?? (children === undefined ? strings.copy : undefined),
   } as ButtonProps;
 
   return <Button {...resolvedProps} />;

--- a/web/lib/opal/src/components/buttons/filter-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/filter-button/components.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Interactive,
   type InteractiveStatefulInteraction,
@@ -8,6 +10,7 @@ import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { SvgX } from "@opal/icons";
 import { iconWrapper } from "@opal/components/buttons/icon-wrapper";
 import { ChevronIcon } from "@opal/components/buttons/chevron";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -50,6 +53,7 @@ function FilterButton({
   interaction,
   ...statefulProps
 }: FilterButtonProps) {
+  const strings = useOpalStrings();
   // Derive open state: explicit prop > Radix data-state (injected via Slot chain)
   const dataState = (statefulProps as Record<string, unknown>)["data-state"] as
     | string
@@ -91,7 +95,7 @@ function FilterButton({
             icon={SvgX}
             size="2xs"
             prominence="tertiary"
-            tooltip="Clear filter"
+            tooltip={strings.clearFilter}
             interaction="hover"
             onClick={(e) => {
               e.stopPropagation();

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import "@opal/components/cards/shared.css";
 import "@opal/components/cards/message-card/styles.css";
 import { cn } from "@opal/utils";
@@ -18,6 +20,7 @@ import {
   SvgX,
   SvgXOctagon,
 } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -144,6 +147,7 @@ function MessageCard({
 }: MessageCardProps) {
   const { icon: DefaultIcon, iconClass } = VARIANT_CONFIG[variant];
   const Icon = iconOverride ?? DefaultIcon;
+  const strings = useOpalStrings();
 
   const right = onClose ? (
     <Button
@@ -151,7 +155,8 @@ function MessageCard({
       prominence="internal"
       size="md"
       onClick={onClose}
-      aria-label="Close"
+      aria-label={strings.close}
+      data-message-card-close=""
     />
   ) : (
     rightChildren

--- a/web/lib/opal/src/components/code/components.tsx
+++ b/web/lib/opal/src/components/code/components.tsx
@@ -8,6 +8,7 @@ import { copyText } from "@opal/utils";
 import SvgCheck from "@opal/icons/check";
 import SvgCopy from "@opal/icons/copy";
 import "@opal/components/code/styles.css";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,6 +26,7 @@ interface CodeProps extends WithoutStyles<React.HTMLAttributes<HTMLElement>> {
 
 export function Code({ children, showCopyButton = true, ...props }: CodeProps) {
   const [copied, setCopied] = useState(false);
+  const strings = useOpalStrings();
 
   function handleCopy() {
     copyText(children)
@@ -49,8 +51,8 @@ export function Code({ children, showCopyButton = true, ...props }: CodeProps) {
                 prominence="tertiary"
                 icon={copied ? SvgCheck : SvgCopy}
                 onClick={handleCopy}
-                tooltip={copied ? "Copied!" : "Copy"}
-                aria-label="Copy code"
+                tooltip={copied ? strings.copied : strings.copy}
+                aria-label={strings.copyCode}
               />
             </div>
           </Hoverable.Item>

--- a/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
@@ -11,6 +11,7 @@ import {
   makeSegmentChangeHandler,
   makeSegmentKeyDownHandler,
 } from "@opal/components/inputs/segmented";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Segment helpers
@@ -25,9 +26,9 @@ interface Segments {
 const EMPTY_SEGMENTS: Segments = { month: "", day: "", year: "" };
 
 const SEGMENT_FIELDS = [
-  { part: "month", label: "Month", placeholder: "MM", maxLen: 2 },
-  { part: "day", label: "Day", placeholder: "DD", maxLen: 2 },
-  { part: "year", label: "Year", placeholder: "YYYY", maxLen: 4 },
+  { part: "month", placeholder: "MM", maxLen: 2 },
+  { part: "day", placeholder: "DD", maxLen: 2 },
+  { part: "year", placeholder: "YYYY", maxLen: 4 },
 ] as const;
 
 function toSegments(date: Date | null): Segments {
@@ -117,6 +118,7 @@ function InputDatePicker({
     toSegments(value)
   );
   const [open, setOpen] = React.useState(false);
+  const strings = useOpalStrings();
 
   const monthRef = React.useRef<HTMLInputElement>(null);
   const dayRef = React.useRef<HTMLInputElement>(null);
@@ -185,7 +187,7 @@ function InputDatePicker({
           <div
             className="opal-input-segmented-content"
             role="group"
-            aria-label="Date"
+            aria-label={strings.date}
           >
             {SEGMENT_FIELDS.map((field, i) => (
               <React.Fragment key={field.part}>
@@ -196,7 +198,7 @@ function InputDatePicker({
                   disabled={disabled}
                   ref={segmentRefs[field.part]}
                   id={field.part === "month" ? id : undefined}
-                  aria-label={field.label}
+                  aria-label={strings[field.part]}
                   placeholder={field.placeholder}
                   maxLength={field.maxLen}
                   data-wide={field.part === "year" ? true : undefined}
@@ -223,7 +225,7 @@ function InputDatePicker({
                 icon={SvgX}
                 prominence="internal"
                 size="sm"
-                tooltip="Clear"
+                tooltip={strings.clear}
                 onClick={() => onChange(null)}
               />
             )}
@@ -232,7 +234,7 @@ function InputDatePicker({
                 icon={SvgCalendar}
                 prominence="internal"
                 size="sm"
-                tooltip="Open calendar"
+                tooltip={strings.openCalendar}
                 disabled={disabled}
               />
             </Popover.Trigger>

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -21,6 +21,7 @@ import {
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { ContentAction } from "@opal/layouts";
 import { SvgChevronDownSmall } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Context
@@ -230,6 +231,7 @@ function InputSelectTrigger({
 }: InputSelectTriggerProps) {
   const { variant, currentValue, selectedItemDisplay } =
     useInputSelectContext();
+  const strings = useOpalStrings();
 
   // Read every render, the refs already hold the latest children/icon.
   let displayContent: React.ReactNode;
@@ -256,7 +258,7 @@ function InputSelectTrigger({
       />
     );
   } else {
-    const effectivePlaceholder = placeholder || "Select an option";
+    const effectivePlaceholder = placeholder || strings.selectAnOption;
     displayContent =
       typeof effectivePlaceholder === "string" ? (
         <Text as="p" color="text-03">
@@ -491,8 +493,9 @@ interface InputSelectSearchProps {
 function InputSelectSearch({
   value,
   onChange,
-  placeholder = "Search...",
+  placeholder,
 }: InputSelectSearchProps) {
+  const strings = useOpalStrings();
   const rowRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -547,7 +550,7 @@ function InputSelectSearch({
         clearButton
         value={value}
         onChange={onChange}
-        placeholder={placeholder}
+        placeholder={placeholder ?? strings.search}
       />
     </div>
   );

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef } from "react";
 import type { IconFunctionComponent } from "@opal/types";
 import { Button, Tag, TAG_REMOVE_CLASS } from "@opal/components";
 import { SvgX } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,6 +86,7 @@ function InputTags({
 }: InputTagsProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const strings = useOpalStrings();
 
   useEffect(() => {
     if (focusOnMount) inputRef.current?.focus();
@@ -175,7 +177,7 @@ function InputTags({
           prominence="internal"
           icon={SvgX}
           size="xs"
-          tooltip="Clear"
+          tooltip={strings.clear}
           onClick={(event) => {
             event.stopPropagation();
             onClear();

--- a/web/lib/opal/src/components/inputs/input-time/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-time/components.tsx
@@ -11,6 +11,7 @@ import {
   makeSegmentChangeHandler,
   makeSegmentKeyDownHandler,
 } from "@opal/components/inputs/segmented";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types and segment helpers
@@ -36,13 +37,10 @@ const SEGMENT_LIMITS: Record<keyof TimeSegments, number> = {
   seconds: 59,
 };
 
-const SEGMENT_META: Record<
-  keyof TimeSegments,
-  { label: string; placeholder: string }
-> = {
-  hours: { label: "Hours", placeholder: "HH" },
-  minutes: { label: "Minutes", placeholder: "MM" },
-  seconds: { label: "Seconds", placeholder: "SS" },
+const SEGMENT_PLACEHOLDERS: Record<keyof TimeSegments, string> = {
+  hours: "HH",
+  minutes: "MM",
+  seconds: "SS",
 };
 
 function isValidTime(time: TimeValue): boolean {
@@ -146,6 +144,7 @@ function InputTime({
   const [segments, setSegments] = React.useState<TimeSegments>(() =>
     toSegments(value)
   );
+  const strings = useOpalStrings();
 
   const hoursRef = React.useRef<HTMLInputElement>(null);
   const minutesRef = React.useRef<HTMLInputElement>(null);
@@ -206,7 +205,7 @@ function InputTime({
         <div
           className="opal-input-segmented-content"
           role="group"
-          aria-label="Time"
+          aria-label={strings.time}
         >
           {segmentParts.map((part, i) => (
             <React.Fragment key={part}>
@@ -217,8 +216,8 @@ function InputTime({
                 disabled={disabled}
                 ref={segmentRefs[part]}
                 id={part === "hours" ? id : undefined}
-                aria-label={SEGMENT_META[part].label}
-                placeholder={SEGMENT_META[part].placeholder}
+                aria-label={strings[part]}
+                placeholder={SEGMENT_PLACEHOLDERS[part]}
                 maxLength={2}
                 value={segments[part]}
                 onChange={handleSegmentChange(
@@ -243,7 +242,7 @@ function InputTime({
               icon={SvgX}
               prominence="internal"
               size="sm"
-              tooltip="Clear"
+              tooltip={strings.clear}
               onClick={() => onChange(null)}
             />
           </div>

--- a/web/lib/opal/src/components/inputs/input-type-in/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-type-in/components.tsx
@@ -95,8 +95,8 @@ export default function InputTypeIn({
       <input
         ref={ref}
         type="text"
-        // dir="auto": typed text and, while empty, the placeholder decide
-        // the direction, so punctuation sits on the correct side.
+        // dir="auto": typed text decides the direction so punctuation sits on the
+        // correct side. While empty it inherits the page direction (see styles.css).
         dir="auto"
         name={name}
         disabled={disabled}

--- a/web/lib/opal/src/components/inputs/input-type-in/styles.css
+++ b/web/lib/opal/src/components/inputs/input-type-in/styles.css
@@ -22,3 +22,9 @@
 .opal-input-field::placeholder {
   @apply font-main-ui-muted text-text-02;
 }
+
+/* dir="auto" resolves to LTR while the value is empty, which would pin the
+   placeholder to the wrong edge under RTL, so it follows the page instead. */
+.opal-input-field[dir="auto"]:placeholder-shown {
+  direction: inherit;
+}

--- a/web/lib/opal/src/components/inputs/password-input-type-in/components.tsx
+++ b/web/lib/opal/src/components/inputs/password-input-type-in/components.tsx
@@ -9,6 +9,7 @@ import {
 } from "@opal/components";
 import { cn } from "@opal/utils";
 import { SvgEye, SvgEyeClosed } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // Backend placeholder pattern - indicates a stored value that can't be revealed
 const BACKEND_PLACEHOLDER_PATTERN = /^•+$/; // All bullet characters (U+2022)
@@ -85,6 +86,7 @@ function PasswordInputTypeIn({
   const [isPasswordVisible, setIsPasswordVisible] = React.useState(false);
   const [isFocused, setIsFocused] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const strings = useOpalStrings();
 
   const realValue = String(value || "");
   const hasValue = realValue.length > 0;
@@ -109,10 +111,10 @@ function PasswordInputTypeIn({
   const showToggleButton = hasValue || isFocused;
   const isRevealed = isPasswordVisible && !effectiveNonRevealable;
   const toggleLabel = effectiveNonRevealable
-    ? "Value cannot be revealed"
+    ? strings.valueCannotBeRevealed
     : isPasswordVisible
-      ? "Hide password"
-      : "Show password";
+      ? strings.hidePassword
+      : strings.showPassword;
 
   const isNativeMask = mask === "native";
   // The ✱ presentation only draws while idle. Focus anywhere in the field

--- a/web/lib/opal/src/components/loader/components.tsx
+++ b/web/lib/opal/src/components/loader/components.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import "@opal/components/loader/styles.css";
 import { cn } from "@opal/utils";
 import type { IconFunctionComponent } from "@opal/types";
 import { SvgLoader } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Shared
@@ -58,11 +61,12 @@ function IconLoader({
   size = 24,
   color = "border-02",
 }: IconLoaderProps) {
+  const strings = useOpalStrings();
   return (
     <Icon
       size={size}
       role="status"
-      aria-label="Loading"
+      aria-label={strings.loading}
       className={cn("shrink-0 motion-safe:animate-spin", COLOR_CLASS[color])}
     />
   );
@@ -113,10 +117,11 @@ const MARK_PATHS = [
  * For a full-page loading state with a label, use `PageLoader`.
  */
 function OnyxLoader({ size = 64, color = "border-02" }: OnyxLoaderProps) {
+  const strings = useOpalStrings();
   return (
     <div
       role="status"
-      aria-label="Loading"
+      aria-label={strings.loading}
       className={cn("relative shrink-0", COLOR_CLASS[color])}
       style={{ width: size, height: size }}
     >

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -15,6 +15,7 @@ import { Content, Section, type SectionProps } from "@opal/layouts";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { SvgX } from "@opal/icons";
 import useContainerCenter from "@opal/hooks/useContainerCenter";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Root + Overlay
@@ -344,6 +345,7 @@ function ModalHeader({
   ...props
 }: ModalHeaderProps) {
   const { closeButtonRef, setHasDescription } = useModalContext();
+  const strings = useOpalStrings();
 
   React.useLayoutEffect(() => {
     setHasDescription(!!description);
@@ -357,7 +359,7 @@ function ModalHeader({
     >
       <DialogPrimitive.Close asChild>
         <Button
-          aria-label="Close"
+          aria-label={strings.close}
           icon={SvgX}
           prominence="tertiary"
           size="sm"

--- a/web/lib/opal/src/components/pagination/components.tsx
+++ b/web/lib/opal/src/components/pagination/components.tsx
@@ -17,6 +17,7 @@ import {
   type ReactNode,
 } from "react";
 import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -207,6 +208,7 @@ function GoToPagePopup({ totalPages, onSubmit, children }: GoToPagePopupProps) {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
+  const strings = useOpalStrings();
 
   const parsed = parseInt(value, 10);
   const isValid = !isNaN(parsed) && parsed >= 1 && parsed <= totalPages;
@@ -258,7 +260,7 @@ function GoToPagePopup({ totalPages, onSubmit, children }: GoToPagePopupProps) {
             value={value}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            placeholder="Go to page"
+            placeholder={strings.goToPage}
             ref={focusOnMount}
             className={cn(
               "w-28 bg-transparent px-1.5 py-1 rounded-08",
@@ -273,7 +275,7 @@ function GoToPagePopup({ totalPages, onSubmit, children }: GoToPagePopupProps) {
               icon={SvgArrowRight}
               size="lg"
               onClick={handleSubmit}
-              tooltip="Go to page"
+              tooltip={strings.goToPage}
             />
           </Disabled>
         </PopoverPrimitive.Content>
@@ -301,6 +303,7 @@ function NavButtons({
   size,
   children,
 }: NavButtonsProps) {
+  const strings = useOpalStrings();
   return (
     <>
       <Disabled disabled={currentPage <= 1}>
@@ -309,7 +312,7 @@ function NavButtons({
           onClick={() => onChange(Math.max(1, currentPage - 1))}
           size={size}
           prominence="tertiary"
-          tooltip="Previous page"
+          tooltip={strings.previousPage}
         />
       </Disabled>
       {children}
@@ -319,7 +322,7 @@ function NavButtons({
           onClick={() => onChange(Math.min(totalPages, currentPage + 1))}
           size={size}
           prominence="tertiary"
-          tooltip="Next page"
+          tooltip={strings.nextPage}
         />
       </Disabled>
     </>

--- a/web/lib/opal/src/components/progress-bar/components.tsx
+++ b/web/lib/opal/src/components/progress-bar/components.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import "@opal/components/progress-bar/styles.css";
 import { cn } from "@opal/utils";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -20,7 +23,7 @@ interface ProgressBarProps {
   max?: number;
   /** @default "blue" */
   color?: ProgressBarColor;
-  /** Accessible label. @default "Progress" */
+  /** Accessible label. Defaults to the Opal progress label. */
   "aria-label"?: string;
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -34,9 +37,10 @@ function ProgressBar({
   value,
   max = 100,
   color = "blue",
-  "aria-label": ariaLabel = "Progress",
+  "aria-label": ariaLabel,
   ref,
 }: ProgressBarProps) {
+  const strings = useOpalStrings();
   const fraction = max > 0 ? Math.min(1, Math.max(0, value / max)) : 0;
 
   return (
@@ -44,7 +48,7 @@ function ProgressBar({
       ref={ref}
       className="opal-progress-bar bg-background-tint-00"
       role="progressbar"
-      aria-label={ariaLabel}
+      aria-label={ariaLabel ?? strings.progress}
       aria-valuenow={value}
       aria-valuemin={0}
       aria-valuemax={max}

--- a/web/lib/opal/src/components/table/ColumnSortabilityPopover.tsx
+++ b/web/lib/opal/src/components/table/ColumnSortabilityPopover.tsx
@@ -11,6 +11,7 @@ import { Button, Divider, LineItemButton, Text } from "@opal/components";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 import { SvgArrowUpDown, SvgSortOrder, SvgCheck } from "@opal/icons";
 import { Popover } from "@opal/components/popover/components";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Popover UI
@@ -20,18 +21,15 @@ interface SortingPopoverProps<TData extends RowData = RowData> {
   table: Table<TData>;
   sorting: SortingState;
   footerText?: string;
-  ascendingLabel?: string;
-  descendingLabel?: string;
 }
 
 function SortingPopover<TData extends RowData>({
   table,
   sorting,
   footerText,
-  ascendingLabel = "Ascending",
-  descendingLabel = "Descending",
 }: SortingPopoverProps<TData>) {
   const size = useTableSize();
+  const strings = useOpalStrings();
   const [open, setOpen] = useState(false);
   const sortableColumns = table
     .getAllLeafColumns()
@@ -47,7 +45,7 @@ function SortingPopover<TData extends RowData>({
           interaction={open ? "hover" : "rest"}
           size={size === "md" ? "sm" : "md"}
           prominence="tertiary"
-          tooltip="Sort"
+          tooltip={strings.sort}
         />
       </Popover.Trigger>
 
@@ -63,12 +61,12 @@ function SortingPopover<TData extends RowData>({
             ) : undefined
           }
         >
-          <Divider title="Sort by" />
+          <Divider title={strings.sortBy} />
 
           <LineItemButton
             selectVariant="select-heavy"
             state={currentSort === null ? "selected" : "empty"}
-            title="Manual Ordering"
+            title={strings.manualOrdering}
             sizePreset="main-ui"
             rightChildren={
               currentSort === null ? (
@@ -112,12 +110,12 @@ function SortingPopover<TData extends RowData>({
 
           {currentSort !== null && (
             <>
-              <Divider title="Sorting Order" />
+              <Divider title={strings.sortingOrder} />
 
               <LineItemButton
                 selectVariant="select-heavy"
                 state={!currentSort.desc ? "selected" : "empty"}
-                title={ascendingLabel}
+                title={strings.ascending}
                 sizePreset="main-ui"
                 rightChildren={
                   !currentSort.desc ? (
@@ -132,7 +130,7 @@ function SortingPopover<TData extends RowData>({
               <LineItemButton
                 selectVariant="select-heavy"
                 state={currentSort.desc ? "selected" : "empty"}
-                title={descendingLabel}
+                title={strings.descending}
                 sizePreset="main-ui"
                 rightChildren={
                   currentSort.desc ? (
@@ -157,8 +155,6 @@ function SortingPopover<TData extends RowData>({
 
 interface CreateSortingColumnOptions {
   footerText?: string;
-  ascendingLabel?: string;
-  descendingLabel?: string;
 }
 
 function createSortingColumn<TData>(
@@ -175,8 +171,6 @@ function createSortingColumn<TData>(
         table={table}
         sorting={table.getState().sorting}
         footerText={options?.footerText}
-        ascendingLabel={options?.ascendingLabel}
-        descendingLabel={options?.descendingLabel}
       />
     ),
     cell: () => null,

--- a/web/lib/opal/src/components/table/ColumnVisibilityPopover.tsx
+++ b/web/lib/opal/src/components/table/ColumnVisibilityPopover.tsx
@@ -11,6 +11,7 @@ import { Button, Divider, LineItemButton, Tag } from "@opal/components";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 import { SvgColumn, SvgCheck } from "@opal/icons";
 import { Popover } from "@opal/components/popover/components";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Popover UI
@@ -26,6 +27,7 @@ function ColumnVisibilityPopover<TData extends RowData>({
   columnVisibility,
 }: ColumnVisibilityPopoverProps<TData>) {
   const size = useTableSize();
+  const strings = useOpalStrings();
   const [open, setOpen] = useState(false);
 
   // User-defined columns only (exclude internal qualifier/actions)
@@ -47,12 +49,12 @@ function ColumnVisibilityPopover<TData extends RowData>({
           interaction={open ? "hover" : "rest"}
           size={size === "md" ? "sm" : "md"}
           prominence="tertiary"
-          tooltip="Columns"
+          tooltip={strings.columns}
         />
       </Popover.Trigger>
 
       <Popover.Content width="lg" align="end" side="bottom">
-        <Divider title="Shown Columns" />
+        <Divider title={strings.shownColumns} />
         <Popover.Menu>
           {dataColumns.map((column) => {
             const canHide = column.getCanHide();
@@ -72,7 +74,7 @@ function ColumnVisibilityPopover<TData extends RowData>({
                 rightChildren={
                   !canHide ? (
                     <div className="flex items-center">
-                      <Tag title="Always Shown" color="blue" />
+                      <Tag title={strings.alwaysShown} color="blue" />
                     </div>
                   ) : isVisible ? (
                     <SvgCheck size={16} className="text-action-selection-05" />

--- a/web/lib/opal/src/components/table/Footer.test.tsx
+++ b/web/lib/opal/src/components/table/Footer.test.tsx
@@ -25,26 +25,26 @@ function renderSummaryFooter(strings: OpalStrings = defaultOpalStrings) {
   return {
     summary: summaryRow?.textContent ?? "",
     // Every chunk is its own span, which is what keeps the spacing stable.
-    spanCount: summaryRow?.children.length ?? 0,
+    childTags: [...(summaryRow?.children ?? [])].map((child) => child.tagName),
     range: footer.querySelector('span[dir="ltr"]'),
   };
 }
 
 describe("Footer summary", () => {
   it("renders the English summary with the range in an LTR isolate", () => {
-    const { summary, spanCount, range } = renderSummaryFooter();
+    const { summary, childTags, range } = renderSummaryFooter();
     expect(summary).toBe("Showing 1~10 of 22 users");
-    expect(spanCount).toBe(4);
+    expect(childTags).toEqual(["SPAN", "SPAN", "SPAN", "SPAN"]);
     expect(range).toHaveTextContent("1~10");
   });
 
   it("renders a translated summary around the same styled nodes", () => {
-    const { summary, spanCount, range } = renderSummaryFooter({
+    const { summary, childTags, range } = renderSummaryFooter({
       ...defaultOpalStrings,
       showing: (range, total) => ["عرض ", range, " من ", total],
     });
     expect(summary).toBe("عرض 1~10 من 22 users");
-    expect(spanCount).toBe(4);
+    expect(childTags).toEqual(["SPAN", "SPAN", "SPAN", "SPAN"]);
     expect(range).toHaveTextContent("1~10");
   });
 });

--- a/web/lib/opal/src/components/table/Footer.test.tsx
+++ b/web/lib/opal/src/components/table/Footer.test.tsx
@@ -20,29 +20,31 @@ function renderSummaryFooter(strings: OpalStrings = defaultOpalStrings) {
   );
   const footer = container.querySelector(".table-footer");
   if (!footer) throw new Error("footer did not render");
+  // The left side holds the summary row first, then any extra action.
+  const summaryRow = footer.firstElementChild?.firstElementChild;
   return {
-    summary: footer.firstElementChild?.textContent ?? "",
+    summary: summaryRow?.textContent ?? "",
+    // Every chunk is its own span, which is what keeps the spacing stable.
+    spanCount: summaryRow?.children.length ?? 0,
     range: footer.querySelector('span[dir="ltr"]'),
   };
 }
 
 describe("Footer summary", () => {
   it("renders the English summary with the range in an LTR isolate", () => {
-    const { summary, range } = renderSummaryFooter();
+    const { summary, spanCount, range } = renderSummaryFooter();
     expect(summary).toBe("Showing 1~10 of 22 users");
+    expect(spanCount).toBe(4);
     expect(range).toHaveTextContent("1~10");
   });
 
   it("renders a translated summary around the same styled nodes", () => {
-    const { summary, range } = renderSummaryFooter({
+    const { summary, spanCount, range } = renderSummaryFooter({
       ...defaultOpalStrings,
-      showing: (range, total) => (
-        <>
-          عرض {range} من {total}
-        </>
-      ),
+      showing: (range, total) => ["عرض ", range, " من ", total],
     });
     expect(summary).toBe("عرض 1~10 من 22 users");
+    expect(spanCount).toBe(4);
     expect(range).toHaveTextContent("1~10");
   });
 });

--- a/web/lib/opal/src/components/table/Footer.test.tsx
+++ b/web/lib/opal/src/components/table/Footer.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@tests/setup/test-utils";
+import Footer from "@opal/components/table/Footer";
+import { OpalStringsProvider, defaultOpalStrings } from "@opal/strings";
+import type { OpalStrings } from "@opal/strings";
+
+function renderSummaryFooter(strings: OpalStrings = defaultOpalStrings) {
+  const { container } = render(
+    <OpalStringsProvider strings={strings}>
+      <Footer
+        mode="summary"
+        rangeStart={1}
+        rangeEnd={10}
+        totalItems={22}
+        currentPage={1}
+        totalPages={3}
+        onPageChange={() => {}}
+        units="users"
+      />
+    </OpalStringsProvider>
+  );
+  const footer = container.querySelector(".table-footer");
+  if (!footer) throw new Error("footer did not render");
+  return {
+    summary: footer.firstElementChild?.textContent ?? "",
+    range: footer.querySelector('span[dir="ltr"]'),
+  };
+}
+
+describe("Footer summary", () => {
+  it("renders the English summary with the range in an LTR isolate", () => {
+    const { summary, range } = renderSummaryFooter();
+    expect(summary).toBe("Showing 1~10 of 22 users");
+    expect(range).toHaveTextContent("1~10");
+  });
+
+  it("renders a translated summary around the same styled nodes", () => {
+    const { summary, range } = renderSummaryFooter({
+      ...defaultOpalStrings,
+      showing: (range, total) => (
+        <>
+          عرض {range} من {total}
+        </>
+      ),
+    });
+    expect(summary).toBe("عرض 1~10 من 22 users");
+    expect(range).toHaveTextContent("1~10");
+  });
+});

--- a/web/lib/opal/src/components/table/Footer.tsx
+++ b/web/lib/opal/src/components/table/Footer.tsx
@@ -4,6 +4,8 @@ import { Button, Pagination, SelectButton } from "@opal/components";
 import { Text } from "@opal/components";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 import { SvgEye, SvgXCircle } from "@opal/icons";
+import { useOpalStrings, type OpalStrings } from "@opal/strings";
+import { richNodes } from "@opal/utils";
 import type { ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
@@ -85,13 +87,16 @@ function getSelectionMessage(
   state: SelectionState,
   multi: boolean,
   count: number,
-  isViewingSelected: boolean
+  isViewingSelected: boolean,
+  strings: OpalStrings
 ): string {
   if (state === "none" && !isViewingSelected) {
-    return multi ? "Select items to continue" : "Select an item to continue";
+    return multi
+      ? strings.selectItemsToContinue
+      : strings.selectAnItemToContinue;
   }
-  if (!multi) return "Item selected";
-  return `${count} item${count !== 1 ? "s" : ""} selected`;
+  if (!multi) return strings.singleItemSelected;
+  return strings.selectedItemCount(count);
 }
 
 /**
@@ -182,11 +187,13 @@ function SelectionLeft({
   onClear,
   isSmall,
 }: SelectionLeftProps) {
+  const strings = useOpalStrings();
   const message = getSelectionMessage(
     selectionState,
     multiSelect,
     selectedCount,
-    isViewingSelected
+    isViewingSelected,
+    strings
   );
   const hasSelection = selectionState !== "none";
   // Show buttons when items are selected OR when the view filter is active
@@ -217,7 +224,7 @@ function SelectionLeft({
               icon={SvgEye}
               state={isViewingSelected ? "selected" : "empty"}
               onClick={onView}
-              tooltip="View selected"
+              tooltip={strings.viewSelected}
               size={isSmall ? "sm" : "md"}
             />
           )}
@@ -225,7 +232,7 @@ function SelectionLeft({
             <Button
               icon={SvgXCircle}
               onClick={onClear}
-              tooltip="Deselect all"
+              tooltip={strings.deselectAll}
               size={isSmall ? "sm" : "md"}
               prominence="tertiary"
             />
@@ -251,22 +258,25 @@ function SummaryLeft({
   units,
   isSmall,
 }: SummaryLeftProps) {
+  const strings = useOpalStrings();
   const suffix = units ? ` ${units}` : "";
   const bodyFont = isSmall ? "secondary-body" : "main-ui-muted";
   const monoFont = isSmall ? "secondary-mono" : "main-ui-mono";
+  // The range is an LTR isolate so "1~10" keeps its digit order in RTL copy.
+  const range = (
+    <Text font={monoFont} color="text-03" dir="ltr">
+      {`${rangeStart}~${rangeEnd}`}
+    </Text>
+  );
+  const total = (
+    <Text font={monoFont} color="text-03">
+      {`${totalItems}${suffix}`}
+    </Text>
+  );
   return (
     <div className="flex flex-row items-center w-fit h-fit px-1">
       <Text font={bodyFont} color="text-03">
-        {`Showing `}
-      </Text>
-      <Text font={monoFont} color="text-03">
-        {`${rangeStart}~${rangeEnd}`}
-      </Text>
-      <Text font={bodyFont} color="text-03">
-        {` of `}
-      </Text>
-      <Text font={monoFont} color="text-03">
-        {`${totalItems}${suffix}`}
+        {richNodes(strings.showing(range, total))}
       </Text>
     </div>
   );

--- a/web/lib/opal/src/components/table/Footer.tsx
+++ b/web/lib/opal/src/components/table/Footer.tsx
@@ -5,8 +5,7 @@ import { Text } from "@opal/components";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 import { SvgEye, SvgXCircle } from "@opal/icons";
 import { useOpalStrings, type OpalStrings } from "@opal/strings";
-import { richNodes } from "@opal/utils";
-import type { ReactNode } from "react";
+import { Children, type ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -273,11 +272,19 @@ function SummaryLeft({
       {`${totalItems}${suffix}`}
     </Text>
   );
+  // Each text chunk gets its own Text span, so the summary keeps the sibling
+  // layout (and spacing) it had before the words came from a translation.
+  const parts = Children.toArray(strings.showing(range, total)).map(
+    (part, index) =>
+      typeof part === "string" ? (
+        <Text key={index} font={bodyFont} color="text-03">
+          {part}
+        </Text>
+      ) : (
+        part
+      )
+  );
   return (
-    <div className="flex flex-row items-center w-fit h-fit px-1">
-      <Text font={bodyFont} color="text-03">
-        {richNodes(strings.showing(range, total))}
-      </Text>
-    </div>
+    <div className="flex flex-row items-center w-fit h-fit px-1">{parts}</div>
   );
 }

--- a/web/lib/opal/src/components/table/TableHead.tsx
+++ b/web/lib/opal/src/components/table/TableHead.tsx
@@ -5,6 +5,7 @@ import type { WithoutStyles } from "@opal/types";
 import { Button } from "@opal/components";
 import { SvgChevronDown, SvgChevronUp, SvgHandle, SvgSort } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
+import { useOpalStrings } from "@opal/strings";
 
 export type SortDirection = "none" | "ascending" | "descending";
 
@@ -78,6 +79,7 @@ export default function TableHead({
 }: TableHeadProps) {
   const resolvedSize = useTableSize();
   const isSmall = resolvedSize === "md";
+  const strings = useOpalStrings();
   return (
     <th
       {...thProps}
@@ -113,7 +115,7 @@ export default function TableHead({
             <Button
               icon={iconFn(sorted ?? "none")}
               onClick={onSort}
-              tooltip="Sort"
+              tooltip={strings.sort}
               tooltipSide="top"
               prominence="internal"
               size="sm"

--- a/web/lib/opal/src/components/table/TableRow.tsx
+++ b/web/lib/opal/src/components/table/TableRow.tsx
@@ -6,6 +6,7 @@ import type { WithoutStyles } from "@opal/types";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { SvgHandle } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,6 +39,7 @@ function SortableTableRow({
   ...props
 }: TableRowProps) {
   const resolvedSize = useTableSize();
+  const strings = useOpalStrings();
 
   const {
     attributes,
@@ -82,7 +84,7 @@ function SortableTableRow({
               "opacity-0 group-hover/row:opacity-100 transition-opacity",
               "flex items-center justify-center rounded-sm"
             )}
-            aria-label="Drag to reorder"
+            aria-label={strings.dragToReorder}
             onMouseDown={(e) => e.preventDefault()}
             {...listeners}
           >

--- a/web/lib/opal/src/components/tabs/components.tsx
+++ b/web/lib/opal/src/components/tabs/components.tsx
@@ -21,6 +21,7 @@ import {
   usePillIndicator,
   useHorizontalScroll,
 } from "@opal/components/tabs/hooks";
+import { useOpalStrings } from "@opal/strings";
 
 /* =============================================================================
    TABS ROOT
@@ -73,6 +74,7 @@ function TabsList({
   const scrollArrowsRef = useRef<HTMLDivElement>(null);
   const rightChildrenRef = useRef<HTMLDivElement>(null);
   const [rightOffset, setRightOffset] = useState(0);
+  const strings = useOpalStrings();
   const { variant } = useTabsContext() ?? { variant: "contained" as const };
   const isPill = variant === "pill" || variant === "underline";
 
@@ -158,7 +160,7 @@ function TabsList({
             size="sm"
             icon={SvgChevronLeft}
             onClick={handleScrollLeft}
-            tooltip="Scroll tabs left"
+            tooltip={strings.scrollTabsLeft}
           />
           <Button
             disabled={!canScrollRight}
@@ -166,7 +168,7 @@ function TabsList({
             size="sm"
             icon={SvgChevronRight}
             onClick={handleScrollRight}
-            tooltip="Scroll tabs right"
+            tooltip={strings.scrollTabsRight}
           />
         </div>
       )}
@@ -228,6 +230,7 @@ function TabsTrigger({
   ...props
 }: TabsTriggerProps) {
   const { variant } = useTabsContext() ?? { variant: "contained" as const };
+  const strings = useOpalStrings();
 
   const inner = (
     <>
@@ -246,7 +249,7 @@ function TabsTrigger({
       {isLoading && (
         <span
           className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin ms-1"
-          aria-label="Loading"
+          aria-label={strings.loading}
         />
       )}
     </>

--- a/web/lib/opal/src/components/tag/components.tsx
+++ b/web/lib/opal/src/components/tag/components.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import "@opal/components/tag/styles.css";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { Text, Tooltip } from "@opal/components";
 import { SvgAlertTriangle, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
 import { TAG_COLORS, type TagColor } from "@opal/components/tag/colors";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -70,6 +73,7 @@ function Tag({
   tooltip,
   error = false,
 }: TagProps) {
+  const strings = useOpalStrings();
   const config = TAG_COLORS[color];
   const editable = onRemove !== undefined;
   const capped = editable || truncate;
@@ -125,7 +129,9 @@ function Tag({
             type="button"
             className={TAG_REMOVE_CLASS}
             aria-label={
-              typeof title === "string" ? `Remove ${title}` : "Remove"
+              typeof title === "string"
+                ? strings.removeItem(title)
+                : strings.remove
             }
             onClick={(event) => {
               event.stopPropagation();

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -9,6 +9,7 @@ import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
 import { useState } from "react";
 import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -101,6 +102,7 @@ function ContentLg({
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toPlainString(title));
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
+  const strings = useOpalStrings();
 
   const config = CONTENT_LG_PRESETS[sizePreset];
 
@@ -187,7 +189,7 @@ function ContentLg({
                 icon={SvgEdit}
                 prominence="internal"
                 size={config.editButtonSize}
-                tooltip="Edit"
+                tooltip={strings.edit}
                 tooltipSide="right"
                 onClick={startEditing}
               />

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -11,6 +11,7 @@ import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
 import { useEffect, useRef, useState, useImperativeHandle } from "react";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -168,6 +169,7 @@ function ContentMd({
 }: ContentMdProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toPlainString(title));
+  const strings = useOpalStrings();
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Move focus to the edit input as soon as editing starts.
@@ -311,7 +313,7 @@ function ContentMd({
                 icon={SvgEdit}
                 prominence="internal"
                 size={config.editButtonSize}
-                tooltip="Edit"
+                tooltip={strings.edit}
                 tooltipSide="right"
                 onClick={startEditing}
               />

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -9,6 +9,7 @@ import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { cn } from "@opal/utils";
 import { useState } from "react";
 import useFocusOnMount from "@opal/hooks/useFocusOnMount";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -121,6 +122,7 @@ function ContentXl({
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toPlainString(title));
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
+  const strings = useOpalStrings();
 
   const config = CONTENT_XL_PRESETS[sizePreset];
 
@@ -237,7 +239,7 @@ function ContentXl({
               icon={SvgEdit}
               prominence="internal"
               size={config.editButtonSize}
-              tooltip="Edit"
+              tooltip={strings.edit}
               tooltipSide="right"
               onClick={startEditing}
             />

--- a/web/lib/opal/src/layouts/page-loader/components.tsx
+++ b/web/lib/opal/src/layouts/page-loader/components.tsx
@@ -1,12 +1,15 @@
+"use client";
+
 import type { RichStr } from "@opal/types";
 import { OnyxLoader, Text } from "@opal/components";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // PageLoader
 // ---------------------------------------------------------------------------
 
 interface PageLoaderProps {
-  /** Label beneath the mark, markdown() opt-in. @default "Loading …" */
+  /** Label beneath the mark, markdown() opt-in. Defaults to the Opal loading label. */
   text?: string | RichStr;
 }
 
@@ -15,12 +18,13 @@ interface PageLoaderProps {
  * the available space. Use for page/route-level loading. For an inline or
  * section-level loader without a label, use `OnyxLoader` directly.
  */
-function PageLoader({ text = "Loading …" }: PageLoaderProps) {
+function PageLoader({ text }: PageLoaderProps) {
+  const strings = useOpalStrings();
   return (
     <div className="flex h-full min-h-[60vh] w-full flex-col items-center justify-center gap-3 p-5">
       <OnyxLoader />
       <Text font="main-ui-muted" color="text-03">
-        {text}
+        {text ?? strings.loadingPage}
       </Text>
     </div>
   );

--- a/web/lib/opal/src/layouts/toast/components.tsx
+++ b/web/lib/opal/src/layouts/toast/components.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState, useSyncExternalStore } from "react";
 import { clickOnKeyDown, cn } from "@opal/utils";
 import { MessageCard, Text } from "@opal/components";
+import { useOpalStrings } from "@opal/strings";
 import {
   MAX_VISIBLE_TOASTS,
   toast,
@@ -80,6 +81,7 @@ function ToastContainer({ errorAppendix }: ToastContainerProps) {
       toast.setAutoDismiss(t.id, EXPANDED_DURATION_MS);
     }
   }, []);
+  const strings = useOpalStrings();
 
   if (visible.length === 0) return null;
 
@@ -129,12 +131,12 @@ function ToastContainer({ errorAppendix }: ToastContainerProps) {
             className={className}
             role="button"
             tabIndex={0}
-            aria-label="Show the full message"
+            aria-label={strings.showFullMessage}
             onKeyDown={clickOnKeyDown(() => handleExpand(t))}
             onClick={(e) => {
               // Don't intercept clicks on the inner close button.
               if (
-                (e.target as HTMLElement).closest('button[aria-label="Close"]')
+                (e.target as HTMLElement).closest("[data-message-card-close]")
               ) {
                 return;
               }

--- a/web/lib/opal/src/strings.test.tsx
+++ b/web/lib/opal/src/strings.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@tests/setup/test-utils";
+import {
+  OpalStringsProvider,
+  defaultOpalStrings,
+  useOpalStrings,
+} from "@opal/strings";
+
+function Probe() {
+  const strings = useOpalStrings();
+  return (
+    <>
+      <span>{strings.copy}</span>
+      <span>{strings.selectedItemCount(2)}</span>
+      <span>{strings.showing("1~10", "22")}</span>
+    </>
+  );
+}
+
+describe("useOpalStrings", () => {
+  it("falls back to the English defaults", () => {
+    render(<Probe />);
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+    expect(screen.getByText("2 items selected")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1~10 of 22")).toBeInTheDocument();
+  });
+
+  it("reads the provided strings", () => {
+    render(
+      <OpalStringsProvider
+        strings={{
+          ...defaultOpalStrings,
+          copy: "نسخ",
+          selectedItemCount: (count) => `${count} محدد`,
+          showing: (range, total) => (
+            <>
+              عرض {range} من {total}
+            </>
+          ),
+        }}
+      >
+        <Probe />
+      </OpalStringsProvider>
+    );
+    expect(screen.getByText("نسخ")).toBeInTheDocument();
+    expect(screen.getByText("2 محدد")).toBeInTheDocument();
+    expect(screen.getByText("عرض 1~10 من 22")).toBeInTheDocument();
+  });
+});

--- a/web/lib/opal/src/strings.test.tsx
+++ b/web/lib/opal/src/strings.test.tsx
@@ -31,11 +31,7 @@ describe("useOpalStrings", () => {
           ...defaultOpalStrings,
           copy: "نسخ",
           selectedItemCount: (count) => `${count} محدد`,
-          showing: (range, total) => (
-            <>
-              عرض {range} من {total}
-            </>
-          ),
+          showing: (range, total) => ["عرض ", range, " من ", total],
         }}
       >
         <Probe />

--- a/web/lib/opal/src/strings.tsx
+++ b/web/lib/opal/src/strings.tsx
@@ -54,7 +54,7 @@ export type OpalStrings = {
   selectAnItemToContinue: string;
   singleItemSelected: string;
   selectedItemCount: (count: number) => string;
-  /** Table footer summary, e.g. "Showing 1~10 of 22". Both arguments are styled inline nodes. */
+  /** Table footer summary, e.g. "Showing 1~10 of 22", as text chunks around the two styled nodes. */
   showing: (range: ReactNode, total: ReactNode) => ReactNode;
 };
 
@@ -108,11 +108,7 @@ export const defaultOpalStrings: OpalStrings = {
   singleItemSelected: "Item selected",
   selectedItemCount: (count) =>
     `${count} item${count !== 1 ? "s" : ""} selected`,
-  showing: (range, total) => (
-    <>
-      Showing {range} of {total}
-    </>
-  ),
+  showing: (range, total) => ["Showing ", range, " of ", total],
 };
 
 const OpalStringsContext = createContext<OpalStrings>(defaultOpalStrings);

--- a/web/lib/opal/src/strings.tsx
+++ b/web/lib/opal/src/strings.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext, type ReactNode } from "react";
 /**
  * Labels Opal renders itself. Hosts translate them via `OpalStringsProvider`.
  */
-export interface OpalStrings {
+export type OpalStrings = {
   close: string;
   loading: string;
   loadingPage: string;
@@ -56,7 +56,7 @@ export interface OpalStrings {
   selectedItemCount: (count: number) => string;
   /** Table footer summary, e.g. "Showing 1~10 of 22". Both arguments are styled inline nodes. */
   showing: (range: ReactNode, total: ReactNode) => ReactNode;
-}
+};
 
 export const defaultOpalStrings: OpalStrings = {
   close: "Close",

--- a/web/lib/opal/src/strings.tsx
+++ b/web/lib/opal/src/strings.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Labels Opal renders itself. Hosts translate them via `OpalStringsProvider`.
+ */
+export interface OpalStrings {
+  close: string;
+  loading: string;
+  loadingPage: string;
+  copy: string;
+  copied: string;
+  copyCode: string;
+  clear: string;
+  clearFilter: string;
+  date: string;
+  time: string;
+  edit: string;
+  search: string;
+  progress: string;
+  remove: string;
+  removeItem: (title: string) => string;
+  showFullMessage: string;
+  selectAnOption: string;
+  openCalendar: string;
+  month: string;
+  day: string;
+  year: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+  showPassword: string;
+  hidePassword: string;
+  valueCannotBeRevealed: string;
+  scrollTabsLeft: string;
+  scrollTabsRight: string;
+  previousPage: string;
+  nextPage: string;
+  goToPage: string;
+  sort: string;
+  sortBy: string;
+  manualOrdering: string;
+  sortingOrder: string;
+  ascending: string;
+  descending: string;
+  columns: string;
+  shownColumns: string;
+  alwaysShown: string;
+  dragToReorder: string;
+  viewSelected: string;
+  deselectAll: string;
+  selectItemsToContinue: string;
+  selectAnItemToContinue: string;
+  singleItemSelected: string;
+  selectedItemCount: (count: number) => string;
+  /** Table footer summary, e.g. "Showing 1~10 of 22". Both arguments are styled inline nodes. */
+  showing: (range: ReactNode, total: ReactNode) => ReactNode;
+}
+
+export const defaultOpalStrings: OpalStrings = {
+  close: "Close",
+  loading: "Loading",
+  loadingPage: "Loading …",
+  copy: "Copy",
+  copied: "Copied!",
+  copyCode: "Copy code",
+  clear: "Clear",
+  clearFilter: "Clear filter",
+  date: "Date",
+  time: "Time",
+  edit: "Edit",
+  search: "Search...",
+  progress: "Progress",
+  remove: "Remove",
+  removeItem: (title) => `Remove ${title}`,
+  showFullMessage: "Show the full message",
+  selectAnOption: "Select an option",
+  openCalendar: "Open calendar",
+  month: "Month",
+  day: "Day",
+  year: "Year",
+  hours: "Hours",
+  minutes: "Minutes",
+  seconds: "Seconds",
+  showPassword: "Show password",
+  hidePassword: "Hide password",
+  valueCannotBeRevealed: "Value cannot be revealed",
+  scrollTabsLeft: "Scroll tabs left",
+  scrollTabsRight: "Scroll tabs right",
+  previousPage: "Previous page",
+  nextPage: "Next page",
+  goToPage: "Go to page",
+  sort: "Sort",
+  sortBy: "Sort by",
+  manualOrdering: "Manual Ordering",
+  sortingOrder: "Sorting Order",
+  ascending: "Ascending",
+  descending: "Descending",
+  columns: "Columns",
+  shownColumns: "Shown Columns",
+  alwaysShown: "Always Shown",
+  dragToReorder: "Drag to reorder",
+  viewSelected: "View selected",
+  deselectAll: "Deselect all",
+  selectItemsToContinue: "Select items to continue",
+  selectAnItemToContinue: "Select an item to continue",
+  singleItemSelected: "Item selected",
+  selectedItemCount: (count) =>
+    `${count} item${count !== 1 ? "s" : ""} selected`,
+  showing: (range, total) => (
+    <>
+      Showing {range} of {total}
+    </>
+  ),
+};
+
+const OpalStringsContext = createContext<OpalStrings>(defaultOpalStrings);
+
+interface OpalStringsProviderProps {
+  strings: OpalStrings;
+  children: ReactNode;
+}
+
+export function OpalStringsProvider({
+  strings,
+  children,
+}: OpalStringsProviderProps) {
+  return (
+    <OpalStringsContext.Provider value={strings}>
+      {children}
+    </OpalStringsContext.Provider>
+  );
+}
+
+export function useOpalStrings(): OpalStrings {
+  return useContext(OpalStringsContext);
+}

--- a/web/lib/opal/src/time.test.ts
+++ b/web/lib/opal/src/time.test.ts
@@ -1,0 +1,50 @@
+import {
+  humanReadableFormat,
+  humanReadableFormatShort,
+  timeAgo,
+} from "@opal/time";
+
+const minutesAgo = (n: number) =>
+  new Date(Date.now() - n * 60_000).toISOString();
+const daysAgo = (n: number) => minutesAgo(n * 24 * 60);
+
+describe("timeAgo", () => {
+  it("returns null without a date or with an unparseable one", () => {
+    expect(timeAgo(null, "en")).toBeNull();
+    expect(timeAgo(undefined, "en")).toBeNull();
+    expect(timeAgo("not a date", "en")).toBeNull();
+  });
+
+  it("never reads as the future, even for a timestamp just ahead of now", () => {
+    expect(timeAgo(minutesAgo(-2), "en")).toBe("0 seconds ago");
+  });
+
+  it("renders whole minutes, hours, days, months and years in English", () => {
+    expect(timeAgo(minutesAgo(42), "en")).toBe("42 minutes ago");
+    expect(timeAgo(minutesAgo(5 * 60), "en")).toBe("5 hours ago");
+    expect(timeAgo(daysAgo(12), "en")).toBe("12 days ago");
+    expect(timeAgo(daysAgo(14 + 30), "en")).toBe("1 month ago");
+    expect(timeAgo(daysAgo(3 * 365), "en")).toBe("3 years ago");
+  });
+
+  it("follows the locale", () => {
+    // Digit shaping for "ar" differs between ICU builds, so only the words are asserted.
+    expect(timeAgo(daysAgo(3), "ar")).toMatch(/^قبل .* أيام$/);
+    expect(timeAgo(daysAgo(3), "de")).toBe("vor 3 Tagen");
+  });
+});
+
+describe("date formatters", () => {
+  // Local midnight, so the calendar day is the same in every test timezone.
+  const june6 = new Date(2026, 5, 6).toISOString();
+
+  it("formats in the requested locale", () => {
+    expect(humanReadableFormatShort(june6, "en")).toBe("Jun 6, 2026");
+    expect(humanReadableFormatShort(june6, "de")).toBe("6. Juni 2026");
+    expect(humanReadableFormat(june6, "fr")).toBe("6 juin 2026");
+  });
+
+  it("returns an empty string for a missing short date", () => {
+    expect(humanReadableFormatShort(null, "en")).toBe("");
+  });
+});

--- a/web/lib/opal/src/time.ts
+++ b/web/lib/opal/src/time.ts
@@ -1,129 +1,134 @@
-function conditionallyAddPlural(noun: string, cnt: number): string {
-  return cnt === 1 ? noun : `${noun}s`;
+/** Date and duration helpers. The date formatters take the active UI locale (BCP 47). */
+
+// Rows in long tables format many dates per render, so formatters are reused per locale.
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+function relativeTimeFormatter(locale: string): Intl.RelativeTimeFormat {
+  let formatter = relativeTimeFormatters.get(locale);
+  if (!formatter) {
+    formatter = new Intl.RelativeTimeFormat(locale, { numeric: "always" });
+    relativeTimeFormatters.set(locale, formatter);
+  }
+  return formatter;
 }
 
 /**
- * Returns a human-readable relative time string for a past date, or `null`
- * if the input is absent. Granularity increases with distance: seconds →
- * minutes → hours → days → weeks → months → years.
- *
- * @example
- * timeAgo(new Date(Date.now() - 3_000).toISOString())                    // "3 seconds ago"
- * timeAgo(new Date(Date.now() - 42 * 60_000).toISOString())              // "42 minutes ago"
- * timeAgo(new Date(Date.now() - 5 * 3_600_000).toISOString())            // "5 hours ago"
- * timeAgo(new Date(Date.now() - 12 * 86_400_000).toISOString())          // "12 days ago"
- * timeAgo(new Date(Date.now() - 14 * 86_400_000).toISOString())          // "2 weeks ago"
- * timeAgo(new Date(Date.now() - 240 * 86_400_000).toISOString())         // "8 months ago"
- * timeAgo(new Date(Date.now() - 3 * 365 * 86_400_000).toISOString())     // "3 years ago"
- * timeAgo(null)                                                           // null
+ * Formats how long ago a date was, e.g. "12 days ago", or null without a date.
  */
-export function timeAgo(dateString: string | undefined | null): string | null {
+export function timeAgo(
+  dateString: string | undefined | null,
+  locale: string
+): string | null {
   if (!dateString) {
     return null;
   }
 
-  const date = new Date(dateString);
-  const now = new Date();
-  const secondsDiff = Math.floor((now.getTime() - date.getTime()) / 1000);
+  const time = new Date(dateString).getTime();
+  if (Number.isNaN(time)) {
+    return null;
+  }
+
+  const formatter = relativeTimeFormatter(locale);
+  // Clamped so clock skew on a stored timestamp never reads as "in 5 seconds".
+  const secondsDiff = Math.max(0, Math.floor((Date.now() - time) / 1000));
 
   if (secondsDiff < 60) {
-    return `${secondsDiff} ${conditionallyAddPlural("second", secondsDiff)} ago`;
+    return formatter.format(-secondsDiff, "second");
   }
 
   const minutesDiff = Math.floor(secondsDiff / 60);
   if (minutesDiff < 60) {
-    return `${minutesDiff} ${conditionallyAddPlural("minute", minutesDiff)} ago`;
+    return formatter.format(-minutesDiff, "minute");
   }
 
   const hoursDiff = Math.floor(minutesDiff / 60);
   if (hoursDiff < 24) {
-    return `${hoursDiff} ${conditionallyAddPlural("hour", hoursDiff)} ago`;
+    return formatter.format(-hoursDiff, "hour");
   }
 
   const daysDiff = Math.floor(hoursDiff / 24);
   if (daysDiff < 30) {
-    return `${daysDiff} ${conditionallyAddPlural("day", daysDiff)} ago`;
-  }
-
-  const weeksDiff = Math.floor(daysDiff / 7);
-  if (weeksDiff < 4) {
-    return `${weeksDiff} ${conditionallyAddPlural("week", weeksDiff)} ago`;
+    return formatter.format(-daysDiff, "day");
   }
 
   const monthsDiff = Math.floor(daysDiff / 30);
   if (monthsDiff < 12) {
-    return `${monthsDiff} ${conditionallyAddPlural("month", monthsDiff)} ago`;
+    return formatter.format(-monthsDiff, "month");
   }
 
-  const yearsDiff = Math.floor(monthsDiff / 12);
-  return `${yearsDiff} ${conditionallyAddPlural("year", yearsDiff)} ago`;
+  return formatter.format(-Math.floor(monthsDiff / 12), "year");
 }
 
 /**
- * Formats a date string using the browser's locale and timezone, producing a
- * short, human-friendly date-and-time string.
+ * Formats a date string as a short date-and-time in the local timezone.
  *
  * @example
- * localizeAndPrettify("2025-01-15T10:30:00Z") // "1/15/2025, 10:30:00 AM"
+ * localizeAndPrettify("2025-01-15T10:30:00Z", "en") // "1/15/2025, 10:30:00 AM"
  */
-export function localizeAndPrettify(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toLocaleString();
+export function localizeAndPrettify(
+  dateString: string,
+  locale: string
+): string {
+  return new Date(dateString).toLocaleString(locale);
 }
 
 /**
  * Formats a date string as a long-form date: full month name, numeric day,
- * and four-digit year, in US English.
+ * and four-digit year.
  *
  * @example
- * humanReadableFormat("2025-01-15T10:30:00Z") // "January 15, 2025"
+ * humanReadableFormat("2025-01-15T10:30:00Z", "en") // "January 15, 2025"
  */
-export function humanReadableFormat(dateString: string): string {
-  const date = new Date(dateString);
-  const formatter = new Intl.DateTimeFormat("en-US", {
+export function humanReadableFormat(
+  dateString: string,
+  locale: string
+): string {
+  return new Intl.DateTimeFormat(locale, {
     month: "long",
     day: "numeric",
     year: "numeric",
-  });
-  return formatter.format(date);
+  }).format(new Date(dateString));
 }
 
 /**
  * Formats a date as a short-form date: abbreviated month name, numeric day,
- * and four-digit year, in US English. Returns an empty string for a null input.
+ * and four-digit year. Returns an empty string for a null input.
  *
  * @example
- * humanReadableFormatShort("2025-01-15T10:30:00Z") // "Jan 15, 2025"
- * humanReadableFormatShort(null)                   // ""
+ * humanReadableFormatShort("2025-01-15T10:30:00Z", "en") // "Jan 15, 2025"
+ * humanReadableFormatShort(null, "en")                   // ""
  */
-export function humanReadableFormatShort(date: string | Date | null): string {
+export function humanReadableFormatShort(
+  date: string | Date | null,
+  locale: string
+): string {
   if (!date) return "";
   const d = typeof date === "string" ? new Date(date) : date;
-  const formatter = new Intl.DateTimeFormat("en-US", {
+  return new Intl.DateTimeFormat(locale, {
     month: "short",
     day: "numeric",
     year: "numeric",
-  });
-  return formatter.format(d);
+  }).format(d);
 }
 
 /**
  * Formats a datetime string as a long-form date with clock time: full month
- * name, numeric day, four-digit year, and 12-hour time, in US English.
+ * name, numeric day, four-digit year, and the locale's clock format.
  *
  * @example
- * humanReadableFormatWithTime("2025-01-15T10:30:00Z") // "January 15, 2025 at 10:30 AM"
+ * humanReadableFormatWithTime("2025-01-15T10:30:00Z", "en") // "January 15, 2025 at 10:30 AM"
  */
-export function humanReadableFormatWithTime(datetimeString: string): string {
-  const date = new Date(datetimeString);
-  const formatter = new Intl.DateTimeFormat("en-US", {
+export function humanReadableFormatWithTime(
+  datetimeString: string,
+  locale: string
+): string {
+  return new Intl.DateTimeFormat(locale, {
     month: "long",
     day: "numeric",
     year: "numeric",
     hour: "numeric",
     minute: "numeric",
-  });
-  return formatter.format(date);
+  }).format(new Date(datetimeString));
 }
 
 export type TimeFilter = "day" | "week" | "month" | "year";

--- a/web/lib/opal/tsup.config.ts
+++ b/web/lib/opal/tsup.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     "src/illustrations/index.ts",
     "src/logos/index.ts",
     "src/hooks/index.ts",
+    "src/strings.tsx",
     "src/time.ts",
     "src/types.ts",
     "src/utils.ts",

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { markdown } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
 import { Content, InputErrorText, InputVertical, toast } from "@opal/layouts";
@@ -59,6 +59,7 @@ function trialDaysRemaining(trialEnd: Date, now: number = Date.now()): number {
 
 function getExpirationState(
   billing: BillingInformation,
+  locale: string,
   license?: LicenseStatus
 ) {
   const isAnnualBilling = billing.billing_period === "annual";
@@ -87,7 +88,7 @@ function getExpirationState(
         variant: "error" as const,
         daysRemaining: 0,
         daysUntilDeletion,
-        expirationDate: humanReadableFormatShort(gracePeriodEnd),
+        expirationDate: humanReadableFormatShort(gracePeriodEnd, locale),
       };
     }
 
@@ -96,7 +97,7 @@ function getExpirationState(
       return {
         variant: "warning" as const,
         daysRemaining,
-        expirationDate: humanReadableFormatShort(expiresAt),
+        expirationDate: humanReadableFormatShort(expiresAt, locale),
       };
     }
   }
@@ -123,7 +124,7 @@ function getExpirationState(
         variant: "error" as const,
         daysRemaining: 0,
         daysUntilDeletion,
-        expirationDate: humanReadableFormatShort(gracePeriodEnd),
+        expirationDate: humanReadableFormatShort(gracePeriodEnd, locale),
       };
     }
 
@@ -133,7 +134,7 @@ function getExpirationState(
       return {
         variant: "warning" as const,
         daysRemaining,
-        expirationDate: humanReadableFormatShort(expiresAt),
+        expirationDate: humanReadableFormatShort(expiresAt, locale),
       };
     }
   }
@@ -172,6 +173,7 @@ function SubscriptionCard({
   onRefresh?: () => Promise<void>;
 }) {
   const t = useTranslations("admin.billing");
+  const locale = useLocale();
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [isEndingTrial, setIsEndingTrial] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -184,7 +186,7 @@ function SubscriptionCard({
     : t("subscription.businessPlan.name");
   const PlanIcon = isEnterprise ? SvgOrganization : SvgUsers;
   const expirationDate = billing?.current_period_end ?? license?.expires_at;
-  const formattedDate = formatDateShort(expirationDate);
+  const formattedDate = formatDateShort(expirationDate, locale);
 
   const isExpiredFromBilling =
     billing?.status === "expired" || billing?.status === "cancelled";
@@ -206,7 +208,7 @@ function SubscriptionCard({
   } else if (isOnTrial) {
     // The trial ending and the first charge are one event, so both halves of
     // this line have to come from the same date.
-    const trialDate = formatDateShort(license?.trial_end);
+    const trialDate = formatDateShort(license?.trial_end, locale);
     const daysLeft = trialDaysRemaining(trialEnd);
     subtitle =
       daysLeft <= 0
@@ -417,6 +419,7 @@ function SeatsCard({
   hideUpdateSeats?: boolean;
 }) {
   const t = useTranslations("admin.billing");
+  const locale = useLocale();
   const [isEditing, setIsEditing] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -484,7 +487,7 @@ function SeatsCard({
   const seatDifference = newSeatCount - totalSeats;
   const isAdding = seatDifference > 0;
   const isRemoving = seatDifference < 0;
-  const nextBillingDate = formatDateShort(billing?.current_period_end);
+  const nextBillingDate = formatDateShort(billing?.current_period_end, locale);
   const seatCount = Math.abs(seatDifference);
 
   if (isEditing) {
@@ -664,6 +667,7 @@ function SeatsCard({
 
 function PaymentSection({ billing }: { billing: BillingInformation }) {
   const t = useTranslations("admin.billing");
+  const locale = useLocale();
   const handleOpenPortal = async () => {
     try {
       const response = await createCustomerPortalSession({
@@ -679,7 +683,7 @@ function PaymentSection({ billing }: { billing: BillingInformation }) {
 
   if (!billing.payment_method_enabled) return null;
 
-  const lastPaymentDate = formatDateShort(billing.current_period_start);
+  const lastPaymentDate = formatDateShort(billing.current_period_start, locale);
 
   return (
     <div className="billing-payment-section">
@@ -764,7 +768,10 @@ export default function BillingDetailsView({
   isGraceSyncing,
 }: BillingDetailsViewProps) {
   const t = useTranslations("admin.billing");
-  const expirationState = billing ? getExpirationState(billing, license) : null;
+  const locale = useLocale();
+  const expirationState = billing
+    ? getExpirationState(billing, locale, license)
+    : null;
   const disableBillingActions =
     isAirGapped || hasStripeError || isManualLicenseOnly;
 

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Section } from "@/layouts/general-layouts";
 import { InputHorizontal } from "@opal/layouts";
 import { Button, Divider } from "@opal/components";
@@ -99,6 +99,7 @@ interface CheckoutViewProps {
 
 export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
   const t = useTranslations("admin.billing");
+  const locale = useLocale();
   const { user } = useUser();
   const { data: usersData } = useUsers({ includeApiKeys: false });
 
@@ -128,8 +129,8 @@ export default function CheckoutView({ onAdjustPlan }: CheckoutViewProps) {
   const trialEndDate = useMemo(() => {
     const date = new Date();
     date.setMonth(date.getMonth() + 1);
-    return formatDateShort(date.toISOString());
-  }, []);
+    return formatDateShort(date.toISOString(), locale);
+  }, [locale]);
 
   const handleSubmit = async () => {
     setIsSubmitting(true);

--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Button, Card } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import InputFile from "@/refresh-components/inputs/InputFile";
@@ -30,6 +30,7 @@ export default function LicenseActivationCard({
   hideClose,
 }: LicenseActivationCardProps) {
   const t = useTranslations("admin.billing");
+  const locale = useLocale();
   const [licenseKey, setLicenseKey] = useState("");
   const [isActivating, setIsActivating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,7 +46,7 @@ export default function LicenseActivationCard({
     license?.status === "gated_access" ||
     isDateExpired;
   const expirationDate = license?.expires_at
-    ? formatDateShort(license.expires_at)
+    ? formatDateShort(license.expires_at, locale)
     : null;
 
   const handleActivate = async () => {

--- a/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   createTableColumns,
   EmptyMessageCard,
@@ -49,7 +49,8 @@ interface ColumnHeaders {
 
 function buildColumns(
   onErrorClick: (errorMessage: string) => void,
-  headers: ColumnHeaders
+  headers: ColumnHeaders,
+  locale: string
 ) {
   return [
     tc.column("time_started", {
@@ -58,7 +59,7 @@ function buildColumns(
       enableSorting: false,
       cell: (value) => (
         <Text as="span" font="main-ui-body" color="text-04">
-          {value ? localizeAndPrettify(value) : "-"}
+          {value ? localizeAndPrettify(value, locale) : "-"}
         </Text>
       ),
     }),
@@ -171,6 +172,7 @@ export function DocPermissionSyncAttemptsTable({
   onPageChange,
 }: DocPermissionSyncAttemptsTableProps) {
   const t = useTranslations("admin.connector");
+  const locale = useLocale();
   const [openErrorMessage, setOpenErrorMessage] = useState<string | null>(null);
   const handleErrorClick = useCallback(
     (errorMessage: string) => setOpenErrorMessage(errorMessage),
@@ -178,14 +180,18 @@ export function DocPermissionSyncAttemptsTable({
   );
   const columns = useMemo(
     () =>
-      buildColumns(handleErrorClick, {
-        timeStarted: t("docPermissionsTable.columns.timeStarted"),
-        status: t("docPermissionsTable.columns.status"),
-        docsSynced: t("docPermissionsTable.columns.docsSynced"),
-        permissionErrors: t("docPermissionsTable.columns.permissionErrors"),
-        errorMessage: t("docPermissionsTable.columns.errorMessage"),
-      }),
-    [handleErrorClick, t]
+      buildColumns(
+        handleErrorClick,
+        {
+          timeStarted: t("docPermissionsTable.columns.timeStarted"),
+          status: t("docPermissionsTable.columns.status"),
+          docsSynced: t("docPermissionsTable.columns.docsSynced"),
+          permissionErrors: t("docPermissionsTable.columns.permissionErrors"),
+          errorMessage: t("docPermissionsTable.columns.errorMessage"),
+        },
+        locale
+      ),
+    [handleErrorClick, t, locale]
   );
 
   if (!attempts.length) {

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   createTableColumns,
   EmptyMessageCard,
@@ -66,7 +66,8 @@ interface ColumnHeaders {
 // "5/3/2026, 12:00:00 PM") stays on a single line.
 function buildColumns(
   onErrorClick: (errorMessage: string) => void,
-  headers: ColumnHeaders
+  headers: ColumnHeaders,
+  locale: string
 ) {
   return [
     tc.column("time_started", {
@@ -75,7 +76,7 @@ function buildColumns(
       enableSorting: false,
       cell: (value) => (
         <Text as="span" font="main-ui-body" color="text-04">
-          {value ? localizeAndPrettify(value) : "-"}
+          {value ? localizeAndPrettify(value, locale) : "-"}
         </Text>
       ),
     }),
@@ -198,6 +199,7 @@ export function ExternalGroupSyncAttemptsTable({
   onPageChange,
 }: ExternalGroupSyncAttemptsTableProps) {
   const t = useTranslations("admin.connector");
+  const locale = useLocale();
   const [openErrorMessage, setOpenErrorMessage] = useState<string | null>(null);
   const handleErrorClick = useCallback(
     (errorMessage: string) => setOpenErrorMessage(errorMessage),
@@ -205,15 +207,19 @@ export function ExternalGroupSyncAttemptsTable({
   );
   const columns = useMemo(
     () =>
-      buildColumns(handleErrorClick, {
-        timeStarted: t("groupMembershipTable.columns.timeStarted"),
-        status: t("groupMembershipTable.columns.status"),
-        users: t("groupMembershipTable.columns.users"),
-        groups: t("groupMembershipTable.columns.groups"),
-        memberships: t("groupMembershipTable.columns.memberships"),
-        errorMessage: t("groupMembershipTable.columns.errorMessage"),
-      }),
-    [handleErrorClick, t]
+      buildColumns(
+        handleErrorClick,
+        {
+          timeStarted: t("groupMembershipTable.columns.timeStarted"),
+          status: t("groupMembershipTable.columns.status"),
+          users: t("groupMembershipTable.columns.users"),
+          groups: t("groupMembershipTable.columns.groups"),
+          memberships: t("groupMembershipTable.columns.memberships"),
+          errorMessage: t("groupMembershipTable.columns.errorMessage"),
+        },
+        locale
+      ),
+    [handleErrorClick, t, locale]
   );
 
   if (!attempts.length) {

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -12,7 +12,7 @@ import { localizeAndPrettify } from "@opal/time";
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
 import { useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { SvgAlertTriangle } from "@opal/icons";
 
 export interface IndexAttemptErrorsModalProps {
@@ -38,6 +38,7 @@ export default function IndexAttemptErrorsModal({
   supportsTargetedReindex,
 }: IndexAttemptErrorsModalProps) {
   const t = useTranslations("admin.connector");
+  const locale = useLocale();
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
     [errors.items]
@@ -85,7 +86,7 @@ export default function IndexAttemptErrorsModal({
                   errors.items.map((error) => (
                     <TableRow key={error.id} className="h-16">
                       <TableCell>
-                        {localizeAndPrettify(error.time_created)}
+                        {localizeAndPrettify(error.time_created, locale)}
                       </TableCell>
                       <TableCell>
                         {error.document_link ? (

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   Table,
   TableHead,
@@ -38,6 +38,7 @@ export function IndexAttemptsTable({
   onPageChange,
 }: IndexingAttemptsTableProps) {
   const t = useTranslations("admin.connector");
+  const locale = useLocale();
   const [indexAttemptTracePopupId, setIndexAttemptTracePopupId] = useState<
     number | null
   >(null);
@@ -120,7 +121,7 @@ export function IndexAttemptsTable({
               >
                 <TableCell>
                   {indexAttempt.time_started
-                    ? localizeAndPrettify(indexAttempt.time_started)
+                    ? localizeAndPrettify(indexAttempt.time_started, locale)
                     : "-"}
                 </TableCell>
                 <TableCell>

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -16,7 +16,7 @@ import { credentialTemplates } from "@/lib/connectors/credentials";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import Title from "@/components/ui/title";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState, use } from "react";
 import useSWR, { mutate } from "swr";
 import {
@@ -96,6 +96,7 @@ const PAGES_PER_BATCH = 8;
 
 function Main({ ccPairId }: { ccPairId: number }) {
   const t = useTranslations("admin.connector");
+  const locale = useLocale();
   const router = useRouter();
   const { user } = useUser();
 
@@ -660,7 +661,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
               {t("statusCard.lastIndexed.label")}
             </div>
             <div className="text-sm text-text-default">
-              {timeAgo(ccPair?.last_indexed) ?? "-"}
+              {timeAgo(ccPair?.last_indexed, locale) ?? "-"}
             </div>
           </div>
 
@@ -689,8 +690,12 @@ function Main({ ccPairId }: { ccPairId: number }) {
                 </Text>
                 <Text as="p" className="text-sm text-text-default">
                   {ccPair.last_permission_sync_attempt_finished
-                    ? timeAgo(ccPair.last_permission_sync_attempt_finished)
-                    : (timeAgo(ccPair.last_full_permission_sync) ?? "-")}
+                    ? timeAgo(
+                        ccPair.last_permission_sync_attempt_finished,
+                        locale
+                      )
+                    : (timeAgo(ccPair.last_full_permission_sync, locale) ??
+                      "-")}
                 </Text>
               </div>
             </>

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   Table,
   TableRow,
@@ -150,6 +150,7 @@ function ConnectorRow({
   isEditable: boolean;
 }) {
   const t = useTranslations("admin.indexing");
+  const locale = useLocale();
   const router = useRouter();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
@@ -174,7 +175,7 @@ function ConnectorRow({
         <Truncated>{ccPairsIndexingStatus.name}</Truncated>
       </TableCell>
       <TableCell>
-        {timeAgo(ccPairsIndexingStatus?.last_success) || "-"}
+        {timeAgo(ccPairsIndexingStatus?.last_success, locale) || "-"}
       </TableCell>
       <TableCell>
         <CCPairStatus

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { SvgCheckCircle, SvgClock, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
@@ -34,6 +34,7 @@ export default function ScimSyncCard({
   onRegenerate,
 }: ScimSyncCardProps) {
   const t = useTranslations("admin.scim");
+  const locale = useLocale();
 
   return (
     <Card border="solid" rounding={4}>
@@ -101,7 +102,7 @@ export default function ScimSyncCard({
                       </Text>
                     )}
                     <Text as="p" secondaryBody text03>
-                      {timeAgo(lastUsedAt)}
+                      {timeAgo(lastUsedAt, locale)}
                     </Text>
                   </>
                 ) : (

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
@@ -365,6 +365,7 @@ function BudgetSection({
   budgetResetAt,
 }: BudgetSectionProps) {
   const t = useTranslations("settings.usage");
+  const locale = useLocale();
   // budget_* are null when the user has no cost limit; show a graceful empty state.
   const hasBudget = budgetCents !== null;
   const remaining = budgetRemainingCents ?? 0;
@@ -373,7 +374,7 @@ function BudgetSection({
     hasBudget && budgetCents > 0 ? Math.min(1, spent / budgetCents) : 0;
   const budgetReset = budgetResetAt
     ? t("budget.resetsOn", {
-        date: formatCalendarDay(budgetResetAt.slice(0, 10)),
+        date: formatCalendarDay(budgetResetAt.slice(0, 10), locale),
       })
     : null;
 

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -22,7 +22,7 @@ import PreviewModal from "@/sections/modals/PreviewModal";
 import Text from "@/refresh-components/texts/Text";
 import useOnMount from "@/hooks/useOnMount";
 import SharedAppInputBar from "@/sections/input/SharedAppInputBar";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 export interface SharedChatDisplayProps {
   chatSession: BackendChatSession | null;
@@ -34,6 +34,7 @@ export default function SharedChatDisplay({
   persona,
 }: SharedChatDisplayProps) {
   const t = useTranslations("chat.sharedChat");
+  const locale = useLocale();
   const [presentingDocument, setPresentingDocument] =
     useState<MinimalOnyxDocument | null>(null);
 
@@ -107,7 +108,7 @@ export default function SharedChatDisplay({
             <div className="flex flex-col items-end">
               <Text as="p" text03 secondaryBody>
                 {t("header.sharedOn.text", {
-                  date: humanReadableFormat(chatSession.time_created),
+                  date: humanReadableFormat(chatSession.time_created, locale),
                 })}
               </Text>
               {chatSession.owner_name && (

--- a/web/src/app/ee/admin/billing/SubscriptionSummary.tsx
+++ b/web/src/app/ee/admin/billing/SubscriptionSummary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { InfoItem } from "./InfoItem";
 import { statusToDisplay, BillingInformation } from "@/lib/billing";
 import { formatDateShort } from "@/lib/dateUtils";
@@ -12,6 +12,7 @@ export function SubscriptionSummary({
   billingInformation,
 }: SubscriptionSummaryProps) {
   const t = useTranslations("admin.billing.info");
+  const locale = useLocale();
   return (
     <div className="grid grid-cols-2 gap-4">
       <InfoItem
@@ -24,11 +25,11 @@ export function SubscriptionSummary({
       />
       <InfoItem
         title={t("summary.billingStart.label")}
-        value={formatDateShort(billingInformation.current_period_start)}
+        value={formatDateShort(billingInformation.current_period_start, locale)}
       />
       <InfoItem
         title={t("summary.billingEnd.label")}
-        value={formatDateShort(billingInformation.current_period_end)}
+        value={formatDateShort(billingInformation.current_period_end, locale)}
       />
     </div>
   );

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   Table,
   TableHead,
@@ -37,7 +37,10 @@ import {
   ITEMS_PER_PAGE,
   PAGES_PER_BATCH,
 } from "@/app/ee/admin/performance/query-history/constants";
-import { humanReadableFormatWithTime } from "@opal/time";
+import {
+  humanReadableFormatShort,
+  humanReadableFormatWithTime,
+} from "@opal/time";
 import { Modal } from "@opal/components";
 import { Button, Divider } from "@opal/components";
 import { Badge } from "@/components/ui/badge";
@@ -155,6 +158,7 @@ function PreviousQueryHistoryExportsModal({
   setShowModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const t = useTranslations("admin.queryHistory");
+  const locale = useLocale();
   const { data: queryHistoryTasks } = useSWR<TaskQueueState[]>(
     LIST_QUERY_HISTORY_URL,
     errorHandlingFetcher,
@@ -208,10 +212,14 @@ function PreviousQueryHistoryExportsModal({
               {paginatedTasks.map((task, index) => (
                 <TableRow key={index}>
                   <TableCell>
-                    {humanReadableFormatWithTime(task.startTime)}
+                    {humanReadableFormatWithTime(task.startTime, locale)}
                   </TableCell>
-                  <TableCell>{task.start.toDateString()}</TableCell>
-                  <TableCell>{task.end.toDateString()}</TableCell>
+                  <TableCell>
+                    {humanReadableFormatShort(task.start, locale)}
+                  </TableCell>
+                  <TableCell>
+                    {humanReadableFormatShort(task.end, locale)}
+                  </TableCell>
                   <TableCell>
                     <ExportBadge status={task.status} />
                   </TableCell>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -22,6 +22,7 @@ import { AuthenticationShell } from "@/lib/auth/components";
 import ProductGatingWrapper from "@/providers/ProductGatingWrapper";
 import SWRConfigProvider from "@/providers/SWRConfigProvider";
 import { NextIntlClientProvider } from "next-intl";
+import OpalStringsBridge from "@/i18n/OpalStringsBridge";
 import { getLocale, getMessages } from "next-intl/server";
 import { DirectionProvider } from "@radix-ui/react-direction";
 import { cookies } from "next/headers";
@@ -148,43 +149,47 @@ export default async function Layout({ children }: LayoutProps) {
 
       <body className={`relative font-hanken`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
-          {/* Radix reads direction from context, not the DOM, so popovers,
+          <OpalStringsBridge>
+            {/* Radix reads direction from context, not the DOM, so popovers,
               menus and roving focus need this alongside <html dir>. */}
-          <DirectionProvider dir={dir}>
-            <ThemeProvider
-              attribute="class"
-              defaultTheme="system"
-              enableSystem
-              disableTransitionOnChange
-            >
-              <div className="text-text min-h-screen bg-background">
-                <TooltipProvider>
-                  <PHProvider>
-                    <SWRConfigProvider>
-                      <AppHealthBanner />
-                      <BannerQueue />
-                      <AuthenticationShell>
-                        <AppProvider>
-                          <PostHogRuntimeInitializer />
-                          <CustomAnalyticsScript />
-                          <PostHogPageTracker />
-                          <div id={MODAL_ROOT_ID} className="h-screen w-screen">
-                            <ProductGatingWrapper>
-                              {children}
-                            </ProductGatingWrapper>
-                          </div>
-                          <WebVitals />
-                          {process.env.NEXT_PUBLIC_ENABLE_STATS === "true" && (
-                            <StatsOverlayLoader />
-                          )}
-                        </AppProvider>
-                      </AuthenticationShell>
-                    </SWRConfigProvider>
-                  </PHProvider>
-                </TooltipProvider>
-              </div>
-            </ThemeProvider>
-          </DirectionProvider>
+            <DirectionProvider dir={dir}>
+              <ThemeProvider
+                attribute="class"
+                defaultTheme="system"
+                enableSystem
+                disableTransitionOnChange
+              >
+                <div className="text-text min-h-screen bg-background">
+                  <TooltipProvider>
+                    <PHProvider>
+                      <SWRConfigProvider>
+                        <AppHealthBanner />
+                        <BannerQueue />
+                        <AuthenticationShell>
+                          <AppProvider>
+                            <PostHogRuntimeInitializer />
+                            <CustomAnalyticsScript />
+                            <PostHogPageTracker />
+                            <div
+                              id={MODAL_ROOT_ID}
+                              className="h-screen w-screen"
+                            >
+                              <ProductGatingWrapper>
+                                {children}
+                              </ProductGatingWrapper>
+                            </div>
+                            <WebVitals />
+                            {process.env.NEXT_PUBLIC_ENABLE_STATS ===
+                              "true" && <StatsOverlayLoader />}
+                          </AppProvider>
+                        </AuthenticationShell>
+                      </SWRConfigProvider>
+                    </PHProvider>
+                  </TooltipProvider>
+                </div>
+              </ThemeProvider>
+            </DirectionProvider>
+          </OpalStringsBridge>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/web/src/components/search/DocumentUpdatedAtBadge.tsx
+++ b/web/src/components/search/DocumentUpdatedAtBadge.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useLocale, useTranslations } from "next-intl";
 import { timeAgo } from "@opal/time";
 import { MetadataBadge } from "../MetadataBadge";
 
@@ -8,10 +11,13 @@ export function DocumentUpdatedAtBadge({
   updatedAt: string;
   modal?: boolean;
 }) {
+  const t = useTranslations("common.documentDisplay");
+  const locale = useLocale();
+  const relative = timeAgo(updatedAt, locale) ?? "";
   return (
     <MetadataBadge
       flexNone={modal}
-      value={(modal ? "" : "Updated ") + timeAgo(updatedAt)}
+      value={modal ? relative : t("updated.text", { date: relative })}
     />
   );
 }

--- a/web/src/ee/sections/SearchCard.tsx
+++ b/web/src/ee/sections/SearchCard.tsx
@@ -13,6 +13,7 @@ import { Interactive } from "@opal/core";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { timeAgo } from "@opal/time";
 import { useMemo } from "react";
+import { useLocale } from "next-intl";
 
 export interface SearchResultCardProps {
   /** The search result document to display */
@@ -33,6 +34,7 @@ export default function SearchCard({
   document,
   onDocumentClick,
 }: SearchResultCardProps) {
+  const locale = useLocale();
   const isWebSource =
     document.is_internet || document.source_type === ValidSources.Web;
 
@@ -92,7 +94,7 @@ export default function SearchCard({
                 {document.updated_at &&
                   !isNaN(new Date(document.updated_at).getTime()) && (
                     <Text secondaryBody text02>
-                      {timeAgo(document.updated_at)}
+                      {timeAgo(document.updated_at, locale)}
                     </Text>
                   )}
               </Section>

--- a/web/src/i18n/OpalStringsBridge.test.tsx
+++ b/web/src/i18n/OpalStringsBridge.test.tsx
@@ -1,0 +1,48 @@
+import { NextIntlClientProvider } from "next-intl";
+import { render } from "@tests/setup/test-utils";
+import Footer from "@opal/components/table/Footer";
+import type { Locale } from "@/i18n/config";
+import OpalStringsBridge from "@/i18n/OpalStringsBridge";
+import arabicMessages from "@/i18n/messages/ar.json";
+import englishMessages from "@/i18n/messages/en.json";
+
+type Messages = typeof englishMessages;
+
+function renderFooterThroughBridge(locale: Locale, messages: Messages) {
+  const { container } = render(
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <OpalStringsBridge>
+        <Footer
+          mode="summary"
+          rangeStart={1}
+          rangeEnd={10}
+          totalItems={22}
+          currentPage={1}
+          totalPages={3}
+          onPageChange={() => {}}
+          units="users"
+        />
+      </OpalStringsBridge>
+    </NextIntlClientProvider>
+  );
+  const summaryRow =
+    container.querySelector(".table-footer")?.firstElementChild
+      ?.firstElementChild;
+  if (!summaryRow) throw new Error("footer summary did not render");
+  return summaryRow;
+}
+
+describe("OpalStringsBridge", () => {
+  it("keeps the English footer summary as four sibling spans", () => {
+    const row = renderFooterThroughBridge("en", englishMessages);
+    expect(row.textContent).toBe("Showing 1~10 of 22 users");
+    expect(row.children).toHaveLength(4);
+  });
+
+  it("splits a translated rich message into the same span layout", () => {
+    const row = renderFooterThroughBridge("ar", arabicMessages);
+    expect(row.textContent).toBe("عرض 1~10 من 22 users");
+    expect(row.children).toHaveLength(4);
+    expect(row.querySelector('span[dir="ltr"]')).toHaveTextContent("1~10");
+  });
+});

--- a/web/src/i18n/OpalStringsBridge.test.tsx
+++ b/web/src/i18n/OpalStringsBridge.test.tsx
@@ -36,13 +36,23 @@ describe("OpalStringsBridge", () => {
   it("keeps the English footer summary as four sibling spans", () => {
     const row = renderFooterThroughBridge("en", englishMessages);
     expect(row.textContent).toBe("Showing 1~10 of 22 users");
-    expect(row.children).toHaveLength(4);
+    expect([...row.children].map((child) => child.tagName)).toEqual([
+      "SPAN",
+      "SPAN",
+      "SPAN",
+      "SPAN",
+    ]);
   });
 
   it("splits a translated rich message into the same span layout", () => {
     const row = renderFooterThroughBridge("ar", arabicMessages);
     expect(row.textContent).toBe("عرض 1~10 من 22 users");
-    expect(row.children).toHaveLength(4);
+    expect([...row.children].map((child) => child.tagName)).toEqual([
+      "SPAN",
+      "SPAN",
+      "SPAN",
+      "SPAN",
+    ]);
     expect(row.querySelector('span[dir="ltr"]')).toHaveTextContent("1~10");
   });
 });

--- a/web/src/i18n/OpalStringsBridge.tsx
+++ b/web/src/i18n/OpalStringsBridge.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { OpalStringsProvider, type OpalStrings } from "@opal/strings";
+
+interface OpalStringsBridgeProps {
+  children: ReactNode;
+}
+
+/** Feeds Opal's built-in labels from the `opal` catalog namespace. */
+export default function OpalStringsBridge({
+  children,
+}: OpalStringsBridgeProps) {
+  const t = useTranslations("opal");
+  const strings = useMemo<OpalStrings>(
+    () => ({
+      close: t("common.close"),
+      loading: t("common.loading"),
+      loadingPage: t("common.loadingPage"),
+      copy: t("common.copy"),
+      copied: t("common.copied"),
+      copyCode: t("common.copyCode"),
+      clear: t("common.clear"),
+      clearFilter: t("common.clearFilter"),
+      date: t("common.date"),
+      time: t("common.time"),
+      edit: t("common.edit"),
+      search: t("common.search"),
+      progress: t("common.progress"),
+      remove: t("common.remove"),
+      removeItem: (title) => t("common.removeItem", { title }),
+      showFullMessage: t("common.showFullMessage"),
+      selectAnOption: t("common.selectAnOption"),
+      openCalendar: t("common.openCalendar"),
+      month: t("input.month"),
+      day: t("input.day"),
+      year: t("input.year"),
+      hours: t("input.hours"),
+      minutes: t("input.minutes"),
+      seconds: t("input.seconds"),
+      showPassword: t("input.showPassword"),
+      hidePassword: t("input.hidePassword"),
+      valueCannotBeRevealed: t("input.valueCannotBeRevealed"),
+      scrollTabsLeft: t("tabs.scrollLeft"),
+      scrollTabsRight: t("tabs.scrollRight"),
+      previousPage: t("pagination.previousPage"),
+      nextPage: t("pagination.nextPage"),
+      goToPage: t("pagination.goToPage"),
+      sort: t("table.sort"),
+      sortBy: t("table.sortBy"),
+      manualOrdering: t("table.manualOrdering"),
+      sortingOrder: t("table.sortingOrder"),
+      ascending: t("table.ascending"),
+      descending: t("table.descending"),
+      columns: t("table.columns"),
+      shownColumns: t("table.shownColumns"),
+      alwaysShown: t("table.alwaysShown"),
+      dragToReorder: t("table.dragToReorder"),
+      viewSelected: t("table.viewSelected"),
+      deselectAll: t("table.deselectAll"),
+      selectItemsToContinue: t("table.selectItemsToContinue"),
+      selectAnItemToContinue: t("table.selectAnItemToContinue"),
+      singleItemSelected: t("table.singleItemSelected"),
+      selectedItemCount: (count) => t("table.selectedItemCount", { count }),
+      showing: (range, total) =>
+        t.rich("table.showing", { range: () => range, total: () => total }),
+    }),
+    [t]
+  );
+  return (
+    <OpalStringsProvider strings={strings}>{children}</OpalStringsProvider>
+  );
+}

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "مسح",
+      "clearFilter": "مسح الفلتر",
+      "close": "إغلاق",
+      "copied": "تم النسخ!",
+      "copy": "نسخ",
+      "copyCode": "نسخ الكود",
+      "date": "التاريخ",
+      "edit": "تعديل",
+      "loading": "جارٍ التحميل",
+      "loadingPage": "جارٍ التحميل…",
+      "openCalendar": "فتح التقويم",
+      "progress": "التقدم",
+      "remove": "إزالة",
+      "removeItem": "إزالة {title}",
+      "search": "بحث...",
+      "selectAnOption": "اختر خيارًا",
+      "showFullMessage": "عرض الرسالة كاملة",
+      "time": "الوقت"
+    },
+    "input": {
+      "day": "اليوم",
+      "hidePassword": "إخفاء كلمة المرور",
+      "hours": "الساعات",
+      "minutes": "الدقائق",
+      "month": "الشهر",
+      "seconds": "الثواني",
+      "showPassword": "إظهار كلمة المرور",
+      "valueCannotBeRevealed": "لا يمكن إظهار القيمة",
+      "year": "السنة"
+    },
+    "pagination": {
+      "goToPage": "الانتقال إلى صفحة",
+      "nextPage": "الصفحة التالية",
+      "previousPage": "الصفحة السابقة"
+    },
+    "table": {
+      "alwaysShown": "معروض دائمًا",
+      "ascending": "تصاعدي",
+      "columns": "الأعمدة",
+      "descending": "تنازلي",
+      "deselectAll": "إلغاء تحديد الكل",
+      "dragToReorder": "اسحب لإعادة الترتيب",
+      "manualOrdering": "ترتيب يدوي",
+      "selectAnItemToContinue": "حدد عنصرًا للمتابعة",
+      "selectedItemCount": "{count, plural, zero {لم يتم تحديد أي عنصر} one {تم تحديد عنصر واحد} two {تم تحديد عنصرين} few {تم تحديد # عناصر} many {تم تحديد # عنصرًا} other {تم تحديد # عنصر}}",
+      "selectItemsToContinue": "حدد عناصر للمتابعة",
+      "showing": "عرض <range></range> من <total></total>",
+      "shownColumns": "الأعمدة المعروضة",
+      "singleItemSelected": "تم تحديد عنصر",
+      "sort": "ترتيب",
+      "sortBy": "ترتيب حسب",
+      "sortingOrder": "اتجاه الترتيب",
+      "viewSelected": "عرض المحدد"
+    },
+    "tabs": {
+      "scrollLeft": "تمرير التبويبات لليسار",
+      "scrollRight": "تمرير التبويبات لليمين"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "Leeren",
+      "clearFilter": "Filter zurücksetzen",
+      "close": "Schließen",
+      "copied": "Kopiert!",
+      "copy": "Kopieren",
+      "copyCode": "Code kopieren",
+      "date": "Datum",
+      "edit": "Bearbeiten",
+      "loading": "Wird geladen",
+      "loadingPage": "Wird geladen …",
+      "openCalendar": "Kalender öffnen",
+      "progress": "Fortschritt",
+      "remove": "Entfernen",
+      "removeItem": "{title} entfernen",
+      "search": "Suchen...",
+      "selectAnOption": "Option auswählen",
+      "showFullMessage": "Vollständige Nachricht anzeigen",
+      "time": "Uhrzeit"
+    },
+    "input": {
+      "day": "Tag",
+      "hidePassword": "Passwort verbergen",
+      "hours": "Stunden",
+      "minutes": "Minuten",
+      "month": "Monat",
+      "seconds": "Sekunden",
+      "showPassword": "Passwort anzeigen",
+      "valueCannotBeRevealed": "Wert kann nicht angezeigt werden",
+      "year": "Jahr"
+    },
+    "pagination": {
+      "goToPage": "Zu Seite springen",
+      "nextPage": "Nächste Seite",
+      "previousPage": "Vorherige Seite"
+    },
+    "table": {
+      "alwaysShown": "Immer angezeigt",
+      "ascending": "Aufsteigend",
+      "columns": "Spalten",
+      "descending": "Absteigend",
+      "deselectAll": "Auswahl aufheben",
+      "dragToReorder": "Ziehen zum Umsortieren",
+      "manualOrdering": "Manuelle Reihenfolge",
+      "selectAnItemToContinue": "Element auswählen, um fortzufahren",
+      "selectedItemCount": "{count, plural, one {# Element ausgewählt} other {# Elemente ausgewählt}}",
+      "selectItemsToContinue": "Elemente auswählen, um fortzufahren",
+      "showing": "<range></range> von <total></total> angezeigt",
+      "shownColumns": "Angezeigte Spalten",
+      "singleItemSelected": "Element ausgewählt",
+      "sort": "Sortieren",
+      "sortBy": "Sortieren nach",
+      "sortingOrder": "Sortierrichtung",
+      "viewSelected": "Auswahl anzeigen"
+    },
+    "tabs": {
+      "scrollLeft": "Tabs nach links scrollen",
+      "scrollRight": "Tabs nach rechts scrollen"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "Clear",
+      "clearFilter": "Clear filter",
+      "close": "Close",
+      "copied": "Copied!",
+      "copy": "Copy",
+      "copyCode": "Copy code",
+      "date": "Date",
+      "edit": "Edit",
+      "loading": "Loading",
+      "loadingPage": "Loading …",
+      "openCalendar": "Open calendar",
+      "progress": "Progress",
+      "remove": "Remove",
+      "removeItem": "Remove {title}",
+      "search": "Search...",
+      "selectAnOption": "Select an option",
+      "showFullMessage": "Show the full message",
+      "time": "Time"
+    },
+    "input": {
+      "day": "Day",
+      "hidePassword": "Hide password",
+      "hours": "Hours",
+      "minutes": "Minutes",
+      "month": "Month",
+      "seconds": "Seconds",
+      "showPassword": "Show password",
+      "valueCannotBeRevealed": "Value cannot be revealed",
+      "year": "Year"
+    },
+    "pagination": {
+      "goToPage": "Go to page",
+      "nextPage": "Next page",
+      "previousPage": "Previous page"
+    },
+    "table": {
+      "alwaysShown": "Always Shown",
+      "ascending": "Ascending",
+      "columns": "Columns",
+      "descending": "Descending",
+      "deselectAll": "Deselect all",
+      "dragToReorder": "Drag to reorder",
+      "manualOrdering": "Manual Ordering",
+      "selectAnItemToContinue": "Select an item to continue",
+      "selectedItemCount": "{count, plural, one {# item selected} other {# items selected}}",
+      "selectItemsToContinue": "Select items to continue",
+      "showing": "Showing <range></range> of <total></total>",
+      "shownColumns": "Shown Columns",
+      "singleItemSelected": "Item selected",
+      "sort": "Sort",
+      "sortBy": "Sort by",
+      "sortingOrder": "Sorting Order",
+      "viewSelected": "View selected"
+    },
+    "tabs": {
+      "scrollLeft": "Scroll tabs left",
+      "scrollRight": "Scroll tabs right"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "Borrar",
+      "clearFilter": "Quitar filtro",
+      "close": "Cerrar",
+      "copied": "¡Copiado!",
+      "copy": "Copiar",
+      "copyCode": "Copiar código",
+      "date": "Fecha",
+      "edit": "Editar",
+      "loading": "Cargando",
+      "loadingPage": "Cargando…",
+      "openCalendar": "Abrir calendario",
+      "progress": "Progreso",
+      "remove": "Quitar",
+      "removeItem": "Quitar {title}",
+      "search": "Buscar...",
+      "selectAnOption": "Selecciona una opción",
+      "showFullMessage": "Mostrar el mensaje completo",
+      "time": "Hora"
+    },
+    "input": {
+      "day": "Día",
+      "hidePassword": "Ocultar contraseña",
+      "hours": "Horas",
+      "minutes": "Minutos",
+      "month": "Mes",
+      "seconds": "Segundos",
+      "showPassword": "Mostrar contraseña",
+      "valueCannotBeRevealed": "El valor no se puede mostrar",
+      "year": "Año"
+    },
+    "pagination": {
+      "goToPage": "Ir a la página",
+      "nextPage": "Página siguiente",
+      "previousPage": "Página anterior"
+    },
+    "table": {
+      "alwaysShown": "Siempre visible",
+      "ascending": "Ascendente",
+      "columns": "Columnas",
+      "descending": "Descendente",
+      "deselectAll": "Deseleccionar todo",
+      "dragToReorder": "Arrastra para reordenar",
+      "manualOrdering": "Orden manual",
+      "selectAnItemToContinue": "Selecciona un elemento para continuar",
+      "selectedItemCount": "{count, plural, one {# elemento seleccionado} other {# elementos seleccionados}}",
+      "selectItemsToContinue": "Selecciona elementos para continuar",
+      "showing": "Mostrando <range></range> de <total></total>",
+      "shownColumns": "Columnas visibles",
+      "singleItemSelected": "Elemento seleccionado",
+      "sort": "Ordenar",
+      "sortBy": "Ordenar por",
+      "sortingOrder": "Dirección del orden",
+      "viewSelected": "Ver seleccionados"
+    },
+    "tabs": {
+      "scrollLeft": "Desplazar pestañas a la izquierda",
+      "scrollRight": "Desplazar pestañas a la derecha"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "Effacer",
+      "clearFilter": "Effacer le filtre",
+      "close": "Fermer",
+      "copied": "Copié !",
+      "copy": "Copier",
+      "copyCode": "Copier le code",
+      "date": "Date",
+      "edit": "Modifier",
+      "loading": "Chargement",
+      "loadingPage": "Chargement…",
+      "openCalendar": "Ouvrir le calendrier",
+      "progress": "Progression",
+      "remove": "Retirer",
+      "removeItem": "Retirer {title}",
+      "search": "Rechercher...",
+      "selectAnOption": "Sélectionnez une option",
+      "showFullMessage": "Afficher le message complet",
+      "time": "Heure"
+    },
+    "input": {
+      "day": "Jour",
+      "hidePassword": "Masquer le mot de passe",
+      "hours": "Heures",
+      "minutes": "Minutes",
+      "month": "Mois",
+      "seconds": "Secondes",
+      "showPassword": "Afficher le mot de passe",
+      "valueCannotBeRevealed": "La valeur ne peut pas être affichée",
+      "year": "Année"
+    },
+    "pagination": {
+      "goToPage": "Aller à la page",
+      "nextPage": "Page suivante",
+      "previousPage": "Page précédente"
+    },
+    "table": {
+      "alwaysShown": "Toujours affichée",
+      "ascending": "Croissant",
+      "columns": "Colonnes",
+      "descending": "Décroissant",
+      "deselectAll": "Tout désélectionner",
+      "dragToReorder": "Glisser pour réordonner",
+      "manualOrdering": "Ordre manuel",
+      "selectAnItemToContinue": "Sélectionnez un élément pour continuer",
+      "selectedItemCount": "{count, plural, one {# élément sélectionné} other {# éléments sélectionnés}}",
+      "selectItemsToContinue": "Sélectionnez des éléments pour continuer",
+      "showing": "Affichage de <range></range> sur <total></total>",
+      "shownColumns": "Colonnes affichées",
+      "singleItemSelected": "Élément sélectionné",
+      "sort": "Trier",
+      "sortBy": "Trier par",
+      "sortingOrder": "Sens du tri",
+      "viewSelected": "Voir la sélection"
+    },
+    "tabs": {
+      "scrollLeft": "Faire défiler les onglets vers la gauche",
+      "scrollRight": "Faire défiler les onglets vers la droite"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "クリア",
+      "clearFilter": "フィルターをクリア",
+      "close": "閉じる",
+      "copied": "コピーしました",
+      "copy": "コピー",
+      "copyCode": "コードをコピー",
+      "date": "日付",
+      "edit": "編集",
+      "loading": "読み込み中",
+      "loadingPage": "読み込み中…",
+      "openCalendar": "カレンダーを開く",
+      "progress": "進行状況",
+      "remove": "削除",
+      "removeItem": "{title} を削除",
+      "search": "検索...",
+      "selectAnOption": "オプションを選択",
+      "showFullMessage": "メッセージ全体を表示",
+      "time": "時刻"
+    },
+    "input": {
+      "day": "日",
+      "hidePassword": "パスワードを非表示",
+      "hours": "時",
+      "minutes": "分",
+      "month": "月",
+      "seconds": "秒",
+      "showPassword": "パスワードを表示",
+      "valueCannotBeRevealed": "値を表示できません",
+      "year": "年"
+    },
+    "pagination": {
+      "goToPage": "ページへ移動",
+      "nextPage": "次のページ",
+      "previousPage": "前のページ"
+    },
+    "table": {
+      "alwaysShown": "常に表示",
+      "ascending": "昇順",
+      "columns": "列",
+      "descending": "降順",
+      "deselectAll": "すべて選択解除",
+      "dragToReorder": "ドラッグして並べ替え",
+      "manualOrdering": "手動の順序",
+      "selectAnItemToContinue": "続行するには項目を選択してください",
+      "selectedItemCount": "{count, plural, one {# 件の項目を選択済み} other {# 件の項目を選択済み}}",
+      "selectItemsToContinue": "続行するには項目を選択してください",
+      "showing": "<total></total> 件中 <range></range> 件を表示",
+      "shownColumns": "表示中の列",
+      "singleItemSelected": "項目を選択済み",
+      "sort": "並べ替え",
+      "sortBy": "並べ替え基準",
+      "sortingOrder": "並べ替え順",
+      "viewSelected": "選択項目を表示"
+    },
+    "tabs": {
+      "scrollLeft": "タブを左にスクロール",
+      "scrollRight": "タブを右にスクロール"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "지우기",
+      "clearFilter": "필터 지우기",
+      "close": "닫기",
+      "copied": "복사됨!",
+      "copy": "복사",
+      "copyCode": "코드 복사",
+      "date": "날짜",
+      "edit": "편집",
+      "loading": "로딩 중",
+      "loadingPage": "로딩 중…",
+      "openCalendar": "캘린더 열기",
+      "progress": "진행률",
+      "remove": "제거",
+      "removeItem": "{title} 제거",
+      "search": "검색...",
+      "selectAnOption": "옵션 선택",
+      "showFullMessage": "전체 메시지 보기",
+      "time": "시간"
+    },
+    "input": {
+      "day": "일",
+      "hidePassword": "비밀번호 숨기기",
+      "hours": "시",
+      "minutes": "분",
+      "month": "월",
+      "seconds": "초",
+      "showPassword": "비밀번호 표시",
+      "valueCannotBeRevealed": "값을 표시할 수 없습니다",
+      "year": "년"
+    },
+    "pagination": {
+      "goToPage": "페이지로 이동",
+      "nextPage": "다음 페이지",
+      "previousPage": "이전 페이지"
+    },
+    "table": {
+      "alwaysShown": "항상 표시",
+      "ascending": "오름차순",
+      "columns": "열",
+      "descending": "내림차순",
+      "deselectAll": "모두 선택 해제",
+      "dragToReorder": "드래그하여 순서 변경",
+      "manualOrdering": "수동 정렬",
+      "selectAnItemToContinue": "계속하려면 항목을 선택하세요",
+      "selectedItemCount": "{count, plural, one {#개 항목 선택됨} other {#개 항목 선택됨}}",
+      "selectItemsToContinue": "계속하려면 항목을 선택하세요",
+      "showing": "<total></total>개 중 <range></range> 표시",
+      "shownColumns": "표시된 열",
+      "singleItemSelected": "항목 선택됨",
+      "sort": "정렬",
+      "sortBy": "정렬 기준",
+      "sortingOrder": "정렬 순서",
+      "viewSelected": "선택 항목 보기"
+    },
+    "tabs": {
+      "scrollLeft": "탭을 왼쪽으로 스크롤",
+      "scrollRight": "탭을 오른쪽으로 스크롤"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "Limpar",
+      "clearFilter": "Limpar filtro",
+      "close": "Fechar",
+      "copied": "Copiado!",
+      "copy": "Copiar",
+      "copyCode": "Copiar código",
+      "date": "Data",
+      "edit": "Editar",
+      "loading": "Carregando",
+      "loadingPage": "Carregando…",
+      "openCalendar": "Abrir calendário",
+      "progress": "Progresso",
+      "remove": "Remover",
+      "removeItem": "Remover {title}",
+      "search": "Pesquisar...",
+      "selectAnOption": "Selecione uma opção",
+      "showFullMessage": "Mostrar a mensagem completa",
+      "time": "Hora"
+    },
+    "input": {
+      "day": "Dia",
+      "hidePassword": "Ocultar senha",
+      "hours": "Horas",
+      "minutes": "Minutos",
+      "month": "Mês",
+      "seconds": "Segundos",
+      "showPassword": "Mostrar senha",
+      "valueCannotBeRevealed": "O valor não pode ser exibido",
+      "year": "Ano"
+    },
+    "pagination": {
+      "goToPage": "Ir para a página",
+      "nextPage": "Próxima página",
+      "previousPage": "Página anterior"
+    },
+    "table": {
+      "alwaysShown": "Sempre exibida",
+      "ascending": "Crescente",
+      "columns": "Colunas",
+      "descending": "Decrescente",
+      "deselectAll": "Desmarcar tudo",
+      "dragToReorder": "Arraste para reordenar",
+      "manualOrdering": "Ordem manual",
+      "selectAnItemToContinue": "Selecione um item para continuar",
+      "selectedItemCount": "{count, plural, one {# item selecionado} other {# itens selecionados}}",
+      "selectItemsToContinue": "Selecione itens para continuar",
+      "showing": "Mostrando <range></range> de <total></total>",
+      "shownColumns": "Colunas exibidas",
+      "singleItemSelected": "Item selecionado",
+      "sort": "Ordenar",
+      "sortBy": "Ordenar por",
+      "sortingOrder": "Direção da ordenação",
+      "viewSelected": "Ver selecionados"
+    },
+    "tabs": {
+      "scrollLeft": "Rolar abas para a esquerda",
+      "scrollRight": "Rolar abas para a direita"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -12582,6 +12582,67 @@
       }
     }
   },
+  "opal": {
+    "common": {
+      "clear": "清除",
+      "clearFilter": "清除筛选",
+      "close": "关闭",
+      "copied": "已复制！",
+      "copy": "复制",
+      "copyCode": "复制代码",
+      "date": "日期",
+      "edit": "编辑",
+      "loading": "加载中",
+      "loadingPage": "加载中…",
+      "openCalendar": "打开日历",
+      "progress": "进度",
+      "remove": "移除",
+      "removeItem": "移除 {title}",
+      "search": "搜索...",
+      "selectAnOption": "选择一个选项",
+      "showFullMessage": "显示完整消息",
+      "time": "时间"
+    },
+    "input": {
+      "day": "日",
+      "hidePassword": "隐藏密码",
+      "hours": "小时",
+      "minutes": "分钟",
+      "month": "月",
+      "seconds": "秒",
+      "showPassword": "显示密码",
+      "valueCannotBeRevealed": "无法显示该值",
+      "year": "年"
+    },
+    "pagination": {
+      "goToPage": "跳转到页面",
+      "nextPage": "下一页",
+      "previousPage": "上一页"
+    },
+    "table": {
+      "alwaysShown": "始终显示",
+      "ascending": "升序",
+      "columns": "列",
+      "descending": "降序",
+      "deselectAll": "取消全选",
+      "dragToReorder": "拖动以重新排序",
+      "manualOrdering": "手动排序",
+      "selectAnItemToContinue": "选择一个项目以继续",
+      "selectedItemCount": "{count, plural, one {已选择 # 个项目} other {已选择 # 个项目}}",
+      "selectItemsToContinue": "选择项目以继续",
+      "showing": "显示 <range></range>，共 <total></total>",
+      "shownColumns": "显示的列",
+      "singleItemSelected": "已选择项目",
+      "sort": "排序",
+      "sortBy": "排序依据",
+      "sortingOrder": "排序方向",
+      "viewSelected": "查看已选"
+    },
+    "tabs": {
+      "scrollLeft": "向左滚动标签",
+      "scrollRight": "向右滚动标签"
+    }
+  },
   "settings": {
     "accounts": {
       "email": {

--- a/web/src/lib/dateUtils.ts
+++ b/web/src/lib/dateUtils.ts
@@ -2,8 +2,7 @@
 
 import { useEffect } from "react";
 import { useState } from "react";
-
-import { DEFAULT_LOCALE } from "@/i18n/config";
+import { humanReadableFormatShort } from "@opal/time";
 
 export const useNightTime = () => {
   const [isNight, setIsNight] = useState(false);
@@ -115,7 +114,7 @@ export const buildDateString = (date: Date | null) => {
 export const getFormattedDateRangeString = (
   from: Date | null,
   to: Date | null,
-  locale: string = DEFAULT_LOCALE
+  locale: string
 ) => {
   if (!from || !to) return null;
 
@@ -168,28 +167,19 @@ export const getTimeAgoString = (date: Date | null) => {
   return `${diffMonths}mo ago`;
 };
 
-/**
- * Format a date to short format like "Jan 27, 2026".
- * Always shows date, never time.
- */
+/** Short date like "Jan 27, 2026", or an em dash when there is no date. */
 export const formatDateShort = (
   dateStr: string | null | undefined,
-  locale: string = DEFAULT_LOCALE
-): string => {
-  if (!dateStr) return "—";
-  return new Date(dateStr).toLocaleDateString(locale, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-};
+  locale: string
+): string => (dateStr ? humanReadableFormatShort(dateStr, locale) : "—");
 
 // Parses at local midnight so the day never shifts the way `formatDateShort` can for callers west of UTC.
 export const formatCalendarDay = (
   dateStr: string,
+  locale: string,
   { withYear = false }: { withYear?: boolean } = {}
 ): string =>
-  new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+  new Date(`${dateStr}T00:00:00`).toLocaleDateString(locale, {
     month: "short",
     day: "numeric",
     ...(withYear && { year: "numeric" }),
@@ -236,10 +226,7 @@ export function formatElapsedTime(totalSeconds: number): string {
     .padStart(2, "0")}`;
 }
 
-export const getFormattedDateTime = (
-  date: Date | null,
-  locale: string = DEFAULT_LOCALE
-) => {
+export const getFormattedDateTime = (date: Date | null, locale: string) => {
   if (!date) return null;
 
   const now = new Date();

--- a/web/src/lib/projects/components/ProjectChatSessionList.tsx
+++ b/web/src/lib/projects/components/ProjectChatSessionList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { deleteChatSession } from "@/app/app/services/lib";
 import {
   moveChatSession as moveChatSessionService,
@@ -54,6 +54,7 @@ function ProjectChatItem({
 }: ProjectChatItemProps) {
   const t = useTranslations("chat");
   const tSidebar = useTranslations("sidebar");
+  const locale = useLocale();
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [pendingMoveProjectId, setPendingMoveProjectId] = useState<
@@ -65,8 +66,8 @@ function ProjectChatItem({
   const [searchTerm, setSearchTerm] = useState("");
 
   const lastUpdateTime = useMemo(
-    () => timeAgo(chat.time_updated),
-    [chat.time_updated]
+    () => timeAgo(chat.time_updated, locale),
+    [chat.time_updated, locale]
   );
 
   const { refreshChatSessions, removeSession } = useChatSessions();

--- a/web/src/refresh-components/buttons/source-tag/SourceTagDetailsCard.tsx
+++ b/web/src/refresh-components/buttons/source-tag/SourceTagDetailsCard.tsx
@@ -13,6 +13,7 @@ import { SourceIcon } from "@/components/SourceIcon";
 import { WebResultIcon } from "@/components/WebResultIcon";
 import { ValidSources } from "@/lib/types";
 import { timeAgo } from "@opal/time";
+import { useLocale } from "next-intl";
 import type { IconProps } from "@opal/types";
 import { SubQuestionDetail } from "@/app/app/interfaces";
 
@@ -70,6 +71,7 @@ const SourceTagDetailsCardInner = ({
   onPrev,
   onNext,
 }: SourceTagDetailsCardProps) => {
+  const locale = useLocale();
   const currentSource = sources[currentIndex];
   if (!currentSource) return null;
 
@@ -81,7 +83,8 @@ const SourceTagDetailsCardInner = ({
   const relativeDate = timeAgo(
     currentSource.metadata?.date instanceof Date
       ? currentSource.metadata.date.toISOString()
-      : currentSource.metadata?.date
+      : currentSource.metadata?.date,
+    locale
   );
 
   return (

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useCallback,
 } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import ActionCard from "@/sections/actions/ActionCard";
 import Actions from "@/sections/actions/Actions";
 import ToolItem from "@/sections/actions/ToolItem";
@@ -108,6 +108,7 @@ export default function MCPActionCard({
   className,
 }: MCPActionCardProps) {
   const t = useTranslations("actions");
+  const locale = useLocale();
   const [isToolsExpanded, setIsToolsExpanded] = useState(initialExpanded);
   const [searchQuery, setSearchQuery] = useState("");
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(false);
@@ -261,7 +262,7 @@ export default function MCPActionCard({
 
   // Left action for ToolsList footer
   const leftAction = useMemo(() => {
-    const lastRefreshedText = timeAgo(server.last_refreshed_at);
+    const lastRefreshedText = timeAgo(server.last_refreshed_at, locale);
 
     return (
       <div className="flex items-center gap-2">
@@ -284,6 +285,7 @@ export default function MCPActionCard({
   }, [
     canManageStatus,
     server.last_refreshed_at,
+    locale,
     serverId,
     mutate,
     onRefreshTools,

--- a/web/src/sections/banners/BannerQueue.tsx
+++ b/web/src/sections/banners/BannerQueue.tsx
@@ -8,7 +8,7 @@
 // there is no content area.
 
 import { usePathname, useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Button, Text } from "@opal/components";
 import { cn, markdown } from "@opal/utils";
 import { timeAgo } from "@opal/time";
@@ -68,6 +68,7 @@ const CONNECTORS_LINK = "/admin/indexing/status";
 
 export default function BannerQueue() {
   const t = useTranslations("chat.banners");
+  const locale = useLocale();
   const pathname = usePathname();
   const router = useRouter();
   const { inlineStart: contentInlineStart } = useContainerCenter();
@@ -129,7 +130,7 @@ export default function BannerQueue() {
       link: notification.additional_data?.link ?? null,
       ctaLabel: config?.ctaLabel ?? defaultCtaLabel,
     };
-  const relativeTime = timeAgo(notification.last_shown);
+  const relativeTime = timeAgo(notification.last_shown, locale);
   const sourceLabel = config?.sourceLabel ?? t("defaultSource.label");
   // Disclose collapsed same-type siblings so dismissing the visible one
   // never surfaces the rest as a surprise.

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -7,7 +7,7 @@ import React, {
   useCallback,
   useRef,
 } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
 import {
@@ -190,6 +190,7 @@ export default function SourceHierarchyBrowser({
   initialNodeId,
 }: SourceHierarchyBrowserProps) {
   const t = useTranslations("knowledge");
+  const locale = useLocale();
 
   // State for hierarchy nodes (loaded once per source)
   const [allNodes, setAllNodes] = useState<HierarchyNodeSummary[]>([]);
@@ -1023,7 +1024,8 @@ export default function SourceHierarchyBrowser({
                       {isFolder
                         ? "—"
                         : timeAgo(
-                            (item.data as DocumentSummary).last_modified
+                            (item.data as DocumentSummary).last_modified,
+                            locale
                           ) || "—"}
                     </Text>
                   </TableLayouts.TableCell>

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTableContent.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTableContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
 import Text from "@/refresh-components/texts/Text";
@@ -161,6 +161,7 @@ export function RecentFilesTableContent({
   hasProcessingFiles,
 }: RecentFilesTableContentProps) {
   const t = useTranslations("knowledge");
+  const locale = useLocale();
   const [searchValue, setSearchValue] = useState("");
 
   const filteredFiles = useMemo(() => {
@@ -190,7 +191,7 @@ export function RecentFilesTableContent({
       width: 8,
       render: (file) => (
         <Text text03 secondaryBody>
-          {timeAgo(file.last_accessed_at || file.created_at)}
+          {timeAgo(file.last_accessed_at || file.created_at, locale)}
         </Text>
       ),
     },

--- a/web/src/sections/modals/UserFilesModal.tsx
+++ b/web/src/sections/modals/UserFilesModal.tsx
@@ -26,7 +26,7 @@ import useFilter from "@/hooks/useFilter";
 import { Button } from "@opal/components";
 import ScrollIndicatorDiv from "@/refresh-components/ScrollIndicatorDiv";
 import { timeAgo } from "@opal/time";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 function getIcon(
   file: ProjectFile,
@@ -72,6 +72,7 @@ function FileAttachment({
   onDelete,
 }: FileAttachmentProps) {
   const t = useTranslations("chat.modals.userFiles");
+  const locale = useLocale();
   const isProcessing =
     String(file.status) === UserFileStatus.PROCESSING ||
     String(file.status) === UserFileStatus.UPLOADING ||
@@ -84,7 +85,7 @@ function FileAttachment({
     deleting: t("fileStatus.deleting.label"),
   });
   const rightText = file.last_accessed_at
-    ? (timeAgo(file.last_accessed_at) ?? "")
+    ? (timeAgo(file.last_accessed_at, locale) ?? "")
     : "";
 
   return (

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import type { Route } from "next";
 import { useAppPosition } from "@/lib/position/hooks";
 import CommandMenu, {
@@ -69,6 +69,7 @@ export default function ChatSearchCommandMenu({
   trigger,
 }: ChatSearchCommandMenuProps) {
   const t = useTranslations("sidebar");
+  const locale = useLocale();
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [activeFilter, setActiveFilter] = useState<
@@ -277,7 +278,7 @@ export default function ChatSearchCommandMenu({
                             text03
                             data-testid="command-menu-timestamp"
                           >
-                            {timeAgo(chat.time)}
+                            {timeAgo(chat.time, locale)}
                           </Text>
                         )
                       }
@@ -338,7 +339,7 @@ export default function ChatSearchCommandMenu({
                           text03
                           data-testid="command-menu-timestamp"
                         >
-                          {timeAgo(project.time)}
+                          {timeAgo(project.time, locale)}
                         </Text>
                       )
                     }

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { track, AnalyticsEvent } from "@/lib/analytics/utils";
 import type { Notification as NotificationData } from "@/lib/notifications/interfaces";
 import { NotificationType } from "@/lib/notifications/interfaces";
@@ -65,6 +65,7 @@ function NotificationItem({
   dismiss,
 }: NotificationItemProps) {
   const t = useTranslations("sidebar");
+  const locale = useLocale();
 
   return (
     <Hoverable.Root group="notifications-popover/NotificationItem">
@@ -80,7 +81,7 @@ function NotificationItem({
           <Section justifyContent="start">
             <Section height="fit" gap={2} flexDirection="row">
               <Text font="secondary-body" color="text-02">
-                {timeAgo(notification.first_shown) ?? ""}
+                {timeAgo(notification.first_shown, locale) ?? ""}
               </Text>
               {state === "new" && (
                 <div className="w-4 flex flex-col items-center justify-center">

--- a/web/src/sections/usage/AnalyticsChart.tsx
+++ b/web/src/sections/usage/AnalyticsChart.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useLocale } from "next-intl";
 import { Card, EmptyMessageCard, MessageCard, Text } from "@opal/components";
 import { SvgX } from "@opal/icons";
 import { PageLoader, Section } from "@opal/layouts";
@@ -11,12 +12,12 @@ import { ChartSeries, ChartState } from "@/sections/usage/interfaces";
 
 const CHART_BODY_HEIGHT = 20;
 
-function formatDay(dateStr: string): string {
+function formatDay(dateStr: string, locale: string): string {
   const [year, month, day] = dateStr.split("-").map(Number);
   if (year === undefined || month === undefined || day === undefined) {
     return dateStr;
   }
-  return formatCalendarDay(dateStr);
+  return formatCalendarDay(dateStr, locale);
 }
 
 /** Keeps the underlying failure in the console when a chart shows its error card. */
@@ -159,9 +160,12 @@ export function AnalyticsChart({
   headerChildren,
   stacked = false,
   allowDecimals = true,
-  xAxisFormatter = formatDay,
+  xAxisFormatter,
   yAxisFormatter,
 }: AnalyticsChartProps) {
+  const locale = useLocale();
+  const formatXAxis =
+    xAxisFormatter ?? ((value: string) => formatDay(value, locale));
   return (
     <Card border="solid" rounding={4} padding={6}>
       <Section
@@ -194,7 +198,7 @@ export function AnalyticsChart({
           timeRange={timeRange}
           stacked={stacked}
           allowDecimals={allowDecimals}
-          xAxisFormatter={xAxisFormatter}
+          xAxisFormatter={formatXAxis}
           {...(yAxisFormatter && { yAxisFormatter })}
         />
       </Section>

--- a/web/src/sections/usage/UserUsageDetailModal.tsx
+++ b/web/src/sections/usage/UserUsageDetailModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Button, Modal, ProgressBar, Text, Tooltip } from "@opal/components";
 import { Section } from "@opal/layouts";
 import type { IconFunctionComponent } from "@opal/types";
@@ -173,6 +173,7 @@ function BreakdownList({
 
 function DailySpendStrip({ days }: { days: DailySpend[] }) {
   const t = useTranslations("admin.usage");
+  const locale = useLocale();
   const max = Math.max(...days.map((day) => day.cost_cents));
   if (days.length < 2 || max <= 0 || days.length > MAX_DAILY_COLUMNS) {
     return null;
@@ -195,7 +196,7 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
           days: days
             .map((day) =>
               t("detail.dailySpend.day.ariaLabel", {
-                day: formatCalendarDay(day.day),
+                day: formatCalendarDay(day.day, locale),
                 cost: formatCost(day.cost_cents),
               })
             )
@@ -212,7 +213,7 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
           <Tooltip
             key={day.day}
             tooltip={t("detail.dailySpend.day.tooltip", {
-              day: formatCalendarDay(day.day),
+              day: formatCalendarDay(day.day, locale),
               cost: formatCost(day.cost_cents),
             })}
             side="top"
@@ -243,10 +244,10 @@ function DailySpendStrip({ days }: { days: DailySpend[] }) {
         height="fit"
       >
         <Text font="secondary-body" color="text-03">
-          {formatCalendarDay(days[0]!.day)}
+          {formatCalendarDay(days[0]!.day, locale)}
         </Text>
         <Text font="secondary-body" color="text-03">
-          {formatCalendarDay(days[days.length - 1]!.day)}
+          {formatCalendarDay(days[days.length - 1]!.day, locale)}
         </Text>
       </Section>
     </Section>

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -12,8 +12,8 @@ import { formatCost, formatTokens } from "@/lib/utils";
 import SpendByUserTable from "@/sections/usage/SpendByUserTable";
 import UserUsageDetailModal from "@/sections/usage/UserUsageDetailModal";
 
-function formatDate(value: string): string {
-  return formatCalendarDay(value, { withYear: true });
+function formatDate(value: string, locale: string): string {
+  return formatCalendarDay(value, locale, { withYear: true });
 }
 
 function SummaryMetric({
@@ -105,8 +105,8 @@ export default function PerUserUsagePanel({
       >
         {usage
           ? t("panel.description", {
-              start: formatDate(usage.start),
-              end: formatDate(usage.end),
+              start: formatDate(usage.start, locale),
+              end: formatDate(usage.end, locale),
             })
           : t("panel.emptyDescription")}
       </Text>
@@ -234,7 +234,7 @@ export default function PerUserUsagePanel({
           user={selectedUser}
           periodLabel={
             usage
-              ? `${formatDate(usage.start)} – ${formatDate(usage.end)}`
+              ? `${formatDate(usage.start, locale)} – ${formatDate(usage.end, locale)}`
               : undefined
           }
           onOpenChange={(open) => {

--- a/web/src/views/admin/UsersPage/UsersTable.tsx
+++ b/web/src/views/admin/UsersPage/UsersTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Table, createTableColumns } from "@opal/components";
 import { Content, toast } from "@opal/layouts";
 import { Button } from "@opal/components";
@@ -62,10 +62,10 @@ function renderStatusColumn(
   );
 }
 
-function renderLastUpdatedColumn(value: string | null) {
+function renderLastUpdatedColumn(value: string | null, locale: string) {
   return (
     <Text as="span" secondaryBody text03>
-      {value ? (timeAgo(value) ?? "\u2014") : "\u2014"}
+      {value ? (timeAgo(value, locale) ?? "\u2014") : "\u2014"}
     </Text>
   );
 }
@@ -86,7 +86,11 @@ interface ColumnLabels {
   scimSynced: string;
 }
 
-function buildColumns(onMutate: () => void, labels: ColumnLabels) {
+function buildColumns(
+  onMutate: () => void,
+  labels: ColumnLabels,
+  locale: string
+) {
   return [
     tc.qualifier({
       content: "icon",
@@ -127,7 +131,7 @@ function buildColumns(onMutate: () => void, labels: ColumnLabels) {
     tc.column("updated_at", {
       header: labels.lastUpdated,
       weight: 14,
-      cell: renderLastUpdatedColumn,
+      cell: (value) => renderLastUpdatedColumn(value, locale),
     }),
     tc.actions({
       cell: (row) => <UserRowActions user={row} onMutate={onMutate} />,
@@ -155,6 +159,7 @@ export default function UsersTable({
   statusCounts,
 }: UsersTableProps) {
   const t = useTranslations("admin.users");
+  const locale = useLocale();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedAccountTypes, setSelectedAccountTypes] = useState<
     AccountType[]
@@ -177,21 +182,25 @@ export default function UsersTable({
 
   const columns = useMemo(
     () =>
-      buildColumns(refresh, {
-        name: t("table.columns.name.header"),
-        groups: t("table.columns.groups.header"),
-        accountType: t("table.columns.accountType.header"),
-        lastUpdated: t("table.columns.lastUpdated.header"),
-        statusHeader: t("table.columns.status.header"),
-        status: {
-          [UserStatus.ACTIVE]: t("status.active.label"),
-          [UserStatus.INACTIVE]: t("status.inactive.label"),
-          [UserStatus.INVITED]: t("status.invited.label"),
-          [UserStatus.REQUESTED]: t("status.requested.label"),
+      buildColumns(
+        refresh,
+        {
+          name: t("table.columns.name.header"),
+          groups: t("table.columns.groups.header"),
+          accountType: t("table.columns.accountType.header"),
+          lastUpdated: t("table.columns.lastUpdated.header"),
+          statusHeader: t("table.columns.status.header"),
+          status: {
+            [UserStatus.ACTIVE]: t("status.active.label"),
+            [UserStatus.INACTIVE]: t("status.inactive.label"),
+            [UserStatus.INVITED]: t("status.invited.label"),
+            [UserStatus.REQUESTED]: t("status.requested.label"),
+          },
+          scimSynced: t("table.status.scimSynced.label"),
         },
-        scimSynced: t("table.status.scimSynced.label"),
-      }),
-    [refresh, t]
+        locale
+      ),
+    [refresh, t, locale]
   );
 
   // Client-side filtering

--- a/web/src/views/admin/WorkspaceAnalyticsPage/UsageReports.tsx
+++ b/web/src/views/admin/WorkspaceAnalyticsPage/UsageReports.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { format, startOfDay, subDays } from "date-fns";
 import useSWR from "swr";
 import {
@@ -46,10 +46,15 @@ const POLL_INTERVAL_MS = 3_000;
 const SLOW_REPORT_AFTER_MS = 20_000;
 const REPORT_TIMEOUT_MS = 5 * 60_000;
 
-function periodLabel(report: UsageReport, allTimeLabel: string): string {
+function periodLabel(
+  report: UsageReport,
+  allTimeLabel: string,
+  locale: string
+): string {
   return report.period_from
-    ? `${humanReadableFormat(report.period_from)} – ${humanReadableFormat(
-        report.period_to!
+    ? `${humanReadableFormat(report.period_from, locale)} – ${humanReadableFormat(
+        report.period_to!,
+        locale
       )}`
     : allTimeLabel;
 }
@@ -96,7 +101,8 @@ interface ReportRowProps {
 
 function ReportRow({ report, justArrived }: ReportRowProps) {
   const t = useTranslations("admin.analytics");
-  const label = periodLabel(report, t("reports.period.allTime.label"));
+  const locale = useLocale();
+  const label = periodLabel(report, t("reports.period.allTime.label"), locale);
   return (
     <div
       className={
@@ -112,7 +118,7 @@ function ReportRow({ report, justArrived }: ReportRowProps) {
         title={label}
         description={t("reports.row.description", {
           requestor: report.requestor ?? t("reports.row.systemRequestor.label"),
-          time: humanReadableFormatWithTime(report.time_created),
+          time: humanReadableFormatWithTime(report.time_created, locale),
         })}
         padding={1}
         center


### PR DESCRIPTION
## Description

Opal (`web/lib/opal`) has no i18n runtime, so its own labels stayed English under any locale and its date helpers pinned `en-US`. In Arabic that showed as "Copy", "Showing 1~10 of 22" with the digits reversed by bidi, and "3 days ago".

- `OpalStrings` context with English defaults. Every Opal label (footer, pagination, tabs, copy, code, modal, message card, table popovers, segmented inputs, tag, password toggle, loaders) reads `useOpalStrings()`.
- `OpalStringsBridge` in the root layout feeds it from a new `opal` catalog namespace in all nine locales.
- `@opal/time` formatters and `formatDateShort` / `formatCalendarDay` take the active locale, passed from `useLocale()` at every call site. `timeAgo` uses `Intl.RelativeTimeFormat`, clamps clock skew to "0 seconds ago", and returns null for an unparseable date.
- The footer range is an LTR isolate so "1~10" keeps its order under RTL.
- An empty `dir="auto"` input follows the page direction. Chrome resolves it to LTR otherwise.

Out of scope: DayPicker locale and the MM/DD/YYYY segment order. 378 of the added lines are catalog entries.

| | Before | After |
|---|---|---|
| Users table footer and search placeholder | ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/before-users-footer.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/after-users-footer.jpg) |
| Copy tooltip | ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/before-copy-tooltip-v2.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/after-copy-tooltip-v2.jpg) |
| Last indexed | ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/before-last-indexed.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/after-last-indexed.jpg) |
| License date | ![before](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/before-license-date.jpg) | ![after](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-opal-locale/after-license-date.jpg) |

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01FKRTAPBZHBE1mc44bkxkWe