### PR TITLE
chore(web): type JSON responses in admin pages

### DIFF
--- a/web/.type-coverage-baseline.yaml
+++ b/web/.type-coverage-baseline.yaml
@@ -8,12 +8,12 @@
 # `ods type-coverage typescript --update`.
 #
 # Generated file: do not edit by hand.
-total: 98.5
+total: 98.6
 packages:
   .: 100
   src: 99.4
   src/app: 99.5
-  src/app/admin: 96.3
+  src/app/admin: 96.5
   src/app/anonymous: 100
   src/app/api: 98.4
   src/app/app: 98.2
@@ -128,5 +128,5 @@ packages:
   src/sections/skills: 99.8
   src/sections/usage: 99.6
   src/views: 99
-  src/views/admin: 99.1
+  src/views/admin: 99.3
   types: 100

--- a/web/src/app/admin/connectors/[connector]/pages/utils/files.ts
+++ b/web/src/app/admin/connectors/[connector]/pages/utils/files.ts
@@ -1,6 +1,8 @@
 import { toast } from "@opal/layouts";
 import { createConnector, runConnector } from "@/lib/connector";
 import { createCredential, linkCredential } from "@/lib/credential";
+import type { ErrorResponseBody } from "@/lib/fetcher";
+import type { FileUploadResponse } from "@/lib/fileConnector";
 import { FileConfig } from "@/lib/connectors/connectors";
 import { AccessType, ValidSources } from "@/lib/types";
 
@@ -20,7 +22,8 @@ export const submitFiles = async (
     method: "POST",
     body: formData,
   });
-  const responseJson = await response.json();
+  const responseJson: Partial<FileUploadResponse> & ErrorResponseBody =
+    await response.json();
   if (!response.ok) {
     toast.error(`Unable to upload files - ${responseJson.detail}`);
     return;
@@ -77,7 +80,8 @@ export const submitFiles = async (
     groups
   );
   if (!credentialResponse.ok) {
-    const credentialResponseJson = await credentialResponse.json();
+    const credentialResponseJson: ErrorResponseBody =
+      await credentialResponse.json();
     toast.error(
       `Unable to link connector to credential - ${credentialResponseJson.detail}`
     );

--- a/web/src/app/admin/connectors/[connector]/pages/utils/google_site.ts
+++ b/web/src/app/admin/connectors/[connector]/pages/utils/google_site.ts
@@ -1,6 +1,8 @@
 import { toast } from "@opal/layouts";
 import { createConnector, runConnector } from "@/lib/connector";
 import { linkCredential } from "@/lib/credential";
+import type { ErrorResponseBody } from "@/lib/fetcher";
+import type { FileUploadResponse } from "@/lib/fileConnector";
 import { GoogleSitesConfig } from "@/lib/connectors/connectors";
 import { ValidSources } from "@/lib/types";
 
@@ -28,13 +30,14 @@ export const submitGoogleSite = async (
         body: formData,
       }
     );
-    const responseJson = await response.json();
+    const responseJson: Partial<FileUploadResponse> & ErrorResponseBody =
+      await response.json();
     if (!response.ok) {
       toast.error(`Unable to upload files - ${responseJson.detail}`);
       return false;
     }
 
-    const filePaths = responseJson.file_paths as string[];
+    const filePaths = responseJson.file_paths;
     if (!filePaths || filePaths.length === 0) {
       toast.error(
         "File upload was successful, but no file path was returned. Cannot create connector."
@@ -77,7 +80,8 @@ export const submitGoogleSite = async (
       groups
     );
     if (!credentialResponse.ok) {
-      const credentialResponseJson = await credentialResponse.json();
+      const credentialResponseJson: ErrorResponseBody =
+        await credentialResponse.json();
       toast.error(
         `Unable to link connector to credential - ${credentialResponseJson.detail}`
       );

--- a/web/src/app/admin/discord-bot/lib.ts
+++ b/web/src/app/admin/discord-bot/lib.ts
@@ -6,6 +6,7 @@ import {
   DiscordChannelConfig,
   DiscordChannelConfigUpdate,
 } from "@/app/admin/discord-bot/types";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 const BASE_URL = "/api/manage/admin/discord-bot";
 
@@ -28,7 +29,7 @@ export async function createBotConfig(
     body: JSON.stringify({ bot_token: botToken }),
   });
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to create bot config");
   }
   return response.json();
@@ -54,7 +55,7 @@ export async function fetchGuildConfigs(): Promise<DiscordGuildConfig[]> {
 export async function createGuildConfig(): Promise<DiscordGuildConfigCreateResponse> {
   const response = await fetch(`${BASE_URL}/guilds`, { method: "POST" });
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to create guild config");
   }
   return response.json();
@@ -80,7 +81,7 @@ export async function updateGuildConfig(
     body: JSON.stringify(update),
   });
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to update guild config");
   }
   return response.json();
@@ -121,7 +122,7 @@ export async function updateChannelConfig(
     }
   );
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to update channel config");
   }
   return response.json();

--- a/web/src/app/admin/documents/lib.ts
+++ b/web/src/app/admin/documents/lib.ts
@@ -1,4 +1,9 @@
-export const updateBoost = async (documentId: string, boost: number) => {
+import type { ErrorResponseBody } from "@/lib/fetcher";
+
+export const updateBoost = async (
+  documentId: string,
+  boost: number
+): Promise<string | null> => {
   const response = await fetch("/api/manage/admin/doc-boosts", {
     method: "POST",
     headers: {
@@ -12,7 +17,7 @@ export const updateBoost = async (documentId: string, boost: number) => {
   if (response.ok) {
     return null;
   }
-  const responseJson = await response.json();
+  const responseJson: ErrorResponseBody = await response.json();
   return responseJson.message || responseJson.detail || "Unknown error";
 };
 

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -9,6 +9,7 @@ import { useCreateModal } from "@opal/components";
 import { SettingsLayouts, toast } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
 import { PageLoader } from "@opal/layouts";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 import type { ScimTokenCreatedResponse, ScimModalView } from "./interfaces";
 import { generateScimToken } from "./svc";
@@ -64,7 +65,7 @@ function ScimContent() {
       if (!response.ok) {
         let detail: string;
         try {
-          const body = await response.clone().json();
+          const body: ErrorResponseBody = await response.clone().json();
           detail = body.detail ?? JSON.stringify(body);
         } catch {
           detail = await response.text();

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -471,9 +471,9 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     }
 
     // Re-fetch group to check sync status before saving
-    const freshGroups = await fetch(SWR_KEYS.adminUserGroupsWithDefault).then(
-      (r) => r.json()
-    );
+    const freshGroups: UserGroup[] = await fetch(
+      SWR_KEYS.adminUserGroupsWithDefault
+    ).then((r) => r.json());
     const freshGroup = freshGroups.find((g: UserGroup) => g.id === groupId);
     if (freshGroup && !freshGroup.is_up_to_date) {
       toast.error(t("edit.toasts.syncing"));

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -1,7 +1,9 @@
 /** API helpers for the Groups pages. */
 
 import type { ScopedMutator } from "swr";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import type { UserGroup } from "@/lib/types";
 
 const USER_GROUP_URL = SWR_KEYS.adminUserGroups;
 
@@ -57,7 +59,7 @@ async function createGroup(
   if (!res.ok) {
     throw await responseError(res, "Failed to create group");
   }
-  const group = await res.json();
+  const group: UserGroup = await res.json();
   return group.id;
 }
 
@@ -89,7 +91,7 @@ async function setGroupIncognito(
     body: JSON.stringify({ enabled }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
+    const detail: ErrorResponseBody | null = await res.json().catch(() => null);
     throw new Error(
       detail?.detail ?? `Failed to update incognito access: ${res.statusText}`
     );

--- a/web/src/views/admin/ImageGenerationPage/svc.ts
+++ b/web/src/views/admin/ImageGenerationPage/svc.ts
@@ -3,6 +3,8 @@
  * API functions for managing image generation configurations
  */
 
+import type { ErrorResponseBody } from "@/lib/fetcher";
+
 // Types
 export interface ImageGenerationConfigView {
   image_provider_id: string; // Primary key
@@ -87,7 +89,7 @@ export async function testImageGenerationApiKey(
     });
 
     if (!response.ok) {
-      const error = await response.json();
+      const error: ErrorResponseBody = await response.json();
       return {
         ok: false,
         errorMessage: error.detail || "API key validation failed",
@@ -159,7 +161,7 @@ export async function createImageGenerationConfig(
   });
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to create config");
   }
 
@@ -213,7 +215,7 @@ export async function updateImageGenerationConfig(
   });
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to update config");
   }
 
@@ -234,7 +236,7 @@ export async function setDefaultImageGenerationConfig(
   );
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to set default");
   }
 }
@@ -253,7 +255,7 @@ export async function unsetDefaultImageGenerationConfig(
   );
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to unset default");
   }
 }
@@ -269,7 +271,7 @@ export async function deleteImageGenerationConfig(
   });
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody = await response.json();
     throw new Error(error.detail || "Failed to delete config");
   }
 }

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { mutate } from "swr";
 import { PageLoader } from "@opal/layouts";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { useConnectorIndexingStatusWithPagination } from "@/lib/hooks";
 import type { ConnectorIndexingStatusLite } from "@/lib/types";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
@@ -1021,7 +1022,7 @@ export default function IndexSettingsPage() {
                 // reload; a generic failure would lose that.
                 const detail = await response
                   .json()
-                  .then((body) => body?.detail as string | undefined)
+                  .then((body: ErrorResponseBody) => body?.detail)
                   .catch((parseError) => {
                     console.error(
                       "Failed to parse set-new-search-settings error response",

--- a/web/src/views/admin/ServiceAccountsPage/index.tsx
+++ b/web/src/views/admin/ServiceAccountsPage/index.tsx
@@ -107,7 +107,7 @@ export default function ServiceAccountsPage() {
         );
         return;
       }
-      const newKey = (await response.json()) as APIKey;
+      const newKey: APIKey = await response.json();
       setFullApiKey(newKey.api_key);
       mutate(API_KEY_SWR_KEY);
     } catch (e) {

--- a/web/src/views/admin/VoicePage/shared.tsx
+++ b/web/src/views/admin/VoicePage/shared.tsx
@@ -29,6 +29,7 @@ import {
   fetchVoicesByType,
   deleteVoiceProvider,
 } from "@/lib/voice/svc";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import {
   getVoiceProviderDetail,
   resolveModelId,
@@ -175,7 +176,9 @@ export function VoiceProviderSetupModal({
         });
 
         if (!testResponse.ok) {
-          const data = await testResponse.json().catch(() => ({}));
+          const data: ErrorResponseBody = await testResponse
+            .json()
+            .catch(() => ({}));
           toast.error(
             typeof data?.detail === "string"
               ? data.detail
@@ -221,7 +224,7 @@ export function VoiceProviderSetupModal({
       if (response.ok) {
         onSuccess();
       } else {
-        const data = await response.json().catch(() => ({}));
+        const data: ErrorResponseBody = await response.json().catch(() => ({}));
         toast.error(
           typeof data?.detail === "string"
             ? data.detail
@@ -434,7 +437,7 @@ export function VoiceDisconnectModal({
     try {
       const res = await deleteVoiceProvider(disconnectTarget.providerId);
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
+        const body: ErrorResponseBody = await res.json().catch(() => ({}));
         throw new Error(
           typeof body?.detail === "string"
             ? body.detail

--- a/web/src/views/admin/WorkspaceAnalyticsPage/svc.ts
+++ b/web/src/views/admin/WorkspaceAnalyticsPage/svc.ts
@@ -1,5 +1,6 @@
 /** API helpers for the Workspace Analytics page. */
 
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { ReportPeriod } from "@/views/admin/WorkspaceAnalyticsPage/interfaces";
 
@@ -27,10 +28,12 @@ export async function generateUsageReport(
     }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch((parseError: unknown) => {
-      console.error("Usage report error response was not JSON:", parseError);
-      return null;
-    });
+    const detail: ErrorResponseBody | null = await res
+      .json()
+      .catch((parseError: unknown) => {
+        console.error("Usage report error response was not JSON:", parseError);
+        return null;
+      });
     throw new Error(
       detail?.detail ?? `Failed to start report generation: ${res.statusText}`
     );


### PR DESCRIPTION
## Description

This PR is part of a stack that raises TypeScript type coverage in `web/`. It is on top of #14649.

It uses the #14649 pattern to type the JSON responses in `src/app/admin/**` and `src/views/admin/**`:
- Annotated `res.json()` bindings and return types.
- Casts on JSON reads replaced with annotated bindings (`ServiceAccountsPage`, `IndexSettingsPage`, `google_site.ts`).
- Reused types only: `ErrorResponseBody`, `FileUploadResponse`, `UserGroup` and `APIKey`. No new types.

The emitted JavaScript does not change. The change removes 100 uncovered items. It raises the `src/app/admin` floor from 96.2 to 96.4 and the `src/views/admin` floor from 99.1 to 99.3.

### Not in this PR
- Inline `(await res.json()).detail` reads. They need a new binding.
- Error messages where `detail || message` can be `undefined` but the caller needs a `string` (`toast.error`, next-intl arguments). They need a runtime fallback.

### Possible bugs found
These are not changed here:
- `submitConnector` in `AddConnectorPage.tsx` types the response as `Connector<T>`. The backend sends `ObjectCreationIdResponse` or `StatusResponse`. On the mock-credential path, `response.id` is always undefined, so `connectorIdRef` is never set.
- `SlackTokensForm.tsx:73` calls `errorMsg.includes(...)`. It throws when the error body has no `detail` and no `message`.

## How Has This Been Tested?

- For each changed file, the JavaScript emitted from the base and from this branch (types and comments removed) is the same.
- `ods type-coverage typescript --check` passes, and the per-file report shows no file with more uncovered items.
- `bun run test src/views/admin/GroupsPage` passes.
- `prek` (oxlint and oxfmt) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit types to JSON responses in `src/app/admin/**` and `src/views/admin/**`, removing 100 uncovered TypeScript items and raising the coverage floors from 96.3 to 96.5 and 99.1 to 99.3. The emitted JavaScript is unchanged.

- Replaces casts on JSON reads with annotated bindings (`ServiceAccountsPage`, `IndexSettingsPage`, `google_site.ts`).
- Reuses only existing types (`ErrorResponseBody`, `FileUploadResponse`, `UserGroup`, `APIKey`) and declares no new ones.
- Leaves inline `(await res.json()).detail` reads and `detail || message` paths that need runtime fallbacks for later.

**Known issues found, not changed**
- `submitConnector` in `AddConnectorPage.tsx` types its response as `Connector<T>`, but the backend sends `ObjectCreationIdResponse` or `StatusResponse`; on the mock-credential path `response.id` is always undefined, so `connectorIdRef` is never set.
- `SlackTokensForm.tsx:73` calls `errorMsg.includes(...)`, which throws when the error body has no `detail` or `message`.

<sup>Written for commit b6789a9d7b33c6e781443f41af8ffd2ba45eb875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

