### PR TITLE
fix(scim): exempt the SCIM discovery documents from the tier gate

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -33,6 +33,7 @@ from onyx.server.settings.models import Tier
 #   /tenants/billing-* - Legacy billing endpoints (backwards compatibility)
 #   /manage/users, /users - User management (needed for seat limit resolution)
 #   /notifications - Needed for UI to load properly
+#   /scim/v2/{ServiceProviderConfig,ResourceTypes,Schemas} - Static SCIM discovery docs
 LICENSE_ENFORCEMENT_ALLOWED_PREFIXES: frozenset[str] = frozenset(
     {
         "/auth",
@@ -60,6 +61,11 @@ LICENSE_ENFORCEMENT_ALLOWED_PREFIXES: frozenset[str] = frozenset(
         "/users",
         # Notifications - needed for UI to load properly
         "/notifications",
+        # SCIM discovery is unauthenticated. A bearer-less cloud probe resolves
+        # to the default schema, which never reaches the /scim ENTERPRISE floor.
+        "/scim/v2/ServiceProviderConfig",
+        "/scim/v2/ResourceTypes",
+        "/scim/v2/Schemas",
     }
 )
 

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
@@ -225,3 +225,34 @@ async def test_402_payload_includes_required_tier(
     # Body is set on JSONResponse via `content`, accessible as `.body`.
     payload = json.loads(bytes(response.body))
     assert payload["required_tier"] == "enterprise"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/scim/v2/ServiceProviderConfig",
+        "/scim/v2/ResourceTypes",
+        "/scim/v2/Schemas",
+    ],
+)
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_scim_discovery_passes_without_tier_check(
+    mock_get_tier: MagicMock, path: str, middleware_harness: MiddlewareHarness
+) -> None:
+    middleware, call_next = middleware_harness
+    response = await middleware(_make_request(path), call_next)
+    assert response.status_code == 200
+    mock_get_tier.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/scim/v2/Users", "/scim/v2/Groups"])
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_business_blocked_from_scim_resources(
+    mock_get_tier: MagicMock, path: str, middleware_harness: MiddlewareHarness
+) -> None:
+    mock_get_tier.return_value = Tier.BUSINESS
+    middleware, call_next = middleware_harness
+    response = await middleware(_make_request(path), call_next)
+    assert response.status_code == 402


### PR DESCRIPTION
## Description

On cloud, `GET /scim/v2/ServiceProviderConfig` (and `/ResourceTypes`, `/Schemas`) returns 402 `FEATURE_NOT_AVAILABLE` for every tenant when called without a bearer token. The request carries no tenant, so tenant tracking resolves it to the default schema, and the tier gate then checks that schema's tier, which is never Enterprise. A customer probing the endpoint from the SCIM docs read this as a missing Enterprise entitlement. Each such hit also costs a Redis read plus a control-plane round trip, because the default schema's tier is never cached.

The three discovery routes are already public for auth and return module-level constants. This adds them to `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES`, so the tier gate and the self-hosted license gate skip them. `/scim/v2/Users` and `/scim/v2/Groups` stay behind the Enterprise gate and the bearer-token check.

## How Has This Been Tested?

- Reproduced on cloud.onyx.app: unauthenticated discovery returns 402, the same path with a tenant-bearing bearer returns 200.
- New unit tests in `test_tier_gate.py`: the three discovery paths pass without calling `get_tier`, and `/scim/v2/Users` and `/scim/v2/Groups` still return 402 at Business. The discovery cases fail on main (402) and pass with this change.
- `test_tier_gate.py` and `test_license_enforcement.py`: 58 passed. `ruff format --check`, `ruff check`, `ty check`: clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_018qRo52ToJJibGMwozGcRYw
