### PR TITLE
fix(auth): upgrade a placeholder on the session that holds its row lock

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -548,6 +548,14 @@ def _upgrade_placeholder_to_web_login__no_commit(
     if user is None:
         return False
 
+    # The caller decided to promote from a read taken before this lock. Confirm
+    # the row is still a placeholder now that it is held: a concurrent login may
+    # have promoted it already, and an admin may have since deactivated the
+    # resulting account. Promoting again would reactivate a disabled account and
+    # re-check a seat that is already taken.
+    if user.account_type.is_web_login():
+        return False
+
     # The row is active once this returns: it already was, or the promotion
     # below reactivates it.
     seat_added = False

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -526,6 +526,41 @@ def _invalidate_license_cache_after_seat_change() -> None:
     )()
 
 
+def _upgrade_placeholder_to_web_login__no_commit(
+    user_id: uuid.UUID, is_verified_by_default: bool, db_session: Session
+) -> bool:
+    """Promote a placeholder row (EXT_PERM_USER, BOT) to a real web login.
+
+    Does NOT commit. Must run on the session that already holds the ``"user"``
+    row lock from ``reconcile_user_email__no_commit``; a second connection
+    would wait on that lock until the callback returns, which it never does.
+
+    Returns whether the upgrade consumed a seat.
+    """
+    user = (
+        db_session.query(User)
+        .filter(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .first()
+    )
+    if user is None:
+        return False
+
+    was_inactive = not user.is_active
+    # The row is active either way once this returns: it already was, or it is
+    # activated below.
+    seat_added = False
+    if _upgrade_will_add_seat(user, will_become_active=True):
+        enforce_seat_limit_locked(db_session, seats_needed=1)
+        seat_added = True
+
+    user.is_verified = is_verified_by_default
+    user.account_type = AccountType.STANDARD
+    if was_inactive:
+        user.is_active = True
+    assign_user_to_default_groups__no_commit(db_session, user)
+    return seat_added
+
+
 async def resolve_tenant_for_user(email: str, request: Request | None = None) -> str:
     """Workspace to bind a user to. An explicit override wins, since an SSO login
     knows its workspace before the user row exists."""
@@ -1180,44 +1215,27 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
             # Handle case where user has used product outside of web and is now creating an account through web
             if not user.account_type.is_web_login():
-                if user.id:
-                    user_by_session = await db_session.get(User, user.id)
-                    if user_by_session:
-                        user = user_by_session
+                # Cache the id before the commit below expires `user`. Reading
+                # an attribute off an expired object here triggers a sync lazy
+                # load, which raises MissingGreenlet in this async context.
+                refreshed_user_id = user.id
 
-                # Lock + check + upgrade in one transaction.
-                was_inactive = not user.is_active
-                seat_added = False
-                with get_session_with_current_tenant() as sync_db:
-                    sync_user = (
-                        sync_db.query(User)
-                        .filter(User.id == user.id)  # ty: ignore[invalid-argument-type]
-                        .first()
+                # Runs on this session, which already holds the `"user"` row
+                # lock taken by reconcile_user_email__no_commit above. A second
+                # connection would wait on that lock for the whole callback.
+                seat_added = await db_session.run_sync(
+                    partial(
+                        _upgrade_placeholder_to_web_login__no_commit,
+                        refreshed_user_id,
+                        is_verified_by_default,
                     )
-                    if sync_user:
-                        will_become_active = (
-                            True if was_inactive else bool(sync_user.is_active)
-                        )
-                        if _upgrade_will_add_seat(
-                            sync_user, will_become_active=will_become_active
-                        ):
-                            enforce_seat_limit_locked(sync_db, seats_needed=1)
-                            seat_added = True
-                        sync_user.is_verified = is_verified_by_default
-                        sync_user.account_type = AccountType.STANDARD
-                        if was_inactive:
-                            sync_user.is_active = True
-                        assign_user_to_default_groups__no_commit(sync_db, sync_user)
-                        sync_db.commit()
+                )
+                await db_session.commit()
                 if seat_added:
                     _invalidate_license_cache_after_seat_change()
 
-                # Refresh the async user object so downstream code
-                # (e.g. oidc_expiry check) sees the updated fields.
-                # Cache id before expire. Accessing attrs on an expired object
-                # triggers a sync lazy-load which raises MissingGreenlet in this
-                # async context.
-                refreshed_user_id = user.id
+                # Reload so downstream code (e.g. the oidc_expiry check) sees
+                # the upgraded fields.
                 self.user_db.session.expire(user)
                 user = await self.user_db.get(refreshed_user_id)
                 assert user is not None

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -139,9 +139,11 @@ from onyx.db.pat import resolve_pat
 from onyx.db.pinned_personas import seed_pinned_personas_from_featured
 from onyx.db.users import (
     assign_user_to_default_groups__no_commit,
+    fetch_user_by_id,
     get_user_by_email,
     get_user_by_oauth_account,
     is_limited_user,
+    promote_placeholder_to_web_login__no_commit,
     reconcile_user_email__no_commit,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -535,29 +537,27 @@ def _upgrade_placeholder_to_web_login__no_commit(
     row lock from ``reconcile_user_email__no_commit``; a second connection
     would wait on that lock until the callback returns, which it never does.
 
+    Locks the row again rather than trusting that one: an email change commits
+    the reconcile before this runs, which drops it. Re-locking on the same
+    connection is a no-op when it is still held, and serializes concurrent
+    first logins when it is not.
+
     Returns whether the upgrade consumed a seat.
     """
-    user = (
-        db_session.query(User)
-        .filter(User.id == user_id)  # ty: ignore[invalid-argument-type]
-        .first()
-    )
+    user = fetch_user_by_id(db_session, user_id, for_update=True)
     if user is None:
         return False
 
-    was_inactive = not user.is_active
-    # The row is active either way once this returns: it already was, or it is
-    # activated below.
+    # The row is active once this returns: it already was, or the promotion
+    # below reactivates it.
     seat_added = False
     if _upgrade_will_add_seat(user, will_become_active=True):
         enforce_seat_limit_locked(db_session, seats_needed=1)
         seat_added = True
 
-    user.is_verified = is_verified_by_default
-    user.account_type = AccountType.STANDARD
-    if was_inactive:
-        user.is_active = True
-    assign_user_to_default_groups__no_commit(db_session, user)
+    promote_placeholder_to_web_login__no_commit(
+        db_session, user, is_verified=is_verified_by_default
+    )
     return seat_added
 
 

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -906,6 +906,23 @@ def assign_user_to_default_groups__no_commit(
     )
 
 
+def promote_placeholder_to_web_login__no_commit(
+    db_session: Session, user: User, is_verified: bool
+) -> None:
+    """Turn a placeholder row (EXT_PERM_USER, BOT) into a real web login.
+
+    Does NOT commit. The caller holds the ``"user"`` row lock and commits this
+    with the rest of its transaction, so the seat check it ran stays valid.
+
+    A placeholder is deactivated until its owner shows up, so this reactivates
+    the row rather than turning the owner away.
+    """
+    user.is_verified = is_verified
+    user.account_type = AccountType.STANDARD
+    user.is_active = True
+    assign_user_to_default_groups__no_commit(db_session, user)
+
+
 def get_active_admin_count(db_session: Session) -> int:
     """Count for the share dialog's Admins row — same filter set as
     get_active_admin_users (no API-key dummies or system placeholders).

--- a/backend/tests/external_dependency_unit/auth/test_oauth_callback_oidc_expiry_session.py
+++ b/backend/tests/external_dependency_unit/auth/test_oauth_callback_oidc_expiry_session.py
@@ -6,6 +6,7 @@ leave a second transaction idle on `"user"`.
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from datetime import datetime, timezone
 from uuid import uuid4
@@ -19,13 +20,18 @@ import onyx.auth.users as users_module
 from onyx.auth.users import UserManager
 from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccountType
 from onyx.db.models import OAuthAccount, User
 from onyx.server.security.store import _build_env_defaults
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
 
 _CALLBACK_TIMEOUT_SECONDS = 5
 _POLL_INTERVAL_SECONDS = 0.2
 _OAUTH_NAME = "oidc"
+# The wedge is unbounded, so this only has to outrun a healthy callback.
+_UPGRADE_TIMEOUT_SECONDS = 30
 
 
 def _idle_user_lock_pids(exclude: set[int]) -> list[int]:
@@ -202,4 +208,120 @@ async def test_existing_oauth_login_clears_oidc_expiry_when_tracking_disabled(
     finally:
         _delete_oauth_accounts(db_session, user)
         delete_test_user(db_session, user)
+        db_session.commit()
+
+
+def _terminate_idle_user_lock_holders(exclude: set[int]) -> list[int]:
+    """Free a wedged worker thread so the run can finish and report."""
+    pids = _idle_user_lock_pids(exclude)
+    for pid in pids:
+        with get_session_with_current_tenant() as session:
+            session.execute(text("SELECT pg_terminate_backend(:pid)"), {"pid": pid})
+    return pids
+
+
+def _call_oauth_callback_on_worker_thread(
+    *,
+    user_email: str,
+    account_id: str,
+    returned: list[User],
+    raised: list[BaseException],
+) -> None:
+    """A wedge blocks its event loop, so it cannot be cancelled from inside.
+    Drive the callback on its own thread and let the test thread time it out.
+    """
+    CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+
+    async def _call() -> User:
+        async with get_async_session_context_manager() as session:
+            manager = UserManager(SQLAlchemyUserDatabase(session, User, OAuthAccount))
+            return await manager.oauth_callback(
+                oauth_name=_OAUTH_NAME,
+                access_token="entra-access-token",
+                account_id=account_id,
+                account_email=user_email,
+                expires_at=int(time.time()) + 3600,
+                is_verified_by_default=True,
+            )
+
+    try:
+        returned.append(asyncio.run(_call()))
+    except BaseException as exc:  # noqa: BLE001 - reported by the test thread
+        raised.append(exc)
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_ext_perm_user_first_web_login_does_not_wedge(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A placeholder row's first web login must not deadlock the event loop.
+
+    `reconcile_user_email__no_commit` leaves a `FOR UPDATE` lock on the `"user"`
+    row and returns None when the address is already current, so the callback
+    never commits it. Upgrading the row on a second, synchronous connection then
+    waits on that lock. The wait runs on the event-loop thread, so the whole API
+    server stops answering — including `/health` — and nothing is logged.
+    """
+    monkeypatch.setattr(users_module, "MULTI_TENANT", False)
+    monkeypatch.setattr(
+        users_module,
+        "get_security_settings",
+        # Off by default, and the setting that would otherwise commit first.
+        lambda: _build_env_defaults().model_copy(
+            update={"track_external_idp_expiry": False}
+        ),
+    )
+
+    user = create_test_user(
+        db_session, "ext_perm_upgrade", account_type=AccountType.EXT_PERM_USER
+    )
+    user_id = user.id
+    # A permission-synced placeholder has never logged in, so it carries no
+    # OAuth link. The IdP subject below is therefore new to this row.
+    account_id = f"entra-{uuid4().hex}"
+    sync_pid = int(db_session.execute(text("SELECT pg_backend_pid()")).scalar())
+
+    returned: list[User] = []
+    raised: list[BaseException] = []
+    worker = threading.Thread(
+        target=_call_oauth_callback_on_worker_thread,
+        kwargs={
+            "user_email": user.email,
+            "account_id": account_id,
+            "returned": returned,
+            "raised": raised,
+        },
+        daemon=True,
+    )
+    try:
+        worker.start()
+        worker.join(timeout=_UPGRADE_TIMEOUT_SECONDS)
+
+        if worker.is_alive():
+            blockers = _terminate_idle_user_lock_holders({sync_pid})
+            worker.join(timeout=_UPGRADE_TIMEOUT_SECONDS)
+            pytest.fail(
+                "oauth_callback wedged upgrading an EXT_PERM_USER; it waited on "
+                f'a `"user"` row lock held by pids={blockers}'
+            )
+        if raised:
+            raise raised[0]
+
+        assert returned, "worker finished without a result"
+        assert returned[0].account_type == AccountType.STANDARD
+
+        db_session.expire_all()
+        persisted = db_session.get(User, user_id)
+        assert persisted is not None
+        assert persisted.account_type == AccountType.STANDARD
+        assert persisted.is_active
+
+        sync_pid = int(db_session.execute(text("SELECT pg_backend_pid()")).scalar())
+        _assert_no_idle_user_lock({sync_pid})
+    finally:
+        db_session.rollback()
+        reloaded = db_session.get(User, user_id)
+        if reloaded is not None:
+            _delete_oauth_accounts(db_session, reloaded)
+            delete_test_user(db_session, reloaded)
         db_session.commit()

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -9,8 +9,9 @@ Tests cover:
 """
 
 from collections.abc import Iterator
+from functools import partial
 from types import SimpleNamespace, TracebackType
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,7 +19,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import exceptions
 
 from onyx.auth.schemas import UserCreate
-from onyx.auth.users import UserManager
+from onyx.auth.users import UserManager, _upgrade_placeholder_to_web_login__no_commit
 from onyx.db.enums import AccountType
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -713,12 +714,10 @@ class TestOAuthNoAutoLinkExemptions:
     @patch("onyx.auth.users.remove_user_from_invited_users")
     @patch("onyx.auth.users.assign_user_to_default_groups__no_commit")
     @patch("onyx.auth.users._upgrade_will_add_seat", return_value=False)
-    @patch("onyx.auth.users.get_session_with_current_tenant")
     @patch("onyx.auth.users.SQLAlchemyUserDatabase")
     async def test_placeholder_promoted_without_auto_link(
         self,
         mock_user_db_cls: MagicMock,
-        mock_sync_session_factory: MagicMock,
         mock_will_add_seat: MagicMock,  # noqa: ARG002
         mock_assign_groups: MagicMock,
         mock_remove_invited: MagicMock,  # noqa: ARG002
@@ -751,10 +750,19 @@ class TestOAuthNoAutoLinkExemptions:
         mock_sync_db.query.return_value.filter.return_value.first.return_value = (
             sync_user
         )
-        mock_sync_session_factory.return_value.__enter__ = MagicMock(
-            return_value=mock_sync_db
-        )
-        mock_sync_session_factory.return_value.__exit__ = MagicMock(return_value=False)
+
+        # The upgrade runs on the callback's own session, so drive the real
+        # helper through run_sync rather than a second session. Email
+        # reconciliation arrives here too and stays stubbed out.
+        def _upgrade_only(fn: Any) -> Any:
+            if (
+                isinstance(fn, partial)
+                and fn.func is _upgrade_placeholder_to_web_login__no_commit
+            ):
+                return fn(mock_sync_db)
+            return None
+
+        mock_async_session.run_sync = AsyncMock(side_effect=_upgrade_only)
 
         result = await user_manager.oauth_callback(
             oauth_name="okta",
@@ -774,7 +782,8 @@ class TestOAuthNoAutoLinkExemptions:
         # short-circuit a placeholder before it reaches the upgrade.
         assert sync_user.is_active is True
         mock_assign_groups.assert_called_once()
-        mock_sync_db.commit.assert_called_once()
+        # Committed on the session holding the row lock, not a second one.
+        cast(AsyncMock, mock_async_session.commit).assert_awaited()
         assert result is placeholder
 
     @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -712,12 +712,15 @@ class TestOAuthNoAutoLinkExemptions:
     @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
     @patch("onyx.auth.users.get_async_session_context_manager")
     @patch("onyx.auth.users.remove_user_from_invited_users")
-    @patch("onyx.auth.users.assign_user_to_default_groups__no_commit")
+    # Patched where promote_placeholder_to_web_login__no_commit resolves it.
+    @patch("onyx.db.users.assign_user_to_default_groups__no_commit")
     @patch("onyx.auth.users._upgrade_will_add_seat", return_value=False)
+    @patch("onyx.auth.users.fetch_user_by_id")
     @patch("onyx.auth.users.SQLAlchemyUserDatabase")
     async def test_placeholder_promoted_without_auto_link(
         self,
         mock_user_db_cls: MagicMock,
+        mock_fetch_user_by_id: MagicMock,
         mock_will_add_seat: MagicMock,  # noqa: ARG002
         mock_assign_groups: MagicMock,
         mock_remove_invited: MagicMock,  # noqa: ARG002
@@ -747,9 +750,9 @@ class TestOAuthNoAutoLinkExemptions:
 
         sync_user = MagicMock(is_active=is_active)
         mock_sync_db = MagicMock()
-        mock_sync_db.query.return_value.filter.return_value.first.return_value = (
-            sync_user
-        )
+        # The row is re-locked through the db layer, so stub that lookup rather
+        # than the query chain behind it.
+        mock_fetch_user_by_id.return_value = sync_user
 
         # The upgrade runs on the callback's own session, so drive the real
         # helper through run_sync rather than a second session. Email
@@ -782,6 +785,11 @@ class TestOAuthNoAutoLinkExemptions:
         # short-circuit a placeholder before it reaches the upgrade.
         assert sync_user.is_active is True
         mock_assign_groups.assert_called_once()
+        # An email change commits the reconcile and drops its lock, so the
+        # upgrade has to take the row itself rather than assume it holds it.
+        mock_fetch_user_by_id.assert_called_once_with(
+            mock_sync_db, "placeholder-id", for_update=True
+        )
         # Committed on the session holding the row lock, not a second one.
         cast(AsyncMock, mock_async_session.commit).assert_awaited()
         assert result is placeholder

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -13,6 +13,7 @@ from functools import partial
 from types import SimpleNamespace, TracebackType
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from fastapi.security import OAuth2PasswordRequestForm
@@ -748,7 +749,10 @@ class TestOAuthNoAutoLinkExemptions:
         user_manager = self._manager_with_existing(placeholder, mock_user_db_cls)
         mock_async_session.get = AsyncMock(return_value=placeholder)
 
-        sync_user = MagicMock(is_active=is_active)
+        # Still a placeholder under the lock: no concurrent login won the race.
+        sync_user = MagicMock(
+            is_active=is_active, account_type=AccountType.EXT_PERM_USER
+        )
         mock_sync_db = MagicMock()
         # The row is re-locked through the db layer, so stub that lookup rather
         # than the query chain behind it.
@@ -1197,3 +1201,76 @@ class TestPasswordAuthKillSwitch:
             "onyx.db.user_tenant_mapping",
             "get_tenant_id_for_email",
         )
+
+
+class TestPlaceholderUpgradeRace:
+    """The promote decision is made before the row lock, so it is re-checked."""
+
+    @patch("onyx.auth.users.promote_placeholder_to_web_login__no_commit")
+    @patch("onyx.auth.users.enforce_seat_limit_locked")
+    @patch("onyx.auth.users._upgrade_will_add_seat", return_value=True)
+    @patch("onyx.auth.users.fetch_user_by_id")
+    def test_already_promoted_row_is_left_alone(
+        self,
+        mock_fetch_user_by_id: MagicMock,
+        mock_will_add_seat: MagicMock,  # noqa: ARG002
+        mock_enforce_seat_limit: MagicMock,
+        mock_promote: MagicMock,
+    ) -> None:
+        """A concurrent login can promote the row and an admin can then disable
+        it. Re-promoting would reactivate a deliberately disabled account."""
+        db_session = MagicMock()
+        deactivated = MagicMock(
+            account_type=AccountType.STANDARD,
+            is_active=False,
+        )
+        mock_fetch_user_by_id.return_value = deactivated
+
+        seat_added = _upgrade_placeholder_to_web_login__no_commit(
+            uuid4(), True, db_session
+        )
+
+        assert seat_added is False
+        mock_promote.assert_not_called()
+        # The seat was consumed by whoever won the race.
+        mock_enforce_seat_limit.assert_not_called()
+        assert deactivated.is_active is False
+
+    @patch("onyx.auth.users.promote_placeholder_to_web_login__no_commit")
+    @patch("onyx.auth.users.enforce_seat_limit_locked")
+    @patch("onyx.auth.users._upgrade_will_add_seat", return_value=True)
+    @patch("onyx.auth.users.fetch_user_by_id")
+    def test_placeholder_still_promotes(
+        self,
+        mock_fetch_user_by_id: MagicMock,
+        mock_will_add_seat: MagicMock,  # noqa: ARG002
+        mock_enforce_seat_limit: MagicMock,
+        mock_promote: MagicMock,
+    ) -> None:
+        db_session = MagicMock()
+        placeholder = MagicMock(
+            account_type=AccountType.EXT_PERM_USER,
+            is_active=False,
+        )
+        mock_fetch_user_by_id.return_value = placeholder
+
+        seat_added = _upgrade_placeholder_to_web_login__no_commit(
+            uuid4(), True, db_session
+        )
+
+        assert seat_added is True
+        mock_enforce_seat_limit.assert_called_once()
+        mock_promote.assert_called_once_with(db_session, placeholder, is_verified=True)
+
+    @patch("onyx.auth.users.promote_placeholder_to_web_login__no_commit")
+    @patch("onyx.auth.users.fetch_user_by_id", return_value=None)
+    def test_missing_row_is_a_no_op(
+        self,
+        mock_fetch_user_by_id: MagicMock,  # noqa: ARG002
+        mock_promote: MagicMock,
+    ) -> None:
+        assert (
+            _upgrade_placeholder_to_web_login__no_commit(uuid4(), True, MagicMock())
+            is False
+        )
+        mock_promote.assert_not_called()


### PR DESCRIPTION
## Description

A user row that had never logged in through the web — `EXT_PERM_USER` (created by
connector permission sync) or `BOT` — wedged the entire api_server on their first
OIDC login. Every request stopped, including `/health`, and nothing was logged,
because a lock wait is not an error.

`oauth_callback` deadlocked against itself:

1. `reconcile_user_email__no_commit` takes `SELECT ... FOR UPDATE` on the `"user"`
   row (`onyx/db/users.py`, `.with_for_update(of=User)`).
2. It returns `None` when the address is already current — the normal case — and
   `oauth_callback` then skips its only `await db_session.commit()`. The row lock
   stays held on the async connection.
3. `track_external_idp_expiry` is off by default, so the `user_db.update(...)`
   that would otherwise commit does not run.
4. The placeholder-upgrade branch then opened a **second, synchronous** connection
   with `get_session_with_current_tenant()` — on the event-loop thread — and
   updated that same row.

The second connection waited on the first. The first could not commit, because the
event loop that would advance it was blocked inside the second. Postgres
`lock_timeout` defaults to `0`, so the wait never ended.

`AccountType.is_web_login()` is False only for `EXT_PERM_USER` and `BOT`, which is
why only these accounts triggered it and ordinary users were unaffected.

The fix runs the upgrade through `db_session.run_sync(...)` on the session that
already holds the lock, then commits it — one connection, one transaction. This
also removes a sync-session-on-the-event-loop call from the login path.

Affects every 4.6.x and 4.7.x release and `main`.

### Follow-ups, not in this PR

- 17 other `get_session_with_current_tenant()` calls still run inside `async def`.
  They block the event loop for the duration and can deadlock the same way if they
  ever contend with a lock the caller holds.
- `_acquire_advisory_lock` restores `lock_timeout` to `DEFAULT` (`0`) after its own
  bounded acquisition, so later row-lock waits in that transaction are unbounded.
- `reconcile_user_email__no_commit` can merge a shadow user and still return `None`.
  Those writes are only committed on the rename branch, so on the ordinary path they
  are rolled back when the session closes.

## How Has This Been Tested?

New regression test:
`backend/tests/external_dependency_unit/auth/test_oauth_callback_oidc_expiry_session.py::test_ext_perm_user_first_web_login_does_not_wedge`

It drives the callback on a worker thread, because a wedge blocks its own event
loop and cannot be cancelled from inside. On unfixed code it **fails** in 30 s with
the blocking pids rather than hanging the suite, and terminates the blocking backend
so the run can finish. Verified both ways:

- fix reverted → `FAILED ... oauth_callback wedged upgrading an EXT_PERM_USER`
- fix applied → passes

Reproduced the original hang end to end against a real Postgres before fixing.
Captured while wedged:

```
blocked pid=117 state=active
  UPDATE "user" SET account_type='STANDARD', updated_at=now(), is_verified=true ...
BLOCKED BY pid=118 state=idle in transaction held_for=0:00:24.9
```

with the event-loop thread stopped inside `assign_user_to_default_groups__no_commit`
→ SQLAlchemy autoflush → `do_execute`.

Suites run locally against real Postgres + Redis:

- `backend/tests/unit/onyx/auth/` — 428 passed, 1 skipped
- `backend/tests/external_dependency_unit/auth/` — 128 passed, 8 skipped
- `backend/tests/unit` — 8980 passed, 33 skipped, 19 failed; the same 19 fail on a
  clean checkout of `main` (license reclaim, license API, process isolation) and are
  unrelated to this change.

`pre-commit` clean on all changed files (`ty`, `ruff`, `ruff format`).

`test_placeholder_promoted_without_auto_link` was rewired: it patched
`get_session_with_current_tenant`, which this path no longer calls. It now drives
the real upgrade helper through `run_sync` and asserts the commit lands on the
callback's own session.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock that wedged the entire API server when an `EXT_PERM_USER` or `BOT` account logged in through OIDC for the first time, and closes a race in the upgrade path.

**Bug Fixes**
- Runs the placeholder upgrade on the async session that already holds the row lock, then commits, instead of opening a second synchronous connection that waits forever.
- Re-locks the row (`fetch_user_by_id(for_update=True)`) rather than trusting the lock left by email reconciliation, so concurrent first logins are serialized when an email change commits and drops it.
- Re-checks the row is still a placeholder under the lock before promoting, so a concurrent login can't reactivate a disabled account or run a stale seat check.
- Moves the field writes and default-group assignment into a new `promote_placeholder_to_web_login__no_commit` helper in the db layer.
- Adds a regression test that runs the callback on a worker thread to detect the hang.
- Affects all 4.6.x and 4.7.x releases and `main`.

<sup>Written for commit f6b736066f4958b6377f86d22481d0c394d0f89c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

