### PR TITLE
fix(cli): refuse host filesystem access from remote TUI clients

### DIFF
--- a/cli/cmd/serve.go
+++ b/cli/cmd/serve.go
@@ -100,6 +100,9 @@ environment variable (the --host-key flag takes precedence).`,
   onyx-cli serve --host 0.0.0.0 --port 2222
   onyx-cli serve --idle-timeout 30m --max-session-timeout 2h`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Sessions here belong to remote clients; keep them off the host filesystem.
+			tui.RemoteMode = true
+
 			serverCfg := config.Load()
 			if serverCfg.ServerURL == "" {
 				return exitcodes.New(exitcodes.NotConfigured, "server URL is not configured\n  Run: onyx-cli chat to complete first-time setup")

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -267,6 +267,10 @@ func cmdSelectModel(m Model, idxStr string) (Model, tea.Cmd) {
 }
 
 func cmdAttach(m Model, pathStr string) (Model, tea.Cmd) {
+	if RemoteMode {
+		m.viewport.addWarning("/attach is disabled over SSH: paths resolve on the server host, not yours.")
+		return m, nil
+	}
 	if pathStr == "" {
 		m.viewport.addWarning("Usage: /attach <file_path>")
 		return m, nil

--- a/cli/internal/tui/commands_test.go
+++ b/cli/internal/tui/commands_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -276,6 +278,43 @@ func TestSelectAgentFromPickerUsesIDWhenNameMatches(t *testing.T) {
 	m, _ = cmdSelectAgentByID(m, "1")
 	if m.agentID != 1 {
 		t.Errorf("agentID = %d, want 1", m.agentID)
+	}
+}
+
+func TestAttachRefusedInRemoteMode(t *testing.T) {
+	RemoteMode = true
+	t.Cleanup(func() { RemoteMode = false })
+
+	m := NewModel(config.DefaultConfig(), nil)
+	m, cmd := cmdAttach(m, "/etc/passwd")
+
+	if cmd != nil {
+		t.Fatal("expected no upload command in remote mode")
+	}
+	if len(m.viewport.entries) == 0 {
+		t.Fatal("expected a warning entry")
+	}
+	got := m.viewport.entries[len(m.viewport.entries)-1].content
+	if !strings.Contains(got, "disabled over SSH") {
+		t.Errorf("warning = %q, want a refusal mentioning SSH", got)
+	}
+}
+
+func TestDetectFileDropIgnoredInRemoteMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	if got := detectFileDrop(path); got != path {
+		t.Fatalf("local detectFileDrop = %q, want %q", got, path)
+	}
+
+	RemoteMode = true
+	t.Cleanup(func() { RemoteMode = false })
+
+	if got := detectFileDrop(path); got != "" {
+		t.Errorf("remote detectFileDrop = %q, want no match", got)
 	}
 }
 

--- a/cli/internal/tui/input.go
+++ b/cli/internal/tui/input.go
@@ -204,8 +204,12 @@ type fileDropMsg struct {
 	path string
 }
 
-// detectFileDrop checks if the text looks like a file path.
+// detectFileDrop checks if the text looks like a file path. It never matches
+// in remote mode, where the path would resolve on the server host.
 func detectFileDrop(text string) string {
+	if RemoteMode {
+		return ""
+	}
 	cleaned := strings.Trim(text, "'\"")
 	if cleaned == "" {
 		return ""

--- a/cli/internal/tui/sshauth.go
+++ b/cli/internal/tui/sshauth.go
@@ -14,6 +14,11 @@ const (
 	MaxAPIKeyRetries = 5
 )
 
+// RemoteMode marks this process as serving the TUI to remote clients.
+// Commands that touch the host filesystem are refused while it is set,
+// because those paths resolve on the operator's machine, not the client's.
+var RemoteMode bool
+
 // --- auth prompt (bubbletea model) ---
 
 type authState int


### PR DESCRIPTION
## Description

`onyx serve` exposes the TUI to remote SSH clients, but `/attach` and the file-drop detector resolve paths on the operator's host rather than the client's — so a remote client could read files from the server.

A package-level `RemoteMode` flag is set by `serve` before any listener exists. `cmdAttach` refuses with a clear warning, and `detectFileDrop` returns early before the `~` expansion and the `os.Stat`, which also closes the file-existence oracle. Both routes into `client.UploadFile` are covered, since `handleFileDrop` goes through `cmdAttach`.

Part of a security-scan burndown.

## How Has This Been Tested?

- `go build ./...` and `go vet ./...` clean
- `go test ./internal/tui/...` passes, including two new regression tests: `/attach` refused in remote mode, and file-drop detection matching locally but refusing remotely
- `gofmt -l` clean on the changed files

Not covered here: `client.UploadFile` still has an unbounded `io.Copy`, which is now a local-only concern since remote clients cannot reach it. The SSH layer also still has no client authentication — that is a separate design change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security issue where remote TUI clients could read arbitrary server files via `/attach` and file-drop detection, which resolve paths on the operator's host rather than the client's machine.

- `serve` sets a package-level `RemoteMode` flag before any listener starts.
- `/attach` is refused with a warning once the flag is set; `detectFileDrop` returns early, which also closes the file-existence oracle.
- Adds two regression tests covering the local behavior and remote refusal.
- `client.UploadFile`'s unbounded `io.Copy` remains a local-only concern since remote clients can no longer reach it.

<sup>Written for commit 112c53a3931a56351cd06930ee4dfe5d3dd44ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

