### PR TITLE
fix(web): center the chat footer disclaimer and raise its cap to 500 (#14551) to release v4.6

### DIFF
--- a/web/lib/opal/src/components/text/README.md
+++ b/web/lib/opal/src/components/text/README.md
@@ -13,11 +13,12 @@ inline markdown rendering via `RichStr` — pass `markdown("*bold* text")` as ch
 | `color`    | `TextColor`                                     | `"text-04"`      | Text color                                                                                     |
 | `as`       | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"`         | HTML tag to render                                                                             |
 | `nowrap`   | `boolean`                                       | `false`          | Prevent text wrapping                                                                          |
+| `wordWrap` | `"wrap-normal" \| "wrap-break-word" \| "wrap-anywhere" \| "break-all" \| "break-keep"` | — | How a run of characters with nowhere to wrap behaves; unset leaves normal CSS wrapping |
 | `maxLines` | `number`                                        | —                | Truncate to N lines with an ellipsis (`1` = single-line truncate; `2+` = `-webkit-line-clamp`) |
 | `children` | `string \| RichStr`                             | —                | Plain string or `markdown()` for inline markdown                                               |
 
 > **No `className` or `style`.** `Text` strips both (its props extend `WithoutStyles`); every
-> aspect of its appearance is driven by `font`, `color`, `nowrap`, and `maxLines`. For layout
+> aspect of its appearance is driven by `font`, `color`, `nowrap`, `wordWrap`, and `maxLines`. For layout
 > concerns (margin, flex, width, alignment) wrap `Text` in a container or move the utility class
 > to the parent — don't reach for `className`. All other HTML attributes (`id`, `onClick`,
 > `title`, `aria-*`, `data-*`) pass straight through to the rendered element.

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -25,6 +25,32 @@ interface TextProps extends WithoutStyles<
   /** Prevent text wrapping. */
   nowrap?: boolean;
 
+  /**
+   * How a run of characters with nowhere to wrap should behave. Ordinary
+   * wrapping only breaks at whitespace, so a URL, an identifier or any single
+   * long token overflows its container instead of wrapping.
+   *
+   * - `"wrap-normal"` — the CSS default: break at whitespace only, and let a
+   *   long run overflow. Spell it out to override an inherited value, since
+   *   `overflow-wrap` inherits and omitting this prop cannot undo an
+   *   ancestor's.
+   * - `"wrap-break-word"` — break only when the run would otherwise overflow.
+   * - `"wrap-anywhere"` — as above, and count the break when min-content is
+   *   measured, so the element can shrink as a flex item.
+   * - `"break-all"` — break between any two characters.
+   * - `"break-keep"` — never break within a word (CJK).
+   *
+   * Overlaps `nowrap`, which is the older way to say "one line" and wins
+   * because it removes the wrap opportunities this would act on. Prefer this
+   * prop; `nowrap` is kept so existing callers are undisturbed.
+   */
+  wordWrap?:
+    | "wrap-normal"
+    | "wrap-break-word"
+    | "wrap-anywhere"
+    | "break-all"
+    | "break-keep";
+
   /** Truncate text to N lines with ellipsis. `1` uses simple truncation; `2+` uses `-webkit-line-clamp`. */
   maxLines?: number;
 
@@ -91,6 +117,7 @@ function Text({
   color = "text-04",
   as: Tag = "span",
   nowrap,
+  wordWrap,
   maxLines,
   children,
   ...rest
@@ -100,6 +127,7 @@ function Text({
     FONT_CONFIG[font],
     COLOR_CONFIG[color],
     nowrap && "whitespace-nowrap",
+    wordWrap,
     maxLines === 1 && "truncate",
     maxLines && maxLines > 1 && "overflow-hidden"
   );

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -25,7 +25,7 @@ const CHAR_LIMITS = {
   custom_greeting_message: 50,
   custom_login_subtitle: 100,
   custom_header_content: 100,
-  custom_lower_disclaimer_content: 200,
+  custom_lower_disclaimer_content: 500,
   custom_popup_header: 100,
   custom_popup_content: 500,
   consent_screen_prompt: 200,

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -613,7 +613,13 @@ function Footer() {
     <RootLayout.Footer>
       <div
         className={cn(
-          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto",
+          // Wrapping a long disclaimer needs both halves. `[&>*]:min-w-0`
+          // lets the text shrink, since a flex item's min-width is `auto`
+          // and otherwise holds it at its min-content width. `wordWrap` on
+          // the Text below then lets an unbroken run split, which ordinary
+          // wrapping will not do — it only breaks at whitespace, so a
+          // pasted URL or one long token would still overflow.
+          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto [&>*]:min-w-0",
           // # Note (from @raunakab):
           //
           // The conditional rendering of vertical padding based on the current page is intentional.
@@ -631,7 +637,12 @@ function Footer() {
           appFocus.isChat() ? "pb-2" : "py-2"
         )}
       >
-        <Text font="secondary-action" color="text-03">
+        <Text
+          font="secondary-action"
+          color="text-03"
+          as="p"
+          wordWrap="wrap-anywhere"
+        >
           {markdown(customFooterContent)}
         </Text>
       </div>

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -619,7 +619,12 @@ function Footer() {
           // the Text below then lets an unbroken run split, which ordinary
           // wrapping will not do — it only breaks at whitespace, so a
           // pasted URL or one long token would still overflow.
-          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto [&>*]:min-w-0",
+          //
+          // `text-center` sits here rather than on the Text because
+          // `justify-center` only centers the box: once the disclaimer wraps,
+          // the box fills the row and the lines fall back to `text-align:
+          // start`. `text-align` is inherited, so it reaches the text.
+          "relative w-full flex flex-row justify-center items-center text-center gap-2 px-2 sm:px-4 mt-auto [&>*]:min-w-0",
           // # Note (from @raunakab):
           //
           // The conditional rendering of vertical padding based on the current page is intentional.


### PR DESCRIPTION
## Description

Backport to `release/v4.6`. Two commits, both about the chat footer disclaimer.

**1. `fix(appearance): Give the chat footer 500 characters (#14499)`** — a clean
cherry-pick of `48ae108237` (the `release/v4.7` pick of #14499). It raises the
disclaimer cap from 200 to 500 and brings the wrapping work with it: `as="p"` and
`wordWrap="wrap-anywhere"` on the footer `Text`, `[&>*]:min-w-0` on the wrapper,
and the `wordWrap` prop on `@opal/Text`. `release/v4.6` is currently the only
active release branch still capped at 200.

I reworded the subject: the commit as it exists on `release/v4.7` says *"to
release v4.7 (#14509)"*, which would be wrong here. Original authorship is
preserved.

**2. `fix(web): center the chat footer disclaimer when it wraps (#14551)`** —
backport of #14551. The footer row centers with `justify-center`, which centers
the text *box*, not the lines inside it. One-line text hugs its content and looks
centered; wrapped text fills the row and falls back to `text-align: start`. The
regression dates to #12082 (present since v4.2.0), so `release/v4.6` is affected
today.

**The second commit is hand-ported, not a cherry-pick.** #14551 sets
`textPosition="text-center"` on the footer `Text`, and that prop arrived with
#14512, which is not on this branch. `text-center` on the wrapper `div` is
equivalent — `text-align` is inherited — and carries no type surface.

Together these give `release/v4.6` both the 500-character cap and correct
centering, which is what a self-hosted deployment with a long disclaimer needs.

> Note: #14551 is still open at the time of writing. Opening this alongside it so
> all three can be reviewed together. If review changes the approach on main, this
> will be refreshed to match.

## How Has This Been Tested?

`bun` is not available in my environment, so the repo hooks did not run locally;
CI's `quality-checks` job runs the same `typescript-check` / `oxlint` / `oxfmt`
prek hooks and is the real gate. (`build-web-image` sets `SKIP_TYPE_CHECK=1`, so
its result is not type evidence.) This branch has more surface than the v4.7
backport, since the cherry-pick touches `@opal/Text` and the admin theme page.

Verified by hand:

- The cherry-pick applied **conflict-free**.
- The picked footer markup compiles on this branch: v4.6's `Text` already defines
  `as?: "p" | "span" | "li" | "h1" | "h2" | "h3"`, and the pick adds `wordWrap`
  and wires it into `cn(...)`. Worth checking, because v4.6's footer previously
  rendered a bare `span`.
- v4.6's `TextProps` is a flat interface rather than main's discriminated union,
  so there is no union-arm constraint to trip over.
- `textPosition` appears nowhere on this branch (0 occurrences in both
  `AppChrome.tsx` and `@opal/Text`), confirming the hand-port is self-consistent.
- The resulting footer region is byte-identical to the `release/v4.7` backport.

A visual check of a wrapped multi-line disclaimer is worth doing before merge.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports two chat footer fixes to `release/v4.6`: raises the disclaimer cap from 200 to 500 characters and centers wrapped text correctly.

- Adds a `wordWrap` prop to `@opal/Text` to support breaking long tokens.
- Applies `as="p"` and `wordWrap="wrap-anywhere"` to the footer text, and `text-center` on the wrapper to center wrapped lines.
- The centering fix is hand-ported because `textPosition` isn't available on this branch; `text-center` on the wrapper achieves the same effect via inheritance.

<sup>Written for commit d793034cbb166a38fa8aeccee6f0d0b3e9d2d7cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

