### PR TITLE
chore(ruff): enable the PIE lint rules

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1937,10 +1937,8 @@ class FastAPIUserWithRefreshRouter(FastAPIUsers[models.UP, models.ID]):
         )
 
         refresh_responses: OpenAPIResponseType = {
-            **{
-                status.HTTP_401_UNAUTHORIZED: {
-                    "description": "Missing token or inactive user."
-                }
+            status.HTTP_401_UNAUTHORIZED: {
+                "description": "Missing token or inactive user."
             },
             **backend.transport.get_openapi_login_responses_success(),
         }

--- a/backend/onyx/chat/citation_utils.py
+++ b/backend/onyx/chat/citation_utils.py
@@ -176,11 +176,7 @@ def collapse_citations(
         citation_str = match.group()
 
         # Determine bracket style
-        if (
-            citation_str.startswith("[[")
-            or citation_str.startswith("【【")
-            or citation_str.startswith("［［")
-        ):
+        if citation_str.startswith(("[[", "【【", "［［")):
             open_bracket = citation_str[:2]
             close_bracket = citation_str[-2:]
             content = citation_str[2:-2]

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -411,10 +411,7 @@ class GoogleDriveConnector(
         parsed = urlparse(url)
         netloc = parsed.netloc.lower()
 
-        if not (
-            netloc.startswith("docs.google.com")
-            or netloc.startswith("drive.google.com")
-        ):
+        if not netloc.startswith(("docs.google.com", "drive.google.com")):
             return NormalizationResult(normalized_url=None, use_default=False)
 
         file_id = _extract_drive_file_id(parsed)

--- a/backend/onyx/db/seeding/chat_history_seeding.py
+++ b/backend/onyx/db/seeding/chat_history_seeding.py
@@ -33,13 +33,13 @@ def seed_chat_history(
     """
     with get_session_with_current_tenant() as db_session:
         logger.info("Seeding %s sessions.", num_sessions)
-        for y in range(0, num_sessions):
+        for y in range(num_sessions):
             create_chat_session(db_session, f"pytest_session_{y}", user_id, persona_id)
 
         # randomize all session times
         logger.info("Seeding %s messages per session.", num_messages)
         rows = db_session.query(ChatSession).all()
-        for x in range(0, len(rows)):
+        for x in range(len(rows)):
             if x % 1024 == 0:
                 logger.info("Seeded messages for %s sessions so far.", x)
 
@@ -55,7 +55,7 @@ def seed_chat_history(
 
             current_message_type = MessageType.USER
             parent_message = root_message
-            for x in range(0, num_messages):
+            for x in range(num_messages):
                 if current_message_type == MessageType.USER:
                     msg = f"pytest_message_user_{x}"
                 else:

--- a/backend/onyx/server/features/build/webapp_proxy.py
+++ b/backend/onyx/server/features/build/webapp_proxy.py
@@ -193,8 +193,7 @@ async def _proxy_request(
         for key, value in request.headers.items()
         if not (
             (lowered := key.lower()) in EXCLUDED_REQUEST_HEADERS
-            or lowered.startswith("x-onyx-")
-            or lowered.startswith("sec-fetch-")
+            or lowered.startswith(("x-onyx-", "sec-fetch-"))
         )
     }
 

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -8,11 +8,11 @@ from onyx.connectors.models import Document, HierarchyNode, TextSection
 from onyx.db.enums import HierarchyNodeType
 from tests.daily.connectors.utils import ConnectorOutput, load_all_from_connector
 
-ALL_FILES = list(range(0, 60))
+ALL_FILES = list(range(60))
 SHARED_DRIVE_FILES = list(range(20, 25))
 
 
-ADMIN_FILE_IDS = list(range(0, 5))
+ADMIN_FILE_IDS = list(range(5))
 ADMIN_FOLDER_3_FILE_IDS = list(range(65, 70))  # This folder is shared with test_user_1
 TEST_USER_1_FILE_IDS = list(range(5, 10))
 TEST_USER_2_FILE_IDS = list(range(10, 15))
@@ -476,7 +476,7 @@ ACCESS_MAPPING: dict[str, list[int]] = {
         # This user has been given shared access to folder 3 in Admin's My Drive
         + ADMIN_FOLDER_3_FILE_IDS
         # This user has been given shared access to files 0 and 1 in Admin's My Drive
-        + list(range(0, 2))
+        + list(range(2))
     ),
     TEST_USER_2_EMAIL: (
         TEST_USER_2_FILE_IDS

--- a/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
@@ -80,7 +80,7 @@ def test_all(
         + FOLDER_1_1_FILE_IDS
         + FOLDER_1_2_FILE_IDS
         + ADMIN_FOLDER_3_FILE_IDS
-        + list(range(0, 2))
+        + list(range(2))
     )
 
     retrieved_docs = _check_for_error(output, expected_file_ids)
@@ -157,7 +157,7 @@ def test_shared_with_me_only(
     )
     output = load_connector_outputs(connector)
 
-    expected_file_ids = ADMIN_FOLDER_3_FILE_IDS + list(range(0, 2))
+    expected_file_ids = ADMIN_FOLDER_3_FILE_IDS + list(range(2))
     assert_expected_docs_in_retrieved_docs(
         retrieved_docs=output.documents,
         expected_file_ids=expected_file_ids,

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -57,8 +57,6 @@ from tests.external_dependency_unit.indexing_helpers import (
 class _MockCheckpoint(ConnectorCheckpoint):
     """Minimal checkpoint type for the mock connector."""
 
-    pass
-
 
 # Module-level config so the connector instance (constructed by the factory
 # with empty kwargs) can pick up test-specific behavior.

--- a/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
+++ b/backend/tests/unit/onyx/mcp_server/test_agent_scoped_search.py
@@ -55,8 +55,8 @@ async def stub(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_Stub, None]:
 
     def _handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
-        is_inventory = path.endswith("/manage/indexed-sources") or path.endswith(
-            "/manage/document-set"
+        is_inventory = path.endswith(
+            ("/manage/indexed-sources", "/manage/document-set")
         )
         if is_inventory and state.inventory_status is not None:
             return httpx.Response(state.inventory_status, json={"detail": "boom"})

--- a/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
+++ b/backend/tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py
@@ -499,7 +499,7 @@ def test_existing_oauth_connectors_report_manual_capability(
 def test_oauth_details_defaults_non_oauth_sources_to_manual(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(standard_oauth, "_discover_oauth_connectors", lambda: {})
+    monkeypatch.setattr(standard_oauth, "_discover_oauth_connectors", dict)
 
     details = standard_oauth.oauth_details(
         source=DocumentSource.SALESFORCE, _=cast(User, object())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,19 @@ ignore = [
     "B904", # raise-without-from-inside-except (~465 existing violations).
 ]
 # G004: f-strings in logging break Sentry's message-pattern grouping.
-select = ["ARG", "B", "C901", "E", "F", "G004", "I", "PERF", "S", "W"]
+select = [
+  "ARG",
+  "B",
+  "C901",
+  "E",
+  "F",
+  "G004",
+  "I",
+  "PERF",
+  "PIE",
+  "S",
+  "W",
+]
 
 [tool.ruff.lint.mccabe]
 # Ruff's default is 10, which flags 429 functions. 20 is a ratchet: it stops new


### PR DESCRIPTION
## Summary

Add `PIE` to the ruff `select` list in `pyproject.toml` and fix every violation it reports. `ruff check .` is clean.

The code changes are mechanical:

- **PIE810** — merge repeated `startswith`/`endswith` calls into one tuple call (`citation_utils.py`, `google_drive/connector.py`, `webapp_proxy.py`, `test_agent_scoped_search.py`).
- **PIE808** — drop the redundant `0` start argument from `range` (`chat_history_seeding.py`, google drive test consts).
- **PIE790** — remove a `pass` that follows a docstring (`test_persistent_indexing.py`).
- **PIE807** — replace `lambda: {}` with `dict` (`test_standard_connector_oauth_pkce.py`).
- **PIE800** — remove an unnecessary dict spread (`auth/users.py`).

No behavior changes.

## Test plan

- `ruff check .` — passes.
- `pre-commit run --files <changed files>` — passes, including the `ty` type check and `ruff format`.
- `pytest tests/unit/onyx/mcp_server/test_agent_scoped_search.py tests/unit/onyx/server/documents/test_standard_connector_oauth_pkce.py` — 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables ruff's PIE lint rules and fixes every violation it reports. All edits are mechanical lint fixes with no behavior changes.

**Refactors**
- Merges repeated `startswith`/`endswith` calls into tuple calls (PIE810).
- Drops redundant `0` start arguments from `range` (PIE808).
- Removes a `pass` that follows a docstring (PIE790).
- Replaces `lambda: {}` with `dict` (PIE807).
- Removes an unnecessary dict spread (PIE800).

`ruff check .` passes, and the 32 targeted unit tests pass.

<sup>Written for commit 955d5397576ce7f661a363553bcbdff8e0e9b3ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

