### PR TITLE
fix(llm): send reasoning_effort=none for GPT-5.4+ tool calls over chat completions

### DIFF
--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -516,7 +516,7 @@ def openai_chat_variant_rejects_reasoning(model_name: str) -> bool:
 
 # GPT-5.4+ refuse function tools over chat completions unless reasoning_effort
 # is explicitly "none", and omitting it fails the same way. gpt-5.2 and earlier
-# accept any effort. Version-gated so new releases need no code change.
+# accept tools with reasoning. Version-gated so new releases need no code change.
 _OPENAI_CHAT_TOOLS_REQUIRE_REASONING_NONE_MIN_VERSION = (5, 4)
 
 # Tolerates vendor prefixes ("openai.gpt-5.6-sol") and alias suffixes
@@ -527,17 +527,16 @@ _OPENAI_GPT_VERSION_PATTERN = re.compile(r"(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?"
 
 def parse_openai_gpt_version(model_name: str) -> tuple[int, int] | None:
     """(major, minor) from a GPT model name, None for any other name."""
-    base_model_name = model_name.lower().split("/")[-1]
-    match = _OPENAI_GPT_VERSION_PATTERN.search(base_model_name)
+    match = _OPENAI_GPT_VERSION_PATTERN.search(model_name.lower())
     if match is None:
         return None
     return (int(match.group(1)), int(match.group(2) or 0))
 
 
 def openai_chat_tools_require_reasoning_none(model_name: str) -> bool:
-    """Name-only, like `openai_model_rejects_reasoning_effort`: these names are
-    GPT models wherever they're hosted, and a gateway alias missing from the
-    registry must still match or its tool calls fail outright."""
+    """True for gpt-5.4 and later, by name alone: the names are OpenAI's wherever
+    they're hosted, and a registry-unknown alias must still match or its tool
+    calls fail outright."""
     version = parse_openai_gpt_version(model_name)
     return (
         version is not None

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -526,7 +526,8 @@ _OPENAI_GPT_VERSION_PATTERN = re.compile(r"(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?"
 
 
 def parse_openai_gpt_version(model_name: str) -> tuple[int, int] | None:
-    """(major, minor) from a GPT model name, None for any other name."""
+    """(major, minor) from a GPT model name, minor 0 when absent. None for any
+    other name."""
     match = _OPENAI_GPT_VERSION_PATTERN.search(model_name.lower())
     if match is None:
         return None

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -526,12 +526,15 @@ _OPENAI_GPT_VERSION_PATTERN = re.compile(r"(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?"
 
 
 def parse_openai_gpt_version(model_name: str) -> tuple[int, int] | None:
-    """(major, minor) from a GPT model name, minor 0 when absent. None for any
-    other name."""
+    """(major, minor) from a GPT model name, minor 0 when absent and Azure's
+    dotless "gpt-35" read as (3, 5). None for any other name."""
     match = _OPENAI_GPT_VERSION_PATTERN.search(model_name.lower())
     if match is None:
         return None
-    return (int(match.group(1)), int(match.group(2) or 0))
+    major, minor = match.group(1), match.group(2)
+    if minor is None and len(major) > 1:
+        return (int(major[0]), int(major[1:]))
+    return (int(major), int(minor or 0))
 
 
 def openai_chat_tools_require_reasoning_none(model_name: str) -> bool:

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -431,6 +431,13 @@ def openai_model_rejects_reasoning_effort(model_name: str) -> bool:
     return base_model_name.startswith(_OPENAI_MODELS_REJECTING_REASONING_EFFORT)
 
 
+# Providers that reach OpenAI models over OpenAI's own API shapes: a registry
+# model takes the responses bridge there, anything else chat completions.
+OPENAI_API_PROVIDERS = frozenset(
+    {LlmProviderNames.OPENAI, LlmProviderNames.LITELLM_PROXY, LlmProviderNames.AZURE}
+)
+
+
 def is_true_openai_model(model_provider: str, model_name: str) -> bool:
     """
     Determines if a model is a true OpenAI model or just using OpenAI-compatible API.
@@ -442,11 +449,7 @@ def is_true_openai_model(model_provider: str, model_name: str) -> bool:
     OpenAI models from OpenAI and Azure should use responses.
     """
 
-    if model_provider not in {
-        LlmProviderNames.OPENAI,
-        LlmProviderNames.LITELLM_PROXY,
-        LlmProviderNames.AZURE,
-    }:
+    if model_provider not in OPENAI_API_PROVIDERS:
         return False
 
     model_map = get_model_map()
@@ -509,6 +512,37 @@ def openai_chat_variant_rejects_reasoning(model_name: str) -> bool:
     params on every surface despite being reasoning models (an OpenAI bug).
     Registry-gated so a name merely containing "-chat" doesn't false-positive."""
     return "-chat" in model_name and is_openai_registry_model_name(model_name)
+
+
+# GPT-5.4+ refuse function tools over chat completions unless reasoning_effort
+# is explicitly "none", and omitting it fails the same way. gpt-5.2 and earlier
+# accept any effort. Version-gated so new releases need no code change.
+_OPENAI_CHAT_TOOLS_REQUIRE_REASONING_NONE_MIN_VERSION = (5, 4)
+
+# Tolerates vendor prefixes ("openai.gpt-5.6-sol") and alias suffixes
+# ("gpt-5.6-sol-01-ptu") so gateway and Azure deployment names match, while the
+# boundary keeps "chatgpt-4o-latest" out.
+_OPENAI_GPT_VERSION_PATTERN = re.compile(r"(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?")
+
+
+def parse_openai_gpt_version(model_name: str) -> tuple[int, int] | None:
+    """(major, minor) from a GPT model name, None for any other name."""
+    base_model_name = model_name.lower().split("/")[-1]
+    match = _OPENAI_GPT_VERSION_PATTERN.search(base_model_name)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2) or 0))
+
+
+def openai_chat_tools_require_reasoning_none(model_name: str) -> bool:
+    """Name-only, like `openai_model_rejects_reasoning_effort`: these names are
+    GPT models wherever they're hosted, and a gateway alias missing from the
+    registry must still match or its tool calls fail outright."""
+    version = parse_openai_gpt_version(model_name)
+    return (
+        version is not None
+        and version >= _OPENAI_CHAT_TOOLS_REQUIRE_REASONING_NONE_MIN_VERSION
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -385,13 +385,13 @@ def _log_azure_responses_api_version_override(
 def _log_chat_completions_tools_disable_reasoning(
     model: str, api_base: str | None
 ) -> None:
-    """Log once per model per process, for the same reason as
-    _log_azure_responses_api_version_override."""
+    """Log once per model and api_base per process, for the same reason as
+    `_log_azure_responses_api_version_override`."""
     logger.warning(
         "%s at %s is reached over chat completions, where GPT-5.4+ cannot "
         "combine function tools with reasoning. Tool-bearing requests send "
-        "reasoning_effort=none; switch the provider to the responses API mode "
-        "to keep reasoning.",
+        "reasoning_effort=none. To keep reasoning, switch the provider to the "
+        "responses API mode or use a model name the registry knows.",
         model,
         api_base,
     )
@@ -669,6 +669,8 @@ class LitellmLLM(LLM):
         #########################
         # Optional kwargs - should only be passed to LiteLLM under certain conditions
         optional_kwargs: dict[str, Any] = {}
+        # Kwargs the provider requires, which the retry ladder must never strip.
+        required_kwarg_keys: frozenset[str] = frozenset()
 
         # Model name
         is_openai_compatible_proxy = self._api_surface in OPENAI_COMPATIBLE_SURFACES
@@ -753,6 +755,23 @@ class LitellmLLM(LLM):
             user_default=self.config.reasoning_effort_user_default,
             maximum=self.config.reasoning_effort_max,
         )
+
+        # Tool turns over chat completions for GPT-5.4+ trade reasoning for a
+        # working call. Responses routes, registry bridge included, are exempt.
+        forces_reasoning_none = (
+            bool(tools)
+            and not is_openai_model
+            and (
+                self._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
+                or self._model_provider in OPENAI_API_PROVIDERS
+            )
+            and any(
+                openai_chat_tools_require_reasoning_none(name)
+                for name in model_identity_names
+            )
+        )
+        if forces_reasoning_none:
+            reasoning_effort = ReasoningEffort.OFF
 
         # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
         # of the major providers. Not setting it sets it to OFF.
@@ -857,30 +876,11 @@ class LitellmLLM(LLM):
                 else:
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value
 
-        # GPT-5.4+ over chat completions accept function tools only with an
-        # explicit reasoning_effort "none" (omitting it fails too), so tool turns
-        # there trade reasoning for a working call. The responses bridge is exempt.
-        # Kwargs the provider requires, which the retry ladder must never strip.
-        required_kwarg_keys: frozenset[str] = frozenset()
-        if (
-            tools
-            and not is_openai_model
-            and (
-                self._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
-                or self._model_provider in OPENAI_API_PROVIDERS
-            )
-            and any(
-                openai_chat_tools_require_reasoning_none(name)
-                for name in model_identity_names
-            )
-        ):
-            for key in _REASONING_KWARG_KEYS:
-                optional_kwargs.pop(key, None)
+        if forces_reasoning_none:
             optional_kwargs["reasoning_effort"] = OPENAI_REASONING_EFFORT[
                 ReasoningEffort.OFF
             ]
             required_kwarg_keys = frozenset({"reasoning_effort"})
-            reasoning_effort = ReasoningEffort.OFF
             _log_chat_completions_tools_disable_reasoning(model, self._api_base)
 
         if tools:

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -860,6 +860,8 @@ class LitellmLLM(LLM):
         # GPT-5.4+ over chat completions accept function tools only with an
         # explicit reasoning_effort "none" (omitting it fails too), so tool turns
         # there trade reasoning for a working call. The responses bridge is exempt.
+        # Kwargs the provider requires, which the retry ladder must never strip.
+        required_kwarg_keys: frozenset[str] = frozenset()
         if (
             tools
             and not is_openai_model
@@ -877,6 +879,7 @@ class LitellmLLM(LLM):
             optional_kwargs["reasoning_effort"] = OPENAI_REASONING_EFFORT[
                 ReasoningEffort.OFF
             ]
+            required_kwarg_keys = frozenset({"reasoning_effort"})
             reasoning_effort = ReasoningEffort.OFF
             _log_chat_completions_tools_disable_reasoning(model, self._api_base)
 
@@ -1044,7 +1047,9 @@ class LitellmLLM(LLM):
             attempts = [optional_kwargs]
             for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
                 stripped = {
-                    k: v for k, v in optional_kwargs.items() if k not in strip_keys
+                    k: v
+                    for k, v in optional_kwargs.items()
+                    if k not in strip_keys or k in required_kwarg_keys
                 }
                 if len(stripped) < len(attempts[-1]):
                     attempts.append(stripped)

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -97,8 +97,8 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_STREAM_OPTIONS = (
 )
 
 # Best-effort tuning kwargs, never worth failing a chat over. _completion
-# retries provider rejections without them: reasoning keys first, then all.
-# Semantics-changing keys (tools, tool_choice, messages) are never stripped.
+# retries provider rejections without them (reasoning keys first, then all),
+# keeping keys a provider requires. Never tools, tool_choice or messages.
 _REASONING_KWARG_KEYS = frozenset(
     {"thinking", "output_config", "reasoning", "reasoning_effort"}
 )
@@ -113,6 +113,11 @@ _KWARG_ERROR_ALIASES: dict[str, tuple[str, ...]] = {
     "reasoning_effort": ("reasoning_effort", "effort"),
     "temperature": ("temperature",),
 }
+
+# Substring of the OpenAI-family 400 that names "none" as the only effort
+# accepted alongside function tools. Omitting the parameter gets the same 400.
+_REASONING_NONE_DEMAND = "set reasoning_effort to 'none'"
+_OPENAI_REASONING_NONE = OPENAI_REASONING_EFFORT[ReasoningEffort.OFF]
 
 
 def _merge_under(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
@@ -150,6 +155,25 @@ def _rejection_names_strippable_kwargs(error: Exception, strippable: set[str]) -
         for key in strippable
         for alias in _KWARG_ERROR_ALIASES.get(key, (key,))
     )
+
+
+def _rejection_demands_reasoning_none(error: Exception) -> bool:
+    return _REASONING_NONE_DEMAND in str(error).lower()
+
+
+def _retry_attempts(
+    kwargs: dict[str, Any], required_keys: frozenset[str]
+) -> list[dict[str, Any]]:
+    """The ladder: the kwargs as given, then without reasoning keys, then
+    without every best-effort key, skipping steps that drop nothing."""
+    attempts = [kwargs]
+    for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
+        stripped = {
+            k: v for k, v in kwargs.items() if k not in strip_keys or k in required_keys
+        }
+        if len(stripped) < len(attempts[-1]):
+            attempts.append(stripped)
+    return attempts
 
 
 class LLMTimeoutError(Exception):
@@ -758,8 +782,8 @@ class LitellmLLM(LLM):
 
         # Tool turns over chat completions for GPT-5.4+ trade reasoning for a
         # working call. Responses routes, registry bridge included, are exempt.
-        forces_reasoning_none = (
-            bool(tools)
+        if (
+            tools
             and not is_openai_model
             and (
                 self._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
@@ -769,9 +793,11 @@ class LitellmLLM(LLM):
                 openai_chat_tools_require_reasoning_none(name)
                 for name in model_identity_names
             )
-        )
-        if forces_reasoning_none:
+        ):
             reasoning_effort = ReasoningEffort.OFF
+            optional_kwargs["reasoning_effort"] = _OPENAI_REASONING_NONE
+            required_kwarg_keys = frozenset({"reasoning_effort"})
+            _log_chat_completions_tools_disable_reasoning(model, self._api_base)
 
         # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
         # of the major providers. Not setting it sets it to OFF.
@@ -875,13 +901,6 @@ class LitellmLLM(LLM):
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.HIGH.value
                 else:
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value
-
-        if forces_reasoning_none:
-            optional_kwargs["reasoning_effort"] = OPENAI_REASONING_EFFORT[
-                ReasoningEffort.OFF
-            ]
-            required_kwarg_keys = frozenset({"reasoning_effort"})
-            _log_chat_completions_tools_disable_reasoning(model, self._api_base)
 
         if tools:
             # OpenAI will error if parallel_tool_calls is True and tools are not specified
@@ -1041,18 +1060,9 @@ class LitellmLLM(LLM):
                         **passthrough_kwargs,
                     )
 
-            # Retry ladder for provider 400s: drop reasoning kwargs, then every
-            # best-effort kwarg. Unknown models or capability drift degrade to
-            # provider defaults with a warning instead of failing the message.
-            attempts = [optional_kwargs]
-            for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
-                stripped = {
-                    k: v
-                    for k, v in optional_kwargs.items()
-                    if k not in strip_keys or k in required_kwarg_keys
-                }
-                if len(stripped) < len(attempts[-1]):
-                    attempts.append(stripped)
+            # Provider 400s degrade to provider defaults with a warning instead
+            # of failing the message, or learn the "none" a provider demands.
+            attempts = _retry_attempts(optional_kwargs, required_kwarg_keys)
 
             for i, opts in enumerate(attempts):
                 # Last write wins: sent_kwargs holds what the returning (or
@@ -1073,17 +1083,35 @@ class LitellmLLM(LLM):
                 try:
                     return _call_litellm(opts)
                 except BadRequestError as e:
-                    if i == len(attempts) - 1:
+                    if (
+                        _rejection_demands_reasoning_none(e)
+                        and opts.get("reasoning_effort") != _OPENAI_REASONING_NONE
+                    ):
+                        # A name the version gate cannot place learns "none" from
+                        # the 400 itself, one round trip late. Rebuilt attempts all
+                        # carry it, so the loop picks up the tail and this fires once.
+                        reasoning_effort = ReasoningEffort.OFF
+                        forced = {
+                            k: v
+                            for k, v in opts.items()
+                            if k not in _REASONING_KWARG_KEYS
+                        } | {"reasoning_effort": _OPENAI_REASONING_NONE}
+                        attempts[i + 1 :] = _retry_attempts(
+                            forced, required_kwarg_keys | {"reasoning_effort"}
+                        )
+                        _log_chat_completions_tools_disable_reasoning(
+                            model, self._api_base
+                        )
+                    elif i == len(attempts) - 1:
                         raise
-                    # Only retry rejections a later attempt can strip away.
-                    remaining_strippable = set(opts) - set(attempts[-1])
-                    if not _rejection_names_strippable_kwargs(e, remaining_strippable):
+                    elif not _rejection_names_strippable_kwargs(
+                        e, set(opts) - set(attempts[-1])
+                    ):
                         raise
                     logger.warning(
-                        "Provider rejected request for model %s. Retrying "
-                        "without %s: %s",
+                        "Provider rejected request for model %s. Retrying with %s: %s",
                         model,
-                        sorted(set(opts) - set(attempts[i + 1])),
+                        sorted(_BEST_EFFORT_KWARG_KEYS & attempts[i + 1].keys()),
                         e,
                     )
             raise RuntimeError("unreachable: retry ladder always returns or raises")

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -38,12 +38,14 @@ from onyx.llm.interfaces import (
     ToolChoice,
 )
 from onyx.llm.model_capabilities import (
+    OPENAI_API_PROVIDERS,
     ReasoningParamStyle,
     anthropic_omits_sampling_params,
     anthropic_supports_thinking,
     anthropic_uses_adaptive_thinking,
     is_true_openai_model,
     model_is_reasoning_model,
+    openai_chat_tools_require_reasoning_none,
     openai_chat_variant_rejects_reasoning,
     openai_model_rejects_reasoning_effort,
     resolve_reasoning_param_style,
@@ -376,6 +378,22 @@ def _log_azure_responses_api_version_override(
         "chat-completions calls.",
         api_base,
         configured_api_version,
+    )
+
+
+@lru_cache(maxsize=None)
+def _log_chat_completions_tools_disable_reasoning(
+    model: str, api_base: str | None
+) -> None:
+    """Log once per model per process, for the same reason as
+    _log_azure_responses_api_version_override."""
+    logger.warning(
+        "%s at %s is reached over chat completions, where GPT-5.4+ cannot "
+        "combine function tools with reasoning. Tool-bearing requests send "
+        "reasoning_effort=none; switch the provider to the responses API mode "
+        "to keep reasoning.",
+        model,
+        api_base,
     )
 
 
@@ -838,6 +856,29 @@ class LitellmLLM(LLM):
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.HIGH.value
                 else:
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value
+
+        # GPT-5.4+ over chat completions accept function tools only with an
+        # explicit reasoning_effort "none" (omitting it fails too), so tool turns
+        # there trade reasoning for a working call. The responses bridge is exempt.
+        if (
+            tools
+            and not is_openai_model
+            and (
+                self._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
+                or self._model_provider in OPENAI_API_PROVIDERS
+            )
+            and any(
+                openai_chat_tools_require_reasoning_none(name)
+                for name in model_identity_names
+            )
+        ):
+            for key in _REASONING_KWARG_KEYS:
+                optional_kwargs.pop(key, None)
+            optional_kwargs["reasoning_effort"] = OPENAI_REASONING_EFFORT[
+                ReasoningEffort.OFF
+            ]
+            reasoning_effort = ReasoningEffort.OFF
+            _log_chat_completions_tools_disable_reasoning(model, self._api_base)
 
         if tools:
             # OpenAI will error if parallel_tool_calls is True and tools are not specified

--- a/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
+++ b/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
@@ -1,5 +1,5 @@
-"""The request builder must send an explicit reasoning_effort "none" when GPT-5.4+
-take function tools over chat completions, and leave responses routes and older
+"""`_completion` must send an explicit reasoning_effort "none" when GPT-5.4+ take
+function tools over chat completions, and leave responses routes and older
 models alone."""
 
 from typing import Any
@@ -152,3 +152,39 @@ def test_forced_none_survives_the_retry_ladder() -> None:
     assert "temperature" in calls[0] and "temperature" not in calls[1]
     assert calls[0]["reasoning_effort"] == "none"
     assert calls[1]["reasoning_effort"] == "none"
+
+
+def test_opaque_alias_learns_none_from_the_rejection() -> None:
+    """An alias with no version in its name cannot be matched by name, so the
+    ladder must send "none" once the provider demands it, keeping the rest."""
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if kwargs.get("reasoning_effort") != "none":
+            raise BadRequestError(
+                message=(
+                    "Function tools with reasoning_effort are not supported for "
+                    "prod-gpt in /v1/chat/completions. To use function tools, use "
+                    "/v1/responses or set reasoning_effort to 'none'."
+                ),
+                model="m",
+                llm_provider="azure",
+            )
+        return None
+
+    llm = _azure_llm("prod-gpt")
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=_TOOLS,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=ReasoningEffort.AUTO,
+        )
+
+    assert len(calls) == 2
+    assert "reasoning_effort" not in calls[0]
+    assert calls[1]["reasoning_effort"] == "none"
+    assert calls[1]["temperature"] == calls[0]["temperature"]

--- a/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
+++ b/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
@@ -1,0 +1,123 @@
+"""GPT-5.4+ over chat completions accept function tools only with an explicit
+reasoning_effort of "none". The request builder must send that value rather
+than omit the parameter, and leave the responses surface and older models
+alone."""
+
+from typing import Any
+from unittest.mock import patch
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import ReasoningEffort, UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.well_known_providers.constants import (
+    BIFROST_API_MODE_CHAT_COMPLETIONS,
+    BIFROST_API_MODE_CONFIG_KEY,
+    BIFROST_API_MODE_RESPONSES,
+)
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def _bifrost_llm(model_name: str, api_mode: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=LlmProviderNames.BIFROST,
+        model_name=model_name,
+        max_input_tokens=100000,
+        api_base="https://bifrost.example/v1",
+        custom_config={BIFROST_API_MODE_CONFIG_KEY: api_mode},
+    )
+
+
+def _azure_llm(model_name: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=LlmProviderNames.AZURE,
+        model_name=model_name,
+        max_input_tokens=100000,
+        api_base="https://example.openai.azure.com",
+        api_version="2025-04-01-preview",
+    )
+
+
+def _sent_kwargs(
+    llm: LitellmLLM,
+    tools: list[dict] | None,
+    effort: ReasoningEffort = ReasoningEffort.AUTO,
+) -> dict[str, Any]:
+    with patch("onyx.llm.litellm_singleton.litellm.completion") as completion:
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=tools,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=effort,
+        )
+    return dict(completion.call_args.kwargs)
+
+
+def test_chat_completions_tools_send_explicit_none() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS), _TOOLS
+    )
+    assert kwargs["reasoning_effort"] == "none"
+    assert "reasoning" not in kwargs
+
+
+def test_off_still_sends_explicit_none_with_tools() -> None:
+    """OFF normally omits every reasoning kwarg, which these models reject."""
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS),
+        _TOOLS,
+        ReasoningEffort.OFF,
+    )
+    assert kwargs["reasoning_effort"] == "none"
+
+
+def test_chat_completions_without_tools_keeps_reasoning() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS), None
+    )
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_responses_surface_keeps_reasoning_with_tools() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_RESPONSES), _TOOLS
+    )
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_older_models_keep_reasoning_with_tools() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.2", BIFROST_API_MODE_CHAT_COMPLETIONS), _TOOLS
+    )
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_azure_deployment_alias_sends_explicit_none() -> None:
+    """An alias the registry doesn't know takes Azure chat completions, where
+    the model rejects the tools even with no reasoning kwarg at all."""
+    kwargs = _sent_kwargs(_azure_llm("gpt-5.6-sol-01-ptu"), _TOOLS)
+    assert kwargs["model"] == "azure/gpt-5.6-sol-01-ptu"
+    assert kwargs["reasoning_effort"] == "none"
+    assert "reasoning" not in kwargs
+
+
+def test_azure_registry_model_keeps_reasoning_on_responses_bridge() -> None:
+    kwargs = _sent_kwargs(_azure_llm("gpt-5.6-sol"), _TOOLS)
+    assert kwargs["model"] == "azure/responses/gpt-5.6-sol"
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs

--- a/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
+++ b/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
@@ -1,7 +1,6 @@
-"""GPT-5.4+ over chat completions accept function tools only with an explicit
-reasoning_effort of "none". The request builder must send that value rather
-than omit the parameter, and leave the responses surface and older models
-alone."""
+"""The request builder must send an explicit reasoning_effort "none" when GPT-5.4+
+take function tools over chat completions, and leave responses routes and older
+models alone."""
 
 from typing import Any
 from unittest.mock import patch
@@ -126,8 +125,8 @@ def test_azure_registry_model_keeps_reasoning_on_responses_bridge() -> None:
 
 
 def test_forced_none_survives_the_retry_ladder() -> None:
-    """A rejection of another optional kwarg must not strip the required
-    "none" on retry, or the retry fails the way the original request would."""
+    """A rejection of another optional kwarg must not strip the required "none"
+    on retry, or the retry hits the 400 that value exists to avoid."""
     calls: list[dict[str, Any]] = []
 
     def completion(**kwargs: Any) -> Any:

--- a/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
+++ b/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
@@ -16,7 +16,7 @@ from onyx.llm.well_known_providers.constants import (
     BIFROST_API_MODE_RESPONSES,
 )
 
-_TOOLS = [
+_TOOLS: list[dict[str, Any]] = [
     {
         "type": "function",
         "function": {

--- a/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
+++ b/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
@@ -6,6 +6,8 @@ alone."""
 from typing import Any
 from unittest.mock import patch
 
+from litellm.exceptions import BadRequestError
+
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.models import ReasoningEffort, UserMessage
 from onyx.llm.multi_llm import LitellmLLM
@@ -121,3 +123,33 @@ def test_azure_registry_model_keeps_reasoning_on_responses_bridge() -> None:
     assert kwargs["model"] == "azure/responses/gpt-5.6-sol"
     assert kwargs["reasoning"]["effort"] == "medium"
     assert "reasoning_effort" not in kwargs
+
+
+def test_forced_none_survives_the_retry_ladder() -> None:
+    """A rejection of another optional kwarg must not strip the required
+    "none" on retry, or the retry fails the way the original request would."""
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise BadRequestError(
+                message="temperature is not supported", model="m", llm_provider="openai"
+            )
+        return None
+
+    llm = _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS)
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=_TOOLS,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=ReasoningEffort.AUTO,
+        )
+
+    assert len(calls) == 2
+    assert "temperature" in calls[0] and "temperature" not in calls[1]
+    assert calls[0]["reasoning_effort"] == "none"
+    assert calls[1]["reasoning_effort"] == "none"

--- a/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
@@ -5,7 +5,9 @@ from onyx.llm.constants import LlmProviderNames
 from onyx.llm.model_capabilities import (
     ReasoningParamStyle,
     is_openai_registry_model_name,
+    openai_chat_tools_require_reasoning_none,
     parse_anthropic_model_version,
+    parse_openai_gpt_version,
     resolve_reasoning_param_style,
     supported_reasoning_efforts,
 )
@@ -81,6 +83,56 @@ def test_parse_anthropic_model_version(
 )
 def test_is_openai_registry_model_name(model_name: str, expected: bool) -> None:
     assert is_openai_registry_model_name(model_name) is expected
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        ("gpt-5.6-sol", (5, 6)),
+        ("gpt-5.4-mini", (5, 4)),
+        ("gpt-5", (5, 0)),
+        ("gpt-4o", (4, 0)),
+        ("gpt-4.1-mini", (4, 1)),
+        # Gateway vendor prefixes and Azure deployment aliases
+        ("azure/gpt-5.6-sol", (5, 6)),
+        ("bedrock_mantle/openai.gpt-5.6-luna", (5, 6)),
+        ("gpt-5.6-sol-01-ptu", (5, 6)),
+        # "gpt-" inside another word is not a GPT model
+        ("chatgpt-4o-latest", None),
+        ("gpt-oss-120b", None),
+        ("claude-sonnet-5", None),
+        ("o3", None),
+    ],
+)
+def test_parse_openai_gpt_version(
+    model_name: str, expected: tuple[int, int] | None
+) -> None:
+    assert parse_openai_gpt_version(model_name) == expected
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        # gpt-5.4 is the first release to reject tools alongside reasoning
+        # over chat completions. Its -mini and -nano variants do too.
+        ("gpt-5.4", True),
+        ("gpt-5.4-mini", True),
+        ("gpt-5.4-nano", True),
+        ("gpt-5.5", True),
+        ("gpt-5.6-sol", True),
+        ("azure/gpt-5.6-sol", True),
+        ("gpt-5.6-sol-01-ptu", True),
+        ("gpt-5.2", False),
+        ("gpt-5", False),
+        ("gpt-4.1", False),
+        ("o3", False),
+        ("claude-sonnet-5", False),
+    ],
+)
+def test_openai_chat_tools_require_reasoning_none(
+    model_name: str, expected: bool
+) -> None:
+    assert openai_chat_tools_require_reasoning_none(model_name) is expected
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
@@ -97,7 +97,7 @@ def test_is_openai_registry_model_name(model_name: str, expected: bool) -> None:
         ("azure/gpt-5.6-sol", (5, 6)),
         ("bedrock_mantle/openai.gpt-5.6-luna", (5, 6)),
         ("gpt-5.6-sol-01-ptu", (5, 6)),
-        # "gpt-" inside another word is not a GPT model
+        # "gpt-" glued to another word, or with no version after it, is not GPT
         ("chatgpt-4o-latest", None),
         ("gpt-oss-120b", None),
         ("claude-sonnet-5", None),
@@ -120,12 +120,9 @@ def test_parse_openai_gpt_version(
         ("gpt-5.4-nano", True),
         ("gpt-5.5", True),
         ("gpt-5.6-sol", True),
-        ("azure/gpt-5.6-sol", True),
-        ("gpt-5.6-sol-01-ptu", True),
         ("gpt-5.2", False),
         ("gpt-5", False),
         ("gpt-4.1", False),
-        ("o3", False),
         ("claude-sonnet-5", False),
     ],
 )

--- a/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
@@ -97,6 +97,9 @@ def test_is_openai_registry_model_name(model_name: str, expected: bool) -> None:
         ("azure/gpt-5.6-sol", (5, 6)),
         ("bedrock_mantle/openai.gpt-5.6-luna", (5, 6)),
         ("gpt-5.6-sol-01-ptu", (5, 6)),
+        # Azure spells GPT-3.5 without the dot
+        ("gpt-35-turbo", (3, 5)),
+        ("gpt-35-turbo-16k", (3, 5)),
         # "gpt-" glued to another word, or with no version after it, is not GPT
         ("chatgpt-4o-latest", None),
         ("gpt-oss-120b", None),
@@ -123,6 +126,7 @@ def test_parse_openai_gpt_version(
         ("gpt-5.2", False),
         ("gpt-5", False),
         ("gpt-4.1", False),
+        ("gpt-35-turbo", False),
         ("claude-sonnet-5", False),
     ],
 )


### PR DESCRIPTION
## Description

**What:** For tool-bearing requests on an OpenAI chat-completions route to GPT 5.4+, send `reasoning_effort="none"` instead of the reasoning kwargs and keep it through the retry ladder. An alias the name rule cannot place (`prod-gpt`) learns the value from the provider's 400 and retries with it. The responses bridge is untouched. A once-per-model warning points admins to responses mode to keep reasoning.

**Why:** GPT-5.4 and later reject function tools over `/v1/chat/completions` unless `reasoning_effort` is explicitly `"none"`. Omitting it fails with the same 400, so the retry ladder strips the reasoning kwarg and fails again. Every chat-completions route (Bifrost, Portkey, OpenAI-compatible, or an Azure deployment alias the registry does not know) breaks on every tool turn. The responses API has no such limit.

## How Has This Been Tested?

- Unit tests: `test_chat_completions_tools_reasoning_none.py` (9 cases, 5 fail without the fix) and name-rule cases in `test_reasoning_capabilities.py`.
- curl against OpenAI and Bifrost: tools + medium and tools + omitted return the 400, tools + none returns 200, for gpt-5.4 (incl. mini and nano), 5.5 and the 5.6 line. gpt-5.2 and earlier accept tools with reasoning.
- Live before and after in dev1 through a Bifrost chat-mode provider and an OpenAI-compatible provider: the error before, a completed tool call and answer after.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://claude.ai/code/session_01YPfAvBiTDkHDrgrNg7azy6
