### PR TITLE
fix(llm): send reasoning_effort=none for GPT-5.4+ tool calls over chat completions (#14603) to release v4.6

### DIFF
--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -431,6 +431,13 @@ def openai_model_rejects_reasoning_effort(model_name: str) -> bool:
     return base_model_name.startswith(_OPENAI_MODELS_REJECTING_REASONING_EFFORT)
 
 
+# Providers that reach OpenAI models over OpenAI's own API shapes: a registry
+# model takes the responses bridge there, anything else chat completions.
+OPENAI_API_PROVIDERS = frozenset(
+    {LlmProviderNames.OPENAI, LlmProviderNames.LITELLM_PROXY, LlmProviderNames.AZURE}
+)
+
+
 def is_true_openai_model(model_provider: str, model_name: str) -> bool:
     """
     Determines if a model is a true OpenAI model or just using OpenAI-compatible API.
@@ -442,11 +449,7 @@ def is_true_openai_model(model_provider: str, model_name: str) -> bool:
     OpenAI models from OpenAI and Azure should use responses.
     """
 
-    if model_provider not in {
-        LlmProviderNames.OPENAI,
-        LlmProviderNames.LITELLM_PROXY,
-        LlmProviderNames.AZURE,
-    }:
+    if model_provider not in OPENAI_API_PROVIDERS:
         return False
 
     model_map = get_model_map()
@@ -509,6 +512,40 @@ def openai_chat_variant_rejects_reasoning(model_name: str) -> bool:
     params on every surface despite being reasoning models (an OpenAI bug).
     Registry-gated so a name merely containing "-chat" doesn't false-positive."""
     return "-chat" in model_name and is_openai_registry_model_name(model_name)
+
+
+# GPT-5.4+ refuse function tools over chat completions unless reasoning_effort
+# is explicitly "none", and omitting it fails the same way. gpt-5.2 and earlier
+# accept tools with reasoning. Version-gated so new releases need no code change.
+_OPENAI_CHAT_TOOLS_REQUIRE_REASONING_NONE_MIN_VERSION = (5, 4)
+
+# Tolerates vendor prefixes ("openai.gpt-5.6-sol") and alias suffixes
+# ("gpt-5.6-sol-01-ptu") so gateway and Azure deployment names match, while the
+# boundary keeps "chatgpt-4o-latest" out.
+_OPENAI_GPT_VERSION_PATTERN = re.compile(r"(?:^|[^a-z0-9])gpt-(\d+)(?:\.(\d+))?")
+
+
+def parse_openai_gpt_version(model_name: str) -> tuple[int, int] | None:
+    """(major, minor) from a GPT model name, minor 0 when absent and Azure's
+    dotless "gpt-35" read as (3, 5). None for any other name."""
+    match = _OPENAI_GPT_VERSION_PATTERN.search(model_name.lower())
+    if match is None:
+        return None
+    major, minor = match.group(1), match.group(2)
+    if minor is None and len(major) > 1:
+        return (int(major[0]), int(major[1:]))
+    return (int(major), int(minor or 0))
+
+
+def openai_chat_tools_require_reasoning_none(model_name: str) -> bool:
+    """True for gpt-5.4 and later, by name alone: the names are OpenAI's wherever
+    they're hosted, and a registry-unknown alias must still match or its tool
+    calls fail outright."""
+    version = parse_openai_gpt_version(model_name)
+    return (
+        version is not None
+        and version >= _OPENAI_CHAT_TOOLS_REQUIRE_REASONING_NONE_MIN_VERSION
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -37,12 +37,14 @@ from onyx.llm.interfaces import (
     ToolChoice,
 )
 from onyx.llm.model_capabilities import (
+    OPENAI_API_PROVIDERS,
     ReasoningParamStyle,
     anthropic_omits_sampling_params,
     anthropic_supports_thinking,
     anthropic_uses_adaptive_thinking,
     is_true_openai_model,
     model_is_reasoning_model,
+    openai_chat_tools_require_reasoning_none,
     openai_chat_variant_rejects_reasoning,
     openai_model_rejects_reasoning_effort,
     resolve_reasoning_param_style,
@@ -93,8 +95,8 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_STREAM_OPTIONS = (
 )
 
 # Best-effort tuning kwargs, never worth failing a chat over. _completion
-# retries provider rejections without them: reasoning keys first, then all.
-# Semantics-changing keys (tools, tool_choice, messages) are never stripped.
+# retries provider rejections without them (reasoning keys first, then all),
+# keeping keys a provider requires. Never tools, tool_choice or messages.
 _REASONING_KWARG_KEYS = frozenset(
     {"thinking", "output_config", "reasoning", "reasoning_effort"}
 )
@@ -109,6 +111,11 @@ _KWARG_ERROR_ALIASES: dict[str, tuple[str, ...]] = {
     "reasoning_effort": ("reasoning_effort", "effort"),
     "temperature": ("temperature",),
 }
+
+# Substring of the OpenAI-family 400 that names "none" as the only effort
+# accepted alongside function tools. Omitting the parameter gets the same 400.
+_REASONING_NONE_DEMAND = "set reasoning_effort to 'none'"
+_OPENAI_REASONING_NONE = OPENAI_REASONING_EFFORT[ReasoningEffort.OFF]
 
 
 def _merge_under(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
@@ -134,6 +141,25 @@ def _rejection_names_strippable_kwargs(error: Exception, strippable: set[str]) -
         for key in strippable
         for alias in _KWARG_ERROR_ALIASES.get(key, (key,))
     )
+
+
+def _rejection_demands_reasoning_none(error: Exception) -> bool:
+    return _REASONING_NONE_DEMAND in str(error).lower()
+
+
+def _retry_attempts(
+    kwargs: dict[str, Any], required_keys: frozenset[str]
+) -> list[dict[str, Any]]:
+    """The ladder: the kwargs as given, then without reasoning keys, then
+    without every best-effort key, skipping steps that drop nothing."""
+    attempts = [kwargs]
+    for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
+        stripped = {
+            k: v for k, v in kwargs.items() if k not in strip_keys or k in required_keys
+        }
+        if len(stripped) < len(attempts[-1]):
+            attempts.append(stripped)
+    return attempts
 
 
 class LLMTimeoutError(Exception):
@@ -362,6 +388,22 @@ def _log_azure_responses_api_version_override(
         "chat-completions calls.",
         api_base,
         configured_api_version,
+    )
+
+
+@lru_cache(maxsize=None)
+def _log_chat_completions_tools_disable_reasoning(
+    model: str, api_base: str | None
+) -> None:
+    """Log once per model and api_base per process, for the same reason as
+    `_log_azure_responses_api_version_override`."""
+    logger.warning(
+        "%s at %s is reached over chat completions, where GPT-5.4+ cannot "
+        "combine function tools with reasoning. Tool-bearing requests send "
+        "reasoning_effort=none. To keep reasoning, switch the provider to the "
+        "responses API mode or use a model name the registry knows.",
+        model,
+        api_base,
     )
 
 
@@ -632,6 +674,8 @@ class LitellmLLM(LLM):
         #########################
         # Optional kwargs - should only be passed to LiteLLM under certain conditions
         optional_kwargs: dict[str, Any] = {}
+        # Kwargs the provider requires, which the retry ladder must never strip.
+        required_kwarg_keys: frozenset[str] = frozenset()
 
         # Model name
         is_openai_compatible_proxy = self._api_surface in OPENAI_COMPATIBLE_SURFACES
@@ -706,6 +750,25 @@ class LitellmLLM(LLM):
 
         if stream and not is_vertex_model_rejecting_stream_options:
             optional_kwargs["stream_options"] = {"include_usage": True}
+
+        # Tool turns over chat completions for GPT-5.4+ trade reasoning for a
+        # working call. Responses routes, registry bridge included, are exempt.
+        if (
+            tools
+            and not is_openai_model
+            and (
+                self._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
+                or self._model_provider in OPENAI_API_PROVIDERS
+            )
+            and any(
+                openai_chat_tools_require_reasoning_none(name)
+                for name in model_identity_names
+            )
+        ):
+            reasoning_effort = ReasoningEffort.OFF
+            optional_kwargs["reasoning_effort"] = _OPENAI_REASONING_NONE
+            required_kwarg_keys = frozenset({"reasoning_effort"})
+            _log_chat_completions_tools_disable_reasoning(model, self._api_base)
 
         # Note, there is a reasoning_effort parameter in LiteLLM but it is completely jank and does not work for any
         # of the major providers. Not setting it sets it to OFF.
@@ -968,16 +1031,9 @@ class LitellmLLM(LLM):
                         **passthrough_kwargs,
                     )
 
-            # Retry ladder for provider 400s: drop reasoning kwargs, then every
-            # best-effort kwarg. Unknown models or capability drift degrade to
-            # provider defaults with a warning instead of failing the message.
-            attempts = [optional_kwargs]
-            for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
-                stripped = {
-                    k: v for k, v in optional_kwargs.items() if k not in strip_keys
-                }
-                if len(stripped) < len(attempts[-1]):
-                    attempts.append(stripped)
+            # Provider 400s degrade to provider defaults with a warning instead
+            # of failing the message, or learn the "none" a provider demands.
+            attempts = _retry_attempts(optional_kwargs, required_kwarg_keys)
 
             for i, opts in enumerate(attempts):
                 # Last write wins: sent_kwargs holds what the returning (or
@@ -996,17 +1052,35 @@ class LitellmLLM(LLM):
                 try:
                     return _call_litellm(opts)
                 except BadRequestError as e:
-                    if i == len(attempts) - 1:
+                    if (
+                        _rejection_demands_reasoning_none(e)
+                        and opts.get("reasoning_effort") != _OPENAI_REASONING_NONE
+                    ):
+                        # A name the version gate cannot place learns "none" from
+                        # the 400 itself, one round trip late. Rebuilt attempts all
+                        # carry it, so the loop picks up the tail and this fires once.
+                        reasoning_effort = ReasoningEffort.OFF
+                        forced = {
+                            k: v
+                            for k, v in opts.items()
+                            if k not in _REASONING_KWARG_KEYS
+                        } | {"reasoning_effort": _OPENAI_REASONING_NONE}
+                        attempts[i + 1 :] = _retry_attempts(
+                            forced, required_kwarg_keys | {"reasoning_effort"}
+                        )
+                        _log_chat_completions_tools_disable_reasoning(
+                            model, self._api_base
+                        )
+                    elif i == len(attempts) - 1:
                         raise
-                    # Only retry rejections a later attempt can strip away.
-                    remaining_strippable = set(opts) - set(attempts[-1])
-                    if not _rejection_names_strippable_kwargs(e, remaining_strippable):
+                    elif not _rejection_names_strippable_kwargs(
+                        e, set(opts) - set(attempts[-1])
+                    ):
                         raise
                     logger.warning(
-                        "Provider rejected request for model %s. Retrying "
-                        "without %s: %s",
+                        "Provider rejected request for model %s. Retrying with %s: %s",
                         model,
-                        sorted(set(opts) - set(attempts[i + 1])),
+                        sorted(_BEST_EFFORT_KWARG_KEYS & attempts[i + 1].keys()),
                         e,
                     )
             raise RuntimeError("unreachable: retry ladder always returns or raises")

--- a/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
+++ b/backend/tests/unit/onyx/llm/test_chat_completions_tools_reasoning_none.py
@@ -1,0 +1,190 @@
+"""`_completion` must send an explicit reasoning_effort "none" when GPT-5.4+ take
+function tools over chat completions, and leave responses routes and older
+models alone."""
+
+from typing import Any
+from unittest.mock import patch
+
+from litellm.exceptions import BadRequestError
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import ReasoningEffort, UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.well_known_providers.constants import (
+    BIFROST_API_MODE_CHAT_COMPLETIONS,
+    BIFROST_API_MODE_CONFIG_KEY,
+    BIFROST_API_MODE_RESPONSES,
+)
+
+_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def _bifrost_llm(model_name: str, api_mode: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=LlmProviderNames.BIFROST,
+        model_name=model_name,
+        max_input_tokens=100000,
+        api_base="https://bifrost.example/v1",
+        custom_config={BIFROST_API_MODE_CONFIG_KEY: api_mode},
+    )
+
+
+def _azure_llm(model_name: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=LlmProviderNames.AZURE,
+        model_name=model_name,
+        max_input_tokens=100000,
+        api_base="https://example.openai.azure.com",
+        api_version="2025-04-01-preview",
+    )
+
+
+def _sent_kwargs(
+    llm: LitellmLLM,
+    tools: list[dict] | None,
+    effort: ReasoningEffort = ReasoningEffort.AUTO,
+) -> dict[str, Any]:
+    with patch("onyx.llm.litellm_singleton.litellm.completion") as completion:
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=tools,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=effort,
+        )
+    return dict(completion.call_args.kwargs)
+
+
+def test_chat_completions_tools_send_explicit_none() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS), _TOOLS
+    )
+    assert kwargs["reasoning_effort"] == "none"
+    assert "reasoning" not in kwargs
+
+
+def test_off_still_sends_explicit_none_with_tools() -> None:
+    """OFF normally omits every reasoning kwarg, which these models reject."""
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS),
+        _TOOLS,
+        ReasoningEffort.OFF,
+    )
+    assert kwargs["reasoning_effort"] == "none"
+
+
+def test_chat_completions_without_tools_keeps_reasoning() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS), None
+    )
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_responses_surface_keeps_reasoning_with_tools() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_RESPONSES), _TOOLS
+    )
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_older_models_keep_reasoning_with_tools() -> None:
+    kwargs = _sent_kwargs(
+        _bifrost_llm("openai/gpt-5.2", BIFROST_API_MODE_CHAT_COMPLETIONS), _TOOLS
+    )
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_azure_deployment_alias_sends_explicit_none() -> None:
+    """An alias the registry doesn't know takes Azure chat completions, where
+    the model rejects the tools even with no reasoning kwarg at all."""
+    kwargs = _sent_kwargs(_azure_llm("gpt-5.6-sol-01-ptu"), _TOOLS)
+    assert kwargs["model"] == "azure/gpt-5.6-sol-01-ptu"
+    assert kwargs["reasoning_effort"] == "none"
+    assert "reasoning" not in kwargs
+
+
+def test_azure_registry_model_keeps_reasoning_on_responses_bridge() -> None:
+    kwargs = _sent_kwargs(_azure_llm("gpt-5.6-sol"), _TOOLS)
+    assert kwargs["model"] == "azure/responses/gpt-5.6-sol"
+    assert kwargs["reasoning"]["effort"] == "medium"
+    assert "reasoning_effort" not in kwargs
+
+
+def test_forced_none_survives_the_retry_ladder() -> None:
+    """A rejection of another optional kwarg must not strip the required "none"
+    on retry, or the retry hits the 400 that value exists to avoid."""
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise BadRequestError(
+                message="temperature is not supported", model="m", llm_provider="openai"
+            )
+        return None
+
+    llm = _bifrost_llm("openai/gpt-5.6-sol", BIFROST_API_MODE_CHAT_COMPLETIONS)
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=_TOOLS,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=ReasoningEffort.AUTO,
+        )
+
+    assert len(calls) == 2
+    assert "temperature" in calls[0] and "temperature" not in calls[1]
+    assert calls[0]["reasoning_effort"] == "none"
+    assert calls[1]["reasoning_effort"] == "none"
+
+
+def test_opaque_alias_learns_none_from_the_rejection() -> None:
+    """An alias with no version in its name cannot be matched by name, so the
+    ladder must send "none" once the provider demands it, keeping the rest."""
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if kwargs.get("reasoning_effort") != "none":
+            raise BadRequestError(
+                message=(
+                    "Function tools with reasoning_effort are not supported for "
+                    "prod-gpt in /v1/chat/completions. To use function tools, use "
+                    "/v1/responses or set reasoning_effort to 'none'."
+                ),
+                model="m",
+                llm_provider="azure",
+            )
+        return None
+
+    llm = _azure_llm("prod-gpt")
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=_TOOLS,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=ReasoningEffort.AUTO,
+        )
+
+    assert len(calls) == 2
+    assert "reasoning_effort" not in calls[0]
+    assert calls[1]["reasoning_effort"] == "none"
+    assert calls[1]["temperature"] == calls[0]["temperature"]

--- a/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_capabilities.py
@@ -5,7 +5,9 @@ from onyx.llm.constants import LlmProviderNames
 from onyx.llm.model_capabilities import (
     ReasoningParamStyle,
     is_openai_registry_model_name,
+    openai_chat_tools_require_reasoning_none,
     parse_anthropic_model_version,
+    parse_openai_gpt_version,
     resolve_reasoning_param_style,
     supported_reasoning_efforts,
 )
@@ -81,6 +83,57 @@ def test_parse_anthropic_model_version(
 )
 def test_is_openai_registry_model_name(model_name: str, expected: bool) -> None:
     assert is_openai_registry_model_name(model_name) is expected
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        ("gpt-5.6-sol", (5, 6)),
+        ("gpt-5.4-mini", (5, 4)),
+        ("gpt-5", (5, 0)),
+        ("gpt-4o", (4, 0)),
+        ("gpt-4.1-mini", (4, 1)),
+        # Gateway vendor prefixes and Azure deployment aliases
+        ("azure/gpt-5.6-sol", (5, 6)),
+        ("bedrock_mantle/openai.gpt-5.6-luna", (5, 6)),
+        ("gpt-5.6-sol-01-ptu", (5, 6)),
+        # Azure spells GPT-3.5 without the dot
+        ("gpt-35-turbo", (3, 5)),
+        ("gpt-35-turbo-16k", (3, 5)),
+        # "gpt-" glued to another word, or with no version after it, is not GPT
+        ("chatgpt-4o-latest", None),
+        ("gpt-oss-120b", None),
+        ("claude-sonnet-5", None),
+        ("o3", None),
+    ],
+)
+def test_parse_openai_gpt_version(
+    model_name: str, expected: tuple[int, int] | None
+) -> None:
+    assert parse_openai_gpt_version(model_name) == expected
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        # gpt-5.4 is the first release to reject tools alongside reasoning
+        # over chat completions. Its -mini and -nano variants do too.
+        ("gpt-5.4", True),
+        ("gpt-5.4-mini", True),
+        ("gpt-5.4-nano", True),
+        ("gpt-5.5", True),
+        ("gpt-5.6-sol", True),
+        ("gpt-5.2", False),
+        ("gpt-5", False),
+        ("gpt-4.1", False),
+        ("gpt-35-turbo", False),
+        ("claude-sonnet-5", False),
+    ],
+)
+def test_openai_chat_tools_require_reasoning_none(
+    model_name: str, expected: bool
+) -> None:
+    assert openai_chat_tools_require_reasoning_none(model_name) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cherry-pick of commit 1d58224a2af7b650b60c81f643465de60b1bad1c to release/v4.6 branch.

Original PR: #14603

- [x] [Optional] Override Linear Check
