### PR TITLE
feat(i18n): move the remaining hardcoded admin and chat strings into the catalog

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -180,6 +180,7 @@ module.exports = {
         "**/src/refresh-pages/**/*.test.ts",
         "**/src/sections/**/*.test.ts",
         "**/src/components/**/*.test.ts",
+        "**/src/views/**/*.test.ts",
         "**/lib/opal/**/*.test.ts",
         // Add more patterns here as you add more unit tests
       ],

--- a/web/src/app/app/message/messageComponents/timeline/hooks/useTimelineHeader.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/useTimelineHeader.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { TurnGroup } from "../transformers";
 import {
   PacketType,
@@ -28,6 +28,7 @@ export function useTimelineHeader(
   isGeneratingImage?: boolean
 ): TimelineHeaderResult {
   const t = useTranslations("chat.messages.timeline");
+  const locale = useLocale();
 
   return useMemo(() => {
     const hasPackets = turnGroups.length > 0;
@@ -78,7 +79,9 @@ export function useTimelineHeader(
       } else {
         headerText = formatSearchHeader(
           searchState.sourceFilters,
-          searchState.timeFilter
+          searchState.timeFilter,
+          t,
+          locale
         );
       }
       return { headerText, hasPackets, userStopped };
@@ -159,5 +162,5 @@ export function useTimelineHeader(
     }
 
     return { headerText: thinkingHeader, hasPackets, userStopped };
-  }, [turnGroups, stopReason, isGeneratingImage, t]);
+  }, [turnGroups, stopReason, isGeneratingImage, t, locale]);
 }

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { SvgSearch, SvgSearchMenu } from "@opal/icons";
 import { SearchToolPacket } from "@/app/app/services/streamingModels";
 import {
@@ -63,6 +63,7 @@ export const InternalSearchToolRenderer: MessageRenderer<
   children,
 }) => {
   const t = useTranslations("chat.messages.timeline");
+  const locale = useLocale();
   const searchState = constructCurrentSearchState(packets);
   const { queries, results, sourceFilters, timeFilter, isComplete } =
     searchState;
@@ -73,7 +74,12 @@ export const InternalSearchToolRenderer: MessageRenderer<
 
   const hasResults = results.length > 0;
 
-  const queriesHeader = formatSearchHeader(sourceFilters, timeFilter);
+  const queriesHeader = formatSearchHeader(
+    sourceFilters,
+    timeFilter,
+    t,
+    locale
+  );
 
   if (queries.length === 0) {
     return children([

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/__tests__/searchStateUtils.test.ts
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/__tests__/searchStateUtils.test.ts
@@ -1,3 +1,7 @@
+import { createTranslator } from "next-intl";
+import en from "@/i18n/messages/en.json";
+import ar from "@/i18n/messages/ar.json";
+import type { TimelineTranslate } from "@/app/app/message/messageComponents/toolDisplayHelpers";
 import {
   constructCurrentSearchState,
   formatSearchHeader,
@@ -15,54 +19,112 @@ function filterPacket(obj: Partial<SearchToolFilterDelta>): SearchToolPacket {
   };
 }
 
+// The header helpers take the same translator the renderer gets from
+// useTranslations, so the tests build one from the real catalogs.
+const tEn = createTranslator({
+  locale: "en",
+  messages: en,
+  namespace: "chat.messages.timeline",
+}) as TimelineTranslate;
+const tAr = createTranslator({
+  locale: "ar",
+  messages: ar,
+  namespace: "chat.messages.timeline",
+}) as TimelineTranslate;
+
 describe("formatTimeWindow", () => {
   it("returns null when there is no time filter", () => {
-    expect(formatTimeWindow(null)).toBeNull();
-    expect(formatTimeWindow({ start: null, end: null })).toBeNull();
+    expect(formatTimeWindow(null, tEn, "en")).toBeNull();
+    expect(formatTimeWindow({ start: null, end: null }, tEn, "en")).toBeNull();
   });
 
   it("phrases a lower-bound-only window as 'since'", () => {
-    expect(formatTimeWindow({ start: "2024-01-05T12:00:00Z", end: null })).toBe(
-      "since Jan 5, 2024"
-    );
+    expect(
+      formatTimeWindow({ start: "2024-01-05T12:00:00Z", end: null }, tEn, "en")
+    ).toBe("since Jan 5, 2024");
   });
 
   it("phrases an upper-bound-only window as 'before'", () => {
-    expect(formatTimeWindow({ start: null, end: "2024-03-10T12:00:00Z" })).toBe(
-      "before Mar 10, 2024"
-    );
+    expect(
+      formatTimeWindow({ start: null, end: "2024-03-10T12:00:00Z" }, tEn, "en")
+    ).toBe("before Mar 10, 2024");
   });
 
   it("formats day boundaries as their UTC date regardless of local timezone", () => {
     // A single-day window as the backend emits it: midnight to end-of-day UTC.
     expect(
-      formatTimeWindow({
-        start: "2026-07-15T00:00:00+00:00",
-        end: "2026-07-15T23:59:59.999999+00:00",
-      })
+      formatTimeWindow(
+        {
+          start: "2026-07-15T00:00:00+00:00",
+          end: "2026-07-15T23:59:59.999999+00:00",
+        },
+        tEn,
+        "en"
+      )
     ).toBe("from Jul 15, 2026 to Jul 15, 2026");
   });
 
   it("phrases a bounded window as 'from ... to ...'", () => {
     expect(
-      formatTimeWindow({
-        start: "2024-01-05T12:00:00Z",
-        end: "2024-03-10T12:00:00Z",
-      })
+      formatTimeWindow(
+        {
+          start: "2024-01-05T12:00:00Z",
+          end: "2024-03-10T12:00:00Z",
+        },
+        tEn,
+        "en"
+      )
     ).toBe("from Jan 5, 2024 to Mar 10, 2024");
+  });
+
+  it("translates the phrase and formats the date in the active locale", () => {
+    const window = formatTimeWindow(
+      { start: "2024-01-05T12:00:00Z", end: null },
+      tAr,
+      "ar"
+    );
+    expect(window).toContain("منذ");
+    expect(window).toContain("يناير");
+    expect(window).not.toContain("Jan");
   });
 });
 
 describe("formatSearchHeader", () => {
   it("appends the time window to the default header", () => {
     expect(
-      formatSearchHeader([], { start: "2024-01-05T12:00:00Z", end: null })
+      formatSearchHeader(
+        [],
+        { start: "2024-01-05T12:00:00Z", end: null },
+        tEn,
+        "en"
+      )
     ).toBe("Searching internal documents (since Jan 5, 2024)");
   });
 
   it("leaves the header untouched when no time window applies", () => {
-    expect(formatSearchHeader([])).toBe("Searching internal documents");
-    expect(formatSearchHeader([], null)).toBe("Searching internal documents");
+    expect(formatSearchHeader([], null, tEn, "en")).toBe(
+      "Searching internal documents"
+    );
+  });
+
+  it("names up to three sources and counts the rest", () => {
+    expect(formatSearchHeader(["slack", "notion"], null, tEn, "en")).toBe(
+      "Searching Slack, Notion"
+    );
+    expect(
+      formatSearchHeader(
+        ["slack", "notion", "confluence", "jira", "github"],
+        null,
+        tEn,
+        "en"
+      )
+    ).toBe("Searching Slack, Notion, Confluence +2 more");
+  });
+
+  it("translates the default header", () => {
+    expect(formatSearchHeader([], null, tAr, "ar")).toBe(
+      "جارٍ البحث في المستندات الداخلية"
+    );
   });
 });
 

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
@@ -1,3 +1,4 @@
+import type { TimelineTranslate } from "@/app/app/message/messageComponents/toolDisplayHelpers";
 import {
   PacketType,
   SearchToolPacket,
@@ -48,52 +49,73 @@ export interface SearchState {
 
 const MAX_HEADER_SOURCES = 3;
 
-// The bounds are day-granularity UTC dates; format in UTC so a midnight start
-// doesn't render as the previous day in western timezones. Locale is pinned to
-// match the surrounding hardcoded-English header copy.
-const formatFilterDate = (iso: string): string =>
-  new Date(iso).toLocaleDateString("en-US", {
+// The bounds are day-granularity UTC dates. Format in UTC so a midnight start
+// doesn't render as the previous day in western timezones.
+const formatFilterDate = (iso: string, locale: string): string =>
+  new Date(iso).toLocaleDateString(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
     timeZone: "UTC",
   });
 
-// Phrases a window as "since <date>", "before <date>", or "from <date> to <date>".
+// Phrases a window with the timeWindow catalog entries: since, before, or between.
 export const formatTimeWindow = (
-  timeFilter: TimeFilter | null
+  timeFilter: TimeFilter | null,
+  t: TimelineTranslate,
+  locale: string
 ): string | null => {
   if (!timeFilter) return null;
   const { start, end } = timeFilter;
   if (start && end) {
-    return `from ${formatFilterDate(start)} to ${formatFilterDate(end)}`;
+    return t("internalSearch.timeWindow.between", {
+      start: formatFilterDate(start, locale),
+      end: formatFilterDate(end, locale),
+    });
   }
-  if (start) return `since ${formatFilterDate(start)}`;
-  if (end) return `before ${formatFilterDate(end)}`;
+  if (start) {
+    return t("internalSearch.timeWindow.since", {
+      date: formatFilterDate(start, locale),
+    });
+  }
+  if (end) {
+    return t("internalSearch.timeWindow.before", {
+      date: formatFilterDate(end, locale),
+    });
+  }
   return null;
 };
 
 export const formatSearchHeader = (
   sourceFilters: string[],
-  timeFilter: TimeFilter | null = null
+  timeFilter: TimeFilter | null,
+  t: TimelineTranslate,
+  locale: string
 ): string => {
-  let base: string;
+  let header: string;
   if (sourceFilters.length === 0) {
-    base = "Searching internal documents";
+    header = t("internalSearch.header.default");
   } else {
     const names = sourceFilters.map((source) =>
       isValidSource(source)
         ? getSourceDisplayName(source as ValidSources)
         : source
     );
-    const shown = names.slice(0, MAX_HEADER_SOURCES);
-    const overflow = names.length - shown.length;
-    const label =
-      overflow > 0 ? `${shown.join(", ")} +${overflow} more` : shown.join(", ");
-    base = `Searching ${label}`;
+    const shown = names.slice(0, MAX_HEADER_SOURCES).join(", ");
+    const overflow = names.length - MAX_HEADER_SOURCES;
+    const sources =
+      overflow > 0
+        ? t("internalSearch.header.sourcesOverflow", {
+            sources: shown,
+            count: overflow,
+          })
+        : shown;
+    header = t("internalSearch.header.sources", { sources });
   }
-  const timeWindowText = formatTimeWindow(timeFilter);
-  return timeWindowText ? `${base} (${timeWindowText})` : base;
+  const timeWindow = formatTimeWindow(timeFilter, t, locale);
+  return timeWindow
+    ? t("internalSearch.header.withTimeWindow", { header, timeWindow })
+    : header;
 };
 
 /** Constructs the current search state from search tool packets. */

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -169,8 +169,11 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
                           count: formatTokens(row.cache_creation_tokens),
                         }),
                     ]
-                      .filter(Boolean)
-                      .join(" · ")}
+                      .filter((label): label is string => label !== false)
+                      // One pair message per join so translators own the separator.
+                      .reduce((first, rest) =>
+                        t("modelUsage.joined", { first, rest })
+                      )}
                   </Text>
                 </Section>
               </div>

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -333,11 +333,13 @@ function ModelPriceSection({ prices, defaultPrice }: ModelPriceSectionProps) {
                             color="text-03"
                             wordWrap="whitespace-nowrap"
                           >
-                            {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
-                              price.output_per_mtok
-                            )} out · ${formatMtok(
-                              price.cache_per_mtok ?? price.input_per_mtok
-                            )} cache`}
+                            {t("modelPrices.priceRow", {
+                              input: formatMtok(price.input_per_mtok),
+                              output: formatMtok(price.output_per_mtok),
+                              cache: formatMtok(
+                                price.cache_per_mtok ?? price.input_per_mtok
+                              ),
+                            })}
                           </Text>
                         </div>
                       ))}

--- a/web/src/ee/views/admin/HooksPage/HookFormModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookFormModal.tsx
@@ -24,6 +24,11 @@ import {
   HookTimeoutError,
   HookConnectError,
 } from "@/ee/views/admin/HooksPage/svc";
+import {
+  hookPointDescription,
+  hookPointName,
+  type HooksTranslate,
+} from "@/ee/views/admin/HooksPage/hookPoints";
 import type {
   HookFailStrategy,
   HookFormState,
@@ -50,8 +55,6 @@ interface HookFormModalProps {
 // ---------------------------------------------------------------------------
 
 const MAX_TIMEOUT_SECONDS = 600;
-
-type HooksTranslate = ReturnType<typeof useTranslations<"admin.hooks">>;
 
 function buildInitialValues(
   hook: HookResponse | undefined,
@@ -171,9 +174,10 @@ export default function HookFormModal({
     onOpenChange(false);
   }
 
-  const hookPointDisplayName =
-    spec?.display_name ?? spec?.hook_point ?? hook?.hook_point ?? "";
-  const hookPointDescription = spec?.description;
+  const hookPointDisplayName = spec
+    ? hookPointName(spec, t)
+    : (hook?.hook_point ?? "");
+  const pointDescription = spec ? hookPointDescription(spec, t) : undefined;
   const docsUrl = spec?.docs_url;
 
   return (
@@ -285,7 +289,7 @@ export default function HookFormModal({
                     variant="section"
                     padding={0}
                     title={hookPointDisplayName}
-                    description={hookPointDescription}
+                    description={pointDescription}
                     rightChildren={
                       <div className="flex flex-col items-end gap-1">
                         <Content

--- a/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
+++ b/web/src/ee/views/admin/HooksPage/HookLogsModal.tsx
@@ -10,6 +10,7 @@ import { useHookExecutionLogs } from "@/ee/hooks/useHookExecutionLogs";
 import { formatDateTimeLog } from "@/lib/dateUtils";
 import { downloadFile } from "@/lib/download";
 import { Section } from "@/layouts/general-layouts";
+import { hookPointName } from "@/ee/views/admin/HooksPage/hookPoints";
 import type {
   HookExecutionRecord,
   HookPointMeta,
@@ -115,7 +116,7 @@ export default function HookLogsModal({ hook, spec }: HookLogsModalProps) {
           title={t("logs.header.title")}
           description={t("logs.header.description", {
             name: hook.name,
-            point: spec?.display_name ?? hook.hook_point,
+            point: spec ? hookPointName(spec, t) : hook.hook_point,
           })}
           onClose={onClose}
         />

--- a/web/src/ee/views/admin/HooksPage/hookPoints.ts
+++ b/web/src/ee/views/admin/HooksPage/hookPoints.ts
@@ -1,0 +1,38 @@
+import type { useTranslations } from "next-intl";
+import type { HookPointMeta } from "@/ee/views/admin/HooksPage/interfaces";
+
+export type HooksTranslate = ReturnType<typeof useTranslations<"admin.hooks">>;
+
+// Backend hook_point ids and their "admin.hooks.points" catalog entries. An id
+// this build does not know (a newer backend) falls back to the API's English.
+const HOOK_POINT_KEYS = {
+  document_ingestion: "documentIngestion",
+  document_push: "documentPush",
+  query_processing: "queryProcessing",
+} as const;
+
+type HookPointKey = (typeof HOOK_POINT_KEYS)[keyof typeof HOOK_POINT_KEYS];
+
+function hookPointKey(hookPoint: string): HookPointKey | undefined {
+  if (!Object.prototype.hasOwnProperty.call(HOOK_POINT_KEYS, hookPoint)) {
+    return undefined;
+  }
+  // SAFETY: the own-property check above proves hookPoint is a key of the map.
+  return HOOK_POINT_KEYS[hookPoint as keyof typeof HOOK_POINT_KEYS];
+}
+
+export function hookPointName(
+  spec: Pick<HookPointMeta, "hook_point" | "display_name">,
+  t: HooksTranslate
+): string {
+  const key = hookPointKey(spec.hook_point);
+  return key ? t(`points.${key}.name`) : spec.display_name;
+}
+
+export function hookPointDescription(
+  spec: Pick<HookPointMeta, "hook_point" | "description">,
+  t: HooksTranslate
+): string {
+  const key = hookPointKey(spec.hook_point);
+  return key ? t(`points.${key}.description`) : spec.description;
+}

--- a/web/src/ee/views/admin/HooksPage/index.tsx
+++ b/web/src/ee/views/admin/HooksPage/index.tsx
@@ -2,7 +2,7 @@
 
 import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -464,6 +464,7 @@ function ConnectedHookCard({
 
 export default function HooksPage() {
   const t = useTranslations("admin.hooks");
+  const locale = useLocale();
   const adminRouteTitle = useAdminRouteTitle();
   const router = useRouter();
   const settings = useSettings();
@@ -520,9 +521,9 @@ export default function HooksPage() {
             hookPointDescription(spec, t).toLowerCase().includes(searchLower))
       )
       .sort((a: HookPointMeta, b: HookPointMeta) =>
-        hookPointName(a, t).localeCompare(hookPointName(b, t))
+        hookPointName(a, t).localeCompare(hookPointName(b, t), locale)
       );
-  }, [specs, hooksByPoint, search, t]);
+  }, [specs, hooksByPoint, search, t, locale]);
 
   useEffect(() => {
     if (settings.isLoading) return;

--- a/web/src/ee/views/admin/HooksPage/index.tsx
+++ b/web/src/ee/views/admin/HooksPage/index.tsx
@@ -37,6 +37,10 @@ import { InputTypeIn } from "@opal/components";
 import HookFormModal from "@/ee/views/admin/HooksPage/HookFormModal";
 import HookStatusPopover from "@/ee/views/admin/HooksPage/HookStatusPopover";
 import {
+  hookPointDescription,
+  hookPointName,
+} from "@/ee/views/admin/HooksPage/hookPoints";
+import {
   activateHook,
   deactivateHook,
   deleteHook,
@@ -188,8 +192,8 @@ function UnconnectedHookCard({ spec, onConnect }: UnconnectedHookCardProps) {
             sizePreset="main-ui"
             variant="section"
             icon={Icon}
-            title={spec.display_name}
-            description={spec.description}
+            title={hookPointName(spec, t)}
+            description={hookPointDescription(spec, t)}
           />
 
           {spec.docs_url && (
@@ -371,7 +375,7 @@ function ConnectedHookCard({
                     : undefined
                 }
                 description={t("card.hookPoint.description", {
-                  name: spec?.display_name ?? hook.hook_point,
+                  name: spec ? hookPointName(spec, t) : hook.hook_point,
                 })}
               />
 
@@ -477,12 +481,13 @@ export default function HooksPage() {
   } = useHooks();
 
   const hookExtractor = useCallback(
-    (hook: HookResponse) =>
-      `${hook.name} ${
-        specs?.find((s: HookPointMeta) => s.hook_point === hook.hook_point)
-          ?.display_name ?? ""
-      }`,
-    [specs]
+    (hook: HookResponse) => {
+      const spec = specs?.find(
+        (s: HookPointMeta) => s.hook_point === hook.hook_point
+      );
+      return `${hook.name} ${spec ? hookPointName(spec, t) : ""}`;
+    },
+    [specs, t]
   );
 
   const sortedHooks = useMemo(
@@ -511,13 +516,13 @@ export default function HooksPage() {
         (spec: HookPointMeta) =>
           (hooksByPoint[spec.hook_point]?.length ?? 0) === 0 &&
           (!searchLower ||
-            spec.display_name.toLowerCase().includes(searchLower) ||
-            spec.description.toLowerCase().includes(searchLower))
+            hookPointName(spec, t).toLowerCase().includes(searchLower) ||
+            hookPointDescription(spec, t).toLowerCase().includes(searchLower))
       )
       .sort((a: HookPointMeta, b: HookPointMeta) =>
-        a.display_name.localeCompare(b.display_name)
+        hookPointName(a, t).localeCompare(hookPointName(b, t))
       );
-  }, [specs, hooksByPoint, search]);
+  }, [specs, hooksByPoint, search, t]);
 
   useEffect(() => {
     if (settings.isLoading) return;

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "{count} إخراج"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "عرض نماذج أقل"

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "عرض المجموعة"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, zero {# موصّل} one {موصّل واحد} two {موصّلان} few {# موصّلات} many {# موصّلًا} other {# موصّل}}",
+          "documentSets": "{count, plural, zero {# مجموعة مستندات} one {مجموعة مستندات واحدة} two {مجموعتا مستندات} few {# مجموعات مستندات} many {# مجموعة مستندات} other {# مجموعة مستندات}}",
+          "agents": "{count, plural, zero {# وكيل} one {وكيل واحد} two {وكيلان} few {# وكلاء} many {# وكيلًا} other {# وكيل}}",
+          "noPrivateResources": "لا توجد موصّلات / مجموعات مستندات / وكلاء خاصة"
+        },
+        "memberCount": "{count, plural, zero {# أعضاء} one {عضو واحد} two {عضوان} few {# أعضاء} many {# عضوًا} other {# عضو}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "حد الرموز",
           "placeholder": "حد الرموز (بالآلاف)",
           "unit": "(بالآلاف)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "المشرفون",
+          "description": "مجموعة مشرفين مضمّنة بصلاحية كاملة لإدارة جميع الأذونات."
+        },
+        "basic": {
+          "name": "أساسي",
+          "description": "المجموعة الافتراضية لجميع المستخدمين بأذونات أساسية."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "فشل التحقق: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "استيعاب المستندات",
+          "description": "يعمل على كل مستند قبل دخوله مسار الفهرسة. يتيح تصفية المستندات أو إعادة كتابتها أو إسقاطها."
+        },
+        "documentPush": {
+          "name": "دفع المستندات",
+          "description": "يُشغَّل بعد فهرسة كل مستند بنجاح. يدفع المستندات المفهرسة إلى وجهة خارجية مثل ويكي أو مستودع بيانات. يُشغَّل فقط للموصّلات العامة في عمليات النشر أحادية المستأجر."
+        },
+        "queryProcessing": {
+          "name": "معالجة الاستعلامات",
+          "description": "يعمل على كل استعلام مستخدم قبل دخوله المسار. يتيح إعادة كتابة الاستعلامات أو تصفيتها أو رفضها."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusPaused": "متوقف مؤقتًا",
         "submit": "حذف وإعادة الفهرسة",
         "title": "{count, plural, one {سيُحذف هذا الموصل} other {ستُحذف هذه الموصلات (#)}}"
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "نموذج التضمين الإنجليزي من Cohere. أداء جيد للمهام باللغة الإنجليزية.",
+        "cohereEmbedEnglishLightV3": "نموذج التضمين الإنجليزي الخفيف من Cohere. أسرع وأكثر كفاءة للمهام الأبسط.",
+        "cohereEmbedV4": "أحدث نموذج تضمين متعدد اللغات من Cohere بمخرجات افتراضية بأبعاد 1536 لجودة استرجاع أعلى.",
+        "openaiTextEmbedding3Large": "نموذج التضمين الكبير من OpenAI. أفضل أداء لكنه أعلى تكلفة.",
+        "openaiTextEmbedding3Small": "نموذج التضمين الأحدث والأكثر كفاءة من OpenAI. توازن جيد بين الأداء والتكلفة.",
+        "googleGeminiEmbedding001": "نموذج تضمين Gemini من Google. قوي وفعّال.",
+        "googleTextEmbedding005": "نموذج تضمين أصغر وأخف من Google.",
+        "googleGeminiEmbedding2": "أحدث نموذج تضمين متعدد الوسائط من Google (متاح للعموم). أعلى جودة استرجاع بمخرجات بأبعاد 3072.",
+        "googleGeminiEmbedding2Preview": "الإصدار التجريبي من Gemini Embedding 2. حلّ محله gemini-embedding-2 في عمليات الإعداد الجديدة.",
+        "voyageLarge2Instruct": "نموذج التضمين الكبير من Voyage. أداء عالٍ مع ضبط دقيق بالتعليمات.",
+        "voyageLight2Instruct": "نموذج التضمين الخفيف من Voyage. توازن جيد بين الأداء والكفاءة.",
+        "nomicEmbedTextV1": "نموذج التضمين من Nomic المتخصص في الاسترجاع والتشابه والتجميع والتصنيف.",
+        "e5BaseV2": "نموذج أصغر وأسرع من النموذج الافتراضي. أسرع بنحو مرتين من النموذج الافتراضي على حساب جودة بحث أقل.",
+        "e5SmallV2": "أصغر وأسرع إصدار من سلسلة نماذج E5. إذا كنت تشغّل Onyx على نظام محدود الموارد فقد يكون هذا خيارًا جيدًا.",
+        "multilingualE5Base": "للمجموعات النصية بلغات غير الإنجليزية، هذا هو الخيار المناسب.",
+        "multilingualE5Small": "للمجموعات النصية بلغات غير الإنجليزية مع نظام محدود الموارد، هذا هو الخيار المناسب."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "تفعيل عدة موفري SSO متاح في خطة Business أو Enterprise."
       },
       "copyRedirectUri": {
-        "tooltip": "نسخ عنوان إعادة التوجيه"
+        "tooltip": "نسخ عنوان إعادة التوجيه",
+        "successToast": "تم نسخ عنوان URI لإعادة التوجيه",
+        "errorToast": "تعذّر النسخ"
       },
       "editProvider": {
         "tooltip": "تعديل"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "حدث خطأ غير متوقع."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "استخدام Google كموفّر هوية."
+        },
+        "oidc": {
+          "description": "ربط موفّر OpenID Connect عام."
+        },
+        "saml": {
+          "description": "ربط موفّر هوية SAML."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "معرّف العميل",
+          "description": "معرّف عميل OAuth من وحدة تحكم موفّرك.",
+          "placeholder": "معرّف العميل"
+        },
+        "clientSecret": {
+          "label": "سر العميل",
+          "description": "سر عميل OAuth. يُخزَّن مشفّرًا.",
+          "placeholder": "سر العميل"
+        },
+        "pkceEnabled": {
+          "label": "تفعيل PKCE",
+          "description": "إرسال تحدي رمز PKCE مع تدفق تسجيل الدخول لهذا الموفّر. قد يفرض إعداد على مستوى النشر تفعيله."
+        },
+        "scopes": {
+          "label": "النطاقات",
+          "description": "تجاوز نطاقات OAuth المطلوبة عند تسجيل الدخول. الفارغ يستخدم الإعدادات الافتراضية للنشر.",
+          "placeholder": "أضف نطاقًا (مثل openid)"
+        },
+        "openidConfigUrl": {
+          "label": "عنوان URL لإعدادات OpenID",
+          "description": "عنوان URL لمستند اكتشاف OpenID Connect الخاص بموفّر الهوية."
+        },
+        "requireVerifiedEmail": {
+          "label": "اشتراط مطالبة البريد الإلكتروني الموثّق",
+          "description": "رفض تسجيل الدخول عندما يحذف موفّر الهوية مطالبة email_verified الاختيارية. اتركه معطّلًا لموفّري الهوية الذين لا يرسلونها، مثل Microsoft Entra ID."
+        },
+        "idpEntityId": {
+          "label": "معرّف كيان موفّر الهوية",
+          "description": "معرّف كيان موفّر الهوية (المُصدِر)."
+        },
+        "idpSsoUrl": {
+          "label": "عنوان URL لتسجيل الدخول الموحّد لموفّر الهوية",
+          "description": "نقطة نهاية موفّر الهوية التي تستقبل طلبات تسجيل الدخول."
+        },
+        "idpX509Cert": {
+          "label": "شهادة X.509 لموفّر الهوية",
+          "description": "شهادة التوقيع لموفّر الهوية، تُستخدم للتحقق من التأكيدات."
+        },
+        "spEntityId": {
+          "label": "معرّف كيان موفّر الخدمة",
+          "description": "معرّف كيان هذا المثيل، المسجّل لدى موفّر الهوية."
+        },
+        "spX509Cert": {
+          "label": "شهادة X.509 لموفّر الخدمة",
+          "description": "فقط إذا كان هذا المثيل يوقّع الطلبات أو يفكّ تشفير التأكيدات."
+        },
+        "spPrivateKey": {
+          "label": "المفتاح الخاص لموفّر الخدمة",
+          "description": "المفتاح الخاص المرتبط بشهادة موفّر الخدمة. يُخزَّن مشفّرًا."
+        },
+        "emailAttribute": {
+          "label": "سمة البريد الإلكتروني",
+          "description": "سمة SAML التي تحوي بريد المستخدم الإلكتروني. الافتراضي هو المفاتيح الشائعة.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "تم الاتصال بـ {label}",
         "disconnected": "تم قطع الاتصال بـ {label}",
         "unexpectedError": "حدث خطأ غير متوقع."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "تقييم ومراقبة نماذج اللغة الكبيرة",
+          "fields": {
+            "apiKey": {
+              "label": "مفتاح API",
+              "description": "الصق [مفتاح API](https://www.braintrust.dev/app) من Braintrust."
+            },
+            "project": {
+              "label": "اسم المشروع",
+              "description": "اسم مشروع Braintrust الذي تُسجَّل فيه التتبعات."
+            },
+            "apiUrl": {
+              "label": "عنوان URL لواجهة API",
+              "description": "الافتراضي هو منطقة الولايات المتحدة. الصق عنوان URL لواجهة Braintrust API للمناطق الأخرى أو الاستضافة الذاتية."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "منصة مراقبة مفتوحة المصدر سحابية أو مستضافة ذاتيًا",
+          "fields": {
+            "secretKey": {
+              "label": "المفتاح السري",
+              "description": "الصق [مفتاح API](https://cloud.langfuse.com) من Langfuse."
+            },
+            "publicKey": {
+              "label": "المفتاح العام",
+              "placeholder": "المفتاح العام"
+            },
+            "host": {
+              "label": "عنوان URL الأساسي لواجهة API",
+              "description": "الافتراضي هو منطقة الاتحاد الأوروبي. الصق عنوان URL الأساسي لـ Langfuse للمناطق الأخرى أو الاستضافة الذاتية."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "حدث خطأ غير متوقع."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "زاحف ويب مضمّن. يعمل مع معظم الصفحات لكنه أقل كفاءة في الحالات الاستثنائية."
+        },
+        "firecrawl": {
+          "subtitle": "زاحف مفتوح المصدر رائد."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "معرّف محرك البحث",
+          "placeholder": "أدخل معرّف محرك البحث",
+          "description": "الصق [معرّف محرك البحث](https://programmablesearchengine.google.com/controlpanel/all) لاستخدامه في البحث على الويب."
+        },
+        "searxngBaseUrl": {
+          "label": "عنوان URL الأساسي لـ SearXNG",
+          "description": "الصق عنوان URL الأساسي لـ [مثيل SearXNG](https://docs.searxng.org/admin/installation.html) الخاص بك."
+        },
+        "firecrawlBaseUrl": {
+          "label": "عنوان URL الأساسي لواجهة API",
+          "description": "عنوان URL الأساسي لواجهة Firecrawl API الخاصة بك."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "جارٍ القراءة"
+          },
+          "header": {
+            "default": "جارٍ البحث في المستندات الداخلية",
+            "sources": "جارٍ البحث في {sources}",
+            "sourcesOverflow": "{sources} +{count} أخرى",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "منذ {date}",
+            "before": "قبل {date}",
+            "between": "من {start} إلى {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "أخرى"
         },
         "title": "أسعار النماذج",
-        "unavailable": "الأسعار غير متاحة"
+        "unavailable": "الأسعار غير متاحة",
+        "priceRow": "{input} إدخال · {output} إخراج · {cache} ذاكرة مؤقتة"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, zero {# موصّل} one {موصّل واحد} two {موصّلان} few {# موصّلات} many {# موصّلًا} other {# موصّل}}",
           "documentSets": "{count, plural, zero {# مجموعة مستندات} one {مجموعة مستندات واحدة} two {مجموعتا مستندات} few {# مجموعات مستندات} many {# مجموعة مستندات} other {# مجموعة مستندات}}",
           "agents": "{count, plural, zero {# وكيل} one {وكيل واحد} two {وكيلان} few {# وكلاء} many {# وكيلًا} other {# وكيل}}",
-          "noPrivateResources": "لا توجد موصّلات / مجموعات مستندات / وكلاء خاصة"
+          "noPrivateResources": "لا توجد موصّلات / مجموعات مستندات / وكلاء خاصة",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, zero {# أعضاء} one {عضو واحد} two {عضوان} few {# أعضاء} many {# عضوًا} other {# عضو}}"
       },

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "Gruppe anzeigen"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, one {# Konnektor} other {# Konnektoren}}",
+          "documentSets": "{count, plural, one {# Dokumentensatz} other {# Dokumentensätze}}",
+          "agents": "{count, plural, one {# Agent} other {# Agenten}}",
+          "noPrivateResources": "Keine privaten Konnektoren / Dokumentensätze / Agenten"
+        },
+        "memberCount": "{count, plural, one {# Mitglied} other {# Mitglieder}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Token-Limit",
           "placeholder": "Token-Limit (Tausend)",
           "unit": "(Tausend)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "Admin",
+          "description": "Integrierte Admin-Gruppe mit vollem Zugriff zur Verwaltung aller Berechtigungen."
+        },
+        "basic": {
+          "name": "Basis",
+          "description": "Standardgruppe für alle Benutzer mit Basisberechtigungen."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "Validierung fehlgeschlagen: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "Dokumentenaufnahme",
+          "description": "Wird für jedes Dokument ausgeführt, bevor es in die Indexierungspipeline gelangt. Ermöglicht das Filtern, Umschreiben oder Verwerfen von Dokumenten."
+        },
+        "documentPush": {
+          "name": "Dokumenten-Push",
+          "description": "Wird ausgelöst, nachdem ein Dokument erfolgreich indexiert wurde. Überträgt indexierte Dokumente an ein externes Ziel wie ein Wiki oder Data Warehouse. Nur für öffentliche Konnektoren in Single-Tenant-Deployments."
+        },
+        "queryProcessing": {
+          "name": "Anfrageverarbeitung",
+          "description": "Wird für jede Benutzeranfrage ausgeführt, bevor sie in die Pipeline gelangt. Ermöglicht das Umschreiben, Filtern oder Ablehnen von Anfragen."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "ungültig",
         "statusPaused": "pausiert",
         "restoreHint": "Um einen Konnektor zu behalten, brechen Sie hier ab, setzen Sie ihn fort oder korrigieren Sie ihn und starten Sie die Neuindizierung erneut – dann wird er übernommen. Andernfalls fügen Sie ihn nach Abschluss der Neuindizierung erneut hinzu."
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Englisches Embedding-Modell von Cohere. Gute Leistung bei englischsprachigen Aufgaben.",
+        "cohereEmbedEnglishLightV3": "Leichtgewichtiges englisches Embedding-Modell von Cohere. Schneller und effizienter für einfachere Aufgaben.",
+        "cohereEmbedV4": "Neuestes mehrsprachiges Embedding-Modell von Cohere mit standardmäßig 1536 Dimensionen für bessere Retrieval-Qualität.",
+        "openaiTextEmbedding3Large": "Großes Embedding-Modell von OpenAI. Beste Leistung, aber teurer.",
+        "openaiTextEmbedding3Small": "Neueres, effizienteres Embedding-Modell von OpenAI. Gutes Verhältnis von Leistung und Kosten.",
+        "googleGeminiEmbedding001": "Gemini-Embedding-Modell von Google. Leistungsstark und effizient.",
+        "googleTextEmbedding005": "Kleineres, leichteres Embedding-Modell von Google.",
+        "googleGeminiEmbedding2": "Neuestes multimodales Embedding-Modell von Google (GA). Höchste Retrieval-Qualität mit 3072 Dimensionen.",
+        "googleGeminiEmbedding2Preview": "Vorschauversion von Gemini Embedding 2. Für neue Einrichtungen durch gemini-embedding-2 ersetzt.",
+        "voyageLarge2Instruct": "Großes Embedding-Modell von Voyage. Hohe Leistung durch Instruction-Fine-Tuning.",
+        "voyageLight2Instruct": "Leichtgewichtiges Embedding-Modell von Voyage. Gutes Verhältnis von Leistung und Effizienz.",
+        "nomicEmbedTextV1": "Embedding-Modell von Nomic, spezialisiert auf Retrieval, Ähnlichkeit, Clustering und Klassifikation.",
+        "e5BaseV2": "Ein kleineres und schnelleres Modell als der Standard. Etwa doppelt so schnell wie das Standardmodell, bei geringerer Suchqualität.",
+        "e5SmallV2": "Die kleinste und schnellste Variante der E5-Modellreihe. Eine gute Wahl, wenn Onyx auf einem System mit begrenzten Ressourcen läuft.",
+        "multilingualE5Base": "Für Korpora in anderen Sprachen als Englisch ist dies die richtige Wahl.",
+        "multilingualE5Small": "Für Korpora in anderen Sprachen als Englisch auf einem System mit begrenzten Ressourcen ist dies die richtige Wahl."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "Mehrere aktivierte SSO-Anbieter sind im Business- oder Enterprise-Tarif verfügbar."
       },
       "copyRedirectUri": {
-        "tooltip": "Weiterleitungs-URI kopieren"
+        "tooltip": "Weiterleitungs-URI kopieren",
+        "successToast": "Weiterleitungs-URI kopiert",
+        "errorToast": "Kopieren nicht möglich"
       },
       "editProvider": {
         "tooltip": "Bearbeiten"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Google als Identitätsanbieter verwenden."
+        },
+        "oidc": {
+          "description": "Einen generischen OpenID-Connect-Anbieter verbinden."
+        },
+        "saml": {
+          "description": "Einen SAML-Identitätsanbieter verbinden."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "Client-ID",
+          "description": "Die OAuth-Client-ID aus der Konsole Ihres Anbieters.",
+          "placeholder": "Client-ID"
+        },
+        "clientSecret": {
+          "label": "Client-Secret",
+          "description": "Das OAuth-Client-Secret. Wird verschlüsselt gespeichert.",
+          "placeholder": "Client-Secret"
+        },
+        "pkceEnabled": {
+          "label": "PKCE aktivieren",
+          "description": "Eine PKCE-Code-Challenge im Anmeldeablauf dieses Anbieters senden. Eine deploymentweite Einstellung kann dies erzwingen."
+        },
+        "scopes": {
+          "label": "Scopes",
+          "description": "Die bei der Anmeldung angeforderten OAuth-Scopes überschreiben. Leer verwendet die Standardwerte des Deployments.",
+          "placeholder": "Scope hinzufügen (z. B. openid)"
+        },
+        "openidConfigUrl": {
+          "label": "OpenID-Konfigurations-URL",
+          "description": "Die URL des OpenID-Connect-Discovery-Dokuments des IdP."
+        },
+        "requireVerifiedEmail": {
+          "label": "Verifizierten E-Mail-Claim verlangen",
+          "description": "Anmeldungen ablehnen, wenn der IdP den optionalen Claim email_verified nicht sendet. Für IdPs ohne diesen Claim, wie Microsoft Entra ID, deaktiviert lassen."
+        },
+        "idpEntityId": {
+          "label": "IdP-Entity-ID",
+          "description": "Die Entity-ID (Issuer) des Identitätsanbieters."
+        },
+        "idpSsoUrl": {
+          "label": "IdP-SSO-URL",
+          "description": "Der IdP-Endpunkt, der Anmeldeanfragen empfängt."
+        },
+        "idpX509Cert": {
+          "label": "IdP-X.509-Zertifikat",
+          "description": "Das Signaturzertifikat des IdP zur Prüfung von Assertions."
+        },
+        "spEntityId": {
+          "label": "SP-Entity-ID",
+          "description": "Die Entity-ID dieser Instanz, beim IdP registriert."
+        },
+        "spX509Cert": {
+          "label": "SP-X.509-Zertifikat",
+          "description": "Nur wenn diese Instanz Anfragen signiert oder Assertions entschlüsselt."
+        },
+        "spPrivateKey": {
+          "label": "SP-Private-Key",
+          "description": "Der zum SP-Zertifikat gehörende private Schlüssel. Wird verschlüsselt gespeichert."
+        },
+        "emailAttribute": {
+          "label": "E-Mail-Attribut",
+          "description": "SAML-Attribut mit der E-Mail-Adresse des Benutzers. Standardmäßig werden gängige Schlüssel verwendet.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} verbunden",
         "disconnected": "{label} getrennt",
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "LLM-Evaluierung und -Monitoring",
+          "fields": {
+            "apiKey": {
+              "label": "API-Schlüssel",
+              "description": "Fügen Sie Ihren [API-Schlüssel](https://www.braintrust.dev/app) von Braintrust ein."
+            },
+            "project": {
+              "label": "Projektname",
+              "description": "Name des Braintrust-Projekts, in dem Traces protokolliert werden."
+            },
+            "apiUrl": {
+              "label": "API-URL",
+              "description": "Standard ist die US-Region. Fügen Sie Ihre Braintrust-API-URL für andere Regionen oder Self-Hosting ein."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "Cloud- oder selbst gehostete Open-Source-Observability-Plattform",
+          "fields": {
+            "secretKey": {
+              "label": "Secret Key",
+              "description": "Fügen Sie Ihren [API-Schlüssel](https://cloud.langfuse.com) von Langfuse ein."
+            },
+            "publicKey": {
+              "label": "Public Key",
+              "placeholder": "Public Key"
+            },
+            "host": {
+              "label": "API-Basis-URL",
+              "description": "Standard ist die EU-Region. Fügen Sie Ihre Langfuse-Basis-URL für andere Regionen oder Self-Hosting ein."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "Ein unerwarteter Fehler ist aufgetreten."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "Integrierter Web-Crawler. Funktioniert für die meisten Seiten, ist in Sonderfällen aber weniger leistungsfähig."
+        },
+        "firecrawl": {
+          "subtitle": "Führender Open-Source-Crawler."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "Suchmaschinen-ID",
+          "placeholder": "Geben Sie Ihre Suchmaschinen-ID ein",
+          "description": "Fügen Sie Ihre [Suchmaschinen-ID](https://programmablesearchengine.google.com/controlpanel/all) für die Websuche ein."
+        },
+        "searxngBaseUrl": {
+          "label": "SearXNG-Basis-URL",
+          "description": "Fügen Sie die Basis-URL Ihrer [SearXNG-Instanz](https://docs.searxng.org/admin/installation.html) ein."
+        },
+        "firecrawlBaseUrl": {
+          "label": "API-Basis-URL",
+          "description": "Die Basis-URL Ihrer Firecrawl-API."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "Liest"
+          },
+          "header": {
+            "default": "Interne Dokumente werden durchsucht",
+            "sources": "Suche in {sources}",
+            "sourcesOverflow": "{sources} +{count} weitere",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "seit {date}",
+            "before": "vor {date}",
+            "between": "von {start} bis {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "Andere"
         },
         "title": "Modellpreise",
-        "unavailable": "Preise nicht verfügbar"
+        "unavailable": "Preise nicht verfügbar",
+        "priceRow": "{input} Eingabe · {output} Ausgabe · {cache} Cache"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "{count} Ausgabe"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "Weniger Modelle anzeigen"

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, one {# Konnektor} other {# Konnektoren}}",
           "documentSets": "{count, plural, one {# Dokumentensatz} other {# Dokumentensätze}}",
           "agents": "{count, plural, one {# Agent} other {# Agenten}}",
-          "noPrivateResources": "Keine privaten Konnektoren / Dokumentensätze / Agenten"
+          "noPrivateResources": "Keine privaten Konnektoren / Dokumentensätze / Agenten",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, one {# Mitglied} other {# Mitglieder}}"
       },

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "View group"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, one {# connector} other {# connectors}}",
+          "documentSets": "{count, plural, one {# document set} other {# document sets}}",
+          "agents": "{count, plural, one {# agent} other {# agents}}",
+          "noPrivateResources": "No private connectors / document sets / agents"
+        },
+        "memberCount": "{count, plural, one {# Member} other {# Members}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Token Limit",
           "placeholder": "Token limit (thousands)",
           "unit": "(thousands)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "Admin",
+          "description": "Built-in admin group with full access to manage all permissions."
+        },
+        "basic": {
+          "name": "Basic",
+          "description": "Default group for all users with basic permissions."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "Validation failed: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "Document Ingestion",
+          "description": "Runs on every document before it enters the indexing pipeline. Allows filtering, rewriting, or dropping documents."
+        },
+        "documentPush": {
+          "name": "Document Push",
+          "description": "Fires after each document is successfully indexed. Push indexed documents to an external destination such as a wiki or data warehouse. Only fires for public connectors in single-tenant deployments."
+        },
+        "queryProcessing": {
+          "name": "Query Processing",
+          "description": "Runs on every user query before it enters the pipeline. Allows rewriting, filtering, or rejecting queries."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "invalid",
         "statusPaused": "paused",
         "restoreHint": "To keep a connector, cancel here, resume or fix it, then re-index — it will be carried over. Otherwise, add it back once the re-index finishes."
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Cohere's English embedding model. Good performance for English-language tasks.",
+        "cohereEmbedEnglishLightV3": "Cohere's lightweight English embedding model. Faster and more efficient for simpler tasks.",
+        "cohereEmbedV4": "Cohere's latest multilingual embedding model with the default 1536-dim output for stronger retrieval quality.",
+        "openaiTextEmbedding3Large": "OpenAI's large embedding model. Best performance, but more expensive.",
+        "openaiTextEmbedding3Small": "OpenAI's newer, more efficient embedding model. Good balance of performance and cost.",
+        "googleGeminiEmbedding001": "Google's Gemini embedding model. Powerful and efficient.",
+        "googleTextEmbedding005": "Smaller, lighter-weight embedding model from Google.",
+        "googleGeminiEmbedding2": "Google's latest multimodal embedding model (GA). Highest-quality retrieval with a 3072-dim output.",
+        "googleGeminiEmbedding2Preview": "Preview version of Gemini Embedding 2. Superseded by gemini-embedding-2 for new setups.",
+        "voyageLarge2Instruct": "Voyage's large embedding model. High performance with instruction fine-tuning.",
+        "voyageLight2Instruct": "Voyage's lightweight embedding model. Good balance of performance and efficiency.",
+        "nomicEmbedTextV1": "Nomic's embedding model specialized for retrieval, similarity, clustering and classification.",
+        "e5BaseV2": "A smaller and faster model than the default. It is around 2x faster than the default model at the cost of lower search quality.",
+        "e5SmallV2": "The smallest and fastest version of the E5 line of models. If you're running Onyx on a resource constrained system, then this may be a good choice.",
+        "multilingualE5Base": "For corpora in other languages besides English, this is the one to choose.",
+        "multilingualE5Small": "For corpora in other languages besides English, as well as being on a resource constrained system, this is the one to choose."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "Multiple enabled SSO providers are available on the Business or Enterprise plan."
       },
       "copyRedirectUri": {
-        "tooltip": "Copy redirect URI"
+        "tooltip": "Copy redirect URI",
+        "successToast": "Redirect URI copied",
+        "errorToast": "Could not copy"
       },
       "editProvider": {
         "tooltip": "Edit"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "Unexpected error occurred."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Use Google as the identity provider."
+        },
+        "oidc": {
+          "description": "Connect a generic OpenID Connect provider."
+        },
+        "saml": {
+          "description": "Connect a SAML identity provider."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "Client ID",
+          "description": "The OAuth client ID from your provider's console.",
+          "placeholder": "Client ID"
+        },
+        "clientSecret": {
+          "label": "Client Secret",
+          "description": "The OAuth client secret. Stored encrypted.",
+          "placeholder": "Client secret"
+        },
+        "pkceEnabled": {
+          "label": "Enable PKCE",
+          "description": "Send a PKCE code challenge with this provider's login flow. A deployment-wide setting may force this on."
+        },
+        "scopes": {
+          "label": "Scopes",
+          "description": "Override the OAuth scopes requested at login. Empty uses the deployment defaults.",
+          "placeholder": "Add a scope (e.g. openid)"
+        },
+        "openidConfigUrl": {
+          "label": "OpenID Configuration URL",
+          "description": "The IdP's OpenID Connect discovery document URL."
+        },
+        "requireVerifiedEmail": {
+          "label": "Require Verified Email Claim",
+          "description": "Reject sign-ins when the IdP omits the optional email_verified claim. Leave off for IdPs that do not send it, such as Microsoft Entra ID."
+        },
+        "idpEntityId": {
+          "label": "IdP Entity ID",
+          "description": "The identity provider's entity ID (issuer)."
+        },
+        "idpSsoUrl": {
+          "label": "IdP SSO URL",
+          "description": "The IdP endpoint that receives sign-in requests."
+        },
+        "idpX509Cert": {
+          "label": "IdP X.509 Certificate",
+          "description": "The IdP's signing certificate, used to verify assertions."
+        },
+        "spEntityId": {
+          "label": "SP Entity ID",
+          "description": "This instance's entity ID, registered with the IdP."
+        },
+        "spX509Cert": {
+          "label": "SP X.509 Certificate",
+          "description": "Only if this instance signs requests or decrypts assertions."
+        },
+        "spPrivateKey": {
+          "label": "SP Private Key",
+          "description": "Private key paired with the SP certificate. Stored encrypted."
+        },
+        "emailAttribute": {
+          "label": "Email Attribute",
+          "description": "SAML attribute holding the user's email. Defaults to common keys.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} connected",
         "disconnected": "{label} disconnected",
         "unexpectedError": "Unexpected error occurred."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "LLM evaluation and monitoring",
+          "fields": {
+            "apiKey": {
+              "label": "API Key",
+              "description": "Paste your [API key](https://www.braintrust.dev/app) from Braintrust."
+            },
+            "project": {
+              "label": "Project Name",
+              "description": "Braintrust project name traces are logged to."
+            },
+            "apiUrl": {
+              "label": "API URL",
+              "description": "Default to the US region. Paste your Braintrust API URL for other regions or self-hosting."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "Cloud or self-hosted open-source observability platform",
+          "fields": {
+            "secretKey": {
+              "label": "Secret Key",
+              "description": "Paste your [API key](https://cloud.langfuse.com) from Langfuse."
+            },
+            "publicKey": {
+              "label": "Public Key",
+              "placeholder": "Public Key"
+            },
+            "host": {
+              "label": "API Base URL",
+              "description": "Default to EU region. Paste your Langfuse base URL for other regions or self-hosting."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "Unexpected error occurred."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "Built-in web crawler. Works for most pages but less performant in edge cases."
+        },
+        "firecrawl": {
+          "subtitle": "Leading open-source crawler."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "Search Engine ID",
+          "placeholder": "Enter your search engine ID",
+          "description": "Paste your [search engine ID](https://programmablesearchengine.google.com/controlpanel/all) to use for web search."
+        },
+        "searxngBaseUrl": {
+          "label": "SearXNG Base URL",
+          "description": "Paste the base URL of your [SearXNG instance](https://docs.searxng.org/admin/installation.html)."
+        },
+        "firecrawlBaseUrl": {
+          "label": "API Base URL",
+          "description": "Your Firecrawl API base URL."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "Reading"
+          },
+          "header": {
+            "default": "Searching internal documents",
+            "sources": "Searching {sources}",
+            "sourcesOverflow": "{sources} +{count} more",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "since {date}",
+            "before": "before {date}",
+            "between": "from {start} to {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "Other"
         },
         "title": "Model prices",
-        "unavailable": "Prices unavailable"
+        "unavailable": "Prices unavailable",
+        "priceRow": "{input} in · {output} out · {cache} cache"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, one {# connector} other {# connectors}}",
           "documentSets": "{count, plural, one {# document set} other {# document sets}}",
           "agents": "{count, plural, one {# agent} other {# agents}}",
-          "noPrivateResources": "No private connectors / document sets / agents"
+          "noPrivateResources": "No private connectors / document sets / agents",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, one {# Member} other {# Members}}"
       },

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "{count} out"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "Show fewer models"

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "{count} de salida"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "Mostrar menos modelos"

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "Ver el grupo"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, one {# conector} other {# conectores}}",
+          "documentSets": "{count, plural, one {# conjunto de documentos} other {# conjuntos de documentos}}",
+          "agents": "{count, plural, one {# agente} other {# agentes}}",
+          "noPrivateResources": "Sin conectores / conjuntos de documentos / agentes privados"
+        },
+        "memberCount": "{count, plural, one {# miembro} other {# miembros}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Límite de tokens",
           "placeholder": "Límite de tokens (en miles)",
           "unit": "(en miles)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "Administradores",
+          "description": "Grupo de administradores integrado con acceso completo para gestionar todos los permisos."
+        },
+        "basic": {
+          "name": "Básico",
+          "description": "Grupo predeterminado para todos los usuarios con permisos básicos."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "La validación falló: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "Ingesta de documentos",
+          "description": "Se ejecuta en cada documento antes de entrar en la canalización de indexación. Permite filtrar, reescribir o descartar documentos."
+        },
+        "documentPush": {
+          "name": "Envío de documentos",
+          "description": "Se activa después de indexar correctamente cada documento. Envía los documentos indexados a un destino externo, como un wiki o un almacén de datos. Solo se activa para conectores públicos en despliegues de un solo inquilino."
+        },
+        "queryProcessing": {
+          "name": "Procesamiento de consultas",
+          "description": "Se ejecuta en cada consulta del usuario antes de entrar en la canalización. Permite reescribir, filtrar o rechazar consultas."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "no válido",
         "statusPaused": "en pausa",
         "restoreHint": "Para conservar un conector, cancela aquí, reanúdalo o corrígelo y vuelve a reindexar: así se trasladará. Si no, añádelo de nuevo cuando termine la reindexación."
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Modelo de embeddings en inglés de Cohere. Buen rendimiento en tareas en inglés.",
+        "cohereEmbedEnglishLightV3": "Modelo ligero de embeddings en inglés de Cohere. Más rápido y eficiente para tareas sencillas.",
+        "cohereEmbedV4": "El modelo de embeddings multilingüe más reciente de Cohere, con salida de 1536 dimensiones por defecto para una mejor calidad de recuperación.",
+        "openaiTextEmbedding3Large": "Modelo de embeddings grande de OpenAI. El mejor rendimiento, pero más caro.",
+        "openaiTextEmbedding3Small": "Modelo de embeddings más nuevo y eficiente de OpenAI. Buen equilibrio entre rendimiento y coste.",
+        "googleGeminiEmbedding001": "Modelo de embeddings Gemini de Google. Potente y eficiente.",
+        "googleTextEmbedding005": "Modelo de embeddings más pequeño y ligero de Google.",
+        "googleGeminiEmbedding2": "El modelo de embeddings multimodal más reciente de Google (GA). Recuperación de máxima calidad con salida de 3072 dimensiones.",
+        "googleGeminiEmbedding2Preview": "Versión preliminar de Gemini Embedding 2. Sustituida por gemini-embedding-2 en nuevas configuraciones.",
+        "voyageLarge2Instruct": "Modelo de embeddings grande de Voyage. Alto rendimiento con ajuste fino por instrucciones.",
+        "voyageLight2Instruct": "Modelo ligero de embeddings de Voyage. Buen equilibrio entre rendimiento y eficiencia.",
+        "nomicEmbedTextV1": "Modelo de embeddings de Nomic especializado en recuperación, similitud, agrupación y clasificación.",
+        "e5BaseV2": "Un modelo más pequeño y rápido que el predeterminado. Es unas 2 veces más rápido que el modelo predeterminado a costa de una menor calidad de búsqueda.",
+        "e5SmallV2": "La versión más pequeña y rápida de la línea de modelos E5. Si ejecutas Onyx en un sistema con recursos limitados, puede ser una buena opción.",
+        "multilingualE5Base": "Para corpus en idiomas distintos del inglés, esta es la opción indicada.",
+        "multilingualE5Small": "Para corpus en idiomas distintos del inglés en un sistema con recursos limitados, esta es la opción indicada."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "Tener varios proveedores de SSO activados está disponible en el plan Business o Enterprise."
       },
       "copyRedirectUri": {
-        "tooltip": "Copiar el URI de redirección"
+        "tooltip": "Copiar el URI de redirección",
+        "successToast": "URI de redirección copiada",
+        "errorToast": "No se pudo copiar"
       },
       "editProvider": {
         "tooltip": "Editar"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "Ocurrió un error inesperado."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Usar Google como proveedor de identidad."
+        },
+        "oidc": {
+          "description": "Conectar un proveedor genérico de OpenID Connect."
+        },
+        "saml": {
+          "description": "Conectar un proveedor de identidad SAML."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "ID de cliente",
+          "description": "El ID de cliente de OAuth de la consola de tu proveedor.",
+          "placeholder": "ID de cliente"
+        },
+        "clientSecret": {
+          "label": "Secreto de cliente",
+          "description": "El secreto de cliente de OAuth. Se almacena cifrado.",
+          "placeholder": "Secreto de cliente"
+        },
+        "pkceEnabled": {
+          "label": "Habilitar PKCE",
+          "description": "Enviar un desafío de código PKCE en el flujo de inicio de sesión de este proveedor. Un ajuste global del despliegue puede forzarlo."
+        },
+        "scopes": {
+          "label": "Ámbitos",
+          "description": "Sobrescribe los ámbitos de OAuth solicitados al iniciar sesión. Vacío usa los valores predeterminados del despliegue.",
+          "placeholder": "Añade un ámbito (p. ej. openid)"
+        },
+        "openidConfigUrl": {
+          "label": "URL de configuración de OpenID",
+          "description": "La URL del documento de descubrimiento de OpenID Connect del IdP."
+        },
+        "requireVerifiedEmail": {
+          "label": "Requerir reclamación de correo verificado",
+          "description": "Rechazar inicios de sesión cuando el IdP omite la reclamación opcional email_verified. Déjalo desactivado para IdP que no la envían, como Microsoft Entra ID."
+        },
+        "idpEntityId": {
+          "label": "ID de entidad del IdP",
+          "description": "El ID de entidad (emisor) del proveedor de identidad."
+        },
+        "idpSsoUrl": {
+          "label": "URL de SSO del IdP",
+          "description": "El punto de conexión del IdP que recibe las solicitudes de inicio de sesión."
+        },
+        "idpX509Cert": {
+          "label": "Certificado X.509 del IdP",
+          "description": "El certificado de firma del IdP, usado para verificar las aserciones."
+        },
+        "spEntityId": {
+          "label": "ID de entidad del SP",
+          "description": "El ID de entidad de esta instancia, registrado en el IdP."
+        },
+        "spX509Cert": {
+          "label": "Certificado X.509 del SP",
+          "description": "Solo si esta instancia firma solicitudes o descifra aserciones."
+        },
+        "spPrivateKey": {
+          "label": "Clave privada del SP",
+          "description": "Clave privada asociada al certificado del SP. Se almacena cifrada."
+        },
+        "emailAttribute": {
+          "label": "Atributo de correo",
+          "description": "Atributo SAML que contiene el correo del usuario. Por defecto usa las claves habituales.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} conectado",
         "disconnected": "{label} desconectado",
         "unexpectedError": "Ocurrió un error inesperado."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "Evaluación y monitorización de LLM",
+          "fields": {
+            "apiKey": {
+              "label": "Clave de API",
+              "description": "Pega tu [clave de API](https://www.braintrust.dev/app) de Braintrust."
+            },
+            "project": {
+              "label": "Nombre del proyecto",
+              "description": "Nombre del proyecto de Braintrust donde se registran las trazas."
+            },
+            "apiUrl": {
+              "label": "URL de la API",
+              "description": "Por defecto se usa la región de EE. UU. Pega la URL de la API de Braintrust para otras regiones o autoalojamiento."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "Plataforma de observabilidad de código abierto en la nube o autoalojada",
+          "fields": {
+            "secretKey": {
+              "label": "Clave secreta",
+              "description": "Pega tu [clave de API](https://cloud.langfuse.com) de Langfuse."
+            },
+            "publicKey": {
+              "label": "Clave pública",
+              "placeholder": "Clave pública"
+            },
+            "host": {
+              "label": "URL base de la API",
+              "description": "Por defecto se usa la región de la UE. Pega la URL base de Langfuse para otras regiones o autoalojamiento."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "Ocurrió un error inesperado."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "Rastreador web integrado. Funciona con la mayoría de las páginas, pero rinde menos en casos límite."
+        },
+        "firecrawl": {
+          "subtitle": "Rastreador de código abierto líder."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "ID del motor de búsqueda",
+          "placeholder": "Introduce el ID de tu motor de búsqueda",
+          "description": "Pega tu [ID del motor de búsqueda](https://programmablesearchengine.google.com/controlpanel/all) para usarlo en la búsqueda web."
+        },
+        "searxngBaseUrl": {
+          "label": "URL base de SearXNG",
+          "description": "Pega la URL base de tu [instancia de SearXNG](https://docs.searxng.org/admin/installation.html)."
+        },
+        "firecrawlBaseUrl": {
+          "label": "URL base de la API",
+          "description": "La URL base de tu API de Firecrawl."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "Leyendo"
+          },
+          "header": {
+            "default": "Buscando en documentos internos",
+            "sources": "Buscando en {sources}",
+            "sourcesOverflow": "{sources} +{count} más",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "desde {date}",
+            "before": "antes del {date}",
+            "between": "del {start} al {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "Otros"
         },
         "title": "Precios de los modelos",
-        "unavailable": "Precios no disponibles"
+        "unavailable": "Precios no disponibles",
+        "priceRow": "{input} entrada · {output} salida · {cache} caché"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, one {# conector} other {# conectores}}",
           "documentSets": "{count, plural, one {# conjunto de documentos} other {# conjuntos de documentos}}",
           "agents": "{count, plural, one {# agente} other {# agentes}}",
-          "noPrivateResources": "Sin conectores / conjuntos de documentos / agentes privados"
+          "noPrivateResources": "Sin conectores / conjuntos de documentos / agentes privados",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, one {# miembro} other {# miembros}}"
       },

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, one {# connecteur} other {# connecteurs}}",
           "documentSets": "{count, plural, one {# ensemble de documents} other {# ensembles de documents}}",
           "agents": "{count, plural, one {# agent} other {# agents}}",
-          "noPrivateResources": "Aucun connecteur / ensemble de documents / agent privé"
+          "noPrivateResources": "Aucun connecteur / ensemble de documents / agent privé",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, one {# membre} other {# membres}}"
       },

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "Voir le groupe"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, one {# connecteur} other {# connecteurs}}",
+          "documentSets": "{count, plural, one {# ensemble de documents} other {# ensembles de documents}}",
+          "agents": "{count, plural, one {# agent} other {# agents}}",
+          "noPrivateResources": "Aucun connecteur / ensemble de documents / agent privé"
+        },
+        "memberCount": "{count, plural, one {# membre} other {# membres}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Limite de jetons",
           "placeholder": "Limite de jetons (milliers)",
           "unit": "(milliers)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "Admin",
+          "description": "Groupe d'administration intégré avec un accès complet à la gestion de toutes les autorisations."
+        },
+        "basic": {
+          "name": "Basique",
+          "description": "Groupe par défaut pour tous les utilisateurs avec des autorisations de base."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "Échec de la validation : {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "Ingestion de documents",
+          "description": "S'exécute sur chaque document avant son entrée dans le pipeline d'indexation. Permet de filtrer, réécrire ou supprimer des documents."
+        },
+        "documentPush": {
+          "name": "Envoi de documents",
+          "description": "Se déclenche après l'indexation réussie de chaque document. Envoie les documents indexés vers une destination externe, comme un wiki ou un entrepôt de données. Uniquement pour les connecteurs publics dans les déploiements mono-locataire."
+        },
+        "queryProcessing": {
+          "name": "Traitement des requêtes",
+          "description": "S'exécute sur chaque requête utilisateur avant son entrée dans le pipeline. Permet de réécrire, filtrer ou rejeter des requêtes."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "non valide",
         "statusPaused": "en pause",
         "restoreHint": "Pour conserver un connecteur, annulez ici, reprenez-le ou corrigez-le, puis relancez la réindexation : il sera alors repris. Sinon, rajoutez-le une fois la réindexation terminée."
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Modèle d'embedding anglais de Cohere. Bonnes performances pour les tâches en anglais.",
+        "cohereEmbedEnglishLightV3": "Modèle d'embedding anglais léger de Cohere. Plus rapide et plus efficace pour les tâches simples.",
+        "cohereEmbedV4": "Dernier modèle d'embedding multilingue de Cohere, avec une sortie par défaut de 1536 dimensions pour une meilleure qualité de recherche.",
+        "openaiTextEmbedding3Large": "Grand modèle d'embedding d'OpenAI. Meilleures performances, mais plus coûteux.",
+        "openaiTextEmbedding3Small": "Modèle d'embedding plus récent et plus efficace d'OpenAI. Bon équilibre entre performances et coût.",
+        "googleGeminiEmbedding001": "Modèle d'embedding Gemini de Google. Puissant et efficace.",
+        "googleTextEmbedding005": "Modèle d'embedding plus petit et plus léger de Google.",
+        "googleGeminiEmbedding2": "Dernier modèle d'embedding multimodal de Google (GA). Recherche de la plus haute qualité avec une sortie de 3072 dimensions.",
+        "googleGeminiEmbedding2Preview": "Version préliminaire de Gemini Embedding 2. Remplacée par gemini-embedding-2 pour les nouvelles configurations.",
+        "voyageLarge2Instruct": "Grand modèle d'embedding de Voyage. Hautes performances grâce au fine-tuning par instructions.",
+        "voyageLight2Instruct": "Modèle d'embedding léger de Voyage. Bon équilibre entre performances et efficacité.",
+        "nomicEmbedTextV1": "Modèle d'embedding de Nomic spécialisé dans la recherche, la similarité, le clustering et la classification.",
+        "e5BaseV2": "Un modèle plus petit et plus rapide que celui par défaut. Environ 2 fois plus rapide que le modèle par défaut, au prix d'une qualité de recherche moindre.",
+        "e5SmallV2": "La version la plus petite et la plus rapide de la gamme E5. Un bon choix si Onyx tourne sur un système aux ressources limitées.",
+        "multilingualE5Base": "Pour les corpus dans d'autres langues que l'anglais, c'est le modèle à choisir.",
+        "multilingualE5Small": "Pour les corpus dans d'autres langues que l'anglais sur un système aux ressources limitées, c'est le modèle à choisir."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "L'activation de plusieurs fournisseurs SSO est disponible avec le forfait Business ou Enterprise."
       },
       "copyRedirectUri": {
-        "tooltip": "Copier l'URI de redirection"
+        "tooltip": "Copier l'URI de redirection",
+        "successToast": "URI de redirection copiée",
+        "errorToast": "Copie impossible"
       },
       "editProvider": {
         "tooltip": "Modifier"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "Une erreur inattendue est survenue."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Utiliser Google comme fournisseur d'identité."
+        },
+        "oidc": {
+          "description": "Connecter un fournisseur OpenID Connect générique."
+        },
+        "saml": {
+          "description": "Connecter un fournisseur d'identité SAML."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "ID client",
+          "description": "L'ID client OAuth issu de la console de votre fournisseur.",
+          "placeholder": "ID client"
+        },
+        "clientSecret": {
+          "label": "Secret client",
+          "description": "Le secret client OAuth. Stocké chiffré.",
+          "placeholder": "Secret client"
+        },
+        "pkceEnabled": {
+          "label": "Activer PKCE",
+          "description": "Envoyer un code challenge PKCE dans le flux de connexion de ce fournisseur. Un paramètre global du déploiement peut l'imposer."
+        },
+        "scopes": {
+          "label": "Scopes",
+          "description": "Remplacer les scopes OAuth demandés à la connexion. Vide utilise les valeurs par défaut du déploiement.",
+          "placeholder": "Ajouter un scope (ex. openid)"
+        },
+        "openidConfigUrl": {
+          "label": "URL de configuration OpenID",
+          "description": "L'URL du document de découverte OpenID Connect de l'IdP."
+        },
+        "requireVerifiedEmail": {
+          "label": "Exiger la revendication d'e-mail vérifié",
+          "description": "Refuser les connexions lorsque l'IdP omet la revendication facultative email_verified. À laisser désactivé pour les IdP qui ne l'envoient pas, comme Microsoft Entra ID."
+        },
+        "idpEntityId": {
+          "label": "ID d'entité IdP",
+          "description": "L'ID d'entité (émetteur) du fournisseur d'identité."
+        },
+        "idpSsoUrl": {
+          "label": "URL SSO de l'IdP",
+          "description": "Le point de terminaison de l'IdP qui reçoit les demandes de connexion."
+        },
+        "idpX509Cert": {
+          "label": "Certificat X.509 de l'IdP",
+          "description": "Le certificat de signature de l'IdP, utilisé pour vérifier les assertions."
+        },
+        "spEntityId": {
+          "label": "ID d'entité SP",
+          "description": "L'ID d'entité de cette instance, enregistré auprès de l'IdP."
+        },
+        "spX509Cert": {
+          "label": "Certificat X.509 du SP",
+          "description": "Uniquement si cette instance signe les requêtes ou déchiffre les assertions."
+        },
+        "spPrivateKey": {
+          "label": "Clé privée du SP",
+          "description": "Clé privée associée au certificat du SP. Stockée chiffrée."
+        },
+        "emailAttribute": {
+          "label": "Attribut e-mail",
+          "description": "Attribut SAML contenant l'e-mail de l'utilisateur. Utilise les clés courantes par défaut.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} connecté",
         "disconnected": "{label} déconnecté",
         "unexpectedError": "Une erreur inattendue est survenue."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "Évaluation et supervision des LLM",
+          "fields": {
+            "apiKey": {
+              "label": "Clé API",
+              "description": "Collez votre [clé API](https://www.braintrust.dev/app) Braintrust."
+            },
+            "project": {
+              "label": "Nom du projet",
+              "description": "Nom du projet Braintrust dans lequel les traces sont enregistrées."
+            },
+            "apiUrl": {
+              "label": "URL de l'API",
+              "description": "Région US par défaut. Collez l'URL de l'API Braintrust pour d'autres régions ou un auto-hébergement."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "Plateforme d'observabilité open source, cloud ou auto-hébergée",
+          "fields": {
+            "secretKey": {
+              "label": "Clé secrète",
+              "description": "Collez votre [clé API](https://cloud.langfuse.com) Langfuse."
+            },
+            "publicKey": {
+              "label": "Clé publique",
+              "placeholder": "Clé publique"
+            },
+            "host": {
+              "label": "URL de base de l'API",
+              "description": "Région UE par défaut. Collez l'URL de base Langfuse pour d'autres régions ou un auto-hébergement."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "Une erreur inattendue est survenue."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "Robot d'exploration intégré. Fonctionne pour la plupart des pages, mais moins performant dans les cas limites."
+        },
+        "firecrawl": {
+          "subtitle": "Robot d'exploration open source de référence."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "ID du moteur de recherche",
+          "placeholder": "Saisissez l'ID de votre moteur de recherche",
+          "description": "Collez votre [ID de moteur de recherche](https://programmablesearchengine.google.com/controlpanel/all) à utiliser pour la recherche web."
+        },
+        "searxngBaseUrl": {
+          "label": "URL de base SearXNG",
+          "description": "Collez l'URL de base de votre [instance SearXNG](https://docs.searxng.org/admin/installation.html)."
+        },
+        "firecrawlBaseUrl": {
+          "label": "URL de base de l'API",
+          "description": "L'URL de base de votre API Firecrawl."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "Lecture"
+          },
+          "header": {
+            "default": "Recherche dans les documents internes",
+            "sources": "Recherche dans {sources}",
+            "sourcesOverflow": "{sources} +{count} autres",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "depuis le {date}",
+            "before": "avant le {date}",
+            "between": "du {start} au {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "Autres"
         },
         "title": "Prix des modèles",
-        "unavailable": "Prix indisponibles"
+        "unavailable": "Prix indisponibles",
+        "priceRow": "{input} entrée · {output} sortie · {cache} cache"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "{count} en sortie"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "Afficher moins de modèles"

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "出力 {count}"
-        }
+        },
+        "joined": "{first}・{rest}"
       },
       "showFewerModels": {
         "ariaLabel": "表示するモデルを減らす"

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, other {# 個のコネクタ}}",
           "documentSets": "{count, plural, other {# 個のドキュメントセット}}",
           "agents": "{count, plural, other {# 個のエージェント}}",
-          "noPrivateResources": "非公開のコネクタ / ドキュメントセット / エージェントはありません"
+          "noPrivateResources": "非公開のコネクタ / ドキュメントセット / エージェントはありません",
+          "joined": "{first}・{rest}"
         },
         "memberCount": "{count, plural, other {# 人のメンバー}}"
       },

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "グループを表示"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, other {# 個のコネクタ}}",
+          "documentSets": "{count, plural, other {# 個のドキュメントセット}}",
+          "agents": "{count, plural, other {# 個のエージェント}}",
+          "noPrivateResources": "非公開のコネクタ / ドキュメントセット / エージェントはありません"
+        },
+        "memberCount": "{count, plural, other {# 人のメンバー}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Token 上限",
           "placeholder": "Token 上限 (千単位)",
           "unit": "(千単位)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "管理者",
+          "description": "すべての権限を管理できる組み込みの管理者グループ。"
+        },
+        "basic": {
+          "name": "基本",
+          "description": "基本権限を持つ全ユーザーのデフォルトグループ。"
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "検証に失敗しました: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "ドキュメント取り込み",
+          "description": "インデックス作成パイプラインに入る前のすべてのドキュメントに対して実行されます。ドキュメントのフィルタリング、書き換え、破棄が可能です。"
+        },
+        "documentPush": {
+          "name": "ドキュメントプッシュ",
+          "description": "各ドキュメントのインデックス作成が成功した後に発火します。インデックス済みドキュメントを wiki やデータウェアハウスなどの外部先へプッシュします。シングルテナント環境の公開コネクタでのみ発火します。"
+        },
+        "queryProcessing": {
+          "name": "クエリ処理",
+          "description": "パイプラインに入る前のすべてのユーザークエリに対して実行されます。クエリの書き換え、フィルタリング、拒否が可能です。"
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "無効",
         "statusPaused": "一時停止中",
         "restoreHint": "コネクタを残したい場合は、ここでキャンセルし、再開または修正してから再インデックスを実行してください。そうすれば新しいインデックスに引き継がれます。そうしない場合は、再インデックスの完了後に追加し直してください。"
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Cohere の英語向け埋め込みモデル。英語タスクで良好な性能。",
+        "cohereEmbedEnglishLightV3": "Cohere の軽量な英語向け埋め込みモデル。単純なタスクではより高速で効率的。",
+        "cohereEmbedV4": "Cohere の最新の多言語埋め込みモデル。デフォルトの 1536 次元出力で検索品質を向上。",
+        "openaiTextEmbedding3Large": "OpenAI の大規模埋め込みモデル。最高の性能だが高コスト。",
+        "openaiTextEmbedding3Small": "OpenAI の新しく効率的な埋め込みモデル。性能とコストのバランスが良い。",
+        "googleGeminiEmbedding001": "Google の Gemini 埋め込みモデル。強力で効率的。",
+        "googleTextEmbedding005": "Google のより小型で軽量な埋め込みモデル。",
+        "googleGeminiEmbedding2": "Google の最新のマルチモーダル埋め込みモデル（GA）。3072 次元出力で最高品質の検索。",
+        "googleGeminiEmbedding2Preview": "Gemini Embedding 2 のプレビュー版。新規セットアップでは gemini-embedding-2 に置き換えられました。",
+        "voyageLarge2Instruct": "Voyage の大規模埋め込みモデル。指示によるファインチューニングで高性能。",
+        "voyageLight2Instruct": "Voyage の軽量な埋め込みモデル。性能と効率のバランスが良い。",
+        "nomicEmbedTextV1": "検索、類似度、クラスタリング、分類に特化した Nomic の埋め込みモデル。",
+        "e5BaseV2": "デフォルトより小型で高速なモデル。検索品質は下がるが、デフォルトモデルの約 2 倍高速。",
+        "e5SmallV2": "E5 系モデルの中で最小かつ最速のバージョン。リソースが限られた環境で Onyx を実行している場合に適しています。",
+        "multilingualE5Base": "英語以外の言語のコーパスには、これを選択してください。",
+        "multilingualE5Small": "英語以外の言語のコーパスで、かつリソースが限られた環境の場合は、これを選択してください。"
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "複数の SSO プロバイダーを有効にできるのは、Business プランまたは Enterprise プランです。"
       },
       "copyRedirectUri": {
-        "tooltip": "リダイレクト URI をコピー"
+        "tooltip": "リダイレクト URI をコピー",
+        "successToast": "リダイレクト URI をコピーしました",
+        "errorToast": "コピーできませんでした"
       },
       "editProvider": {
         "tooltip": "編集"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "予期しないエラーが発生しました。"
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Google を ID プロバイダーとして使用します。"
+        },
+        "oidc": {
+          "description": "汎用の OpenID Connect プロバイダーを接続します。"
+        },
+        "saml": {
+          "description": "SAML ID プロバイダーを接続します。"
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "クライアント ID",
+          "description": "プロバイダーのコンソールで発行された OAuth クライアント ID。",
+          "placeholder": "クライアント ID"
+        },
+        "clientSecret": {
+          "label": "クライアントシークレット",
+          "description": "OAuth クライアントシークレット。暗号化して保存されます。",
+          "placeholder": "クライアントシークレット"
+        },
+        "pkceEnabled": {
+          "label": "PKCE を有効化",
+          "description": "このプロバイダーのログインフローで PKCE コードチャレンジを送信します。デプロイ全体の設定により強制される場合があります。"
+        },
+        "scopes": {
+          "label": "スコープ",
+          "description": "ログイン時に要求する OAuth スコープを上書きします。空の場合はデプロイのデフォルトを使用します。",
+          "placeholder": "スコープを追加（例: openid）"
+        },
+        "openidConfigUrl": {
+          "label": "OpenID 設定 URL",
+          "description": "IdP の OpenID Connect ディスカバリードキュメントの URL。"
+        },
+        "requireVerifiedEmail": {
+          "label": "メール検証済みクレームを必須にする",
+          "description": "IdP が任意の email_verified クレームを省略した場合にサインインを拒否します。Microsoft Entra ID など、このクレームを送信しない IdP ではオフにしてください。"
+        },
+        "idpEntityId": {
+          "label": "IdP エンティティ ID",
+          "description": "ID プロバイダーのエンティティ ID（発行者）。"
+        },
+        "idpSsoUrl": {
+          "label": "IdP SSO URL",
+          "description": "サインインリクエストを受け取る IdP のエンドポイント。"
+        },
+        "idpX509Cert": {
+          "label": "IdP X.509 証明書",
+          "description": "アサーションの検証に使用する IdP の署名証明書。"
+        },
+        "spEntityId": {
+          "label": "SP エンティティ ID",
+          "description": "IdP に登録されたこのインスタンスのエンティティ ID。"
+        },
+        "spX509Cert": {
+          "label": "SP X.509 証明書",
+          "description": "このインスタンスがリクエストに署名する、またはアサーションを復号する場合のみ。"
+        },
+        "spPrivateKey": {
+          "label": "SP 秘密鍵",
+          "description": "SP 証明書と対になる秘密鍵。暗号化して保存されます。"
+        },
+        "emailAttribute": {
+          "label": "メール属性",
+          "description": "ユーザーのメールアドレスを含む SAML 属性。デフォルトでは一般的なキーを使用します。",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} に接続しました",
         "disconnected": "{label} を切断しました",
         "unexpectedError": "予期しないエラーが発生しました。"
+      },
+      "providers": {
+        "braintrust": {
+          "description": "LLM の評価とモニタリング",
+          "fields": {
+            "apiKey": {
+              "label": "API キー",
+              "description": "Braintrust の [API キー](https://www.braintrust.dev/app)を貼り付けてください。"
+            },
+            "project": {
+              "label": "プロジェクト名",
+              "description": "トレースを記録する Braintrust のプロジェクト名。"
+            },
+            "apiUrl": {
+              "label": "API URL",
+              "description": "デフォルトは米国リージョンです。他のリージョンやセルフホストの場合は Braintrust の API URL を貼り付けてください。"
+            }
+          }
+        },
+        "langfuse": {
+          "description": "クラウドまたはセルフホスト型のオープンソース可観測性プラットフォーム",
+          "fields": {
+            "secretKey": {
+              "label": "シークレットキー",
+              "description": "Langfuse の [API キー](https://cloud.langfuse.com)を貼り付けてください。"
+            },
+            "publicKey": {
+              "label": "パブリックキー",
+              "placeholder": "パブリックキー"
+            },
+            "host": {
+              "label": "API ベース URL",
+              "description": "デフォルトは EU リージョンです。他のリージョンやセルフホストの場合は Langfuse のベース URL を貼り付けてください。"
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "予期しないエラーが発生しました。"
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "組み込みのウェブクローラー。ほとんどのページで動作しますが、特殊なケースでは性能が落ちます。"
+        },
+        "firecrawl": {
+          "subtitle": "代表的なオープンソースのクローラー。"
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "検索エンジン ID",
+          "placeholder": "検索エンジン ID を入力",
+          "description": "ウェブ検索に使用する[検索エンジン ID](https://programmablesearchengine.google.com/controlpanel/all)を貼り付けてください。"
+        },
+        "searxngBaseUrl": {
+          "label": "SearXNG ベース URL",
+          "description": "[SearXNG インスタンス](https://docs.searxng.org/admin/installation.html)のベース URL を貼り付けてください。"
+        },
+        "firecrawlBaseUrl": {
+          "label": "API ベース URL",
+          "description": "Firecrawl API のベース URL。"
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "読み取り中"
+          },
+          "header": {
+            "default": "社内ドキュメントを検索中",
+            "sources": "{sources}を検索中",
+            "sourcesOverflow": "{sources} 他{count}件",
+            "withTimeWindow": "{header}({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "{date}以降",
+            "before": "{date}より前",
+            "between": "{start}から{end}まで"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "その他"
         },
         "title": "モデル料金",
-        "unavailable": "料金情報がありません"
+        "unavailable": "料金情報がありません",
+        "priceRow": "入力 {input} · 出力 {output} · キャッシュ {cache}"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, other {커넥터 #개}}",
           "documentSets": "{count, plural, other {문서 세트 #개}}",
           "agents": "{count, plural, other {에이전트 #개}}",
-          "noPrivateResources": "비공개 커넥터 / 문서 세트 / 에이전트 없음"
+          "noPrivateResources": "비공개 커넥터 / 문서 세트 / 에이전트 없음",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, other {멤버 #명}}"
       },

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "그룹 보기"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, other {커넥터 #개}}",
+          "documentSets": "{count, plural, other {문서 세트 #개}}",
+          "agents": "{count, plural, other {에이전트 #개}}",
+          "noPrivateResources": "비공개 커넥터 / 문서 세트 / 에이전트 없음"
+        },
+        "memberCount": "{count, plural, other {멤버 #명}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Token 한도",
           "placeholder": "Token 한도(천 단위)",
           "unit": "(천 단위)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "관리자",
+          "description": "모든 권한을 관리할 수 있는 기본 내장 관리자 그룹입니다."
+        },
+        "basic": {
+          "name": "기본",
+          "description": "기본 권한을 가진 모든 사용자의 기본 그룹입니다."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "검증 실패: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "문서 수집",
+          "description": "인덱싱 파이프라인에 들어가기 전 모든 문서에 대해 실행됩니다. 문서를 필터링, 재작성 또는 제외할 수 있습니다."
+        },
+        "documentPush": {
+          "name": "문서 푸시",
+          "description": "각 문서가 성공적으로 인덱싱된 후 실행됩니다. 인덱싱된 문서를 위키나 데이터 웨어하우스 같은 외부 대상으로 푸시합니다. 단일 테넌트 배포의 공개 커넥터에서만 실행됩니다."
+        },
+        "queryProcessing": {
+          "name": "쿼리 처리",
+          "description": "파이프라인에 들어가기 전 모든 사용자 쿼리에 대해 실행됩니다. 쿼리를 재작성, 필터링 또는 거부할 수 있습니다."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "유효하지 않음",
         "statusPaused": "일시 중지됨",
         "restoreHint": "커넥터를 유지하려면 여기서 취소하고 재개하거나 문제를 해결한 뒤 다시 재인덱싱하세요. 그러면 새 인덱스로 이전됩니다. 그렇지 않으면 재인덱싱이 끝난 뒤 다시 추가하세요."
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Cohere의 영어 임베딩 모델입니다. 영어 작업에 좋은 성능을 보입니다.",
+        "cohereEmbedEnglishLightV3": "Cohere의 경량 영어 임베딩 모델입니다. 단순한 작업에 더 빠르고 효율적입니다.",
+        "cohereEmbedV4": "Cohere의 최신 다국어 임베딩 모델로, 기본 1536차원 출력으로 더 높은 검색 품질을 제공합니다.",
+        "openaiTextEmbedding3Large": "OpenAI의 대형 임베딩 모델입니다. 성능은 가장 좋지만 비용이 더 높습니다.",
+        "openaiTextEmbedding3Small": "OpenAI의 더 새롭고 효율적인 임베딩 모델입니다. 성능과 비용의 균형이 좋습니다.",
+        "googleGeminiEmbedding001": "Google의 Gemini 임베딩 모델입니다. 강력하고 효율적입니다.",
+        "googleTextEmbedding005": "Google의 더 작고 가벼운 임베딩 모델입니다.",
+        "googleGeminiEmbedding2": "Google의 최신 멀티모달 임베딩 모델(GA)입니다. 3072차원 출력으로 최고 품질의 검색을 제공합니다.",
+        "googleGeminiEmbedding2Preview": "Gemini Embedding 2의 프리뷰 버전입니다. 새 설정에서는 gemini-embedding-2로 대체되었습니다.",
+        "voyageLarge2Instruct": "Voyage의 대형 임베딩 모델입니다. 지시 미세 조정으로 높은 성능을 제공합니다.",
+        "voyageLight2Instruct": "Voyage의 경량 임베딩 모델입니다. 성능과 효율의 균형이 좋습니다.",
+        "nomicEmbedTextV1": "검색, 유사도, 클러스터링, 분류에 특화된 Nomic의 임베딩 모델입니다.",
+        "e5BaseV2": "기본 모델보다 더 작고 빠른 모델입니다. 검색 품질은 낮아지지만 기본 모델보다 약 2배 빠릅니다.",
+        "e5SmallV2": "E5 모델 계열 중 가장 작고 빠른 버전입니다. 리소스가 제한된 시스템에서 Onyx를 실행한다면 좋은 선택입니다.",
+        "multilingualE5Base": "영어 이외의 언어로 된 코퍼스에는 이 모델을 선택하세요.",
+        "multilingualE5Small": "영어 이외의 언어로 된 코퍼스이면서 리소스가 제한된 시스템이라면 이 모델을 선택하세요."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "여러 SSO 공급자를 동시에 사용하려면 Business 또는 Enterprise 요금제가 필요합니다."
       },
       "copyRedirectUri": {
-        "tooltip": "리디렉션 URI 복사"
+        "tooltip": "리디렉션 URI 복사",
+        "successToast": "리디렉션 URI를 복사했습니다",
+        "errorToast": "복사할 수 없습니다"
       },
       "editProvider": {
         "tooltip": "편집"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "예기치 않은 오류가 발생했습니다."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Google을 ID 공급자로 사용합니다."
+        },
+        "oidc": {
+          "description": "일반 OpenID Connect 공급자를 연결합니다."
+        },
+        "saml": {
+          "description": "SAML ID 공급자를 연결합니다."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "클라이언트 ID",
+          "description": "공급자 콘솔의 OAuth 클라이언트 ID입니다.",
+          "placeholder": "클라이언트 ID"
+        },
+        "clientSecret": {
+          "label": "클라이언트 시크릿",
+          "description": "OAuth 클라이언트 시크릿입니다. 암호화되어 저장됩니다.",
+          "placeholder": "클라이언트 시크릿"
+        },
+        "pkceEnabled": {
+          "label": "PKCE 사용",
+          "description": "이 공급자의 로그인 흐름에서 PKCE 코드 챌린지를 전송합니다. 배포 전체 설정에 의해 강제될 수 있습니다."
+        },
+        "scopes": {
+          "label": "스코프",
+          "description": "로그인 시 요청하는 OAuth 스코프를 재정의합니다. 비워 두면 배포 기본값을 사용합니다.",
+          "placeholder": "스코프 추가 (예: openid)"
+        },
+        "openidConfigUrl": {
+          "label": "OpenID 구성 URL",
+          "description": "IdP의 OpenID Connect 검색 문서 URL입니다."
+        },
+        "requireVerifiedEmail": {
+          "label": "이메일 검증 클레임 필수",
+          "description": "IdP가 선택적 email_verified 클레임을 생략하면 로그인을 거부합니다. Microsoft Entra ID처럼 이를 보내지 않는 IdP에서는 꺼 두세요."
+        },
+        "idpEntityId": {
+          "label": "IdP 엔터티 ID",
+          "description": "ID 공급자의 엔터티 ID(발급자)입니다."
+        },
+        "idpSsoUrl": {
+          "label": "IdP SSO URL",
+          "description": "로그인 요청을 받는 IdP 엔드포인트입니다."
+        },
+        "idpX509Cert": {
+          "label": "IdP X.509 인증서",
+          "description": "어설션 검증에 사용되는 IdP의 서명 인증서입니다."
+        },
+        "spEntityId": {
+          "label": "SP 엔터티 ID",
+          "description": "IdP에 등록된 이 인스턴스의 엔터티 ID입니다."
+        },
+        "spX509Cert": {
+          "label": "SP X.509 인증서",
+          "description": "이 인스턴스가 요청에 서명하거나 어설션을 복호화하는 경우에만 필요합니다."
+        },
+        "spPrivateKey": {
+          "label": "SP 개인 키",
+          "description": "SP 인증서와 쌍을 이루는 개인 키입니다. 암호화되어 저장됩니다."
+        },
+        "emailAttribute": {
+          "label": "이메일 속성",
+          "description": "사용자 이메일이 담긴 SAML 속성입니다. 기본값은 일반적인 키입니다.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label}에 연결했습니다",
         "disconnected": "{label} 연결을 해제했습니다",
         "unexpectedError": "예기치 않은 오류가 발생했습니다."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "LLM 평가 및 모니터링",
+          "fields": {
+            "apiKey": {
+              "label": "API 키",
+              "description": "Braintrust의 [API 키](https://www.braintrust.dev/app)를 붙여넣으세요."
+            },
+            "project": {
+              "label": "프로젝트 이름",
+              "description": "트레이스가 기록되는 Braintrust 프로젝트 이름입니다."
+            },
+            "apiUrl": {
+              "label": "API URL",
+              "description": "기본값은 미국 리전입니다. 다른 리전이나 자체 호스팅의 경우 Braintrust API URL을 붙여넣으세요."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "클라우드 또는 자체 호스팅 오픈소스 관측 플랫폼",
+          "fields": {
+            "secretKey": {
+              "label": "시크릿 키",
+              "description": "Langfuse의 [API 키](https://cloud.langfuse.com)를 붙여넣으세요."
+            },
+            "publicKey": {
+              "label": "퍼블릭 키",
+              "placeholder": "퍼블릭 키"
+            },
+            "host": {
+              "label": "API 기본 URL",
+              "description": "기본값은 EU 리전입니다. 다른 리전이나 자체 호스팅의 경우 Langfuse 기본 URL을 붙여넣으세요."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "예기치 않은 오류가 발생했습니다."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "기본 내장 웹 크롤러입니다. 대부분의 페이지에서 작동하지만 예외적인 경우 성능이 떨어집니다."
+        },
+        "firecrawl": {
+          "subtitle": "대표적인 오픈소스 크롤러입니다."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "검색 엔진 ID",
+          "placeholder": "검색 엔진 ID를 입력하세요",
+          "description": "웹 검색에 사용할 [검색 엔진 ID](https://programmablesearchengine.google.com/controlpanel/all)를 붙여넣으세요."
+        },
+        "searxngBaseUrl": {
+          "label": "SearXNG 기본 URL",
+          "description": "[SearXNG 인스턴스](https://docs.searxng.org/admin/installation.html)의 기본 URL을 붙여넣으세요."
+        },
+        "firecrawlBaseUrl": {
+          "label": "API 기본 URL",
+          "description": "Firecrawl API 기본 URL입니다."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "읽는 중"
+          },
+          "header": {
+            "default": "내부 문서 검색 중",
+            "sources": "{sources} 검색 중",
+            "sourcesOverflow": "{sources} 외 {count}개",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "{date} 이후",
+            "before": "{date} 이전",
+            "between": "{start}부터 {end}까지"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "기타"
         },
         "title": "모델 가격",
-        "unavailable": "가격 정보 없음"
+        "unavailable": "가격 정보 없음",
+        "priceRow": "입력 {input} · 출력 {output} · 캐시 {cache}"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "출력 {count}"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "모델 적게 표시"

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, one {# conector} other {# conectores}}",
           "documentSets": "{count, plural, one {# conjunto de documentos} other {# conjuntos de documentos}}",
           "agents": "{count, plural, one {# agente} other {# agentes}}",
-          "noPrivateResources": "Nenhum conector / conjunto de documentos / agente privado"
+          "noPrivateResources": "Nenhum conector / conjunto de documentos / agente privado",
+          "joined": "{first} · {rest}"
         },
         "memberCount": "{count, plural, one {# membro} other {# membros}}"
       },

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "{count} de saída"
-        }
+        },
+        "joined": "{first} · {rest}"
       },
       "showFewerModels": {
         "ariaLabel": "Mostrar menos modelos"

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "Ver grupo"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, one {# conector} other {# conectores}}",
+          "documentSets": "{count, plural, one {# conjunto de documentos} other {# conjuntos de documentos}}",
+          "agents": "{count, plural, one {# agente} other {# agentes}}",
+          "noPrivateResources": "Nenhum conector / conjunto de documentos / agente privado"
+        },
+        "memberCount": "{count, plural, one {# membro} other {# membros}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Limite de tokens",
           "placeholder": "Limite de tokens (milhares)",
           "unit": "(milhares)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "Admin",
+          "description": "Grupo de administradores integrado com acesso total para gerenciar todas as permissões."
+        },
+        "basic": {
+          "name": "Básico",
+          "description": "Grupo padrão para todos os usuários com permissões básicas."
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "A validação falhou: {status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "Ingestão de documentos",
+          "description": "Executa em cada documento antes de entrar no pipeline de indexação. Permite filtrar, reescrever ou descartar documentos."
+        },
+        "documentPush": {
+          "name": "Envio de documentos",
+          "description": "Dispara após cada documento ser indexado com sucesso. Envia documentos indexados para um destino externo, como um wiki ou data warehouse. Dispara apenas para conectores públicos em implantações de inquilino único."
+        },
+        "queryProcessing": {
+          "name": "Processamento de consultas",
+          "description": "Executa em cada consulta do usuário antes de entrar no pipeline. Permite reescrever, filtrar ou rejeitar consultas."
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "inválido",
         "statusPaused": "pausado",
         "restoreHint": "Para manter um conector, cancele aqui, retome-o ou corrija-o e reindexe novamente — assim ele será levado adiante. Caso contrário, adicione-o de volta quando a reindexação terminar."
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Modelo de embeddings em inglês da Cohere. Bom desempenho em tarefas em inglês.",
+        "cohereEmbedEnglishLightV3": "Modelo leve de embeddings em inglês da Cohere. Mais rápido e eficiente para tarefas simples.",
+        "cohereEmbedV4": "O modelo de embeddings multilíngue mais recente da Cohere, com saída padrão de 1536 dimensões para melhor qualidade de recuperação.",
+        "openaiTextEmbedding3Large": "Modelo de embeddings grande da OpenAI. Melhor desempenho, porém mais caro.",
+        "openaiTextEmbedding3Small": "Modelo de embeddings mais novo e eficiente da OpenAI. Bom equilíbrio entre desempenho e custo.",
+        "googleGeminiEmbedding001": "Modelo de embeddings Gemini do Google. Poderoso e eficiente.",
+        "googleTextEmbedding005": "Modelo de embeddings menor e mais leve do Google.",
+        "googleGeminiEmbedding2": "O modelo de embeddings multimodal mais recente do Google (GA). Recuperação da mais alta qualidade com saída de 3072 dimensões.",
+        "googleGeminiEmbedding2Preview": "Versão prévia do Gemini Embedding 2. Substituída pelo gemini-embedding-2 em novas configurações.",
+        "voyageLarge2Instruct": "Modelo de embeddings grande da Voyage. Alto desempenho com ajuste fino por instruções.",
+        "voyageLight2Instruct": "Modelo leve de embeddings da Voyage. Bom equilíbrio entre desempenho e eficiência.",
+        "nomicEmbedTextV1": "Modelo de embeddings da Nomic especializado em recuperação, similaridade, agrupamento e classificação.",
+        "e5BaseV2": "Um modelo menor e mais rápido que o padrão. É cerca de 2x mais rápido que o modelo padrão, com menor qualidade de busca.",
+        "e5SmallV2": "A versão menor e mais rápida da linha de modelos E5. Se você executa o Onyx em um sistema com recursos limitados, pode ser uma boa escolha.",
+        "multilingualE5Base": "Para corpora em outros idiomas além do inglês, esta é a escolha certa.",
+        "multilingualE5Small": "Para corpora em outros idiomas além do inglês em um sistema com recursos limitados, esta é a escolha certa."
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "Vários provedores de SSO ativados estão disponíveis nos planos Business ou Enterprise."
       },
       "copyRedirectUri": {
-        "tooltip": "Copiar URI de redirecionamento"
+        "tooltip": "Copiar URI de redirecionamento",
+        "successToast": "URI de redirecionamento copiada",
+        "errorToast": "Não foi possível copiar"
       },
       "editProvider": {
         "tooltip": "Editar"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "Ocorreu um erro inesperado."
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "Usar o Google como provedor de identidade."
+        },
+        "oidc": {
+          "description": "Conectar um provedor genérico de OpenID Connect."
+        },
+        "saml": {
+          "description": "Conectar um provedor de identidade SAML."
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "ID do cliente",
+          "description": "O ID de cliente OAuth do console do seu provedor.",
+          "placeholder": "ID do cliente"
+        },
+        "clientSecret": {
+          "label": "Segredo do cliente",
+          "description": "O segredo de cliente OAuth. Armazenado criptografado.",
+          "placeholder": "Segredo do cliente"
+        },
+        "pkceEnabled": {
+          "label": "Ativar PKCE",
+          "description": "Enviar um code challenge PKCE no fluxo de login deste provedor. Uma configuração global da implantação pode forçar isso."
+        },
+        "scopes": {
+          "label": "Escopos",
+          "description": "Substituir os escopos OAuth solicitados no login. Vazio usa os padrões da implantação.",
+          "placeholder": "Adicionar um escopo (ex.: openid)"
+        },
+        "openidConfigUrl": {
+          "label": "URL de configuração do OpenID",
+          "description": "A URL do documento de descoberta OpenID Connect do IdP."
+        },
+        "requireVerifiedEmail": {
+          "label": "Exigir claim de e-mail verificado",
+          "description": "Rejeitar logins quando o IdP omitir o claim opcional email_verified. Deixe desativado para IdPs que não o enviam, como o Microsoft Entra ID."
+        },
+        "idpEntityId": {
+          "label": "ID da entidade do IdP",
+          "description": "O ID de entidade (emissor) do provedor de identidade."
+        },
+        "idpSsoUrl": {
+          "label": "URL de SSO do IdP",
+          "description": "O endpoint do IdP que recebe as solicitações de login."
+        },
+        "idpX509Cert": {
+          "label": "Certificado X.509 do IdP",
+          "description": "O certificado de assinatura do IdP, usado para verificar asserções."
+        },
+        "spEntityId": {
+          "label": "ID da entidade do SP",
+          "description": "O ID de entidade desta instância, registrado no IdP."
+        },
+        "spX509Cert": {
+          "label": "Certificado X.509 do SP",
+          "description": "Apenas se esta instância assinar solicitações ou descriptografar asserções."
+        },
+        "spPrivateKey": {
+          "label": "Chave privada do SP",
+          "description": "Chave privada associada ao certificado do SP. Armazenada criptografada."
+        },
+        "emailAttribute": {
+          "label": "Atributo de e-mail",
+          "description": "Atributo SAML que contém o e-mail do usuário. Usa chaves comuns por padrão.",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} conectado",
         "disconnected": "{label} desconectado",
         "unexpectedError": "Ocorreu um erro inesperado."
+      },
+      "providers": {
+        "braintrust": {
+          "description": "Avaliação e monitoramento de LLM",
+          "fields": {
+            "apiKey": {
+              "label": "Chave de API",
+              "description": "Cole sua [chave de API](https://www.braintrust.dev/app) do Braintrust."
+            },
+            "project": {
+              "label": "Nome do projeto",
+              "description": "Nome do projeto do Braintrust onde os traces são registrados."
+            },
+            "apiUrl": {
+              "label": "URL da API",
+              "description": "O padrão é a região dos EUA. Cole a URL da API do Braintrust para outras regiões ou auto-hospedagem."
+            }
+          }
+        },
+        "langfuse": {
+          "description": "Plataforma de observabilidade de código aberto na nuvem ou auto-hospedada",
+          "fields": {
+            "secretKey": {
+              "label": "Chave secreta",
+              "description": "Cole sua [chave de API](https://cloud.langfuse.com) do Langfuse."
+            },
+            "publicKey": {
+              "label": "Chave pública",
+              "placeholder": "Chave pública"
+            },
+            "host": {
+              "label": "URL base da API",
+              "description": "O padrão é a região da UE. Cole a URL base do Langfuse para outras regiões ou auto-hospedagem."
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "Ocorreu um erro inesperado."
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "Rastreador web integrado. Funciona na maioria das páginas, mas tem desempenho menor em casos extremos."
+        },
+        "firecrawl": {
+          "subtitle": "Rastreador de código aberto líder."
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "ID do mecanismo de busca",
+          "placeholder": "Insira o ID do seu mecanismo de busca",
+          "description": "Cole o [ID do mecanismo de busca](https://programmablesearchengine.google.com/controlpanel/all) para usar na busca na web."
+        },
+        "searxngBaseUrl": {
+          "label": "URL base do SearXNG",
+          "description": "Cole a URL base da sua [instância SearXNG](https://docs.searxng.org/admin/installation.html)."
+        },
+        "firecrawlBaseUrl": {
+          "label": "URL base da API",
+          "description": "A URL base da sua API do Firecrawl."
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "Lendo"
+          },
+          "header": {
+            "default": "Pesquisando documentos internos",
+            "sources": "Pesquisando {sources}",
+            "sourcesOverflow": "{sources} +{count} mais",
+            "withTimeWindow": "{header} ({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "desde {date}",
+            "before": "antes de {date}",
+            "between": "de {start} a {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "Outros"
         },
         "title": "Preços dos modelos",
-        "unavailable": "Preços indisponíveis"
+        "unavailable": "Preços indisponíveis",
+        "priceRow": "{input} entrada · {output} saída · {cache} cache"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -3886,7 +3886,8 @@
           "connectors": "{count, plural, other {# 个连接器}}",
           "documentSets": "{count, plural, other {# 个文档集}}",
           "agents": "{count, plural, other {# 个智能体}}",
-          "noPrivateResources": "没有私有连接器 / 文档集 / 智能体"
+          "noPrivateResources": "没有私有连接器 / 文档集 / 智能体",
+          "joined": "{first}・{rest}"
         },
         "memberCount": "{count, plural, other {# 名成员}}"
       },

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -13249,7 +13249,8 @@
         },
         "tokensOut": {
           "label": "输出 {count}"
-        }
+        },
+        "joined": "{first}・{rest}"
       },
       "showFewerModels": {
         "ariaLabel": "显示更少模型"

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -3881,7 +3881,14 @@
         },
         "viewGroup": {
           "label": "查看用户组"
-        }
+        },
+        "resourceCounts": {
+          "connectors": "{count, plural, other {# 个连接器}}",
+          "documentSets": "{count, plural, other {# 个文档集}}",
+          "agents": "{count, plural, other {# 个智能体}}",
+          "noPrivateResources": "没有私有连接器 / 文档集 / 智能体"
+        },
+        "memberCount": "{count, plural, other {# 名成员}}"
       },
       "create": {
         "header": {
@@ -4130,6 +4137,16 @@
           "header": "Token 上限",
           "placeholder": "Token 上限（千）",
           "unit": "(千)"
+        }
+      },
+      "builtIn": {
+        "admin": {
+          "name": "管理员",
+          "description": "内置管理员组，拥有管理所有权限的完整访问权。"
+        },
+        "basic": {
+          "name": "基本",
+          "description": "所有用户的默认组，拥有基本权限。"
         }
       }
     },
@@ -4389,6 +4406,20 @@
         },
         "validationFailed": {
           "message": "验证失败:{status}"
+        }
+      },
+      "points": {
+        "documentIngestion": {
+          "name": "文档摄取",
+          "description": "在每个文档进入索引管道之前运行。允许过滤、重写或丢弃文档。"
+        },
+        "documentPush": {
+          "name": "文档推送",
+          "description": "在每个文档成功索引后触发。将已索引的文档推送到外部目标，如 wiki 或数据仓库。仅在单租户部署中的公共连接器上触发。"
+        },
+        "queryProcessing": {
+          "name": "查询处理",
+          "description": "在每个用户查询进入管道之前运行。允许重写、过滤或拒绝查询。"
         }
       }
     },
@@ -4958,6 +4989,24 @@
         "statusInvalid": "无效",
         "statusPaused": "已暂停",
         "restoreHint": "如需保留某个连接器，请在此取消，先恢复或修复它，然后重新索引，它就会被迁移过去。否则请在重新索引完成后重新添加。"
+      },
+      "modelDescriptions": {
+        "cohereEmbedEnglishV3": "Cohere 的英语嵌入模型。在英语任务上表现良好。",
+        "cohereEmbedEnglishLightV3": "Cohere 的轻量级英语嵌入模型。处理简单任务更快、更高效。",
+        "cohereEmbedV4": "Cohere 最新的多语言嵌入模型，默认 1536 维输出，检索质量更高。",
+        "openaiTextEmbedding3Large": "OpenAI 的大型嵌入模型。性能最佳，但成本更高。",
+        "openaiTextEmbedding3Small": "OpenAI 更新、更高效的嵌入模型。性能与成本平衡良好。",
+        "googleGeminiEmbedding001": "Google 的 Gemini 嵌入模型。强大且高效。",
+        "googleTextEmbedding005": "Google 更小、更轻量的嵌入模型。",
+        "googleGeminiEmbedding2": "Google 最新的多模态嵌入模型（GA）。3072 维输出，检索质量最高。",
+        "googleGeminiEmbedding2Preview": "Gemini Embedding 2 的预览版。新部署已由 gemini-embedding-2 取代。",
+        "voyageLarge2Instruct": "Voyage 的大型嵌入模型。经过指令微调，性能出色。",
+        "voyageLight2Instruct": "Voyage 的轻量级嵌入模型。性能与效率平衡良好。",
+        "nomicEmbedTextV1": "Nomic 的嵌入模型，专注于检索、相似度、聚类和分类。",
+        "e5BaseV2": "比默认模型更小、更快的模型。速度约为默认模型的 2 倍，但搜索质量较低。",
+        "e5SmallV2": "E5 系列模型中最小、最快的版本。如果您在资源受限的系统上运行 Onyx，这是一个不错的选择。",
+        "multilingualE5Base": "如果语料库包含英语以外的语言，请选择此模型。",
+        "multilingualE5Small": "如果语料库包含英语以外的语言，且系统资源受限，请选择此模型。"
       }
     },
     "indexing": {
@@ -6799,7 +6848,9 @@
         "gatedTooltip": "同时启用多个 SSO 提供商需要 Business 或 Enterprise 方案。"
       },
       "copyRedirectUri": {
-        "tooltip": "复制重定向 URI"
+        "tooltip": "复制重定向 URI",
+        "successToast": "已复制重定向 URI",
+        "errorToast": "无法复制"
       },
       "editProvider": {
         "tooltip": "编辑"
@@ -6911,6 +6962,75 @@
       },
       "toasts": {
         "unexpectedError": "发生意外错误。"
+      },
+      "providerTypes": {
+        "googleOauth": {
+          "description": "使用 Google 作为身份提供方。"
+        },
+        "oidc": {
+          "description": "连接通用的 OpenID Connect 提供方。"
+        },
+        "saml": {
+          "description": "连接 SAML 身份提供方。"
+        }
+      },
+      "configFields": {
+        "clientId": {
+          "label": "客户端 ID",
+          "description": "来自提供方控制台的 OAuth 客户端 ID。",
+          "placeholder": "客户端 ID"
+        },
+        "clientSecret": {
+          "label": "客户端密钥",
+          "description": "OAuth 客户端密钥。加密存储。",
+          "placeholder": "客户端密钥"
+        },
+        "pkceEnabled": {
+          "label": "启用 PKCE",
+          "description": "在此提供方的登录流程中发送 PKCE code challenge。部署级设置可能会强制启用。"
+        },
+        "scopes": {
+          "label": "作用域",
+          "description": "覆盖登录时请求的 OAuth 作用域。留空则使用部署默认值。",
+          "placeholder": "添加作用域（例如 openid）"
+        },
+        "openidConfigUrl": {
+          "label": "OpenID 配置 URL",
+          "description": "IdP 的 OpenID Connect 发现文档 URL。"
+        },
+        "requireVerifiedEmail": {
+          "label": "要求已验证邮箱声明",
+          "description": "当 IdP 省略可选的 email_verified 声明时拒绝登录。对于不发送该声明的 IdP（如 Microsoft Entra ID），请保持关闭。"
+        },
+        "idpEntityId": {
+          "label": "IdP 实体 ID",
+          "description": "身份提供方的实体 ID（颁发者）。"
+        },
+        "idpSsoUrl": {
+          "label": "IdP SSO URL",
+          "description": "接收登录请求的 IdP 端点。"
+        },
+        "idpX509Cert": {
+          "label": "IdP X.509 证书",
+          "description": "IdP 的签名证书，用于验证断言。"
+        },
+        "spEntityId": {
+          "label": "SP 实体 ID",
+          "description": "此实例在 IdP 注册的实体 ID。"
+        },
+        "spX509Cert": {
+          "label": "SP X.509 证书",
+          "description": "仅当此实例对请求签名或解密断言时需要。"
+        },
+        "spPrivateKey": {
+          "label": "SP 私钥",
+          "description": "与 SP 证书配对的私钥。加密存储。"
+        },
+        "emailAttribute": {
+          "label": "邮箱属性",
+          "description": "包含用户邮箱的 SAML 属性。默认使用常见键名。",
+          "placeholder": "email"
+        }
       }
     },
     "standardAnswers": {
@@ -7448,6 +7568,42 @@
         "connected": "{label} 已连接",
         "disconnected": "{label} 已断开连接",
         "unexpectedError": "发生意外错误。"
+      },
+      "providers": {
+        "braintrust": {
+          "description": "LLM 评估与监控",
+          "fields": {
+            "apiKey": {
+              "label": "API 密钥",
+              "description": "粘贴您在 Braintrust 的 [API 密钥](https://www.braintrust.dev/app)。"
+            },
+            "project": {
+              "label": "项目名称",
+              "description": "记录跟踪数据的 Braintrust 项目名称。"
+            },
+            "apiUrl": {
+              "label": "API URL",
+              "description": "默认为美国区域。其他区域或自托管请粘贴您的 Braintrust API URL。"
+            }
+          }
+        },
+        "langfuse": {
+          "description": "云端或自托管的开源可观测性平台",
+          "fields": {
+            "secretKey": {
+              "label": "密钥",
+              "description": "粘贴您在 Langfuse 的 [API 密钥](https://cloud.langfuse.com)。"
+            },
+            "publicKey": {
+              "label": "公钥",
+              "placeholder": "公钥"
+            },
+            "host": {
+              "label": "API 基础 URL",
+              "description": "默认为欧盟区域。其他区域或自托管请粘贴您的 Langfuse 基础 URL。"
+            }
+          }
+        }
       }
     },
     "usage": {
@@ -8073,6 +8229,35 @@
       },
       "unexpectedError": {
         "message": "发生意外错误。"
+      },
+      "contentProviders": {
+        "onyxWebCrawler": {
+          "subtitle": "内置网页爬虫。适用于大多数页面，但在特殊情况下性能较低。"
+        },
+        "firecrawl": {
+          "subtitle": "领先的开源爬虫。"
+        },
+        "exa": {
+          "subtitle": "Exa.ai"
+        },
+        "tavily": {
+          "subtitle": "Tavily AI"
+        }
+      },
+      "configFields": {
+        "searchEngineId": {
+          "label": "搜索引擎 ID",
+          "placeholder": "输入您的搜索引擎 ID",
+          "description": "粘贴用于网页搜索的[搜索引擎 ID](https://programmablesearchengine.google.com/controlpanel/all)。"
+        },
+        "searxngBaseUrl": {
+          "label": "SearXNG 基础 URL",
+          "description": "粘贴您的 [SearXNG 实例](https://docs.searxng.org/admin/installation.html)的基础 URL。"
+        },
+        "firecrawlBaseUrl": {
+          "label": "API 基础 URL",
+          "description": "您的 Firecrawl API 基础 URL。"
+        }
       }
     }
   },
@@ -9816,6 +10001,17 @@
           },
           "reading": {
             "status": "正在读取"
+          },
+          "header": {
+            "default": "正在搜索内部文档",
+            "sources": "正在搜索 {sources}",
+            "sourcesOverflow": "{sources} 及另外 {count} 个",
+            "withTimeWindow": "{header}({timeWindow})"
+          },
+          "timeWindow": {
+            "since": "自 {date} 起",
+            "before": "{date} 之前",
+            "between": "从 {start} 到 {end}"
           }
         },
         "interruptedThinking": {
@@ -13037,7 +13233,8 @@
           "label": "其他"
         },
         "title": "模型价格",
-        "unavailable": "价格不可用"
+        "unavailable": "价格不可用",
+        "priceRow": "输入 {input} · 输出 {output} · 缓存 {cache}"
       },
       "modelUsage": {
         "cacheReads": {

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -13,6 +13,7 @@ import {
   EmbeddingModel,
   EmbeddingProvider,
   EmbeddingProviderName,
+  IndexSettingsTranslator,
 } from "@/lib/indexing/types";
 import { DOCS_ADMINS_PATH } from "@/lib/constants";
 
@@ -35,8 +36,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Cohere's English embedding model. Good performance for English-language tasks.",
+        descriptionKey: "modelDescriptions.cohereEmbedEnglishV3",
       },
       {
         modelName: "embed-english-light-v3.0",
@@ -44,8 +44,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Cohere's lightweight English embedding model. Faster and more efficient for simpler tasks.",
+        descriptionKey: "modelDescriptions.cohereEmbedEnglishLightV3",
       },
       {
         modelName: "embed-v4.0",
@@ -53,8 +52,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Cohere's latest multilingual embedding model with the default 1536-dim output for stronger retrieval quality.",
+        descriptionKey: "modelDescriptions.cohereEmbedV4",
       },
     ],
   },
@@ -72,8 +70,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "OpenAI's large embedding model. Best performance, but more expensive.",
+        descriptionKey: "modelDescriptions.openaiTextEmbedding3Large",
       },
       {
         modelName: "text-embedding-3-small",
@@ -81,8 +78,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "OpenAI's newer, more efficient embedding model. Good balance of performance and cost.",
+        descriptionKey: "modelDescriptions.openaiTextEmbedding3Small",
       },
     ],
   },
@@ -100,7 +96,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description: "Google's Gemini embedding model. Powerful and efficient.",
+        descriptionKey: "modelDescriptions.googleGeminiEmbedding001",
       },
       {
         modelName: "text-embedding-005",
@@ -108,7 +104,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description: "Smaller, lighter-weight embedding model from Google.",
+        descriptionKey: "modelDescriptions.googleTextEmbedding005",
       },
       {
         modelName: "gemini-embedding-2",
@@ -116,8 +112,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Google's latest multimodal embedding model (GA). Highest-quality retrieval with a 3072-dim output.",
+        descriptionKey: "modelDescriptions.googleGeminiEmbedding2",
       },
       {
         modelName: "gemini-embedding-2-preview",
@@ -125,8 +120,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Preview version of Gemini Embedding 2. Superseded by gemini-embedding-2 for new setups.",
+        descriptionKey: "modelDescriptions.googleGeminiEmbedding2Preview",
       },
     ],
   },
@@ -145,8 +139,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Voyage's large embedding model. High performance with instruction fine-tuning.",
+        descriptionKey: "modelDescriptions.voyageLarge2Instruct",
       },
       {
         modelName: "voyage-light-2-instruct",
@@ -154,8 +147,7 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
-        description:
-          "Voyage's lightweight embedding model. Good balance of performance and efficiency.",
+        descriptionKey: "modelDescriptions.voyageLight2Instruct",
       },
     ],
   },
@@ -191,8 +183,7 @@ export const SELF_HOSTED_PROVIDERS: EmbeddingProvider[] = [
         normalize: true,
         queryPrefix: "search_query: ",
         passagePrefix: "search_document: ",
-        description:
-          "Nomic's embedding model specialized for retrieval, similarity, clustering and classification.",
+        descriptionKey: "modelDescriptions.nomicEmbedTextV1",
       },
     ],
   },
@@ -208,8 +199,7 @@ export const SELF_HOSTED_PROVIDERS: EmbeddingProvider[] = [
         normalize: true,
         queryPrefix: "query: ",
         passagePrefix: "passage: ",
-        description:
-          "A smaller and faster model than the default. It is around 2x faster than the default model at the cost of lower search quality.",
+        descriptionKey: "modelDescriptions.e5BaseV2",
       },
       {
         modelName: "intfloat/e5-small-v2",
@@ -217,8 +207,7 @@ export const SELF_HOSTED_PROVIDERS: EmbeddingProvider[] = [
         normalize: true,
         queryPrefix: "query: ",
         passagePrefix: "passage: ",
-        description:
-          "The smallest and fastest version of the E5 line of models. If you're running Onyx on a resource constrained system, then this may be a good choice.",
+        descriptionKey: "modelDescriptions.e5SmallV2",
       },
       {
         modelName: "intfloat/multilingual-e5-base",
@@ -226,8 +215,7 @@ export const SELF_HOSTED_PROVIDERS: EmbeddingProvider[] = [
         normalize: true,
         queryPrefix: "query: ",
         passagePrefix: "passage: ",
-        description:
-          "For corpora in other languages besides English, this is the one to choose.",
+        descriptionKey: "modelDescriptions.multilingualE5Base",
       },
       {
         modelName: "intfloat/multilingual-e5-small",
@@ -235,8 +223,7 @@ export const SELF_HOSTED_PROVIDERS: EmbeddingProvider[] = [
         normalize: true,
         queryPrefix: "query: ",
         passagePrefix: "passage: ",
-        description:
-          "For corpora in other languages besides English, as well as being on a resource constrained system, this is the one to choose.",
+        descriptionKey: "modelDescriptions.multilingualE5Small",
       },
     ],
   },
@@ -303,6 +290,14 @@ export function findRegistryModel(modelName: string): EmbeddingModel | null {
     if (m) return m;
   }
   return null;
+}
+
+/** Translated registry description, undefined without a key. */
+export function embeddingModelDescription(
+  model: EmbeddingModel | null | undefined,
+  t: IndexSettingsTranslator
+): string | undefined {
+  return model?.descriptionKey ? t(model.descriptionKey) : undefined;
 }
 
 /**

--- a/web/src/lib/indexing/types.ts
+++ b/web/src/lib/indexing/types.ts
@@ -1,4 +1,12 @@
+import type { useTranslations } from "next-intl";
 import type { IconFunctionComponent } from "@opal/types";
+
+/** Translator for the `admin.indexSettings` namespace, threaded into helpers
+ *  that live outside a component and so cannot call the hook themselves. */
+export type IndexSettingsTranslator = ReturnType<
+  typeof useTranslations<"admin.indexSettings">
+>;
+export type IndexSettingsMessageKey = Parameters<IndexSettingsTranslator>[0];
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -67,10 +75,11 @@ export interface EmbeddingModel {
   normalize: boolean;
   queryPrefix?: string | null;
   passagePrefix?: string | null;
-  description: string;
+  // Absent for custom models, which have no registry description.
+  descriptionKey?: IndexSettingsMessageKey;
 }
 
-export type EmbeddingModelSpec = Omit<EmbeddingModel, "description">;
+export type EmbeddingModelSpec = Omit<EmbeddingModel, "descriptionKey">;
 
 /**
  * Always write all three fields together. A name without its spec and provider forces

--- a/web/src/lib/sso/utils.ts
+++ b/web/src/lib/sso/utils.ts
@@ -1,13 +1,19 @@
+import type { useTranslations } from "next-intl";
 import { SvgGlobe, SvgUserKey } from "@opal/icons";
 import { SvgGoogle } from "@opal/logos";
 import type { IconFunctionComponent } from "@opal/types";
 import { toast } from "@opal/layouts";
 import { SSOProviderType } from "@/lib/sso/interfaces";
 
+export type SSOTranslate = ReturnType<
+  typeof useTranslations<"admin.ssoProviders">
+>;
+export type SSOMessageKey = Parameters<SSOTranslate>[0];
+
 interface SSOProviderDetail {
   label: string;
   icon: IconFunctionComponent;
-  description: string;
+  descriptionKey: SSOMessageKey;
 }
 
 export const SSO_PROVIDER_DETAILS: Record<SSOProviderType, SSOProviderDetail> =
@@ -15,17 +21,17 @@ export const SSO_PROVIDER_DETAILS: Record<SSOProviderType, SSOProviderDetail> =
     GOOGLE_OAUTH: {
       label: "Google",
       icon: SvgGoogle,
-      description: "Use Google as the identity provider.",
+      descriptionKey: "providerTypes.googleOauth.description",
     },
     OIDC: {
       label: "OIDC",
       icon: SvgGlobe,
-      description: "Connect a generic OpenID Connect provider.",
+      descriptionKey: "providerTypes.oidc.description",
     },
     SAML: {
       label: "SAML",
       icon: SvgUserKey,
-      description: "Connect a SAML identity provider.",
+      descriptionKey: "providerTypes.saml.description",
     },
   };
 
@@ -45,47 +51,45 @@ export type SSOConfigFieldKind =
 
 // One entry per admin-editable key in a provider type's backend config model.
 // `name` must match the backend config field exactly, since values are sent
-// as config.<name>.
+// as config.<name>. The user-facing text lives in "admin.ssoProviders".
 export interface SSOConfigField {
   name: string;
-  label: string;
+  labelKey: SSOMessageKey;
   kind: SSOConfigFieldKind;
-  description: string;
+  descriptionKey: SSOMessageKey;
   optional?: boolean;
+  placeholderKey?: SSOMessageKey;
+  // URLs, PEM markers and ids are not translated.
   placeholder?: string;
 }
 
 const CLIENT_ID_FIELD: SSOConfigField = {
   name: "client_id",
-  label: "Client ID",
+  labelKey: "configFields.clientId.label",
   kind: "text",
-  description: "The OAuth client ID from your provider's console.",
-  placeholder: "Client ID",
+  descriptionKey: "configFields.clientId.description",
+  placeholderKey: "configFields.clientId.placeholder",
 };
 const CLIENT_SECRET_FIELD: SSOConfigField = {
   name: "client_secret",
-  label: "Client Secret",
+  labelKey: "configFields.clientSecret.label",
   kind: "password",
-  description: "The OAuth client secret. Stored encrypted.",
-  placeholder: "Client secret",
+  descriptionKey: "configFields.clientSecret.description",
+  placeholderKey: "configFields.clientSecret.placeholder",
 };
 const PKCE_FIELD: SSOConfigField = {
   name: "pkce_enabled",
-  label: "Enable PKCE",
+  labelKey: "configFields.pkceEnabled.label",
   kind: "switch",
-  description:
-    "Send a PKCE code challenge with this provider's login flow. " +
-    "A deployment-wide setting may force this on.",
+  descriptionKey: "configFields.pkceEnabled.description",
 };
 const SCOPES_FIELD: SSOConfigField = {
   name: "scopes",
-  label: "Scopes",
+  labelKey: "configFields.scopes.label",
   kind: "chips",
   optional: true,
-  description:
-    "Override the OAuth scopes requested at login. " +
-    "Empty uses the deployment defaults.",
-  placeholder: "Add a scope (e.g. openid)",
+  descriptionKey: "configFields.scopes.description",
+  placeholderKey: "configFields.scopes.placeholder",
 };
 
 export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
@@ -101,19 +105,16 @@ export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
       CLIENT_SECRET_FIELD,
       {
         name: "openid_config_url",
-        label: "OpenID Configuration URL",
+        labelKey: "configFields.openidConfigUrl.label",
         kind: "text",
-        description: "The IdP's OpenID Connect discovery document URL.",
+        descriptionKey: "configFields.openidConfigUrl.description",
         placeholder: "https://example.com/.well-known/openid-configuration",
       },
       {
         name: "require_verified_email",
-        label: "Require Verified Email Claim",
+        labelKey: "configFields.requireVerifiedEmail.label",
         kind: "switch",
-        description:
-          "Reject sign-ins when the IdP omits the optional email_verified " +
-          "claim. Leave off for IdPs that do not send it, such as " +
-          "Microsoft Entra ID.",
+        descriptionKey: "configFields.requireVerifiedEmail.description",
       },
       PKCE_FIELD,
       SCOPES_FIELD,
@@ -121,68 +122,67 @@ export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
     SAML: [
       {
         name: "idp_entity_id",
-        label: "IdP Entity ID",
+        labelKey: "configFields.idpEntityId.label",
         kind: "text",
-        description: "The identity provider's entity ID (issuer).",
+        descriptionKey: "configFields.idpEntityId.description",
         placeholder: "https://idp.example.com/entity",
       },
       {
         name: "idp_sso_url",
-        label: "IdP SSO URL",
+        labelKey: "configFields.idpSsoUrl.label",
         kind: "text",
-        description: "The IdP endpoint that receives sign-in requests.",
+        descriptionKey: "configFields.idpSsoUrl.description",
         placeholder: "https://idp.example.com/sso",
       },
       {
         name: "idp_x509_cert",
-        label: "IdP X.509 Certificate",
+        labelKey: "configFields.idpX509Cert.label",
         kind: "textarea",
-        description:
-          "The IdP's signing certificate, used to verify assertions.",
+        descriptionKey: "configFields.idpX509Cert.description",
         placeholder: "-----BEGIN CERTIFICATE-----",
       },
       {
         name: "sp_entity_id",
-        label: "SP Entity ID",
+        labelKey: "configFields.spEntityId.label",
         kind: "text",
-        description: "This instance's entity ID, registered with the IdP.",
+        descriptionKey: "configFields.spEntityId.description",
         placeholder: "onyx",
       },
       {
         name: "sp_x509_cert",
-        label: "SP X.509 Certificate",
+        labelKey: "configFields.spX509Cert.label",
         kind: "textarea",
-        description:
-          "Only if this instance signs requests or decrypts assertions.",
+        descriptionKey: "configFields.spX509Cert.description",
         optional: true,
         placeholder: "-----BEGIN CERTIFICATE-----",
       },
       {
         name: "sp_private_key",
-        label: "SP Private Key",
+        labelKey: "configFields.spPrivateKey.label",
         kind: "password",
-        description:
-          "Private key paired with the SP certificate. Stored encrypted.",
+        descriptionKey: "configFields.spPrivateKey.description",
         optional: true,
         placeholder: "-----BEGIN PRIVATE KEY-----",
       },
       {
         name: "email_attribute",
-        label: "Email Attribute",
+        labelKey: "configFields.emailAttribute.label",
         kind: "text",
-        description:
-          "SAML attribute holding the user's email. Defaults to common keys.",
+        descriptionKey: "configFields.emailAttribute.description",
         optional: true,
-        placeholder: "email",
+        placeholderKey: "configFields.emailAttribute.placeholder",
       },
     ],
   };
 
-export async function copyRedirectUri(redirectUri: string): Promise<void> {
+export async function copyRedirectUri(
+  redirectUri: string,
+  t: SSOTranslate
+): Promise<void> {
   try {
     await navigator.clipboard.writeText(redirectUri);
-    toast.success("Redirect URI copied");
+    toast.success(t("copyRedirectUri.successToast"));
   } catch {
-    toast.error("Could not copy");
+    toast.error(t("copyRedirectUri.errorToast"));
   }
 }

--- a/web/src/lib/tracing/utils.ts
+++ b/web/src/lib/tracing/utils.ts
@@ -1,21 +1,30 @@
+import type { useTranslations } from "next-intl";
 import { SvgBraintrust, SvgLangfuse } from "@opal/logos";
 import type { IconFunctionComponent } from "@opal/types";
 import type { TracingProviderType } from "@/lib/tracing/types";
+
+export type TracingTranslate = ReturnType<
+  typeof useTranslations<"admin.tracing">
+>;
+export type TracingMessageKey = Parameters<TracingTranslate>[0];
 
 export interface TracingFieldSpec {
   // Form field name. The secret field is always sent as the provider `api_key`;
   // config field names map to keys in the provider `config` object.
   name: string;
-  label: string;
+  // The user-facing text lives in the "admin.tracing" catalog namespace.
+  labelKey: TracingMessageKey;
+  descriptionKey?: TracingMessageKey;
+  placeholderKey?: TracingMessageKey;
+  // URLs and default values are not translated.
   placeholder?: string;
-  help?: string;
   optional?: boolean;
   defaultValue?: string;
 }
 
 export interface TracingProviderDetail {
   label: string;
-  description: string;
+  descriptionKey: TracingMessageKey;
   logo: IconFunctionComponent;
   secretField: TracingFieldSpec;
   configFields: TracingFieldSpec[];
@@ -27,54 +36,52 @@ export const TRACING_PROVIDER_DETAILS: Record<
 > = {
   braintrust: {
     label: "Braintrust",
-    description: "LLM evaluation and monitoring",
+    descriptionKey: "providers.braintrust.description",
     logo: SvgBraintrust,
     secretField: {
       name: "api_key",
-      label: "API Key",
-      placeholder: "API Key",
-      help: "Paste your [API key](https://www.braintrust.dev/app) from Braintrust.",
+      labelKey: "providers.braintrust.fields.apiKey.label",
+      descriptionKey: "providers.braintrust.fields.apiKey.description",
     },
     configFields: [
       {
         name: "project",
-        label: "Project Name",
+        labelKey: "providers.braintrust.fields.project.label",
         placeholder: "Onyx",
         optional: true,
         defaultValue: "Onyx",
-        help: "Braintrust project name traces are logged to.",
+        descriptionKey: "providers.braintrust.fields.project.description",
       },
       {
         name: "api_url",
-        label: "API URL",
+        labelKey: "providers.braintrust.fields.apiUrl.label",
         placeholder: "https://api.braintrust.dev",
         optional: true,
-        help: "Default to the US region. Paste your Braintrust API URL for other regions or self-hosting.",
+        descriptionKey: "providers.braintrust.fields.apiUrl.description",
       },
     ],
   },
   langfuse: {
     label: "Langfuse",
-    description: "Cloud or self-hosted open-source observability platform",
+    descriptionKey: "providers.langfuse.description",
     logo: SvgLangfuse,
     secretField: {
       name: "api_key",
-      label: "Secret Key",
-      placeholder: "Secret Key",
-      help: "Paste your [API key](https://cloud.langfuse.com) from Langfuse.",
+      labelKey: "providers.langfuse.fields.secretKey.label",
+      descriptionKey: "providers.langfuse.fields.secretKey.description",
     },
     configFields: [
       {
         name: "public_key",
-        label: "Public Key",
-        placeholder: "Public Key",
+        labelKey: "providers.langfuse.fields.publicKey.label",
+        placeholderKey: "providers.langfuse.fields.publicKey.placeholder",
       },
       {
         name: "host",
-        label: "API Base URL",
+        labelKey: "providers.langfuse.fields.host.label",
         placeholder: "https://cloud.langfuse.com",
         optional: true,
-        help: "Default to EU region. Paste your Langfuse base URL for other regions or self-hosting.",
+        descriptionKey: "providers.langfuse.fields.host.description",
       },
     ],
   },

--- a/web/src/lib/webSearch/types.ts
+++ b/web/src/lib/webSearch/types.ts
@@ -1,4 +1,11 @@
+import type { useTranslations } from "next-intl";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
+
+// Registry text (content subtitles, config fields) lives in "admin.webSearch".
+export type WebSearchTranslate = ReturnType<
+  typeof useTranslations<"admin.webSearch">
+>;
+export type WebSearchMessageKey = Parameters<WebSearchTranslate>[0];
 
 // ── Provider type literals ────────────────────────────────────────────────────
 
@@ -97,15 +104,14 @@ export interface ConfigFieldSpec {
 
 export interface SearchProviderDetail {
   label: string;
+  // Brand or product name, not translated.
   subtitle: string;
-  helper: string;
   logo?: IconFunctionComponent;
   apiKeyUrl?: string;
 }
 
 export interface ContentProviderDetail {
   label: string;
-  subtitle: string;
-  description: string;
+  subtitleKey: WebSearchMessageKey;
   logo?: IconFunctionComponent;
 }

--- a/web/src/lib/webSearch/utils.ts
+++ b/web/src/lib/webSearch/utils.ts
@@ -18,6 +18,7 @@ import type {
   SearchProviderDetail,
   ContentProviderDetail,
   ConfigFieldSpec,
+  WebSearchTranslate,
 } from "@/lib/webSearch/types";
 
 // ── Search provider registry ──────────────────────────────────────────────────
@@ -29,21 +30,18 @@ export const SEARCH_PROVIDER_DETAILS: Record<
   exa: {
     label: "Exa",
     subtitle: "Exa.ai",
-    helper: "Connect to Exa to set up web search.",
     logo: SvgExa,
     apiKeyUrl: "https://dashboard.exa.ai/api-keys",
   },
   serper: {
     label: "Serper",
     subtitle: "Serper.dev",
-    helper: "Connect to Serper to set up web search.",
     logo: SvgSerper,
     apiKeyUrl: "https://serper.dev/api-key",
   },
   brave: {
     label: "Brave",
     subtitle: "Brave Search API",
-    helper: "Connect to Brave Search API to set up web search.",
     logo: SvgBrave,
     apiKeyUrl:
       "https://api-dashboard.search.brave.com/app/documentation/web-search/get-started",
@@ -51,20 +49,17 @@ export const SEARCH_PROVIDER_DETAILS: Record<
   google_pse: {
     label: "Google PSE",
     subtitle: "Google",
-    helper: "Connect to Google PSE to set up web search.",
     logo: SvgGoogle,
     apiKeyUrl: "https://programmablesearchengine.google.com/controlpanel/all",
   },
   searxng: {
     label: "SearXNG",
     subtitle: "SearXNG",
-    helper: "Connect to SearXNG to set up web search.",
     logo: SvgSearxng,
   },
   tavily: {
     label: "Tavily",
     subtitle: "Tavily AI",
-    helper: "Connect to Tavily to set up web search.",
     apiKeyUrl: "https://app.tavily.com/home",
     logo: SvgTavily,
   },
@@ -226,29 +221,21 @@ export function getSingleConfigFieldValueForForm(
 export const CONTENT_PROVIDER_DETAILS: Record<string, ContentProviderDetail> = {
   onyx_web_crawler: {
     label: "Onyx Web Crawler",
-    subtitle:
-      "Built-in web crawler. Works for most pages but less performant in edge cases.",
-    description:
-      "Onyx's built-in crawler processes URLs returned by your search engine.",
+    subtitleKey: "contentProviders.onyxWebCrawler.subtitle",
   },
   firecrawl: {
     label: "Firecrawl",
-    subtitle: "Leading open-source crawler.",
-    description:
-      "Connect Firecrawl to fetch and summarize page content from search results.",
+    subtitleKey: "contentProviders.firecrawl.subtitle",
     logo: SvgFirecrawl,
   },
   exa: {
     label: "Exa",
-    subtitle: "Exa.ai",
-    description:
-      "Use Exa to fetch and summarize page content from search results.",
+    subtitleKey: "contentProviders.exa.subtitle",
     logo: SvgExa,
   },
   tavily: {
     label: "Tavily",
-    subtitle: "Tavily AI",
-    description: "Use Tavily to extract page content from URLs.",
+    subtitleKey: "contentProviders.tavily.subtitle",
     logo: SvgTavily,
   },
 };
@@ -379,38 +366,36 @@ export function getSingleContentConfigFieldValueForForm(
 // ── Config field specs ────────────────────────────────────────────────────────
 
 export function getSearchConfigField(
-  providerType: string
+  providerType: string,
+  t: WebSearchTranslate
 ): ConfigFieldSpec | undefined {
   if (providerType === "google_pse") {
     return {
-      title: "Search Engine ID",
-      placeholder: "Enter your search engine ID",
-      subDescription: markdown(
-        "Paste your [search engine ID](https://programmablesearchengine.google.com/controlpanel/all) to use for web search."
-      ),
+      title: t("configFields.searchEngineId.label"),
+      placeholder: t("configFields.searchEngineId.placeholder"),
+      subDescription: markdown(t("configFields.searchEngineId.description")),
     };
   }
   if (providerType === "searxng") {
     return {
-      title: "SearXNG Base URL",
+      title: t("configFields.searxngBaseUrl.label"),
       placeholder: "https://your-searxng-instance.com",
-      subDescription: markdown(
-        "Paste the base URL of your [SearXNG instance](https://docs.searxng.org/admin/installation.html)."
-      ),
+      subDescription: markdown(t("configFields.searxngBaseUrl.description")),
     };
   }
   return undefined;
 }
 
 export function getContentConfigField(
-  providerType: string
+  providerType: string,
+  t: WebSearchTranslate
 ): ConfigFieldSpec | undefined {
   if (providerType === "firecrawl") {
     return {
-      title: "API Base URL",
+      title: t("configFields.firecrawlBaseUrl.label"),
       placeholder: "https://api.firecrawl.dev/v2/scrape",
       defaultValue: "https://api.firecrawl.dev/v2/scrape",
-      subDescription: "Your Firecrawl API base URL.",
+      subDescription: t("configFields.firecrawlBaseUrl.description"),
     };
   }
   return undefined;

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -29,6 +29,7 @@ import {
   CREATABLE_SSO_PROVIDER_TYPES,
   SSO_PROVIDER_DETAILS,
   type SSOConfigField,
+  type SSOTranslate,
 } from "@/lib/sso/utils";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
@@ -64,8 +65,6 @@ const ALL_CONFIG_FIELDS: SSOConfigField[] = Array.from(
   ).values()
 );
 
-type SSOTranslate = ReturnType<typeof useTranslations<"admin.ssoProviders">>;
-
 function configSchemaForType(fields: SSOConfigField[], t: SSOTranslate) {
   const shape: Record<string, Yup.AnySchema> = {};
   for (const field of fields) {
@@ -80,7 +79,9 @@ function configSchemaForType(fields: SSOConfigField[], t: SSOTranslate) {
     shape[field.name] = field.optional
       ? Yup.string().optional()
       : Yup.string().required(
-          t("modals.provider.validation.fieldRequired", { field: field.label })
+          t("modals.provider.validation.fieldRequired", {
+            field: t(field.labelKey),
+          })
         );
   }
   return Yup.object(shape);
@@ -222,26 +223,30 @@ function ConfigInput({
   field: SSOConfigField;
   isEditing: boolean;
 }) {
+  const t = useTranslations("admin.ssoProviders");
   const name = `config.${field.name}`;
+  const placeholder = field.placeholderKey
+    ? t(field.placeholderKey)
+    : field.placeholder;
   if (field.kind === "switch") {
     return <SwitchField name={name} />;
   }
   if (field.kind === "chips") {
-    return <TagListField name={name} placeholder={field.placeholder} />;
+    return <TagListField name={name} placeholder={placeholder} />;
   }
   if (field.kind === "textarea") {
-    return <InputTextAreaField name={name} placeholder={field.placeholder} />;
+    return <InputTextAreaField name={name} placeholder={placeholder} />;
   }
   if (field.kind === "password") {
     return (
       <PasswordInputTypeInField
         name={name}
-        placeholder={field.placeholder}
+        placeholder={placeholder}
         isNonRevealable={isEditing}
       />
     );
   }
-  return <InputTypeInField name={name} placeholder={field.placeholder} />;
+  return <InputTypeInField name={name} placeholder={placeholder} />;
 }
 
 export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
@@ -375,7 +380,7 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                               key={type}
                               value={type}
                               icon={detail.icon}
-                              description={detail.description}
+                              description={t(detail.descriptionKey)}
                               wrapDescription
                             >
                               {detail.label}
@@ -419,11 +424,11 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                       title={
                         field.optional
                           ? t("modals.provider.configField.optionalTitle", {
-                              label: field.label,
+                              label: t(field.labelKey),
                             })
-                          : field.label
+                          : t(field.labelKey)
                       }
-                      description={field.description}
+                      description={t(field.descriptionKey)}
                       withLabel={`config.${field.name}`}
                     >
                       <ConfigInput field={field} isEditing={isEditing} />

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import useSWR, { useSWRConfig } from "swr";
 import useGroupMemberCandidates from "./useGroupMemberCandidates";
+import { displayGroupName } from "@/views/admin/GroupsPage/utils";
 import {
   Button,
   Card,
@@ -649,7 +650,9 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 </Text>
                 <InputTypeIn
                   placeholder={t("form.name.placeholder")}
-                  value={groupName}
+                  value={
+                    isDefaultGroup ? displayGroupName(group, t) : groupName
+                  }
                   variant={canManage ? "primary" : "readOnly"}
                   onChange={(e) => setGroupName(e.target.value)}
                 />

--- a/web/src/views/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/views/admin/GroupsPage/GroupCard.tsx
@@ -12,9 +12,10 @@ import Text from "@/refresh-components/texts/Text";
 import {
   isBuiltInGroup,
   buildGroupDescription,
+  displayGroupName,
   formatMemberCount,
-} from "./utils";
-import { refreshGroupLists, renameGroup } from "./svc";
+} from "@/views/admin/GroupsPage/utils";
+import { refreshGroupLists, renameGroup } from "@/views/admin/GroupsPage/svc";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { can } from "@/lib/permissions/resource-actions";
@@ -52,8 +53,8 @@ function GroupCard({ group }: GroupCardProps) {
       <Section alignItems="start" height="fit">
         <ContentAction
           icon={isAdmin ? SvgUserManage : SvgUsers}
-          title={group.name}
-          description={buildGroupDescription(group)}
+          title={displayGroupName(group, t)}
+          description={buildGroupDescription(group, t)}
           sizePreset="main-content"
           variant="section"
           tag={builtIn ? { title: t("card.defaultTag.label") } : undefined}
@@ -64,7 +65,8 @@ function GroupCard({ group }: GroupCardProps) {
               <div className="py-1">
                 <Text mainUiBody text03>
                   {formatMemberCount(
-                    group.users.filter((u) => u.is_active).length
+                    group.users.filter((u) => u.is_active).length,
+                    t
                   )}
                 </Text>
               </div>

--- a/web/src/views/admin/GroupsPage/__tests__/utils.test.ts
+++ b/web/src/views/admin/GroupsPage/__tests__/utils.test.ts
@@ -1,0 +1,80 @@
+import { createTranslator } from "next-intl";
+import en from "@/i18n/messages/en.json";
+import ar from "@/i18n/messages/ar.json";
+import type { UserGroup } from "@/lib/types";
+import {
+  buildGroupDescription,
+  displayGroupName,
+  formatMemberCount,
+  type GroupsTranslate,
+} from "@/views/admin/GroupsPage/utils";
+
+const tEn = createTranslator({
+  locale: "en",
+  messages: en,
+  namespace: "admin.groups",
+}) as GroupsTranslate;
+const tAr = createTranslator({
+  locale: "ar",
+  messages: ar,
+  namespace: "admin.groups",
+}) as GroupsTranslate;
+
+function group(overrides: Partial<UserGroup>): UserGroup {
+  return {
+    id: 1,
+    name: "Team",
+    is_default: false,
+    is_up_to_date: true,
+    users: [],
+    cc_pairs: [],
+    document_sets: [],
+    personas: [],
+    ...overrides,
+  } as UserGroup;
+}
+
+describe("displayGroupName", () => {
+  it("translates the two built-in groups and leaves custom names alone", () => {
+    expect(
+      displayGroupName(group({ name: "Admin", is_default: true }), tAr)
+    ).toBe("المشرفون");
+    expect(
+      displayGroupName(group({ name: "Basic", is_default: true }), tAr)
+    ).toBe("أساسي");
+    expect(displayGroupName(group({ name: "Admin" }), tAr)).toBe("Admin");
+  });
+});
+
+describe("buildGroupDescription", () => {
+  it("describes built-in groups from the catalog", () => {
+    expect(
+      buildGroupDescription(group({ name: "Basic", is_default: true }), tEn)
+    ).toBe("Default group for all users with basic permissions.");
+  });
+
+  it("pluralizes resource counts and joins them", () => {
+    const custom = group({
+      cc_pairs: [{}, {}, {}] as UserGroup["cc_pairs"],
+      document_sets: [{}] as UserGroup["document_sets"],
+      personas: [{}, {}] as UserGroup["personas"],
+    });
+    expect(buildGroupDescription(custom, tEn)).toBe(
+      "3 connectors · 1 document set · 2 agents"
+    );
+  });
+
+  it("falls back to the empty label", () => {
+    expect(buildGroupDescription(group({}), tEn)).toBe(
+      "No private connectors / document sets / agents"
+    );
+  });
+});
+
+describe("formatMemberCount", () => {
+  it("pluralizes in English and uses the Arabic forms", () => {
+    expect(formatMemberCount(1, tEn)).toBe("1 Member");
+    expect(formatMemberCount(306, tEn)).toBe("306 Members");
+    expect(formatMemberCount(2, tAr)).toBe("عضوان");
+  });
+});

--- a/web/src/views/admin/GroupsPage/utils.ts
+++ b/web/src/views/admin/GroupsPage/utils.ts
@@ -1,15 +1,34 @@
+import type { useTranslations } from "next-intl";
 import type { UserGroup } from "@/lib/types";
+
+export type GroupsTranslate = ReturnType<
+  typeof useTranslations<"admin.groups">
+>;
 
 /** Whether this group is a system default group (Admin, Basic). */
 export function isBuiltInGroup(group: UserGroup): boolean {
   return group.is_default;
 }
 
-/** Human-readable description for built-in groups. */
-const BUILT_IN_DESCRIPTIONS: Record<string, string> = {
-  Basic: "Default group for all users with basic permissions.",
-  Admin: "Built-in admin group with full access to manage all permissions.",
-};
+// The two built-in groups the backend creates, keyed by their stored name.
+const BUILT_IN_GROUP_KEYS = { Admin: "admin", Basic: "basic" } as const;
+
+function builtInGroupKey(group: UserGroup) {
+  if (
+    !isBuiltInGroup(group) ||
+    !Object.prototype.hasOwnProperty.call(BUILT_IN_GROUP_KEYS, group.name)
+  ) {
+    return undefined;
+  }
+  // SAFETY: the own-property check above proves the name is a key of the map.
+  return BUILT_IN_GROUP_KEYS[group.name as keyof typeof BUILT_IN_GROUP_KEYS];
+}
+
+/** The group name as shown to the user. Built-in names are translated. */
+export function displayGroupName(group: UserGroup, t: GroupsTranslate): string {
+  const key = builtInGroupKey(group);
+  return key ? t(`builtIn.${key}.name`) : group.name;
+}
 
 /**
  * Build the description line(s) shown beneath the group name.
@@ -18,38 +37,40 @@ const BUILT_IN_DESCRIPTIONS: Record<string, string> = {
  * Custom groups list resource counts ("3 connectors · 2 document sets · 2 agents")
  * or fall back to "No private connectors / document sets / agents".
  */
-export function buildGroupDescription(group: UserGroup): string {
+export function buildGroupDescription(
+  group: UserGroup,
+  t: GroupsTranslate
+): string {
   if (isBuiltInGroup(group)) {
-    return BUILT_IN_DESCRIPTIONS[group.name] ?? "";
+    const key = builtInGroupKey(group);
+    return key ? t(`builtIn.${key}.description`) : "";
   }
 
   const parts: string[] = [];
   if (group.cc_pairs.length > 0) {
     parts.push(
-      `${group.cc_pairs.length} connector${
-        group.cc_pairs.length !== 1 ? "s" : ""
-      }`
+      t("card.resourceCounts.connectors", { count: group.cc_pairs.length })
     );
   }
   if (group.document_sets.length > 0) {
     parts.push(
-      `${group.document_sets.length} document set${
-        group.document_sets.length !== 1 ? "s" : ""
-      }`
+      t("card.resourceCounts.documentSets", {
+        count: group.document_sets.length,
+      })
     );
   }
   if (group.personas.length > 0) {
     parts.push(
-      `${group.personas.length} agent${group.personas.length !== 1 ? "s" : ""}`
+      t("card.resourceCounts.agents", { count: group.personas.length })
     );
   }
 
   return parts.length > 0
     ? parts.join(" · ")
-    : "No private connectors / document sets / agents";
+    : t("card.resourceCounts.noPrivateResources");
 }
 
 /** Format the member count badge, e.g. "306 Members" or "1 Member". */
-export function formatMemberCount(count: number): string {
-  return `${count} ${count === 1 ? "Member" : "Members"}`;
+export function formatMemberCount(count: number, t: GroupsTranslate): string {
+  return t("card.memberCount", { count });
 }

--- a/web/src/views/admin/GroupsPage/utils.ts
+++ b/web/src/views/admin/GroupsPage/utils.ts
@@ -65,9 +65,11 @@ export function buildGroupDescription(
     );
   }
 
-  return parts.length > 0
-    ? parts.join(" · ")
-    : t("card.resourceCounts.noPrivateResources");
+  if (parts.length === 0) return t("card.resourceCounts.noPrivateResources");
+  // One pair message per join so translators own the separator and its order.
+  return parts.reduce((first, rest) =>
+    t("card.resourceCounts.joined", { first, rest })
+  );
 }
 
 /** Format the member count badge, e.g. "306 Members" or "1 Member". */

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -66,6 +66,7 @@ import {
   CLOUD_BASED_PROVIDERS,
   CUSTOM_PROVIDER,
   SELF_HOSTED_PROVIDERS,
+  embeddingModelDescription,
   findProvider,
   findRegistryModel,
   isCloudBased,
@@ -584,7 +585,7 @@ function EmbeddingModelCard({
           <Content
             icon={provider.icon}
             title={model.modelName}
-            description={model.description}
+            description={embeddingModelDescription(model, t)}
             sizePreset="main-ui"
             variant="section"
           />
@@ -717,7 +718,6 @@ export default function IndexSettingsPage() {
       normalize: currentEmbeddingModel.normalize,
       queryPrefix: currentEmbeddingModel.query_prefix,
       passagePrefix: currentEmbeddingModel.passage_prefix,
-      description: "",
     };
   }, [currentEmbeddingModel]);
 
@@ -1665,11 +1665,12 @@ export default function IndexSettingsPage() {
                                           currentProvider?.icon ?? SvgServer
                                         }
                                         title={currentEmbeddingModel.model_name}
-                                        description={
+                                        description={embeddingModelDescription(
                                           findRegistryModel(
                                             currentEmbeddingModel.model_name
-                                          )?.description
-                                        }
+                                          ),
+                                          t
+                                        )}
                                         sizePreset="main-ui"
                                         variant="section"
                                       />

--- a/web/src/views/admin/IndexSettingsPage/shared.tsx
+++ b/web/src/views/admin/IndexSettingsPage/shared.tsx
@@ -8,16 +8,13 @@ import { markdown } from "@opal/utils";
 import { Divider, Text } from "@opal/components";
 import type { RichStr } from "@opal/types";
 import { InputHorizontal, InputVertical } from "@opal/layouts";
-import type { EmbeddingProvider } from "@/lib/indexing/types";
+import type {
+  EmbeddingProvider,
+  IndexSettingsTranslator,
+} from "@/lib/indexing/types";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
-
-/** Translator for the `admin.indexSettings` namespace, threaded into helpers
- *  that live outside a component and so cannot call the hook themselves. */
-export type IndexSettingsTranslator = ReturnType<
-  typeof useTranslations<"admin.indexSettings">
->;
 
 // ---------------------------------------------------------------------------
 // Formik-aware field components

--- a/web/src/views/admin/SSOProvidersPage.tsx
+++ b/web/src/views/admin/SSOProvidersPage.tsx
@@ -178,7 +178,7 @@ export default function SSOProvidersPage() {
                           tooltip={t("copyRedirectUri.tooltip")}
                           disabled={isPending}
                           onClick={() => {
-                            void copyRedirectUri(provider.redirect_uri);
+                            void copyRedirectUri(provider.redirect_uri, t);
                           }}
                         />
                         <Switch

--- a/web/src/views/admin/TracingPage/TracingSetupModal.tsx
+++ b/web/src/views/admin/TracingPage/TracingSetupModal.tsx
@@ -55,14 +55,14 @@ export function TracingSetupModal({ state, onSaved }: TracingSetupModalProps) {
     [detail.secretField.name]: hasStoredKey
       ? Yup.string()
       : Yup.string().required(
-          t("field.required.error", { label: detail.secretField.label })
+          t("field.required.error", { label: t(detail.secretField.labelKey) })
         ),
   };
   for (const field of detail.configFields) {
     shape[field.name] = field.optional
       ? Yup.string()
       : Yup.string().required(
-          t("field.required.error", { label: field.label })
+          t("field.required.error", { label: t(field.labelKey) })
         );
   }
   const validationSchema = Yup.object().shape(shape);

--- a/web/src/views/admin/TracingPage/index.tsx
+++ b/web/src/views/admin/TracingPage/index.tsx
@@ -95,7 +95,7 @@ export default function TracingPage() {
                 key={providerType}
                 icon={detail.logo}
                 title={detail.label}
-                description={detail.description}
+                description={t(detail.descriptionKey)}
                 status={connected ? "selected" : "disconnected"}
                 selectedLabel={t("provider.connected.label")}
                 onConnect={() => {

--- a/web/src/views/admin/TracingPage/shared.tsx
+++ b/web/src/views/admin/TracingPage/shared.tsx
@@ -13,20 +13,23 @@ interface SecretFieldProps {
 
 export function SecretField({ field }: SecretFieldProps) {
   const t = useTranslations("admin.tracing");
+  const label = t(field.labelKey);
 
   return (
     <InputVertical
-      title={
-        field.optional
-          ? t("field.optional.title", { label: field.label })
-          : field.label
-      }
+      title={field.optional ? t("field.optional.title", { label }) : label}
       withLabel={field.name}
-      subDescription={field.help ? markdown(field.help) : undefined}
+      subDescription={
+        field.descriptionKey ? markdown(t(field.descriptionKey)) : undefined
+      }
     >
       <PasswordInputTypeInField
         name={field.name}
-        placeholder={field.placeholder ?? field.label}
+        placeholder={
+          field.placeholderKey
+            ? t(field.placeholderKey)
+            : (field.placeholder ?? label)
+        }
       />
     </InputVertical>
   );
@@ -38,20 +41,23 @@ interface ConfigFieldProps {
 
 export function ConfigField({ field }: ConfigFieldProps) {
   const t = useTranslations("admin.tracing");
+  const label = t(field.labelKey);
 
   return (
     <InputVertical
-      title={
-        field.optional
-          ? t("field.optional.title", { label: field.label })
-          : field.label
-      }
+      title={field.optional ? t("field.optional.title", { label }) : label}
       withLabel={field.name}
-      subDescription={field.help ? markdown(field.help) : undefined}
+      subDescription={
+        field.descriptionKey ? markdown(t(field.descriptionKey)) : undefined
+      }
     >
       <InputTypeInField
         name={field.name}
-        placeholder={field.placeholder ?? ""}
+        placeholder={
+          field.placeholderKey
+            ? t(field.placeholderKey)
+            : (field.placeholder ?? "")
+        }
       />
     </InputVertical>
   );

--- a/web/src/views/admin/WebSearchPage/WebSearchSetupModal.tsx
+++ b/web/src/views/admin/WebSearchPage/WebSearchSetupModal.tsx
@@ -102,8 +102,8 @@ export function WebSearchSetupModal({ state }: WebSearchSetupModalProps) {
 
   const configField =
     category === "search"
-      ? getSearchConfigField(providerType)
-      : getContentConfigField(providerType);
+      ? getSearchConfigField(providerType, t)
+      : getContentConfigField(providerType, t);
 
   const providerLabel =
     category === "search"

--- a/web/src/views/admin/WebSearchPage/index.tsx
+++ b/web/src/views/admin/WebSearchPage/index.tsx
@@ -484,9 +484,11 @@ export default function WebSearchPage() {
                   CONTENT_PROVIDER_DETAILS[provider.provider_type]?.label ||
                   provider.provider_type;
 
-                const subtitle =
-                  CONTENT_PROVIDER_DETAILS[provider.provider_type]?.subtitle ||
-                  provider.provider_type;
+                const subtitleKey =
+                  CONTENT_PROVIDER_DETAILS[provider.provider_type]?.subtitleKey;
+                const subtitle = subtitleKey
+                  ? t(subtitleKey)
+                  : provider.provider_type;
 
                 const providerId = provider.id;
                 const isConfigured = isContentProviderConfigured(


### PR DESCRIPTION
## Description

**Bug**: with the UI set to Arabic, text that is built in code instead of the catalog still shows in English: the internal search header, the usage price and token rows, the web search, embedding, tracing and SSO registries, the built-in group names and resource counts, and the hook point names the backend sends.

**Fix**: move every one of them into the next-intl catalog, all nine locales.

- The search header and time window take the timeline translator and the locale, so the date follows the UI language too.
- Registries stay data and carry catalog keys typed against their namespace, so a missing key fails `types:check`. Consumers resolve them with the translator they already have. Brand names, URLs and ids stay literal.
- Hook point names map the backend id to a catalog entry and fall back to the API text for an unknown id, sorted in the UI locale.
- Built-in group names, descriptions, resource counts and member counts use ICU plurals. Lists of translated counts (group resources, usage token labels) join through a pair message so translators own the separator.

Stacked on #14552 (part 1, Opal locale). Part 3 is #14564 (backend reply language). The tools footer count is #14581 on main and is not touched here. Connector display names (Web, File, Google Storage) are not touched.

| Page | Arabic |
| --- | --- |
| Groups | ![groups](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-catalog-strings/pr2-after-groups-ar.jpg) |
| Hooks | ![hooks](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-catalog-strings/pr2-after-hooks-ar.jpg) |
| SSO modal | ![sso](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-catalog-strings/pr2-after-sso-modal-ar.jpg) |

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01FKRTAPBZHBE1mc44bkxkWe
