### PR TITLE
fix(web): Harden the service-account name field

### DIFF
--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "أدخل اسمًا",
+          "required": "الاسم مطلوب",
           "title": "الاسم"
         },
         "submitButton": {

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "Geben Sie einen Namen ein",
+          "required": "Name ist erforderlich",
           "title": "Name"
         },
         "submitButton": {

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "Enter a name",
+          "required": "Name is required",
           "title": "Name"
         },
         "submitButton": {

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "Introduce un nombre",
+          "required": "El nombre es obligatorio",
           "title": "Nombre"
         },
         "submitButton": {

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "Saisissez un nom",
+          "required": "Le nom est requis",
           "title": "Nom"
         },
         "submitButton": {

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "名前を入力",
+          "required": "名前は必須です",
           "title": "名前"
         },
         "submitButton": {

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "이름 입력",
+          "required": "이름은 필수입니다",
           "title": "이름"
         },
         "submitButton": {

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "Insira um nome",
+          "required": "O nome é obrigatório",
           "title": "Nome"
         },
         "submitButton": {

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -6321,6 +6321,7 @@
         },
         "name": {
           "placeholder": "输入名称",
+          "required": "名称为必填项",
           "title": "名称"
         },
         "submitButton": {

--- a/web/src/views/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
@@ -12,7 +12,6 @@ import type { APIKey } from "@/views/admin/ServiceAccountsPage/interfaces";
 import { Modal } from "@opal/components";
 import { Button } from "@opal/components";
 import { InputTypeIn } from "@opal/components";
-import { FormikField } from "@/refresh-components/form/FormikField";
 import { InputVertical, toast } from "@opal/layouts";
 import { SvgCheck, SvgKey, SvgLogOut, SvgUsers } from "@opal/icons";
 import useGroups from "@/hooks/useGroups";
@@ -67,7 +66,7 @@ export default function ApiKeyFormModal({
         <Formik
           initialValues={{
             service_account_name: apiKey?.api_key_name || "",
-            group_ids: apiKey?.groups.map((g) => g.id) || ([] as number[]),
+            group_ids: apiKey?.groups.map((g) => g.id) ?? [],
           }}
           validationSchema={Yup.object().shape({
             service_account_name: Yup.string()
@@ -119,7 +118,7 @@ export default function ApiKeyFormModal({
             }
           }}
         >
-          {({ isSubmitting, values, setFieldValue }) => {
+          {({ isSubmitting, values, setFieldValue, isValid, dirty }) => {
             const memberGroupIds = new Set(values.group_ids);
             const joinedGroups = (allGroups ?? []).filter((g) =>
               memberGroupIds.has(g.id)
@@ -288,9 +287,7 @@ export default function ApiKeyFormModal({
                     {t("formModal.cancelButton.label")}
                   </Button>
                   <Button
-                    disabled={
-                      isSubmitting || !values.service_account_name.trim()
-                    }
+                    disabled={isSubmitting || !isValid || !dirty}
                     type="submit"
                   >
                     {isUpdate

--- a/web/src/views/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
@@ -20,6 +20,7 @@ import LineItem from "@/refresh-components/buttons/LineItem";
 import { ShadowDiv } from "@opal/components";
 import { cn } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
+import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 
 interface ApiKeyFormModalProps {
   onClose: () => void;
@@ -64,14 +65,14 @@ export default function ApiKeyFormModal({
         />
         <Formik
           initialValues={{
-            name: apiKey?.api_key_name || "",
+            service_account_name: apiKey?.api_key_name || "",
             group_ids: apiKey?.groups.map((g) => g.id) || ([] as number[]),
           }}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
 
             const payload = {
-              name: values.name || undefined,
+              name: values.service_account_name || undefined,
               group_ids: values.group_ids,
             };
 
@@ -132,18 +133,17 @@ export default function ApiKeyFormModal({
               <Form className="w-full overflow-visible">
                 <Modal.Body>
                   <InputVertical
-                    withLabel="name"
+                    withLabel="service_account_name"
                     title={t("formModal.name.title")}
                   >
-                    <FormikField<string>
-                      name="name"
-                      render={(field) => (
-                        <InputTypeIn
-                          {...field}
-                          placeholder={t("formModal.name.placeholder")}
-                          clearButton
-                        />
-                      )}
+                    {/* The field key doubles as the input's DOM name and id,
+                        and name="name" reads as a contact-name field to
+                        browser autofill (Safari suggests contacts). */}
+                    <InputTypeInField
+                      name="service_account_name"
+                      autoComplete="off"
+                      placeholder={t("formModal.name.placeholder")}
+                      clearButton
                     />
                   </InputVertical>
 
@@ -282,7 +282,9 @@ export default function ApiKeyFormModal({
                     {t("formModal.cancelButton.label")}
                   </Button>
                   <Button
-                    disabled={isSubmitting || !values.name.trim()}
+                    disabled={
+                      isSubmitting || !values.service_account_name.trim()
+                    }
                     type="submit"
                   >
                     {isUpdate

--- a/web/src/views/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { Form, Formik } from "formik";
+import * as Yup from "yup";
 import {
   createApiKey,
   updateApiKey,
@@ -68,6 +69,11 @@ export default function ApiKeyFormModal({
             service_account_name: apiKey?.api_key_name || "",
             group_ids: apiKey?.groups.map((g) => g.id) || ([] as number[]),
           }}
+          validationSchema={Yup.object().shape({
+            service_account_name: Yup.string()
+              .trim()
+              .required(t("formModal.name.required")),
+          })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
 


### PR DESCRIPTION
## Description

Three fixes to the service-account form modal, found while auditing it for the `LineItem` migration.

**Safari suggested the user's contacts in the name field.** The Formik field key doubles as the input's DOM `name` and `id`, and `name="name"` reads as a contact-name field to browser autofill heuristics. The key becomes `service_account_name` — the payload still sends `name`, which is what the API expects — and the field opts out with `autoComplete="off"`, since fuzzy heuristics can match any attribute *containing* "name" and the rename alone is not a guarantee. The rendered label and placeholder are unchanged.

**The name is now required, with an error on blur.** It was enforced only by silently disabling the submit button. A Yup schema (`.trim().required(...)`) marks the field required, and both halves of the UX come free from machinery that already existed: `InputTypeInField` flips to its error variant on touched+error, and `InputVertical` with a string `withLabel` renders the Formik error text. Leaving the field and tabbing away turns it red with "Name is required", in all nine locales.

**The submit button follows Formik's own `isValid`/`dirty`** instead of re-implementing the name check inline, so it always agrees with the schema. Note one deliberate behaviour change: on the update path the form starts clean, so a no-op "save without edits" is now disabled until something changes.

Also drops a stale `[] as number[]` widening cast — `??` collapses the union on its own.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the service-account form modal so Safari no longer autofills contacts in the name field, the name is now required with an inline error on blur, and the submit button follows Formik's own validity state. The API payload still sends `name` and `group_ids` unchanged.

**Behavior changes**
- On the edit path, the form starts clean, so saving without edits is now disabled until something changes.

<sup>Written for commit 42249bf5fdb6bbe8d6e1b175066e09849dd18a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->