### PR TITLE
Fix empty answers after successful retrieval

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -57,6 +57,8 @@ from onyx.prompts.chat_prompts import (
 from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import (
+    AgentResponseDelta,
+    AgentResponseStart,
     OverallStop,
     Packet,
     ToolCallDebug,
@@ -92,6 +94,11 @@ logger = setup_logger()
 # Used when no token_counter is available to measure the non-vision image
 # marker; intentionally generous so budgeting stays conservative.
 _NON_VISION_MARKER_TOKEN_FALLBACK = 40
+
+_EMPTY_SYNTHESIS_FALLBACK = (
+    "I found relevant sources, but I could not synthesize a reliable answer from "
+    "them. Please try asking a more specific question."
+)
 
 
 class EmptyLLMResponseError(ClassifiedLLMError):
@@ -299,6 +306,45 @@ def _try_fallback_tool_extraction(
         )
 
     return llm_step_result, True
+
+
+def _emit_empty_synthesis_fallback(
+    *,
+    emitter: Emitter,
+    state_container: ChatStateContainer,
+    gathered_documents: list[SearchDoc],
+    placement: Placement,
+    pre_answer_processing_time: float | None,
+    reasoning: str | None,
+    raw_answer: str | None,
+    finish_reason: str | None,
+) -> LlmStepResult:
+    """Emit a useful response when retrieval succeeded but synthesis was empty."""
+    if pre_answer_processing_time is not None:
+        state_container.set_pre_answer_processing_time(pre_answer_processing_time)
+    emitter.emit(
+        Packet(
+            placement=placement,
+            obj=AgentResponseStart(
+                final_documents=gathered_documents,
+                pre_answer_processing_seconds=pre_answer_processing_time,
+            ),
+        )
+    )
+    emitter.emit(
+        Packet(
+            placement=placement,
+            obj=AgentResponseDelta(content=_EMPTY_SYNTHESIS_FALLBACK),
+        )
+    )
+    state_container.set_answer_tokens(_EMPTY_SYNTHESIS_FALLBACK)
+    return LlmStepResult(
+        reasoning=reasoning,
+        answer=_EMPTY_SYNTHESIS_FALLBACK,
+        tool_calls=None,
+        raw_answer=raw_answer,
+        finish_reason=finish_reason,
+    )
 
 
 # Default 6 covers the common search → open_url pattern:
@@ -879,6 +925,8 @@ def run_llm_loop(
         )
 
         reasoning_cycles = 0
+        llm_cycle_count = 0
+        pre_answer_processing_time: float | None = None
         for llm_cycle_count in range(MAX_LLM_CYCLES):
             # Handling tool calls based on cycle count and past cycle conditions
             out_of_cycles = llm_cycle_count == MAX_LLM_CYCLES - 1
@@ -1387,11 +1435,29 @@ def run_llm_loop(
                 should_cite_documents = True
 
         if not llm_step_result.answer and not llm_step_result.tool_calls:
-            raise _build_empty_llm_response_error(
-                llm=llm,
-                llm_step_result=llm_step_result,
-                tool_choice=tool_choice,
-            )
+            if (
+                gathered_documents
+                and llm_step_result.finish_reason not in _REFUSAL_FINISH_REASONS
+            ):
+                # Retrieval succeeded, but the final synthesis can still be empty
+                # for some providers and broad questions. Keep the retrieved
+                # documents visible and give the user an actionable response.
+                llm_step_result = _emit_empty_synthesis_fallback(
+                    emitter=emitter,
+                    state_container=state_container,
+                    gathered_documents=gathered_documents,
+                    placement=Placement(turn_index=llm_cycle_count + reasoning_cycles),
+                    pre_answer_processing_time=pre_answer_processing_time,
+                    reasoning=llm_step_result.reasoning,
+                    raw_answer=llm_step_result.raw_answer,
+                    finish_reason=llm_step_result.finish_reason,
+                )
+            else:
+                raise _build_empty_llm_response_error(
+                    llm=llm,
+                    llm_step_result=llm_step_result,
+                    tool_choice=tool_choice,
+                )
 
         if not llm_step_result.answer:
             raise RuntimeError(
@@ -1402,10 +1468,7 @@ def run_llm_loop(
 
         emitter.emit(
             Packet(
-                placement=Placement(
-                    turn_index=llm_cycle_count  # ty: ignore[possibly-unresolved-reference]
-                    + reasoning_cycles
-                ),
+                placement=Placement(turn_index=llm_cycle_count + reasoning_cycles),
                 obj=OverallStop(type="stop"),
             )
         )

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -5,10 +5,13 @@ from unittest.mock import Mock
 
 import pytest
 
+from onyx.chat.chat_state import ChatStateContainer
 from onyx.chat.llm_loop import (
+    _EMPTY_SYNTHESIS_FALLBACK,
     _REFUSAL_FINISH_REASONS,
     EmptyLLMResponseError,
     _build_empty_llm_response_error,
+    _emit_empty_synthesis_fallback,
     _try_fallback_tool_extraction,
     construct_message_history,
     select_reminder_text,
@@ -22,11 +25,17 @@ from onyx.chat.models import (
     LlmStepResult,
     ToolCallSimple,
 )
-from onyx.configs.constants import MessageType
+from onyx.configs.constants import DocumentSource, MessageType
+from onyx.context.search.models import SearchDoc
 from onyx.file_store.models import ChatFileType
 from onyx.llm.interfaces import LLMConfig, ToolChoiceOptions
 from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER, OPEN_URL_REMINDER
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import (
+    AgentResponseDelta,
+    AgentResponseStart,
+    Packet,
+)
 from onyx.tools.models import ToolCallKickoff
 
 
@@ -1447,3 +1456,49 @@ class TestSelectReminderText:
             ran_image_gen=True, just_ran_web_search=True, has_open_url_tool=True
         )
         assert result == IMAGE_GEN_REMINDER
+
+
+class TestEmptySynthesisFallback:
+    def test_emits_answer_and_preserves_retrieved_documents(self) -> None:
+        emitter = Mock()
+        state_container = ChatStateContainer()
+        document = SearchDoc(
+            document_id="document-1",
+            chunk_ind=0,
+            semantic_identifier="Document 1",
+            blurb="Relevant content",
+            source_type=DocumentSource.WEB,
+            boost=1,
+            hidden=False,
+            metadata={},
+            match_highlights=[],
+        )
+
+        result = _emit_empty_synthesis_fallback(
+            emitter=emitter,
+            state_container=state_container,
+            gathered_documents=[document],
+            placement=Placement(turn_index=2),
+            pre_answer_processing_time=1.25,
+            reasoning=None,
+            raw_answer=None,
+            finish_reason="stop",
+        )
+
+        assert result.answer == _EMPTY_SYNTHESIS_FALLBACK
+        assert state_container.get_answer_tokens() == _EMPTY_SYNTHESIS_FALLBACK
+        assert state_container.get_pre_answer_processing_time() == 1.25
+        emitted_packets = [call.args[0] for call in emitter.emit.call_args_list]
+        assert emitted_packets == [
+            Packet(
+                placement=Placement(turn_index=2),
+                obj=AgentResponseStart(
+                    final_documents=[document],
+                    pre_answer_processing_seconds=1.25,
+                ),
+            ),
+            Packet(
+                placement=Placement(turn_index=2),
+                obj=AgentResponseDelta(content=_EMPTY_SYNTHESIS_FALLBACK),
+            ),
+        ]


### PR DESCRIPTION
## Summary

Fixes #14333.

When retrieval succeeds but the final synthesis returns no answer or tool call, emit a clear fallback response and preserve the retrieved documents for citations. Genuine empty provider streams without retrieved context keep the existing classified error behavior.

## Validation

- 167 focused chat tests passed.
- Ruff format and lint passed.
- ty passed.
- Relevant pre-commit hooks passed.
- The full pre-commit run was blocked by an unrelated Go linter dependency download failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #14333. When retrieval succeeds but the final synthesis returns no answer or tool call, the chat now emits a fallback response and preserves the retrieved documents for citations. Genuine empty provider streams without retrieved context still raise the existing classified error.

<sup>Written for commit 789dfdeb838e372c5f12f78c4469002014ee029b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

