### PR TITLE
feat(terraform): let node groups pin a Kubernetes version independent of the control plane

### DIFF
--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -147,9 +147,17 @@ module "eks" {
     }
   } : {}
 
-  eks_managed_node_group_defaults = {
-    ami_type = "AL2023_x86_64_STANDARD"
-  }
+  # Node groups follow the control-plane version unless node_group_version pins
+  # them. Upstream resolves each group as
+  # try(group.cluster_version, defaults.cluster_version, cluster version).
+  eks_managed_node_group_defaults = merge(
+    {
+      ami_type = "AL2023_x86_64_STANDARD"
+    },
+    var.node_group_version != null ? {
+      cluster_version = var.node_group_version
+    } : {}
+  )
 
   eks_managed_node_groups = {
     for k, v in merge(var.eks_managed_node_groups, local.gpu_node_groups, local.craft_sandbox_node_groups) : k => merge(v,

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -9,6 +9,12 @@ variable "cluster_version" {
   default     = "1.33"
 }
 
+variable "node_group_version" {
+  type        = string
+  description = "Kubernetes version for the managed node groups. null (default) makes them follow cluster_version, which is what upgrades and rolls every node. Pin this to the version the nodes already run to apply unrelated changes without a roll, then bump it in its own change window."
+  default     = null
+}
+
 variable "vpc_id" {
   type        = string
   description = "The ID of the VPC"


### PR DESCRIPTION
## Description

Managed node groups inherit their Kubernetes version from the control plane, so
once a control plane has hopped, *any* apply on that cluster also upgrades the
node groups and replaces every node. Unrelated changes — enabling log
aggregation, closing drift — cannot land without a full node roll, and
`-target` does not help because the dependency graph pulls the EKS module in
anyway.

Add `node_group_version`. It defaults to `null`, which keeps today's behavior
exactly. Set it to the version the nodes already run and an apply leaves them
alone; bump it later in its own change window, so the roll becomes a deliberate
one-line change rather than a side effect of unrelated work.

Upstream `terraform-aws-modules/eks` v20 resolves each group as
`try(group.cluster_version, defaults.cluster_version, cluster_version)`, so
setting it on `eks_managed_node_group_defaults` covers every group in one place.

## How Has This Been Tested?

- `terraform plan` against a live cluster whose control plane is a minor ahead
  of its node groups. With the pin set, the `version = "1.33" -> "1.36"` line
  disappears from all three node groups — that change alone would have replaced
  every node.
- With `node_group_version` unset, the plan is byte-identical to before this
  change, confirming the default is a strict no-op.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `node_group_version` to the EKS module so managed node groups can pin a Kubernetes version separate from the control plane. Previously, any apply on a cluster whose control plane had upgraded also upgraded the node groups and replaced every node; with the new variable, unrelated changes can land without a full node roll. The default is `null`, which keeps the existing behavior exactly.

- Setting the pin on `eks_managed_node_group_defaults` covers all managed node groups in one place.
- Bumping the pin later makes the node roll a deliberate one-line change instead of a side effect of unrelated work.

<sup>Written for commit 2f416f1224f912785aef155c89d29026b1a7cb43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


