### PR TITLE
chore(web): replace casts on literals with satisfies and annotations

### DIFF
--- a/web/.type-coverage-baseline.yaml
+++ b/web/.type-coverage-baseline.yaml
@@ -8,7 +8,7 @@
 # `ods type-coverage typescript --update`.
 #
 # Generated file: do not edit by hand.
-total: 98.7
+total: 98.8
 packages:
   .: 100
   src: 99.4
@@ -48,7 +48,7 @@ packages:
   src/components/ui: 99.9
   src/components/voice: 100
   src/ee/hooks: 93.5
-  src/ee/lib: 99
+  src/ee/lib: 100
   src/ee/providers: 99.3
   src/ee/sections: 99.7
   src/ee/views: 99.7
@@ -68,9 +68,9 @@ packages:
   src/lib/billing: 100
   src/lib/build: 100
   src/lib/chat: 98.5
-  src/lib/connectors: 96.4
+  src/lib/connectors: 98.4
   src/lib/constants: 100
-  src/lib/credentials: 97.2
+  src/lib/credentials: 97.3
   src/lib/extension: 100
   src/lib/externalApps: 100
   src/lib/headers: 100
@@ -83,7 +83,7 @@ packages:
   src/lib/oauth: 100
   src/lib/permissions: 100
   src/lib/position: 100
-  src/lib/projects: 99.6
+  src/lib/projects: 99.7
   src/lib/search: 99.1
   src/lib/searchFilters: 95.3
   src/lib/settings: 96.6

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -49,7 +49,7 @@ export const SlackChannelConfigCreationForm = ({
     : false;
 
   const [searchEnabledAgents, nonSearchAgents] = useMemo(() => {
-    return personas.reduce(
+    return personas.reduce<[MinimalAgent[], MinimalAgent[]]>(
       (acc, persona) => {
         if (
           persona.tools.some((tool) => tool.in_code_tool_id === SEARCH_TOOL_ID)
@@ -60,7 +60,7 @@ export const SlackChannelConfigCreationForm = ({
         }
         return acc;
       },
-      [[], []] as [MinimalAgent[], MinimalAgent[]]
+      [[], []]
     );
   }, [personas]);
 

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -183,7 +183,7 @@ const createInitialSessionData = (
 ): ChatSessionData => ({
   sessionId,
   messageTree: new Map<number, Message>(),
-  chatState: "input" as ChatState,
+  chatState: "input",
   regenerationState: null,
   canContinue: false,
   submittedMessage: "",

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1005,7 +1005,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
   noSessionOutputPanelOpen: false,
 
   // Temporary active tab when no session exists
-  noSessionActiveOutputTab: "preview" as OutputTabType,
+  noSessionActiveOutputTab: "preview",
 
   // ===========================================================================
   // Session Management (mirrors chat's pattern)
@@ -1292,7 +1292,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const session = state.sessions.get(sessionId);
       if (!session) return state;
 
-      const streamItems = session.streamItems.map((item) => {
+      const streamItems = session.streamItems.map((item): StreamItem => {
         if (item.type === "tool_call" && item.toolCall.id === toolCallId) {
           return {
             ...item,
@@ -1300,7 +1300,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           };
         }
         return item;
-      }) as StreamItem[];
+      });
 
       const updatedSession: BuildSessionData = {
         ...session,
@@ -1333,7 +1333,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
 
       if (latestInFlightIndex === -1) return state;
 
-      const streamItems = session.streamItems.map((item, index) => {
+      const streamItems = session.streamItems.map((item, index): StreamItem => {
         if (index === latestInFlightIndex && item.type === "tool_call") {
           return {
             ...item,
@@ -1341,7 +1341,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           };
         }
         return item;
-      }) as StreamItem[];
+      });
 
       const updatedSession: BuildSessionData = {
         ...session,
@@ -1371,7 +1371,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       let streamItems: StreamItem[];
       if (existingIndex >= 0) {
         // Update existing todo_list
-        streamItems = session.streamItems.map((item, index) => {
+        streamItems = session.streamItems.map((item, index): StreamItem => {
           if (index === existingIndex && item.type === "todo_list") {
             return {
               ...item,
@@ -1379,7 +1379,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
             };
           }
           return item;
-        }) as StreamItem[];
+        });
       } else {
         // Create new todo_list item
         streamItems = [

--- a/web/src/ee/lib/search/svc.ts
+++ b/web/src/ee/lib/search/svc.ts
@@ -23,7 +23,7 @@ export async function classifyQuery(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       user_query: query,
-    } as SearchFlowClassificationRequest),
+    } satisfies SearchFlowClassificationRequest),
     signal,
   });
 

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -2000,23 +2000,20 @@ type ConnectorField = ConnectionConfiguration["values"][number];
 const buildInitialValuesForFields = (
   fields: ConnectorField[]
 ): Record<string, any> =>
-  fields.reduce(
-    (acc, field) => {
-      if (field.type === "select") {
-        acc[field.name] = null;
-      } else if (field.type === "list") {
-        acc[field.name] = field.default || [];
-      } else if (field.type === "multiselect") {
-        acc[field.name] = field.default || [];
-      } else if (field.type === "checkbox") {
-        acc[field.name] = field.default ?? false;
-      } else if (field.default !== undefined) {
-        acc[field.name] = field.default;
-      }
-      return acc;
-    },
-    {} as Record<string, any>
-  );
+  fields.reduce<Record<string, any>>((acc, field) => {
+    if (field.type === "select") {
+      acc[field.name] = null;
+    } else if (field.type === "list") {
+      acc[field.name] = field.default || [];
+    } else if (field.type === "multiselect") {
+      acc[field.name] = field.default || [];
+    } else if (field.type === "checkbox") {
+      acc[field.name] = field.default ?? false;
+    } else if (field.default !== undefined) {
+      acc[field.name] = field.default;
+    }
+    return acc;
+  }, {});
 
 export function createConnectorInitialValues(
   connector: ConfigurableSources
@@ -2048,32 +2045,31 @@ export function createConnectorValidationSchema(
           ? schema.min(1, "Select at least one group you manage")
           : schema
       ),
-    ...[...configuration.values, ...configuration.advanced_values].reduce(
-      (acc, field) => {
-        let schema: any =
-          field.type === "select"
-            ? Yup.string()
-            : field.type === "list"
+    ...[...configuration.values, ...configuration.advanced_values].reduce<
+      Record<string, any>
+    >((acc, field) => {
+      let schema: any =
+        field.type === "select"
+          ? Yup.string()
+          : field.type === "list"
+            ? Yup.array().of(Yup.string())
+            : field.type === "multiselect"
               ? Yup.array().of(Yup.string())
-              : field.type === "multiselect"
-                ? Yup.array().of(Yup.string())
-                : field.type === "string_pair_list"
-                  ? Yup.array().of(Yup.object())
-                  : field.type === "checkbox"
-                    ? Yup.boolean()
-                    : field.type === "file"
-                      ? Yup.mixed()
-                      : Yup.string();
+              : field.type === "string_pair_list"
+                ? Yup.array().of(Yup.object())
+                : field.type === "checkbox"
+                  ? Yup.boolean()
+                  : field.type === "file"
+                    ? Yup.mixed()
+                    : Yup.string();
 
-        if (!field.optional) {
-          schema = schema.required(`${field.label} is required`);
-        }
+      if (!field.optional) {
+        schema = schema.required(`${field.label} is required`);
+      }
 
-        acc[field.name] = schema;
-        return acc;
-      },
-      {} as Record<string, any>
-    ),
+      acc[field.name] = schema;
+      return acc;
+    }, {}),
     // These are advanced settings
     indexingStart: Yup.string().nullable(),
     pruneFreq: Yup.number().min(

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -318,77 +318,130 @@ export interface TestRailCredentialJson {
   testrail_api_key: string;
 }
 
+// Gmail and Google Drive use dedicated credential UIs, so their templates are partial.
+type CredentialTemplateMap = Record<ValidSources, object | null> & {
+  github: GithubCredentialJson;
+  gitlab: GitlabCredentialJson;
+  lumapps: LumAppsCredentialJson;
+  bitbucket: BitbucketCredentialJson;
+  slack: SlackCredentialJson;
+  bookstack: BookstackCredentialJson;
+  outline: OutlineCredentialJson;
+  confluence: ConfluenceCredentialJson;
+  jira: JiraCredentialJson;
+  productboard: ProductboardCredentialJson;
+  slab: SlabCredentialJson;
+  coda: CodaCredentialJson;
+  notion: NotionCredentialJson;
+  guru: GuruCredentialJson;
+  gong: GongCredentialJson;
+  zulip: ZulipCredentialJson;
+  linear: LinearCredentialJson;
+  hubspot: HubSpotCredentialJson;
+  document360: Document360CredentialJson;
+  loopio: LoopioCredentialJson;
+  box: BoxCredentialJson;
+  dropbox: DropboxCredentialJson;
+  salesforce: SalesforceCredentialJson;
+  sharepoint: CredentialTemplateWithAuth<SharepointCredentialJson>;
+  asana: AsanaCredentialJson;
+  teams: TeamsCredentialJson;
+  zendesk: ZendeskCredentialJson;
+  discourse: DiscourseCredentialJson;
+  axero: AxeroCredentialJson;
+  clickup: ClickupCredentialJson;
+  s3: CredentialTemplateWithAuth<S3CredentialJson>;
+  r2: R2CredentialJson;
+  google_cloud_storage: GCSCredentialJson;
+  oci_storage: OCICredentialJson;
+  freshdesk: FreshdeskCredentialJson;
+  fireflies: FirefliesCredentialJson;
+  braintrust: BraintrustCredentialJson;
+  canvas: CanvasCredentialJson;
+  egnyte: EgnyteCredentialJson;
+  airtable: AirtableCredentialJson;
+  drupal_wiki: DrupalWikiCredentialJson;
+  discord: DiscordCredentialJson;
+  google_drive: Partial<GoogleDriveCredentialJson>;
+  gmail: Partial<GmailCredentialJson>;
+  gitbook: GitbookCredentialJson;
+  highspot: HighspotCredentialJson;
+  imap: ImapCredentialJson;
+  testrail: TestRailCredentialJson;
+};
+
 export const credentialTemplates: Record<ValidSources, any> = {
   github: {
     github_access_token: "",
     github_base_url: null,
-  } as GithubCredentialJson,
+  },
   gitlab: {
     gitlab_url: "",
     gitlab_access_token: "",
-  } as GitlabCredentialJson,
+  },
   lumapps: {
     lumapps_application_id: "",
     lumapps_api_key: "",
     lumapps_service_user: "",
-  } as LumAppsCredentialJson,
+  },
   bitbucket: {
     bitbucket_email: "",
     bitbucket_api_token: "",
-  } as BitbucketCredentialJson,
-  slack: { slack_bot_token: "" } as SlackCredentialJson,
+  },
+  slack: { slack_bot_token: "" },
   bookstack: {
     bookstack_base_url: "",
     bookstack_api_token_id: "",
     bookstack_api_token_secret: "",
-  } as BookstackCredentialJson,
+  },
   outline: {
     outline_base_url: "",
     outline_api_token: "",
-  } as OutlineCredentialJson,
+  },
   confluence: {
     confluence_username: "",
     confluence_access_token: "",
-  } as ConfluenceCredentialJson,
+  },
   jira: {
     jira_user_email: null,
     jira_api_token: "",
-  } as JiraCredentialJson,
-  productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
-  slab: { slab_bot_token: "" } as SlabCredentialJson,
-  coda: { coda_bearer_token: "" } as CodaCredentialJson,
-  notion: { notion_integration_token: "" } as NotionCredentialJson,
-  guru: { guru_user: "", guru_user_token: "" } as GuruCredentialJson,
+  },
+  productboard: { productboard_access_token: "" },
+  slab: { slab_bot_token: "" },
+  coda: { coda_bearer_token: "" },
+  notion: { notion_integration_token: "" },
+  guru: { guru_user: "", guru_user_token: "" },
   gong: {
     gong_access_key: "",
     gong_access_key_secret: "",
     gong_base_url: null,
-  } as GongCredentialJson,
-  zulip: { zuliprc_content: "" } as ZulipCredentialJson,
-  linear: { linear_api_key: "" } as LinearCredentialJson,
-  hubspot: { hubspot_access_token: "" } as HubSpotCredentialJson,
+  },
+  zulip: { zuliprc_content: "" },
+  linear: { linear_api_key: "" },
+  hubspot: { hubspot_access_token: "" },
   document360: {
     portal_id: "",
     document360_api_token: "",
-  } as Document360CredentialJson,
+  },
   loopio: {
     loopio_subdomain: "",
     loopio_client_id: "",
     loopio_client_token: "",
-  } as LoopioCredentialJson,
+  },
   box: {
     box_client_id: "",
     box_client_secret: "",
     box_enterprise_id: "",
     box_user_email: null,
-  } as BoxCredentialJson,
-  dropbox: { dropbox_access_token: "" } as DropboxCredentialJson,
+  },
+  dropbox: { dropbox_access_token: "" },
   salesforce: {
     sf_username: "",
     sf_password: "",
     sf_security_token: "",
     is_sandbox: false,
-  } as SalesforceCredentialJson,
+  },
+  // SAFETY: the certificate template seeds sp_private_key with null, which TypedFile does not allow.
   sharepoint: {
     authentication_method: "client_credentials",
     authMethods: [
@@ -421,29 +474,29 @@ export const credentialTemplates: Record<ValidSources, any> = {
   } as CredentialTemplateWithAuth<SharepointCredentialJson>,
   asana: {
     asana_api_token_secret: "",
-  } as AsanaCredentialJson,
+  },
   teams: {
     teams_client_id: "",
     teams_client_secret: "",
     teams_directory_id: "",
-  } as TeamsCredentialJson,
+  },
   zendesk: {
     zendesk_subdomain: "",
     zendesk_email: "",
     zendesk_token: "",
-  } as ZendeskCredentialJson,
+  },
   discourse: {
     discourse_api_key: "",
     discourse_api_username: "",
-  } as DiscourseCredentialJson,
+  },
   axero: {
     base_url: "",
     axero_api_token: "",
-  } as AxeroCredentialJson,
+  },
   clickup: {
     clickup_api_token: "",
     clickup_team_id: "",
-  } as ClickupCredentialJson,
+  },
 
   s3: {
     authentication_method: "access_key",
@@ -474,45 +527,45 @@ export const credentialTemplates: Record<ValidSources, any> = {
         disablePermSync: false,
       },
     ],
-  } as CredentialTemplateWithAuth<S3CredentialJson>,
+  },
   r2: {
     account_id: "",
     r2_access_key_id: "",
     r2_secret_access_key: "",
-  } as R2CredentialJson,
+  },
   google_cloud_storage: {
     access_key_id: "",
     secret_access_key: "",
-  } as GCSCredentialJson,
+  },
   oci_storage: {
     namespace: "",
     region: "",
     access_key_id: "",
     secret_access_key: "",
-  } as OCICredentialJson,
+  },
   freshdesk: {
     freshdesk_domain: "",
     freshdesk_api_key: "",
-  } as FreshdeskCredentialJson,
+  },
   fireflies: {
     fireflies_api_key: "",
-  } as FirefliesCredentialJson,
+  },
   braintrust: {
     braintrust_api_key: "",
-  } as BraintrustCredentialJson,
+  },
   canvas: {
     canvas_access_token: "",
-  } as CanvasCredentialJson,
+  },
   egnyte: {
     domain: "",
     access_token: "",
-  } as EgnyteCredentialJson,
+  },
   airtable: {
     airtable_access_token: "",
-  } as AirtableCredentialJson,
+  },
   drupal_wiki: {
     drupal_wiki_api_token: "",
-  } as DrupalWikiCredentialJson,
+  },
   xenforo: null,
   google_sites: null,
   file: null,
@@ -524,29 +577,29 @@ export const credentialTemplates: Record<ValidSources, any> = {
   not_applicable: null,
   ingestion_api: null,
   federated_slack: null,
-  discord: { discord_bot_token: "" } as DiscordCredentialJson,
+  discord: { discord_bot_token: "" },
 
   // NOTE: These are Special Cases
-  google_drive: { google_tokens: "" } as GoogleDriveCredentialJson,
-  gmail: { google_tokens: "" } as GmailCredentialJson,
+  google_drive: { google_tokens: "" },
+  gmail: { google_tokens: "" },
   gitbook: {
     gitbook_api_key: "",
-  } as GitbookCredentialJson,
+  },
   highspot: {
     highspot_url: "",
     highspot_key: "",
     highspot_secret: "",
-  } as HighspotCredentialJson,
+  },
   imap: {
     imap_username: "",
     imap_password: "",
-  } as ImapCredentialJson,
+  },
   testrail: {
     testrail_base_url: "",
     testrail_username: "",
     testrail_api_key: "",
-  } as TestRailCredentialJson,
-};
+  },
+} satisfies CredentialTemplateMap;
 
 export const credentialDisplayNames: Record<string, string> = {
   // Github

--- a/web/src/lib/credentials/components/CreateCredential.tsx
+++ b/web/src/lib/credentials/components/CreateCredential.tsx
@@ -205,17 +205,15 @@ export default function CreateCredential({
     templateWithAuth?.authMethods?.[0]?.value || undefined;
 
   return (
-    <Formik
-      initialValues={
-        {
-          name: "",
-          is_public: isGlobalHolder || !businessTier,
-          groups: [],
-          ...(initialAuthMethod && {
-            authentication_method: initialAuthMethod,
-          }),
-        } as CreateCredentialFormValues
-      }
+    <Formik<CreateCredentialFormValues>
+      initialValues={{
+        name: "",
+        is_public: isGlobalHolder || !businessTier,
+        groups: [],
+        ...(initialAuthMethod && {
+          authentication_method: initialAuthMethod,
+        }),
+      }}
       validationSchema={validationSchema}
       onSubmit={() => {}} // This will be overridden by our custom submit handlers
     >

--- a/web/src/lib/projects/providers.tsx
+++ b/web/src/lib/projects/providers.tsx
@@ -661,7 +661,7 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
                 latest.name !== f.name ||
                 latest.file_type !== f.file_type
               ) {
-                next.push({ ...f, ...latest } as ProjectFile);
+                next.push({ ...f, ...latest });
                 changed = true;
                 continue;
               }
@@ -678,7 +678,7 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
         setCurrentProjectDetails((prev) => {
           if (!prev || !prev.files || prev.files.length === 0) return prev;
           let changed = false;
-          const nextFiles = prev.files.map((f) => {
+          const nextFiles = prev.files.map((f): ProjectFile => {
             const latest = statusById.get(f.id);
             if (latest) {
               if (
@@ -687,13 +687,13 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
                 latest.file_type !== f.file_type
               ) {
                 changed = true;
-                return { ...f, ...latest } as ProjectFile;
+                return { ...f, ...latest };
               }
             }
             return f;
           });
           return changed
-            ? ({ ...prev, files: nextFiles } as ProjectDetails)
+            ? ({ ...prev, files: nextFiles } satisfies ProjectDetails)
             : prev;
         });
 

--- a/web/src/lib/tools/svc.ts
+++ b/web/src/lib/tools/svc.ts
@@ -75,7 +75,7 @@ export async function updateToolsStatus(
     body: JSON.stringify({
       tool_ids: toolIds,
       enabled: enabled,
-    } as ToolStatusUpdateRequest),
+    } satisfies ToolStatusUpdateRequest),
   });
 
   if (!response.ok) {

--- a/web/src/sections/actions/MCPPageContent.tsx
+++ b/web/src/sections/actions/MCPPageContent.tsx
@@ -56,8 +56,8 @@ export default function MCPPageContent() {
   >([]);
   const [searchQuery, setSearchQuery] = useState("");
 
-  const mcpServers = useMemo(
-    () => (mcpData?.mcp_servers || []) as MCPServer[],
+  const mcpServers = useMemo<MCPServer[]>(
+    () => mcpData?.mcp_servers || [],
     [mcpData?.mcp_servers]
   );
   const isLoading = isMcpLoading;

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -287,7 +287,7 @@ export default function BedrockModal({
         (existingLlmProvider?.custom_config
           ?.AWS_BEARER_TOKEN_BEDROCK as string) ?? "",
     },
-  } as BedrockModalValues;
+  };
 
   const validationSchema = buildValidationSchema(t, isOnboarding, {
     extra: {

--- a/web/src/sections/modals/languageModels/LMStudioModal.tsx
+++ b/web/src/sections/modals/languageModels/LMStudioModal.tsx
@@ -133,7 +133,7 @@ export default function LMStudioModal({
     custom_config: {
       LM_STUDIO_API_KEY: existingLlmProvider?.custom_config?.LM_STUDIO_API_KEY,
     },
-  } as LMStudioModalValues;
+  };
 
   const validationSchema = buildValidationSchema(t, isOnboarding, {
     apiBase: true,

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -180,7 +180,7 @@ export default function OllamaModal({
       existingLlmProvider
     ),
     api_base: existingLlmProvider?.api_base ?? defaultApiBase,
-  } as OllamaModalValues;
+  };
 
   const validationSchema = useMemo(
     () =>

--- a/web/src/sections/modals/languageModels/VertexAIModal.tsx
+++ b/web/src/sections/modals/languageModels/VertexAIModal.tsx
@@ -213,7 +213,7 @@ export default function VertexAIModal({
       vertex_project:
         (existingLlmProvider?.custom_config?.vertex_project as string) ?? "",
     },
-  } as VertexAIModalValues;
+  };
 
   const validationSchema = buildValidationSchema(t, isOnboarding, {
     extra: {

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -2611,27 +2611,20 @@ function ConnectorsSettings() {
   ];
 
   // Group indexed connectors by source
-  const groupedConnectors = ccPairs.reduce(
-    (acc, ccPair) => {
-      if (!acc[ccPair.source]) {
-        acc[ccPair.source] = {
-          source: ccPair.source,
-          hasActiveConnector: false,
-        };
-      }
-      if (ACTIVE_STATUSES.includes(ccPair.status)) {
-        acc[ccPair.source]!.hasActiveConnector = true;
-      }
-      return acc;
-    },
-    {} as Record<
-      string,
-      {
-        source: ValidSources;
-        hasActiveConnector: boolean;
-      }
-    >
-  );
+  const groupedConnectors = ccPairs.reduce<
+    Record<string, { source: ValidSources; hasActiveConnector: boolean }>
+  >((acc, ccPair) => {
+    if (!acc[ccPair.source]) {
+      acc[ccPair.source] = {
+        source: ccPair.source,
+        hasActiveConnector: false,
+      };
+    }
+    if (ACTIVE_STATUSES.includes(ccPair.status)) {
+      acc[ccPair.source]!.hasActiveConnector = true;
+    }
+    return acc;
+  }, {});
 
   const hasConnectors =
     Object.keys(groupedConnectors).length > 0 || federatedConnectors.length > 0;


### PR DESCRIPTION
## Description

This PR is part of a stack that raises TypeScript type coverage in `web/`. It is on top of #14653.

Replace 67 casts on literals with `satisfies`, annotations and generic arguments. Unlike a cast, these let the compiler check the value:
- `credentialTemplates` in `lib/connectors/credentials.ts`: remove 47 per-entry casts. A new `CredentialTemplateMap` type holds the credential type of each source, and the object uses `satisfies CredentialTemplateMap`. The exported type stays `Record<ValidSources, any>`, because `CreateCredential.tsx` needs runtime narrowing before it can use a stricter type.
- Object spreads in `lib/projects/providers.tsx`, string literals cast to unions in `useBuildSessionStore.ts` and `useChatSessionStore.ts`, and request literals in `ee/lib/search/svc.ts` and `lib/tools/svc.ts`.
- Form initial values in four LLM provider modals, `MCPPageContent.tsx`, `SettingsPage.tsx` and the Slack channel form.

The emitted JavaScript does not change. The change removes 67 uncovered items and raises 5 floors. For example, `src/lib/connectors` goes from 96.4 to 98.4 and `src/ee/lib` from 99 to 100.

### What the stricter types showed
- **Gmail and Google Drive templates:** they have no `google_primary_admin`, which the type requires. Both sources use their own credential UIs, so the map types them as `Partial<...>`.
- **Sharepoint certificate template:** it sets `sp_private_key: null`, but the type allows only `TypedFile | undefined`. The cast stays, with a `SAFETY` comment.
- **Seven other LLM modals:** their form types need `api_key: string`, but `useInitialValues` returns `string | undefined`. They keep their casts.

### Not in this PR
- Empty objects cast to types with required keys (`{} as Record<ValidSources, ...>`), and partial `User` objects. They need runtime changes.
- CSS custom properties cast to `CSSProperties`. They need a module augmentation.
- `.filter(Boolean) as T[]`. It needs a type predicate.

## How Has This Been Tested?

- For each changed file, the JavaScript emitted from the base and from this branch (types and comments removed) is the same.
- `ods type-coverage typescript --check` passes, and the per-file report shows no file with more uncovered items.
- Jest suites for credentials, projects, tools, `MCPPageContent`, craft hooks, connectors and `languageModels` pass (111 tests).
- `prek` (oxlint and oxfmt) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces 67 casts on literals in `web/` with `satisfies`, annotations, and generic arguments so the compiler checks the values instead of bypassing type checks. Emitted JavaScript is unchanged, and type coverage rises overall and in four packages.

**Refactors**
- New `CredentialTemplateMap` type checks each credential template against its source's credential type; the exported type stays `Record<ValidSources, any>` because `CreateCredential.tsx` needs runtime narrowing.
- Gmail and Google Drive templates are typed `Partial` because they use dedicated credential UIs and lack `google_primary_admin`.
- The Sharepoint template keeps its cast because it seeds `sp_private_key: null`, which `TypedFile` disallows; a `SAFETY` comment marks it.
- Seven LLM modals keep casts because their forms require `api_key: string` but `useInitialValues` returns `string | undefined`.
- Empty-object casts, CSS custom property casts, and `.filter(Boolean) as T[]` are out of scope; they need runtime or module changes.

<sup>Written for commit 445cfb94a077ba42080b245389423c07871d9faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

