### PR TITLE
fix(opal): Drop the hardcoded top gap on tab panels

### DIFF
--- a/web/lib/opal/src/components/tabs/components.tsx
+++ b/web/lib/opal/src/components/tabs/components.tsx
@@ -297,7 +297,7 @@ interface TabsContentProps extends WithoutStyles<
 
 function TabsContent({ padding, children, ...props }: TabsContentProps) {
   return (
-    <TabsPrimitive.Content {...props} className="w-full pt-4">
+    <TabsPrimitive.Content {...props} className="w-full">
       {padding ? (
         <div style={{ padding: spacingToRem(padding) }}>{children}</div>
       ) : (

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -245,9 +245,9 @@ function KindSlot({ tab, panel, children }: KindSlotProps) {
             ) : active ? (
               <Tabs.Content value={kind}>{content}</Tabs.Content>
             ) : (
-              // Mirrors the top padding Tabs.Content applies, so the height an
-              // unselected kind holds matches what it occupies once selected.
-              <div className="w-full pt-4">{content}</div>
+              // Mirrors the w-full wrapper Tabs.Content applies, so the height
+              // an unselected kind holds matches what it occupies once selected.
+              <div className="w-full">{content}</div>
             )}
           </div>
         );


### PR DESCRIPTION
## Description

Opal's `Tabs.Content` forced `pt-4` onto every panel, with no way to opt out — the props are `WithoutStyles`, so a caller cannot cancel it. The padding was meant as the gap under a tab strip, but a panel does not always sit under one: the Index Settings model picker renders its panels inside an expandable card, away from the strip, so the rem landed as a stray gap above the first embedding-provider group.

The gap is deleted rather than made configurable. Spacing between a strip and its panel belongs to the layout that composes them — `GeneralLayouts.Section` already offers `padding`/`gap` props at every call site — so a surface that wants the old spacing can say so where it places the two.

Also deletes the hand-rolled copy in `craft/v1/apps/page.tsx`, which mirrored the padding so unselected panels held the same height as selected ones. With nothing left to mirror, keeping it would have produced the same bug in reverse (a height jump on tab switch). The `w-full` wrapper stays.

**Blast radius:** 15 `Tabs.Content` call sites across 10 files lose the 1rem strip-to-panel gap (the strip keeps its own 5px bottom padding). Consumers that use only `Tabs.List`/`Tabs.Trigger` — the chat parallel-timeline tabs, agents navigation, Bifrost/Portkey modals — are unaffected. If any surface looks too tight after this, the fix is a `Section` padding prop at that call site.

## Screenshots + Videos

### Before

There's an extra 1rem of padding at the top. Ugly.

<img width="869" height="320" alt="image" src="https://github.com/user-attachments/assets/edbf5f5c-c260-476f-a447-e487d151aa00" />

### After

No more 1rem of padding at the top. Pretty.

<img width="859" height="301" alt="image" src="https://github.com/user-attachments/assets/7551c7af-4a79-40fe-b889-986007b5d9d5" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hardcoded `pt-4` top gap from `Tabs.Content` panels so spacing is controlled by the layout that composes them, fixing a stray gap in the Index Settings model picker.

- `Tabs.Content` no longer forces a 1rem gap; 15 call sites lose it, but callers can restore it via `GeneralLayouts.Section` padding props.
- Also removes the mirrored padding in `craft/v1/apps/page.tsx` so unselected panels don't jump in height when switching tabs.

<sup>Written for commit c3af678d66195d656c0bd891716b323579d755d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->