### PR TITLE
ci: gate merge-queue checks on RunsOn Spot reruns

### DIFF
--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -84,3 +84,17 @@ jobs:
       - name: Run Database Tests
         working-directory: ./backend
         run: pytest tests/integration/tests/migrations/
+
+  # Keeps the pull request in the merge queue while RunsOn reruns database-tests
+  # after an EC2 Spot interruption. The gate fails when database-tests fails for
+  # any other reason. Require "database-tests-gate / pass" in the main ruleset,
+  # not "database-tests".
+  database-tests-gate:
+    if: ${{ always() && needs.changes.outputs.db == 'true' }}
+    needs: [changes, database-tests]
+    permissions:
+      actions: read
+      checks: read
+    uses: runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@451eea7c3d2c58d14a1f80f0bbb99eaa347b9471 # ratchet:runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@v1.0.0
+    with:
+      job_results: ${{ toJSON(needs) }}

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -78,3 +78,17 @@ jobs:
         env:
           TERM: xterm-256color
         run: ty check --output-format github
+
+  # Keeps the pull request in the merge queue while RunsOn reruns mypy-check
+  # after an EC2 Spot interruption. The gate fails when mypy-check fails for any
+  # other reason. Require "mypy-check-gate / pass" in the main ruleset, not
+  # "mypy-check".
+  mypy-check-gate:
+    if: ${{ always() && needs.changes.outputs.python == 'true' }}
+    needs: [changes, mypy-check]
+    permissions:
+      actions: read
+      checks: read
+    uses: runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@451eea7c3d2c58d14a1f80f0bbb99eaa347b9471 # ratchet:runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@v1.0.0
+    with:
+      job_results: ${{ toJSON(needs) }}

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -79,3 +79,17 @@ jobs:
     - name: Run Tests
       shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
       run: py.test -o junit_family=xunit2 -v -n auto backend/tests/unit
+
+  # Keeps the pull request in the merge queue while RunsOn reruns backend-check
+  # after an EC2 Spot interruption. The gate fails when backend-check fails for
+  # any other reason. Require "backend-check-gate / pass" in the main ruleset,
+  # not "backend-check".
+  backend-check-gate:
+    if: ${{ always() && needs.changes.outputs.python == 'true' }}
+    needs: [changes, backend-check]
+    permissions:
+      actions: read
+      checks: read
+    uses: runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@451eea7c3d2c58d14a1f80f0bbb99eaa347b9471 # ratchet:runs-on/spot-retry-gate/.github/workflows/merge-queue.yml@v1.0.0
+    with:
+      job_results: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Description

Adds the [`runs-on/spot-retry-gate`](https://github.com/runs-on/spot-retry-gate) reusable workflow after the three merge-queue required checks that run on RunsOn Spot runners: `backend-check`, `mypy-check` and `database-tests`.

RunsOn v3.3.0 reruns a job after an EC2 Spot interruption (onyx-infra #670). The merge queue does not wait for that rerun: the first failed attempt ejects the pull request from the queue. The gate job reads the failed job's annotations. When the failure was a Spot interruption, the gate passes and the required check stays pending until the rerun completes. When the job failed for any other reason, the gate fails.

Each gate carries the same `if` as its Spot job and depends on `changes`. When paths-filter skips the job, the gate is skipped too, and a skipped required check still lets the pull request merge. The reusable workflow is pinned to the commit of `v1.0.0`; no `v1` tag exists yet.

Follow-up after this is on `main` (ruleset for `main`, needs admin):

1. Replace the required checks `backend-check`, `mypy-check` and `database-tests` with `backend-check-gate / pass`, `mypy-check-gate / pass` and `database-tests-gate / pass`.
2. Raise the merge queue timeout from 45 to 90 minutes, so a rerun fits inside the window.

Until step 1 is done, the gate jobs run but change nothing.

## How Has This Been Tested?

- `pre-commit run --files` on the three workflows: zizmor, actionlint, check-yaml and ripsecrets pass.
- The gate jobs run on this pull request. Check that `<job>-gate / pass` appears next to each Spot job and passes.
- A real interruption was tested on the staging stack with `roc interrupt`; the rerun completed on attempt 2. The gate itself has not seen a live interruption yet.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the merge-queue required checks on RunsOn Spot runners so an EC2 Spot interruption no longer ejects the pull request from the merge queue. Adds a `runs-on/spot-retry-gate` reusable workflow after `backend-check`, `mypy-check`, and `database-tests`.

- The gate passes when the failed job was interrupted by a Spot reclaim, keeping the check pending until RunsOn's rerun completes; it fails for any other cause.
- Each gate shares its Spot job's `if` condition and is skipped when paths-filter skips the job.
- The reusable workflow is pinned to the commit of `v1.0.0`.

**Rollout**
- On `main`, replace the required checks with `backend-check-gate / pass`, `mypy-check-gate / pass`, and `database-tests-gate / pass`.
- Raise the merge queue timeout from 45 to 90 minutes so a rerun fits in the window.
- Until the ruleset is updated, the gates run but change nothing.

<sup>Written for commit 73ee600ff2f493285569f291d3f7a7e915ca0b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

