### PR TITLE
fix(web): show an error toast when the Slack bot error response is not JSON

### DIFF
--- a/web/.type-coverage-baseline.yaml
+++ b/web/.type-coverage-baseline.yaml
@@ -13,7 +13,7 @@ packages:
   .: 100
   src: 99.4
   src/app: 99.5
-  src/app/admin: 96.2
+  src/app/admin: 96.3
   src/app/anonymous: 100
   src/app/api: 98.4
   src/app/app: 98.2

--- a/web/src/app/admin/bots/SlackTokensForm.test.tsx
+++ b/web/src/app/admin/bots/SlackTokensForm.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import { SlackTokensForm } from "@/app/admin/bots/SlackTokensForm";
+
+const mockToastError = jest.fn();
+const mockToastSuccess = jest.fn();
+
+jest.mock("@opal/layouts", () => ({
+  ...jest.requireActual("@opal/layouts"),
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const emptyBot = {
+  name: "",
+  enabled: true,
+  bot_token: "",
+  app_token: "",
+  user_token: "",
+};
+
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  fetchSpy = jest.spyOn(global, "fetch");
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  jest.clearAllMocks();
+});
+
+async function fillAndSubmitNewBot() {
+  const user = setupUser();
+  render(
+    <SlackTokensForm
+      isUpdate={false}
+      initialValues={emptyBot}
+      router={{ push: jest.fn() }}
+    />
+  );
+
+  await user.type(screen.getByLabelText(/name this slack bot/i), "Support");
+  await user.type(screen.getByLabelText(/slack bot token/i), "xoxb-1");
+  await user.type(screen.getByLabelText(/slack app token/i), "xapp-1");
+  await user.click(screen.getByRole("button", { name: /create/i }));
+}
+
+test("shows an error toast when the error response is not JSON", async () => {
+  // Mock POST /api/manage/admin/slack-app/bots (proxy error page)
+  fetchSpy.mockResolvedValueOnce({
+    ok: false,
+    status: 502,
+    json: async () => {
+      throw new SyntaxError("Unexpected token '<'");
+    },
+  } as unknown as Response);
+
+  await fillAndSubmitNewBot();
+
+  await waitFor(() => {
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Error creating Slack Bot - Unexpected server response (HTTP 502)"
+    );
+  });
+  expect(mockToastSuccess).not.toHaveBeenCalled();
+});
+
+test("shows an error toast when the JSON body has no detail or message", async () => {
+  // Mock POST /api/manage/admin/slack-app/bots (JSON without detail/message)
+  fetchSpy.mockResolvedValueOnce({
+    ok: false,
+    status: 500,
+    json: async () => ({}),
+  } as unknown as Response);
+
+  await fillAndSubmitNewBot();
+
+  await waitFor(() => {
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Error creating Slack Bot - Unexpected server response (HTTP 500)"
+    );
+  });
+});
+
+test("maps an invalid bot token detail to the translated message", async () => {
+  // Mock POST /api/manage/admin/slack-app/bots (backend token validation)
+  fetchSpy.mockResolvedValueOnce({
+    ok: false,
+    status: 400,
+    json: async () => ({ detail: "Invalid bot token: invalid_auth" }),
+  } as unknown as Response);
+
+  await fillAndSubmitNewBot();
+
+  await waitFor(() => {
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Error creating Slack Bot - Slack Bot Token is invalid"
+    );
+  });
+});
+
+test("shows the backend detail for other errors", async () => {
+  // Mock POST /api/manage/admin/slack-app/bots (generic backend error)
+  fetchSpy.mockResolvedValueOnce({
+    ok: false,
+    status: 400,
+    json: async () => ({ detail: "A bot with this name already exists" }),
+  } as unknown as Response);
+
+  await fillAndSubmitNewBot();
+
+  await waitFor(() => {
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Error creating Slack Bot - A bot with this name already exists"
+    );
+  });
+});

--- a/web/src/app/admin/bots/SlackTokensForm.tsx
+++ b/web/src/app/admin/bots/SlackTokensForm.tsx
@@ -4,7 +4,11 @@ import { TextFormField } from "@/components/Field";
 import { useTranslations } from "next-intl";
 import { Form, Formik } from "formik";
 import * as Yup from "yup";
-import { createSlackBot, updateSlackBot } from "./new/lib";
+import {
+  createSlackBot,
+  parseSlackBotErrorMessage,
+  updateSlackBot,
+} from "./new/lib";
 import { Button, Divider } from "@opal/components";
 import { useEffect } from "react";
 import { DOCS_ADMINS_PATH } from "@/lib/constants";
@@ -67,8 +71,11 @@ export const SlackTokensForm = ({
           );
           router.push(`/admin/bots/${encodeURIComponent(botId)}`);
         } else {
-          const responseJson = await response.json();
-          let errorMsg = responseJson.detail || responseJson.message;
+          let errorMsg =
+            (await parseSlackBotErrorMessage(response)) ??
+            t("tokensForm.unexpectedResponse.message", {
+              status: response.status,
+            });
 
           if (errorMsg.includes("Invalid bot token:")) {
             errorMsg = t("tokensForm.invalidBotToken.message");

--- a/web/src/app/admin/bots/new/lib.ts
+++ b/web/src/app/admin/bots/new/lib.ts
@@ -52,3 +52,24 @@ export const deleteSlackBot = async (id: number) => {
     },
   });
 };
+
+/**
+ * Reads the error message from a failed Slack bot response. The backend sends
+ * `{ detail }`; a proxy may send `{ message }` or a non-JSON page. Returns
+ * `null` when the body is not JSON or has neither field as a string.
+ */
+export const parseSlackBotErrorMessage = async (
+  response: Response
+): Promise<string | null> => {
+  const body: unknown = await response.json().catch(() => null);
+  if (typeof body !== "object" || body === null) {
+    return null;
+  }
+  if ("detail" in body && typeof body.detail === "string") {
+    return body.detail;
+  }
+  if ("message" in body && typeof body.message === "string") {
+    return body.message;
+  }
+  return null;
+};

--- a/web/src/i18n/messages/ar.json
+++ b/web/src/i18n/messages/ar.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "سمِّ بوت Slack هذا:"
         },
+        "unexpectedResponse": {
+          "message": "استجابة غير متوقعة من الخادم (HTTP {status})"
+        },
         "updateButton": {
           "label": "تحديث"
         },

--- a/web/src/i18n/messages/de.json
+++ b/web/src/i18n/messages/de.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "Benennen Sie diesen Slack-Bot:"
         },
+        "unexpectedResponse": {
+          "message": "Unerwartete Serverantwort (HTTP {status})"
+        },
         "updateButton": {
           "label": "Aktualisieren"
         },

--- a/web/src/i18n/messages/en.json
+++ b/web/src/i18n/messages/en.json
@@ -6873,6 +6873,9 @@
         "name": {
           "label": "Name This Slack Bot:"
         },
+        "unexpectedResponse": {
+          "message": "Unexpected server response (HTTP {status})"
+        },
         "updateButton": {
           "label": "Update"
         },

--- a/web/src/i18n/messages/es.json
+++ b/web/src/i18n/messages/es.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "Ponle un nombre a este bot de Slack:"
         },
+        "unexpectedResponse": {
+          "message": "Respuesta inesperada del servidor (HTTP {status})"
+        },
         "updateButton": {
           "label": "Actualizar"
         },

--- a/web/src/i18n/messages/fr.json
+++ b/web/src/i18n/messages/fr.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "Nommez ce bot Slack :"
         },
+        "unexpectedResponse": {
+          "message": "Réponse inattendue du serveur (HTTP {status})"
+        },
         "updateButton": {
           "label": "Mettre à jour"
         },

--- a/web/src/i18n/messages/ja.json
+++ b/web/src/i18n/messages/ja.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "この Slack ボットの名前:"
         },
+        "unexpectedResponse": {
+          "message": "予期しないサーバー応答 (HTTP {status})"
+        },
         "updateButton": {
           "label": "更新"
         },

--- a/web/src/i18n/messages/ko.json
+++ b/web/src/i18n/messages/ko.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "이 Slack 봇의 이름:"
         },
+        "unexpectedResponse": {
+          "message": "예기치 않은 서버 응답 (HTTP {status})"
+        },
         "updateButton": {
           "label": "업데이트"
         },

--- a/web/src/i18n/messages/pt.json
+++ b/web/src/i18n/messages/pt.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "Dê um nome a este bot do Slack:"
         },
+        "unexpectedResponse": {
+          "message": "Resposta inesperada do servidor (HTTP {status})"
+        },
         "updateButton": {
           "label": "Atualizar"
         },

--- a/web/src/i18n/messages/zh.json
+++ b/web/src/i18n/messages/zh.json
@@ -6843,6 +6843,9 @@
         "name": {
           "label": "为此 Slack 机器人命名："
         },
+        "unexpectedResponse": {
+          "message": "服务器返回了意外的响应 (HTTP {status})"
+        },
         "updateButton": {
           "label": "更新"
         },


### PR DESCRIPTION
## Description

Closes #14652.

The Slack bot token form read the error body with `response.json()` and then called `errorMsg.includes(...)`. When the backend or a proxy returned a non-JSON error page (502, 504, or a plain-text 500 from a network failure to `slack.com`), the promise rejected and no toast appeared. When the JSON body had no `detail` and no `message`, `errorMsg` was `undefined` and the handler threw a `TypeError`.

Changes:

- Add `parseSlackBotErrorMessage` in `web/src/app/admin/bots/new/lib.ts`. It reads `detail` or `message` from the body, and returns `null` when the body is not JSON or has neither field as a string.
- Use it in `SlackTokensForm`. When it returns `null`, the toast shows a translated fallback that includes the HTTP status: `admin.slackBots.tokensForm.unexpectedResponse.message`.
- Add the new key to `en.json` and every other locale file.
- Raise the `src/app/admin` type coverage floor from 96.2 to 96.3, since the untyped body read is gone.

## How Has This Been Tested?

- New component test `web/src/app/admin/bots/SlackTokensForm.test.tsx` covers four cases: a non-JSON error body, a JSON body with no `detail` or `message`, an `Invalid bot token:` detail, and a generic backend `detail`.
- `bun run test -- SlackTokensForm.test` and `bun run test -- src/i18n` pass.
- `pre-commit run --files ...` passes on all touched files, including the TypeScript type check and coverage hook.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #14652 by making the Slack bot token form always show an error toast when saving fails. Previously, non-JSON error bodies (proxy 502/504, plain-text 500) or JSON without `detail` or `message` crashed the handler with no feedback.

**Bug Fixes**
- Adds `parseSlackBotErrorMessage` to read `detail` or `message` safely, returning `null` when the body isn't JSON or lacks both fields.
- Shows a translated fallback toast with the HTTP status when no error message is available.
- Adds the new translation key to all locale files and raises the `src/app/admin` type coverage floor.

<sup>Written for commit 90323aecf22b13340bb22fc9b6bb45b7cf67d50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

