### PR TITLE
feat(chat): tell the model the user's interface language

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1385,6 +1385,7 @@ def _run_models(
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session_id),
                     all_injected_file_metadata=setup.all_injected_file_metadata,
+                    user_language=setup.user_memory_context.user_info.language,
                 )
             else:
                 run_llm_loop(

--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import SUPPORTED_LANGUAGE_ENGLISH_NAMES, SupportedLanguage
 from onyx.db.memory import UserMemoryContext
 from onyx.db.persona import get_default_behavior_persona
 from onyx.db.user_file import calculate_user_files_token_count
@@ -31,6 +32,7 @@ from onyx.prompts.user_info import (
     ORGANIZATION_PROFILE_PROMPT,
     TEAM_INFORMATION_PROMPT,
     USER_INFORMATION_HEADER,
+    USER_LANGUAGE_PROMPT,
     USER_MEMORIES_PROMPT,
     USER_PREFERENCES_PROMPT,
     USER_ROLE_PROMPT,
@@ -159,12 +161,30 @@ def process_prompt_template(
     return processed_prompt
 
 
+def build_language_section(language: SupportedLanguage | None) -> str | None:
+    """English needs no hint, so only another UI language yields a section.
+    Deep research appends the same section to its own system prompts."""
+    if language is None or language is SupportedLanguage.EN:
+        return None
+    return USER_LANGUAGE_PROMPT.format(
+        language=SUPPORTED_LANGUAGE_ENGLISH_NAMES[language]
+    )
+
+
+def with_language_section(prompt: str, language_section: str | None) -> str:
+    """Deep research builds its own system prompts, so the reply-language hint that
+    build_system_prompt adds for chat is appended to the user-facing ones here."""
+    if not language_section:
+        return prompt
+    return f"{prompt}\n\n{language_section}"
+
+
 def _build_user_information_section(
     user_memory_context: UserMemoryContext | None,
     company_context: str | None,
 ) -> str:
-    """Build the complete '# User Information' section with all sub-sections
-    in the correct order: Basic Info → Team Info → Preferences → Memories."""
+    """'# User Information' sub-sections, in order: Basic Info → Organization Profile →
+    Team Info → Language → Preferences → Memories."""
     sections: list[str] = []
 
     if user_memory_context:
@@ -205,6 +225,11 @@ def _build_user_information_section(
 
     if user_memory_context:
         ctx = user_memory_context
+
+        # Language sits before Preferences so an explicit preference wins over the hint.
+        language_section = build_language_section(ctx.user_info.language)
+        if language_section:
+            sections.append(language_section)
 
         if ctx.user_preferences:
             sections.append(

--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -30,6 +30,7 @@ from onyx.prompts.tool_prompts import (
 from onyx.prompts.user_info import (
     BASIC_INFORMATION_PROMPT,
     ORGANIZATION_PROFILE_PROMPT,
+    QUERY_LANGUAGE_PROMPT,
     TEAM_INFORMATION_PROMPT,
     USER_INFORMATION_HEADER,
     USER_LANGUAGE_PROMPT,
@@ -161,21 +162,19 @@ def process_prompt_template(
     return processed_prompt
 
 
-def build_language_section(language: SupportedLanguage | None) -> str | None:
-    """English needs no hint, so only another UI language yields a section.
-    Deep research appends the same section to its own system prompts."""
+def build_language_section(language: SupportedLanguage | None) -> str:
+    """The branch is decided here so the model never has to notice whether a
+    language was given. English is the column default and counts as no choice."""
     if language is None or language is SupportedLanguage.EN:
-        return None
+        return QUERY_LANGUAGE_PROMPT
     return USER_LANGUAGE_PROMPT.format(
         language=SUPPORTED_LANGUAGE_ENGLISH_NAMES[language]
     )
 
 
-def with_language_section(prompt: str, language_section: str | None) -> str:
-    """Deep research builds its own system prompts, so the reply-language hint that
+def with_language_section(prompt: str, language_section: str) -> str:
+    """Deep research builds its own system prompts, so the reply-language line that
     build_system_prompt adds for chat is appended to the user-facing ones here."""
-    if not language_section:
-        return prompt
     return f"{prompt}\n\n{language_section}"
 
 
@@ -223,13 +222,16 @@ def _build_user_information_section(
             TEAM_INFORMATION_PROMPT.format(team_information=company_context.strip())
         )
 
+    # Language sits before Preferences so an explicit preference wins over the hint.
+    # Every prompt carries one line, so the model never infers whether a language was set.
+    sections.append(
+        build_language_section(
+            user_memory_context.user_info.language if user_memory_context else None
+        )
+    )
+
     if user_memory_context:
         ctx = user_memory_context
-
-        # Language sits before Preferences so an explicit preference wins over the hint.
-        language_section = build_language_section(ctx.user_info.language)
-        if language_section:
-            sections.append(language_section)
 
         if ctx.user_preferences:
             sections.append(
@@ -241,9 +243,6 @@ def _build_user_information_section(
             sections.append(
                 USER_MEMORIES_PROMPT.format(user_memories=formatted_memories)
             )
-
-    if not sections:
-        return ""
 
     return USER_INFORMATION_HEADER + "\n".join(sections)
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -319,6 +319,20 @@ class SupportedLanguage(str, PyEnum):
     AR = "ar"
 
 
+# Prompts name the language in English so the model gets a word, not a code.
+SUPPORTED_LANGUAGE_ENGLISH_NAMES: dict[SupportedLanguage, str] = {
+    SupportedLanguage.EN: "English",
+    SupportedLanguage.ES: "Spanish",
+    SupportedLanguage.PT: "Portuguese",
+    SupportedLanguage.FR: "French",
+    SupportedLanguage.DE: "German",
+    SupportedLanguage.JA: "Japanese",
+    SupportedLanguage.ZH: "Simplified Chinese",
+    SupportedLanguage.KO: "Korean",
+    SupportedLanguage.AR: "Arabic",
+}
+
+
 class DefaultAppMode(str, PyEnum):
     AUTO = "AUTO"
     CHAT = "CHAT"

--- a/backend/onyx/db/memory.py
+++ b/backend/onyx/db/memory.py
@@ -6,7 +6,11 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.login_claims_capture import get_idp_profile
 from onyx.db.engine.sql_engine import get_session_with_current_tenant_if_none
+from onyx.db.enums import SupportedLanguage
 from onyx.db.models import Memory, User
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 MAX_MEMORIES_PER_USER = 10
 
@@ -23,15 +27,8 @@ class UserInfo(BaseModel):
     # `{{user.<key>}}` placeholder key (e.g. department/job_title/city/email),
     # for author-controlled placeholder substitution in agent prompts.
     placeholder_values: dict[str, str] = Field(default_factory=dict)
-
-    def to_dict(self) -> dict:
-        return {
-            "name": self.name,
-            "role": self.role,
-            "email": self.email,
-            "organization_profile": self.organization_profile,
-            "placeholder_values": self.placeholder_values,
-        }
+    # UI language. Drives the reply-language hint in the system prompt.
+    language: SupportedLanguage | None = None
 
 
 class UserMemoryContext(BaseModel):
@@ -68,6 +65,18 @@ class UserMemoryContext(BaseModel):
         return result
 
 
+def supported_language_or_none(code: str | None) -> SupportedLanguage | None:
+    """The column is written through the enum, so any other value is stale or
+    corrupt data. It is logged and dropped rather than allowed to break chat."""
+    if not code:
+        return None
+    try:
+        return SupportedLanguage(code)
+    except ValueError:
+        logger.warning("Unknown user language %r, omitting the language hint", code)
+        return None
+
+
 def get_memories(user: User, db_session: Session) -> UserMemoryContext:
     # `{{user.<key>}}` placeholder values: IdP directory profile plus basic
     # identity. Identity keys use setdefault so a directory field never gets
@@ -87,6 +96,7 @@ def get_memories(user: User, db_session: Session) -> UserMemoryContext:
         email=user.email,
         organization_profile=profile_views.fields,
         placeholder_values=placeholder_values,
+        language=supported_language_or_none(user.language),
     )
 
     user_preferences = None

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -112,7 +112,7 @@ def generate_final_report(
     turn_index: int,
     citation_mapping: CitationMapping,
     user_identity: LLMUserIdentity | None,
-    language_section: str | None,
+    language_section: str,
     reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
     saved_reasoning: str | None = None,
     pre_answer_processing_time: float | None = None,
@@ -244,10 +244,10 @@ def run_deep_research_llm_loop(
         available_tokens = llm.config.max_input_tokens
 
         # The clarification, the research-agent reports and the final report reach the
-        # user. The plan and the research tasks keep the query's language so the
-        # searches stay in it.
+        # user, so they carry the reply-language line. The plan and the research tasks
+        # keep the query's language so the searches stay in it.
         language_section = build_language_section(user_language)
-        language_tokens = token_counter(language_section) if language_section else 0
+        language_tokens = token_counter(language_section)
 
         llm_step_result: LlmStepResult | None = None
 

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -18,12 +18,14 @@ from onyx.chat.models import (
     LlmStepResult,
     ToolCallSimple,
 )
+from onyx.chat.prompt_utils import build_language_section, with_language_section
 from onyx.configs.chat_configs import (
     DR_REPORT_LLM_TIMEOUT_S,
     SKIP_DEEP_RESEARCH_CLARIFICATION,
 )
 from onyx.configs.constants import MessageType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import SupportedLanguage
 from onyx.db.tools import get_tool_by_name
 from onyx.deep_research.dr_mock_tools import (
     RESEARCH_AGENT_TOOL_NAME,
@@ -110,6 +112,7 @@ def generate_final_report(
     turn_index: int,
     citation_mapping: CitationMapping,
     user_identity: LLMUserIdentity | None,
+    language_section: str | None,
     reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
     saved_reasoning: str | None = None,
     pre_answer_processing_time: float | None = None,
@@ -123,8 +126,11 @@ def generate_final_report(
     """
     with function_span("generate_report") as span:
         span.span_data.input = f"history_length={len(history)}, turn_index={turn_index}"
-        final_report_prompt = FINAL_REPORT_PROMPT.format(
-            current_datetime=get_current_llm_day_time(full_sentence=False),
+        final_report_prompt = with_language_section(
+            FINAL_REPORT_PROMPT.format(
+                current_datetime=get_current_llm_day_time(full_sentence=False),
+            ),
+            language_section,
         )
         system_prompt = ChatMessageSimple(
             message=final_report_prompt,
@@ -205,6 +211,7 @@ def run_deep_research_llm_loop(
     custom_agent_prompt: str | None,  # noqa: ARG001
     llm: LLM,
     token_counter: Callable[[str], int],
+    user_language: SupportedLanguage | None,
     reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
     skip_clarification: bool = False,
     user_identity: LLMUserIdentity | None = None,
@@ -236,6 +243,12 @@ def run_deep_research_llm_loop(
 
         available_tokens = llm.config.max_input_tokens
 
+        # The clarification, the research-agent reports and the final report reach the
+        # user. The plan and the research tasks keep the query's language so the
+        # searches stay in it.
+        language_section = build_language_section(user_language)
+        language_tokens = token_counter(language_section) if language_section else 0
+
         llm_step_result: LlmStepResult | None = None
 
         # Filter tools to only allow web search, internal search, and open URL
@@ -254,13 +267,17 @@ def run_deep_research_llm_loop(
         )
         if not SKIP_DEEP_RESEARCH_CLARIFICATION and not skip_clarification:
             with function_span("clarification_step") as span:
-                clarification_prompt = CLARIFICATION_PROMPT.format(
-                    current_datetime=get_current_llm_day_time(full_sentence=False),
-                    internal_search_clarification_guidance=internal_search_clarification_guidance,
+                clarification_prompt = with_language_section(
+                    CLARIFICATION_PROMPT.format(
+                        current_datetime=get_current_llm_day_time(full_sentence=False),
+                        internal_search_clarification_guidance=internal_search_clarification_guidance,
+                    ),
+                    language_section,
                 )
                 system_prompt = ChatMessageSimple(
                     message=clarification_prompt,
-                    token_count=300,  # Skips the exact token count but has enough leeway
+                    # Skips the exact token count but has enough leeway
+                    token_count=300 + language_tokens,
                     message_type=MessageType.SYSTEM,
                 )
 
@@ -463,6 +480,7 @@ def run_deep_research_llm_loop(
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
                         reasoning_effort=reasoning_effort,
+                        language_section=language_section,
                         pre_answer_processing_time=elapsed_seconds,
                         all_injected_file_metadata=all_injected_file_metadata,
                     )
@@ -568,6 +586,7 @@ def run_deep_research_llm_loop(
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
                         reasoning_effort=reasoning_effort,
+                        language_section=language_section,
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
                         all_injected_file_metadata=all_injected_file_metadata,
@@ -590,6 +609,7 @@ def run_deep_research_llm_loop(
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
                         reasoning_effort=reasoning_effort,
+                        language_section=language_section,
                         saved_reasoning=most_recent_reasoning,
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
@@ -665,6 +685,7 @@ def run_deep_research_llm_loop(
                             citation_mapping=citation_mapping,
                             user_identity=user_identity,
                             reasoning_effort=reasoning_effort,
+                            language_section=language_section,
                             pre_answer_processing_time=time.monotonic()
                             - processing_start_time,
                             all_injected_file_metadata=all_injected_file_metadata,
@@ -701,6 +722,7 @@ def run_deep_research_llm_loop(
                         is_reasoning_model=is_reasoning_model,
                         token_counter=token_counter,
                         citation_mapping=citation_mapping,
+                        language_section=language_section,
                         user_identity=user_identity,
                         # Session override wins in sub-agents. AUTO keeps the tuned LOW default.
                         reasoning_effort=(

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -20,7 +20,7 @@ If you need to ask questions, follow these guidelines:
 - Be concise and do not ask more than 5 questions.
 - If there are ambiguous terms or questions, ask the user to clarify.
 - Your questions should be a numbered list for clarity.
-- Respond in the same language as the user's query.
+- Respond in the user's interface language if one is given below, otherwise in the same language as the user's query.
 - Make sure to gather all the information needed to carry out the research task in a concise, well-structured manner.{{internal_search_clarification_guidance}}
 - Wrap up with a quick sentence on what the clarification will help with, it's ok to reference the user query closely here.
 """.strip()

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -20,7 +20,6 @@ If you need to ask questions, follow these guidelines:
 - Be concise and do not ask more than 5 questions.
 - If there are ambiguous terms or questions, ask the user to clarify.
 - Your questions should be a numbered list for clarity.
-- Respond in the user's interface language if one is given below, otherwise in the same language as the user's query.
 - Make sure to gather all the information needed to carry out the research task in a concise, well-structured manner.{{internal_search_clarification_guidance}}
 - Wrap up with a quick sentence on what the clarification will help with, it's ok to reference the user query closely here.
 """.strip()

--- a/backend/onyx/prompts/deep_research/research_agent.py
+++ b/backend/onyx/prompts/deep_research/research_agent.py
@@ -51,7 +51,7 @@ Remove any obviously irrelevant or duplicative information.
 
 If a statement seems not trustworthy or is contradictory to other statements, it is important to flag it.
 
-Write the report in the same language as the provided task.
+Write the report in the user's interface language if one is given below, otherwise in the same language as the provided task.
 
 Cite all sources INLINE using the format [1], [2], [3], etc. based on the `document` field of the source. \
 Cite inline as opposed to leaving all citations until the very end of the response.
@@ -64,7 +64,7 @@ Please write me a comprehensive report on the research topic given the context a
 
 Remember to include AS MUCH INFORMATION AS POSSIBLE and as faithful to the original sources as possible. \
 Keep it free of formatting and focus on the facts only. Be sure to include all context for each fact to avoid misinterpretation or misattribution. \
-Respond in the same language as the topic provided above.
+Respond in the user's interface language if the system prompt names one, otherwise in the same language as the topic provided above.
 
 Cite every fact INLINE using the format [1], [2], [3], etc. based on the `document` field of the source.
 

--- a/backend/onyx/prompts/deep_research/research_agent.py
+++ b/backend/onyx/prompts/deep_research/research_agent.py
@@ -51,8 +51,6 @@ Remove any obviously irrelevant or duplicative information.
 
 If a statement seems not trustworthy or is contradictory to other statements, it is important to flag it.
 
-Write the report in the user's interface language if one is given below, otherwise in the same language as the provided task.
-
 Cite all sources INLINE using the format [1], [2], [3], etc. based on the `document` field of the source. \
 Cite inline as opposed to leaving all citations until the very end of the response.
 """
@@ -63,8 +61,7 @@ Please write me a comprehensive report on the research topic given the context a
 {research_topic}
 
 Remember to include AS MUCH INFORMATION AS POSSIBLE and as faithful to the original sources as possible. \
-Keep it free of formatting and focus on the facts only. Be sure to include all context for each fact to avoid misinterpretation or misattribution. \
-Respond in the user's interface language if the system prompt names one, otherwise in the same language as the topic provided above.
+Keep it free of formatting and focus on the facts only. Be sure to include all context for each fact to avoid misinterpretation or misattribution.
 
 Cite every fact INLINE using the format [1], [2], [3], etc. based on the `document` field of the source.
 

--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -59,6 +59,8 @@ The current directory in the file system can be used to save and persist user fi
 Use this to give the user a way to download the file OR to display generated images.
 Internet access for this session is disabled. Do not make external web requests or API calls as they will fail.
 Use `openpyxl` to read and write Excel files. You have access to libraries like numpy, pandas, scipy, matplotlib, and PIL.
+Write chart titles, axis labels, legends, and other text rendered into images in the language you reply in. \
+The sandbox fonts cannot shape Arabic or render CJK glyphs (they come out as disconnected letters or boxes), so for those languages write the rendered text in English and explain the labels in your reply.
 IMPORTANT: each call to this tool runs in a fresh, stateless sandbox. Variables, imports, and in-memory state from previous calls will NOT be available, \
 and files written by a previous call will NOT be available in later calls. \
 Therefore batch multi-step work into a single script per call: e.g. load a workbook once, read all needed sheets, apply all edits, and save the result in one execution — not one small step per call.

--- a/backend/onyx/prompts/user_info.py
+++ b/backend/onyx/prompts/user_info.py
@@ -31,6 +31,12 @@ USER_PREFERENCES_PROMPT = """
 {user_preferences}
 """.lstrip()
 
+# The UI language is the default reply language. An explicit request in chat still wins.
+USER_LANGUAGE_PROMPT = """
+## Language
+The user's interface language is {language}. Reply in {language} unless the user asks for a different language.
+""".lstrip()
+
 # User memories should look something like:
 # - Memory 1
 # - Memory 2

--- a/backend/onyx/prompts/user_info.py
+++ b/backend/onyx/prompts/user_info.py
@@ -31,10 +31,16 @@ USER_PREFERENCES_PROMPT = """
 {user_preferences}
 """.lstrip()
 
-# The UI language is the default reply language. An explicit request in chat still wins.
+# The backend picks the branch, so the model always gets one definitive line.
 USER_LANGUAGE_PROMPT = """
 ## Language
-The user's interface language is {language}. Reply in {language} unless the user asks for a different language.
+The user's interface language is {language}. Reply in {language}. If the user explicitly asks for another language, use that one.
+""".lstrip()
+
+# English is the column default, so it is not a choice and follows the message.
+QUERY_LANGUAGE_PROMPT = """
+## Language
+Reply in the language the user writes in.
 """.lstrip()
 
 # User memories should look something like:

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -18,6 +18,7 @@ from onyx.chat.emitter import Emitter
 from onyx.chat.llm_loop import construct_message_history
 from onyx.chat.llm_step import run_llm_step, run_llm_step_pkt_generator
 from onyx.chat.models import ChatMessageSimple, LlmStepResult, ToolCallSimple
+from onyx.chat.prompt_utils import with_language_section
 from onyx.configs.chat_configs import DR_REPORT_LLM_TIMEOUT_S
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDocsResponse
@@ -102,6 +103,7 @@ def generate_intermediate_report(
     user_identity: LLMUserIdentity | None,
     emitter: Emitter,
     placement: Placement,
+    language_section: str | None,
     reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> str:
     # NOTE: This step outputs a lot of tokens and has been observed to run for more than 10 minutes in a nontrivial percentage of
@@ -113,9 +115,11 @@ def generate_intermediate_report(
         # Having the state container here to handle the tokens and not passed through means there is no way to
         # get partial saves of the report. Arguably this is not useful anyway so not going to implement partial saves.
         state_container = ChatStateContainer()
+        # The report streams to the UI, so it follows the user's interface language.
+        report_prompt = with_language_section(RESEARCH_REPORT_PROMPT, language_section)
         system_prompt = ChatMessageSimple(
-            message=RESEARCH_REPORT_PROMPT,
-            token_count=token_counter(RESEARCH_REPORT_PROMPT),
+            message=report_prompt,
+            token_count=token_counter(report_prompt),
             message_type=MessageType.SYSTEM,
         )
 
@@ -223,6 +227,7 @@ def run_research_agent_call(
     is_reasoning_model: bool,
     token_counter: Callable[[str], int],
     user_identity: LLMUserIdentity | None,
+    language_section: str | None,
     reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> ResearchAgentCallResult | None:
     turn_index = research_agent_call.placement.turn_index
@@ -414,6 +419,7 @@ def run_research_agent_call(
                         citation_processor=citation_processor,
                         user_identity=user_identity,
                         emitter=emitter,
+                        language_section=language_section,
                         reasoning_effort=reasoning_effort,
                         placement=Placement(
                             turn_index=turn_index,
@@ -615,6 +621,7 @@ def run_research_agent_call(
                 citation_processor=citation_processor,
                 user_identity=user_identity,
                 emitter=emitter,
+                language_section=language_section,
                 reasoning_effort=reasoning_effort,
                 placement=Placement(
                     turn_index=turn_index,
@@ -673,6 +680,7 @@ def run_research_agent_calls(
     is_reasoning_model: bool,
     token_counter: Callable[[str], int],
     citation_mapping: CitationMapping,
+    language_section: str | None,
     user_identity: LLMUserIdentity | None = None,
     reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> CombinedResearchAgentCallResult:
@@ -690,6 +698,7 @@ def run_research_agent_calls(
                 is_reasoning_model,
                 token_counter,
                 user_identity,
+                language_section,
                 reasoning_effort,
             ),
         )
@@ -803,6 +812,7 @@ if __name__ == "__main__":
             is_reasoning_model=is_reasoning,
             token_counter=token_counter,
             user_identity=None,
+            language_section=None,
         )
 
         if result is None:

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -18,7 +18,7 @@ from onyx.chat.emitter import Emitter
 from onyx.chat.llm_loop import construct_message_history
 from onyx.chat.llm_step import run_llm_step, run_llm_step_pkt_generator
 from onyx.chat.models import ChatMessageSimple, LlmStepResult, ToolCallSimple
-from onyx.chat.prompt_utils import with_language_section
+from onyx.chat.prompt_utils import build_language_section, with_language_section
 from onyx.configs.chat_configs import DR_REPORT_LLM_TIMEOUT_S
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDocsResponse
@@ -103,7 +103,7 @@ def generate_intermediate_report(
     user_identity: LLMUserIdentity | None,
     emitter: Emitter,
     placement: Placement,
-    language_section: str | None,
+    language_section: str,
     reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> str:
     # NOTE: This step outputs a lot of tokens and has been observed to run for more than 10 minutes in a nontrivial percentage of
@@ -115,7 +115,7 @@ def generate_intermediate_report(
         # Having the state container here to handle the tokens and not passed through means there is no way to
         # get partial saves of the report. Arguably this is not useful anyway so not going to implement partial saves.
         state_container = ChatStateContainer()
-        # The report streams to the UI, so it follows the user's interface language.
+        # The report streams to the UI, so it carries the reply-language line.
         report_prompt = with_language_section(RESEARCH_REPORT_PROMPT, language_section)
         system_prompt = ChatMessageSimple(
             message=report_prompt,
@@ -227,7 +227,7 @@ def run_research_agent_call(
     is_reasoning_model: bool,
     token_counter: Callable[[str], int],
     user_identity: LLMUserIdentity | None,
-    language_section: str | None,
+    language_section: str,
     reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> ResearchAgentCallResult | None:
     turn_index = research_agent_call.placement.turn_index
@@ -680,7 +680,7 @@ def run_research_agent_calls(
     is_reasoning_model: bool,
     token_counter: Callable[[str], int],
     citation_mapping: CitationMapping,
-    language_section: str | None,
+    language_section: str,
     user_identity: LLMUserIdentity | None = None,
     reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> CombinedResearchAgentCallResult:
@@ -812,7 +812,7 @@ if __name__ == "__main__":
             is_reasoning_model=is_reasoning,
             token_counter=token_counter,
             user_identity=None,
-            language_section=None,
+            language_section=build_language_section(None),
         )
 
         if result is None:

--- a/backend/tests/unit/onyx/chat/test_user_language_prompt.py
+++ b/backend/tests/unit/onyx/chat/test_user_language_prompt.py
@@ -1,0 +1,85 @@
+"""Guards the Language system-prompt block: present for a non-English UI language,
+absent for English or no language, ordered before User Preferences, tolerant of an
+unknown stored code, backed by an English name for every language the enum knows,
+and appended to the deep research prompts that the user reads."""
+
+from unittest.mock import patch
+
+from onyx.chat.prompt_utils import (
+    build_language_section,
+    build_system_prompt,
+    with_language_section,
+)
+from onyx.db.enums import SUPPORTED_LANGUAGE_ENGLISH_NAMES, SupportedLanguage
+from onyx.db.memory import UserInfo, UserMemoryContext, supported_language_or_none
+from onyx.prompts.deep_research.orchestration_layer import CLARIFICATION_PROMPT
+from onyx.prompts.deep_research.research_agent import (
+    RESEARCH_REPORT_PROMPT,
+    USER_REPORT_QUERY,
+)
+
+
+def _prompt_for(
+    language: SupportedLanguage | None, user_preferences: str | None = None
+) -> str:
+    context = UserMemoryContext(
+        user_info=UserInfo(email="user@example.com", language=language),
+        user_preferences=user_preferences,
+    )
+    # get_company_context reads the KV store. Patched so the test controls all inputs.
+    with patch("onyx.chat.prompt_utils.get_company_context", return_value=None):
+        return build_system_prompt("Base prompt.", user_memory_context=context)
+
+
+def test_language_block_names_the_language_in_english() -> None:
+    prompt = _prompt_for(SupportedLanguage.AR)
+    assert "## Language" in prompt
+    assert "The user's interface language is Arabic." in prompt
+    assert "Reply in Arabic" in prompt
+
+
+def test_english_prompt_is_identical_to_having_no_language() -> None:
+    english_prompt = _prompt_for(SupportedLanguage.EN)
+    assert "## Language" not in english_prompt
+    assert english_prompt == _prompt_for(None)
+
+
+def test_language_block_precedes_user_preferences() -> None:
+    prompt = _prompt_for(SupportedLanguage.DE, user_preferences="Answer tersely.")
+    assert prompt.index("## Language") < prompt.index("## User Preferences")
+
+
+def test_unknown_stored_code_is_dropped_with_a_warning() -> None:
+    with patch("onyx.db.memory.logger.warning") as warning:
+        assert supported_language_or_none("xx") is None
+    warning.assert_called_once_with(
+        "Unknown user language %r, omitting the language hint", "xx"
+    )
+    assert supported_language_or_none("") is None
+    assert supported_language_or_none("ar") is SupportedLanguage.AR
+
+
+def test_every_supported_language_has_an_english_name() -> None:
+    assert set(SUPPORTED_LANGUAGE_ENGLISH_NAMES) == set(SupportedLanguage)
+
+
+def test_deep_research_prompt_gets_the_same_language_section() -> None:
+    section = build_language_section(SupportedLanguage.JA)
+    assert section is not None
+    prompt = with_language_section(CLARIFICATION_PROMPT, section)
+    assert prompt.startswith(CLARIFICATION_PROMPT)
+    assert prompt.endswith(section)
+    assert "interface language is Japanese" in prompt
+
+
+def test_deep_research_prompts_defer_to_the_language_section() -> None:
+    # Each user-facing deep research prompt yields to the appended section, so the
+    # two never contradict each other for a user who types in another language.
+    assert "interface language if one is given below" in CLARIFICATION_PROMPT
+    assert "interface language if one is given below" in RESEARCH_REPORT_PROMPT
+    assert "interface language if the system prompt names one" in USER_REPORT_QUERY
+
+
+def test_deep_research_prompt_is_unchanged_without_a_language() -> None:
+    assert build_language_section(SupportedLanguage.EN) is None
+    assert with_language_section(CLARIFICATION_PROMPT, None) == CLARIFICATION_PROMPT

--- a/backend/tests/unit/onyx/chat/test_user_language_prompt.py
+++ b/backend/tests/unit/onyx/chat/test_user_language_prompt.py
@@ -1,7 +1,8 @@
-"""Guards the Language system-prompt block: present for a non-English UI language,
-absent for English or no language, ordered before User Preferences, tolerant of an
-unknown stored code, backed by an English name for every language the enum knows,
-and appended to the deep research prompts that the user reads."""
+"""Guards the Language system-prompt block: one definitive line in every prompt,
+naming the UI language when a non-English one is set and deferring to the message
+otherwise, ordered before User Preferences, tolerant of an unknown stored code, backed
+by an English name for every language the enum knows, and appended unchanged to the
+deep research prompts that the user reads."""
 
 from unittest.mock import patch
 
@@ -17,6 +18,9 @@ from onyx.prompts.deep_research.research_agent import (
     RESEARCH_REPORT_PROMPT,
     USER_REPORT_QUERY,
 )
+from onyx.prompts.user_info import QUERY_LANGUAGE_PROMPT
+
+FOLLOW_THE_MESSAGE = "Reply in the language the user writes in."
 
 
 def _prompt_for(
@@ -34,14 +38,23 @@ def _prompt_for(
 def test_language_block_names_the_language_in_english() -> None:
     prompt = _prompt_for(SupportedLanguage.AR)
     assert "## Language" in prompt
-    assert "The user's interface language is Arabic." in prompt
-    assert "Reply in Arabic" in prompt
+    assert "The user's interface language is Arabic. Reply in Arabic." in prompt
+    assert "If the user explicitly asks for another language" in prompt
+    assert FOLLOW_THE_MESSAGE not in prompt
 
 
-def test_english_prompt_is_identical_to_having_no_language() -> None:
+def test_english_follows_the_message_like_no_language() -> None:
     english_prompt = _prompt_for(SupportedLanguage.EN)
-    assert "## Language" not in english_prompt
+    assert FOLLOW_THE_MESSAGE in english_prompt
+    assert "interface language" not in english_prompt
     assert english_prompt == _prompt_for(None)
+
+
+def test_prompt_without_user_context_still_gets_a_language_line() -> None:
+    with patch("onyx.chat.prompt_utils.get_company_context", return_value=None):
+        prompt = build_system_prompt("Base prompt.")
+    assert prompt.count("## Language") == 1
+    assert FOLLOW_THE_MESSAGE in prompt
 
 
 def test_language_block_precedes_user_preferences() -> None:
@@ -65,21 +78,18 @@ def test_every_supported_language_has_an_english_name() -> None:
 
 def test_deep_research_prompt_gets_the_same_language_section() -> None:
     section = build_language_section(SupportedLanguage.JA)
-    assert section is not None
     prompt = with_language_section(CLARIFICATION_PROMPT, section)
     assert prompt.startswith(CLARIFICATION_PROMPT)
     assert prompt.endswith(section)
-    assert "interface language is Japanese" in prompt
+    assert "interface language is Japanese. Reply in Japanese." in prompt
 
 
-def test_deep_research_prompts_defer_to_the_language_section() -> None:
-    # Each user-facing deep research prompt yields to the appended section, so the
-    # two never contradict each other for a user who types in another language.
-    assert "interface language if one is given below" in CLARIFICATION_PROMPT
-    assert "interface language if one is given below" in RESEARCH_REPORT_PROMPT
-    assert "interface language if the system prompt names one" in USER_REPORT_QUERY
-
-
-def test_deep_research_prompt_is_unchanged_without_a_language() -> None:
-    assert build_language_section(SupportedLanguage.EN) is None
-    assert with_language_section(CLARIFICATION_PROMPT, None) == CLARIFICATION_PROMPT
+def test_deep_research_prompts_leave_the_language_to_the_section() -> None:
+    # The appended section is the only language instruction, so the prompts no
+    # longer ask the model to work out whether a language was given.
+    for prompt in (CLARIFICATION_PROMPT, RESEARCH_REPORT_PROMPT, USER_REPORT_QUERY):
+        assert "language" not in prompt.lower()
+    assert build_language_section(None) == QUERY_LANGUAGE_PROMPT
+    assert with_language_section(CLARIFICATION_PROMPT, QUERY_LANGUAGE_PROMPT).endswith(
+        FOLLOW_THE_MESSAGE + "\n"
+    )


### PR DESCRIPTION
## Description

**Bug**: a user who sets the UI to Arabic still gets English answers to an English-looking prompt. Nothing in the system prompt mentions the language preference.

**Fix**: tell the model the interface language instead of translating the prompts.

- `UserInfo.language` carries the user's `SupportedLanguage`. `get_memories` fills it and drops an unknown stored code with a warning, so chat never fails on stale data.
- `build_system_prompt` adds one `## Language` line to every prompt, decided in code so the model never has to notice whether a language was given: "Reply in Arabic. If the user explicitly asks for another language, use that one." for a non-English UI language, and "Reply in the language the user writes in." otherwise. English is the column default, so it counts as no choice. The line sits before User Preferences so an explicit preference still wins.
- Deep research appends the same section to the clarification, research-agent report and final report prompts, the outputs the user reads, and those prompts no longer carry a language sentence of their own. The research plan and research tasks keep the query's language so searches run in it.
- The Python tool guidance asks for chart titles, axis labels and legends in the reply language, with an English fallback for Arabic and CJK, which the sandbox fonts cannot render.

Part 3 of the Arabic RTL follow-ups. Parts 1 and 2 are frontend (Opal locale, catalog strings). Custom agent prompts do not get a `{{user.language}}` placeholder yet.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01FKRTAPBZHBE1mc44bkxkWe

