### PR TITLE
feat(deployment): add a healthcheck to the code-interpreter service

### DIFF
--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
@@ -494,6 +494,25 @@ services:
     env_file:
       - path: .env
         required: false
+    healthcheck:
+      # /health probes the executor backend, not just the API process: it needs
+      # the Docker daemon reachable and the executor image present on the host.
+      # That image is pulled only during startup and `docker run --pull never`
+      # is used per request, so a host that loses it (e.g. `docker system prune
+      # --all`) stays broken until this container restarts. The service answers
+      # 200 with status != ok in that state, so the body has to be read.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,urllib.request; r = json.load(urllib.request.urlopen('http://localhost:8000/health', timeout=5)); raise SystemExit(0 if r['status'] == 'ok' else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # First run pulls the executor image and does not serve until it lands.
+      start_period: 120s
 
     # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
@@ -550,6 +550,25 @@ services:
     env_file:
       - path: .env
         required: false
+    healthcheck:
+      # /health probes the executor backend, not just the API process: it needs
+      # the Docker daemon reachable and the executor image present on the host.
+      # That image is pulled only during startup and `docker run --pull never`
+      # is used per request, so a host that loses it (e.g. `docker system prune
+      # --all`) stays broken until this container restarts. The service answers
+      # 200 with status != ok in that state, so the body has to be read.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,urllib.request; r = json.load(urllib.request.urlopen('http://localhost:8000/health', timeout=5)); raise SystemExit(0 if r['status'] == 'ok' else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # First run pulls the executor image and does not serve until it lands.
+      start_period: 120s
 
     # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -479,6 +479,25 @@ services:
     env_file:
       - path: .env
         required: false
+    healthcheck:
+      # /health probes the executor backend, not just the API process: it needs
+      # the Docker daemon reachable and the executor image present on the host.
+      # That image is pulled only during startup and `docker run --pull never`
+      # is used per request, so a host that loses it (e.g. `docker system prune
+      # --all`) stays broken until this container restarts. The service answers
+      # 200 with status != ok in that state, so the body has to be read.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,urllib.request; r = json.load(urllib.request.urlopen('http://localhost:8000/health', timeout=5)); raise SystemExit(0 if r['status'] == 'ok' else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # First run pulls the executor image and does not serve until it lands.
+      start_period: 120s
 
     # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -494,6 +494,25 @@ services:
     env_file:
       - path: .env
         required: false
+    healthcheck:
+      # /health probes the executor backend, not just the API process: it needs
+      # the Docker daemon reachable and the executor image present on the host.
+      # That image is pulled only during startup and `docker run --pull never`
+      # is used per request, so a host that loses it (e.g. `docker system prune
+      # --all`) stays broken until this container restarts. The service answers
+      # 200 with status != ok in that state, so the body has to be read.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,urllib.request; r = json.load(urllib.request.urlopen('http://localhost:8000/health', timeout=5)); raise SystemExit(0 if r['status'] == 'ok' else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # First run pulls the executor image and does not serve until it lands.
+      start_period: 120s
 
     # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock

--- a/deployment/docker_compose/docker-compose.template.yml
+++ b/deployment/docker_compose/docker-compose.template.yml
@@ -663,6 +663,25 @@ services:
     env_file:
       - path: .env
         required: false
+    healthcheck:
+      # /health probes the executor backend, not just the API process: it needs
+      # the Docker daemon reachable and the executor image present on the host.
+      # That image is pulled only during startup and `docker run --pull never`
+      # is used per request, so a host that loses it (e.g. `docker system prune
+      # --all`) stays broken until this container restarts. The service answers
+      # 200 with status != ok in that state, so the body has to be read.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,urllib.request; r = json.load(urllib.request.urlopen('http://localhost:8000/health', timeout=5)); raise SystemExit(0 if r['status'] == 'ok' else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # First run pulls the executor image and does not serve until it lands.
+      start_period: 120s
 
     # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -550,6 +550,25 @@ services:
     env_file:
       - path: .env
         required: false
+    healthcheck:
+      # /health probes the executor backend, not just the API process: it needs
+      # the Docker daemon reachable and the executor image present on the host.
+      # That image is pulled only during startup and `docker run --pull never`
+      # is used per request, so a host that loses it (e.g. `docker system prune
+      # --all`) stays broken until this container restarts. The service answers
+      # 200 with status != ok in that state, so the body has to be read.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,urllib.request; r = json.load(urllib.request.urlopen('http://localhost:8000/health', timeout=5)); raise SystemExit(0 if r['status'] == 'ok' else 1)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # First run pulls the executor image and does not serve until it lands.
+      start_period: 120s
 
     # Below is needed for the `docker-out-of-docker` execution mode
     # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock


### PR DESCRIPTION
## Description

> [!NOTE]
> Stacked on #14553. Review/merge that first — this PR targets it as its base.

The code-interpreter service had no healthcheck, so Docker and `onyx-cli deploy status` both reported it as fine whenever the container was merely running (`status.go` only tests `strings.HasPrefix(svc.Status, "Up")`). It is a FastAPI orchestrator that shells out to the host Docker socket, so its process stays up and serving while its executor backend is broken. Operators see "Up", and the first sign of trouble is a failed tool call in chat.

`/health` already probes the backend rather than the process — in `python-sandbox`, `app/main.py` routes it to `get_executor().check_health()`, which shells out fresh on each call to verify the Docker daemon answers *and* that the executor image is present locally.

That second check matters. The executor image is pulled **only** in the FastAPI lifespan (`_ensure_docker_image_available`), and every execution runs `docker run --pull never`. A host that loses the image — `docker system prune --all` is the usual way, cf. #10142 — stays broken until this container restarts. Nothing re-pulls it.

That state answers **200 with `status: "error"`**, so the probe reads the body instead of relying on the status code. `start_period` is 120s because the first run pulls the executor image and does not serve until it lands.

Scope note: this makes the failure visible, it does not self-heal it. `restart: unless-stopped` reacts to the process exiting, not to a failing healthcheck, and that is unchanged here. The gain is truthful `onyx-cli deploy status` and `docker ps` output, and a service other things can now gate on with `depends_on: condition: service_healthy`.

## How Has This Been Tested?

Ran the exact probe command against a stub server for all three states:

| `/health` body | exit |
|---|---|
| `{"status": "ok"}` | 0 |
| `{"status": "error"}` (200) | 1 |
| unreachable | 1 |

- `python` is on `PATH` image-wide in the sandbox image (`python:3.11-slim` base, plus `ENV PATH="/app/.venv/bin:..."`), so the probe runs without the entrypoint.
- `ods generate-compose --write` regenerated the three variants and synced the CLI's embedded copies; `pre-commit run --files ...` passes.
- Parsed every generated file with PyYAML to confirm the one-liner survives generation intact.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a healthcheck to the code-interpreter service so Docker and `onyx-cli deploy status` report it unhealthy when its executor backend is broken, not just when the container is running. The probe reads the `/health` endpoint response body because the service returns 200 with `status: "error"` when the executor image is missing or the Docker daemon is unreachable.

- Uses a `start_period` of 120s because the first run pulls the executor image before serving.
- Does not change restart behavior; the service still only restarts on process exit, not on healthcheck failure.

<sup>Written for commit 55b4467a0dbaaf98a19db414239b35c6dc14170c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

