### PR TITLE
chore(web): type JSON responses in src/lib services

### DIFF
--- a/web/.type-coverage-baseline.yaml
+++ b/web/.type-coverage-baseline.yaml
@@ -8,7 +8,7 @@
 # `ods type-coverage typescript --update`.
 #
 # Generated file: do not edit by hand.
-total: 98.4
+total: 98.5
 packages:
   .: 100
   src: 99.4
@@ -59,41 +59,41 @@ packages:
   src/layouts: 100
   src/layouts/chromes: 99.8
   src/layouts/craft: 96.1
-  src/lib: 98.4
+  src/lib: 98.8
   src/lib/agents: 99.2
   src/lib/analytics: 99.4
   src/lib/app: 100
-  src/lib/auth: 95.4
+  src/lib/auth: 98
   src/lib/banner: 99.3
-  src/lib/billing: 93.8
+  src/lib/billing: 100
   src/lib/build: 100
-  src/lib/chat: 97.9
+  src/lib/chat: 98.5
   src/lib/connectors: 96.4
   src/lib/constants: 100
-  src/lib/credentials: 96.9
+  src/lib/credentials: 97.2
   src/lib/extension: 100
   src/lib/externalApps: 100
   src/lib/headers: 100
-  src/lib/hierarchy: 96.6
+  src/lib/hierarchy: 100
   src/lib/hooks: 95.7
-  src/lib/indexing: 98.3
-  src/lib/languageModels: 96.8
+  src/lib/indexing: 99.4
+  src/lib/languageModels: 98.8
   src/lib/multiModel: 100
-  src/lib/notifications: 97.3
-  src/lib/oauth: 84.8
+  src/lib/notifications: 99.3
+  src/lib/oauth: 100
   src/lib/permissions: 100
   src/lib/position: 100
-  src/lib/projects: 99.3
-  src/lib/search: 97.2
+  src/lib/projects: 99.6
+  src/lib/search: 99.1
   src/lib/searchFilters: 95.3
   src/lib/settings: 96.6
   src/lib/sidebar: 100
-  src/lib/skills: 97.3
+  src/lib/skills: 97.4
   src/lib/sso: 99.2
-  src/lib/tools: 97.4
+  src/lib/tools: 97.5
   src/lib/tracing: 96.9
   src/lib/usage: 97.9
-  src/lib/users: 97.8
+  src/lib/users: 99
   src/lib/voice: 98.3
   src/lib/webSearch: 97.3
   src/providers: 99.4
@@ -128,5 +128,5 @@ packages:
   src/sections/skills: 99.8
   src/sections/usage: 99.6
   src/views: 99
-  src/views/admin: 99
+  src/views/admin: 99.1
   types: 100

--- a/web/src/lib/auth/components.tsx
+++ b/web/src/lib/auth/components.tsx
@@ -8,7 +8,7 @@ import { getExtensionContext } from "@/lib/extension/utils";
 import { Modal } from "@opal/components";
 import { Button, Text } from "@opal/components";
 import { SvgLogOut, SvgCheckCircle, SvgXCircle } from "@opal/icons";
-import { SessionEndReason } from "@/lib/auth/types";
+import { SessionEndReason, type FastApiUsersErrorBody } from "@/lib/auth/types";
 import { SvgGoogle } from "@opal/logos";
 import { useCaptcha } from "@/lib/hooks/useCaptcha";
 import { verifyCaptchaForOAuth } from "@/lib/auth/svc";
@@ -363,7 +363,9 @@ export function EmailPasswordForm({
       );
 
       if (!response.ok) {
-        const errorBody: any = await response.json().catch(() => ({}));
+        const errorBody: FastApiUsersErrorBody = await response
+          .json()
+          .catch(() => ({}));
         const errorDetail = errorBody.detail;
         let errorMsg = tCommon("errors.unknown.message");
         if (response.status === 429) {
@@ -405,7 +407,9 @@ export function EmailPasswordForm({
         validatedNextUrl ??
         `/app${isSignup && !isJoin ? "?new_team=true" : ""}`;
     } else {
-      const errorBody: any = await loginResponse.json().catch(() => ({}));
+      const errorBody: FastApiUsersErrorBody = await loginResponse
+        .json()
+        .catch(() => ({}));
       const errorDetail = errorBody.detail;
       let errorMsg = tCommon("errors.unknown.message");
       if (loginResponse.status === 429) {

--- a/web/src/lib/auth/svc.ts
+++ b/web/src/lib/auth/svc.ts
@@ -1,5 +1,6 @@
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { AuthTypeMetadata, type SSOProviderType } from "@/lib/auth/types";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 interface AuthTypeAPIResponse {
   multi_tenant: boolean;
@@ -62,7 +63,7 @@ export async function forgotPassword(email: string): Promise<void> {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch((e) => {
+    const error: ErrorResponseBody = await response.json().catch((e) => {
       console.warn("forgotPassword: failed to parse error response", e);
       return {};
     });
@@ -104,7 +105,7 @@ export async function requestEmailVerification(email: string): Promise<void> {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch((e) => {
+    const error: ErrorResponseBody = await response.json().catch((e) => {
       console.warn(
         "requestEmailVerification: failed to parse error response",
         e
@@ -142,7 +143,7 @@ export async function verifyCaptchaForOAuth(token: string): Promise<void> {
   });
 
   if (!response.ok) {
-    const body = await response.json().catch((e) => {
+    const body: ErrorResponseBody = await response.json().catch((e) => {
       console.warn("verifyCaptchaForOAuth: failed to parse error response", e);
       return {};
     });
@@ -167,7 +168,7 @@ export async function impersonateUser(
   });
 
   if (!response.ok) {
-    const error = await response.json().catch((e) => {
+    const error: ErrorResponseBody = await response.json().catch((e) => {
       console.warn("impersonateUser: failed to parse error response", e);
       return {};
     });

--- a/web/src/lib/auth/svcSS.ts
+++ b/web/src/lib/auth/svcSS.ts
@@ -1,3 +1,4 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import "server-only";
 
 import { buildUrl, UrlBuilder } from "@/lib/utilsSS";
@@ -91,7 +92,7 @@ export async function authErrorRedirect(
 ): Promise<NextResponse> {
   const errorUrl = new URL("/auth/error", getDomain(request));
   try {
-    const body = await response.json();
+    const body: ErrorResponseBody = await response.json();
     const detail = body?.detail;
     if (typeof detail === "string" && detail) {
       errorUrl.searchParams.set("error", detail);

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -6,6 +6,13 @@ export enum SessionEndReason {
   UNRECOGNIZED = "SESSION_UNRECOGNIZED",
 }
 
+// Error body of the fastapi-users routes (`fastapi_users.router.common.ErrorModel`).
+// The register and reset-password routes send an object when the password is
+// invalid.
+export interface FastApiUsersErrorBody {
+  detail?: string | { code: string; reason: string };
+}
+
 export type SSOProviderType = "GOOGLE_OAUTH" | "OIDC" | "SAML";
 
 export interface SSOProviderOption {

--- a/web/src/lib/billing/svc.ts
+++ b/web/src/lib/billing/svc.ts
@@ -15,6 +15,7 @@
  */
 
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import {
   CreateCheckoutSessionRequest,
   CreateCheckoutSessionResponse,
@@ -38,7 +39,7 @@ async function billingPost<T>(endpoint: string, body?: unknown): Promise<T> {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
+    const error: ErrorResponseBody = await response.json().catch(() => ({}));
     throw new Error(error.detail || "Billing request failed");
   }
 
@@ -80,7 +81,7 @@ export async function endTrial(): Promise<EndTrialResponse> {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
+    const error: ErrorResponseBody = await response.json().catch(() => ({}));
     const detail = error.detail || "Failed to end trial";
     if (response.status === 402) {
       throw new PaymentMethodRequiredError(detail);
@@ -123,7 +124,7 @@ async function selfHostedPost<T>(endpoint: string): Promise<T> {
   }
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
+    const error: ErrorResponseBody = await response.json().catch(() => ({}));
     throw new Error(error.detail || "License request failed");
   }
 
@@ -171,7 +172,7 @@ export async function uploadLicense(
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
+    const error: ErrorResponseBody = await response.json().catch(() => ({}));
     throw new Error(error.detail || "License upload failed");
   }
 

--- a/web/src/lib/ccPair.ts
+++ b/web/src/lib/ccPair.ts
@@ -1,3 +1,4 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
 import { toast } from "@opal/layouts";
 
@@ -19,7 +20,7 @@ export async function setCCPairStatus(
     );
 
     if (!response.ok) {
-      const { detail } = await response.json();
+      const { detail }: ErrorResponseBody = await response.json();
       toast.error(`Failed to update connector status - ${detail}`);
       return;
     }

--- a/web/src/lib/chat/exportChatSession.ts
+++ b/web/src/lib/chat/exportChatSession.ts
@@ -64,7 +64,7 @@ export async function exportChatSession(
   if (!response.ok) {
     throw new Error(`Failed to fetch chat session: ${response.status}`);
   }
-  const session = (await response.json()) as BackendChatSession;
+  const session: BackendChatSession = await response.json();
 
   const title = chatName.trim() || UNNAMED_CHAT;
   const base = sanitizeFilename(chatName);

--- a/web/src/lib/chat/fetchBackendChatSessionSS.ts
+++ b/web/src/lib/chat/fetchBackendChatSessionSS.ts
@@ -6,5 +6,5 @@ export async function fetchBackendChatSessionSS(
 ): Promise<BackendChatSession | null> {
   const response = await fetchSS(`/chat/get-chat-session/${chatId}`);
   if (!response.ok) return null;
-  return (await response.json()) as BackendChatSession;
+  return await response.json();
 }

--- a/web/src/lib/connector.ts
+++ b/web/src/lib/connector.ts
@@ -130,7 +130,7 @@ export async function deleteConnectorIfExistsAndIsUnlinked({
 }): Promise<string | null> {
   const connectorsResponse = await fetch("/api/manage/connector");
   if (connectorsResponse.ok) {
-    const connectors = (await connectorsResponse.json()) as Connector<any>[];
+    const connectors: Connector<any>[] = await connectorsResponse.json();
     const matchingConnectors = connectors.filter(
       (connector) =>
         connector.source === source && (!name || connector.name === name)

--- a/web/src/lib/connectors/oauth.ts
+++ b/web/src/lib/connectors/oauth.ts
@@ -28,7 +28,7 @@ export async function getConnectorOauthRedirectUrl(
       throw new Error(await parseErrorDetail(response, OAUTH_REDIRECT_ERROR));
     }
 
-    const data = (await response.json()) as OAuthRedirectResponse;
+    const data: OAuthRedirectResponse = await response.json();
     return data.redirect_url;
   } catch (error) {
     console.error(`${OAUTH_REDIRECT_LOG_ERROR} for ${connector}:`, error);

--- a/web/src/lib/credentials/components/CredentialSection.tsx
+++ b/web/src/lib/credentials/components/CredentialSection.tsx
@@ -3,7 +3,7 @@
 import { AccessType, ValidSources } from "@/lib/types";
 import { useTranslations } from "next-intl";
 import useSWR, { mutate } from "swr";
-import { errorHandlingFetcher } from "@/lib/fetcher";
+import { errorHandlingFetcher, type ErrorResponseBody } from "@/lib/fetcher";
 import { useState } from "react";
 import {
   deleteCredential,
@@ -133,7 +133,7 @@ export default function CredentialSection({
 
       toast.success(t("credentials.swap.success.toast"));
     } else {
-      const errorData = await response.json();
+      const errorData: ErrorResponseBody = await response.json();
       toast.error(
         t("credentials.swap.error.toast", {
           detail:

--- a/web/src/lib/documentDeletion.ts
+++ b/web/src/lib/documentDeletion.ts
@@ -4,7 +4,7 @@ import { DeletionAttemptSnapshot } from "./types";
 export async function scheduleDeletionJobForConnector(
   connectorId: number,
   credentialId: number
-) {
+): Promise<string | null> {
   // Will schedule a background job which will:
   // 1. Remove all documents indexed by the connector / credential pair
   // 2. Remove the connector (if this is the only pair using the connector)

--- a/web/src/lib/fetcher.ts
+++ b/web/src/lib/fetcher.ts
@@ -1,7 +1,16 @@
+/** JSON body of a backend error response. `OnyxError` and the request
+ * validation handler both send `error_code` and a string `detail`; the
+ * validation and `ValueError` handlers also send `message`. */
+export interface ErrorResponseBody {
+  detail?: string;
+  error_code?: string;
+  message?: string;
+}
+
 export class FetchError extends Error {
   status: number;
-  info: any;
-  constructor(message: string, status: number, info: any) {
+  info: ErrorResponseBody | null;
+  constructor(message: string, status: number, info: ErrorResponseBody | null) {
     super(message);
     this.status = status;
     this.info = info;
@@ -9,7 +18,7 @@ export class FetchError extends Error {
 }
 
 export class RedirectError extends FetchError {
-  constructor(message: string, status: number, info: any) {
+  constructor(message: string, status: number, info: ErrorResponseBody | null) {
     super(message, status, info);
   }
 }

--- a/web/src/lib/fileConnector.ts
+++ b/web/src/lib/fileConnector.ts
@@ -1,3 +1,5 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
+
 export interface ConnectorFileInfo {
   file_id: string;
   file_name: string;
@@ -39,7 +41,7 @@ export async function updateConnectorFiles(
   );
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(
       `Failed to update connector files (${response.status}): ${
         error.detail || "Unknown error"

--- a/web/src/lib/gmail.ts
+++ b/web/src/lib/gmail.ts
@@ -25,8 +25,7 @@ export const setupGmailOAuth = async ({
       `Failed to create credential - ${credentialCreationResponse.status}`,
     ];
   }
-  const credential =
-    (await credentialCreationResponse.json()) as Credential<{}>;
+  const credential: Credential<{}> = await credentialCreationResponse.json();
 
   const authorizationUrlResponse = await fetch(
     `/api/manage/connector/gmail/authorize/${credential.id}`
@@ -37,9 +36,8 @@ export const setupGmailOAuth = async ({
       `Failed to create credential - ${authorizationUrlResponse.status}`,
     ];
   }
-  const authorizationUrlJson = (await authorizationUrlResponse.json()) as {
-    auth_url: string;
-  };
+  const authorizationUrlJson: { auth_url: string } =
+    await authorizationUrlResponse.json();
 
   return [authorizationUrlJson.auth_url, ""];
 };

--- a/web/src/lib/googleDrive.ts
+++ b/web/src/lib/googleDrive.ts
@@ -29,8 +29,7 @@ export const setupGoogleDriveOAuth = async ({
       `Failed to create credential - ${credentialCreationResponse.status}`,
     ];
   }
-  const credential =
-    (await credentialCreationResponse.json()) as Credential<{}>;
+  const credential: Credential<{}> = await credentialCreationResponse.json();
 
   const authorizationUrlResponse = await fetch(
     `/api/manage/connector/google-drive/authorize/${credential.id}`
@@ -42,9 +41,8 @@ export const setupGoogleDriveOAuth = async ({
     ];
   }
 
-  const authorizationUrlJson = (await authorizationUrlResponse.json()) as {
-    auth_url: string;
-  };
+  const authorizationUrlJson: { auth_url: string } =
+    await authorizationUrlResponse.json();
 
   return [authorizationUrlJson.auth_url, ""];
 };

--- a/web/src/lib/hierarchy/svc.ts
+++ b/web/src/lib/hierarchy/svc.ts
@@ -1,3 +1,4 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { ValidSources } from "@/lib/types";
 import {
   HierarchyNodesResponse,
@@ -13,7 +14,7 @@ async function extractErrorDetail(
   fallback: string
 ): Promise<string> {
   try {
-    const body = await response.json();
+    const body: ErrorResponseBody = await response.json();
     if (body.detail) return body.detail;
   } catch {
     // JSON parsing failed — fall through to fallback

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -1,3 +1,4 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import type { Settings } from "@/lib/settings/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
@@ -78,7 +79,7 @@ export async function connectEmbeddingProvider({
     });
 
     if (!testResponse.ok) {
-      const err = await testResponse.json();
+      const err: ErrorResponseBody = await testResponse.json();
       throw new Error(err.detail ?? "Embedding test failed");
     }
   }
@@ -103,7 +104,7 @@ export async function connectEmbeddingProvider({
   });
 
   if (!saveResponse.ok) {
-    const err = await saveResponse.json();
+    const err: ErrorResponseBody = await saveResponse.json();
     throw new Error(err.detail ?? "Failed to save provider");
   }
 }
@@ -121,7 +122,7 @@ export async function disconnectEmbeddingProvider(
   );
 
   if (!response.ok) {
-    const err = await response.json();
+    const err: ErrorResponseBody = await response.json();
     throw new Error(err.detail ?? "Failed to disconnect provider");
   }
 }

--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 import type { ScopedMutator } from "swr";
-import { errorHandlingFetcher } from "@/lib/fetcher";
+import { errorHandlingFetcher, type ErrorResponseBody } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 /**
@@ -106,7 +106,7 @@ export async function refreshCostOverrides(
 /** Pull the backend's `detail`/`error_code`, falling back to the status text. */
 async function extractError(response: Response): Promise<string> {
   try {
-    const data = await response.json();
+    const data: ErrorResponseBody = await response.json();
     return data.detail || data.error_code || response.statusText;
   } catch {
     return response.statusText;

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -12,6 +12,7 @@
  */
 
 import { SWR_KEYS } from "@/lib/swr-keys";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import {
   LLMProviderName,
   type ModelConfiguration,
@@ -189,7 +190,7 @@ export const fetchBedrockModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
@@ -244,7 +245,7 @@ export const fetchOllamaModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
@@ -303,7 +304,7 @@ export const fetchOpenRouterModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch (jsonError) {
         console.warn(
@@ -363,7 +364,7 @@ export const fetchLMStudioModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch (jsonError) {
         console.warn(
@@ -422,7 +423,7 @@ export const fetchBifrostModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch (jsonError) {
         console.warn(
@@ -484,7 +485,7 @@ export const fetchOpenAICompatibleModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
@@ -544,7 +545,7 @@ export const fetchLiteLLMProxyModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch {
         // ignore JSON parsing errors
@@ -691,7 +692,7 @@ export const fetchNebiusTokenfactoryModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch (jsonError) {
         console.warn(
@@ -751,7 +752,7 @@ export const fetchPortkeyModels = async (
     if (!response.ok) {
       let errorMessage = "Failed to fetch models";
       try {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         errorMessage = errorData.detail || errorData.message || errorMessage;
       } catch (jsonError) {
         console.warn(

--- a/web/src/lib/notifications/api.ts
+++ b/web/src/lib/notifications/api.ts
@@ -1,5 +1,6 @@
 import { mutate } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 /** Revalidate every notifications cache: the mixed feed (useSWRInfinite keys
  * serialize with a $inf$ prefix, so match by inclusion), the by-type variants,
@@ -19,7 +20,7 @@ async function handleNotificationMutation(
     return;
   }
 
-  const error = await response.json().catch(() => ({}));
+  const error: ErrorResponseBody = await response.json().catch(() => ({}));
   throw new Error(error.detail || fallbackMessage);
 }
 

--- a/web/src/lib/oauth/api.ts
+++ b/web/src/lib/oauth/api.ts
@@ -1,3 +1,4 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import {
   OAuthConfig,
   OAuthConfigCreate,
@@ -16,7 +17,9 @@ export async function createOAuthConfig(
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await response
+      .json()
+      .catch(() => ({}));
     throw new Error(
       errorData.detail ||
         `Failed to create OAuth config: ${response.statusText}`
@@ -30,7 +33,9 @@ export async function getOAuthConfig(id: number): Promise<OAuthConfig> {
   const response = await fetch(`/api/admin/oauth-config/${id}`);
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await response
+      .json()
+      .catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to fetch OAuth config: ${response.statusText}`
     );
@@ -50,7 +55,9 @@ export async function updateOAuthConfig(
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await response
+      .json()
+      .catch(() => ({}));
     throw new Error(
       errorData.detail ||
         `Failed to update OAuth config: ${response.statusText}`
@@ -61,6 +68,12 @@ export async function updateOAuthConfig(
 }
 
 // User OAuth Flow
+
+// Mirrors `OAuthInitiateResponse` in backend/onyx/server/features/oauth_config/models.py.
+interface OAuthInitiateResponse {
+  authorization_url: string;
+  state: string;
+}
 
 export async function initiateOAuthFlow(
   oauthConfigId: number,
@@ -76,14 +89,16 @@ export async function initiateOAuthFlow(
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await response
+      .json()
+      .catch(() => ({}));
     throw new Error(
       errorData.detail ||
         `Failed to initiate OAuth flow: ${response.statusText}`
     );
   }
 
-  const data = await response.json();
+  const data: OAuthInitiateResponse = await response.json();
   // Redirect to authorization URL
   window.location.href = data.authorization_url;
 }

--- a/web/src/lib/oauth_utils.ts
+++ b/web/src/lib/oauth_utils.ts
@@ -38,7 +38,7 @@ export async function prepareOAuthAuthorizationRequest(
   }
 
   // Parse the JSON response
-  const data = (await response.json()) as OAuthPrepareAuthorizationResponse;
+  const data: OAuthPrepareAuthorizationResponse = await response.json();
   return data;
 }
 
@@ -148,7 +148,7 @@ export async function handleOAuthSlackAuthorizationResponse(
   }
 
   // Parse the JSON response
-  const data = (await response.json()) as OAuthSlackCallbackResponse;
+  const data: OAuthSlackCallbackResponse = await response.json();
   return data;
 }
 
@@ -186,7 +186,7 @@ export async function handleOAuthGoogleDriveAuthorizationResponse(
   }
 
   // Parse the JSON response
-  const data = (await response.json()) as OAuthBaseCallbackResponse;
+  const data: OAuthBaseCallbackResponse = await response.json();
   return data;
 }
 
@@ -226,7 +226,7 @@ export async function handleOAuthConfluenceAuthorizationResponse(
   }
 
   // Parse the JSON response
-  const data = (await response.json()) as OAuthBaseCallbackResponse;
+  const data: OAuthBaseCallbackResponse = await response.json();
   return data;
 }
 
@@ -275,8 +275,8 @@ export async function handleOAuthConfluencePrepareFinalization(
   }
 
   // Parse the JSON response
-  const data =
-    (await response.json()) as OAuthConfluencePrepareFinalizationResponse;
+  const data: OAuthConfluencePrepareFinalizationResponse =
+    await response.json();
   return data;
 }
 
@@ -317,6 +317,6 @@ export async function handleOAuthConfluenceFinalize(
   }
 
   // Parse the JSON response
-  const data = (await response.json()) as OAuthConfluenceFinalizeResponse;
+  const data: OAuthConfluenceFinalizeResponse = await response.json();
   return data;
 }

--- a/web/src/lib/projects/svc.ts
+++ b/web/src/lib/projects/svc.ts
@@ -122,7 +122,7 @@ export async function getProjectInstructions(
   if (!response.ok) {
     handleRequestError("Fetch project instructions", response);
   }
-  const data = (await response.json()) as { instructions: string | null };
+  const data: { instructions: string | null } = await response.json();
   return data.instructions ?? null;
 }
 
@@ -138,7 +138,7 @@ export async function upsertProjectInstructions(
   if (!response.ok) {
     handleRequestError("Update project instructions", response);
   }
-  const data = (await response.json()) as { instructions: string | null };
+  const data: { instructions: string | null } = await response.json();
   return data.instructions ?? null;
 }
 
@@ -196,7 +196,7 @@ export async function deleteUserFile(
   if (!response.ok) {
     handleRequestError("Delete file", response);
   }
-  return (await response.json()) as UserFileDeleteResult;
+  return await response.json();
 }
 
 export async function getUserFileStatuses(
@@ -224,7 +224,7 @@ export async function getSessionProjectTokenCount(
   if (!response.ok) {
     return 0;
   }
-  const data = (await response.json()) as { total_tokens: number };
+  const data: { total_tokens: number } = await response.json();
   return data.total_tokens ?? 0;
 }
 
@@ -247,7 +247,7 @@ export async function getProjectTokenCount(projectId: number): Promise<number> {
   if (!response.ok) {
     return 0;
   }
-  const data = (await response.json()) as { total_tokens: number };
+  const data: { total_tokens: number } = await response.json();
   return data.total_tokens ?? 0;
 }
 
@@ -260,8 +260,9 @@ export async function getMaxSelectedDocumentTokens(
   if (!response.ok) {
     return null;
   }
-  const json = await response.json();
-  return (json?.max_tokens as number) ?? null;
+  // Mirrors `MaxSelectedDocumentTokens` in chat_backend.py.
+  const json: { max_tokens: number } = await response.json();
+  return json?.max_tokens ?? null;
 }
 
 export async function moveChatSession(

--- a/web/src/lib/search/streamingUtils.ts
+++ b/web/src/lib/search/streamingUtils.ts
@@ -32,7 +32,7 @@ export async function* handleSSEStream<T extends PacketType>(
         if (line.trim() === "") continue;
 
         try {
-          const data = JSON.parse(line) as T;
+          const data: T = JSON.parse(line);
           yield data;
         } catch (error) {
           console.error("Error parsing SSE data:", error);
@@ -42,7 +42,7 @@ export async function* handleSSEStream<T extends PacketType>(
           if (jsonObjects) {
             for (const jsonObj of jsonObjects) {
               try {
-                const data = JSON.parse(jsonObj) as T;
+                const data: T = JSON.parse(jsonObj);
                 yield data;
               } catch (innerError) {
                 console.error("Error parsing extracted JSON:", innerError);
@@ -56,7 +56,7 @@ export async function* handleSSEStream<T extends PacketType>(
     // Process any remaining data in the buffer
     if (buffer.trim() !== "") {
       try {
-        const data = JSON.parse(buffer) as T;
+        const data: T = JSON.parse(buffer);
         yield data;
       } catch (error) {
         console.error("Error parsing remaining buffer:", error);

--- a/web/src/lib/search/utilsSS.ts
+++ b/web/src/lib/search/utilsSS.ts
@@ -8,18 +8,18 @@ export async function fetchValidFilterInfo() {
     fetchSS("/manage/document-set"),
   ]);
 
-  let connectors = [] as Connector<any>[];
+  let connectors: Connector<any>[] = [];
   if (connectorsResponse.ok) {
-    connectors = (await connectorsResponse.json()) as Connector<any>[];
+    connectors = await connectorsResponse.json();
   } else {
     console.log(
       `Failed to fetch connectors - ${connectorsResponse.status} - ${connectorsResponse.statusText}`
     );
   }
 
-  let documentSets = [] as DocumentSetSummary[];
+  let documentSets: DocumentSetSummary[] = [];
   if (documentSetResponse.ok) {
-    documentSets = (await documentSetResponse.json()) as DocumentSetSummary[];
+    documentSets = await documentSetResponse.json();
   } else {
     console.log(
       `Failed to fetch document sets - ${documentSetResponse.status} - ${documentSetResponse.statusText}`

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -39,7 +39,7 @@ async function handle<T>(res: Response): Promise<T> {
   if (res.status === 204) {
     return undefined as T;
   }
-  return (await res.json()) as T;
+  return await res.json();
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/streamingTTS.ts
+++ b/web/src/lib/streamingTTS.ts
@@ -3,6 +3,7 @@
  * Plays audio chunks as they arrive for smooth, low-latency playback.
  */
 
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { INTERNAL_URL, IS_DEV } from "@/lib/constants";
 
 /**
@@ -137,7 +138,7 @@ export class HTTPStreamingTTSPlayer {
       if (!response.ok) {
         let message = `TTS request failed (${response.status})`;
         try {
-          const errorJson = await response.json();
+          const errorJson: ErrorResponseBody = await response.json();
           if (errorJson.detail) message = errorJson.detail;
         } catch {
           // response wasn't JSON — use status text
@@ -259,7 +260,7 @@ export class HTTPStreamingTTSPlayer {
     if (!response.ok) {
       let message = `TTS request failed (${response.status})`;
       try {
-        const errorJson = await response.json();
+        const errorJson: ErrorResponseBody = await response.json();
         if (errorJson.detail) message = errorJson.detail;
       } catch {
         // response wasn't JSON — use status text
@@ -394,7 +395,8 @@ export class WebSocketStreamingTTSPlayer {
     if (!tokenResponse.ok) {
       throw new Error("Failed to get WebSocket authentication token");
     }
-    const { token } = await tokenResponse.json();
+    // Mirrors `WSTokenResponse` in backend/onyx/server/manage/voice/user_api.py.
+    const { token }: { token: string } = await tokenResponse.json();
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const host = IS_DEV ? new URL(INTERNAL_URL).host : window.location.host;

--- a/web/src/lib/tools/svc.ts
+++ b/web/src/lib/tools/svc.ts
@@ -359,7 +359,8 @@ export async function validateToolDefinition(toolData: {
       return { data: null, error: errorDetail };
     }
 
-    const responseJson = await response.json();
+    // Mirrors `ValidateToolResponse` in backend/onyx/server/features/tool/api.py.
+    const responseJson: { methods: MethodSpec[] } = await response.json();
     return { data: responseJson.methods, error: null };
   } catch (error) {
     console.error("Error validating tool:", error);

--- a/web/src/lib/users/svc.ts
+++ b/web/src/lib/users/svc.ts
@@ -14,7 +14,7 @@ export async function getCurrentUser(): Promise<User | null> {
   if (!response.ok) {
     return null;
   }
-  const user = await response.json();
+  const user: User = await response.json();
   return user;
 }
 

--- a/web/src/lib/users/svcSS.ts
+++ b/web/src/lib/users/svcSS.ts
@@ -16,7 +16,7 @@ export async function getCurrentUserSS(): Promise<User | null> {
 
     if (!response.ok) return null;
 
-    const user = await response.json();
+    const user: User = await response.json();
     return user;
   } catch (e) {
     console.log(`Error fetching user: ${e}`);

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -10,7 +10,7 @@ export const getBackendVersion = async (): Promise<string | null> => {
     }
 
     const data: { backend_version: string } = await res.json();
-    return data.backend_version as string;
+    return data.backend_version;
   } catch (e) {
     console.log(`Error fetching backend version info: ${e}`);
     return null;


### PR DESCRIPTION
## Description

This PR is part of a stack that raises TypeScript type coverage in `web/`. It is on top of #14648.

`response.json()` returns `Promise<any>`. That `any` spreads into each binding without an annotation, each field read, and each caller of a service function without a return type. This PR types the JSON responses in the `src/lib/**` services:
- Annotated bindings (`const data: Foo = await res.json()`) and return types (`Promise<Foo>`).
- Removed casts on JSON reads: `(await res.json()) as Foo` becomes an annotated binding.
- New `ErrorResponseBody` in `fetcher.ts` for backend error bodies. `FetchError.info` changes from `any` to `ErrorResponseBody | null`. The backend always sends `detail` as a string: `OnyxError` does, and the validation handler in `onyx/main.py` replaces the FastAPI error array with a string.
- New `FastApiUsersErrorBody` in `auth/types.ts` for the fastapi-users login and signup errors, where `detail` can be an object.
- New `OAuthInitiateResponse` type, and inline response types in `tools/svc.ts`, `projects/svc.ts` and `streamingTTS.ts`. Each one matches its backend model (`OAuthInitiateResponse`, `ValidateToolResponse`, `MaxSelectedDocumentTokens` and `WSTokenResponse`).

The emitted JavaScript does not change. The change removes 222 uncovered items and raises 17 floors in the baseline. For example, `src/lib/oauth` goes from 84.8 to 100 and `src/lib/billing` from 93.8 to 100. No floor goes down.

### Not in this PR
- Sites that need a runtime change, such as inline `(await res.json()).detail` reads and `JSON.parse` narrowing. A later PR in the stack changes them.
- `parseErrorDetail` and its copies. A later PR merges them.

### Possible bug found
`handleFederatedOAuthCallback` in `src/lib/oauth_utils.ts` reads `result.success` and `result.message`. The backend `OAuthCallbackResult` (`federated/models.py`) has neither field. This PR does not change it.

## How Has This Been Tested?

- For each changed file, the JavaScript emitted from the base and from this branch (types and comments removed) is the same.
- `ods type-coverage typescript --check` passes, and the per-file report shows no file with more uncovered items.
- Jest suites for `auth`, `skills`, `projects`, `languageModels`, `tools`, `billing`, `oauth`, `search`, `chat`, `indexing`, `credentials` and `fetcher` pass (163 tests).
- `prek` (oxlint and oxfmt) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types the `response.json()` results in `web/src/lib` services so implicit `any` no longer spreads through the codebase. No emitted JavaScript changes.

- Adds `ErrorResponseBody` in `fetcher.ts` and changes `FetchError.info` from `any` to `ErrorResponseBody | null`.
- Adds `FastApiUsersErrorBody` for fastapi-users login and signup errors, where `detail` can be a string or an object.
- Adds response types matching backend models for OAuth initiate, tool validation, token counts, and WebSocket token endpoints.
- Replaces `as` casts on JSON reads with annotated bindings and return types.
- Raises `src/lib` type coverage from 98.4% to 98.8%; removes 222 uncovered items and no floor goes down.

**Migration**
- `FetchError.info` is now `ErrorResponseBody | null`; callers that read fields not in that type will need to narrow or update.

<sup>Written for commit 20ae6235d6a3287de085f3b78581cd80afc9ba2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

