### PR TITLE
fix(deploy): stop nginx from proxying to retired api_server addresses after upgrade

### DIFF
--- a/cli/internal/deploy/deployfiles/embedded/data/nginx/app.conf.template
+++ b/cli/internal/deploy/deployfiles/embedded/data/nginx/app.conf.template
@@ -7,24 +7,10 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '"$http_user_agent" "$http_x_forwarded_for" '
                 'rt=$request_time';
 
-upstream api_server {
-    # fail_timeout=0 means we always retry an upstream even if it failed
-    # to return a good HTTP response
-
-    # for UNIX domain socket setups
-    #server unix:/tmp/gunicorn.sock fail_timeout=0;
-
-    # for a TCP configuration
-    # TODO: use gunicorn to manage multiple processes
-    server ${ONYX_BACKEND_API_HOST}:8080 fail_timeout=0;
-}
-
-upstream web_server {
-    server ${ONYX_WEB_SERVER_HOST}:3000 fail_timeout=0;
-}
-
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
+# Docker's embedded DNS. Upstream hosts are resolved per request (see the
+# $..._upstream variables below) rather than once at startup, so a container
+# that compose recreates with a new address is reached without a reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
@@ -38,6 +24,12 @@ server {
     client_max_body_size 5G;    # Maximum upload size
 
     access_log /var/log/nginx/access.log custom_main;
+
+    # A variable in proxy_pass makes nginx resolve the host per request. Keep
+    # these names out of any `upstream {}` block: nginx would match the block
+    # and pin its addresses again.
+    set $api_upstream ${ONYX_BACKEND_API_HOST}:8080;
+    set $web_upstream ${ONYX_WEB_SERVER_HOST}:3000;
 
     # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
@@ -62,7 +54,7 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location ~ ^/scim(/.*)?$ {
@@ -78,7 +70,7 @@ server {
         proxy_connect_timeout ${NGINX_PROXY_CONNECT_TIMEOUT}s;
         proxy_send_timeout ${NGINX_PROXY_SEND_TIMEOUT}s;
         proxy_read_timeout ${NGINX_PROXY_READ_TIMEOUT}s;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     # Match both /api/* and /openapi.json in a single rule
@@ -108,7 +100,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location / {
@@ -130,7 +122,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web_server;
+        proxy_pass http://$web_upstream;
     }
 
 }

--- a/cli/internal/deploy/deployfiles/embedded/data/nginx/app.conf.template.prod
+++ b/cli/internal/deploy/deployfiles/embedded/data/nginx/app.conf.template.prod
@@ -7,24 +7,10 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '"$http_user_agent" "$http_x_forwarded_for" '
                 'rt=$request_time';
 
-upstream api_server {
-    # fail_timeout=0 means we always retry an upstream even if it failed
-    # to return a good HTTP response
-
-    # for UNIX domain socket setups
-    #server unix:/tmp/gunicorn.sock fail_timeout=0;
-
-    # for a TCP configuration
-    # TODO: use gunicorn to manage multiple processes
-    server ${ONYX_BACKEND_API_HOST}:8080 fail_timeout=0;
-}
-
-upstream web_server {
-    server ${ONYX_WEB_SERVER_HOST}:3000 fail_timeout=0;
-}
-
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
+# Docker's embedded DNS. Upstream hosts are resolved per request (see the
+# $..._upstream variables below) rather than once at startup, so a container
+# that compose recreates with a new address is reached without a reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
@@ -38,6 +24,12 @@ server {
     client_max_body_size 5G;    # Maximum upload size
 
     access_log /var/log/nginx/access.log custom_main;
+
+    # A variable in proxy_pass makes nginx resolve the host per request. Keep
+    # these names out of any `upstream {}` block: nginx would match the block
+    # and pin its addresses again.
+    set $api_upstream ${ONYX_BACKEND_API_HOST}:8080;
+    set $web_upstream ${ONYX_WEB_SERVER_HOST}:3000;
 
     # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
@@ -62,7 +54,7 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location ~ ^/scim(/.*)?$ {
@@ -79,7 +71,7 @@ server {
         proxy_connect_timeout ${NGINX_PROXY_CONNECT_TIMEOUT}s;
         proxy_send_timeout ${NGINX_PROXY_SEND_TIMEOUT}s;
         proxy_read_timeout ${NGINX_PROXY_READ_TIMEOUT}s;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     # Match both /api/* and /openapi.json in a single rule
@@ -110,7 +102,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location / {
@@ -133,7 +125,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web_server;
+        proxy_pass http://$web_upstream;
     }
 
     location /.well-known/acme-challenge/ {

--- a/cli/internal/deploy/deployfiles/embedded/data/nginx/run-nginx.sh
+++ b/cli/internal/deploy/deployfiles/embedded/data/nginx/run-nginx.sh
@@ -24,16 +24,15 @@ envsubst '$DOMAIN $SSL_CERT_FILE_NAME $SSL_CERT_KEY_FILE_NAME $ONYX_BACKEND_API_
 if [ "${MCP_SERVER_ENABLED}" = "True" ] || [ "${MCP_SERVER_ENABLED}" = "true" ]; then
   echo "MCP server is enabled, creating MCP configuration..."
   # shellcheck disable=SC2016
-  envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp_upstream.conf.inc.template" > /etc/nginx/conf.d/mcp_upstream.conf.inc
-  # shellcheck disable=SC2016
-  envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp.conf.inc.template" > /etc/nginx/conf.d/mcp.conf.inc
+  envsubst '$ONYX_MCP_SERVER_HOST $ONYX_WEB_SERVER_HOST' < "/etc/nginx/conf.d/mcp.conf.inc.template" > /etc/nginx/conf.d/mcp.conf.inc
 else
   echo "MCP server is disabled, removing MCP configuration..."
-  # Leave empty placeholder files so nginx includes do not fail
-  # These files are empty because MCP server is disabled
-  echo "# Empty file - MCP server is disabled" > /etc/nginx/conf.d/mcp_upstream.conf.inc
+  # Leave an empty placeholder file so the nginx include does not fail
   echo "# Empty file - MCP server is disabled" > /etc/nginx/conf.d/mcp.conf.inc
 fi
+# app.conf templates from before upstream hosts were resolved per request
+# include this file at http level; keep it so a hand-edited one still loads.
+echo "# Empty file - upstream hosts are set per request in app.conf" > /etc/nginx/conf.d/mcp_upstream.conf.inc
 
 # Start nginx and reload every 6 hours
 while :; do sleep 6h & wait; nginx -s reload; done & nginx -g "daemon off;"

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
@@ -391,8 +391,8 @@ services:
   nginx:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
+    # nginx resolves api_server / web_server per request and would start without
+    # them; starting it once they are healthy avoids 502s while they come up.
     depends_on:
       api_server:
         condition: service_healthy

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
@@ -438,8 +438,8 @@ services:
   nginx:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
+    # nginx resolves api_server / web_server per request and would start without
+    # them; starting it once they are healthy avoids 502s while they come up.
     depends_on:
       api_server:
         condition: service_healthy

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
@@ -249,9 +250,11 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		in.rollbackEnv(envPath, envBytes)
 		return err
 	}
+	before := in.runningContainers(ctx)
 	if err := in.startServices(ctx, targetTag, installedTag, hostPort); err != nil {
 		return err
 	}
+	in.restartKeptNginx(ctx, targetTag, hostPort, before)
 
 	now := time.Now().UTC()
 	manifest.InstalledTag = targetTag
@@ -280,6 +283,29 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 
 	in.printUpgradeSuccess(hostPort, installedTag, targetTag)
 	return nil
+}
+
+// restartKeptNginx restarts nginx when `up` left it running. Compose replaces
+// a container only when its own config or image changed, and nginx's do not
+// change with the Onyx version. nginx reads its config templates only at
+// start though, so the templates this release ships take effect only after a
+// restart; before it runs them, nginx keeps addresses `up` may have retired.
+// Skipped when `up` already replaced the container (a floating tag, or a
+// compose config change).
+func (in *installer) restartKeptNginx(ctx context.Context, tag string, hostPort int, before map[string]string) {
+	id := before["nginx"]
+	if id == "" || in.runningContainers(ctx)["nginx"] != id {
+		return
+	}
+	in.infof("Restarting nginx so this release's nginx config takes effect...")
+	cmd := in.compose.Command(in.deploymentDir(), in.composeRunEnv(tag, hostPort), in.composeFileNames(false), "restart", "nginx")
+	if _, err := in.deps.Runner.Run(ctx, cmd); err != nil {
+		in.warnf("Could not restart nginx: %v", err)
+		in.infof("It serves with the previous nginx config until you restart it, from %s:", in.deploymentDir())
+		in.cmdf("%s", strings.Join(append([]string{cmd.Name}, cmd.Args...), " "))
+		return
+	}
+	in.successf("Restarted nginx")
 }
 
 // printUpgradeSuccess mirrors printSuccess: a summary card when the wizard

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -383,3 +383,136 @@ func TestUpgradeConfigFailureLeavesVersionAlone(t *testing.T) {
 		}
 	}
 }
+
+// Compose leaves nginx alone on an upgrade (its own config and image are the
+// same), but nginx reads its config templates only at start: the upgrade
+// restarts the container `up` kept so this release's templates take effect.
+func TestUpgradeRestartsNginxLeftRunning(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		switch {
+		case strings.Contains(a, "ps -q"):
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		case strings.Contains(a, "{{.Names}}"):
+			return dockercmd.Result{Stdout: "onyx-api_server-1\tapi1\nonyx-nginx-1\tnginx1\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUpgrade: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	up, restart := -1, -1
+	for i, c := range running.calls {
+		a := argv(c)
+		if strings.Contains(a, " up -d") {
+			up = i
+		}
+		if strings.HasSuffix(a, " restart nginx") {
+			restart = i
+			if !strings.Contains(a, "-f docker-compose.yml") {
+				t.Errorf("restart must name the deployment's compose files: %s", a)
+			}
+			if c.Env["IMAGE_TAG"] != "v4.2.0" {
+				t.Errorf("restart env = %+v, want the target tag", c.Env)
+			}
+		}
+	}
+	if up < 0 {
+		t.Fatal("compose up never ran")
+	}
+	if restart < 0 {
+		t.Fatalf("nginx was not restarted after up; calls:\n%s", callList(running))
+	}
+	if restart < up {
+		t.Errorf("nginx restarted before up (restart at %d, up at %d)", restart, up)
+	}
+}
+
+// A container `up` replaced already runs this release's config: no restart.
+func TestUpgradeSkipsNginxRestartWhenRecreated(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	var upSeen bool
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		switch {
+		case strings.Contains(a, " up -d"):
+			upSeen = true
+		case strings.Contains(a, "ps -q"):
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		case strings.Contains(a, "{{.Names}}"):
+			id := "nginx1"
+			if upSeen {
+				id = "nginx2"
+			}
+			return dockercmd.Result{Stdout: "onyx-nginx-1\t" + id + "\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUpgrade: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	for _, c := range running.calls {
+		if strings.HasSuffix(argv(c), " restart nginx") {
+			t.Errorf("nginx was restarted although up had replaced it: %s", argv(c))
+		}
+	}
+}
+
+// A failed restart is reported with the command to run by hand, not treated
+// as a failed upgrade: the services are already up on the target version.
+func TestUpgradeNginxRestartFailureIsAWarning(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		switch {
+		case strings.HasSuffix(a, " restart nginx"):
+			return dockercmd.Result{}, errors.New("exit status 1: no such service: nginx")
+		case strings.Contains(a, "ps -q"):
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		case strings.Contains(a, "{{.Names}}"):
+			return dockercmd.Result{Stdout: "onyx-nginx-1\tnginx1\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err != nil {
+		t.Fatalf("a failed nginx restart must not fail the upgrade: %v", err)
+	}
+	out := outBuf(deps).String()
+	if !strings.Contains(out, "Could not restart nginx") || !strings.Contains(out, "restart nginx") {
+		t.Errorf("output must warn and show the restart command:\n%s", out)
+	}
+	manifest, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.InstalledTag != "v4.2.0" {
+		t.Errorf("InstalledTag = %q, want v4.2.0", manifest.InstalledTag)
+	}
+}
+
+func callList(r *fakeRunner) string {
+	lines := make([]string, 0, len(r.calls))
+	for _, c := range r.calls {
+		lines = append(lines, argv(c))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/deployment/data/nginx/app.conf.template
+++ b/deployment/data/nginx/app.conf.template
@@ -7,24 +7,10 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '"$http_user_agent" "$http_x_forwarded_for" '
                 'rt=$request_time';
 
-upstream api_server {
-    # fail_timeout=0 means we always retry an upstream even if it failed
-    # to return a good HTTP response
-
-    # for UNIX domain socket setups
-    #server unix:/tmp/gunicorn.sock fail_timeout=0;
-
-    # for a TCP configuration
-    # TODO: use gunicorn to manage multiple processes
-    server ${ONYX_BACKEND_API_HOST}:8080 fail_timeout=0;
-}
-
-upstream web_server {
-    server ${ONYX_WEB_SERVER_HOST}:3000 fail_timeout=0;
-}
-
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
+# Docker's embedded DNS. Upstream hosts are resolved per request (see the
+# $..._upstream variables below) rather than once at startup, so a container
+# that compose recreates with a new address is reached without a reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
@@ -38,6 +24,12 @@ server {
     client_max_body_size 5G;    # Maximum upload size
 
     access_log /var/log/nginx/access.log custom_main;
+
+    # A variable in proxy_pass makes nginx resolve the host per request. Keep
+    # these names out of any `upstream {}` block: nginx would match the block
+    # and pin its addresses again.
+    set $api_upstream ${ONYX_BACKEND_API_HOST}:8080;
+    set $web_upstream ${ONYX_WEB_SERVER_HOST}:3000;
 
     # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
@@ -62,7 +54,7 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location ~ ^/scim(/.*)?$ {
@@ -78,7 +70,7 @@ server {
         proxy_connect_timeout ${NGINX_PROXY_CONNECT_TIMEOUT}s;
         proxy_send_timeout ${NGINX_PROXY_SEND_TIMEOUT}s;
         proxy_read_timeout ${NGINX_PROXY_READ_TIMEOUT}s;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     # Match both /api/* and /openapi.json in a single rule
@@ -108,7 +100,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location / {
@@ -130,7 +122,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web_server;
+        proxy_pass http://$web_upstream;
     }
 
 }

--- a/deployment/data/nginx/app.conf.template.no-letsencrypt
+++ b/deployment/data/nginx/app.conf.template.no-letsencrypt
@@ -7,24 +7,10 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '"$http_user_agent" "$http_x_forwarded_for" '
                 'rt=$request_time';
 
-upstream api_server {
-    # fail_timeout=0 means we always retry an upstream even if it failed
-    # to return a good HTTP response
-
-    # for UNIX domain socket setups
-    #server unix:/tmp/gunicorn.sock fail_timeout=0;
-
-    # for a TCP configuration
-    # TODO: use gunicorn to manage multiple processes
-    server api_server:8080 fail_timeout=0;
-}
-
-upstream web_server {
-    server web_server:3000 fail_timeout=0;
-}
-
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
+# Docker's embedded DNS. Upstream hosts are resolved per request (see the
+# $..._upstream variables below) rather than once at startup, so a container
+# that compose recreates with a new address is reached without a reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
@@ -38,6 +24,12 @@ server {
     client_max_body_size 5G;    # Maximum upload size
 
     access_log /var/log/nginx/access.log custom_main;
+
+    # A variable in proxy_pass makes nginx resolve the host per request. Keep
+    # these names out of any `upstream {}` block: nginx would match the block
+    # and pin its addresses again.
+    set $api_upstream ${ONYX_BACKEND_API_HOST}:8080;
+    set $web_upstream ${ONYX_WEB_SERVER_HOST}:3000;
 
     # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
@@ -62,7 +54,7 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location ~ ^/scim(/.*)?$ {
@@ -76,7 +68,7 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     # Match both /api/* and /openapi.json in a single rule
@@ -102,7 +94,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location / {
@@ -120,7 +112,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web_server;
+        proxy_pass http://$web_upstream;
     }
 }
 

--- a/deployment/data/nginx/app.conf.template.prod
+++ b/deployment/data/nginx/app.conf.template.prod
@@ -7,24 +7,10 @@ log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '"$http_user_agent" "$http_x_forwarded_for" '
                 'rt=$request_time';
 
-upstream api_server {
-    # fail_timeout=0 means we always retry an upstream even if it failed
-    # to return a good HTTP response
-
-    # for UNIX domain socket setups
-    #server unix:/tmp/gunicorn.sock fail_timeout=0;
-
-    # for a TCP configuration
-    # TODO: use gunicorn to manage multiple processes
-    server ${ONYX_BACKEND_API_HOST}:8080 fail_timeout=0;
-}
-
-upstream web_server {
-    server ${ONYX_WEB_SERVER_HOST}:3000 fail_timeout=0;
-}
-
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
+# Docker's embedded DNS. Upstream hosts are resolved per request (see the
+# $..._upstream variables below) rather than once at startup, so a container
+# that compose recreates with a new address is reached without a reload.
+resolver 127.0.0.11 valid=10s ipv6=off;
 
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
@@ -38,6 +24,12 @@ server {
     client_max_body_size 5G;    # Maximum upload size
 
     access_log /var/log/nginx/access.log custom_main;
+
+    # A variable in proxy_pass makes nginx resolve the host per request. Keep
+    # these names out of any `upstream {}` block: nginx would match the block
+    # and pin its addresses again.
+    set $api_upstream ${ONYX_BACKEND_API_HOST}:8080;
+    set $web_upstream ${ONYX_WEB_SERVER_HOST}:3000;
 
     # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
@@ -62,7 +54,7 @@ server {
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location ~ ^/scim(/.*)?$ {
@@ -79,7 +71,7 @@ server {
         proxy_connect_timeout ${NGINX_PROXY_CONNECT_TIMEOUT}s;
         proxy_send_timeout ${NGINX_PROXY_SEND_TIMEOUT}s;
         proxy_read_timeout ${NGINX_PROXY_READ_TIMEOUT}s;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     # Match both /api/* and /openapi.json in a single rule
@@ -110,7 +102,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://api_server;
+        proxy_pass http://$api_upstream;
     }
 
     location / {
@@ -133,7 +125,7 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://web_server;
+        proxy_pass http://$web_upstream;
     }
 
     location /.well-known/acme-challenge/ {

--- a/deployment/data/nginx/mcp.conf.inc.template
+++ b/deployment/data/nginx/mcp.conf.inc.template
@@ -9,12 +9,19 @@ location = /mcp/oauth/callback {
     proxy_set_header Host $host;
     proxy_http_version 1.1;
     proxy_redirect off;
-    proxy_pass http://web_server;
+    # Resolved per request, like $web_upstream in app.conf. Set here as well
+    # so this file loads with an app.conf that predates those variables.
+    set $mcp_web_upstream ${ONYX_WEB_SERVER_HOST}:3000;
+    proxy_pass http://$mcp_web_upstream;
 }
 
 # MCP Server - Model Context Protocol for LLM integrations
 # Match /mcp, /mcp/, or /mcp/* but NOT /mcpserver, /mcpapi, etc.
 location ~ ^/mcp(/.*)?$ {
+    # Resolved per request, like $api_upstream in app.conf. `set` runs in
+    # order with the rewrites below, so it has to come before `break`.
+    set $mcp_upstream ${ONYX_MCP_SERVER_HOST}:8090;
+
     # misc headers
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -34,5 +41,5 @@ location ~ ^/mcp(/.*)?$ {
     proxy_redirect off;
     rewrite ^/mcp(/.*)$ $1 break;
     rewrite ^/mcp/?$ / break;
-    proxy_pass http://mcp_server;
+    proxy_pass http://$mcp_upstream;
 }

--- a/deployment/data/nginx/mcp_upstream.conf.inc.template
+++ b/deployment/data/nginx/mcp_upstream.conf.inc.template
@@ -1,3 +1,0 @@
-upstream mcp_server {
-    server ${ONYX_MCP_SERVER_HOST}:8090 fail_timeout=0;
-}

--- a/deployment/data/nginx/run-nginx.sh
+++ b/deployment/data/nginx/run-nginx.sh
@@ -24,16 +24,15 @@ envsubst '$DOMAIN $SSL_CERT_FILE_NAME $SSL_CERT_KEY_FILE_NAME $ONYX_BACKEND_API_
 if [ "${MCP_SERVER_ENABLED}" = "True" ] || [ "${MCP_SERVER_ENABLED}" = "true" ]; then
   echo "MCP server is enabled, creating MCP configuration..."
   # shellcheck disable=SC2016
-  envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp_upstream.conf.inc.template" > /etc/nginx/conf.d/mcp_upstream.conf.inc
-  # shellcheck disable=SC2016
-  envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp.conf.inc.template" > /etc/nginx/conf.d/mcp.conf.inc
+  envsubst '$ONYX_MCP_SERVER_HOST $ONYX_WEB_SERVER_HOST' < "/etc/nginx/conf.d/mcp.conf.inc.template" > /etc/nginx/conf.d/mcp.conf.inc
 else
   echo "MCP server is disabled, removing MCP configuration..."
-  # Leave empty placeholder files so nginx includes do not fail
-  # These files are empty because MCP server is disabled
-  echo "# Empty file - MCP server is disabled" > /etc/nginx/conf.d/mcp_upstream.conf.inc
+  # Leave an empty placeholder file so the nginx include does not fail
   echo "# Empty file - MCP server is disabled" > /etc/nginx/conf.d/mcp.conf.inc
 fi
+# app.conf templates from before upstream hosts were resolved per request
+# include this file at http level; keep it so a hand-edited one still loads.
+echo "# Empty file - upstream hosts are set per request in app.conf" > /etc/nginx/conf.d/mcp_upstream.conf.inc
 
 # Start nginx and reload every 6 hours
 while :; do sleep 6h & wait; nginx -s reload; done & nginx -g "daemon off;"

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -391,8 +391,8 @@ services:
   nginx:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
+    # nginx resolves api_server / web_server per request and would start without
+    # them; starting it once they are healthy avoids 502s while they come up.
     depends_on:
       api_server:
         condition: service_healthy

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -391,8 +391,8 @@ services:
   nginx:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
+    # nginx resolves api_server / web_server per request and would start without
+    # them; starting it once they are healthy avoids 502s while they come up.
     depends_on:
       api_server:
         condition: service_healthy

--- a/deployment/docker_compose/docker-compose.template.yml
+++ b/deployment/docker_compose/docker-compose.template.yml
@@ -503,8 +503,8 @@ services:
   nginx:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
+    # nginx resolves api_server / web_server per request and would start without
+    # them; starting it once they are healthy avoids 502s while they come up.
     depends_on:
       api_server:
         condition: service_healthy

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -438,8 +438,8 @@ services:
   nginx:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/library/nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
+    # nginx resolves api_server / web_server per request and would start without
+    # them; starting it once they are healthy avoids 502s while they come up.
     depends_on:
       api_server:
         condition: service_healthy


### PR DESCRIPTION
## Description

`onyx-cli deploy upgrade` reports success while nginx still proxies to the previous `api_server` container. `/api/*` returns 502 until nginx reloads, which happens every 6 hours. Three onyx-infra deploys failed this way (runs 30586830295, 30671076941, 34277944494).

The chain, confirmed from the code:

1. The upgrade path runs `docker compose up -d --wait` without a recreate flag for pinned tags. Compose only replaces a container whose own config or image changed. `api_server` and `web_server` change (new image), nginx does not (`nginx:1.25.5-alpine`, same config), so nginx keeps running.
2. `app.conf.template*` declared `upstream api_server { server api_server:8080; }`. nginx resolves that name once, at config load. The retired address stays until `nginx -s reload`, which `run-nginx.sh` sends every 6 hours.
3. The compose healthchecks do not cross nginx to `api_server`, so `--wait` passes and the CLI prints success.

### What changes

**nginx resolves upstream hosts per request (durable fix).** Each `app.conf.template*` sets `resolver 127.0.0.11 valid=10s ipv6=off;` (Docker's embedded DNS on every user-defined network) and proxies to a variable: `set $api_upstream ${ONYX_BACKEND_API_HOST}:8080;` then `proxy_pass http://$api_upstream;`. A variable in `proxy_pass` makes nginx resolve the name at request time. The static `upstream {}` blocks are removed. They must go: when a variable's value matches an `upstream` block name, nginx uses the block and pins the address again.

- `mcp.conf.inc.template` gets the same treatment (`$mcp_upstream`, `$mcp_web_upstream`). `mcp_upstream.conf.inc.template` is removed.
- `run-nginx.sh` still writes an empty `mcp_upstream.conf.inc`, so a hand-edited older `app.conf.template` that includes it keeps loading. The MCP include sets its own variables for the same reason: an undefined variable in `proxy_pass` is a config-time `[emerg]`.
- The `depends_on` comment in the compose template said nginx crashes without the upstreams. That is no longer true; the ordering now only avoids 502s while they come up.

**The CLI restarts nginx after `up` when `up` kept the same container (immediate fix).** `runUpgrade` records the running container IDs before `up` and runs `docker compose restart nginx` afterwards when nginx's ID is unchanged. A restart, not a reload, is required: the compose command copies the templates into the container and renders them only at container start. This is also what puts the new template into service on existing installs, where compose never recreates nginx. A failed restart is a warning with the command to run by hand, not a failed upgrade: the stack is already up on the target version.

The ticket's alternative, `--always-recreate-deps`, does not work. For a bare `up -d`, compose sets the target list to every service, so the dependency recreate strategy never applies. The flag also targets dependencies (what nginx depends on), not dependents.

### Not changed

- `deployment/helm/charts/onyx/templates/nginx-conf.yaml` keeps its static upstreams. Kubernetes Service ClusterIPs are stable, so it does not have this problem.
- nginx stays at 1.25.5. The `resolve` parameter on `server` (nginx OSS 1.27.3+) would need an image bump coupled to the template change; a user with a hand-edited compose file would get a template their image cannot load.

## How Has This Been Tested?

- `cd cli && go test ./internal/deploy/...` and `go vet`: pass. New tests `TestUpgradeRestartsNginxLeftRunning`, `TestUpgradeSkipsNginxRestartWhenRecreated` and `TestUpgradeNginxRestartFailureIsAWarning`. `TestEmbeddedFilesMatchSource` covers the embedded copies, regenerated with `ods generate-compose --write`.
- `pre-commit run --files <changed files>`: pass (shellcheck, golangci-lint, compose sync).
- Rendered every template the way `run-nginx.sh` does (standard, prod, no-letsencrypt; MCP on and off) and ran `nginx -t` (nginx 1.28.3) on each: all pass. Also passed: the compatibility case of HEAD's `app.conf.template` next to the new `mcp.conf.inc` and `run-nginx.sh`.
- Live comparison with a local nginx, echo backends, and a fake DNS server: old (HEAD) and new standard and prod configs side by side.
  - 64/64 requests (16 URIs × GET/POST) reached the same backend with an identical request line and headers in old and new. This includes encoded paths and queries (`/api/foo%20bar?q=%2F`, `/scim/v2/Users?filter=userName%20eq%20%22a%22`), the regex locations, `/mcp` rewrites, `/mcp/oauth/callback`, and the prod 443 → 80 hop. A variable `proxy_pass` without a URI part keeps nginx's URI handling unchanged, so the concern about regex locations in the ticket does not apply.
  - Simulated a recreated `api_server`: DNS moved to a new address and the old one stopped answering. Old configs: 502 on `/api/health` and `/mcp/tools`. New configs: 200 from the new address with no reload. Removing the name from DNS gives 502 with `api_server could not be resolved`; adding it back recovers.
- Not verified on a live Docker host: this container has no Docker daemon. The DNS behaviour was checked against a local resolver, not against 127.0.0.11 inside a compose network.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 502 errors on `/api/*` after `onyx-cli deploy upgrade`. nginx pinned upstream addresses at startup and kept proxying to retired containers until its 6-hourly reload; it now resolves them per request, and the CLI restarts nginx when compose leaves it running.

**Bug Fixes**
- nginx resolves `api_server` and `web_server` per request via Docker's embedded DNS and `proxy_pass` variables instead of static `upstream {}` blocks.
- MCP locations resolve `$mcp_upstream` and `$mcp_web_upstream` the same way; the removed `mcp_upstream.conf.inc.template` is replaced by an empty include so hand-edited older templates keep loading.
- `runUpgrade` restarts nginx after `up` when nginx's container ID is unchanged, so the new templates take effect on existing installs.
- A failed restart is a warning with the manual command, not a failed upgrade.
- The Helm chart keeps static upstreams because Kubernetes Service addresses are stable.

<sup>Written for commit 69556bd38b9ee68e5c30b6a85cf515ac471a42a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

