### PR TITLE
chore(web): type JSON responses in app, craft and ee code

### DIFF
--- a/web/.type-coverage-baseline.yaml
+++ b/web/.type-coverage-baseline.yaml
@@ -8,21 +8,21 @@
 # `ods type-coverage typescript --update`.
 #
 # Generated file: do not edit by hand.
-total: 98.6
+total: 98.7
 packages:
   .: 100
   src: 99.4
   src/app: 99.5
   src/app/admin: 96.5
   src/app/anonymous: 100
-  src/app/api: 98.4
-  src/app/app: 98.7
-  src/app/auth: 98.1
+  src/app/api: 100
+  src/app/app: 98.9
+  src/app/auth: 98.8
   src/app/components: 100
   src/app/config: 100
-  src/app/connector: 90
-  src/app/craft: 99
-  src/app/ee: 95.7
+  src/app/connector: 100
+  src/app/craft: 99.2
+  src/app/ee: 95.8
   src/app/federated: 97
   src/app/mcp: 99.5
   src/app/nrf: 99.2
@@ -51,8 +51,8 @@ packages:
   src/ee/lib: 99
   src/ee/providers: 99.3
   src/ee/sections: 99.7
-  src/ee/views: 99
-  src/hooks: 98.3
+  src/ee/views: 99.7
+  src/hooks: 98.5
   src/i18n: 99
   src/i18n/messages: 100
   src/interfaces: 100
@@ -96,7 +96,7 @@ packages:
   src/lib/users: 99
   src/lib/voice: 98.3
   src/lib/webSearch: 97.3
-  src/providers: 99.4
+  src/providers: 99.5
   src/refresh-components: 99.7
   src/refresh-components/avatars: 99.7
   src/refresh-components/buttons: 99.7
@@ -120,13 +120,13 @@ packages:
   src/sections/document-sidebar: 99.5
   src/sections/input: 99.8
   src/sections/knowledge: 99.7
-  src/sections/modals: 99.2
+  src/sections/modals: 99.5
   src/sections/model-selector: 99.6
   src/sections/onboarding: 99.8
   src/sections/settings: 100
   src/sections/sidebar: 99.4
   src/sections/skills: 99.8
   src/sections/usage: 99.6
-  src/views: 99.1
+  src/views: 99.3
   src/views/admin: 99.3
   types: 100

--- a/web/src/app/api/chat/mcp/oauth/callback/route.ts
+++ b/web/src/app/api/chat/mcp/oauth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 // Proxies browser callback to backend OAuth callback endpoint and then
 // redirects back to the chat UI.
@@ -40,7 +41,7 @@ export async function GET(req: NextRequest) {
     );
 
     if (!resp.ok) {
-      const err = await resp.json().catch(() => ({}) as any);
+      const err: ErrorResponseBody = await resp.json().catch(() => ({}));
       return NextResponse.json(
         { error: err.detail || "OAuth callback failed" },
         { status: 400 }

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -22,6 +22,7 @@ import {
 import { ReadonlyURLSearchParams } from "next/navigation";
 import { SEARCH_PARAM_NAMES } from "./searchParams";
 import { Packet } from "./streamingModels";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 export async function updateLlmOverrideForChatSession(
   chatSessionId: string,
@@ -74,6 +75,12 @@ export async function updateReasoningEffortForChatSession(
   return response;
 }
 
+// Mirrors backend `CreateChatSessionID`. Older servers omit `incognito`.
+interface CreateChatSessionResponse {
+  chat_session_id: string;
+  incognito?: boolean;
+}
+
 export async function createChatSession(
   personaId: number,
   description: string | null,
@@ -103,7 +110,8 @@ export async function createChatSession(
     );
     throw Error("Failed to create chat session");
   }
-  const chatSessionResponseJson = await createChatSessionResponse.json();
+  const chatSessionResponseJson: CreateChatSessionResponse =
+    await createChatSessionResponse.json();
   // A server that omits the echo (e.g. an old pod mid-deploy) did not pin the
   // mode, so proceeding would silently persist a believed-incognito chat.
   if (incognito && chatSessionResponseJson.incognito !== true) {
@@ -234,7 +242,9 @@ export async function* sendMessage({
   });
 
   if (!response.ok) {
-    const data = await response.json().catch(() => ({}));
+    const data: ErrorResponseBody & RateLimitDetails = await response
+      .json()
+      .catch(() => ({}));
 
     // Surface the usage rate-limit (429) as a structured StreamingError packet
     // so the chat UI can render the dedicated usage-limit banner. Throwing a
@@ -293,7 +303,7 @@ export async function* resumeStream(
   );
 
   if (!response.ok) {
-    const data = await response.json().catch(() => ({}));
+    const data: ErrorResponseBody = await response.json().catch(() => ({}));
     throw new Error(data.detail ?? `HTTP error! status: ${response.status}`);
   }
 
@@ -426,7 +436,7 @@ export async function getAvailableContextTokens(
   if (!response.ok) {
     return null;
   }
-  const data = (await response.json()) as { available_tokens: number };
+  const data: { available_tokens: number } = await response.json();
   return data?.available_tokens ?? null;
 }
 

--- a/web/src/app/app/shared/[chatId]/page.tsx
+++ b/web/src/app/app/shared/[chatId]/page.tsx
@@ -4,6 +4,7 @@ import type { Route } from "next";
 import { requireAuth } from "@/lib/auth/svcSS";
 import SharedChatDisplay from "@/app/app/shared/[chatId]/SharedChatDisplay";
 import { Agent } from "@/lib/agents/types";
+import type { BackendChatSession } from "@/app/app/interfaces";
 
 // This is used for rendering a persona in the shared chat display
 export function constructMiniFiedPersona(name: string, id: number): Agent {
@@ -32,7 +33,9 @@ export function constructMiniFiedPersona(name: string, id: number): Agent {
   };
 }
 
-async function getSharedChat(chatId: string) {
+async function getSharedChat(
+  chatId: string
+): Promise<BackendChatSession | null> {
   const response = await fetchSS(
     `/chat/get-chat-session/${chatId}?is_shared=True`
   );

--- a/web/src/app/auth/forgot-password/utils.ts
+++ b/web/src/app/auth/forgot-password/utils.ts
@@ -1,3 +1,5 @@
+import type { ErrorResponseBody } from "@/lib/fetcher";
+
 export const forgotPassword = async (
   email: string,
   fallbackErrorMessage: string
@@ -11,7 +13,7 @@ export const forgotPassword = async (
   });
 
   if (!response.ok) {
-    const error = await response.json();
+    const error: ErrorResponseBody | null = await response.json();
     const errorMessage = error?.detail || fallbackErrorMessage;
     throw new Error(errorMessage);
   }

--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -10,6 +10,7 @@ import { TextFormField } from "@/components/Field";
 import { Button } from "@opal/components";
 import Text from "@/refresh-components/texts/Text";
 import { useTranslations } from "next-intl";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 export default function ImpersonatePage() {
   const t = useTranslations("auth");
@@ -40,7 +41,7 @@ export default function ImpersonatePage() {
       });
 
       if (!response.ok) {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         toast.error(errorData.detail || genericError);
         helpers.setSubmitting(false);
       } else {

--- a/web/src/app/auth/libSS.ts
+++ b/web/src/app/auth/libSS.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { getDomain } from "@/lib/redirectSS";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function authErrorRedirect(
@@ -10,7 +11,7 @@ export async function authErrorRedirect(
 ): Promise<NextResponse> {
   const errorUrl = new URL("/auth/error", getDomain(request));
   try {
-    const body = await response.json();
+    const body: ErrorResponseBody | null = await response.json();
     const detail = body?.detail;
     if (typeof detail === "string" && detail) {
       errorUrl.searchParams.set("error", detail);

--- a/web/src/app/connector/oauth/callback/[source]/route.tsx
+++ b/web/src/app/connector/oauth/callback/[source]/route.tsx
@@ -1,9 +1,15 @@
 import { INTERNAL_URL } from "@/lib/constants";
 import { NextRequest, NextResponse } from "next/server";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 // TODO: deprecate this and just go directly to the backend via /api/...
 // For some reason Egnyte doesn't work when using /api, so leaving this as is for now
 // If we do try and remove this, make sure we test the Egnyte connector oauth flow
+// Backend `CallbackResponse` on success, or an error body.
+interface OAuthCallbackProxyBody extends ErrorResponseBody {
+  redirect_url?: string;
+}
+
 export async function GET(request: NextRequest) {
   try {
     const backendUrl = new URL(INTERNAL_URL);
@@ -17,7 +23,7 @@ export async function GET(request: NextRequest) {
       signal: request.signal,
     });
 
-    const responseData = await response.json();
+    const responseData: OAuthCallbackProxyBody = await response.json();
     if (responseData.redirect_url) {
       return NextResponse.redirect(responseData.redirect_url);
     }

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -25,6 +25,7 @@ import {
   RateLimitDetails,
 } from "@/app/app/interfaces";
 import { BUILD_API_BASE } from "@/app/craft/v1/constants";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 import { CRAFT_GATEWAY_PROVIDER } from "@/app/craft/onboarding/constants";
 import type { BuildLlmSelection } from "@/app/craft/onboarding/constants";
 
@@ -59,7 +60,7 @@ export async function processSSEStream(
         const dataStr = line.slice(line.indexOf(":") + 1).trim();
         if (dataStr) {
           try {
-            const data = JSON.parse(dataStr);
+            const data: StreamPacket = JSON.parse(dataStr);
             // The backend sends `event: message` for all events and puts the
             // actual type in data.type. Only use SSE event type as fallback
             // if data.type is not present and SSE event is not "message".
@@ -95,7 +96,7 @@ export interface CreateSessionOptions {
 // falling back to the status code when the body isn't the expected shape.
 async function errorDetail(res: Response, fallback: string): Promise<string> {
   try {
-    const body = await res.json();
+    const body: ErrorResponseBody | null = await res.json();
     if (typeof body?.detail === "string" && body.detail.trim()) {
       return body.detail;
     }
@@ -103,6 +104,16 @@ async function errorDetail(res: Response, fallback: string): Promise<string> {
     // body wasn't JSON — fall through
   }
   return `${fallback}: ${res.status}`;
+}
+
+// Mirrors backend `SessionListResponse`.
+interface ApiSessionListResponse {
+  sessions: ApiSessionResponse[];
+}
+
+// Mirrors backend `SessionNameGenerateResponse`.
+interface ApiSessionNameGenerateResponse {
+  name: string;
 }
 
 export async function createSession(
@@ -177,7 +188,7 @@ export async function fetchSessionHistory(): Promise<SessionHistoryItem[]> {
     throw new Error(`Failed to fetch session history: ${res.status}`);
   }
 
-  const data = await res.json();
+  const data: ApiSessionListResponse = await res.json();
   return data.sessions.map((s: ApiSessionResponse) => ({
     id: s.id,
     title: s.name || `Session ${s.id.slice(0, 8)}...`,
@@ -198,7 +209,7 @@ export async function generateSessionName(sessionId: string): Promise<string> {
     throw new Error(`Failed to generate session name: ${res.status}`);
   }
 
-  const data = await res.json();
+  const data: ApiSessionNameGenerateResponse = await res.json();
   return data.name;
 }
 
@@ -274,7 +285,7 @@ export async function restoreSession(
       continue;
     }
 
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to restore session: ${res.status}`
     );
@@ -353,6 +364,11 @@ function extractAttachmentsFromMetadata(
   });
 }
 
+// Mirrors backend `MessageListResponse`.
+interface ApiMessageListResponse {
+  messages: ApiMessageResponse[];
+}
+
 export async function fetchMessages(
   sessionId: string
 ): Promise<BuildMessage[]> {
@@ -362,7 +378,7 @@ export async function fetchMessages(
     throw new Error(`Failed to fetch messages: ${res.status}`);
   }
 
-  const data = await res.json();
+  const data: ApiMessageListResponse = await res.json();
   return data.messages.map((m: ApiMessageResponse) => ({
     id: m.id,
     type: m.type,
@@ -466,7 +482,7 @@ export async function fetchActiveTurn(
     throw new Error(`Failed to fetch active turn: ${res.status}`);
   }
 
-  return (await res.json()) as ApiInteractiveTurnResponse | null;
+  return await res.json();
 }
 
 export async function fetchTurnEventStream(
@@ -534,7 +550,7 @@ export async function fetchArtifacts(sessionId: string): Promise<Artifact[]> {
     throw new Error(`Failed to fetch artifacts: ${res.status}`);
   }
 
-  const data = await res.json();
+  const data: ApiArtifactResponse[] = await res.json();
   // Backend returns a direct array, not wrapped in an object
   return data.map((a: ApiArtifactResponse) => ({
     id: a.id,
@@ -722,7 +738,7 @@ export async function uploadFile(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(errorData.detail || `Failed to upload file: ${res.status}`);
   }
 
@@ -750,7 +766,7 @@ export async function deleteFile(
   );
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(errorData.detail || `Failed to delete file: ${res.status}`);
   }
 }
@@ -773,7 +789,7 @@ export async function exportDocx(
   );
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to export as DOCX: ${res.status}`
     );
@@ -810,7 +826,7 @@ export async function fetchPptxPreview(
   );
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to generate PPTX preview: ${res.status}`
     );
@@ -863,11 +879,11 @@ export async function postApprovalDecision(
   );
 
   if (res.status === 409) {
-    const body = (await res.json().catch(() => ({}))) as { detail?: string };
+    const body: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new ApprovalConflictError(body.detail ?? "decision conflict");
   }
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to post approval decision: ${res.status}`
     );
@@ -886,11 +902,11 @@ export async function postApprovalSessionGrant(
   );
 
   if (res.status === 409) {
-    const body = (await res.json().catch(() => ({}))) as { detail?: string };
+    const body: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new ApprovalConflictError(body.detail ?? "decision conflict");
   }
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to approve for session: ${res.status}`
     );
@@ -942,7 +958,7 @@ export async function uploadLibraryFiles(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to upload files: ${res.status}`
     );
@@ -968,7 +984,7 @@ export async function uploadLibraryZip(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(errorData.detail || `Failed to upload zip: ${res.status}`);
   }
 
@@ -988,7 +1004,7 @@ export async function createLibraryDirectory(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to create directory: ${res.status}`
     );
@@ -1009,7 +1025,7 @@ export async function deleteLibraryFile(documentId: string): Promise<void> {
   );
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
+    const errorData: ErrorResponseBody = await res.json().catch(() => ({}));
     throw new Error(errorData.detail || `Failed to delete file: ${res.status}`);
   }
 }

--- a/web/src/app/craft/services/externalAppsService.ts
+++ b/web/src/app/craft/services/externalAppsService.ts
@@ -10,12 +10,13 @@ import {
   ExternalAppType,
 } from "@/app/craft/v1/apps/registry";
 import { BUILD_API_BASE } from "@/app/craft/v1/constants";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 async function readErrorDetail(
   res: Response,
   fallback: string
 ): Promise<string> {
-  const data = (await res.json().catch(() => ({}))) as { detail?: string };
+  const data: ErrorResponseBody = await res.json().catch(() => ({}));
   return data.detail ?? `${fallback} (HTTP ${res.status}).`;
 }
 

--- a/web/src/app/craft/v1/tasks/api.ts
+++ b/web/src/app/craft/v1/tasks/api.ts
@@ -15,13 +15,14 @@ import type {
   RunNowResponse,
 } from "@/app/craft/v1/tasks/interfaces";
 import { BUILD_API_BASE } from "@/app/craft/v1/constants";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 const API_BASE = `${BUILD_API_BASE}/scheduled-tasks`;
 
 async function readError(res: Response, fallback: string): Promise<never> {
   let detail: string | undefined;
   try {
-    const body = (await res.json()) as { detail?: string };
+    const body: ErrorResponseBody | null = await res.json();
     detail = body?.detail;
   } catch {
     // ignore parse errors
@@ -47,7 +48,7 @@ export async function createScheduledTask(
     body: JSON.stringify(body),
   });
   if (!res.ok) await readError(res, "Failed to create scheduled task");
-  return (await res.json()) as ScheduledTaskListItem;
+  return await res.json();
 }
 
 export async function updateScheduledTask(
@@ -60,7 +61,7 @@ export async function updateScheduledTask(
     body: JSON.stringify(body),
   });
   if (!res.ok) await readError(res, "Failed to update scheduled task");
-  return (await res.json()) as ScheduledTaskDetail;
+  return await res.json();
 }
 
 export async function deleteScheduledTask(taskId: string): Promise<void> {
@@ -75,7 +76,7 @@ export async function runScheduledTaskNow(
 ): Promise<RunNowResponse> {
   const res = await fetch(`${API_BASE}/${taskId}/run-now`, { method: "POST" });
   if (!res.ok) await readError(res, "Failed to run scheduled task");
-  return (await res.json()) as RunNowResponse;
+  return await res.json();
 }
 
 // ---------------------------------------------------------------------------
@@ -95,5 +96,5 @@ export async function listScheduledTaskRuns(
     : `${API_BASE}/${taskId}/runs`;
   const res = await fetch(url, { method: "GET" });
   if (!res.ok) await readError(res, "Failed to load runs");
-  return (await res.json()) as ScheduledRunListResponse;
+  return await res.json();
 }

--- a/web/src/app/ee/admin/performance/query-history/KickoffCSVExport.tsx
+++ b/web/src/app/ee/admin/performance/query-history/KickoffCSVExport.tsx
@@ -70,8 +70,8 @@ export default function KickoffCSVExport({
       return;
     }
 
-    const { request_id } =
-      (await response.json()) as StartQueryHistoryExportResponse;
+    const { request_id }: StartQueryHistoryExportResponse =
+      await response.json();
     // `window.setInterval` returns a number; the bare global resolves to the
     // Node overload, which returns a `Timeout` object.
     const timer = window.setInterval(
@@ -102,8 +102,8 @@ export default function KickoffCSVExport({
       return;
     }
 
-    const { status } =
-      (await response.json()) as CheckQueryHistoryExportStatusResponse;
+    const { status }: CheckQueryHistoryExportStatusResponse =
+      await response.json();
 
     if (status === "SUCCESS") {
       reset();

--- a/web/src/app/ee/admin/standard-answer/StandardAnswerCreationForm.tsx
+++ b/web/src/app/ee/admin/standard-answer/StandardAnswerCreationForm.tsx
@@ -229,8 +229,8 @@ export const StandardAnswerCreationForm = ({
                       );
                       return;
                     }
-                    const newCategory =
-                      (await response.json()) as StandardAnswerCategory;
+                    const newCategory: StandardAnswerCategory =
+                      await response.json();
                     setFieldValue("categories", [
                       ...values.categories,
                       newCategory,

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -87,7 +87,7 @@ export function AgentStats({ agentId }: AgentStatsProps) {
           throw new Error(t("agentStats.fetchFailed.message"));
         }
 
-        const data = (await res.json()) as AgentStatsResponse;
+        const data: AgentStatsResponse = await res.json();
         setAgentStats(data);
       } catch (err) {
         setError(

--- a/web/src/ee/views/admin/HooksPage/svc.ts
+++ b/web/src/ee/views/admin/HooksPage/svc.ts
@@ -5,6 +5,7 @@ import {
   HookUpdateRequest,
   HookValidateResponse,
 } from "@/ee/views/admin/HooksPage/interfaces";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 export class HookAuthError extends Error {}
 export class HookTimeoutError extends Error {}
@@ -12,7 +13,7 @@ export class HookConnectError extends Error {}
 
 async function parseError(res: Response, fallback: string): Promise<Error> {
   try {
-    const body = await res.json();
+    const body: ErrorResponseBody | null = await res.json();
     if (body?.error_code === "CREDENTIAL_INVALID") {
       return new HookAuthError(body?.detail ?? "Invalid API key.");
     }

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -36,6 +36,7 @@ import {
 } from "@/lib/projects/svc";
 import { AppInputBarHandle } from "@/sections/input/AppInputBar";
 import { useSharedSearchFilters } from "@/lib/searchFilters/providers";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 // Runs currently being re-attached; module-level so effect re-runs (incl.
 // strict mode) can't start a second tail for the same run.
@@ -211,7 +212,7 @@ export default function useChatSessionController({
         setIsFetchingChatMessages(existingChatSessionId, false);
         let detail = "An unexpected error occurred.";
         try {
-          const errorBody = await response.json();
+          const errorBody: ErrorResponseBody = await response.json();
           detail = errorBody.detail || detail;
         } catch {
           // ignore parse errors
@@ -226,8 +227,8 @@ export default function useChatSessionController({
         return;
       }
 
-      const session = await response.json();
-      const chatSession = session as BackendChatSession;
+      const session: BackendChatSession = await response.json();
+      const chatSession = session;
       // Restore the incognito UI state on reload of a live incognito session.
       // The id must come back too, or a later upload would be sent with none
       // and land as an ordinary indexed file.
@@ -360,8 +361,8 @@ export default function useChatSessionController({
                 `/api/chat/get-chat-session/${sessionId}`
               );
               if (settledResponse.ok && stillCurrent()) {
-                const settled =
-                  (await settledResponse.json()) as BackendChatSession;
+                const settled: BackendChatSession =
+                  await settledResponse.json();
                 updateSessionAndMessageTree(
                   sessionId,
                   processRawChatHistory(settled.messages, settled.packets)

--- a/web/src/hooks/useFeedbackController.ts
+++ b/web/src/hooks/useFeedbackController.ts
@@ -6,6 +6,7 @@ import { FeedbackType } from "@/app/app/interfaces";
 import { handleChatFeedback, removeChatFeedback } from "@/app/app/services/lib";
 import { getMessageByMessageId } from "@/app/app/services/messageTree";
 import { toast } from "@opal/layouts";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 /**
  * Hook for managing chat message feedback (like/dislike)
@@ -59,7 +60,7 @@ export default function useFeedbackController() {
           if (!response.ok) {
             // Rollback on error
             updateCurrentMessageFeedback(messageId, previousFeedback);
-            const errorData = await response.json();
+            const errorData: ErrorResponseBody = await response.json();
             toast.error(
               `Failed to remove feedback - ${
                 errorData.detail || errorData.message
@@ -78,7 +79,7 @@ export default function useFeedbackController() {
           if (!response.ok) {
             // Rollback on error
             updateCurrentMessageFeedback(messageId, previousFeedback);
-            const errorData = await response.json();
+            const errorData: ErrorResponseBody = await response.json();
             toast.error(
               `Failed to submit feedback - ${
                 errorData.detail || errorData.message

--- a/web/src/hooks/useVoiceRecorder.ts
+++ b/web/src/hooks/useVoiceRecorder.ts
@@ -251,7 +251,7 @@ class VoiceRecorderSession {
     if (!tokenResponse.ok) {
       throw new Error("Failed to get WebSocket authentication token");
     }
-    const { token } = await tokenResponse.json();
+    const { token }: { token: string } = await tokenResponse.json();
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const host = IS_DEV ? new URL(INTERNAL_URL).host : window.location.host;

--- a/web/src/providers/VoiceModeProvider.tsx
+++ b/web/src/providers/VoiceModeProvider.tsx
@@ -453,7 +453,7 @@ export function VoiceModeProvider({ children }: { children: React.ReactNode }) {
     if (!tokenResponse.ok) {
       throw new Error("Failed to get WebSocket authentication token");
     }
-    const { token } = await tokenResponse.json();
+    const { token }: { token: string } = await tokenResponse.json();
 
     // In development, the Next.js dev server (port 3000) does not proxy
     // WebSocket connections, so we connect directly to the backend (port 8080).

--- a/web/src/sections/modals/NewTeamModal.tsx
+++ b/web/src/sections/modals/NewTeamModal.tsx
@@ -17,6 +17,7 @@ import {
   SvgPlus,
   SvgSimpleLoader,
 } from "@opal/icons";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 export interface TenantByDomainResponse {
   tenant_id: string;
   number_of_users: number;
@@ -63,14 +64,14 @@ export default function NewTeamModal() {
       if (!response.ok) {
         throw new Error(`Failed to fetch team info: ${response.status}`);
       }
-      const responseJson = await response.json();
+      const responseJson: TenantByDomainResponse | null = await response.json();
       if (!responseJson) {
         setShowNewTeamModal(false);
         setExistingTenant(null);
         return;
       }
 
-      const data = responseJson as TenantByDomainResponse;
+      const data = responseJson;
       setExistingTenant(data);
     } catch (error) {
       console.error("Failed to fetch tenant info:", error);
@@ -96,7 +97,9 @@ export default function NewTeamModal() {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
+        const errorData: ErrorResponseBody = await response
+          .json()
+          .catch(() => ({}));
         throw new Error(
           errorData.detail ||
             errorData.message ||

--- a/web/src/sections/modals/NewTenantModal.tsx
+++ b/web/src/sections/modals/NewTenantModal.tsx
@@ -11,6 +11,7 @@ import { NewTenantInfo } from "@/lib/types";
 import { useRouter } from "next/navigation";
 import Text from "@/refresh-components/texts/Text";
 import { InputErrorText, toast } from "@opal/layouts";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 // App domain should not be hardcoded
 const APP_DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN || "onyx.app";
@@ -48,7 +49,9 @@ export default function NewTenantModal({
         });
 
         if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
+          const errorData: ErrorResponseBody = await response
+            .json()
+            .catch(() => ({}));
           throw new Error(
             errorData.detail ||
               errorData.message ||
@@ -94,7 +97,9 @@ export default function NewTenantModal({
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
+        const errorData: ErrorResponseBody = await response
+          .json()
+          .catch(() => ({}));
         throw new Error(
           errorData.detail ||
             errorData.message ||

--- a/web/src/sections/modals/languageModels/svc.ts
+++ b/web/src/sections/modals/languageModels/svc.ts
@@ -13,6 +13,7 @@ import {
   LlmModalsTranslator,
   TestApiKeyResult,
 } from "@/sections/modals/languageModels/utils";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 // ─── Test helpers ─────────────────────────────────────────────────────────
 
@@ -229,7 +230,7 @@ export async function submitProvider<T extends BaseLLMFormValues>({
   // ── Set as default ──────────────────────────────────────────────────
   if (shouldMarkAsDefault && testModelName) {
     try {
-      const newLlmProvider = await response.json();
+      const newLlmProvider: LLMProviderView = await response.json();
       if (newLlmProvider?.id != null) {
         const setDefaultResponse = await fetch("/api/admin/llm/default", {
           method: "POST",
@@ -240,7 +241,9 @@ export async function submitProvider<T extends BaseLLMFormValues>({
           }),
         });
         if (!setDefaultResponse.ok) {
-          const err = await setDefaultResponse.json().catch(() => ({}));
+          const err: ErrorResponseBody = await setDefaultResponse
+            .json()
+            .catch(() => ({}));
           toast.error(err?.detail ?? t("toasts.setDefaultFailed"));
           setSubmitting(false);
           return;

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -107,6 +107,7 @@ import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
 import { can } from "@/lib/permissions/resource-actions";
 import { useDraft, draftKey } from "@/hooks/useDraft";
+import type { Agent } from "@/lib/agents/types";
 
 // Length of the translated starterExamples array, which is local to
 // AgentStarterMessages, shared here so the editor can size against it.
@@ -181,7 +182,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
         return;
       }
 
-      const { file_id } = await response.json();
+      const { file_id }: { file_id: string } = await response.json();
       setFieldValue("uploaded_image_id", file_id);
       setPopoverOpen(false);
     } catch (error) {
@@ -1036,7 +1037,7 @@ export default function AgentEditorPage({
       }
 
       // Success
-      const agent = await personaResponse.json();
+      const agent: Agent = await personaResponse.json();
 
       // clear() (not clearDraft) so an in-flight debounced write is cancelled too.
       clearAgentDraftRef.current?.();

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -1037,7 +1037,8 @@ export default function AgentEditorPage({
       }
 
       // Success
-      const agent: Agent = await personaResponse.json();
+      const agent: Omit<Agent, "user_permission"> =
+        await personaResponse.json();
 
       // clear() (not clearDraft) so an in-flight debounced write is cancelled too.
       clearAgentDraftRef.current?.();

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -98,6 +98,7 @@ import { findModelConfigId } from "@/lib/languageModels/options";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { DOCS_BASE_URL } from "@/lib/constants";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
+import type { ErrorResponseBody } from "@/lib/fetcher";
 
 interface PAT {
   id: number;
@@ -107,6 +108,11 @@ interface PAT {
   expires_at: string | null;
   last_used_at: string | null;
   scopes: string[] | null;
+}
+
+// Mirrors backend `CreatedTokenResponse`.
+interface CreatedPAT extends PAT {
+  token: string;
 }
 
 interface PatScopeOption {
@@ -481,7 +487,7 @@ function usePATCreation({
       });
 
       if (response.ok) {
-        const data = await response.json();
+        const data: CreatedPAT = await response.json();
         setNewlyCreatedToken({
           id: data.id,
           token: data.token,
@@ -490,7 +496,7 @@ function usePATCreation({
         toast.success(t("apiKeys.toasts.created"));
         await onCreateSuccess?.();
       } else {
-        const errorData = await response.json();
+        const errorData: ErrorResponseBody = await response.json();
         toast.error(errorData.detail || t("apiKeys.toasts.createFailed"));
       }
     } catch (error) {
@@ -2090,7 +2096,7 @@ function AccountsAccessSettings() {
           toast.success(t("accounts.passwordModal.toasts.updated"));
           setShowPasswordModal(false);
         } else {
-          const errorData = await response.json();
+          const errorData: ErrorResponseBody = await response.json();
           toast.error(
             errorData.detail || t("accounts.passwordModal.toasts.updateFailed")
           );


### PR DESCRIPTION
## Description

This PR is part of a stack that raises TypeScript type coverage in `web/`. It is on top of #14650.

It uses the #14649 pattern to type the JSON responses in the rest of `src/`. Legacy `src/components/` is not changed. The changed areas are craft services, `app/ee`, `ee/views`, `app/auth`, `app/connector`, `app/app/services`, hooks, modals and views:
- Annotated `res.json()` bindings and return types. Casts on JSON reads become annotated bindings.
- New local response types, each matching its backend model:
  - `ApiSessionListResponse`, `ApiSessionNameGenerateResponse` and `ApiMessageListResponse` in `craft/services/apiServices.ts`.
  - `CreateChatSessionResponse` in `app/app/services/lib.tsx`.
  - `CreatedPAT` in `SettingsPage.tsx`.
  - `OAuthCallbackProxyBody` in the connector OAuth callback route.
- Reused types: `ErrorResponseBody`, `StreamPacket`, `LLMProviderView`, `Agent` and `BackendChatSession`.

The emitted JavaScript does not change. The change removes 217 uncovered items and raises 11 floors. For example, `src/app/connector` goes from 90 to 100 and `src/app/api` from 98.4 to 100. The total floor goes from 98.6 to 98.7.

### Not in this PR
- Inline `(await res.json()).detail` reads. They need a new binding.
- Error messages where `detail || message` can be `undefined` but an ICU argument needs a `string` (`MCPAuthenticationModal.tsx`, `StandardAnswerCreationForm.tsx`).
- `resetPassword` in `forgot-password/utils.ts`. Its `detail` can be an object, so it needs a `typeof` check.
- Craft packet parsing, `useBuildSessionStore.ts` and `useChatController.ts`. Later PRs in the stack change them.

## How Has This Been Tested?

- For each changed file, the JavaScript emitted from the base and from this branch (types and comments removed) is the same.
- `ods type-coverage typescript --check` passes, and the per-file report shows no file with more uncovered items.
- Jest suites for craft services and tasks, `app/app/services`, hooks, `languageModels`, auth, ee, views and providers pass (186 tests).
- `prek` (oxlint and oxfmt) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types the JSON responses in craft services, `app/ee`, `ee/views`, `app/auth`, `app/connector`, app services, hooks, modals, and views so TypeScript type coverage rises from 98.6% to 98.7% without changing the emitted JavaScript.

- Replaces `as` casts on JSON reads with annotated bindings on `res.json()` calls and function return types.
- Adds local response types for backend models, including `ApiSessionListResponse`, `ApiMessageListResponse`, `CreateChatSessionResponse`, `OAuthCallbackProxyBody`, and `CreatedPAT`.
- Types persona create/update responses as `Omit<Agent, "user_permission">` since those endpoints return a `PersonaSnapshot` without that field.
- Reuses `ErrorResponseBody` for error handling across the changed files.
- Leaves legacy `src/components/` unchanged.
- Leaves inline `detail` reads, `useBuildSessionStore.ts`, and `useChatController.ts` for later PRs in the stack.

<sup>Written for commit f28ff369ee8c5c647b068c23e22b2f68d84a11bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

