### PR TITLE
fix(indexing): stop deleting visible punctuation from indexed text

### DIFF
--- a/backend/onyx/utils/text_processing.py
+++ b/backend/onyx/utils/text_processing.py
@@ -54,7 +54,7 @@ _INITIAL_FILTER = re.compile(
     "["
     "\U0000fff0-\U0000ffff"  # Specials
     "\U0001f000-\U0001f9ff"  # Emoticons
-    "\U00002000-\U0000206f"  # General Punctuation
+    "\U0000200b-\U0000200f\U0000202a-\U0000202e\U00002060-\U0000206f"  # Format controls
     "\U00002190-\U000021ff"  # Arrows
     "\U00002700-\U000027bf"  # Dingbats
     "]+",

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -108,8 +108,9 @@ def test_image_indexing(
         assert len(documents) == 2
         for document in documents:
             # Whitespace-normalize: PDF text extractors differ in inter-word spacing.
-            normalized = " ".join(document.content.split())
-            if "These are Johns dogs" in normalized:
+            # The PDF uses a curly apostrophe, which indexing preserves.
+            normalized = " ".join(document.content.split()).replace("\u2019", "'")
+            if "These are John's dogs" in normalized:
                 assert document.image_file_id is None
             else:
                 assert document.image_file_id is not None

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -675,6 +675,22 @@ def test_first_empty_section_with_title_is_processed_not_skipped() -> None:
 # --- clean_text is applied to section text -----------------------------------
 
 
+def test_chunking_preserves_numeric_ranges() -> None:
+    dc = _make_document_chunker()
+    text = "Collect for 1–2 weeks at 1–5%; use 3–6 clusters."
+    doc = _make_doc(sections=[Section(type=SectionType.TEXT, text=text, link="l1")])
+    chunks = dc.chunk(
+        document=doc,
+        sections=doc.processed_sections,
+        title_prefix="",
+        metadata_suffix_semantic="",
+        metadata_suffix_keyword="",
+        content_token_limit=CHUNK_LIMIT,
+    )
+    assert len(chunks) == 1
+    assert chunks[0].content == text
+
+
 def test_clean_text_strips_control_chars_from_section_content() -> None:
     """clean_text() should remove control chars before the text enters the
     accumulator — verifies the call isn't dropped by a refactor."""

--- a/backend/tests/unit/onyx/utils/test_clean_text.py
+++ b/backend/tests/unit/onyx/utils/test_clean_text.py
@@ -1,0 +1,19 @@
+import pytest
+
+from onyx.utils.text_processing import clean_text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Collect signatures for 1\u20132 weeks at 1\u20135%; use 3\u20136 clusters.",
+        "The customer\u2019s \u2018approved\u2019 range is \u201c10\u201320\u201d.",
+        "First\u2002second\u2028third\u2029fourth",
+    ],
+)
+def test_clean_text_preserves_punctuation_and_word_boundaries(text: str) -> None:
+    assert clean_text(text) == text
+
+
+def test_clean_text_still_removes_controls() -> None:
+    assert clean_text("a\x00\x01\u200b\u202e\u2060\u2066\u206ab\n\tc") == "ab\n\tc"


### PR DESCRIPTION
## Description

`clean_text()` runs on every document section during indexing. Its `_INITIAL_FILTER`
stripped the whole General Punctuation block, U+2000 through U+206F. That block holds
visible punctuation, so ordinary text was corrupted before it reached the index:

- `1–2 weeks` became `12 weeks`
- `1–5%` became `15%`
- `3–6 clusters` became `36 clusters`

Smart quotes, apostrophes, bullets, ellipses and Unicode spaces were also deleted, so
words joined together. The damage happened at index time, not at retrieval or prompt
time, and the raw uploaded files kept the original characters.

This change keeps only the format-control subranges of that block:

- U+200B..U+200F: zero-width characters and bidi marks
- U+202A..U+202E: bidi embedding and override controls
- U+2060..U+206F: word joiner, invisible operators, deprecated format controls

All other filter ranges stay the same. Visible punctuation, Unicode spaces, and the line
and paragraph separators now survive.

Note for operators: content indexed before this change is already damaged in the index.
It needs reprocessing from the original source. Re-embedding the stored chunks does not
repair it.

## How Has This Been Tested?

New unit tests:

- `backend/tests/unit/onyx/utils/test_clean_text.py`: numeric ranges, smart quotes,
  Unicode spaces and line/paragraph separators survive; zero-width, bidi override and
  word-joiner characters are still removed.
- `test_chunking_preserves_numeric_ranges` in
  `backend/tests/unit/onyx/indexing/test_document_chunker.py`: an end-to-end chunking
  regression that pins the section text through the chunker.

Both tests fail on `main` and pass with this change.

One existing expectation had to change. `tests/image_indexing` branched on
`"These are Johns dogs"`, but `Sample.pdf` really contains `These are John’s dogs`
with a curly apostrophe. The old filter deleted that apostrophe, which is why the
corrupted spelling matched. The assertion now normalizes the apostrophe and matches the
real extracted text. That check failed on this branch before the update, which is direct
evidence the apostrophe now survives indexing end to end.

```
uv run pytest tests/unit/onyx/utils/test_clean_text.py \
  tests/unit/onyx/indexing/test_document_chunker.py \
  tests/unit/onyx/utils/test_vespa_query.py \
  tests/unit/onyx/document_index/vespa/shared_utils/test_utils.py \
  tests/unit/onyx/onyxbot/test_slack_formatting.py \
  tests/unit/onyx/utils/test_parse_bracketed_list.py
```

99 passed. `pre-commit run --files <changed files>` passes, including `ruff`,
`ruff format` and `ty`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `clean_text()` during indexing so visible punctuation (en dashes, smart quotes, Unicode spaces) is no longer stripped from indexed text. Previously the filter removed the entire General Punctuation block, corrupting ranges like `1–2 weeks` into `12 weeks`; now only format-control subranges are removed.

- Limits the removal to zero-width characters, bidi marks, and invisible format controls within U+2000–U+206F.
- Adds unit tests and a chunking regression test that fail on `main` and pass with this change, and updates the image indexing test to expect the PDF's actual curly apostrophe.
- Content indexed before this fix is already corrupted and must be reprocessed from the original source; re-embedding stored chunks won't repair it.

<sup>Written for commit 59dbd8b56ceebf87a59fcf853551c7cb7169eeaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

