### PR TITLE
refactor(opal): Name card colors for the tokens they paint

### DIFF
--- a/web/lib/opal/src/components/cards/card/Card.stories.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.stories.tsx
@@ -40,7 +40,7 @@ export const SurfaceColors: Story = {
     <div className="flex flex-col gap-4 w-96">
       {CARD_COLORS.map((bg) => (
         <Card key={bg} color={bg} border="solid">
-          <p>backgroundVariant: {bg}</p>
+          <p>color: {bg}</p>
         </Card>
       ))}
     </div>
@@ -99,7 +99,7 @@ export const AllCombinations: Story = {
                   border={border}
                 >
                   <p className="text-xs">
-                    bg: {bg}, border: {border}
+                    color: {bg}, border: {border}
                   </p>
                 </Card>
               ))

--- a/web/lib/opal/src/components/cards/card/Card.stories.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.stories.tsx
@@ -2,7 +2,16 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { Button, Card } from "@opal/components";
 
-const BACKGROUND_VARIANTS = ["none", "light", "heavy"] as const;
+const CARD_COLORS = [
+  "transparent",
+  "background-tint-00",
+  "background-tint-01",
+  "status-info-00",
+  "status-success-00",
+  "status-warning-00",
+  "status-error-00",
+  "theme-amber-01",
+] as const;
 const BORDER_VARIANTS = ["none", "dashed", "solid"] as const;
 const PADDING_VARIANTS = [0, 0.5, 1, 2, 4, 6] as const;
 const ROUNDING_VARIANTS = [1, 2, 3, 4] as const;
@@ -26,11 +35,11 @@ export const Default: Story = {
   ),
 };
 
-export const BackgroundVariants: Story = {
+export const SurfaceColors: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-96">
-      {BACKGROUND_VARIANTS.map((bg) => (
-        <Card key={bg} background={bg} border="solid">
+      {CARD_COLORS.map((bg) => (
+        <Card key={bg} color={bg} border="solid">
           <p>backgroundVariant: {bg}</p>
         </Card>
       ))}
@@ -81,12 +90,12 @@ export const AllCombinations: Story = {
         <div key={padding}>
           <p className="font-bold pb-2">padding: {padding}</p>
           <div className="grid grid-cols-3 gap-4">
-            {BACKGROUND_VARIANTS.map((bg) =>
+            {CARD_COLORS.map((bg) =>
               BORDER_VARIANTS.map((border) => (
                 <Card
                   key={`${padding}-${bg}-${border}`}
                   padding={padding}
-                  background={bg}
+                  color={bg}
                   border={border}
                 >
                   <p className="text-xs">

--- a/web/lib/opal/src/components/cards/card/Card.test.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.test.tsx
@@ -35,16 +35,16 @@ describe("Card data attributes", () => {
 
   it("keeps its own styling attributes authoritative", () => {
     render(
-      <Card background="heavy" data-background="spoofed">
+      <Card color="background-tint-01" data-color="spoofed">
         <p>Body</p>
       </Card>
     );
 
-    // The card's own `data-background` is written after the spread, so a caller
+    // The card's own `data-color` is written after the spread, so a caller
     // cannot repurpose it to drive the stylesheet.
     expect(screen.getByText("Body").parentElement).toHaveAttribute(
-      "data-background",
-      "heavy"
+      "data-color",
+      "background-tint-01"
     );
   });
 
@@ -89,7 +89,7 @@ describe("Card disabled", () => {
 
   it("stacks with background and border rather than replacing them", () => {
     render(
-      <Card disabled background="none" border="dashed">
+      <Card disabled color="transparent" border="dashed">
         <p>Body</p>
       </Card>
     );

--- a/web/lib/opal/src/components/cards/card/Card.test.tsx
+++ b/web/lib/opal/src/components/cards/card/Card.test.tsx
@@ -87,7 +87,7 @@ describe("Card disabled", () => {
     );
   });
 
-  it("stacks with background and border rather than replacing them", () => {
+  it("stacks with color and border rather than replacing them", () => {
     render(
       <Card disabled color="transparent" border="dashed">
         <p>Body</p>
@@ -95,7 +95,7 @@ describe("Card disabled", () => {
     );
     const card = screen.getByText("Body").parentElement;
     expect(card).toHaveAttribute("data-disabled");
-    expect(card).toHaveAttribute("data-background", "none");
+    expect(card).toHaveAttribute("data-color", "transparent");
     expect(card).toHaveAttribute("data-border", "dashed");
   });
 

--- a/web/lib/opal/src/components/cards/card/README.md
+++ b/web/lib/opal/src/components/cards/card/README.md
@@ -2,7 +2,7 @@
 
 **Import:** `import { Card, type CardProps } from "@opal/components";`
 
-A container component with configurable background, border, padding, and rounding. Has two mutually-exclusive modes:
+A container component with configurable surface color, border, padding, and rounding. Has two mutually-exclusive modes:
 
 - **Plain** (default) — renders children inside a single styled `<div>`.
 - **Expandable** (`expandable: true`) — renders children as an always-visible header plus an `expandedContent` prop that animates open/closed.
@@ -21,17 +21,17 @@ import { Card } from "@opal/components";
 
 ### Plain mode props
 
-| Prop          | Type                            | Default     | Description                                                            |
-| ------------- | ------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `padding`     | `Spacing`                       | `4`         | Padding, as a spacing step (`N / 4` rem)                               |
-| `rounding`    | `Rounding`                      | `3`         | Corner radius step (`N / 4` rem, or `"full"`)                          |
-| `background`  | `"none" \| "light" \| "heavy"`  | `"light"`   | Background fill intensity                                              |
-| `border`      | `"none" \| "dashed" \| "solid"` | `"none"`    | Border style                                                           |
-| `borderColor` | `StatusVariants`                | `"default"` | Status-palette border color (needs `border` ≠ `"none"`)                |
-| `disabled`    | `boolean`                       | `false`     | Dims the card and shows a not-allowed cursor. Visual only — see below. |
-| `ref`         | `React.Ref<HTMLDivElement>`     | —           | Ref forwarded to the root div                                          |
-| `children`    | `React.ReactNode`               | —           | Card content                                                           |
-| `data-*`      | `string \| boolean`             | —           | Forwarded to the root. See below.                                      |
+| Prop          | Type                            | Default                | Description                                                                                                   |
+| ------------- | ------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `padding`     | `Spacing`                       | `4`                    | Padding, as a spacing step (`N / 4` rem)                                                                      |
+| `rounding`    | `Rounding`                      | `3`                    | Corner radius step (`N / 4` rem, or `"full"`)                                                                 |
+| `color`       | `CardColor`                     | `"background-tint-00"` | Surface color, named for the token it paints (`"transparent"`, `"background-tint-01"`, `"status-info-00"`, …) |
+| `border`      | `"none" \| "dashed" \| "solid"` | `"none"`               | Border style                                                                                                  |
+| `borderColor` | `StatusVariants`                | `"default"`            | Status-palette border color (needs `border` ≠ `"none"`)                                                       |
+| `disabled`    | `boolean`                       | `false`                | Dims the card and shows a not-allowed cursor. Visual only — see below.                                        |
+| `ref`         | `React.Ref<HTMLDivElement>`     | —                      | Ref forwarded to the root div                                                                                 |
+| `children`    | `React.ReactNode`               | —                      | Card content                                                                                                  |
+| `data-*`      | `string \| boolean`             | —                      | Forwarded to the root. See below.                                                                             |
 
 ### `disabled`
 
@@ -52,7 +52,7 @@ when you want a tooltip explaining why:
 </Disabled>
 ```
 
-It is a boolean rather than a variant value, so it stacks with `background` and
+It is a boolean rather than a variant value, so it stacks with `color` and
 `border` instead of replacing them — a disabled card can still be transparent
 with a dashed border.
 
@@ -74,7 +74,7 @@ card's appearance is still its own; behavioural props such as `onClick` are a
 deliberate API decision rather than something inherited by a rest spread (use
 `SelectCard` for an interactive card).
 
-The card's own `data-background`, `data-border`, `data-shadow`, and
+The card's own `data-color`, `data-border`, `data-shadow`, and
 `data-opal-status-border` are written after the forwarded attributes, so a caller
 cannot repurpose them to drive the stylesheet.
 
@@ -148,7 +148,7 @@ Everything from plain mode, **plus**:
 - **Always controlled.** `expanded` is a pure one-way visual prop. There is no `defaultExpanded` or `onExpandChange` — the caller owns state entirely (`useState` at the call site).
 - **No React context.** The component renders a flat tree; there are no compound sub-components (`Card.Header` / `Card.Content`) and no exported context hooks.
 - **Rounding adapts automatically.** When `expanded && expandedContent !== undefined`, the header's bottom corners flatten and the content's top corners flatten so they meet seamlessly. When collapsed (or when `expandedContent` is undefined), the header is fully rounded.
-- **Content background is always transparent.** The `background` prop applies to the header only; the content slot never fills its own background so the page shows through and keeps the two regions visually distinct.
+- **Content background is always transparent.** The `color` prop applies to the header only; the content slot never fills its own background so the page shows through and keeps the two regions visually distinct.
 - **Content has no intrinsic padding.** The `padding` prop applies to the header only. Callers own any padding inside whatever they pass to `expandedContent` — wrap it in a `<div className="p-4">` (or whatever) if you want spacing.
 - **Animation.** Content uses a pure CSS grid `0fr ↔ 1fr` animation with an opacity fade (~200ms ease-out). No `@radix-ui/react-collapsible` dependency.
 
@@ -162,7 +162,7 @@ Because Card doesn't own the trigger, it also doesn't generate IDs or ARIA attri
 type CardBaseProps = {
   padding?: Spacing;
   rounding?: Rounding;
-  background?: "none" | "light" | "heavy";
+  color?: CardColor;
   border?: "none" | "dashed" | "solid";
   borderColor?: StatusVariants;
   ref?: React.Ref<HTMLDivElement>;

--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -1,7 +1,7 @@
 import "@opal/components/cards/shared.css";
 import "@opal/components/cards/card/styles.css";
 import type {
-  BackgroundVariants,
+  CardColor,
   BorderVariants,
   Spacing,
   Rounding,
@@ -53,14 +53,12 @@ type CardBaseProps = {
   rounding?: Rounding;
 
   /**
-   * Background fill intensity.
-   * - `"none"`: transparent background.
-   * - `"light"`: subtle tinted background (`bg-background-tint-00`).
-   * - `"heavy"`: stronger tinted background (`bg-background-tint-01`).
+   * Surface color, named for the token it paints — the card analog of
+   * `Text`'s `color`. `"transparent"` renders no fill.
    *
-   * @default "light"
+   * @default "background-tint-00"
    */
-  background?: BackgroundVariants;
+  color?: CardColor;
 
   /**
    * Border style.
@@ -231,7 +229,7 @@ function Card(props: CardProps) {
   const {
     padding: paddingProp = 4,
     rounding: roundingProp = 3,
-    background = "light",
+    color = "background-tint-00",
     border = "none",
     borderColor = "default",
     shadow = "none",
@@ -261,7 +259,7 @@ function Card(props: CardProps) {
         className="opal-card"
         style={{ ...paddingStyle, borderRadius: radius }}
         {...dataAttributes(props)}
-        data-background={background}
+        data-color={color}
         data-border={border}
         data-opal-status-border={borderColor}
         data-shadow={shadow}
@@ -292,7 +290,7 @@ function Card(props: CardProps) {
       <div
         className="opal-card-expandable-header"
         style={{ ...paddingStyle, ...headerRadius }}
-        data-background={background}
+        data-color={color}
         data-border={border}
         data-opal-status-border={borderColor}
       >

--- a/web/lib/opal/src/components/cards/card/styles.css
+++ b/web/lib/opal/src/components/cards/card/styles.css
@@ -8,17 +8,37 @@
   @apply w-full overflow-clip;
 }
 
-/* Background variants */
-.opal-card[data-background="none"] {
+/* Surface colors — one rule per token, names match the palette */
+.opal-card[data-color="transparent"] {
   @apply bg-transparent;
 }
 
-.opal-card[data-background="light"] {
+.opal-card[data-color="background-tint-00"] {
   @apply bg-background-tint-00;
 }
 
-.opal-card[data-background="heavy"] {
+.opal-card[data-color="background-tint-01"] {
   @apply bg-background-tint-01;
+}
+
+.opal-card[data-color="status-info-00"] {
+  @apply bg-status-info-00;
+}
+
+.opal-card[data-color="status-success-00"] {
+  @apply bg-status-success-00;
+}
+
+.opal-card[data-color="status-warning-00"] {
+  @apply bg-status-warning-00;
+}
+
+.opal-card[data-color="status-error-00"] {
+  @apply bg-status-error-00;
+}
+
+.opal-card[data-color="theme-amber-01"] {
+  @apply bg-theme-amber-01;
 }
 
 /* Disabled — visual only. The card dims and takes a not-allowed cursor, but
@@ -75,16 +95,36 @@
   @apply w-full overflow-clip transition-[border-radius] duration-200 ease-out;
 }
 
-.opal-card-expandable-header[data-background="none"] {
+.opal-card-expandable-header[data-color="transparent"] {
   @apply bg-transparent;
 }
 
-.opal-card-expandable-header[data-background="light"] {
+.opal-card-expandable-header[data-color="background-tint-00"] {
   @apply bg-background-tint-00;
 }
 
-.opal-card-expandable-header[data-background="heavy"] {
+.opal-card-expandable-header[data-color="background-tint-01"] {
   @apply bg-background-tint-01;
+}
+
+.opal-card-expandable-header[data-color="status-info-00"] {
+  @apply bg-status-info-00;
+}
+
+.opal-card-expandable-header[data-color="status-success-00"] {
+  @apply bg-status-success-00;
+}
+
+.opal-card-expandable-header[data-color="status-warning-00"] {
+  @apply bg-status-warning-00;
+}
+
+.opal-card-expandable-header[data-color="status-error-00"] {
+  @apply bg-status-error-00;
+}
+
+.opal-card-expandable-header[data-color="theme-amber-01"] {
+  @apply bg-theme-amber-01;
 }
 
 .opal-card-expandable-header[data-border="none"] {

--- a/web/lib/opal/src/components/cards/empty-message-card/README.md
+++ b/web/lib/opal/src/components/cards/empty-message-card/README.md
@@ -8,18 +8,18 @@ A pre-configured Card for empty states. Renders a transparent card with a dashed
 
 ### Base props (all presets)
 
-| Prop         | Type                          | Default       | Description                        |
-| ------------ | ----------------------------- | ------------- | ---------------------------------- |
-| `sizePreset` | `"secondary" \| "main-ui"`   | `"secondary"` | Controls layout and text sizing    |
-| `icon`       | `IconFunctionComponent`       | `SvgEmpty`    | Icon displayed alongside the title |
-| `title`      | `string \| RichStr`           | —             | Primary message text (required)    |
-| `padding`    | `0 \| 0.5 \| 1 \| 2 \| 4 \| 6` | `4` | Padding, as a spacing step (`N / 4` rem). Closed set. |
-| `ref`        | `React.Ref<HTMLDivElement>`   | —             | Ref forwarded to the root div      |
+| Prop         | Type                           | Default       | Description                                           |
+| ------------ | ------------------------------ | ------------- | ----------------------------------------------------- |
+| `sizePreset` | `"secondary" \| "main-ui"`     | `"secondary"` | Controls layout and text sizing                       |
+| `icon`       | `IconFunctionComponent`        | `SvgEmpty`    | Icon displayed alongside the title                    |
+| `title`      | `string \| RichStr`            | —             | Primary message text (required)                       |
+| `padding`    | `0 \| 0.5 \| 1 \| 2 \| 4 \| 6` | `4`           | Padding, as a spacing step (`N / 4` rem). Closed set. |
+| `ref`        | `React.Ref<HTMLDivElement>`    | —             | Ref forwarded to the root div                         |
 
 ### `sizePreset="main-ui"` only
 
-| Prop          | Type                | Default | Description              |
-| ------------- | ------------------- | ------- | ------------------------ |
+| Prop          | Type                | Default | Description               |
+| ------------- | ------------------- | ------- | ------------------------- |
 | `description` | `string \| RichStr` | —       | Optional description text |
 
 > `description` is **not accepted** when `sizePreset` is `"secondary"` (the default).

--- a/web/lib/opal/src/components/cards/empty-message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/empty-message-card/components.tsx
@@ -56,7 +56,7 @@ function EmptyMessageCard(props: EmptyMessageCardProps) {
   return (
     <Card
       ref={ref}
-      background="none"
+      color="transparent"
       border="dashed"
       padding={padding}
       rounding={3}

--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -8,17 +8,17 @@ and border colors.
 
 ## Props
 
-| Prop             | Type                                                       | Default     | Description                                                                                |
-| ---------------- | ---------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
-| `variant`        | `"default" \| "info" \| "success" \| "warning" \| "error"` | `"default"` | Visual variant (controls background, border, and icon)                                     |
-| `icon`           | `IconFunctionComponent`                                    | per variant | Override the default variant icon                                                          |
-| `title`          | `string \| RichStr`                                        | —           | Main title text                                                                            |
-| `description`    | `string \| RichStr`                                        | —           | Description below the title                                                                |
-| `padding`        | `1 \| 2`                                                   | `2`         | Padding around the outer card, as a spacing step (`N / 4` rem). Narrowed to two densities. |
-| `headerPadding`  | `Spacing`                                                  | `0`         | Padding around the header Content area, as a spacing step (`N / 4` rem)                    |
-| `bottomChildren` | `ReactNode`                                                | —           | Content below a divider, under the main content                                            |
-| `rightChildren`  | `ReactNode`                                                | —           | Content on the right side. Mutually exclusive with `onClose`.                              |
-| `onClose`        | `() => void`                                               | —           | Close button callback. When omitted, no close button is rendered.                          |
+| Prop             | Type                                                                    | Default     | Description                                                                                |
+| ---------------- | ----------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `variant`        | `"default" \| "info" \| "success" \| "warning" \| "pending" \| "error"` | `"default"` | Visual variant (controls background, border, and icon)                                     |
+| `icon`           | `IconFunctionComponent`                                                 | per variant | Override the default variant icon                                                          |
+| `title`          | `string \| RichStr`                                                     | —           | Main title text                                                                            |
+| `description`    | `string \| RichStr`                                                     | —           | Description below the title                                                                |
+| `padding`        | `1 \| 2`                                                                | `2`         | Padding around the outer card, as a spacing step (`N / 4` rem). Narrowed to two densities. |
+| `headerPadding`  | `Spacing`                                                               | `0`         | Padding around the header Content area, as a spacing step (`N / 4` rem)                    |
+| `bottomChildren` | `ReactNode`                                                             | —           | Content below a divider, under the main content                                            |
+| `rightChildren`  | `ReactNode`                                                             | —           | Content on the right side. Mutually exclusive with `onClose`.                              |
+| `onClose`        | `() => void`                                                            | —           | Close button callback. When omitted, no close button is rendered.                          |
 
 ## Usage
 

--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -3,7 +3,7 @@
 **Import:** `import { MessageCard } from "@opal/components";`
 
 A styled card for displaying messages, alerts, or status notifications. Uses `Content` internally
-for consistent title/description/icon layout. Built on `Card`, which owns the surface — each variant maps to a `CardColor`, a border color, and an icon. Supports 5 variants with corresponding background
+for consistent title/description/icon layout. Built on `Card`, which owns the surface — each variant maps to a `CardColor`, a border color, and an icon. Supports 6 variants — `default`, `info`, `success`, `warning`, `pending`, `error` — with corresponding background
 and border colors.
 
 ## Props

--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -3,22 +3,22 @@
 **Import:** `import { MessageCard } from "@opal/components";`
 
 A styled card for displaying messages, alerts, or status notifications. Uses `Content` internally
-for consistent title/description/icon layout. Supports 5 variants with corresponding background
+for consistent title/description/icon layout. Built on `Card`, which owns the surface — each variant maps to a `CardColor`, a border color, and an icon. Supports 5 variants with corresponding background
 and border colors.
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `variant` | `"default" \| "info" \| "success" \| "warning" \| "error"` | `"default"` | Visual variant (controls background, border, and icon) |
-| `icon` | `IconFunctionComponent` | per variant | Override the default variant icon |
-| `title` | `string \| RichStr` | — | Main title text |
-| `description` | `string \| RichStr` | — | Description below the title |
-| `padding` | `1 \| 2` | `2` | Padding around the outer card, as a spacing step (`N / 4` rem). Narrowed to two densities. |
-| `headerPadding` | `Spacing` | `0` | Padding around the header Content area, as a spacing step (`N / 4` rem) |
-| `bottomChildren` | `ReactNode` | — | Content below a divider, under the main content |
-| `rightChildren` | `ReactNode` | — | Content on the right side. Mutually exclusive with `onClose`. |
-| `onClose` | `() => void` | — | Close button callback. When omitted, no close button is rendered. |
+| Prop             | Type                                                       | Default     | Description                                                                                |
+| ---------------- | ---------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| `variant`        | `"default" \| "info" \| "success" \| "warning" \| "error"` | `"default"` | Visual variant (controls background, border, and icon)                                     |
+| `icon`           | `IconFunctionComponent`                                    | per variant | Override the default variant icon                                                          |
+| `title`          | `string \| RichStr`                                        | —           | Main title text                                                                            |
+| `description`    | `string \| RichStr`                                        | —           | Description below the title                                                                |
+| `padding`        | `1 \| 2`                                                   | `2`         | Padding around the outer card, as a spacing step (`N / 4` rem). Narrowed to two densities. |
+| `headerPadding`  | `Spacing`                                                  | `0`         | Padding around the header Content area, as a spacing step (`N / 4` rem)                    |
+| `bottomChildren` | `ReactNode`                                                | —           | Content below a divider, under the main content                                            |
+| `rightChildren`  | `ReactNode`                                                | —           | Content on the right side. Mutually exclusive with `onClose`.                              |
+| `onClose`        | `() => void`                                               | —           | Close button callback. When omitted, no close button is rendered.                          |
 
 ## Usage
 

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import "@opal/components/cards/shared.css";
 import "@opal/components/cards/message-card/styles.css";
 import { cn } from "@opal/utils";
 import type {
+  CardColor,
   IconFunctionComponent,
   Spacing,
   RichStr,
@@ -11,6 +11,7 @@ import type {
 } from "@opal/types";
 import { spacingToRem } from "@opal/shared";
 import { ContentAction } from "@opal/layouts";
+import { Card } from "@opal/components/cards/card/components";
 import { Button, Divider } from "@opal/components";
 import {
   SvgAlertCircle,
@@ -83,14 +84,38 @@ type MessageCardProps = MessageCardBaseProps &
 
 const VARIANT_CONFIG: Record<
   StatusVariants,
-  { icon: IconFunctionComponent; iconClass: string }
+  { icon: IconFunctionComponent; iconClass: string; color: CardColor }
 > = {
-  default: { icon: SvgAlertCircle, iconClass: "stroke-text-03" },
-  info: { icon: SvgAlertCircle, iconClass: "stroke-status-info-05" },
-  success: { icon: SvgCheckCircle, iconClass: "stroke-status-success-05" },
-  warning: { icon: SvgAlertTriangle, iconClass: "stroke-status-warning-05" },
-  pending: { icon: SvgClock, iconClass: "stroke-theme-amber-05" },
-  error: { icon: SvgXOctagon, iconClass: "stroke-status-error-05" },
+  default: {
+    icon: SvgAlertCircle,
+    iconClass: "stroke-text-03",
+    color: "background-tint-01",
+  },
+  info: {
+    icon: SvgAlertCircle,
+    iconClass: "stroke-status-info-05",
+    color: "status-info-00",
+  },
+  success: {
+    icon: SvgCheckCircle,
+    iconClass: "stroke-status-success-05",
+    color: "status-success-00",
+  },
+  warning: {
+    icon: SvgAlertTriangle,
+    iconClass: "stroke-status-warning-05",
+    color: "status-warning-00",
+  },
+  pending: {
+    icon: SvgClock,
+    iconClass: "stroke-theme-amber-05",
+    color: "theme-amber-01",
+  },
+  error: {
+    icon: SvgXOctagon,
+    iconClass: "stroke-status-error-05",
+    color: "status-error-00",
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -145,7 +170,7 @@ function MessageCard({
   onClose,
   ref,
 }: MessageCardProps) {
-  const { icon: DefaultIcon, iconClass } = VARIANT_CONFIG[variant];
+  const { icon: DefaultIcon, iconClass, color } = VARIANT_CONFIG[variant];
   const Icon = iconOverride ?? DefaultIcon;
   const strings = useOpalStrings();
 
@@ -162,35 +187,43 @@ function MessageCard({
     rightChildren
   );
 
+  // Built on Card: the root owns color, border, rounding, and padding, so
+  // this component keeps only its message layout. The wrapper preserves the
+  // stretch behavior the old root class carried, since Card takes no
+  // className.
   return (
-    <div
-      className="opal-message-card"
-      style={{ padding: spacingToRem(padding) }}
-      data-variant={variant}
-      data-opal-status-border={variant}
-      ref={ref}
-    >
-      <div style={{ padding: spacingToRem(headerPadding) }}>
-        <ContentAction
-          icon={(props) => (
-            <Icon {...props} className={cn(props.className, iconClass)} />
-          )}
-          title={title}
-          description={description}
-          titleMaxLines={titleMaxLines}
-          sizePreset="main-ui"
-          variant="section"
-          padding={1}
-          rightChildren={right}
-        />
-      </div>
+    <div className="opal-message-card" ref={ref} data-variant={variant}>
+      <Card
+        color={color}
+        border="solid"
+        borderColor={variant}
+        rounding={4}
+        padding={padding}
+      >
+        <div className="opal-message-card-layout">
+          <div style={{ padding: spacingToRem(headerPadding) }}>
+            <ContentAction
+              icon={(props) => (
+                <Icon {...props} className={cn(props.className, iconClass)} />
+              )}
+              title={title}
+              description={description}
+              titleMaxLines={titleMaxLines}
+              sizePreset="main-ui"
+              variant="section"
+              padding={1}
+              rightChildren={right}
+            />
+          </div>
 
-      {bottomChildren && (
-        <>
-          <Divider paddingParallel={2} paddingPerpendicular={1} />
-          {bottomChildren}
-        </>
-      )}
+          {bottomChildren && (
+            <>
+              <Divider paddingParallel={2} paddingPerpendicular={1} />
+              {bottomChildren}
+            </>
+          )}
+        </div>
+      </Card>
     </div>
   );
 }

--- a/web/lib/opal/src/components/cards/message-card/styles.css
+++ b/web/lib/opal/src/components/cards/message-card/styles.css
@@ -1,32 +1,13 @@
 @reference "#reference.css";
 
+/* The surface (color, border, rounding, padding) lives on Card. This file
+   keeps only what Card cannot express: the stretch behavior of the old root
+   and the message layout. */
+
 .opal-message-card {
-  @apply flex flex-col gap-1 w-full self-stretch rounded-16 border;
+  @apply w-full self-stretch;
 }
 
-/* Variant background colors. Border *color* lives in `cards/shared.css` and
-   is keyed off the `data-opal-status-border` attribute. */
-
-.opal-message-card[data-variant="default"] {
-  @apply bg-background-tint-01;
-}
-
-.opal-message-card[data-variant="info"] {
-  @apply bg-status-info-00;
-}
-
-.opal-message-card[data-variant="success"] {
-  @apply bg-status-success-00;
-}
-
-.opal-message-card[data-variant="warning"] {
-  @apply bg-status-warning-00;
-}
-
-.opal-message-card[data-variant="pending"] {
-  @apply bg-theme-amber-01;
-}
-
-.opal-message-card[data-variant="error"] {
-  @apply bg-status-error-00;
+.opal-message-card-layout {
+  @apply flex flex-col gap-1 w-full;
 }

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -134,13 +134,6 @@ export type OrientationVariants = "horizontal" | "vertical";
 export type BorderVariants = "none" | "dashed" | "solid";
 
 /**
- * Background fill variants shared across card-like surfaces.
- *
- * - `"none"`: transparent background.
- * - `"light"`: lightly tinted background.
- * - `"heavy"`: heavily tinted background.
- */
-/**
  * Card surface colors, named for the token they paint — no intensity
  * adjectives. `"transparent"` is the sentinel for no fill.
  */

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -140,7 +140,19 @@ export type BorderVariants = "none" | "dashed" | "solid";
  * - `"light"`: lightly tinted background.
  * - `"heavy"`: heavily tinted background.
  */
-export type BackgroundVariants = "none" | "light" | "heavy";
+/**
+ * Card surface colors, named for the token they paint — no intensity
+ * adjectives. `"transparent"` is the sentinel for no fill.
+ */
+export type CardColor =
+  | "transparent"
+  | "background-tint-00"
+  | "background-tint-01"
+  | "status-info-00"
+  | "status-success-00"
+  | "status-warning-00"
+  | "status-error-00"
+  | "theme-amber-01";
 
 // ---------------------------------------------------------------------------
 // Color Types

--- a/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
@@ -119,7 +119,7 @@ export const FileReaderToolRenderer: MessageRenderer<
                 </Text>
               </Section>
               {hasPreview && (
-                <Card background="none" border="solid" padding={2} rounding={4}>
+                <Card color="transparent" border="solid" padding={2} rounding={4}>
                   <Section alignItems="start" height="fit" gap={1}>
                     <Text as="span" secondaryMono text04>
                       {state.previewStart}

--- a/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
@@ -119,7 +119,12 @@ export const FileReaderToolRenderer: MessageRenderer<
                 </Text>
               </Section>
               {hasPreview && (
-                <Card color="transparent" border="solid" padding={2} rounding={4}>
+                <Card
+                  color="transparent"
+                  border="solid"
+                  padding={2}
+                  rounding={4}
+                >
                   <Section alignItems="start" height="fit" gap={1}>
                     <Text as="span" secondaryMono text04>
                       {state.previewStart}

--- a/web/src/app/craft/v1/apps/admin/AddAppCatalogModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/AddAppCatalogModal.tsx
@@ -91,7 +91,7 @@ function CatalogCard({
   onClick,
 }: CatalogCardProps) {
   return (
-    <Card background="light" border="solid" rounding={4}>
+    <Card color="background-tint-00" border="solid" rounding={4}>
       {/* h-full centers the row inside grid-stretched cards of uneven height. */}
       <div className="h-full flex items-center gap-3 w-full">
         <Icon className="w-8 h-8 shrink-0" />

--- a/web/src/app/craft/v1/apps/oauth/callback/page.tsx
+++ b/web/src/app/craft/v1/apps/oauth/callback/page.tsx
@@ -84,7 +84,7 @@ export default function ExternalAppsOAuthCallbackPage() {
         description={t("description")}
       />
       <SettingsLayouts.Body>
-        <Card background="light" border="solid" rounding={4}>
+        <Card color="background-tint-00" border="solid" rounding={4}>
           <div className="flex flex-col gap-2">
             {status === "exchanging" && (
               <Text font="main-content-body">{t("exchanging.label")}</Text>

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -159,7 +159,7 @@ function AppConnections({ query }: AppConnectionsProps) {
 
   if (isLoading) {
     return (
-      <Card background="none" border="dashed" rounding={4}>
+      <Card color="transparent" border="dashed" rounding={4}>
         <Text font="main-content-body">{t("loading.label")}</Text>
       </Card>
     );
@@ -411,7 +411,7 @@ function ConnectableCard({
           highlight && "ring-2 ring-action-selection-04"
         )}
       >
-        <Card background="light" border="solid" rounding={4}>
+        <Card color="background-tint-00" border="solid" rounding={4}>
           <ContentAction
             sizePreset="main-ui"
             variant="section"

--- a/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
@@ -80,7 +80,7 @@ export default function PreApprovalPicker({
 
   if ((appsLoading || mcpLoading) && !hasOptions) {
     return (
-      <Card background="none" border="dashed" rounding={4}>
+      <Card color="transparent" border="dashed" rounding={4}>
         <Text font="secondary-body" color="text-03">
           {t("loading.label")}
         </Text>
@@ -90,7 +90,7 @@ export default function PreApprovalPicker({
 
   if ((appsError || mcpError) && !hasOptions) {
     return (
-      <Card background="none" border="dashed" rounding={4}>
+      <Card color="transparent" border="dashed" rounding={4}>
         <Text font="secondary-body" color="text-03">
           {t("errors.loadFailed")}
         </Text>
@@ -100,7 +100,7 @@ export default function PreApprovalPicker({
 
   if (!hasOptions) {
     return (
-      <Card background="none" border="dashed" rounding={4}>
+      <Card color="transparent" border="dashed" rounding={4}>
         <Text font="secondary-body" color="text-03">
           {t("empty.label")}
         </Text>
@@ -114,7 +114,7 @@ export default function PreApprovalPicker({
       data-testid="pre-approval-picker"
     >
       {(appsError || mcpError) && (
-        <Card background="none" border="dashed" rounding={4}>
+        <Card color="transparent" border="dashed" rounding={4}>
           <Text font="secondary-body" color="text-03">
             {t("errors.partialLoadFailed")}
           </Text>
@@ -201,7 +201,7 @@ function PreApprovalRow({ option, checked, onToggle }: PreApprovalRowProps) {
       )}
       data-testid={option.testId}
     >
-      <Card background="light" border="solid" rounding={4}>
+      <Card color="background-tint-00" border="solid" rounding={4}>
         <label
           className="flex w-full cursor-pointer items-center gap-3"
           htmlFor={checkboxId}

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -185,7 +185,12 @@ export default function MCPOAuthCallbackPage() {
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        <Card padding={6} rounding={4} color="background-tint-00" border="solid">
+        <Card
+          padding={6}
+          rounding={4}
+          color="background-tint-00"
+          border="solid"
+        >
           <div className="flex flex-col items-stretch gap-4">
             {state.phase === "processing" && (
               <div className="flex flex-col items-center gap-3 p-5 text-center">

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -185,7 +185,7 @@ export default function MCPOAuthCallbackPage() {
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        <Card padding={6} rounding={4} background="light" border="solid">
+        <Card padding={6} rounding={4} color="background-tint-00" border="solid">
           <div className="flex flex-col items-stretch gap-4">
             {state.phase === "processing" && (
               <div className="flex flex-col items-center gap-3 p-5 text-center">

--- a/web/src/lib/projects/components/ProjectChatSessionList.tsx
+++ b/web/src/lib/projects/components/ProjectChatSessionList.tsx
@@ -316,7 +316,7 @@ export default function ProjectChatSessionList() {
         {isLoadingProjectDetails && !currentProjectDetails ? (
           <SvgSimpleLoader className="mx-4" />
         ) : projectChats.length === 0 ? (
-          <Card rounding={3} border="dashed" background="none" padding={2}>
+          <Card rounding={3} border="dashed" color="transparent" padding={2}>
             <div className="p-1">
               <Text as="p" font="secondary-body" color="text-02">
                 {t("projects.sessionList.empty.message")}

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -182,7 +182,7 @@ function BedrockModalInternals({
       </InputPadder>
 
       {authMethod === AUTH_METHOD_ACCESS_KEY && (
-        <Card background="light" border="none" padding={2}>
+        <Card color="background-tint-00" border="none" padding={2}>
           <Section gap={4}>
             <InputVertical
               withLabel={FIELD_AWS_ACCESS_KEY_ID}
@@ -214,7 +214,7 @@ function BedrockModalInternals({
       )}
 
       {authMethod === AUTH_METHOD_LONG_TERM_API_KEY && (
-        <Card background="light" border="none" padding={2}>
+        <Card color="background-tint-00" border="none" padding={2}>
           <Section gap={2}>
             <InputVertical
               withLabel={FIELD_AWS_BEARER_TOKEN_BEDROCK}

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -88,7 +88,7 @@ function OllamaModalInternals({
 
   return (
     <>
-      <Card background="light" border="none" padding={2}>
+      <Card color="background-tint-00" border="none" padding={2}>
         <Tabs value={tab} onValueChange={(value) => setTab(value as Tab)}>
           <Tabs.List>
             <Tabs.Trigger value={Tab.TAB_SELF_HOSTED}>

--- a/web/src/sections/modals/languageModels/VertexAIModal.tsx
+++ b/web/src/sections/modals/languageModels/VertexAIModal.tsx
@@ -145,7 +145,7 @@ function VertexAIModalInternals({
               title={t("vertexAi.workloadIdentityNotice.title")}
             />
           </InputPadder>
-          <Card background="light" border="none" padding={2}>
+          <Card color="background-tint-00" border="none" padding={2}>
             <InputVertical
               withLabel={FIELD_VERTEX_PROJECT}
               title={t("vertexAi.projectField.title")}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -303,7 +303,7 @@ export function ModelAccessField() {
       </InputPadder>
 
       {!isPublic && (
-        <Card background="light" border="none" padding={2}>
+        <Card color="background-tint-00" border="none" padding={2}>
           <Section gap={2}>
             <InputComboBox
               placeholder={t("access.comboBox.placeholder")}
@@ -315,7 +315,7 @@ export function ModelAccessField() {
               searchIcon
             />
 
-            <Card background="heavy" border="none" padding={2}>
+            <Card color="background-tint-01" border="none" padding={2}>
               <ContentAction
                 icon={SvgUserManage}
                 title={t("access.admin.title")}
@@ -339,7 +339,7 @@ export function ModelAccessField() {
                   const memberCount = group?.users.length ?? 0;
                   return (
                     <div key={`group-${id}`} className="min-w-0">
-                      <Card background="heavy" border="none" padding={2}>
+                      <Card color="background-tint-01" border="none" padding={2}>
                         <ContentAction
                           icon={SvgUsers}
                           title={group?.name ?? t("access.group.name", { id })}
@@ -374,7 +374,7 @@ export function ModelAccessField() {
                   const agent = agentMap.get(id);
                   return (
                     <div key={`agent-${id}`} className="min-w-0">
-                      <Card background="heavy" border="none" padding={2}>
+                      <Card color="background-tint-01" border="none" padding={2}>
                         <ContentAction
                           icon={
                             agent
@@ -813,7 +813,7 @@ export function ModelSelectionField({
   const visibleModels = models.filter((m) => m.is_visible);
 
   return (
-    <Card background="light" border="none" padding={2}>
+    <Card color="background-tint-00" border="none" padding={2}>
       <Section gap={2}>
         <InputHorizontal
           title={t("models.field.title")}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -339,7 +339,11 @@ export function ModelAccessField() {
                   const memberCount = group?.users.length ?? 0;
                   return (
                     <div key={`group-${id}`} className="min-w-0">
-                      <Card color="background-tint-01" border="none" padding={2}>
+                      <Card
+                        color="background-tint-01"
+                        border="none"
+                        padding={2}
+                      >
                         <ContentAction
                           icon={SvgUsers}
                           title={group?.name ?? t("access.group.name", { id })}
@@ -374,7 +378,11 @@ export function ModelAccessField() {
                   const agent = agentMap.get(id);
                   return (
                     <div key={`agent-${id}`} className="min-w-0">
-                      <Card color="background-tint-01" border="none" padding={2}>
+                      <Card
+                        color="background-tint-01"
+                        border="none"
+                        padding={2}
+                      >
                         <ContentAction
                           icon={
                             agent

--- a/web/src/sections/onboarding/steps/FinalStep.tsx
+++ b/web/src/sections/onboarding/steps/FinalStep.tsx
@@ -25,7 +25,7 @@ const FinalStepItem = React.memo(
       : {};
 
     return (
-      <Card background="none" border="solid" padding={1} rounding={4}>
+      <Card color="transparent" border="solid" padding={1} rounding={4}>
         <Section alignItems="start" height="fit">
           <ContentAction
             icon={Icon}

--- a/web/src/views/admin/ExternalAppsPage/IntegrationCard.tsx
+++ b/web/src/views/admin/ExternalAppsPage/IntegrationCard.tsx
@@ -58,7 +58,7 @@ export default function IntegrationCard({ integration }: IntegrationCardProps) {
 
   return (
     <Hoverable.Root group="integration-row">
-      <Card background="light" border="solid" rounding={4}>
+      <Card color="background-tint-00" border="solid" rounding={4}>
         <div className="flex items-center gap-3 w-full">
           {/* Off rows read as inert at a glance; controls keep full opacity. */}
           <div

--- a/web/src/views/admin/ExternalAppsPage/index.tsx
+++ b/web/src/views/admin/ExternalAppsPage/index.tsx
@@ -388,7 +388,7 @@ function AppsAdminContent({
 function LoadingCard() {
   const t = useTranslations("admin.externalApps");
   return (
-    <Card background="none" border="dashed" rounding={4}>
+    <Card color="transparent" border="dashed" rounding={4}>
       <Text font="main-content-body">{t("loading.label")}</Text>
     </Card>
   );


### PR DESCRIPTION
## Description

Two Opal cards changes that prepare the group-picker consolidation, and stand on their own.

**`Card`'s `background` becomes `color`, named for the token it paints.** The old values were intensity adjectives — `"none" | "light" | "heavy"` — where a reader cannot tell what `"heavy"` renders without opening the stylesheet. The new union is the card analog of `Text`'s `color`: every value is the token itself, with `"transparent"` as the no-fill sentinel.

```ts
export type CardColor =
  | "transparent"
  | "background-tint-00" | "background-tint-01"
  | "status-info-00" | "status-success-00" | "status-warning-00" | "status-error-00"
  | "theme-amber-01";
```

Sixteen call-site files move mechanically (`none` → `transparent`, `light` → `background-tint-00`, `heavy` → `background-tint-01`). Modal's own `background` prop and `TableQualifier`'s boolean are unrelated namesakes and untouched.

**`MessageCard` is rebased onto `Card`.** It previously hand-rolled its own root — duplicating Card's border machinery (same `data-opal-status-border` mechanism) and carrying a private stylesheet purely because `Card` could not express status backgrounds. With the status tokens in `CardColor`, it renders a `Card` (`color` per variant, `border="solid"` keyed to the variant, `rounding={4}` ≙ the old `rounded-16`, padding pass-through) and keeps only its message layout. Its stylesheet shrinks to a stretch wrapper (Card takes no `className`) and the `flex-col gap-1` layout.

This lands the intended cards architecture: `card` and `select-card` are the two roots — inert and interactive — with `message-card` and `empty-message-card` both built on `Card`.

**No visual changes intended** — every mapping is token-for-token. One nuance: `Card` brings `overflow-clip`, which the old `MessageCard` root lacked; only observable if something inside a message card absolutely-positions past its edge (portalled popovers are unaffected).

## Test plan

- Card stories: the `SurfaceColors` matrix renders all 8 tokens, bordered.
- `Card.test.tsx` updated: the card's own `data-color` stays authoritative over a spoofed caller value.
- Eyeball a `MessageCard` per variant (info/success/warning/error/pending) — identical surface, border, radius as before.
- Spot-check a swept caller (e.g. language-model modals, ExternalApps cards) for unchanged rendering.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `Card`'s `background` prop to `color` so values name the token they paint, and rebuilds `MessageCard` on `Card` so it no longer hand-rolls its own surface. No visual changes intended.

- `Card`'s `color` accepts `"transparent"`, `"background-tint-00"`, `"background-tint-01"`, the four status tokens, and `"theme-amber-01"`, replacing `"none" | "light" | "heavy"`.
- Sixteen call sites move mechanically: `none` → `transparent`, `light` → `background-tint-00`, `heavy` → `background-tint-01`.
- `MessageCard` renders a `Card` with per-variant color, solid border, and rounding 4, keeping only its message layout; it ships six variants and its README says so.
- Tests, stories, and READMEs were swept to the `color` naming so nothing still asserts `data-background`.
- `Card` brings `overflow-clip`, which the old `MessageCard` root lacked; only observable if content inside absolutely positions past its edge.

<sup>Written for commit 6176e2b2f5060d014e7e921a248af292ec1001af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

