### PR TITLE
feat(opal): add InputMultiSelect and its Formik field

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -67,6 +67,11 @@ Never import from `web/src/components/`. It is legacy and being deleted. The one
   `settings.appearance.colorMode.title`. Rewording the English never changes the key.
 - Use ICU for arguments and plurals. Never concatenate translated fragments.
 - Dates and numbers: `useFormatter` and `useLocale`, not hard-coded `"en-US"`.
+- **Opal built-in strings**: Opal has no next-intl. A label an Opal component renders itself rides
+  the `OpalStrings` contract instead: add a typed key with an English default in
+  `web/lib/opal/src/strings.tsx`, read it in the component via `useOpalStrings()`, map it from the
+  `opal.*` catalog namespace in `web/src/i18n/OpalStringsBridge.tsx`, and add the key to every
+  locale file. Never hard-code a user-facing string inside an Opal component.
 - New styles use logical properties (`ms-`, `pe-`, `start-`) instead of `ml-`, `pr-`, `left-`.
 
 ## Tests

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -67,12 +67,25 @@ Never import from `web/src/components/`. It is legacy and being deleted. The one
   `settings.appearance.colorMode.title`. Rewording the English never changes the key.
 - Use ICU for arguments and plurals. Never concatenate translated fragments.
 - Dates and numbers: `useFormatter` and `useLocale`, not hard-coded `"en-US"`.
-- **Opal built-in strings**: Opal has no next-intl. A label an Opal component renders itself rides
-  the `OpalStrings` contract instead: add a typed key with an English default in
-  `web/lib/opal/src/strings.tsx`, read it in the component via `useOpalStrings()`, map it from the
-  `opal.*` catalog namespace in `web/src/i18n/OpalStringsBridge.tsx`, and add the key to every
-  locale file. Never hard-code a user-facing string inside an Opal component.
 - New styles use logical properties (`ms-`, `pe-`, `start-`) instead of `ml-`, `pr-`, `left-`.
+
+### Opal i18n
+
+Opal has no next-intl. A label an Opal component renders itself (a built-in placeholder, empty
+state, aria-label — anything not passed in by the caller) rides the `OpalStrings` contract:
+
+1. Add a typed key to `OpalStrings` in `web/lib/opal/src/strings.tsx`, with an English default in
+   `defaultOpalStrings` right below. Prefix component-scoped keys with the component name
+   (`comboBoxNoOptions`, `multiSelectEmptyTitle`). A string with arguments is a function-valued
+   entry (`(count) => string`).
+2. Read it in the component with `useOpalStrings()` from `@opal/strings`.
+3. Map it in `web/src/i18n/OpalStringsBridge.tsx` from the `opal.*` catalog namespace
+   (`t("multiSelect.emptyTitle")`) — the bridge wraps the app in `layout.tsx` and feeds Opal the
+   host translations.
+4. Add the key under `opal.<component>.<name>` in `en.json` and every other locale file.
+
+Never hard-code a user-facing string inside an Opal component, and never import next-intl there —
+the contract keeps Opal host-agnostic while the app supplies real translations.
 
 ## Tests
 

--- a/web/lib/opal/src/components/README.md
+++ b/web/lib/opal/src/components/README.md
@@ -27,6 +27,7 @@ The barrel file at `index.ts` re-exports each component and its prop types. Each
 | [InputComboBox](./inputs/input-combo-box/)     | Filterable input/select hybrid with create-new support       | [README](./inputs/input-combo-box/README.md)   |
 | [InputImage](./inputs/input-image/)            | Circular image dropzone with edit overlay                    | [README](./inputs/input-image/README.md)       |
 | [InputKeyValue](./inputs/input-key-value/)     | Key/value pair editor with validation                        | [README](./inputs/input-key-value/README.md)   |
+| [InputMultiSelect](./inputs/input-multi-select/) | Searchable multi-select with a selected-items list below | [README](./inputs/input-multi-select/README.md) |
 | [InputNumber](./inputs/input-number/)          | Number field with steppers and reset                         | [README](./inputs/input-number/README.md)      |
 | [ListFieldInput](./inputs/list-field-input/)   | Type-and-Enter list builder with removable chips below       | [README](./inputs/list-field-input/README.md)  |
 

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -36,6 +36,13 @@ export {
   type AttachmentItemButtonProps,
 } from "@opal/components/buttons/attachment-item-button/components";
 
+/* InputMultiSelect */
+export {
+  InputMultiSelect,
+  type InputMultiSelectProps,
+  type InputMultiSelectItem,
+} from "@opal/components/inputs/input-multi-select/components";
+
 /* LineItemButton */
 export {
   LineItemButton,

--- a/web/lib/opal/src/components/inputs/input-multi-select/InputMultiSelect.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-multi-select/InputMultiSelect.stories.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InputMultiSelect } from "@opal/components";
+import SvgUsers from "@opal/icons/users";
+import SvgLogOut from "@opal/icons/log-out";
+
+const meta: Meta<typeof InputMultiSelect> = {
+  title: "opal/components/InputMultiSelect",
+  component: InputMultiSelect,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InputMultiSelect>;
+
+const GROUPS = [
+  { id: "1", title: "Engineering", description: "14 members", icon: SvgUsers },
+  { id: "2", title: "Design", description: "5 members", icon: SvgUsers },
+  { id: "3", title: "Sales", description: "9 members", icon: SvgUsers },
+  { id: "4", title: "Support", description: "7 members", icon: SvgUsers },
+  { id: "5", title: "Leadership", description: "3 members", icon: SvgUsers },
+];
+
+function Controlled(props: { initial?: string[]; disabled?: boolean }) {
+  const [value, setValue] = useState<string[]>(props.initial ?? []);
+  return (
+    <div className="w-96">
+      <InputMultiSelect
+        items={GROUPS}
+        value={value}
+        onChange={setValue}
+        placeholder="Search groups…"
+        removeIcon={SvgLogOut}
+        disabled={props.disabled}
+      />
+    </div>
+  );
+}
+
+/** Empty selection shows the EmptyMessageCard. */
+export const Default: Story = {
+  render: () => <Controlled />,
+};
+
+export const WithSelection: Story = {
+  render: () => <Controlled initial={["1", "3"]} />,
+};
+
+export const Disabled: Story = {
+  render: () => <Controlled initial={["2"]} disabled />,
+};
+
+export const Loading: Story = {
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <div className="w-96">
+        <InputMultiSelect
+          items={[]}
+          value={value}
+          onChange={setValue}
+          placeholder="Search groups…"
+          loading
+        />
+      </div>
+    );
+  },
+};

--- a/web/lib/opal/src/components/inputs/input-multi-select/README.md
+++ b/web/lib/opal/src/components/inputs/input-multi-select/README.md
@@ -1,0 +1,51 @@
+# InputMultiSelect
+
+**Import:** `import { InputMultiSelect, type InputMultiSelectProps, type InputMultiSelectItem } from "@opal/components";`
+
+Searchable multi-select on a tinted container: a search input opens a
+dropdown of options, and the current selection lives in a list below it.
+Clicking a dropdown row toggles it; clicking a selected row removes it.
+While nothing is selected, the list shows an `EmptyMessageCard`.
+
+Controlled only — pair it with `InputMultiSelectField` from `@opal/form`
+inside a Formik form:
+
+```tsx
+<InputMultiSelectField
+  name="group_ids"
+  items={groups.map((g) => ({
+    id: String(g.id),
+    title: g.name,
+    description: t("memberCount", { count: g.users.length }),
+    icon: SvgUsers,
+  }))}
+  placeholder={t("search.placeholder")}
+  removeIcon={SvgLogOut}
+  container={modalContentEl}
+/>
+```
+
+## Props
+
+| Prop          | Type                          | Default  | Description                                                       |
+| ------------- | ----------------------------- | -------- | ----------------------------------------------------------------- |
+| `items`       | `InputMultiSelectItem[]`      | —        | Full option set; filtered internally by title (case-insensitive)  |
+| `value`       | `string[]`                    | —        | Selected item ids (controlled)                                    |
+| `onChange`    | `(next: string[]) => void`    | —        | Next selected-id set on every toggle or removal                   |
+| `placeholder` | `string`                      | —        | Search input placeholder                                          |
+| `disabled`    | `boolean`                     | —        | Disables the input, dropdown, and rows                            |
+| `loading`     | `boolean`                     | —        | Loading row in the dropdown instead of options                    |
+| `removeIcon`  | `IconFunctionComponent`       | `SvgX`   | Trailing icon on selected rows (e.g. `SvgLogOut` for memberships) |
+| `container`   | `HTMLElement \| null`         | —        | Dropdown portal container (a modal's content element)             |
+
+Unlisted props are DOM and reach the search input, so `data-testid` hooks
+land on the element tests drive.
+
+`InputMultiSelectItem`: `{ id: string; title; description?; icon? }`. `title`
+is also the filter target. Selected dropdown rows show a check in place of
+the item icon.
+
+## Out of scope
+
+Grouped options, async search, and create-new (`InputComboBox`'s territory);
+chips-style display (`AddPeoplePicker`). Number ids: callers `String()` them.

--- a/web/lib/opal/src/components/inputs/input-multi-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-multi-select/components.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import "@opal/components/inputs/input-multi-select/styles.css";
+import React, { useMemo, useState } from "react";
+import type {
+  IconFunctionComponent,
+  RichStr,
+  WithoutStyles,
+} from "@opal/types";
+import {
+  EmptyMessageCard,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  ShadowDiv,
+} from "@opal/components";
+import { SvgCheck, SvgX } from "@opal/icons";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InputMultiSelectItem {
+  id: string;
+
+  /** Main label; also what the search filters on. */
+  title: string | RichStr;
+
+  /** Caller-formatted metadata under the title, e.g. a member count. */
+  description?: string | RichStr;
+
+  /** Leading icon. Selected dropdown rows show a check instead. */
+  icon?: IconFunctionComponent;
+}
+
+/**
+ * `value`/`onChange`/`disabled` are owned by this component's contract and
+ * `children` has no meaning for it; everything else a caller passes that is
+ * not listed below is DOM and reaches the search input (so `data-*` hooks
+ * land on the element tests actually drive).
+ */
+interface InputMultiSelectProps extends Omit<
+  WithoutStyles<React.InputHTMLAttributes<HTMLInputElement>>,
+  "value" | "onChange" | "disabled" | "children"
+> {
+  /** Full option set; the component filters it by title as the user types. */
+  items: InputMultiSelectItem[];
+
+  /** Selected item ids — fully controlled. */
+  value: string[];
+
+  /** Called with the next selected-id set on every toggle or removal. */
+  onChange: (next: string[]) => void;
+
+  /** Placeholder for the search input. */
+  placeholder?: string;
+
+  /** Disables the search input, the dropdown, and every row. */
+  disabled?: boolean;
+
+  /** Shows a loading row in the dropdown instead of options. */
+  loading?: boolean;
+
+  /**
+   * Trailing icon on selected-list rows; clicking the row removes the item.
+   *
+   * @default SvgX
+   */
+  removeIcon?: IconFunctionComponent;
+
+  /** Portal container for the dropdown (e.g. a modal's content element). */
+  container?: HTMLElement | null;
+}
+
+// ---------------------------------------------------------------------------
+// InputMultiSelect
+// ---------------------------------------------------------------------------
+
+/**
+ * Searchable multi-select: a search input opens a dropdown of options, and
+ * the current selection lives in a list below it. Clicking a dropdown row
+ * toggles it; clicking a selected row removes it.
+ *
+ * Controlled only — pair it with `InputMultiSelectField` from `@opal/form`
+ * inside a Formik form.
+ */
+function InputMultiSelect({
+  items,
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  loading,
+  removeIcon: RemoveIcon = SvgX,
+  container,
+  ...inputProps
+}: InputMultiSelectProps) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const selectedIds = useMemo(() => new Set(value), [value]);
+  const selectedItems = useMemo(
+    () => items.filter((item) => selectedIds.has(item.id)),
+    [items, selectedIds]
+  );
+
+  const filteredItems = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return items;
+    return items.filter((item) =>
+      String(item.title).toLowerCase().includes(trimmed)
+    );
+  }, [items, query]);
+
+  function toggle(id: string) {
+    onChange(
+      selectedIds.has(id)
+        ? value.filter((selected) => selected !== id)
+        : [...value, id]
+    );
+  }
+
+  return (
+    <div className="opal-input-multi-select">
+      <Popover
+        open={!disabled && open}
+        onOpenChange={(next) => !disabled && setOpen(next)}
+      >
+        <Popover.Trigger asChild>
+          {/* A plain div: the trigger would otherwise nest a <button> around
+              the input. */}
+          <div>
+            <InputTypeIn
+              {...inputProps}
+              searchIcon
+              placeholder={placeholder}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              variant={disabled ? "disabled" : undefined}
+            />
+          </div>
+        </Popover.Trigger>
+        <Popover.Content width="trigger" align="start" container={container}>
+          {loading ? (
+            <LineItemButton
+              presentational
+              sizePreset="main-ui"
+              variant="section"
+              color="muted"
+              title="Loading …"
+            />
+          ) : filteredItems.length === 0 ? (
+            <LineItemButton
+              presentational
+              sizePreset="main-ui"
+              variant="section"
+              color="muted"
+              title="No matching options."
+            />
+          ) : (
+            <ShadowDiv
+              shadowHeight="0.75rem"
+              className="opal-input-multi-select-dropdown"
+            >
+              {filteredItems.map((item) => {
+                const selected = selectedIds.has(item.id);
+                return (
+                  <LineItemButton
+                    key={item.id}
+                    sizePreset="main-ui"
+                    variant="section"
+                    icon={selected ? SvgCheck : item.icon}
+                    title={item.title}
+                    titleMaxLines={1}
+                    description={item.description}
+                    descriptionMaxLines={1}
+                    state={selected ? "selected" : "empty"}
+                    onClick={() => toggle(item.id)}
+                  />
+                );
+              })}
+            </ShadowDiv>
+          )}
+        </Popover.Content>
+      </Popover>
+
+      <ShadowDiv
+        shadowHeight="0.75rem"
+        className="opal-input-multi-select-selected"
+      >
+        {selectedItems.length === 0 ? (
+          // NOTE: plain English on purpose — Opal's i18n pattern for these
+          // built-in strings lands in a follow-up.
+          <EmptyMessageCard
+            sizePreset="main-ui"
+            padding={2}
+            title="Nothing selected yet."
+            description="Search above to add items."
+          />
+        ) : (
+          selectedItems.map((item) => (
+            <div key={item.id} className="opal-input-multi-select-row">
+              <LineItemButton
+                sizePreset="main-ui"
+                variant="section"
+                icon={item.icon}
+                title={item.title}
+                titleMaxLines={1}
+                description={item.description}
+                descriptionMaxLines={1}
+                disabled={disabled}
+                rightChildren={<RemoveIcon height={16} width={16} />}
+                onClick={() => toggle(item.id)}
+              />
+            </div>
+          ))
+        )}
+      </ShadowDiv>
+    </div>
+  );
+}
+
+export {
+  InputMultiSelect,
+  type InputMultiSelectProps,
+  type InputMultiSelectItem,
+};

--- a/web/lib/opal/src/components/inputs/input-multi-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-multi-select/components.tsx
@@ -16,6 +16,7 @@ import {
 } from "@opal/components";
 import { SvgCheck, SvgX } from "@opal/icons";
 import { useOpalStrings } from "@opal/strings";
+import { toPlainString } from "@opal/components/text/InlineMarkdown";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,10 +41,10 @@ interface InputMultiSelectItem {
  * not listed below is DOM and reaches the search input (so `data-*` hooks
  * land on the element tests actually drive).
  */
-interface InputMultiSelectProps extends Omit<
+type InputMultiSelectProps = Omit<
   WithoutStyles<React.InputHTMLAttributes<HTMLInputElement>>,
   "value" | "onChange" | "disabled" | "children"
-> {
+> & {
   /** Full option set; the component filters it by title as the user types. */
   items: InputMultiSelectItem[];
 
@@ -71,7 +72,7 @@ interface InputMultiSelectProps extends Omit<
 
   /** Portal container for the dropdown (e.g. a modal's content element). */
   container?: HTMLElement | null;
-}
+};
 
 // ---------------------------------------------------------------------------
 // InputMultiSelect
@@ -110,7 +111,7 @@ function InputMultiSelect({
     const trimmed = query.trim().toLowerCase();
     if (!trimmed) return items;
     return items.filter((item) =>
-      String(item.title).toLowerCase().includes(trimmed)
+      toPlainString(item.title).toLowerCase().includes(trimmed)
     );
   }, [items, query]);
 

--- a/web/lib/opal/src/components/inputs/input-multi-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-multi-select/components.tsx
@@ -15,6 +15,7 @@ import {
   ShadowDiv,
 } from "@opal/components";
 import { SvgCheck, SvgX } from "@opal/icons";
+import { useOpalStrings } from "@opal/strings";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,6 +96,7 @@ function InputMultiSelect({
   container,
   ...inputProps
 }: InputMultiSelectProps) {
+  const strings = useOpalStrings();
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
 
@@ -147,7 +149,7 @@ function InputMultiSelect({
               sizePreset="main-ui"
               variant="section"
               color="muted"
-              title="Loading …"
+              title={strings.loading}
             />
           ) : filteredItems.length === 0 ? (
             <LineItemButton
@@ -155,7 +157,7 @@ function InputMultiSelect({
               sizePreset="main-ui"
               variant="section"
               color="muted"
-              title="No matching options."
+              title={strings.multiSelectNoResults}
             />
           ) : (
             <ShadowDiv
@@ -189,13 +191,11 @@ function InputMultiSelect({
         className="opal-input-multi-select-selected"
       >
         {selectedItems.length === 0 ? (
-          // NOTE: plain English on purpose — Opal's i18n pattern for these
-          // built-in strings lands in a follow-up.
           <EmptyMessageCard
             sizePreset="main-ui"
             padding={2}
-            title="Nothing selected yet."
-            description="Search above to add items."
+            title={strings.multiSelectEmptyTitle}
+            description={strings.multiSelectEmptyDescription}
           />
         ) : (
           selectedItems.map((item) => (

--- a/web/lib/opal/src/components/inputs/input-multi-select/styles.css
+++ b/web/lib/opal/src/components/inputs/input-multi-select/styles.css
@@ -1,0 +1,26 @@
+@reference "#reference.css";
+
+/* ============================================================================
+   InputMultiSelect — layout only
+
+   Search input (dropdown anchor) above the selected-items list, on a tinted
+   container. Row colors come from LineItemButton's Interactive palette.
+   ============================================================================ */
+
+.opal-input-multi-select {
+  @apply flex w-full flex-col gap-2 rounded-08 bg-background-tint-02 p-1;
+}
+
+.opal-input-multi-select-dropdown {
+  @apply flex max-h-[15rem] flex-col gap-1 rounded-08;
+}
+
+.opal-input-multi-select-selected {
+  @apply flex max-h-[11rem] flex-col gap-1 rounded-08;
+}
+
+/* Selected rows rest on their own surface so they read against the tinted
+   container. */
+.opal-input-multi-select-row {
+  @apply rounded-08 bg-background-tint-01;
+}

--- a/web/lib/opal/src/form/InputMultiSelectField.tsx
+++ b/web/lib/opal/src/form/InputMultiSelectField.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useField } from "formik";
+import { InputMultiSelect, type InputMultiSelectProps } from "@opal/components";
+
+export interface InputMultiSelectFieldProps extends Omit<
+  InputMultiSelectProps,
+  "value" | "onChange"
+> {
+  /** Formik field name; the field's value is the selected-id array. */
+  name: string;
+}
+
+/**
+ * `InputMultiSelect` bound to a Formik `string[]` field. The base component
+ * stays controlled and Formik-free; this wrapper supplies the array value
+ * and writes toggles back through the field helpers.
+ */
+export function InputMultiSelectField({
+  name,
+  ...inputProps
+}: InputMultiSelectFieldProps) {
+  const [field, , helpers] = useField<string[]>(name);
+
+  return (
+    <InputMultiSelect
+      {...inputProps}
+      id={name}
+      name={name}
+      value={field.value ?? []}
+      onChange={(next) => void helpers.setValue(next)}
+    />
+  );
+}

--- a/web/lib/opal/src/form/InputMultiSelectField.tsx
+++ b/web/lib/opal/src/form/InputMultiSelectField.tsx
@@ -3,13 +3,13 @@
 import { useField } from "formik";
 import { InputMultiSelect, type InputMultiSelectProps } from "@opal/components";
 
-export interface InputMultiSelectFieldProps extends Omit<
+export type InputMultiSelectFieldProps = Omit<
   InputMultiSelectProps,
   "value" | "onChange"
-> {
+> & {
   /** Formik field name; the field's value is the selected-id array. */
   name: string;
-}
+};
 
 /**
  * `InputMultiSelect` bound to a Formik `string[]` field. The base component
@@ -20,7 +20,7 @@ export function InputMultiSelectField({
   name,
   ...inputProps
 }: InputMultiSelectFieldProps) {
-  const [field, , helpers] = useField<string[]>(name);
+  const [field, meta, helpers] = useField<string[]>(name);
 
   return (
     <InputMultiSelect
@@ -28,7 +28,12 @@ export function InputMultiSelectField({
       id={name}
       name={name}
       value={field.value ?? []}
-      onChange={(next) => void helpers.setValue(next)}
+      onChange={(next) => {
+        void helpers.setValue(next);
+        // A toggle is an interaction: mark the field touched so validation
+        // gated on meta.touched shows without waiting for a submit.
+        if (!meta.touched) void helpers.setTouched(true, false);
+      }}
     />
   );
 }

--- a/web/lib/opal/src/form/index.ts
+++ b/web/lib/opal/src/form/index.ts
@@ -5,3 +5,7 @@ export {
   type FormFieldState,
 } from "@opal/form/FieldContext";
 export { FieldMessage } from "@opal/form/FieldMessage";
+export {
+  InputMultiSelectField,
+  type InputMultiSelectFieldProps,
+} from "@opal/form/InputMultiSelectField";

--- a/web/lib/opal/src/strings.tsx
+++ b/web/lib/opal/src/strings.tsx
@@ -75,6 +75,9 @@ export type OpalStrings = {
   comboBoxOtherOptions: string;
   comboBoxCreate: string;
   comboBoxCreateOption: (prefix: string, value: string) => string;
+  multiSelectNoResults: string;
+  multiSelectEmptyTitle: string;
+  multiSelectEmptyDescription: string;
   keyValueKey: string;
   keyValueValue: string;
   keyValueAddLine: string;
@@ -171,6 +174,9 @@ export const defaultOpalStrings: OpalStrings = {
   comboBoxOtherOptions: "Other options",
   comboBoxCreate: "Create",
   comboBoxCreateOption: (prefix, value) => `${prefix} "${value}"`,
+  multiSelectNoResults: "No matching options",
+  multiSelectEmptyTitle: "Nothing selected yet",
+  multiSelectEmptyDescription: "Search above to add items",
   keyValueKey: "Key",
   keyValueValue: "Value",
   keyValueAddLine: "Add Line",

--- a/web/src/i18n/OpalStringsBridge.tsx
+++ b/web/src/i18n/OpalStringsBridge.tsx
@@ -90,6 +90,9 @@ export default function OpalStringsBridge({
       comboBoxCreate: t("comboBox.create"),
       comboBoxCreateOption: (prefix, value) =>
         t("comboBox.createOption", { prefix, value }),
+      multiSelectNoResults: t("multiSelect.noResults"),
+      multiSelectEmptyTitle: t("multiSelect.emptyTitle"),
+      multiSelectEmptyDescription: t("multiSelect.emptyDescription"),
       keyValueKey: t("keyValue.key"),
       keyValueValue: t("keyValue.value"),
       keyValueAddLine: t("keyValue.addLine"),

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {تم العثور على خطأ تحقق واحد} other {تم العثور على # من أخطاء التحقق}}",
       "value": "القيمة"
     },
+    "multiSelect": {
+      "emptyDescription": "ابحث في الأعلى لإضافة عناصر",
+      "emptyTitle": "لم يتم تحديد أي شيء بعد",
+      "noResults": "لا توجد خيارات مطابقة"
+    },
     "pagination": {
       "goToPage": "الانتقال إلى صفحة",
       "nextPage": "الصفحة التالية",

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {# Validierungsfehler gefunden} other {# Validierungsfehler gefunden}}",
       "value": "Wert"
     },
+    "multiSelect": {
+      "emptyDescription": "Oben suchen, um Einträge hinzuzufügen",
+      "emptyTitle": "Noch nichts ausgewählt",
+      "noResults": "Keine passenden Optionen"
+    },
     "pagination": {
       "goToPage": "Zu Seite springen",
       "nextPage": "Nächste Seite",

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {# validation error found} other {# validation errors found}}",
       "value": "Value"
     },
+    "multiSelect": {
+      "emptyDescription": "Search above to add items",
+      "emptyTitle": "Nothing selected yet",
+      "noResults": "No matching options"
+    },
     "pagination": {
       "goToPage": "Go to page",
       "nextPage": "Next page",

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {# error de validación encontrado} other {# errores de validación encontrados}}",
       "value": "Valor"
     },
+    "multiSelect": {
+      "emptyDescription": "Busca arriba para añadir elementos",
+      "emptyTitle": "Aún no hay nada seleccionado",
+      "noResults": "No hay opciones coincidentes"
+    },
     "pagination": {
       "goToPage": "Ir a la página",
       "nextPage": "Página siguiente",

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {# erreur de validation trouvée} other {# erreurs de validation trouvées}}",
       "value": "Valeur"
     },
+    "multiSelect": {
+      "emptyDescription": "Recherchez ci-dessus pour ajouter des éléments",
+      "emptyTitle": "Rien de sélectionné pour le moment",
+      "noResults": "Aucune option correspondante"
+    },
     "pagination": {
       "goToPage": "Aller à la page",
       "nextPage": "Page suivante",

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {#件の検証エラーが見つかりました} other {#件の検証エラーが見つかりました}}",
       "value": "値"
     },
+    "multiSelect": {
+      "emptyDescription": "上の検索欄から項目を追加してください",
+      "emptyTitle": "まだ何も選択されていません",
+      "noResults": "一致するオプションがありません"
+    },
     "pagination": {
       "goToPage": "ページへ移動",
       "nextPage": "次のページ",

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {유효성 검사 오류 #개 발견} other {유효성 검사 오류 #개 발견}}",
       "value": "값"
     },
+    "multiSelect": {
+      "emptyDescription": "위에서 검색하여 항목을 추가하세요",
+      "emptyTitle": "아직 선택된 항목이 없습니다",
+      "noResults": "일치하는 옵션이 없습니다"
+    },
     "pagination": {
       "goToPage": "페이지로 이동",
       "nextPage": "다음 페이지",

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {# erro de validação encontrado} other {# erros de validação encontrados}}",
       "value": "Valor"
     },
+    "multiSelect": {
+      "emptyDescription": "Pesquise acima para adicionar itens",
+      "emptyTitle": "Nada selecionado ainda",
+      "noResults": "Nenhuma opção correspondente"
+    },
     "pagination": {
       "goToPage": "Ir para a página",
       "nextPage": "Próxima página",

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -12772,6 +12772,11 @@
       "validationSummary": "{count, plural, one {发现 # 个验证错误} other {发现 # 个验证错误}}",
       "value": "值"
     },
+    "multiSelect": {
+      "emptyDescription": "在上方搜索以添加项目",
+      "emptyTitle": "尚未选择任何内容",
+      "noResults": "没有匹配的选项"
+    },
     "pagination": {
       "goToPage": "跳转到页面",
       "nextPage": "下一页",


### PR DESCRIPTION
## Description

Adds `InputMultiSelect` to Opal: a searchable multi-select extracted from the pattern three admin modals (`ApiKeyFormModal`, `EditServiceAccountModal`, `EditUserModal`) each hand-roll today. A search input opens a dropdown of options (`LineItemButton` rows — check icon + selected state on toggle), the current selection lives in a list below on the tinted container (rows remove on click, trailing `removeIcon`, default `SvgX`), and an `EmptyMessageCard` fills the empty state.

- Controlled-only contract: `value: string[]` / `onChange(next)`. `InputMultiSelectField` in `@opal/form` binds it to a Formik `string[]` field (`formik` was already a peerDependency).
- Filtering is internal (case-insensitive substring on title). Grouped options, async search, create-new (`InputComboBox`'s territory), and chips display (`AddPeoplePicker`) are deliberately out of scope.
- Unlisted props are DOM and reach the search input, so existing `data-testid` hooks (`groups-search-input`) survive the migration as caller props.
- Built-in strings (loading / no results / empty state) are plain English for now; the Opal i18n pattern for these lands separately.

Pure addition — no consumers change. A follow-up migrates the three modals, deleting ~15 `LineItem` call sites and unblocking the `LineItem.tsx` retirement.

## Screenshots + Videos

TODO

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `InputMultiSelect` to Opal and its Formik field: a searchable multi-select with a dropdown of options and a selected-items list below, extracted from the group-picker admin modals. The built-in loading, no-results, and empty-state strings now ride the `OpalStrings` contract and are translated across all locales.

- Controlled-only contract (`value`/`onChange`), with `InputMultiSelectField` binding it to a Formik `string[]` field.
- Filters options by title (case-insensitive) via `toPlainString` so `RichStr` titles match visible text; grouped, async search, create-new, and chips display are out of scope.
- The field marks itself touched on the first toggle so validation gated on `meta.touched` shows before submit.
- Unlisted props are DOM and reach the search input, so existing `data-testid` hooks keep working.
- Documents the Opal built-in strings pattern in `web/AGENTS.md`; pure addition, no consumers change.

<sup>Written for commit e38799685a26c77aca93a5fbd5f03579236cbc7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

