### PR TITLE
fix(web): center the chat footer disclaimer when it wraps (#14551) to release v4.7

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -619,7 +619,12 @@ function Footer() {
           // the Text below then lets an unbroken run split, which ordinary
           // wrapping will not do — it only breaks at whitespace, so a
           // pasted URL or one long token would still overflow.
-          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto [&>*]:min-w-0",
+          //
+          // `text-center` sits here rather than on the Text because
+          // `justify-center` only centers the box: once the disclaimer wraps,
+          // the box fills the row and the lines fall back to `text-align:
+          // start`. `text-align` is inherited, so it reaches the text.
+          "relative w-full flex flex-row justify-center items-center text-center gap-2 px-2 sm:px-4 mt-auto [&>*]:min-w-0",
           // # Note (from @raunakab):
           //
           // The conditional rendering of vertical padding based on the current page is intentional.


### PR DESCRIPTION
## Description

Backport of #14551 to `release/v4.7`.

The chat footer disclaimer is left-aligned once it wraps to more than one line.
The footer row centers with `justify-center`, which centers the text *box*, not
the lines inside it. While the disclaimer fits one line the box hugs its content
and looks centered. As soon as it wraps, the box fills the row and the lines fall
back to `text-align: start`.

The regression dates to #12082, which replaced the footer's `MinimalMarkdown`
(that set `text-center` on both the wrapper and the markdown `p`) with `Text` +
`markdown()` without carrying the alignment over. So it has been present since
v4.2.0, and `release/v4.7` is affected today.

**Hand-ported, not a cherry-pick.** #14551 sets `textPosition="text-center"` on
the footer `Text`. That prop arrived with #14512, which is not on this branch, so
the exact diff from main would apply as text here and then fail to build. Setting
`text-center` on the footer's wrapper `div` is equivalent — `text-align` is
inherited, so it reaches the text — and it carries no type surface.

> Note: #14551 is still open at the time of writing. Opening this alongside it so
> both can be reviewed together. If review changes the approach on main, this will
> be refreshed to match.

## How Has This Been Tested?

`bun` is not available in my environment, so the repo hooks did not run locally;
CI's `quality-checks` job runs the same `typescript-check` / `oxlint` / `oxfmt`
prek hooks and is the real gate here. (Note `build-web-image` sets
`SKIP_TYPE_CHECK=1`, so its result is not type evidence.)

Verified by hand:

- The change is a Tailwind class inside an existing `cn(...)` call, so it adds no
  type surface at all.
- Measured the underlying behaviour in headless Chromium across 1280–1920px: with
  `justify-center` alone, text that fits one line renders centered and text that
  wraps renders left-aligned. ~200 characters is the one-line threshold at 1440px,
  and 500 characters wraps at every width tested.
- Confirmed the resulting footer region is byte-identical to the `release/v4.6`
  backport branch.

A visual check of a wrapped multi-line disclaimer is worth doing before merge,
since the change is purely visual.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat footer disclaimer so it stays centered when it wraps to multiple lines. Previously `justify-center` centered only the text box, so wrapped lines fell back to left-aligned. This hand-ports the fix to `release/v4.7` by setting `text-center` on the wrapper `div` instead of the `Text` prop used on main, since that prop isn't available on this branch. The change is purely visual and carries no type surface.

<sup>Written for commit 107be4fd6e6d00615d80ef06de5becbf6fa509b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

