### PR TITLE
fix(cli): reload the proxy after an upgrade replaces the app containers

### DIFF
--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1163,7 +1163,56 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 		in.infof("If the issue persists, please contact: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)
 	}
+	if prevTag != "" {
+		// Only after an upgrade: a fresh install starts the proxy alongside
+		// everything else, so it already resolved the containers it serves.
+		in.reloadProxy(ctx, dir, env, files)
+	}
 	return nil
+}
+
+// proxyService is the compose service that fronts the deployment. Absent from
+// onyx-lite, which publishes the app directly.
+const proxyService = "nginx"
+
+// reloadProxy makes nginx re-read its config after an upgrade replaced the app
+// containers.
+//
+// nginx resolves an upstream named in an `upstream` block once, when it loads
+// its config, and the generated config sets no `resolver`. `up` replaces
+// api_server with a container on a new address but leaves the proxy running,
+// so nginx keeps sending traffic to the address the old container had and
+// answers 502. The proxy's own config reload runs every six hours, so a
+// deployment can serve 502s long after an otherwise clean upgrade.
+//
+// Best effort: `up` has already succeeded by this point, so a proxy that will
+// not reload is reported and the upgrade still counts as done.
+func (in *installer) reloadProxy(ctx context.Context, dir string, env map[string]string, files []string) {
+	idCmd := in.compose.Command(dir, env, files, "ps", "-q", proxyService)
+	res, err := in.deps.Runner.Run(ctx, idCmd)
+	if err != nil || strings.TrimSpace(res.Stdout) == "" {
+		// No proxy in this deployment, or it is not running.
+		return
+	}
+
+	// nginx refuses a reload that would load a broken config and keeps the
+	// running workers, which looks the same from here as a reload that worked.
+	// Testing first separates the two.
+	testCmd := in.compose.Command(dir, env, files, "exec", "-T", proxyService, "nginx", "-t")
+	if _, err := in.deps.Runner.Run(ctx, testCmd); err != nil {
+		in.warnf("Did not reload %s: its config does not pass `nginx -t` (%v).", proxyService, err)
+		in.infof("It may still route to the previous containers and answer 502.")
+		return
+	}
+
+	reloadCmd := in.compose.Command(dir, env, files, "exec", "-T", proxyService, "nginx", "-s", "reload")
+	if _, err := in.deps.Runner.Run(ctx, reloadCmd); err != nil {
+		in.warnf("Could not reload %s: %v", proxyService, err)
+		in.infof("It may still route to the previous containers and answer 502.")
+		in.cmdf("docker compose exec %s nginx -s reload", proxyService)
+		return
+	}
+	in.successf("Reloaded %s onto the new containers", proxyService)
 }
 
 // explainIncompleteStart says what a half-finished `up` left behind. Unlike a

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1189,6 +1189,10 @@ const proxyService = "nginx"
 // Best effort: `up` has already succeeded by this point, so a proxy that will
 // not reload is reported and the upgrade still counts as done.
 func (in *installer) reloadProxy(ctx context.Context, dir string, env map[string]string, files []string) {
+	// Built up front so the two failure paths can print it as the command to
+	// run by hand.
+	reloadCmd := in.compose.Command(dir, env, files, "exec", "-T", proxyService, "nginx", "-s", "reload")
+
 	idCmd := in.compose.Command(dir, env, files, "ps", "-q", proxyService)
 	res, err := in.deps.Runner.Run(ctx, idCmd)
 	if err != nil {
@@ -1196,7 +1200,7 @@ func (in *installer) reloadProxy(ctx context.Context, dir string, env map[string
 		// rather than let a running proxy keep a stale address unreported.
 		in.warnf("Could not tell whether %s is running: %v", proxyService, err)
 		in.infof("If it is, it may still route to the replaced containers and answer 502.")
-		in.cmdf("docker compose exec %s nginx -s reload", proxyService)
+		in.cmdf("%s", displayCommand(reloadCmd))
 		return
 	}
 	if strings.TrimSpace(res.Stdout) == "" {
@@ -1210,18 +1214,29 @@ func (in *installer) reloadProxy(ctx context.Context, dir string, env map[string
 	testCmd := in.compose.Command(dir, env, files, "exec", "-T", proxyService, "nginx", "-t")
 	if _, err := in.deps.Runner.Run(ctx, testCmd); err != nil {
 		in.warnf("Did not reload %s: its config does not pass `nginx -t` (%v).", proxyService, err)
-		in.infof("It may still route to the previous containers and answer 502.")
+		in.infof("It may still route to the replaced containers and answer 502.")
 		return
 	}
 
-	reloadCmd := in.compose.Command(dir, env, files, "exec", "-T", proxyService, "nginx", "-s", "reload")
 	if _, err := in.deps.Runner.Run(ctx, reloadCmd); err != nil {
 		in.warnf("Could not reload %s: %v", proxyService, err)
-		in.infof("It may still route to the previous containers and answer 502.")
-		in.cmdf("docker compose exec %s nginx -s reload", proxyService)
+		in.infof("It may still route to the replaced containers and answer 502.")
+		in.cmdf("%s", displayCommand(reloadCmd))
 		return
 	}
 	in.successf("Reloaded %s onto the new containers", proxyService)
+}
+
+// displayCommand renders a built command the way an operator would retype it.
+// The compose invocation carries the project name, the -f list and the
+// standalone-vs-plugin choice, so a hand-written approximation would target
+// the wrong stack on any deployment that is not the default one.
+func displayCommand(c dockercmd.Command) string {
+	line := strings.Join(append([]string{c.Name}, c.Args...), " ")
+	if c.Dir == "" {
+		return line
+	}
+	return fmt.Sprintf("cd %s && %s", c.Dir, line)
 }
 
 // explainIncompleteStart says what a half-finished `up` left behind. Unlike a

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1171,8 +1171,9 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 	return nil
 }
 
-// proxyService is the compose service that fronts the deployment. Absent from
-// onyx-lite, which publishes the app directly.
+// proxyService is the compose service that fronts the deployment. Every mode
+// layers its overlay onto a base file that defines it, so it is present
+// whatever the mode — but it is not necessarily running.
 const proxyService = "nginx"
 
 // reloadProxy makes nginx re-read its config after an upgrade replaced the app
@@ -1190,8 +1191,16 @@ const proxyService = "nginx"
 func (in *installer) reloadProxy(ctx context.Context, dir string, env map[string]string, files []string) {
 	idCmd := in.compose.Command(dir, env, files, "ps", "-q", proxyService)
 	res, err := in.deps.Runner.Run(ctx, idCmd)
-	if err != nil || strings.TrimSpace(res.Stdout) == "" {
-		// No proxy in this deployment, or it is not running.
+	if err != nil {
+		// Not the same as an absent proxy: the state is unknown, so say so
+		// rather than let a running proxy keep a stale address unreported.
+		in.warnf("Could not tell whether %s is running: %v", proxyService, err)
+		in.infof("If it is, it may still route to the replaced containers and answer 502.")
+		in.cmdf("docker compose exec %s nginx -s reload", proxyService)
+		return
+	}
+	if strings.TrimSpace(res.Stdout) == "" {
+		// Not running, so it holds no address to re-resolve.
 		return
 	}
 

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -426,9 +426,9 @@ func TestUpgradeReloadsProxyAfterRecreate(t *testing.T) {
 	}
 }
 
-// onyx-lite publishes the app directly and has no nginx service, so there is
+// A proxy that is not running holds no address to re-resolve, so there is
 // nothing to reload and nothing to warn about.
-func TestUpgradeSkipsProxyReloadWhenAbsent(t *testing.T) {
+func TestUpgradeSkipsProxyReloadWhenNotRunning(t *testing.T) {
 	runner := &fakeRunner{handler: healthyDockerHandler}
 	root := installFixture(t, runner, "v4.0.0")
 
@@ -451,7 +451,41 @@ func TestUpgradeSkipsProxyReloadWhenAbsent(t *testing.T) {
 
 	for _, c := range running.calls {
 		if strings.Contains(argv(c), "exec -T "+proxyService) {
-			t.Errorf("ran %q against a deployment with no proxy", argv(c))
+			t.Errorf("ran %q against a proxy that is not running", argv(c))
+		}
+	}
+}
+
+// A failed probe is not the same as an absent proxy: a running proxy could
+// still be holding the replaced container's address, so the run must say the
+// state is unknown rather than report a clean upgrade.
+func TestUpgradeWarnsWhenProxyStateUnknown(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		if strings.HasSuffix(a, "ps -q "+proxyService) {
+			return dockercmd.Result{}, errors.New("docker daemon unreachable")
+		}
+		if strings.Contains(a, "ps -q") {
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	if err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("an unreadable proxy state must not fail the upgrade: %v", err)
+	}
+
+	if got := outBuf(deps).String(); !strings.Contains(got, "Could not tell whether "+proxyService) {
+		t.Errorf("probe failure was swallowed; output was %q", got)
+	}
+	for _, c := range running.calls {
+		if strings.Contains(argv(c), "nginx -s reload") {
+			t.Error("reloaded a proxy whose state could not be read")
 		}
 	}
 }

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -383,3 +383,105 @@ func TestUpgradeConfigFailureLeavesVersionAlone(t *testing.T) {
 		}
 	}
 }
+
+// nginx resolves the upstreams named in its config once, at load. An upgrade
+// replaces api_server with a container on a new address but leaves the proxy
+// running, so without a reload nginx keeps answering 502 from the address the
+// old container had.
+func TestUpgradeReloadsProxyAfterRecreate(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -q") {
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	if err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("upgrade failed: %v", err)
+	}
+
+	up, reload := -1, -1
+	for i, c := range running.calls {
+		line := argv(c)
+		switch {
+		case strings.Contains(line, "up -d"):
+			up = i
+		case strings.Contains(line, "exec -T nginx nginx -s reload"):
+			reload = i
+		}
+	}
+	if reload < 0 {
+		t.Fatal("upgrade must reload the proxy, or it keeps routing to the replaced containers")
+	}
+	if up < 0 {
+		t.Fatal("expected an `up` call")
+	}
+	if reload < up {
+		t.Errorf("reloaded the proxy at call %d, before `up` at %d — it must re-resolve after the containers move", reload, up)
+	}
+}
+
+// onyx-lite publishes the app directly and has no nginx service, so there is
+// nothing to reload and nothing to warn about.
+func TestUpgradeSkipsProxyReloadWhenAbsent(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		if strings.HasSuffix(a, "ps -q "+proxyService) {
+			return dockercmd.Result{Stdout: ""}, nil
+		}
+		if strings.Contains(a, "ps -q") {
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	if err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("upgrade failed: %v", err)
+	}
+
+	for _, c := range running.calls {
+		if strings.Contains(argv(c), "exec -T "+proxyService) {
+			t.Errorf("ran %q against a deployment with no proxy", argv(c))
+		}
+	}
+}
+
+// nginx keeps its running workers when a reload would load a broken config, so
+// the upgrade says so instead of reporting a reload that did not take effect.
+func TestUpgradeDoesNotReloadProxyWithBrokenConfig(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		if strings.Contains(a, "ps -q") {
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		}
+		if strings.Contains(a, "nginx -t") {
+			return dockercmd.Result{}, errors.New("nginx: configuration file test failed")
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	if err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("a proxy that fails its config test must not fail the upgrade: %v", err)
+	}
+
+	for _, c := range running.calls {
+		if strings.Contains(argv(c), "nginx -s reload") {
+			t.Error("reloaded the proxy even though `nginx -t` failed")
+		}
+	}
+}


### PR DESCRIPTION
## Description

`deploy upgrade` recreated api_server but left the long-running nginx container
alone, so the deployment served 502s after an upgrade that reported success.

nginx resolves an upstream named in an `upstream` block **once**, when it loads
its config, and the generated config sets no `resolver`:

```nginx
upstream api_server {
    server ${ONYX_BACKEND_API_HOST}:8080 fail_timeout=0;
}
```

`up` replaces api_server with a container on a new address. nginx keeps sending
traffic to the address the old container had and answers 502, while api_server
itself is healthy on `:8080/health`. Nothing corrects it until `run-nginx.sh`
reaches its six-hourly reload, so a deployment can serve 502s for **hours**
after a clean upgrade. It also makes the deploy workflow's post-upgrade health
check fail on a deployment that is otherwise fine.

This has bitten three real deploys on the same host (v4.4.8, v4.7.0, v4.7.1),
each time fixed by hand with `docker exec onyx-nginx-1 nginx -s reload`.

`up` is now followed by a proxy reload. Design notes:

- **Best effort.** `up` has already succeeded by this point, so a proxy that
  will not reload is reported and the upgrade still counts as done.
- **`nginx -t` runs first.** nginx keeps its running workers when a reload would
  load a broken config, which from the outside looks the same as a reload that
  worked. Testing first separates the two and says which happened.
- **Skipped on a fresh install** (`prevTag == ""`), where the proxy starts
  alongside the containers it serves and has nothing stale to re-resolve.
- **Skipped where there is no proxy.** `docker-compose.onyx-lite.yml` has no
  nginx service, so `ps -q nginx` is empty and the whole step is a no-op.

Only the CLI-driven recreate is covered. A proxy left stale by a manual
`docker compose restart`, an OOM kill or host reboot ordering still needs the
dynamic-resolver change, which is a larger change to the nginx template and
deliberately out of scope here.

Kubernetes deployments are unaffected — Services update their endpoints when a
pod is replaced.

## How Has This Been Tested?

Three new tests in `upgrade_test.go`, all passing:

- `TestUpgradeReloadsProxyAfterRecreate` — asserts the reload happens **and**
  that it is ordered after `up`, since re-resolving before the containers move
  would fix nothing.
- `TestUpgradeSkipsProxyReloadWhenAbsent` — a deployment with no proxy gets no
  `exec` at all.
- `TestUpgradeDoesNotReloadProxyWithBrokenConfig` — a failing `nginx -t` does
  not reload and does not fail the upgrade.

Full CLI suite green (`go test ./...`, every package), plus `go vet`, `gofmt`
and the repo's `golangci-lint` hook.

## Rollout

Merging this does not change any deployment on its own. The CLI ships on its own
`cli/vX.Y.Z` tags and the deploy workflow pins `ONYX_CLI_VERSION` (currently
`v1.3.2`), so this needs a new CLI tag and a bump of that pin to take effect.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `deploy upgrade` reload the proxy after it replaces the app containers, so deployments no longer serve 502s for hours after an otherwise clean upgrade.

- Runs `nginx -t` first, so a broken config is reported instead of silently keeping stale workers.
- Reload is best-effort: a proxy that won't reload is reported but doesn't fail the upgrade.
- Skipped on fresh installs and when the proxy is not running.
- Failure warnings print the exact reload command attempted, including project name, compose files, and plugin-vs-standalone choice, so it targets the right stack.
- Kubernetes deployments are unaffected.

**Rollout**
- Requires a new CLI tag and bumping `ONYX_CLI_VERSION` in the deploy workflow.

<sup>Written for commit 1df643614eb6fbd5fdd7286240fca1c95f33aea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

