### PR TITLE
refactor(web): add JSON value types and typed readers

### DIFF
--- a/web/src/lib/json.test.ts
+++ b/web/src/lib/json.test.ts
@@ -1,0 +1,62 @@
+import {
+  isJsonArray,
+  isJsonObject,
+  readArray,
+  readNumber,
+  readObject,
+  readString,
+} from "@/lib/json";
+import type { JsonObject } from "@/lib/json";
+
+describe("isJsonObject", () => {
+  it("accepts plain objects only", () => {
+    expect(isJsonObject({ a: 1 })).toBe(true);
+    expect(isJsonObject([])).toBe(false);
+    expect(isJsonObject(null)).toBe(false);
+    expect(isJsonObject(undefined)).toBe(false);
+    expect(isJsonObject("text")).toBe(false);
+  });
+});
+
+describe("isJsonArray", () => {
+  it("accepts arrays only", () => {
+    expect(isJsonArray([1, "two"])).toBe(true);
+    expect(isJsonArray({ 0: 1 })).toBe(false);
+    expect(isJsonArray(null)).toBe(false);
+  });
+});
+
+describe("readers", () => {
+  const packet: JsonObject = {
+    session_id: "abc",
+    sessionId: "ignored",
+    request_id: null,
+    requestId: "req-1",
+    used_tokens: 42,
+    count: "7",
+    meta: { parent: "p" },
+    items: [1, 2],
+  };
+
+  it("uses the first key whose value is set", () => {
+    expect(readString(packet, "session_id", "sessionId")).toBe("abc");
+    expect(readString(packet, "request_id", "requestId")).toBe("req-1");
+  });
+
+  it("returns null when no key is set", () => {
+    expect(readString(packet, "missing", "also_missing")).toBeNull();
+  });
+
+  it("returns null when the first set value has a different type", () => {
+    expect(readString(packet, "used_tokens", "session_id")).toBeNull();
+    expect(readNumber(packet, "count")).toBeNull();
+    expect(readObject(packet, "items")).toBeNull();
+    expect(readArray(packet, "meta")).toBeNull();
+  });
+
+  it("reads each JSON type", () => {
+    expect(readNumber(packet, "used_tokens")).toBe(42);
+    expect(readObject(packet, "meta")).toEqual({ parent: "p" });
+    expect(readArray(packet, "items")).toEqual([1, 2]);
+  });
+});

--- a/web/src/lib/json.ts
+++ b/web/src/lib/json.ts
@@ -1,0 +1,69 @@
+// Types for data decoded from JSON, such as a `JSON.parse` result or a stream
+// packet. Narrow with the predicates and readers below instead of casting.
+
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
+
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+export function isJsonObject(
+  value: JsonValue | undefined
+): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isJsonArray(
+  value: JsonValue | undefined
+): value is JsonValue[] {
+  return Array.isArray(value);
+}
+
+// The backend sends some fields in both snake_case and camelCase, so each
+// reader takes several keys. Like `a ?? b`, a reader uses the first key whose
+// value is not null or undefined. It returns null when that value has a
+// different type.
+function firstSetValue(
+  source: JsonObject,
+  keys: string[]
+): JsonValue | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+export function readString(
+  source: JsonObject,
+  ...keys: string[]
+): string | null {
+  const value = firstSetValue(source, keys);
+  return typeof value === "string" ? value : null;
+}
+
+export function readNumber(
+  source: JsonObject,
+  ...keys: string[]
+): number | null {
+  const value = firstSetValue(source, keys);
+  return typeof value === "number" ? value : null;
+}
+
+export function readObject(
+  source: JsonObject,
+  ...keys: string[]
+): JsonObject | null {
+  const value = firstSetValue(source, keys);
+  return isJsonObject(value) ? value : null;
+}
+
+export function readArray(
+  source: JsonObject,
+  ...keys: string[]
+): JsonValue[] | null {
+  const value = firstSetValue(source, keys);
+  return isJsonArray(value) ? value : null;
+}


### PR DESCRIPTION
## Description

This PR is the first in a stack that raises TypeScript type coverage in `web/` and removes items from `web/.type-coverage-baseline.yaml` (gate added in #14628).

Add `web/src/lib/json.ts`:
- `JsonValue`, `JsonObject` and `JsonPrimitive` types for data decoded from JSON.
- The `isJsonObject` and `isJsonArray` predicates.
- The `readString`, `readNumber`, `readObject` and `readArray` readers. A reader takes one or more keys, because the backend sends some fields in both snake_case and camelCase. It uses the first key whose value is set, and returns `null` when that value has a different type.

Nothing imports the module yet. Later PRs in the stack use it to replace casts on stream packets and `JSON.parse` results.

## How Has This Been Tested?

- New unit tests in `web/src/lib/json.test.ts`.
- `ods type-coverage typescript --check` passes.
- `prek` (oxlint and oxfmt) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `web/src/lib/json.ts` with JSON value types and typed readers so decoded JSON can be narrowed without casts. Nothing imports the module yet; later PRs in the stack use it to raise TypeScript coverage in `web/` and remove items from `web/.type-coverage-baseline.yaml`.

- Exports `JsonValue`, `JsonObject`, `JsonPrimitive` plus the `isJsonObject` and `isJsonArray` predicates.
- Readers `readString`, `readNumber`, `readObject`, `readArray` accept multiple keys because the backend sends some fields in both snake_case and camelCase; they use the first key whose value is set and return `null` when that value has a different type.
- Adds unit tests in `web/src/lib/json.test.ts`.

<sup>Written for commit 5ca80b4a29d61589c78f9c698391b7c4e8e58e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

