### PR TITLE
chore: upgrade code-interpreter to v0.4.7

### DIFF
--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.prod.yml
@@ -488,7 +488,7 @@ services:
     # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
     # Pinned so an upgrade cannot move it to an untested build. Bump with the
     # release that has been tested against it.
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.7}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/docker-compose.yml
@@ -544,7 +544,7 @@ services:
     # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
     # Pinned so an upgrade cannot move it to an untested build. Bump with the
     # release that has been tested against it.
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.7}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -473,7 +473,7 @@ services:
     # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
     # Pinned so an upgrade cannot move it to an untested build. Bump with the
     # release that has been tested against it.
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.7}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -488,7 +488,7 @@ services:
     # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
     # Pinned so an upgrade cannot move it to an untested build. Bump with the
     # release that has been tested against it.
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.7}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.template.yml
+++ b/deployment/docker_compose/docker-compose.template.yml
@@ -657,7 +657,7 @@ services:
     # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
     # Pinned so an upgrade cannot move it to an untested build. Bump with the
     # release that has been tested against it.
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.7}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -544,7 +544,7 @@ services:
     # The sandbox ships on its own release line, so IMAGE_TAG does not cover it.
     # Pinned so an upgrade cannot move it to an untested build. Bump with the
     # release that has been tested against it.
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.6}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.7}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -22,6 +22,6 @@ dependencies:
   version: 5.4.0
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
-  version: 0.4.6
-digest: sha256:9921b46a454cead472303a75a0c0c109691fabb2468739ecc51429f731314792
-generated: "2026-08-17T11:23:15.803513-07:00"
+  version: 0.4.7
+digest: sha256:681302da1941b2b598cf91339f60e2d1df0f93ddacf5b3572dece19db12e04b1
+generated: "2026-09-10T12:04:48.564979336-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.22
+version: 0.8.23
 appVersion: latest
 annotations:
   category: Productivity
@@ -76,6 +76,6 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: code-interpreter
-    version: 0.4.6
+    version: 0.4.7
     repository: https://onyx-dot-app.github.io/python-sandbox/
     condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description

Upgrades the code-interpreter image to pull in https://github.com/onyx-dot-app/python-sandbox/pull/75

Closes https://github.com/onyx-dot-app/onyx/issues/10142

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the `code-interpreter` image from 0.4.6 to 0.4.7 to pull in a sandbox fix. Updates the pinned tag across all docker-compose files and the Helm chart dependency; the Helm chart version bumps from 0.8.22 to 0.8.23.

<sup>Written for commit 8ad2ea010ba80e77a0a9d1fd0bd4914d7ded5570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

