### PR TITLE
chore(web): remove redundant `as Route` casts

### DIFF
--- a/web/.type-coverage-baseline.yaml
+++ b/web/.type-coverage-baseline.yaml
@@ -13,18 +13,18 @@ packages:
   .: 100
   src: 99.4
   src/app: 99.5
-  src/app/admin: 96.2
+  src/app/admin: 96.3
   src/app/anonymous: 100
   src/app/api: 98.4
   src/app/app: 98.2
-  src/app/auth: 98
+  src/app/auth: 98.1
   src/app/components: 100
   src/app/config: 100
   src/app/connector: 90
   src/app/craft: 99
-  src/app/ee: 95.6
+  src/app/ee: 95.7
   src/app/federated: 97
-  src/app/mcp: 99.3
+  src/app/mcp: 99.5
   src/app/nrf: 99.2
   src/app/oauth-config: 100
   src/components: 97.7
@@ -58,9 +58,9 @@ packages:
   src/interfaces: 100
   src/layouts: 100
   src/layouts/chromes: 99.8
-  src/layouts/craft: 92.5
+  src/layouts/craft: 96.1
   src/lib: 98.4
-  src/lib/agents: 99.1
+  src/lib/agents: 99.2
   src/lib/analytics: 99.4
   src/lib/app: 100
   src/lib/auth: 95.4
@@ -82,7 +82,7 @@ packages:
   src/lib/notifications: 97.3
   src/lib/oauth: 84.8
   src/lib/permissions: 100
-  src/lib/position: 98.6
+  src/lib/position: 100
   src/lib/projects: 99.3
   src/lib/search: 97.2
   src/lib/searchFilters: 95.3
@@ -92,14 +92,14 @@ packages:
   src/lib/sso: 99.2
   src/lib/tools: 97.4
   src/lib/tracing: 96.9
-  src/lib/usage: 97.4
+  src/lib/usage: 97.9
   src/lib/users: 97.8
   src/lib/voice: 98.3
   src/lib/webSearch: 97.3
   src/providers: 99.4
   src/refresh-components: 99.7
   src/refresh-components/avatars: 99.7
-  src/refresh-components/buttons: 99.6
+  src/refresh-components/buttons: 99.7
   src/refresh-components/cards: 98.4
   src/refresh-components/commandmenu: 99.7
   src/refresh-components/form: 98.6
@@ -113,7 +113,7 @@ packages:
   src/sections: 100
   src/sections/actions: 99.1
   src/sections/admin: 100
-  src/sections/agents: 99.6
+  src/sections/agents: 99.8
   src/sections/banners: 98.5
   src/sections/cards: 100
   src/sections/chat: 99.7
@@ -122,7 +122,7 @@ packages:
   src/sections/knowledge: 99.7
   src/sections/modals: 99.2
   src/sections/model-selector: 99.6
-  src/sections/onboarding: 99.7
+  src/sections/onboarding: 99.8
   src/sections/settings: 100
   src/sections/sidebar: 99.4
   src/sections/skills: 99.8

--- a/web/src/app/admin/bots/SlackBotTable.tsx
+++ b/web/src/app/admin/bots/SlackBotTable.tsx
@@ -3,7 +3,6 @@
 import { PageSelector } from "@/components/PageSelector";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import { useEffect, useState } from "react";
 import {
   Table,
@@ -24,18 +23,18 @@ function ClickableTableRow({
   children,
   ...props
 }: {
-  url: string;
+  url: `/admin/bots/${number}`;
   children: React.ReactNode;
   [key: string]: any;
 }) {
   const router = useRouter();
 
   useEffect(() => {
-    router.prefetch(url as Route);
+    router.prefetch(url);
   }, [router, url]);
 
   const navigate = () => {
-    router.push(url as Route);
+    router.push(url);
   };
 
   return (

--- a/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
+++ b/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
@@ -14,7 +14,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import Link from "next/link";
-import type { Route } from "next";
 import { useState } from "react";
 import { deleteSlackChannelConfig, isPersonaASlackBotPersona } from "./lib";
 import { Card } from "@/components/ui/card";
@@ -106,9 +105,7 @@ export default function SlackChannelConfigsTable({
                           slackChannelConfig.persona
                         ) ? (
                           <Link
-                            href={
-                              `/app/agents/edit/${slackChannelConfig.persona.id}` as Route
-                            }
+                            href={`/app/agents/edit/${slackChannelConfig.persona.id}`}
                             className="text-primary hover:underline"
                           >
                             {slackChannelConfig.persona.name}

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -23,7 +23,6 @@ import { RadioGroup } from "@/components/ui/radio-group";
 import { RadioGroupItemField } from "@/components/ui/RadioGroupItemField";
 import { AlertCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import { Tooltip } from "@opal/components";
 import { SourceIcon } from "@/components/SourceIcon";
 import Link from "next/link";
@@ -380,7 +379,7 @@ export function SlackChannelConfigFormFields({
                     <button
                       type="button"
                       onClick={() =>
-                        router.push(`/app/agents/edit/${persona.id}` as Route)
+                        router.push(`/app/agents/edit/${persona.id}`)
                       }
                       key={persona.id}
                       className="p-2 bg-background-100 cursor-pointer rounded-md flex items-center gap-2"

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -18,7 +18,6 @@ import {
   ConnectorIndexingStatusLite,
   FederatedConnectorStatus,
 } from "@/lib/types";
-import type { Route } from "next";
 import { useRouter } from "next/navigation";
 import Truncated from "@/refresh-components/texts/Truncated";
 import {
@@ -47,13 +46,13 @@ import { can } from "@/lib/permissions/resource-actions";
 // row to not navigate as expected.
 function navigateWithModifier(
   e: React.MouseEvent,
-  url: string,
+  url: `/admin/connector/${number}` | `/admin/federated/${number}`,
   router: ReturnType<typeof useRouter>
 ) {
   if (e.metaKey || e.ctrlKey) {
     window.open(url, "_blank");
   } else {
-    router.push(url as Route);
+    router.push(url);
   }
 }
 
@@ -159,7 +158,7 @@ function ConnectorRow({
   const router = useRouter();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
-  const connectorUrl = `/admin/connector/${ccPairsIndexingStatus.cc_pair_id}`;
+  const connectorUrl: `/admin/connector/${number}` = `/admin/connector/${ccPairsIndexingStatus.cc_pair_id}`;
 
   const handleRowClick = (e: React.MouseEvent) => {
     navigateWithModifier(e, connectorUrl, router);
@@ -243,7 +242,7 @@ function FederatedConnectorRow({
   const router = useRouter();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
-  const federatedUrl = `/admin/federated/${federatedConnector.id}`;
+  const federatedUrl: `/admin/federated/${number}` = `/admin/federated/${federatedConnector.id}`;
 
   const handleRowClick = (e: React.MouseEvent) => {
     navigateWithModifier(e, federatedUrl, router);

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -94,6 +94,7 @@ export default function Layout({ children }: LayoutProps) {
             <InputSelect
               value={pathname}
               onValueChange={(href) =>
+                // SAFETY: the options are the static hrefs in `tabs`.
                 router.push(href as Route, { scroll: false })
               }
             >

--- a/web/src/app/auth/impersonate/layout.tsx
+++ b/web/src/app/auth/impersonate/layout.tsx
@@ -20,7 +20,7 @@ export default async function Layout({ children }: LayoutProps) {
   }
 
   if (!authResult.user?.is_cloud_superuser) {
-    redirect("/app" as Route);
+    redirect("/app");
   }
 
   return <>{children}</>;

--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -3,7 +3,6 @@
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import { Formik, Form, FormikHelpers } from "formik";
 import * as Yup from "yup";
 import { toast } from "@opal/layouts";
@@ -46,7 +45,7 @@ export default function ImpersonatePage() {
         helpers.setSubmitting(false);
       } else {
         helpers.setSubmitting(false);
-        router.push("/app" as Route);
+        router.push("/app");
       }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : genericError);

--- a/web/src/app/craft/layout.tsx
+++ b/web/src/app/craft/layout.tsx
@@ -28,7 +28,7 @@ export default async function Layout({ children }: LayoutProps) {
   // Only explicit true enables the feature; false or undefined = disabled
   const settings = await fetchSettingsSS();
   if (settings?.settings?.onyx_craft_enabled !== true) {
-    redirect("/app" as Route);
+    redirect("/app");
   }
 
   return <>{children}</>;

--- a/web/src/app/craft/v1/apps/admin/page.tsx
+++ b/web/src/app/craft/v1/apps/admin/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
-import type { Route } from "next";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
 export default function ExternalAppsAdminRedirect() {
-  redirect(ADMIN_ROUTES.CRAFT_APPS.path as Route);
+  redirect(ADMIN_ROUTES.CRAFT_APPS.path);
 }

--- a/web/src/app/craft/v1/apps/admin/skillAssociationNavigation.ts
+++ b/web/src/app/craft/v1/apps/admin/skillAssociationNavigation.ts
@@ -35,7 +35,7 @@ export function externalAppContextFromSearchParams({
 }
 
 export function externalAppAdminUrl(externalAppId: number): Route {
-  return `/admin/craft/apps?editAppId=${externalAppId}` as Route;
+  return `/admin/craft/apps?editAppId=${externalAppId}`;
 }
 
 export function skillEditorUrlForApp(
@@ -44,12 +44,12 @@ export function skillEditorUrlForApp(
 ): Route {
   const params = externalAppParams(app);
   if (draftId) params.set("draft", draftId);
-  return `/craft/v1/skills/new?${params.toString()}` as Route;
+  return `/craft/v1/skills/new?${params.toString()}`;
 }
 
 export function skillEditUrlForApp(
   skillId: string,
   app: ExternalAppAdminResponse
-): Route {
-  return `/craft/v1/skills/edit/${skillId}?${externalAppParams(app).toString()}` as Route;
+): `/craft/v1/skills/edit/${string}?${string}` {
+  return `/craft/v1/skills/edit/${skillId}?${externalAppParams(app).toString()}`;
 }

--- a/web/src/app/craft/v1/apps/manage/page.tsx
+++ b/web/src/app/craft/v1/apps/manage/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
-import type { Route } from "next";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
 export default function ManageAppsPage() {
-  redirect(ADMIN_ROUTES.CRAFT_APPS.path as Route);
+  redirect(ADMIN_ROUTES.CRAFT_APPS.path);
 }

--- a/web/src/app/craft/v1/apps/oauth/callback/page.tsx
+++ b/web/src/app/craft/v1/apps/oauth/callback/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { Route } from "next";
 import { mutate as globalMutate } from "swr";
 import { SettingsLayouts } from "@opal/layouts";
 import { Button, Card, Text } from "@opal/components";
@@ -66,7 +65,7 @@ export default function ExternalAppsOAuthCallbackPage() {
           return;
         }
         await globalMutate(SWR_KEYS.buildExternalApps);
-        setTimeout(() => router.push(CRAFT_APPS_PATH as Route), 800);
+        setTimeout(() => router.push(CRAFT_APPS_PATH), 800);
       } catch (e) {
         setStatus("error");
         setErrorMessage(e instanceof Error ? e.message : String(e));
@@ -101,7 +100,7 @@ export default function ExternalAppsOAuthCallbackPage() {
                   </Text>
                 )}
                 <div className="pt-2">
-                  <Button onClick={() => router.push(CRAFT_APPS_PATH as Route)}>
+                  <Button onClick={() => router.push(CRAFT_APPS_PATH)}>
                     {t("backButton")}
                   </Button>
                 </div>

--- a/web/src/app/craft/v1/constants.ts
+++ b/web/src/app/craft/v1/constants.ts
@@ -1,7 +1,9 @@
+import type { Route } from "next";
+
 export const CRAFT_PATH = "/craft/v1";
 export const CRAFT_TASKS_PATH = `${CRAFT_PATH}/tasks`;
 export const CRAFT_SKILLS_PATH = `${CRAFT_PATH}/skills`;
-export const CRAFT_APPS_PATH = `${CRAFT_PATH}/apps`;
+export const CRAFT_APPS_PATH = `${CRAFT_PATH}/apps` satisfies Route;
 export const CRAFT_OAUTH_COOKIE_NAME = "build_mode_oauth";
 
 // Backend BFF root for Craft/build endpoints (routes through the frontend

--- a/web/src/app/craft/v1/tasks/constants.ts
+++ b/web/src/app/craft/v1/tasks/constants.ts
@@ -4,19 +4,23 @@
 
 import type { Route } from "next";
 
-export const TASKS_PATH = "/craft/v1/tasks" as Route;
-export const NEW_TASK_PATH = `${TASKS_PATH}/new` as Route;
+export const TASKS_PATH = "/craft/v1/tasks" satisfies Route;
+export const NEW_TASK_PATH = `${TASKS_PATH}/new` satisfies Route;
 
-export function taskDetailPath(taskId: string): Route {
-  return `${TASKS_PATH}/${taskId}` as Route;
+export function taskDetailPath(
+  taskId: string
+): `${typeof TASKS_PATH}/${string}` {
+  return `${TASKS_PATH}/${taskId}`;
 }
 
-export function taskEditPath(taskId: string): Route {
-  return `${TASKS_PATH}/${taskId}/edit` as Route;
+export function taskEditPath(
+  taskId: string
+): `${typeof TASKS_PATH}/${string}/edit` {
+  return `${TASKS_PATH}/${taskId}/edit`;
 }
 
 export function buildSessionPath(sessionId: string): Route {
-  return `/craft/v1?sessionId=${sessionId}` as Route;
+  return `/craft/v1?sessionId=${sessionId}`;
 }
 
 // Default page size for the scheduled task list.

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -20,7 +20,6 @@ import { Feedback, TaskStatus } from "@/lib/types";
 import { DateRange } from "@opal/components";
 import { PageSelector } from "@/components/PageSelector";
 import Link from "next/link";
-import type { Route } from "next";
 import { FeedbackBadge } from "@/app/ee/admin/performance/query-history/FeedbackBadge";
 import KickoffCSVExport from "@/app/ee/admin/performance/query-history/KickoffCSVExport";
 import CardSection from "@/components/admin/CardSection";
@@ -89,9 +88,7 @@ function QueryHistoryTableRow({
       {/* Wrapping in <td> to avoid console warnings */}
       <td className="w-0 p-0">
         <Link
-          href={
-            `/ee/admin/performance/query-history/${chatSessionMinimal.id}` as Route
-          }
+          href={`/ee/admin/performance/query-history/${chatSessionMinimal.id}`}
           className="absolute w-full h-full start-0 top-0"
         ></Link>
       </td>

--- a/web/src/app/ee/admin/standard-answer/StandardAnswerCreationForm.tsx
+++ b/web/src/app/ee/admin/standard-answer/StandardAnswerCreationForm.tsx
@@ -7,7 +7,6 @@ import { StandardAnswerCategory, StandardAnswer } from "@/lib/types";
 import CardSection from "@/components/admin/CardSection";
 import { Form, Formik, ErrorMessage } from "formik";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import * as Yup from "yup";
 import {
   createStandardAnswer,
@@ -99,7 +98,7 @@ export const StandardAnswerCreationForm = ({
             }
             formikHelpers.setSubmitting(false);
             if (response.ok) {
-              router.push(`/ee/admin/standard-answer?u=${Date.now()}` as Route);
+              router.push(`/ee/admin/standard-answer?u=${Date.now()}`);
             } else {
               const responseJson = await response.json();
               const errorMsg = responseJson.detail || responseJson.message;

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/table";
 
 import Link from "next/link";
-import type { Route } from "next";
 import { StandardAnswer, StandardAnswerCategory } from "@/lib/types";
 import { SvgSearch } from "@opal/icons";
 import { useState, JSX } from "react";
@@ -117,7 +116,7 @@ const StandardAnswersTableRow = ({
       entries={[
         <Link
           key={`edit-${standardAnswer.id}`}
-          href={`/ee/admin/standard-answer/${standardAnswer.id}` as Route}
+          href={`/ee/admin/standard-answer/${standardAnswer.id}`}
         >
           <SvgEdit size={16} />
         </Link>,

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -243,7 +243,7 @@ export default function MCPOAuthCallbackPage() {
                 />
                 <Button
                   width="full"
-                  onClick={() => router.push(DEFAULT_REDIRECT_PATH as Route)}
+                  onClick={() => router.push(DEFAULT_REDIRECT_PATH)}
                 >
                   {t("mcpOauthCallback.backToChatButton.label")}
                 </Button>

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -273,6 +273,7 @@ export default function useChatController({
     const isOnChatPage = pathname === "/app";
 
     if (isOnChatPage && !navigatingAway.current) {
+      // SAFETY: buildChatUrl with search=false builds `/app?...`.
       router.push(newUrl as Route, { scroll: false });
     }
 
@@ -404,6 +405,7 @@ export default function useChatController({
           const newUrl = params.toString()
             ? `${pathname}?${params.toString()}`
             : pathname;
+          // SAFETY: built from the current pathname, which is a route of this app.
           router.replace(newUrl as Route, { scroll: false });
         }
       }

--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -181,6 +181,7 @@ function usePaginatedFetch<T extends PaginatedType>({
       if (disableUrlSync || !currentPath || !searchParams) return;
       const params = new URLSearchParams(searchParams);
       params.set("page", page.toString());
+      // SAFETY: currentPath is the current pathname, a route of this app.
       router.replace(`${currentPath}?${params.toString()}` as Route, {
         scroll: false,
       });

--- a/web/src/interfaces/onboarding.ts
+++ b/web/src/interfaces/onboarding.ts
@@ -1,3 +1,4 @@
+import type { Route } from "next";
 import type { IconProps } from "@opal/types";
 
 export enum OnboardingStep {
@@ -49,7 +50,7 @@ export type FinalStepItemProps = {
   description: string;
   icon: React.FunctionComponent<IconProps>;
   buttonText: string;
-  buttonHref: string;
+  buttonHref: Route;
 };
 
 export type OnboardingActions = {

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -22,7 +22,7 @@ export function createCraftManageLayout(required: Permission) {
       return redirect(authResult.redirect as Route);
     }
     if (!hasPermission(authResult.user?.admin_capabilities ?? [], required)) {
-      return redirect("/craft/v1" as Route);
+      return redirect("/craft/v1");
     }
     return <>{children}</>;
   };

--- a/web/src/lib/agents/components/AgentViewerModal.tsx
+++ b/web/src/lib/agents/components/AgentViewerModal.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import { FullAgent } from "@/lib/agents/types";
 import { Modal } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
@@ -205,7 +204,7 @@ export function AgentViewerModal({ agent, onClose }: AgentViewerModalProps) {
         [SEARCH_PARAM_NAMES.USER_PROMPT]: message,
         [SEARCH_PARAM_NAMES.SEND_ON_LOAD]: "true",
       });
-      router.push(`/app?${params.toString()}` as Route);
+      router.push(`/app?${params.toString()}`);
     },
     [agent.id, router]
   );

--- a/web/src/lib/auth/components.tsx
+++ b/web/src/lib/auth/components.tsx
@@ -3,7 +3,6 @@
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import { useSessionWatcher } from "@/lib/auth/hooks";
 import { getExtensionContext } from "@/lib/extension/utils";
 import { Modal } from "@opal/components";
@@ -65,7 +64,7 @@ export function AuthenticationShell({ children }: AuthenticationShellProps) {
     );
     router.push(
       returnTo
-        ? (`/auth/login?next=${encodeURIComponent(returnTo)}` as Route)
+        ? `/auth/login?next=${encodeURIComponent(returnTo)}`
         : "/auth/login"
     );
   }

--- a/web/src/lib/position/hooks.ts
+++ b/web/src/lib/position/hooks.ts
@@ -55,12 +55,12 @@ function hrefFor(value: AppPositionType): Route {
         [SEARCH_PARAM_NAMES.PROJECT_ID]: value.id,
       });
     case "more-agents":
-      return "/app/agents" as Route;
+      return "/app/agents";
     case "user-settings":
-      return "/app/settings" as Route;
+      return "/app/settings";
     case "shared-chat":
     case "new-session":
-      return "/app" as Route;
+      return "/app";
   }
 }
 

--- a/web/src/refresh-components/buttons/BackButton.tsx
+++ b/web/src/refresh-components/buttons/BackButton.tsx
@@ -8,7 +8,7 @@ import { SvgArrowLeft } from "@opal/icons";
 
 export interface BackButtonProps {
   behaviorOverride?: () => void;
-  routerOverride?: string;
+  routerOverride?: Route;
 }
 
 export default function BackButton({
@@ -26,7 +26,7 @@ export default function BackButton({
         if (behaviorOverride) {
           behaviorOverride();
         } else if (routerOverride) {
-          router.push(routerOverride as Route);
+          router.push(routerOverride);
         } else {
           router.back();
         }

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -8,7 +8,6 @@ import { Button } from "@opal/components";
 import { usePinnedAgents } from "@/lib/agents/hooks";
 import { noProp } from "@/lib/utils";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import { can } from "@/lib/permissions/resource-actions";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
@@ -94,7 +93,7 @@ export default function AgentCard({ agent, onView }: AgentCardProps) {
                           icon={SvgBarChart}
                           prominence="tertiary"
                           onClick={noProp(() =>
-                            router.push(`/ee/agents/stats/${agent.id}` as Route)
+                            router.push(`/ee/agents/stats/${agent.id}`)
                           )}
                           tooltip={t("card.viewStats.tooltip")}
                         />
@@ -106,7 +105,7 @@ export default function AgentCard({ agent, onView }: AgentCardProps) {
                           icon={SvgEdit}
                           prominence="tertiary"
                           onClick={noProp(() =>
-                            router.push(`/app/agents/edit/${agent.id}` as Route)
+                            router.push(`/app/agents/edit/${agent.id}`)
                           )}
                           tooltip={t("card.edit.tooltip")}
                         />

--- a/web/src/sections/modals/NewTeamModal.tsx
+++ b/web/src/sections/modals/NewTeamModal.tsx
@@ -118,6 +118,7 @@ export default function NewTeamModal() {
 
   const handleContinueToNewOrg = () => {
     const newUrl = window.location.pathname;
+    // SAFETY: the current pathname is a route of this app.
     router.replace(newUrl as Route);
     setShowNewTeamModal(false);
   };

--- a/web/src/sections/onboarding/constants.ts
+++ b/web/src/sections/onboarding/constants.ts
@@ -1,3 +1,4 @@
+import type { Route } from "next";
 import { OnboardingStep } from "@/interfaces/onboarding";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SvgGlobe, SvgImage, SvgUsers } from "@opal/icons";
@@ -62,7 +63,7 @@ export type FinalSetupItemConfig = {
   descriptionKey: string;
   icon: IconFunctionComponent;
   buttonTextKey: string;
-  buttonHref: string;
+  buttonHref: Route;
 };
 
 export const FINAL_SETUP_CONFIG = [

--- a/web/src/sections/onboarding/steps/FinalStep.tsx
+++ b/web/src/sections/onboarding/steps/FinalStep.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import Link from "next/link";
-import type { Route } from "next";
 import { useTranslations } from "next-intl";
 import { Button, Card } from "@opal/components";
 import { FINAL_SETUP_CONFIG } from "@/sections/onboarding/constants";
@@ -35,7 +34,7 @@ const FinalStepItem = React.memo(
             variant="section"
             padding={1}
             rightChildren={
-              <Link href={buttonHref as Route} {...linkProps}>
+              <Link href={buttonHref} {...linkProps}>
                 <Button prominence="tertiary" rightIcon={SvgExternalLink}>
                   {buttonText}
                 </Button>

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -10,7 +10,6 @@ import {
 import { useTranslations } from "next-intl";
 import useSWR, { useSWRConfig } from "swr";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
 import {
   Button,
   Card,
@@ -239,9 +238,7 @@ export default function SkillEditorPage({
 
   function leaveEditor() {
     router.push(
-      hasAppContext
-        ? externalAppAdminUrl(externalAppId)
-        : ("/craft/v1/skills" as Route)
+      hasAppContext ? externalAppAdminUrl(externalAppId) : "/craft/v1/skills"
     );
   }
 
@@ -297,7 +294,7 @@ export default function SkillEditorPage({
         router.replace(
           isCreatingForApp
             ? externalAppAdminUrl(externalAppId)
-            : ("/craft/v1/skills" as Route)
+            : "/craft/v1/skills"
         );
         return;
       }

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { Route } from "next";
 import {
   Button,
   InputTypeIn,
@@ -77,7 +76,7 @@ export default function SkillsPage() {
   });
 
   function handleEdit(item: CustomSkillCardItem) {
-    router.push(`/craft/v1/skills/edit/${item.id}` as Route);
+    router.push(`/craft/v1/skills/edit/${item.id}`);
   }
 
   async function updateSkillEnabled(
@@ -306,7 +305,7 @@ export default function SkillsPage() {
                   description={t("page.createMenu.scratch.description")}
                   onClick={() => {
                     setCreateMenuOpen(false);
-                    router.push("/craft/v1/skills/new" as Route);
+                    router.push("/craft/v1/skills/new");
                   }}
                   title={t("page.createMenu.scratch.title")}
                 />
@@ -430,7 +429,7 @@ export default function SkillsPage() {
         onContinue={(draft) => {
           const draftId = stageSkillCreationDraft(draft);
           setCreateOpen(false);
-          router.push(`/craft/v1/skills/new?draft=${draftId}` as Route);
+          router.push(`/craft/v1/skills/new?draft=${draftId}`);
         }}
       />
 

--- a/web/src/views/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/views/admin/AgentsPage/AgentRowActions.tsx
@@ -32,7 +32,6 @@ import {
   toggleAgentListed,
 } from "@/lib/agents/svc";
 import type { Agent } from "@/lib/agents/types";
-import type { Route } from "next";
 import { ShareAgentModal } from "@/lib/agents/components";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
@@ -122,9 +121,7 @@ export default function AgentRowActions({
               data-testid={`edit-agent-${agent.id}`}
               onClick={() =>
                 router.push(
-                  `/app/agents/edit/${
-                    agent.id
-                  }?u=${Date.now()}&admin=true` as Route
+                  `/app/agents/edit/${agent.id}?u=${Date.now()}&admin=true`
                 )
               }
             />
@@ -239,7 +236,7 @@ export default function AgentRowActions({
                       icon={SvgBarChart}
                       onClick={() => {
                         setPopoverOpen(false);
-                        router.push(`/ee/agents/stats/${agent.id}` as Route);
+                        router.push(`/ee/agents/stats/${agent.id}`);
                       }}
                       title={t("rowActions.statsItem.title")}
                     />

--- a/web/src/views/admin/ExternalAppsPage/index.tsx
+++ b/web/src/views/admin/ExternalAppsPage/index.tsx
@@ -4,7 +4,6 @@ import { useAdminRouteTitle } from "@/lib/adminNavLabels";
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { Route } from "next";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -174,7 +173,7 @@ function AppsAdminContent({
     setModalState(null);
     if (deepLinkedAppId) {
       setDismissedDeepLink(deepLinkedAppId);
-      router.replace("/admin/craft/apps" as Route);
+      router.replace("/admin/craft/apps");
     }
   }
 

--- a/web/src/views/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/views/admin/GroupsPage/GroupCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { Route } from "next";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import type { UserGroup } from "@/lib/types";
@@ -76,9 +75,7 @@ function GroupCard({ group }: GroupCardProps) {
                   prominence="tertiary"
                   tooltip={t("card.viewGroup.label")}
                   aria-label={t("card.viewGroup.label")}
-                  onClick={() =>
-                    router.push(`/admin/groups/${group.id}` as Route)
-                  }
+                  onClick={() => router.push(`/admin/groups/${group.id}`)}
                 />
               )}
             </Section>

--- a/web/src/views/admin/GroupsPage/index.tsx
+++ b/web/src/views/admin/GroupsPage/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { Route } from "next";
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -86,7 +85,7 @@ function GroupsPage() {
           emptyStateText={t("list.empty.text")}
           onAction={
             canCreateGroup
-              ? () => router.push("/admin/groups/create" as Route)
+              ? () => router.push("/admin/groups/create")
               : undefined
           }
           actionLabel={canCreateGroup ? t("list.newGroup.label") : undefined}


### PR DESCRIPTION
## Description

Remove 44 `as Route` casts that Next.js typed routes do not need. This is the top commit of the type coverage stack, rebased onto `main` so it can merge on its own.

- Path constants in `craft/v1/constants.ts` and `craft/v1/tasks/constants.ts` use `satisfies Route`. The compiler checks the literal and keeps its narrow type.
- Path builders with a dynamic segment, in `skillAssociationNavigation.ts` and `craft/v1/tasks/constants.ts`, return a template literal type. `router.push` accepts the result without a cast.
- Five casts stay, each with a `SAFETY` comment. Their paths come from the server or from `window.location`, and a later runtime guard will replace them.

The emitted JavaScript does not change. The change raises 11 floors. For example, `src/layouts/craft` goes from 92.5 to 96.1 and `src/lib/position` from 98.6 to 100.

## How Has This Been Tested?

- `ods type-coverage typescript --update` type-checks `web/` on this tree and rewrote the floors. Every floor that moved went up.
- The source hunks are the same as in the stacked commit 62223aaeda. Only the floors differ.
- `pre-commit` (oxfmt, oxlint) passes on the changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes 44 redundant `as Route` casts from Next.js typed routes so paths keep their narrow literal types instead of being widened to `Route`. Emitted JavaScript is unchanged.

**Refactors**
- Path constants now use `satisfies Route`, which preserves the literal type after the compiler checks it.
- Path builders with dynamic segments return template literal types that `router.push` accepts without a cast.
- Five casts stay for paths from the server or `window.location`, each marked with a `SAFETY` comment for a later runtime guard.
- Type coverage floors rise across 11 packages; `src/lib/position` reaches 100.

<sup>Written for commit 36554bf5e4152f4ec83e55230c9e125a80f42e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

