### PR TITLE
feat(i18n): format numbers and dates in the UI locale, with Arabic-Indic digits for Arabic

### DIFF
--- a/web/lib/opal/src/components/pagination/components.tsx
+++ b/web/lib/opal/src/components/pagination/components.tsx
@@ -7,6 +7,7 @@ import { containerSizeVariants } from "@opal/shared";
 import type { RichStr, WithoutStyles } from "@opal/types";
 import { Text } from "@opal/components";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
+import { textChunks } from "@opal/components/text/chunks";
 import { cn } from "@opal/utils";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import {
@@ -167,15 +168,6 @@ function getPageNumbers(
   ];
 }
 
-function monoClass(size: PaginationSize): string {
-  return size === "sm" ? "font-secondary-mono" : "font-main-ui-mono";
-}
-
-function textClasses(size: PaginationSize, style: "mono" | "muted"): string {
-  if (style === "mono") return monoClass(size);
-  return size === "sm" ? "font-secondary-body" : "font-main-ui-muted";
-}
-
 const PAGE_NUMBER_FONT: Record<
   PaginationSize,
   { active: string; inactive: string }
@@ -210,19 +202,20 @@ function GoToPagePopup({ totalPages, onSubmit, children }: GoToPagePopupProps) {
   const focusOnMount = useFocusOnMount<HTMLInputElement>();
   const strings = useOpalStrings();
 
-  const parsed = parseInt(value, 10);
-  const isValid = !isNaN(parsed) && parsed >= 1 && parsed <= totalPages;
+  // The host's parser accepts the digits the page numbers are displayed in.
+  const page = strings.parseNumber(value);
+  const isValid = page !== null && page >= 1 && page <= totalPages;
 
   function handleChange(e: ChangeEvent<HTMLInputElement>) {
     const raw = e.target.value;
-    if (raw === "" || /^\d+$/.test(raw)) {
+    if (raw === "" || strings.parseNumber(raw) !== null) {
       setValue(raw);
     }
   }
 
   function handleSubmit() {
-    if (!isValid) return;
-    onSubmit(parsed);
+    if (page === null || !isValid) return;
+    onSubmit(page);
     setOpen(false);
     setValue("");
   }
@@ -342,11 +335,12 @@ function PaginationSimple({
   units,
   ...props
 }: SimplePaginationProps) {
+  const strings = useOpalStrings();
   const handleChange = (page: number) => onChange?.(page);
 
-  const label = `${currentPage}/${totalPages}${
-    units ? ` ${toPlainString(units)}` : ""
-  }`;
+  const label = `${strings.formatNumber(currentPage)}/${strings.formatNumber(
+    totalPages
+  )}${units ? ` ${toPlainString(units)}` : ""}`;
 
   return (
     <div {...props} className="flex items-center">
@@ -383,28 +377,38 @@ function PaginationCount({
   units,
   ...props
 }: CountPaginationProps) {
+  const strings = useOpalStrings();
   const handleChange = (page: number) => onChange?.(page);
   const rangeStart = totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1;
   const rangeEnd = Math.min(currentPage * pageSize, totalItems);
+  const monoFont = size === "sm" ? "secondary-mono" : "main-ui-mono";
+  const mutedFont = size === "sm" ? "secondary-body" : "main-ui-muted";
+  // The range is an LTR isolate so "1~10" keeps its digit order in RTL copy.
+  const range = (
+    <Text font={monoFont} color="inherit" dir="ltr">
+      {`${strings.formatNumber(rangeStart)}~${strings.formatNumber(rangeEnd)}`}
+    </Text>
+  );
+  const total = (
+    <Text font={monoFont} color="inherit">
+      {strings.formatNumber(totalItems)}
+    </Text>
+  );
+  // Words between the numbers take the muted style. The flex gap spaces them.
+  const summary = textChunks(
+    strings.rangeOfTotal(range, total),
+    mutedFont,
+    "inherit",
+    true
+  );
 
   return (
     <div {...props} className="flex items-center gap-1">
       {/* Summary: range of total [units] */}
-      <span
-        className={cn(
-          "inline-flex items-center gap-1",
-          monoClass(size),
-          "text-text-03"
-        )}
-      >
-        {rangeStart}~{rangeEnd}
-        <span className={textClasses(size, "muted")}>of</span>
-        {totalItems}
+      <span className={cn("inline-flex items-center gap-1", "text-text-03")}>
+        {summary}
         {units && (
-          <Text
-            color="inherit"
-            font={size === "sm" ? "secondary-body" : "main-ui-muted"}
-          >
+          <Text color="inherit" font={mutedFont}>
             {units}
           </Text>
         )}
@@ -421,7 +425,7 @@ function PaginationCount({
           {!hidePages && (
             <GoToPagePopup totalPages={totalPages} onSubmit={handleChange}>
               <Button size={size} prominence="tertiary">
-                {String(currentPage)}
+                {strings.formatNumber(currentPage)}
               </Button>
             </GoToPagePopup>
           )}
@@ -442,6 +446,7 @@ function PaginationList({
   size = "lg",
   ...props
 }: ListPaginationProps) {
+  const strings = useOpalStrings();
   const pageNumbers = getPageNumbers(currentPage, totalPages);
   const fonts = PAGE_NUMBER_FONT[size];
 
@@ -498,7 +503,7 @@ function PaginationList({
                       isActive ? fonts.active : fonts.inactive
                     )}
                   >
-                    {page}
+                    {strings.formatNumber(page)}
                   </div>
                 )}
               />

--- a/web/lib/opal/src/components/table/Footer.tsx
+++ b/web/lib/opal/src/components/table/Footer.tsx
@@ -4,8 +4,9 @@ import { Button, Pagination, SelectButton } from "@opal/components";
 import { Text } from "@opal/components";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 import { SvgEye, SvgXCircle } from "@opal/icons";
+import { textChunks } from "@opal/components/text/chunks";
 import { useOpalStrings, type OpalStrings } from "@opal/strings";
-import { Children, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -264,26 +265,15 @@ function SummaryLeft({
   // The range is an LTR isolate so "1~10" keeps its digit order in RTL copy.
   const range = (
     <Text font={monoFont} color="text-03" dir="ltr">
-      {`${rangeStart}~${rangeEnd}`}
+      {`${strings.formatNumber(rangeStart)}~${strings.formatNumber(rangeEnd)}`}
     </Text>
   );
   const total = (
     <Text font={monoFont} color="text-03">
-      {`${totalItems}${suffix}`}
+      {`${strings.formatNumber(totalItems)}${suffix}`}
     </Text>
   );
-  // Each text chunk gets its own Text span, so the summary keeps the sibling
-  // layout (and spacing) it had before the words came from a translation.
-  const parts = Children.toArray(strings.showing(range, total)).map(
-    (part, index) =>
-      typeof part === "string" ? (
-        <Text key={index} font={bodyFont} color="text-03">
-          {part}
-        </Text>
-      ) : (
-        part
-      )
-  );
+  const parts = textChunks(strings.showing(range, total), bodyFont, "text-03");
   return (
     <div className="flex flex-row items-center w-fit h-fit px-1">{parts}</div>
   );

--- a/web/lib/opal/src/components/text/chunks.tsx
+++ b/web/lib/opal/src/components/text/chunks.tsx
@@ -1,0 +1,22 @@
+import { Children, type ReactNode } from "react";
+import type { TextColor, TextFont } from "@onyx-ai/shared/contracts";
+import { Text } from "@opal/components/text/components";
+
+/** Wraps the string parts of a translated rich message in Text so every chunk is a sibling span.
+ *  `trim` drops the spaces around words when a flex gap already separates them. */
+export function textChunks(
+  nodes: ReactNode,
+  font: TextFont,
+  color: TextColor,
+  trim = false
+): ReactNode[] {
+  return Children.toArray(nodes).map((part, index) =>
+    typeof part === "string" ? (
+      <Text key={index} font={font} color={color}>
+        {trim ? part.trim() : part}
+      </Text>
+    ) : (
+      part
+    )
+  );
+}

--- a/web/lib/opal/src/strings.tsx
+++ b/web/lib/opal/src/strings.tsx
@@ -54,8 +54,14 @@ export type OpalStrings = {
   selectAnItemToContinue: string;
   singleItemSelected: string;
   selectedItemCount: (count: number) => string;
+  /** Locale digits, no grouping, for the counts Opal renders itself (footer range, page numbers). */
+  formatNumber: (value: number) => string;
+  /** Inverse of formatNumber for typed input: a whole number in the locale digits (ASCII always accepted), else null. */
+  parseNumber: (text: string) => number | null;
   /** Table footer summary, e.g. "Showing 1~10 of 22", as text chunks around the two styled nodes. */
   showing: (range: ReactNode, total: ReactNode) => ReactNode;
+  /** Pagination count summary, e.g. "1~10 of 22", same chunk shape as `showing`. */
+  rangeOfTotal: (range: ReactNode, total: ReactNode) => ReactNode;
 };
 
 export const defaultOpalStrings: OpalStrings = {
@@ -108,7 +114,10 @@ export const defaultOpalStrings: OpalStrings = {
   singleItemSelected: "Item selected",
   selectedItemCount: (count) =>
     `${count} item${count !== 1 ? "s" : ""} selected`,
+  formatNumber: (value) => String(value),
+  parseNumber: (text) => (/^\d+$/.test(text) ? Number(text) : null),
   showing: (range, total) => ["Showing ", range, " of ", total],
+  rangeOfTotal: (range, total) => [range, " of ", total],
 };
 
 const OpalStringsContext = createContext<OpalStrings>(defaultOpalStrings);

--- a/web/lib/opal/src/time.test.ts
+++ b/web/lib/opal/src/time.test.ts
@@ -28,9 +28,13 @@ describe("timeAgo", () => {
   });
 
   it("follows the locale", () => {
-    // Digit shaping for "ar" differs between ICU builds, so only the words are asserted.
+    // Digit shaping for bare "ar" differs between ICU builds, so only the words are asserted.
     expect(timeAgo(daysAgo(3), "ar")).toMatch(/^قبل .* أيام$/);
     expect(timeAgo(daysAgo(3), "de")).toBe("vor 3 Tagen");
+  });
+
+  it("shapes digits from the numbering system on the locale tag", () => {
+    expect(timeAgo(daysAgo(3), "ar-u-nu-arab")).toBe("قبل ٣ أيام");
   });
 });
 
@@ -42,6 +46,7 @@ describe("date formatters", () => {
     expect(humanReadableFormatShort(june6, "en")).toBe("Jun 6, 2026");
     expect(humanReadableFormatShort(june6, "de")).toBe("6. Juni 2026");
     expect(humanReadableFormat(june6, "fr")).toBe("6 juin 2026");
+    expect(humanReadableFormatShort(june6, "ar-u-nu-arab")).toContain("٢٠٢٦");
   });
 
   it("returns an empty string for a missing short date", () => {

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -642,14 +642,17 @@ function Main({ ccPairId }: { ccPairId: number }) {
               {t("statusCard.documentsIndexed.label")}
             </div>
             <div className="text-sm text-text-default flex items-center gap-x-1">
-              {ccPair.num_docs_indexed.toLocaleString()}
+              {ccPair.num_docs_indexed.toLocaleString(locale)}
               {ccPair.status ===
                 ConnectorCredentialPairStatus.INITIAL_INDEXING &&
                 ccPair.overall_indexing_speed !== null &&
                 ccPair.num_docs_indexed > 0 && (
                   <div className="ms-0.5 text-xs font-medium">
                     {t("statusCard.indexingSpeed", {
-                      speed: ccPair.overall_indexing_speed.toFixed(1),
+                      speed: ccPair.overall_indexing_speed.toLocaleString(
+                        locale,
+                        { minimumFractionDigits: 1, maximumFractionDigits: 1 }
+                      ),
                     })}
                   </div>
                 )}

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -78,6 +78,7 @@ function SummaryRow({
   onToggle: () => void;
 }) {
   const t = useTranslations("admin.indexing");
+  const locale = useLocale();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
   return (
@@ -103,7 +104,9 @@ function SummaryRow({
         <div className="text-sm text-neutral-500 dark:text-neutral-300">
           {t("status.summary.totalConnectors.label")}
         </div>
-        <div className="text-xl font-semibold">{summary.total_connectors}</div>
+        <div className="text-xl font-semibold">
+          {summary.total_connectors.toLocaleString(locale)}
+        </div>
       </TableCell>
 
       <TableCell>
@@ -111,7 +114,8 @@ function SummaryRow({
           {t("status.summary.activeConnectors.label")}
         </div>
         <p className="flex text-xl mx-auto font-semibold items-center text-lg mt-1">
-          {summary.active_connectors}/{summary.total_connectors}
+          {summary.active_connectors.toLocaleString(locale)}/
+          {summary.total_connectors.toLocaleString(locale)}
         </p>
       </TableCell>
 
@@ -121,7 +125,8 @@ function SummaryRow({
             {t("status.summary.publicConnectors.label")}
           </div>
           <p className="flex text-xl mx-auto font-semibold items-center text-lg mt-1">
-            {summary.public_connectors}/{summary.total_connectors}
+            {summary.public_connectors.toLocaleString(locale)}/
+            {summary.total_connectors.toLocaleString(locale)}
           </p>
         </TableCell>
       )}
@@ -131,7 +136,7 @@ function SummaryRow({
           {t("status.summary.totalDocsIndexed.label")}
         </div>
         <div className="text-xl font-semibold">
-          {summary.total_docs_indexed.toLocaleString()}
+          {summary.total_docs_indexed.toLocaleString(locale)}
         </div>
       </TableCell>
 
@@ -213,7 +218,9 @@ function ConnectorRow({
           )}
         </TableCell>
       )}
-      <TableCell>{ccPairsIndexingStatus.docs_indexed}</TableCell>
+      <TableCell>
+        {ccPairsIndexingStatus.docs_indexed.toLocaleString(locale)}
+      </TableCell>
       <TableCell>
         {isEditable && (
           <Tooltip tooltip={t("status.manageConnector.tooltip")}>

--- a/web/src/app/ee/admin/billing/BillingAlerts.tsx
+++ b/web/src/app/ee/admin/billing/BillingAlerts.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from "next-intl";
 import { MessageCard, Text } from "@opal/components";
 import { BillingInformation, BillingStatus } from "@/lib/billing/interfaces";
 
@@ -6,6 +7,7 @@ export function BillingAlerts({
 }: {
   billingInformation: BillingInformation;
 }) {
+  const locale = useLocale();
   const isTrialing = billingInformation.status === BillingStatus.TRIALING;
   const isCancelled = billingInformation.cancel_at_period_end;
   const isExpired = billingInformation.current_period_end
@@ -24,12 +26,14 @@ export function BillingAlerts({
     messages.push(
       `Your subscription will cancel on ${new Date(
         billingInformation.current_period_end
-      ).toLocaleDateString()}. You can resubscribe before this date to remain uninterrupted.`
+      ).toLocaleDateString(
+        locale
+      )}. You can resubscribe before this date to remain uninterrupted.`
     );
   }
   if (isTrialing) {
     const trialEndStr = billingInformation.trial_end
-      ? new Date(billingInformation.trial_end).toLocaleDateString()
+      ? new Date(billingInformation.trial_end).toLocaleDateString(locale)
       : "N/A";
     messages.push(
       `You're currently on a trial. Your trial ends on ${trialEndStr}.`

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Card, Text } from "@opal/components";
 import { Section } from "@opal/layouts";
 import {
@@ -35,6 +35,7 @@ interface SummaryMetricProps {
 }
 
 function SummaryMetric({ label, value }: SummaryMetricProps) {
+  const locale = useLocale();
   return (
     <Section
       flexDirection="column"
@@ -47,7 +48,7 @@ function SummaryMetric({ label, value }: SummaryMetricProps) {
       <Text font="secondary-body" color="text-03">
         {label}
       </Text>
-      <Text font="heading-h3">{value.toLocaleString()}</Text>
+      <Text font="heading-h3">{value.toLocaleString(locale)}</Text>
     </Section>
   );
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -142,6 +142,11 @@
     margin-inline-start: 0;
   }
 
+  /* Arabic reads Eastern Arabic-Indic digits, list markers included. */
+  :lang(ar) .prose ol {
+    list-style-type: arabic-indic;
+  }
+
   .prose ul {
     list-style-type: disc;
     padding-inline-start: 1.5rem;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -26,7 +26,7 @@ import OpalStringsBridge from "@/i18n/OpalStringsBridge";
 import { getLocale, getMessages } from "next-intl/server";
 import { DirectionProvider } from "@radix-ui/react-direction";
 import { cookies } from "next/headers";
-import { htmlDirForLocale, type HtmlDir } from "@/i18n/config";
+import { htmlDirForLocale, messageLocale, type HtmlDir } from "@/i18n/config";
 
 // No generic at the end of either fallback list: the generic comes last in
 // the composed --font-* variables on <html> below, after the per-locale CJK
@@ -65,12 +65,16 @@ interface LayoutProps {
 }
 
 export default async function Layout({ children }: LayoutProps) {
-  // Locale comes from the NEXT_LOCALE cookie (see src/i18n/request.ts), which
-  // UserProvider keeps in sync with the user's stored language preference.
+  // The runtime tag comes from the NEXT_LOCALE cookie (see src/i18n/request.ts),
+  // which the backend sets from the stored language.
   const locale = await getLocale();
   const messages = await getMessages();
+  // <html lang> and the direction follow the stored language, not the runtime
+  // tag: UserProvider refreshes whenever <html lang> differs from the stored
+  // language, and the numbering system belongs to Intl, not the document.
+  const language = messageLocale(locale);
 
-  let dir: HtmlDir = htmlDirForLocale(locale);
+  let dir: HtmlDir = htmlDirForLocale(language);
   // Dev-only escape hatch so QA can preview either direction without
   // switching account language: set an "onyx-dir" cookie to "rtl" or
   // "ltr" (with path=/) and reload.
@@ -83,7 +87,7 @@ export default async function Layout({ children }: LayoutProps) {
 
   return (
     <html
-      lang={locale}
+      lang={language}
       dir={dir}
       // The app-wide font variables are composed here instead of with
       // next/font's `variable` option: the CJK tail (--font-cjk-sans,

--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { JSX } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { MinimalOnyxDocument, OnyxDocument } from "@/lib/search/interfaces";
 import { SourceIcon } from "../SourceIcon";
 import { WebResultIcon } from "../WebResultIcon";
@@ -133,6 +133,7 @@ export function CompactDocumentCard({
   updatePresentingDocument,
 }: CompactDocumentCardProps) {
   const t = useTranslations("common.documentDisplay");
+  const locale = useLocale();
   const isWebSource =
     document.is_internet || document.source_type === ValidSources.Web;
 
@@ -178,7 +179,7 @@ export function CompactDocumentCard({
               className="line-clamp-2 text-start m-0!"
             >
               {t("updated.text", {
-                date: new Date(document.updated_at).toLocaleDateString(),
+                date: new Date(document.updated_at).toLocaleDateString(locale),
               })}
             </Text>
           )}

--- a/web/src/i18n/OpalStringsBridge.test.tsx
+++ b/web/src/i18n/OpalStringsBridge.test.tsx
@@ -1,14 +1,14 @@
 import { NextIntlClientProvider } from "next-intl";
 import { render } from "@tests/setup/test-utils";
 import Footer from "@opal/components/table/Footer";
-import type { Locale } from "@/i18n/config";
+import { runtimeLocale, type RuntimeLocale } from "@/i18n/config";
 import OpalStringsBridge from "@/i18n/OpalStringsBridge";
 import arabicMessages from "@/i18n/messages/ar.json";
 import englishMessages from "@/i18n/messages/en.json";
 
 type Messages = typeof englishMessages;
 
-function renderFooterThroughBridge(locale: Locale, messages: Messages) {
+function renderFooterThroughBridge(locale: RuntimeLocale, messages: Messages) {
   const { container } = render(
     <NextIntlClientProvider locale={locale} messages={messages}>
       <OpalStringsBridge>
@@ -54,5 +54,11 @@ describe("OpalStringsBridge", () => {
       "SPAN",
     ]);
     expect(row.querySelector('span[dir="ltr"]')).toHaveTextContent("1~10");
+  });
+
+  it("renders the footer digits in the numbering system of the runtime locale", () => {
+    const row = renderFooterThroughBridge(runtimeLocale("ar"), arabicMessages);
+    expect(row.textContent).toBe("عرض ١~١٠ من ٢٢ users");
+    expect(row.querySelector('span[dir="ltr"]')).toHaveTextContent("١~١٠");
   });
 });

--- a/web/src/i18n/OpalStringsBridge.tsx
+++ b/web/src/i18n/OpalStringsBridge.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { OpalStringsProvider, type OpalStrings } from "@opal/strings";
+import { createLocaleIntegerParser } from "@/i18n/numbers";
 
 interface OpalStringsBridgeProps {
   children: ReactNode;
@@ -13,8 +14,11 @@ export default function OpalStringsBridge({
   children,
 }: OpalStringsBridgeProps) {
   const t = useTranslations("opal");
-  const strings = useMemo<OpalStrings>(
-    () => ({
+  const locale = useLocale();
+  const strings = useMemo<OpalStrings>(() => {
+    // Counts such as "1234~1250" are identifiers, so no grouping separators.
+    const digits = new Intl.NumberFormat(locale, { useGrouping: false });
+    return {
       close: t("common.close"),
       loading: t("common.loading"),
       loadingPage: t("common.loadingPage"),
@@ -63,11 +67,17 @@ export default function OpalStringsBridge({
       selectAnItemToContinue: t("table.selectAnItemToContinue"),
       singleItemSelected: t("table.singleItemSelected"),
       selectedItemCount: (count) => t("table.selectedItemCount", { count }),
+      formatNumber: (value) => digits.format(value),
+      parseNumber: createLocaleIntegerParser(digits),
       showing: (range, total) =>
         t.rich("table.showing", { range: () => range, total: () => total }),
-    }),
-    [t]
-  );
+      rangeOfTotal: (range, total) =>
+        t.rich("pagination.rangeOfTotal", {
+          range: () => range,
+          total: () => total,
+        }),
+    };
+  }, [t, locale]);
   return (
     <OpalStringsProvider strings={strings}>{children}</OpalStringsProvider>
   );

--- a/web/src/i18n/config.test.ts
+++ b/web/src/i18n/config.test.ts
@@ -1,4 +1,9 @@
-import { SUPPORTED_LOCALES } from "@/i18n/config";
+import {
+  SUPPORTED_LOCALES,
+  htmlDirForLocale,
+  messageLocale,
+  runtimeLocale,
+} from "@/i18n/config";
 
 describe("SUPPORTED_LOCALES", () => {
   it("matches the backend SupportedLanguage enum", () => {
@@ -16,5 +21,35 @@ describe("SUPPORTED_LOCALES", () => {
       "ko",
       "ar",
     ]);
+  });
+});
+
+describe("runtime locale", () => {
+  it("adds the Arabic-Indic numbering system to Arabic only", () => {
+    expect(runtimeLocale("ar")).toBe("ar-u-nu-arab");
+    for (const locale of SUPPORTED_LOCALES.filter((l) => l !== "ar")) {
+      expect(runtimeLocale(locale)).toBe(locale);
+    }
+  });
+
+  it("recovers the stored language from a runtime tag, English for unknown tags", () => {
+    expect(messageLocale("ar-u-nu-arab")).toBe("ar");
+    expect(messageLocale("de")).toBe("de");
+    expect(messageLocale("xx-u-nu-arab")).toBe("en");
+  });
+
+  it("detects RTL from the stored language behind a runtime tag", () => {
+    expect(htmlDirForLocale(messageLocale("ar-u-nu-arab"))).toBe("rtl");
+    expect(htmlDirForLocale("ar")).toBe("rtl");
+    expect(htmlDirForLocale("en")).toBe("ltr");
+  });
+
+  it("formats digits in Arabic-Indic under the runtime tag", () => {
+    expect(new Intl.NumberFormat(runtimeLocale("ar")).format(1234)).toBe(
+      "١٬٢٣٤"
+    );
+    expect(new Intl.NumberFormat(runtimeLocale("en")).format(1234)).toBe(
+      "1,234"
+    );
   });
 });

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -54,7 +54,25 @@ export const RTL_LOCALES: readonly Locale[] = ["ar"];
 
 export type HtmlDir = "ltr" | "rtl";
 
-export function htmlDirForLocale(locale: string): HtmlDir {
-  // SAFETY: cast narrows only for the readonly-array `includes` signature.
-  return RTL_LOCALES.includes(locale as Locale) ? "rtl" : "ltr";
+export function htmlDirForLocale(locale: Locale): HtmlDir {
+  return RTL_LOCALES.includes(locale) ? "rtl" : "ltr";
+}
+
+// Arabic reads Eastern Arabic-Indic digits. The numbering system rides on the
+// runtime locale tag, so any Intl call given useLocale() shapes digits without
+// a numberingSystem option.
+const NUMBERING_SYSTEMS: Partial<Record<Locale, string>> = { ar: "arab" };
+
+export type RuntimeLocale = Locale | `${Locale}-u-nu-${string}`;
+
+/** The locale handed to next-intl and Intl for a stored language. */
+export function runtimeLocale(locale: Locale): RuntimeLocale {
+  const system = NUMBERING_SYSTEMS[locale];
+  return system ? `${locale}-u-nu-${system}` : locale;
+}
+
+/** The stored language behind a runtime tag ("ar-u-nu-arab" is "ar"). Unknown tags fall back to English. */
+export function messageLocale(locale: string): Locale {
+  const base = locale.split("-u-")[0] ?? locale;
+  return isSupportedLocale(base) ? base : DEFAULT_LOCALE;
 }

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "الانتقال إلى صفحة",
       "nextPage": "الصفحة التالية",
-      "previousPage": "الصفحة السابقة"
+      "previousPage": "الصفحة السابقة",
+      "rangeOfTotal": "<range></range> من <total></total>"
     },
     "table": {
       "alwaysShown": "معروض دائمًا",

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "Zu Seite springen",
       "nextPage": "Nächste Seite",
-      "previousPage": "Vorherige Seite"
+      "previousPage": "Vorherige Seite",
+      "rangeOfTotal": "<range></range> von <total></total>"
     },
     "table": {
       "alwaysShown": "Immer angezeigt",

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "Go to page",
       "nextPage": "Next page",
-      "previousPage": "Previous page"
+      "previousPage": "Previous page",
+      "rangeOfTotal": "<range></range> of <total></total>"
     },
     "table": {
       "alwaysShown": "Always Shown",

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "Ir a la página",
       "nextPage": "Página siguiente",
-      "previousPage": "Página anterior"
+      "previousPage": "Página anterior",
+      "rangeOfTotal": "<range></range> de <total></total>"
     },
     "table": {
       "alwaysShown": "Siempre visible",

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "Aller à la page",
       "nextPage": "Page suivante",
-      "previousPage": "Page précédente"
+      "previousPage": "Page précédente",
+      "rangeOfTotal": "<range></range> sur <total></total>"
     },
     "table": {
       "alwaysShown": "Toujours affichée",

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "ページへ移動",
       "nextPage": "次のページ",
-      "previousPage": "前のページ"
+      "previousPage": "前のページ",
+      "rangeOfTotal": "<range></range> / <total></total>"
     },
     "table": {
       "alwaysShown": "常に表示",

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "페이지로 이동",
       "nextPage": "다음 페이지",
-      "previousPage": "이전 페이지"
+      "previousPage": "이전 페이지",
+      "rangeOfTotal": "<range></range> / <total></total>"
     },
     "table": {
       "alwaysShown": "항상 표시",

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "Ir para a página",
       "nextPage": "Próxima página",
-      "previousPage": "Página anterior"
+      "previousPage": "Página anterior",
+      "rangeOfTotal": "<range></range> de <total></total>"
     },
     "table": {
       "alwaysShown": "Sempre exibida",

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -12814,7 +12814,8 @@
     "pagination": {
       "goToPage": "跳转到页面",
       "nextPage": "下一页",
-      "previousPage": "上一页"
+      "previousPage": "上一页",
+      "rangeOfTotal": "<range></range> / <total></total>"
     },
     "table": {
       "alwaysShown": "始终显示",

--- a/web/src/i18n/numbers.test.ts
+++ b/web/src/i18n/numbers.test.ts
@@ -1,0 +1,26 @@
+import { runtimeLocale } from "@/i18n/config";
+import { createLocaleIntegerParser } from "@/i18n/numbers";
+
+function parserFor(locale: string) {
+  return createLocaleIntegerParser(
+    new Intl.NumberFormat(locale, { useGrouping: false })
+  );
+}
+
+describe("createLocaleIntegerParser", () => {
+  it("reads Eastern Arabic-Indic and ASCII digits in the Arabic UI", () => {
+    const parse = parserFor(runtimeLocale("ar"));
+    expect(parse("١٢")).toBe(12);
+    expect(parse("12")).toBe(12);
+    expect(parse("٠٣")).toBe(3);
+  });
+
+  it("returns null for anything that is not a whole number", () => {
+    const parse = parserFor("en");
+    expect(parse("")).toBeNull();
+    expect(parse("1a")).toBeNull();
+    expect(parse("-1")).toBeNull();
+    expect(parse("1.5")).toBeNull();
+    expect(parse("١")).toBeNull();
+  });
+});

--- a/web/src/i18n/numbers.ts
+++ b/web/src/i18n/numbers.ts
@@ -1,0 +1,23 @@
+/** Parses whole numbers typed in the digits `format` prints, so users can enter what the UI shows.
+ *  ASCII digits are always accepted. */
+export function createLocaleIntegerParser(
+  format: Intl.NumberFormat
+): (text: string) => number | null {
+  const localeDigits = Array.from({ length: 10 }, (_, digit) =>
+    format.format(digit)
+  );
+  return (text) => {
+    if (text === "") return null;
+    let ascii = "";
+    for (const char of text) {
+      const digit = localeDigits.indexOf(char);
+      if (digit !== -1) {
+        ascii += digit;
+        continue;
+      }
+      if (!/^\d$/.test(char)) return null;
+      ascii += char;
+    }
+    return Number(ascii);
+  };
+}

--- a/web/src/i18n/request.ts
+++ b/web/src/i18n/request.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_LOCALE,
   LOCALE_COOKIE_NAME,
   isSupportedLocale,
+  runtimeLocale,
 } from "@/i18n/config";
 import englishMessages from "@/i18n/messages/en.json";
 
@@ -39,12 +40,14 @@ export default getRequestConfig(async () => {
     ? cookieLocale
     : DEFAULT_LOCALE;
 
-  if (locale === DEFAULT_LOCALE) {
-    return { locale, messages: english };
-  }
-
-  // SAFETY: same catalog shape as en.json, enforced by the i18n catalog test.
-  const overlay = (await import(`@/i18n/messages/${locale}.json`))
-    .default as MessageTree;
-  return { locale, messages: withEnglishFallback(english, overlay) };
+  const messages =
+    locale === DEFAULT_LOCALE
+      ? english
+      : withEnglishFallback(
+          english,
+          // SAFETY: same catalog shape as en.json, enforced by the i18n catalog test.
+          (await import(`@/i18n/messages/${locale}.json`))
+            .default as MessageTree
+        );
+  return { locale: runtimeLocale(locale), messages };
 });

--- a/web/src/i18n/types.d.ts
+++ b/web/src/i18n/types.d.ts
@@ -1,12 +1,13 @@
 import type en from "@/i18n/messages/en.json";
-import type { Locale } from "@/i18n/config";
+import type { RuntimeLocale } from "@/i18n/config";
 
 // Makes message keys type-safe: `useTranslations`/`getTranslations` calls
 // autocomplete against the English catalog, and a key that is missing from
 // en.json is a compile error caught by `bun run types:check`.
+// The locale is the runtime tag: the message locale, plus a numbering system for Arabic.
 declare module "next-intl" {
   interface AppConfig {
-    Locale: Locale;
+    Locale: RuntimeLocale;
     Messages: typeof en;
   }
 }

--- a/web/src/lib/credentials/components/ModifyCredential.tsx
+++ b/web/src/lib/credentials/components/ModifyCredential.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Modal } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { Badge } from "@/components/ui/badge";
@@ -36,6 +36,7 @@ function CredentialSelectionTable({
   onDeleteCredential,
 }: CredentialSelectionTableProps) {
   const t = useTranslations("admin");
+  const locale = useLocale();
   const [selectedCredentialId, setSelectedCredentialId] = useState<
     number | null
   >(null);
@@ -128,10 +129,10 @@ function CredentialSelectionTable({
                     </p>
                   </td>
                   <td className="p-2">
-                    {new Date(credential.time_created).toLocaleString()}
+                    {new Date(credential.time_created).toLocaleString(locale)}
                   </td>
                   <td className="p-2">
-                    {new Date(credential.time_updated).toLocaleString()}
+                    {new Date(credential.time_updated).toLocaleString(locale)}
                   </td>
                   <td className="p-2 flex gap-x-2 content-center mt-auto">
                     <Button

--- a/web/src/refresh-components/inputs/InputDatePicker.tsx
+++ b/web/src/refresh-components/inputs/InputDatePicker.tsx
@@ -6,7 +6,7 @@ import Calendar from "@/refresh-components/Calendar";
 import { Popover } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { SvgCalendar } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 
@@ -40,6 +40,7 @@ export default function InputDatePicker({
   maxDate,
 }: InputDatePickerProps) {
   const t = useTranslations("common.datePicker");
+  const locale = useLocale();
   const validStartYear = Math.max(startYear, 1970);
   const normalizedMaxDate = useMemo(
     () => (maxDate ? normalizeDate(maxDate) : undefined),
@@ -75,7 +76,7 @@ export default function InputDatePicker({
       <Popover.Trigger asChild id={name} name={name}>
         <Button disabled={disabled} prominence="secondary" icon={SvgCalendar}>
           {selectedDate
-            ? selectedDate.toLocaleDateString()
+            ? selectedDate.toLocaleDateString(locale)
             : t("selectDate.label")}
         </Button>
       </Popover.Trigger>

--- a/web/src/views/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/views/admin/UsersPage/UsersSummary.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { SvgArrowUpRight, SvgFilterPlus, SvgUserSync } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Button, Card } from "@opal/components";
@@ -21,7 +21,8 @@ type StatCellProps = {
 
 function StatCell({ value, label, onFilter }: StatCellProps) {
   const t = useTranslations("admin.users");
-  const display = value === null ? "\u2014" : value.toLocaleString();
+  const locale = useLocale();
+  const display = value === null ? "\u2014" : value.toLocaleString(locale);
 
   const cellClassName = `relative flex flex-col items-start gap-0.5 w-full p-2 rounded-08 transition-colors ${
     onFilter ? "cursor-pointer hover:bg-background-tint-02" : ""


### PR DESCRIPTION
## Description

**Bug**: numbers and dates did not follow the UI language. Opal counts were raw `String(n)`, and the raw `toLocaleString()` / `toLocaleDateString()` calls used the browser locale, so a German UI could show `1,234` from an English browser. Arabic was the worst case: Chrome resolves the bare `ar` locale to Western digits, so the words were Arabic and every number was not.

**Fix**: format through the runtime locale everywhere, and put the numbering system on that locale tag.

- The stored language maps to a runtime locale (`runtimeLocale` in `i18n/config.ts`). Only `ar` gets an extension, `ar-u-nu-arab`; the other eight map to themselves and keep Latin digits with their own separators and date order (`de` 1.234,5 and 9.9.2026, `fr` 1 234,5, `ja` 2026/9/9). next-intl, Intl and the Opal date helpers all read `useLocale()`, so ICU plurals, dates, relative times and prices switch together.
- `<html lang>` and the direction keep the stored language. UserProvider refreshes the page whenever that attribute differs from the stored language, so the runtime tag must not leak there.
- Markdown ordered lists use `arabic-indic` markers under `:lang(ar)`.
- The Opal table footer and the three pagination variants format through a new `OpalStrings.formatNumber` (ungrouped in every locale, these are identifiers), the go-to-page field accepts the digits it displays plus ASCII (`OpalStrings.parseNumber`), and the pagination summary stops hardcoding "of" (`opal.pagination.rangeOfTotal`, nine locales). The users, indexing status, connector, agent stats, billing and credentials pages pass the locale to their formatters.

Digits inside model prose are not touched. Eastern Arabic-Indic is the standard in Egypt, the Gulf and the Levant; the Maghreb reads Western digits, so the Arabic mapping is a product call.

Stacked on #14580 (part 2), which sits on #14552 (part 1). Part 3 is #14564.

| Page | Arabic |
| --- | --- |
| Groups | ![groups](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-arabic-digits/pr4-after-groups-digits-ar.jpg) |
| Chat list markers | ![chat](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-arabic-digits/pr4-after-list-markers-ar.jpg) |
| Indexing status | ![indexing](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/ui-screenshots/i18n-arabic-digits/pr4-after-indexing-status-ar.jpg) |

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01FKRTAPBZHBE1mc44bkxkWe
