### PR TITLE
fix(sharepoint): index files synced in with back-dated modification times [mirror of #13608 for edits]

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -364,6 +364,10 @@ def _drive_item_in_time_window(
     is present: a file copied or synced into a drive keeps its original
     modification date, which can predate the window even though the file is new
     to the drive. Items carrying neither timestamp are kept.
+
+    Checking only the latest change attributes each item to exactly one poll
+    window. A change after `end` lands in the next window, which starts
+    POLL_CONNECTOR_OFFSET before this one ends.
     """
     if start is None and end is None:
         return True

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -320,6 +320,25 @@ class CertificateData(BaseModel):
     thumbprint: str
 
 
+def _parse_sharepoint_datetime(value: Any) -> datetime | None:
+    """Parse a SharePoint Graph datetime that may be an ISO string or datetime."""
+    if not value:
+        return None
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if not value.tzinfo:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _timestamp_in_window(
+    timestamp: datetime,
+    start: datetime | None,
+    end: datetime | None,
+) -> bool:
+    return (start is None or timestamp >= start) and (end is None or timestamp <= end)
+
+
 def _site_page_in_time_window(
     page: dict[str, Any],
     start: datetime | None,
@@ -328,15 +347,10 @@ def _site_page_in_time_window(
     """Return True if the page's lastModifiedDateTime falls within [start, end]."""
     if start is None and end is None:
         return True
-    raw = page.get("lastModifiedDateTime")
-    if not raw:
+    last_modified = _parse_sharepoint_datetime(page.get("lastModifiedDateTime"))
+    if last_modified is None:
         return True
-    if not isinstance(raw, str):
-        raise ValueError(f"lastModifiedDateTime is not a string: {raw}")
-    last_modified = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    return (start is None or last_modified >= start) and (
-        end is None or last_modified <= end
-    )
+    return _timestamp_in_window(last_modified, start, end)
 
 
 def _drive_item_in_time_window(
@@ -346,10 +360,10 @@ def _drive_item_in_time_window(
 ) -> bool:
     """Return True if a drive item falls within [start, end].
 
-    Uses the later of `createdDateTime` and `lastModifiedDateTime`: a file
-    copied or synced into a drive keeps its original modification date, which
-    can predate the window even though the file is new to the drive. Items
-    carrying neither timestamp are kept.
+    Uses the later of `createdDateTime` and `lastModifiedDateTime`, or whichever
+    is present: a file copied or synced into a drive keeps its original
+    modification date, which can predate the window even though the file is new
+    to the drive. Items carrying neither timestamp are kept.
     """
     if start is None and end is None:
         return True
@@ -367,8 +381,7 @@ def _drive_item_in_time_window(
     if not timestamps:
         return True
 
-    item_ts = max(timestamps)
-    return (start is None or item_ts >= start) and (end is None or item_ts <= end)
+    return _timestamp_in_window(max(timestamps), start, end)
 
 
 # Transport-level exceptions that indicate a transient network/server-side
@@ -1220,17 +1233,6 @@ def _convert_sitepage_to_document(
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
     )
     return doc
-
-
-def _parse_sharepoint_datetime(value: Any) -> datetime | None:
-    """Parse a SharePoint Graph datetime that may be an ISO string or datetime."""
-    if not value:
-        return None
-    if isinstance(value, str):
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if not value.tzinfo:
-        return value.replace(tzinfo=timezone.utc)
-    return value
 
 
 def _convert_driveitem_to_slim_document(
@@ -2147,13 +2149,11 @@ class SharepointConnector(
                         folder_queue.append(child_url)
                         continue
 
-                    # Skip non-file items (e.g. OneNote notebooks without a "file" facet)
-                    # but still yield them — the downstream conversion handles filtering
-                    # by extension / mime type.
-
                     if not _drive_item_in_time_window(item, start, end):
                         continue
 
+                    # Non-file items (e.g. OneNote notebooks without a "file" facet) are
+                    # yielded too. The downstream conversion filters by extension and mime.
                     yield DriveItemData.from_graph_json(item)
 
                 page_url = data.get("@odata.nextLink")

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -219,16 +219,6 @@ class DriveItemData(BaseModel):
 
     @classmethod
     def from_graph_json(cls, item: dict[str, Any]) -> "DriveItemData":
-        last_mod_raw = item.get(DRIVE_ITEM_LAST_MODIFIED_DATETIME_PROPERTY)
-        last_mod: datetime | None = None
-        if isinstance(last_mod_raw, str):
-            last_mod = datetime.fromisoformat(last_mod_raw.replace("Z", "+00:00"))
-
-        created_raw = item.get(DRIVE_ITEM_CREATED_DATETIME_PROPERTY)
-        created: datetime | None = None
-        if isinstance(created_raw, str):
-            created = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
-
         last_modified_by = item.get(DRIVE_ITEM_LAST_MODIFIED_BY_PROPERTY, {}).get(
             "user", {}
         )
@@ -242,8 +232,12 @@ class DriveItemData(BaseModel):
             size=item.get(DRIVE_ITEM_SIZE_PROPERTY),
             mime_type=item.get(DRIVE_ITEM_FILE_PROPERTY, {}).get("mimeType"),
             download_url=item.get(DRIVE_ITEM_DOWNLOAD_URL_PROPERTY),
-            created_datetime=created,
-            last_modified_datetime=last_mod,
+            created_datetime=_parse_sharepoint_datetime(
+                item.get(DRIVE_ITEM_CREATED_DATETIME_PROPERTY)
+            ),
+            last_modified_datetime=_parse_sharepoint_datetime(
+                item.get(DRIVE_ITEM_LAST_MODIFIED_DATETIME_PROPERTY)
+            ),
             last_modified_by_display_name=last_modified_by.get("displayName"),
             last_modified_by_email=(
                 last_modified_by.get("email")
@@ -320,7 +314,7 @@ class CertificateData(BaseModel):
     thumbprint: str
 
 
-def _parse_sharepoint_datetime(value: Any) -> datetime | None:
+def _parse_sharepoint_datetime(value: str | datetime | None) -> datetime | None:
     """Parse a SharePoint Graph datetime that may be an ISO string or datetime."""
     if not value:
         return None
@@ -1175,24 +1169,10 @@ def _convert_sitepage_to_document(
     if not page_text and title:
         page_text = title
 
-    # Parse creation and modification info
-    created_datetime = site_page.get("createdDateTime")
-    if created_datetime:
-        if isinstance(created_datetime, str):
-            created_datetime = datetime.fromisoformat(
-                created_datetime.replace("Z", "+00:00")
-            )
-        elif not created_datetime.tzinfo:
-            created_datetime = created_datetime.replace(tzinfo=timezone.utc)
-
-    last_modified_datetime = site_page.get("lastModifiedDateTime")
-    if last_modified_datetime:
-        if isinstance(last_modified_datetime, str):
-            last_modified_datetime = datetime.fromisoformat(
-                last_modified_datetime.replace("Z", "+00:00")
-            )
-        elif not last_modified_datetime.tzinfo:
-            last_modified_datetime = last_modified_datetime.replace(tzinfo=timezone.utc)
+    created_datetime = _parse_sharepoint_datetime(site_page.get("createdDateTime"))
+    last_modified_datetime = _parse_sharepoint_datetime(
+        site_page.get("lastModifiedDateTime")
+    )
 
     # Extract owner information
     primary_owners = []

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -357,8 +357,10 @@ def _drive_item_in_time_window(
     timestamps = [
         ts
         for ts in (
-            _parse_sharepoint_datetime(item.get("createdDateTime")),
-            _parse_sharepoint_datetime(item.get("lastModifiedDateTime")),
+            _parse_sharepoint_datetime(item.get(DRIVE_ITEM_CREATED_DATETIME_PROPERTY)),
+            _parse_sharepoint_datetime(
+                item.get(DRIVE_ITEM_LAST_MODIFIED_DATETIME_PROPERTY)
+            ),
         )
         if ts is not None
     ]

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -324,11 +324,15 @@ def _parse_sharepoint_datetime(value: Any) -> datetime | None:
     """Parse a SharePoint Graph datetime that may be an ISO string or datetime."""
     if not value:
         return None
-    if isinstance(value, str):
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if not value.tzinfo:
-        return value.replace(tzinfo=timezone.utc)
-    return value
+    parsed = (
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if isinstance(value, str)
+        else value
+    )
+    # Graph timestamps are UTC. A naive value would not compare with aware bounds.
+    if not parsed.tzinfo:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def _timestamp_in_window(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -318,11 +318,12 @@ def _parse_sharepoint_datetime(value: str | datetime | None) -> datetime | None:
     """Parse a SharePoint Graph datetime that may be an ISO string or datetime."""
     if not value:
         return None
-    parsed = (
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
-        if isinstance(value, str)
-        else value
-    )
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    elif isinstance(value, datetime):
+        parsed = value
+    else:
+        raise TypeError(f"Unsupported Graph datetime value: {value!r}")
     # Graph timestamps are UTC. A naive value would not compare with aware bounds.
     if not parsed.tzinfo:
         return parsed.replace(tzinfo=timezone.utc)
@@ -1049,16 +1050,8 @@ def _convert_driveitem_to_document_with_permissions(
         source=DocumentSource.SHAREPOINT,
         semantic_identifier=driveitem.name,
         external_access=external_access,
-        doc_created_at=(
-            driveitem.created_datetime.replace(tzinfo=timezone.utc)
-            if driveitem.created_datetime
-            else None
-        ),
-        doc_updated_at=(
-            driveitem.last_modified_datetime.replace(tzinfo=timezone.utc)
-            if driveitem.last_modified_datetime
-            else None
-        ),
+        doc_created_at=driveitem.created_datetime,
+        doc_updated_at=driveitem.last_modified_datetime,
         primary_owners=[
             BasicExpertInfo(
                 display_name=driveitem.last_modified_by_display_name or "",
@@ -1249,11 +1242,7 @@ def _convert_driveitem_to_slim_document(
         id=driveitem.id,
         external_access=external_access,
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
-        doc_created_at=(
-            driveitem.created_datetime.replace(tzinfo=timezone.utc)
-            if driveitem.created_datetime
-            else None
-        ),
+        doc_created_at=driveitem.created_datetime,
     )
 
 
@@ -2414,13 +2403,7 @@ class SharepointConnector(
                                     id=driveitem.id,
                                     external_access=ExternalAccess.empty(),
                                     parent_hierarchy_raw_node_id=parent_hierarchy_url,
-                                    doc_created_at=(
-                                        driveitem.created_datetime.replace(
-                                            tzinfo=timezone.utc
-                                        )
-                                        if driveitem.created_datetime
-                                        else None
-                                    ),
+                                    doc_created_at=driveitem.created_datetime,
                                 )
                             )
                     except Exception as e:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -81,6 +81,7 @@ from onyx.file_processing.image_utils import (
     store_image_and_create_section,
 )
 from onyx.file_store.staging import RawFileCallback
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_after import parse_retry_after_seconds
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
@@ -325,9 +326,7 @@ def _parse_sharepoint_datetime(value: str | datetime | None) -> datetime | None:
     else:
         raise TypeError(f"Unsupported Graph datetime value: {value!r}")
     # Graph timestamps are UTC. A naive value would not compare with aware bounds.
-    if not parsed.tzinfo:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    return datetime_to_utc(parsed)
 
 
 def _timestamp_in_window(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -339,6 +339,36 @@ def _site_page_in_time_window(
     )
 
 
+def _drive_item_in_time_window(
+    item: dict[str, Any],
+    start: datetime | None,
+    end: datetime | None,
+) -> bool:
+    """Return True if a drive item falls within [start, end].
+
+    Uses the later of `createdDateTime` and `lastModifiedDateTime`: a file
+    copied or synced into a drive keeps its original modification date, which
+    can predate the window even though the file is new to the drive. Items
+    carrying neither timestamp are kept.
+    """
+    if start is None and end is None:
+        return True
+
+    timestamps = [
+        ts
+        for ts in (
+            _parse_sharepoint_datetime(item.get("createdDateTime")),
+            _parse_sharepoint_datetime(item.get("lastModifiedDateTime")),
+        )
+        if ts is not None
+    ]
+    if not timestamps:
+        return True
+
+    item_ts = max(timestamps)
+    return (start is None or item_ts >= start) and (end is None or item_ts <= end)
+
+
 # Transport-level exceptions that indicate a transient network/server-side
 # problem rather than an HTTP error. These can occur both as bare exceptions
 # (older office365 SDK paths that don't wrap them) and as the underlying
@@ -2119,18 +2149,8 @@ class SharepointConnector(
                     # but still yield them — the downstream conversion handles filtering
                     # by extension / mime type.
 
-                    # NOTE: We are now including items without a lastModifiedDateTime,
-                    # and respecting when only one of start or end is set.
-                    if start is not None or end is not None:
-                        raw_ts = item.get(DRIVE_ITEM_LAST_MODIFIED_DATETIME_PROPERTY)
-                        if raw_ts:
-                            mod_dt = datetime.fromisoformat(
-                                raw_ts.replace("Z", "+00:00")
-                            )
-                            if start is not None and mod_dt < start:
-                                continue
-                            if end is not None and mod_dt > end:
-                                continue
+                    if not _drive_item_in_time_window(item, start, end):
+                        continue
 
                     yield DriveItemData.from_graph_json(item)
 
@@ -2220,14 +2240,8 @@ class SharepointConnector(
                 ):
                     continue
 
-                if start is not None or end is not None:
-                    raw_ts = item.get(DRIVE_ITEM_LAST_MODIFIED_DATETIME_PROPERTY)
-                    if raw_ts:
-                        mod_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-                        if start is not None and mod_dt < start:
-                            continue
-                        if end is not None and mod_dt > end:
-                            continue
+                if not _drive_item_in_time_window(item, start, end):
+                    continue
 
                 yield DriveItemData.from_graph_json(item)
 
@@ -2295,14 +2309,8 @@ class SharepointConnector(
                 or DRIVE_ITEM_DELETED_PROPERTY in item
             ):
                 continue
-            if start is not None or end is not None:
-                raw_ts = item.get(DRIVE_ITEM_LAST_MODIFIED_DATETIME_PROPERTY)
-                if raw_ts:
-                    mod_dt = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-                    if start is not None and mod_dt < start:
-                        continue
-                    if end is not None and mod_dt > end:
-                        continue
+            if not _drive_item_in_time_window(item, start, end):
+                continue
             items.append(DriveItemData.from_graph_json(item))
 
         next_url = data.get("@odata.nextLink")

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -327,7 +327,7 @@ def _parse_sharepoint_datetime(value: str | datetime | None) -> datetime | None:
     # Graph timestamps are UTC. A naive value would not compare with aware bounds.
     if not parsed.tzinfo:
         return parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return parsed.astimezone(timezone.utc)
 
 
 def _timestamp_in_window(

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -1,0 +1,169 @@
+"""Tests for [start, end] filtering of drive items in the SharePoint connector.
+
+When a file is copied, moved, or synced into OneDrive/SharePoint, Microsoft
+Graph preserves the file's original modification date in
+``lastModifiedDateTime`` while setting ``createdDateTime`` to the moment the
+file landed in the drive.  Filtering on ``lastModifiedDateTime`` alone makes an
+incremental run discard those files, so they only ever show up after a manual
+full re-index.
+
+These tests pin the behaviour for all three item sources: the BFS children
+traversal, the streaming delta traversal, and the per-page delta fetch used by
+checkpointed runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from onyx.connectors.sharepoint.connector import DriveItemData, SharepointConnector
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+DRIVE_ID = "fake-drive-id"
+
+# The incremental window: "everything that changed since the last run".
+START = datetime(2026, 3, 1, tzinfo=timezone.utc)
+END = datetime(2026, 3, 2, tzinfo=timezone.utc)
+
+# A file synced in during the window, carrying its original (much older)
+# modification date from the user's local filesystem.
+SYNCED_IN_ITEM = {
+    "id": "synced-in",
+    "name": "old_report.pdf",
+    "webUrl": "https://example.sharepoint.com/old_report.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2026-03-01T10:00:00Z",
+    "lastModifiedDateTime": "2025-11-14T08:30:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
+# A file that genuinely predates the window on both timestamps.
+UNCHANGED_ITEM = {
+    "id": "unchanged",
+    "name": "ancient.pdf",
+    "webUrl": "https://example.sharepoint.com/ancient.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2025-01-05T09:00:00Z",
+    "lastModifiedDateTime": "2025-02-06T09:00:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
+# A file that landed after the window closed.
+AFTER_WINDOW_ITEM = {
+    "id": "after-window",
+    "name": "future.pdf",
+    "webUrl": "https://example.sharepoint.com/future.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2026-03-05T10:00:00Z",
+    "lastModifiedDateTime": "2026-03-05T10:00:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
+
+def _connector(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any]
+) -> SharepointConnector:
+    """A connector whose Graph calls always return ``payload``."""
+    connector = SharepointConnector()
+    connector.graph_api_base = GRAPH_API_BASE
+
+    def fake_get_json(
+        self: SharepointConnector,  # noqa: ARG001
+        url: str,  # noqa: ARG001
+        params: dict[str, str] | None = None,  # noqa: ARG001
+    ) -> dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr(SharepointConnector, "_graph_api_get_json", fake_get_json)
+    return connector
+
+
+def _paged_ids(connector: SharepointConnector) -> list[str]:
+    return [
+        item.id
+        for item in connector._iter_drive_items_paged(
+            drive_id=DRIVE_ID, start=START, end=END
+        )
+    ]
+
+
+def _delta_pages_ids(connector: SharepointConnector) -> list[str]:
+    return [
+        item.id
+        for item in connector._iter_delta_pages(
+            initial_url=f"{GRAPH_API_BASE}/drives/{DRIVE_ID}/root/delta",
+            drive_id=DRIVE_ID,
+            start=START,
+            end=END,
+            page_size=200,
+            allow_full_resync=False,
+        )
+    ]
+
+
+def _one_delta_page_ids(connector: SharepointConnector) -> list[str]:
+    items, _ = connector._fetch_one_delta_page(
+        page_url=f"{GRAPH_API_BASE}/drives/{DRIVE_ID}/root/delta",
+        drive_id=DRIVE_ID,
+        start=START,
+        end=END,
+    )
+    return [item.id for item in items]
+
+
+# Each item source applies the same window filter, so they get the same cases.
+ITEM_SOURCES: list[tuple[str, Callable[[SharepointConnector], list[str]]]] = [
+    ("iter_drive_items_paged", _paged_ids),
+    ("iter_delta_pages", _delta_pages_ids),
+    ("fetch_one_delta_page", _one_delta_page_ids),
+]
+
+
+@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+def test_file_synced_in_during_window_is_returned(
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,  # noqa: ARG001
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    """A file added during the window counts as new even when its
+    lastModifiedDateTime was back-dated by the sync client."""
+    connector = _connector(monkeypatch, {"value": [SYNCED_IN_ITEM]})
+
+    assert collect_ids(connector) == ["synced-in"]
+
+
+@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+def test_file_untouched_before_window_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,  # noqa: ARG001
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    """Widening the filter must not drag in genuinely unchanged files."""
+    connector = _connector(monkeypatch, {"value": [UNCHANGED_ITEM]})
+
+    assert collect_ids(connector) == []
+
+
+@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+def test_file_added_after_window_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,  # noqa: ARG001
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    connector = _connector(monkeypatch, {"value": [AFTER_WINDOW_ITEM]})
+
+    assert collect_ids(connector) == []
+
+
+def test_created_datetime_is_parsed_onto_drive_item_data() -> None:
+    """The filter relies on createdDateTime surviving the JSON parse."""
+    item = DriveItemData.from_graph_json(SYNCED_IN_ITEM)
+
+    assert item.created_datetime == datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc)
+    assert item.last_modified_datetime == datetime(
+        2025, 11, 14, 8, 30, tzinfo=timezone.utc
+    )

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -18,6 +18,7 @@ from onyx.connectors.sharepoint.connector import (
     GRAPH_API_BASE,
     DriveItemData,
     SharepointConnector,
+    _parse_sharepoint_datetime,
 )
 
 DRIVE_ID = "fake-drive-id"
@@ -184,3 +185,12 @@ def test_created_datetime_is_parsed_onto_drive_item_data() -> None:
     assert item.last_modified_datetime == datetime(
         2025, 11, 14, 8, 30, tzinfo=timezone.utc
     )
+
+
+def test_parse_sharepoint_datetime_makes_naive_values_aware() -> None:
+    """The window bounds are aware, so parsed values must be too."""
+    expected = datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc)
+
+    assert _parse_sharepoint_datetime("2026-03-01T10:00:00") == expected
+    assert _parse_sharepoint_datetime(datetime(2026, 3, 1, 10, 0)) == expected
+    assert _parse_sharepoint_datetime(None) is None

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -220,10 +220,14 @@ def test_created_datetime_is_parsed_onto_drive_item_data() -> None:
     )
 
 
-def test_parse_sharepoint_datetime_makes_naive_values_aware() -> None:
-    """The window bounds are aware, so parsed values must be too."""
+def test_parse_sharepoint_datetime_returns_aware_utc() -> None:
+    """The window bounds are aware UTC, so parsed values must be too."""
     expected = datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc)
 
+    assert _parse_sharepoint_datetime("2026-03-01T10:00:00Z") == expected
     assert _parse_sharepoint_datetime("2026-03-01T10:00:00") == expected
+    assert _parse_sharepoint_datetime("2026-03-01T12:00:00+02:00") == expected
     assert _parse_sharepoint_datetime(datetime(2026, 3, 1, 10, 0)) == expected
     assert _parse_sharepoint_datetime(None) is None
+    with pytest.raises(TypeError):
+        _parse_sharepoint_datetime(1772359200)  # ty: ignore[invalid-argument-type]

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -1,15 +1,9 @@
-"""Tests for [start, end] filtering of drive items in the SharePoint connector.
+"""[start, end] filtering of drive items in the SharePoint connector.
 
-When a file is copied, moved, or synced into OneDrive/SharePoint, Microsoft
-Graph preserves the file's original modification date in
-``lastModifiedDateTime`` while setting ``createdDateTime`` to the moment the
-file landed in the drive.  Filtering on ``lastModifiedDateTime`` alone makes an
-incremental run discard those files, so they only ever show up after a manual
-full re-index.
-
-These tests pin the behaviour for all three item sources: the BFS children
-traversal, the streaming delta traversal, and the per-page delta fetch used by
-checkpointed runs.
+Graph preserves a file's original ``lastModifiedDateTime`` when it is copied or
+synced in, setting only ``createdDateTime`` to the arrival time, so filtering on
+modification alone strands those files until a full re-index. Covers all three
+item sources: BFS children, streaming delta, and per-page delta.
 """
 
 from __future__ import annotations
@@ -20,9 +14,12 @@ from typing import Any
 
 import pytest
 
-from onyx.connectors.sharepoint.connector import DriveItemData, SharepointConnector
+from onyx.connectors.sharepoint.connector import (
+    GRAPH_API_BASE,
+    DriveItemData,
+    SharepointConnector,
+)
 
-GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
 DRIVE_ID = "fake-drive-id"
 
 # The incremental window: "everything that changed since the last run".
@@ -41,7 +38,7 @@ SYNCED_IN_ITEM = {
     "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
 }
 
-# A file that genuinely predates the window on both timestamps.
+# A file that predates the window on both timestamps.
 UNCHANGED_ITEM = {
     "id": "unchanged",
     "name": "ancient.pdf",
@@ -69,7 +66,6 @@ def _connector(
 ) -> SharepointConnector:
     """A connector whose Graph calls always return ``payload``."""
     connector = SharepointConnector()
-    connector.graph_api_base = GRAPH_API_BASE
 
     def fake_get_json(
         self: SharepointConnector,  # noqa: ARG001
@@ -116,17 +112,16 @@ def _one_delta_page_ids(connector: SharepointConnector) -> list[str]:
 
 
 # Each item source applies the same window filter, so they get the same cases.
-ITEM_SOURCES: list[tuple[str, Callable[[SharepointConnector], list[str]]]] = [
-    ("iter_drive_items_paged", _paged_ids),
-    ("iter_delta_pages", _delta_pages_ids),
-    ("fetch_one_delta_page", _one_delta_page_ids),
+ITEM_SOURCES = [
+    pytest.param(_paged_ids, id="iter_drive_items_paged"),
+    pytest.param(_delta_pages_ids, id="iter_delta_pages"),
+    pytest.param(_one_delta_page_ids, id="fetch_one_delta_page"),
 ]
 
 
-@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
 def test_file_synced_in_during_window_is_returned(
     monkeypatch: pytest.MonkeyPatch,
-    source_name: str,  # noqa: ARG001
     collect_ids: Callable[[SharepointConnector], list[str]],
 ) -> None:
     """A file added during the window counts as new even when its
@@ -136,22 +131,21 @@ def test_file_synced_in_during_window_is_returned(
     assert collect_ids(connector) == ["synced-in"]
 
 
-@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
 def test_file_untouched_before_window_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
-    source_name: str,  # noqa: ARG001
     collect_ids: Callable[[SharepointConnector], list[str]],
 ) -> None:
-    """Widening the filter must not drag in genuinely unchanged files."""
+    """Items whose createdDateTime and lastModifiedDateTime both predate the
+    window stay out."""
     connector = _connector(monkeypatch, {"value": [UNCHANGED_ITEM]})
 
     assert collect_ids(connector) == []
 
 
-@pytest.mark.parametrize("source_name,collect_ids", ITEM_SOURCES)
+@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
 def test_file_added_after_window_is_skipped(
     monkeypatch: pytest.MonkeyPatch,
-    source_name: str,  # noqa: ARG001
     collect_ids: Callable[[SharepointConnector], list[str]],
 ) -> None:
     connector = _connector(monkeypatch, {"value": [AFTER_WINDOW_ITEM]})

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -49,6 +49,17 @@ UNCHANGED_ITEM = {
     "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
 }
 
+# A file created in the window and modified after it closed.
+STRADDLING_ITEM = {
+    "id": "straddling",
+    "name": "in_progress.pdf",
+    "webUrl": "https://example.sharepoint.com/in_progress.pdf",
+    "file": {"mimeType": "application/pdf"},
+    "createdDateTime": "2026-03-01T12:00:00Z",
+    "lastModifiedDateTime": "2026-03-03T09:00:00Z",
+    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+}
+
 # A file that landed after the window closed.
 AFTER_WINDOW_ITEM = {
     "id": "after-window",
@@ -149,6 +160,18 @@ def test_file_added_after_window_is_skipped(
     collect_ids: Callable[[SharepointConnector], list[str]],
 ) -> None:
     connector = _connector(monkeypatch, {"value": [AFTER_WINDOW_ITEM]})
+
+    assert collect_ids(connector) == []
+
+
+@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
+def test_file_modified_after_window_waits_for_the_next_window(
+    monkeypatch: pytest.MonkeyPatch,
+    collect_ids: Callable[[SharepointConnector], list[str]],
+) -> None:
+    """Only the latest change places an item, so a file created in this window
+    but modified after it belongs to the next poll window."""
+    connector = _connector(monkeypatch, {"value": [STRADDLING_ITEM]})
 
     assert collect_ids(connector) == []
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_time_window_filtering.py
@@ -27,50 +27,56 @@ DRIVE_ID = "fake-drive-id"
 START = datetime(2026, 3, 1, tzinfo=timezone.utc)
 END = datetime(2026, 3, 2, tzinfo=timezone.utc)
 
+
+def _item(item_id: str, created: str | None, modified: str | None) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "id": item_id,
+        "name": f"{item_id}.pdf",
+        "webUrl": f"https://example.sharepoint.com/{item_id}.pdf",
+        "file": {"mimeType": "application/pdf"},
+        "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
+    }
+    if created is not None:
+        item["createdDateTime"] = created
+    if modified is not None:
+        item["lastModifiedDateTime"] = modified
+    return item
+
+
 # A file synced in during the window, carrying its original (much older)
 # modification date from the user's local filesystem.
-SYNCED_IN_ITEM = {
-    "id": "synced-in",
-    "name": "old_report.pdf",
-    "webUrl": "https://example.sharepoint.com/old_report.pdf",
-    "file": {"mimeType": "application/pdf"},
-    "createdDateTime": "2026-03-01T10:00:00Z",
-    "lastModifiedDateTime": "2025-11-14T08:30:00Z",
-    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
-}
+SYNCED_IN_ITEM = _item("synced-in", "2026-03-01T10:00:00Z", "2025-11-14T08:30:00Z")
 
 # A file that predates the window on both timestamps.
-UNCHANGED_ITEM = {
-    "id": "unchanged",
-    "name": "ancient.pdf",
-    "webUrl": "https://example.sharepoint.com/ancient.pdf",
-    "file": {"mimeType": "application/pdf"},
-    "createdDateTime": "2025-01-05T09:00:00Z",
-    "lastModifiedDateTime": "2025-02-06T09:00:00Z",
-    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
-}
+UNCHANGED_ITEM = _item("unchanged", "2025-01-05T09:00:00Z", "2025-02-06T09:00:00Z")
 
 # A file created in the window and modified after it closed.
-STRADDLING_ITEM = {
-    "id": "straddling",
-    "name": "in_progress.pdf",
-    "webUrl": "https://example.sharepoint.com/in_progress.pdf",
-    "file": {"mimeType": "application/pdf"},
-    "createdDateTime": "2026-03-01T12:00:00Z",
-    "lastModifiedDateTime": "2026-03-03T09:00:00Z",
-    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
-}
+STRADDLING_ITEM = _item("straddling", "2026-03-01T12:00:00Z", "2026-03-03T09:00:00Z")
 
 # A file that landed after the window closed.
-AFTER_WINDOW_ITEM = {
-    "id": "after-window",
-    "name": "future.pdf",
-    "webUrl": "https://example.sharepoint.com/future.pdf",
-    "file": {"mimeType": "application/pdf"},
-    "createdDateTime": "2026-03-05T10:00:00Z",
-    "lastModifiedDateTime": "2026-03-05T10:00:00Z",
-    "parentReference": {"driveId": DRIVE_ID, "path": "/drives/d1/root:"},
-}
+AFTER_WINDOW_ITEM = _item(
+    "after-window", "2026-03-05T10:00:00Z", "2026-03-05T10:00:00Z"
+)
+
+# Files whose latest change sits exactly on a bound.
+AT_START_ITEM = _item("at-start", "2026-03-01T00:00:00Z", "2025-12-01T00:00:00Z")
+AT_END_ITEM = _item("at-end", "2026-02-01T00:00:00Z", "2026-03-02T00:00:00Z")
+
+# A file Graph returned without either timestamp.
+NO_TIMESTAMPS_ITEM = _item("no-timestamps", None, None)
+
+ALL_ITEMS = [
+    SYNCED_IN_ITEM,
+    UNCHANGED_ITEM,
+    STRADDLING_ITEM,
+    AFTER_WINDOW_ITEM,
+    AT_START_ITEM,
+    AT_END_ITEM,
+    NO_TIMESTAMPS_ITEM,
+]
+
+Window = tuple[datetime | None, datetime | None]
+Collector = Callable[[SharepointConnector, Window], list[str]]
 
 
 def _connector(
@@ -90,35 +96,38 @@ def _connector(
     return connector
 
 
-def _paged_ids(connector: SharepointConnector) -> list[str]:
+def _paged_ids(connector: SharepointConnector, window: Window) -> list[str]:
+    start, end = window
     return [
         item.id
         for item in connector._iter_drive_items_paged(
-            drive_id=DRIVE_ID, start=START, end=END
+            drive_id=DRIVE_ID, start=start, end=end
         )
     ]
 
 
-def _delta_pages_ids(connector: SharepointConnector) -> list[str]:
+def _delta_pages_ids(connector: SharepointConnector, window: Window) -> list[str]:
+    start, end = window
     return [
         item.id
         for item in connector._iter_delta_pages(
             initial_url=f"{GRAPH_API_BASE}/drives/{DRIVE_ID}/root/delta",
             drive_id=DRIVE_ID,
-            start=START,
-            end=END,
+            start=start,
+            end=end,
             page_size=200,
             allow_full_resync=False,
         )
     ]
 
 
-def _one_delta_page_ids(connector: SharepointConnector) -> list[str]:
+def _one_delta_page_ids(connector: SharepointConnector, window: Window) -> list[str]:
+    start, end = window
     items, _ = connector._fetch_one_delta_page(
         page_url=f"{GRAPH_API_BASE}/drives/{DRIVE_ID}/root/delta",
         drive_id=DRIVE_ID,
-        start=START,
-        end=END,
+        start=start,
+        end=end,
     )
     return [item.id for item in items]
 
@@ -130,51 +139,75 @@ ITEM_SOURCES = [
     pytest.param(_one_delta_page_ids, id="fetch_one_delta_page"),
 ]
 
+# (window, ids expected out of ALL_ITEMS). Order follows ALL_ITEMS.
+WINDOW_CASES = [
+    pytest.param(
+        (START, END),
+        ["synced-in", "at-start", "at-end", "no-timestamps"],
+        id="bounded",
+    ),
+    pytest.param(
+        (START, None),
+        [
+            "synced-in",
+            "straddling",
+            "after-window",
+            "at-start",
+            "at-end",
+            "no-timestamps",
+        ],
+        id="start_only",
+    ),
+    pytest.param(
+        (None, END),
+        ["synced-in", "unchanged", "at-start", "at-end", "no-timestamps"],
+        id="end_only",
+    ),
+    pytest.param(
+        (None, None),
+        [item["id"] for item in ALL_ITEMS],
+        id="no_window",
+    ),
+]
+
+
+@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
+@pytest.mark.parametrize("window,expected_ids", WINDOW_CASES)
+def test_window_filter_matches_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    collect_ids: Collector,
+    window: Window,
+    expected_ids: list[str],
+) -> None:
+    """Bounds are inclusive, either bound may be absent, items with no timestamp
+    stay, and the later of the two timestamps places an item."""
+    connector = _connector(monkeypatch, {"value": ALL_ITEMS})
+
+    assert collect_ids(connector, window) == expected_ids
+
 
 @pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
 def test_file_synced_in_during_window_is_returned(
     monkeypatch: pytest.MonkeyPatch,
-    collect_ids: Callable[[SharepointConnector], list[str]],
+    collect_ids: Collector,
 ) -> None:
     """A file added during the window counts as new even when its
     lastModifiedDateTime was back-dated by the sync client."""
     connector = _connector(monkeypatch, {"value": [SYNCED_IN_ITEM]})
 
-    assert collect_ids(connector) == ["synced-in"]
-
-
-@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
-def test_file_untouched_before_window_is_skipped(
-    monkeypatch: pytest.MonkeyPatch,
-    collect_ids: Callable[[SharepointConnector], list[str]],
-) -> None:
-    """Items whose createdDateTime and lastModifiedDateTime both predate the
-    window stay out."""
-    connector = _connector(monkeypatch, {"value": [UNCHANGED_ITEM]})
-
-    assert collect_ids(connector) == []
-
-
-@pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
-def test_file_added_after_window_is_skipped(
-    monkeypatch: pytest.MonkeyPatch,
-    collect_ids: Callable[[SharepointConnector], list[str]],
-) -> None:
-    connector = _connector(monkeypatch, {"value": [AFTER_WINDOW_ITEM]})
-
-    assert collect_ids(connector) == []
+    assert collect_ids(connector, (START, END)) == ["synced-in"]
 
 
 @pytest.mark.parametrize("collect_ids", ITEM_SOURCES)
 def test_file_modified_after_window_waits_for_the_next_window(
     monkeypatch: pytest.MonkeyPatch,
-    collect_ids: Callable[[SharepointConnector], list[str]],
+    collect_ids: Collector,
 ) -> None:
     """Only the latest change places an item, so a file created in this window
     but modified after it belongs to the next poll window."""
     connector = _connector(monkeypatch, {"value": [STRADDLING_ITEM]})
 
-    assert collect_ids(connector) == []
+    assert collect_ids(connector, (START, END)) == []
 
 
 def test_created_datetime_is_parsed_onto_drive_item_data() -> None:


### PR DESCRIPTION
## Description

Mirror of #13608 so the team can edit and merge it here, then close the original.

Fixes #13583 (the timestamp half).

Drive items are filtered on the later of `createdDateTime` and `lastModifiedDateTime`, so files synced in with a back-dated modification time are no longer skipped by incremental runs. The three duplicated checks in `_iter_drive_items_paged`, `_iter_delta_pages` and `_fetch_one_delta_page` collapse into one helper, `_drive_item_in_time_window`.

Edits on top of the contributor's commit:

- Rebased onto main. The conflict was main's rename of the `lastModifiedDateTime` literal to a constant inside the blocks this PR deletes.
- `_parse_sharepoint_datetime` is the single Graph timestamp parser: the window helpers, `DriveItemData.from_graph_json` and the site-page converter all use it, and the inline copies are gone. It returns aware UTC for every input and raises `TypeError` on unsupported types.
- The four call sites that re-applied `tzinfo=UTC` on drive item timestamps are removed, since the parser guarantees it.
- Both window helpers share `_timestamp_in_window`.
- Docstring states why only the latest change places an item: a change after `end` belongs to the next poll window, which starts `POLL_CONNECTOR_OFFSET` before this one ends.
- Tests cover start-only, end-only, no window, values on each bound, items with no timestamps, and the parser's inputs (Z, naive, offset, datetime, None, bad type) across all three item sources.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/onyx/connectors/sharepoint`: 166 passed, 20 of them in `test_time_window_filtering.py`.
- `ruff check`, `ruff format --check` and `ty check` clean.
- Local Greptile review 5/5 with zero comments on two consecutive rounds, Codex read-only review no findings.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01FtEb6QQhfA1uLCHtnpduBh
