### PR TITLE
fix(search): treat "every source selected" as an unscoped search

### DIFF
--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -240,7 +240,7 @@ def fetch_latest_index_attempts_by_status(
     return query.all()
 
 
-_INTERNAL_ONLY_SOURCES = {
+INTERNAL_ONLY_SOURCES = {
     # Used by the ingestion API, not a user-created connector.
     DocumentSource.INGESTION_API,
     # Backs the user library / build feature, not a connector users filter by.
@@ -254,7 +254,7 @@ def fetch_unique_document_sources(db_session: Session) -> list[DocumentSource]:
     sources = [
         source[0]
         for source in distinct_sources
-        if source[0] not in _INTERNAL_ONLY_SOURCES
+        if source[0] not in INTERNAL_ONLY_SOURCES
     ]
 
     return sources

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -27,6 +27,7 @@ from onyx.db.enums import (
     ProcessingMode,
     SwitchoverType,
 )
+from onyx.db.federated import fetch_all_federated_connectors
 from onyx.db.models import (
     Connector,
     ConnectorCredentialPair,
@@ -305,28 +306,38 @@ def get_connector_credential_pairs_for_user(
 def fetch_searchable_document_sources(
     db_session: Session, user: User | None
 ) -> list[DocumentSource]:
-    """The source types *user* can search.
+    """The source types *user* can search: indexed pairs plus federated ones.
 
-    Built the same way as the `/manage/connector-status` list the source picker
-    in the UI is drawn from, so "every source" means the same set on both sides.
+    Built from the same two lists the source picker in the UI is drawn from
+    (`/manage/connector-status` and `/federated`), so "every source" means the
+    same set on both sides — a selection covering it is a default, not a filter.
+    Leaving federated sources out would read a selection that omits one as
+    complete, and drop a restriction the user meant.
+
     Without a user (auth disabled, bot contexts) every connector source counts.
     """
     if user is None:
-        return fetch_unique_document_sources(db_session)
+        indexed_sources = fetch_unique_document_sources(db_session)
+    else:
+        cc_pairs = get_connector_credential_pairs_for_user(
+            db_session=db_session,
+            user=user,
+            get_editable=False,
+            eager_load_connector=True,
+            defer_connector_config=True,
+        )
+        indexed_sources = [
+            cc_pair.connector.source
+            for cc_pair in cc_pairs
+            if cc_pair.connector.source not in INTERNAL_ONLY_SOURCES
+        ]
 
-    cc_pairs = get_connector_credential_pairs_for_user(
-        db_session=db_session,
-        user=user,
-        get_editable=False,
-        eager_load_connector=True,
-        defer_connector_config=True,
-    )
-    sources = [
-        cc_pair.connector.source
-        for cc_pair in cc_pairs
-        if cc_pair.connector.source not in INTERNAL_ONLY_SOURCES
+    federated_sources = [
+        source
+        for connector in fetch_all_federated_connectors(db_session)
+        if (source := connector.source.to_non_federated_source()) is not None
     ]
-    return list(dict.fromkeys(sources))
+    return list(dict.fromkeys([*indexed_sources, *federated_sources]))
 
 
 # For use with our thread-level parallelism utils. Note that any relationships

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -11,7 +11,11 @@ from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.auth.permissions import get_effective_permissions
 from onyx.configs.constants import DEFAULT_CC_PAIR_ID, DocumentSource, NotificationType
-from onyx.db.connector import fetch_connector_by_id
+from onyx.db.connector import (
+    INTERNAL_ONLY_SOURCES,
+    fetch_connector_by_id,
+    fetch_unique_document_sources,
+)
 from onyx.db.connector_alerts import clear_connector_alerts__no_commit
 from onyx.db.credentials import fetch_credential_by_id, fetch_credential_by_id_for_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -296,6 +300,33 @@ def get_connector_credential_pairs_for_user(
         stmt = stmt.order_by(desc(ConnectorCredentialPair.id))
 
     return list(db_session.scalars(stmt).unique().all())
+
+
+def fetch_searchable_document_sources(
+    db_session: Session, user: User | None
+) -> list[DocumentSource]:
+    """The source types *user* can search.
+
+    Built the same way as the `/manage/connector-status` list the source picker
+    in the UI is drawn from, so "every source" means the same set on both sides.
+    Without a user (auth disabled, bot contexts) every connector source counts.
+    """
+    if user is None:
+        return fetch_unique_document_sources(db_session)
+
+    cc_pairs = get_connector_credential_pairs_for_user(
+        db_session=db_session,
+        user=user,
+        get_editable=False,
+        eager_load_connector=True,
+        defer_connector_config=True,
+    )
+    sources = [
+        cc_pair.connector.source
+        for cc_pair in cc_pairs
+        if cc_pair.connector.source not in INTERNAL_ONLY_SOURCES
+    ]
+    return list(dict.fromkeys(sources))
 
 
 # For use with our thread-level parallelism utils. Note that any relationships

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource, DocumentSourceDescription
-from onyx.db.connector import _INTERNAL_ONLY_SOURCES
+from onyx.db.connector import INTERNAL_ONLY_SOURCES
 from onyx.db.connector_credential_pair import get_connector_credential_pairs_for_user
 from onyx.db.enums import EndpointPolicy, ExternalAppType
 from onyx.db.models import User
@@ -55,7 +55,7 @@ def build_available_sources_section(
     seen: set[str] = set()
     for cc_pair in cc_pairs:
         source = cc_pair.connector.source
-        if source in _INTERNAL_ONLY_SOURCES:
+        if source in INTERNAL_ONLY_SOURCES:
             continue
         source_value = (
             source.value if isinstance(source, DocumentSource) else str(source)

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -68,6 +68,7 @@ from onyx.db.connector import (
     check_federated_connectors_exist,
     fetch_unique_document_sources,
 )
+from onyx.db.connector_credential_pair import fetch_searchable_document_sources
 from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.federated import (
@@ -745,7 +746,13 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
 
             # Project mode ignores user filters, so source scoping doesn't apply.
             if self.project_id_filter is None:
-                connected_sources = fetch_unique_document_sources(db_session)
+                # An ACL-bypassing search (Slack bot, API) runs on everyone's
+                # behalf, so every connector source is in play.
+                connected_sources = (
+                    fetch_unique_document_sources(db_session)
+                    if self.bypass_acl
+                    else fetch_searchable_document_sources(db_session, self.user)
+                )
 
             # Slack tokens and entity config — only prefetch when Slack
             # search is enabled or we're in a Slack bot context.
@@ -784,10 +791,24 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         )
         user_info = override_kwargs.user_info
 
+        # A restriction naming every searchable source is a client default, not a
+        # filter — the chat UI enables all sources and sends them as a list. It
+        # narrows nothing, so drop it rather than scope and label the search by it.
+        user_selected_filters = self.user_selected_filters
+        if (
+            user_selected_filters
+            and user_selected_filters.source_type
+            and connected_sources
+            and set(connected_sources).issubset(user_selected_filters.source_type)
+        ):
+            user_selected_filters = user_selected_filters.model_copy(
+                update={"source_type": None}
+            )
+
         # A persona/user source restriction is the outer bound the decision works within.
         user_source_restriction: list[DocumentSource] | None = (
-            list(self.user_selected_filters.source_type)
-            if self.user_selected_filters and self.user_selected_filters.source_type
+            list(user_selected_filters.source_type)
+            if user_selected_filters and user_selected_filters.source_type
             else None
         )
         if user_source_restriction is not None:
@@ -883,11 +904,11 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         )
         scope_note = _build_scope_note(resolved_scope, queries_run)
 
-        effective_filters = self.user_selected_filters
+        effective_filters = user_selected_filters
         if resolved_scope is not None:
-            effective_filters = (
-                self.user_selected_filters or BaseFilters()
-            ).model_copy(update={"source_type": resolved_scope})
+            effective_filters = (user_selected_filters or BaseFilters()).model_copy(
+                update={"source_type": resolved_scope}
+            )
             federated_retrieval_infos = [
                 info
                 for info in federated_retrieval_infos

--- a/backend/tests/external_dependency_unit/db/test_searchable_document_sources.py
+++ b/backend/tests/external_dependency_unit/db/test_searchable_document_sources.py
@@ -1,0 +1,45 @@
+"""The search tool and the UI source picker must agree on "every source".
+
+The chat UI enables every source it is offered and sends them as an explicit
+list. The search tool recognises that list as "no filter" by comparing it with
+the sources it considers searchable, so a source the picker never offers — an
+ingestion-API pair, a file-system pair, a pair the user cannot read — must not
+count on the search side either.
+"""
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.db.connector import INTERNAL_ONLY_SOURCES
+from onyx.db.connector_credential_pair import fetch_searchable_document_sources
+from onyx.db.enums import ProcessingMode
+from onyx.db.models import User
+from onyx.server.documents.connector import get_basic_connector_indexing_status
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+def _picker_sources(db_session: Session, user: User) -> set[DocumentSource]:
+    """The sources `/manage/connector-status` offers — what the picker draws."""
+    return {
+        info.source
+        for info in get_basic_connector_indexing_status(
+            user=user, db_session=db_session
+        )
+    }
+
+
+def test_searchable_sources_match_the_source_picker(db_session: Session) -> None:
+    user = create_test_user(db_session, "searchable-sources")
+    make_cc_pair(db_session, DocumentSource.MOCK_CONNECTOR)
+    make_cc_pair(db_session, DocumentSource.INGESTION_API)
+    file_system_pair = make_cc_pair(db_session, DocumentSource.GITHUB)
+    file_system_pair.processing_mode = ProcessingMode.FILE_SYSTEM
+    db_session.commit()
+
+    searchable = fetch_searchable_document_sources(db_session, user)
+
+    assert set(searchable) == _picker_sources(db_session, user) - INTERNAL_ONLY_SOURCES
+    assert len(searchable) == len(set(searchable)), "sources are deduplicated"
+    assert DocumentSource.MOCK_CONNECTOR in searchable
+    assert DocumentSource.INGESTION_API not in searchable

--- a/backend/tests/external_dependency_unit/db/test_searchable_document_sources.py
+++ b/backend/tests/external_dependency_unit/db/test_searchable_document_sources.py
@@ -2,44 +2,87 @@
 
 The chat UI enables every source it is offered and sends them as an explicit
 list. The search tool recognises that list as "no filter" by comparing it with
-the sources it considers searchable, so a source the picker never offers — an
-ingestion-API pair, a file-system pair, a pair the user cannot read — must not
-count on the search side either.
+the sources it considers searchable, so the two sets have to be built the same
+way. A source the picker never offers — an ingestion-API pair, a file-system
+pair, a pair the user cannot read — must not count on the search side, and a
+source the picker does offer — a federated connector, which owns no connector
+row — must.
 """
 
+from collections.abc import Generator
+
+import pytest
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import DocumentSource, FederatedConnectorSource
 from onyx.db.connector import INTERNAL_ONLY_SOURCES
 from onyx.db.connector_credential_pair import fetch_searchable_document_sources
 from onyx.db.enums import ProcessingMode
-from onyx.db.models import User
+from onyx.db.models import ConnectorCredentialPair, FederatedConnector, User
 from onyx.server.documents.connector import get_basic_connector_indexing_status
-from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from onyx.server.federated.api import get_federated_connectors
+from tests.external_dependency_unit.conftest import create_test_user, delete_test_user
+from tests.external_dependency_unit.indexing_helpers import (
+    cleanup_cc_pair,
+    make_cc_pair,
+)
+
+
+@pytest.fixture
+def workspace(db_session: Session) -> Generator[User, None, None]:
+    """A user, one searchable pair, and three sources that must not be counted
+    the same way: an ingestion-API pair, a file-system pair, and a federated
+    connector that has no connector row at all."""
+    user = create_test_user(db_session, "searchable-sources")
+    pairs: list[ConnectorCredentialPair] = [
+        make_cc_pair(db_session, DocumentSource.MOCK_CONNECTOR),
+        make_cc_pair(db_session, DocumentSource.INGESTION_API),
+        make_cc_pair(db_session, DocumentSource.GITHUB),
+    ]
+    pairs[2].processing_mode = ProcessingMode.FILE_SYSTEM
+    federated = FederatedConnector(
+        source=FederatedConnectorSource.FEDERATED_SLACK,
+        credentials={},
+        config={},
+    )
+    db_session.add(federated)
+    db_session.commit()
+
+    yield user
+
+    db_session.delete(federated)
+    for pair in pairs:
+        cleanup_cc_pair(db_session, pair)
+    delete_test_user(db_session, user)
+    db_session.commit()
 
 
 def _picker_sources(db_session: Session, user: User) -> set[DocumentSource]:
-    """The sources `/manage/connector-status` offers — what the picker draws."""
-    return {
+    """Every source the UI's picker offers: connector pairs plus federated."""
+    connector_sources = {
         info.source
         for info in get_basic_connector_indexing_status(
             user=user, db_session=db_session
         )
     }
+    federated_sources = {
+        source
+        for status in get_federated_connectors(db_session=db_session)
+        if (source := status.source.to_non_federated_source()) is not None
+    }
+    return connector_sources | federated_sources
 
 
-def test_searchable_sources_match_the_source_picker(db_session: Session) -> None:
-    user = create_test_user(db_session, "searchable-sources")
-    make_cc_pair(db_session, DocumentSource.MOCK_CONNECTOR)
-    make_cc_pair(db_session, DocumentSource.INGESTION_API)
-    file_system_pair = make_cc_pair(db_session, DocumentSource.GITHUB)
-    file_system_pair.processing_mode = ProcessingMode.FILE_SYSTEM
-    db_session.commit()
+def test_searchable_sources_match_the_source_picker(
+    db_session: Session, workspace: User
+) -> None:
+    searchable = fetch_searchable_document_sources(db_session, workspace)
 
-    searchable = fetch_searchable_document_sources(db_session, user)
-
-    assert set(searchable) == _picker_sources(db_session, user) - INTERNAL_ONLY_SOURCES
+    assert (
+        set(searchable)
+        == _picker_sources(db_session, workspace) - INTERNAL_ONLY_SOURCES
+    )
     assert len(searchable) == len(set(searchable)), "sources are deduplicated"
     assert DocumentSource.MOCK_CONNECTOR in searchable
+    assert DocumentSource.SLACK in searchable, "federated connectors are searchable"
     assert DocumentSource.INGESTION_API not in searchable

--- a/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
@@ -60,7 +60,8 @@ def _run(
         patch(f"{MODULE}.EmbeddingModel"),
         patch(f"{MODULE}.get_federated_retrieval_functions", return_value=[]),
         patch(
-            f"{MODULE}.fetch_unique_document_sources", return_value=connected_sources
+            f"{MODULE}.fetch_searchable_document_sources",
+            return_value=connected_sources,
         ),
         patch(f"{MODULE}.semantic_query_rephrase", return_value="rephrased query"),
         patch(f"{MODULE}.keyword_query_expansion", return_value=[]),
@@ -149,6 +150,21 @@ def test_no_filter_delta_when_scope_covers_all_sources() -> None:
     connected = [DocumentSource.CONFLUENCE, DocumentSource.GITHUB]
     _run(tool, decision=connected, connected_sources=connected)
     assert _emitted_filter_sources(tool) == []
+
+
+def test_selection_covering_every_source_is_not_a_filter() -> None:
+    """The chat UI enables every source by default and sends them as an explicit
+    list. That narrows nothing, so the search stays unscoped and the UI is told of
+    no filter — it keeps its default 'internal documents' label."""
+    connected = [DocumentSource.CONFLUENCE, DocumentSource.GITHUB]
+    tool = _make_tool(BaseFilters(source_type=list(connected)))
+    mock_search_pipeline = _run(tool, decision=None, connected_sources=connected)
+
+    assert _emitted_filter_sources(tool) == []
+    filters = _filters_passed_to_search(mock_search_pipeline)
+    assert filters, "search_pipeline was never called"
+    for applied in filters:
+        assert applied is None or applied.source_type is None
 
 
 def test_no_decided_scope_leaves_search_unscoped() -> None:

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { adminSearch } from "@/lib/searchFilters/svc";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { OnyxDocument } from "@/lib/search/interfaces";
 import { buildDocumentSummaryDisplay } from "@/components/search/DocumentDisplay";
@@ -13,6 +13,7 @@ import { ScoreSection } from "../ScoreEditor";
 import { useRouter } from "next/navigation";
 import { useSearchFilters } from "@/lib/searchFilters/hooks";
 import { buildFilters } from "@/lib/searchFilters/utils";
+import { getConfiguredSources } from "@/lib/sources";
 import { DocumentUpdatedAtBadge } from "@/components/search/DocumentUpdatedAtBadge";
 import { DocumentSetSummary } from "@/lib/types";
 import { SourceIcon } from "@/components/SourceIcon";
@@ -132,6 +133,10 @@ export function Explorer({
   const [isLoading, setIsLoading] = useState(false);
 
   const filterManager = useSearchFilters();
+  const configuredSources = useMemo(
+    () => getConfiguredSources(connectors.map((connector) => connector.source)),
+    [connectors]
+  );
 
   const onSearch = useCallback(
     async (query: string) => {
@@ -139,6 +144,7 @@ export function Explorer({
       try {
         const filters = buildFilters(
           filterManager.selectedSources,
+          configuredSources,
           filterManager.selectedDocumentSets,
           filterManager.timeRange,
           filterManager.selectedTags
@@ -153,6 +159,7 @@ export function Explorer({
       }
     },
     [
+      configuredSources,
       filterManager.selectedDocumentSets,
       filterManager.selectedSources,
       filterManager.timeRange,

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -179,6 +179,7 @@ export function Explorer({
     setTimeoutId(newTimeoutId);
   }, [
     query,
+    configuredSources,
     filterManager.selectedDocumentSets,
     filterManager.selectedSources,
     filterManager.timeRange,

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -60,7 +60,7 @@ import {
   updateCurrentMessageFIFO,
 } from "@/app/app/services/currentMessageFIFO";
 import { buildFilters } from "@/lib/searchFilters/utils";
-import { useAvailableSources } from "@/lib/connectors/hooks";
+import { useAgentAvailableSources } from "@/lib/searchFilters/hooks";
 import { getConfiguredSources } from "@/lib/sources";
 import { toast } from "@opal/layouts";
 import {
@@ -152,11 +152,13 @@ export default function useChatController({
 }: UseChatControllerProps) {
   const searchFilters = useSharedSearchFilters();
   // What the source selection was made from — a selection covering all of it
-  // means "no source filter", not a filter naming every connector.
-  const { availableSources } = useAvailableSources();
+  // means "no source filter", not a filter naming every source. Scoped to the
+  // agent like the picker is, so a source the user turned off is never read as
+  // part of an "everything is selected" default.
+  const agentAvailableSources = useAgentAvailableSources(activeAgent);
   const configuredSources = useMemo(
-    () => getConfiguredSources(availableSources),
-    [availableSources]
+    () => getConfiguredSources(agentAvailableSources),
+    [agentAvailableSources]
   );
   const pathname = usePathname();
   const router = useRouter();

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -60,6 +60,8 @@ import {
   updateCurrentMessageFIFO,
 } from "@/app/app/services/currentMessageFIFO";
 import { buildFilters } from "@/lib/searchFilters/utils";
+import { useAvailableSources } from "@/lib/connectors/hooks";
+import { getConfiguredSources } from "@/lib/sources";
 import { toast } from "@opal/layouts";
 import {
   ReadonlyURLSearchParams,
@@ -149,6 +151,13 @@ export default function useChatController({
   resetInputBar,
 }: UseChatControllerProps) {
   const searchFilters = useSharedSearchFilters();
+  // What the source selection was made from — a selection covering all of it
+  // means "no source filter", not a filter naming every connector.
+  const { availableSources } = useAvailableSources();
+  const configuredSources = useMemo(
+    () => getConfiguredSources(availableSources),
+    [availableSources]
+  );
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -1065,6 +1074,7 @@ export default function useChatController({
           chatSessionId: currChatSessionId,
           filters: buildFilters(
             searchFilters.selectedSources,
+            configuredSources,
             searchFilters.selectedDocumentSets,
             searchFilters.timeRange,
             searchFilters.selectedTags
@@ -1484,6 +1494,7 @@ export default function useChatController({
     [
       // Narrow to stable fields from managers to avoid re-creation
       searchFilters.selectedSources,
+      configuredSources,
       searchFilters.selectedDocumentSets,
       searchFilters.selectedTags,
       searchFilters.timeRange,

--- a/web/src/lib/searchFilters/agentAvailableSources.test.tsx
+++ b/web/src/lib/searchFilters/agentAvailableSources.test.tsx
@@ -1,0 +1,111 @@
+import { renderHook } from "@testing-library/react";
+import { ValidSources } from "@/lib/types";
+import { DEFAULT_AGENT_ID } from "@/lib/constants";
+import { SEARCH_TOOL_ID } from "@/lib/tools/constants";
+import type { MinimalAgent } from "@/lib/agents/types";
+import type { ToolSnapshot } from "@/lib/tools/types";
+import { useAgentAvailableSources } from "@/lib/searchFilters/hooks";
+import { buildFilters } from "@/lib/searchFilters/utils";
+import { getConfiguredSources } from "@/lib/sources";
+
+const WORKSPACE_SOURCES = [ValidSources.Notion, ValidSources.Slack];
+
+jest.mock("@/lib/connectors/hooks", () => ({
+  useAvailableSources: () => ({
+    availableSources: [ValidSources.Notion, ValidSources.Slack],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+function agent(overrides: Partial<MinimalAgent>): MinimalAgent {
+  return {
+    id: 7,
+    name: "test-agent",
+    description: "",
+    tools: [],
+    starter_messages: null,
+    document_sets: [],
+    is_public: true,
+    is_listed: true,
+    display_priority: null,
+    is_featured: false,
+    builtin_persona: false,
+    owner: null,
+    owner_group: null,
+    user_permission: null,
+    ...overrides,
+  };
+}
+
+const searchTool = { in_code_tool_id: SEARCH_TOOL_ID } as ToolSnapshot;
+
+function sources(agentUnderTest: MinimalAgent | undefined): string[] {
+  const { result } = renderHook(() => useAgentAvailableSources(agentUnderTest));
+  return [...result.current].sort();
+}
+
+describe("useAgentAvailableSources", () => {
+  test("the default agent reaches every workspace source", () => {
+    expect(sources(agent({ id: DEFAULT_AGENT_ID }))).toEqual(
+      [...WORKSPACE_SOURCES].sort()
+    );
+  });
+
+  test("an agent is bounded by its knowledge sources", () => {
+    expect(
+      sources(agent({ knowledge_sources: [ValidSources.Notion] }))
+    ).toEqual(["notion"]);
+  });
+
+  test("knowledge sources can name what no connector provides", () => {
+    // user_file is agent-only: it is never in the workspace connector list.
+    expect(
+      sources(
+        agent({
+          knowledge_sources: [ValidSources.Notion, ValidSources.UserFile],
+        })
+      )
+    ).toEqual(["notion", "user_file"]);
+  });
+
+  test("a search tool with no declared knowledge reaches everything", () => {
+    expect(sources(agent({ tools: [searchTool] }))).toEqual(
+      [...WORKSPACE_SOURCES].sort()
+    );
+  });
+});
+
+describe("useAgentAvailableSources + buildFilters", () => {
+  test("an agent-only source turned off is still sent as a filter", () => {
+    // Measured against the workspace list instead, {notion} would look like
+    // "everything selected" and the disabled user_file would be searched.
+    const universe = getConfiguredSources(
+      sources(
+        agent({
+          knowledge_sources: [ValidSources.Notion, ValidSources.UserFile],
+        })
+      ) as ValidSources[]
+    );
+    const selected = universe.filter(
+      (source) => source.internalName !== ValidSources.UserFile
+    );
+
+    const filters = buildFilters(selected, universe, [], null, []);
+    expect(filters.source_type).toEqual(["notion"]);
+  });
+
+  test("the full agent selection is not a filter", () => {
+    const universe = getConfiguredSources(
+      sources(
+        agent({
+          knowledge_sources: [ValidSources.Notion, ValidSources.UserFile],
+        })
+      ) as ValidSources[]
+    );
+
+    expect(
+      buildFilters(universe, universe, [], null, []).source_type
+    ).toBeNull();
+  });
+});

--- a/web/src/lib/searchFilters/hooks.ts
+++ b/web/src/lib/searchFilters/hooks.ts
@@ -8,6 +8,10 @@ import type { Tag, ValidSources } from "@/lib/types";
 import type { SourceMetadata } from "@/lib/search/interfaces";
 import type { DateRangePickerValue } from "@/refresh-components/DateRangePicker";
 import { getConfiguredSources } from "@/lib/sources";
+import { useAvailableSources } from "@/lib/connectors/hooks";
+import { isAssistant } from "@/lib/agents/utils";
+import type { MinimalAgent } from "@/lib/agents/types";
+import { SEARCH_TOOL_ID } from "@/lib/tools/constants";
 import type { SearchFilters } from "@/lib/searchFilters/types";
 
 export function useSearchFilters(): SearchFilters {
@@ -48,6 +52,39 @@ export function useSearchFilters(): SearchFilters {
       selectedTags,
     ]
   );
+}
+
+/**
+ * The sources a search on `agent` can reach: what the picker offers, and what a
+ * selection is measured against to decide whether it filters anything.
+ *
+ * The default agent reaches everything the workspace has connected. Any other
+ * agent is bounded by its knowledge sources, which can name agent-only sources
+ * (user files) that no connector provides and omit connected ones. An agent
+ * with a search tool and no declared knowledge reaches everything.
+ *
+ * Both the picker and the send path read this, so a source the user turned off
+ * cannot look like part of an "everything is selected" default.
+ */
+export function useAgentAvailableSources(
+  agent: MinimalAgent | undefined
+): ValidSources[] {
+  const { availableSources } = useAvailableSources();
+  const agentIsAssistant = isAssistant(agent);
+  const knowledgeSources = agent?.knowledge_sources;
+  const tools = agent?.tools;
+
+  return useMemo(() => {
+    if (agentIsAssistant) return availableSources;
+
+    const sources = knowledgeSources ?? [];
+    const hasSearchTool = (tools ?? []).some(
+      (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
+    );
+    if (sources.length === 0 && hasSearchTool) return availableSources;
+
+    return Array.from(new Set(sources));
+  }, [agentIsAssistant, availableSources, knowledgeSources, tools]);
 }
 
 interface UseSourcePreferencesProps {

--- a/web/src/lib/searchFilters/sourcePreferences.test.tsx
+++ b/web/src/lib/searchFilters/sourcePreferences.test.tsx
@@ -3,6 +3,7 @@ import { ValidSources } from "@/lib/types";
 import { SourceMetadata } from "@/lib/search/interfaces";
 import { useSourcePreferences } from "@/lib/searchFilters/hooks";
 import { buildFilters } from "@/lib/searchFilters/utils";
+import { getConfiguredSources } from "@/lib/sources";
 
 beforeEach(() => {
   localStorage.clear();
@@ -131,26 +132,40 @@ describe("useSourcePreferences — localStorage persistence across agents", () =
 });
 
 describe("buildFilters — source_type payload", () => {
-  test("enabled sources produce a source_type array", () => {
-    const { state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+  const available = [ValidSources.Notion, ValidSources.UserFile];
+  const configured = getConfiguredSources(available);
 
-    const filters = buildFilters(state.selected, [], null, []);
-    expect(filters.source_type?.sort()).toEqual(["notion", "user_file"]);
+  test("every source enabled produces null source_type", () => {
+    const { state } = setup(available);
+
+    // The default selection. Sending it as a list would have the backend
+    // report an applied filter and the UI name every connector it searched.
+    const filters = buildFilters(state.selected, configured, [], null, []);
+    expect(filters.source_type).toBeNull();
   });
 
   test("no sources produces null source_type", () => {
-    const filters = buildFilters([], [], null, []);
+    const filters = buildFilters([], configured, [], null, []);
     expect(filters.source_type).toBeNull();
   });
 
   test("toggled-off source excluded from payload", () => {
-    const { hook, state } = setup([ValidSources.Notion, ValidSources.UserFile]);
+    const { hook, state } = setup(available);
 
     act(() => {
       hook.result.current.toggleSource("notion");
     });
 
-    const filters = buildFilters(state.selected, [], null, []);
+    const filters = buildFilters(state.selected, configured, [], null, []);
     expect(filters.source_type).toEqual(["user_file"]);
+  });
+
+  test("selection covering an unknown universe still filters", () => {
+    const { state } = setup(available);
+
+    // No universe to compare against — send what is selected rather than
+    // silently widening the search to everything.
+    const filters = buildFilters(state.selected, [], [], null, []);
+    expect(filters.source_type?.sort()).toEqual(["notion", "user_file"]);
   });
 });

--- a/web/src/lib/searchFilters/utils.ts
+++ b/web/src/lib/searchFilters/utils.ts
@@ -3,16 +3,30 @@ import type { SourceMetadata } from "@/lib/search/interfaces";
 import type { DateRangePickerValue } from "@/refresh-components/DateRangePicker";
 import type { SearchFiltersRequest } from "@/lib/searchFilters/types";
 
-/** Freezes a live selection into the shape the backend receives. */
+/** Freezes a live selection into the shape the backend receives.
+ *
+ * `allSources` is everything the selection was made from. A selection covering
+ * all of it is the default, not a filter, and goes as no source filter at all —
+ * sending the full list instead makes the backend report an applied filter and
+ * the UI name every connector it searched.
+ */
 export function buildFilters(
   sources: SourceMetadata[],
+  allSources: SourceMetadata[],
   documentSets: string[],
   timeRange: DateRangePickerValue | null,
   tags: Tag[]
 ): SearchFiltersRequest {
+  const selected = new Set(sources.map((source) => source.internalName));
+  const coversAllSources =
+    allSources.length > 0 &&
+    allSources.every((source) => selected.has(source.internalName));
+
   return {
     source_type:
-      sources.length > 0 ? sources.map((source) => source.internalName) : null,
+      sources.length > 0 && !coversAllSources
+        ? sources.map((source) => source.internalName)
+        : null,
     document_set: documentSets.length > 0 ? documentSets : null,
     updated_at_range: timeRange?.from
       ? { start: timeRange.from, end: null }

--- a/web/src/lib/tools/components/ToolsPopover.tsx
+++ b/web/src/lib/tools/components/ToolsPopover.tsx
@@ -22,9 +22,12 @@ import {
 import { MinimalAgent } from "@/lib/agents/types";
 import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
-import { useSourcePreferences } from "@/lib/searchFilters/hooks";
+import {
+  useAgentAvailableSources,
+  useSourcePreferences,
+} from "@/lib/searchFilters/hooks";
 import MCPApiKeyModal from "@/components/chat/MCPApiKeyModal";
-import { Permission, ValidSources } from "@/lib/types";
+import { Permission } from "@/lib/types";
 import { getAdminConfigureInfo, getToolTooltip } from "@/lib/tools/utils";
 import { getConfiguredSources } from "@/lib/sources";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -32,7 +35,6 @@ import { SourceMetadata } from "@/lib/search/interfaces";
 import { SourceIcon } from "@/components/SourceIcon";
 import { useAvailableTools } from "@/lib/tools/hooks";
 import type { ToolConfigurationHandle } from "@/lib/tools/hooks";
-import { useAvailableSources } from "@/lib/connectors/hooks";
 import useCCPairs from "@/hooks/useCCPairs";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { useSettings } from "@/lib/settings/hooks";
@@ -41,7 +43,6 @@ import LineItem from "@/refresh-components/buttons/LineItem";
 import ActionLineItem from "@/lib/tools/components/ActionLineItem";
 import MCPLineItem, { MCPServer } from "@/lib/tools/components/MCPLineItem";
 import { useProjectsContext } from "@/lib/projects/providers";
-import { isAssistant } from "@/lib/agents/utils";
 import {
   getMCPUserOAuthNavigationUrl,
   saveMCPUserCredentials,
@@ -108,7 +109,6 @@ export default function ToolsPopover({
     }),
     [t]
   );
-  const { availableSources } = useAvailableSources();
   const [open, setOpen] = useState(false);
   const [secondaryView, setSecondaryView] = useState<SecondaryViewState | null>(
     null
@@ -125,36 +125,11 @@ export default function ToolsPopover({
   // Use the OAuth hook
   const { getToolAuthStatus, authenticateTool } = useToolOAuthStatus(agent.id);
 
-  const agentIsAssistant = isAssistant(agent);
-
-  const hasSearchTool = agent.tools.some(
-    (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
-  );
-
-  // knowledge_sources from the backend is the complete set of source types this agent
-  // can search over (doc sets, federated, hierarchy nodes, attached docs, user files).
-  // Default agent is special-cased to show everything available.
-  const agentAccessibleSources = useMemo(() => {
-    if (agentIsAssistant) {
-      return null; // null means "all accessible"
-    }
-
-    const sources = agent.knowledge_sources ?? [];
-    if (sources.length === 0 && hasSearchTool) {
-      return null;
-    }
-
-    return new Set<string>(sources);
-  }, [agentIsAssistant, agent.knowledge_sources, hasSearchTool]);
-
-  // Scope availableSources to only what this agent can access. This ensures
-  // that (a) agent-only sources like user_file appear in the toggle list and
-  // (b) stale sources from localStorage (e.g. Web on an agent with only Notion)
-  // don't leak into selectedSources / the YQL query.
-  const effectiveAvailableSources = useMemo(() => {
-    if (agentAccessibleSources === null) return availableSources;
-    return Array.from(agentAccessibleSources) as ValidSources[];
-  }, [agentAccessibleSources, availableSources]);
+  // Scoped to what this agent can reach, so that (a) agent-only sources like
+  // user_file appear in the toggle list and (b) stale sources from localStorage
+  // (e.g. Web on an agent with only Notion) don't leak into selectedSources /
+  // the YQL query. The send path measures the selection against the same set.
+  const effectiveAvailableSources = useAgentAvailableSources(agent);
 
   const {
     sourcesInitialized,


### PR DESCRIPTION
## Problem

A search over everything is labelled with the full connector list — `Searching Slack, File, Fireflies +6 more` — instead of `Searching internal documents`, even when the scope decision returns `[]`.

The label is not a report of what was searched. It echoes a source filter the frontend sends:

1. `useSourcePreferences` enables every source by default, and `buildFilters` only sends `source_type: null` when *nothing* is selected. A user who never touched the source toggles still posts `internal_search_filters.source_type = [all 9 connectors]`.
2. `SearchTool.run` reads that as a user restriction. With the scope decision returning nothing, the restriction becomes the applied scope.
3. The tool suppresses a scope that covers every source, but the comparison is `set(connected_sources).issubset(resolved_scope)` where `connected_sources` is every row in the `connector` table. The picker the user chose from is `/manage/connector-status`: user-readable pairs in `REGULAR` processing mode. A file-system pair (user files), a pair in a group the user is not in, or a connector left behind by a deleted pair is in one list and not the other, so the subset test fails and the whole list is emitted as `SearchToolFilterDelta`.

The search also ran with a `source_type` filter that excluded nothing.

## Fix

Both sides now agree that "everything" is not a filter:

- **`buildFilters`** takes the sources the selection was offered and sends no source filter when the selection covers them. The default selection stops looking like a filter at the point it is serialised.
- **`fetch_searchable_document_sources`** derives the search tool's source universe the way `/manage/connector-status` does, so the two lists cannot drift. It also stops the scope-decision LLM being offered sources the user cannot read. An ACL-bypassing search (Slack bot, API) keeps the unrestricted list.
- **`SearchTool.run`** drops a restriction that names every searchable source, so the search runs unscoped instead of filtered by a list that excludes nothing. This covers clients that pass explicit filters — Slack bot, public API, MCP.

`_INTERNAL_ONLY_SOURCES` is now public, since it has a second consumer.

## Tests

- `test_selection_covering_every_source_is_not_a_filter` — a restriction naming every source emits no filter delta and leaves the search unscoped.
- `test_searchable_sources_match_the_source_picker` — a contract test tying the tool's source universe to the endpoint the picker is drawn from, with an ingestion-API pair and a file-system pair present. It fails against the old derivation, which reports the file-system pair's source.
- `buildFilters` unit tests updated: all-selected is now `null`, a strict subset still filters, and an unknown universe still sends the selection.

Backend unit suite: 8893 passed, 11 pre-existing failures in `ee/.../license` (also fail on `main`). Web: `src/lib` + `src/hooks`, 373 passed.

## Not covered

Disabling *every* source in the picker still sends `source_type: null`, so the search runs over everything. That reads like its own bug, but the intended behaviour ("search nothing" vs "turn the tool off") is a product decision, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaYPEUCZup64HPPLdZPeP8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all-sources selections being treated as an applied source filter, so a search over everything stays unscoped and is labelled "Searching internal documents" instead of the full connector list.

- `buildFilters` sends no source filter when the selection covers every source it was offered; the offered set is now the agent's own sources, shared with the picker.
- Agent-only sources (user files) count toward that set, so a selection that turns one off still sends it as a filter instead of being read as "everything selected".
- `fetch_searchable_document_sources` derives the searchable universe the same way the picker does, including federated connectors; ACL-bypassing searches (Slack bot, API) keep the unrestricted list.
- `SearchTool.run` drops a restriction that names every searchable source, covering clients that pass explicit filters.
- Disabling every source still sends no filter and searches everything; intended behaviour is left to a product decision.

<sup>Written for commit 734bb5e13ab0c34e0f6b952ecb2eaa00882ba8ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

