### PR TITLE
fix(craft): validate sandbox tar members and stop running install scripts

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -62,6 +62,7 @@ import binascii
 import io
 import json
 import mimetypes
+import posixpath
 import re
 import secrets
 import shlex
@@ -298,6 +299,37 @@ def _validate_strict_path(path: str) -> None:
         raise ValueError("Invalid path: contains disallowed characters")
     if not re.match(r"^[a-zA-Z0-9_\-./]+$", path.lstrip("/")):
         raise ValueError("Invalid path: contains disallowed characters")
+
+
+def _validate_opencode_history_archive(archive_bytes: bytes) -> None:
+    """Rejects members that would land outside ``OPENCODE_DATA_DIR``.
+
+    The archive is built inside the sandbox, but ``put_archive`` extracts it as
+    the Docker daemon, so an unchecked member could plant a root-run file (e.g.
+    ``firewall-init.sh``) anywhere under ``WORKSPACE_ROOT``.
+    """
+    archive_root = posixpath.basename(OPENCODE_DATA_DIR)
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
+            members = tar.getmembers()
+    except tarfile.TarError as e:
+        raise RuntimeError(f"Opencode history archive is unreadable: {e}") from e
+
+    for member in members:
+        if not (member.isfile() or member.isdir()):
+            raise RuntimeError(
+                f"Opencode history archive member is not a file or directory: "
+                f"{member.name}"
+            )
+        name = posixpath.normpath(member.name)
+        if (
+            member.name.startswith("/")
+            or ".." in member.name.split("/")
+            or (name != archive_root and not name.startswith(f"{archive_root}/"))
+        ):
+            raise RuntimeError(
+                f"Opencode history archive member escapes {archive_root}: {member.name}"
+            )
 
 
 _COMPOSE_INTERNAL_HOSTNAMES = {
@@ -1388,6 +1420,8 @@ echo "Session cleanup complete"
             )
             return
 
+        _validate_opencode_history_archive(archive_bytes)
+
         try:
             # put_archive untars (gzip ok) into the stopped container's writable layer.
             if not container.put_archive(WORKSPACE_ROOT, archive_bytes):
@@ -1461,7 +1495,7 @@ if [ -f "$web_dir/bun.lock" ]; then
     ) 9>{BUN_CACHE_DIR}.lock
     cd "$web_dir"
     BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
-        bun install --frozen-lockfile --backend=hardlink
+        bun install --frozen-lockfile --ignore-scripts --backend=hardlink
 fi
 """
         try:

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -312,7 +312,8 @@ def _validate_opencode_history_archive(archive_bytes: bytes) -> None:
     try:
         with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
             members = tar.getmembers()
-    except tarfile.TarError as e:
+    except (tarfile.TarError, EOFError) as e:
+        # A truncated gzip stream raises EOFError, not TarError.
         raise RuntimeError(f"Opencode history archive is unreadable: {e}") from e
 
     for member in members:

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
@@ -422,7 +422,7 @@ if [ -f "$web_dir/bun.lock" ]; then
     ) 9>"$BUN_CACHE_DIR.lock"
     cd "$web_dir"
     BUN_INSTALL_CACHE_DIR="$BUN_CACHE_DIR" \\
-        bun install --frozen-lockfile --backend=hardlink
+        bun install --frozen-lockfile --ignore-scripts --backend=hardlink
 fi
 """
 

--- a/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_history_archive_validation.py
+++ b/backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_history_archive_validation.py
@@ -1,0 +1,135 @@
+"""Tests for _validate_opencode_history_archive in docker_sandbox_manager."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    _validate_opencode_history_archive,
+)
+
+ARCHIVE_ROOT = ".opencode-data"
+
+
+def _archive(members: Sequence[tarfile.TarInfo]) -> bytes:
+    """Pack members into a gzip tar, giving regular files a payload."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for member in members:
+            if member.isreg():
+                tar.addfile(member, io.BytesIO(b"x" * member.size))
+            else:
+                tar.addfile(member)
+    return buf.getvalue()
+
+
+def _file(name: str, size: int = 4) -> tarfile.TarInfo:
+    member = tarfile.TarInfo(name=name)
+    member.size = size
+    member.mode = 0o644
+    return member
+
+
+def _directory(name: str) -> tarfile.TarInfo:
+    member = tarfile.TarInfo(name=name)
+    member.type = tarfile.DIRTYPE
+    member.mode = 0o755
+    return member
+
+
+def _special(name: str, member_type: bytes, linkname: str = "") -> tarfile.TarInfo:
+    member = tarfile.TarInfo(name=name)
+    member.type = member_type
+    member.linkname = linkname
+    return member
+
+
+def test_valid_tree_accepted() -> None:
+    archive = _archive(
+        [
+            _directory(ARCHIVE_ROOT),
+            _directory(f"{ARCHIVE_ROOT}/opencode"),
+            _file(f"{ARCHIVE_ROOT}/opencode/opencode.db", size=16),
+            _file(f"{ARCHIVE_ROOT}/opencode/project/session/message.json"),
+            _file(f"./{ARCHIVE_ROOT}/auth.json"),
+        ]
+    )
+
+    _validate_opencode_history_archive(archive)
+
+
+def test_archive_built_like_the_sidecar_accepted(tmp_path: Path) -> None:
+    """Mirrors create_opencode_history_archive_file's tar.add(arcname=...) shape."""
+    staged_root = tmp_path / ARCHIVE_ROOT
+    (staged_root / "opencode").mkdir(parents=True)
+    (staged_root / "opencode" / "opencode.db").write_bytes(b"SQLite format 3\x00")
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        tar.add(staged_root, arcname=ARCHIVE_ROOT, recursive=True)
+
+    _validate_opencode_history_archive(buf.getvalue())
+
+
+def test_empty_archive_accepted() -> None:
+    _validate_opencode_history_archive(_archive([]))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "/etc/passwd",
+        f"/{ARCHIVE_ROOT}/opencode.db",
+        f"{ARCHIVE_ROOT}/../evil",
+        "../evil",
+        f"{ARCHIVE_ROOT}/opencode/../../evil",
+        "evil.sh",
+        "managed/.onyx/firewall-init.sh",
+        ".opencode-database/evil",
+        f"{ARCHIVE_ROOT}-evil/payload",
+    ],
+)
+def test_member_outside_archive_root_rejected(name: str) -> None:
+    with pytest.raises(RuntimeError, match="escapes"):
+        _validate_opencode_history_archive(_archive([_file(name)]))
+
+
+@pytest.mark.parametrize(
+    ("member_type", "linkname"),
+    [
+        (tarfile.SYMTYPE, "/etc/passwd"),
+        (tarfile.LNKTYPE, f"{ARCHIVE_ROOT}/opencode/opencode.db"),
+        (tarfile.CHRTYPE, ""),
+        (tarfile.BLKTYPE, ""),
+        (tarfile.FIFOTYPE, ""),
+    ],
+)
+def test_special_member_rejected(member_type: bytes, linkname: str) -> None:
+    """Names stay inside the root so only the member type can fail the check."""
+    archive = _archive(
+        [_special(f"{ARCHIVE_ROOT}/opencode/entry", member_type, linkname)]
+    )
+
+    with pytest.raises(RuntimeError, match="not a file or directory"):
+        _validate_opencode_history_archive(archive)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        b"not a gzip archive",
+        gzip.compress(b"gzip, but not a tar"),
+        _archive([_file(f"{ARCHIVE_ROOT}/opencode.db", size=8192)])[:60],
+    ],
+    ids=["empty", "not-gzip", "gzip-not-tar", "truncated-gzip"],
+)
+def test_unreadable_archive_rejected(payload: bytes) -> None:
+    with pytest.raises(RuntimeError, match="unreadable"):
+        _validate_opencode_history_archive(payload)


### PR DESCRIPTION
## Description

**Unvalidated tar extraction as root.** `_maybe_restore_opencode_history` passed a sandbox-built archive straight to `put_archive`, which the Docker daemon extracts as root. Members are now rejected unless they are a regular file or directory — no symlinks, hardlinks, devices or fifos — and unless their normalised name stays under `.opencode-data/`. Leading slashes and any `..` segment are refused, as is an archive that will not open as gzip.

**`bun install` ran dependency lifecycle scripts.** The sidecar installed from an agent-authored `package.json` without `--ignore-scripts`. Verified before changing it that the shipped template declares no `preinstall`/`postinstall`/`prepare`, that `bun.lock` records no lifecycle scripts, and that the native packages all ship prebuilt per-platform binaries — so nothing in the current dependency set needs a build step.

Part of a security-scan burndown.

## How Has This Been Tested?

- `pytest backend/tests/unit/onyx/server/features/craft` — 748 passed
- `ruff check` / `ruff format --check` / `ty check` clean
- Exercised the validator against forged archives covering each rejection class, plus a valid `.opencode-data/` tree to confirm the happy path still passes.

Not covered here: there is still no total-size cap on the archive, so a gzip bomb in a stored snapshot remains possible. Three other `bun install` call sites still run scripts (`nextjs_dev.py` session start and wake, and the trusted build-time Dockerfile warm).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two security findings in the craft sandbox restore flow: tar archives are validated before Docker extracts them as root, and `bun install` no longer runs dependency lifecycle scripts.

- `_maybe_restore_opencode_history` now rejects members that aren't regular files or directories, have leading slashes or `..` segments, or land outside `.opencode-data/`; unreadable or truncated archives now raise `RuntimeError`.
- Both restore paths now pass `--ignore-scripts` to `bun install`; verified the shipped template and lockfile declare no lifecycle scripts.
- Adds unit tests covering valid archives, each rejection class, and `..` traversal that normalizes back inside the root.
- Remaining gaps: no total-size cap on restored archives, and three other `bun install` call sites still run scripts.

<sup>Written for commit 103a899e2a259111dab0a35193f5de529fbc01dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

