### PR TITLE
fix: keep tool results within the model input budget

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -19,6 +19,7 @@ from onyx.chat.llm_step import (
     _looks_like_xml_tool_call_payload,
     extract_tool_calls_from_response_text,
     run_llm_step,
+    translate_history_to_llm_format,
 )
 from onyx.chat.models import (
     ChatMessageSimple,
@@ -34,8 +35,9 @@ from onyx.chat.prompt_utils import (
     get_default_base_system_prompt,
     process_prompt_template,
 )
+from onyx.chat.tool_result_budget import fit_tool_results, shorten_tool_result
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
-from onyx.configs.chat_configs import MAX_LLM_CYCLES
+from onyx.configs.chat_configs import MAX_LLM_CYCLES, MAX_TOOL_RESULT_TOKENS
 from onyx.configs.constants import DocumentSource, MessageType
 from onyx.configs.model_configs import GEN_AI_INPUT_TOKEN_SAFETY_MARGIN
 from onyx.context.search.models import SearchDoc, SearchDocsResponse
@@ -44,10 +46,11 @@ from onyx.db.memory import UserMemoryContext, add_memory, update_memory_at_index
 from onyx.db.models import Persona
 from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.exceptions import ClassifiedLLMError
+from onyx.llm.exceptions import ClassifiedLLMError, InputBudgetExceededError
+from onyx.llm.input_budget import estimate_request_tokens
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions
 from onyx.llm.model_capabilities import is_true_openai_model
-from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import LLMInputBudget, ReasoningEffort
 from onyx.llm.utils import model_supports_image_input
 from onyx.prompts.chat_prompts import (
     IMAGE_GEN_REMINDER,
@@ -82,7 +85,6 @@ from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.tools.tool_runner import run_tool_calls
-from onyx.tools.utils import compute_all_tool_tokens
 from onyx.tracing.framework.create import ChatTraceMetadata, trace
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_incognito_record_mode
@@ -388,6 +390,56 @@ def construct_message_history(
     token_counter: Callable[[str], int] | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
     image_files_replayed_as_markers: bool = False,
+    request_token_counter: Callable[[list[ChatMessageSimple]], int] | None = None,
+) -> list[ChatMessageSimple]:
+    minimum_budget = 0
+    maximum_budget = available_tokens
+    history_budget = maximum_budget
+    while minimum_budget <= maximum_budget:
+        try:
+            result = _construct_message_history(
+                system_prompt=system_prompt,
+                custom_agent_prompt=custom_agent_prompt,
+                simple_chat_history=simple_chat_history,
+                reminder_message=reminder_message,
+                context_files=context_files,
+                available_tokens=history_budget,
+                last_n_user_messages=last_n_user_messages,
+                token_counter=token_counter,
+                all_injected_file_metadata=all_injected_file_metadata,
+                image_files_replayed_as_markers=image_files_replayed_as_markers,
+            )
+        except InputBudgetExceededError:
+            if history_budget == available_tokens:
+                raise
+            minimum_budget = history_budget + 1
+        else:
+            if request_token_counter is None:
+                return result
+            deficit = request_token_counter(result) - available_tokens
+            if deficit <= 0:
+                return result
+            maximum_budget = history_budget - 1
+            next_budget = history_budget - deficit
+            if minimum_budget <= next_budget <= maximum_budget:
+                history_budget = next_budget
+                continue
+        # Serialization can expand result text. Keep both allowance bounds.
+        history_budget = (minimum_budget + maximum_budget) // 2
+    raise InputBudgetExceededError()
+
+
+def _construct_message_history(
+    system_prompt: ChatMessageSimple | None,
+    custom_agent_prompt: ChatMessageSimple | None,
+    simple_chat_history: list[ChatMessageSimple],
+    reminder_message: ChatMessageSimple | None,
+    context_files: ExtractedContextFiles | None,
+    available_tokens: int,
+    last_n_user_messages: int | None = None,
+    token_counter: Callable[[str], int] | None = None,
+    all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
+    image_files_replayed_as_markers: bool = False,
 ) -> list[ChatMessageSimple]:
     if last_n_user_messages is not None:
         if last_n_user_messages <= 0:
@@ -437,7 +489,9 @@ def construct_message_history(
     history_token_budget -= reminder_message.token_count if reminder_message else 0
 
     if history_token_budget < 0:
-        raise ValueError("Not enough tokens available to construct message history")
+        raise InputBudgetExceededError(
+            "Not enough tokens available to construct message history"
+        )
 
     if system_prompt:
         system_prompt.should_cache = True
@@ -493,6 +547,12 @@ def construct_message_history(
 
     # Calculate tokens needed for the last user message and everything after it
     last_user_tokens = _replay_token_count(last_user_message)
+    if token_counter:
+        messages_after_last_user = fit_tool_results(
+            messages_after_last_user,
+            history_token_budget - last_user_tokens,
+            token_counter,
+        )
     after_user_tokens = sum(
         _replay_token_count(msg) for msg in messages_after_last_user
     )
@@ -500,7 +560,7 @@ def construct_message_history(
     # Check if we can fit at least the last user message and messages after it
     required_tokens = last_user_tokens + after_user_tokens
     if required_tokens > history_token_budget:
-        raise ValueError(
+        raise InputBudgetExceededError(
             f"Not enough tokens to include the last user message and subsequent messages. "
             f"Required: {required_tokens}, Available: {history_token_budget}"
         )
@@ -1021,23 +1081,48 @@ def run_llm_loop(
                 else None
             )
 
-            tool_token_budget = compute_all_tool_tokens(final_tools, token_counter)
+            tool_defs = [tool.tool_definition() for tool in final_tools]
+            request_overhead_tokens = estimate_request_tokens(
+                [], tool_defs, token_counter
+            )
+
+            def request_token_counter(
+                history: list[ChatMessageSimple],
+                tool_definitions: list[dict[str, Any]] = tool_defs,
+                reserved_request_tokens: int = request_overhead_tokens,
+            ) -> int:
+                messages = llm.prepare_messages(
+                    translate_history_to_llm_format(history, llm.config),
+                    bool(tool_definitions),
+                )
+                image_tokens = (
+                    0
+                    if image_files_replayed_as_markers
+                    else sum(message.image_token_count for message in history)
+                )
+                # Tool definitions and the envelope were reserved before history selection.
+                return (
+                    estimate_request_tokens(
+                        messages, tool_definitions, token_counter, image_tokens
+                    )
+                    - reserved_request_tokens
+                )
+
             truncated_message_history = construct_message_history(
                 system_prompt=system_prompt,
                 custom_agent_prompt=custom_agent_prompt_msg,
                 simple_chat_history=simple_chat_history,
                 reminder_message=reminder_msg,
                 context_files=context_files,
-                available_tokens=max(0, available_tokens - tool_token_budget),
+                available_tokens=max(0, available_tokens - request_overhead_tokens),
                 token_counter=token_counter,
                 all_injected_file_metadata=all_injected_file_metadata,
                 image_files_replayed_as_markers=image_files_replayed_as_markers,
+                request_token_counter=request_token_counter,
             )
 
             # This calls the LLM, yields packets (reasoning, answers, etc.) and returns the result
             # It also pre-processes the tool calls in preparation for running them
-            tool_defs = [tool.tool_definition() for tool in final_tools]
-
             # Calculate total processing time from loop start until now
             # This measures how long the user waits before the answer starts streaming
             pre_answer_processing_time = time.monotonic() - loop_start_time
@@ -1058,6 +1143,18 @@ def run_llm_loop(
                 user_identity=user_identity,
                 pre_answer_processing_time=pre_answer_processing_time,
                 reasoning_effort=reasoning_effort,
+                input_budget=LLMInputBudget(
+                    max_tokens=available_tokens,
+                    token_counter=token_counter,
+                    image_tokens=(
+                        0
+                        if image_files_replayed_as_markers
+                        else sum(
+                            message.image_token_count
+                            for message in truncated_message_history
+                        )
+                    ),
+                ),
             )
             if has_reasoned:
                 reasoning_cycles += 1
@@ -1320,6 +1417,18 @@ def run_llm_loop(
                     tr for tr in tool_responses if tr.tool_call is not None
                 ]
 
+                tool_call_order = {
+                    call.tool_call_id: index for index, call in enumerate(tool_calls)
+                }
+
+                def response_order(
+                    response: ToolResponse, call_order: dict[str, int] = tool_call_order
+                ) -> int:
+                    assert response.tool_call is not None
+                    return call_order[response.tool_call.tool_call_id]
+
+                valid_tool_responses.sort(key=response_order)
+
                 # Build ToolCallSimple list for all tool calls in this turn
                 tool_calls_simple: list[ToolCallSimple] = []
                 for tool_response in valid_tool_responses:
@@ -1356,8 +1465,13 @@ def run_llm_loop(
                     tc = tool_response.tool_call
                     assert tc is not None  # Already filtered above
 
-                    tool_response_message = tool_response.llm_facing_response
-                    tool_response_token_count = token_counter(tool_response_message)
+                    tool_response_message, tool_response_token_count = (
+                        shorten_tool_result(
+                            tool_response.llm_facing_response,
+                            MAX_TOOL_RESULT_TOKENS,
+                            token_counter,
+                        )
+                    )
 
                     tool_response_msg = ChatMessageSimple(
                         message=tool_response_message,

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -47,7 +47,7 @@ from onyx.db.models import Persona
 from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.exceptions import ClassifiedLLMError, InputBudgetExceededError
-from onyx.llm.input_budget import estimate_request_tokens
+from onyx.llm.input_budget import count_prompt_image_tokens, estimate_request_tokens
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions
 from onyx.llm.model_capabilities import is_true_openai_model
 from onyx.llm.models import LLMInputBudget, ReasoningEffort
@@ -408,6 +408,7 @@ def construct_message_history(
                 token_counter=token_counter,
                 all_injected_file_metadata=all_injected_file_metadata,
                 image_files_replayed_as_markers=image_files_replayed_as_markers,
+                defer_image_tokens=request_token_counter is not None,
             )
         except InputBudgetExceededError:
             if history_budget == available_tokens:
@@ -440,6 +441,7 @@ def _construct_message_history(
     token_counter: Callable[[str], int] | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
     image_files_replayed_as_markers: bool = False,
+    defer_image_tokens: bool = False,
 ) -> list[ChatMessageSimple]:
     if last_n_user_messages is not None:
         if last_n_user_messages <= 0:
@@ -452,7 +454,7 @@ def _construct_message_history(
     # of the images, so charging the stored image token cost would evict
     # history that actually fits.
     marker_tokens = 0
-    if image_files_replayed_as_markers:
+    if image_files_replayed_as_markers and not defer_image_tokens:
         sample_marker = NON_VISION_IMAGE_MARKER.format(file_id="0" * 36)
         marker_tokens = (
             token_counter(sample_marker)
@@ -461,6 +463,8 @@ def _construct_message_history(
         )
 
     def _replay_token_count(msg: ChatMessageSimple) -> int:
+        if defer_image_tokens:
+            return max(0, msg.token_count - msg.image_token_count)
         if not image_files_replayed_as_markers:
             return msg.token_count
         # Charge markers for every IMAGE entry, including ones whose stored
@@ -479,6 +483,10 @@ def _construct_message_history(
     # actual token counts for the budget.
     project_messages = _build_project_message(context_files, token_counter)
     project_messages_tokens = sum(m.token_count for m in project_messages)
+    if defer_image_tokens and context_files and context_files.file_texts:
+        project_messages_tokens -= sum(
+            image.token_count for image in context_files.image_files
+        )
 
     history_token_budget = available_tokens
     history_token_budget -= system_prompt.token_count if system_prompt else 0
@@ -1091,15 +1099,9 @@ def run_llm_loop(
                 tool_definitions: list[dict[str, Any]] = tool_defs,
                 reserved_request_tokens: int = request_overhead_tokens,
             ) -> int:
-                messages = llm.prepare_messages(
-                    translate_history_to_llm_format(history, llm.config),
-                    bool(tool_definitions),
-                )
-                image_tokens = (
-                    0
-                    if image_files_replayed_as_markers
-                    else sum(message.image_token_count for message in history)
-                )
+                prompt = translate_history_to_llm_format(history, llm.config)
+                messages = llm.prepare_messages(prompt, bool(tool_definitions))
+                image_tokens = count_prompt_image_tokens(prompt)
                 # Tool definitions and the envelope were reserved before history selection.
                 return (
                     estimate_request_tokens(
@@ -1146,14 +1148,6 @@ def run_llm_loop(
                 input_budget=LLMInputBudget(
                     max_tokens=available_tokens,
                     token_counter=token_counter,
-                    image_tokens=(
-                        0
-                        if image_files_replayed_as_markers
-                        else sum(
-                            message.image_token_count
-                            for message in truncated_message_history
-                        )
-                    ),
                 ),
             )
             if has_reasoned:

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -35,6 +35,7 @@ from onyx.llm.models import (
     FunctionCall,
     ImageContentPart,
     ImageUrlDetail,
+    LLMInputBudget,
     ReasoningEffort,
     SystemMessage,
     TextContentPart,
@@ -1091,6 +1092,7 @@ def run_llm_step_pkt_generator(
     is_deep_research: bool = False,
     pre_answer_processing_time: float | None = None,
     timeout_override: int | None = None,
+    input_budget: LLMInputBudget | None = None,
 ) -> Generator[Packet, None, tuple[LlmStepResult, bool]]:
     """Run an LLM step and stream the response as packets.
     NOTE: DO NOT TOUCH THIS FUNCTION BEFORE ASKING YUHONG, this is very finicky and
@@ -1313,6 +1315,7 @@ def run_llm_step_pkt_generator(
             reasoning_effort=reasoning_effort,
             user_identity=user_identity,
             timeout_override=timeout_override,
+            input_budget=input_budget,
         ):
             # On the first chunk, not at stream end: a mid-step stop persists
             # from another thread and needs this step's params already there.
@@ -1592,6 +1595,7 @@ def run_llm_step(
     is_deep_research: bool = False,
     pre_answer_processing_time: float | None = None,
     timeout_override: int | None = None,
+    input_budget: LLMInputBudget | None = None,
 ) -> tuple[LlmStepResult, bool]:
     """Wrapper around run_llm_step_pkt_generator that consumes packets and emits them.
 
@@ -1615,6 +1619,7 @@ def run_llm_step(
         is_deep_research=is_deep_research,
         pre_answer_processing_time=pre_answer_processing_time,
         timeout_override=timeout_override,
+        input_budget=input_budget,
     )
 
     while True:

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -973,6 +973,7 @@ def translate_history_to_llm_format(
                         )
                         image_part = ImageContentPart(
                             type="image_url",
+                            token_count=img_file.token_count,
                             image_url=ImageUrlDetail(
                                 url=image_url,
                                 detail=None,

--- a/backend/onyx/chat/tool_result_budget.py
+++ b/backend/onyx/chat/tool_result_budget.py
@@ -1,0 +1,102 @@
+from collections.abc import Callable
+
+from onyx.chat.models import ChatMessageSimple
+from onyx.configs.constants import MessageType
+from onyx.llm.exceptions import InputBudgetExceededError
+
+TOOL_RESULT_TRUNCATION_NOTICE = (
+    "\n\n[Tool result truncated. This is an incomplete text excerpt.]"
+)
+
+
+def shorten_tool_result(
+    text: str,
+    max_tokens: int,
+    token_counter: Callable[[str], int],
+    token_count: int | None = None,
+) -> tuple[str, int]:
+    count = token_counter(text) if token_count is None else token_count
+    if count <= max_tokens:
+        return text, count
+    notice_tokens = token_counter(TOOL_RESULT_TRUNCATION_NOTICE)
+    if max_tokens < notice_tokens:
+        raise InputBudgetExceededError()
+
+    original = text.removesuffix(TOOL_RESULT_TRUNCATION_NOTICE)
+    prefix_length = min(
+        len(original), len(original) * (max_tokens - notice_tokens) // count
+    )
+    while prefix_length:
+        candidate = original[:prefix_length] + TOOL_RESULT_TRUNCATION_NOTICE
+        candidate_tokens = token_counter(candidate)
+        if candidate_tokens <= max_tokens:
+            return candidate, candidate_tokens
+        # Token counts need not be monotonic across character boundaries.
+        prefix_length = min(
+            prefix_length - 1, prefix_length * max_tokens // candidate_tokens
+        )
+    return TOOL_RESULT_TRUNCATION_NOTICE, notice_tokens
+
+
+def fit_tool_results(
+    messages: list[ChatMessageSimple],
+    max_tokens: int,
+    token_counter: Callable[[str], int],
+) -> list[ChatMessageSimple]:
+    total_tokens = sum(message.token_count for message in messages)
+    if total_tokens <= max_tokens:
+        return messages
+
+    result_indices = [
+        index
+        for index, message in enumerate(messages)
+        if message.message_type == MessageType.TOOL_CALL_RESPONSE
+    ]
+    notice_tokens = token_counter(TOOL_RESULT_TRUNCATION_NOTICE)
+    last_call_index = max(
+        (index for index, message in enumerate(messages) if message.tool_calls),
+        default=-1,
+    )
+    current_indices = [index for index in result_indices if index > last_call_index]
+
+    def capacity(indices: list[int]) -> int:
+        return (
+            max_tokens
+            - total_tokens
+            + sum(messages[index].token_count for index in indices)
+        )
+
+    def minimum(indices: list[int]) -> int:
+        return sum(min(messages[index].token_count, notice_tokens) for index in indices)
+
+    # Preserve earlier cycles when the current batch can absorb the deficit.
+    indices = (
+        current_indices
+        if current_indices and capacity(current_indices) >= minimum(current_indices)
+        else result_indices
+    )
+    remaining = capacity(indices)
+    if not indices or remaining < minimum(indices):
+        raise InputBudgetExceededError()
+
+    allowances: dict[int, int] = {}
+    pending = sorted(indices, key=lambda index: messages[index].token_count)
+    while pending and messages[pending[0]].token_count <= remaining // len(pending):
+        index = pending.pop(0)
+        allowances[index] = messages[index].token_count
+        remaining -= allowances[index]
+    if pending:
+        share, extra = divmod(remaining, len(pending))
+        for order, index in enumerate(sorted(pending)):
+            allowances[index] = share + (order < extra)
+
+    result = messages.copy()
+    for index in indices:
+        message = messages[index]
+        text, count = shorten_tool_result(
+            message.message, allowances[index], token_counter, message.token_count
+        )
+        result[index] = message.model_copy(
+            update={"message": text, "token_count": count}
+        )
+    return result

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -2,6 +2,11 @@ import os
 
 NUM_RETURNED_HITS = 50
 
+# The shared request budget can reduce each result below this ceiling.
+MAX_TOOL_RESULT_TOKENS = int(os.environ.get("MAX_TOOL_RESULT_TOKENS") or "20000")
+if MAX_TOOL_RESULT_TOKENS <= 0:
+    raise ValueError("MAX_TOOL_RESULT_TOKENS must be a positive integer")
+
 # May be less depending on model
 MAX_CHUNKS_FED_TO_CHAT = int(os.environ.get("MAX_CHUNKS_FED_TO_CHAT") or 25)
 

--- a/backend/onyx/llm/exceptions.py
+++ b/backend/onyx/llm/exceptions.py
@@ -10,3 +10,15 @@ class ClassifiedLLMError(RuntimeError):
         self.client_error_msg = client_error_msg
         self.error_code = error_code
         self.is_retryable = is_retryable
+
+
+class InputBudgetExceededError(ClassifiedLLMError):
+    def __init__(
+        self,
+        message: str = "Not enough tokens available for the required chat context.",
+    ) -> None:
+        super().__init__(
+            client_error_msg=message,
+            error_code="CONTEXT_TOO_LONG",
+            is_retryable=False,
+        )

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -31,7 +31,7 @@ from onyx.llm.utils import (
 from onyx.llm.well_known_providers.constants import (
     PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING,
 )
-from onyx.natural_language_processing.utils import get_tokenizer
+from onyx.natural_language_processing.utils import count_tokens, get_tokenizer
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 from onyx.utils.headers import build_llm_extra_headers
 from onyx.utils.logger import setup_logger
@@ -540,5 +540,7 @@ def get_llm_tokenizer_encode_func(llm: LLM) -> Callable[[str], list[int]]:
 
 
 def get_llm_token_counter(llm: LLM) -> Callable[[str], int]:
-    tokenizer_encode_func = get_llm_tokenizer_encode_func(llm)
-    return lambda text: len(tokenizer_encode_func(text))
+    tokenizer = get_tokenizer(
+        model_name=llm.config.model_name, provider_type=llm.config.model_provider
+    )
+    return lambda text: count_tokens(text, tokenizer)

--- a/backend/onyx/llm/input_budget.py
+++ b/backend/onyx/llm/input_budget.py
@@ -1,0 +1,32 @@
+import json
+from collections.abc import Callable
+from typing import Any
+
+
+def estimate_request_tokens(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+    token_counter: Callable[[str], int],
+    image_tokens: int = 0,
+) -> int:
+    """Estimate prepared input, retaining image costs without tokenizing image data."""
+    counted_messages: list[dict[str, Any]] = []
+    for message in messages:
+        counted_message = {
+            key: value for key, value in message.items() if key != "cache_control"
+        }
+        content = message.get("content")
+        if isinstance(content, list):
+            counted_message["content"] = [
+                {
+                    key: value
+                    for key, value in part.items()
+                    if key not in {"image_url", "cache_control"}
+                }
+                for part in content
+            ]
+        counted_messages.append(counted_message)
+    payload = {"messages": counted_messages, "tools": tools or None}
+    return image_tokens + token_counter(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    )

--- a/backend/onyx/llm/input_budget.py
+++ b/backend/onyx/llm/input_budget.py
@@ -2,6 +2,19 @@ import json
 from collections.abc import Callable
 from typing import Any
 
+from onyx.llm.models import ImageContentPart, LanguageModelInput, UserMessage
+
+
+def count_prompt_image_tokens(prompt: LanguageModelInput) -> int:
+    messages = prompt if isinstance(prompt, list) else [prompt]
+    return sum(
+        part.token_count
+        for message in messages
+        if isinstance(message, UserMessage) and isinstance(message.content, list)
+        for part in message.content
+        if isinstance(part, ImageContentPart)
+    )
+
 
 def estimate_request_tokens(
     messages: list[dict[str, Any]],

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from onyx.llm.model_response import ModelResponse, ModelResponseStream
 from onyx.llm.models import (
     LanguageModelInput,
+    LLMInputBudget,
     ReasoningEffort,
     ToolChoice,
     ToolChoiceOptions,  # noqa: F401  # re-exported: onyx.chat imports it from here
@@ -87,6 +88,11 @@ class LLM(abc.ABC):
     def config(self) -> LLMConfig:
         raise NotImplementedError
 
+    def prepare_messages(
+        self, prompt: LanguageModelInput, has_tools: bool
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
     def invoke(
         self,
         prompt: LanguageModelInput,
@@ -111,5 +117,6 @@ class LLM(abc.ABC):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         raise NotImplementedError

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class LLMInputBudget(BaseModel):
@@ -10,7 +10,6 @@ class LLMInputBudget(BaseModel):
 
     max_tokens: int
     token_counter: Callable[[str], int]
-    image_tokens: int = 0
 
 
 class LLMErrorInfo(BaseModel):
@@ -180,6 +179,8 @@ class ImageUrlDetail(BaseModel):
 class ImageContentPart(BaseModel):
     type: Literal["image_url"] = "image_url"
     image_url: ImageUrlDetail
+    # Internal estimate, excluded from provider payloads.
+    token_count: int = Field(default=0, exclude=True)
 
 
 ContentPart = TextContentPart | ImageContentPart

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -1,7 +1,16 @@
+from collections.abc import Callable
 from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
+
+
+class LLMInputBudget(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    max_tokens: int
+    token_counter: Callable[[str], int]
+    image_tokens: int = 0
 
 
 class LLMErrorInfo(BaseModel):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -29,6 +29,8 @@ from onyx.llm.custom_config_mapping import (
     UI_ONLY_CONFIG_KEYS,
     map_custom_config_to_model_kwargs,
 )
+from onyx.llm.exceptions import InputBudgetExceededError
+from onyx.llm.input_budget import estimate_request_tokens
 from onyx.llm.interfaces import (
     LLM,
     LanguageModelInput,
@@ -56,6 +58,7 @@ from onyx.llm.models import (
     ANTHROPIC_ADAPTIVE_REASONING_EFFORT,
     ANTHROPIC_REASONING_EFFORT_BUDGET,
     OPENAI_REASONING_EFFORT,
+    LLMInputBudget,
     NamedToolChoice,
     ToolChoiceOptions,
     resolve_reasoning_effort,
@@ -587,6 +590,52 @@ class LitellmLLM(LLM):
             # Log but don't fail the LLM call if tracking fails
             logger.warning("Failed to track LLM cost: %s", e)
 
+    def prepare_messages(
+        self, prompt: LanguageModelInput, has_tools: bool
+    ) -> list[dict[str, Any]]:
+        model_identity_names = resolve_model_identity_names(
+            self.config.model_name, self.config.deployment_name
+        )
+        is_claude_model = any("claude" in name.lower() for name in model_identity_names)
+        messages = _prompt_to_dicts(prompt)
+
+        if not (
+            is_claude_model
+            and (
+                self._model_provider in _THINKING_BLOCK_PROVIDERS
+                or self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES
+            )
+        ):
+            messages = _strip_thinking_blocks_from_messages(messages)
+
+        # Bedrock's Converse API requires toolConfig when messages
+        # contain toolUse/toolResult content blocks. When no tools are
+        # provided for this request but the history contains tool
+        # content from previous turns, strip it to plain text.
+        is_bedrock = self._model_provider in {
+            LlmProviderNames.BEDROCK,
+            LlmProviderNames.BEDROCK_CONVERSE,
+        }
+        if is_bedrock and not has_tools and _messages_contain_tool_content(messages):
+            messages = _strip_tool_content_from_messages(messages)
+
+        # Some models (e.g. Mistral) reject a user message
+        # immediately after a tool message. Insert a synthetic
+        # assistant bridge message to satisfy the ordering
+        # constraint. Check the provider, the LiteLLM routing
+        # override, and every identity name (deployment alias and
+        # model name) to catch Mistral served behind Azure or
+        # OpenAI-compatible endpoints (e.g. vLLM).
+        is_mistral_model = (
+            self._model_provider == LlmProviderNames.MISTRAL
+            or self._custom_llm_provider == LlmProviderNames.MISTRAL
+            or _is_mistral_family_name(model_identity_names)
+        )
+        if is_mistral_model:
+            messages = _fix_tool_user_message_ordering(messages)
+
+        return messages
+
     def _completion(
         self,
         prompt: LanguageModelInput,
@@ -600,6 +649,7 @@ class LitellmLLM(LLM):
         max_tokens: int | None = None,
         user_identity: LLMUserIdentity | None = None,
         client: "HTTPHandler | None" = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Union["ModelResponse", "CustomStreamWrapper"]:
         # Lazy loading to avoid memory bloat for non-inference flows
         from litellm.exceptions import BadRequestError, RateLimitError, Timeout
@@ -915,42 +965,16 @@ class LitellmLLM(LLM):
             if "api_key" not in passthrough_kwargs:
                 passthrough_kwargs["api_key"] = self._api_key or None
 
-            messages = _prompt_to_dicts(prompt)
-
-            if not (
-                is_claude_model
-                and (
-                    self._model_provider in _THINKING_BLOCK_PROVIDERS
-                    or self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES
+            messages = self.prepare_messages(prompt, bool(tools))
+            if input_budget is not None:
+                estimated_tokens = estimate_request_tokens(
+                    messages,
+                    tools,
+                    input_budget.token_counter,
+                    input_budget.image_tokens,
                 )
-            ):
-                messages = _strip_thinking_blocks_from_messages(messages)
-
-            # Bedrock's Converse API requires toolConfig when messages
-            # contain toolUse/toolResult content blocks. When no tools are
-            # provided for this request but the history contains tool
-            # content from previous turns, strip it to plain text.
-            is_bedrock = self._model_provider in {
-                LlmProviderNames.BEDROCK,
-                LlmProviderNames.BEDROCK_CONVERSE,
-            }
-            if is_bedrock and not tools and _messages_contain_tool_content(messages):
-                messages = _strip_tool_content_from_messages(messages)
-
-            # Some models (e.g. Mistral) reject a user message
-            # immediately after a tool message. Insert a synthetic
-            # assistant bridge message to satisfy the ordering
-            # constraint. Check the provider, the LiteLLM routing
-            # override, and every identity name (deployment alias and
-            # model name) to catch Mistral served behind Azure or
-            # OpenAI-compatible endpoints (e.g. vLLM).
-            is_mistral_model = (
-                is_mistral
-                or self._custom_llm_provider == LlmProviderNames.MISTRAL
-                or _is_mistral_family_name(model_identity_names)
-            )
-            if is_mistral_model:
-                messages = _fix_tool_user_message_ordering(messages)
+                if estimated_tokens > input_budget.max_tokens:
+                    raise InputBudgetExceededError()
 
             # Only pass tool_choice when tools are present — some providers (e.g. Fireworks)
             # reject requests where tool_choice is explicitly null.
@@ -1202,6 +1226,7 @@ class LitellmLLM(LLM):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         from litellm import CustomStreamWrapper as LiteLLMCustomStreamWrapper
         from litellm import HTTPHandler
@@ -1272,6 +1297,7 @@ class LitellmLLM(LLM):
                         reasoning_effort=reasoning_effort,
                         user_identity=user_identity,
                         client=client,
+                        input_budget=input_budget,
                     ),
                 )
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -30,7 +30,7 @@ from onyx.llm.custom_config_mapping import (
     map_custom_config_to_model_kwargs,
 )
 from onyx.llm.exceptions import InputBudgetExceededError
-from onyx.llm.input_budget import estimate_request_tokens
+from onyx.llm.input_budget import count_prompt_image_tokens, estimate_request_tokens
 from onyx.llm.interfaces import (
     LLM,
     LanguageModelInput,
@@ -971,7 +971,7 @@ class LitellmLLM(LLM):
                     messages,
                     tools,
                     input_budget.token_counter,
-                    input_budget.image_tokens,
+                    count_prompt_image_tokens(prompt),
                 )
                 if estimated_tokens > input_budget.max_tokens:
                     raise InputBudgetExceededError()

--- a/backend/tests/external_dependency_unit/mock_llm.py
+++ b/backend/tests/external_dependency_unit/mock_llm.py
@@ -27,6 +27,7 @@ from onyx.llm.model_response import (
     ModelResponseStream,
     StreamingChoice,
 )
+from onyx.llm.models import LLMInputBudget
 
 T = TypeVar("T")
 
@@ -298,6 +299,13 @@ class MockLLM(LLM, MockLLMController):
             max_input_tokens=1000000000,
         )
 
+    def prepare_messages(
+        self, prompt: LanguageModelInput, has_tools: bool
+    ) -> list[dict[str, Any]]:
+        del has_tools
+        messages = prompt if isinstance(prompt, list) else [prompt]
+        return [message.model_dump(exclude_none=True) for message in messages]
+
     def invoke(
         self,
         prompt: LanguageModelInput,
@@ -322,7 +330,9 @@ class MockLLM(LLM, MockLLMController):
         max_tokens: int | None = None,  # noqa: ARG002
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,  # noqa: ARG002
         user_identity: LLMUserIdentity | None = None,  # noqa: ARG002
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
+        del input_budget
         if not self.stream_controller:
             return
 

--- a/backend/tests/unit/onyx/chat/test_emitted_image_budget.py
+++ b/backend/tests/unit/onyx/chat/test_emitted_image_budget.py
@@ -1,0 +1,220 @@
+"""Charge image tokens only when the translated request contains the image."""
+
+from collections.abc import Mapping
+from contextlib import nullcontext
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import litellm
+import pytest
+from litellm.types.utils import Delta
+
+from onyx.chat.chat_state import ChatStateContainer
+from onyx.chat.emitter import NullEmitter
+from onyx.chat.llm_loop import construct_message_history, run_llm_loop
+from onyx.chat.models import ChatLoadedFile, ChatMessageSimple, ExtractedContextFiles
+from onyx.configs.constants import MessageType
+from onyx.file_store.models import ChatFileType
+from onyx.llm.exceptions import InputBudgetExceededError
+from onyx.llm.factory import get_llm_token_counter
+from onyx.llm.input_budget import estimate_request_tokens
+from onyx.llm.multi_llm import LitellmLLM
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _run_image_history(
+    history: list[ChatMessageSimple],
+    max_input_tokens: int,
+    *,
+    capped: bool,
+    vision: bool,
+    context_files: ExtractedContextFiles | None = None,
+) -> tuple[Mapping[str, Any], int]:
+    llm = LitellmLLM(
+        api_key="test-key",
+        model_provider="azure",
+        model_name="gpt-4o",
+        max_input_tokens=max_input_tokens,
+        timeout=30,
+    )
+    response = litellm.ModelResponse(
+        choices=[
+            litellm.Choices(
+                delta=Delta(role="assistant", content="done"), finish_reason="stop"
+            )
+        ],
+        model="gpt-4o",
+    )
+    with (
+        patch("litellm.completion", return_value=[response]) as completion,
+        patch("onyx.llm.litellm_singleton.config.initialize_litellm"),
+        patch("onyx.chat.llm_step.ENABLE_AZURE_IMAGE_CAP", capped),
+        patch("onyx.chat.llm_step._AZURE_DEFAULT_IMAGE_CAP", 1),
+        patch("onyx.chat.llm_step.model_supports_image_input", return_value=vision),
+        patch("onyx.chat.llm_loop.model_supports_image_input", return_value=vision),
+        patch("onyx.chat.llm_loop.get_default_base_system_prompt", return_value=""),
+        patch(
+            "onyx.chat.llm_loop.get_session_with_current_tenant",
+            return_value=nullcontext(MagicMock()),
+        ),
+        patch(
+            "onyx.llm.multi_llm.estimate_request_tokens", wraps=estimate_request_tokens
+        ) as final_estimator,
+    ):
+        run_llm_loop(
+            emitter=NullEmitter(),
+            state_container=ChatStateContainer(),
+            simple_chat_history=history,
+            tools=[],
+            custom_agent_prompt=None,
+            context_files=(
+                context_files
+                if context_files is not None
+                else ExtractedContextFiles(
+                    file_texts=[],
+                    image_files=[],
+                    total_token_count=0,
+                    use_as_search_filter=False,
+                    file_metadata=[],
+                    uncapped_token_count=0,
+                )
+            ),
+            persona=None,
+            user_memory_context=None,
+            llm=llm,
+            token_counter=get_llm_token_counter(llm),
+        )
+    completion.assert_called_once()
+    return completion.call_args.kwargs, final_estimator.call_args.args[3]
+
+
+def _image_history(*, invalid_images: bool = False) -> list[ChatMessageSimple]:
+    images = [
+        ChatLoadedFile(
+            file_id=f"image-{index}",
+            file_type=ChatFileType.IMAGE,
+            filename=f"image-{index}.png",
+            content=_PNG_BYTES if index == 0 or not invalid_images else b"invalid",
+            content_text=None,
+            token_count=3_000,
+        )
+        for index in range(3)
+    ]
+    return [
+        ChatMessageSimple(
+            message="Keep this earlier question.",
+            token_count=10,
+            message_type=MessageType.USER,
+        ),
+        ChatMessageSimple(
+            message="Keep this earlier answer.",
+            token_count=10,
+            message_type=MessageType.ASSISTANT,
+        ),
+        ChatMessageSimple(
+            message="Describe the images.",
+            token_count=9_010,
+            image_token_count=9_000,
+            message_type=MessageType.USER,
+            image_files=images,
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    (
+        "capped",
+        "vision",
+        "invalid_images",
+        "maximum",
+        "expected_images",
+        "expected_tokens",
+    ),
+    [
+        (True, True, False, 8_000, 1, 3_000),
+        (False, True, True, 8_000, 1, 3_000),
+        (False, False, False, 8_000, 0, 0),
+        (False, True, False, 15_000, 3, 9_000),
+    ],
+)
+def test_only_emitted_images_consume_the_request_budget(
+    capped: bool,
+    vision: bool,
+    invalid_images: bool,
+    maximum: int,
+    expected_images: int,
+    expected_tokens: int,
+) -> None:
+    history = _image_history(invalid_images=invalid_images)
+    saved_images = history[-1].image_files
+    saved_counts = [
+        (message.token_count, message.image_token_count) for message in history
+    ]
+    request, image_tokens = _run_image_history(
+        history, maximum, capped=capped, vision=vision
+    )
+    messages = request["messages"]
+    assert messages[0]["content"] == "Keep this earlier question."
+    assert messages[1]["content"] == "Keep this earlier answer."
+    emitted_parts = [
+        part
+        for message in messages
+        if isinstance(message.get("content"), list)
+        for part in message["content"]
+    ]
+    assert sum(part["type"] == "image_url" for part in emitted_parts) == expected_images
+    assert image_tokens == expected_tokens
+    assert all("token_count" not in part for part in emitted_parts)
+    assert history[-1].image_files is saved_images
+    assert [
+        (message.token_count, message.image_token_count) for message in history
+    ] == saved_counts
+    if not vision:
+        assert sum("image-" in part.get("text", "") for part in emitted_parts) == 3
+
+
+def test_project_images_are_charged_without_a_stored_message_image_cost() -> None:
+    history = _image_history()
+    history[-1].token_count = 10
+    history[-1].image_token_count = 0
+    with pytest.raises(InputBudgetExceededError):
+        _run_image_history(history, 8_000, capped=False, vision=True)
+
+
+@pytest.mark.parametrize("vision", [True, False])
+def test_mixed_project_images_do_not_evict_project_text(vision: bool) -> None:
+    history = _image_history()
+    history[-1].token_count = 10
+    history[-1].image_token_count = 0
+    images = history[-1].image_files
+    assert images is not None
+    context_files = ExtractedContextFiles(
+        file_texts=["Keep this project text."],
+        image_files=images,
+        total_token_count=9_010,
+        use_as_search_filter=False,
+        file_metadata=[],
+        uncapped_token_count=9_010,
+    )
+    request, image_tokens = _run_image_history(
+        history, 8_000, capped=True, vision=vision, context_files=context_files
+    )
+    assert request["messages"][0]["content"] == "Keep this earlier question."
+    assert any(
+        isinstance(message.get("content"), str)
+        and "Keep this project text." in message["content"]
+        for message in request["messages"]
+    )
+    assert image_tokens == (3_000 if vision else 0)
+    assert context_files.total_token_count == 9_010
+    assert history[-1].image_token_count == 0
+    with pytest.raises(InputBudgetExceededError):
+        construct_message_history(
+            system_prompt=None,
+            custom_agent_prompt=None,
+            simple_chat_history=history,
+            reminder_message=None,
+            context_files=context_files,
+            available_tokens=8_000,
+        )

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -24,6 +24,7 @@ from onyx.chat.models import (
 )
 from onyx.configs.constants import MessageType
 from onyx.file_store.models import ChatFileType
+from onyx.llm.exceptions import InputBudgetExceededError
 from onyx.llm.interfaces import LLMConfig, ToolChoiceOptions
 from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER, OPEN_URL_REMINDER
 from onyx.server.query_and_chat.placement import Placement
@@ -521,7 +522,7 @@ class TestConstructMessageHistory:
 
         # Total required: 50 (system) + 50 (custom) + 100 (project) + 50 (user) = 250
         # But only 200 available
-        with pytest.raises(ValueError, match="Not enough tokens"):
+        with pytest.raises(InputBudgetExceededError, match="Not enough tokens"):
             construct_message_history(
                 system_prompt=system_prompt,
                 custom_agent_prompt=custom_agent,
@@ -545,7 +546,8 @@ class TestConstructMessageHistory:
         # Required: 10 (system) + 30 (user2) + 30 (assistant_with_tool) = 70 tokens
         # After subtracting system: 40 tokens available, but need 60 for user2 + assistant_with_tool
         with pytest.raises(
-            ValueError, match="Not enough tokens to include the last user message"
+            InputBudgetExceededError,
+            match="Not enough tokens to include the last user message",
         ):
             construct_message_history(
                 system_prompt=system_prompt,

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -20,6 +20,7 @@ from onyx.chat.models import StreamingError
 from onyx.configs.constants import MessageType
 from onyx.db.chat import set_preferred_response
 from onyx.db.models import ChatMessage
+from onyx.llm.exceptions import InputBudgetExceededError
 from onyx.llm.interfaces import ToolChoiceOptions
 from onyx.llm.override_models import LLMOverride
 from onyx.server.query_and_chat.models import SendMessageRequest
@@ -447,16 +448,27 @@ class TestRunModels:
         assert errors[0].error_code == "UNKNOWN_ERROR"
         assert "intentional test failure" in errors[0].error
 
-    def test_context_window_overflow_surfaces_as_context_too_long(self) -> None:
-        """A provider context-window rejection in a worker surfaces as
-        CONTEXT_TOO_LONG and non-retryable through the _run_model -> drain path."""
+    @pytest.mark.parametrize(
+        "overflow_error",
+        [
+            pytest.param(
+                ContextWindowExceededError(
+                    "This model's maximum context length is 8192 tokens",
+                    model="gpt-4",
+                    llm_provider="openai",
+                ),
+                id="provider",
+            ),
+            pytest.param(InputBudgetExceededError(), id="local-input-budget"),
+        ],
+    )
+    def test_context_window_overflow_surfaces_as_context_too_long(
+        self, overflow_error: Exception
+    ) -> None:
+        """Provider and local input limits use the same streaming error."""
 
         def overflow(**_kwargs: Any) -> None:
-            raise ContextWindowExceededError(
-                "This model's maximum context length is 8192 tokens",
-                model="gpt-4",
-                llm_provider="openai",
-            )
+            raise overflow_error
 
         with (
             patch("onyx.chat.process_message.run_llm_loop", side_effect=overflow),

--- a/backend/tests/unit/onyx/chat/test_tool_result_budget.py
+++ b/backend/tests/unit/onyx/chat/test_tool_result_budget.py
@@ -1,0 +1,643 @@
+"""Regression tests for tool results that exceed the model input budget."""
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from contextlib import nullcontext
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import litellm
+import pytest
+from litellm.types.utils import ChatCompletionDeltaToolCall, Delta
+from litellm.types.utils import Function as LiteLLMFunction
+
+from onyx.chat.chat_state import ChatStateContainer
+from onyx.chat.emitter import NullEmitter
+from onyx.chat.llm_loop import run_llm_loop
+from onyx.chat.llm_step import translate_history_to_llm_format
+from onyx.chat.models import ChatMessageSimple, ExtractedContextFiles, ToolCallSimple
+from onyx.chat.tool_result_budget import (
+    TOOL_RESULT_TRUNCATION_NOTICE,
+    shorten_tool_result,
+)
+from onyx.configs.constants import MessageType
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.exceptions import InputBudgetExceededError
+from onyx.llm.factory import get_llm_token_counter
+from onyx.llm.input_budget import estimate_request_tokens
+from onyx.llm.models import (
+    AssistantMessage,
+    FunctionCall,
+    LanguageModelInput,
+    LLMInputBudget,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.interface import Tool
+from onyx.tools.models import ToolResponse
+
+
+class _ScriptedResultTool(Tool[None]):
+    def __init__(self, results: dict[str, str]) -> None:
+        super().__init__(NullEmitter())
+        self._results = results
+
+    @property
+    def id(self) -> int:
+        return 1
+
+    @property
+    def name(self) -> str:
+        return "scripted_result"
+
+    @property
+    def description(self) -> str:
+        return "Return deterministic text for a test case."
+
+    @property
+    def display_name(self) -> str:
+        return "Scripted result"
+
+    def tool_definition(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"label": {"type": "string"}},
+                    "required": ["label"],
+                },
+            },
+        }
+
+    def emit_start(self, placement: Placement) -> None:
+        pass
+
+    def run(
+        self,
+        placement: Placement,
+        override_kwargs: None,
+        **llm_kwargs: Any,
+    ) -> ToolResponse:
+        del placement, override_kwargs
+        result = self._results[llm_kwargs["label"]]
+        return ToolResponse(rich_response=result, llm_facing_response=result)
+
+
+def _make_llm(max_input_tokens: int) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=LlmProviderNames.OPENAI,
+        model_name="gpt-3.5-turbo",
+        max_input_tokens=max_input_tokens,
+        timeout=30,
+    )
+
+
+def _make_provider_llm(provider: str, model: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=provider,
+        model_name=model,
+        max_input_tokens=32_000,
+        timeout=30,
+    )
+
+
+def _make_context_files() -> ExtractedContextFiles:
+    return ExtractedContextFiles(
+        file_texts=[],
+        image_files=[],
+        use_as_search_filter=False,
+        total_token_count=0,
+        file_metadata=[],
+        uncapped_token_count=0,
+    )
+
+
+def _tool_call_chunk(labels: list[str]) -> litellm.ModelResponse:
+    delta = Delta(role="assistant", content=None)
+    delta.tool_calls = [
+        ChatCompletionDeltaToolCall(
+            id=f"call-{label}",
+            function=LiteLLMFunction(
+                name="scripted_result",
+                arguments=json.dumps({"label": label}),
+            ),
+            type="function",
+            index=index,
+        )
+        for index, label in enumerate(labels)
+    ]
+    return litellm.ModelResponse(
+        id="tool-call-response",
+        choices=[
+            litellm.Choices(
+                delta=delta,
+                finish_reason="tool_calls",
+                index=0,
+            )
+        ],
+        model="gpt-3.5-turbo",
+    )
+
+
+def _answer_chunk() -> litellm.ModelResponse:
+    return litellm.ModelResponse(
+        id="answer-response",
+        choices=[
+            litellm.Choices(
+                delta=Delta(role="assistant", content="done"),
+                finish_reason="stop",
+                index=0,
+            )
+        ],
+        model="gpt-3.5-turbo",
+    )
+
+
+def _run_scripted_loop(
+    *,
+    results: dict[str, str],
+    max_input_tokens: int,
+    tool_batches: list[list[str]] | None = None,
+    completion_requests: list[dict[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], ChatStateContainer]:
+    llm = _make_llm(max_input_tokens)
+    token_counter = get_llm_token_counter(llm)
+    recorded_requests = completion_requests if completion_requests is not None else []
+    batches = tool_batches or [list(results)]
+
+    def fake_completion(**kwargs: Any) -> list[litellm.ModelResponse]:
+        recorded_requests.append(kwargs)
+        request_index = len(recorded_requests) - 1
+        if request_index < len(batches):
+            return [_tool_call_chunk(batches[request_index])]
+        return [_answer_chunk()]
+
+    user_text = "Use each scripted result, then answer."
+    history = [
+        ChatMessageSimple(
+            message=user_text,
+            token_count=token_counter(user_text),
+            message_type=MessageType.USER,
+        )
+    ]
+    state_container = ChatStateContainer()
+
+    with (
+        patch("litellm.completion", side_effect=fake_completion),
+        patch(
+            "onyx.chat.llm_loop.get_session_with_current_tenant",
+            return_value=nullcontext(MagicMock()),
+        ),
+        patch("onyx.chat.llm_loop.get_default_base_system_prompt", return_value=""),
+        patch("onyx.llm.litellm_singleton.config.initialize_litellm"),
+    ):
+        run_llm_loop(
+            emitter=NullEmitter(),
+            state_container=state_container,
+            simple_chat_history=history,
+            tools=[_ScriptedResultTool(results)],
+            custom_agent_prompt=None,
+            context_files=_make_context_files(),
+            persona=None,
+            user_memory_context=None,
+            llm=llm,
+            token_counter=token_counter,
+        )
+
+    return recorded_requests, state_container
+
+
+def _request_text_tokens(
+    request: dict[str, Any], token_counter: Callable[[str], int]
+) -> int:
+    request_text = json.dumps(
+        {
+            "messages": request["messages"],
+            "tools": request.get("tools"),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return token_counter(request_text)
+
+
+def _assert_tool_call_associations(messages: list[dict[str, Any]]) -> None:
+    assistant_tool_messages = [
+        message
+        for message in messages
+        if message["role"] == "assistant" and message.get("tool_calls")
+    ]
+    call_ids = [
+        call["id"]
+        for message in assistant_tool_messages
+        for call in message["tool_calls"]
+    ]
+    response_ids = [
+        message["tool_call_id"] for message in messages if message["role"] == "tool"
+    ]
+    assert response_ids == call_ids
+
+
+def test_one_excessive_tool_result_allows_bounded_followup_request() -> None:
+    max_input_tokens = 32_000
+    llm = _make_llm(max_input_tokens)
+    token_counter = get_llm_token_counter(llm)
+    result = "result " * 40_000
+
+    requests, state_container = _run_scripted_loop(
+        results={"large": result},
+        max_input_tokens=max_input_tokens,
+    )
+
+    assert len(requests) == 2
+    followup = requests[1]
+    tool_messages = [
+        message for message in followup["messages"] if message["role"] == "tool"
+    ]
+    assert len(tool_messages) == 1
+    _assert_tool_call_associations(followup["messages"])
+    assert token_counter(tool_messages[0]["content"]) <= 20_000
+    assert tool_messages[0]["content"] != result
+    assert "truncat" in tool_messages[0]["content"].lower()
+    assert _request_text_tokens(followup, token_counter) <= int(max_input_tokens * 0.95)
+    assert state_container.get_tool_calls()[0].tool_call_response == result
+
+
+def test_batch_of_individually_acceptable_results_shares_request_budget() -> None:
+    max_input_tokens = 24_000
+    llm = _make_llm(max_input_tokens)
+    token_counter = get_llm_token_counter(llm)
+    results: dict[str, str] = {
+        f"result-{index}": "result " * 8_000 for index in range(3)
+    }
+
+    assert all(token_counter(result) < 20_000 for result in results.values())
+    assert sum(token_counter(result) for result in results.values()) > int(
+        max_input_tokens * 0.95
+    )
+
+    requests, state_container = _run_scripted_loop(
+        results=results,
+        max_input_tokens=max_input_tokens,
+    )
+
+    assert len(requests) == 2
+    followup = requests[1]
+    tool_messages = [
+        message for message in followup["messages"] if message["role"] == "tool"
+    ]
+    assert len(tool_messages) == 3
+    _assert_tool_call_associations(followup["messages"])
+    assert _request_text_tokens(followup, token_counter) <= int(max_input_tokens * 0.95)
+    assert [call.tool_call_id for call in state_container.get_tool_calls()] == [
+        "call-result-0",
+        "call-result-1",
+        "call-result-2",
+    ]
+    assert [call.tool_call_response for call in state_container.get_tool_calls()] == [
+        results[label] for label in results
+    ]
+
+
+def test_small_tool_result_stays_unchanged() -> None:
+    result = "A short complete result."
+
+    requests, state_container = _run_scripted_loop(
+        results={"small": result},
+        max_input_tokens=1_000,
+    )
+
+    tool_message = next(
+        message for message in requests[1]["messages"] if message["role"] == "tool"
+    )
+    assert tool_message["content"] == result
+    assert state_container.get_tool_calls()[0].tool_call_response == result
+
+
+def test_unicode_json_result_retains_original_prefix_and_saved_value() -> None:
+    result = '{"title":"雪だるま ☃️","payload":"' + "漢字🙂" * 30_000 + '"}'
+
+    requests, state_container = _run_scripted_loop(
+        results={"unicode": result},
+        max_input_tokens=32_000,
+    )
+
+    tool_message = next(
+        message for message in requests[1]["messages"] if message["role"] == "tool"
+    )
+    shortened = tool_message["content"]
+    prefix, separator, notice = shortened.rpartition("\n\n")
+    assert separator
+    assert result.startswith(prefix)
+    assert "incomplete text excerpt" in notice
+    assert not prefix.endswith("}")
+    shortened.encode("utf-8")
+    assert state_container.get_tool_calls()[0].tool_call_response == result
+
+
+def test_json_escape_expansion_keeps_a_feasible_followup_request() -> None:
+    max_input_tokens = 8_000
+    result = "\\" * 100_000
+    llm = _make_llm(max_input_tokens)
+    token_counter = get_llm_token_counter(llm)
+
+    requests, state_container = _run_scripted_loop(
+        results={"escapes": result},
+        max_input_tokens=max_input_tokens,
+    )
+
+    assert len(requests) == 2
+    assert _request_text_tokens(requests[1], token_counter) <= int(
+        max_input_tokens * 0.95
+    )
+    assert state_container.get_tool_calls()[0].tool_call_response == result
+
+
+def test_repeated_tool_cycles_recompute_the_shared_budget() -> None:
+    max_input_tokens = 32_000
+    results: dict[str, str] = {
+        "first": "first-result " * 9_000,
+        "second": "second-result " * 9_000,
+    }
+    llm = _make_llm(max_input_tokens)
+    token_counter = get_llm_token_counter(llm)
+
+    requests, state_container = _run_scripted_loop(
+        results=results,
+        max_input_tokens=max_input_tokens,
+        tool_batches=[["first"], ["second"]],
+    )
+
+    assert len(requests) == 3
+    assert all(
+        _request_text_tokens(request, token_counter) <= int(max_input_tokens * 0.95)
+        for request in requests
+    )
+    final_tool_messages = [
+        message for message in requests[-1]["messages"] if message["role"] == "tool"
+    ]
+    assert len(final_tool_messages) == 2
+    _assert_tool_call_associations(requests[-1]["messages"])
+    assert (
+        sum(
+            "incomplete text excerpt" in message["content"]
+            for message in final_tool_messages
+        )
+        == 1
+    )
+    assert [call.tool_call_response for call in state_container.get_tool_calls()] == [
+        results["first"],
+        results["second"],
+    ]
+
+
+def test_ollama_conversion_charges_tool_labels_and_reminder() -> None:
+    llm = _make_provider_llm(LlmProviderNames.OLLAMA_CHAT, "llama3")
+    history = [
+        ChatMessageSimple(
+            message="",
+            token_count=1,
+            message_type=MessageType.ASSISTANT,
+            tool_calls=[
+                ToolCallSimple(
+                    tool_call_id="call-1",
+                    tool_name="scripted_result",
+                    tool_arguments={"label": "x"},
+                    token_count=1,
+                )
+            ],
+        ),
+        ChatMessageSimple(
+            message="result",
+            token_count=1,
+            message_type=MessageType.TOOL_CALL_RESPONSE,
+            tool_call_id="call-1",
+        ),
+        ChatMessageSimple(
+            message="Current reminder",
+            token_count=2,
+            message_type=MessageType.USER_REMINDER,
+        ),
+    ]
+
+    prepared = llm.prepare_messages(
+        translate_history_to_llm_format(history, llm.config),
+        True,
+    )
+
+    assert "[Tool Call] name=scripted_result id=call-1" in prepared[0]["content"]
+    assert prepared[1]["content"] == "[Tool Result] id=call-1\nresult"
+    assert prepared[2]["content"] == (
+        "<system-reminder>\nCurrent reminder\n</system-reminder>"
+    )
+
+
+def test_mistral_conversion_includes_tool_to_user_bridge() -> None:
+    llm = _make_provider_llm(LlmProviderNames.MISTRAL, "mistral-small")
+    prompt: LanguageModelInput = [
+        AssistantMessage(
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    id="call-1",
+                    function=FunctionCall(
+                        name="scripted_result", arguments='{"label":"x"}'
+                    ),
+                )
+            ],
+        ),
+        ToolMessage(content="result", tool_call_id="call-1"),
+        UserMessage(content="Current reminder"),
+    ]
+
+    prepared = llm.prepare_messages(prompt, True)
+
+    assert [message["role"] for message in prepared] == [
+        "assistant",
+        "tool",
+        "assistant",
+        "user",
+    ]
+    assert prepared[2]["content"] == "Noted. Continuing."
+
+
+def test_bedrock_final_cycle_converts_tool_history_without_definitions() -> None:
+    llm = _make_provider_llm(LlmProviderNames.BEDROCK, "anthropic.claude-3-haiku")
+    prompt: LanguageModelInput = [
+        AssistantMessage(
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    id="call-1",
+                    function=FunctionCall(
+                        name="scripted_result", arguments='{"label":"x"}'
+                    ),
+                )
+            ],
+        ),
+        ToolMessage(content="result", tool_call_id="call-1"),
+    ]
+
+    prepared = llm.prepare_messages(prompt, False)
+
+    assert all(message["role"] != "tool" for message in prepared)
+    assert all("tool_calls" not in message for message in prepared)
+    assert "[Tool Call]" in prepared[0]["content"]
+    assert "[Tool Result] id=call-1" in prepared[1]["content"]
+
+
+def test_final_request_guard_stops_before_litellm_completion() -> None:
+    llm = _make_llm(32_000)
+    token_counter = get_llm_token_counter(llm)
+
+    with (
+        patch("litellm.completion") as completion,
+        pytest.raises(InputBudgetExceededError) as exc_info,
+    ):
+        list(
+            llm.stream(
+                UserMessage(content="This request does not fit."),
+                input_budget=LLMInputBudget(
+                    max_tokens=0,
+                    token_counter=token_counter,
+                ),
+            )
+        )
+
+    completion.assert_not_called()
+    assert exc_info.value.error_code == "CONTEXT_TOO_LONG"
+    assert exc_info.value.is_retryable is False
+
+
+def test_final_request_guard_accepts_exact_estimated_budget() -> None:
+    llm = _make_llm(32_000)
+    token_counter = get_llm_token_counter(llm)
+    prompt = UserMessage(content="This request exactly fits its estimate.")
+    prepared = llm.prepare_messages(prompt, False)
+    estimated_tokens = estimate_request_tokens(prepared, None, token_counter)
+
+    with patch("litellm.completion", return_value=[_answer_chunk()]) as completion:
+        responses = list(
+            llm.stream(
+                prompt,
+                input_budget=LLMInputBudget(
+                    max_tokens=estimated_tokens,
+                    token_counter=token_counter,
+                ),
+            )
+        )
+
+    assert responses
+    completion.assert_called_once()
+
+
+def test_notice_is_included_in_each_shortening_limit() -> None:
+    token_counter = get_llm_token_counter(_make_llm(32_000))
+    notice_tokens = token_counter(TOOL_RESULT_TRUNCATION_NOTICE)
+    result = "result " * 100
+
+    with pytest.raises(InputBudgetExceededError) as exc_info:
+        shorten_tool_result(result, notice_tokens - 1, token_counter)
+    assert exc_info.value.error_code == "CONTEXT_TOO_LONG"
+    assert exc_info.value.is_retryable is False
+
+    at_notice, at_notice_tokens = shorten_tool_result(
+        result, notice_tokens, token_counter
+    )
+    assert at_notice == TOOL_RESULT_TRUNCATION_NOTICE
+    assert at_notice_tokens == notice_tokens
+
+    above_notice, above_notice_tokens = shorten_tool_result(
+        result, notice_tokens + 1, token_counter
+    )
+    assert result.startswith(above_notice.removesuffix(TOOL_RESULT_TRUNCATION_NOTICE))
+    assert above_notice.endswith(TOOL_RESULT_TRUNCATION_NOTICE)
+    assert above_notice_tokens <= notice_tokens + 1
+
+    shortened_again, shortened_again_tokens = shorten_tool_result(
+        above_notice, notice_tokens, token_counter, above_notice_tokens
+    )
+    assert shortened_again.count(TOOL_RESULT_TRUNCATION_NOTICE) == 1
+    assert shortened_again_tokens == notice_tokens
+
+
+def test_tiny_budget_stops_before_a_second_provider_request() -> None:
+    completion_requests: list[dict[str, Any]] = []
+
+    with pytest.raises(InputBudgetExceededError) as exc_info:
+        _run_scripted_loop(
+            results={"tiny": "result " * 1_000},
+            max_input_tokens=100,
+            completion_requests=completion_requests,
+        )
+
+    assert len(completion_requests) == 1
+    assert exc_info.value.error_code == "CONTEXT_TOO_LONG"
+    assert exc_info.value.is_retryable is False
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected_value"),
+    [(None, "20000"), ("7", "7")],
+)
+def test_configured_tool_result_ceiling_accepts_default_and_positive_values(
+    configured_value: str | None, expected_value: str
+) -> None:
+    env = os.environ.copy()
+    if configured_value is None:
+        env.pop("MAX_TOOL_RESULT_TOKENS", None)
+    else:
+        env["MAX_TOOL_RESULT_TOKENS"] = configured_value
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from onyx.configs.chat_configs import MAX_TOOL_RESULT_TOKENS; "
+            "print(MAX_TOOL_RESULT_TOKENS)",
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == expected_value
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "error_fragment"),
+    [
+        ("0", "MAX_TOOL_RESULT_TOKENS must be a positive integer"),
+        ("-1", "MAX_TOOL_RESULT_TOKENS must be a positive integer"),
+        ("not-an-integer", "invalid literal for int()"),
+    ],
+)
+def test_configured_tool_result_ceiling_rejects_invalid_values(
+    configured_value: str, error_fragment: str
+) -> None:
+    env = os.environ.copy()
+    env["MAX_TOOL_RESULT_TOKENS"] = configured_value
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import onyx.configs.chat_configs"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert error_fragment in result.stderr

--- a/backend/tests/unit/onyx/chat/test_tool_result_budget.py
+++ b/backend/tests/unit/onyx/chat/test_tool_result_budget.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from collections.abc import Callable
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -41,6 +42,8 @@ from onyx.llm.multi_llm import LitellmLLM
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.interface import Tool
 from onyx.tools.models import ToolResponse
+
+_BACKEND_DIR = Path(__file__).parents[4]
 
 
 class _ScriptedResultTool(Tool[None]):
@@ -609,6 +612,7 @@ def test_configured_tool_result_ceiling_accepts_default_and_positive_values(
         ],
         check=False,
         capture_output=True,
+        cwd=_BACKEND_DIR,
         env=env,
         text=True,
     )
@@ -635,6 +639,7 @@ def test_configured_tool_result_ceiling_rejects_invalid_values(
         [sys.executable, "-c", "import onyx.configs.chat_configs"],
         check=False,
         capture_output=True,
+        cwd=_BACKEND_DIR,
         env=env,
         text=True,
     )

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -38,6 +38,7 @@ from onyx.llm.model_response import (
 from onyx.llm.model_response import FunctionCall as DeltaFunctionCall
 from onyx.llm.models import (
     LanguageModelInput,
+    LLMInputBudget,
     ReasoningEffort,
     ToolChoice,
     UserMessage,
@@ -104,6 +105,7 @@ class _FakeLLM(LLM):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         self._stream_calls += 1
         self._last_prompt = prompt
@@ -350,6 +352,7 @@ class _ExplodingLLM(LLM):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         raise RuntimeError("stream-boom")
         yield  # pragma: no cover — unreachable, keeps this a generator
@@ -512,6 +515,7 @@ class _ToolStreamLLM(LLM):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         frames = [
             _delta(0, id="call_1", name="search", arguments='{"q":"'),
@@ -592,6 +596,7 @@ class _UsageStreamLLM(LLM):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         yield ModelResponseStream(
             id="stream-id",
@@ -619,6 +624,7 @@ class _UsageThenExplodeLLM(_UsageStreamLLM):
         max_tokens: int | None = None,
         reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
         user_identity: LLMUserIdentity | None = None,
+        input_budget: LLMInputBudget | None = None,
     ) -> Iterator[ModelResponseStream]:
         yield ModelResponseStream(
             id="stream-id",

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.prod.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.prod.template
@@ -80,3 +80,8 @@ DB_READONLY_PASSWORD=password
 # Show extra/uncommon connectors
 # See https://docs.onyx.app/admins/connectors/overview for a full list of connectors
 SHOW_EXTRA_CONNECTORS=False
+
+# Maximum tokens per model-facing tool result. Results can be smaller to fit the shared input budget.
+# Saved results remain complete. The existing input margin still applies.
+# Output tokens are not reserved again. Use a positive integer.
+# MAX_TOOL_RESULT_TOKENS=20000

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -318,6 +318,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # JWT_EXPECTED_ISSUER=
 
 ## Gen AI Settings
+# Maximum tokens per model-facing tool result. Results can be smaller to fit the shared input budget.
+# Saved results remain complete. The existing input margin still applies.
+# Output tokens are not reserved again. Use a positive integer.
+# MAX_TOOL_RESULT_TOKENS=20000
 # GEN_AI_MAX_TOKENS=
 # LLM_SOCKET_READ_TIMEOUT=
 # IMAGE_SUMMARIZATION_TIMEOUT=

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -80,3 +80,8 @@ DB_READONLY_PASSWORD=password
 # Show extra/uncommon connectors
 # See https://docs.onyx.app/admins/connectors/overview for a full list of connectors
 SHOW_EXTRA_CONNECTORS=False
+
+# Maximum tokens per model-facing tool result. Results can be smaller to fit the shared input budget.
+# Saved results remain complete. The existing input margin still applies.
+# Output tokens are not reserved again. Use a positive integer.
+# MAX_TOOL_RESULT_TOKENS=20000

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -318,6 +318,10 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # JWT_EXPECTED_ISSUER=
 
 ## Gen AI Settings
+# Maximum tokens per model-facing tool result. Results can be smaller to fit the shared input budget.
+# Saved results remain complete. The existing input margin still applies.
+# Output tokens are not reserved again. Use a positive integer.
+# MAX_TOOL_RESULT_TOKENS=20000
 # GEN_AI_MAX_TOKENS=
 # LLM_SOCKET_READ_TIMEOUT=
 # IMAGE_SUMMARIZATION_TIMEOUT=

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.21
+version: 0.8.22
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1583,6 +1583,10 @@ configMap:
   # clouds (e.g. *.blob.core.usgovcloudapi.net).
   AZURE_STORAGE_ACCOUNT_URL: ""
   # Gen AI Settings
+  # Maximum tokens per model-facing tool result. Results can be smaller to fit the shared input budget.
+  # Saved results remain complete. The existing input margin still applies.
+  # Output tokens are not reserved again. Use a positive integer.
+  MAX_TOOL_RESULT_TOKENS: "20000"
   GEN_AI_MAX_TOKENS: ""
   LLM_SOCKET_READ_TIMEOUT: "60"
   IMAGE_SUMMARIZATION_TIMEOUT: "300"


### PR DESCRIPTION
## Description

Large MCP and custom-tool results can exceed the model input budget and stop the next chat request.

Apply per-result and shared token limits to model-facing text, then check the prepared request while preserving complete saved results.

Fixes #11007.

## How Has This Been Tested?

- At `1370136`: 121 focused tests passed. Repository pre-commit and commit hooks passed.
- Independent review at `1370136`: five targeted tests passed, including the shared input/output context regression.
- Final merge `38f3b8c`: the effective issue patch matches the reviewed patch. Merge hooks and diff checks passed. Tests were not repeated.
- Historical results at `ffd62be`: 8,991 backend tests passed, 33 skipped; 1,106 chat and LLM tests passed. These are not current-head full-suite results.
- The full suite, live interface, and real-provider tests were not run for the repair.
- GitHub workflow runs for `38f3b8c` require maintainer approval. Human review remains pending.

AI assistance: Codex helped implement, test, and review this change.

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11007. Large tool results no longer exceed the model input budget; they are truncated per result and share a token budget before the request is sent, while saved results remain complete.

**Changes**
- Budgets measure the prepared request, so serialization expansion, tool definitions, and emitted images count toward the limit.
- Image tokens are charged only when the image is actually sent; stored history and context files keep their original counts.
- Adds `MAX_TOOL_RESULT_TOKENS` (default 20000) to cap each model-facing tool result.
- Requests that still can't fit raise a context-too-long error instead of being sent.

<sup>Written for commit 38f3b8cd8197d08ca80c311f8370d68bd9baed84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



