### PR TITLE
fix: keep disabled actions out of chat and unblock Chat Preferences toggles

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -930,6 +930,12 @@ def build_chat_turn(
     ):
         forced_tool_id = None
 
+    # construct_tools skips disabled tools, and a forced id it did not build fails
+    # the whole message. Callers name the forced tool from the persona's attached
+    # tools, which stay attached when an admin disables one.
+    if forced_tool_id in {tool.id for tool in all_tools if not tool.enabled}:
+        forced_tool_id = None
+
     # TODO(nmgarza5): Once summarization is done, we don't need to load all files from the beginning.
     # Load all files needed for this chat chain into memory.
     files = load_all_chat_files(chat_history, db_session)

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -2148,9 +2148,10 @@ def update_default_assistant_configuration(
             if not should_expose_tool_to_fe(tool):
                 raise ValueError(f"Tool with ID {tool_id} cannot be assigned")
 
-            # A disabled tool may stay attached: attaching makes a tool available to
-            # the persona, not usable by it (see Persona__Tool). Rejecting one here
-            # would block every toggle, since the caller resends the whole list.
+            # A disabled tool stays attached, because disabling one does not detach
+            # it. Callers resend the whole list, so rejecting a disabled id here
+            # failed every update rather than just the tool being toggled.
+            # construct_tools keeps a disabled tool out of chat.
             persona.tools.append(tool)
 
     db_session.commit()

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -2148,11 +2148,9 @@ def update_default_assistant_configuration(
             if not should_expose_tool_to_fe(tool):
                 raise ValueError(f"Tool with ID {tool_id} cannot be assigned")
 
-            if not tool.enabled:
-                raise ValueError(
-                    f"Enable tool {tool.display_name or tool.name} before assigning it"
-                )
-
+            # A disabled tool may stay attached: attaching makes a tool available to
+            # the persona, not usable by it (see Persona__Tool). Rejecting one here
+            # would block every toggle, since the caller resends the whole list.
             persona.tools.append(tool)
 
     db_session.commit()

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -335,13 +335,14 @@ def handle_regular_answer(
 
         # Slack answers should be grounded in retrieval (pre-#7399 behavior):
         # force the search tool on the first LLM cycle, but only when the
-        # channel persona actually has a usable one — non-search personas and
-        # deployments without connectors keep the unforced behavior.
+        # channel persona actually has a usable one — non-search personas,
+        # disabled search tools and deployments without connectors keep the
+        # unforced behavior.
         forced_search_tool_id = next(
             (
                 tool.id
                 for tool in persona.tools
-                if tool.in_code_tool_id == SEARCH_TOOL_ID
+                if tool.in_code_tool_id == SEARCH_TOOL_ID and tool.enabled
             ),
             None,
         )

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -237,6 +237,13 @@ def _construct_tools_impl(
 
     added_search_tool = False
     for db_tool_model in persona.tools:
+        # Disabling an action leaves it attached to its personas, so an attached
+        # tool is not necessarily a usable one (see Persona__Tool). Only the tool
+        # listing endpoints filtered on this, which left a disabled tool callable
+        # by any request that sends no allowed_tool_ids whitelist.
+        if not db_tool_model.enabled:
+            continue
+
         # If allowed_tool_ids is specified, skip tools not in the allowed list
         if allowed_tool_ids is not None and db_tool_model.id not in allowed_tool_ids:
             continue

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_transfer.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_transfer.py
@@ -253,10 +253,18 @@ def test_transfer_rejects_builtin_persona(db_session: Session) -> None:
     target = create_test_user(db_session, "target")
     persona = create_test_persona(db_session, owner, builtin_persona=True)
 
-    with pytest.raises(ValueError):
-        transfer_persona_ownership(
-            persona_id=persona.id,
-            user=owner,
-            db_session=db_session,
-            new_owner_user_id=target.id,
-        )
+    try:
+        with pytest.raises(ValueError):
+            transfer_persona_ownership(
+                persona_id=persona.id,
+                user=owner,
+                db_session=db_session,
+                new_owner_user_id=target.id,
+            )
+    finally:
+        # get_default_assistant() reads the builtin persona with one_or_none(),
+        # so a stray one breaks every later test in this directory that touches
+        # the default assistant.
+        db_session.rollback()
+        db_session.delete(persona)
+        db_session.commit()

--- a/backend/tests/external_dependency_unit/db/test_default_assistant_disabled_tool.py
+++ b/backend/tests/external_dependency_unit/db/test_default_assistant_disabled_tool.py
@@ -1,0 +1,107 @@
+"""Regression coverage for `update_default_assistant_configuration`.
+
+Chat Preferences resends the default assistant's whole tool list on every toggle, and
+`GET /admin/default-assistant/configuration` includes attached tools that are disabled.
+Disabling a tool also leaves its `Persona__Tool` row in place, so rejecting a disabled
+id here blocked every toggle on the page with "Enable tool X before assigning it" — and
+the page renders no switch for a disabled tool, so the admin could not clear the block.
+"""
+
+from collections.abc import Callable, Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import Tool
+from onyx.db.persona import (
+    get_default_assistant,
+    update_default_assistant_configuration,
+)
+
+ToolFactory = Callable[..., Tool]
+
+
+@pytest.fixture
+def make_tool(db_session: Session) -> Generator[ToolFactory, None, None]:
+    """Build throwaway custom actions, and leave neither them nor their effect on the
+    tenant-wide default assistant behind for the next test."""
+    persona = get_default_assistant(db_session)
+    assert persona is not None, "default assistant is seeded by migrations"
+    original_tool_ids = [tool.id for tool in persona.tools]
+    created_tool_ids: list[int] = []
+
+    def _make_tool(*, enabled: bool) -> Tool:
+        tool = Tool(
+            name=f"default-assistant-toggle-{uuid4().hex[:8]}",
+            description="default assistant toggle test action",
+            in_code_tool_id=None,
+            openapi_schema={"openapi": "3.0.0"},
+            custom_headers=[],
+            user_id=None,
+            passthrough_auth=False,
+            enabled=enabled,
+        )
+        db_session.add(tool)
+        db_session.commit()
+        db_session.refresh(tool)
+        created_tool_ids.append(tool.id)
+        return tool
+
+    try:
+        yield _make_tool
+    finally:
+        db_session.rollback()
+        # Restore the tool list first: it drops the associations to the created
+        # tools, which would otherwise block deleting them.
+        persona = get_default_assistant(db_session)
+        assert persona is not None
+        persona.tools = (
+            db_session.query(Tool).filter(Tool.id.in_(original_tool_ids)).all()
+        )
+        db_session.commit()
+
+        db_session.query(Tool).filter(Tool.id.in_(created_tool_ids)).delete(
+            synchronize_session=False
+        )
+        db_session.commit()
+
+
+def test_toggle_succeeds_while_a_disabled_tool_is_attached(
+    db_session: Session, make_tool: ToolFactory
+) -> None:
+    """The reported flow: an attached-but-disabled tool must not block a toggle."""
+    disabled_tool = make_tool(enabled=False)
+    attached_tool = make_tool(enabled=True)
+    newly_toggled_tool = make_tool(enabled=True)
+
+    update_default_assistant_configuration(
+        db_session=db_session, tool_ids=[disabled_tool.id, attached_tool.id]
+    )
+
+    # What GET /configuration hands the frontend still includes the disabled tool.
+    persona = get_default_assistant(db_session)
+    assert persona is not None
+    assert disabled_tool.id in [tool.id for tool in persona.tools]
+
+    # Toggling another tool on resends the whole list, disabled tool included.
+    update_default_assistant_configuration(
+        db_session=db_session,
+        tool_ids=[disabled_tool.id, attached_tool.id, newly_toggled_tool.id],
+    )
+
+    persona = get_default_assistant(db_session)
+    assert persona is not None
+    assert {disabled_tool.id, attached_tool.id, newly_toggled_tool.id} <= {
+        tool.id for tool in persona.tools
+    }
+
+
+def test_unknown_tool_id_is_still_rejected(
+    db_session: Session,
+    make_tool: ToolFactory,  # noqa: ARG001  # restores the default assistant
+) -> None:
+    with pytest.raises(ValueError, match="not found"):
+        update_default_assistant_configuration(
+            db_session=db_session, tool_ids=[2_000_000_000]
+        )

--- a/backend/tests/external_dependency_unit/tools/test_disabled_tool_not_constructed.py
+++ b/backend/tests/external_dependency_unit/tools/test_disabled_tool_not_constructed.py
@@ -1,0 +1,143 @@
+"""A disabled action must not reach the model.
+
+Disabling an action leaves its `Persona__Tool` rows in place, and `construct_tools`
+used to build every attached tool. Only the tool *listing* endpoints filtered on
+`enabled`, so a disabled tool stayed callable by any request that sends no
+`allowed_tool_ids` whitelist — which is most of them (the Slack bot and evals pass
+None, and the web client omits it unless the user turned something off in chat).
+"""
+
+import queue
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat.emitter import Emitter
+from onyx.db.models import Persona, Tool, User
+from onyx.llm.factory import get_default_llm
+from onyx.tools.tool_constructor import construct_tools
+from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
+from tests.external_dependency_unit.conftest import create_test_user
+
+OPENAPI_SCHEMA: dict[str, Any] = {
+    "openapi": "3.0.0",
+    "info": {"title": "Disabled Tool API", "version": "1.0.0"},
+    "servers": [{"url": "https://api.example.com"}],
+    "paths": {
+        "/test": {
+            "get": {
+                "operationId": "test_operation",
+                "summary": "Test operation",
+                "description": "A test operation",
+                "responses": {"200": {"description": "Success"}},
+            }
+        }
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _default_llm_provider(db_session: Session) -> None:
+    ensure_default_llm_provider(db_session)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_session: Session) -> Generator[None, None, None]:
+    """These rows are public and listed, so leaving them behind would widen what
+    other tests see in persona and action listings."""
+    yield
+    db_session.rollback()
+    for persona in (
+        db_session.query(Persona)
+        .filter(Persona.name.like("Disabled Tool Persona %"))
+        .all()
+    ):
+        persona.tools = []
+        persona.users = []
+        db_session.delete(persona)
+    db_session.commit()
+
+    db_session.query(Tool).filter(Tool.name.like("disabled-tool-check-%")).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+
+
+def _create_tool(db_session: Session, user: User, *, enabled: bool) -> Tool:
+    tool = Tool(
+        name=f"disabled-tool-check-{uuid4().hex[:8]}",
+        description="disabled tool construction test action",
+        openapi_schema=OPENAPI_SCHEMA,
+        user_id=user.id,
+        passthrough_auth=False,
+        enabled=enabled,
+    )
+    db_session.add(tool)
+    db_session.commit()
+    db_session.refresh(tool)
+    return tool
+
+
+def _create_persona(db_session: Session, user: User, tools: list[Tool]) -> Persona:
+    persona = Persona(
+        name=f"Disabled Tool Persona {uuid4().hex[:8]}",
+        description="disabled tool construction test persona",
+        system_prompt="You are a helpful assistant",
+        task_prompt="Answer the user's question",
+        tools=tools,
+        document_sets=[],
+        users=[user],
+        groups=[],
+        is_listed=True,
+        is_public=True,
+        display_priority=None,
+        starter_messages=None,
+        deleted=False,
+    )
+    db_session.add(persona)
+    db_session.commit()
+    db_session.refresh(persona)
+    return persona
+
+
+def test_disabled_tool_is_not_constructed(db_session: Session) -> None:
+    """Without a whitelist nothing else filters, so `enabled` has to."""
+    user = create_test_user(db_session, "disabled_tool_user")
+    disabled_tool = _create_tool(db_session, user, enabled=False)
+    enabled_tool = _create_tool(db_session, user, enabled=True)
+    persona = _create_persona(db_session, user, [disabled_tool, enabled_tool])
+
+    tool_dict = construct_tools(
+        persona=persona,
+        db_session=db_session,
+        emitter=Emitter(merged_queue=queue.Queue()),
+        user=user,
+        llm=get_default_llm(),
+    )
+
+    assert disabled_tool.id not in tool_dict
+    assert enabled_tool.id in tool_dict
+
+
+def test_disabled_tool_is_not_constructed_even_when_whitelisted(
+    db_session: Session,
+) -> None:
+    """`allowed_tool_ids` is built from what the frontend can see, which is not
+    filtered on `enabled` — so a whitelist must not resurrect a disabled tool."""
+    user = create_test_user(db_session, "disabled_tool_whitelist_user")
+    disabled_tool = _create_tool(db_session, user, enabled=False)
+    persona = _create_persona(db_session, user, [disabled_tool])
+
+    tool_dict = construct_tools(
+        persona=persona,
+        db_session=db_session,
+        emitter=Emitter(merged_queue=queue.Queue()),
+        user=user,
+        llm=get_default_llm(),
+        allowed_tool_ids=[disabled_tool.id],
+    )
+
+    assert disabled_tool.id not in tool_dict

--- a/backend/tests/external_dependency_unit/tools/test_disabled_tool_not_constructed.py
+++ b/backend/tests/external_dependency_unit/tools/test_disabled_tool_not_constructed.py
@@ -20,7 +20,9 @@ from onyx.db.models import Persona, Tool, User
 from onyx.llm.factory import get_default_llm
 from onyx.tools.tool_constructor import construct_tools
 from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
-from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
+
+USER_EMAIL_PREFIX = "disabled_tool_check_user"
 
 OPENAPI_SCHEMA: dict[str, Any] = {
     "openapi": "3.0.0",
@@ -47,7 +49,8 @@ def _default_llm_provider(db_session: Session) -> None:
 @pytest.fixture(autouse=True)
 def _cleanup(db_session: Session) -> Generator[None, None, None]:
     """These rows are public and listed, so leaving them behind would widen what
-    other tests see in persona and action listings."""
+    other tests see in persona and action listings. Ordered by foreign key:
+    personas reference both, and tool.user_id references the user."""
     yield
     db_session.rollback()
     for persona in (
@@ -62,6 +65,14 @@ def _cleanup(db_session: Session) -> Generator[None, None, None]:
 
     db_session.query(Tool).filter(Tool.name.like("disabled-tool-check-%")).delete(
         synchronize_session=False
+    )
+    db_session.commit()
+
+    delete_test_user(
+        db_session,
+        *db_session.query(User)
+        .filter(User.__table__.c.email.like(f"{USER_EMAIL_PREFIX}_%@example.com"))
+        .all(),
     )
     db_session.commit()
 
@@ -105,7 +116,7 @@ def _create_persona(db_session: Session, user: User, tools: list[Tool]) -> Perso
 
 def test_disabled_tool_is_not_constructed(db_session: Session) -> None:
     """Without a whitelist nothing else filters, so `enabled` has to."""
-    user = create_test_user(db_session, "disabled_tool_user")
+    user = create_test_user(db_session, USER_EMAIL_PREFIX)
     disabled_tool = _create_tool(db_session, user, enabled=False)
     enabled_tool = _create_tool(db_session, user, enabled=True)
     persona = _create_persona(db_session, user, [disabled_tool, enabled_tool])
@@ -127,7 +138,7 @@ def test_disabled_tool_is_not_constructed_even_when_whitelisted(
 ) -> None:
     """`allowed_tool_ids` is built from what the frontend can see, which is not
     filtered on `enabled` — so a whitelist must not resurrect a disabled tool."""
-    user = create_test_user(db_session, "disabled_tool_whitelist_user")
+    user = create_test_user(db_session, USER_EMAIL_PREFIX)
     disabled_tool = _create_tool(db_session, user, enabled=False)
     persona = _create_persona(db_session, user, [disabled_tool])
 

--- a/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
+++ b/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
@@ -583,16 +583,18 @@ def test_private_channel_non_ephemeral_attributes_usage(
 
 
 @pytest.mark.parametrize(
-    "has_search_tool,search_available,expected_forced_id",
+    "has_search_tool,search_available,search_enabled,expected_forced_id",
     [
-        (True, True, 77),  # persona has SearchTool and it is usable -> forced
-        (True, False, None),  # SearchTool attached but unavailable -> not forced
-        (False, True, None),  # persona without SearchTool -> not forced
+        (True, True, True, 77),  # persona has SearchTool and it is usable -> forced
+        (True, False, True, None),  # SearchTool attached but unavailable -> not forced
+        (True, True, False, None),  # SearchTool attached but disabled -> not forced
+        (False, True, True, None),  # persona without SearchTool -> not forced
     ],
 )
 def test_search_tool_forced_only_when_usable(
     has_search_tool: bool,
     search_available: bool,
+    search_enabled: bool,
     expected_forced_id: int | None,
 ) -> None:
     """Slack answers force the persona's search tool on the first LLM cycle
@@ -604,6 +606,7 @@ def test_search_tool_forced_only_when_usable(
         search_tool = MagicMock()
         search_tool.id = 77
         search_tool.in_code_tool_id = "SearchTool"
+        search_tool.enabled = search_enabled
         persona.tools = [search_tool]
 
     user = MagicMock()


### PR DESCRIPTION
## Description

Two related bugs around the `Tool.enabled` flag. Disabling an action never detaches it from a persona, and neither side of that state was handled correctly.

**1. A disabled tool blocked every toggle in Chat Preferences.**

Toggling any tool or MCP action failed with "Failed to update tools", logging `400: Enable tool <name> before assigning it`. `GET /admin/default-assistant/configuration` returns every attached tool id with no `enabled` filter, and `ChatPreferencesPage.tsx` treats that list as the complete desired state, resending it on each toggle. `update_default_assistant_configuration` then rejected the whole request over one disabled id. The page's switches come from `GET /api/tool` (`only_enabled=True`), so the offending tool had no switch and admins could not clear the block.

Fixed by dropping the `enabled` check on that write path. The unknown-id and `should_expose_tool_to_fe` checks are unchanged.

**2. A disabled tool was still callable in chat.**

Found while reviewing the first fix, whose justification depends on this. `construct_tools` built every tool attached to the persona with no `enabled` check, so an action an admin switched off kept working. `allowed_tool_ids` was the only other filter and does not cover it:

- The Slack bot and evals pass `allowed_tool_ids=None`, so no filtering happens.
- The web client omits it unless the user turned something off in the chat popover, so most messages also do no filtering.
- When it *is* sent it is built from `MinimalPersonaSnapshot.tools`, filtered by `should_expose_tool_to_fe` and not by `enabled` — so a whitelist could contain a disabled tool.

`get_all_mcp_tools_for_server` has no `enabled` predicate either, so a disabled MCP tool got a live `MCPTool`.

Fixed by skipping disabled tools in the construction loop. This makes the `Persona__Tool` contract — "an entry represents a tool that is **available**… it does NOT necessarily mean the tool is actually usable" — hold for the `enabled` flag, as it already did for unconfigured built-ins via `is_available()`.

Together: a disabled action stays attached and stops being callable, which is what the admin switch implies.

**Follow-on from fix 2: nothing may force a tool that is no longer constructed.**

Raised in review. `process_message` raises `Forced tool <id> not found in tools` when the forced id is absent, so skipping a disabled tool turns a forced disabled tool into a failed message. Both producers of a forced id name it from the persona's attached tools, which are not filtered on `enabled`:

- The Slack bot forces the persona's search tool. It now skips a disabled one, which is what the comment above that lookup already claimed ("only when the channel persona actually has a usable one").
- The web client's `useChatController` only checks that the agent *has* the tool. `build_chat_turn` therefore drops a disabled forced id for every caller, next to the existing guard that drops the search tool when search is off.

Behaviour note: on deployments where a disabled action was silently still running in chat, it now stops. That is the intended meaning of the switch, but it is a visible change. No migration or data repair is needed.

Bug 1 was reported on self-hosted 4.6.x, introduced in #6343 (first released in v2.5.0). Bug 2 predates it.

## How Has This Been Tested?

Each test below was confirmed to fail without its fix and pass with it.

- `db/test_default_assistant_disabled_tool.py` replays the reported flow — attach a disabled tool, then toggle another tool on by resending the full list. Also asserts an unknown tool id is still rejected, so the remaining validation is intact.
- `tools/test_disabled_tool_not_constructed.py` asserts `construct_tools` omits a disabled tool both with no whitelist and when the whitelist names it. Without the fix it builds a live `CustomTool`.
- `test_search_tool_forced_only_when_usable` gains a disabled case, so Slack no longer forces a search tool an admin switched off.

Also ran `tools/test_oauth_tool_integration.py`, `unit/onyx/tools/test_construct_tools_no_vectordb.py` and `unit/onyx/chat/test_multi_model_streaming.py` — the existing `construct_tools` and forced-tool coverage.

Two clean-up fixes to tests, both found by the CI failure on the first push:

- `test_transfer_rejects_builtin_persona` left a second builtin persona behind. `get_default_assistant` reads that row with `one_or_none()`, so every later test in `external_dependency_unit/db` that touches the default assistant raised `MultipleResultsFound`. It now deletes the persona it creates.
- The disabled-tool tests left their users behind. `_cleanup` now passes them to `delete_test_user`, after the personas and tools that reference them.

Both were verified by comparing row counts before and after a run, and by running the whole `external_dependency_unit/db` directory in CI's order.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

