### PR TITLE
fix(i18n): Translate the enabled-count phrase

### DIFF
--- a/mobile/src/components/ui/text.tsx
+++ b/mobile/src/components/ui/text.tsx
@@ -43,6 +43,7 @@ const COLOR_CONFIG: Record<TextColor, string | null> = {
   "text-light-05": "text-text-light-05",
   "text-dark-03": "text-text-dark-03",
   "text-dark-05": "text-text-dark-05",
+  "action-selection-05": "text-action-selection-05",
   "status-error-01": "text-status-error-01",
   "status-error-02": "text-status-error-02",
   "status-error-05": "text-status-error-05",

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -133,6 +133,7 @@ const COLOR_CONFIG: Record<TextColor, string | null> = {
   "text-light-05": "text-text-light-05",
   "text-dark-03": "text-text-dark-03",
   "text-dark-05": "text-text-dark-05",
+  "action-selection-05": "text-action-selection-05",
   "status-error-01": "text-status-error-01",
   "status-error-02": "text-status-error-02",
   "status-error-05": "text-status-error-05",

--- a/web/lib/shared/src/contracts/typography.ts
+++ b/web/lib/shared/src/contracts/typography.ts
@@ -47,6 +47,7 @@ export type TextColor =
   | "text-light-05"
   | "text-dark-03"
   | "text-dark-05"
+  | "action-selection-05"
   | "status-error-01"
   | "status-error-02"
   | "status-error-05"

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "حفظ"
       }
     },
+    "enabledCount": {
+      "label": "<value>{enabled}</value> من {total}",
+      "tools": "{total, plural, one {<value>{enabled}</value> من {total} أداة} other {<value>{enabled}</value> من {total} أدوات}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "<value>{enabled}</value> من {total}",
-      "tools": "{total, plural, one {<value>{enabled}</value> من {total} أداة} other {<value>{enabled}</value> من {total} أدوات}}"
+      "label": "<value>{enabled}</value> من {total}"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "Speichern"
       }
     },
+    "enabledCount": {
+      "label": "<value>{enabled}</value> von {total}",
+      "tools": "{total, plural, one {<value>{enabled}</value> von {total} Tool} other {<value>{enabled}</value> von {total} Tools}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "<value>{enabled}</value> von {total}",
-      "tools": "{total, plural, one {<value>{enabled}</value> von {total} Tool} other {<value>{enabled}</value> von {total} Tools}}"
+      "label": "<value>{enabled}</value> von {total}"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "Save"
       }
     },
+    "enabledCount": {
+      "label": "<value>{enabled}</value> of {total}",
+      "tools": "{total, plural, one {<value>{enabled}</value> of {total} tool} other {<value>{enabled}</value> of {total} tools}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "<value>{enabled}</value> of {total}",
-      "tools": "{total, plural, one {<value>{enabled}</value> of {total} tool} other {<value>{enabled}</value> of {total} tools}}"
+      "label": "<value>{enabled}</value> of {total}"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "<value>{enabled}</value> de {total}",
-      "tools": "{total, plural, one {<value>{enabled}</value> de {total} herramienta} other {<value>{enabled}</value> de {total} herramientas}}"
+      "label": "<value>{enabled}</value> de {total}"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "Guardar"
       }
     },
+    "enabledCount": {
+      "label": "<value>{enabled}</value> de {total}",
+      "tools": "{total, plural, one {<value>{enabled}</value> de {total} herramienta} other {<value>{enabled}</value> de {total} herramientas}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "Enregistrer"
       }
     },
+    "enabledCount": {
+      "label": "<value>{enabled}</value> sur {total}",
+      "tools": "{total, plural, one {<value>{enabled}</value> sur {total} outil} other {<value>{enabled}</value> sur {total} outils}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "<value>{enabled}</value> sur {total}",
-      "tools": "{total, plural, one {<value>{enabled}</value> sur {total} outil} other {<value>{enabled}</value> sur {total} outils}}"
+      "label": "<value>{enabled}</value> sur {total}"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "{total} 中 <value>{enabled}</value>",
-      "tools": "{total, plural, one {{total} 個中 <value>{enabled}</value> 個のツール} other {{total} 個中 <value>{enabled}</value> 個のツール}}"
+      "label": "{total} 中 <value>{enabled}</value>"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "保存"
       }
     },
+    "enabledCount": {
+      "label": "{total} 中 <value>{enabled}</value>",
+      "tools": "{total, plural, one {{total} 個中 <value>{enabled}</value> 個のツール} other {{total} 個中 <value>{enabled}</value> 個のツール}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "{total}개 중 <value>{enabled}</value>개",
-      "tools": "{total, plural, one {{total}개 도구 중 <value>{enabled}</value>개} other {{total}개 도구 중 <value>{enabled}</value>개}}"
+      "label": "{total}개 중 <value>{enabled}</value>개"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "저장"
       }
     },
+    "enabledCount": {
+      "label": "{total}개 중 <value>{enabled}</value>개",
+      "tools": "{total, plural, one {{total}개 도구 중 <value>{enabled}</value>개} other {{total}개 도구 중 <value>{enabled}</value>개}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "<value>{enabled}</value> de {total}",
-      "tools": "{total, plural, one {<value>{enabled}</value> de {total} ferramenta} other {<value>{enabled}</value> de {total} ferramentas}}"
+      "label": "<value>{enabled}</value> de {total}"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "Salvar"
       }
     },
+    "enabledCount": {
+      "label": "<value>{enabled}</value> de {total}",
+      "tools": "{total, plural, one {<value>{enabled}</value> de {total} ferramenta} other {<value>{enabled}</value> de {total} ferramentas}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -10730,6 +10730,10 @@
         "ariaLabel": "保存"
       }
     },
+    "enabledCount": {
+      "label": "{total} 个中的 <value>{enabled}</value> 个",
+      "tools": "{total, plural, one {{total} 个工具中的 <value>{enabled}</value> 个} other {{total} 个工具中的 <value>{enabled}</value> 个}}"
+    },
     "errorPages": {
       "accessRestricted": {
         "billingAdminHint": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -10731,8 +10731,7 @@
       }
     },
     "enabledCount": {
-      "label": "{total} 个中的 <value>{enabled}</value> 个",
-      "tools": "{total, plural, one {{total} 个工具中的 <value>{enabled}</value> 个} other {{total} 个工具中的 <value>{enabled}</value> 个}}"
+      "label": "{total} 个中的 <value>{enabled}</value> 个"
     },
     "errorPages": {
       "accessRestricted": {

--- a/web/src/lib/tools/components/EnabledCount.stories.tsx
+++ b/web/src/lib/tools/components/EnabledCount.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import EnabledCount from "./EnabledCount";
 
 const meta: Meta<typeof EnabledCount> = {
-  title: "refresh-components/EnabledCount",
+  title: "tools/EnabledCount",
   component: EnabledCount,
   tags: ["autodocs"],
   parameters: {
@@ -20,17 +20,8 @@ export const Default: Story = {
   },
 };
 
-export const WithNoun: Story = {
-  args: {
-    noun: "tool",
-    enabledCount: 3,
-    totalCount: 10,
-  },
-};
-
 export const AllEnabled: Story = {
   args: {
-    noun: "tool",
     enabledCount: 8,
     totalCount: 8,
   },
@@ -38,16 +29,13 @@ export const AllEnabled: Story = {
 
 export const NoneEnabled: Story = {
   args: {
-    noun: "tool",
     enabledCount: 0,
     totalCount: 15,
   },
 };
 
-/** The singular branch of the plural: "1 of 1 tool", not "tools". */
 export const SingleItem: Story = {
   args: {
-    noun: "tool",
     enabledCount: 1,
     totalCount: 1,
   },

--- a/web/src/lib/tools/components/EnabledCount.stories.tsx
+++ b/web/src/lib/tools/components/EnabledCount.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import EnabledCount from "./EnabledCount";
+import EnabledCount from "@/lib/tools/components/EnabledCount";
 
 const meta: Meta<typeof EnabledCount> = {
   title: "tools/EnabledCount",

--- a/web/src/lib/tools/components/EnabledCount.tsx
+++ b/web/src/lib/tools/components/EnabledCount.tsx
@@ -8,16 +8,15 @@ import { richNodes } from "@opal/utils";
 interface EnabledCountProps {
   enabledCount: number;
   totalCount: number;
-  /**
-   * What is being counted, when the count reads better with the noun spelled
-   * out. A fixed set rather than free text: every noun needs its own plural
-   * forms in each locale, so it cannot be supplied by the caller.
-   */
-  noun?: "tool";
 }
 
+/**
+ * How many of a set of tools are switched on, e.g. "3 of 12".
+ *
+ * The noun is left to the surrounding row, which already names what is being
+ * counted — every call site is a tool context.
+ */
 export default function EnabledCount({
-  noun,
   enabledCount,
   totalCount,
 }: EnabledCountProps) {
@@ -33,17 +32,11 @@ export default function EnabledCount({
   return (
     <Text color="text-03">
       {richNodes(
-        noun === "tool"
-          ? t.rich("enabledCount.tools", {
-              enabled: enabledCount,
-              total: totalCount,
-              value,
-            })
-          : t.rich("enabledCount.label", {
-              enabled: enabledCount,
-              total: totalCount,
-              value,
-            })
+        t.rich("enabledCount.label", {
+          enabled: enabledCount,
+          total: totalCount,
+          value,
+        })
       )}
     </Text>
   );

--- a/web/src/lib/tools/components/MCPLineItem.tsx
+++ b/web/src/lib/tools/components/MCPLineItem.tsx
@@ -19,7 +19,7 @@ import {
   MCPAuthenticationPerformer,
   ToolSnapshot,
 } from "@/lib/tools/types";
-import EnabledCount from "./EnabledCount";
+import EnabledCount from "@/lib/tools/components/EnabledCount";
 
 export interface MCPServer {
   id: number;

--- a/web/src/lib/tools/components/MCPLineItem.tsx
+++ b/web/src/lib/tools/components/MCPLineItem.tsx
@@ -19,7 +19,7 @@ import {
   MCPAuthenticationPerformer,
   ToolSnapshot,
 } from "@/lib/tools/types";
-import EnabledCount from "@/refresh-components/EnabledCount";
+import EnabledCount from "./EnabledCount";
 
 export interface MCPServer {
   id: number;

--- a/web/src/lib/tools/components/ToolLineItem.tsx
+++ b/web/src/lib/tools/components/ToolLineItem.tsx
@@ -29,7 +29,7 @@ import { useToolsPopover } from "@/lib/tools/providers";
 import { ToolSnapshot } from "@/lib/tools/types";
 import { getAdminConfigureInfo, getToolTooltip } from "@/lib/tools/utils";
 import { Permission } from "@/lib/types";
-import EnabledCount from "@/refresh-components/EnabledCount";
+import EnabledCount from "./EnabledCount";
 import { useUser } from "@/providers/UserProvider";
 
 // Names the hover group that swaps the source count for the disable button.

--- a/web/src/lib/tools/components/ToolLineItem.tsx
+++ b/web/src/lib/tools/components/ToolLineItem.tsx
@@ -29,7 +29,7 @@ import { useToolsPopover } from "@/lib/tools/providers";
 import { ToolSnapshot } from "@/lib/tools/types";
 import { getAdminConfigureInfo, getToolTooltip } from "@/lib/tools/utils";
 import { Permission } from "@/lib/types";
-import EnabledCount from "./EnabledCount";
+import EnabledCount from "@/lib/tools/components/EnabledCount";
 import { useUser } from "@/providers/UserProvider";
 
 // Names the hover group that swaps the source count for the disable button.

--- a/web/src/refresh-components/EnabledCount.stories.tsx
+++ b/web/src/refresh-components/EnabledCount.stories.tsx
@@ -20,9 +20,9 @@ export const Default: Story = {
   },
 };
 
-export const WithName: Story = {
+export const WithNoun: Story = {
   args: {
-    name: "connector",
+    noun: "tool",
     enabledCount: 3,
     totalCount: 10,
   },
@@ -30,7 +30,7 @@ export const WithName: Story = {
 
 export const AllEnabled: Story = {
   args: {
-    name: "source",
+    noun: "tool",
     enabledCount: 8,
     totalCount: 8,
   },
@@ -38,15 +38,16 @@ export const AllEnabled: Story = {
 
 export const NoneEnabled: Story = {
   args: {
-    name: "item",
+    noun: "tool",
     enabledCount: 0,
     totalCount: 15,
   },
 };
 
+/** The singular branch of the plural: "1 of 1 tool", not "tools". */
 export const SingleItem: Story = {
   args: {
-    name: "document",
+    noun: "tool",
     enabledCount: 1,
     totalCount: 1,
   },

--- a/web/src/refresh-components/EnabledCount.tsx
+++ b/web/src/refresh-components/EnabledCount.tsx
@@ -1,24 +1,46 @@
 "use client";
 
-import { memo } from "react";
+import { memo, type ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import Text from "@/refresh-components/texts/Text";
 
 interface EnabledCountProps {
-  name?: string;
   enabledCount: number;
   totalCount: number;
+  /**
+   * What is being counted, when the count reads better with the noun spelled
+   * out. A fixed set rather than free text: every noun needs its own plural
+   * forms in each locale, so it cannot be supplied by the caller.
+   */
+  noun?: "tool";
 }
 
 const EnabledCount = memo(
-  ({ name, enabledCount, totalCount }: EnabledCountProps) => {
+  ({ noun, enabledCount, totalCount }: EnabledCountProps) => {
+    const t = useTranslations("common");
+
+    // The enabled figure is picked out from the rest of the phrase. It has to
+    // be a tag rather than a separate element, because where the number falls
+    // in the sentence is the translation's business, not this component's.
+    const value = (chunks: ReactNode) => (
+      <Text mainUiBody className="text-action-selection-05">
+        {chunks}
+      </Text>
+    );
+
     return (
       <Text text03 mainUiBody>
-        <Text mainUiBody className="text-action-selection-05">
-          {enabledCount}
-        </Text>
-        {` of ${totalCount} ${name ?? ""}${
-          name && totalCount !== 1 ? "s" : ""
-        }`}
+        {noun === "tool"
+          ? t.rich("enabledCount.tools", {
+              enabled: enabledCount,
+              total: totalCount,
+              value,
+            })
+          : t.rich("enabledCount.label", {
+              enabled: enabledCount,
+              total: totalCount,
+              value,
+            })}
       </Text>
     );
   }

--- a/web/src/refresh-components/EnabledCount.tsx
+++ b/web/src/refresh-components/EnabledCount.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { memo, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { useTranslations } from "next-intl";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
+import { richNodes } from "@opal/utils";
 
 interface EnabledCountProps {
   enabledCount: number;
@@ -15,22 +16,24 @@ interface EnabledCountProps {
   noun?: "tool";
 }
 
-const EnabledCount = memo(
-  ({ noun, enabledCount, totalCount }: EnabledCountProps) => {
-    const t = useTranslations("common");
+export default function EnabledCount({
+  noun,
+  enabledCount,
+  totalCount,
+}: EnabledCountProps) {
+  const t = useTranslations("common");
 
-    // The enabled figure is picked out from the rest of the phrase. It has to
-    // be a tag rather than a separate element, because where the number falls
-    // in the sentence is the translation's business, not this component's.
-    const value = (chunks: ReactNode) => (
-      <Text mainUiBody className="text-action-selection-05">
-        {chunks}
-      </Text>
-    );
+  // The enabled figure is picked out from the rest of the phrase. It has to
+  // be a tag rather than a separate element, because where the number falls
+  // in the sentence is the translation's business, not this component's.
+  function value(chunks: ReactNode) {
+    return <Text color="action-selection-05">{richNodes(chunks)}</Text>;
+  }
 
-    return (
-      <Text text03 mainUiBody>
-        {noun === "tool"
+  return (
+    <Text color="text-03">
+      {richNodes(
+        noun === "tool"
           ? t.rich("enabledCount.tools", {
               enabled: enabledCount,
               total: totalCount,
@@ -40,11 +43,8 @@ const EnabledCount = memo(
               enabled: enabledCount,
               total: totalCount,
               value,
-            })}
-      </Text>
-    );
-  }
-);
-EnabledCount.displayName = "EnabledCount";
-
-export default EnabledCount;
+            })
+      )}
+    </Text>
+  );
+}

--- a/web/src/sections/actions/ToolsList.tsx
+++ b/web/src/sections/actions/ToolsList.tsx
@@ -96,7 +96,7 @@ const ToolsList: React.FC<ToolsListProps> = ({
                 <EnabledCount
                   enabledCount={enabledCount}
                   totalCount={totalCount}
-                  name="tool"
+                  noun="tool"
                 />
               )}
               {onToggleShowOnlyEnabled && enabledCount > 0 && (

--- a/web/src/sections/actions/ToolsList.tsx
+++ b/web/src/sections/actions/ToolsList.tsx
@@ -7,7 +7,7 @@ import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import FadingEdgeContainer from "@/refresh-components/FadingEdgeContainer";
 import ToolItemSkeleton from "@/sections/actions/skeleton/ToolItemSkeleton";
-import EnabledCount from "@/refresh-components/EnabledCount";
+import EnabledCount from "@/lib/tools/components/EnabledCount";
 import { SvgEye, SvgXCircle } from "@opal/icons";
 
 export interface ToolsListProps {
@@ -96,7 +96,6 @@ const ToolsList: React.FC<ToolsListProps> = ({
                 <EnabledCount
                   enabledCount={enabledCount}
                   totalCount={totalCount}
-                  noun="tool"
                 />
               )}
               {onToggleShowOnlyEnabled && enabledCount > 0 && (

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -87,7 +87,7 @@ import { useAvailableTools } from "@/lib/tools/hooks";
 import { getActionIcon } from "@/lib/tools/utils";
 import { AgentEditorMCPServer, MCPTool, ToolSnapshot } from "@/lib/tools/types";
 import useFilter from "@/hooks/useFilter";
-import EnabledCount from "@/refresh-components/EnabledCount";
+import EnabledCount from "@/lib/tools/components/EnabledCount";
 import { useAppPosition } from "@/lib/position/hooks";
 import { isDateInFuture } from "@/lib/dateUtils";
 import {


### PR DESCRIPTION
## Description

`EnabledCount` built its phrase by string concatenation: `` `of ${totalCount} ${name}${name && totalCount !== 1 ? "s" : ""}` `` — a hardcoded " of " and a plural made by appending `s`. Neither survives translation, and the i18n lint rule missed it because a JSX expression is not raw JSX text.

The `name` prop becomes `noun?: "tool"`, a fixed set rather than free text: every noun needs its own plural forms in each locale, and an arbitrary string cannot be pluralised across nine of them. Production only ever passed `"tool"`; the stories had invented four others, so they move to the real one. The other three call sites never passed `name`, so nothing else changes.

**The emphasised figure is now a translation tag, not a leading element.** This is the part that matters:

| Locale | Phrase |
| --- | --- |
| en | `3 of 12 tools` |
| ja | `12 個中 3 個のツール` |
| zh | `12 个工具中的 3 个` |

Rendering the number and appending the rest is correct in English and wrong in CJK. Passing it as a `t.rich` tag lets the message file decide where it goes.

The component stays in `refresh-components`. Moving it into Opal was tried and reverted: Opal has no i18n runtime and no `next-intl` dependency, so an Opal version would have to take the phrase pre-translated, which pushes `t.rich` boilerplate out to every call site for no gain. Worth revisiting only alongside a decision about whether Opal components may translate at all.

## Test plan

- The ICU shapes are covered by the existing `catalog.test.ts` key-parity and shape checks.
- Worth eyeballing in the tools popover, an MCP server row, and the agent editor: the count should read "3 of 12 tools", with the first figure in the selection colour.
- Switching locale to `ja` or `zh` should reorder the sentence rather than produce "3 の 12".

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
