### PR TITLE
fix(deployment): pin the code-interpreter image

### DIFF
--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
@@ -485,7 +485,10 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
+    # Pinned so an upgrade cannot move it to an untested build. Bump with the
+    # release that has been tested against it.
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
@@ -541,7 +541,10 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
+    # Pinned so an upgrade cannot move it to an untested build. Bump with the
+    # release that has been tested against it.
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -15,6 +15,11 @@
 ## debugging tools (vim, nano, curl, ps, psql) that the default image leaves out.
 IMAGE_TAG=latest
 
+## The code-interpreter (Python sandbox) service ships on its own release line,
+## so IMAGE_TAG above does not cover it. The compose files pin a tested version;
+## set this only to run a different one.
+# CODE_INTERPRETER_IMAGE_TAG=
+
 ## Onyx Craft Configuration (off by default).
 ## When enabling Craft through the installer's --include-craft or by manually adding
 ## docker-compose.craft.yml, the sandbox image follows IMAGE_TAG above.

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -470,7 +470,10 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
+    # Pinned so an upgrade cannot move it to an untested build. Bump with the
+    # release that has been tested against it.
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -485,7 +485,10 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
+    # Pinned so an upgrade cannot move it to an untested build. Bump with the
+    # release that has been tested against it.
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.template.yml
+++ b/deployment/docker_compose/docker-compose.template.yml
@@ -654,7 +654,10 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
+    # Pinned so an upgrade cannot move it to an untested build. Bump with the
+    # release that has been tested against it.
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -541,7 +541,10 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
+    # Pinned so an upgrade cannot move it to an untested build. Bump with the
+    # release that has been tested against it.
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -15,6 +15,11 @@
 ## debugging tools (vim, nano, curl, ps, psql) that the default image leaves out.
 IMAGE_TAG=latest
 
+## The code-interpreter (Python sandbox) service ships on its own release line,
+## so IMAGE_TAG above does not cover it. The compose files pin a tested version;
+## set this only to run a different one.
+# CODE_INTERPRETER_IMAGE_TAG=
+
 ## Onyx Craft Configuration (off by default).
 ## When enabling Craft through the installer's --include-craft or by manually adding
 ## docker-compose.craft.yml, the sandbox image follows IMAGE_TAG above.


### PR DESCRIPTION
## Description

The code-interpreter service resolved to `onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}`, and nothing ever set that variable — `onyx-cli` has no reference to it at all, and `IMAGE_TAG` does not cover it, because the sandbox ships on its own release line out of `onyx-dot-app/python-sandbox`.

So every `onyx-cli deploy upgrade` ran `docker compose pull`, moved the sandbox to whatever `latest` pointed at that day, and recreated the container because the image ID changed. The sandbox version was decoupled from the Onyx version it was tested against. `cli/internal/deploy/install/install.go:1045` already assumes otherwise:

> not every image follows IMAGE_TAG: code-interpreter carries its own version line, so it is pinned separately

This makes that true. The default becomes `0.4.6`, the current release; `CODE_INTERPRETER_IMAGE_TAG` still overrides it, and `env.template` now documents that.

`docker-compose.multitenant-dev.yml` keeps `latest` on purpose: it is a development file, is not generated from the template, and tracking the newest sandbox there is the point.

## How Has This Been Tested?

- `0.4.6` and `latest` are the same digest today (`sha256:f961ada02d11029adcfbaa4811ef227ae724ebfcab33f261e59d6205591d3136`), so this pins current behavior rather than changing it.
- `ods generate-compose --write` regenerated the three variants and synced the CLI's embedded copies; `pre-commit run --files ...` passes, including the `sync docker compose files from template` hook.
- Confirmed the image reference parses as expected in every generated file.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `code-interpreter` sandbox to `0.4.6`, the current release, so `onyx-cli deploy upgrade` no longer pulls whatever `latest` happens to be. Previously the compose files defaulted to `${CODE_INTERPRETER_IMAGE_TAG:-latest}`; nothing ever set that variable, so each upgrade moved the sandbox to an untested build and recreated the container.

`CODE_INTERPRETER_IMAGE_TAG` still overrides the pin, and `env.template` now documents it. `docker-compose.multitenant-dev.yml` intentionally keeps `latest`.

<sup>Written for commit 34fadd97d4ce0466e7bd64a5c3a75f8e46e35afb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

