### PR TITLE
fix(auth): block email/password and is_verified mass assignment

### DIFF
--- a/backend/onyx/auth/schemas.py
+++ b/backend/onyx/auth/schemas.py
@@ -57,7 +57,7 @@ class UserUpdate(schemas.BaseUserUpdate):
 
     @override
     def create_update_dict(self) -> dict[str, Any]:
-        d = super().create_update_dict()
+        d: dict[str, Any] = super().create_update_dict()
         # Email changes must go through the verification flow, password changes
         # through /password/change-password, which requires the old password.
         d.pop("email", None)

--- a/backend/onyx/auth/schemas.py
+++ b/backend/onyx/auth/schemas.py
@@ -51,8 +51,18 @@ class UserCreate(schemas.BaseUserCreate):
 
 
 class UserUpdate(schemas.BaseUserUpdate):
-    """Intentionally empty: keeps account_type and permissions out of the
-    fastapi-users PATCH endpoints."""
+    """Keeps account_type and permissions out of the fastapi-users PATCH
+    endpoints, and strips the identity/credential fields the stock PATCH /users/me
+    would otherwise change with no ownership proof and no re-auth."""
+
+    @override
+    def create_update_dict(self) -> dict[str, Any]:
+        d = super().create_update_dict()
+        # Email changes must go through the verification flow, password changes
+        # through /password/change-password, which requires the old password.
+        d.pop("email", None)
+        d.pop("password", None)
+        return d
 
 
 class AuthBackend(str, Enum):

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -845,7 +845,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # object triggers a sync lazy-load which raises MissingGreenlet
                     # in this async context.
                     user_id = user.id
-                    self._upgrade_user_to_standard__sync(user_id, user_create, is_admin)
+                    self._upgrade_user_to_standard__sync(
+                        user_id, user_create, is_admin, safe=safe
+                    )
                     # Expire so the async session re-fetches the row updated by
                     # the sync session above.
                     self.user_db.session.expire(user)
@@ -875,7 +877,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # object triggers a sync lazy-load which raises MissingGreenlet
                     # in this async context.
                     user_id = user.id
-                    self._upgrade_user_to_standard__sync(user_id, user_create, is_admin)
+                    self._upgrade_user_to_standard__sync(
+                        user_id, user_create, is_admin, safe=safe
+                    )
                     # Expire so the async session re-fetches the row updated by
                     # the sync session above.
                     self.user_db.session.expire(user)
@@ -896,12 +900,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         user_id: uuid.UUID,
         user_create: UserCreate,
         is_admin: bool,
+        safe: bool,
     ) -> None:
         """Upgrade a non-web user to STANDARD + assign groups in one tx.
 
         Enforces the seat limit inside the same transaction when the
         upgrade flips an uncounted user (EXT_PERM_USER, SERVICE_ACCOUNT)
         into a counted one.
+
+        ``safe`` marks the public register path, where the request body is
+        untrusted and cannot decide is_verified.
         """
         seat_added = False
         with get_session_with_current_tenant() as sync_db:
@@ -919,7 +927,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 sync_user.hashed_password = self.password_helper.hash(
                     user_create.password
                 )
-                sync_user.is_verified = user_create.is_verified or False
+                # A registrant must not self-verify an address they do not own.
+                sync_user.is_verified = (
+                    False if safe else (user_create.is_verified or False)
+                )
                 sync_user.account_type = AccountType.STANDARD
                 assign_user_to_default_groups__no_commit(
                     sync_db,

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -1274,3 +1274,63 @@ class TestPlaceholderUpgradeRace:
             is False
         )
         mock_promote.assert_not_called()
+
+
+class TestStandardUpgradeVerification:
+    """Registering over a placeholder row runs the upgrade with the request body.
+    On the public register path that body is untrusted, so it cannot self-verify."""
+
+    @staticmethod
+    def _run_upgrade(
+        mock_get_session: MagicMock, is_verified: bool, safe: bool
+    ) -> MagicMock:
+        user_manager = UserManager(MagicMock())
+        user_manager.password_helper = MagicMock()
+        sync_user = MagicMock(
+            is_active=True,
+            is_verified=False,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        sync_db = MagicMock()
+        sync_db.query.return_value.filter.return_value.first.return_value = sync_user
+        mock_get_session.return_value.__enter__.return_value = sync_db
+
+        user_manager._upgrade_user_to_standard__sync(
+            uuid4(),
+            UserCreate(
+                email="placeholder@corp.com",
+                password="SecurePassword123!",
+                is_verified=is_verified,
+            ),
+            is_admin=False,
+            safe=safe,
+        )
+        return sync_user
+
+    @patch("onyx.auth.users.assign_user_to_default_groups__no_commit")
+    @patch("onyx.auth.users._upgrade_will_add_seat", return_value=False)
+    @patch("onyx.auth.users.get_session_with_current_tenant")
+    def test_safe_upgrade_ignores_client_supplied_verification(
+        self,
+        mock_get_session: MagicMock,
+        mock_will_add_seat: MagicMock,  # noqa: ARG002
+        mock_assign_groups: MagicMock,  # noqa: ARG002
+    ) -> None:
+        sync_user = self._run_upgrade(mock_get_session, is_verified=True, safe=True)
+
+        assert sync_user.is_verified is False
+        assert sync_user.account_type == AccountType.STANDARD
+
+    @patch("onyx.auth.users.assign_user_to_default_groups__no_commit")
+    @patch("onyx.auth.users._upgrade_will_add_seat", return_value=False)
+    @patch("onyx.auth.users.get_session_with_current_tenant")
+    def test_trusted_upgrade_keeps_caller_supplied_verification(
+        self,
+        mock_get_session: MagicMock,
+        mock_will_add_seat: MagicMock,  # noqa: ARG002
+        mock_assign_groups: MagicMock,  # noqa: ARG002
+    ) -> None:
+        sync_user = self._run_upgrade(mock_get_session, is_verified=True, safe=False)
+
+        assert sync_user.is_verified is True
+        assert sync_user.account_type == AccountType.STANDARD

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -1284,14 +1284,14 @@ class TestStandardUpgradeVerification:
     def _run_upgrade(
         mock_get_session: MagicMock, is_verified: bool, safe: bool
     ) -> MagicMock:
-        user_manager = UserManager(MagicMock())
+        user_manager: UserManager = UserManager(MagicMock())
         user_manager.password_helper = MagicMock()
-        sync_user = MagicMock(
+        sync_user: MagicMock = MagicMock(
             is_active=True,
             is_verified=False,
             account_type=AccountType.EXT_PERM_USER,
         )
-        sync_db = MagicMock()
+        sync_db: MagicMock = MagicMock()
         sync_db.query.return_value.filter.return_value.first.return_value = sync_user
         mock_get_session.return_value.__enter__.return_value = sync_db
 
@@ -1316,7 +1316,9 @@ class TestStandardUpgradeVerification:
         mock_will_add_seat: MagicMock,  # noqa: ARG002
         mock_assign_groups: MagicMock,  # noqa: ARG002
     ) -> None:
-        sync_user = self._run_upgrade(mock_get_session, is_verified=True, safe=True)
+        sync_user: MagicMock = self._run_upgrade(
+            mock_get_session, is_verified=True, safe=True
+        )
 
         assert sync_user.is_verified is False
         assert sync_user.account_type == AccountType.STANDARD
@@ -1330,7 +1332,9 @@ class TestStandardUpgradeVerification:
         mock_will_add_seat: MagicMock,  # noqa: ARG002
         mock_assign_groups: MagicMock,  # noqa: ARG002
     ) -> None:
-        sync_user = self._run_upgrade(mock_get_session, is_verified=True, safe=False)
+        sync_user: MagicMock = self._run_upgrade(
+            mock_get_session, is_verified=True, safe=False
+        )
 
         assert sync_user.is_verified is True
         assert sync_user.account_type == AccountType.STANDARD

--- a/backend/tests/unit/onyx/auth/test_user_update_schema.py
+++ b/backend/tests/unit/onyx/auth/test_user_update_schema.py
@@ -1,0 +1,24 @@
+"""
+Unit tests for UserUpdate schema dict methods.
+
+PATCH /users/me builds its update from create_update_dict, so that path must not
+carry email or password. The is_superuser-gated admin route uses
+create_update_dict_superuser, which keeps both on purpose.
+"""
+
+from onyx.auth.schemas import UserUpdate
+
+
+def test_create_update_dict_drops_email_and_password() -> None:
+    uu = UserUpdate(email="attacker@evil.com", password="newpassword123")
+    d = uu.create_update_dict()
+    assert "email" not in d
+    assert "password" not in d
+
+
+def test_create_update_dict_superuser_retains_email_and_password() -> None:
+    """Deliberate carve-out: an admin may set both for another user."""
+    uu = UserUpdate(email="new@b.com", password="newpassword123")
+    d = uu.create_update_dict_superuser()
+    assert d["email"] == "new@b.com"
+    assert d["password"] == "newpassword123"

--- a/backend/tests/unit/onyx/auth/test_user_update_schema.py
+++ b/backend/tests/unit/onyx/auth/test_user_update_schema.py
@@ -6,19 +6,21 @@ carry email or password. The is_superuser-gated admin route uses
 create_update_dict_superuser, which keeps both on purpose.
 """
 
+from typing import Any
+
 from onyx.auth.schemas import UserUpdate
 
 
 def test_create_update_dict_drops_email_and_password() -> None:
-    uu = UserUpdate(email="attacker@evil.com", password="newpassword123")
-    d = uu.create_update_dict()
+    uu: UserUpdate = UserUpdate(email="attacker@evil.com", password="newpassword123")
+    d: dict[str, Any] = uu.create_update_dict()
     assert "email" not in d
     assert "password" not in d
 
 
 def test_create_update_dict_superuser_retains_email_and_password() -> None:
     """Deliberate carve-out: an admin may set both for another user."""
-    uu = UserUpdate(email="new@b.com", password="newpassword123")
-    d = uu.create_update_dict_superuser()
+    uu: UserUpdate = UserUpdate(email="new@b.com", password="newpassword123")
+    d: dict[str, Any] = uu.create_update_dict_superuser()
     assert d["email"] == "new@b.com"
     assert d["password"] == "newpassword123"


### PR DESCRIPTION
## Description

Two mass-assignment gaps on the user model.

**`PATCH /users/me`.** fastapi-users' `CreateUpdateDictModel.create_update_dict` only excludes `id`, `is_superuser`, `is_active`, `is_verified` and `oauth_accounts` — so `email` and `password` stayed client-writable. `UserUpdate` now overrides `create_update_dict` and pops both. Scope: this is the `safe=True` path only; `create_update_dict_superuser`, used by the `is_superuser`-gated admin route, is deliberately left alone.

**Registration could self-verify.** On the public register path the request body could set `is_verified`, letting a registrant mark an address they do not own as verified. `_upgrade_user_to_standard__sync` now takes `safe` and forces `is_verified = False` when set. Both call sites are inside `UserManager.create`, whose signature already carries `safe`; the stock register router passes `safe=True`, and trusted internal callers keep current behaviour.

Part of a security-scan burndown.

## How Has This Been Tested?

- `pytest backend/tests/unit/onyx/auth backend/tests/unit/onyx/server/auth` — 452 passed, 1 skipped
- `ruff check` / `ruff format --check` / `ty check` clean
- Verified the excluded-field list directly against the pinned `fastapi_users/schemas.py` in the lockfile environment rather than relying on documentation.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two mass-assignment vulnerabilities on the user model: `email` and `password` were client-writable on `PATCH /users/me`, and a registrant could set `is_verified` on the public register path. Both are now blocked.

- `UserUpdate.create_update_dict` removes `email` and `password` from update payloads, so those changes must go through the verification and change-password flows.
- The public register path (`safe=True`) forces `is_verified` to `False`; trusted internal callers keep the existing behavior.
- The admin route using `create_update_dict_superuser` is unchanged and still allows superusers to set these fields.
- Adds tests covering both halves of each change, including the intended superuser carve-out.

<sup>Written for commit ed4e647ef59346be8ddceab0264738b80d05e754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

