### PR TITLE
fix(craft-dev): unbreak fresh local kind setup

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.20
+version: 0.8.21
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -102,6 +102,12 @@ sandboxImagePrepull:
 # ---- Secrets ----
 
 auth:
+  objectstorage:
+    values:
+      s3_aws_access_key_id: "minioadmin"
+      s3_aws_secret_access_key: "minioadmin"
+      rootUser: "minioadmin"
+      rootPassword: "minioadmin"
   sandboxPushSecret:
     enabled: true
     values:

--- a/deployment/helm/dev/craft-up.sh
+++ b/deployment/helm/dev/craft-up.sh
@@ -36,6 +36,8 @@ SANDBOX_IMAGE="onyxdotapp/sandbox:dev"
 SANDBOX_IMAGE_DIR="$REPO_ROOT/backend/onyx/server/features/build/sandbox/image"
 ENV_K8S="$REPO_ROOT/.vscode/.env.k8s"
 ENV_K8S_TEMPLATE="$REPO_ROOT/.vscode/.env.k8s.template"
+ENV_WEB="$REPO_ROOT/.vscode/.env.web"
+ENV_WEB_TEMPLATE="$REPO_ROOT/.vscode/env.web_template.txt"
 
 require() {
   local bin="$1"
@@ -95,18 +97,29 @@ fi
 echo "==> bringing up kind cluster + helm install (k8s-up.sh) ..."
 "$SCRIPT_DIR/k8s-up.sh" ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
 
-# ---- 2. bootstrap .vscode/.env.k8s if missing ----
+# ---- 2. bootstrap the vscode env files if missing ----
 
-if [[ -f "$ENV_K8S" ]]; then
-  echo "==> .vscode/.env.k8s already exists; leaving it untouched"
-else
-  if [[ ! -f "$ENV_K8S_TEMPLATE" ]]; then
-    echo "error: .vscode/.env.k8s.template missing — cannot bootstrap .env.k8s" >&2
+# Never overwrite an existing file: it holds dev-edited secrets.
+bootstrap_env_file() {
+  local dest="$1" template="$2" hint="${3:-}"
+  local name; name="$(basename "$dest")"
+
+  if [[ -f "$dest" ]]; then
+    echo "==> .vscode/$name already exists; leaving it untouched"
+    return
+  fi
+  if [[ ! -f "$template" ]]; then
+    echo "error: $(basename "$template") missing — cannot bootstrap $name" >&2
     exit 1
   fi
-  cp "$ENV_K8S_TEMPLATE" "$ENV_K8S"
-  echo "==> created .vscode/.env.k8s from template — edit <REPLACE THIS> values (at minimum GEN_AI_API_KEY)"
-fi
+  cp "$template" "$dest"
+  echo "==> created .vscode/$name from template${hint:+ — $hint}"
+}
+
+bootstrap_env_file "$ENV_K8S" "$ENV_K8S_TEMPLATE" \
+  "edit <REPLACE THIS> values (at minimum GEN_AI_API_KEY)"
+
+bootstrap_env_file "$ENV_WEB" "$ENV_WEB_TEMPLATE"
 
 # ---- 3. sandbox image build + load ----
 

--- a/deployment/helm/dev/k8s-up.sh
+++ b/deployment/helm/dev/k8s-up.sh
@@ -197,7 +197,11 @@ if command -v telepresence >/dev/null 2>&1; then
   fi
 else
   echo "note: telepresence CLI not found; skipping traffic-manager install."
-  echo "  install with: brew install datawire/blackbird/telepresence-oss"
+  echo "  install the OSS binary:"
+  echo "    curl -fLo /opt/homebrew/bin/telepresence \\"
+  echo "      https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64"
+  echo "    chmod +x /opt/homebrew/bin/telepresence"
+  echo "  see docs/craft/dev/local-kubernetes.md for the full setup"
 fi
 
 # ---- 4. next steps ----

--- a/docs/craft/dev/local-kubernetes.md
+++ b/docs/craft/dev/local-kubernetes.md
@@ -131,9 +131,10 @@ The chart pins images to the `:edge` tag in
 with `pullPolicy: Always`, so in-cluster pods track nightly builds off `main`
 rather than the released `:latest`.
 
-**2. Bootstrap `.vscode/.env.k8s`.** Copies `.vscode/.env.k8s.template` to
-`.vscode/.env.k8s` if absent. Existing files are never overwritten — your
-secrets stay intact across `craft-up` runs.
+**2. Bootstrap the vscode env files.** Copies `.vscode/.env.k8s.template` to
+`.vscode/.env.k8s`, and `.vscode/env.web_template.txt` to `.vscode/.env.web`
+(read by the `Web Server` launch). Only absent files are created — existing
+ones are never overwritten, so your secrets stay intact across `craft-up` runs.
 
 **3. Build and load the sandbox image.** The chart points sandbox pods at
 `onyxdotapp/sandbox:dev`, which is local-only. Skipping this is the most


### PR DESCRIPTION
## Description

`make craft-up` fails on a new machine. Three separate problems block it.

**1. Helm install aborts on the MinIO password.** A fresh install fails with:

```
Error: execution error at (onyx/templates/auth-secrets.yaml:11:4): Secret value
for 'rootPassword' is required but not set and no existing secret found. Please
set auth.objectstorage.values.rootPassword in values.yaml
```

`values.yaml` ships the object-storage credentials empty so production fails
closed instead of running on `minioadmin` (#12003). That commit did not add the
values back to `values-localdev.yaml`, so the local overlay has nothing to
supply. Existing clusters keep working, because `auth-secrets.yaml` falls back
to the secret already in the cluster through its `lookup`. Only a fresh cluster
fails, which is why this went unnoticed.

This change sets the credentials in the localdev overlay only. Production keeps
its fail-closed behaviour and uses `existingSecret` / `externalSecret`. The
values match `S3_AWS_*` in `.vscode/.env.k8s.template`, which the chart and the
env file must agree on.

**2. `craft-up.sh` does not create `.vscode/.env.web`.** The script bootstraps
`.vscode/.env.k8s` but not `.vscode/.env.web`. The `Web Server` launch config
reads `.env.web`, so `Run All Onyx Services (k8s)` starts the api server and
every celery worker, but not the web server. The copy-if-absent logic now lives
in a `bootstrap_env_file` helper, because it would otherwise be duplicated.
Existing files are never overwritten, so dev-edited secrets stay intact.

**3. `k8s-up.sh` recommends the paid telepresence build.** The install hint
pointed at `brew install datawire/blackbird/telepresence-oss`. That tap ships
the paid Ambassador build. The hint now points to the OSS binary on GitHub
releases, which is what `docs/craft/dev/local-kubernetes.md` already used.

**Chart version bumped 0.8.20 -> 0.8.21.** `pr-helm-chart-version.yml` gates on
`deployment/helm/charts/onyx/**`, and `values-localdev.yaml` is inside that
path. Without the bump, `helm-chart-releases.yml` silently never republishes
the chart.

## How Has This Been Tested?

No automated test. All three problems are one-time developer setup paths that
run outside the test suites. Verified by hand:

- `helm template` with the localdev overlay renders 85 resources. It failed
  before this change.
- `onyx-objectstorage` carries all four keys: `s3_aws_access_key_id` and
  `s3_aws_secret_access_key` for the Onyx S3 client, plus `rootUser` and
  `rootPassword` for the MinIO subchart's `existingSecret`.
- `bootstrap_env_file` creates both files on first run, reports "leaving it
  untouched" on the second, and fails fast when a template is missing.
- Ran the comparison logic from `pr-helm-chart-version.yml` locally:
  `0.8.20 (main) -> 0.8.21 (PR)` passes.
- `pre-commit run --files` passes, including `shellcheck`, `Check YAML`, and
  `ripsecrets`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- No Linear ticket: found while setting up a new development machine. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
